### PR TITLE
Restore definition of NativeMethods as an object for React Native

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -13,7 +13,7 @@ import type {
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
   MeasureOnSuccessCallback,
-  NativeMethods,
+  INativeMethods,
   ViewConfig,
   TouchedViewDataAtPoint,
 } from './ReactNativeTypes';
@@ -109,7 +109,7 @@ const noop = () => {};
 /**
  * This is used for refs on host components.
  */
-class ReactFabricHostComponent implements NativeMethods {
+class ReactFabricHostComponent implements INativeMethods {
   _nativeTag: number;
   viewConfig: ViewConfig;
   currentProps: Props;

--- a/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
@@ -13,7 +13,7 @@ import type {
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
   MeasureOnSuccessCallback,
-  NativeMethods,
+  INativeMethods,
   ViewConfig,
 } from './ReactNativeTypes';
 import type {Instance} from './ReactNativeHostConfig';
@@ -30,7 +30,7 @@ import {
   warnForStyleProps,
 } from './NativeMethodsMixinUtils';
 
-class ReactNativeFiberHostComponent implements NativeMethods {
+class ReactNativeFiberHostComponent implements INativeMethods {
   _children: Array<Instance | number>;
   _nativeTag: number;
   _internalFiberInstanceHandleDEV: Object;

--- a/packages/react-native-renderer/src/ReactNativePublicCompat.js
+++ b/packages/react-native-renderer/src/ReactNativePublicCompat.js
@@ -68,6 +68,7 @@ export function findHostInstance_DEPRECATED<TElementType: ElementType>(
     hostInstance = findHostInstance(componentOrHandle);
   }
 
+  // $FlowFixMe[incompatible-exact] we need to fix the definition of `HostComponent` to use NativeMethods as an interface, not as a type.
   return hostInstance;
 }
 

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -95,7 +95,10 @@ export type PartialViewConfig = $ReadOnly<{
   validAttributes?: PartialAttributeConfiguration,
 }>;
 
-export interface NativeMethods {
+/**
+ * Current usages should migrate to this definition
+ */
+export interface INativeMethods {
   blur(): void;
   focus(): void;
   measure(callback: MeasureOnSuccessCallback): void;
@@ -107,6 +110,23 @@ export interface NativeMethods {
   ): void;
   setNativeProps(nativeProps: {...}): void;
 }
+
+export type NativeMethods = $ReadOnly<{|
+  blur(): void,
+  focus(): void,
+  measure(callback: MeasureOnSuccessCallback): void,
+  measureInWindow(callback: MeasureInWindowOnSuccessCallback): void,
+  measureLayout(
+    relativeToNativeNode: number | ElementRef<HostComponent<mixed>>,
+    onSuccess: MeasureLayoutOnSuccessCallback,
+    onFail?: () => void,
+  ): void,
+  setNativeProps(nativeProps: {...}): void,
+|}>;
+
+// This validates that INativeMethods and NativeMethods stay in sync using Flow!
+declare var ensureNativeMethodsAreSynced: NativeMethods;
+(ensureNativeMethodsAreSynced: INativeMethods);
 
 export type HostComponent<T> = AbstractComponent<T, $ReadOnly<NativeMethods>>;
 


### PR DESCRIPTION
## Summary

In #26283, I changed definition of `NativeMethods` from an object to an interface. This is correct but introduces a lot of errors in React Native, so this restores the original definition and exports the fixed type as a separate type so we can gradually migrate in React Native.

## How did you test this change?

Manually applied this change in React Native and validated the errors are gone.