### PR TITLE
Internal `act`: Call scope function after an async gap

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
@@ -20,7 +20,7 @@ describe('Store component filters', () => {
   let internalAct;
 
   const act = async (callback: Function) => {
-    internalAct(callback);
+    await internalAct(callback);
     jest.runAllTimers(); // Flush Bridge operations
   };
 
@@ -373,7 +373,6 @@ describe('Store component filters', () => {
       legacyRender(<Wrapper shouldSuspend={false} />, container),
     );
     expect(store).toMatchInlineSnapshot(`
-      ✕ 1, ⚠ 0
       [root]
         ▾ <Wrapper>
             <Component>
@@ -383,7 +382,6 @@ describe('Store component filters', () => {
       legacyRender(<Wrapper shouldSuspend={true} />, container),
     );
     expect(store).toMatchInlineSnapshot(`
-      ✕ 2, ⚠ 0
       [root]
         ▾ <Wrapper>
           ▾ <Loading>

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
@@ -315,7 +315,9 @@ describe('ReactSuspenseFuzz', () => {
 
     const rand = Random.create(SEED);
 
-    const NUMBER_OF_TEST_CASES = 500;
+    // If this is too large the test will time out. We use a scheduled CI
+    // workflow to run these tests with a random seed.
+    const NUMBER_OF_TEST_CASES = 250;
     const ELEMENTS_PER_CASE = 12;
 
     for (let i = 0; i < NUMBER_OF_TEST_CASES; i++) {


### PR DESCRIPTION
This adds an async gap to our internal implementation of `act` (the one used by our repo, not the public API). Rather than call the provided scope function synchronously when `act` is called, we call it in a separate async task. This is an extra precaution to ensure that our tests do not accidentally rely on work being queued synchronously, because that is an implementation detail that we should be allowed to change. We don't do this in the public version of `act`, though we maybe should in the future, for the same rationale. That might be tricky, though, because it could break existing tests.

This also fixes the issue where our internal `act` requires an async function. You can pass it a regular function, too.