### PR TITLE
[Flight] Add support for returning `undefined` from render

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -556,7 +556,8 @@ export function parseModelString(
             throw chunk.reason;
         }
       }
-      case 'U': {
+      case 'u': {
+        // matches "$undefined"
         // Special encoding for `undefined` which can't be serialized as JSON otherwise.
         return undefined;
       }

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -556,6 +556,10 @@ export function parseModelString(
             throw chunk.reason;
         }
       }
+      case 'U': {
+        // Special encoding for `undefined` which can't be serialized as JSON otherwise.
+        return undefined;
+      }
       default: {
         // We assume that anything else is a reference ID.
         const id = parseInt(value.substring(1), 16);

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -213,6 +213,22 @@ describe('ReactFlight', () => {
     expect(ReactNoop).toMatchRenderedOutput(null);
   });
 
+  it('can render an empty fragment', async () => {
+    function Empty() {
+      return <React.Fragment />;
+    }
+
+    const model = <Empty />;
+
+    const transport = ReactNoopFlightServer.render(model);
+
+    await act(async () => {
+      ReactNoop.render(await ReactNoopFlightClient.read(transport));
+    });
+
+    expect(ReactNoop).toMatchRenderedOutput(null);
+  });
+
   it('can render a lazy component as a shared component on the server', async () => {
     function SharedComponent({text}) {
       return (

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -197,6 +197,22 @@ describe('ReactFlight', () => {
     expect(ReactNoop).toMatchRenderedOutput(<span>ABC</span>);
   });
 
+  it('can render undefined', async () => {
+    function Undefined() {
+      return undefined;
+    }
+
+    const model = <Undefined />;
+
+    const transport = ReactNoopFlightServer.render(model);
+
+    await act(async () => {
+      ReactNoop.render(await ReactNoopFlightClient.read(transport));
+    });
+
+    expect(ReactNoop).toMatchRenderedOutput(null);
+  });
+
   it('can render a lazy component as a shared component on the server', async () => {
     function SharedComponent({text}) {
       return (

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -548,7 +548,7 @@ function serializeProviderReference(name: string): string {
 }
 
 function serializeUndefined(): string {
-  return '$U';
+  return '$undefined';
 }
 
 function serializeClientReference(

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -117,6 +117,7 @@ export type ReactClientValue =
   | number
   | symbol
   | null
+  | void
   | Iterable<ReactClientValue>
   | Array<ReactClientValue>
   | ReactClientObject
@@ -544,6 +545,10 @@ function serializeSymbolReference(name: string): string {
 
 function serializeProviderReference(name: string): string {
   return '$P' + name;
+}
+
+function serializeUndefined(): string {
+  return '$U';
 }
 
 function serializeClientReference(
@@ -1134,12 +1139,12 @@ export function resolveModelToJSON(
     return escapeStringValue(value);
   }
 
-  if (
-    typeof value === 'boolean' ||
-    typeof value === 'number' ||
-    typeof value === 'undefined'
-  ) {
+  if (typeof value === 'boolean' || typeof value === 'number') {
     return value;
+  }
+
+  if (typeof value === 'undefined') {
+    return serializeUndefined();
   }
 
   if (typeof value === 'function') {


### PR DESCRIPTION
## Summary

Adds support for returning `undefined` from Server Components.
Also fixes a bug where rendering an empty fragment would throw the same error as returning undefined.

## How did you test this change?

- [x] test failed with same error message I got when returning undefined from Server Components in a Next.js app
- [x] test passes after adding encoding for `undefined` 
