### PR TITLE
Codemod redundant async act scopes

### DIFF
--- a/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
+++ b/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
@@ -152,7 +152,7 @@ describe('ReactInternalTestUtils', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A', 'B', 'C']);

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -475,7 +475,7 @@ describe('ReactFlight', () => {
       return use(promise);
     }
 
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         ReactNoop.render(
           <>
@@ -554,7 +554,7 @@ describe('ReactFlight', () => {
       return use(promise);
     }
 
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         ReactNoop.render(
           <NoErrorExpected>

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
@@ -61,7 +61,7 @@ describe('ReactHooksInspectionIntegration', () => {
     const {onMouseDown: setStateA, onMouseUp: setStateB} =
       renderer.root.findByType('div').props;
 
-    await act(async () => setStateA('Hi'));
+    await act(() => setStateA('Hi'));
 
     childFiber = renderer.root.findByType(Foo)._currentFiber();
     tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
@@ -83,7 +83,7 @@ describe('ReactHooksInspectionIntegration', () => {
       },
     ]);
 
-    await act(async () => setStateB('world!'));
+    await act(() => setStateB('world!'));
 
     childFiber = renderer.root.findByType(Foo)._currentFiber();
     tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
@@ -141,7 +141,7 @@ describe('ReactHooksInspectionIntegration', () => {
       );
     }
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(<Foo prop="prop" />);
     });
 
@@ -203,7 +203,7 @@ describe('ReactHooksInspectionIntegration', () => {
       },
     ]);
 
-    await act(async () => {
+    await act(() => {
       updateStates();
     });
 
@@ -301,7 +301,7 @@ describe('ReactHooksInspectionIntegration', () => {
       );
     }
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(<Foo prop="prop" />);
     });
 
@@ -370,7 +370,7 @@ describe('ReactHooksInspectionIntegration', () => {
       },
     ]);
 
-    await act(async () => {
+    await act(() => {
       updateStates();
     });
 
@@ -984,7 +984,7 @@ describe('ReactHooksInspectionIntegration', () => {
       children: ['count: ', '1'],
     });
 
-    await act(async () => incrementCount());
+    await act(() => incrementCount());
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       props: {},

--- a/packages/react-dom/src/__tests__/ReactDOMConsoleErrorReporting-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMConsoleErrorReporting-test.js
@@ -72,11 +72,11 @@ describe('ReactDOMConsoleErrorReporting', () => {
       }
 
       const root = ReactDOMClient.createRoot(container);
-      await act(async () => {
+      await act(() => {
         root.render(<Foo />);
       });
 
-      await act(async () => {
+      await act(() => {
         container.firstChild.dispatchEvent(
           new MouseEvent('click', {
             bubbles: true,
@@ -146,7 +146,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       // Check next render doesn't throw.
       windowOnError.mockReset();
       console.error.mockReset();
-      await act(async () => {
+      await act(() => {
         root.render(<NoError />);
       });
       expect(container.textContent).toBe('OK');
@@ -229,7 +229,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       // Check next render doesn't throw.
       windowOnError.mockReset();
       console.error.mockReset();
-      await act(async () => {
+      await act(() => {
         root.render(<NoError />);
       });
       expect(container.textContent).toBe('OK');
@@ -247,7 +247,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       }
 
       const root = ReactDOMClient.createRoot(container);
-      await act(async () => {
+      await act(() => {
         root.render(
           <ErrorBoundary>
             <Foo />
@@ -315,7 +315,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       // Check next render doesn't throw.
       windowOnError.mockReset();
       console.error.mockReset();
-      await act(async () => {
+      await act(() => {
         root.render(<NoError />);
       });
       expect(container.textContent).toBe('OK');
@@ -384,7 +384,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       // Check next render doesn't throw.
       windowOnError.mockReset();
       console.error.mockReset();
-      await act(async () => {
+      await act(() => {
         root.render(<NoError />);
       });
       expect(container.textContent).toBe('OK');
@@ -405,7 +405,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       }
 
       const root = ReactDOMClient.createRoot(container);
-      await act(async () => {
+      await act(() => {
         root.render(
           <ErrorBoundary>
             <Foo />
@@ -456,7 +456,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       // Check next render doesn't throw.
       windowOnError.mockReset();
       console.error.mockReset();
-      await act(async () => {
+      await act(() => {
         root.render(<NoError />);
       });
       expect(container.textContent).toBe('OK');
@@ -525,7 +525,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       // Check next render doesn't throw.
       windowOnError.mockReset();
       console.error.mockReset();
-      await act(async () => {
+      await act(() => {
         root.render(<NoError />);
       });
       expect(container.textContent).toBe('OK');
@@ -546,7 +546,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       }
 
       const root = ReactDOMClient.createRoot(container);
-      await act(async () => {
+      await act(() => {
         root.render(
           <ErrorBoundary>
             <Foo />
@@ -597,7 +597,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       // Check next render doesn't throw.
       windowOnError.mockReset();
       console.error.mockReset();
-      await act(async () => {
+      await act(() => {
         root.render(<NoError />);
       });
       expect(container.textContent).toBe('OK');
@@ -623,11 +623,11 @@ describe('ReactDOMConsoleErrorReporting', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(<Foo />, container);
       });
 
-      await act(async () => {
+      await act(() => {
         container.firstChild.dispatchEvent(
           new MouseEvent('click', {
             bubbles: true,
@@ -698,7 +698,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       // Check next render doesn't throw.
       windowOnError.mockReset();
       console.error.mockReset();
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(<NoError />, container);
       });
       expect(container.textContent).toBe('OK');
@@ -765,7 +765,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       // Check next render doesn't throw.
       windowOnError.mockReset();
       console.error.mockReset();
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(<NoError />, container);
       });
       expect(container.textContent).toBe('OK');
@@ -784,7 +784,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
         throw Error('Boom');
       }
 
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(
           <ErrorBoundary>
             <Foo />
@@ -837,7 +837,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       // Check next render doesn't throw.
       windowOnError.mockReset();
       console.error.mockReset();
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(<NoError />, container);
       });
       expect(container.textContent).toBe('OK');
@@ -907,7 +907,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       // Check next render doesn't throw.
       windowOnError.mockReset();
       console.error.mockReset();
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(<NoError />, container);
       });
       expect(container.textContent).toBe('OK');
@@ -929,7 +929,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
         return null;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(
           <ErrorBoundary>
             <Foo />
@@ -982,7 +982,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       // Check next render doesn't throw.
       windowOnError.mockReset();
       console.error.mockReset();
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(<NoError />, container);
       });
       expect(container.textContent).toBe('OK');
@@ -1053,7 +1053,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       // Check next render doesn't throw.
       windowOnError.mockReset();
       console.error.mockReset();
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(<NoError />, container);
       });
       expect(container.textContent).toBe('OK');
@@ -1075,7 +1075,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
         return null;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(
           <ErrorBoundary>
             <Foo />
@@ -1128,7 +1128,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
       // Check next render doesn't throw.
       windowOnError.mockReset();
       console.error.mockReset();
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(<NoError />, container);
       });
       expect(container.textContent).toBe('OK');

--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
@@ -423,7 +423,7 @@ describe('ReactDOMFiberAsync', () => {
       }
 
       const root = ReactDOMClient.createRoot(container);
-      await act(async () => {
+      await act(() => {
         root.render(<Form />);
       });
 
@@ -474,7 +474,7 @@ describe('ReactDOMFiberAsync', () => {
       }
 
       const root = ReactDOMClient.createRoot(container);
-      await act(async () => {
+      await act(() => {
         root.render(<Form />);
       });
 
@@ -484,7 +484,7 @@ describe('ReactDOMFiberAsync', () => {
       // Dispatch a click event on the Disable-button.
       const firstEvent = document.createEvent('Event');
       firstEvent.initEvent('click', true, true);
-      await act(async () => {
+      await act(() => {
         disableButton.dispatchEvent(firstEvent);
       });
 
@@ -498,7 +498,7 @@ describe('ReactDOMFiberAsync', () => {
       const secondEvent = document.createEvent('Event');
       secondEvent.initEvent('click', true, true);
       // This should force the pending update to flush which disables the submit button before the event is invoked.
-      await act(async () => {
+      await act(() => {
         submitButton.dispatchEvent(secondEvent);
       });
 
@@ -533,7 +533,7 @@ describe('ReactDOMFiberAsync', () => {
       }
 
       const root = ReactDOMClient.createRoot(container);
-      await act(async () => {
+      await act(() => {
         root.render(<Form />);
       });
 
@@ -543,7 +543,7 @@ describe('ReactDOMFiberAsync', () => {
       // Dispatch a click event on the Enable-button.
       const firstEvent = document.createEvent('Event');
       firstEvent.initEvent('click', true, true);
-      await act(async () => {
+      await act(() => {
         enableButton.dispatchEvent(firstEvent);
       });
 
@@ -557,7 +557,7 @@ describe('ReactDOMFiberAsync', () => {
       const secondEvent = document.createEvent('Event');
       secondEvent.initEvent('click', true, true);
       // This should force the pending update to flush which enables the submit button before the event is invoked.
-      await act(async () => {
+      await act(() => {
         submitButton.dispatchEvent(secondEvent);
       });
 
@@ -643,7 +643,7 @@ describe('ReactDOMFiberAsync', () => {
     }
 
     const oldRoot = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       oldRoot.render(<OldApp />);
     });
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -349,7 +349,7 @@ describe('ReactDOMFizzServer', () => {
     };
 
     try {
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(
           <div>
             <div>
@@ -373,7 +373,7 @@ describe('ReactDOMFizzServer', () => {
           <div>Loading...</div>
         </div>,
       );
-      await act(async () => {
+      await act(() => {
         resolveA({default: Text});
       });
       expect(getVisibleChildren(container)).toEqual(
@@ -382,7 +382,7 @@ describe('ReactDOMFizzServer', () => {
           <div>Loading...</div>
         </div>,
       );
-      await act(async () => {
+      await act(() => {
         resolveB({default: TextWithPunctuation});
       });
       expect(getVisibleChildren(container)).toEqual(
@@ -432,7 +432,7 @@ describe('ReactDOMFizzServer', () => {
 
     // Server-side
     const [App, resolve] = makeApp();
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<App />);
       pipe(writable);
     });
@@ -441,7 +441,7 @@ describe('ReactDOMFizzServer', () => {
         <span>Loading...</span>
       </div>,
     );
-    await act(async () => {
+    await act(() => {
       resolve();
     });
     expect(getVisibleChildren(container)).toEqual(
@@ -453,7 +453,7 @@ describe('ReactDOMFizzServer', () => {
 
     // Client-side
     const [HydrateApp, hydrateResolve] = makeApp();
-    await act(async () => {
+    await act(() => {
       ReactDOMClient.hydrateRoot(container, <HydrateApp />);
     });
 
@@ -464,7 +464,7 @@ describe('ReactDOMFizzServer', () => {
       </div>,
     );
 
-    await act(async () => {
+    await act(() => {
       hydrateResolve();
     });
     expect(getVisibleChildren(container)).toEqual(
@@ -485,7 +485,7 @@ describe('ReactDOMFizzServer', () => {
         });
       });
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(
           <div>
             <Suspense fallback={<Text text="Loading..." />}>
@@ -497,7 +497,7 @@ describe('ReactDOMFizzServer', () => {
         pipe(writable);
       });
       expect(getVisibleChildren(container)).toEqual(<div>Loading...</div>);
-      await act(async () => {
+      await act(() => {
         resolve({default: Text});
       });
       expect(getVisibleChildren(container)).toEqual(<div>Hello</div>);
@@ -545,7 +545,7 @@ describe('ReactDOMFizzServer', () => {
     const expectedDigest = onError(theError);
     loggedErrors.length = 0;
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<App isClient={false} />, {
         bootstrapScriptContent: '__INIT__();',
         onError,
@@ -562,7 +562,7 @@ describe('ReactDOMFizzServer', () => {
 
     expect(loggedErrors).toEqual([]);
 
-    await act(async () => {
+    await act(() => {
       rejectComponent(theError);
     });
 
@@ -604,7 +604,7 @@ describe('ReactDOMFizzServer', () => {
       });
     });
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <div>
           <Suspense fallback={<Text text="Loading..." />}>
@@ -624,7 +624,7 @@ describe('ReactDOMFizzServer', () => {
         renderOptions.unstable_externalRuntimeSrc,
       ).length,
     ).toBe(1);
-    await act(async () => {
+    await act(() => {
       resolveElement({default: <Text text="Hello" />});
     });
     expect(getVisibleChildren(container)).toEqual(<div>Hello</div>);
@@ -658,7 +658,7 @@ describe('ReactDOMFizzServer', () => {
       );
     }
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <App isClient={false} />,
 
@@ -684,7 +684,7 @@ describe('ReactDOMFizzServer', () => {
 
     expect(loggedErrors).toEqual([]);
 
-    await act(async () => {
+    await act(() => {
       rejectElement(theError);
     });
 
@@ -754,7 +754,7 @@ describe('ReactDOMFizzServer', () => {
     const expectedDigest = onError(theError);
     loggedErrors.length = 0;
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <App />,
 
@@ -822,7 +822,7 @@ describe('ReactDOMFizzServer', () => {
     const expectedDigest = onError(theError);
     loggedErrors.length = 0;
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <App />,
 
@@ -845,7 +845,7 @@ describe('ReactDOMFizzServer', () => {
 
     expect(getVisibleChildren(container)).toEqual(<div>Loading...</div>);
 
-    await act(async () => {
+    await act(() => {
       rejectComponent(theError);
     });
 
@@ -878,7 +878,7 @@ describe('ReactDOMFizzServer', () => {
   });
 
   it('should asynchronously load the suspense boundary', async () => {
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <div>
           <Suspense fallback={<Text text="Loading..." />}>
@@ -889,7 +889,7 @@ describe('ReactDOMFizzServer', () => {
       pipe(writable);
     });
     expect(getVisibleChildren(container)).toEqual(<div>Loading...</div>);
-    await act(async () => {
+    await act(() => {
       resolveText('Hello World');
     });
     expect(getVisibleChildren(container)).toEqual(<div>Hello World</div>);
@@ -917,7 +917,7 @@ describe('ReactDOMFizzServer', () => {
       ReactDOMClient.hydrateRoot(container, <App />);
     };
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<App />, {
         bootstrapScriptContent: '__INIT__();',
       });
@@ -937,7 +937,7 @@ describe('ReactDOMFizzServer', () => {
     expect(getVisibleChildren(container)).toEqual(<div>Loading...</div>);
 
     // The server now updates the content in place in the fallback.
-    await act(async () => {
+    await act(() => {
       resolveText('Hello');
     });
 
@@ -991,7 +991,7 @@ describe('ReactDOMFizzServer', () => {
     const loggedErrors = [];
 
     // We originally suspend the boundary and start streaming the loading state.
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <App />,
 
@@ -1017,7 +1017,7 @@ describe('ReactDOMFizzServer', () => {
     expect(getVisibleChildren(container)).toEqual(<div>Loading...</div>);
 
     const theError = new Error('Error Message');
-    await act(async () => {
+    await act(() => {
       rejectText('This Errors', theError);
     });
 
@@ -1073,7 +1073,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     // We originally suspend the boundary and start streaming the loading state.
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<App showMore={false} />);
       pipe(writable);
     });
@@ -1146,7 +1146,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     let controls;
-    await act(async () => {
+    await act(() => {
       controls = renderToPipeableStream(<App />, {onError});
       controls.pipe(writable);
     });
@@ -1166,7 +1166,7 @@ describe('ReactDOMFizzServer', () => {
     expect(getVisibleChildren(container)).toEqual(<div>Loading...</div>);
 
     // We abort the server response.
-    await act(async () => {
+    await act(() => {
       controls.abort();
     });
 
@@ -1216,7 +1216,7 @@ describe('ReactDOMFizzServer', () => {
       writable.write(chunk, encoding, next);
     };
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         // We use two nested boundaries to flush out coverage of an old reentrancy bug.
         <Suspense fallback="Loading...">
@@ -1240,7 +1240,7 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <Suspense fallback={<Text text="Loading B..." />}>
           <Text text="This will show B: " />
@@ -1264,7 +1264,7 @@ describe('ReactDOMFizzServer', () => {
       <div id="container-B">Loading B...</div>,
     ]);
 
-    await act(async () => {
+    await act(() => {
       resolveText('B');
     });
 
@@ -1275,7 +1275,7 @@ describe('ReactDOMFizzServer', () => {
       </div>,
     ]);
 
-    await act(async () => {
+    await act(() => {
       resolveText('A');
     });
 
@@ -1336,7 +1336,7 @@ describe('ReactDOMFizzServer', () => {
       );
     }
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<App />);
       pipe(writable);
     });
@@ -1347,15 +1347,15 @@ describe('ReactDOMFizzServer', () => {
       </div>,
     );
 
-    await act(async () => {
+    await act(() => {
       resolveText('Hello');
     });
 
-    await act(async () => {
+    await act(() => {
       resolveText('World');
     });
 
-    await act(async () => {
+    await act(() => {
       resolveText('my-path');
       resolveText('my-mi');
     });
@@ -1423,7 +1423,7 @@ describe('ReactDOMFizzServer', () => {
       );
     }
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<App />);
       pipe(writable);
     });
@@ -1438,15 +1438,15 @@ describe('ReactDOMFizzServer', () => {
       </table>,
     );
 
-    await act(async () => {
+    await act(() => {
       resolveText('A');
     });
 
-    await act(async () => {
+    await act(() => {
       resolveText('B');
     });
 
-    await act(async () => {
+    await act(() => {
       resolveText('C');
     });
 
@@ -1476,7 +1476,7 @@ describe('ReactDOMFizzServer', () => {
       );
     }
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <App />,
 
@@ -1499,7 +1499,7 @@ describe('ReactDOMFizzServer', () => {
       </svg>,
     );
 
-    await act(async () => {
+    await act(() => {
       resolveText('my-path');
     });
 
@@ -1562,7 +1562,7 @@ describe('ReactDOMFizzServer', () => {
     };
 
     try {
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<A />);
         pipe(writable);
       });
@@ -1589,7 +1589,7 @@ describe('ReactDOMFizzServer', () => {
         expect(mockError).not.toHaveBeenCalled();
       }
 
-      await act(async () => {
+      await act(() => {
         resolveText('Hello');
         resolveText('World');
       });
@@ -1660,7 +1660,7 @@ describe('ReactDOMFizzServer', () => {
       }
     }
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <TestProvider ctx="A">
           <div>
@@ -1680,7 +1680,7 @@ describe('ReactDOMFizzServer', () => {
         Loading: <b>A</b>
       </div>,
     );
-    await act(async () => {
+    await act(() => {
       resolveText('Hello: ');
     });
     expect(getVisibleChildren(container)).toEqual(
@@ -1717,7 +1717,7 @@ describe('ReactDOMFizzServer', () => {
       );
     }
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <div>
           <PrintA />
@@ -1741,7 +1741,7 @@ describe('ReactDOMFizzServer', () => {
         A0<div>Loading...</div>A0
       </div>,
     );
-    await act(async () => {
+    await act(() => {
       resolveText('Child:');
     });
     expect(getVisibleChildren(container)).toEqual(
@@ -1778,7 +1778,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     const loggedErrors = [];
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <div>
           <PrintA />
@@ -1846,7 +1846,7 @@ describe('ReactDOMFizzServer', () => {
     loggedErrors.length = 0;
 
     let controls;
-    await act(async () => {
+    await act(() => {
       controls = renderToPipeableStream(
         <App isClient={false} />,
 
@@ -1874,7 +1874,7 @@ describe('ReactDOMFizzServer', () => {
     expect(loggedErrors).toEqual([]);
 
     // Error the content, but we don't have a fallback yet.
-    await act(async () => {
+    await act(() => {
       rejectText('Hello', theError);
     });
 
@@ -1885,7 +1885,7 @@ describe('ReactDOMFizzServer', () => {
     expect(getVisibleChildren(container)).toEqual('Loading root...');
 
     // Unblock the loading state
-    await act(async () => {
+    await act(() => {
       resolveText('Loading...');
     });
 
@@ -1929,7 +1929,7 @@ describe('ReactDOMFizzServer', () => {
   });
 
   it('should be able to abort the fallback if the main content finishes first', async () => {
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <Suspense fallback={<Text text="Loading Outer" />}>
           <div>
@@ -1950,7 +1950,7 @@ describe('ReactDOMFizzServer', () => {
     expect(getVisibleChildren(container)).toEqual('Loading Outer');
     // We should have received a partial segment containing the a partial of the fallback.
     expect(container.innerHTML).toContain('Inner');
-    await act(async () => {
+    await act(() => {
       resolveText('Hello');
     });
     // We should've been able to display the content without waiting for the rest of the fallback.
@@ -2026,7 +2026,7 @@ describe('ReactDOMFizzServer', () => {
 
     await jest.runAllTimers();
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<App isClient={false} />);
       pipe(writable);
     });
@@ -2036,7 +2036,7 @@ describe('ReactDOMFizzServer', () => {
     expect(container.innerHTML).not.toContain('Avoided Fallback');
 
     // resolve first suspense component with avoidThisFallback
-    await act(async () => {
+    await act(() => {
       promiseRes[0]();
     });
 
@@ -2050,7 +2050,7 @@ describe('ReactDOMFizzServer', () => {
 
     expect(container.innerHTML).not.toContain('Avoided Fallback2');
 
-    await act(async () => {
+    await act(() => {
       promiseRes[1]();
     });
 
@@ -2136,7 +2136,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     const loggedErrors = [];
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <Suspense fallback="Loading...">
           <App />
@@ -2219,7 +2219,7 @@ describe('ReactDOMFizzServer', () => {
       );
     }
     const loggedErrors = [];
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <Suspense fallback="Loading...">
           <App />
@@ -2306,7 +2306,7 @@ describe('ReactDOMFizzServer', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -2396,7 +2396,7 @@ describe('ReactDOMFizzServer', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -2486,7 +2486,7 @@ describe('ReactDOMFizzServer', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -2539,7 +2539,7 @@ describe('ReactDOMFizzServer', () => {
         </div>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<App />, {
         onError(error) {
           Scheduler.log('[s!] ' + error.message);
@@ -2576,7 +2576,7 @@ describe('ReactDOMFizzServer', () => {
     expect(serverFallback).toBe(clientFallback);
 
     // When we're able to fully hydrate, we expect a clean client render.
-    await act(async () => {
+    await act(() => {
       resolveText('Yay!');
     });
     await waitForAll([
@@ -2624,7 +2624,7 @@ describe('ReactDOMFizzServer', () => {
           </div>
         );
       }
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App color="red" />, {
           onError(error) {
             Scheduler.log('[s!] ' + error.message);
@@ -2670,7 +2670,7 @@ describe('ReactDOMFizzServer', () => {
       expect(clientFallback2).toBe(serverFallback);
 
       // When we're able to fully hydrate, we expect a clean client render.
-      await act(async () => {
+      await act(() => {
         resolveText('Yay!');
       });
       await waitForAll([
@@ -2722,7 +2722,7 @@ describe('ReactDOMFizzServer', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(
           <App fallbackText="Loading..." />,
           {
@@ -2784,7 +2784,7 @@ describe('ReactDOMFizzServer', () => {
       expect(clientFallback2).not.toBe(clientFallback1);
 
       // Verify we can still do a clean content render after.
-      await act(async () => {
+      await act(() => {
         resolveText('Yay!');
       });
       await waitForAll(['Yay!']);
@@ -2851,7 +2851,7 @@ describe('ReactDOMFizzServer', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -2883,7 +2883,7 @@ describe('ReactDOMFizzServer', () => {
         </div>,
       );
 
-      await act(async () => {
+      await act(() => {
         resolveText('Yay!');
       });
       await waitForAll(['Yay!']);
@@ -3001,7 +3001,7 @@ describe('ReactDOMFizzServer', () => {
       );
     }
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<App />);
       pipe(writable);
     });
@@ -3065,7 +3065,7 @@ describe('ReactDOMFizzServer', () => {
       return <span>{context}</span>;
     }
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<Foo />);
       pipe(writable);
     });
@@ -3087,7 +3087,7 @@ describe('ReactDOMFizzServer', () => {
       {name: 'b', value: 'b'},
     ]).map(item => <li key={item.get('value')}>{item.get('name')}</li>);
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<ul>{mappedJSX}</ul>);
       pipe(writable);
     });
@@ -3119,7 +3119,7 @@ describe('ReactDOMFizzServer', () => {
 
     let abort;
     const loggedErrors = [];
-    await act(async () => {
+    await act(() => {
       const {pipe, abort: abortImpl} = renderToPipeableStream(<App />, {
         onError(error) {
           // In this test we contrive erroring with strings so we push the error whereas in most
@@ -3202,7 +3202,7 @@ describe('ReactDOMFizzServer', () => {
 
     let abort;
     const loggedErrors = [];
-    await act(async () => {
+    await act(() => {
       const {pipe, abort: abortImpl} = renderToPipeableStream(<App />, {
         onError(error) {
           loggedErrors.push(error.message);
@@ -3264,7 +3264,7 @@ describe('ReactDOMFizzServer', () => {
   });
 
   it('warns in dev if you access digest from errorInfo in onRecoverableError', async () => {
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(
         <div>
           <Suspense fallback={'loading...'}>
@@ -3341,7 +3341,7 @@ describe('ReactDOMFizzServer', () => {
         )}`;
       }
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />, {
           onError,
         });
@@ -3389,7 +3389,7 @@ describe('ReactDOMFizzServer', () => {
         )}`;
       }
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />, {
           onError,
         });
@@ -3429,7 +3429,7 @@ describe('ReactDOMFizzServer', () => {
       const expectedDigest = onError(theError);
       loggedErrors.length = 0;
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />, {
           onError,
         });
@@ -3529,7 +3529,7 @@ describe('ReactDOMFizzServer', () => {
       window.__test_outlet = '';
       const stringWithScriptsInIt =
         'prescription pre<scription pre<Scription pre</scRipTion pre</ScripTion </script><script><!-- <script> -->';
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<div />, {
           bootstrapScriptContent:
             'window.__test_outlet = "This should have been replaced";var x = "' +
@@ -3550,7 +3550,7 @@ describe('ReactDOMFizzServer', () => {
       const el = document.createElement('p');
       el.textContent = '{"one":1,\u2028\u2029"two":2}';
       const stringWithLSAndPSCharacters = el.textContent;
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<div />, {
           bootstrapScriptContent:
             'let x = ' +
@@ -3571,7 +3571,7 @@ describe('ReactDOMFizzServer', () => {
       window.__test_outlet = null;
       // this boolean expression will be cast to a number due to the bitwise &. we will look for a truthy value (1) below
       const booleanLogicString = '1 < 2 & 3 > 1';
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<div />, {
           bootstrapScriptContent:
             'let x = ' + booleanLogicString + '; window.__test_outlet = x;',
@@ -3635,7 +3635,7 @@ describe('ReactDOMFizzServer', () => {
       const {pipe} = renderToPipeableStream(<App />);
       pipe(writable);
     });
-    await act(async () => {
+    await act(() => {
       resolveText('Hello');
     });
 
@@ -3696,7 +3696,7 @@ describe('ReactDOMFizzServer', () => {
     };
 
     const [ServerApp, serverResolve] = makeApp();
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<ServerApp />);
       pipe(writable);
     });
@@ -3770,7 +3770,7 @@ describe('ReactDOMFizzServer', () => {
     };
 
     const [ServerApp, serverResolve] = makeApp();
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<ServerApp text="initial" />);
       pipe(writable);
     });
@@ -3845,7 +3845,7 @@ describe('ReactDOMFizzServer', () => {
     };
 
     try {
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App text="initial" />);
         pipe(writable);
       });
@@ -3932,7 +3932,7 @@ describe('ReactDOMFizzServer', () => {
       );
     };
 
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<App />);
       pipe(writable);
     });
@@ -4022,7 +4022,7 @@ describe('ReactDOMFizzServer', () => {
     };
 
     try {
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -4151,7 +4151,7 @@ describe('ReactDOMFizzServer', () => {
     };
 
     try {
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -4272,7 +4272,7 @@ describe('ReactDOMFizzServer', () => {
     };
 
     try {
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -4341,7 +4341,7 @@ describe('ReactDOMFizzServer', () => {
         </Suspense>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<App />);
       pipe(writable);
     });
@@ -4387,7 +4387,7 @@ describe('ReactDOMFizzServer', () => {
         </div>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = renderToPipeableStream(<App />);
       pipe(writable);
     });
@@ -4540,7 +4540,7 @@ describe('ReactDOMFizzServer', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App name="Foo" />);
         pipe(writable);
       });
@@ -4578,7 +4578,7 @@ describe('ReactDOMFizzServer', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App name="Foo" />);
         pipe(writable);
       });
@@ -4638,7 +4638,7 @@ describe('ReactDOMFizzServer', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -4831,7 +4831,7 @@ describe('ReactDOMFizzServer', () => {
         '<div id="app-div">start<!--$?--><template id="B:0"></template>[loading first]<!--/$--><!--$?--><template id="B:1"></template>[loading second]<!--/$-->end</div>',
       );
 
-      await act(async () => {
+      await act(() => {
         resolveText('first suspended');
       });
 
@@ -4858,7 +4858,7 @@ describe('ReactDOMFizzServer', () => {
         </div>,
       );
 
-      await act(async () => {
+      await act(() => {
         resolveText('second suspended');
       });
 
@@ -4961,7 +4961,7 @@ describe('ReactDOMFizzServer', () => {
       }
 
       prepareJSDOMForTitle();
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -4985,7 +4985,7 @@ describe('ReactDOMFizzServer', () => {
       }
 
       prepareJSDOMForTitle();
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -5010,7 +5010,7 @@ describe('ReactDOMFizzServer', () => {
       prepareJSDOMForTitle();
 
       await expect(async () => {
-        await act(async () => {
+        await act(() => {
           const {pipe} = renderToPipeableStream(<App />);
           pipe(writable);
         });
@@ -5072,7 +5072,7 @@ describe('ReactDOMFizzServer', () => {
 
       if (gate(flags => flags.enableFloat)) {
         await expect(async () => {
-          await act(async () => {
+          await act(() => {
             const {pipe} = renderToPipeableStream(<App />);
             pipe(writable);
           });
@@ -5081,7 +5081,7 @@ describe('ReactDOMFizzServer', () => {
         ]);
       } else {
         await expect(async () => {
-          await act(async () => {
+          await act(() => {
             const {pipe} = renderToPipeableStream(<App />);
             pipe(writable);
           });
@@ -5135,7 +5135,7 @@ describe('ReactDOMFizzServer', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -5195,7 +5195,7 @@ describe('ReactDOMFizzServer', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -5234,7 +5234,7 @@ describe('ReactDOMFizzServer', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -5303,7 +5303,7 @@ describe('ReactDOMFizzServer', () => {
       }
 
       const reportedServerErrors = [];
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />, {
           onError(error) {
             reportedServerErrors.push(error);
@@ -5364,7 +5364,7 @@ describe('ReactDOMFizzServer', () => {
         return use(thenable);
       }
 
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -5395,7 +5395,7 @@ describe('ReactDOMFizzServer', () => {
       }
       // Because the thenable resolves synchronously, we should be able to finish
       // rendering synchronously, with no fallback.
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -5418,7 +5418,7 @@ describe('ReactDOMFizzServer', () => {
           </button>
         );
       }
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
@@ -5449,7 +5449,7 @@ describe('ReactDOMFizzServer', () => {
       const reportedServerErrors = [];
       let caughtError;
       try {
-        await act(async () => {
+        await act(() => {
           const {pipe} = renderToPipeableStream(<App />, {
             onError(e) {
               reportedServerErrors.push(e);
@@ -5478,7 +5478,7 @@ describe('ReactDOMFizzServer', () => {
           return <span />;
         }
       }
-      await act(async () => {
+      await act(() => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzSuppressHydrationWarning-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzSuppressHydrationWarning-test.js
@@ -141,7 +141,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         </div>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
       );
@@ -180,7 +180,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         </div>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
       );
@@ -220,7 +220,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         </div>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
       );
@@ -271,7 +271,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         </div>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
       );
@@ -307,7 +307,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         </div>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
       );
@@ -353,7 +353,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         </div>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
       );
@@ -404,7 +404,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         </div>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
       );
@@ -453,7 +453,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         </div>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
       );
@@ -509,7 +509,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         </div>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
       );
@@ -546,7 +546,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         </div>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
       );
@@ -579,7 +579,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         </div>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
       );
@@ -624,7 +624,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         </div>
       );
     }
-    await act(async () => {
+    await act(() => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
       );

--- a/packages/react-dom/src/__tests__/ReactDOMHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHooks-test.js
@@ -135,7 +135,7 @@ describe('ReactDOMHooks', () => {
     Scheduler.unstable_flushAll();
 
     inputRef.current.value = 'abc';
-    await act(async () => {
+    await act(() => {
       inputRef.current.dispatchEvent(
         new Event('input', {
           bubbles: true,

--- a/packages/react-dom/src/__tests__/ReactDOMNativeEventHeuristic-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMNativeEventHeuristic-test.js
@@ -74,7 +74,7 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
     }
 
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<Form />);
     });
 
@@ -231,12 +231,12 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
       return <div ref={target}>{isHover ? 'hovered' : 'not hovered'}</div>;
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(<Foo />);
     });
     expect(container.textContent).toEqual('not hovered');
 
-    await act(async () => {
+    await act(() => {
       const mouseOverEvent = document.createEvent('MouseEvents');
       mouseOverEvent.initEvent('mouseover', true, true);
       dispatchAndSetCurrentEvent(target.current, mouseOverEvent);
@@ -261,12 +261,12 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
       return <div ref={target}>{isHover ? 'hovered' : 'not hovered'}</div>;
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(<Foo />);
     });
     expect(container.textContent).toEqual('not hovered');
 
-    await act(async () => {
+    await act(() => {
       // Note: React does not use native mouseenter/mouseleave events
       // but we should still correctly determine their priority.
       const mouseEnterEvent = document.createEvent('MouseEvents');
@@ -291,7 +291,7 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
       return <div ref={target}>{hoverString}</div>;
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(<Foo hovered={false} />);
     });
     expect(container.textContent).toEqual('not hovered');
@@ -337,7 +337,7 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
       return <div ref={target}>Count: {count}</div>;
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(<Foo />);
     });
     expect(container.textContent).toEqual('Count: 0');
@@ -378,7 +378,7 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
       );
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(<Foo />);
     });
     expect(container.textContent).toEqual('Count: 0');

--- a/packages/react-dom/src/__tests__/ReactDOMNestedEvents-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMNestedEvents-test.js
@@ -59,14 +59,14 @@ describe('ReactDOMNestedEvents', () => {
     document.body.appendChild(container);
     const root = ReactDOMClient.createRoot(container);
 
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     expect(buttonRef.current.innerHTML).toEqual(
       'Clicked: false, Focused: false',
     );
 
-    await act(async () => {
+    await act(() => {
       buttonRef.current.click();
     });
     assertLog(['Value right after focus call: Clicked: false, Focused: false']);

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -398,7 +398,7 @@ describe('ReactDOMRoot', () => {
       return <div>{value}</div>;
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(<Foo value="a" />);
     });
 
@@ -422,12 +422,12 @@ describe('ReactDOMRoot', () => {
 
   it('unmount is synchronous', async () => {
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render('Hi');
     });
     expect(container.textContent).toEqual('Hi');
 
-    await act(async () => {
+    await act(() => {
       root.unmount();
       // Should have already unmounted
       expect(container.textContent).toEqual('');
@@ -436,7 +436,7 @@ describe('ReactDOMRoot', () => {
 
   it('throws if an unmounted root is updated', async () => {
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render('Hi');
     });
     expect(container.textContent).toEqual('Hi');
@@ -463,7 +463,7 @@ describe('ReactDOMRoot', () => {
       return 'Hi';
     }
 
-    await act(async () => {
+    await act(() => {
       root1.render(<App step={1} />);
     });
     expect(container1.textContent).toEqual('Hi');

--- a/packages/react-dom/src/__tests__/ReactDOMSafariMicrotaskBug-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSafariMicrotaskBug-test.js
@@ -66,7 +66,7 @@ describe('ReactDOMSafariMicrotaskBug-test', () => {
       );
     }
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<Foo />);
     });
     expect(container.textContent).toBe('1');
@@ -86,11 +86,11 @@ describe('ReactDOMSafariMicrotaskBug-test', () => {
       );
     }
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<Foo />);
     });
     expect(container.textContent).toBe('0');
-    await act(async () => {
+    await act(() => {
       container.firstChild.dispatchEvent(
         new MouseEvent('click', {bubbles: true}),
       );

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -454,7 +454,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(deleted.length).toBe(0);
 
     // Performing an update should force it to delete the boundary
-    await act(async () => {
+    await act(() => {
       root.render(<App value={true} />);
     });
 
@@ -510,7 +510,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(ref.current).toBe(null);
 
     await expect(async () => {
-      await act(async () => {
+      await act(() => {
         ReactDOMClient.hydrateRoot(container, <App hasB={false} />, {
           onRecoverableError(error) {
             Scheduler.log(error.message);
@@ -579,7 +579,7 @@ describe('ReactDOMServerPartialHydration', () => {
       expect(ref.current).toBe(null);
 
       shouldSuspend = true;
-      await act(async () => {
+      await act(() => {
         ReactDOMClient.hydrateRoot(container, <App hasB={false} />);
       });
 
@@ -636,7 +636,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(ref.current).toBe(null);
 
     await expect(async () => {
-      await act(async () => {
+      await act(() => {
         ReactDOMClient.hydrateRoot(container, <App hasB={false} />, {
           onRecoverableError(error) {
             Scheduler.log(error.message);
@@ -698,7 +698,7 @@ describe('ReactDOMServerPartialHydration', () => {
 
     expect(deleted.length).toBe(0);
 
-    await act(async () => {
+    await act(() => {
       root.render(<App deleted={true} />);
     });
 
@@ -744,7 +744,7 @@ describe('ReactDOMServerPartialHydration', () => {
     // On the client we try to hydrate.
     suspend = true;
     await expect(async () => {
-      await act(async () => {
+      await act(() => {
         ReactDOM.hydrate(<App />, container);
       });
     }).toErrorDev(
@@ -829,14 +829,14 @@ describe('ReactDOMServerPartialHydration', () => {
     // hydrating anyway.
     suspend = true;
 
-    await act(async () => {
+    await act(() => {
       ReactDOMClient.hydrateRoot(container, <App />);
     });
 
     expect(container.firstChild.firstChild.tagName).not.toBe('DIV');
 
     // In this state, we can still update the siblings.
-    await act(async () => showSibling());
+    await act(() => showSibling());
 
     expect(container.firstChild.firstChild.tagName).toBe('DIV');
     expect(container.firstChild.firstChild.textContent).toBe('First');
@@ -885,14 +885,14 @@ describe('ReactDOMServerPartialHydration', () => {
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    await act(async () => {
+    await act(() => {
       ReactDOMClient.hydrateRoot(container, <App />);
     });
 
     expect(container.firstChild.children[1].textContent).toBe('Middle');
 
     // In this state, we can still delete the boundary.
-    await act(async () => hideMiddle());
+    await act(() => hideMiddle());
 
     expect(container.firstChild.children[1].textContent).toBe('After');
   });
@@ -1096,7 +1096,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(ref.current).toBe(null);
 
     // Render an update, but leave it still suspended.
-    await act(async () => {
+    await act(() => {
       root.render(<App text="Hi" className="hi" />);
     });
 
@@ -1177,7 +1177,7 @@ describe('ReactDOMServerPartialHydration', () => {
 
     // Render an update, but leave it still suspended.
     // Flushing now should delete the existing content and show the fallback.
-    await act(async () => {
+    await act(() => {
       root.render(<App text="Hi" className="hi" />);
     });
 
@@ -1253,7 +1253,7 @@ describe('ReactDOMServerPartialHydration', () => {
 
     // Render an update, but leave it still suspended.
     // Flushing now should delete the existing content and show the fallback.
-    await act(async () => {
+    await act(() => {
       root.render(<App text="Hi" className="hi" />);
     });
 
@@ -1570,7 +1570,7 @@ describe('ReactDOMServerPartialHydration', () => {
 
     // Render an update, but leave it still suspended.
     // Flushing now should delete the existing content and show the fallback.
-    await act(async () => {
+    await act(() => {
       root.render(
         <Context.Provider value={{text: 'Hi', className: 'hi'}}>
           <App />
@@ -1880,7 +1880,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(container.textContent).toBe('AB');
 
     // Add more rows before we've hydrated the first two.
-    await act(async () => {
+    await act(() => {
       root.render(<App showMore={true} />);
     });
 
@@ -2313,7 +2313,7 @@ describe('ReactDOMServerPartialHydration', () => {
     // The new update doesn't suspend.
     // Since we're still suspended on the original data, we can't hydrate.
     // This will force all expiration times to flush.
-    await act(async () => {
+    await act(() => {
       root.render(
         <ClassName.Provider value={'hi'}>
           <App text="Hi" />
@@ -2395,7 +2395,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(container.textContent).toBe('Click meHello');
 
     // We're now partially hydrated.
-    await act(async () => {
+    await act(() => {
       a.click();
     });
     expect(clicks).toBe(0);
@@ -2486,7 +2486,7 @@ describe('ReactDOMServerPartialHydration', () => {
     jest.runAllTimers();
 
     // We're now partially hydrated.
-    await act(async () => {
+    await act(() => {
       a.click();
     });
     // We should not have invoked the event yet because we're not
@@ -2568,7 +2568,7 @@ describe('ReactDOMServerPartialHydration', () => {
     ReactDOMClient.hydrateRoot(container, <App />);
 
     // We'll do one click before hydrating.
-    await act(async () => {
+    await act(() => {
       a.click();
     });
     // This should be delayed.
@@ -2578,7 +2578,7 @@ describe('ReactDOMServerPartialHydration', () => {
     jest.runAllTimers();
 
     // We're now partially hydrated.
-    await act(async () => {
+    await act(() => {
       a.click();
     });
     expect(clicks).toBe(0);
@@ -2671,7 +2671,7 @@ describe('ReactDOMServerPartialHydration', () => {
     jest.runAllTimers();
 
     // We're now partially hydrated.
-    await act(async () => {
+    await act(() => {
       a.click();
     });
     // We should not have invoked the event yet because we're not
@@ -2752,7 +2752,7 @@ describe('ReactDOMServerPartialHydration', () => {
     jest.runAllTimers();
 
     // We're now partially hydrated.
-    await act(async () => {
+    await act(() => {
       span.click();
     });
     expect(clicksOnChild).toBe(0);
@@ -2840,7 +2840,7 @@ describe('ReactDOMServerPartialHydration', () => {
     Scheduler.unstable_flushAll();
 
     // The Suspense boundary is not yet hydrated.
-    await act(async () => {
+    await act(() => {
       a.click();
     });
     expect(clicks).toBe(0);
@@ -3115,7 +3115,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(container.textContent).toBe('Click meHello');
 
     // We're now partially hydrated.
-    await act(async () => {
+    await act(() => {
       form.dispatchEvent(
         new window.Event('submit', {
           bubbles: true,
@@ -3415,7 +3415,7 @@ describe('ReactDOMServerPartialHydration', () => {
     container.innerHTML = finalHTML;
 
     await expect(async () => {
-      await act(async () => {
+      await act(() => {
         ReactDOMClient.hydrateRoot(container, <App isClient={true} />, {
           onRecoverableError(error) {
             Scheduler.log('Log recoverable error: ' + error.message);
@@ -3462,7 +3462,7 @@ describe('ReactDOMServerPartialHydration', () => {
       <DirectTextChild text="good" />,
     );
     await expect(async () => {
-      await act(async () => {
+      await act(() => {
         ReactDOMClient.hydrateRoot(container, <DirectTextChild text="bad" />, {
           onRecoverableError(error) {
             Scheduler.log(error.message);
@@ -3503,7 +3503,7 @@ describe('ReactDOMServerPartialHydration', () => {
       <TextChildWithSibling text="good" />,
     );
     await expect(async () => {
-      await act(async () => {
+      await act(() => {
         ReactDOMClient.hydrateRoot(
           container2,
           <TextChildWithSibling text="bad" />,

--- a/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
@@ -276,7 +276,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
     assertLog([]);
 
     // This click target cannot be hydrated yet because it's suspended.
-    await act(async () => {
+    await act(() => {
       const result = dispatchClickEvent(spanD);
       expect(result).toBe(true);
     });
@@ -558,7 +558,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
     assertLog([]);
 
     // Continuing rendering will render B next.
-    await act(async () => {
+    await act(() => {
       const target = createEventTarget(spanD);
       target.virtualclick();
     });
@@ -1110,7 +1110,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
 
       dispatchClickEvent(innerDiv);
 
-      await act(async () => {
+      await act(() => {
         jest.runAllTimers();
         Scheduler.unstable_flushAllWithoutAsserting();
         OuterScheduler.unstable_flushAllWithoutAsserting();
@@ -1181,7 +1181,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
       assertLog([]);
 
       // fire scheduled Replay
-      await act(async () => {
+      await act(() => {
         jest.runAllTimers();
         Scheduler.unstable_flushAllWithoutAsserting();
         OuterScheduler.unstable_flushAllWithoutAsserting();
@@ -1210,7 +1210,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
       expect(InnerScheduler.unstable_clearLog()).toEqual([]);
 
       // Replay outer event
-      await act(async () => {
+      await act(() => {
         Scheduler.unstable_flushAllWithoutAsserting();
         OuterScheduler.unstable_flushAllWithoutAsserting();
         InnerScheduler.unstable_flushAllWithoutAsserting();
@@ -1240,7 +1240,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
       // Outer was hydrated earlier
       expect(OuterScheduler.unstable_clearLog()).toEqual([]);
 
-      await act(async () => {
+      await act(() => {
         Scheduler.unstable_flushAllWithoutAsserting();
         OuterScheduler.unstable_flushAllWithoutAsserting();
         InnerScheduler.unstable_flushAllWithoutAsserting();
@@ -1812,7 +1812,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
     const root = ReactDOMClient.hydrateRoot(container, <App text="A" />);
     await waitForPaint(['App A']);
 
-    await act(async () => {
+    await act(() => {
       ReactDOM.flushSync(() => {
         root.render(<App text="B" />);
       });
@@ -1848,7 +1848,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
     const root = ReactDOMClient.hydrateRoot(container, <App text="A" />);
     await waitForPaint(['App A']);
 
-    await act(async () => {
+    await act(() => {
       TODO_scheduleContinuousSchedulerTask(() => {
         root.render(<App text="B" />);
       });
@@ -1883,7 +1883,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
     const initialSpan = container.getElementsByTagName('span')[0];
     const root = ReactDOMClient.hydrateRoot(container, <App text="A" />);
     await waitForPaint(['App A']);
-    await act(async () => {
+    await act(() => {
       root.render(<App text="B" />);
     });
     assertLog(['App B', 'Child A', 'App B', 'Child B']);

--- a/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
@@ -161,7 +161,7 @@ describe('ReactDOMServerSuspense', () => {
     expect(divB.tagName).toBe('DIV');
     expect(divB.textContent).toBe('B');
 
-    await act(async () => {
+    await act(() => {
       ReactDOMClient.hydrateRoot(parent, example);
     });
 

--- a/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.js
@@ -182,7 +182,7 @@ describe('ReactDOMSuspensePlaceholder', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(<App />, container);
       });
       expect(container.innerHTML).toEqual(
@@ -192,14 +192,14 @@ describe('ReactDOMSuspensePlaceholder', () => {
 
       // Update the inline display style. It will be overridden because it's
       // inside a hidden fallback.
-      await act(async () => setIsVisible(true));
+      await act(() => setIsVisible(true));
       expect(container.innerHTML).toEqual(
         '<span style="display: none;">Sibling</span><span style=' +
           '"display: none;"></span>Loading...',
       );
 
       // Unsuspend. The style should now match the inline prop.
-      await act(async () => resolveText('Async'));
+      await act(() => resolveText('Async'));
       expect(container.innerHTML).toEqual(
         '<span style="display: inline;">Sibling</span><span style="">Async</span>',
       );

--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
@@ -1864,7 +1864,7 @@ describe('ReactErrorBoundaries', () => {
 
   it('catches errors in useEffect', async () => {
     const container = document.createElement('div');
-    await act(async () => {
+    await act(() => {
       ReactDOM.render(
         <ErrorBoundary>
           <BrokenUseEffect>Initial value</BrokenUseEffect>

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1678,11 +1678,11 @@ describe('ReactUpdates', () => {
       }
 
       const container = document.createElement('div');
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(<Terminating />, container);
       });
       expect(container.textContent).toBe('50');
-      await act(async () => {
+      await act(() => {
         _setStep(0);
       });
       expect(container.textContent).toBe('50');
@@ -1701,7 +1701,7 @@ describe('ReactUpdates', () => {
       }
 
       const container = document.createElement('div');
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(<Terminating />, container);
       });
 

--- a/packages/react-dom/src/__tests__/ReactWrongReturnPointer-test.js
+++ b/packages/react-dom/src/__tests__/ReactWrongReturnPointer-test.js
@@ -189,15 +189,15 @@ test('regression (#20932): return pointer is correct before entering deleted tre
   }
 
   const root = ReactNoop.createRoot();
-  await act(async () => {
+  await act(() => {
     root.render(<App />);
   });
   assertLog(['Suspend! [0]', 'Loading Async...', 'Loading Tail...']);
-  await act(async () => {
+  await act(() => {
     resolveText(0);
   });
   assertLog([0, 'Tail']);
-  await act(async () => {
+  await act(() => {
     setAsyncText(x => x + 1);
   });
   assertLog([

--- a/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
+++ b/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
@@ -50,11 +50,11 @@ module.exports = function (initModules) {
   // promisified version of ReactDOM.render()
   async function asyncReactDOMRender(reactElement, domElement, forceHydrate) {
     if (forceHydrate) {
-      await act(async () => {
+      await act(() => {
         ReactDOM.hydrate(reactElement, domElement);
       });
     } else {
-      await act(async () => {
+      await act(() => {
         ReactDOM.render(reactElement, domElement);
       });
     }

--- a/packages/react-dom/src/events/__tests__/DOMPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMPluginEventSystem-test.internal.js
@@ -652,7 +652,7 @@ describe('DOMPluginEventSystem', () => {
           Scheduler.unstable_flushAll();
 
           // The Suspense boundary is not yet hydrated.
-          await act(async () => {
+          await act(() => {
             a.click();
           });
           expect(clicks).toBe(0);
@@ -703,14 +703,14 @@ describe('DOMPluginEventSystem', () => {
             );
           }
 
-          await act(async () => {
+          await act(() => {
             ReactDOM.render(<Parent />, container);
           });
 
           const parent = container.lastChild;
           expect(parent.id).toEqual('parent');
 
-          await act(async () => {
+          await act(() => {
             dispatchClickEvent(parent);
           });
 
@@ -719,7 +719,7 @@ describe('DOMPluginEventSystem', () => {
           const child = parent.lastChild;
           expect(child.id).toEqual('child');
 
-          await act(async () => {
+          await act(() => {
             dispatchClickEvent(child);
           });
 
@@ -752,14 +752,14 @@ describe('DOMPluginEventSystem', () => {
             );
           }
 
-          await act(async () => {
+          await act(() => {
             ReactDOM.render(<Parent />, container);
           });
 
           const parent = container.lastChild;
           expect(parent.id).toEqual('parent');
 
-          await act(async () => {
+          await act(() => {
             dispatchClickEvent(parent);
           });
 
@@ -768,7 +768,7 @@ describe('DOMPluginEventSystem', () => {
           const child = parent.lastChild;
           expect(child.id).toEqual('child');
 
-          await act(async () => {
+          await act(() => {
             dispatchClickEvent(child);
           });
 
@@ -2575,7 +2575,7 @@ describe('DOMPluginEventSystem', () => {
 
             const root = ReactDOMClient.createRoot(container2);
 
-            await act(async () => {
+            await act(() => {
               root.render(<Component />);
             });
             jest.runAllTimers();
@@ -2587,7 +2587,7 @@ describe('DOMPluginEventSystem', () => {
             expect(onAfterBlur).toHaveBeenCalledTimes(0);
 
             suspend = true;
-            await act(async () => {
+            await act(() => {
               root.render(<Component />);
             });
             jest.runAllTimers();
@@ -2661,7 +2661,7 @@ describe('DOMPluginEventSystem', () => {
 
             const root = ReactDOMClient.createRoot(container2);
 
-            await act(async () => {
+            await act(() => {
               root.render(<Component />);
             });
             jest.runAllTimers();
@@ -2672,7 +2672,7 @@ describe('DOMPluginEventSystem', () => {
             expect(onBeforeBlur).toHaveBeenCalledTimes(0);
 
             suspend = true;
-            await act(async () => {
+            await act(() => {
               root.render(<Component />);
             });
             jest.runAllTimers();
@@ -2726,7 +2726,7 @@ describe('DOMPluginEventSystem', () => {
             document.body.appendChild(container2);
 
             const root = ReactDOMClient.createRoot(container2);
-            await act(async () => {
+            await act(() => {
               root.render(<Component />);
             });
 
@@ -2737,7 +2737,7 @@ describe('DOMPluginEventSystem', () => {
 
             // Suspend. This hides the input node, causing it to lose focus.
             suspend = true;
-            await act(async () => {
+            await act(() => {
               root.render(<Component />);
             });
 

--- a/packages/react-dom/src/events/plugins/__tests__/ChangeEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/ChangeEventPlugin-test.js
@@ -753,12 +753,12 @@ describe('ChangeEventPlugin', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         root.render(<Foo />);
       });
       expect(container.textContent).toEqual('not hovered');
 
-      await act(async () => {
+      await act(() => {
         const mouseOverEvent = document.createEvent('MouseEvents');
         mouseOverEvent.initEvent('mouseover', true, true);
         target.current.dispatchEvent(mouseOverEvent);

--- a/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
@@ -301,7 +301,7 @@ describe('SimpleEventPlugin', function () {
       }
 
       // Click the button to trigger the side-effect
-      await act(async () => click());
+      await act(() => click());
       assertLog([
         // The handler fired
         'Side-effect',
@@ -370,17 +370,17 @@ describe('SimpleEventPlugin', function () {
       }
 
       // Click the button a single time
-      await act(async () => click());
+      await act(() => click());
       // The counter should update synchronously, even in concurrent mode.
       expect(button.textContent).toEqual('Count: 1');
 
       // Click the button many more times
-      await act(async () => click());
-      await act(async () => click());
-      await act(async () => click());
-      await act(async () => click());
-      await act(async () => click());
-      await act(async () => click());
+      await act(() => click());
+      await act(() => click());
+      await act(() => click());
+      await act(() => click());
+      await act(() => click());
+      await act(() => click());
 
       // Flush the remaining work
       await waitForAll([]);

--- a/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocusWithin-test.internal.js
@@ -312,7 +312,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
         </div>
       );
     };
-    await act(async () => {
+    await act(() => {
       ReactDOM.render(<Component />, container);
     });
 
@@ -508,7 +508,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
 
       const root = ReactDOMClient.createRoot(container2);
 
-      await act(async () => {
+      await act(() => {
         root.render(<Component />);
       });
       jest.runAllTimers();
@@ -522,7 +522,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       expect(onAfterBlurWithin).toHaveBeenCalledTimes(0);
 
       suspend = true;
-      await act(async () => {
+      await act(() => {
         root.render(<Component />);
       });
       jest.runAllTimers();
@@ -567,7 +567,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
 
       const root = ReactDOMClient.createRoot(container2);
 
-      await act(async () => {
+      await act(() => {
         root.render(<Component />);
       });
       jest.runAllTimers();
@@ -576,14 +576,14 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       expect(onAfterBlurWithin).toHaveBeenCalledTimes(0);
 
       suspend = true;
-      await act(async () => {
+      await act(() => {
         root.render(<Component />);
       });
       jest.runAllTimers();
       expect(onBeforeBlurWithin).toHaveBeenCalledTimes(0);
       expect(onAfterBlurWithin).toHaveBeenCalledTimes(0);
 
-      await act(async () => {
+      await act(() => {
         root.render(<Component />);
       });
       jest.runAllTimers();
@@ -592,7 +592,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
 
       buttonRef.current.focus();
       suspend = false;
-      await act(async () => {
+      await act(() => {
         root.render(<Component />);
       });
       jest.runAllTimers();

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -50,7 +50,7 @@ describe('ReactFabric', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(<View foo="test" />, 1);
     });
     expect(nativeFabricUIManager.createNode).toBeCalled();
@@ -68,13 +68,13 @@ describe('ReactFabric', () => {
 
     nativeFabricUIManager.createNode.mockReturnValue(firstNode);
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(<View foo="foo" />, 11);
     });
 
     expect(nativeFabricUIManager.createNode).toHaveBeenCalledTimes(1);
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(<View foo="bar" />, 11);
     });
 
@@ -98,7 +98,7 @@ describe('ReactFabric', () => {
       uiViewClassName: 'RCTText',
     }));
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(<Text foo="a">1</Text>, 11);
     });
     expect(nativeFabricUIManager.cloneNode).not.toBeCalled();
@@ -109,7 +109,7 @@ describe('ReactFabric', () => {
     ).not.toBeCalled();
 
     // If no properties have changed, we shouldn't call cloneNode.
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(<Text foo="a">1</Text>, 11);
     });
     expect(nativeFabricUIManager.cloneNode).not.toBeCalled();
@@ -120,7 +120,7 @@ describe('ReactFabric', () => {
     ).not.toBeCalled();
 
     // Only call cloneNode for the changed property (and not for text).
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(<Text foo="b">1</Text>, 11);
     });
     expect(nativeFabricUIManager.cloneNode).not.toBeCalled();
@@ -133,7 +133,7 @@ describe('ReactFabric', () => {
     ).not.toBeCalled();
 
     // Only call cloneNode for the changed text (and no other properties).
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(<Text foo="b">2</Text>, 11);
     });
     expect(nativeFabricUIManager.cloneNode).not.toBeCalled();
@@ -148,7 +148,7 @@ describe('ReactFabric', () => {
     ).not.toBeCalled();
 
     // Call cloneNode for both changed text and properties.
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(<Text foo="c">3</Text>, 11);
     });
     expect(nativeFabricUIManager.cloneNode).not.toBeCalled();
@@ -169,7 +169,7 @@ describe('ReactFabric', () => {
       uiViewClassName: 'RCTText',
     }));
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <Text foo="a" bar="a">
           1
@@ -184,7 +184,7 @@ describe('ReactFabric', () => {
       nativeFabricUIManager.cloneNodeWithNewChildrenAndProps,
     ).not.toBeCalled();
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <Text foo="a" bar="b">
           1
@@ -201,7 +201,7 @@ describe('ReactFabric', () => {
       nativeFabricUIManager.__dumpHierarchyForJestTestsOnly(),
     ).toMatchSnapshot();
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <Text foo="b" bar="b">
           2
@@ -228,7 +228,7 @@ describe('ReactFabric', () => {
     nativeFabricUIManager.dispatchCommand.mockClear();
 
     let viewRef;
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <View
           ref={ref => {
@@ -259,7 +259,7 @@ describe('ReactFabric', () => {
     nativeFabricUIManager.dispatchCommand.mockReset();
 
     let viewRef;
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <BasicClass
           ref={ref => {
@@ -289,7 +289,7 @@ describe('ReactFabric', () => {
     nativeFabricUIManager.sendAccessibilityEvent.mockClear();
 
     let viewRef;
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <View
           ref={ref => {
@@ -321,7 +321,7 @@ describe('ReactFabric', () => {
     nativeFabricUIManager.sendAccessibilityEvent.mockReset();
 
     let viewRef;
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <BasicClass
           ref={ref => {
@@ -386,14 +386,14 @@ describe('ReactFabric', () => {
     const before = 'abcdefghijklmnopqrst';
     const after = 'mxhpgwfralkeoivcstzy';
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(<Component chars={before} />, 11);
     });
     expect(
       nativeFabricUIManager.__dumpHierarchyForJestTestsOnly(),
     ).toMatchSnapshot();
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(<Component chars={after} />, 11);
     });
     expect(
@@ -428,7 +428,7 @@ describe('ReactFabric', () => {
 
     const ref = React.createRef();
     // Wrap in a host node.
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <View>
           <Component ref={ref} />
@@ -461,7 +461,7 @@ describe('ReactFabric', () => {
       }
     }
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(<Component />, 11);
     });
     expect(mockArgs.length).toEqual(0);
@@ -483,7 +483,7 @@ describe('ReactFabric', () => {
       );
     });
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <View foo="a">
           <View foo="b" />
@@ -508,7 +508,7 @@ describe('ReactFabric', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <Text>
           <View />
@@ -517,7 +517,7 @@ describe('ReactFabric', () => {
       );
     });
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <Text>
           <Image />
@@ -542,13 +542,13 @@ describe('ReactFabric', () => {
     }));
 
     await expect(async () => {
-      await act(async () => {
+      await act(() => {
         ReactFabric.render(<View>this should warn</View>, 11);
       });
     }).toErrorDev(['Text strings must be rendered within a <Text> component.']);
 
     await expect(async () => {
-      await act(async () => {
+      await act(() => {
         ReactFabric.render(
           <Text>
             <ScrollView>hi hello hi</ScrollView>
@@ -567,7 +567,7 @@ describe('ReactFabric', () => {
 
     const Indirection = () => 'Hi';
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <Text>
           <Indirection />
@@ -591,7 +591,7 @@ describe('ReactFabric', () => {
     const touchStart = jest.fn();
     const touchStart2 = jest.fn();
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(<View onTouchStart={touchStart} />, 11);
     });
 
@@ -617,7 +617,7 @@ describe('ReactFabric', () => {
     expect(touchStart).toBeCalled();
     expect(touchStart2).not.toBeCalled();
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(<View onTouchStart={touchStart2} />, 11);
     });
 
@@ -665,7 +665,7 @@ describe('ReactFabric', () => {
 
       const event = {};
 
-      await act(async () => {
+      await act(() => {
         ReactFabric.render(
           <View
             onSkippedBubblingEventCapture={ancestorCapture}
@@ -752,7 +752,7 @@ describe('ReactFabric', () => {
     const ref1 = React.createRef();
     const ref2 = React.createRef();
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <View id="parent">
           <View
@@ -834,7 +834,7 @@ describe('ReactFabric', () => {
       }
     }
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <ContainsStrictModeChild ref={n => (parent = n)} />,
         11,
@@ -871,7 +871,7 @@ describe('ReactFabric', () => {
       }
     }
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <StrictMode>
           <IsInStrictMode ref={n => (parent = n)} />
@@ -914,7 +914,7 @@ describe('ReactFabric', () => {
       }
     }
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <ContainsStrictModeChild ref={n => (parent = n)} />,
         11,
@@ -949,7 +949,7 @@ describe('ReactFabric', () => {
       }
     }
 
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <StrictMode>
           <IsInStrictMode ref={n => (parent = n)} />
@@ -980,7 +980,7 @@ describe('ReactFabric', () => {
     nativeFabricUIManager.sendAccessibilityEvent.mockReset();
 
     let viewRef;
-    await act(async () => {
+    await act(() => {
       ReactFabric.render(
         <View
           ref={ref => {
@@ -991,7 +991,7 @@ describe('ReactFabric', () => {
       );
     });
     const dangerouslyRetainedViewRef = viewRef;
-    await act(async () => {
+    await act(() => {
       ReactFabric.stopSurface(11);
     });
 

--- a/packages/react-native-renderer/src/__tests__/ReactFabricHostComponent-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabricHostComponent-test.internal.js
@@ -48,7 +48,7 @@ async function mockRenderKeys(keyLists) {
     const keyList = keyLists[i];
     if (Array.isArray(keyList)) {
       const refs = keyList.map(key => undefined);
-      await act(async () => {
+      await act(() => {
         ReactFabric.render(
           <MockView>
             {keyList.map((key, index) => (
@@ -68,7 +68,7 @@ async function mockRenderKeys(keyLists) {
       continue;
     }
     if (keyList == null) {
-      await act(async () => {
+      await act(() => {
         ReactFabric.stopSurface(mockContainerTag);
       });
       result.push(null);

--- a/packages/react-reconciler/src/__tests__/ReactCPUSuspense-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactCPUSuspense-test.js
@@ -176,7 +176,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Initial mount
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     // Inner contents finish in separate commit from outer
@@ -189,7 +189,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     );
 
     // Update
-    await act(async () => {
+    await act(() => {
       setCount(1);
     });
     // Entire update finishes in a single commit
@@ -277,7 +277,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     // Each level commits separately

--- a/packages/react-reconciler/src/__tests__/ReactCache-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactCache-test.js
@@ -185,7 +185,7 @@ describe('ReactCache', () => {
   // @gate enableCacheElement && enableCache
   test('render Cache component', async () => {
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<Cache>Hi</Cache>);
     });
     expect(root).toMatchRenderedOutput('Hi');
@@ -194,7 +194,7 @@ describe('ReactCache', () => {
   // @gate enableCacheElement && enableCache
   test('mount new data', async () => {
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Cache>
           <Suspense fallback={<Text text="Loading..." />}>
@@ -206,13 +206,13 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog(['A']);
     expect(root).toMatchRenderedOutput('A');
 
-    await act(async () => {
+    await act(() => {
       root.render('Bye');
     });
     // no cleanup: cache is still retained at the root
@@ -223,7 +223,7 @@ describe('ReactCache', () => {
   // @gate enableCache
   test('root acts as implicit cache boundary', async () => {
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback={<Text text="Loading..." />}>
           <AsyncText text="A" />
@@ -233,13 +233,13 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog(['A']);
     expect(root).toMatchRenderedOutput('A');
 
-    await act(async () => {
+    await act(() => {
       root.render('Bye');
     });
     // no cleanup: cache is still retained at the root
@@ -267,7 +267,7 @@ describe('ReactCache', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App showMore={false} />);
     });
 
@@ -276,13 +276,13 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [A]', 'Loading...', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...Loading...');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
-    await act(async () => {
+    await act(() => {
       root.render('Bye');
     });
     // no cleanup: cache is still retained at the root
@@ -312,13 +312,13 @@ describe('ReactCache', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App showMore={false} />);
     });
     assertLog([]);
     expect(root).toMatchRenderedOutput('(empty)');
 
-    await act(async () => {
+    await act(() => {
       root.render(<App showMore={true} />);
     });
     // Even though there are two new <Cache /> trees, they should share the same
@@ -326,13 +326,13 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [A]', 'Loading...', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...Loading...');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
-    await act(async () => {
+    await act(() => {
       root.render('Bye');
     });
     // cleanup occurs for the cache shared by the inner cache boundaries (which
@@ -359,7 +359,7 @@ describe('ReactCache', () => {
       }
 
       const root = ReactNoop.createRoot();
-      await act(async () => {
+      await act(() => {
         root.render(<App />);
       });
       // Even though there is a nested <Cache /> boundary, it should share the same
@@ -367,13 +367,13 @@ describe('ReactCache', () => {
       assertLog(['Cache miss! [A]', 'Loading...']);
       expect(root).toMatchRenderedOutput('Loading...');
 
-      await act(async () => {
+      await act(() => {
         resolveMostRecentTextCache('A');
       });
       assertLog(['A', 'A']);
       expect(root).toMatchRenderedOutput('AA');
 
-      await act(async () => {
+      await act(() => {
         root.render('Bye');
       });
       // no cleanup: cache is still retained at the root
@@ -400,7 +400,7 @@ describe('ReactCache', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       seedNextTextCache('A');
       root.render(<App showMore={false} />);
     });
@@ -408,7 +408,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Add a new cache boundary
-    await act(async () => {
+    await act(() => {
       root.render(<App showMore={true} />);
     });
     assertLog([
@@ -418,7 +418,7 @@ describe('ReactCache', () => {
     ]);
     expect(root).toMatchRenderedOutput('A [v1]A [v1]');
 
-    await act(async () => {
+    await act(() => {
       root.render('Bye');
     });
     // no cleanup: cache is still retained at the root
@@ -448,7 +448,7 @@ describe('ReactCache', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       seedNextTextCache('A');
       root.render(<App showMore={false} />);
     });
@@ -456,7 +456,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Add a new cache boundary
-    await act(async () => {
+    await act(() => {
       root.render(<App showMore={true} />);
     });
     assertLog([
@@ -466,7 +466,7 @@ describe('ReactCache', () => {
       'Loading...',
     ]);
     expect(root).toMatchRenderedOutput('A [v1]Loading...');
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog(['A [v2]']);
@@ -475,7 +475,7 @@ describe('ReactCache', () => {
     // Replace all the children: this should retain the root Cache instance,
     // but cleanup the separate cache instance created for the fresh cache
     // boundary
-    await act(async () => {
+    await act(() => {
       root.render('Bye!');
     });
     // Cleanup occurs for the *second* cache instance: the first is still
@@ -524,13 +524,13 @@ describe('ReactCache', () => {
       return <Text text="Content" />;
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['Cache miss! [A]', 'Loading shell...']);
     expect(root).toMatchRenderedOutput('Loading shell...');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog([
@@ -547,7 +547,7 @@ describe('ReactCache', () => {
       </>,
     );
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('B');
     });
     assertLog(['Content']);
@@ -558,7 +558,7 @@ describe('ReactCache', () => {
       </>,
     );
 
-    await act(async () => {
+    await act(() => {
       root.render('Bye');
     });
     // no cleanup: cache is still retained at the root
@@ -608,19 +608,19 @@ describe('ReactCache', () => {
       return <Text text="Content" />;
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(<App showMore={false} />);
     });
     assertLog([]);
     expect(root).toMatchRenderedOutput('(empty)');
 
-    await act(async () => {
+    await act(() => {
       root.render(<App showMore={true} />);
     });
     assertLog(['Cache miss! [A]', 'Loading shell...']);
     expect(root).toMatchRenderedOutput('Loading shell...');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog([
@@ -637,7 +637,7 @@ describe('ReactCache', () => {
       </>,
     );
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('B');
     });
     assertLog(['Content']);
@@ -648,7 +648,7 @@ describe('ReactCache', () => {
       </>,
     );
 
-    await act(async () => {
+    await act(() => {
       root.render('Bye');
     });
     assertLog(['Cache cleanup: A [v1]', 'Cache cleanup: B [v1]']);
@@ -665,7 +665,7 @@ describe('ReactCache', () => {
 
     // Mount initial data
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback={<Text text="Loading..." />}>
           <App />
@@ -675,20 +675,20 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Refresh for new data.
-    await act(async () => {
+    await act(() => {
       startTransition(() => refresh());
     });
     assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     // Note that the version has updated
@@ -699,7 +699,7 @@ describe('ReactCache', () => {
     }
     expect(root).toMatchRenderedOutput('A [v2]');
 
-    await act(async () => {
+    await act(() => {
       root.render('Bye');
     });
     expect(root).toMatchRenderedOutput('Bye');
@@ -715,7 +715,7 @@ describe('ReactCache', () => {
 
     // Mount initial data
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback={<Text text="Loading..." />}>
           <App />
@@ -725,27 +725,27 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Refresh for new data.
-    await act(async () => {
+    await act(() => {
       startTransition(() => refresh());
     });
     assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     // Note that the version has updated, and the previous cache is cleared
     assertLog(['A [v2]', 'Cache cleanup: A [v1]']);
     expect(root).toMatchRenderedOutput('A [v2]');
 
-    await act(async () => {
+    await act(() => {
       root.render('Bye');
     });
     // the original root cache already cleaned up when the refresh completed
@@ -763,7 +763,7 @@ describe('ReactCache', () => {
 
     // Mount initial data
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback={<Text text="Loading..." />}>
           <App />
@@ -773,14 +773,14 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Refresh for new data.
-    await act(async () => {
+    await act(() => {
       refresh();
     });
     assertLog([
@@ -793,14 +793,14 @@ describe('ReactCache', () => {
     ]);
     expect(root).toMatchRenderedOutput('Loading...');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     // Note that the version has updated, and the previous cache is cleared
     assertLog(['A [v2]']);
     expect(root).toMatchRenderedOutput('A [v2]');
 
-    await act(async () => {
+    await act(() => {
       root.render('Bye');
     });
     // the original root cache already cleaned up when the refresh completed
@@ -827,7 +827,7 @@ describe('ReactCache', () => {
 
     // Mount initial data
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Cache>
           <Suspense fallback={<Text text="Loading..." />}>
@@ -839,14 +839,14 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Refresh for new data.
-    await act(async () => {
+    await act(() => {
       // Refresh the cache with seeded data, like you would receive from a
       // server mutation.
       // TODO: Seeding multiple typed textCaches. Should work by calling `refresh`
@@ -863,7 +863,7 @@ describe('ReactCache', () => {
     assertLog(['A [v2]']);
     expect(root).toMatchRenderedOutput('A [v2]');
 
-    await act(async () => {
+    await act(() => {
       root.render('Bye');
     });
     // the refreshed cache boundary is unmounted and cleans up
@@ -898,7 +898,7 @@ describe('ReactCache', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       seedNextTextCache('A');
       root.render(<App showMore={false} />);
     });
@@ -906,7 +906,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Add a new cache boundary
-    await act(async () => {
+    await act(() => {
       seedNextTextCache('A');
       root.render(<App showMore={true} />);
     });
@@ -919,13 +919,13 @@ describe('ReactCache', () => {
 
     // Now refresh the shell. This should also cause the "Show More" contents to
     // refresh, since its cache is nested inside the outer one.
-    await act(async () => {
+    await act(() => {
       startTransition(() => refreshShell());
     });
     assertLog(['Cache miss! [A]', 'Loading...', 'Loading...']);
     expect(root).toMatchRenderedOutput('A [v1]A [v2]');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog([
@@ -937,7 +937,7 @@ describe('ReactCache', () => {
     ]);
     expect(root).toMatchRenderedOutput('A [v3]A [v3]');
 
-    await act(async () => {
+    await act(() => {
       root.render('Bye!');
     });
     // Unmounting children releases the refreshed cache instance only; the root
@@ -980,12 +980,12 @@ describe('ReactCache', () => {
       // treated like sibling providers that happen to share an underlying
       // cache, as opposed to consumers of the root-level cache.
       const root = ReactNoop.createRoot();
-      await act(async () => {
+      await act(() => {
         root.render(<App showMore={false} />);
       });
 
       // Now reveal the boundaries. In a real app  this would be a navigation.
-      await act(async () => {
+      await act(() => {
         root.render(<App showMore={true} />);
       });
 
@@ -994,7 +994,7 @@ describe('ReactCache', () => {
       assertLog(['Cache miss! [A]', 'Loading...', 'Loading...']);
       expect(root).toMatchRenderedOutput('Loading...Loading...');
 
-      await act(async () => {
+      await act(() => {
         resolveMostRecentTextCache('A');
       });
       assertLog(['A [v1]', 'A [v1]']);
@@ -1007,7 +1007,7 @@ describe('ReactCache', () => {
       });
       assertLog(['Cache miss! [A]', 'Loading...']);
 
-      await act(async () => {
+      await act(() => {
         resolveMostRecentTextCache('A');
       });
       assertLog(['A [v2]']);
@@ -1019,7 +1019,7 @@ describe('ReactCache', () => {
       // a fresh boundary). Therefore this causes cleanup for both the fresh cache
       // instance in the refreshed first boundary and cleanup for the non-refreshed
       // sibling boundary.
-      await act(async () => {
+      await act(() => {
         root.render('Bye!');
       });
       assertLog(['Cache cleanup: A [v2]', 'Cache cleanup: A [v1]']);
@@ -1054,13 +1054,13 @@ describe('ReactCache', () => {
       }
 
       const root = ReactNoop.createRoot();
-      await act(async () => {
+      await act(() => {
         root.render(<App showMore={false} />);
       });
       assertLog(['Cache miss! [A]', 'Cache miss! [B]', 'Loading...']);
       expect(root).toMatchRenderedOutput('Loading...');
 
-      await act(async () => {
+      await act(() => {
         // This will resolve the content in the first cache
         resolveMostRecentTextCache('A');
         resolveMostRecentTextCache('B');
@@ -1079,13 +1079,13 @@ describe('ReactCache', () => {
       expect(root).toMatchRenderedOutput('Loading... A [v1] B [v1]');
 
       // Now resolve the second tree
-      await act(async () => {
+      await act(() => {
         resolveMostRecentTextCache('A');
       });
       assertLog(['A [v2]']);
       expect(root).toMatchRenderedOutput('A [v2] A [v1] B [v1]');
 
-      await act(async () => {
+      await act(() => {
         root.render('Bye!');
       });
       // Unmounting children releases both cache boundaries, but the original
@@ -1107,7 +1107,7 @@ describe('ReactCache', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback={<Text text="Loading..." />}>(empty)</Suspense>,
       );
@@ -1115,7 +1115,7 @@ describe('ReactCache', () => {
     assertLog([]);
     expect(root).toMatchRenderedOutput('(empty)');
 
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <Suspense fallback={<Text text="Loading..." />}>
@@ -1127,7 +1127,7 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('(empty)');
 
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <Suspense fallback={<Text text="Loading..." />}>
@@ -1144,14 +1144,14 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('(empty)');
 
     // Resolve the request
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog(['A [v1]', 'A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]A [v1]');
 
     // Now do another transition
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <Suspense fallback={<Text text="Loading..." />}>
@@ -1172,7 +1172,7 @@ describe('ReactCache', () => {
     ]);
     expect(root).toMatchRenderedOutput('A [v1]A [v1]');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog(['A [v1]', 'A [v1]', 'A [v2]']);
@@ -1182,7 +1182,7 @@ describe('ReactCache', () => {
     // commits, so both fresh cache instances are released by their cache boundaries,
     // cleaning up v1 (used for the first two children which render together) and
     // v2 (used for the third boundary added later).
-    await act(async () => {
+    await act(() => {
       root.render('Bye!');
     });
     assertLog(['Cache cleanup: A [v1]', 'Cache cleanup: A [v2]']);
@@ -1225,13 +1225,13 @@ describe('ReactCache', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['0']);
     expect(root).toMatchRenderedOutput('0');
 
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         showMore();
       });
@@ -1239,7 +1239,7 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('0');
 
-    await act(async () => {
+    await act(() => {
       updateUnrelated(1);
     });
     assertLog([
@@ -1251,7 +1251,7 @@ describe('ReactCache', () => {
     ]);
     expect(root).toMatchRenderedOutput('1');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog(['A [v1]']);
@@ -1261,7 +1261,7 @@ describe('ReactCache', () => {
     // render after calling showMore(). This instance is cleaned up when that boundary
     // is unmounted. Bc root cache instance is never accessed, the inner cache
     // boundary ends up at v1.
-    await act(async () => {
+    await act(() => {
       root.render('Bye!');
     });
     assertLog(['Cache cleanup: A [v1]']);
@@ -1272,7 +1272,7 @@ describe('ReactCache', () => {
   test('cache boundary uses a fresh cache when its key changes', async () => {
     const root = ReactNoop.createRoot();
     seedNextTextCache('A');
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback="Loading...">
           <Cache key="A">
@@ -1285,7 +1285,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A [v1]');
 
     seedNextTextCache('B');
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback="Loading...">
           <Cache key="B">
@@ -1300,7 +1300,7 @@ describe('ReactCache', () => {
     // Unmount children: the fresh cache instance for B cleans up since the cache boundary
     // is the only owner, while the original cache instance (for A) is still retained by
     // the root.
-    await act(async () => {
+    await act(() => {
       root.render('Bye!');
     });
     assertLog(['Cache cleanup: B [v2]']);
@@ -1310,7 +1310,7 @@ describe('ReactCache', () => {
   // @gate enableCacheElement && enableCache
   test('overlapping transitions after an initial mount use the same fresh cache', async () => {
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback="Loading...">
           <Cache key="A">
@@ -1322,14 +1322,14 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [A]']);
     expect(root).toMatchRenderedOutput('Loading...');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // After a mount, subsequent transitions use a fresh cache
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <Suspense fallback="Loading...">
@@ -1346,7 +1346,7 @@ describe('ReactCache', () => {
     // Update to a different text and with a different key for the cache
     // boundary: this should still use the fresh cache instance created
     // for the earlier transition
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <Suspense fallback="Loading...">
@@ -1360,7 +1360,7 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [C]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('C');
     });
     assertLog(['C [v2]']);
@@ -1368,7 +1368,7 @@ describe('ReactCache', () => {
 
     // Unmount children: the fresh cache used for the updates is freed, while the
     // original cache (with A) is still retained at the root.
-    await act(async () => {
+    await act(() => {
       root.render('Bye!');
     });
     assertLog(['Cache cleanup: B [v2]', 'Cache cleanup: C [v2]']);
@@ -1378,7 +1378,7 @@ describe('ReactCache', () => {
   // @gate enableCacheElement && enableCache
   test('overlapping updates after an initial mount use the same fresh cache', async () => {
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback="Loading...">
           <Cache key="A">
@@ -1390,14 +1390,14 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [A]']);
     expect(root).toMatchRenderedOutput('Loading...');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('A');
     });
     assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // After a mount, subsequent updates use a fresh cache
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback="Loading...">
           <Cache key="B">
@@ -1411,7 +1411,7 @@ describe('ReactCache', () => {
 
     // A second update uses the same fresh cache: even though this is a new
     // Cache boundary, the render uses the fresh cache from the pending update.
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback="Loading...">
           <Cache key="C">
@@ -1423,7 +1423,7 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [C]']);
     expect(root).toMatchRenderedOutput('Loading...');
 
-    await act(async () => {
+    await act(() => {
       resolveMostRecentTextCache('C');
     });
     assertLog(['C [v2]']);
@@ -1431,7 +1431,7 @@ describe('ReactCache', () => {
 
     // Unmount children: the fresh cache used for the updates is freed, while the
     // original cache (with A) is still retained at the root.
-    await act(async () => {
+    await act(() => {
       root.render('Bye!');
     });
     assertLog(['Cache cleanup: B [v2]', 'Cache cleanup: C [v2]']);
@@ -1442,7 +1442,7 @@ describe('ReactCache', () => {
   test('cleans up cache only used in an aborted transition', async () => {
     const root = ReactNoop.createRoot();
     seedNextTextCache('A');
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback="Loading...">
           <Cache key="A">
@@ -1456,7 +1456,7 @@ describe('ReactCache', () => {
 
     // Start a transition from A -> B..., which should create a fresh cache
     // for the new cache boundary (bc of the different key)
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <Suspense fallback="Loading...">
@@ -1471,7 +1471,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // ...but cancel by transitioning "back" to A (which we never really left)
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <Suspense fallback="Loading...">
@@ -1486,7 +1486,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Unmount children: ...
-    await act(async () => {
+    await act(() => {
       root.render('Bye!');
     });
     assertLog([]);
@@ -1502,7 +1502,7 @@ describe('ReactCache', () => {
       return <AsyncText showVersion={true} text={text} />;
     }
     seedNextTextCache('A');
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback="Loading...">
           <Example text="A" />
@@ -1512,7 +1512,7 @@ describe('ReactCache', () => {
     assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         refresh();
       });
@@ -1520,7 +1520,7 @@ describe('ReactCache', () => {
     assertLog(['Cache miss! [A]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
-    await act(async () => {
+    await act(() => {
       root.render('Bye!');
     });
     assertLog([
@@ -1544,7 +1544,7 @@ describe('ReactCache', () => {
       return <AsyncText showVersion={true} text={text} />;
     }
     seedNextTextCache('A');
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback="Loading...">
           <Cache>
@@ -1556,7 +1556,7 @@ describe('ReactCache', () => {
     assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         refresh();
       });
@@ -1565,7 +1565,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Unmount the boundary before the refresh can complete
-    await act(async () => {
+    await act(() => {
       root.render('Bye!');
     });
     assertLog([
@@ -1594,14 +1594,14 @@ describe('ReactCache', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App prerenderMore={false} />);
     });
     assertLog([]);
     expect(root).toMatchRenderedOutput(<div hidden={true} />);
 
     seedNextTextCache('More');
-    await act(async () => {
+    await act(() => {
       root.render(<App prerenderMore={true} />);
     });
     assertLog(['More']);
@@ -1629,7 +1629,7 @@ describe('ReactCache', () => {
     function MoreArgs({a, b}) {
       return (types(a) === types(a, b)).toString() + ' ';
     }
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <Print a="e" b="f" />
@@ -1641,7 +1641,7 @@ describe('ReactCache', () => {
       );
     });
     expect(root).toMatchRenderedOutput('string string true false false false ');
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <Print a="e" b={null} />
@@ -1654,7 +1654,7 @@ describe('ReactCache', () => {
     });
     expect(root).toMatchRenderedOutput('string object true false false false ');
     const obj = {};
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <Print a="e" b={obj} />
@@ -1667,7 +1667,7 @@ describe('ReactCache', () => {
     });
     expect(root).toMatchRenderedOutput('string object true false false false ');
     const sameObj = {};
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <Print a={sameObj} b={sameObj} />
@@ -1681,7 +1681,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('object object true true false false ');
     const objA = {};
     const objB = {};
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <Print a={objA} b={objB} />
@@ -1694,7 +1694,7 @@ describe('ReactCache', () => {
     });
     expect(root).toMatchRenderedOutput('object object true false false false ');
     const sameSymbol = Symbol();
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <Print a={sameSymbol} b={sameSymbol} />
@@ -1707,7 +1707,7 @@ describe('ReactCache', () => {
     });
     expect(root).toMatchRenderedOutput('symbol symbol true true false false ');
     const notANumber = +'nan';
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <Print a={1} b={notANumber} />
@@ -1749,7 +1749,7 @@ describe('ReactCache', () => {
 
       return 'Blank';
     }
-    await act(async () => {
+    await act(() => {
       root.render(<Test />);
     });
     expect(x).toBe(y);

--- a/packages/react-reconciler/src/__tests__/ReactClassSetStateCallback-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactClassSetStateCallback-test.js
@@ -33,12 +33,12 @@ describe('ReactClassSetStateCallback', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog([0]);
 
-    await act(async () => {
+    await act(() => {
       if (gate(flags => flags.enableUnifiedSyncLane)) {
         React.startTransition(() => {
           app.setState({step: 1}, () => Scheduler.log('Callback 1'));

--- a/packages/react-reconciler/src/__tests__/ReactConcurrentErrorRecovery-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactConcurrentErrorRecovery-test.js
@@ -197,14 +197,14 @@ describe('ReactConcurrentErrorRecovery', () => {
     const root = ReactNoop.createRoot();
     seedNextTextCache('A1');
     seedNextTextCache('B1');
-    await act(async () => {
+    await act(() => {
       root.render(<App step={1} />);
     });
     assertLog(['A1', 'B1']);
     expect(root).toMatchRenderedOutput('A1B1');
 
     // Start a refresh transition
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<App step={2} />);
       });
@@ -214,7 +214,7 @@ describe('ReactConcurrentErrorRecovery', () => {
     expect(root).toMatchRenderedOutput('A1B1');
 
     // B fails to load.
-    await act(async () => {
+    await act(() => {
       rejectText('B2', new Error('Oops!'));
     });
 
@@ -238,7 +238,7 @@ describe('ReactConcurrentErrorRecovery', () => {
     expect(root).toMatchRenderedOutput('A1B1');
 
     // A finishes loading.
-    await act(async () => {
+    await act(() => {
       resolveText('A2');
     });
     if (gate(flags => flags.replayFailedUnitOfWorkWithInvokeGuardedCallback)) {
@@ -300,14 +300,14 @@ describe('ReactConcurrentErrorRecovery', () => {
     const root = ReactNoop.createRoot();
     seedNextTextCache('A1');
     seedNextTextCache('B1');
-    await act(async () => {
+    await act(() => {
       root.render(<App step={1} />);
     });
     assertLog(['A1', 'B1']);
     expect(root).toMatchRenderedOutput('A1B1');
 
     // Start a refresh transition
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<App step={2} />);
       });
@@ -317,7 +317,7 @@ describe('ReactConcurrentErrorRecovery', () => {
     expect(root).toMatchRenderedOutput('A1B1');
 
     // A fails to load.
-    await act(async () => {
+    await act(() => {
       rejectText('A2', new Error('Oops!'));
     });
 
@@ -341,7 +341,7 @@ describe('ReactConcurrentErrorRecovery', () => {
     expect(root).toMatchRenderedOutput('A1B1');
 
     // B finishes loading.
-    await act(async () => {
+    await act(() => {
       resolveText('B2');
     });
     if (gate(flags => flags.replayFailedUnitOfWorkWithInvokeGuardedCallback)) {
@@ -385,7 +385,7 @@ describe('ReactConcurrentErrorRecovery', () => {
     // The initial render suspends without a Suspense boundary. Since it's
     // wrapped in startTransition, it suspends instead of erroring.
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<AsyncText text="Async" />);
       });
@@ -397,7 +397,7 @@ describe('ReactConcurrentErrorRecovery', () => {
     // boundary. (This is only interesting because when a component suspends
     // outside of a transition, we throw an error, which can be captured by
     // an error boundary.
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <ErrorBoundary>
@@ -410,7 +410,7 @@ describe('ReactConcurrentErrorRecovery', () => {
     expect(root).toMatchRenderedOutput(null);
 
     // Continues rendering once data resolves
-    await act(async () => {
+    await act(() => {
       resolveText('Async');
     });
     assertLog(['Async']);
@@ -447,7 +447,7 @@ describe('ReactConcurrentErrorRecovery', () => {
 
       // Suspend and throw in the same transition
       const root = ReactNoop.createRoot();
-      await act(async () => {
+      await act(() => {
         startTransition(() => {
           root.render(
             <ErrorBoundary>
@@ -468,7 +468,7 @@ describe('ReactConcurrentErrorRecovery', () => {
       expect(root).toMatchRenderedOutput(null);
 
       // Try the reverse order, too: throw then suspend
-      await act(async () => {
+      await act(() => {
         startTransition(() => {
           root.render(
             <ErrorBoundary>

--- a/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
@@ -203,13 +203,13 @@ describe('ReactLazyContextPropagation', () => {
         return <Text text={value} />;
       }
 
-      await act(async () => {
+      await act(() => {
         root.render(<App />);
       });
       assertLog([0]);
       expect(root).toMatchRenderedOutput('0');
 
-      await act(async () => {
+      await act(() => {
         setValue(1);
       });
       assertLog([1]);
@@ -245,13 +245,13 @@ describe('ReactLazyContextPropagation', () => {
       return <Text text={value} />;
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog([0]);
     expect(root).toMatchRenderedOutput('0');
 
-    await act(async () => {
+    await act(() => {
       setValue(1);
     });
     assertLog([1]);
@@ -288,13 +288,13 @@ describe('ReactLazyContextPropagation', () => {
       return <Text text={value} />;
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog([0]);
     expect(root).toMatchRenderedOutput('0');
 
-    await act(async () => {
+    await act(() => {
       setValue(1);
     });
     assertLog([1]);
@@ -326,13 +326,13 @@ describe('ReactLazyContextPropagation', () => {
       return <Text text={value} />;
     });
 
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['Consumer', 0]);
     expect(root).toMatchRenderedOutput('0');
 
-    await act(async () => {
+    await act(() => {
       // Intentionally calling setState to some other arbitrary value before
       // setting it back to the current one. That way an update is scheduled,
       // but we'll bail out during render when nothing has changed.
@@ -388,13 +388,13 @@ describe('ReactLazyContextPropagation', () => {
     }
 
     await seedNextTextCache('A');
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
-    await act(async () => {
+    await act(() => {
       // Intentionally not wrapping in startTransition, so that the fallback
       // the fallback displays despite this being a refresh.
       setContext('B');
@@ -468,13 +468,13 @@ describe('ReactLazyContextPropagation', () => {
     }
 
     await seedNextTextCache('A');
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A', 'A', 'A']);
     expect(root).toMatchRenderedOutput('AAA');
 
-    await act(async () => {
+    await act(() => {
       // Intentionally not wrapping in startTransition, so that the fallback
       // the fallback displays despite this being a refresh.
       setContext('B');
@@ -529,13 +529,13 @@ describe('ReactLazyContextPropagation', () => {
     }
 
     await seedNextTextCache('A');
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
-    await act(async () => {
+    await act(() => {
       // Intentionally not wrapping in startTransition, so that the fallback
       // the fallback displays despite this being a refresh.
       setContext('B');
@@ -583,13 +583,13 @@ describe('ReactLazyContextPropagation', () => {
     }
 
     await seedNextTextCache('A');
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
-    await act(async () => {
+    await act(() => {
       setContext('B');
     });
     assertLog(['B', 'B']);
@@ -644,13 +644,13 @@ describe('ReactLazyContextPropagation', () => {
     }
 
     await seedNextTextCache('A');
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A', 'A', 'A']);
     expect(root).toMatchRenderedOutput('AAA');
 
-    await act(async () => {
+    await act(() => {
       setContext('B');
     });
     assertLog(['B', 'B', 'B']);
@@ -686,13 +686,13 @@ describe('ReactLazyContextPropagation', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
-    await act(async () => {
+    await act(() => {
       setContext('B');
     });
     assertLog(['B', 'B']);
@@ -740,13 +740,13 @@ describe('ReactLazyContextPropagation', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
-    await act(async () => {
+    await act(() => {
       setContext('B');
     });
     assertLog(['B', 'B']);
@@ -803,13 +803,13 @@ describe('ReactLazyContextPropagation', () => {
 
     const root = ReactNoop.createRoot();
     await seedNextTextCache('A');
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
-    await act(async () => {
+    await act(() => {
       setContext('B');
     });
     assertLog(['Suspend! [B]', 'Loading...']);
@@ -864,13 +864,13 @@ describe('ReactLazyContextPropagation', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
-    await act(async () => {
+    await act(() => {
       setContext('B');
     });
     assertLog(['B', 'B']);
@@ -913,13 +913,13 @@ describe('ReactLazyContextPropagation', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
-    await act(async () => {
+    await act(() => {
       setContext('B');
     });
     assertLog(['B', 'B']);

--- a/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
@@ -68,7 +68,7 @@ describe('ReactDeferredValue', () => {
     const root = ReactNoop.createRoot();
 
     // Initial render
-    await act(async () => {
+    await act(() => {
       root.render(<App value={1} />);
     });
     assertLog(['Original: 1', 'Deferred: 1']);
@@ -129,7 +129,7 @@ describe('ReactDeferredValue', () => {
     const root = ReactNoop.createRoot();
 
     // Initial render
-    await act(async () => {
+    await act(() => {
       root.render(<App value={1} />);
     });
     assertLog(['Original: 1', 'Deferred: 1']);
@@ -195,7 +195,7 @@ describe('ReactDeferredValue', () => {
     const root = ReactNoop.createRoot();
 
     // Initial render
-    await act(async () => {
+    await act(() => {
       root.render(<App value={1} />);
     });
     assertLog(['Original: 1', 'Deferred: 1']);

--- a/packages/react-reconciler/src/__tests__/ReactEffectOrdering-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactEffectOrdering-test.js
@@ -53,11 +53,11 @@ describe('ReactEffectOrdering', () => {
       return 'Child';
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(<Parent />);
     });
     expect(root).toMatchRenderedOutput('Child');
-    await act(async () => {
+    await act(() => {
       root.render(null);
     });
     assertLog(['Unmount parent', 'Unmount child']);
@@ -80,11 +80,11 @@ describe('ReactEffectOrdering', () => {
       return 'Child';
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(<Parent />);
     });
     expect(root).toMatchRenderedOutput('Child');
-    await act(async () => {
+    await act(() => {
       root.render(null);
     });
     assertLog(['Unmount parent', 'Unmount child']);

--- a/packages/react-reconciler/src/__tests__/ReactExpiration-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactExpiration-test.js
@@ -456,7 +456,7 @@ describe('ReactExpiration', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['Sync pri: 0', 'Normal pri: 0']);
@@ -527,7 +527,7 @@ describe('ReactExpiration', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['Sync pri: 0', 'Idle pri: 0']);
@@ -590,7 +590,7 @@ describe('ReactExpiration', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A0', 'B0', 'C']);
@@ -682,7 +682,7 @@ describe('ReactExpiration', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A0', 'B0']);
@@ -723,13 +723,13 @@ describe('ReactExpiration', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App step={0} />);
     });
     assertLog(['A0', 'B0', 'C0', 'Effect: 0']);
     expect(root).toMatchRenderedOutput('A0B0C0');
 
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<App step={1} />);
       });

--- a/packages/react-reconciler/src/__tests__/ReactFlushSync-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFlushSync-test.js
@@ -95,13 +95,13 @@ describe('ReactFlushSync', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['0, 0']);
     expect(root).toMatchRenderedOutput('0, 0');
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.flushSync(() => {
         startTransition(() => {
           // This should be async even though flushSync is on the stack, because
@@ -132,7 +132,7 @@ describe('ReactFlushSync', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       ReactNoop.flushSync(() => {
         root.render(<App />);
       });
@@ -155,7 +155,7 @@ describe('ReactFlushSync', () => {
     }
 
     const root = ReactNoop.createLegacyRoot();
-    await act(async () => {
+    await act(() => {
       ReactNoop.flushSync(() => {
         root.render(<App />);
       });
@@ -182,7 +182,7 @@ describe('ReactFlushSync', () => {
     }
 
     const root = ReactNoop.createLegacyRoot();
-    await act(async () => {
+    await act(() => {
       ReactNoop.flushSync(() => {
         root.render(<App step={1} />);
       });

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -92,7 +92,7 @@ describe('ReactHooks', () => {
     expect(root).toMatchRenderedOutput('0, 0');
 
     // Normal update
-    await act(async () => {
+    await act(() => {
       setCounter1(1);
       setCounter2(1);
     });
@@ -100,12 +100,12 @@ describe('ReactHooks', () => {
     assertLog(['Parent: 1, 1', 'Child: 1, 1', 'Effect: 1, 1']);
 
     // Update that bails out.
-    await act(async () => setCounter1(1));
+    await act(() => setCounter1(1));
     assertLog(['Parent: 1, 1']);
 
     // This time, one of the state updates but the other one doesn't. So we
     // can't bail out.
-    await act(async () => {
+    await act(() => {
       setCounter1(1);
       setCounter2(2);
     });
@@ -113,7 +113,7 @@ describe('ReactHooks', () => {
     assertLog(['Parent: 1, 2', 'Child: 1, 2', 'Effect: 1, 2']);
 
     // Lots of updates that eventually resolve to the current values.
-    await act(async () => {
+    await act(() => {
       setCounter1(9);
       setCounter2(3);
       setCounter1(4);
@@ -127,7 +127,7 @@ describe('ReactHooks', () => {
     assertLog(['Parent: 1, 2']);
 
     // prepare to check SameValue
-    await act(async () => {
+    await act(() => {
       setCounter1(0 / -1);
       setCounter2(NaN);
     });
@@ -135,7 +135,7 @@ describe('ReactHooks', () => {
     assertLog(['Parent: 0, NaN', 'Child: 0, NaN', 'Effect: 0, NaN']);
 
     // check if re-setting to negative 0 / NaN still bails out
-    await act(async () => {
+    await act(() => {
       setCounter1(0 / -1);
       setCounter2(NaN);
       setCounter2(Infinity);
@@ -145,7 +145,7 @@ describe('ReactHooks', () => {
     assertLog(['Parent: 0, NaN']);
 
     // check if changing negative 0 to positive 0 does not bail out
-    await act(async () => {
+    await act(() => {
       setCounter1(0);
     });
     assertLog(['Parent: 0, NaN', 'Child: 0, NaN', 'Effect: 0, NaN']);
@@ -180,7 +180,7 @@ describe('ReactHooks', () => {
     expect(root).toMatchRenderedOutput('0, 0 (light)');
 
     // Normal update
-    await act(async () => {
+    await act(() => {
       setCounter1(1);
       setCounter2(1);
     });
@@ -188,12 +188,12 @@ describe('ReactHooks', () => {
     assertLog(['Parent: 1, 1 (light)', 'Child: 1, 1 (light)']);
 
     // Update that bails out.
-    await act(async () => setCounter1(1));
+    await act(() => setCounter1(1));
     assertLog(['Parent: 1, 1 (light)']);
 
     // This time, one of the state updates but the other one doesn't. So we
     // can't bail out.
-    await act(async () => {
+    await act(() => {
       setCounter1(1);
       setCounter2(2);
     });
@@ -202,7 +202,7 @@ describe('ReactHooks', () => {
 
     // Updates bail out, but component still renders because props
     // have changed
-    await act(async () => {
+    await act(() => {
       setCounter1(1);
       setCounter2(2);
       root.update(<Parent theme="dark" />);
@@ -211,7 +211,7 @@ describe('ReactHooks', () => {
     assertLog(['Parent: 1, 2 (dark)', 'Child: 1, 2 (dark)']);
 
     // Both props and state bail out
-    await act(async () => {
+    await act(() => {
       setCounter1(1);
       setCounter2(2);
       root.update(<Parent theme="dark" />);
@@ -238,7 +238,7 @@ describe('ReactHooks', () => {
     expect(root).toMatchRenderedOutput('0');
 
     await expect(async () => {
-      await act(async () =>
+      await act(() =>
         setCounter(1, () => {
           throw new Error('Expected to ignore the callback.');
         }),
@@ -272,7 +272,7 @@ describe('ReactHooks', () => {
     expect(root).toMatchRenderedOutput('0');
 
     await expect(async () => {
-      await act(async () =>
+      await act(() =>
         dispatch(1, () => {
           throw new Error('Expected to ignore the callback.');
         }),
@@ -323,7 +323,7 @@ describe('ReactHooks', () => {
       return <Child text={text} />;
     }
     const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
-    await act(async () => {
+    await act(() => {
       root.update(
         <ThemeProvider>
           <Parent />
@@ -346,18 +346,18 @@ describe('ReactHooks', () => {
     expect(root).toMatchRenderedOutput('0 (light)');
 
     // Normal update
-    await act(async () => setCounter(1));
+    await act(() => setCounter(1));
     assertLog(['Parent: 1 (light)', 'Child: 1 (light)', 'Effect: 1 (light)']);
     expect(root).toMatchRenderedOutput('1 (light)');
 
     // Update that doesn't change state, so it bails out
-    await act(async () => setCounter(1));
+    await act(() => setCounter(1));
     assertLog(['Parent: 1 (light)']);
     expect(root).toMatchRenderedOutput('1 (light)');
 
     // Update that doesn't change state, but the context changes, too, so it
     // can't bail out
-    await act(async () => {
+    await act(() => {
       setCounter(1);
       setTheme('dark');
     });
@@ -396,7 +396,7 @@ describe('ReactHooks', () => {
     expect(root).toMatchRenderedOutput('0');
 
     // Normal update
-    await act(async () => setCounter(1));
+    await act(() => setCounter(1));
     assertLog(['Parent: 1', 'Child: 1', 'Effect: 1']);
     expect(root).toMatchRenderedOutput('1');
 
@@ -404,30 +404,30 @@ describe('ReactHooks', () => {
     // because the alternate fiber has pending update priority, so we have to
     // enter the render phase before we can bail out. But we bail out before
     // rendering the child, and we don't fire any effects.
-    await act(async () => setCounter(1));
+    await act(() => setCounter(1));
     assertLog(['Parent: 1']);
     expect(root).toMatchRenderedOutput('1');
 
     // Update to the same state again. This times, neither fiber has pending
     // update priority, so we can bail out before even entering the render phase.
-    await act(async () => setCounter(1));
+    await act(() => setCounter(1));
     await waitForAll([]);
     expect(root).toMatchRenderedOutput('1');
 
     // This changes the state to something different so it renders normally.
-    await act(async () => setCounter(2));
+    await act(() => setCounter(2));
     assertLog(['Parent: 2', 'Child: 2', 'Effect: 2']);
     expect(root).toMatchRenderedOutput('2');
 
     // prepare to check SameValue
-    await act(async () => {
+    await act(() => {
       setCounter(0);
     });
     assertLog(['Parent: 0', 'Child: 0', 'Effect: 0']);
     expect(root).toMatchRenderedOutput('0');
 
     // Update to the same state for the first time to flush the queue
-    await act(async () => {
+    await act(() => {
       setCounter(0);
     });
 
@@ -435,14 +435,14 @@ describe('ReactHooks', () => {
     expect(root).toMatchRenderedOutput('0');
 
     // Update again to the same state. Should bail out.
-    await act(async () => {
+    await act(() => {
       setCounter(0);
     });
     await waitForAll([]);
     expect(root).toMatchRenderedOutput('0');
 
     // Update to a different state (positive 0 to negative 0)
-    await act(async () => {
+    await act(() => {
       setCounter(0 / -1);
     });
     assertLog(['Parent: 0', 'Child: 0', 'Effect: 0']);
@@ -629,7 +629,7 @@ describe('ReactHooks', () => {
     }
 
     await expect(async () => {
-      await act(async () => {
+      await act(() => {
         ReactTestRenderer.create(<App deps={'hello'} />);
       });
     }).toErrorDev([
@@ -643,7 +643,7 @@ describe('ReactHooks', () => {
         'When specified, the final argument must be an array.',
     ]);
     await expect(async () => {
-      await act(async () => {
+      await act(() => {
         ReactTestRenderer.create(<App deps={100500} />);
       });
     }).toErrorDev([
@@ -657,7 +657,7 @@ describe('ReactHooks', () => {
         'When specified, the final argument must be an array.',
     ]);
     await expect(async () => {
-      await act(async () => {
+      await act(() => {
         ReactTestRenderer.create(<App deps={{}} />);
       });
     }).toErrorDev([
@@ -671,7 +671,7 @@ describe('ReactHooks', () => {
         'When specified, the final argument must be an array.',
     ]);
 
-    await act(async () => {
+    await act(() => {
       ReactTestRenderer.create(<App deps={[]} />);
       ReactTestRenderer.create(<App deps={null} />);
       ReactTestRenderer.create(<App deps={undefined} />);
@@ -714,7 +714,7 @@ describe('ReactHooks', () => {
     }
 
     const root = ReactTestRenderer.create(null);
-    await act(async () => {
+    await act(() => {
       root.update(<Counter />);
     });
     expect(root).toMatchRenderedOutput('4');
@@ -738,7 +738,7 @@ describe('ReactHooks', () => {
     }
 
     const root = ReactTestRenderer.create(null);
-    await act(async () => {
+    await act(() => {
       root.update(<Counter />);
     });
     expect(root).toMatchRenderedOutput('4');
@@ -761,7 +761,7 @@ describe('ReactHooks', () => {
     }
 
     const root = ReactTestRenderer.create(null);
-    await act(async () => {
+    await act(() => {
       root.update(<Counter />);
     });
     expect(root).toMatchRenderedOutput('4');
@@ -1131,7 +1131,7 @@ describe('ReactHooks', () => {
     }
     // Verify it doesn't think we're still inside a Hook.
     // Should have no warnings.
-    await act(async () => {
+    await act(() => {
       ReactTestRenderer.create(<Valid />);
     });
 
@@ -1488,12 +1488,12 @@ describe('ReactHooks', () => {
           /* eslint-enable no-unused-vars */
         }
         let root;
-        await act(async () => {
+        await act(() => {
           root = ReactTestRenderer.create(<App update={false} />);
         });
         await expect(async () => {
           try {
-            await act(async () => {
+            await act(() => {
               root.update(<App update={true} />);
             });
           } catch (error) {
@@ -1514,7 +1514,7 @@ describe('ReactHooks', () => {
 
         // further warnings for this component are silenced
         try {
-          await act(async () => {
+          await act(() => {
             root.update(<App update={false} />);
           });
         } catch (error) {
@@ -1537,13 +1537,13 @@ describe('ReactHooks', () => {
           /* eslint-enable no-unused-vars */
         }
         let root;
-        await act(async () => {
+        await act(() => {
           root = ReactTestRenderer.create(<App update={false} />);
         });
 
         await expect(async () => {
           try {
-            await act(async () => {
+            await act(() => {
               root.update(<App update={true} />);
             });
           } catch (error) {
@@ -1591,11 +1591,11 @@ describe('ReactHooks', () => {
           /* eslint-enable no-unused-vars */
         }
         let root;
-        await act(async () => {
+        await act(() => {
           root = ReactTestRenderer.create(<App update={false} />);
         });
 
-        await act(async () => {
+        await act(() => {
           expect(() => {
             root.update(<App update={true} />);
           }).toThrow('Rendered fewer hooks than expected. ');
@@ -1703,7 +1703,7 @@ describe('ReactHooks', () => {
       return null;
     }
 
-    await act(async () => {
+    await act(() => {
       ReactTestRenderer.unstable_batchedUpdates(() => {
         ReactTestRenderer.create(
           <>
@@ -1761,7 +1761,7 @@ describe('ReactHooks', () => {
       return null;
     }
 
-    await act(async () => {
+    await act(() => {
       ReactTestRenderer.create(<A />);
     });
 
@@ -1911,7 +1911,7 @@ describe('ReactHooks', () => {
     }
 
     let root;
-    await act(async () => {
+    await act(() => {
       root = ReactTestRenderer.create(
         <ErrorBoundary>
           <Thrower />
@@ -1920,7 +1920,7 @@ describe('ReactHooks', () => {
     });
 
     expect(root).toMatchRenderedOutput('Throw!');
-    await act(async () => setShouldThrow(true));
+    await act(() => setShouldThrow(true));
     expect(root).toMatchRenderedOutput('Error!');
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -294,11 +294,11 @@ describe('ReactHooksWithNoopRenderer', () => {
       await waitForAll(['Count: 0']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 0" />);
 
-      await act(async () => counter.current.updateCount(1));
+      await act(() => counter.current.updateCount(1));
       assertLog(['Count: 1']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 1" />);
 
-      await act(async () => counter.current.updateCount(count => count + 10));
+      await act(() => counter.current.updateCount(count => count + 10));
       assertLog(['Count: 11']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 11" />);
     });
@@ -318,7 +318,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       await waitForAll(['getInitialState', 'Count: 42']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 42" />);
 
-      await act(async () => counter.current.updateCount(7));
+      await act(() => counter.current.updateCount(7));
       assertLog(['Count: 7']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 7" />);
     });
@@ -336,10 +336,10 @@ describe('ReactHooksWithNoopRenderer', () => {
       await waitForAll(['Count: 0']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 0" />);
 
-      await act(async () => counter.current.updateCount(7));
+      await act(() => counter.current.updateCount(7));
       assertLog(['Count: 7']);
 
-      await act(async () => counter.current.updateLabel('Total'));
+      await act(() => counter.current.updateLabel('Total'));
       assertLog(['Total: 7']);
     });
 
@@ -356,13 +356,13 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       const firstUpdater = updater;
 
-      await act(async () => firstUpdater(1));
+      await act(() => firstUpdater(1));
       assertLog(['Count: 1']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 1" />);
 
       const secondUpdater = updater;
 
-      await act(async () => firstUpdater(count => count + 10));
+      await act(() => firstUpdater(count => count + 10));
       assertLog(['Count: 11']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 11" />);
 
@@ -381,7 +381,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       await waitForAll([]);
       ReactNoop.render(null);
       await waitForAll([]);
-      await act(async () => _updateCount(1));
+      await act(() => _updateCount(1));
     });
 
     it('works with memo', async () => {
@@ -401,7 +401,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       await waitForAll([]);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 0" />);
 
-      await act(async () => _updateCount(1));
+      await act(() => _updateCount(1));
       assertLog(['Count: 1']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 1" />);
     });
@@ -476,7 +476,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       const root = ReactNoop.createRoot();
 
-      await act(async () => {
+      await act(() => {
         root.render(
           <>
             <Foo />
@@ -637,7 +637,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       // Test that it works on update, too. This time the log is a bit different
       // because we started with reducerB instead of reducerA.
-      await act(async () => {
+      await act(() => {
         counter.current.dispatch('reset');
       });
       ReactNoop.render(<Counter ref={counter} />);
@@ -785,13 +785,13 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       const root = ReactNoop.createRoot();
 
-      await act(async () => {
+      await act(() => {
         root.render(<ScrollView row={10} />);
       });
       assertLog(['Up']);
       expect(root).toMatchRenderedOutput(<span prop="Up" />);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.discreteUpdates(() => {
           setRow(5);
         });
@@ -851,10 +851,10 @@ describe('ReactHooksWithNoopRenderer', () => {
       await waitForAll(['Count: 0']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 0" />);
 
-      await act(async () => counter.current.dispatch(INCREMENT));
+      await act(() => counter.current.dispatch(INCREMENT));
       assertLog(['Count: 1']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 1" />);
-      await act(async () => {
+      await act(() => {
         counter.current.dispatch(DECREMENT);
         counter.current.dispatch(DECREMENT);
         counter.current.dispatch(DECREMENT);
@@ -893,11 +893,11 @@ describe('ReactHooksWithNoopRenderer', () => {
       await waitForAll(['Init', 'Count: 10']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 10" />);
 
-      await act(async () => counter.current.dispatch(INCREMENT));
+      await act(() => counter.current.dispatch(INCREMENT));
       assertLog(['Count: 11']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 11" />);
 
-      await act(async () => {
+      await act(() => {
         counter.current.dispatch(DECREMENT);
         counter.current.dispatch(DECREMENT);
         counter.current.dispatch(DECREMENT);
@@ -1427,7 +1427,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         return state;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.renderToRootWithID(<Component />, 'root', () =>
           Scheduler.log('Sync effect'),
         );
@@ -1437,7 +1437,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       ReactNoop.unmountRootWithID('root');
       await waitForAll(['passive destroy']);
 
-      await act(async () => {
+      await act(() => {
         updaterFunction(true);
       });
     });
@@ -1624,7 +1624,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 0" />);
       // A flush sync doesn't cause the passive effects to fire.
       // So we haven't added the other update yet.
-      await act(async () => {
+      await act(() => {
         ReactNoop.flushSync(() => {
           _updateCount(2);
         });
@@ -1660,7 +1660,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           }, [props.count]);
           return <Text text={'Count: ' + count} />;
         }
-        await act(async () => {
+        await act(() => {
           ReactNoop.flushSync(() => {
             ReactNoop.renderLegacySyncRoot(<Counter count={0} />);
           });
@@ -2256,7 +2256,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       // @gate skipUnmountedBoundaries
       it('should use the nearest still-mounted boundary if there are no unmounted boundaries', async () => {
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <LogOnlyErrorBoundary>
               <BrokenUseEffectCleanup />
@@ -2269,7 +2269,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           'BrokenUseEffectCleanup useEffect',
         ]);
 
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(<LogOnlyErrorBoundary />);
         });
 
@@ -2294,7 +2294,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           }
         }
 
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <LogOnlyErrorBoundary>
               <Conditional showChildren={true} />
@@ -2308,7 +2308,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           'BrokenUseEffectCleanup useEffect',
         ]);
 
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <LogOnlyErrorBoundary>
               <Conditional showChildren={false} />
@@ -2333,7 +2333,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           }
         }
 
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <ErrorBoundary>
               <Conditional showChildren={true} />
@@ -2346,7 +2346,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           'BrokenUseEffectCleanup useEffect',
         ]);
 
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <ErrorBoundary>
               <Conditional showChildren={false} />
@@ -2381,7 +2381,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           }
         }
 
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(<Conditional showChildren={true} />);
         });
 
@@ -2424,7 +2424,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         prevProps.prop === nextProps.prop;
       const MemoizedChild = React.memo(Child, isEqual);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <Wrapper>
             <MemoizedChild key={1} />
@@ -2434,7 +2434,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       assertLog(['render', 'layout create', 'passive create']);
 
       // Include at least one no-op (memoized) update to trigger original bug.
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <Wrapper>
             <MemoizedChild key={1} />
@@ -2443,7 +2443,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       });
       assertLog([]);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <Wrapper>
             <MemoizedChild key={2} />
@@ -2458,7 +2458,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         'passive create',
       ]);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
       assertLog(['layout destroy', 'passive destroy']);
@@ -2491,7 +2491,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         prevProps.prop === nextProps.prop;
       const MemoizedChild = React.memo(Child, isEqual);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <Wrapper>
             <MemoizedChild key={1} />
@@ -2501,7 +2501,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       assertLog(['render', 'layout create', 'passive create']);
 
       // Include at least one no-op (memoized) update to trigger original bug.
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <Wrapper>
             <MemoizedChild key={1} />
@@ -2510,7 +2510,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       });
       assertLog([]);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <Wrapper>
             <MemoizedChild key={2} />
@@ -2525,7 +2525,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         'passive create',
       ]);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
       assertLog(['layout destroy', 'passive destroy']);
@@ -2545,7 +2545,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       const root1 = ReactNoop.createRoot();
       await expect(async () => {
-        await act(async () => {
+        await act(() => {
           root1.render(<App return={17} />);
         });
       }).toErrorDev([
@@ -2555,7 +2555,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       const root2 = ReactNoop.createRoot();
       await expect(async () => {
-        await act(async () => {
+        await act(() => {
           root2.render(<App return={null} />);
         });
       }).toErrorDev([
@@ -2566,7 +2566,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       const root3 = ReactNoop.createRoot();
       await expect(async () => {
-        await act(async () => {
+        await act(() => {
           root3.render(<App return={Promise.resolve()} />);
         });
       }).toErrorDev([
@@ -2924,7 +2924,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       const root1 = ReactNoop.createRoot();
       await expect(async () => {
-        await act(async () => {
+        await act(() => {
           root1.render(<App return={17} />);
         });
       }).toErrorDev([
@@ -2934,7 +2934,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       const root2 = ReactNoop.createRoot();
       await expect(async () => {
-        await act(async () => {
+        await act(() => {
           root2.render(<App return={null} />);
         });
       }).toErrorDev([
@@ -2945,7 +2945,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       const root3 = ReactNoop.createRoot();
       await expect(async () => {
-        await act(async () => {
+        await act(() => {
           root3.render(<App return={Promise.resolve()} />);
         });
       }).toErrorDev([
@@ -2975,7 +2975,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       const root = ReactNoop.createRoot();
       await expect(async () => {
-        await act(async () => {
+        await act(() => {
           root.render(<App />);
         });
       }).toErrorDev(['Warning: useInsertionEffect must not schedule updates.']);
@@ -2993,7 +2993,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         }, []);
         return null;
       }
-      await act(async () => {
+      await act(() => {
         root.render(<NotInsertion />);
       });
     });
@@ -3013,11 +3013,11 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       const root = ReactNoop.createRoot();
-      await act(async () => {
+      await act(() => {
         root.render(<App foo="hello" />);
       });
       await expect(async () => {
-        await act(async () => {
+        await act(() => {
           root.render(<App foo="goodbye" />);
         });
       }).toErrorDev(['Warning: useInsertionEffect must not schedule updates.']);
@@ -3035,7 +3035,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         }, []);
         return null;
       }
-      await act(async () => {
+      await act(() => {
         root.render(<NotInsertion />);
       });
     });
@@ -3204,7 +3204,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       const root1 = ReactNoop.createRoot();
       await expect(async () => {
-        await act(async () => {
+        await act(() => {
           root1.render(<App return={17} />);
         });
       }).toErrorDev([
@@ -3214,7 +3214,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       const root2 = ReactNoop.createRoot();
       await expect(async () => {
-        await act(async () => {
+        await act(() => {
           root2.render(<App return={null} />);
         });
       }).toErrorDev([
@@ -3225,7 +3225,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       const root3 = ReactNoop.createRoot();
       await expect(async () => {
-        await act(async () => {
+        await act(() => {
           root3.render(<App return={Promise.resolve()} />);
         });
       }).toErrorDev([
@@ -3277,7 +3277,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         </>,
       );
 
-      await act(async () => button.current.increment());
+      await act(() => button.current.increment());
       assertLog([
         // Button should not re-render, because its props haven't changed
         // 'Increment',
@@ -3305,7 +3305,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       );
 
       // Callback should have updated
-      await act(async () => button.current.increment());
+      await act(() => button.current.increment());
       assertLog(['Count: 11']);
       expect(ReactNoop).toMatchRenderedOutput(
         <>
@@ -3423,7 +3423,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 0" />);
       expect(counter.current.count).toBe(0);
 
-      await act(async () => {
+      await act(() => {
         counter.current.dispatch(INCREMENT);
       });
       assertLog(['Count: 1']);
@@ -3453,7 +3453,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 0" />);
       expect(counter.current.count).toBe(0);
 
-      await act(async () => {
+      await act(() => {
         counter.current.dispatch(INCREMENT);
       });
       assertLog(['Count: 1']);
@@ -3490,7 +3490,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(counter.current.count).toBe(0);
       expect(totalRefUpdates).toBe(1);
 
-      await act(async () => {
+      await act(() => {
         counter.current.dispatch(INCREMENT);
       });
       assertLog(['Count: 1']);
@@ -3589,7 +3589,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
 
@@ -3687,7 +3687,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         <span prop="A: 0, B: 0, C: [not loaded]" />,
       );
 
-      await act(async () => {
+      await act(() => {
         updateA(2);
         updateB(3);
       });
@@ -3749,7 +3749,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       ReactNoop.render(<App loadC={true} />);
       await waitForAll(['A: 0, B: 0, C: 0']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="A: 0, B: 0, C: 0" />);
-      await act(async () => {
+      await act(() => {
         updateA(2);
         updateB(3);
         updateC(4);
@@ -3855,7 +3855,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(ReactNoop).toMatchRenderedOutput('1');
     });
 
-    await act(async () => {
+    await act(() => {
       setCounter(2);
     });
     assertLog(['Render: 1', 'Effect: 2', 'Reducer: 2', 'Render: 2']);
@@ -3890,7 +3890,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     await waitForAll(['Render disabled: true', 'Render count: 0']);
     expect(ReactNoop).toMatchRenderedOutput('0');
 
-    await act(async () => {
+    await act(() => {
       // These increments should have no effect, since disabled=true
       increment();
       increment();
@@ -3899,7 +3899,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     assertLog(['Render disabled: true', 'Render count: 0']);
     expect(ReactNoop).toMatchRenderedOutput('0');
 
-    await act(async () => {
+    await act(() => {
       // Enabling the updater should *not* replay the previous increment() actions
       setDisabled(false);
     });
@@ -3939,7 +3939,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     await waitForAll(['Render disabled: true', 'Render count: 0']);
     expect(ReactNoop).toMatchRenderedOutput('0');
 
-    await act(async () => {
+    await act(() => {
       // These increments should have no effect, since disabled=true
       increment();
       increment();
@@ -3948,7 +3948,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     assertLog(['Render count: 0']);
     expect(ReactNoop).toMatchRenderedOutput('0');
 
-    await act(async () => {
+    await act(() => {
       // Enabling the updater should *not* replay the previous increment() actions
       setDisabled(false);
     });
@@ -3988,7 +3988,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     await waitForAll(['Render disabled: true', 'Render count: 0']);
     expect(ReactNoop).toMatchRenderedOutput('0');
 
-    await act(async () => {
+    await act(() => {
       // Although the increment happens first (and would seem to do nothing since disabled=true),
       // because these calls are in a batch the parent updates first. This should cause the child
       // to re-render with disabled=false and *then* process the increment action, which now
@@ -4027,7 +4027,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     }
 
     const root = ReactNoop.createRoot(null);
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <CounterA />
@@ -4037,7 +4037,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     });
     assertLog(['Render A: 0', 'Render B: 0', 'Commit A: 0', 'Commit B: 0']);
 
-    await act(async () => {
+    await act(() => {
       setCounterA(1);
 
       // In the same batch, update B twice. To trigger the condition we're
@@ -4083,7 +4083,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     ]);
     expect(ReactNoop).toMatchRenderedOutput('0');
 
-    await act(async () => dispatch());
+    await act(() => dispatch());
     assertLog(['Step: 5, Shadow: 5']);
     expect(ReactNoop).toMatchRenderedOutput('5');
   });
@@ -4108,10 +4108,10 @@ describe('ReactHooksWithNoopRenderer', () => {
       return `${a ? 'A' : 'a'}${b ? 'B' : 'b'}${c ? 'C' : 'c'}`;
     }
 
-    await act(async () => ReactNoop.render(<App />));
+    await act(() => ReactNoop.render(<App />));
     expect(ReactNoop).toMatchRenderedOutput('abc');
 
-    await act(async () => {
+    await act(() => {
       updateA(true);
       // This update should not get dropped.
       updateC(true);
@@ -4138,7 +4138,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       return label;
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <Child key="A" label="A" />
@@ -4155,7 +4155,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
     // Delete A. This should only unmount the effect on A. In the regression,
     // B's effect would also unmount.
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <Child key="B" label="B" />
@@ -4165,7 +4165,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     assertLog(['Unmount layout A', 'Unmount passive A']);
 
     // Now delete and unmount B.
-    await act(async () => {
+    await act(() => {
       root.render(null);
     });
     assertLog(['Unmount layout B', 'Unmount passive B']);
@@ -4184,7 +4184,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       return label;
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <Child key="A" label="A" />
@@ -4194,7 +4194,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     });
     assertLog(['Mount A', 'Mount B']);
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <Child key="B" label="B" />
@@ -4204,7 +4204,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     });
     assertLog([]);
 
-    await act(async () => {
+    await act(() => {
       root.render(null);
     });
 
@@ -4243,7 +4243,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['Suspend! [A]', 'Suspend! [B]', 'Mount A', 'Mount B']);
@@ -4253,7 +4253,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     });
     assertLog(['Promise resolved [A]', 'A', 'Suspend! [B]']);
 
-    await act(async () => {
+    await act(() => {
       root.render(null);
     });
     // In the regression, SuspenseList would cause the children to "forget" that
@@ -4280,25 +4280,25 @@ describe('ReactHooksWithNoopRenderer', () => {
       return <Text text={`Render: ${count}`} />;
     }
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(<Test />);
     });
 
     assertLog(['Render: 0', 'Effect: 0']);
 
-    await act(async () => {
+    await act(() => {
       handleClick();
     });
 
     assertLog(['Render: 0']);
 
-    await act(async () => {
+    await act(() => {
       handleClick();
     });
 
     assertLog(['Render: 0']);
 
-    await act(async () => {
+    await act(() => {
       handleClick();
     });
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1832,7 +1832,7 @@ describe('ReactIncrementalErrorHandling', () => {
       return 'Everything is fine.';
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(<Oops />);
     });
 
@@ -1890,14 +1890,14 @@ describe('ReactIncrementalErrorHandling', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App shouldThrow={false} />);
     });
     expect(root).toMatchRenderedOutput('All good');
 
     let error;
     try {
-      await act(async () => {
+      await act(() => {
         root.render(<App shouldThrow={true} />);
       });
     } catch (e) {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.js
@@ -102,7 +102,7 @@ describe('ReactIncrementalScheduling', () => {
       return text;
     }
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.renderToRootWithID(<Text text="a:1" />, 'a');
       ReactNoop.renderToRootWithID(<Text text="b:1" />, 'b');
       ReactNoop.renderToRootWithID(<Text text="c:1" />, 'c');

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
@@ -618,13 +618,13 @@ describe('ReactIncrementalUpdates', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['Committed: ']);
     expect(root).toMatchRenderedOutput(null);
 
-    await act(async () => {
+    await act(() => {
       React.startTransition(() => {
         pushToLog('A');
       });
@@ -679,13 +679,13 @@ describe('ReactIncrementalUpdates', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog([]);
     expect(root).toMatchRenderedOutput(null);
 
-    await act(async () => {
+    await act(() => {
       React.startTransition(() => {
         pushToLog('A');
       });
@@ -742,20 +742,20 @@ describe('ReactIncrementalUpdates', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App prop="A" />);
     });
     expect(root).toMatchRenderedOutput('0');
 
     // Changing the prop causes the count to increase by 100
-    await act(async () => {
+    await act(() => {
       root.render(<App prop="B" />);
     });
     expect(root).toMatchRenderedOutput('100');
 
     // Now increment the count by 1 with a state update. And, in the same
     // batch, change the prop back to its original value.
-    await act(async () => {
+    await act(() => {
       root.render(<App prop="A" />);
       app.setState(state => ({count: state.count + 1}));
     });

--- a/packages/react-reconciler/src/__tests__/ReactInterleavedUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactInterleavedUpdates-test.js
@@ -52,7 +52,7 @@ describe('ReactInterleavedUpdates', () => {
 
     const root = ReactNoop.createRoot();
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <Child />
@@ -101,7 +101,7 @@ describe('ReactInterleavedUpdates', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A0', 'B0', 'C0']);

--- a/packages/react-reconciler/src/__tests__/ReactMemo-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactMemo-test.js
@@ -270,7 +270,7 @@ describe('memo', () => {
         }
 
         const root = ReactNoop.createRoot();
-        await act(async () => {
+        await act(() => {
           root.render(<App prop="A" />);
         });
         assertLog([
@@ -280,7 +280,7 @@ describe('memo', () => {
         ]);
 
         // Demonstrate what happens when the props change
-        await act(async () => {
+        await act(() => {
           root.render(<App prop="B" />);
         });
         assertLog([
@@ -294,7 +294,7 @@ describe('memo', () => {
 
         // Demonstrate what happens when the prop object changes but there's a
         // bailout because all the individual props are the same.
-        await act(async () => {
+        await act(() => {
           root.render(<App prop="B" />);
         });
         // Nothing re-renders
@@ -303,7 +303,7 @@ describe('memo', () => {
         // Demonstrate what happens when the prop object changes, it bails out
         // because all the props are the same, but we still render the
         // children because there's a local update in the same batch.
-        await act(async () => {
+        await act(() => {
           root.render(<App prop="B" />);
           setLocalUpdateOnChildren(1);
         });
@@ -316,7 +316,7 @@ describe('memo', () => {
         ]);
 
         // Do the same thing again. We should still reuse the props object.
-        await act(async () => {
+        await act(() => {
           root.render(<App prop="B" />);
           setLocalUpdateOnChildren(2);
         });
@@ -597,12 +597,12 @@ describe('memo', () => {
         }
 
         const root = ReactNoop.createRoot();
-        await act(async () => {
+        await act(() => {
           root.render(<App />);
         });
         expect(root).toMatchRenderedOutput('0');
 
-        await act(async () => {
+        await act(() => {
           setCounter(1);
           ReactNoop.discreteUpdates(() => {
             root.render(<App />);
@@ -633,12 +633,12 @@ describe('memo', () => {
         }
 
         const root = ReactNoop.createRoot();
-        await act(async () => {
+        await act(() => {
           root.render(<App />);
         });
         expect(root).toMatchRenderedOutput('0');
 
-        await act(async () => {
+        await act(() => {
           setCounter(1);
           ReactNoop.discreteUpdates(() => {
             root.render(<App />);

--- a/packages/react-reconciler/src/__tests__/ReactNoopRendererAct-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNoopRendererAct-test.js
@@ -26,7 +26,7 @@ describe('internal act()', () => {
     }
 
     const calledLog = [];
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <App
           callback={() => {
@@ -54,7 +54,7 @@ describe('internal act()', () => {
       }, []);
       return ctr;
     }
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(<App />);
     });
     assertLog(['stage 1', 'stage 2']);

--- a/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
@@ -88,7 +88,7 @@ describe('ReactOffscreen', () => {
     );
 
     // Now try after an update
-    await act(async () => {
+    await act(() => {
       root.render(<App mode="visible" />);
     });
     assertLog(['Normal', 'Deferred']);
@@ -128,7 +128,7 @@ describe('ReactOffscreen', () => {
     }
 
     const root = ReactNoop.createLegacyRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <LegacyHidden mode="hidden">
@@ -151,7 +151,7 @@ describe('ReactOffscreen', () => {
     );
 
     // Test that the children can be updated
-    await act(async () => {
+    await act(() => {
       setState('B');
     });
     assertLog(['B']);
@@ -197,7 +197,7 @@ describe('ReactOffscreen', () => {
     );
 
     // Test that the children can be updated
-    await act(async () => {
+    await act(() => {
       setState('B');
     });
     assertLog(['B']);
@@ -224,7 +224,7 @@ describe('ReactOffscreen', () => {
     const root = ReactNoop.createRoot();
 
     // Mount hidden tree.
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="hidden">
           <Child />
@@ -236,7 +236,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span hidden={true} prop="Child" />);
 
     // Unhide the tree. The layout effect is mounted.
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="visible">
           <Child />
@@ -260,7 +260,7 @@ describe('ReactOffscreen', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="visible">
           <Child />
@@ -271,7 +271,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span prop="Child" />);
 
     // Hide the tree. The layout effect is unmounted.
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="hidden">
           <Child />
@@ -282,7 +282,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span hidden={true} prop="Child" />);
 
     // Unhide the tree. The layout effect is re-mounted.
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="visible">
           <Child />
@@ -313,7 +313,7 @@ describe('ReactOffscreen', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       // Outer and inner offscreen are hidden.
       root.render(
         <Offscreen mode={'hidden'}>
@@ -327,7 +327,7 @@ describe('ReactOffscreen', () => {
     assertLog(['child']);
     expect(root).toMatchRenderedOutput(<span hidden={true} prop="child" />);
 
-    await act(async () => {
+    await act(() => {
       // Inner offscreen is visible.
       root.render(
         <Offscreen mode={'hidden'}>
@@ -341,7 +341,7 @@ describe('ReactOffscreen', () => {
     assertLog(['child']);
     expect(root).toMatchRenderedOutput(<span hidden={true} prop="child" />);
 
-    await act(async () => {
+    await act(() => {
       // Inner offscreen is hidden.
       root.render(
         <Offscreen mode={'hidden'}>
@@ -355,7 +355,7 @@ describe('ReactOffscreen', () => {
     assertLog(['child']);
     expect(root).toMatchRenderedOutput(<span hidden={true} prop="child" />);
 
-    await act(async () => {
+    await act(() => {
       // Inner offscreen is visible.
       root.render(
         <Offscreen mode={'hidden'}>
@@ -368,7 +368,7 @@ describe('ReactOffscreen', () => {
 
     Scheduler.unstable_clearLog();
 
-    await act(async () => {
+    await act(() => {
       // Outer offscreen is visible.
       // Inner offscreen is hidden.
       root.render(
@@ -382,7 +382,7 @@ describe('ReactOffscreen', () => {
 
     assertLog(['child']);
 
-    await act(async () => {
+    await act(() => {
       // Outer offscreen is hidden.
       // Inner offscreen is visible.
       root.render(
@@ -410,7 +410,7 @@ describe('ReactOffscreen', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       // Start the tree hidden. The layout effect is not mounted.
       root.render(
         <Offscreen mode="hidden">
@@ -422,7 +422,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span hidden={true} prop="Child" />);
 
     // Show the tree. The layout effect is mounted.
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="visible">
           <Child />
@@ -433,7 +433,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span prop="Child" />);
 
     // Hide the tree again. The layout effect is un-mounted.
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="hidden">
           <Child />
@@ -459,7 +459,7 @@ describe('ReactOffscreen', () => {
       return <Text text="Child" />;
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="visible">
           <Child />
@@ -470,7 +470,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span prop="Child" />);
 
     // Hide the tree. The layout effect is unmounted.
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="hidden">
           <Child />
@@ -498,7 +498,7 @@ describe('ReactOffscreen', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <LegacyHidden mode="visible">
           <Child />
@@ -507,7 +507,7 @@ describe('ReactOffscreen', () => {
     });
     assertLog(['Child', 'Mount layout']);
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <LegacyHidden mode="hidden">
           <Child />
@@ -516,7 +516,7 @@ describe('ReactOffscreen', () => {
     });
     assertLog(['Child']);
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <LegacyHidden mode="visible">
           <Child />
@@ -525,7 +525,7 @@ describe('ReactOffscreen', () => {
     });
     assertLog(['Child']);
 
-    await act(async () => {
+    await act(() => {
       root.render(null);
     });
     assertLog(['Unmount layout']);
@@ -534,7 +534,7 @@ describe('ReactOffscreen', () => {
   // @gate enableOffscreen
   it('hides new insertions into an already hidden tree', async () => {
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="hidden">
           <span>Hi</span>
@@ -544,7 +544,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span hidden={true}>Hi</span>);
 
     // Insert a new node into the hidden tree
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="hidden">
           <span>Hi</span>
@@ -564,7 +564,7 @@ describe('ReactOffscreen', () => {
   // @gate enableOffscreen
   it('hides updated nodes inside an already hidden tree', async () => {
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="hidden">
           <span>Hi</span>
@@ -574,7 +574,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span hidden={true}>Hi</span>);
 
     // Set the `hidden` prop to on an already hidden node
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="hidden">
           <span hidden={false}>Hi</span>
@@ -585,7 +585,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span hidden={true}>Hi</span>);
 
     // Unhide the boundary
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="visible">
           <span hidden={true}>Hi</span>
@@ -596,7 +596,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span hidden={true}>Hi</span>);
 
     // Remove the `hidden` prop
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="visible">
           <span>Hi</span>
@@ -670,7 +670,7 @@ describe('ReactOffscreen', () => {
 
     // Render a hidden tree
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App show={false} />);
     });
     assertLog(['Outer: 0', 'Inner: 0']);
@@ -751,7 +751,7 @@ describe('ReactOffscreen', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<Offscreen hidden={false} />);
     });
     assertLog([]);
@@ -803,7 +803,7 @@ describe('ReactOffscreen', () => {
     }
 
     // Initial render
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="hidden">
           <Child />
@@ -816,7 +816,7 @@ describe('ReactOffscreen', () => {
     // Schedule an update to a hidden class component. The update will finish
     // rendering in the background, but the callback shouldn't fire yet, because
     // the component isn't visible.
-    await act(async () => {
+    await act(() => {
       child.setState({text: 'B'}, () => {
         Scheduler.log('B update finished');
       });
@@ -827,7 +827,7 @@ describe('ReactOffscreen', () => {
     // Now reveal the hidden component. Simultaneously, schedule another
     // update with a callback to the same component. When the component is
     // revealed, both the B callback and C callback should fire, in that order.
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="visible">
           <Child />
@@ -860,7 +860,7 @@ describe('ReactOffscreen', () => {
 
     // Initial mount
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="visible">
           <Child />
@@ -870,7 +870,7 @@ describe('ReactOffscreen', () => {
     assertLog(['componentDidMount']);
 
     // Hide the class component
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="hidden">
           <Child />
@@ -881,7 +881,7 @@ describe('ReactOffscreen', () => {
 
     // Reappear the class component. componentDidMount should fire, not
     // componentDidUpdate.
-    await act(async () => {
+    await act(() => {
       root.render(
         <Offscreen mode="visible">
           <Child />
@@ -908,7 +908,7 @@ describe('ReactOffscreen', () => {
 
       // Initial mount
       const root = ReactNoop.createRoot();
-      await act(async () => {
+      await act(() => {
         root.render(
           <Offscreen mode="visible">
             <Child key="B" label="B" />
@@ -918,7 +918,7 @@ describe('ReactOffscreen', () => {
       assertLog(['Mount B']);
 
       // Hide the component
-      await act(async () => {
+      await act(() => {
         root.render(
           <Offscreen mode="hidden">
             <Child key="B" label="B" />
@@ -928,7 +928,7 @@ describe('ReactOffscreen', () => {
       assertLog(['Unmount B']);
 
       // Reappear the component and also add some new siblings.
-      await act(async () => {
+      await act(() => {
         root.render(
           <Offscreen mode="visible">
             <Child key="A" label="A" />
@@ -964,7 +964,7 @@ describe('ReactOffscreen', () => {
       // Initial mount
       const bRef = React.createRef();
       const root = ReactNoop.createRoot();
-      await act(async () => {
+      await act(() => {
         root.render(
           <Offscreen mode="visible">
             <Child key="B" ref={bRef} label="B" />
@@ -978,7 +978,7 @@ describe('ReactOffscreen', () => {
       const setStateB = bRef.current.setState.bind(bRef.current);
 
       // Hide the component
-      await act(async () => {
+      await act(() => {
         root.render(
           <Offscreen mode="hidden">
             <Child key="B" ref={bRef} label="B" />
@@ -988,7 +988,7 @@ describe('ReactOffscreen', () => {
       assertLog(['Unmount B']);
 
       // Reappear the component and also add some new siblings.
-      await act(async () => {
+      await act(() => {
         setStateB(null, () => {
           Scheduler.log('setState callback B');
         });
@@ -1033,7 +1033,7 @@ describe('ReactOffscreen', () => {
     const root = ReactNoop.createRoot();
 
     // Mount the app without showing the extra content
-    await act(async () => {
+    await act(() => {
       root.render(<App showMore={false} />);
     });
     assertLog([
@@ -1056,7 +1056,7 @@ describe('ReactOffscreen', () => {
     );
 
     // Reveal the prerendered tree
-    await act(async () => {
+    await act(() => {
       root.render(<App showMore={true} />);
     });
     assertLog([
@@ -1096,7 +1096,7 @@ describe('ReactOffscreen', () => {
     const root = ReactNoop.createRoot();
 
     // Mount the app without showing the extra content
-    await act(async () => {
+    await act(() => {
       root.render(<App showMore={false} />);
     });
     assertLog([
@@ -1119,7 +1119,7 @@ describe('ReactOffscreen', () => {
     );
 
     // Reveal the prerendered tree
-    await act(async () => {
+    await act(() => {
       root.render(<App showMore={true} />);
     });
     assertLog(['Shell', 'More']);
@@ -1151,21 +1151,21 @@ describe('ReactOffscreen', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App show={true} step={1} />);
     });
     assertLog([1, 'Commit mount [1]']);
     expect(root).toMatchRenderedOutput(<span prop={1} />);
 
     // Hide the tree. This will unmount the effect.
-    await act(async () => {
+    await act(() => {
       root.render(<App show={false} step={1} />);
     });
     assertLog(['Commit unmount [1]']);
     expect(root).toMatchRenderedOutput(<span hidden={true} prop={1} />);
 
     // Update.
-    await act(async () => {
+    await act(() => {
       root.render(<App show={false} step={2} />);
     });
     // The update is prerendered but no effects are fired
@@ -1173,7 +1173,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span hidden={true} prop={2} />);
 
     // Reveal the tree.
-    await act(async () => {
+    await act(() => {
       root.render(<App show={true} step={2} />);
     });
     // The update doesn't render because it was already prerendered, but we do
@@ -1212,23 +1212,23 @@ describe('ReactOffscreen', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App show={true} />);
     });
     assertLog(['Mount Child', 'Mount Parent']);
 
     // First demonstrate what happens during a normal deletion
-    await act(async () => {
+    await act(() => {
       root.render(null);
     });
     assertLog(['Unmount Parent', 'Unmount Child']);
 
     // Now redo the same thing but hide instead of deleting
-    await act(async () => {
+    await act(() => {
       root.render(<App show={true} />);
     });
     assertLog(['Mount Child', 'Mount Parent']);
-    await act(async () => {
+    await act(() => {
       root.render(<App show={false} />);
     });
     // The order is the same as during a deletion: parent before child
@@ -1266,7 +1266,7 @@ describe('ReactOffscreen', () => {
     const root = ReactNoop.createRoot();
 
     // Mount the app, including the extra content
-    await act(async () => {
+    await act(() => {
       root.render(<App showMore={true} step={1} />);
     });
     assertLog(['Shell 1', 'More 1', 'Mount Shell 1', 'Mount More 1']);
@@ -1278,7 +1278,7 @@ describe('ReactOffscreen', () => {
     );
 
     // Hide the extra content. while also updating one of its props
-    await act(async () => {
+    await act(() => {
       root.render(<App showMore={false} step={2} />);
     });
     assertLog([
@@ -1333,7 +1333,7 @@ describe('ReactOffscreen', () => {
     const root = ReactNoop.createRoot();
 
     // Prerender the outer contents. No effects should mount.
-    await act(async () => {
+    await act(() => {
       root.render(<App showOuter={false} showInner={false} />);
     });
     assertLog(['Outer']);
@@ -1344,7 +1344,7 @@ describe('ReactOffscreen', () => {
     );
 
     // Prerender the inner contents. No effects should mount.
-    await act(async () => {
+    await act(() => {
       root.render(<App showOuter={false} showInner={true} />);
     });
     assertLog(['Outer', 'Inner']);
@@ -1358,7 +1358,7 @@ describe('ReactOffscreen', () => {
     );
 
     // Reveal the prerendered tree
-    await act(async () => {
+    await act(() => {
       root.render(<App showOuter={true} showInner={true} />);
     });
     // The effects fire, but the tree is not re-rendered because it already
@@ -1409,7 +1409,7 @@ describe('ReactOffscreen', () => {
     const root = ReactNoop.createRoot();
 
     // Prerender the whole tree.
-    await act(async () => {
+    await act(() => {
       root.render(<App showOuter={false} showInner={false} />);
     });
     assertLog(['Outer', 'Inner']);
@@ -1426,7 +1426,7 @@ describe('ReactOffscreen', () => {
     );
 
     // Reveal the outer contents. The inner tree remains hidden.
-    await act(async () => {
+    await act(() => {
       root.render(<App showOuter={true} showInner={false} />);
     });
     assertLog(['Mount Outer']);
@@ -1460,25 +1460,25 @@ describe('ReactOffscreen', () => {
 
       const root = ReactNoop.createRoot();
 
-      await act(async () => {
+      await act(() => {
         root.render(<App mode={'manual'} />);
       });
 
       expect(offscreenRef.current).not.toBeNull();
 
-      await act(async () => {
+      await act(() => {
         root.render(<App mode={'visible'} />);
       });
 
       expect(offscreenRef.current).toBeNull();
 
-      await act(async () => {
+      await act(() => {
         root.render(<App mode={'hidden'} />);
       });
 
       expect(offscreenRef.current).toBeNull();
 
-      await act(async () => {
+      await act(() => {
         root.render(<App mode={'manual'} />);
       });
 
@@ -1525,7 +1525,7 @@ describe('ReactOffscreen', () => {
 
       const root = ReactNoop.createRoot();
 
-      await act(async () => {
+      await act(() => {
         root.render(<App />);
       });
 
@@ -1552,7 +1552,7 @@ describe('ReactOffscreen', () => {
         );
       });
 
-      await act(async () => {
+      await act(() => {
         offscreenRef.current.detach();
       });
 
@@ -1577,7 +1577,7 @@ describe('ReactOffscreen', () => {
         </>,
       );
 
-      await act(async () => {
+      await act(() => {
         offscreenRef.current.attach();
       });
 
@@ -1650,7 +1650,7 @@ describe('ReactOffscreen', () => {
 
       const root = ReactNoop.createRoot();
 
-      await act(async () => {
+      await act(() => {
         root.render(<App />);
       });
 
@@ -1721,19 +1721,19 @@ describe('ReactOffscreen', () => {
 
     const root = ReactNoop.createRoot();
 
-    await act(async () => {
+    await act(() => {
       root.render(<App showOffscreen={true} />);
     });
 
     expect(offscreenRef.current).not.toBeNull();
 
-    await act(async () => {
+    await act(() => {
       root.render(<App showOffscreen={false} />);
     });
 
     expect(offscreenRef.current).toBeNull();
 
-    await act(async () => {
+    await act(() => {
       root.render(<App showOffscreen={true} />);
     });
 
@@ -1757,18 +1757,18 @@ describe('ReactOffscreen', () => {
 
     const root = ReactNoop.createRoot();
 
-    await act(async () => {
+    await act(() => {
       root.render(<App mode={'hidden'} />);
     });
 
     expect(offscreenRef.current).toBeNull();
 
-    await act(async () => {
+    await act(() => {
       root.render(<App mode={'visible'} />);
     });
 
     expect(offscreenRef.current).not.toBeNull();
-    await act(async () => {
+    await act(() => {
       root.render(<App mode={'hidden'} />);
     });
 
@@ -1789,7 +1789,7 @@ describe('ReactOffscreen', () => {
       );
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <App>
           <div />
@@ -1800,7 +1800,7 @@ describe('ReactOffscreen', () => {
     expect(offscreenRef.current).not.toBeNull();
     const firstFiber = offscreenRef.current._current;
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <App>
           <span />
@@ -1844,7 +1844,7 @@ describe('ReactOffscreen', () => {
 
     const root = ReactNoop.createRoot();
 
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
 
@@ -1852,7 +1852,7 @@ describe('ReactOffscreen', () => {
     expect(spanRef.current).not.toBeNull();
     assertLog(['Mount Layout Child', 'Mount Child']);
 
-    await act(async () => {
+    await act(() => {
       offscreenRef.detach();
     });
 
@@ -1860,13 +1860,13 @@ describe('ReactOffscreen', () => {
     assertLog(['Unmount Layout Child', 'Unmount Child']);
 
     // Calling attach on already attached Offscreen.
-    await act(async () => {
+    await act(() => {
       offscreenRef.detach();
     });
 
     assertLog([]);
 
-    await act(async () => {
+    await act(() => {
       offscreenRef.attach();
     });
 
@@ -1900,7 +1900,7 @@ describe('ReactOffscreen', () => {
 
     const root = ReactNoop.createRoot();
 
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
 
@@ -1919,7 +1919,7 @@ describe('ReactOffscreen', () => {
     expect(outerOffscreen).not.toBeNull();
     expect(innerOffscreen).not.toBeNull();
 
-    await act(async () => {
+    await act(() => {
       outerOffscreen.detach();
     });
 
@@ -1932,7 +1932,7 @@ describe('ReactOffscreen', () => {
       'unmount inner',
     ]);
 
-    await act(async () => {
+    await act(() => {
       outerOffscreen.attach();
     });
 
@@ -1943,26 +1943,26 @@ describe('ReactOffscreen', () => {
       'mount middle',
     ]);
 
-    await act(async () => {
+    await act(() => {
       innerOffscreen.detach();
     });
 
     assertLog(['unmount layout inner', 'unmount inner']);
 
     // Calling detach on already detached Offscreen.
-    await act(async () => {
+    await act(() => {
       innerOffscreen.detach();
     });
 
     assertLog([]);
 
-    await act(async () => {
+    await act(() => {
       innerOffscreen.attach();
     });
 
     assertLog(['mount layout inner', 'mount inner']);
 
-    await act(async () => {
+    await act(() => {
       innerOffscreen.detach();
       outerOffscreen.attach();
     });
@@ -1992,13 +1992,13 @@ describe('ReactOffscreen', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
 
     assertLog(['attach child']);
 
-    await act(async () => {
+    await act(() => {
       const instance = offscreen.current;
       // Detach then immediately attach the instance.
       instance.detach();
@@ -2007,14 +2007,14 @@ describe('ReactOffscreen', () => {
 
     assertLog([]);
 
-    await act(async () => {
+    await act(() => {
       const instance = offscreen.current;
       instance.detach();
     });
 
     assertLog(['detach child']);
 
-    await act(async () => {
+    await act(() => {
       const instance = offscreen.current;
       // Attach then immediately detach.
       instance.attach();
@@ -2052,7 +2052,7 @@ describe('ReactOffscreen', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['attach child']);

--- a/packages/react-reconciler/src/__tests__/ReactOffscreenStrictMode-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreenStrictMode-test.js
@@ -33,7 +33,7 @@ describe('ReactOffscreenStrictMode', () => {
 
   // @gate __DEV__ && enableOffscreen
   it('should trigger strict effects when offscreen is visible', async () => {
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.StrictMode>
           <Offscreen mode="visible">
@@ -57,7 +57,7 @@ describe('ReactOffscreenStrictMode', () => {
 
   // @gate __DEV__ && enableOffscreen && useModernStrictMode
   it('should not trigger strict effects when offscreen is hidden', async () => {
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.StrictMode>
           <Offscreen mode="hidden">
@@ -71,7 +71,7 @@ describe('ReactOffscreenStrictMode', () => {
 
     log = [];
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.StrictMode>
           <Offscreen mode="hidden">
@@ -86,7 +86,7 @@ describe('ReactOffscreenStrictMode', () => {
 
     log = [];
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.StrictMode>
           <Offscreen mode="visible">
@@ -109,7 +109,7 @@ describe('ReactOffscreenStrictMode', () => {
 
     log = [];
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.StrictMode>
           <Offscreen mode="hidden">
@@ -143,7 +143,7 @@ describe('ReactOffscreenStrictMode', () => {
       return state;
     }
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.StrictMode>
           <React.Suspense>
@@ -193,7 +193,7 @@ describe('ReactOffscreenStrictMode', () => {
       return null;
     }
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.StrictMode>
           <Offscreen mode="visible">
@@ -205,7 +205,7 @@ describe('ReactOffscreenStrictMode', () => {
 
     log.push('------------------------------');
 
-    await act(async () => {
+    await act(() => {
       resolve();
       shouldSuspend = false;
     });

--- a/packages/react-reconciler/src/__tests__/ReactOffscreenSuspense-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreenSuspense-test.js
@@ -118,7 +118,7 @@ describe('ReactOffscreen', () => {
     // The hidden tree hasn't finished loading, but we should still be able to
     // show the surrounding contents. The outer Suspense boundary
     // isn't affected.
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['Visible', 'Suspend! [Hidden]']);
@@ -158,7 +158,7 @@ describe('ReactOffscreen', () => {
     }
 
     // Unlike Offscreen, LegacyHidden never captures if something suspends
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['Visible', 'Suspend! [Hidden]', 'Loading...']);
@@ -192,7 +192,7 @@ describe('ReactOffscreen', () => {
     // The hidden tree hasn't finished loading, but we should still be able to
     // show the surrounding contents. It doesn't matter that there's no
     // Suspense boundary because the unfinished content isn't visible.
-    await act(async () => {
+    await act(() => {
       root.render(
         <Details open={false}>
           <AsyncText text="Async" />
@@ -204,7 +204,7 @@ describe('ReactOffscreen', () => {
 
     // But when we switch the boundary from hidden to visible, it should
     // now bubble to the nearest Suspense boundary.
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <Details open={true}>
@@ -249,7 +249,7 @@ describe('ReactOffscreen', () => {
     }
 
     // Initial mount. Nothing suspends
-    await act(async () => {
+    await act(() => {
       root.render(
         <Details open={true}>
           <Text text="(empty)" />
@@ -265,7 +265,7 @@ describe('ReactOffscreen', () => {
     );
 
     // Update that suspends inside the currently visible tree
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <Details open={true}>
@@ -285,7 +285,7 @@ describe('ReactOffscreen', () => {
     );
 
     // Update that hides the suspended tree
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <Details open={false}>
@@ -338,12 +338,12 @@ describe('ReactOffscreen', () => {
 
     const root = ReactNoop.createRoot();
     resolveText('A');
-    await act(async () => {
+    await act(() => {
       root.render(<App show={false} />);
     });
     assertLog(['A']);
 
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         setText('B');
       });
@@ -376,13 +376,13 @@ describe('ReactOffscreen', () => {
 
     const root = ReactNoop.createRoot();
     resolveText('A0');
-    await act(async () => {
+    await act(() => {
       root.render(<App show={false} />);
     });
     assertLog(['A0']);
     expect(root).toMatchRenderedOutput(<span hidden={true}>A0</span>);
 
-    await act(async () => {
+    await act(() => {
       React.startTransition(() => {
         setStep(1);
       });
@@ -400,7 +400,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span hidden={true}>A0</span>);
 
     // Resolve the data and finish rendering
-    await act(async () => {
+    await act(() => {
       resolveText('B1');
     });
     assertLog(['B1']);
@@ -462,7 +462,7 @@ describe('ReactOffscreen', () => {
     // Render a hidden tree
     const root = ReactNoop.createRoot();
     resolveText('Async: 0');
-    await act(async () => {
+    await act(() => {
       root.render(<App show={true} />);
     });
     assertLog([

--- a/packages/react-reconciler/src/__tests__/ReactSchedulerIntegration-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSchedulerIntegration-test.js
@@ -79,11 +79,11 @@ describe('ReactSchedulerIntegration', () => {
       });
       return null;
     }
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(<CleanupEffect />);
     });
     assertLog([]);
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(<Effects />);
     });
     assertLog([

--- a/packages/react-reconciler/src/__tests__/ReactSubtreeFlagsWarning-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSubtreeFlagsWarning-test.js
@@ -161,7 +161,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // On initial mount, the suspended component is committed in an incomplete
     // state, without a passive static effect flag.
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['Suspend! [Async]']);
@@ -170,7 +170,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // When the promise resolves, a passive static effect flag is added. In the
     // regression, the "missing expected static flag" would fire, because the
     // previous fiber did not have one.
-    await act(async () => {
+    await act(() => {
       resolveText('Async');
     });
     assertLog(['Async', 'Effect']);

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -410,7 +410,7 @@ describe('ReactSuspense', () => {
     await waitForAll(['default']);
     expect(root).toMatchRenderedOutput('default');
 
-    await act(async () => setValue('new value'));
+    await act(() => setValue('new value'));
     assertLog(['Suspend! [new value]', 'Loading...']);
 
     await resolveText('new value');
@@ -456,7 +456,7 @@ describe('ReactSuspense', () => {
     await waitForAll(['default']);
     expect(root).toMatchRenderedOutput('default');
 
-    await act(async () => setValue('new value'));
+    await act(() => setValue('new value'));
     assertLog(['Suspend! [new value]', 'Loading...']);
 
     await resolveText('new value');
@@ -500,7 +500,7 @@ describe('ReactSuspense', () => {
     await waitForAll(['default']);
     expect(root).toMatchRenderedOutput('default');
 
-    await act(async () => setValue('new value'));
+    await act(() => setValue('new value'));
     assertLog(['Suspend! [new value]', 'Loading...']);
 
     await resolveText('new value');
@@ -544,7 +544,7 @@ describe('ReactSuspense', () => {
     await waitForAll(['default']);
     expect(root).toMatchRenderedOutput('default');
 
-    await act(async () => setValue('new value'));
+    await act(() => setValue('new value'));
     assertLog(['Suspend! [new value]', 'Loading...']);
 
     await resolveText('new value');
@@ -583,7 +583,7 @@ describe('ReactSuspense', () => {
     await waitForAll(['Child 1', 'create layout']);
     expect(root).toMatchRenderedOutput('Child 1');
 
-    await act(async () => {
+    await act(() => {
       _setShow(true);
     });
     assertLog([
@@ -856,7 +856,7 @@ describe('ReactSuspense', () => {
       expect(root).toMatchRenderedOutput('Step: 1');
 
       // Update that suspends
-      await act(async () => {
+      await act(() => {
         instance.setState({step: 2});
       });
       assertLog(['Suspend! [Step: 2]', 'Loading...']);
@@ -976,7 +976,7 @@ describe('ReactSuspense', () => {
       await waitForPaint(['Tab: 0']);
       expect(root).toMatchRenderedOutput('Tab: 0 + sibling');
 
-      await act(async () => setTab(1));
+      await act(() => setTab(1));
       assertLog(['Suspend! [Tab: 1]', ' + sibling', 'Loading...']);
       expect(root).toMatchRenderedOutput('Loading...');
 
@@ -984,7 +984,7 @@ describe('ReactSuspense', () => {
       await waitForPaint(['Tab: 1']);
       expect(root).toMatchRenderedOutput('Tab: 1 + sibling');
 
-      await act(async () => setTab(2));
+      await act(() => setTab(2));
       assertLog(['Suspend! [Tab: 2]', ' + sibling', 'Loading...']);
       expect(root).toMatchRenderedOutput('Loading...');
 
@@ -1018,11 +1018,11 @@ describe('ReactSuspense', () => {
       await waitForPaint(['A:0']);
       expect(root).toMatchRenderedOutput('A:0');
 
-      await act(async () => setStep(1));
+      await act(() => setStep(1));
       assertLog(['Suspend! [A:1]', 'Loading...']);
       expect(root).toMatchRenderedOutput('Loading...');
 
-      await act(async () => {
+      await act(() => {
         root.update(null);
       });
     });
@@ -1103,7 +1103,7 @@ describe('ReactSuspense', () => {
 
       const root = ReactTestRenderer.create(null);
 
-      await act(async () => {
+      await act(() => {
         root.update(<App name="world" />);
       });
     });
@@ -1139,7 +1139,7 @@ describe('ReactSuspense', () => {
       await waitForPaint(['default']);
       expect(root).toMatchRenderedOutput('default');
 
-      await act(async () => setValue('new value'));
+      await act(() => setValue('new value'));
       assertLog(['Suspend! [new value]', 'Loading...']);
 
       await resolveText('new value');
@@ -1183,7 +1183,7 @@ describe('ReactSuspense', () => {
       await waitForPaint(['default']);
       expect(root).toMatchRenderedOutput('default');
 
-      await act(async () => setValue('new value'));
+      await act(() => setValue('new value'));
       assertLog(['Suspend! [new value]', 'Loading...']);
 
       await resolveText('new value');
@@ -1226,7 +1226,7 @@ describe('ReactSuspense', () => {
       await waitForPaint(['default']);
       expect(root).toMatchRenderedOutput('default');
 
-      await act(async () => setValue('new value'));
+      await act(() => setValue('new value'));
       assertLog(['Suspend! [new value]', 'Loading...']);
 
       await resolveText('new value');
@@ -1265,7 +1265,7 @@ describe('ReactSuspense', () => {
       await waitForPaint(['default']);
       expect(root).toMatchRenderedOutput('default');
 
-      await act(async () => setValue('new value'));
+      await act(() => setValue('new value'));
       assertLog(['Suspend! [new value]', 'Loading...']);
 
       await resolveText('new value');
@@ -1316,11 +1316,11 @@ describe('ReactSuspense', () => {
       assertLog(['Received context value [default]', 'default']);
       expect(root).toMatchRenderedOutput('default');
 
-      await act(async () => setValue('new value'));
+      await act(() => setValue('new value'));
       assertLog(['Received context value [new value]', 'Loading...']);
       expect(root).toMatchRenderedOutput('Loading...');
 
-      await act(async () => setValue('default'));
+      await act(() => setValue('default'));
       assertLog(['Received context value [default]', 'default']);
       expect(root).toMatchRenderedOutput('default');
     });

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemantics-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemantics-test.js
@@ -255,7 +255,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount and suspend.
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <App>
             <AsyncText text="Async" ms={1000} />
@@ -308,7 +308,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         </>,
       );
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
       assertLog([
@@ -374,7 +374,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount and suspend.
-      await act(async () => {
+      await act(() => {
         ReactNoop.renderLegacySyncRoot(
           <App>
             <AsyncText text="Async" ms={1000} />
@@ -427,7 +427,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         </>,
       );
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.renderLegacySyncRoot(null);
       });
       assertLog([
@@ -475,7 +475,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount
-      await act(async () => {
+      await act(() => {
         ReactNoop.renderLegacySyncRoot(<App />);
       });
       assertLog([
@@ -501,7 +501,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       );
 
       // Schedule an update that causes React to suspend.
-      await act(async () => {
+      await act(() => {
         ReactNoop.renderLegacySyncRoot(
           <App>
             <AsyncText text="Async" ms={1000} />
@@ -560,7 +560,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         </>,
       );
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.renderLegacySyncRoot(null);
       });
       assertLog([
@@ -605,7 +605,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
       assertLog([
@@ -696,7 +696,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         </>,
       );
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
       assertLog([
@@ -762,7 +762,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
       assertLog([
@@ -849,7 +849,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
           <span prop="Outside" />
         </>,
       );
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
       assertLog([
@@ -890,7 +890,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
       assertLog([
@@ -973,7 +973,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         </>,
       );
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
       assertLog([
@@ -1017,7 +1017,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
       assertLog([
@@ -1100,7 +1100,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         </>,
       );
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
       assertLog([
@@ -1131,7 +1131,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
       assertLog([
@@ -1150,7 +1150,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       );
 
       // Suspend the inner Suspense subtree (only inner effects should be destroyed)
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <App innerChildren={<AsyncText text="InnerAsync_1" ms={1000} />} />,
         );
@@ -1174,7 +1174,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
 
       // Suspend the outer Suspense subtree (outer effects and inner fallback effects should be destroyed)
       // (This check also ensures we don't destroy effects for mounted inner fallback.)
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <App
             outerChildren={<AsyncText text="OuterAsync_1" ms={1000} />}
@@ -1224,7 +1224,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       );
 
       // Suspend the inner Suspense subtree (no effects should be destroyed)
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <App
             outerChildren={<AsyncText text="OuterAsync_1" ms={1000} />}
@@ -1299,7 +1299,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       );
 
       // Suspend the outer Suspense subtree (all effects should be destroyed)
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <App
             outerChildren={<AsyncText text="OuterAsync_2" ms={1000} />}
@@ -1372,7 +1372,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
       assertLog([
@@ -1391,7 +1391,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       );
 
       // Suspend the inner Suspense subtree (only inner effects should be destroyed)
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <App innerChildren={<AsyncText text="InnerAsync_1" ms={1000} />} />,
         );
@@ -1415,7 +1415,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
 
       // Suspend the outer Suspense subtree (outer effects and inner fallback effects should be destroyed)
       // (This check also ensures we don't destroy effects for mounted inner fallback.)
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <App
             outerChildren={<AsyncText text="OuterAsync_1" ms={1000} />}
@@ -1498,7 +1498,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
       assertLog([
@@ -1650,7 +1650,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
       assertLog([
@@ -1669,7 +1669,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       );
 
       // Suspend both the outer boundary and the fallback
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <App
             outerChildren={<AsyncText text="OutsideAsync" ms={1000} />}
@@ -1771,7 +1771,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App shouldSuspend={false} />);
       });
       assertLog([
@@ -1880,7 +1880,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
           );
         }
 
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App />
@@ -1909,7 +1909,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         );
 
         // Schedule an update that causes React to suspend.
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App>
@@ -2016,7 +2016,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
           );
         }
 
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App />
@@ -2045,7 +2045,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         );
 
         // Schedule an update that suspends and triggers our error code.
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App>
@@ -2128,7 +2128,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
           );
         }
 
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App />
@@ -2157,7 +2157,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         );
 
         // Schedule an update that causes React to suspend.
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App>
@@ -2265,7 +2265,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
           );
         }
 
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App />
@@ -2294,7 +2294,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         );
 
         // Schedule an update that suspends and triggers our error code.
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App>
@@ -2371,7 +2371,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
       assertLog([
@@ -2471,7 +2471,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         </>,
       );
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
       assertLog([
@@ -2527,7 +2527,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
       assertLog([
@@ -2623,7 +2623,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         </>,
       );
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
       assertLog([
@@ -2711,7 +2711,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.renderLegacySyncRoot(<App />);
       });
       assertLog([
@@ -2729,7 +2729,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       expect(ReactNoop).toMatchRenderedOutput(null);
 
       // Suspend the inner Suspense subtree (only inner effects should be destroyed)
-      await act(async () => {
+      await act(() => {
         ReactNoop.renderLegacySyncRoot(
           <App children={<AsyncText text="Async" ms={1000} />} />,
         );
@@ -2762,7 +2762,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       ]);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Async" />);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.renderLegacySyncRoot(null);
       });
       assertLog([
@@ -2789,7 +2789,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
       assertLog([
@@ -2810,7 +2810,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       );
 
       // Suspend the inner Suspense subtree (only inner effects should be destroyed)
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <App children={<AsyncText text="Async" ms={1000} />} />,
         );
@@ -2864,7 +2864,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         </>,
       );
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
       assertLog([
@@ -2898,7 +2898,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
       assertLog([
@@ -2916,7 +2916,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       expect(ReactNoop).toMatchRenderedOutput(null);
 
       // Suspend the inner Suspense subtree (only inner effects should be destroyed)
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <App children={<AsyncText text="Async" ms={1000} />} />,
         );
@@ -2962,7 +2962,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       ]);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Async" />);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
       assertLog([
@@ -3002,7 +3002,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
       assertLog([
@@ -3020,7 +3020,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       expect(ReactNoop).toMatchRenderedOutput(null);
 
       // Suspend the inner Suspense subtree (only inner effects should be destroyed)
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <App children={<AsyncText text="Async" ms={1000} />} />,
         );
@@ -3066,7 +3066,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       ]);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Async" />);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
       assertLog([
@@ -3117,7 +3117,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       }
 
       // Mount
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
       assertLog([
@@ -3129,7 +3129,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       expect(ReactNoop).toMatchRenderedOutput(null);
 
       // Suspend the inner Suspense subtree (only inner effects should be destroyed)
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(
           <App children={<AsyncText text="Async" ms={1000} />} />,
         );
@@ -3161,7 +3161,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       ]);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Async" />);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
       assertLog([
@@ -3210,7 +3210,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
           );
         }
 
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App />
@@ -3239,7 +3239,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
         );
 
         // Schedule an update that causes React to suspend.
-        await act(async () => {
+        await act(() => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App>

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemanticsDOM-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemanticsDOM-test.js
@@ -129,12 +129,12 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
       return null;
     }
 
-    await act(async () => {
+    await act(() => {
       const root = ReactDOMClient.createRoot(container);
       root.render(<App />);
     });
 
-    await act(async () => {
+    await act(() => {
       scheduleSuspendingUpdate();
     });
   });
@@ -182,7 +182,7 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
     }
 
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<Parent swap={false} />);
     });
     assertLog(['Loading...']);
@@ -242,7 +242,7 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
     }
 
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<Parent swap={false} />);
     });
     assertLog(['Loading...']);
@@ -294,7 +294,7 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
     }
 
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<Parent swap={false} />);
     });
     assertLog(['Loading...']);
@@ -361,7 +361,7 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
     }
 
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<Parent swap={false} />);
     });
     assertLog(['Loading...']);
@@ -424,7 +424,7 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
     }
 
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<Parent swap={false} />);
     });
     assertLog(['Loading...']);

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
@@ -145,7 +145,7 @@ describe('ReactSuspenseFuzz', () => {
         if ((elapsedTime += 1000) > 1000000) {
           throw new Error('Something did not resolve properly.');
         }
-        await act(async () => {
+        await act(() => {
           ReactNoop.batchedUpdates(() => {
             jest.advanceTimersByTime(1000);
           });

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.js
@@ -298,7 +298,7 @@ describe('ReactSuspenseList', () => {
       </>,
     );
 
-    await act(async () => {
+    await act(() => {
       C.resolve();
     });
 
@@ -312,7 +312,7 @@ describe('ReactSuspenseList', () => {
       </>,
     );
 
-    await act(async () => {
+    await act(() => {
       B.resolve();
     });
 
@@ -2275,7 +2275,7 @@ describe('ReactSuspenseList', () => {
     );
 
     // Update the row adjacent to the list
-    await act(async () => updateAdjacent('C'));
+    await act(() => updateAdjacent('C'));
 
     assertLog(['C']);
 
@@ -2332,7 +2332,7 @@ describe('ReactSuspenseList', () => {
     const previousInst = setAsyncB;
 
     // During an update we suspend on B.
-    await act(async () => setAsyncB(true));
+    await act(() => setAsyncB(true));
 
     assertLog([
       'Suspend! [B]',
@@ -2350,7 +2350,7 @@ describe('ReactSuspenseList', () => {
 
     // Before we resolve we'll rerender the whole list.
     // This should leave the tree intact.
-    await act(async () => ReactNoop.render(<Foo updateList={true} />));
+    await act(() => ReactNoop.render(<Foo updateList={true} />));
 
     assertLog(['A', 'Suspend! [B]', 'Loading B']);
 
@@ -2421,7 +2421,7 @@ describe('ReactSuspenseList', () => {
     const previousInst = setAsyncB;
 
     // During an update we suspend on B.
-    await act(async () => setAsyncB(true));
+    await act(() => setAsyncB(true));
 
     assertLog([
       'Suspend! [B]',
@@ -2439,7 +2439,7 @@ describe('ReactSuspenseList', () => {
 
     // Before we resolve we'll rerender the whole list.
     // This should leave the tree intact.
-    await act(async () => ReactNoop.render(<Foo updateList={true} />));
+    await act(() => ReactNoop.render(<Foo updateList={true} />));
 
     assertLog(['A', 'Suspend! [B]', 'Loading B']);
 

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -665,7 +665,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Mount the Suspense boundary without suspending, so that the subsequent
     // updates suspend with a delay.
-    await act(async () => {
+    await act(() => {
       root.render(<App step={0} shouldSuspend={false} />);
     });
     await advanceTimers(1000);
@@ -1242,7 +1242,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       assertLog(['Suspend! [Result]', 'Loading...']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Loading..." />);
 
-      await act(async () => {
+      await act(() => {
         resolveText('Result');
       });
 
@@ -1312,7 +1312,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </>,
       );
 
-      await act(async () => {
+      await act(() => {
         resolveText('Step: 2');
       });
       assertLog(['Step: 2']);
@@ -1385,7 +1385,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </>,
       );
 
-      await act(async () => {
+      await act(() => {
         resolveText('B');
       });
 
@@ -1427,7 +1427,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       assertLog(['constructor', 'Suspend! [Hi]', 'Loading...']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Loading..." />);
 
-      await act(async () => {
+      await act(() => {
         resolveText('Hi');
       });
 
@@ -1470,7 +1470,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         'Loading...',
       ]);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Loading..." />);
-      await act(async () => {
+      await act(() => {
         resolveText('Hi');
       });
       assertLog(['Hi']);
@@ -1516,7 +1516,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           </>,
         ]);
 
-        await act(async () => {
+        await act(() => {
           resolveText('Hi');
         });
         assertLog(['Hi']);
@@ -1557,7 +1557,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           'Child is hidden: true',
         ]);
 
-        await act(async () => {
+        await act(() => {
           resolveText('Hi');
         });
 
@@ -1630,20 +1630,20 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       }
 
       const root = ReactNoop.createLegacyRoot(null);
-      await act(async () => {
+      await act(() => {
         root.render(<App />);
       });
       assertLog(['Mount']);
       expect(root).toMatchRenderedOutput('Child');
 
       // Suspend the child. This puts it into an inconsistent state.
-      await act(async () => {
+      await act(() => {
         setShouldSuspend(true);
       });
       expect(root).toMatchRenderedOutput('Loading...');
 
       // Unmount everything
-      await act(async () => {
+      await act(() => {
         root.render(null);
       });
       assertLog(['Unmount']);
@@ -1799,7 +1799,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       </>,
     );
 
-    await act(async () => {
+    await act(() => {
       resolveText('B');
     });
 
@@ -1835,7 +1835,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       'Effect [Loading...]',
     ]);
 
-    await act(async () => {
+    await act(() => {
       resolveText('B2');
     });
 
@@ -2081,12 +2081,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       );
     }
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(<App />);
     });
 
     // TODO: assert toErrorDev() when the warning is implemented again.
-    await act(async () => {
+    await act(() => {
       ReactNoop.flushSync(() => _setShow(true));
     });
   });
@@ -2108,12 +2108,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       }
     }
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(<App />);
     });
 
     // TODO: assert toErrorDev() when the warning is implemented again.
-    await act(async () => {
+    await act(() => {
       ReactNoop.flushSync(() => show());
     });
   });
@@ -2135,14 +2135,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       }
     }
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(<App />);
     });
 
     assertLog(['Suspend! [A]']);
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.flushSync(() => showB());
     });
 
@@ -2168,12 +2168,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           </Suspense>
         );
       }
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
 
       // TODO: assert toErrorDev() when the warning is implemented again.
-      await act(async () => {
+      await act(() => {
         ReactNoop.flushSync(() => _setShow(true));
       });
     },
@@ -2195,12 +2195,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       }
     }
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(<App />);
     });
 
     // also make sure lowpriority is okay
-    await act(async () => show(true));
+    await act(() => show(true));
 
     assertLog(['Suspend! [A]']);
     await resolveText('A');
@@ -2221,12 +2221,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       );
     }
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(<App />);
     });
 
     // also make sure lowpriority is okay
-    await act(async () => _setShow(true));
+    await act(() => _setShow(true));
 
     assertLog(['Suspend! [A]']);
     await resolveText('A');
@@ -2993,7 +2993,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App text="Initial" />);
     });
     assertLog(['Suspend! [Initial]']);
@@ -3054,7 +3054,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
 
@@ -3211,7 +3211,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       }
 
       await seedNextTextCache('A');
-      await act(async () => {
+      await act(() => {
         root.render(<Parent />);
       });
       assertLog(['A']);
@@ -3265,7 +3265,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       }
 
       await seedNextTextCache('A');
-      await act(async () => {
+      await act(() => {
         root.render(<Parent />);
       });
       assertLog(['A']);
@@ -3334,7 +3334,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Resolve the initial tree
       await seedNextTextCache('A');
-      await act(async () => {
+      await act(() => {
         root.render(<App />);
       });
       assertLog(['A']);
@@ -3356,7 +3356,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       // Schedule a default pri update on the boundary, and a lower pri update
       // on the fallback. We're testing to make sure the fallback can still
       // update even though the primary tree is suspended.
-      await act(async () => {
+      await act(() => {
         setAppText('C');
         React.startTransition(() => {
           setFallbackText('Still loading...');
@@ -3419,7 +3419,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Mount an initial tree. Resolve A so that it doesn't suspend.
       await seedNextTextCache('A');
-      await act(async () => {
+      await act(() => {
         root.render(<Parent />);
       });
       assertLog(['A']);
@@ -3428,7 +3428,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Schedule another update. This will "flip" the alternate pairs.
       await resolveText('B');
-      await act(async () => {
+      await act(() => {
         setText('B');
       });
       assertLog(['B']);
@@ -3436,7 +3436,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       expect(root).toMatchRenderedOutput(<span prop="B" />);
 
       // Schedule another update. This time, we'll suspend.
-      await act(async () => {
+      await act(() => {
         setText('C');
       });
       assertLog(['Suspend! [C]', 'Loading...']);
@@ -3458,7 +3458,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Update again. This should unsuspend the tree.
       await resolveText('D');
-      await act(async () => {
+      await act(() => {
         setText('D');
       });
       // Even though the fragment fiber is not part of the return path, we should
@@ -3496,7 +3496,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Mount an initial tree. Resolve A so that it doesn't suspend.
       await seedNextTextCache('A');
-      await act(async () => {
+      await act(() => {
         root.render(<Parent />);
       });
       assertLog(['A']);
@@ -3505,7 +3505,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Schedule another update. This will "flip" the alternate pairs.
       await resolveText('B');
-      await act(async () => {
+      await act(() => {
         setText('B');
       });
       assertLog(['B']);
@@ -3513,7 +3513,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       expect(root).toMatchRenderedOutput(<span prop="B" />);
 
       // Schedule another update. This time, we'll suspend.
-      await act(async () => {
+      await act(() => {
         setText('C');
       });
       assertLog(['Suspend! [C]', 'Loading...']);
@@ -3603,7 +3603,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Mount an initial tree. Resolve A so that it doesn't suspend.
       await seedNextTextCache('Inner text: A');
-      await act(async () => {
+      await act(() => {
         root.render(<Parent step={0} />);
       });
       assertLog([
@@ -3623,7 +3623,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       );
 
       // Update. This causes the inner component to suspend.
-      await act(async () => {
+      await act(() => {
         setText('B');
       });
       assertLog([
@@ -3646,7 +3646,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       );
 
       // Schedule a high pri update on the parent.
-      await act(async () => {
+      await act(() => {
         ReactNoop.discreteUpdates(() => {
           root.render(<Parent step={1} />);
         });
@@ -3736,7 +3736,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Mount an initial tree. Resolve A so that it doesn't suspend.
     await seedNextTextCache('Inner: A0');
-    await act(async () => {
+    await act(() => {
       root.render(<Parent step={0} />);
     });
     assertLog(['Outer: A0', 'Inner: A0', 'Commit Child']);
@@ -3748,7 +3748,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     );
 
     // Update. This causes the inner component to suspend.
-    await act(async () => {
+    await act(() => {
       setText('B');
     });
     assertLog(['Outer: B0', 'Suspend! [Inner: B0]', 'Loading...']);
@@ -3764,7 +3764,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Schedule a high pri update on the parent. This will unblock the content.
     await resolveText('Inner: B1');
-    await act(async () => {
+    await act(() => {
       ReactNoop.discreteUpdates(() => {
         root.render(<Parent step={1} />);
       });
@@ -3825,7 +3825,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<Root />);
     });
     assertLog(['']);
@@ -3944,7 +3944,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <UpdatingText />
@@ -4012,13 +4012,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     const root = ReactNoop.createRoot();
 
-    await act(async () => {
+    await act(() => {
       root.render(<App show={false} />);
     });
     assertLog(['Mount Child']);
     expect(root).toMatchRenderedOutput(<span prop="Child" />);
 
-    await act(async () => {
+    await act(() => {
       root.render(<App show={true} />);
     });
     assertLog(['Suspend! [Async]', 'Loading...']);
@@ -4029,7 +4029,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       </>,
     );
 
-    await act(async () => {
+    await act(() => {
       root.render(null);
     });
     assertLog(['Unmount Child']);
@@ -4060,13 +4060,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     const root = ReactNoop.createLegacyRoot();
 
-    await act(async () => {
+    await act(() => {
       root.render(<App show={false} />);
     });
     assertLog(['Mount Child']);
     expect(root).toMatchRenderedOutput(<span prop="Child" />);
 
-    await act(async () => {
+    await act(() => {
       root.render(<App show={true} />);
     });
     assertLog(['Suspend! [Async]', 'Loading...']);
@@ -4077,7 +4077,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       </>,
     );
 
-    await act(async () => {
+    await act(() => {
       root.render(null);
     });
     assertLog(['Unmount Child']);
@@ -4127,7 +4127,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       // Initial render. This mounts a Suspense boundary, so that in the next
       // update we can trigger a "suspend with delay" scenario.
       const root = ReactNoop.createRoot();
-      await act(async () => {
+      await act(() => {
         root.render(<App showMore={false} />);
       });
       assertLog([]);
@@ -4146,7 +4146,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       //
       // The fix was to check if we're in the render phase before calling
       // `prepareFreshStack`.
-      await act(async () => {
+      await act(() => {
         root.render(<App showMore={true} />);
       });
       assertLog(['Suspend! [Async]', 'Loading...', 'Hi']);

--- a/packages/react-reconciler/src/__tests__/ReactThenable-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactThenable-test.js
@@ -98,7 +98,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<App />);
       });
@@ -133,7 +133,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<App />);
       });
@@ -175,7 +175,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['Suspend!', 'Loading...']);
@@ -202,7 +202,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<App />);
       });
@@ -230,7 +230,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<App />);
       });
@@ -276,7 +276,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<App />);
       });
@@ -309,7 +309,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<App />);
       });
@@ -345,7 +345,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<App />);
       });
@@ -398,7 +398,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<App />);
       });
@@ -523,7 +523,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<App />);
       });
@@ -546,7 +546,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback={<Text text="Loading..." />}>
           <Text text="(empty)" />
@@ -556,7 +556,7 @@ describe('ReactThenable', () => {
     assertLog(['(empty)']);
     expect(root).toMatchRenderedOutput('(empty)');
 
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <Suspense fallback={<Text text="Loading..." />}>
@@ -568,7 +568,7 @@ describe('ReactThenable', () => {
     assertLog(['Async text requested [Async]']);
     expect(root).toMatchRenderedOutput('(empty)');
 
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('Async');
     });
     assertLog(['Async text requested [Async]', 'Async']);
@@ -582,7 +582,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <Suspense fallback={<Text text="Loading..." />}>
@@ -596,7 +596,7 @@ describe('ReactThenable', () => {
     expect(root).toMatchRenderedOutput('Loading...');
 
     // Resolve the original data
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('Async');
     });
     // During the retry, a fresh request is initiated. Now we must wait for this
@@ -610,7 +610,7 @@ describe('ReactThenable', () => {
     expect(root).toMatchRenderedOutput('Loading...');
 
     // Flush the second request.
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('Async');
     });
     // This time it finishes because it was during a retry.
@@ -625,11 +625,11 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<Suspense fallback={<Text text="Loading..." />} />);
     });
 
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <Suspense fallback={<Text text="Loading..." />}>
@@ -640,7 +640,7 @@ describe('ReactThenable', () => {
     });
     assertLog(['Async text requested [Will never resolve]']);
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback={<Text text="Loading..." />}>
           <Text text="Something different" />
@@ -659,12 +659,12 @@ describe('ReactThenable', () => {
     }
 
     const root1 = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root1.render(<Suspense fallback={<Text text="Loading..." />} />);
     });
 
     // Start a transition on one root. It will suspend.
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root1.render(
           <Suspense fallback={<Text text="Loading..." />}>
@@ -678,7 +678,7 @@ describe('ReactThenable', () => {
     // While we're waiting for the first root's data to resolve, a second
     // root renders.
     const root2 = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root2.render('Do re mi');
     });
     expect(root2).toMatchRenderedOutput('Do re mi');
@@ -698,11 +698,11 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<Suspense fallback={<Text text="Loading..." />} />);
     });
 
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(
           <Suspense fallback={<Text text="Loading..." />}>
@@ -782,7 +782,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<Parent />);
     });
     assertLog(['childShouldSuspend: false, showChild: true', 'Child']);
@@ -856,7 +856,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<ExcitingText text="Hello" />);
       });
@@ -866,7 +866,7 @@ describe('ReactThenable', () => {
     expect(root).toMatchRenderedOutput(null);
 
     // The data is received.
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('HELLO!');
     });
     assertLog([
@@ -894,42 +894,42 @@ describe('ReactThenable', () => {
 
     // Initial render.
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<Kitchen />);
       });
     });
     assertLog(['Async text requested [apple]']);
     expect(root).toMatchRenderedOutput(null);
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('apple');
     });
     assertLog(['Async text requested [apple]', 'apple carrot']);
     expect(root).toMatchRenderedOutput('apple carrot');
 
     // Update the state variable after the use().
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         _setVegetable('dill');
       });
     });
     assertLog(['Async text requested [apple]']);
     expect(root).toMatchRenderedOutput('apple carrot');
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('apple');
     });
     assertLog(['Async text requested [apple]', 'apple dill']);
     expect(root).toMatchRenderedOutput('apple dill');
 
     // Update the state variable before the use(). The second state is maintained.
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         _setFruit('banana');
       });
     });
     assertLog(['Async text requested [banana]']);
     expect(root).toMatchRenderedOutput('apple dill');
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('banana');
     });
     assertLog(['Async text requested [banana]', 'banana dill']);
@@ -949,28 +949,28 @@ describe('ReactThenable', () => {
 
     // Initial render.
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<Lexicon />);
       });
     });
     assertLog(['Async text requested [aguacate]']);
     expect(root).toMatchRenderedOutput(null);
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('aguacate');
     });
     assertLog(['Async text requested [aguacate]', 'aguacate abogado']);
     expect(root).toMatchRenderedOutput('aguacate abogado');
 
     // Now update the state.
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         _setLawyer('avocat');
       });
     });
     assertLog(['Async text requested [aguacate]']);
     expect(root).toMatchRenderedOutput('aguacate abogado');
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('aguacate');
     });
     assertLog(['Async text requested [aguacate]', 'aguacate avocat']);
@@ -989,7 +989,7 @@ describe('ReactThenable', () => {
       }
 
       const root = ReactNoop.createRoot();
-      await act(async () => {
+      await act(() => {
         startTransition(() => {
           root.render(<App text="Hello" />);
         });
@@ -997,7 +997,7 @@ describe('ReactThenable', () => {
       assertLog(['Async text requested [Hello]']);
       expect(root).toMatchRenderedOutput(null);
 
-      await act(async () => {
+      await act(() => {
         resolveTextRequests('Hello');
       });
       assertLog([
@@ -1019,7 +1019,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback={<Text text="(Loading A...)" />}>
           <AsyncText text="A" />
@@ -1042,19 +1042,19 @@ describe('ReactThenable', () => {
     ]);
     expect(root).toMatchRenderedOutput('(Loading A...)');
 
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('A');
     });
     assertLog(['A', '(Loading C...)', '(Loading B...)']);
     expect(root).toMatchRenderedOutput('A(Loading B...)');
 
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('B');
     });
     assertLog(['B', '(Loading C...)']);
     expect(root).toMatchRenderedOutput('AB(Loading C...)');
 
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('C');
     });
     assertLog(['C']);
@@ -1072,7 +1072,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback={<Text text="(Loading A...)" />}>
           <AsyncText text="A" />
@@ -1095,13 +1095,13 @@ describe('ReactThenable', () => {
     ]);
     expect(root).toMatchRenderedOutput('(Loading A...)');
 
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('A');
     });
     assertLog(['Async text requested [A]']);
     expect(root).toMatchRenderedOutput('(Loading A...)');
 
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('A');
     });
     assertLog([
@@ -1120,13 +1120,13 @@ describe('ReactThenable', () => {
     ]);
     expect(root).toMatchRenderedOutput('A(Loading B...)');
 
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('B');
     });
     assertLog(['Async text requested [B]']);
     expect(root).toMatchRenderedOutput('A(Loading B...)');
 
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('B');
     });
     assertLog([
@@ -1140,13 +1140,13 @@ describe('ReactThenable', () => {
     ]);
     expect(root).toMatchRenderedOutput('AB(Loading C...)');
 
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('C');
     });
     assertLog(['Async text requested [C]']);
     expect(root).toMatchRenderedOutput('AB(Loading C...)');
 
-    await act(async () => {
+    await act(() => {
       resolveTextRequests('C');
     });
     assertLog(['Async text requested [C]', 'C']);
@@ -1174,7 +1174,7 @@ describe('ReactThenable', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       startTransition(() => {
         root.render(<App />);
       });

--- a/packages/react-reconciler/src/__tests__/ReactTransition-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransition-test.js
@@ -185,7 +185,7 @@ describe('ReactTransition', () => {
 
     const root = ReactNoop.createRoot();
 
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['(empty)']);
@@ -245,7 +245,7 @@ describe('ReactTransition', () => {
 
       // Initial render
       const root = ReactNoop.createRoot();
-      await act(async () => {
+      await act(() => {
         seedNextTextCache('A content');
         root.render(<App />);
       });
@@ -257,7 +257,7 @@ describe('ReactTransition', () => {
       );
 
       // Switch to B
-      await act(async () => {
+      await act(() => {
         update('B');
       });
       assertLog([
@@ -278,7 +278,7 @@ describe('ReactTransition', () => {
       );
 
       // Before B finishes loading, switch to C
-      await act(async () => {
+      await act(() => {
         update('C');
       });
       assertLog([
@@ -299,7 +299,7 @@ describe('ReactTransition', () => {
 
       // Finish loading B. But we're not allowed to render B because it's
       // entangled with C. So we're still pending.
-      await act(async () => {
+      await act(() => {
         resolveText('B content');
       });
       assertLog([
@@ -315,7 +315,7 @@ describe('ReactTransition', () => {
       );
 
       // Now finish loading C. This is the terminal update, so it can finish.
-      await act(async () => {
+      await act(() => {
         resolveText('C content');
       });
       assertLog(['C label', 'C content']);
@@ -370,7 +370,7 @@ describe('ReactTransition', () => {
 
       // Initial render
       const root = ReactNoop.createRoot();
-      await act(async () => {
+      await act(() => {
         seedNextTextCache('A content');
         root.render(<App />);
       });
@@ -382,7 +382,7 @@ describe('ReactTransition', () => {
       );
 
       // Switch to B
-      await act(async () => {
+      await act(() => {
         update('B');
       });
       assertLog([
@@ -403,7 +403,7 @@ describe('ReactTransition', () => {
       );
 
       // Before B finishes loading, switch to C
-      await act(async () => {
+      await act(() => {
         update('C');
       });
       assertLog([
@@ -424,7 +424,7 @@ describe('ReactTransition', () => {
 
       // Finish loading B. But we're not allowed to render B because it's
       // entangled with C. So we're still pending.
-      await act(async () => {
+      await act(() => {
         resolveText('B content');
       });
       assertLog([
@@ -440,7 +440,7 @@ describe('ReactTransition', () => {
       );
 
       // Now finish loading C. This is the terminal update, so it can finish.
-      await act(async () => {
+      await act(() => {
         resolveText('C content');
       });
       assertLog(['C label', 'C content']);
@@ -488,14 +488,14 @@ describe('ReactTransition', () => {
 
       // Initial render. Start with all children hidden.
       const root = ReactNoop.createRoot();
-      await act(async () => {
+      await act(() => {
         root.render(<App />);
       });
       assertLog([]);
       expect(root).toMatchRenderedOutput(null);
 
       // Switch to A.
-      await act(async () => {
+      await act(() => {
         startTransition(() => {
           setShowA(true);
         });
@@ -504,7 +504,7 @@ describe('ReactTransition', () => {
       expect(root).toMatchRenderedOutput(null);
 
       // Before A loads, switch to B. This should entangle A with B.
-      await act(async () => {
+      await act(() => {
         startTransition(() => {
           setShowA(false);
           setShowB(true);
@@ -515,7 +515,7 @@ describe('ReactTransition', () => {
 
       // Before A or B loads, switch to C. This should entangle C with B, and
       // transitively entangle C with A.
-      await act(async () => {
+      await act(() => {
         startTransition(() => {
           setShowB(false);
           setShowC(true);
@@ -528,7 +528,7 @@ describe('ReactTransition', () => {
 
       // First resolve B. This will attempt to render C, since everything is
       // entangled.
-      await act(async () => {
+      await act(() => {
         startTransition(() => {
           resolveText('B');
         });
@@ -538,7 +538,7 @@ describe('ReactTransition', () => {
 
       // Now resolve A. Again, this will attempt to render C, since everything
       // is entangled.
-      await act(async () => {
+      await act(() => {
         startTransition(() => {
           resolveText('A');
         });
@@ -547,7 +547,7 @@ describe('ReactTransition', () => {
       expect(root).toMatchRenderedOutput(null);
 
       // Finally, resolve C. This time we can finish.
-      await act(async () => {
+      await act(() => {
         startTransition(() => {
           resolveText('C');
         });
@@ -561,7 +561,7 @@ describe('ReactTransition', () => {
   test('interrupt a refresh transition if a new transition is scheduled', async () => {
     const root = ReactNoop.createRoot();
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <>
           <Suspense fallback={<Text text="Loading..." />} />
@@ -729,7 +729,7 @@ describe('ReactTransition', () => {
 
       const root = ReactNoop.createRoot();
 
-      await act(async () => {
+      await act(() => {
         root.render(<App shouldSuspend={false} step={0} />);
       });
       assertLog(['A0', 'B0', 'C0']);
@@ -793,7 +793,7 @@ describe('ReactTransition', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
 
@@ -801,7 +801,7 @@ describe('ReactTransition', () => {
     assertLog(['Transition pri: 0', 'Normal pri: 0', 'Commit']);
     expect(root).toMatchRenderedOutput('Transition pri: 0, Normal pri: 0');
 
-    await act(async () => {
+    await act(() => {
       updateTransitionPri();
       updateNormalPri();
     });
@@ -845,7 +845,7 @@ describe('ReactTransition', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
 
@@ -853,7 +853,7 @@ describe('ReactTransition', () => {
     assertLog(['(empty)', 'Normal pri: 0', 'Commit']);
     expect(root).toMatchRenderedOutput('(empty), Normal pri: 0');
 
-    await act(async () => {
+    await act(() => {
       updateTransitionPri();
     });
 
@@ -907,7 +907,7 @@ describe('ReactTransition', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['Transition pri: 0', 'Normal pri: 0', 'Commit']);

--- a/packages/react-reconciler/src/__tests__/ReactTransitionTracing-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransitionTracing-test.js
@@ -2208,7 +2208,7 @@ describe('ReactInteractionTracing', () => {
     const root = ReactNoop.createRoot({
       unstable_transitionCallbacks: transitionCallbacks,
     });
-    await act(async () => {
+    await act(() => {
       startTransition(() => root.render(<App />), {name: 'transition'});
       ReactNoop.expire(1000);
       advanceTimers(1000);
@@ -2221,7 +2221,7 @@ describe('ReactInteractionTracing', () => {
       'onTransitionStart(transition, 0)',
     ]);
 
-    await act(async () => {
+    await act(() => {
       resolveText('Text');
       ReactNoop.expire(1000);
       advanceTimers(1000);
@@ -2232,7 +2232,7 @@ describe('ReactInteractionTracing', () => {
       'onTransitionComplete(transition, 0, 2000)',
     ]);
 
-    await act(async () => {
+    await act(() => {
       resolveText('Hidden Text');
       ReactNoop.expire(1000);
       advanceTimers(1000);
@@ -2343,7 +2343,7 @@ describe('ReactInteractionTracing', () => {
       unstable_transitionCallbacks: transitionCallbacks,
     });
 
-    await act(async () => {
+    await act(() => {
       startTransition(() => root.render(<App />), {name: 'transition'});
       ReactNoop.expire(1000);
       advanceTimers(1000);
@@ -2361,7 +2361,7 @@ describe('ReactInteractionTracing', () => {
       'onTransitionProgress(transition, 0, 1000, [two])',
     ]);
 
-    await act(async () => {
+    await act(() => {
       resolveText('Text Two');
       ReactNoop.expire(1000);
       advanceTimers(1000);
@@ -2416,7 +2416,7 @@ describe('ReactInteractionTracing', () => {
       unstable_transitionCallbacks: getTransitionCallbacks('root two'),
     });
 
-    await act(async () => {
+    await act(() => {
       startTransition(() => rootOne.render(<App name="one" />), {
         name: 'transition one',
       });
@@ -2438,7 +2438,7 @@ describe('ReactInteractionTracing', () => {
       'onTransitionProgress(transition two, 0, 1000, [two]) /root two/',
     ]);
 
-    await act(async () => {
+    await act(() => {
       caches[0].resolve('Text one');
       ReactNoop.expire(1000);
       advanceTimers(1000);
@@ -2450,7 +2450,7 @@ describe('ReactInteractionTracing', () => {
       'onTransitionComplete(transition one, 0, 2000) /root one/',
     ]);
 
-    await act(async () => {
+    await act(() => {
       resolveText('Text two');
       ReactNoop.expire(1000);
       advanceTimers(1000);

--- a/packages/react-reconciler/src/__tests__/ReactUpdatePriority-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUpdatePriority-test.js
@@ -46,7 +46,7 @@ describe('ReactUpdatePriority', () => {
       return <Text text={state} />;
     }
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.flushSync(() => {
         root.render(<App />);
       });
@@ -116,7 +116,7 @@ describe('ReactUpdatePriority', () => {
       );
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['A1', 'B1', 'C1']);

--- a/packages/react-reconciler/src/__tests__/ReactUpdaters-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactUpdaters-test.internal.js
@@ -108,12 +108,12 @@ describe('updaters', () => {
     const Child = () => null;
     const container = document.createElement('div');
 
-    await act(async () => {
+    await act(() => {
       ReactDOM.render(<Parent />, container);
     });
     expect(allSchedulerTags).toEqual([[HostRoot]]);
 
-    await act(async () => {
+    await act(() => {
       ReactDOM.render(<Parent />, container);
     });
     expect(allSchedulerTags).toEqual([[HostRoot], [HostRoot]]);
@@ -141,19 +141,19 @@ describe('updaters', () => {
     };
     const Child = () => null;
 
-    await act(async () => {
+    await act(() => {
       ReactDOM.render(<Parent />, document.createElement('div'));
     });
     expect(scheduleForA).not.toBeNull();
     expect(scheduleForB).not.toBeNull();
     expect(allSchedulerTypes).toEqual([[null]]);
 
-    await act(async () => {
+    await act(() => {
       scheduleForA();
     });
     expect(allSchedulerTypes).toEqual([[null], [SchedulingComponentA]]);
 
-    await act(async () => {
+    await act(() => {
       scheduleForB();
     });
     expect(allSchedulerTypes).toEqual([
@@ -174,13 +174,13 @@ describe('updaters', () => {
     }
     const Child = () => null;
     let instance;
-    await act(async () => {
+    await act(() => {
       ReactDOM.render(<Parent />, document.createElement('div'));
     });
     expect(allSchedulerTypes).toEqual([[null]]);
 
     expect(instance).not.toBeNull();
-    await act(async () => {
+    await act(() => {
       instance.setState({});
     });
     expect(allSchedulerTypes).toEqual([[null], [SchedulingComponent]]);
@@ -294,21 +294,21 @@ describe('updaters', () => {
       }
     };
 
-    await act(async () => {
+    await act(() => {
       ReactDOM.render(<Parent />, document.createElement('div'));
       assertLog(['onCommitRoot']);
     });
     expect(setShouldSuspend).not.toBeNull();
     expect(allSchedulerTypes).toEqual([[null]]);
 
-    await act(async () => {
+    await act(() => {
       setShouldSuspend(true);
     });
     assertLog(['onCommitRoot']);
     expect(allSchedulerTypes).toEqual([[null], [Suspender]]);
 
     expect(resolver).not.toBeNull();
-    await act(async () => {
+    await act(() => {
       resolver('abc');
       return promise;
     });
@@ -356,7 +356,7 @@ describe('updaters', () => {
     };
 
     const root = ReactDOMClient.createRoot(document.createElement('div'));
-    await act(async () => {
+    await act(() => {
       root.render(<Parent shouldError={false} />);
     });
     assertLog(['initial', 'onCommitRoot']);
@@ -365,7 +365,7 @@ describe('updaters', () => {
     allSchedulerTypes.splice(0);
     onCommitRootShouldYield = true;
 
-    await act(async () => {
+    await act(() => {
       triggerError();
     });
     assertLog(['onCommitRoot', 'error', 'onCommitRoot']);

--- a/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
+++ b/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
@@ -51,7 +51,7 @@ describe('StrictEffectsMode', () => {
       return text;
     }
 
-    await act(async () => {
+    await act(() => {
       ReactTestRenderer.create(<App text={'mount'} />);
     });
 
@@ -74,7 +74,7 @@ describe('StrictEffectsMode', () => {
     }
 
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(<App text={'mount'} />, {
         unstable_isConcurrent: true,
       });
@@ -93,7 +93,7 @@ describe('StrictEffectsMode', () => {
       assertLog(['useLayoutEffect mount', 'useEffect mount']);
     }
 
-    await act(async () => {
+    await act(() => {
       renderer.update(<App text={'update'} />);
     });
 
@@ -104,7 +104,7 @@ describe('StrictEffectsMode', () => {
       'useEffect mount',
     ]);
 
-    await act(async () => {
+    await act(() => {
       renderer.unmount();
     });
 
@@ -127,7 +127,7 @@ describe('StrictEffectsMode', () => {
     }
 
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(<App text={'mount'} />, {
         unstable_isConcurrent: true,
       });
@@ -146,7 +146,7 @@ describe('StrictEffectsMode', () => {
       assertLog(['useEffect One mount', 'useEffect Two mount']);
     }
 
-    await act(async () => {
+    await act(() => {
       renderer.update(<App text={'update'} />);
     });
 
@@ -157,7 +157,7 @@ describe('StrictEffectsMode', () => {
       'useEffect Two mount',
     ]);
 
-    await act(async () => {
+    await act(() => {
       renderer.unmount(null);
     });
 
@@ -180,7 +180,7 @@ describe('StrictEffectsMode', () => {
     }
 
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(<App text={'mount'} />, {
         unstable_isConcurrent: true,
       });
@@ -199,7 +199,7 @@ describe('StrictEffectsMode', () => {
       assertLog(['useLayoutEffect One mount', 'useLayoutEffect Two mount']);
     }
 
-    await act(async () => {
+    await act(() => {
       renderer.update(<App text={'update'} />);
     });
 
@@ -210,7 +210,7 @@ describe('StrictEffectsMode', () => {
       'useLayoutEffect Two mount',
     ]);
 
-    await act(async () => {
+    await act(() => {
       renderer.unmount();
     });
 
@@ -231,7 +231,7 @@ describe('StrictEffectsMode', () => {
     }
 
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(<App text={'mount'} />, {
         unstable_isConcurrent: true,
       });
@@ -248,13 +248,13 @@ describe('StrictEffectsMode', () => {
       assertLog(['useLayoutEffect mount', 'useEffect mount']);
     }
 
-    await act(async () => {
+    await act(() => {
       renderer.update(<App text={'update'} />);
     });
 
     assertLog(['useLayoutEffect mount', 'useEffect mount']);
 
-    await act(async () => {
+    await act(() => {
       renderer.unmount();
     });
 
@@ -285,7 +285,7 @@ describe('StrictEffectsMode', () => {
       }
     }
 
-    await act(async () => {
+    await act(() => {
       ReactTestRenderer.create(<App />, {unstable_isConcurrent: true});
     });
 
@@ -320,7 +320,7 @@ describe('StrictEffectsMode', () => {
     }
 
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(<App text={'mount'} />, {
         unstable_isConcurrent: true,
       });
@@ -336,13 +336,13 @@ describe('StrictEffectsMode', () => {
       assertLog(['componentDidMount']);
     }
 
-    await act(async () => {
+    await act(() => {
       renderer.update(<App text={'update'} />);
     });
 
     assertLog(['componentDidUpdate']);
 
-    await act(async () => {
+    await act(() => {
       renderer.unmount();
     });
 
@@ -368,7 +368,7 @@ describe('StrictEffectsMode', () => {
       }
     }
 
-    await act(async () => {
+    await act(() => {
       ReactTestRenderer.create(<App text={'mount'} />);
     });
 
@@ -395,7 +395,7 @@ describe('StrictEffectsMode', () => {
       return text;
     }
 
-    await act(async () => {
+    await act(() => {
       ReactTestRenderer.create(<App text={'mount'} />, {
         unstable_isConcurrent: true,
       });
@@ -460,7 +460,7 @@ describe('StrictEffectsMode', () => {
       return showChild && <Child />;
     }
 
-    await act(async () => {
+    await act(() => {
       ReactTestRenderer.create(<App />, {unstable_isConcurrent: true});
     });
 
@@ -477,7 +477,7 @@ describe('StrictEffectsMode', () => {
       assertLog(['App useLayoutEffect mount', 'App useEffect mount']);
     }
 
-    await act(async () => {
+    await act(() => {
       _setShowChild(true);
     });
 
@@ -543,7 +543,7 @@ describe('StrictEffectsMode', () => {
     }
 
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(<App text={'mount'} />, {
         unstable_isConcurrent: true,
       });
@@ -569,7 +569,7 @@ describe('StrictEffectsMode', () => {
       ]);
     }
 
-    await act(async () => {
+    await act(() => {
       renderer.update(<App text={'mount'} />);
     });
 
@@ -580,7 +580,7 @@ describe('StrictEffectsMode', () => {
       'useEffect mount',
     ]);
 
-    await act(async () => {
+    await act(() => {
       renderer.unmount();
     });
 

--- a/packages/react-reconciler/src/__tests__/StrictEffectsModeDefaults-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/StrictEffectsModeDefaults-test.internal.js
@@ -52,7 +52,7 @@ describe('StrictEffectsMode defaults', () => {
       return text;
     }
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.renderLegacySyncRoot(<App text={'mount'} />);
     });
 
@@ -78,7 +78,7 @@ describe('StrictEffectsMode defaults', () => {
       }
     }
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.renderLegacySyncRoot(<App text={'mount'} />);
     });
 
@@ -208,7 +208,7 @@ describe('StrictEffectsMode defaults', () => {
 
         return text;
       }
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App text={'mount'} />);
       });
 
@@ -221,7 +221,7 @@ describe('StrictEffectsMode defaults', () => {
         'useEffect mount',
       ]);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App text={'update'} />);
       });
 
@@ -232,7 +232,7 @@ describe('StrictEffectsMode defaults', () => {
         'useEffect mount',
       ]);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
 
@@ -254,7 +254,7 @@ describe('StrictEffectsMode defaults', () => {
         return text;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App text={'mount'} />);
       });
 
@@ -267,7 +267,7 @@ describe('StrictEffectsMode defaults', () => {
         'useEffect Two mount',
       ]);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App text={'update'} />);
       });
 
@@ -278,7 +278,7 @@ describe('StrictEffectsMode defaults', () => {
         'useEffect Two mount',
       ]);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
 
@@ -300,7 +300,7 @@ describe('StrictEffectsMode defaults', () => {
         return text;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App text={'mount'} />);
       });
 
@@ -313,7 +313,7 @@ describe('StrictEffectsMode defaults', () => {
         'useLayoutEffect Two mount',
       ]);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App text={'update'} />);
       });
 
@@ -324,7 +324,7 @@ describe('StrictEffectsMode defaults', () => {
         'useLayoutEffect Two mount',
       ]);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
 
@@ -344,7 +344,7 @@ describe('StrictEffectsMode defaults', () => {
         return text;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App text={'mount'} />);
       });
 
@@ -355,13 +355,13 @@ describe('StrictEffectsMode defaults', () => {
         'useEffect mount',
       ]);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App text={'update'} />);
       });
 
       assertLog(['useLayoutEffect mount', 'useEffect mount']);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
 
@@ -382,7 +382,7 @@ describe('StrictEffectsMode defaults', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App text={'mount'} />);
       });
 
@@ -416,7 +416,7 @@ describe('StrictEffectsMode defaults', () => {
         }
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
 
@@ -446,7 +446,7 @@ describe('StrictEffectsMode defaults', () => {
         }
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App text={'mount'} />);
       });
 
@@ -456,13 +456,13 @@ describe('StrictEffectsMode defaults', () => {
         'componentDidMount',
       ]);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App text={'update'} />);
       });
 
       assertLog(['componentDidUpdate']);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
 
@@ -489,7 +489,7 @@ describe('StrictEffectsMode defaults', () => {
         return text;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App text={'mount'} />);
       });
 
@@ -539,7 +539,7 @@ describe('StrictEffectsMode defaults', () => {
         return showChild && <Child />;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App />);
       });
 
@@ -552,7 +552,7 @@ describe('StrictEffectsMode defaults', () => {
         'App useEffect mount',
       ]);
 
-      await act(async () => {
+      await act(() => {
         _setShowChild(true);
       });
 
@@ -606,7 +606,7 @@ describe('StrictEffectsMode defaults', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App text={'mount'} />);
       });
 
@@ -622,7 +622,7 @@ describe('StrictEffectsMode defaults', () => {
         'useEffect mount',
       ]);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<App text={'mount'} />);
       });
 
@@ -633,7 +633,7 @@ describe('StrictEffectsMode defaults', () => {
         'useEffect mount',
       ]);
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(null);
       });
 

--- a/packages/react-reconciler/src/__tests__/useEffectEvent-test.js
+++ b/packages/react-reconciler/src/__tests__/useEffectEvent-test.js
@@ -88,7 +88,7 @@ describe('useEffectEvent', () => {
       </>,
     );
 
-    await act(async () => button.current.increment());
+    await act(() => button.current.increment());
     assertLog(['Increment', 'Count: 1']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -97,7 +97,7 @@ describe('useEffectEvent', () => {
       </>,
     );
 
-    await act(async () => button.current.increment());
+    await act(() => button.current.increment());
     assertLog([
       'Increment',
       // Event should use the updated callback function closed over the new value.
@@ -121,7 +121,7 @@ describe('useEffectEvent', () => {
     );
 
     // Event uses the new prop
-    await act(async () => button.current.increment());
+    await act(() => button.current.increment());
     assertLog(['Increment', 'Count: 12']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -174,7 +174,7 @@ describe('useEffectEvent', () => {
       </>,
     );
 
-    await act(async () => button.current.increment());
+    await act(() => button.current.increment());
     assertLog(['Increment', 'Count: 5']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -183,7 +183,7 @@ describe('useEffectEvent', () => {
       </>,
     );
 
-    await act(async () => button.current.multiply());
+    await act(() => button.current.multiply());
     assertLog(['Increment', 'Count: 25']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -233,7 +233,7 @@ describe('useEffectEvent', () => {
       </>,
     );
 
-    await act(async () => button.current.greet());
+    await act(() => button.current.greet());
     assertLog(['Say hej', 'Greeting: undefined says hej']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -327,7 +327,7 @@ describe('useEffectEvent', () => {
       </>,
     );
 
-    await act(async () => button.current.increment());
+    await act(() => button.current.increment());
     assertLog([
       'Increment',
       // Effect should not re-run because the dependency hasn't changed.
@@ -340,7 +340,7 @@ describe('useEffectEvent', () => {
       </>,
     );
 
-    await act(async () => button.current.increment());
+    await act(() => button.current.increment());
     assertLog([
       'Increment',
       // Event should use the updated callback function closed over the new value.
@@ -370,7 +370,7 @@ describe('useEffectEvent', () => {
     );
 
     // Event uses the new prop
-    await act(async () => button.current.increment());
+    await act(() => button.current.increment());
     assertLog(['Increment', 'Count: 34']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -426,7 +426,7 @@ describe('useEffectEvent', () => {
       </>,
     );
 
-    await act(async () => button.current.increment());
+    await act(() => button.current.increment());
     assertLog([
       'Increment',
       // Effect should not re-run because the dependency hasn't changed.
@@ -439,7 +439,7 @@ describe('useEffectEvent', () => {
       </>,
     );
 
-    await act(async () => button.current.increment());
+    await act(() => button.current.increment());
     assertLog([
       'Increment',
       // Event should use the updated callback function closed over the new value.
@@ -469,7 +469,7 @@ describe('useEffectEvent', () => {
     );
 
     // Event uses the new prop
-    await act(async () => button.current.increment());
+    await act(() => button.current.increment());
     assertLog(['Increment', 'Count: 34']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -531,7 +531,7 @@ describe('useEffectEvent', () => {
       </>,
     );
 
-    await act(async () => button.current.increment());
+    await act(() => button.current.increment());
     assertLog([
       'Increment',
       // Effect should not re-run because the dependency hasn't changed.
@@ -544,7 +544,7 @@ describe('useEffectEvent', () => {
       </>,
     );
 
-    await act(async () => button.current.increment());
+    await act(() => button.current.increment());
     assertLog([
       'Increment',
       // Event should use the updated callback function closed over the new value.
@@ -574,7 +574,7 @@ describe('useEffectEvent', () => {
     );
 
     // Event uses the new prop
-    await act(async () => button.current.increment());
+    await act(() => button.current.increment());
     assertLog(['Increment', 'Count: 34']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -604,7 +604,7 @@ describe('useEffectEvent', () => {
     ReactNoop.render(<Counter value={1} />);
     await waitForAll(['Effect value: 1', 'Event value: 1']);
 
-    await act(async () => ReactNoop.render(<Counter value={2} />));
+    await act(() => ReactNoop.render(<Counter value={2} />));
     assertLog(['Effect value: 2', 'Event value: 2']);
   });
 
@@ -678,7 +678,7 @@ describe('useEffectEvent', () => {
 
     // Initial render
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App value={1} />);
     });
     assertLog(['Commit new event handler']);
@@ -686,7 +686,7 @@ describe('useEffectEvent', () => {
     expect(committedEventHandler()).toBe('Value seen by useEffectEvent: 1');
 
     // Update
-    await act(async () => {
+    await act(() => {
       root.render(<App value={2} />);
     });
     // No new event handler should be committed, because it was omitted from
@@ -742,20 +742,20 @@ describe('useEffectEvent', () => {
       return <Text text={`Welcome to the ${roomId} room!`} />;
     }
 
-    await act(async () =>
+    await act(() =>
       ReactNoop.render(<ChatRoom roomId="general" theme="light" />),
     );
-    await act(async () => jest.runAllTimers());
+    await act(() => jest.runAllTimers());
     assertLog(['Welcome to the general room!', 'Connected! theme: light']);
     expect(ReactNoop).toMatchRenderedOutput(
       <span prop="Welcome to the general room!" />,
     );
 
     // change roomId only
-    await act(async () =>
+    await act(() =>
       ReactNoop.render(<ChatRoom roomId="music" theme="light" />),
     );
-    await act(async () => jest.runAllTimers());
+    await act(() => jest.runAllTimers());
     assertLog([
       'Welcome to the music room!',
       // should trigger a reconnect
@@ -767,10 +767,8 @@ describe('useEffectEvent', () => {
     );
 
     // change theme only
-    await act(async () =>
-      ReactNoop.render(<ChatRoom roomId="music" theme="dark" />),
-    );
-    await act(async () => jest.runAllTimers());
+    await act(() => ReactNoop.render(<ChatRoom roomId="music" theme="dark" />));
+    await act(() => jest.runAllTimers());
     // should not trigger a reconnect
     assertLog(['Welcome to the music room!']);
     expect(ReactNoop).toMatchRenderedOutput(
@@ -778,10 +776,10 @@ describe('useEffectEvent', () => {
     );
 
     // change roomId only
-    await act(async () =>
+    await act(() =>
       ReactNoop.render(<ChatRoom roomId="travel" theme="dark" />),
     );
-    await act(async () => jest.runAllTimers());
+    await act(() => jest.runAllTimers());
     assertLog([
       'Welcome to the travel room!',
       // should trigger a reconnect
@@ -841,7 +839,7 @@ describe('useEffectEvent', () => {
     }
 
     const button = React.createRef(null);
-    await act(async () =>
+    await act(() =>
       ReactNoop.render(
         <AppShell>
           <Page url="/shop/1" />
@@ -849,10 +847,10 @@ describe('useEffectEvent', () => {
       ),
     );
     assertLog(['Add to cart', 'url: /shop/1, numberOfItems: 0']);
-    await act(async () => button.current.addToCart());
+    await act(() => button.current.addToCart());
     assertLog(['Add to cart']);
 
-    await act(async () =>
+    await act(() =>
       ReactNoop.render(
         <AppShell>
           <Page url="/shop/2" />

--- a/packages/react-reconciler/src/__tests__/useMemoCache-test.js
+++ b/packages/react-reconciler/src/__tests__/useMemoCache-test.js
@@ -63,7 +63,7 @@ describe('useMemoCache()', () => {
       return 'Ok';
     }
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<Component />);
     });
     expect(root).toMatchRenderedOutput('Ok');
@@ -107,7 +107,7 @@ describe('useMemoCache()', () => {
     });
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<Component />);
     });
     expect(root).toMatchRenderedOutput('Count 0');
@@ -115,7 +115,7 @@ describe('useMemoCache()', () => {
     const data0 = data;
 
     // Changing x should reset the data object
-    await act(async () => {
+    await act(() => {
       setX(1);
     });
     expect(root).toMatchRenderedOutput('Count 1');
@@ -125,7 +125,7 @@ describe('useMemoCache()', () => {
 
     // Forcing an unrelated update shouldn't recreate the
     // data object.
-    await act(async () => {
+    await act(() => {
       forceUpdate();
     });
     expect(root).toMatchRenderedOutput('Count 1');
@@ -183,7 +183,7 @@ describe('useMemoCache()', () => {
     });
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<Component />);
     });
     expect(root).toMatchRenderedOutput('Count 0');
@@ -193,7 +193,7 @@ describe('useMemoCache()', () => {
     // Simultaneously trigger an update to x (should create a new data value)
     // and trigger the setState+early return. The runtime should reset the cache
     // to avoid an inconsistency
-    await act(async () => {
+    await act(() => {
       setX(1);
       setN(1);
     });
@@ -204,7 +204,7 @@ describe('useMemoCache()', () => {
 
     // Forcing an unrelated update shouldn't recreate the
     // data object.
-    await act(async () => {
+    await act(() => {
       setN(3);
     });
     expect(root).toMatchRenderedOutput('Count 1');
@@ -266,7 +266,7 @@ describe('useMemoCache()', () => {
     spyOnDev(console, 'error');
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <ErrorBoundary>
           <Component />
@@ -280,7 +280,7 @@ describe('useMemoCache()', () => {
     // Simultaneously trigger an update to x (should create a new data value)
     // and trigger the setState+early return. The runtime should reset the cache
     // to avoid an inconsistency
-    await act(async () => {
+    await act(() => {
       // this update bumps the count
       setX(1);
       // this triggers a throw.
@@ -293,7 +293,7 @@ describe('useMemoCache()', () => {
 
     // Forcing an unrelated update shouldn't recreate the
     // data object.
-    await act(async () => {
+    await act(() => {
       setN(3);
     });
     expect(root).toMatchRenderedOutput('Count 1');
@@ -352,7 +352,7 @@ describe('useMemoCache()', () => {
     });
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<Component />);
     });
     expect(root).toMatchRenderedOutput('count 0');
@@ -360,7 +360,7 @@ describe('useMemoCache()', () => {
     const data0 = data;
 
     // Changing x should reset the data object
-    await act(async () => {
+    await act(() => {
       setX(1);
     });
     expect(root).toMatchRenderedOutput('count 1');
@@ -370,7 +370,7 @@ describe('useMemoCache()', () => {
 
     // Forcing an unrelated update shouldn't recreate the
     // data object.
-    await act(async () => {
+    await act(() => {
       forceUpdate();
     });
     expect(root).toMatchRenderedOutput('count 1');

--- a/packages/react-reconciler/src/__tests__/useMutableSource-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/useMutableSource-test.internal.js
@@ -1060,18 +1060,18 @@ describe('useMutableSource', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App getSnapshot={getSnapshotA} />);
     });
     expect(root).toMatchRenderedOutput('initial');
 
-    await act(async () => {
+    await act(() => {
       mutateB('Updated B');
       root.render(<App getSnapshot={getSnapshotB} />);
     });
     expect(root).toMatchRenderedOutput('Updated B');
 
-    await act(async () => {
+    await act(() => {
       mutateB('Another update');
     });
     expect(root).toMatchRenderedOutput('Another update');
@@ -1113,12 +1113,12 @@ describe('useMutableSource', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App toggle={false} />);
     });
     expect(root).toMatchRenderedOutput('A: initial');
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.discreteUpdates(() => {
         // Update both A and B to the same value
         mutateA('Update');
@@ -1158,12 +1158,12 @@ describe('useMutableSource', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App toggle={false} />);
     });
     expect(root).toMatchRenderedOutput('A: initial');
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.discreteUpdates(() => {
         // Update both A and B to the same value
         sourceA.value = 'Update';
@@ -1227,7 +1227,7 @@ describe('useMutableSource', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <App
           getSnapshotFirst={getSnapshotA}
@@ -1238,7 +1238,7 @@ describe('useMutableSource', () => {
     // x and y start out reading from different parts of the store.
     assertLog(['x: foo, y: bar']);
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.discreteUpdates(() => {
         // At high priority, toggle y so that it reads from A instead of B.
         // Simultaneously, mutate A.
@@ -1303,7 +1303,7 @@ describe('useMutableSource', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App getSnapshot={getSnapshotA} />);
     });
     assertLog(['Render: foo', 'Commit: foo']);
@@ -1362,7 +1362,7 @@ describe('useMutableSource', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(
         <App
           getSnapshotFirst={getSnapshotA}
@@ -1387,7 +1387,7 @@ describe('useMutableSource', () => {
       // Now mutate A. Both hooks should update.
       // This is at high priority so that it doesn't get batched with default
       // priority updates that might fire during the passive effect
-      await act(async () => {
+      await act(() => {
         ReactNoop.discreteUpdates(() => {
           mutateA('a1');
         });
@@ -1444,7 +1444,7 @@ describe('useMutableSource', () => {
       }
 
       const root = ReactNoop.createRoot();
-      await act(async () => {
+      await act(() => {
         root.render(
           <>
             <Read getSnapshot={getSnapshotA} />
@@ -1590,7 +1590,7 @@ describe('useMutableSource', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App parentConfig={configA} childConfig={configB} />);
     });
     assertLog(['Parent: 1', 'Child: 2', 'Commit: 1, 2']);
@@ -1666,7 +1666,7 @@ describe('useMutableSource', () => {
     }
 
     // Mount ComponentA with data version 1
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.Profiler id="root" onRender={onRender}>
           <ComponentA />
@@ -1713,7 +1713,7 @@ describe('useMutableSource', () => {
         const brokenSubscribe = () => {};
 
         await expect(async () => {
-          await act(async () => {
+          await act(() => {
             ReactNoop.render(
               <Component
                 label="only"

--- a/packages/react-reconciler/src/__tests__/useMutableSourceHydration-test.js
+++ b/packages/react-reconciler/src/__tests__/useMutableSourceHydration-test.js
@@ -165,7 +165,7 @@ describe('useMutableSourceHydration', () => {
     assertLog(['only:one']);
     expect(source.listenerCount).toBe(0);
 
-    await act(async () => {
+    await act(() => {
       ReactDOMClient.hydrateRoot(container, <TestComponent />, {
         mutableSources: [mutableSource],
       });
@@ -200,7 +200,7 @@ describe('useMutableSourceHydration', () => {
     expect(source.listenerCount).toBe(0);
 
     await expect(async () => {
-      await act(async () => {
+      await act(() => {
         ReactDOMClient.hydrateRoot(container, <TestComponent />, {
           mutableSources: [mutableSource],
           onRecoverableError(error) {

--- a/packages/react-reconciler/src/__tests__/useRef-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/useRef-test.internal.js
@@ -82,7 +82,7 @@ describe('useRef', () => {
       return null;
     }
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(<App />);
     });
     assertLog([]);
@@ -152,10 +152,10 @@ describe('useRef', () => {
         );
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<Example phase="mount" />);
       });
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<Example phase="update" />);
       });
     });
@@ -173,7 +173,7 @@ describe('useRef', () => {
         return value;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<Example />);
       });
     });
@@ -192,12 +192,12 @@ describe('useRef', () => {
         return null;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<Example />);
       });
 
       // Should not warn after an update either.
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<Example />);
       });
     });
@@ -216,7 +216,7 @@ describe('useRef', () => {
         return null;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<Example />);
       });
     });
@@ -251,13 +251,13 @@ describe('useRef', () => {
       }
 
       let shouldExpectWarning = true;
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<Example />);
       });
 
       // Should not warn again on update.
       shouldExpectWarning = false;
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<Example />);
       });
     });
@@ -291,7 +291,7 @@ describe('useRef', () => {
         return value;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<Example />);
       });
     });
@@ -323,7 +323,7 @@ describe('useRef', () => {
         return null;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<Example />);
       });
     });
@@ -344,7 +344,7 @@ describe('useRef', () => {
         return null;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<Example />);
       });
 
@@ -358,7 +358,7 @@ describe('useRef', () => {
         return null;
       }
 
-      await act(async () => {
+      await act(() => {
         ReactNoop.render(<Example />);
       });
 

--- a/packages/react-reconciler/src/__tests__/useSyncExternalStore-test.js
+++ b/packages/react-reconciler/src/__tests__/useSyncExternalStore-test.js
@@ -195,19 +195,19 @@ describe('useSyncExternalStore', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       // Start a render that reads from the store and yields value
       root.render(<App />);
     });
     assertLog(['value:initial']);
 
-    await act(async () => {
+    await act(() => {
       store.set('value:changed');
     });
     assertLog(['value:changed']);
 
     // If cached value was updated, we expect a re-render
-    await act(async () => {
+    await act(() => {
       store.set('value:initial');
     });
     assertLog(['value:initial']);

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -864,7 +864,7 @@ describe('ReactFresh', () => {
       });
 
       expect(container.textContent).toBe('Loading');
-      await act(async () => {
+      await act(() => {
         jest.runAllTimers();
       });
       expect(container.textContent).toBe('0');
@@ -1013,7 +1013,7 @@ describe('ReactFresh', () => {
         $RefreshReg$(Hello, 'Hello');
       });
 
-      await act(async () => {
+      await act(() => {
         jest.runAllTimers();
       });
 
@@ -1097,7 +1097,7 @@ describe('ReactFresh', () => {
         $RefreshReg$(Hello, 'Hello');
       });
 
-      await act(async () => {
+      await act(() => {
         jest.runAllTimers();
       });
 
@@ -1182,7 +1182,7 @@ describe('ReactFresh', () => {
         $RefreshReg$(Hello, 'Hello');
       });
 
-      await act(async () => {
+      await act(() => {
         jest.runAllTimers();
       });
 
@@ -1267,7 +1267,7 @@ describe('ReactFresh', () => {
         $RefreshReg$(Hello, 'Hello');
       });
 
-      await act(async () => {
+      await act(() => {
         jest.runAllTimers();
       });
 
@@ -2482,7 +2482,7 @@ describe('ReactFresh', () => {
     expect(el.firstChild.textContent).toBe('0');
     expect(el.firstChild.style.color).toBe('red');
 
-    await internalAct(async () => {
+    await internalAct(() => {
       el.firstChild.dispatchEvent(
         new MouseEvent('click', {
           bubbles: true,

--- a/packages/react-server-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
+++ b/packages/react-server-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
@@ -110,7 +110,7 @@ describe('ReactFlightDOMRelay', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(modelClient.greeting);
     });
 

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -168,7 +168,7 @@ describe('ReactFlightDOM', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<App response={response} />);
     });
     expect(container.innerHTML).toBe(
@@ -205,7 +205,7 @@ describe('ReactFlightDOM', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<App response={response} />);
     });
     expect(container.innerHTML).toBe('<p>$1</p>');
@@ -240,7 +240,7 @@ describe('ReactFlightDOM', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<App response={response} />);
     });
     expect(container.innerHTML).toBe('<p>@div</p>');
@@ -290,7 +290,7 @@ describe('ReactFlightDOM', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<App response={response} />);
     });
     expect(container.innerHTML).toBe('<p>Hello World</p>');
@@ -328,7 +328,7 @@ describe('ReactFlightDOM', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<App response={response} />);
     });
     expect(container.innerHTML).toBe('<p>Hello World</p>');
@@ -369,7 +369,7 @@ describe('ReactFlightDOM', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<App response={response} />);
     });
     expect(container.innerHTML).toBe('<p>Async: Module</p>');
@@ -408,7 +408,7 @@ describe('ReactFlightDOM', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<App response={response} />);
     });
     expect(container.innerHTML).toBe('<p>Async Text</p>');
@@ -446,7 +446,7 @@ describe('ReactFlightDOM', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<App response={response} />);
     });
     expect(container.innerHTML).toBe('<p>and then</p>');
@@ -607,7 +607,7 @@ describe('ReactFlightDOM', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback={<p>(loading)</p>}>
           <ProfilePage response={response} />
@@ -617,17 +617,17 @@ describe('ReactFlightDOM', () => {
     expect(container.innerHTML).toBe('<p>(loading)</p>');
 
     // This isn't enough to show anything.
-    await act(async () => {
+    await act(() => {
       resolveFriends();
     });
     expect(container.innerHTML).toBe('<p>(loading)</p>');
 
     // We can now show the details. Sidebar and posts are still loading.
-    await act(async () => {
+    await act(() => {
       resolveName();
     });
     // Advance time enough to trigger a nested fallback.
-    await act(async () => {
+    await act(() => {
       jest.advanceTimersByTime(500);
     });
     expect(container.innerHTML).toBe(
@@ -723,7 +723,7 @@ describe('ReactFlightDOM', () => {
     const response1 = ReactServerDOMReader.createFromReadableStream(
       stream1.readable,
     );
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback={<p>(loading)</p>}>
           <Page response={response1} />
@@ -751,7 +751,7 @@ describe('ReactFlightDOM', () => {
     const response2 = ReactServerDOMReader.createFromReadableStream(
       stream2.readable,
     );
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback={<p>(loading)</p>}>
           <Page response={response2} />
@@ -799,7 +799,7 @@ describe('ReactFlightDOM', () => {
       return use(res);
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <ErrorBoundary
           fallback={e => (
@@ -816,7 +816,7 @@ describe('ReactFlightDOM', () => {
     });
     expect(container.innerHTML).toBe('<p>(loading)</p>');
 
-    await act(async () => {
+    await act(() => {
       abort('for reasons');
     });
     if (__DEV__) {
@@ -862,7 +862,7 @@ describe('ReactFlightDOM', () => {
       return use(res);
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <ErrorBoundary fallback={e => <p>{e.message}</p>}>
           <Suspense fallback={<p>(loading)</p>}>
@@ -913,7 +913,7 @@ describe('ReactFlightDOM', () => {
       return use(res);
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <ErrorBoundary fallback={e => <p>{e.message}</p>}>
           <Suspense fallback={<p>(loading)</p>}>
@@ -925,7 +925,7 @@ describe('ReactFlightDOM', () => {
 
     expect(container.innerHTML).toBe('<p>(loading)</p>');
 
-    await act(async () => {
+    await act(() => {
       rejectPromise(new Error('async module init error'));
     });
 
@@ -975,7 +975,7 @@ describe('ReactFlightDOM', () => {
       return use(res);
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <ErrorBoundary
           fallback={e => (
@@ -1041,7 +1041,7 @@ describe('ReactFlightDOM', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<App response={response} />);
     });
     expect(container.innerHTML).toBe('<p>async hello</p>');
@@ -1104,7 +1104,7 @@ describe('ReactFlightDOM', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<App response={response} />);
     });
     expect(container.innerHTML).toBe(

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -264,7 +264,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback={<p>(loading)</p>}>
           <ProfilePage response={response} />
@@ -274,13 +274,13 @@ describe('ReactFlightDOMBrowser', () => {
     expect(container.innerHTML).toBe('<p>(loading)</p>');
 
     // This isn't enough to show anything.
-    await act(async () => {
+    await act(() => {
       resolveFriends();
     });
     expect(container.innerHTML).toBe('<p>(loading)</p>');
 
     // We can now show the details. Sidebar and posts are still loading.
-    await act(async () => {
+    await act(() => {
       resolveName();
     });
     // Advance time enough to trigger a nested fallback.
@@ -296,7 +296,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const theError = new Error('Game over');
     // Let's *fail* loading games.
-    await act(async () => {
+    await act(() => {
       rejectGames(theError);
     });
 
@@ -315,7 +315,7 @@ describe('ReactFlightDOMBrowser', () => {
     reportedErrors = [];
 
     // We can now show the sidebar.
-    await act(async () => {
+    await act(() => {
       resolvePhotos();
     });
     expect(container.innerHTML).toBe(
@@ -326,7 +326,7 @@ describe('ReactFlightDOMBrowser', () => {
     );
 
     // Show everything.
-    await act(async () => {
+    await act(() => {
       resolvePosts();
     });
     expect(container.innerHTML).toBe(
@@ -414,7 +414,7 @@ describe('ReactFlightDOMBrowser', () => {
     // Advance time enough to trigger a nested fallback.
     jest.advanceTimersByTime(500);
 
-    await act(async () => {});
+    await act(() => {});
 
     expect(flightResponse).toContain('(loading everything)');
     expect(flightResponse).toContain('(loading sidebar)');
@@ -422,25 +422,25 @@ describe('ReactFlightDOMBrowser', () => {
     expect(flightResponse).not.toContain(':friends:');
     expect(flightResponse).not.toContain(':name:');
 
-    await act(async () => {
+    await act(() => {
       resolveFriends();
     });
 
     expect(flightResponse).toContain(':friends:');
 
-    await act(async () => {
+    await act(() => {
       resolveName();
     });
 
     expect(flightResponse).toContain(':name:');
 
-    await act(async () => {
+    await act(() => {
       resolvePhotos();
     });
 
     expect(flightResponse).toContain(':photos:');
 
-    await act(async () => {
+    await act(() => {
       resolvePosts();
     });
 
@@ -512,7 +512,7 @@ describe('ReactFlightDOMBrowser', () => {
       return use(res);
     }
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <ErrorBoundary fallback={errorBoundaryFn}>
           <Suspense fallback={<p>(loading)</p>}>
@@ -523,7 +523,7 @@ describe('ReactFlightDOMBrowser', () => {
     });
     expect(container.innerHTML).toBe('<p>(loading)</p>');
 
-    await act(async () => {
+    await act(() => {
       controller.abort('for reasons');
     });
     const expectedValue = __DEV__
@@ -553,7 +553,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback="Loading...">
           <Client />
@@ -587,7 +587,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       // Client uses a different renderer.
       // We reset _currentRenderer here to not trigger a warning about multiple
       // renderers concurrently using this context
@@ -618,7 +618,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(
         <Suspense fallback="Loading...">
           <Client />
@@ -676,7 +676,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(
         <ErrorBoundary>
           <Client />
@@ -712,7 +712,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<Client />);
     });
     expect(container.innerHTML).toBe('Hi');
@@ -748,7 +748,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<Client />);
     });
     expect(container.innerHTML).toBe('Hi');
@@ -798,7 +798,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     expect(container.innerHTML).toBe('Click Me');
@@ -840,7 +840,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     expect(container.innerHTML).toBe('Click Me');
@@ -890,7 +890,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
 

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -346,7 +346,7 @@ describe(`onRender`, () => {
     Scheduler.unstable_advanceTime(20); // 30 -> 50
 
     // Updating a sibling should not report a re-render.
-    await act(async () => updateProfilerSibling());
+    await act(() => updateProfilerSibling());
 
     expect(callback).not.toHaveBeenCalled();
   });
@@ -672,7 +672,7 @@ describe(`onRender`, () => {
 
     const onRender = jest.fn();
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.Profiler id="root" onRender={onRender}>
           <Component />
@@ -1590,7 +1590,7 @@ describe(`onCommit`, () => {
     const setCountRef = React.createRef(null);
 
     let renderer = null;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(
         <React.Profiler id="root-mount" onCommit={callback}>
           <React.Profiler id="a">
@@ -1617,7 +1617,7 @@ describe(`onCommit`, () => {
     expect(call[2]).toBe(1010); // durations
     expect(call[3]).toBe(2); // commit start time (before mutations or effects)
 
-    await act(async () => setCountRef.current(count => count + 1));
+    await act(() => setCountRef.current(count => count + 1));
 
     expect(callback).toHaveBeenCalledTimes(2);
 
@@ -1629,7 +1629,7 @@ describe(`onCommit`, () => {
     expect(call[2]).toBe(110); // durations
     expect(call[3]).toBe(1013); // commit start time (before mutations or effects)
 
-    await act(async () => {
+    await act(() => {
       renderer.update(
         <React.Profiler id="root-update" onCommit={callback}>
           <React.Profiler id="b">
@@ -1688,7 +1688,7 @@ describe(`onCommit`, () => {
 
     // Test an error that happens during an effect
 
-    await act(async () => {
+    await act(() => {
       ReactTestRenderer.create(
         <React.Profiler id="root" onCommit={callback}>
           <ErrorBoundary
@@ -1774,7 +1774,7 @@ describe(`onCommit`, () => {
 
     let renderer = null;
 
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(
         <React.Profiler id="root" onCommit={callback}>
           <ErrorBoundary
@@ -1816,7 +1816,7 @@ describe(`onCommit`, () => {
 
     // Test an error that happens during an cleanup function
 
-    await act(async () => {
+    await act(() => {
       renderer.update(
         <React.Profiler id="root" onCommit={callback}>
           <ErrorBoundary
@@ -1901,7 +1901,7 @@ describe(`onPostCommit`, () => {
     Scheduler.unstable_advanceTime(1);
 
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(
         <React.Profiler id="mount-test" onPostCommit={callback}>
           <ComponentWithEffects />
@@ -1922,7 +1922,7 @@ describe(`onPostCommit`, () => {
 
     Scheduler.unstable_advanceTime(1);
 
-    await act(async () => {
+    await act(() => {
       renderer.update(
         <React.Profiler id="update-test" onPostCommit={callback}>
           <ComponentWithEffects />
@@ -1943,7 +1943,7 @@ describe(`onPostCommit`, () => {
 
     Scheduler.unstable_advanceTime(1);
 
-    await act(async () => {
+    await act(() => {
       renderer.update(
         <React.Profiler id="unmount-test" onPostCommit={callback} />,
       );
@@ -1985,7 +1985,7 @@ describe(`onPostCommit`, () => {
 
     Scheduler.unstable_advanceTime(1);
 
-    await act(async () => {
+    await act(() => {
       ReactTestRenderer.create(
         <React.Profiler id="mount-test" onPostCommit={callback}>
           <ComponentWithEffects />
@@ -2033,7 +2033,7 @@ describe(`onPostCommit`, () => {
     const setCountRef = React.createRef(null);
 
     let renderer = null;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(
         <React.Profiler id="root-mount" onPostCommit={callback}>
           <React.Profiler id="a">
@@ -2060,7 +2060,7 @@ describe(`onPostCommit`, () => {
     expect(call[2]).toBe(1010); // durations
     expect(call[3]).toBe(2); // commit start time (before mutations or effects)
 
-    await act(async () => setCountRef.current(count => count + 1));
+    await act(() => setCountRef.current(count => count + 1));
 
     expect(callback).toHaveBeenCalledTimes(2);
 
@@ -2072,7 +2072,7 @@ describe(`onPostCommit`, () => {
     expect(call[2]).toBe(110); // durations
     expect(call[3]).toBe(1013); // commit start time (before mutations or effects)
 
-    await act(async () => {
+    await act(() => {
       renderer.update(
         <React.Profiler id="root-update" onPostCommit={callback}>
           <React.Profiler id="b">
@@ -2131,7 +2131,7 @@ describe(`onPostCommit`, () => {
 
     // Test an error that happens during an effect
 
-    await act(async () => {
+    await act(() => {
       ReactTestRenderer.create(
         <React.Profiler id="root" onPostCommit={callback}>
           <ErrorBoundary
@@ -2218,7 +2218,7 @@ describe(`onPostCommit`, () => {
 
     let renderer = null;
 
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(
         <React.Profiler id="root" onPostCommit={callback}>
           <ErrorBoundary
@@ -2260,7 +2260,7 @@ describe(`onPostCommit`, () => {
 
     // Test an error that happens during an cleanup function
 
-    await act(async () => {
+    await act(() => {
       renderer.update(
         <React.Profiler id="root" onPostCommit={callback}>
           <ErrorBoundary
@@ -2377,7 +2377,7 @@ describe(`onNestedUpdateScheduled`, () => {
 
     const onNestedUpdateScheduled = jest.fn();
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.Profiler
           id="test"
@@ -2438,7 +2438,7 @@ describe(`onNestedUpdateScheduled`, () => {
     const onNestedUpdateScheduledTwo = jest.fn();
     const onNestedUpdateScheduledThree = jest.fn();
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.Profiler
           id="one"
@@ -2486,7 +2486,7 @@ describe(`onNestedUpdateScheduled`, () => {
 
     const onNestedUpdateScheduled = jest.fn();
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.renderToRootWithID(
         <React.Profiler
           id="test"
@@ -2526,7 +2526,7 @@ describe(`onNestedUpdateScheduled`, () => {
 
     const onNestedUpdateScheduled = jest.fn();
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.Profiler
           id="test"
@@ -2552,7 +2552,7 @@ describe(`onNestedUpdateScheduled`, () => {
 
     const onNestedUpdateScheduled = jest.fn();
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.Profiler
           id="test"
@@ -2563,7 +2563,7 @@ describe(`onNestedUpdateScheduled`, () => {
     });
     assertLog(['Component:false']);
 
-    await act(async () => {
+    await act(() => {
       updateFnRef.current();
     });
     assertLog(['Component:true']);
@@ -2582,7 +2582,7 @@ describe(`onNestedUpdateScheduled`, () => {
 
     const onNestedUpdateScheduled = jest.fn();
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.Profiler
           id="test"
@@ -2613,7 +2613,7 @@ describe(`onNestedUpdateScheduled`, () => {
 
     const onNestedUpdateScheduled = jest.fn();
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.Profiler
           id="test"
@@ -2627,7 +2627,7 @@ describe(`onNestedUpdateScheduled`, () => {
     expect(onNestedUpdateScheduled).toHaveBeenCalledTimes(1);
     expect(onNestedUpdateScheduled.mock.calls[0][0]).toBe('test');
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.Profiler
           id="test"
@@ -2659,7 +2659,7 @@ describe(`onNestedUpdateScheduled`, () => {
 
     const onNestedUpdateScheduled = jest.fn();
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.Profiler
           id="test"
@@ -2699,7 +2699,7 @@ describe(`onNestedUpdateScheduled`, () => {
 
     const onNestedUpdateScheduled = jest.fn();
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.Profiler
           id="test"
@@ -2711,7 +2711,7 @@ describe(`onNestedUpdateScheduled`, () => {
     assertLog(['Component:false:false']);
     expect(onNestedUpdateScheduled).not.toHaveBeenCalled();
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.Profiler
           id="test"
@@ -2743,7 +2743,7 @@ describe(`onNestedUpdateScheduled`, () => {
 
     const onNestedUpdateScheduled = jest.fn();
 
-    await act(async () => {
+    await act(() => {
       ReactNoop.render(
         <React.Profiler
           id="test"
@@ -2754,7 +2754,7 @@ describe(`onNestedUpdateScheduled`, () => {
     });
     assertLog(['Component:false']);
 
-    await act(async () => {
+    await act(() => {
       updateFnRef.current();
     });
     assertLog(['Component:true']);

--- a/packages/react/src/__tests__/ReactStartTransition-test.js
+++ b/packages/react/src/__tests__/ReactStartTransition-test.js
@@ -47,14 +47,14 @@ describe('ReactStartTransition', () => {
       return null;
     };
 
-    await act(async () => {
+    await act(() => {
       ReactTestRenderer.create(<Component level={0} />, {
         unstable_isConcurrent: true,
       });
     });
 
     await expect(async () => {
-      await act(async () => {
+      await act(() => {
         React.startTransition(() => {
           subs.forEach(setState => {
             setState(state => state + 1);
@@ -71,7 +71,7 @@ describe('ReactStartTransition', () => {
     );
 
     await expect(async () => {
-      await act(async () => {
+      await act(() => {
         triggerHookTransition(() => {
           subs.forEach(setState => {
             setState(state => state + 1);

--- a/packages/react/src/__tests__/ReactStrictMode-test.internal.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.internal.js
@@ -46,7 +46,7 @@ describe('ReactStrictMode', () => {
     }
 
     it('should default to not strict', async () => {
-      await act(async () => {
+      await act(() => {
         const container = document.createElement('div');
         const root = ReactDOMClient.createRoot(container);
         root.render(<Component label="A" />);
@@ -61,7 +61,7 @@ describe('ReactStrictMode', () => {
 
     if (__DEV__) {
       it('should support enabling strict mode via createRoot option', async () => {
-        await act(async () => {
+        await act(() => {
           const container = document.createElement('div');
           const root = ReactDOMClient.createRoot(container, {
             unstable_strictMode: true,
@@ -82,7 +82,7 @@ describe('ReactStrictMode', () => {
       });
 
       it('should include legacy + strict effects mode', async () => {
-        await act(async () => {
+        await act(() => {
           const container = document.createElement('div');
           const root = ReactDOMClient.createRoot(container);
           root.render(
@@ -105,7 +105,7 @@ describe('ReactStrictMode', () => {
       });
 
       it('should allow level to be increased with nesting', async () => {
-        await act(async () => {
+        await act(() => {
           const container = document.createElement('div');
           const root = ReactDOMClient.createRoot(container);
           root.render(

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -356,7 +356,7 @@ describe('ReactStrictMode', () => {
     const root = ReactDOMClient.createRoot(container);
 
     // Mount
-    await act(async () => {
+    await act(() => {
       root.render(
         <React.StrictMode>
           <Uppercased text="hello" />
@@ -372,7 +372,7 @@ describe('ReactStrictMode', () => {
     log = [];
 
     // Update
-    await act(async () => {
+    await act(() => {
       root.render(
         <React.StrictMode>
           <Uppercased text="goodbye" />
@@ -407,7 +407,7 @@ describe('ReactStrictMode', () => {
     const root = ReactDOMClient.createRoot(container);
 
     // Mount
-    await act(async () => {
+    await act(() => {
       root.render(
         <React.StrictMode>
           <Uppercased text="hello" />
@@ -429,7 +429,7 @@ describe('ReactStrictMode', () => {
     log = [];
 
     // Update
-    await act(async () => {
+    await act(() => {
       root.render(
         <React.StrictMode>
           <Uppercased text="goodbye" />
@@ -463,7 +463,7 @@ describe('ReactStrictMode', () => {
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <React.StrictMode>
           <App />
@@ -472,7 +472,7 @@ describe('ReactStrictMode', () => {
     });
     expect(container.textContent).toBe('0');
 
-    await act(async () => {
+    await act(() => {
       setCount(() => {
         log.push('Compute count: 1');
         return 1;
@@ -501,7 +501,7 @@ describe('ReactStrictMode', () => {
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
 
-    await act(async () => {
+    await act(() => {
       root.render(
         <React.StrictMode>
           <App />
@@ -510,7 +510,7 @@ describe('ReactStrictMode', () => {
     });
     expect(container.textContent).toBe('0');
 
-    await act(async () => {
+    await act(() => {
       dispatch(1);
     });
     expect(container.textContent).toBe('1');

--- a/packages/use-subscription/src/__tests__/useSubscription-test.js
+++ b/packages/use-subscription/src/__tests__/useSubscription-test.js
@@ -81,7 +81,7 @@ describe('useSubscription', () => {
 
     const observable = createBehaviorSubject();
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(
         <Subscription source={observable} />,
         {unstable_isConcurrent: true},
@@ -90,14 +90,14 @@ describe('useSubscription', () => {
     assertLog(['default']);
 
     // Updates while subscribed should re-render the child component
-    await act(async () => observable.next(123));
+    await act(() => observable.next(123));
     assertLog([123]);
-    await act(async () => observable.next('abc'));
+    await act(() => observable.next('abc'));
     assertLog(['abc']);
 
     // Unmounting the subscriber should remove listeners
-    await act(async () => renderer.update(<div />));
-    await act(async () => observable.next(456));
+    await act(() => renderer.update(<div />));
+    await act(() => observable.next(456));
     await waitForAll([]);
   });
 
@@ -133,23 +133,21 @@ describe('useSubscription', () => {
 
     let observable = createReplaySubject('initial');
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(
         <Subscription source={observable} />,
         {unstable_isConcurrent: true},
       );
     });
     assertLog(['initial']);
-    await act(async () => observable.next('updated'));
+    await act(() => observable.next('updated'));
     assertLog(['updated']);
 
     await waitForAll([]);
 
     // Unsetting the subscriber prop should reset subscribed values
     observable = createReplaySubject(undefined);
-    await act(async () =>
-      renderer.update(<Subscription source={observable} />),
-    );
+    await act(() => renderer.update(<Subscription source={observable} />));
     assertLog(['default']);
   });
 
@@ -184,7 +182,7 @@ describe('useSubscription', () => {
     expect(subscriptions).toHaveLength(0);
 
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(
         <Subscription source={observableA} />,
         {unstable_isConcurrent: true},
@@ -197,20 +195,18 @@ describe('useSubscription', () => {
     expect(subscriptions[0]).toBe(observableA);
 
     // Unsetting the subscriber prop should reset subscribed values
-    await act(async () =>
-      renderer.update(<Subscription source={observableB} />),
-    );
+    await act(() => renderer.update(<Subscription source={observableB} />));
 
     assertLog(['b-0']);
     expect(subscriptions).toHaveLength(2);
     expect(subscriptions[1]).toBe(observableB);
 
     // Updates to the old subscribable should not re-render the child component
-    await act(async () => observableA.next('a-1'));
+    await act(() => observableA.next('a-1'));
     await waitForAll([]);
 
     // Updates to the bew subscribable should re-render the child component
-    await act(async () => observableB.next('b-1'));
+    await act(() => observableB.next('b-1'));
     assertLog(['b-1']);
 
     expect(subscriptions).toHaveLength(2);
@@ -245,7 +241,7 @@ describe('useSubscription', () => {
     expect(subscriptions).toHaveLength(0);
 
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(
         <Subscription source={observableA} />,
         {unstable_isConcurrent: true},
@@ -258,19 +254,17 @@ describe('useSubscription', () => {
     expect(subscriptions[0]).toBe(observableA);
 
     // Unsetting the subscriber prop should reset subscribed values
-    await act(async () =>
-      renderer.update(<Subscription source={observableB} />),
-    );
+    await act(() => renderer.update(<Subscription source={observableB} />));
     assertLog(['b-0']);
     expect(subscriptions).toHaveLength(2);
     expect(subscriptions[1]).toBe(observableB);
 
     // Updates to the old subscribable should not re-render the child component
-    await act(async () => observableA.next('a-1'));
+    await act(() => observableA.next('a-1'));
     await waitForAll([]);
 
     // Updates to the bew subscribable should re-render the child component
-    await act(async () => observableB.next('b-1'));
+    await act(() => observableB.next('b-1'));
     assertLog(['b-1']);
 
     expect(subscriptions).toHaveLength(2);
@@ -335,7 +329,7 @@ describe('useSubscription', () => {
     const observableB = createBehaviorSubject('b-0');
 
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(<Parent observed={observableA} />, {
         unstable_isConcurrent: true,
       });
@@ -359,7 +353,7 @@ describe('useSubscription', () => {
     });
 
     // Update again
-    await act(async () => renderer.update(<Parent observed={observableA} />));
+    await act(() => renderer.update(<Parent observed={observableA} />));
 
     // Flush everything and ensure that the correct subscribable is used
     // We expect the last emitted update to be rendered (because of the commit phase value check)
@@ -438,7 +432,7 @@ describe('useSubscription', () => {
     const observableB = createBehaviorSubject('b-0');
 
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(<Parent observed={observableA} />, {
         unstable_isConcurrent: true,
       });
@@ -480,7 +474,7 @@ describe('useSubscription', () => {
 
     // Updates from the new subscribable should be ignored.
     log.splice(0);
-    await act(async () => observableB.next('b-1'));
+    await act(() => observableB.next('b-1'));
     await waitForAll([]);
     expect(log).toEqual([]);
   });
@@ -535,7 +529,7 @@ describe('useSubscription', () => {
     });
 
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(
         <Subscription source={eventHandler} />,
         {unstable_isConcurrent: true},
@@ -569,7 +563,7 @@ describe('useSubscription', () => {
     }
 
     let renderer;
-    await act(async () => {
+    await act(() => {
       renderer = ReactTestRenderer.create(
         <Subscription subscription={subscription1} />,
         {unstable_isConcurrent: true},
@@ -577,7 +571,7 @@ describe('useSubscription', () => {
     });
     await waitForAll([]);
 
-    await act(async () =>
+    await act(() =>
       renderer.update(<Subscription subscription={subscription2} />),
     );
     await waitForAll([]);

--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreNative-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreNative-test.js
@@ -117,7 +117,7 @@ describe('useSyncExternalStore (userspace shim, server rendering)', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
+    await act(() => {
       root.render(<App />);
     });
     assertLog(['client']);
@@ -161,13 +161,13 @@ describe('useSyncExternalStore (userspace shim, server rendering)', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => root.render(<App />));
+    await act(() => root.render(<App />));
 
     assertLog(['A0', 'B0']);
     expect(root).toMatchRenderedOutput('A0B0');
 
     // Update b but not a
-    await act(async () => {
+    await act(() => {
       store.set({a: 0, b: 1});
     });
     // Only b re-renders
@@ -175,7 +175,7 @@ describe('useSyncExternalStore (userspace shim, server rendering)', () => {
     expect(root).toMatchRenderedOutput('A0B1');
 
     // Update a but not b
-    await act(async () => {
+    await act(() => {
       store.set({a: 1, b: 1});
     });
     // Only a re-renders

--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
@@ -142,12 +142,12 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
     const container = document.createElement('div');
     const root = createRoot(container);
-    await act(async () => root.render(<App />));
+    await act(() => root.render(<App />));
 
     assertLog(['Initial']);
     expect(container.textContent).toEqual('Initial');
 
-    await act(async () => {
+    await act(() => {
       store.set('Updated');
     });
     assertLog(['Updated']);
@@ -164,13 +164,13 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
     const container = document.createElement('div');
     const root = createRoot(container);
-    await act(async () => root.render(<App />));
+    await act(() => root.render(<App />));
 
     assertLog(['Initial']);
     expect(container.textContent).toEqual('Initial');
 
     // Update to the same value
-    await act(async () => {
+    await act(() => {
       store.set('Initial');
     });
     // Should not re-render
@@ -192,19 +192,19 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
     const container = document.createElement('div');
     const root = createRoot(container);
-    await act(async () => root.render(<App />));
+    await act(() => root.render(<App />));
 
     assertLog([0]);
     expect(container.textContent).toEqual('0');
 
-    await act(async () => {
+    await act(() => {
       storeA.set(1);
     });
     assertLog([1]);
     expect(container.textContent).toEqual('1');
 
     // Switch stores and update in the same batch
-    await act(async () => {
+    await act(() => {
       ReactDOM.flushSync(() => {
         // This update will be disregarded
         storeA.set(2);
@@ -216,7 +216,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
     expect(container.textContent).toEqual('0');
 
     // Update A
-    await act(async () => {
+    await act(() => {
       storeA.set(3);
     });
     // Nothing happened, because we're no longer subscribed to A
@@ -224,7 +224,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
     expect(container.textContent).toEqual('0');
 
     // Update B
-    await act(async () => {
+    await act(() => {
       storeB.set(1);
     });
     assertLog([1]);
@@ -254,13 +254,13 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
     const container = document.createElement('div');
     const root = createRoot(container);
-    await act(async () => root.render(<App />));
+    await act(() => root.render(<App />));
 
     assertLog(['A0', 'B0']);
     expect(container.textContent).toEqual('A0B0');
 
     // Update b but not a
-    await act(async () => {
+    await act(() => {
       store.set({a: 0, b: 1});
     });
     // Only b re-renders
@@ -268,7 +268,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
     expect(container.textContent).toEqual('A0B1');
 
     // Update a but not b
-    await act(async () => {
+    await act(() => {
       store.set({a: 1, b: 1});
     });
     // Only a re-renders
@@ -295,7 +295,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
       const container = document.createElement('div');
       const root = createRoot(container);
-      await act(async () => root.render(<App />));
+      await act(() => root.render(<App />));
       assertLog([0, 'Passive effect: 0']);
 
       // Schedule an update. We'll intentionally not use `act` so that we can
@@ -365,11 +365,11 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
     const container = document.createElement('div');
     const root = createRoot(container);
-    await act(async () => root.render(<App />));
+    await act(() => root.render(<App />));
     assertLog(['A1']);
     expect(container.textContent).toEqual('A1');
 
-    await act(async () => {
+    await act(() => {
       // Change getSnapshot and update the store in the same batch
       setStep(1);
     });
@@ -423,13 +423,13 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
     const container = document.createElement('div');
     const root = createRoot(container);
-    await act(async () => root.render(<App />));
+    await act(() => root.render(<App />));
     assertLog(['A1']);
     expect(container.textContent).toEqual('A1');
 
     // This will cause a layout effect, and in the layout effect we'll update
     // the store
-    await act(async () => {
+    await act(() => {
       setStep(1);
     });
     assertLog([
@@ -463,7 +463,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
     const container = document.createElement('div');
     const root = createRoot(container);
-    await act(async () =>
+    await act(() =>
       root.render(
         <>
           <Child1 />
@@ -474,7 +474,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
     assertLog([0, 0]);
     expect(container.textContent).toEqual('00');
 
-    await act(async () => {
+    await act(() => {
       store.set(1);
     });
     assertLog([1, 1, 'Reset back to 0', 0, 0]);
@@ -497,11 +497,11 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
     const container = document.createElement('div');
     const root = createRoot(container);
-    await act(async () => root.render(<App />));
+    await act(() => root.render(<App />));
     assertLog([0]);
 
     // Update the store and getSnapshot at the same time
-    await act(async () => {
+    await act(() => {
       ReactDOM.flushSync(() => {
         setGetSnapshot(() => getSnapshotB);
         store.set({a: 1, b: 2});
@@ -546,7 +546,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
     const errorBoundary = React.createRef(null);
     const container = document.createElement('div');
     const root = createRoot(container);
-    await act(async () =>
+    await act(() =>
       root.render(
         <ErrorBoundary ref={errorBoundary}>
           <App />
@@ -557,7 +557,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
     expect(container.textContent).toEqual('0');
 
     // Update that throws in a getSnapshot. We can catch it with an error boundary.
-    await act(async () => {
+    await act(() => {
       store.set({value: 1, throwInGetSnapshot: true, throwInIsEqual: false});
     });
     if (gate(flags => !flags.enableUseSyncExternalStoreShim)) {
@@ -612,15 +612,15 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
     // Initial render that reads a snapshot of NaN. This is OK because we use
     // Object.is algorithm to compare values.
-    await act(async () => root.render(<App />));
+    await act(() => root.render(<App />));
     expect(container.textContent).toEqual('NaN');
 
     // Update to real number
-    await act(async () => store.set(123));
+    await act(() => store.set(123));
     expect(container.textContent).toEqual('123');
 
     // Update back to NaN
-    await act(async () => store.set('not a number'));
+    await act(() => store.set('not a number'));
     expect(container.textContent).toEqual('NaN');
   });
 
@@ -648,13 +648,13 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
       const container = document.createElement('div');
       const root = createRoot(container);
-      await act(async () => root.render(<App />));
+      await act(() => root.render(<App />));
 
       assertLog(['App', 'Selector', 'A0']);
       expect(container.textContent).toEqual('A0');
 
       // Update the store
-      await act(async () => {
+      await act(() => {
         store.set({a: 1, b: 0});
       });
       assertLog([
@@ -707,13 +707,13 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
       const container = document.createElement('div');
       const root = createRoot(container);
-      await act(async () => root.render(<App />));
+      await act(() => root.render(<App />));
 
       assertLog(['A0', 'B0']);
       expect(container.textContent).toEqual('A0B0');
 
       // Update b but not a
-      await act(async () => {
+      await act(() => {
         store.set({a: 0, b: 1});
       });
       // Only b re-renders
@@ -721,7 +721,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
       expect(container.textContent).toEqual('A0B1');
 
       // Update a but not b
-      await act(async () => {
+      await act(() => {
         store.set({a: 1, b: 1});
       });
       // Only a re-renders
@@ -754,7 +754,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
       const serverRenderedDiv = container.getElementsByTagName('div')[0];
 
       if (gate(flags => !flags.enableUseSyncExternalStoreShim)) {
-        await act(async () => {
+        await act(() => {
           ReactDOMClient.hydrateRoot(container, <App />);
         });
         assertLog([
@@ -770,7 +770,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
         // currently hydrating, so `getServerSnapshot` is not called on the
         // client. To avoid this server mismatch warning, user must account for
         // this themselves and return the correct value inside `getSnapshot`.
-        await act(async () => {
+        await act(() => {
           expect(() => ReactDOM.hydrate(<App />, container)).toErrorDev(
             'Text content did not match',
           );
@@ -797,12 +797,12 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
     const container = document.createElement('div');
     const root = createRoot(container);
-    await act(async () => root.render(<App />));
+    await act(() => root.render(<App />));
 
     assertLog(['INITIAL']);
     expect(container.textContent).toEqual('INITIAL');
 
-    await act(async () => {
+    await act(() => {
       store.set('Updated');
     });
     assertLog(['UPDATED']);
@@ -860,12 +860,12 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
     const container = document.createElement('div');
     const root = createRoot(container);
-    await act(async () => {
+    await act(() => {
       root.render(<App step={0} />);
     });
     assertLog(['Inline selector', 'A', 'B', 'C', 'Sibling: 0']);
 
-    await act(async () => {
+    await act(() => {
       root.render(<App step={1} />);
     });
     assertLog([
@@ -920,7 +920,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
       const container = document.createElement('div');
       const root = createRoot(container);
-      await act(async () =>
+      await act(() =>
         root.render(
           <ErrorBoundary>
             <App />
@@ -931,7 +931,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
       expect(container.textContent).toEqual('A');
 
       await expect(async () => {
-        await act(async () => {
+        await act(() => {
           store.set({});
         });
       }).toWarnDev(
@@ -965,7 +965,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
       const container = document.createElement('div');
       const root = createRoot(container);
-      await act(async () =>
+      await act(() =>
         root.render(
           <ErrorBoundary>
             <App />
@@ -976,7 +976,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
       expect(container.textContent).toEqual('A');
 
       await expect(async () => {
-        await act(async () => {
+        await act(() => {
           store.set({});
         });
       }).toWarnDev(


### PR DESCRIPTION
Prior to #26347, our internal `act` API (not the public API) behaved differently depending on whether the scope function returned a promise (i.e. was an async function), for historical reasons that no longer apply. Now that this is fixed, I've codemodded all async act scopes that don't contain an await to be sync.

No pressing motivation other than it looks nicer and the codemod was easy. Might help avoid confusion for new contributors who see async act scopes with nothing async inside and infer it must be like that for a reason.