### PR TITLE
Split out ServerReferenceMetadata into Id and Bound Arguments

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -473,13 +473,16 @@ function createModelReject<T>(chunk: SomeChunk<T>): (error: mixed) => void {
 
 function createServerReferenceProxy<A: Iterable<any>, T>(
   response: Response,
-  metaData: {id: any, bound: Thenable<Array<any>>},
+  metaData: {id: any, bound: null | Thenable<Array<any>>},
 ): (...A) => Promise<T> {
   const callServer = response._callServer;
   const proxy = function (): Promise<T> {
     // $FlowFixMe[method-unbinding]
     const args = Array.prototype.slice.call(arguments);
     const p = metaData.bound;
+    if (!p) {
+      return callServer(metaData.id, args);
+    }
     if (p.status === INITIALIZED) {
       const bound = p.value;
       return callServer(metaData.id, bound.concat(args));

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -15,7 +15,7 @@ import type {
   ClientReferenceMetadata,
   UninitializedModel,
   Response,
-  BundlerConfig,
+  SSRManifest,
 } from './ReactFlightClientHostConfig';
 
 import {
@@ -149,7 +149,7 @@ Chunk.prototype.then = function <T>(
 };
 
 export type ResponseBase = {
-  _bundlerConfig: BundlerConfig,
+  _bundlerConfig: SSRManifest,
   _callServer: CallServerCallback,
   _chunks: Map<number, SomeChunk<any>>,
   ...
@@ -611,7 +611,7 @@ function missingCall() {
 }
 
 export function createResponse(
-  bundlerConfig: BundlerConfig,
+  bundlerConfig: SSRManifest,
   callServer: void | CallServerCallback,
 ): ResponseBase {
   const chunks: Map<number, SomeChunk<any>> = new Map();

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -9,7 +9,7 @@
 
 import type {CallServerCallback} from './ReactFlightClient';
 import type {Response} from './ReactFlightClientHostConfigStream';
-import type {BundlerConfig} from './ReactFlightClientHostConfig';
+import type {SSRManifest} from './ReactFlightClientHostConfig';
 
 import {
   resolveModule,
@@ -121,7 +121,7 @@ function createFromJSONCallback(response: Response) {
 }
 
 export function createResponse(
-  bundlerConfig: BundlerConfig,
+  bundlerConfig: SSRManifest,
   callServer: void | CallServerCallback,
 ): Response {
   // NOTE: CHECK THE COMPILER OUTPUT EACH TIME YOU CHANGE THIS.

--- a/packages/react-client/src/forks/ReactFlightClientHostConfig.custom.js
+++ b/packages/react-client/src/forks/ReactFlightClientHostConfig.custom.js
@@ -26,7 +26,7 @@
 declare var $$$hostConfig: any;
 
 export type Response = any;
-export opaque type BundlerConfig = mixed;
+export opaque type SSRManifest = mixed;
 export opaque type ClientReferenceMetadata = mixed;
 export opaque type ClientReference<T> = mixed; // eslint-disable-line no-unused-vars
 export const resolveClientReference = $$$hostConfig.resolveClientReference;

--- a/packages/react-client/src/forks/ReactFlightClientHostConfig.dom-bun.js
+++ b/packages/react-client/src/forks/ReactFlightClientHostConfig.dom-bun.js
@@ -11,7 +11,7 @@ export * from 'react-client/src/ReactFlightClientHostConfigBrowser';
 export * from 'react-client/src/ReactFlightClientHostConfigStream';
 
 export type Response = any;
-export opaque type BundlerConfig = mixed;
+export opaque type SSRManifest = mixed;
 export opaque type ClientReferenceMetadata = mixed;
 export opaque type ClientReference<T> = mixed; // eslint-disable-line no-unused-vars
 export const resolveClientReference: any = null;

--- a/packages/react-noop-renderer/src/ReactNoopFlightServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightServer.js
@@ -14,7 +14,7 @@
  * environment.
  */
 
-import type {ReactModel} from 'react-server/src/ReactFlightServer';
+import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
 import type {ServerContextJSONValue} from 'shared/ReactTypes';
 
 import {saveModule} from 'react-noop-renderer/flight-modules';
@@ -71,7 +71,7 @@ type Options = {
   identifierPrefix?: string,
 };
 
-function render(model: ReactModel, options?: Options): Destination {
+function render(model: ReactClientValue, options?: Options): Destination {
   const destination: Destination = [];
   const bundlerConfig = undefined;
   const request = ReactNoopFlightServer.createRequest(

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
@@ -31,14 +31,14 @@ import isArray from 'shared/isArray';
 
 export type {ClientReferenceMetadata} from 'ReactFlightDOMRelayClientIntegration';
 
-export type BundlerConfig = null;
+export type SSRManifest = null;
 
 export type UninitializedModel = JSONValue;
 
 export type Response = ResponseBase;
 
 export function resolveClientReference<T>(
-  bundlerConfig: BundlerConfig,
+  bundlerConfig: SSRManifest,
   metadata: ClientReferenceMetadata,
 ): ClientReference<T> {
   return resolveClientReferenceImpl(metadata);

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServer.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServer.js
@@ -9,7 +9,7 @@
 
 import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
 import type {
-  BundlerConfig,
+  ClientManifest,
   Destination,
 } from './ReactFlightDOMRelayServerHostConfig';
 
@@ -27,7 +27,7 @@ type Options = {
 function render(
   model: ReactClientValue,
   destination: Destination,
-  config: BundlerConfig,
+  config: ClientManifest,
   options?: Options,
 ): void {
   const request = createRequest(

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServer.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServer.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {ReactModel} from 'react-server/src/ReactFlightServer';
+import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
 import type {
   BundlerConfig,
   Destination,
@@ -25,7 +25,7 @@ type Options = {
 };
 
 function render(
-  model: ReactModel,
+  model: ReactClientValue,
   destination: Destination,
   config: BundlerConfig,
   options?: Options,

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -9,7 +9,10 @@
 
 import type {RowEncoding, JSONValue} from './ReactFlightDOMRelayProtocol';
 
-import type {Request, ReactModel} from 'react-server/src/ReactFlightServer';
+import type {
+  Request,
+  ReactClientValue,
+} from 'react-server/src/ReactFlightServer';
 
 import type {JSResourceReference} from 'JSResourceReference';
 import JSResourceReferenceImpl from 'JSResourceReferenceImpl';
@@ -76,7 +79,7 @@ export function getServerReferenceId<T>(
 export function getServerReferenceBoundArguments<T>(
   config: BundlerConfig,
   resource: ServerReference<T>,
-): Array<any> {
+): Array<ReactClientValue> {
   throw new Error('Not implemented.');
 }
 
@@ -132,9 +135,9 @@ export function processErrorChunkDev(
 
 function convertModelToJSON(
   request: Request,
-  parent: {+[key: string]: ReactModel} | $ReadOnlyArray<ReactModel>,
+  parent: {+[key: string]: ReactClientValue} | $ReadOnlyArray<ReactClientValue>,
   key: string,
-  model: ReactModel,
+  model: ReactClientValue,
 ): JSONValue {
   const json = resolveModelToJSON(request, parent, key, model);
   if (typeof json === 'object' && json !== null) {
@@ -167,7 +170,7 @@ function convertModelToJSON(
 export function processModelChunk(
   request: Request,
   id: number,
-  model: ReactModel,
+  model: ReactClientValue,
 ): Chunk {
   // $FlowFixMe no good way to define an empty exact object
   const json = convertModelToJSON(request, {}, '', model);

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -26,7 +26,7 @@ export type ServerReferenceId = {};
 
 import type {
   Destination,
-  BundlerConfig,
+  BundlerConfig as ClientManifest,
   ClientReferenceMetadata,
 } from 'ReactFlightDOMRelayServerIntegration';
 
@@ -40,7 +40,7 @@ import {
 
 export type {
   Destination,
-  BundlerConfig,
+  BundlerConfig as ClientManifest,
   ClientReferenceMetadata,
 } from 'ReactFlightDOMRelayServerIntegration';
 
@@ -63,21 +63,21 @@ export function getClientReferenceKey(
 }
 
 export function resolveClientReferenceMetadata<T>(
-  config: BundlerConfig,
+  config: ClientManifest,
   resource: ClientReference<T>,
 ): ClientReferenceMetadata {
   return resolveClientReferenceMetadataImpl(config, resource);
 }
 
 export function getServerReferenceId<T>(
-  config: BundlerConfig,
+  config: ClientManifest,
   resource: ServerReference<T>,
 ): ServerReferenceId {
   throw new Error('Not implemented.');
 }
 
 export function getServerReferenceBoundArguments<T>(
-  config: BundlerConfig,
+  config: ClientManifest,
   resource: ServerReference<T>,
 ): Array<ReactClientValue> {
   throw new Error('Not implemented.');

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -66,10 +66,17 @@ export function resolveClientReferenceMetadata<T>(
   return resolveClientReferenceMetadataImpl(config, resource);
 }
 
-export function resolveServerReferenceMetadata<T>(
+export function getServerReferenceId<T>(
   config: BundlerConfig,
   resource: ServerReference<T>,
-): {id: ServerReferenceId, bound: Promise<Array<any>>} {
+): ServerReferenceId {
+  throw new Error('Not implemented.');
+}
+
+export function getServerReferenceBoundArguments<T>(
+  config: BundlerConfig,
+  resource: ServerReference<T>,
+): Array<any> {
   throw new Error('Not implemented.');
 }
 

--- a/packages/react-server-dom-webpack/src/ReactFlightClientNodeBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightClientNodeBundlerConfig.js
@@ -13,13 +13,11 @@ import type {
   RejectedThenable,
 } from 'shared/ReactTypes';
 
-export type WebpackSSRMap = {
+export type SSRManifest = {
   [clientId: string]: {
     [clientExportName: string]: ClientReference<any>,
   },
 };
-
-export type BundlerConfig = WebpackSSRMap;
 
 export opaque type ClientReferenceMetadata = {
   id: string,
@@ -34,7 +32,7 @@ export opaque type ClientReference<T> = {
 };
 
 export function resolveClientReference<T>(
-  bundlerConfig: BundlerConfig,
+  bundlerConfig: SSRManifest,
   metadata: ClientReferenceMetadata,
 ): ClientReference<T> {
   const resolvedModuleData = bundlerConfig[metadata.id][metadata.name];

--- a/packages/react-server-dom-webpack/src/ReactFlightClientWebpackBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightClientWebpackBundlerConfig.js
@@ -13,13 +13,11 @@ import type {
   RejectedThenable,
 } from 'shared/ReactTypes';
 
-export type WebpackSSRMap = {
+export type SSRManifest = null | {
   [clientId: string]: {
     [clientExportName: string]: ClientReferenceMetadata,
   },
 };
-
-export type BundlerConfig = null | WebpackSSRMap;
 
 export opaque type ClientReferenceMetadata = {
   id: string,
@@ -32,7 +30,7 @@ export opaque type ClientReferenceMetadata = {
 export opaque type ClientReference<T> = ClientReferenceMetadata;
 
 export function resolveClientReference<T>(
-  bundlerConfig: BundlerConfig,
+  bundlerConfig: SSRManifest,
   metadata: ClientReferenceMetadata,
 ): ClientReference<T> {
   if (bundlerConfig) {

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
@@ -11,7 +11,7 @@ import type {Thenable} from 'shared/ReactTypes.js';
 
 import type {Response as FlightResponse} from 'react-client/src/ReactFlightClientStream';
 
-import type {BundlerConfig} from './ReactFlightClientWebpackBundlerConfig';
+import type {SSRManifest} from './ReactFlightClientWebpackBundlerConfig';
 
 import {
   createResponse,
@@ -30,7 +30,7 @@ function noServerCall() {
 }
 
 export type Options = {
-  moduleMap?: BundlerConfig,
+  moduleMap?: SSRManifest,
 };
 
 function createResponseFromOptions(options: void | Options) {

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientNode.js
@@ -11,7 +11,7 @@ import type {Thenable} from 'shared/ReactTypes.js';
 
 import type {Response} from 'react-client/src/ReactFlightClientStream';
 
-import type {BundlerConfig} from 'react-client/src/ReactFlightClientHostConfig';
+import type {SSRManifest} from 'react-client/src/ReactFlightClientHostConfig';
 
 import type {Readable} from 'stream';
 
@@ -34,7 +34,7 @@ function noServerCall() {
 
 function createFromNodeStream<T>(
   stream: Readable,
-  moduleMap: $NonMaybeType<BundlerConfig>,
+  moduleMap: $NonMaybeType<SSRManifest>,
 ): Thenable<T> {
   const response: Response = createResponse(moduleMap, noServerCall);
   stream.on('data', chunk => {

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -9,7 +9,7 @@
 
 import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
 import type {ServerContextJSONValue} from 'shared/ReactTypes';
-import type {BundlerConfig} from './ReactFlightServerWebpackBundlerConfig';
+import type {ClientManifest} from './ReactFlightServerWebpackBundlerConfig';
 
 import {
   createRequest,
@@ -27,7 +27,7 @@ type Options = {
 
 function renderToReadableStream(
   model: ReactClientValue,
-  webpackMap: BundlerConfig,
+  webpackMap: ClientManifest,
   options?: Options,
 ): ReadableStream {
   const request = createRequest(

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {ReactModel} from 'react-server/src/ReactFlightServer';
+import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
 import type {ServerContextJSONValue} from 'shared/ReactTypes';
 import type {BundlerConfig} from './ReactFlightServerWebpackBundlerConfig';
 
@@ -26,7 +26,7 @@ type Options = {
 };
 
 function renderToReadableStream(
-  model: ReactModel,
+  model: ReactClientValue,
   webpackMap: BundlerConfig,
   options?: Options,
 ): ReadableStream {

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
@@ -9,7 +9,7 @@
 
 import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
 import type {ServerContextJSONValue} from 'shared/ReactTypes';
-import type {BundlerConfig} from './ReactFlightServerWebpackBundlerConfig';
+import type {ClientManifest} from './ReactFlightServerWebpackBundlerConfig';
 
 import {
   createRequest,
@@ -27,7 +27,7 @@ type Options = {
 
 function renderToReadableStream(
   model: ReactClientValue,
-  webpackMap: BundlerConfig,
+  webpackMap: ClientManifest,
   options?: Options,
 ): ReadableStream {
   const request = createRequest(

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {ReactModel} from 'react-server/src/ReactFlightServer';
+import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
 import type {ServerContextJSONValue} from 'shared/ReactTypes';
 import type {BundlerConfig} from './ReactFlightServerWebpackBundlerConfig';
 
@@ -26,7 +26,7 @@ type Options = {
 };
 
 function renderToReadableStream(
-  model: ReactModel,
+  model: ReactClientValue,
   webpackMap: BundlerConfig,
   options?: Options,
 ): ReadableStream {

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -12,7 +12,7 @@ import type {
   ReactClientValue,
 } from 'react-server/src/ReactFlightServer';
 import type {Destination} from 'react-server/src/ReactServerStreamConfigNode';
-import type {BundlerConfig} from './ReactFlightServerWebpackBundlerConfig';
+import type {ClientManifest} from './ReactFlightServerWebpackBundlerConfig';
 import type {Writable} from 'stream';
 import type {ServerContextJSONValue} from 'shared/ReactTypes';
 
@@ -40,7 +40,7 @@ type PipeableStream = {
 
 function renderToPipeableStream(
   model: ReactClientValue,
-  webpackMap: BundlerConfig,
+  webpackMap: ClientManifest,
   options?: Options,
 ): PipeableStream {
   const request = createRequest(

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -7,7 +7,10 @@
  * @flow
  */
 
-import type {Request, ReactModel} from 'react-server/src/ReactFlightServer';
+import type {
+  Request,
+  ReactClientValue,
+} from 'react-server/src/ReactFlightServer';
 import type {Destination} from 'react-server/src/ReactServerStreamConfigNode';
 import type {BundlerConfig} from './ReactFlightServerWebpackBundlerConfig';
 import type {Writable} from 'stream';
@@ -36,7 +39,7 @@ type PipeableStream = {
 };
 
 function renderToPipeableStream(
-  model: ReactModel,
+  model: ReactClientValue,
   webpackMap: BundlerConfig,
   options?: Options,
 ): PipeableStream {

--- a/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {ReactModel} from 'react-server/src/ReactFlightServer';
+import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
 
 type WebpackMap = {
   [id: string]: ClientReferenceMetadata,
@@ -18,7 +18,7 @@ export type BundlerConfig = WebpackMap;
 export type ServerReference<T: Function> = T & {
   $$typeof: symbol,
   $$id: string,
-  $$bound: Array<ReactModel>,
+  $$bound: Array<ReactClientValue>,
 };
 
 export type ServerReferenceId = string;
@@ -83,6 +83,6 @@ export function getServerReferenceId<T>(
 export function getServerReferenceBoundArguments<T>(
   config: BundlerConfig,
   serverReference: ServerReference<T>,
-): Array<any> {
+): Array<ReactClientValue> {
   return serverReference.$$bound;
 }

--- a/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
@@ -73,12 +73,16 @@ export function resolveClientReferenceMetadata<T>(
   }
 }
 
-export function resolveServerReferenceMetadata<T>(
+export function getServerReferenceId<T>(
   config: BundlerConfig,
   serverReference: ServerReference<T>,
-): {id: ServerReferenceId, bound: Promise<Array<any>>} {
-  return {
-    id: serverReference.$$id,
-    bound: Promise.resolve(serverReference.$$bound),
-  };
+): ServerReferenceId {
+  return serverReference.$$id;
+}
+
+export function getServerReferenceBoundArguments<T>(
+  config: BundlerConfig,
+  serverReference: ServerReference<T>,
+): Array<any> {
+  return serverReference.$$bound;
 }

--- a/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
@@ -18,7 +18,7 @@ export type BundlerConfig = WebpackMap;
 export type ServerReference<T: Function> = T & {
   $$typeof: symbol,
   $$id: string,
-  $$bound: Array<ReactClientValue>,
+  $$bound: null | Array<ReactClientValue>,
 };
 
 export type ServerReferenceId = string;
@@ -83,6 +83,6 @@ export function getServerReferenceId<T>(
 export function getServerReferenceBoundArguments<T>(
   config: BundlerConfig,
   serverReference: ServerReference<T>,
-): Array<ReactClientValue> {
+): null | Array<ReactClientValue> {
   return serverReference.$$bound;
 }

--- a/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
@@ -9,11 +9,9 @@
 
 import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
 
-type WebpackMap = {
+export type ClientManifest = {
   [id: string]: ClientReferenceMetadata,
 };
-
-export type BundlerConfig = WebpackMap;
 
 export type ServerReference<T: Function> = T & {
   $$typeof: symbol,
@@ -57,7 +55,7 @@ export function isServerReference(reference: Object): boolean {
 }
 
 export function resolveClientReferenceMetadata<T>(
-  config: BundlerConfig,
+  config: ClientManifest,
   clientReference: ClientReference<T>,
 ): ClientReferenceMetadata {
   const resolvedModuleData = config[clientReference.$$id];
@@ -74,14 +72,14 @@ export function resolveClientReferenceMetadata<T>(
 }
 
 export function getServerReferenceId<T>(
-  config: BundlerConfig,
+  config: ClientManifest,
   serverReference: ServerReference<T>,
 ): ServerReferenceId {
   return serverReference.$$id;
 }
 
 export function getServerReferenceBoundArguments<T>(
-  config: BundlerConfig,
+  config: ClientManifest,
   serverReference: ServerReference<T>,
 ): null | Array<ReactClientValue> {
   return serverReference.$$bound;

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
@@ -188,7 +188,7 @@ function transformServerModule(
     newSrc += 'Object.defineProperties(' + local + ',{';
     newSrc += '$$typeof: {value: Symbol.for("react.server.reference")},';
     newSrc += '$$id: {value: ' + JSON.stringify(url + '#' + exported) + '},';
-    newSrc += '$$bound: { value: [] }';
+    newSrc += '$$bound: { value: null }';
     newSrc += '});\n';
   });
   return newSrc;

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
@@ -30,7 +30,7 @@ module.exports = function register() {
       const args = Array.prototype.slice.call(arguments, 1);
       newFn.$$typeof = SERVER_REFERENCE;
       newFn.$$id = this.$$id;
-      newFn.$$bound = this.$$bound.concat(args);
+      newFn.$$bound = this.$$bound ? this.$$bound.concat(args) : args;
     }
     return newFn;
   }: any);
@@ -289,7 +289,7 @@ module.exports = function register() {
           $$typeof: {value: SERVER_REFERENCE},
           // Represents the whole Module object instead of a particular import.
           $$id: {value: moduleId},
-          $$bound: {value: []},
+          $$bound: {value: null},
         });
       } else {
         const keys = Object.keys(exports);
@@ -300,7 +300,7 @@ module.exports = function register() {
             Object.defineProperties((value: any), {
               $$typeof: {value: SERVER_REFERENCE},
               $$id: {value: moduleId + '#' + key},
-              $$bound: {value: []},
+              $$bound: {value: null},
             });
           }
         }

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayClientHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayClientHostConfig.js
@@ -31,14 +31,14 @@ import isArray from 'shared/isArray';
 
 export type {ClientReferenceMetadata} from 'ReactFlightNativeRelayClientIntegration';
 
-export type BundlerConfig = null;
+export type SSRManifest = null;
 
 export type UninitializedModel = JSONValue;
 
 export type Response = ResponseBase;
 
 export function resolveClientReference<T>(
-  bundlerConfig: BundlerConfig,
+  bundlerConfig: SSRManifest,
   metadata: ClientReferenceMetadata,
 ): ClientReference<T> {
   return resolveClientReferenceImpl(metadata);

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServer.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServer.js
@@ -9,7 +9,7 @@
 
 import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
 import type {
-  BundlerConfig,
+  ClientManifest,
   Destination,
 } from './ReactFlightNativeRelayServerHostConfig';
 
@@ -22,7 +22,7 @@ import {
 function render(
   model: ReactClientValue,
   destination: Destination,
-  config: BundlerConfig,
+  config: ClientManifest,
 ): void {
   const request = createRequest(model, config);
   startWork(request);

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServer.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServer.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {ReactModel} from 'react-server/src/ReactFlightServer';
+import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
 import type {
   BundlerConfig,
   Destination,
@@ -20,7 +20,7 @@ import {
 } from 'react-server/src/ReactFlightServer';
 
 function render(
-  model: ReactModel,
+  model: ReactClientValue,
   destination: Destination,
   config: BundlerConfig,
 ): void {

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -8,7 +8,10 @@
  */
 
 import type {RowEncoding, JSONValue} from './ReactFlightNativeRelayProtocol';
-import type {Request, ReactModel} from 'react-server/src/ReactFlightServer';
+import type {
+  Request,
+  ReactClientValue,
+} from 'react-server/src/ReactFlightServer';
 import hasOwnProperty from 'shared/hasOwnProperty';
 import isArray from 'shared/isArray';
 import type {JSResourceReference} from 'JSResourceReference';
@@ -73,7 +76,7 @@ export function getServerReferenceId<T>(
 export function getServerReferenceBoundArguments<T>(
   config: BundlerConfig,
   resource: ServerReference<T>,
-): Array<any> {
+): Array<ReactClientValue> {
   throw new Error('Not implemented.');
 }
 
@@ -128,9 +131,9 @@ export function processErrorChunkDev(
 
 function convertModelToJSON(
   request: Request,
-  parent: {+[key: string]: ReactModel} | $ReadOnlyArray<ReactModel>,
+  parent: {+[key: string]: ReactClientValue} | $ReadOnlyArray<ReactClientValue>,
   key: string,
-  model: ReactModel,
+  model: ReactClientValue,
 ): JSONValue {
   const json = resolveModelToJSON(request, parent, key, model);
   if (typeof json === 'object' && json !== null) {
@@ -162,7 +165,7 @@ function convertModelToJSON(
 export function processModelChunk(
   request: Request,
   id: number,
-  model: ReactModel,
+  model: ReactClientValue,
 ): Chunk {
   // $FlowFixMe no good way to define an empty exact object
   const json = convertModelToJSON(request, {}, '', model);

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -63,10 +63,17 @@ export function resolveClientReferenceMetadata<T>(
   return resolveClientReferenceMetadataImpl(config, resource);
 }
 
-export function resolveServerReferenceMetadata<T>(
+export function getServerReferenceId<T>(
   config: BundlerConfig,
   resource: ServerReference<T>,
-): {id: ServerReferenceId, bound: Promise<Array<any>>} {
+): ServerReferenceId {
+  throw new Error('Not implemented.');
+}
+
+export function getServerReferenceBoundArguments<T>(
+  config: BundlerConfig,
+  resource: ServerReference<T>,
+): Array<any> {
   throw new Error('Not implemented.');
 }
 

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -23,7 +23,7 @@ export type ServerReferenceId = {};
 
 import type {
   Destination,
-  BundlerConfig,
+  BundlerConfig as ClientManifest,
   ClientReferenceMetadata,
 } from 'ReactFlightNativeRelayServerIntegration';
 
@@ -37,7 +37,7 @@ import {
 
 export type {
   Destination,
-  BundlerConfig,
+  BundlerConfig as ClientManifest,
   ClientReferenceMetadata,
 } from 'ReactFlightNativeRelayServerIntegration';
 
@@ -60,21 +60,21 @@ export function getClientReferenceKey(
 }
 
 export function resolveClientReferenceMetadata<T>(
-  config: BundlerConfig,
+  config: ClientManifest,
   resource: ClientReference<T>,
 ): ClientReferenceMetadata {
   return resolveClientReferenceMetadataImpl(config, resource);
 }
 
 export function getServerReferenceId<T>(
-  config: BundlerConfig,
+  config: ClientManifest,
   resource: ServerReference<T>,
 ): ServerReferenceId {
   throw new Error('Not implemented.');
 }
 
 export function getServerReferenceBoundArguments<T>(
-  config: BundlerConfig,
+  config: ClientManifest,
   resource: ServerReference<T>,
 ): Array<ReactClientValue> {
   throw new Error('Not implemented.');

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -10,7 +10,7 @@
 import type {
   Destination,
   Chunk,
-  BundlerConfig,
+  ClientManifest,
   ClientReferenceMetadata,
   ClientReference,
   ClientReferenceKey,
@@ -142,7 +142,7 @@ export type Request = {
   status: 0 | 1 | 2,
   fatalError: mixed,
   destination: null | Destination,
-  bundlerConfig: BundlerConfig,
+  bundlerConfig: ClientManifest,
   cache: Map<Function, mixed>,
   nextChunkId: number,
   pendingChunks: number,
@@ -175,7 +175,7 @@ const CLOSED = 2;
 
 export function createRequest(
   model: ReactClientValue,
-  bundlerConfig: BundlerConfig,
+  bundlerConfig: ClientManifest,
   onError: void | ((error: mixed) => ?string),
   context?: Array<[string, ServerContextJSONValue]>,
   identifierPrefix?: string,

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -44,7 +44,8 @@ import {
   processErrorChunkDev,
   processReferenceChunk,
   resolveClientReferenceMetadata,
-  resolveServerReferenceMetadata,
+  getServerReferenceId,
+  getServerReferenceBoundArguments,
   getClientReferenceKey,
   isClientReference,
   isServerReference,
@@ -595,10 +596,18 @@ function serializeServerReference(
   if (existingId !== undefined) {
     return serializeServerReferenceID(existingId);
   }
+
+  const bound: null | Array<any> = getServerReferenceBoundArguments(
+    request.bundlerConfig,
+    serverReference,
+  );
   const serverReferenceMetadata: {
     id: ServerReferenceId,
-    bound: Promise<Array<any>>,
-  } = resolveServerReferenceMetadata(request.bundlerConfig, serverReference);
+    bound: null | Promise<Array<any>>,
+  } = {
+    id: getServerReferenceId(request.bundlerConfig, serverReference),
+    bound: bound ? Promise.resolve(bound) : null,
+  };
   request.pendingChunks++;
   const metadataId = request.nextChunkId++;
   // We assume that this object doesn't suspend.

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -967,7 +967,7 @@ export function resolveModelToJSON(
     if (
       parent[0] === REACT_ELEMENT_TYPE &&
       parent[1] &&
-      parent[1].$$typeof === REACT_PROVIDER_TYPE &&
+      (parent[1]: any).$$typeof === REACT_PROVIDER_TYPE &&
       key === '3'
     ) {
       insideContextProps = value;

--- a/packages/react-server/src/ReactFlightServerBundlerConfigCustom.js
+++ b/packages/react-server/src/ReactFlightServerBundlerConfigCustom.js
@@ -9,7 +9,7 @@
 
 declare var $$$hostConfig: any;
 
-export opaque type BundlerConfig = mixed;
+export opaque type ClientManifest = mixed;
 export opaque type ClientReference<T> = mixed; // eslint-disable-line no-unused-vars
 export opaque type ServerReference<T> = mixed; // eslint-disable-line no-unused-vars
 export opaque type ClientReferenceMetadata: any = mixed;

--- a/packages/react-server/src/ReactFlightServerBundlerConfigCustom.js
+++ b/packages/react-server/src/ReactFlightServerBundlerConfigCustom.js
@@ -20,5 +20,6 @@ export const isServerReference = $$$hostConfig.isServerReference;
 export const getClientReferenceKey = $$$hostConfig.getClientReferenceKey;
 export const resolveClientReferenceMetadata =
   $$$hostConfig.resolveClientReferenceMetadata;
-export const resolveServerReferenceMetadata =
-  $$$hostConfig.resolveServerReferenceMetadata;
+export const getServerReferenceId = $$$hostConfig.getServerReferenceId;
+export const getServerReferenceBoundArguments =
+  $$$hostConfig.getServerReferenceBoundArguments;

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -64,7 +64,10 @@ ByteSize
 
 // TODO: Implement HTMLData, BlobData and URLData.
 
-import type {Request, ReactModel} from 'react-server/src/ReactFlightServer';
+import type {
+  Request,
+  ReactClientValue,
+} from 'react-server/src/ReactFlightServer';
 
 import {stringToChunk} from './ReactServerStreamConfig';
 
@@ -124,7 +127,7 @@ export function processErrorChunkDev(
 export function processModelChunk(
   request: Request,
   id: number,
-  model: ReactModel,
+  model: ReactClientValue,
 ): Chunk {
   // $FlowFixMe[incompatible-type] stringify can return null
   const json: string = stringify(model, request.toJSON);
@@ -145,7 +148,7 @@ export function processReferenceChunk(
 export function processImportChunk(
   request: Request,
   id: number,
-  clientReferenceMetadata: ReactModel,
+  clientReferenceMetadata: ReactClientValue,
 ): Chunk {
   // $FlowFixMe[incompatible-type] stringify can return null
   const json: string = stringify(clientReferenceMetadata);


### PR DESCRIPTION
This is just moving some stuff around and renaming things.

This tuple is opaque to the Flight implementation and we should probably encode it separately as a single string instead of a model object.

The term "Metadata" isn't the same as when used for ClientReferences so it's not really the right term anyway.

I also made it optional since a bound function with no arguments bound is technically different than a raw instance of that function (it's a clone).

I also renamed the type ReactModel to ReactClientValue. This is the generic serializable type for something that can pass through the serializable boundary from server to client. There will be another one for client to server.

I also filled in missing classes and ensure the serializable sub-types are explicit. E.g. Array and Thenable.