### PR TITLE
Clean up inconsistent naming in Flight implementation

### DIFF
--- a/fixtures/flight-browser/index.html
+++ b/fixtures/flight-browser/index.html
@@ -55,12 +55,12 @@
         return 'Title';
       }
 
-      let model = {
+      let value = {
         title: <Title />,
         content: <HTML />,
       };
 
-      let stream = ReactServerDOMServer.renderToReadableStream(model);
+      let stream = ReactServerDOMServer.renderToReadableStream(value);
       let response = new Response(stream, {
         headers: {'Content-Type': 'text/html'},
       });
@@ -83,12 +83,12 @@
       }
 
       function Shell({ data }) {
-        let model = React.use(data);
+        let value = React.use(data);
         return <div>
           <Suspense fallback="...">
-            <h1>{model.title}</h1>
+            <h1>{value.title}</h1>
           </Suspense>
-          {model.content}
+          {value.content}
         </div>;
       }
 

--- a/fixtures/flight/server/global.js
+++ b/fixtures/flight/server/global.js
@@ -122,8 +122,8 @@ app.all('/', async function (req, res, next) {
         virtualFs = fs;
         buildPath = path.join(__dirname, '../build/');
       }
-      // Read the module map from the virtual file system.
-      const moduleMap = JSON.parse(
+      // Read the SSR manifest from the virtual file system.
+      const ssrManifest = JSON.parse(
         await virtualFs.readFile(
           path.join(buildPath, 'react-ssr-manifest.json'),
           'utf8'
@@ -140,7 +140,7 @@ app.all('/', async function (req, res, next) {
       // For HTML, we're a "client" emulator that runs the client code,
       // so we start by consuming the RSC payload. This needs a module
       // map that reverse engineers the client-side path to the SSR path.
-      const root = await createFromNodeStream(rscResponse, moduleMap);
+      const root = await createFromNodeStream(rscResponse, ssrManifest);
       // Render it into HTML by resolving the client components
       res.set('Content-type', 'text/html');
       const {pipe} = renderToPipeableStream(root, {

--- a/fixtures/flight/server/region.js
+++ b/fixtures/flight/server/region.js
@@ -52,11 +52,11 @@ app.get('/', async function (req, res) {
   // const m = require('../src/App.js');
   const m = await import('../src/App.js');
 
-  let moduleMap;
+  let clientManifest;
   let mainCSSChunks;
   if (process.env.NODE_ENV === 'development') {
-    // Read the module map from the HMR server in development.
-    moduleMap = await (
+    // Read the client manifest from the HMR server in development.
+    clientManifest = await (
       await fetch('http://localhost:3000/react-client-manifest.json')
     ).json();
     mainCSSChunks = (
@@ -65,8 +65,8 @@ app.get('/', async function (req, res) {
       ).json()
     ).main.css;
   } else {
-    // Read the module map from the static build in production.
-    moduleMap = JSON.parse(
+    // Read the client manifest from the static build in production.
+    clientManifest = JSON.parse(
       await readFile(
         path.resolve(__dirname, `../build/react-client-manifest.json`),
         'utf8'
@@ -91,7 +91,7 @@ app.get('/', async function (req, res) {
     ),
     React.createElement(App),
   ];
-  const {pipe} = renderToPipeableStream(root, moduleMap);
+  const {pipe} = renderToPipeableStream(root, clientManifest);
   pipe(res);
 });
 

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -501,7 +501,7 @@ function createServerReferenceProxy<A: Iterable<any>, T>(
   return proxy;
 }
 
-export function parseValueString(
+export function parseJSONValueString(
   response: Response,
   parentObject: Object,
   key: string,
@@ -597,7 +597,7 @@ export function parseValueString(
   return value;
 }
 
-export function parseValueTuple(
+export function parseJSONValueTuple(
   response: Response,
   value: {+[key: string]: JSONValue} | $ReadOnlyArray<JSONValue>,
 ): any {

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -151,7 +151,7 @@ Chunk.prototype.then = function <T>(
 };
 
 export type ResponseBase = {
-  _bundlerConfig: SSRManifest,
+  _ssrManifest: SSRManifest,
   _callServer: CallServerCallback,
   _chunks: Map<number, SomeChunk<any>>,
   ...
@@ -619,12 +619,12 @@ function missingCall() {
 }
 
 export function createResponse(
-  bundlerConfig: SSRManifest,
+  ssrManifest: SSRManifest,
   callServer: void | CallServerCallback,
 ): ResponseBase {
   const chunks: Map<number, SomeChunk<any>> = new Map();
   const response = {
-    _bundlerConfig: bundlerConfig,
+    _ssrManifest: ssrManifest,
     _callServer: callServer !== undefined ? callServer : missingCall,
     _chunks: chunks,
   };
@@ -657,7 +657,7 @@ export function resolveModule(
     model,
   );
   const clientReference = resolveClientReference<$FlowFixMe>(
-    response._bundlerConfig,
+    response._ssrManifest,
     clientReferenceMetadata,
   );
 

--- a/packages/react-client/src/ReactFlightClientHostConfigStream.js
+++ b/packages/react-client/src/ReactFlightClientHostConfigStream.js
@@ -16,8 +16,8 @@ export type Response = ResponseBase & {
   _stringDecoder: StringDecoder,
 };
 
-export type UninitializedModel = string;
+export type UninitializedValue = string;
 
-export function parseModel<T>(response: Response, json: UninitializedModel): T {
+export function parseValue<T>(response: Response, json: UninitializedValue): T {
   return JSON.parse(json, response._fromJSON);
 }

--- a/packages/react-client/src/ReactFlightClientHostConfigStream.js
+++ b/packages/react-client/src/ReactFlightClientHostConfigStream.js
@@ -18,6 +18,9 @@ export type Response = ResponseBase & {
 
 export type UninitializedValue = string;
 
-export function parseValue<T>(response: Response, json: UninitializedValue): T {
-  return JSON.parse(json, response._fromJSON);
+export function parseJSONValue<T>(
+  response: Response,
+  value: UninitializedValue,
+): T {
+  return JSON.parse(value, response._fromJSON);
 }

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -17,8 +17,8 @@ import {
   resolveErrorProd,
   resolveErrorDev,
   createResponse as createResponseBase,
-  parseValueString,
-  parseValueTuple,
+  parseJSONValueString,
+  parseJSONValueTuple,
 } from './ReactFlightClient';
 
 import {
@@ -111,10 +111,10 @@ function createFromJSONCallback(response: Response) {
   return function (key: string, value: JSONValue) {
     if (typeof value === 'string') {
       // We can't use .bind here because we need the "this" value.
-      return parseValueString(response, this, key, value);
+      return parseJSONValueString(response, this, key, value);
     }
     if (typeof value === 'object' && value !== null) {
-      return parseValueTuple(response, value);
+      return parseJSONValueTuple(response, value);
     }
     return value;
   };

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -13,12 +13,12 @@ import type {SSRManifest} from './ReactFlightClientHostConfig';
 
 import {
   resolveModule,
-  resolveModel,
+  resolveValue,
   resolveErrorProd,
   resolveErrorDev,
   createResponse as createResponseBase,
-  parseModelString,
-  parseModelTuple,
+  parseValueString,
+  parseValueTuple,
 } from './ReactFlightClient';
 
 import {
@@ -63,7 +63,7 @@ function processFullRow(response: Response, row: string): void {
     }
     default: {
       // We assume anything else is JSON.
-      resolveModel(response, id, row.substring(colon + 1));
+      resolveValue(response, id, row.substring(colon + 1));
       return;
     }
   }
@@ -111,10 +111,10 @@ function createFromJSONCallback(response: Response) {
   return function (key: string, value: JSONValue) {
     if (typeof value === 'string') {
       // We can't use .bind here because we need the "this" value.
-      return parseModelString(response, this, key, value);
+      return parseValueString(response, this, key, value);
     }
     if (typeof value === 'object' && value !== null) {
-      return parseModelTuple(response, value);
+      return parseValueTuple(response, value);
     }
     return value;
   };

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -13,7 +13,7 @@ import type {SSRManifest} from './ReactFlightClientHostConfig';
 
 import {
   resolveModule,
-  resolveValue,
+  resolveJSONValue,
   resolveErrorProd,
   resolveErrorDev,
   createResponse as createResponseBase,
@@ -63,7 +63,7 @@ function processFullRow(response: Response, row: string): void {
     }
     default: {
       // We assume anything else is JSON.
-      resolveValue(response, id, row.substring(colon + 1));
+      resolveJSONValue(response, id, row.substring(colon + 1));
       return;
     }
   }

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -121,13 +121,13 @@ function createFromJSONCallback(response: Response) {
 }
 
 export function createResponse(
-  bundlerConfig: SSRManifest,
+  ssrManifest: SSRManifest,
   callServer: void | CallServerCallback,
 ): Response {
   // NOTE: CHECK THE COMPILER OUTPUT EACH TIME YOU CHANGE THIS.
   // It should be inlined to one object literal but minor changes can break it.
   const stringDecoder = supportsBinaryStreams ? createStringDecoder() : null;
-  const response: any = createResponseBase(bundlerConfig, callServer);
+  const response: any = createResponseBase(ssrManifest, callServer);
   response._partialRow = '';
   if (supportsBinaryStreams) {
     response._stringDecoder = stringDecoder;

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -126,8 +126,8 @@ describe('ReactFlight', () => {
     const transport = ReactNoopFlightServer.render({
       foo: <Foo />,
     });
-    const model = await ReactNoopFlightClient.read(transport);
-    expect(model).toEqual({
+    const value = await ReactNoopFlightClient.read(transport);
+    expect(value).toEqual({
       foo: {
         bar: (
           <div>
@@ -154,15 +154,15 @@ describe('ReactFlight', () => {
       return <User greeting="Hello" name={firstName + ' ' + lastName} />;
     }
 
-    const model = {
+    const value = {
       greeting: <Greeting firstName="Seb" lastName="Smith" />,
     };
 
-    const transport = ReactNoopFlightServer.render(model);
+    const transport = ReactNoopFlightServer.render(value);
 
     await act(async () => {
-      const rootModel = await ReactNoopFlightClient.read(transport);
-      const greeting = rootModel.greeting;
+      const rootValue = await ReactNoopFlightClient.read(transport);
+      const greeting = rootValue.greeting;
       ReactNoop.render(greeting);
     });
 
@@ -186,9 +186,9 @@ describe('ReactFlight', () => {
       return <ItemList items={iterable} />;
     }
 
-    const model = <Items />;
+    const value = <Items />;
 
-    const transport = ReactNoopFlightServer.render(model);
+    const transport = ReactNoopFlightServer.render(value);
 
     await act(async () => {
       ReactNoop.render(await ReactNoopFlightClient.read(transport));
@@ -202,9 +202,9 @@ describe('ReactFlight', () => {
       return undefined;
     }
 
-    const model = <Undefined />;
+    const value = <Undefined />;
 
-    const transport = ReactNoopFlightServer.render(model);
+    const transport = ReactNoopFlightServer.render(value);
 
     await act(async () => {
       ReactNoop.render(await ReactNoopFlightClient.read(transport));
@@ -218,9 +218,9 @@ describe('ReactFlight', () => {
       return <React.Fragment />;
     }
 
-    const model = <Empty />;
+    const value = <Empty />;
 
-    const transport = ReactNoopFlightServer.render(model);
+    const transport = ReactNoopFlightServer.render(value);
 
     await act(async () => {
       ReactNoop.render(await ReactNoopFlightClient.read(transport));
@@ -258,15 +258,15 @@ describe('ReactFlight', () => {
     const transport = ReactNoopFlightServer.render(<ServerComponent />);
 
     await act(async () => {
-      const rootModel = await ReactNoopFlightClient.read(transport);
-      ReactNoop.render(rootModel);
+      const rootValue = await ReactNoopFlightClient.read(transport);
+      ReactNoop.render(rootValue);
     });
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
     await load();
 
     await act(async () => {
-      const rootModel = await ReactNoopFlightClient.read(transport);
-      ReactNoop.render(rootModel);
+      const rootValue = await ReactNoopFlightClient.read(transport);
+      ReactNoop.render(rootValue);
     });
     expect(ReactNoop).toMatchRenderedOutput(
       <div>
@@ -303,8 +303,8 @@ describe('ReactFlight', () => {
     const transport = ReactNoopFlightServer.render(<ServerComponent />);
 
     await act(async () => {
-      const rootModel = await ReactNoopFlightClient.read(transport);
-      ReactNoop.render(rootModel);
+      const rootValue = await ReactNoopFlightClient.read(transport);
+      ReactNoop.render(rootValue);
     });
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
     spyOnDevAndProd(console, 'error').mockImplementation(() => {});
@@ -340,15 +340,15 @@ describe('ReactFlight', () => {
     const transport = ReactNoopFlightServer.render(<ServerComponent />);
 
     await act(async () => {
-      const rootModel = await ReactNoopFlightClient.read(transport);
-      ReactNoop.render(rootModel);
+      const rootValue = await ReactNoopFlightClient.read(transport);
+      ReactNoop.render(rootValue);
     });
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
     await load();
 
     await act(async () => {
-      const rootModel = await ReactNoopFlightClient.read(transport);
-      ReactNoop.render(rootModel);
+      const rootValue = await ReactNoopFlightClient.read(transport);
+      ReactNoop.render(rootValue);
     });
     expect(ReactNoop).toMatchRenderedOutput(
       <div>
@@ -385,8 +385,8 @@ describe('ReactFlight', () => {
     const transport = ReactNoopFlightServer.render(<ServerComponent />);
 
     await act(async () => {
-      const rootModel = await ReactNoopFlightClient.read(transport);
-      ReactNoop.render(rootModel);
+      const rootValue = await ReactNoopFlightClient.read(transport);
+      ReactNoop.render(rootValue);
     });
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
     spyOnDevAndProd(console, 'error').mockImplementation(() => {});
@@ -423,15 +423,15 @@ describe('ReactFlight', () => {
     const transport = ReactNoopFlightServer.render(<ServerComponent />);
 
     await act(async () => {
-      const rootModel = await ReactNoopFlightClient.read(transport);
-      ReactNoop.render(rootModel);
+      const rootValue = await ReactNoopFlightClient.read(transport);
+      ReactNoop.render(rootValue);
     });
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
     await load();
 
     await act(async () => {
-      const rootModel = await ReactNoopFlightClient.read(transport);
-      ReactNoop.render(rootModel);
+      const rootValue = await ReactNoopFlightClient.read(transport);
+      ReactNoop.render(rootValue);
     });
     expect(ReactNoop).toMatchRenderedOutput(<div>I am client</div>);
   });
@@ -1102,19 +1102,19 @@ describe('ReactFlight', () => {
         );
       }
 
-      const model = {
+      const value = {
         foo: <Foo />,
       };
 
-      const transport = ReactNoopFlightServer.render(model);
+      const transport = ReactNoopFlightServer.render(value);
 
       assertLog([]);
 
       await act(async () => {
         ServerContext._currentRenderer = null;
         ServerContext._currentRenderer2 = null;
-        const flightModel = await ReactNoopFlightClient.read(transport);
-        ReactNoop.render(flightModel.foo);
+        const rootValue = await ReactNoopFlightClient.read(transport);
+        ReactNoop.render(rootValue.foo);
       });
 
       assertLog(['ClientBar']);
@@ -1139,8 +1139,8 @@ describe('ReactFlight', () => {
       });
 
       await act(async () => {
-        const flightModel = await ReactNoopFlightClient.read(transport);
-        ReactNoop.render(flightModel);
+        const rootValue = await ReactNoopFlightClient.read(transport);
+        ReactNoop.render(rootValue);
       });
       expect(ReactNoop).toMatchRenderedOutput(<span>Override</span>);
     });
@@ -1194,10 +1194,10 @@ describe('ReactFlight', () => {
         );
       }
 
-      function ClientApp({serverModel}) {
+      function ClientApp({rootValue}) {
         return (
           <>
-            {serverModel}
+            {rootValue}
             <ClientBaz />
           </>
         );
@@ -1220,8 +1220,8 @@ describe('ReactFlight', () => {
       Scheduler = require('scheduler');
 
       await act(async () => {
-        const serverModel = await ReactNoopFlightClient.read(transport);
-        ReactNoop.render(<ClientApp serverModel={serverModel} />);
+        const rootValue = await ReactNoopFlightClient.read(transport);
+        ReactNoop.render(<ClientApp rootValue={rootValue} />);
       });
 
       expect(ClientContext).not.toBe(ServerContext);

--- a/packages/react-client/src/forks/ReactFlightClientHostConfig.custom.js
+++ b/packages/react-client/src/forks/ReactFlightClientHostConfig.custom.js
@@ -39,7 +39,7 @@ export const requireModule = $$$hostConfig.requireModule;
 export opaque type Source = mixed;
 
 export type UninitializedValue = string;
-export const parseValue = $$$hostConfig.parseValue;
+export const parseJSONValue = $$$hostConfig.parseJSONValue;
 
 export opaque type StringDecoder = mixed; // eslint-disable-line no-undef
 

--- a/packages/react-client/src/forks/ReactFlightClientHostConfig.custom.js
+++ b/packages/react-client/src/forks/ReactFlightClientHostConfig.custom.js
@@ -38,8 +38,8 @@ export const requireModule = $$$hostConfig.requireModule;
 
 export opaque type Source = mixed;
 
-export type UninitializedModel = string;
-export const parseModel = $$$hostConfig.parseModel;
+export type UninitializedValue = string;
+export const parseValue = $$$hostConfig.parseValue;
 
 export opaque type StringDecoder = mixed; // eslint-disable-line no-undef
 

--- a/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
@@ -29,7 +29,7 @@ const {createResponse, processStringChunk, getRoot, close} = ReactFlightClient({
   requireModule(idx: string) {
     return readModule(idx);
   },
-  parseModel(response: Response, json) {
+  parseValue(response: Response, json) {
     return JSON.parse(json, response._fromJSON);
   },
 });

--- a/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
@@ -22,7 +22,7 @@ type Source = Array<string>;
 
 const {createResponse, processStringChunk, getRoot, close} = ReactFlightClient({
   supportsBinaryStreams: false,
-  resolveClientReference(bundlerConfig: null, idx: string) {
+  resolveClientReference(ssrManifest: null, idx: string) {
     return idx;
   },
   preloadModule(idx: string) {},

--- a/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
@@ -29,8 +29,8 @@ const {createResponse, processStringChunk, getRoot, close} = ReactFlightClient({
   requireModule(idx: string) {
     return readModule(idx);
   },
-  parseValue(response: Response, json) {
-    return JSON.parse(json, response._fromJSON);
+  parseJSONValue(response: Response, value) {
+    return JSON.parse(value, response._fromJSON);
   },
 });
 

--- a/packages/react-noop-renderer/src/ReactNoopFlightServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightServer.js
@@ -71,11 +71,11 @@ type Options = {
   identifierPrefix?: string,
 };
 
-function render(model: ReactClientValue, options?: Options): Destination {
+function render(value: ReactClientValue, options?: Options): Destination {
   const destination: Destination = [];
   const clientManifest = undefined;
   const request = ReactNoopFlightServer.createRequest(
-    model,
+    value,
     clientManifest,
     options ? options.onError : undefined,
     options ? options.context : undefined,

--- a/packages/react-noop-renderer/src/ReactNoopFlightServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightServer.js
@@ -54,14 +54,14 @@ const ReactNoopFlightServer = ReactFlightServer({
   isServerReference(reference: Object): boolean {
     return reference.$$typeof === Symbol.for('react.server.reference');
   },
-  getClientReferenceKey(reference: Object): Object {
-    return reference;
+  getClientReferenceKey(clientReference: Object): Object {
+    return clientReference;
   },
   resolveClientReferenceMetadata(
-    config: void,
-    reference: {$$typeof: symbol, value: any},
+    clientManifest: void,
+    clientReference: {$$typeof: symbol, value: any},
   ) {
-    return saveModule(reference.value);
+    return saveModule(clientReference.value);
   },
 });
 
@@ -73,10 +73,10 @@ type Options = {
 
 function render(model: ReactClientValue, options?: Options): Destination {
   const destination: Destination = [];
-  const bundlerConfig = undefined;
+  const clientManifest = undefined;
   const request = ReactNoopFlightServer.createRequest(
     model,
-    bundlerConfig,
+    clientManifest,
     options ? options.onError : undefined,
     options ? options.context : undefined,
     options ? options.identifierPrefix : undefined,

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -13,7 +13,7 @@ import type {Response} from 'react-client/src/ReactFlightClient';
 
 import {
   createResponse,
-  resolveValue,
+  resolveJSONValue,
   resolveModule,
   resolveErrorDev,
   resolveErrorProd,
@@ -26,7 +26,7 @@ export {createResponse, close, getRoot};
 export function resolveRow(response: Response, chunk: RowEncoding): void {
   if (chunk[0] === 'O') {
     // $FlowFixMe unable to refine on array indices
-    resolveValue(response, chunk[1], chunk[2]);
+    resolveJSONValue(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'I') {
     // $FlowFixMe unable to refine on array indices
     resolveModule(response, chunk[1], chunk[2]);

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -13,7 +13,7 @@ import type {Response} from 'react-client/src/ReactFlightClient';
 
 import {
   createResponse,
-  resolveModel,
+  resolveValue,
   resolveModule,
   resolveErrorDev,
   resolveErrorProd,
@@ -26,7 +26,7 @@ export {createResponse, close, getRoot};
 export function resolveRow(response: Response, chunk: RowEncoding): void {
   if (chunk[0] === 'O') {
     // $FlowFixMe unable to refine on array indices
-    resolveModel(response, chunk[1], chunk[2]);
+    resolveValue(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'I') {
     // $FlowFixMe unable to refine on array indices
     resolveModule(response, chunk[1], chunk[2]);

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
@@ -40,14 +40,14 @@ export type UninitializedModel = JSONValue;
 export type Response = ResponseBase;
 
 export function resolveClientReference<T>(
-  bundlerConfig: SSRManifest,
+  ssrManifest: SSRManifest,
   metadata: ClientReferenceMetadata,
 ): ClientReference<T> {
   return resolveClientReferenceImpl(metadata);
 }
 
 export function resolveServerReference<T>(
-  bundlerConfig: ServerManifest,
+  serverManifest: ServerManifest,
   id: ServerReferenceId,
 ): ClientReference<T> {
   throw new Error('Not implemented.');

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
@@ -16,8 +16,8 @@ import type {ClientReferenceMetadata} from 'ReactFlightDOMRelayClientIntegration
 export type ClientReference<T> = JSResourceReference<T>;
 
 import {
-  parseModelString,
-  parseModelTuple,
+  parseValueString,
+  parseValueTuple,
 } from 'react-client/src/ReactFlightClient';
 
 export {
@@ -35,7 +35,7 @@ export type SSRManifest = null;
 export type ServerManifest = null;
 export type ServerReferenceId = string;
 
-export type UninitializedModel = JSONValue;
+export type UninitializedValue = JSONValue;
 
 export type Response = ResponseBase;
 
@@ -53,31 +53,31 @@ export function resolveServerReference<T>(
   throw new Error('Not implemented.');
 }
 
-function parseModelRecursively(
+function parseValueRecursively(
   response: Response,
   parentObj: {+[key: string]: JSONValue} | $ReadOnlyArray<JSONValue>,
   key: string,
   value: JSONValue,
 ): $FlowFixMe {
   if (typeof value === 'string') {
-    return parseModelString(response, parentObj, key, value);
+    return parseValueString(response, parentObj, key, value);
   }
   if (typeof value === 'object' && value !== null) {
     if (isArray(value)) {
       const parsedValue: Array<$FlowFixMe> = [];
       for (let i = 0; i < value.length; i++) {
-        (parsedValue: any)[i] = parseModelRecursively(
+        (parsedValue: any)[i] = parseValueRecursively(
           response,
           value,
           '' + i,
           value[i],
         );
       }
-      return parseModelTuple(response, parsedValue);
+      return parseValueTuple(response, parsedValue);
     } else {
       const parsedValue = {};
       for (const innerKey in value) {
-        (parsedValue: any)[innerKey] = parseModelRecursively(
+        (parsedValue: any)[innerKey] = parseValueRecursively(
           response,
           value,
           innerKey,
@@ -92,6 +92,6 @@ function parseModelRecursively(
 
 const dummy = {};
 
-export function parseModel<T>(response: Response, json: UninitializedModel): T {
-  return (parseModelRecursively(response, dummy, '', json): any);
+export function parseValue<T>(response: Response, json: UninitializedValue): T {
+  return (parseValueRecursively(response, dummy, '', json): any);
 }

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
@@ -53,7 +53,7 @@ export function resolveServerReference<T>(
   throw new Error('Not implemented.');
 }
 
-function parseValueRecursively(
+function parseJSONValueRecursively(
   response: Response,
   parentObj: {+[key: string]: JSONValue} | $ReadOnlyArray<JSONValue>,
   key: string,
@@ -66,7 +66,7 @@ function parseValueRecursively(
     if (isArray(value)) {
       const parsedValue: Array<$FlowFixMe> = [];
       for (let i = 0; i < value.length; i++) {
-        (parsedValue: any)[i] = parseValueRecursively(
+        (parsedValue: any)[i] = parseJSONValueRecursively(
           response,
           value,
           '' + i,
@@ -77,7 +77,7 @@ function parseValueRecursively(
     } else {
       const parsedValue = {};
       for (const innerKey in value) {
-        (parsedValue: any)[innerKey] = parseValueRecursively(
+        (parsedValue: any)[innerKey] = parseJSONValueRecursively(
           response,
           value,
           innerKey,
@@ -92,6 +92,9 @@ function parseValueRecursively(
 
 const dummy = {};
 
-export function parseValue<T>(response: Response, json: UninitializedValue): T {
-  return (parseValueRecursively(response, dummy, '', json): any);
+export function parseJSONValue<T>(
+  response: Response,
+  value: UninitializedValue,
+): T {
+  return (parseJSONValueRecursively(response, dummy, '', value): any);
 }

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
@@ -16,8 +16,8 @@ import type {ClientReferenceMetadata} from 'ReactFlightDOMRelayClientIntegration
 export type ClientReference<T> = JSResourceReference<T>;
 
 import {
-  parseValueString,
-  parseValueTuple,
+  parseJSONValueString,
+  parseJSONValueTuple,
 } from 'react-client/src/ReactFlightClient';
 
 export {
@@ -60,7 +60,7 @@ function parseJSONValueRecursively(
   value: JSONValue,
 ): $FlowFixMe {
   if (typeof value === 'string') {
-    return parseValueString(response, parentObj, key, value);
+    return parseJSONValueString(response, parentObj, key, value);
   }
   if (typeof value === 'object' && value !== null) {
     if (isArray(value)) {
@@ -73,7 +73,7 @@ function parseJSONValueRecursively(
           value[i],
         );
       }
-      return parseValueTuple(response, parsedValue);
+      return parseJSONValueTuple(response, parsedValue);
     } else {
       const parsedValue = {};
       for (const innerKey in value) {

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServer.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServer.js
@@ -25,13 +25,13 @@ type Options = {
 };
 
 function render(
-  model: ReactClientValue,
+  value: ReactClientValue,
   destination: Destination,
   clientManifest: ClientManifest,
   options?: Options,
 ): void {
   const request = createRequest(
-    model,
+    value,
     clientManifest,
     options ? options.onError : undefined,
     undefined, // not currently set up to supply context overrides

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServer.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServer.js
@@ -27,12 +27,12 @@ type Options = {
 function render(
   model: ReactClientValue,
   destination: Destination,
-  config: ClientManifest,
+  clientManifest: ClientManifest,
   options?: Options,
 ): void {
   const request = createRequest(
     model,
-    config,
+    clientManifest,
     options ? options.onError : undefined,
     undefined, // not currently set up to supply context overrides
     options ? options.identifierPrefix : undefined,

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -26,7 +26,7 @@ export type ServerReferenceId = {};
 
 import type {
   Destination,
-  ClientManifest,
+  BundlerConfig as ClientManifest,
   ClientReferenceMetadata,
 } from 'ReactFlightDOMRelayServerIntegration';
 
@@ -40,7 +40,7 @@ import {
 
 export type {
   Destination,
-  ClientManifest,
+  BundlerConfig as ClientManifest,
   ClientReferenceMetadata,
 } from 'ReactFlightDOMRelayServerIntegration';
 

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -30,7 +30,7 @@ import type {
   ClientReferenceMetadata,
 } from 'ReactFlightDOMRelayServerIntegration';
 
-import {resolveModelToJSON} from 'react-server/src/ReactFlightServer';
+import {resolveValueToJSON} from 'react-server/src/ReactFlightServer';
 
 import {
   emitRow,
@@ -133,18 +133,18 @@ export function processErrorChunkDev(
   ];
 }
 
-function convertModelToJSON(
+function convertValueToJSON(
   request: Request,
   parent: {+[key: string]: ReactClientValue} | $ReadOnlyArray<ReactClientValue>,
   key: string,
-  model: ReactClientValue,
+  value: ReactClientValue,
 ): JSONValue {
-  const json = resolveModelToJSON(request, parent, key, model);
+  const json = resolveValueToJSON(request, parent, key, value);
   if (typeof json === 'object' && json !== null) {
     if (isArray(json)) {
       const jsonArray: Array<JSONValue> = [];
       for (let i = 0; i < json.length; i++) {
-        jsonArray[i] = convertModelToJSON(request, json, '' + i, json[i]);
+        jsonArray[i] = convertValueToJSON(request, json, '' + i, json[i]);
       }
       return jsonArray;
     } else {
@@ -153,7 +153,7 @@ function convertModelToJSON(
       const jsonObj: {[key: string]: JSONValue} = {};
       for (const nextKey in json) {
         if (hasOwnProperty.call(json, nextKey)) {
-          jsonObj[nextKey] = convertModelToJSON(
+          jsonObj[nextKey] = convertValueToJSON(
             request,
             json,
             nextKey,
@@ -167,13 +167,13 @@ function convertModelToJSON(
   return json;
 }
 
-export function processModelChunk(
+export function processValueChunk(
   request: Request,
   id: number,
-  model: ReactClientValue,
+  value: ReactClientValue,
 ): Chunk {
   // $FlowFixMe no good way to define an empty exact object
-  const json = convertModelToJSON(request, {}, '', model);
+  const json = convertValueToJSON(request, {}, '', value);
   return ['O', id, json];
 }
 

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -26,7 +26,7 @@ export type ServerReferenceId = {};
 
 import type {
   Destination,
-  BundlerConfig as ClientManifest,
+  ClientManifest,
   ClientReferenceMetadata,
 } from 'ReactFlightDOMRelayServerIntegration';
 
@@ -40,7 +40,7 @@ import {
 
 export type {
   Destination,
-  BundlerConfig as ClientManifest,
+  ClientManifest,
   ClientReferenceMetadata,
 } from 'ReactFlightDOMRelayServerIntegration';
 
@@ -55,30 +55,30 @@ export function isServerReference(reference: Object): boolean {
 export type ClientReferenceKey = ClientReference<any>;
 
 export function getClientReferenceKey(
-  reference: ClientReference<any>,
+  clientReference: ClientReference<any>,
 ): ClientReferenceKey {
   // We use the reference object itself as the key because we assume the
   // object will be cached by the bundler runtime.
-  return reference;
+  return clientReference;
 }
 
 export function resolveClientReferenceMetadata<T>(
-  config: ClientManifest,
-  resource: ClientReference<T>,
+  clientManifest: ClientManifest,
+  clientReference: ClientReference<T>,
 ): ClientReferenceMetadata {
-  return resolveClientReferenceMetadataImpl(config, resource);
+  return resolveClientReferenceMetadataImpl(clientManifest, clientReference);
 }
 
 export function getServerReferenceId<T>(
-  config: ClientManifest,
-  resource: ServerReference<T>,
+  clientManifest: ClientManifest,
+  serverReference: ServerReference<T>,
 ): ServerReferenceId {
   throw new Error('Not implemented.');
 }
 
 export function getServerReferenceBoundArguments<T>(
-  config: ClientManifest,
-  resource: ServerReference<T>,
+  clientManifest: ClientManifest,
+  serverReference: ServerReference<T>,
 ): Array<ReactClientValue> {
   throw new Error('Not implemented.');
 }

--- a/packages/react-server-dom-relay/src/__mocks__/ReactFlightDOMRelayServerIntegration.js
+++ b/packages/react-server-dom-relay/src/__mocks__/ReactFlightDOMRelayServerIntegration.js
@@ -12,8 +12,8 @@ const ReactFlightDOMRelayServerIntegration = {
     destination.push(json);
   },
   close(destination) {},
-  resolveClientReferenceMetadata(config, resource) {
-    return resource._moduleId;
+  resolveClientReferenceMetadata(clientManifest, clientReference) {
+    return clientReference._moduleId;
   },
 };
 

--- a/packages/react-server-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
+++ b/packages/react-server-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
@@ -38,16 +38,16 @@ describe('ReactFlightDOMRelay', () => {
     }
     ReactDOMFlightRelayClient.close(response);
     const promise = ReactDOMFlightRelayClient.getRoot(response);
-    let model;
+    let value;
     let error;
     promise.then(
-      m => (model = m),
+      m => (value = m),
       e => (error = e),
     );
     if (error) {
       throw error;
     }
-    return model;
+    return value;
   }
 
   it('can render a Server Component', () => {
@@ -71,8 +71,8 @@ describe('ReactFlightDOMRelay', () => {
       transport,
     );
 
-    const model = readThrough(transport);
-    expect(model).toEqual({
+    const value = readThrough(transport);
+    expect(value).toEqual({
       foo: {
         bar: (
           <div>
@@ -99,19 +99,19 @@ describe('ReactFlightDOMRelay', () => {
       return <User greeting="Hello" name={firstName + ' ' + lastName} />;
     }
 
-    const model = {
+    const value = {
       greeting: <Greeting firstName="Seb" lastName="Smith" />,
     };
 
     const transport = [];
-    ReactDOMFlightRelayServer.render(model, transport);
+    ReactDOMFlightRelayServer.render(value, transport);
 
-    const modelClient = readThrough(transport);
+    const valueClient = readThrough(transport);
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      root.render(modelClient.greeting);
+      root.render(valueClient.greeting);
     });
 
     expect(container.innerHTML).toEqual('<span>Hello, Seb Smith</span>');
@@ -152,8 +152,8 @@ describe('ReactFlightDOMRelay', () => {
       transport,
     );
 
-    const model = readThrough(transport);
-    expect(model).toEqual({
+    const value = readThrough(transport);
+    expect(value).toEqual({
       foo: {
         bar: (
           <div>
@@ -193,8 +193,8 @@ describe('ReactFlightDOMRelay', () => {
       transport,
     );
 
-    const model = readThrough(transport);
-    expect(model).toEqual({
+    const value = readThrough(transport);
+    expect(value).toEqual({
       foo: {
         bar: 14,
       },
@@ -215,8 +215,8 @@ describe('ReactFlightDOMRelay', () => {
     const transport = [];
     ReactDOMFlightRelayServer.render(<Foo />, transport);
 
-    const model = readThrough(transport);
-    expect(model).toEqual(14);
+    const value = readThrough(transport);
+    expect(value).toEqual(14);
   });
 
   it('should warn in DEV if a class instance polyfill is passed to a host component', () => {

--- a/packages/react-server-dom-webpack/src/ReactFlightClientNodeBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightClientNodeBundlerConfig.js
@@ -36,15 +36,15 @@ export opaque type ClientReference<T> = {
 };
 
 export function resolveClientReference<T>(
-  bundlerConfig: SSRManifest,
+  ssrManifest: SSRManifest,
   metadata: ClientReferenceMetadata,
 ): ClientReference<T> {
-  const resolvedModuleData = bundlerConfig[metadata.id][metadata.name];
+  const resolvedModuleData = ssrManifest[metadata.id][metadata.name];
   return resolvedModuleData;
 }
 
 export function resolveServerReference<T>(
-  bundlerConfig: ServerManifest,
+  serverManifest: ServerManifest,
   id: ServerReferenceId,
 ): ClientReference<T> {
   const idx = id.lastIndexOf('#');

--- a/packages/react-server-dom-webpack/src/ReactFlightClientWebpackBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightClientWebpackBundlerConfig.js
@@ -36,11 +36,11 @@ export opaque type ClientReferenceMetadata = {
 export opaque type ClientReference<T> = ClientReferenceMetadata;
 
 export function resolveClientReference<T>(
-  bundlerConfig: SSRManifest,
+  ssrManifest: SSRManifest,
   metadata: ClientReferenceMetadata,
 ): ClientReference<T> {
-  if (bundlerConfig) {
-    const resolvedModuleData = bundlerConfig[metadata.id][metadata.name];
+  if (ssrManifest) {
+    const resolvedModuleData = ssrManifest[metadata.id][metadata.name];
     if (metadata.async) {
       return {
         id: resolvedModuleData.id,
@@ -56,11 +56,11 @@ export function resolveClientReference<T>(
 }
 
 export function resolveServerReference<T>(
-  bundlerConfig: ServerManifest,
+  serverManifest: ServerManifest,
   id: ServerReferenceId,
 ): ClientReference<T> {
   // This needs to return async: true if it's an async module.
-  return bundlerConfig[id];
+  return serverManifest[id];
 }
 
 // The chunk cache contains all the chunks we've preloaded so far.

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
@@ -30,12 +30,12 @@ function noServerCall() {
 }
 
 export type Options = {
-  moduleMap?: $NonMaybeType<SSRManifest>,
+  ssrManifest?: $NonMaybeType<SSRManifest>,
 };
 
 function createResponseFromOptions(options: void | Options) {
   return createResponse(
-    options && options.moduleMap ? options.moduleMap : null,
+    options && options.ssrManifest ? options.ssrManifest : null,
     noServerCall,
   );
 }

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientNode.js
@@ -34,9 +34,9 @@ function noServerCall() {
 
 function createFromNodeStream<T>(
   stream: Readable,
-  moduleMap: $NonMaybeType<SSRManifest>,
+  ssrManifest: $NonMaybeType<SSRManifest>,
 ): Thenable<T> {
-  const response: Response = createResponse(moduleMap, noServerCall);
+  const response: Response = createResponse(ssrManifest, noServerCall);
   stream.on('data', chunk => {
     if (typeof chunk === 'string') {
       processStringChunk(response, chunk, 0);

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -35,12 +35,12 @@ type Options = {
 };
 
 function renderToReadableStream(
-  model: ReactClientValue,
+  value: ReactClientValue,
   clientManifest: ClientManifest,
   options?: Options,
 ): ReadableStream {
   const request = createRequest(
-    model,
+    value,
     clientManifest,
     options ? options.onError : undefined,
     options ? options.context : undefined,

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -36,12 +36,12 @@ type Options = {
 
 function renderToReadableStream(
   model: ReactClientValue,
-  webpackMap: ClientManifest,
+  clientManifest: ClientManifest,
   options?: Options,
 ): ReadableStream {
   const request = createRequest(
     model,
-    webpackMap,
+    clientManifest,
     options ? options.onError : undefined,
     options ? options.context : undefined,
     options ? options.identifierPrefix : undefined,
@@ -77,9 +77,9 @@ function renderToReadableStream(
 
 function decodeReply<T>(
   body: string | FormData,
-  webpackMap: ServerManifest,
+  serverManifest: ServerManifest,
 ): Thenable<T> {
-  const response = createResponse(webpackMap);
+  const response = createResponse(serverManifest);
   if (typeof body === 'string') {
     resolveField(response, 0, body);
   } else {

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
@@ -35,12 +35,12 @@ type Options = {
 };
 
 function renderToReadableStream(
-  model: ReactClientValue,
+  value: ReactClientValue,
   clientManifest: ClientManifest,
   options?: Options,
 ): ReadableStream {
   const request = createRequest(
-    model,
+    value,
     clientManifest,
     options ? options.onError : undefined,
     options ? options.context : undefined,

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
@@ -36,12 +36,12 @@ type Options = {
 
 function renderToReadableStream(
   model: ReactClientValue,
-  webpackMap: ClientManifest,
+  clientManifest: ClientManifest,
   options?: Options,
 ): ReadableStream {
   const request = createRequest(
     model,
-    webpackMap,
+    clientManifest,
     options ? options.onError : undefined,
     options ? options.context : undefined,
     options ? options.identifierPrefix : undefined,
@@ -77,9 +77,9 @@ function renderToReadableStream(
 
 function decodeReply<T>(
   body: string | FormData,
-  webpackMap: ServerManifest,
+  serverManifest: ServerManifest,
 ): Thenable<T> {
-  const response = createResponse(webpackMap);
+  const response = createResponse(serverManifest);
   if (typeof body === 'string') {
     resolveField(response, 0, body);
   } else {

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -53,12 +53,12 @@ type PipeableStream = {
 };
 
 function renderToPipeableStream(
-  model: ReactClientValue,
+  value: ReactClientValue,
   clientManifest: ClientManifest,
   options?: Options,
 ): PipeableStream {
   const request = createRequest(
-    model,
+    value,
     clientManifest,
     options ? options.onError : undefined,
     options ? options.context : undefined,

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -54,12 +54,12 @@ type PipeableStream = {
 
 function renderToPipeableStream(
   model: ReactClientValue,
-  webpackMap: ClientManifest,
+  clientManifest: ClientManifest,
   options?: Options,
 ): PipeableStream {
   const request = createRequest(
     model,
-    webpackMap,
+    clientManifest,
     options ? options.onError : undefined,
     options ? options.context : undefined,
     options ? options.identifierPrefix : undefined,
@@ -86,9 +86,9 @@ function renderToPipeableStream(
 
 function decodeReplyFromBusboy<T>(
   busboyStream: Busboy,
-  webpackMap: ServerManifest,
+  serverManifest: ServerManifest,
 ): Thenable<T> {
-  const response = createResponse(webpackMap);
+  const response = createResponse(serverManifest);
   busboyStream.on('field', (name, value) => {
     const id = +name;
     resolveField(response, id, value);
@@ -121,9 +121,9 @@ function decodeReplyFromBusboy<T>(
 
 function decodeReply<T>(
   body: string | FormData,
-  webpackMap: ServerManifest,
+  serverManifest: ServerManifest,
 ): Thenable<T> {
-  const response = createResponse(webpackMap);
+  const response = createResponse(serverManifest);
   if (typeof body === 'string') {
     resolveField(response, 0, body);
   } else {

--- a/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
@@ -41,9 +41,11 @@ const CLIENT_REFERENCE_TAG = Symbol.for('react.client.reference');
 const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference');
 
 export function getClientReferenceKey(
-  reference: ClientReference<any>,
+  clientReference: ClientReference<any>,
 ): ClientReferenceKey {
-  return reference.$$async ? reference.$$id + '#async' : reference.$$id;
+  return clientReference.$$async
+    ? clientReference.$$id + '#async'
+    : clientReference.$$id;
 }
 
 export function isClientReference(reference: Object): boolean {
@@ -55,10 +57,10 @@ export function isServerReference(reference: Object): boolean {
 }
 
 export function resolveClientReferenceMetadata<T>(
-  config: ClientManifest,
+  clientManifest: ClientManifest,
   clientReference: ClientReference<T>,
 ): ClientReferenceMetadata {
-  const resolvedModuleData = config[clientReference.$$id];
+  const resolvedModuleData = clientManifest[clientReference.$$id];
   if (clientReference.$$async) {
     return {
       id: resolvedModuleData.id,
@@ -72,14 +74,14 @@ export function resolveClientReferenceMetadata<T>(
 }
 
 export function getServerReferenceId<T>(
-  config: ClientManifest,
+  clientManifest: ClientManifest,
   serverReference: ServerReference<T>,
 ): ServerReferenceId {
   return serverReference.$$id;
 }
 
 export function getServerReferenceBoundArguments<T>(
-  config: ClientManifest,
+  clientManifest: ClientManifest,
   serverReference: ServerReference<T>,
 ): null | Array<ReactClientValue> {
   return serverReference.$$bound;

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -213,7 +213,7 @@ export default class ReactFlightWebpackPlugin {
           if (clientFileNameFound === false) {
             compilation.warnings.push(
               new WebpackError(
-                `Client runtime at ${clientImportName} was not found. React Server Components module map file ${_this.clientManifestFilename} was not created.`,
+                `Client runtime at ${clientImportName} was not found. React Server Components client manifest file ${_this.clientManifestFilename} was not created.`,
               ),
             );
             return;

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -102,10 +102,10 @@ describe('ReactFlightDOM', () => {
     }
 
     function App() {
-      const model = {
+      const value = {
         html: <HTML />,
       };
-      return model;
+      return value;
     }
 
     const {writable, readable} = getTestStream();
@@ -115,8 +115,8 @@ describe('ReactFlightDOM', () => {
     );
     pipe(writable);
     const response = ReactServerDOMClient.createFromReadableStream(readable);
-    const model = await response;
-    expect(model).toEqual({
+    const value = await response;
+    expect(value).toEqual({
       html: (
         <div>
           <span>hello</span>
@@ -583,7 +583,7 @@ describe('ReactFlightDOM', () => {
       );
     }
 
-    const model = {
+    const value = {
       rootContent: <ProfileContent />,
     };
 
@@ -593,7 +593,7 @@ describe('ReactFlightDOM', () => {
 
     const {writable, readable} = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
-      model,
+      value,
       clientManifest,
       {
         onError(x) {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -22,7 +22,7 @@ let act;
 let use;
 let clientExports;
 let clientModuleError;
-let webpackMap;
+let clientManifest;
 let Stream;
 let React;
 let ReactDOMClient;
@@ -38,7 +38,7 @@ describe('ReactFlightDOM', () => {
     const WebpackMock = require('./utils/WebpackMock');
     clientExports = WebpackMock.clientExports;
     clientModuleError = WebpackMock.clientModuleError;
-    webpackMap = WebpackMock.webpackMap;
+    clientManifest = WebpackMock.webpackMap;
 
     Stream = require('stream');
     React = require('react');
@@ -111,7 +111,7 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
       <App />,
-      webpackMap,
+      clientManifest,
     );
     pipe(writable);
     const response = ReactServerDOMClient.createFromReadableStream(readable);
@@ -161,7 +161,7 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
       <RootModel />,
-      webpackMap,
+      clientManifest,
     );
     pipe(writable);
     const response = ReactServerDOMClient.createFromReadableStream(readable);
@@ -198,7 +198,7 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
       <RootModel />,
-      webpackMap,
+      clientManifest,
     );
     pipe(writable);
     const response = ReactServerDOMClient.createFromReadableStream(readable);
@@ -233,7 +233,7 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
       <RootModel />,
-      webpackMap,
+      clientManifest,
     );
     pipe(writable);
     const response = ReactServerDOMClient.createFromReadableStream(readable);
@@ -283,7 +283,7 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
       <Component greeting={hi} />,
-      webpackMap,
+      clientManifest,
     );
     pipe(writable);
     const response = ReactServerDOMClient.createFromReadableStream(readable);
@@ -321,7 +321,7 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
       <Component greeting={'Hello'} />,
-      webpackMap,
+      clientManifest,
     );
     pipe(writable);
     const response = ReactServerDOMClient.createFromReadableStream(readable);
@@ -362,7 +362,7 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
       <AsyncModuleRef text={AsyncModuleRef2.exportName} />,
-      webpackMap,
+      clientManifest,
     );
     pipe(writable);
     const response = ReactServerDOMClient.createFromReadableStream(readable);
@@ -401,7 +401,7 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
       <ServerComponent />,
-      webpackMap,
+      clientManifest,
     );
     pipe(writable);
     const response = ReactServerDOMClient.createFromReadableStream(readable);
@@ -439,7 +439,7 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
       <ThenRef />,
-      webpackMap,
+      clientManifest,
     );
     pipe(writable);
     const response = ReactServerDOMClient.createFromReadableStream(readable);
@@ -594,7 +594,7 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
       model,
-      webpackMap,
+      clientManifest,
       {
         onError(x) {
           reportedErrors.push(x);
@@ -717,7 +717,7 @@ describe('ReactFlightDOM', () => {
     const stream1 = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
       <App color="red" />,
-      webpackMap,
+      clientManifest,
     );
     pipe(stream1.writable);
     const response1 = ReactServerDOMClient.createFromReadableStream(
@@ -745,7 +745,7 @@ describe('ReactFlightDOM', () => {
     const stream2 = getTestStream();
     const {pipe: pipe2} = ReactServerDOMServer.renderToPipeableStream(
       <App color="blue" />,
-      webpackMap,
+      clientManifest,
     );
     pipe2(stream2.writable);
     const response2 = ReactServerDOMClient.createFromReadableStream(
@@ -780,7 +780,7 @@ describe('ReactFlightDOM', () => {
       <div>
         <InfiniteSuspend />
       </div>,
-      webpackMap,
+      clientManifest,
       {
         onError(x) {
           reportedErrors.push(x);
@@ -845,7 +845,7 @@ describe('ReactFlightDOM', () => {
       <div>
         <ClientComponent prop={ClientReference} />
       </div>,
-      webpackMap,
+      clientManifest,
       {
         onError(x) {
           reportedErrors.push(x);
@@ -896,7 +896,7 @@ describe('ReactFlightDOM', () => {
       <div>
         <ClientComponent prop={ClientReference} />
       </div>,
-      webpackMap,
+      clientManifest,
       {
         onError(x) {
           reportedErrors.push(x);
@@ -943,8 +943,8 @@ describe('ReactFlightDOM', () => {
     });
 
     // We simulate a bug in the Webpack bundler which causes an error on the server.
-    for (const id in webpackMap) {
-      Object.defineProperty(webpackMap, id, {
+    for (const id in clientManifest) {
+      Object.defineProperty(clientManifest, id, {
         get: () => {
           throw new Error('bug in the bundler');
         },
@@ -956,7 +956,7 @@ describe('ReactFlightDOM', () => {
       <div>
         <ClientComponent />
       </div>,
-      webpackMap,
+      clientManifest,
       {
         onError(x) {
           reportedErrors.push(x.message);
@@ -1034,7 +1034,7 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
       <ServerComponent />,
-      webpackMap,
+      clientManifest,
     );
     pipe(writable);
     const response = ReactServerDOMClient.createFromReadableStream(readable);
@@ -1091,7 +1091,7 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
       <ServerComponent />,
-      webpackMap,
+      clientManifest,
       {
         onError(x) {
           reportedErrors.push(x);

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -17,7 +17,7 @@ global.TextDecoder = require('util').TextDecoder;
 
 let clientExports;
 let serverExports;
-let webpackMap;
+let clientManifest;
 let webpackServerMap;
 let act;
 let React;
@@ -34,7 +34,7 @@ describe('ReactFlightDOMBrowser', () => {
     const WebpackMock = require('./utils/WebpackMock');
     clientExports = WebpackMock.clientExports;
     serverExports = WebpackMock.serverExports;
-    webpackMap = WebpackMock.webpackMap;
+    clientManifest = WebpackMock.webpackMap;
     webpackServerMap = WebpackMock.webpackServerMap;
     React = require('react');
     ReactDOMClient = require('react-dom/client');
@@ -267,7 +267,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const stream = ReactServerDOMServer.renderToReadableStream(
       model,
-      webpackMap,
+      clientManifest,
       {
         onError(x) {
           reportedErrors.push(x);
@@ -406,7 +406,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const stream = ReactServerDOMServer.renderToReadableStream(
       model,
-      webpackMap,
+      clientManifest,
     );
 
     const reader = stream.getReader();
@@ -508,7 +508,7 @@ describe('ReactFlightDOMBrowser', () => {
       <div>
         <InfiniteSuspend />
       </div>,
-      webpackMap,
+      clientManifest,
       {
         signal: controller.signal,
         onError(x) {
@@ -660,7 +660,7 @@ describe('ReactFlightDOMBrowser', () => {
     const reportedErrors = [];
     const stream = ReactServerDOMServer.renderToReadableStream(
       <Server />,
-      webpackMap,
+      clientManifest,
       {
         onError(x) {
           reportedErrors.push(x);
@@ -797,7 +797,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const stream = ReactServerDOMServer.renderToReadableStream(
       <ClientRef action={boundFn} />,
-      webpackMap,
+      clientManifest,
     );
 
     const response = ReactServerDOMClient.createFromReadableStream(stream, {
@@ -839,7 +839,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const stream = ReactServerDOMServer.renderToReadableStream(
       <ClientRef action={greet.bind(null, 'Hello', 'World')} />,
-      webpackMap,
+      clientManifest,
     );
 
     const response = ReactServerDOMClient.createFromReadableStream(stream, {
@@ -883,7 +883,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     const stream = ReactServerDOMServer.renderToReadableStream(
       <ClientRef action={ServerModule.send} />,
-      webpackMap,
+      clientManifest,
     );
 
     const response = ReactServerDOMClient.createFromReadableStream(stream, {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -103,16 +103,16 @@ describe('ReactFlightDOMBrowser', () => {
     }
 
     function App() {
-      const model = {
+      const value = {
         html: <HTML />,
       };
-      return model;
+      return value;
     }
 
     const stream = ReactServerDOMServer.renderToReadableStream(<App />);
     const response = ReactServerDOMClient.createFromReadableStream(stream);
-    const model = await response;
-    expect(model).toEqual({
+    const value = await response;
+    expect(value).toEqual({
       html: (
         <div>
           <span>hello</span>
@@ -136,16 +136,16 @@ describe('ReactFlightDOMBrowser', () => {
     }
 
     function App() {
-      const model = {
+      const value = {
         html: <HTML />,
       };
-      return model;
+      return value;
     }
 
     const stream = ReactServerDOMServer.renderToReadableStream(<App />);
     const response = ReactServerDOMClient.createFromReadableStream(stream);
-    const model = await response;
-    expect(model).toEqual({
+    const value = await response;
+    expect(value).toEqual({
       html: (
         <div>
           <span>hello</span>
@@ -257,7 +257,7 @@ describe('ReactFlightDOMBrowser', () => {
       );
     }
 
-    const model = {
+    const value = {
       rootContent: <ProfileContent />,
     };
 
@@ -266,7 +266,7 @@ describe('ReactFlightDOMBrowser', () => {
     }
 
     const stream = ReactServerDOMServer.renderToReadableStream(
-      model,
+      value,
       clientManifest,
       {
         onError(x) {
@@ -400,12 +400,12 @@ describe('ReactFlightDOMBrowser', () => {
       );
     }
 
-    const model = {
+    const value = {
       rootContent: <ProfileContent />,
     };
 
     const stream = ReactServerDOMServer.renderToReadableStream(
-      model,
+      value,
       clientManifest,
     );
 
@@ -415,13 +415,13 @@ describe('ReactFlightDOMBrowser', () => {
     let flightResponse = '';
     let isDone = false;
 
-    reader.read().then(function progress({done, value}) {
-      if (done) {
+    reader.read().then(function progress(result) {
+      if (result.done) {
         isDone = true;
         return;
       }
 
-      flightResponse += decoder.decode(value);
+      flightResponse += decoder.decode(result.value);
 
       return reader.read().then(progress);
     });

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -18,7 +18,7 @@ global.TextDecoder = require('util').TextDecoder;
 let clientExports;
 let serverExports;
 let clientManifest;
-let webpackServerMap;
+let serverManifest;
 let act;
 let React;
 let ReactDOMClient;
@@ -35,7 +35,7 @@ describe('ReactFlightDOMBrowser', () => {
     clientExports = WebpackMock.clientExports;
     serverExports = WebpackMock.serverExports;
     clientManifest = WebpackMock.webpackMap;
-    webpackServerMap = WebpackMock.webpackServerMap;
+    serverManifest = WebpackMock.webpackServerMap;
     React = require('react');
     ReactDOMClient = require('react-dom/client');
     ReactServerDOMServer = require('react-server-dom-webpack/server.browser');
@@ -75,7 +75,7 @@ describe('ReactFlightDOMBrowser', () => {
   }
 
   function requireServerRef(ref) {
-    const metaData = webpackServerMap[ref];
+    const metaData = serverManifest[ref];
     const mod = __webpack_require__(metaData.id);
     if (metaData.name === '*') {
       return mod;
@@ -85,7 +85,7 @@ describe('ReactFlightDOMBrowser', () => {
 
   async function callServer(actionId, body) {
     const fn = requireServerRef(actionId);
-    const args = await ReactServerDOMServer.decodeReply(body, webpackServerMap);
+    const args = await ReactServerDOMServer.decodeReply(body, serverManifest);
     return fn.apply(null, args);
   }
 

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -20,7 +20,7 @@ global.TextDecoder = require('util').TextDecoder;
 global.setTimeout = cb => cb();
 
 let clientExports;
-let webpackMap;
+let clientManifest;
 let webpackModules;
 let React;
 let ReactDOMServer;
@@ -33,7 +33,7 @@ describe('ReactFlightDOMEdge', () => {
     jest.resetModules();
     const WebpackMock = require('./utils/WebpackMock');
     clientExports = WebpackMock.clientExports;
-    webpackMap = WebpackMock.webpackMap;
+    clientManifest = WebpackMock.webpackMap;
     webpackModules = WebpackMock.webpackModules;
     React = require('react');
     ReactDOMServer = require('react-dom/server.edge');
@@ -65,13 +65,13 @@ describe('ReactFlightDOMEdge', () => {
     const ClientComponentOnTheServer = clientExports(ClientComponent);
 
     // In the SSR bundle this module won't exist. We simulate this by deleting it.
-    const clientId = webpackMap[ClientComponentOnTheClient.$$id].id;
+    const clientId = clientManifest[ClientComponentOnTheClient.$$id].id;
     delete webpackModules[clientId];
 
     // Instead, we have to provide a translation from the client meta data to the SSR
     // meta data.
-    const ssrMetadata = webpackMap[ClientComponentOnTheServer.$$id];
-    const translationMap = {
+    const ssrMetadata = clientManifest[ClientComponentOnTheServer.$$id];
+    const ssrManifest = {
       [clientId]: {
         '*': ssrMetadata,
       },
@@ -83,10 +83,10 @@ describe('ReactFlightDOMEdge', () => {
 
     const stream = ReactServerDOMServer.renderToReadableStream(
       <App />,
-      webpackMap,
+      clientManifest,
     );
     const response = ReactServerDOMClient.createFromReadableStream(stream, {
-      moduleMap: translationMap,
+      ssrManifest,
     });
 
     function ClientRoot() {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -14,7 +14,7 @@
 global.setImmediate = cb => cb();
 
 let clientExports;
-let webpackMap;
+let clientManifest;
 let webpackModules;
 let React;
 let ReactDOMServer;
@@ -28,7 +28,7 @@ describe('ReactFlightDOMNode', () => {
     jest.resetModules();
     const WebpackMock = require('./utils/WebpackMock');
     clientExports = WebpackMock.clientExports;
-    webpackMap = WebpackMock.webpackMap;
+    clientManifest = WebpackMock.webpackMap;
     webpackModules = WebpackMock.webpackModules;
     React = require('react');
     ReactDOMServer = require('react-dom/server.node');
@@ -67,12 +67,12 @@ describe('ReactFlightDOMNode', () => {
     const ClientComponentOnTheServer = clientExports(ClientComponent);
 
     // In the SSR bundle this module won't exist. We simulate this by deleting it.
-    const clientId = webpackMap[ClientComponentOnTheClient.$$id].id;
+    const clientId = clientManifest[ClientComponentOnTheClient.$$id].id;
     delete webpackModules[clientId];
 
     // Instead, we have to provide a translation from the client meta data to the SSR
     // meta data.
-    const ssrMetadata = webpackMap[ClientComponentOnTheServer.$$id];
+    const ssrMetadata = clientManifest[ClientComponentOnTheServer.$$id];
     const translationMap = {
       [clientId]: {
         '*': ssrMetadata,
@@ -85,7 +85,7 @@ describe('ReactFlightDOMNode', () => {
 
     const stream = ReactServerDOMServer.renderToPipeableStream(
       <App />,
-      webpackMap,
+      clientManifest,
     );
     const readable = new Stream.PassThrough();
     const response = ReactServerDOMClient.createFromNodeStream(

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js
@@ -15,8 +15,7 @@ global.ReadableStream =
 global.TextEncoder = require('util').TextEncoder;
 global.TextDecoder = require('util').TextDecoder;
 
-// let serverExports;
-let webpackServerMap;
+let serverManifest;
 let ReactServerDOMServer;
 let ReactServerDOMClient;
 
@@ -24,8 +23,7 @@ describe('ReactFlightDOMReply', () => {
   beforeEach(() => {
     jest.resetModules();
     const WebpackMock = require('./utils/WebpackMock');
-    // serverExports = WebpackMock.serverExports;
-    webpackServerMap = WebpackMock.webpackServerMap;
+    serverManifest = WebpackMock.webpackServerMap;
     ReactServerDOMServer = require('react-server-dom-webpack/server.browser');
     ReactServerDOMClient = require('react-server-dom-webpack/client');
   });
@@ -34,7 +32,7 @@ describe('ReactFlightDOMReply', () => {
     const body = await ReactServerDOMClient.encodeReply(undefined);
     const missing = await ReactServerDOMServer.decodeReply(
       body,
-      webpackServerMap,
+      serverManifest,
     );
     expect(missing).toBe(undefined);
 
@@ -44,7 +42,7 @@ describe('ReactFlightDOMReply', () => {
     });
     const object = await ReactServerDOMServer.decodeReply(
       body2,
-      webpackServerMap,
+      serverManifest,
     );
     expect(object.array.length).toBe(3);
     expect(object.array[0]).toBe(undefined);
@@ -66,7 +64,7 @@ describe('ReactFlightDOMReply', () => {
     });
     const iterable = await ReactServerDOMServer.decodeReply(
       body,
-      webpackServerMap,
+      serverManifest,
     );
     const items = [];
     // eslint-disable-next-line no-for-of-loops/no-for-of-loops

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
@@ -13,7 +13,7 @@ import type {Response} from 'react-client/src/ReactFlightClient';
 
 import {
   createResponse,
-  resolveValue,
+  resolveJSONValue,
   resolveModule,
   resolveErrorDev,
   resolveErrorProd,
@@ -26,7 +26,7 @@ export {createResponse, close, getRoot};
 export function resolveRow(response: Response, chunk: RowEncoding): void {
   if (chunk[0] === 'O') {
     // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
-    resolveValue(response, chunk[1], chunk[2]);
+    resolveJSONValue(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'I') {
     // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
     resolveModule(response, chunk[1], chunk[2]);

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
@@ -13,7 +13,7 @@ import type {Response} from 'react-client/src/ReactFlightClient';
 
 import {
   createResponse,
-  resolveModel,
+  resolveValue,
   resolveModule,
   resolveErrorDev,
   resolveErrorProd,
@@ -26,7 +26,7 @@ export {createResponse, close, getRoot};
 export function resolveRow(response: Response, chunk: RowEncoding): void {
   if (chunk[0] === 'O') {
     // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
-    resolveModel(response, chunk[1], chunk[2]);
+    resolveValue(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'I') {
     // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
     resolveModule(response, chunk[1], chunk[2]);

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayClientHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayClientHostConfig.js
@@ -40,14 +40,14 @@ export type UninitializedModel = JSONValue;
 export type Response = ResponseBase;
 
 export function resolveClientReference<T>(
-  bundlerConfig: SSRManifest,
+  ssrManifest: SSRManifest,
   metadata: ClientReferenceMetadata,
 ): ClientReference<T> {
   return resolveClientReferenceImpl(metadata);
 }
 
 export function resolveServerReference<T>(
-  bundlerConfig: ServerManifest,
+  serverManifest: ServerManifest,
   id: ServerReferenceId,
 ): ClientReference<T> {
   throw new Error('Not implemented.');

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayClientHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayClientHostConfig.js
@@ -16,8 +16,8 @@ import type {ClientReferenceMetadata} from 'ReactFlightNativeRelayClientIntegrat
 export type ClientReference<T> = JSResourceReference<T>;
 
 import {
-  parseValueString,
-  parseValueTuple,
+  parseJSONValueString,
+  parseJSONValueTuple,
 } from 'react-client/src/ReactFlightClient';
 
 export {
@@ -60,7 +60,7 @@ function parseJSONValueRecursively(
   value: JSONValue,
 ): $FlowFixMe {
   if (typeof value === 'string') {
-    return parseValueString(response, parentObj, key, value);
+    return parseJSONValueString(response, parentObj, key, value);
   }
   if (typeof value === 'object' && value !== null) {
     if (isArray(value)) {
@@ -73,7 +73,7 @@ function parseJSONValueRecursively(
           value[i],
         );
       }
-      return parseValueTuple(response, parsedValue);
+      return parseJSONValueTuple(response, parsedValue);
     } else {
       const parsedValue = {};
       for (const innerKey in value) {

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayClientHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayClientHostConfig.js
@@ -53,7 +53,7 @@ export function resolveServerReference<T>(
   throw new Error('Not implemented.');
 }
 
-function parseValueRecursively(
+function parseJSONValueRecursively(
   response: Response,
   parentObj: {+[key: string]: JSONValue} | $ReadOnlyArray<JSONValue>,
   key: string,
@@ -66,7 +66,7 @@ function parseValueRecursively(
     if (isArray(value)) {
       const parsedValue: Array<$FlowFixMe> = [];
       for (let i = 0; i < value.length; i++) {
-        (parsedValue: any)[i] = parseValueRecursively(
+        (parsedValue: any)[i] = parseJSONValueRecursively(
           response,
           value,
           '' + i,
@@ -77,7 +77,7 @@ function parseValueRecursively(
     } else {
       const parsedValue = {};
       for (const innerKey in value) {
-        (parsedValue: any)[innerKey] = parseValueRecursively(
+        (parsedValue: any)[innerKey] = parseJSONValueRecursively(
           response,
           value,
           innerKey,
@@ -92,6 +92,9 @@ function parseValueRecursively(
 
 const dummy = {};
 
-export function parseValue<T>(response: Response, json: UninitializedValue): T {
-  return (parseValueRecursively(response, dummy, '', json): any);
+export function parseJSONValue<T>(
+  response: Response,
+  json: UninitializedValue,
+): T {
+  return (parseJSONValueRecursively(response, dummy, '', json): any);
 }

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayClientHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayClientHostConfig.js
@@ -16,8 +16,8 @@ import type {ClientReferenceMetadata} from 'ReactFlightNativeRelayClientIntegrat
 export type ClientReference<T> = JSResourceReference<T>;
 
 import {
-  parseModelString,
-  parseModelTuple,
+  parseValueString,
+  parseValueTuple,
 } from 'react-client/src/ReactFlightClient';
 
 export {
@@ -35,7 +35,7 @@ export type SSRManifest = null;
 export type ServerManifest = null;
 export type ServerReferenceId = string;
 
-export type UninitializedModel = JSONValue;
+export type UninitializedValue = JSONValue;
 
 export type Response = ResponseBase;
 
@@ -53,31 +53,31 @@ export function resolveServerReference<T>(
   throw new Error('Not implemented.');
 }
 
-function parseModelRecursively(
+function parseValueRecursively(
   response: Response,
   parentObj: {+[key: string]: JSONValue} | $ReadOnlyArray<JSONValue>,
   key: string,
   value: JSONValue,
 ): $FlowFixMe {
   if (typeof value === 'string') {
-    return parseModelString(response, parentObj, key, value);
+    return parseValueString(response, parentObj, key, value);
   }
   if (typeof value === 'object' && value !== null) {
     if (isArray(value)) {
       const parsedValue: Array<$FlowFixMe> = [];
       for (let i = 0; i < value.length; i++) {
-        (parsedValue: any)[i] = parseModelRecursively(
+        (parsedValue: any)[i] = parseValueRecursively(
           response,
           value,
           '' + i,
           value[i],
         );
       }
-      return parseModelTuple(response, parsedValue);
+      return parseValueTuple(response, parsedValue);
     } else {
       const parsedValue = {};
       for (const innerKey in value) {
-        (parsedValue: any)[innerKey] = parseModelRecursively(
+        (parsedValue: any)[innerKey] = parseValueRecursively(
           response,
           value,
           innerKey,
@@ -92,6 +92,6 @@ function parseModelRecursively(
 
 const dummy = {};
 
-export function parseModel<T>(response: Response, json: UninitializedModel): T {
-  return (parseModelRecursively(response, dummy, '', json): any);
+export function parseValue<T>(response: Response, json: UninitializedValue): T {
+  return (parseValueRecursively(response, dummy, '', json): any);
 }

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServer.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServer.js
@@ -22,9 +22,9 @@ import {
 function render(
   model: ReactClientValue,
   destination: Destination,
-  config: ClientManifest,
+  clientManifest: ClientManifest,
 ): void {
-  const request = createRequest(model, config);
+  const request = createRequest(model, clientManifest);
   startWork(request);
   startFlowing(request, destination);
 }

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServer.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServer.js
@@ -20,11 +20,11 @@ import {
 } from 'react-server/src/ReactFlightServer';
 
 function render(
-  model: ReactClientValue,
+  value: ReactClientValue,
   destination: Destination,
   clientManifest: ClientManifest,
 ): void {
-  const request = createRequest(model, clientManifest);
+  const request = createRequest(value, clientManifest);
   startWork(request);
   startFlowing(request, destination);
 }

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -23,7 +23,7 @@ export type ServerReferenceId = {};
 
 import type {
   Destination,
-  BundlerConfig as ClientManifest,
+  ClientManifest,
   ClientReferenceMetadata,
 } from 'ReactFlightNativeRelayServerIntegration';
 
@@ -37,7 +37,7 @@ import {
 
 export type {
   Destination,
-  BundlerConfig as ClientManifest,
+  ClientManifest,
   ClientReferenceMetadata,
 } from 'ReactFlightNativeRelayServerIntegration';
 
@@ -52,30 +52,30 @@ export function isServerReference(reference: Object): boolean {
 export type ClientReferenceKey = ClientReference<any>;
 
 export function getClientReferenceKey(
-  reference: ClientReference<any>,
+  clientReference: ClientReference<any>,
 ): ClientReferenceKey {
   // We use the reference object itself as the key because we assume the
   // object will be cached by the bundler runtime.
-  return reference;
+  return clientReference;
 }
 
 export function resolveClientReferenceMetadata<T>(
-  config: ClientManifest,
-  resource: ClientReference<T>,
+  clientManifest: ClientManifest,
+  clientReference: ClientReference<T>,
 ): ClientReferenceMetadata {
-  return resolveClientReferenceMetadataImpl(config, resource);
+  return resolveClientReferenceMetadataImpl(clientManifest, clientReference);
 }
 
 export function getServerReferenceId<T>(
-  config: ClientManifest,
-  resource: ServerReference<T>,
+  clientManifest: ClientManifest,
+  serverReference: ServerReference<T>,
 ): ServerReferenceId {
   throw new Error('Not implemented.');
 }
 
 export function getServerReferenceBoundArguments<T>(
-  config: ClientManifest,
-  resource: ServerReference<T>,
+  clientManifest: ClientManifest,
+  serverReference: ServerReference<T>,
 ): Array<ReactClientValue> {
   throw new Error('Not implemented.');
 }

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -23,7 +23,7 @@ export type ServerReferenceId = {};
 
 import type {
   Destination,
-  ClientManifest,
+  BundlerConfig as ClientManifest,
   ClientReferenceMetadata,
 } from 'ReactFlightNativeRelayServerIntegration';
 
@@ -37,7 +37,7 @@ import {
 
 export type {
   Destination,
-  ClientManifest,
+  BundlerConfig as ClientManifest,
   ClientReferenceMetadata,
 } from 'ReactFlightNativeRelayServerIntegration';
 

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -27,7 +27,7 @@ import type {
   ClientReferenceMetadata,
 } from 'ReactFlightNativeRelayServerIntegration';
 
-import {resolveModelToJSON} from 'react-server/src/ReactFlightServer';
+import {resolveValueToJSON} from 'react-server/src/ReactFlightServer';
 
 import {
   emitRow,
@@ -129,18 +129,18 @@ export function processErrorChunkDev(
   ];
 }
 
-function convertModelToJSON(
+function convertValueToJSON(
   request: Request,
   parent: {+[key: string]: ReactClientValue} | $ReadOnlyArray<ReactClientValue>,
   key: string,
-  model: ReactClientValue,
+  value: ReactClientValue,
 ): JSONValue {
-  const json = resolveModelToJSON(request, parent, key, model);
+  const json = resolveValueToJSON(request, parent, key, value);
   if (typeof json === 'object' && json !== null) {
     if (isArray(json)) {
       const jsonArray: Array<JSONValue> = [];
       for (let i = 0; i < json.length; i++) {
-        jsonArray[i] = convertModelToJSON(request, json, '' + i, json[i]);
+        jsonArray[i] = convertValueToJSON(request, json, '' + i, json[i]);
       }
       return jsonArray;
     } else {
@@ -148,7 +148,7 @@ function convertModelToJSON(
       const jsonObj: {[key: string]: JSONValue} = {};
       for (const nextKey in json) {
         if (hasOwnProperty.call(json, nextKey)) {
-          jsonObj[nextKey] = convertModelToJSON(
+          jsonObj[nextKey] = convertValueToJSON(
             request,
             json,
             nextKey,
@@ -162,13 +162,13 @@ function convertModelToJSON(
   return json;
 }
 
-export function processModelChunk(
+export function processValueChunk(
   request: Request,
   id: number,
-  model: ReactClientValue,
+  value: ReactClientValue,
 ): Chunk {
   // $FlowFixMe no good way to define an empty exact object
-  const json = convertModelToJSON(request, {}, '', model);
+  const json = convertValueToJSON(request, {}, '', value);
   return ['O', id, json];
 }
 

--- a/packages/react-server-native-relay/src/__mocks__/ReactFlightNativeRelayServerIntegration.js
+++ b/packages/react-server-native-relay/src/__mocks__/ReactFlightNativeRelayServerIntegration.js
@@ -12,8 +12,8 @@ const ReactFlightNativeRelayServerIntegration = {
     destination.push(json);
   },
   close(destination) {},
-  resolveClientReferenceMetadata(config, resource) {
-    return resource._moduleId;
+  resolveClientReferenceMetadata(clientManifest, clientReference) {
+    return clientReference._moduleId;
   },
 };
 

--- a/packages/react-server-native-relay/src/__tests__/ReactFlightNativeRelay-test.internal.js
+++ b/packages/react-server-native-relay/src/__tests__/ReactFlightNativeRelay-test.internal.js
@@ -50,16 +50,16 @@ describe('ReactFlightNativeRelay', () => {
     }
     ReactNativeFlightRelayClient.close(response);
     const promise = ReactNativeFlightRelayClient.getRoot(response);
-    let model;
+    let value;
     let error;
     promise.then(
-      m => (model = m),
+      m => (value = m),
       e => (error = e),
     );
     if (error) {
       throw error;
     }
-    return model;
+    return value;
   }
 
   it('can render a Server Component', () => {
@@ -83,8 +83,8 @@ describe('ReactFlightNativeRelay', () => {
       transport,
     );
 
-    const model = readThrough(transport);
-    expect(model).toMatchSnapshot();
+    const value = readThrough(transport);
+    expect(value).toMatchSnapshot();
   });
 
   it('can render a Client Component using a module reference and render there', () => {
@@ -101,16 +101,16 @@ describe('ReactFlightNativeRelay', () => {
       return <User greeting="Hello" name={firstName + ' ' + lastName} />;
     }
 
-    const model = {
+    const value = {
       greeting: <Greeting firstName="Seb" lastName="Smith" />,
     };
 
     const transport = [];
-    ReactNativeFlightRelayServer.render(model, transport);
+    ReactNativeFlightRelayServer.render(value, transport);
 
-    const modelClient = readThrough(transport);
+    const valueClient = readThrough(transport);
 
-    ReactFabric.render(modelClient.greeting, 1);
+    ReactFabric.render(valueClient.greeting, 1);
     expect(
       nativeFabricUIManager.__dumpHierarchyForJestTestsOnly(),
     ).toMatchSnapshot();

--- a/packages/react-server/src/ReactFlightReplyServer.js
+++ b/packages/react-server/src/ReactFlightReplyServer.js
@@ -130,7 +130,7 @@ Chunk.prototype.then = function <T>(
 };
 
 export type Response = {
-  _bundlerConfig: ServerManifest,
+  _serverManifest: ServerManifest,
   _chunks: Map<number, SomeChunk<any>>,
   _fromJSON: (key: string, value: JSONValue) => any,
 };
@@ -229,7 +229,7 @@ function loadServerReference<T>(
   key: string,
 ): T {
   const serverReference: ServerReference<T> =
-    resolveServerReference<$FlowFixMe>(response._bundlerConfig, id);
+    resolveServerReference<$FlowFixMe>(response._serverManifest, id);
   // We expect most servers to not really need this because you'd just have all
   // the relevant modules already loaded but it allows for lazy loading of code
   // if needed.
@@ -432,10 +432,10 @@ function parseModelString(
   return value;
 }
 
-export function createResponse(bundlerConfig: ServerManifest): Response {
+export function createResponse(serverManifest: ServerManifest): Response {
   const chunks: Map<number, SomeChunk<any>> = new Map();
   const response: Response = {
-    _bundlerConfig: bundlerConfig,
+    _serverManifest: serverManifest,
     _chunks: chunks,
     _fromJSON: function (this: any, key: string, value: JSONValue) {
       if (typeof value === 'string') {

--- a/packages/react-server/src/ReactFlightReplyServer.js
+++ b/packages/react-server/src/ReactFlightReplyServer.js
@@ -352,7 +352,7 @@ function createValueReject<T>(chunk: SomeChunk<T>): (error: mixed) => void {
   return (error: mixed) => triggerErrorOnChunk(chunk, error);
 }
 
-function parseValueString(
+function parseJSONValueString(
   response: Response,
   parentObject: Object,
   key: string,
@@ -440,7 +440,7 @@ export function createResponse(serverManifest: ServerManifest): Response {
     _fromJSON: function (this: any, key: string, value: JSONValue) {
       if (typeof value === 'string') {
         // We can't use .bind here because we need the "this" value.
-        return parseValueString(response, this, key, value);
+        return parseJSONValueString(response, this, key, value);
       }
       return value;
     },

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -150,7 +150,7 @@ export type Request = {
   status: 0 | 1 | 2,
   fatalError: mixed,
   destination: null | Destination,
-  bundlerConfig: ClientManifest,
+  clientManifest: ClientManifest,
   cache: Map<Function, mixed>,
   nextChunkId: number,
   pendingChunks: number,
@@ -183,7 +183,7 @@ const CLOSED = 2;
 
 export function createRequest(
   model: ReactClientValue,
-  bundlerConfig: ClientManifest,
+  clientManifest: ClientManifest,
   onError: void | ((error: mixed) => ?string),
   context?: Array<[string, ServerContextJSONValue]>,
   identifierPrefix?: string,
@@ -204,7 +204,7 @@ export function createRequest(
     status: OPEN,
     fatalError: null,
     destination: null,
-    bundlerConfig,
+    clientManifest,
     cache: new Map(),
     nextChunkId: 0,
     pendingChunks: 0,
@@ -578,7 +578,7 @@ function serializeClientReference(
   }
   try {
     const clientReferenceMetadata: ClientReferenceMetadata =
-      resolveClientReferenceMetadata(request.bundlerConfig, clientReference);
+      resolveClientReferenceMetadata(request.clientManifest, clientReference);
     request.pendingChunks++;
     const importId = request.nextChunkId++;
     emitImportChunk(request, importId, clientReferenceMetadata);
@@ -621,14 +621,14 @@ function serializeServerReference(
   }
 
   const bound: null | Array<any> = getServerReferenceBoundArguments(
-    request.bundlerConfig,
+    request.clientManifest,
     serverReference,
   );
   const serverReferenceMetadata: {
     id: ServerReferenceId,
     bound: null | Promise<Array<any>>,
   } = {
-    id: getServerReferenceId(request.bundlerConfig, serverReference),
+    id: getServerReferenceId(request.clientManifest, serverReference),
     bound: bound ? Promise.resolve(bound) : null,
   };
   request.pendingChunks++;

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -124,13 +124,13 @@ export function processErrorChunkDev(
   return stringToChunk(row);
 }
 
-export function processModelChunk(
+export function processValueChunk(
   request: Request,
   id: number,
-  model: ReactClientValue,
+  value: ReactClientValue,
 ): Chunk {
   // $FlowFixMe[incompatible-type] stringify can return null
-  const json: string = stringify(model, request.toJSON);
+  const json: string = stringify(value, request.toJSON);
   const row = id.toString(16) + ':' + json + '\n';
   return stringToChunk(row);
 }

--- a/scripts/flow/react-relay-hooks.js
+++ b/scripts/flow/react-relay-hooks.js
@@ -39,7 +39,8 @@ declare module 'ReactFlightDOMRelayServerIntegration' {
   import type {JSResourceReference} from 'JSResourceReference';
 
   declare export opaque type Destination;
-  declare export opaque type ClientManifest;
+  // TODO: Rename to `ClientManifest`.
+  declare export opaque type BundlerConfig;
   declare export function emitRow(
     destination: Destination,
     json: JSONValue,
@@ -48,7 +49,7 @@ declare module 'ReactFlightDOMRelayServerIntegration' {
 
   declare export type ClientReferenceMetadata = JSONValue;
   declare export function resolveClientReferenceMetadata<T>(
-    clientManifest: ClientManifest,
+    clientManifest: BundlerConfig,
     resourceReference: JSResourceReference<T>,
   ): ClientReferenceMetadata;
 }
@@ -72,7 +73,8 @@ declare module 'ReactFlightNativeRelayServerIntegration' {
   import type {JSResourceReference} from 'JSResourceReference';
 
   declare export opaque type Destination;
-  declare export opaque type ClientManifest;
+  // TODO: Rename to `ClientManifest`.
+  declare export opaque type BundlerConfig;
   declare export function emitRow(
     destination: Destination,
     json: JSONValue,
@@ -81,7 +83,7 @@ declare module 'ReactFlightNativeRelayServerIntegration' {
 
   declare export type ClientReferenceMetadata = JSONValue;
   declare export function resolveClientReferenceMetadata<T>(
-    clientManifest: ClientManifest,
+    clientManifest: BundlerConfig,
     resourceReference: JSResourceReference<T>,
   ): ClientReferenceMetadata;
 }

--- a/scripts/flow/react-relay-hooks.js
+++ b/scripts/flow/react-relay-hooks.js
@@ -39,7 +39,7 @@ declare module 'ReactFlightDOMRelayServerIntegration' {
   import type {JSResourceReference} from 'JSResourceReference';
 
   declare export opaque type Destination;
-  declare export opaque type BundlerConfig;
+  declare export opaque type ClientManifest;
   declare export function emitRow(
     destination: Destination,
     json: JSONValue,
@@ -48,7 +48,7 @@ declare module 'ReactFlightDOMRelayServerIntegration' {
 
   declare export type ClientReferenceMetadata = JSONValue;
   declare export function resolveClientReferenceMetadata<T>(
-    config: BundlerConfig,
+    clientManifest: ClientManifest,
     resourceReference: JSResourceReference<T>,
   ): ClientReferenceMetadata;
 }
@@ -72,7 +72,7 @@ declare module 'ReactFlightNativeRelayServerIntegration' {
   import type {JSResourceReference} from 'JSResourceReference';
 
   declare export opaque type Destination;
-  declare export opaque type BundlerConfig;
+  declare export opaque type ClientManifest;
   declare export function emitRow(
     destination: Destination,
     json: JSONValue,
@@ -81,7 +81,7 @@ declare module 'ReactFlightNativeRelayServerIntegration' {
 
   declare export type ClientReferenceMetadata = JSONValue;
   declare export function resolveClientReferenceMetadata<T>(
-    config: BundlerConfig,
+    clientManifest: ClientManifest,
     resourceReference: JSResourceReference<T>,
   ): ClientReferenceMetadata;
 }


### PR DESCRIPTION
## Summary

1. Since `ClientManifest` and `SSRManifest` are now clearly differentiated in their structure (via #26300) and type names (via #26351), this opened up the opportunity to clean up some inconsistencies in how parameters, variables and properties were named (e.g. `config`, `bundlerConfig`, `moduleMap`, `webpackMap`, ...). To improve readability and avoid confusion between the two different types of objects we now always name them either `clientManifest` or `ssrManifest`.

2. After `ReactModel` has been renamed to `ReactClientValue` in #26351, I think we should also rename the params, variables and functions that handle this type accordingly from `model` to `value`.

## How did you test this change?

`yarn test` and `yarn test --prod`