### PR TITLE
[Internal tests] Close MessageChannel port to prevent leak

### DIFF
--- a/packages/internal-test-utils/enqueueTask.js
+++ b/packages/internal-test-utils/enqueueTask.js
@@ -11,6 +11,9 @@ const {MessageChannel} = require('node:worker_threads');
 
 export default function enqueueTask(task: () => void): void {
   const channel = new MessageChannel();
-  channel.port1.onmessage = task;
+  channel.port1.onmessage = () => {
+    channel.port1.close();
+    task();
+  };
   channel.port2.postMessage(undefined);
 }


### PR DESCRIPTION
Node's MessageChannel implementation will leak if you don't explicitly close the port. This updates the enqueueTask function we use in our internal testing helpers to close the port once it's no longer needed.