### PR TITLE
[DevTools] prevent StyleX plugin from throwing when inspecting CSS

### DIFF
--- a/packages/react-devtools-shared/src/backend/StyleX/utils.js
+++ b/packages/react-devtools-shared/src/backend/StyleX/utils.js
@@ -67,7 +67,10 @@ function crawlObjectProperties(
         // Special case; this key is the name of the style's source/file/module.
         sources.add(key);
       } else {
-        resolvedStyles[key] = getPropertyValueForStyleName(value);
+        const propertyValue = getPropertyValueForStyleName(value);
+        if (propertyValue != null) {
+          resolvedStyles[key] = propertyValue;
+        }
       }
     } else {
       const nestedStyle = {};
@@ -90,8 +93,15 @@ function getPropertyValueForStyleName(styleName: string): string | null {
     const styleSheet = ((document.styleSheets[
       styleSheetIndex
     ]: any): CSSStyleSheet);
-    // $FlowFixMe Flow doesn't konw about these properties
-    const rules = styleSheet.rules || styleSheet.cssRules;
+    let rules = [];
+    // this might throw if CORS rules are enforced https://www.w3.org/TR/cssom-1/#the-cssstylesheet-interface
+    try {
+      // $FlowFixMe Flow doesn't konw about these properties
+      rules = styleSheet.rules || styleSheet.cssRules;
+    } catch (_e) {
+      return null;
+    }
+
     // $FlowFixMe `rules` is mixed
     for (let ruleIndex = 0; ruleIndex < rules.length; ruleIndex++) {
       // $FlowFixMe `rules` is mixed

--- a/packages/react-devtools-shared/src/backend/StyleX/utils.js
+++ b/packages/react-devtools-shared/src/backend/StyleX/utils.js
@@ -102,7 +102,7 @@ function getPropertyValueForStyleName(styleName: string): string | null {
     }
 
     for (let ruleIndex = 0; ruleIndex < rules.length; ruleIndex++) {
-      if (!rules[ruleIndex] instanceof CSSStyleRule) {
+      if (!(rules[ruleIndex] instanceof CSSStyleRule)) {
         continue;
       }
       const rule = ((rules[ruleIndex]: any): CSSStyleRule);

--- a/packages/react-devtools-shared/src/backend/StyleX/utils.js
+++ b/packages/react-devtools-shared/src/backend/StyleX/utils.js
@@ -98,7 +98,7 @@ function getPropertyValueForStyleName(styleName: string): string | null {
     try {
       rules = styleSheet.cssRules;
     } catch (_e) {
-      return null;
+      continue;
     }
 
     for (let ruleIndex = 0; ruleIndex < rules.length; ruleIndex++) {

--- a/packages/react-devtools-shared/src/backend/StyleX/utils.js
+++ b/packages/react-devtools-shared/src/backend/StyleX/utils.js
@@ -93,20 +93,20 @@ function getPropertyValueForStyleName(styleName: string): string | null {
     const styleSheet = ((document.styleSheets[
       styleSheetIndex
     ]: any): CSSStyleSheet);
-    let rules = [];
+    let rules: CSSRuleList | null = null;
     // this might throw if CORS rules are enforced https://www.w3.org/TR/cssom-1/#the-cssstylesheet-interface
     try {
-      // $FlowFixMe Flow doesn't konw about these properties
-      rules = styleSheet.rules || styleSheet.cssRules;
+      rules = styleSheet.cssRules;
     } catch (_e) {
       return null;
     }
 
-    // $FlowFixMe `rules` is mixed
     for (let ruleIndex = 0; ruleIndex < rules.length; ruleIndex++) {
-      // $FlowFixMe `rules` is mixed
-      const rule = rules[ruleIndex];
-      // $FlowFixMe Flow doesn't konw about these properties
+      // check if the rule is a CSSStyleRule
+      if (!rules[ruleIndex].hasOwnProperty('selectorText')) {
+        continue;
+      }
+      const rule = ((rules[ruleIndex]: any): CSSStyleRule);
       const {cssText, selectorText, style} = rule;
 
       if (selectorText != null) {

--- a/packages/react-devtools-shared/src/backend/StyleX/utils.js
+++ b/packages/react-devtools-shared/src/backend/StyleX/utils.js
@@ -102,8 +102,7 @@ function getPropertyValueForStyleName(styleName: string): string | null {
     }
 
     for (let ruleIndex = 0; ruleIndex < rules.length; ruleIndex++) {
-      // check if the rule is a CSSStyleRule
-      if (!rules[ruleIndex].hasOwnProperty('selectorText')) {
+      if (!rules[ruleIndex] instanceof CSSStyleRule) {
         continue;
       }
       const rule = ((rules[ruleIndex]: any): CSSStyleRule);


### PR DESCRIPTION
## Summary

An error might happen when we try to read the CSS rules, but the stylesheet does not allow so (often happens on production).

Before:
<img width="713" alt="image" src="https://user-images.githubusercontent.com/1001890/224376546-024f7a32-d314-4dd1-9333-7e47d96a2b7c.png">

After:

<img width="504" alt="image" src="https://user-images.githubusercontent.com/1001890/224376426-964a33c4-0677-4a51-91c2-74074e4dde63.png">


## How did you test this change?

Built a fb version and tested locally (see above screenshot)