### PR TITLE
Convert more Scheduler.unstable_flushAll in tests to new test utils

### DIFF
--- a/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocus-test.internal.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocus-test.internal.js
@@ -15,7 +15,7 @@ let React;
 let ReactFeatureFlags;
 let ReactDOM;
 let useFocus;
-let Scheduler;
+let act;
 
 function initializeModules(hasPointerEvents) {
   setPointerEvent(hasPointerEvents);
@@ -24,8 +24,7 @@ function initializeModules(hasPointerEvents) {
   ReactFeatureFlags.enableCreateEventHandleAPI = true;
   React = require('react');
   ReactDOM = require('react-dom');
-  Scheduler = require('scheduler');
-
+  act = require('internal-test-utils').act;
   // TODO: This import throws outside of experimental mode. Figure out better
   // strategy for gated imports.
   if (__EXPERIMENTAL__ || global.__WWW__) {
@@ -54,7 +53,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
   describe('disabled', () => {
     let onBlur, onFocus, ref;
 
-    const componentInit = () => {
+    const componentInit = async () => {
       onBlur = jest.fn();
       onFocus = jest.fn();
       ref = React.createRef();
@@ -66,13 +65,14 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
         });
         return <div ref={ref} />;
       };
-      ReactDOM.render(<Component />, container);
-      Scheduler.unstable_flushAll();
+      await act(() => {
+        ReactDOM.render(<Component />, container);
+      });
     };
 
     // @gate www
-    it('does not call callbacks', () => {
-      componentInit();
+    it('does not call callbacks', async () => {
+      await componentInit();
       const target = createEventTarget(ref.current);
       target.focus();
       target.blur();
@@ -84,7 +84,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
   describe('onBlur', () => {
     let onBlur, ref;
 
-    const componentInit = () => {
+    const componentInit = async () => {
       onBlur = jest.fn();
       ref = React.createRef();
       const Component = () => {
@@ -93,13 +93,14 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
         });
         return <div ref={ref} />;
       };
-      ReactDOM.render(<Component />, container);
-      Scheduler.unstable_flushAll();
+      await act(() => {
+        ReactDOM.render(<Component />, container);
+      });
     };
 
     // @gate www
-    it('is called after "blur" event', () => {
-      componentInit();
+    it('is called after "blur" event', async () => {
+      await componentInit();
       const target = createEventTarget(ref.current);
       target.focus();
       target.blur();
@@ -110,7 +111,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
   describe('onFocus', () => {
     let onFocus, ref, innerRef;
 
-    const componentInit = () => {
+    const componentInit = async () => {
       onFocus = jest.fn();
       ref = React.createRef();
       innerRef = React.createRef();
@@ -124,21 +125,22 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
           </div>
         );
       };
-      ReactDOM.render(<Component />, container);
-      Scheduler.unstable_flushAll();
+      await act(() => {
+        ReactDOM.render(<Component />, container);
+      });
     };
 
     // @gate www
-    it('is called after "focus" event', () => {
-      componentInit();
+    it('is called after "focus" event', async () => {
+      await componentInit();
       const target = createEventTarget(ref.current);
       target.focus();
       expect(onFocus).toHaveBeenCalledTimes(1);
     });
 
     // @gate www
-    it('is not called if descendants of target receive focus', () => {
-      componentInit();
+    it('is not called if descendants of target receive focus', async () => {
+      await componentInit();
       const target = createEventTarget(innerRef.current);
       target.focus();
       expect(onFocus).not.toBeCalled();
@@ -148,7 +150,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
   describe('onFocusChange', () => {
     let onFocusChange, ref, innerRef;
 
-    const componentInit = () => {
+    const componentInit = async () => {
       onFocusChange = jest.fn();
       ref = React.createRef();
       innerRef = React.createRef();
@@ -162,13 +164,14 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
           </div>
         );
       };
-      ReactDOM.render(<Component />, container);
-      Scheduler.unstable_flushAll();
+      await act(() => {
+        ReactDOM.render(<Component />, container);
+      });
     };
 
     // @gate www
-    it('is called after "blur" and "focus" events', () => {
-      componentInit();
+    it('is called after "blur" and "focus" events', async () => {
+      await componentInit();
       const target = createEventTarget(ref.current);
       target.focus();
       expect(onFocusChange).toHaveBeenCalledTimes(1);
@@ -179,8 +182,8 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
     });
 
     // @gate www
-    it('is not called after "blur" and "focus" events on descendants', () => {
-      componentInit();
+    it('is not called after "blur" and "focus" events on descendants', async () => {
+      await componentInit();
       const target = createEventTarget(innerRef.current);
       target.focus();
       expect(onFocusChange).toHaveBeenCalledTimes(0);
@@ -192,7 +195,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
   describe('onFocusVisibleChange', () => {
     let onFocusVisibleChange, ref, innerRef;
 
-    const componentInit = () => {
+    const componentInit = async () => {
       onFocusVisibleChange = jest.fn();
       ref = React.createRef();
       innerRef = React.createRef();
@@ -206,13 +209,14 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
           </div>
         );
       };
-      ReactDOM.render(<Component />, container);
-      Scheduler.unstable_flushAll();
+      await act(() => {
+        ReactDOM.render(<Component />, container);
+      });
     };
 
     // @gate www
-    it('is called after "focus" and "blur" if keyboard navigation is active', () => {
-      componentInit();
+    it('is called after "focus" and "blur" if keyboard navigation is active', async () => {
+      await componentInit();
       const target = createEventTarget(ref.current);
       const containerTarget = createEventTarget(container);
       // use keyboard first
@@ -226,8 +230,8 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
     });
 
     // @gate www
-    it('is called if non-keyboard event is dispatched on target previously focused with keyboard', () => {
-      componentInit();
+    it('is called if non-keyboard event is dispatched on target previously focused with keyboard', async () => {
+      await componentInit();
       const target = createEventTarget(ref.current);
       const containerTarget = createEventTarget(container);
       // use keyboard first
@@ -245,8 +249,8 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
     });
 
     // @gate www
-    it('is not called after "focus" and "blur" events without keyboard', () => {
-      componentInit();
+    it('is not called after "focus" and "blur" events without keyboard', async () => {
+      await componentInit();
       const target = createEventTarget(ref.current);
       const containerTarget = createEventTarget(container);
       target.pointerdown();
@@ -257,8 +261,8 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
     });
 
     // @gate www
-    it('is not called after "blur" and "focus" events on descendants', () => {
-      componentInit();
+    it('is not called after "blur" and "focus" events on descendants', async () => {
+      await componentInit();
       const innerTarget = createEventTarget(innerRef.current);
       const containerTarget = createEventTarget(container);
       containerTarget.keydown({key: 'Tab'});
@@ -271,7 +275,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
 
   describe('nested Focus components', () => {
     // @gate www
-    it('propagates events in the correct order', () => {
+    it('propagates events in the correct order', async () => {
       const events = [];
       const innerRef = React.createRef();
       const outerRef = React.createRef();
@@ -301,9 +305,9 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
         );
       };
 
-      ReactDOM.render(<Outer />, container);
-      Scheduler.unstable_flushAll();
-
+      await act(() => {
+        ReactDOM.render(<Outer />, container);
+      });
       const innerTarget = createEventTarget(innerRef.current);
       const outerTarget = createEventTarget(outerRef.current);
 

--- a/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocusWithin-test.internal.js
@@ -17,7 +17,6 @@ let ReactDOM;
 let ReactDOMClient;
 let useFocusWithin;
 let act;
-let Scheduler;
 
 function initializeModules(hasPointerEvents) {
   setPointerEvent(hasPointerEvents);
@@ -28,7 +27,6 @@ function initializeModules(hasPointerEvents) {
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMClient = require('react-dom/client');
-  Scheduler = require('scheduler');
   act = require('internal-test-utils').act;
 
   // TODO: This import throws outside of experimental mode. Figure out better
@@ -64,7 +62,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
   describe('disabled', () => {
     let onFocusWithinChange, onFocusWithinVisibleChange, ref;
 
-    const componentInit = () => {
+    const componentInit = async () => {
       onFocusWithinChange = jest.fn();
       onFocusWithinVisibleChange = jest.fn();
       ref = React.createRef();
@@ -76,13 +74,14 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
         });
         return <div ref={focusWithinRef} />;
       };
-      ReactDOM.render(<Component />, container);
-      Scheduler.unstable_flushAll();
+      await act(() => {
+        ReactDOM.render(<Component />, container);
+      });
     };
 
     // @gate www
-    it('prevents custom events being dispatched', () => {
-      componentInit();
+    it('prevents custom events being dispatched', async () => {
+      await componentInit();
       const target = createEventTarget(ref.current);
       target.focus();
       target.blur();
@@ -106,18 +105,19 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       );
     };
 
-    const componentInit = () => {
+    const componentInit = async () => {
       onFocusWithinChange = jest.fn();
       ref = React.createRef();
       innerRef = React.createRef();
       innerRef2 = React.createRef();
-      ReactDOM.render(<Component show={true} />, container);
-      Scheduler.unstable_flushAll();
+      await act(() => {
+        ReactDOM.render(<Component show={true} />, container);
+      });
     };
 
     // @gate www
-    it('is called after "blur" and "focus" events on focus target', () => {
-      componentInit();
+    it('is called after "blur" and "focus" events on focus target', async () => {
+      await componentInit();
       const target = createEventTarget(ref.current);
       target.focus();
       expect(onFocusWithinChange).toHaveBeenCalledTimes(1);
@@ -128,8 +128,8 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
     });
 
     // @gate www
-    it('is called after "blur" and "focus" events on descendants', () => {
-      componentInit();
+    it('is called after "blur" and "focus" events on descendants', async () => {
+      await componentInit();
       const target = createEventTarget(innerRef.current);
       target.focus();
       expect(onFocusWithinChange).toHaveBeenCalledTimes(1);
@@ -140,8 +140,8 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
     });
 
     // @gate www
-    it('is only called once when focus moves within and outside the subtree', () => {
-      componentInit();
+    it('is only called once when focus moves within and outside the subtree', async () => {
+      await componentInit();
       const node = ref.current;
       const innerNode1 = innerRef.current;
       const innerNode2 = innerRef.current;
@@ -182,18 +182,19 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       );
     };
 
-    const componentInit = () => {
+    const componentInit = async () => {
       onFocusWithinVisibleChange = jest.fn();
       ref = React.createRef();
       innerRef = React.createRef();
       innerRef2 = React.createRef();
-      ReactDOM.render(<Component show={true} />, container);
-      Scheduler.unstable_flushAll();
+      await act(() => {
+        ReactDOM.render(<Component show={true} />, container);
+      });
     };
 
     // @gate www
-    it('is called after "focus" and "blur" on focus target if keyboard was used', () => {
-      componentInit();
+    it('is called after "focus" and "blur" on focus target if keyboard was used', async () => {
+      await componentInit();
       const target = createEventTarget(ref.current);
       const containerTarget = createEventTarget(container);
       // use keyboard first
@@ -207,8 +208,8 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
     });
 
     // @gate www
-    it('is called after "focus" and "blur" on descendants if keyboard was used', () => {
-      componentInit();
+    it('is called after "focus" and "blur" on descendants if keyboard was used', async () => {
+      await componentInit();
       const innerTarget = createEventTarget(innerRef.current);
       const containerTarget = createEventTarget(container);
       // use keyboard first
@@ -222,8 +223,8 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
     });
 
     // @gate www
-    it('is called if non-keyboard event is dispatched on target previously focused with keyboard', () => {
-      componentInit();
+    it('is called if non-keyboard event is dispatched on target previously focused with keyboard', async () => {
+      await componentInit();
       const node = ref.current;
       const innerNode1 = innerRef.current;
       const innerNode2 = innerRef2.current;
@@ -260,8 +261,8 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
     });
 
     // @gate www
-    it('is not called after "focus" and "blur" events without keyboard', () => {
-      componentInit();
+    it('is not called after "focus" and "blur" events without keyboard', async () => {
+      await componentInit();
       const innerTarget = createEventTarget(innerRef.current);
       innerTarget.pointerdown();
       innerTarget.pointerup();
@@ -270,8 +271,8 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
     });
 
     // @gate www
-    it('is only called once when focus moves within and outside the subtree', () => {
-      componentInit();
+    it('is only called once when focus moves within and outside the subtree', async () => {
+      await componentInit();
       const node = ref.current;
       const innerNode1 = innerRef.current;
       const innerNode2 = innerRef2.current;
@@ -338,7 +339,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
     });
 
     // @gate www
-    it('is called after a focused element is unmounted', () => {
+    it('is called after a focused element is unmounted', async () => {
       const Component = ({show}) => {
         const focusWithinRef = useFocusWithin(ref, {
           onBeforeBlurWithin,
@@ -352,8 +353,9 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
         );
       };
 
-      ReactDOM.render(<Component show={true} />, container);
-      Scheduler.unstable_flushAll();
+      await act(() => {
+        ReactDOM.render(<Component show={true} />, container);
+      });
 
       const inner = innerRef.current;
       const target = createEventTarget(inner);
@@ -370,7 +372,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
     });
 
     // @gate www
-    it('is called after a nested focused element is unmounted', () => {
+    it('is called after a nested focused element is unmounted', async () => {
       const Component = ({show}) => {
         const focusWithinRef = useFocusWithin(ref, {
           onBeforeBlurWithin,
@@ -388,8 +390,9 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
         );
       };
 
-      ReactDOM.render(<Component show={true} />, container);
-      Scheduler.unstable_flushAll();
+      await act(() => {
+        ReactDOM.render(<Component show={true} />, container);
+      });
 
       const inner = innerRef.current;
       const target = createEventTarget(inner);
@@ -406,7 +409,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
     });
 
     // @gate www
-    it('is called after many elements are unmounted', () => {
+    it('is called after many elements are unmounted', async () => {
       const buttonRef = React.createRef();
       const inputRef = React.createRef();
 
@@ -429,8 +432,9 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
         );
       };
 
-      ReactDOM.render(<Component show={true} />, container);
-      Scheduler.unstable_flushAll();
+      await act(() => {
+        ReactDOM.render(<Component show={true} />, container);
+      });
 
       inputRef.current.focus();
       expect(onBeforeBlurWithin).toHaveBeenCalledTimes(0);
@@ -441,7 +445,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
     });
 
     // @gate www
-    it('is called after a nested focused element is unmounted (with scope query)', () => {
+    it('is called after a nested focused element is unmounted (with scope query)', async () => {
       const TestScope = React.unstable_Scope;
       const testScopeQuery = (type, props) => true;
       let targetNodes;
@@ -464,15 +468,17 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
         );
       };
 
-      ReactDOM.render(<Component show={true} />, container);
-      Scheduler.unstable_flushAll();
+      await act(() => {
+        ReactDOM.render(<Component show={true} />, container);
+      });
 
       const inner = innerRef.current;
       const target = createEventTarget(inner);
       target.keydown({key: 'Tab'});
       target.focus();
-      ReactDOM.render(<Component show={false} />, container);
-      Scheduler.unstable_flushAll();
+      await act(() => {
+        ReactDOM.render(<Component show={false} />, container);
+      });
       expect(targetNodes).toEqual([targetNode]);
     });
 
@@ -511,7 +517,6 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       await act(() => {
         root.render(<Component />);
       });
-      jest.runAllTimers();
       expect(container2.innerHTML).toBe('<div><input></div>');
 
       const inner = innerRef.current;
@@ -525,7 +530,6 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       await act(() => {
         root.render(<Component />);
       });
-      jest.runAllTimers();
       expect(container2.innerHTML).toBe(
         '<div><input style="display: none;">Loading...</div>',
       );
@@ -570,7 +574,6 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       await act(() => {
         root.render(<Component />);
       });
-      jest.runAllTimers();
 
       expect(onBeforeBlurWithin).toHaveBeenCalledTimes(0);
       expect(onAfterBlurWithin).toHaveBeenCalledTimes(0);
@@ -579,14 +582,12 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       await act(() => {
         root.render(<Component />);
       });
-      jest.runAllTimers();
       expect(onBeforeBlurWithin).toHaveBeenCalledTimes(0);
       expect(onAfterBlurWithin).toHaveBeenCalledTimes(0);
 
       await act(() => {
         root.render(<Component />);
       });
-      jest.runAllTimers();
       expect(onBeforeBlurWithin).toHaveBeenCalledTimes(0);
       expect(onAfterBlurWithin).toHaveBeenCalledTimes(0);
 
@@ -595,7 +596,6 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       await act(() => {
         root.render(<Component />);
       });
-      jest.runAllTimers();
       expect(onBeforeBlurWithin).toHaveBeenCalledTimes(1);
       expect(onAfterBlurWithin).toHaveBeenCalledTimes(1);
 

--- a/packages/react-reconciler/src/__tests__/ErrorBoundaryReconciliation-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ErrorBoundaryReconciliation-test.internal.js
@@ -5,8 +5,8 @@ describe('ErrorBoundaryReconciliation', () => {
   let React;
   let ReactFeatureFlags;
   let ReactTestRenderer;
-  let Scheduler;
   let span;
+  let act;
 
   beforeEach(() => {
     jest.resetModules();
@@ -16,8 +16,7 @@ describe('ErrorBoundaryReconciliation', () => {
     ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
     ReactTestRenderer = require('react-test-renderer');
     React = require('react');
-    Scheduler = require('scheduler');
-
+    act = require('internal-test-utils').act;
     DidCatchErrorBoundary = class extends React.Component {
       state = {error: null};
       componentDidCatch(error) {
@@ -52,23 +51,27 @@ describe('ErrorBoundaryReconciliation', () => {
   });
 
   [true, false].forEach(isConcurrent => {
-    function sharedTest(ErrorBoundary, fallbackTagName) {
-      const renderer = ReactTestRenderer.create(
-        <ErrorBoundary fallbackTagName={fallbackTagName}>
-          <BrokenRender fail={false} />
-        </ErrorBoundary>,
-        {unstable_isConcurrent: isConcurrent},
-      );
-      Scheduler.unstable_flushAll();
+    async function sharedTest(ErrorBoundary, fallbackTagName) {
+      let renderer;
+
+      await act(() => {
+        renderer = ReactTestRenderer.create(
+          <ErrorBoundary fallbackTagName={fallbackTagName}>
+            <BrokenRender fail={false} />
+          </ErrorBoundary>,
+          {unstable_isConcurrent: isConcurrent},
+        );
+      });
       expect(renderer).toMatchRenderedOutput(<span prop="BrokenRender" />);
 
-      expect(() => {
-        renderer.update(
-          <ErrorBoundary fallbackTagName={fallbackTagName}>
-            <BrokenRender fail={true} />
-          </ErrorBoundary>,
-        );
-        Scheduler.unstable_flushAll();
+      await expect(async () => {
+        await act(() => {
+          renderer.update(
+            <ErrorBoundary fallbackTagName={fallbackTagName}>
+              <BrokenRender fail={true} />
+            </ErrorBoundary>,
+          );
+        });
       }).toErrorDev(isConcurrent ? ['invalid', 'invalid'] : ['invalid']);
       const Fallback = fallbackTagName;
       expect(renderer).toMatchRenderedOutput(<Fallback prop="ErrorBoundary" />);

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.js
@@ -16,7 +16,6 @@ describe('ReactSuspenseList', () => {
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');
-    act = require('internal-test-utils').act;
     Profiler = React.Profiler;
     Suspense = React.Suspense;
     if (gate(flags => flags.enableSuspenseList)) {
@@ -27,6 +26,7 @@ describe('ReactSuspenseList', () => {
     waitForAll = InternalTestUtils.waitForAll;
     assertLog = InternalTestUtils.assertLog;
     waitFor = InternalTestUtils.waitFor;
+    act = InternalTestUtils.act;
   });
 
   function Text(props) {
@@ -53,7 +53,7 @@ describe('ReactSuspenseList', () => {
   }
 
   // @gate enableSuspenseList
-  it('warns if an unsupported revealOrder option is used', () => {
+  it('warns if an unsupported revealOrder option is used', async () => {
     function Foo() {
       return (
         <SuspenseList revealOrder="something">
@@ -62,9 +62,11 @@ describe('ReactSuspenseList', () => {
       );
     }
 
-    ReactNoop.render(<Foo />);
-
-    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
+    await expect(async () => {
+      await act(() => {
+        ReactNoop.render(<Foo />);
+      });
+    }).toErrorDev([
       'Warning: "something" is not a supported revealOrder on ' +
         '<SuspenseList />. Did you mean "together", "forwards" or "backwards"?' +
         '\n    in SuspenseList (at **)' +
@@ -73,7 +75,7 @@ describe('ReactSuspenseList', () => {
   });
 
   // @gate enableSuspenseList
-  it('warns if a upper case revealOrder option is used', () => {
+  it('warns if a upper case revealOrder option is used', async () => {
     function Foo() {
       return (
         <SuspenseList revealOrder="TOGETHER">
@@ -82,9 +84,11 @@ describe('ReactSuspenseList', () => {
       );
     }
 
-    ReactNoop.render(<Foo />);
-
-    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
+    await expect(async () => {
+      await act(() => {
+        ReactNoop.render(<Foo />);
+      });
+    }).toErrorDev([
       'Warning: "TOGETHER" is not a valid value for revealOrder on ' +
         '<SuspenseList />. Use lowercase "together" instead.' +
         '\n    in SuspenseList (at **)' +
@@ -93,7 +97,7 @@ describe('ReactSuspenseList', () => {
   });
 
   // @gate enableSuspenseList
-  it('warns if a misspelled revealOrder option is used', () => {
+  it('warns if a misspelled revealOrder option is used', async () => {
     function Foo() {
       return (
         <SuspenseList revealOrder="forward">
@@ -102,9 +106,11 @@ describe('ReactSuspenseList', () => {
       );
     }
 
-    ReactNoop.render(<Foo />);
-
-    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
+    await expect(async () => {
+      await act(() => {
+        ReactNoop.render(<Foo />);
+      });
+    }).toErrorDev([
       'Warning: "forward" is not a valid value for revealOrder on ' +
         '<SuspenseList />. React uses the -s suffix in the spelling. ' +
         'Use "forwards" instead.' +
@@ -131,13 +137,15 @@ describe('ReactSuspenseList', () => {
     // No warning
     await waitForAll([]);
 
-    ReactNoop.render(
-      <Foo>
-        <Suspense fallback="Loading">Child</Suspense>
-      </Foo>,
-    );
-
-    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
+    await expect(async () => {
+      await act(() => {
+        ReactNoop.render(
+          <Foo>
+            <Suspense fallback="Loading">Child</Suspense>
+          </Foo>,
+        );
+      });
+    }).toErrorDev([
       'Warning: A single row was passed to a <SuspenseList revealOrder="forwards" />. ' +
         'This is not useful since it needs multiple rows. ' +
         'Did you mean to pass multiple children or an array?' +
@@ -147,7 +155,7 @@ describe('ReactSuspenseList', () => {
   });
 
   // @gate enableSuspenseList
-  it('warns if a single fragment is passed to a "backwards" list', () => {
+  it('warns if a single fragment is passed to a "backwards" list', async () => {
     function Foo() {
       return (
         <SuspenseList revealOrder="backwards">
@@ -156,9 +164,11 @@ describe('ReactSuspenseList', () => {
       );
     }
 
-    ReactNoop.render(<Foo />);
-
-    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
+    await expect(async () => {
+      await act(() => {
+        ReactNoop.render(<Foo />);
+      });
+    }).toErrorDev([
       'Warning: A single row was passed to a <SuspenseList revealOrder="backwards" />. ' +
         'This is not useful since it needs multiple rows. ' +
         'Did you mean to pass multiple children or an array?' +
@@ -168,7 +178,7 @@ describe('ReactSuspenseList', () => {
   });
 
   // @gate enableSuspenseList
-  it('warns if a nested array is passed to a "forwards" list', () => {
+  it('warns if a nested array is passed to a "forwards" list', async () => {
     function Foo({items}) {
       return (
         <SuspenseList revealOrder="forwards">
@@ -182,9 +192,11 @@ describe('ReactSuspenseList', () => {
       );
     }
 
-    ReactNoop.render(<Foo items={['A', 'B']} />);
-
-    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
+    await expect(async () => {
+      await act(() => {
+        ReactNoop.render(<Foo items={['A', 'B']} />);
+      });
+    }).toErrorDev([
       'Warning: A nested array was passed to row #0 in <SuspenseList />. ' +
         'Wrap it in an additional SuspenseList to configure its revealOrder: ' +
         '<SuspenseList revealOrder=...> ... ' +
@@ -1471,7 +1483,7 @@ describe('ReactSuspenseList', () => {
   });
 
   // @gate enableSuspenseList
-  it('warns if an unsupported tail option is used', () => {
+  it('warns if an unsupported tail option is used', async () => {
     function Foo() {
       return (
         <SuspenseList revealOrder="forwards" tail="collapse">
@@ -1481,9 +1493,11 @@ describe('ReactSuspenseList', () => {
       );
     }
 
-    ReactNoop.render(<Foo />);
-
-    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
+    await expect(async () => {
+      await act(() => {
+        ReactNoop.render(<Foo />);
+      });
+    }).toErrorDev([
       'Warning: "collapse" is not a supported value for tail on ' +
         '<SuspenseList />. Did you mean "collapsed" or "hidden"?' +
         '\n    in SuspenseList (at **)' +
@@ -1492,7 +1506,7 @@ describe('ReactSuspenseList', () => {
   });
 
   // @gate enableSuspenseList
-  it('warns if a tail option is used with "together"', () => {
+  it('warns if a tail option is used with "together"', async () => {
     function Foo() {
       return (
         <SuspenseList revealOrder="together" tail="collapsed">
@@ -1501,9 +1515,11 @@ describe('ReactSuspenseList', () => {
       );
     }
 
-    ReactNoop.render(<Foo />);
-
-    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
+    await expect(async () => {
+      await act(() => {
+        ReactNoop.render(<Foo />);
+      });
+    }).toErrorDev([
       'Warning: <SuspenseList tail="collapsed" /> is only valid if ' +
         'revealOrder is "forwards" or "backwards". ' +
         'Did you mean to specify revealOrder="forwards"?' +

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
@@ -13,7 +13,7 @@ let ReactDOM;
 let React;
 let ReactCache;
 let ReactTestRenderer;
-let Scheduler;
+let waitForAll;
 
 describe('ReactTestRenderer', () => {
   beforeEach(() => {
@@ -25,7 +25,8 @@ describe('ReactTestRenderer', () => {
     React = require('react');
     ReactCache = require('react-cache');
     ReactTestRenderer = require('react-test-renderer');
-    Scheduler = require('scheduler');
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
   });
 
   it('should warn if used to render a ReactDOM portal', () => {
@@ -85,16 +86,14 @@ describe('ReactTestRenderer', () => {
 
       const root = ReactTestRenderer.create(<App text="initial" />);
       PendingResources.initial('initial');
-      await Promise.resolve();
-      Scheduler.unstable_flushAll();
+      await waitForAll([]);
       expect(root.toJSON()).toEqual('initial');
 
       root.update(<App text="dynamic" />);
       expect(root.toJSON()).toEqual('fallback');
 
       PendingResources.dynamic('dynamic');
-      await Promise.resolve();
-      Scheduler.unstable_flushAll();
+      await waitForAll([]);
       expect(root.toJSON()).toEqual('dynamic');
     });
 
@@ -111,16 +110,14 @@ describe('ReactTestRenderer', () => {
 
       const root = ReactTestRenderer.create(<App text="initial" />);
       PendingResources.initial('initial');
-      await Promise.resolve();
-      Scheduler.unstable_flushAll();
+      await waitForAll([]);
       expect(root.toJSON().children).toEqual(['initial']);
 
       root.update(<App text="dynamic" />);
       expect(root.toJSON().children).toEqual(['fallback']);
 
       PendingResources.dynamic('dynamic');
-      await Promise.resolve();
-      Scheduler.unstable_flushAll();
+      await waitForAll([]);
       expect(root.toJSON().children).toEqual(['dynamic']);
     });
   });


### PR DESCRIPTION
`Scheduler.unstable_flushAll`  in existing tests doesn't work with microtask. This PR converts most of the remaining `Scheduler.unstable_flushAll()` calls to using internal test utilities to unblock refactoring `ensureRootIsScheduled` with scheduling a microtask.