### PR TITLE
Add disableLegacyContext test gates where needed

### DIFF
--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -587,6 +587,7 @@ describe('ReactCompositeComponent', () => {
     );
   });
 
+  // @gate !disableLegacyContext
   it('should pass context to children when not owner', () => {
     class Parent extends React.Component {
       render() {
@@ -652,6 +653,7 @@ describe('ReactCompositeComponent', () => {
     expect(childRenders).toBe(1);
   });
 
+  // @gate !disableLegacyContext
   it('should pass context when re-rendered for static child', () => {
     let parentInstance = null;
     let childInstance = null;
@@ -712,6 +714,7 @@ describe('ReactCompositeComponent', () => {
     expect(childInstance.context).toEqual({foo: 'bar', flag: true});
   });
 
+  // @gate !disableLegacyContext
   it('should pass context when re-rendered for static child within a composite component', () => {
     class Parent extends React.Component {
       static childContextTypes = {
@@ -768,6 +771,7 @@ describe('ReactCompositeComponent', () => {
     expect(wrapper.childRef.current.context).toEqual({flag: false});
   });
 
+  // @gate !disableLegacyContext
   it('should pass context transitively', () => {
     let childInstance = null;
     let grandchildInstance = null;
@@ -829,6 +833,7 @@ describe('ReactCompositeComponent', () => {
     expect(grandchildInstance.context).toEqual({foo: 'bar', depth: 1});
   });
 
+  // @gate !disableLegacyContext
   it('should pass context when re-rendered', () => {
     let parentInstance = null;
     let childInstance = null;
@@ -883,6 +888,7 @@ describe('ReactCompositeComponent', () => {
     expect(childInstance.context).toEqual({foo: 'bar', depth: 0});
   });
 
+  // @gate !disableLegacyContext
   it('unmasked context propagates through updates', () => {
     class Leaf extends React.Component {
       static contextTypes = {
@@ -946,6 +952,7 @@ describe('ReactCompositeComponent', () => {
     expect(div.children[0].id).toBe('aliens');
   });
 
+  // @gate !disableLegacyContext
   it('should trigger componentWillReceiveProps for context changes', () => {
     let contextChanges = 0;
     let propChanges = 0;
@@ -1219,6 +1226,7 @@ describe('ReactCompositeComponent', () => {
     expect(a).toBe(b);
   });
 
+  // @gate !disableLegacyContext || !__DEV__
   it('context should be passed down from the parent', () => {
     class Parent extends React.Component {
       static childContextTypes = {

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -718,6 +718,7 @@ describe('ReactDOMFiber', () => {
     );
   });
 
+  // @gate !disableLegacyContext
   it('should pass portal context when rendering subtree elsewhere', () => {
     const portalContainer = document.createElement('div');
 
@@ -752,6 +753,7 @@ describe('ReactDOMFiber', () => {
     expect(portalContainer.innerHTML).toBe('<div>bar</div>');
   });
 
+  // @gate !disableLegacyContext
   it('should update portal context if it changes due to setState', () => {
     const portalContainer = document.createElement('div');
 
@@ -796,6 +798,7 @@ describe('ReactDOMFiber', () => {
     expect(container.innerHTML).toBe('');
   });
 
+  // @gate !disableLegacyContext
   it('should update portal context if it changes due to re-render', () => {
     const portalContainer = document.createElement('div');
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1624,6 +1624,7 @@ describe('ReactDOMFizzServer', () => {
     }
   });
 
+  // @gate !disableLegacyContext
   it('should can suspend in a class component with legacy context', async () => {
     class TestProvider extends React.Component {
       static childContextTypes = {

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContext-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContext-test.js
@@ -44,6 +44,13 @@ describe('ReactDOMServerIntegration', () => {
   });
 
   describe('legacy context', function () {
+    // The `itRenders` test abstraction doesn't work with @gate so we have
+    // to do this instead.
+    if (gate(flags => flags.disableLegacyContext)) {
+      test('empty test to stop Jest from being a complainy complainer', () => {});
+      return;
+    }
+
     let PurpleContext, RedContext;
     beforeEach(() => {
       class Parent extends React.Component {

--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
@@ -775,6 +775,7 @@ describe('ReactErrorBoundaries', () => {
     assertLog(['ErrorBoundary componentWillUnmount']);
   });
 
+  // @gate !disableLegacyContext || !__DEV__
   it('renders an error state if context provider throws in componentWillMount', () => {
     class BrokenComponentWillMountWithContext extends React.Component {
       static childContextTypes = {foo: PropTypes.number};
@@ -799,45 +800,45 @@ describe('ReactErrorBoundaries', () => {
     expect(container.firstChild.textContent).toBe('Caught an error: Hello.');
   });
 
-  if (!require('shared/ReactFeatureFlags').disableModulePatternComponents) {
-    it('renders an error state if module-style context provider throws in componentWillMount', () => {
-      function BrokenComponentWillMountWithContext() {
-        return {
-          getChildContext() {
-            return {foo: 42};
-          },
-          render() {
-            return <div>{this.props.children}</div>;
-          },
-          UNSAFE_componentWillMount() {
-            throw new Error('Hello');
-          },
-        };
-      }
-      BrokenComponentWillMountWithContext.childContextTypes = {
-        foo: PropTypes.number,
+  // @gate !disableModulePatternComponents
+  // @gate !disableLegacyContext
+  it('renders an error state if module-style context provider throws in componentWillMount', () => {
+    function BrokenComponentWillMountWithContext() {
+      return {
+        getChildContext() {
+          return {foo: 42};
+        },
+        render() {
+          return <div>{this.props.children}</div>;
+        },
+        UNSAFE_componentWillMount() {
+          throw new Error('Hello');
+        },
       };
+    }
+    BrokenComponentWillMountWithContext.childContextTypes = {
+      foo: PropTypes.number,
+    };
 
-      const container = document.createElement('div');
-      expect(() =>
-        ReactDOM.render(
-          <ErrorBoundary>
-            <BrokenComponentWillMountWithContext />
-          </ErrorBoundary>,
-          container,
-        ),
-      ).toErrorDev(
-        'Warning: The <BrokenComponentWillMountWithContext /> component appears to be a function component that ' +
-          'returns a class instance. ' +
-          'Change BrokenComponentWillMountWithContext to a class that extends React.Component instead. ' +
-          "If you can't use a class try assigning the prototype on the function as a workaround. " +
-          '`BrokenComponentWillMountWithContext.prototype = React.Component.prototype`. ' +
-          "Don't use an arrow function since it cannot be called with `new` by React.",
-      );
+    const container = document.createElement('div');
+    expect(() =>
+      ReactDOM.render(
+        <ErrorBoundary>
+          <BrokenComponentWillMountWithContext />
+        </ErrorBoundary>,
+        container,
+      ),
+    ).toErrorDev(
+      'Warning: The <BrokenComponentWillMountWithContext /> component appears to be a function component that ' +
+        'returns a class instance. ' +
+        'Change BrokenComponentWillMountWithContext to a class that extends React.Component instead. ' +
+        "If you can't use a class try assigning the prototype on the function as a workaround. " +
+        '`BrokenComponentWillMountWithContext.prototype = React.Component.prototype`. ' +
+        "Don't use an arrow function since it cannot be called with `new` by React.",
+    );
 
-      expect(container.firstChild.textContent).toBe('Caught an error: Hello.');
-    });
-  }
+    expect(container.firstChild.textContent).toBe('Caught an error: Hello.');
+  });
 
   it('mounts the error message if mounting fails', () => {
     function renderError(error) {

--- a/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
@@ -59,6 +59,7 @@ describe('ReactFunctionComponent', () => {
     expect(container.textContent).toBe('');
   });
 
+  // @gate !disableLegacyContext
   it('should pass context thru stateless component', () => {
     class Child extends React.Component {
       static contextTypes = {
@@ -305,6 +306,7 @@ describe('ReactFunctionComponent', () => {
 
   // This guards against a regression caused by clearing the current debug fiber.
   // https://github.com/facebook/react/issues/10831
+  // @gate !disableLegacyContext || !__DEV__
   it('should warn when giving a function ref with context', () => {
     function Child() {
       return null;
@@ -375,6 +377,7 @@ describe('ReactFunctionComponent', () => {
     ]);
   });
 
+  // @gate !disableLegacyContext
   it('should receive context', () => {
     class Parent extends React.Component {
       static childContextTypes = {

--- a/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
@@ -800,6 +800,7 @@ describe('ReactLegacyErrorBoundaries', () => {
     expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
   });
 
+  // @gate !disableLegacyContext || !__DEV__
   it('renders an error state if context provider throws in componentWillMount', () => {
     class BrokenComponentWillMountWithContext extends React.Component {
       static childContextTypes = {foo: PropTypes.number};

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -340,6 +340,7 @@ describe('ReactDOMServer', () => {
       expect(markup).toContain('hello, world');
     });
 
+    // @gate !disableLegacyContext
     it('renders with context when using custom constructor', () => {
       class Component extends React.Component {
         constructor() {

--- a/packages/react-dom/src/__tests__/renderSubtreeIntoContainer-test.js
+++ b/packages/react-dom/src/__tests__/renderSubtreeIntoContainer-test.js
@@ -17,6 +17,7 @@ const renderSubtreeIntoContainer =
   require('react-dom').unstable_renderSubtreeIntoContainer;
 
 describe('renderSubtreeIntoContainer', () => {
+  // @gate !disableLegacyContext
   it('should pass context when rendering subtree elsewhere', () => {
     const portal = document.createElement('div');
 
@@ -99,6 +100,7 @@ describe('renderSubtreeIntoContainer', () => {
     }
   });
 
+  // @gate !disableLegacyContext
   it('should update context if it changes due to setState', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -159,6 +161,7 @@ describe('renderSubtreeIntoContainer', () => {
     expect(portal.firstChild.innerHTML).toBe('changed-changed');
   });
 
+  // @gate !disableLegacyContext
   it('should update context if it changes due to re-render', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -238,6 +241,7 @@ describe('renderSubtreeIntoContainer', () => {
     expect(portal.firstChild.innerHTML).toBe('hello');
   });
 
+  // @gate !disableLegacyContext
   it('should get context through non-context-provider parent', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -281,6 +285,7 @@ describe('renderSubtreeIntoContainer', () => {
     expect(portal.textContent).toBe('foo');
   });
 
+  // @gate !disableLegacyContext
   it('should get context through middle non-context-provider layer', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);

--- a/packages/react-native-renderer/src/__tests__/ReactNativeEvents-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeEvents-test.internal.js
@@ -197,6 +197,7 @@ it('handles events', () => {
   ]);
 });
 
+// @gate !disableLegacyContext || !__DEV__
 it('handles events on text nodes', () => {
   expect(RCTEventEmitter.register).toHaveBeenCalledTimes(1);
   const EventEmitter = RCTEventEmitter.register.mock.calls[0][0];

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1159,6 +1159,12 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(ReactNoop.getChildrenAsJSX('f')).toEqual(null);
   });
 
+  // NOTE: When legacy context is removed, it's probably fine to just delete
+  // this test. There's plenty of test coverage of stack unwinding in general
+  // because it's used for new context, suspense, and many other features.
+  // It has to be tested independently for each feature anyway. So although it
+  // doesn't look like it, this test is specific to legacy context.
+  // @gate !disableLegacyContext
   it('unwinds the context stack correctly on error', async () => {
     class Provider extends React.Component {
       static childContextTypes = {message: PropTypes.string};

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -984,6 +984,7 @@ describe('ReactNewContext', () => {
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Child" />);
     });
 
+    // @gate !disableLegacyContext
     it('provider does not bail out if legacy context changed above', async () => {
       const Context = React.createContext(0);
 

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -35,6 +35,7 @@ describe('ReactContextValidator', () => {
   // TODO: This behavior creates a runtime dependency on propTypes. We should
   // ensure that this is not required for ES6 classes with Flow.
 
+  // @gate !disableLegacyContext
   it('should filter out context not in contextTypes', () => {
     class Component extends React.Component {
       render() {
@@ -70,6 +71,7 @@ describe('ReactContextValidator', () => {
     expect(instance.childRef.current.context).toEqual({foo: 'abc'});
   });
 
+  // @gate !disableLegacyContext
   it('should pass next context to lifecycles', () => {
     let componentDidMountContext;
     let componentDidUpdateContext;
@@ -148,6 +150,7 @@ describe('ReactContextValidator', () => {
     expect(componentDidUpdateContext).toEqual({foo: 'def'});
   });
 
+  // @gate !disableLegacyContext || !__DEV__
   it('should check context types', () => {
     class Component extends React.Component {
       render() {
@@ -213,6 +216,7 @@ describe('ReactContextValidator', () => {
     );
   });
 
+  // @gate !disableLegacyContext || !__DEV__
   it('should check child context types', () => {
     class Component extends React.Component {
       getChildContext() {
@@ -278,6 +282,7 @@ describe('ReactContextValidator', () => {
 
   // TODO (bvaughn) Remove this test and the associated behavior in the future.
   // It has only been added in Fiber to match the (unintentional) behavior in Stack.
+  // @gate !disableLegacyContext || !__DEV__
   it('should warn (but not error) if getChildContext method is missing', () => {
     class ComponentA extends React.Component {
       static childContextTypes = {
@@ -314,6 +319,7 @@ describe('ReactContextValidator', () => {
 
   // TODO (bvaughn) Remove this test and the associated behavior in the future.
   // It has only been added in Fiber to match the (unintentional) behavior in Stack.
+  // @gate !disableLegacyContext
   it('should pass parent context if getChildContext method is missing', () => {
     class ParentContextProvider extends React.Component {
       static childContextTypes = {
@@ -474,6 +480,7 @@ describe('ReactContextValidator', () => {
     expect(renderedContext).toBe(secondContext);
   });
 
+  // @gate !disableLegacyContext || !__DEV__
   it('should warn if both contextType and contextTypes are defined', () => {
     const Context = React.createContext();
 

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -302,6 +302,7 @@ describe('ReactJSXElementValidator', () => {
     );
   });
 
+  // @gate !disableLegacyContext || !__DEV__
   it('should warn on invalid context types', () => {
     class NullContextTypeComponent extends React.Component {
       render() {

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -985,6 +985,7 @@ describe('context legacy', () => {
     jest.restoreAllMocks();
   });
 
+  // @gate !disableLegacyContext || !__DEV__
   it('should warn if the legacy context API have been used in strict mode', () => {
     class LegacyContextProvider extends React.Component {
       getChildContext() {

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -16,6 +16,7 @@ import ReactDOM = require('react-dom');
 import ReactDOMClient = require('react-dom/client');
 import ReactDOMTestUtils = require('react-dom/test-utils');
 import PropTypes = require('prop-types');
+import ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
 // Before Each
 
@@ -511,9 +512,11 @@ describe('ReactTypeScriptClass', function() {
     test(React.createElement(Foo, {update: true}), 'DIV', 'updated');
   });
 
-  it('renders based on context in the constructor', function() {
-    test(React.createElement(ProvideChildContextTypes), 'SPAN', 'foo');
-  });
+  if (!ReactFeatureFlags.disableLegacyContext) {
+    it('renders based on context in the constructor', function() {
+      test(React.createElement(ProvideChildContextTypes), 'SPAN', 'foo');
+    });
+  }
 
   it('renders only once when setting state in componentWillMount', function() {
     renderCount = 0;
@@ -592,27 +595,29 @@ describe('ReactTypeScriptClass', function() {
     expect(lifeCycles).toEqual(['will-unmount']);
   });
 
-  it(
-    'warns when classic properties are defined on the instance, ' +
-      'but does not invoke them.',
-    function() {
-      getInitialStateWasCalled = false;
-      getDefaultPropsWasCalled = false;
-      expect(() =>
-        test(React.createElement(ClassicProperties), 'SPAN', 'foo')
-      ).toErrorDev([
-        'getInitialState was defined on ClassicProperties, ' +
-          'a plain JavaScript class.',
-        'getDefaultProps was defined on ClassicProperties, ' +
-          'a plain JavaScript class.',
-        'propTypes was defined as an instance property on ClassicProperties.',
-        'contextTypes was defined as an instance property on ClassicProperties.',
-        'contextType was defined as an instance property on ClassicProperties.',
-      ]);
-      expect(getInitialStateWasCalled).toBe(false);
-      expect(getDefaultPropsWasCalled).toBe(false);
-    }
-  );
+  if (!ReactFeatureFlags.disableLegacyContext) {
+    it(
+      'warns when classic properties are defined on the instance, ' +
+        'but does not invoke them.',
+      function() {
+        getInitialStateWasCalled = false;
+        getDefaultPropsWasCalled = false;
+        expect(() =>
+          test(React.createElement(ClassicProperties), 'SPAN', 'foo')
+        ).toErrorDev([
+          'getInitialState was defined on ClassicProperties, ' +
+            'a plain JavaScript class.',
+          'getDefaultProps was defined on ClassicProperties, ' +
+            'a plain JavaScript class.',
+          'propTypes was defined as an instance property on ClassicProperties.',
+          'contextTypes was defined as an instance property on ClassicProperties.',
+          'contextType was defined as an instance property on ClassicProperties.',
+        ]);
+        expect(getInitialStateWasCalled).toBe(false);
+        expect(getDefaultPropsWasCalled).toBe(false);
+      }
+    );
+  }
 
   it(
     'does not warn about getInitialState() on class components ' +
@@ -680,9 +685,11 @@ describe('ReactTypeScriptClass', function() {
     );
   });
 
-  it('supports this.context passed via getChildContext', function() {
-    test(React.createElement(ProvideContext), 'DIV', 'bar-through-context');
-  });
+  if (!ReactFeatureFlags.disableLegacyContext) {
+    it('supports this.context passed via getChildContext', function() {
+      test(React.createElement(ProvideContext), 'DIV', 'bar-through-context');
+    });
+  }
 
   it('supports string refs', function() {
     const ref = React.createRef();

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -291,6 +291,7 @@ describe('create-react-class-integration', () => {
     expect(instance.state.occupation).toEqual('clown');
   });
 
+  // @gate !disableLegacyContext
   it('renders based on context getInitialState', () => {
     const Foo = createReactClass({
       contextTypes: {

--- a/scripts/jest/setupTests.www.js
+++ b/scripts/jest/setupTests.www.js
@@ -13,7 +13,6 @@ jest.mock('shared/ReactFeatureFlags', () => {
   // TODO: Many tests were written before we started running them against the
   // www configuration. Update those tests so that they work against the www
   // configuration, too. Then remove these overrides.
-  wwwFlags.disableLegacyContext = defaultFlags.disableLegacyContext;
   wwwFlags.disableJavaScriptURLs = defaultFlags.disableJavaScriptURLs;
 
   return wwwFlags;


### PR DESCRIPTION
The www builds include disableLegacyContext as a dynamic flag, so we should be running the tests in that mode, too. Previously we were overriding the flag during the test run. This strategy usually doesn't work because the flags get compiled out in the final build, but we happen to not test www in build mode, only source.

To get of this hacky override, I added a test gate to every test that uses legacy context. When we eventually remove legacy context from the codebase, this should make it slightly easier to find which tests are affected. And removes one more hack from our hack-ridden test config.

Given that sometimes www has features enabled that aren't on in other builds, we might want to consider testing its build artifacts in CI, rather than just source. That would have forced this cleanup to happen sooner. Currently we only test the public builds in CI.