### PR TITLE
Remote `.internal` override from untrusted URL tests

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.js
@@ -149,6 +149,13 @@ function runTests(itRenders, itRejectsRendering, expectToReject) {
 }
 
 describe('ReactDOMServerIntegration - Untrusted URLs', () => {
+  // The `itRenders` helpers don't work with the gate pragma, so we have to do
+  // this instead.
+  if (gate(flags => flags.disableJavaScriptURLs)) {
+    it("empty test so Jest doesn't complain", () => {});
+    return;
+  }
+
   function initModules() {
     jest.resetModules();
     React = require('react');
@@ -181,6 +188,13 @@ describe('ReactDOMServerIntegration - Untrusted URLs', () => {
 });
 
 describe('ReactDOMServerIntegration - Untrusted URLs - disableJavaScriptURLs', () => {
+  // The `itRenders` helpers don't work with the gate pragma, so we have to do
+  // this instead.
+  if (gate(flags => !flags.disableJavaScriptURLs)) {
+    it("empty test so Jest doesn't complain", () => {});
+    return;
+  }
+
   function initModules() {
     jest.resetModules();
     const ReactFeatureFlags = require('shared/ReactFeatureFlags');

--- a/scripts/jest/setupTests.www.js
+++ b/scripts/jest/setupTests.www.js
@@ -6,16 +6,7 @@ jest.mock('shared/ReactFeatureFlags', () => {
     () => jest.requireActual('shared/forks/ReactFeatureFlags.www-dynamic'),
     {virtual: true}
   );
-
-  const wwwFlags = jest.requireActual('shared/forks/ReactFeatureFlags.www');
-  const defaultFlags = jest.requireActual('shared/ReactFeatureFlags');
-
-  // TODO: Many tests were written before we started running them against the
-  // www configuration. Update those tests so that they work against the www
-  // configuration, too. Then remove these overrides.
-  wwwFlags.disableJavaScriptURLs = defaultFlags.disableJavaScriptURLs;
-
-  return wwwFlags;
+  return jest.requireActual('shared/forks/ReactFeatureFlags.www');
 });
 
 jest.mock('scheduler/src/SchedulerFeatureFlags', () => {


### PR DESCRIPTION
Adding `.internal` to a test file prevents it from being tested in build mode. The best practice is to instead gate the test based on whether the feature is enabled.

Ideally we'd use the `@gate` pragma in these tests, but the `itRenders` test helpers don't support that.