### PR TITLE
[Flight fixture] Remove redundant `use`

### DIFF
--- a/fixtures/flight/src/index.js
+++ b/fixtures/flight/src/index.js
@@ -27,12 +27,7 @@ let data = createFromFetch(
   }
 );
 
-// TODO: Once not needed once children can be promises.
-function Content() {
-  return React.use(data);
-}
-
 // TODO: This transition shouldn't really be necessary but it is for now.
 React.startTransition(() => {
-  ReactDOM.hydrateRoot(document, <Content />);
+  ReactDOM.hydrateRoot(document, data);
 });


### PR DESCRIPTION
Now that promises are renderable nodes, we can remove the `use` call from the root of the Flight fixture.

Uncached promises will likely be accompanied by a warning when they are rendered outside a transition. But this promise is the result of a Flight response, so it's cached. And it's also a rendered as part of a transition. So it's fine. Indeed, this is the canonical way to use this feature.