### PR TITLE
Remove internal `act` from DevTools e2e test

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
@@ -17,10 +17,9 @@ describe('Store component filters', () => {
   let legacyRender;
   let store: Store;
   let utils;
-  let internalAct;
 
   const act = async (callback: Function) => {
-    await internalAct(callback);
+    await React.unstable_act(callback);
     jest.runAllTimers(); // Flush Bridge operations
   };
 
@@ -34,7 +33,6 @@ describe('Store component filters', () => {
     React = require('react');
     Types = require('react-devtools-shared/src/types');
     utils = require('./utils');
-    internalAct = require('internal-test-utils').act;
 
     legacyRender = utils.legacyRender;
   });


### PR DESCRIPTION
For various reasons some of the DevTools e2e tests uses our repo's private internal version of `act`. It should really just be using the public one.

This converts one of the usages, because it was causing CI to fail.