### PR TITLE
Don't "fix up" mismatched text content with suppressedHydrationWarning

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -3813,7 +3813,7 @@ describe('ReactDOMFizzServer', () => {
         'Logged recoverable error: There was an error while hydrating this Suspense boundary. Switched to client rendering.',
       ]);
     }).toErrorDev(
-      'Warning: Prop `name` did not match. Server: "initial" Client: "replaced"',
+      'Warning: Text content did not match. Server: "initial" Client: "replaced',
     );
     expect(getVisibleChildren(container)).toEqual(
       <div>

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -5617,7 +5617,7 @@ background-color: green;
       ]);
     });
 
-    // @gate enableFloat && enableHostSingletons && (enableClientRenderFallbackOnTextMismatch || !__DEV__)
+    // @gate enableFloat && enableHostSingletons && enableClientRenderFallbackOnTextMismatch
     it('can render a title before a singleton even if that singleton clears its contents', async () => {
       await actIntoEmptyDocument(() => {
         const {pipe} = renderToPipeableStream(

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -728,6 +728,11 @@ function prepareToHydrateHostTextInstance(fiber: Fiber): boolean {
             isConcurrentMode,
             shouldWarnIfMismatchDev,
           );
+          if (isConcurrentMode) {
+            // In concurrent mode we never update the mismatched text,
+            // even if the error was ignored.
+            return false;
+          }
           break;
         }
         case HostSingleton:
@@ -747,6 +752,11 @@ function prepareToHydrateHostTextInstance(fiber: Fiber): boolean {
             isConcurrentMode,
             shouldWarnIfMismatchDev,
           );
+          if (isConcurrentMode) {
+            // In concurrent mode we never update the mismatched text,
+            // even if the error was ignored.
+            return false;
+          }
           break;
         }
       }


### PR DESCRIPTION
In concurrent mode we error if child nodes mismatches which triggers a recreation of the whole hydration boundary. This ensures that we don't replay the wrong thing, transform state or other security issues.

For text content, we respect `suppressedHydrationWarning` to allow for things like `<div suppressedHydrationWarning>{timestamp}</div>` to ignore the timestamp. This mode actually still patches up the text content to be the client rendered content.

In principle we shouldn't have to do that because either value should be ok, and arguably it's better not to trigger layout thrash after the fact.

We do have a lot of code still to deal with patching up the tree because that's what legacy mode does which is still in the code base. When we delete legacy mode we would still be stuck with a lot of it just to deal with this case.

Therefore I propose that we change the semantics to not patch up hydration errors for text nodes. We already don't for attributes.