### PR TITLE
Restore some guards in ReactFabricGlobalResponderHandler after refactor

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
+++ b/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
@@ -9,7 +9,7 @@
 
 const ReactFabricGlobalResponderHandler = {
   onChange: function (from: any, to: any, blockNativeResponder: boolean) {
-    if (from) {
+    if (from && from.stateNode) {
       // equivalent to clearJSResponder
       nativeFabricUIManager.setIsJSResponder(
         from.stateNode.node,
@@ -18,7 +18,7 @@ const ReactFabricGlobalResponderHandler = {
       );
     }
 
-    if (to) {
+    if (to && to.stateNode) {
       // equivalent to setJSResponder
       nativeFabricUIManager.setIsJSResponder(
         to.stateNode.node,


### PR DESCRIPTION
## Summary

I refactored this code in #26290 but forgot to add guards when the fiber or the state node where null, and this is typed as `any` so Flow didn't catch it.

This restores the same logic to guard against null.

## How did you test this change?

Existing tests.