### PR TITLE
Remove layout effect warning on the server

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
@@ -1607,13 +1607,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
       );
     }
 
-    let finalHTML;
-    expect(() => {
-      finalHTML = ReactDOMServer.renderToString(<App />);
-    }).toErrorDev([
-      'useLayoutEffect does nothing on the server',
-      'useLayoutEffect does nothing on the server',
-    ]);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
 
     assertLog(['App', 'A', 'B']);
 

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -440,23 +440,6 @@ function useRef<T>(initialValue: T): {current: T} {
   }
 }
 
-export function useLayoutEffect(
-  create: () => (() => void) | void,
-  inputs: Array<mixed> | void | null,
-) {
-  if (__DEV__) {
-    currentHookNameInDev = 'useLayoutEffect';
-    console.error(
-      'useLayoutEffect does nothing on the server, because its effect cannot ' +
-        "be encoded into the server renderer's output format. This will lead " +
-        'to a mismatch between the initial, non-hydrated UI and the intended ' +
-        'UI. To avoid this, useLayoutEffect should only be used in ' +
-        'components that render exclusively on the client. ' +
-        'See https://reactjs.org/link/uselayouteffect-ssr for common fixes.',
-    );
-  }
-}
-
 function dispatchAction<A>(
   componentIdentity: Object,
   queue: UpdateQueue<A>,
@@ -633,7 +616,7 @@ export const HooksDispatcher: Dispatcher = {
   useRef,
   useState,
   useInsertionEffect: noop,
-  useLayoutEffect,
+  useLayoutEffect: noop,
   useCallback,
   // useImperativeHandle is not run in the server environment
   useImperativeHandle: noop,


### PR DESCRIPTION
## Overview

This PR unfortunately removes the warning emitted when using layout effects on the server:

> useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.

## Why this warning exists
The new docs explain this really well. Adding a screenshot because as part of this change, we'll be removing these docs.

<img width="1562" alt="Screenshot 2023-03-15 at 10 56 17 AM" src="https://user-images.githubusercontent.com/2440089/225349148-f0e57c3f-95f5-4f2e-9178-d9b9b221c28d.png">

## Why are we changing it

In practice, users are not just ignoring this warning, but creating hooks to bypass this warning by switching the useLayoutEffect hook on the server instead of fixing it. This battle seems to be lost, so let's remove the warning so at least users don't need to use the indirection hook any more. In practice, if it's an issue, you should see the problems like flashing the wrong content on first load in development.
