### PR TITLE
Fix a test case in ReactUpdates-test

### DIFF
--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1646,12 +1646,12 @@ describe('ReactUpdates', () => {
       try {
         const container = document.createElement('div');
         expect(() => {
-          ReactDOM.render(<App />, container);
+          const root = ReactDOMClient.createRoot(container);
+          root.render(<App />);
           while (error === null) {
             Scheduler.unstable_flushNumberOfYields(1);
             Scheduler.unstable_clearLog();
           }
-          expect(error).toContain('Warning: Maximum update depth exceeded.');
           expect(stack).toContain(' NonTerminating');
           // rethrow error to prevent going into an infinite loop when act() exits
           throw error;


### PR DESCRIPTION
Just noticed the test isn't testing what it is meant to test properly.
The error `Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot` is thrown, the inner `expect(error).toContain('Warning: Maximum update depth exceeded.');`  failed and threw jest error, and the outer `.toThrow('Maximum update depth exceeded.')` happens to catch it makes the test pass.