### PR TITLE
Remove hydrate entry point from www builds

### DIFF
--- a/packages/react-dom/index.classic.fb.js
+++ b/packages/react-dom/index.classic.fb.js
@@ -24,7 +24,6 @@ export {
   hydrateRoot,
   findDOMNode,
   flushSync,
-  hydrate,
   render,
   unmountComponentAtNode,
   unstable_batchedUpdates,


### PR DESCRIPTION
As I understand it this isn't used at Meta and it would let us get rid of at least legacy mode hydration code when we remove legacy mode from OSS builds.