### PR TITLE
Improve Error Messages when pass event handlers to server component

### DIFF
--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -511,7 +511,7 @@ describe('ReactFlight', () => {
       startTransition(() => {
         ReactNoop.render(
           <>
-            <ErrorBoundary expectedMessage="Event handlers cannot be passed to Client Component props.">
+            <ErrorBoundary expectedMessage="Event handlers cannot be passed to Server Component props.">
               <Render promise={ReactNoopFlightClient.read(event)} />
             </ErrorBoundary>
             <ErrorBoundary
@@ -526,7 +526,7 @@ describe('ReactFlight', () => {
             <ErrorBoundary expectedMessage="Refs cannot be used in Server Components, nor passed to Client Components.">
               <Render promise={ReactNoopFlightClient.read(refs)} />
             </ErrorBoundary>
-            <ErrorBoundary expectedMessage="Event handlers cannot be passed to Client Component props.">
+            <ErrorBoundary expectedMessage="Event handlers cannot be passed to Server Component props.">
               <Render promise={ReactNoopFlightClient.read(eventClient)} />
             </ErrorBoundary>
             <ErrorBoundary

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -890,7 +890,7 @@ export function resolveModelToJSON(
     }
     if (/^on[A-Z]/.test(key)) {
       throw new Error(
-        'Event handlers cannot be passed to Client Component props.' +
+        'Event handlers cannot be passed to Server Component props.' +
           describeObjectForErrorMessage(parent, key) +
           '\nIf you need interactivity, consider converting part of this to a Client Component.',
       );

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -360,7 +360,7 @@
   "371": "Text string must be rendered within a <Text> component.\n\nText: %s",
   "372": "Cannot call unstable_createEventHandle with \"%s\", as it is not an event known to React.",
   "373": "This Hook is not supported in Server Components.",
-  "374": "Event handlers cannot be passed to Client Component props.%s\nIf you need interactivity, consider converting part of this to a Client Component.",
+  "374": "Event handlers cannot be passed to Server Component props.%s\nIf you need interactivity, consider converting part of this to a Client Component.",
   "375": "Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with \"use server\".%s",
   "376": "Only global symbols received from Symbol.for(...) can be passed to Client Components. The symbol Symbol.for(%s) cannot be found among global symbols.%s",
   "377": "BigInt (%s) is not yet supported in Client Component props.%s",


### PR DESCRIPTION
when i use event handlers in a server component, i got an error on the terminal output:

```bash
error - Error: Event handlers cannot be passed to Client Component props.
  <div onClick={function} className=...>
               ^^^^^^^^^^
If you need interactivity, consider converting part of this to a Client Component.
    at stringify (<anonymous>
```
    
but the fact is i can use event in client component, not server component