### PR TITLE
FIX: Use `typos` tool to detect various (`~140`) typos across react codebase :) ✨

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ commands:
             - ~/.cache/yarn
 
 # The CircleCI API doesn't yet support triggering a specific workflow, but it
-# does support triggering a pipeline. So as a workaround you can triggger the
+# does support triggering a pipeline. So as a workaround you can trigger the
 # entire pipeline and use parameters to disable everything except the workflow
 # you want. CircleCI recommends this workaround here:
 # https://support.circleci.com/hc/en-us/articles/360050351292-How-to-trigger-a-workflow-via-CircleCI-API-v2-

--- a/fixtures/nesting/README.md
+++ b/fixtures/nesting/README.md
@@ -68,7 +68,7 @@ We will use three different `package.json`s: one for non-React code at the root,
 - **`src/legacy/package.json`**: This is where we declare the `react` and `react-dom`  dependencies for the "legacy" trees. In this demo, we're using React 16.8 (although, as noted above, we could downgrade it further below). This is **also** where we specify any third-party libraries that use React. For example, we include `react-router` and `react-redux` in this example. 
 - **`src/modern/package.json`**: This is where we declare the `react` and `react-dom`  dependencies for the "modern" trees. In this demo, we're using React 17. Here, we also specify third-party dependencies that use React and are used from the modern part of our app. This is why we *also* have `react-router` and `react-redux` in this file. (Their versions don't strictly have to match their `legacy` counterparts, but features that rely on context may require workarounds if they differ.)
 
-The `scripts` in the root `package.json` are set up so that when you run `npm install` in it, it also runs `npm intall` in both `src/legacy` and `src/modern` folders.
+The `scripts` in the root `package.json` are set up so that when you run `npm install` in it, it also runs `npm install` in both `src/legacy` and `src/modern` folders.
 
 **Note:** This demo is set up to use a few third-party dependencies (React Router and Redux). These are not essential, and you can remove them from the demo. They are included so we can show how to make them work with this approach.
 

--- a/fixtures/nesting/src/legacy/createLegacyRoot.js
+++ b/fixtures/nesting/src/legacy/createLegacyRoot.js
@@ -17,7 +17,7 @@ function Bridge({children, context}) {
       <__RouterContext.Provider value={context.router}>
         {/*
           If we used the newer react-redux@7.x in the legacy/package.json,
-          we woud instead import {ReactReduxContext} from 'react-redux'
+          we would instead import {ReactReduxContext} from 'react-redux'
           and render <ReactReduxContext.Provider value={context.reactRedux}>.
         */}
         <Provider store={context.reactRedux.store}>{children}</Provider>

--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -347,7 +347,7 @@ function startServer(
 
     // The renderer interface doesn't read saved component filters directly,
     // because they are generally stored in localStorage within the context of the extension.
-    // Because of this it relies on the extension to pass filters, so include them wth the response here.
+    // Because of this it relies on the extension to pass filters, so include them with the response here.
     // This will ensure that saved filters are shared across different web pages.
     const savedPreferencesString = `
       window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = ${JSON.stringify(

--- a/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
+++ b/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
@@ -1404,7 +1404,7 @@ describe('Timeline profiler', () => {
           }
         `);
 
-        // There should be two batches of renders: Suspeneded and resolved.
+        // There should be two batches of renders: Suspended and resolved.
         expect(timelineData.batchUIDToMeasuresMap.size).toBe(2);
         expect(timelineData.componentMeasures).toHaveLength(2);
       });
@@ -1462,7 +1462,7 @@ describe('Timeline profiler', () => {
           }
         `);
 
-        // There should be two batches of renders: Suspeneded and resolved.
+        // There should be two batches of renders: Suspended and resolved.
         expect(timelineData.batchUIDToMeasuresMap.size).toBe(2);
         expect(timelineData.componentMeasures).toHaveLength(2);
       });
@@ -1520,7 +1520,7 @@ describe('Timeline profiler', () => {
           }
         `);
 
-        // There should be two batches of renders: Suspeneded and resolved.
+        // There should be two batches of renders: Suspended and resolved.
         expect(timelineData.batchUIDToMeasuresMap.size).toBe(2);
         expect(timelineData.componentMeasures).toHaveLength(2);
       });
@@ -1578,7 +1578,7 @@ describe('Timeline profiler', () => {
           }
         `);
 
-        // There should be two batches of renders: Suspeneded and resolved.
+        // There should be two batches of renders: Suspended and resolved.
         expect(timelineData.batchUIDToMeasuresMap.size).toBe(2);
         expect(timelineData.componentMeasures).toHaveLength(2);
       });
@@ -2461,7 +2461,7 @@ describe('Timeline profiler', () => {
       });
 
       it('should generate component stacks for state update', async () => {
-        function CommponentWithChildren({initialRender}) {
+        function ComponentWithChildren({initialRender}) {
           Scheduler.log('Render ComponentWithChildren');
           return <Child initialRender={initialRender} />;
         }
@@ -2475,7 +2475,7 @@ describe('Timeline profiler', () => {
           return null;
         }
 
-        renderRootHelper(<CommponentWithChildren initialRender={false} />);
+        renderRootHelper(<ComponentWithChildren initialRender={false} />);
 
         await waitForAll([
           'Render ComponentWithChildren',
@@ -2496,7 +2496,7 @@ describe('Timeline profiler', () => {
               "componentName": "Child",
               "componentStack": "
               in Child (at **)
-              in CommponentWithChildren (at **)",
+              in ComponentWithChildren (at **)",
               "lanes": "0b0000000000000000000000000100000",
               "timestamp": 10,
               "type": "schedule-state-update",

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -2878,7 +2878,7 @@ describe('InspectedElement', () => {
         expect(store.getElementIDAtIndex(1)).toBe(null);
       });
 
-      // Inpsect <ErrorBoundary /> to toggle off the error state
+      // Inspect <ErrorBoundary /> to toggle off the error state
       inspectedElement = await inspect(0);
       expect(inspectedElement.canToggleError).toBe(true);
       expect(inspectedElement.isErrored).toBe(true);

--- a/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
+++ b/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
@@ -1736,7 +1736,7 @@ describe('Timeline profiler', () => {
 
         describe('errors thrown while rendering', () => {
           // @reactVersion >= 18.0
-          it('shoult parse Errors thrown during render', async () => {
+          it('should parse Errors thrown during render', async () => {
             jest.spyOn(console, 'error');
 
             class ErrorBoundary extends React.Component {

--- a/packages/react-devtools-shared/src/__tests__/profilingHostRoot-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilingHostRoot-test.js
@@ -35,7 +35,7 @@ describe('profiling HostRoot', () => {
     effectDurations = [];
     passiveEffectDurations = [];
 
-    // This is the DevTools hook installed by the env.beforEach()
+    // This is the DevTools hook installed by the env.beforeEach()
     // The hook is installed as a read-only property on the window,
     // so for our test purposes we can just override the commit hook.
     const hook = global.__REACT_DEVTOOLS_GLOBAL_HOOK__;

--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -185,13 +185,13 @@ describe('utils', () => {
     });
 
     // @reactVersion >= 16.0
-    it('should format string substituions', () => {
+    it('should format string substitution', () => {
       expect(
         formatWithStyles(['%s %s %s', 'a', 'b', 'c'], 'color: gray'),
       ).toEqual(['%c%s %s %s', 'color: gray', 'a', 'b', 'c']);
 
       // The last letter isn't gray here but I think it's not a big
-      // deal, since there is a string substituion but it's incorrect
+      // deal, since there is a string substitution but it's incorrect
       expect(formatWithStyles(['%s %s', 'a', 'b', 'c'], 'color: gray')).toEqual(
         ['%c%s %s', 'color: gray', 'a', 'b', 'c'],
       );
@@ -218,7 +218,7 @@ describe('utils', () => {
     });
 
     // @reactVersion >= 16.0
-    it('should properly format escaped string substituions', () => {
+    it('should properly format escaped string substitution', () => {
       expect(formatWithStyles(['%%s'], 'color: gray')).toEqual([
         '%c%s',
         'color: gray',

--- a/packages/react-devtools-shared/src/backend/profilingHooks.js
+++ b/packages/react-devtools-shared/src/backend/profilingHooks.js
@@ -216,7 +216,7 @@ export function createProfilingHooks({
     type: ReactMeasureType,
     lanes: Lanes,
   ): void {
-    // Decide what depth thi work should be rendered at, based on what's on the top of the stack.
+    // Decide what depth this work should be rendered at, based on what's on the top of the stack.
     // It's okay to render over top of "idle" work but everything else should be on its own row.
     let depth = 0;
     if (currentReactMeasuresStack.length > 0) {
@@ -304,7 +304,7 @@ export function createProfilingHooks({
       // Some metadata only needs to be logged once per session,
       // but if profiling information is being recorded via the Performance tab,
       // DevTools has no way of knowing when the recording starts.
-      // Because of that, we log thie type of data periodically (once per commit).
+      // Because of that, we log this type of data periodically (once per commit).
       markMetadata();
     }
   }

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -641,7 +641,7 @@ export function attach(
     // For example, ASTs cached for the component (for named hooks) may no longer be valid.
     // Send a signal to the frontend to purge this cached information.
     // The "fastRefreshScheduled" dispatched is global (not Fiber or even Renderer specific).
-    // This is less effecient since it means the front-end will need to purge the entire cache,
+    // This is less efficient since it means the front-end will need to purge the entire cache,
     // but this is probably an okay trade off in order to reduce coupling between the DevTools and Fast Refresh.
     renderer.scheduleRefresh = (...args) => {
       try {

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -444,7 +444,7 @@ export default class Store extends EventEmitter<{
   }
 
   // This build of DevTools supports the legacy profiler.
-  // This is a static flag, controled by the Store config.
+  // This is a static flag, controlled by the Store config.
   get supportsProfiling(): boolean {
     return this._supportsProfiling;
   }
@@ -461,7 +461,7 @@ export default class Store extends EventEmitter<{
   }
 
   // This build of DevTools supports the Timeline profiler.
-  // This is a static flag, controled by the Store config.
+  // This is a static flag, controlled by the Store config.
   get supportsTimeline(): boolean {
     return this._supportsTimeline;
   }

--- a/packages/react-devtools-shared/src/devtools/utils.js
+++ b/packages/react-devtools-shared/src/devtools/utils.js
@@ -191,7 +191,7 @@ export function smartStringify(value: any): string {
 // [url, row, column]
 export type Stack = [string, number, number];
 
-const STACK_DELIMETER = /\n\s+at /;
+const STACK_DELIMITER = /\n\s+at /;
 const STACK_SOURCE_LOCATION = /([^\s]+) \((.+):(.+):(.+)\)/;
 
 export function stackToComponentSources(
@@ -199,7 +199,7 @@ export function stackToComponentSources(
 ): Array<[string, ?Stack]> {
   const out: Array<[string, ?Stack]> = [];
   stack
-    .split(STACK_DELIMETER)
+    .split(STACK_DELIMITER)
     .slice(1)
     .forEach(entry => {
       const match = STACK_SOURCE_LOCATION.exec(entry);

--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js
@@ -156,7 +156,7 @@ export default class ErrorBoundary extends Component<Props, State> {
           <CaughtErrorView
             callStack={callStack}
             componentStack={componentStack}
-            errorMessage={errorMessage || 'Error occured in inspected element'}
+            errorMessage={errorMessage || 'Error occurred in inspected element'}
             info={
               <>
                 React DevTools encountered an error while trying to inspect the

--- a/packages/react-devtools-shared/src/devtools/views/Settings/GeneralSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/GeneralSettings.js
@@ -23,7 +23,7 @@ function getChangeLogUrl(version: ?string): string | null {
   // Version numbers are in the format of: <major>.<minor>.<patch>-<sha>
   // e.g. "4.23.0-f0dd459e0"
   // GitHub CHANGELOG headers are in the format of: <major>.<minor>.<patch>
-  // but the "." are stripped from anchor tags, becomming: <major><minor><patch>
+  // but the "." are stripped from anchor tags, becoming: <major><minor><patch>
   const versionAnchor = version.replace(/^(\d+)\.(\d+)\.(\d+).*/, '$1$2$3');
   return `${CHANGE_LOG_URL}#${versionAnchor}`;
 }

--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -229,7 +229,7 @@ export function installHook(target: any): DevToolsHook | null {
   // NOTE: KEEP IN SYNC with src/backend/console.js:patchForStrictMode
   // This function hides or dims console logs during the initial double renderer
   // in Strict Mode. We need this function because during initial render,
-  // React and DevTools are connecting and the renderer interface isn't avaiable
+  // React and DevTools are connecting and the renderer interface isn't available
   // and we want to be able to have consistent logging behavior for double logs
   // during the initial renderer.
   function patchConsoleForInitialRenderInStrictMode({

--- a/packages/react-devtools-shared/src/hooks/parseHookNames/parseSourceAndMetadata.js
+++ b/packages/react-devtools-shared/src/hooks/parseHookNames/parseSourceAndMetadata.js
@@ -339,7 +339,7 @@ function parseSourceAST(
             originalSourceCode.indexOf('@flow') > 0 ? 'flow' : 'typescript';
 
           // TODO (named hooks) This is probably where we should check max source length,
-          // rather than in loadSourceAndMetatada -> loadSourceFiles().
+          // rather than in loadSourceAndMetadata -> loadSourceFiles().
           // TODO(#22319): Support source files that are html files with inline script tags.
           const originalSourceAST = withSyncPerfMeasurements(
             '[@babel/parser] parse(originalSourceCode)',

--- a/packages/react-devtools-shared/src/inspectedElementMutableSource.js
+++ b/packages/react-devtools-shared/src/inspectedElementMutableSource.js
@@ -36,7 +36,7 @@ import UnknownHookError from 'react-devtools-shared/src/errors/UnknownHookError'
 // the backend will send a "no-change" message if the element hasn't updated (rendered) since the last time it was asked.
 // In this case, the frontend cache should reuse the previous (cached) value.
 // Using a WeakMap keyed on Element generally works well for this, since Elements are mutable and stable in the Store.
-// This doens't work properly though when component filters are changed,
+// This doesn't work properly though when component filters are changed,
 // because this will cause the Store to dump all roots and re-initialize the tree (recreating the Element objects).
 // So instead we key on Element ID (which is stable in this case) and use an LRU for eviction.
 const inspectedElementCache: LRUCache<number, InspectedElementFrontend> =

--- a/packages/react-devtools-shell/src/app/devtools.js
+++ b/packages/react-devtools-shell/src/app/devtools.js
@@ -10,7 +10,7 @@ import {initialize as initializeFrontend} from 'react-devtools-inline/frontend';
 import {initDevTools} from 'react-devtools-shared/src/devtools';
 
 // This is a pretty gross hack to make the runtime loaded named-hooks-code work.
-// TODO (Webpack 5) Hoepfully we can remove this once we upgrade to Webpack 5.
+// TODO (Webpack 5) Hopefully we can remove this once we upgrade to Webpack 5.
 // $FlowFixMe
 __webpack_public_path__ = '/dist/'; // eslint-disable-line no-undef
 

--- a/packages/react-devtools-shell/src/e2e-regression/devtools.js
+++ b/packages/react-devtools-shell/src/e2e-regression/devtools.js
@@ -8,7 +8,7 @@ import {
 import {initialize as createDevTools} from 'react-devtools-inline/frontend';
 
 // This is a pretty gross hack to make the runtime loaded named-hooks-code work.
-// TODO (Webpack 5) Hoepfully we can remove this once we upgrade to Webpack 5.
+// TODO (Webpack 5) Hopefully we can remove this once we upgrade to Webpack 5.
 // $FlowFixMe
 __webpack_public_path__ = '/dist/'; // eslint-disable-line no-undef
 

--- a/packages/react-devtools-shell/src/e2e/devtools.js
+++ b/packages/react-devtools-shell/src/e2e/devtools.js
@@ -17,7 +17,7 @@ import {
 import {initialize as createDevTools} from 'react-devtools-inline/frontend';
 
 // This is a pretty gross hack to make the runtime loaded named-hooks-code work.
-// TODO (Webpack 5) Hoepfully we can remove this once we upgrade to Webpack 5.
+// TODO (Webpack 5) Hopefully we can remove this once we upgrade to Webpack 5.
 // $FlowFixMe
 __webpack_public_path__ = '/dist/'; // eslint-disable-line no-undef
 

--- a/packages/react-devtools-shell/src/perf-regression/devtools.js
+++ b/packages/react-devtools-shell/src/perf-regression/devtools.js
@@ -7,7 +7,7 @@ import {
 import {initialize as createDevTools} from 'react-devtools-inline/frontend';
 
 // This is a pretty gross hack to make the runtime loaded named-hooks-code work.
-// TODO (Webpack 5) Hoepfully we can remove this once we upgrade to Webpack 5.
+// TODO (Webpack 5) Hopefully we can remove this once we upgrade to Webpack 5.
 // $FlowFixMe
 __webpack_public_path__ = '/dist/'; // eslint-disable-line no-undef
 

--- a/packages/react-devtools-timeline/src/content-views/SnapshotsView.js
+++ b/packages/react-devtools-timeline/src/content-views/SnapshotsView.js
@@ -70,7 +70,7 @@ export class SnapshotsView extends View {
     while (x < visibleArea.origin.x + visibleArea.size.width) {
       const snapshot = this._findClosestSnapshot(x);
       if (snapshot === null) {
-        // This shold never happen.
+        // This should never happen.
         break;
       }
 

--- a/packages/react-devtools-timeline/src/import-worker/index.js
+++ b/packages/react-devtools-timeline/src/import-worker/index.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-// This file uses workerize to load ./importFile.worker as a webworker and instanciates it,
+// This file uses workerize to load ./importFile.worker as a webworker and instantiates it,
 // exposing flow typed functions that can be used on other files.
 
 import * as importFileModule from './importFile';

--- a/packages/react-devtools-timeline/src/import-worker/preprocessData.js
+++ b/packages/react-devtools-timeline/src/import-worker/preprocessData.js
@@ -109,7 +109,7 @@ function updateLaneToLabelMap(
   laneLabelTuplesString: string,
 ): void {
   // These marks appear multiple times in the data;
-  // We only need to extact them once.
+  // We only need to extract them once.
   if (profilerData.laneToLabelMap.size === 0) {
     const laneLabelTuples = laneLabelTuplesString.split(',');
     for (let laneIndex = 0; laneIndex < laneLabelTuples.length; laneIndex++) {
@@ -283,7 +283,7 @@ function processEventDispatch(
 
     profilerData.nativeEvents.push(nativeEvent);
 
-    // Keep track of curent event in case future ones overlap.
+    // Keep track of current event in case future ones overlap.
     // We separate them into different vertical lanes in this case.
     state.nativeEventStack.push(nativeEvent);
   }
@@ -1044,7 +1044,7 @@ export default async function preprocessData(
   // We'll thus expect there to be a 'Profile' event; if there is not one, we
   // can deduce that there are no flame chart events. As we expect React
   // scheduling profiling user timing marks to be recorded together with browser
-  // flame chart events, we can futher deduce that the data is invalid and we
+  // flame chart events, we can further deduce that the data is invalid and we
   // don't bother finding React events.
   const indexOfProfileEvent = timeline.findIndex(
     event => event.name === 'Profile',

--- a/packages/react-devtools-timeline/src/view-base/Surface.js
+++ b/packages/react-devtools-timeline/src/view-base/Surface.js
@@ -54,8 +54,8 @@ const getCanvasContext = memoize(
 type ResetHoveredEventFn = () => void;
 
 /**
- * Represents the canvas surface and a view heirarchy. A surface is also the
- * place where all interactions enter the view heirarchy.
+ * Represents the canvas surface and a view hierarchy. A surface is also the
+ * place where all interactions enter the view hierarchy.
  */
 export class Surface {
   rootView: ?View;

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -435,7 +435,7 @@ export function createSelectElement(
   return element;
 }
 
-// Creates elements in the HTML namesapce
+// Creates elements in the HTML namespace
 export function createHTMLElement(
   type: string,
   props: Object,

--- a/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
@@ -808,7 +808,7 @@ function clearContainerSparingly(container: Node) {
         const element: Element = (node: any);
         clearContainerSparingly(element);
         // If these singleton instances had previously been rendered with React they
-        // may still hold on to references to the previous fiber tree. We detatch them
+        // may still hold on to references to the previous fiber tree. We detach them
         // prospectively to reset them to a baseline starting state since we cannot create
         // new instances.
         detachDeletedInstance(element);
@@ -942,7 +942,7 @@ export function shouldSkipHydratableForInstance(
         // Scripts are a little tricky, we exclude known resources and then similar to links try to use high-entropy attributes
         // to reject poor matches. One challenge with scripts are inline scripts. We don't attempt to check text content which could
         // in theory lead to a hydration error later if a 3rd party injected an inline script before the React rendered nodes.
-        // Falling back to client rendering if this happens should be seemless though so we will try this hueristic and revisit later
+        // Falling back to client rendering if this happens should be seamless though so we will try this heuristic and revisit later
         // if we learn it is problematic
         const srcAttr = element.getAttribute('src');
         if (
@@ -966,7 +966,7 @@ export function shouldSkipHydratableForInstance(
       }
     }
     // We have excluded the most likely cases of mismatch between hoistable tags, 3rd party script inserted tags,
-    // and browser extension inserted tags. While it is possible this is not the right match it is a decent hueristic
+    // and browser extension inserted tags. While it is possible this is not the right match it is a decent heuristic
     // that should work in the vast majority of cases.
     return false;
   }

--- a/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
@@ -170,7 +170,7 @@ const endInlineScript = stringToPrecomputedChunk('</script>');
 
 const startScriptSrc = stringToPrecomputedChunk('<script src="');
 const startModuleSrc = stringToPrecomputedChunk('<script type="module" src="');
-const scriptIntegirty = stringToPrecomputedChunk('" integrity="');
+const scriptIntegrity = stringToPrecomputedChunk('" integrity="');
 const endAsyncScript = stringToPrecomputedChunk('" async=""></script>');
 
 /**
@@ -260,7 +260,7 @@ export function createResponseState(
       );
       if (integrity) {
         bootstrapChunks.push(
-          scriptIntegirty,
+          scriptIntegrity,
           stringToChunk(escapeTextForBrowser(integrity)),
         );
       }
@@ -280,7 +280,7 @@ export function createResponseState(
       );
       if (integrity) {
         bootstrapChunks.push(
-          scriptIntegirty,
+          scriptIntegrity,
           stringToChunk(escapeTextForBrowser(integrity)),
         );
       }
@@ -1590,7 +1590,7 @@ function pushStyle(
     if (__DEV__) {
       if (href.includes(' ')) {
         console.error(
-          'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but ecountered spaces instead. using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this ocurred is "%s".',
+          'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but ecountered spaces instead. using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this occurred is "%s".',
           href,
         );
       }
@@ -2766,7 +2766,7 @@ export function writeStartClientRenderedSuspenseBoundary(
   destination: Destination,
   responseState: ResponseState,
   errorDigest: ?string,
-  errorMesssage: ?string,
+  errorMessage: ?string,
   errorComponentStack: ?string,
 ): boolean {
   let result;
@@ -2784,11 +2784,11 @@ export function writeStartClientRenderedSuspenseBoundary(
     );
   }
   if (__DEV__) {
-    if (errorMesssage) {
+    if (errorMessage) {
       writeChunk(destination, clientRenderedSuspenseBoundaryError1B);
       writeChunk(
         destination,
-        stringToChunk(escapeTextForBrowser(errorMesssage)),
+        stringToChunk(escapeTextForBrowser(errorMessage)),
       );
       writeChunk(
         destination,
@@ -3276,7 +3276,7 @@ function escapeJSStringsForInstructionScripts(input: string): string {
   const escaped = JSON.stringify(input);
   return escaped.replace(regexForJSStringsInInstructionScripts, match => {
     switch (match) {
-      // santizing breaking out of strings and script tags
+      // sanitizing breaking out of strings and script tags
       case '<':
         return '\\u003c';
       case '\u2028':
@@ -3298,7 +3298,7 @@ function escapeJSObjectForInstructionScripts(input: Object): string {
   const escaped = JSON.stringify(input);
   return escaped.replace(regexForJSStringsInScripts, match => {
     switch (match) {
-      // santizing breaking out of strings and script tags
+      // sanitizing breaking out of strings and script tags
       case '&':
         return '\\u0026';
       case '>':
@@ -3933,7 +3933,7 @@ function writeStyleResourceAttributeInJS(
       attributeValue = '';
       break;
 
-    // Santized URLs
+    // Sanitized URLs
     case 'src':
     case 'href': {
       if (__DEV__) {
@@ -4130,7 +4130,7 @@ function writeStyleResourceAttributeInAttr(
       attributeValue = '';
       break;
 
-    // Santized URLs
+    // Sanitized URLs
     case 'src':
     case 'href': {
       if (__DEV__) {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -3567,7 +3567,7 @@ describe('ReactDOMFizzServer', () => {
     });
 
     it('does not escape <, >, or & characters', async () => {
-      // these characters valid javascript and may be necessary in scripts and won't be interpretted properly
+      // these characters valid javascript and may be necessary in scripts and won't be interpreted properly
       // escaped outside of a string context within javascript
       window.__test_outlet = null;
       // this boolean expression will be cast to a number due to the bitwise &. we will look for a truthy value (1) below
@@ -3900,7 +3900,7 @@ describe('ReactDOMFizzServer', () => {
     }
   });
 
-  it('supresses hydration warnings when an error occurs within a Suspense boundary', async () => {
+  it('suppresses hydration warnings when an error occurs within a Suspense boundary', async () => {
     let isClient = false;
     let shouldThrow = true;
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -357,7 +357,7 @@ describe('ReactDOMFizzServerBrowser', () => {
     expect(isComplete).toBe(true);
   });
 
-  it('should stream large contents that might overlow individual buffers', async () => {
+  it('should stream large contents that might overflow individual buffers', async () => {
     const str492 = `(492) This string is intentionally 492 bytes long because we want to make sure we process chunks that will overflow buffer boundaries. It will repeat to fill out the bytes required (inclusive of this prompt):: foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux q :: total count (492)`;
     const str2049 = `(2049) This string is intentionally 2049 bytes long because we want to make sure we process chunks that will overflow buffer boundaries. It will repeat to fill out the bytes required (inclusive of this prompt):: foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy  :: total count (2049)`;
 
@@ -365,7 +365,7 @@ describe('ReactDOMFizzServerBrowser', () => {
     // an exact view boundary. it's not critical to test this edge case but
     // since we are setting up a test in general for larger chunks I contrived it
     // as such for now. I don't think it needs to be maintained if in the future
-    // the view sizes change or become dynamic becasue of the use of byobRequest
+    // the view sizes change or become dynamic because of the use of byobRequest
     let stream;
     stream = await ReactDOMFizzServer.renderToReadableStream(
       <>

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -2549,7 +2549,7 @@ body {
       </html>,
     );
 
-    // We inject some styles, divs, scripts into the begginning, middle, and end
+    // We inject some styles, divs, scripts into the beginning, middle, and end
     // of the head / body.
     const injectedStyle = document.createElement('style');
     injectedStyle.textContent = 'body { background-color: blue; }';
@@ -2562,7 +2562,7 @@ body {
     document.head.prepend(injectedDiv);
     document.head.appendChild(injectedDiv.cloneNode(true));
     // We do not prepend a <div> in body because this will conflict with hyration
-    // We still mostly hydrate by matchign tag and <div> does not have any attributes to
+    // We still mostly hydrate by matching tag and <div> does not have any attributes to
     // differentiate between likely-inject and likely-rendered cases. If a <div> is prepended
     // in the <body> and you render a <div> as the first child of <body> there will be a conflict.
     // We consider this a rare edge case and even if it does happen the fallback to client rendering
@@ -4822,7 +4822,7 @@ background-color: green;
           ).pipe(writable);
         });
       }).toErrorDev(
-        'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but ecountered spaces instead. using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this ocurred is "foo bar".',
+        'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but ecountered spaces instead. using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this occurred is "foo bar".',
       );
     });
   });

--- a/packages/react-dom/src/__tests__/ReactDOMImageLoad-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMImageLoad-test.internal.js
@@ -296,7 +296,7 @@ describe('ReactDOMImageLoad', () => {
       'render start',
       'Img b',
       'Yield',
-      // yield is ignored becasue we are sync rendering
+      // yield is ignored because we are sync rendering
       'last layout',
       'last passive',
     ]);

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -2144,7 +2144,7 @@ describe('ReactDOMInput', () => {
   describe('checked inputs without a value property', function () {
     // In absence of a value, radio and checkboxes report a value of "on".
     // Between 16 and 16.2, we assigned a node's value to it's current
-    // value in order to "dettach" it from defaultValue. This had the unfortunate
+    // value in order to "detach" it from defaultValue. This had the unfortunate
     // side-effect of assigning value="on" to radio and checkboxes
     it('does not add "on" in absence of value on a checkbox', function () {
       ReactDOM.render(

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -789,8 +789,8 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     function Sibling() {
-      const [visible, setVisibilty] = React.useState(false);
-      showSibling = () => setVisibilty(true);
+      const [visible, setVisibility] = React.useState(false);
+      showSibling = () => setVisibility(true);
       if (visible) {
         return <div>First</div>;
       }
@@ -851,8 +851,8 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     function App() {
-      const [visible, setVisibilty] = React.useState(true);
-      hideMiddle = () => setVisibilty(false);
+      const [visible, setVisibility] = React.useState(true);
+      hideMiddle = () => setVisibility(false);
 
       return (
         <div>

--- a/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
@@ -1216,7 +1216,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
       });
 
       // Inner is still blocked so when Outer replays the event in capture phase
-      // inner ends up caling stopPropagation
+      // inner ends up calling stopPropagation
       assertLog([]);
       OuterTestUtils.assertLog([]);
       InnerTestUtils.assertLog(['Suspend Inner']);

--- a/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
@@ -631,7 +631,7 @@ describe('ReactDOM HostSingleton', () => {
     );
     await waitForAll([]);
 
-    // We construct and insert some artificial stylesheets mimicing what a 3rd party script might do
+    // We construct and insert some artificial stylesheets mimicking what a 3rd party script might do
     // In the future we could hydrate with these already in the document but the rules are restrictive
     // still so it would fail and fall back to client rendering
     const [a, b, c, d, e, f, g, h] = 'abcdefgh'.split('').map(letter => {

--- a/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.js
@@ -350,7 +350,7 @@ describe('ReactDOMTestSelectors', () => {
     });
 
     // @gate www || experimental
-    it('should support filtering by explicit accessibiliy role', () => {
+    it('should support filtering by explicit accessibility role', () => {
       function Example() {
         return (
           <div>
@@ -375,7 +375,7 @@ describe('ReactDOMTestSelectors', () => {
     });
 
     // @gate www || experimental
-    it('should support filtering by explicit secondary accessibiliy role', () => {
+    it('should support filtering by explicit secondary accessibility role', () => {
       const ref = React.createRef();
 
       function Example() {
@@ -400,7 +400,7 @@ describe('ReactDOMTestSelectors', () => {
     });
 
     // @gate www || experimental
-    it('should support filtering by implicit accessibiliy role', () => {
+    it('should support filtering by implicit accessibility role', () => {
       function Example() {
         return (
           <div>
@@ -423,7 +423,7 @@ describe('ReactDOMTestSelectors', () => {
     });
 
     // @gate www || experimental
-    it('should support filtering by implicit accessibiliy role with attributes qualifications', () => {
+    it('should support filtering by implicit accessibility role with attributes qualifications', () => {
       function Example() {
         return (
           <div>

--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -150,7 +150,7 @@ describe('ReactMount', () => {
     document.body.appendChild(iFrame);
 
     if (gate(flags => flags.enableHostSingletons)) {
-      // HostSingletons make the warning for document.body unecessary
+      // HostSingletons make the warning for document.body unnecessary
       ReactDOM.render(<div />, iFrame.contentDocument.body);
     } else {
       expect(() =>

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -121,7 +121,7 @@ export {
   // See the "enableGetInspectorDataForInstanceInProduction" flag.
   getInspectorDataForInstance,
   // The public instance has a reference to the internal instance handle.
-  // This method allows it to acess the most recent shadow node for
+  // This method allows it to access the most recent shadow node for
   // the instance (it's only accessible through it).
   getNodeFromInternalInstanceHandle,
 };

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -45,9 +45,9 @@ import {isCompatibleFamilyForHotReloading} from './ReactFiberHotReloading';
 import {getIsHydrating} from './ReactFiberHydrationContext';
 import {pushTreeFork} from './ReactFiberTreeContext';
 import {createThenableState, trackUsedThenable} from './ReactFiberThenable';
-import {readContextDuringReconcilation} from './ReactFiberNewContext';
+import {readContextDuringReconciliation} from './ReactFiberNewContext';
 
-// This tracks the thenables that are unwrapped during reconcilation.
+// This tracks the thenables that are unwrapped during reconciliation.
 let thenableState: ThenableState | null = null;
 let thenableIndexCounter: number = 0;
 
@@ -584,7 +584,7 @@ function createChildReconciler(
         const context: ReactContext<mixed> = (newChild: any);
         return createChild(
           returnFiber,
-          readContextDuringReconcilation(returnFiber, context, lanes),
+          readContextDuringReconciliation(returnFiber, context, lanes),
           lanes,
         );
       }
@@ -675,7 +675,7 @@ function createChildReconciler(
         return updateSlot(
           returnFiber,
           oldFiber,
-          readContextDuringReconcilation(returnFiber, context, lanes),
+          readContextDuringReconciliation(returnFiber, context, lanes),
           lanes,
         );
       }
@@ -765,7 +765,7 @@ function createChildReconciler(
           existingChildren,
           returnFiber,
           newIdx,
-          readContextDuringReconcilation(returnFiber, context, lanes),
+          readContextDuringReconciliation(returnFiber, context, lanes),
           lanes,
         );
       }
@@ -1429,7 +1429,7 @@ function createChildReconciler(
       // The structure is a bit unfortunate. Ideally, we shouldn't need to
       // replay the entire begin phase of the parent fiber in order to reconcile
       // the children again. This would require a somewhat significant refactor,
-      // because reconcilation happens deep within the begin phase, and
+      // because reconciliation happens deep within the begin phase, and
       // depending on the type of work, not always at the end. We should
       // consider as an future improvement.
       if (typeof newChild.then === 'function') {
@@ -1450,7 +1450,7 @@ function createChildReconciler(
         return reconcileChildFibersImpl(
           returnFiber,
           currentFirstChild,
-          readContextDuringReconcilation(returnFiber, context, lanes),
+          readContextDuringReconciliation(returnFiber, context, lanes),
           lanes,
         );
       }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1659,7 +1659,7 @@ function updateHostHoistable(
   // the host implementation of getResource to consider children in the
   // resource construction but they will otherwise be discarded. In practice
   // this precludes all but the simplest children and Host specific warnings
-  // should be implemented to warn when children are passsed when otherwise not
+  // should be implemented to warn when children are passed when otherwise not
   // expected
   return null;
 }
@@ -4023,7 +4023,7 @@ function beginWork(
     didReceiveUpdate = false;
 
     if (getIsHydrating() && isForkedChild(workInProgress)) {
-      // Check if this child belongs to a list of muliple children in
+      // Check if this child belongs to a list of multiple children in
       // its parent.
       //
       // In a true multi-threaded implementation, we would render children on

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2979,7 +2979,7 @@ function commitMutationEffectsOnFiber(
           const isUpdate = current !== null;
           const wasHiddenByAncestorOffscreen =
             offscreenSubtreeIsHidden || offscreenSubtreeWasHidden;
-          // Only trigger disapper layout effects if:
+          // Only trigger disappear layout effects if:
           //   - This is an update, not first mount.
           //   - This Offscreen was not hidden before.
           //   - Ancestor Offscreen was not hidden in previous commit.
@@ -4259,7 +4259,7 @@ export function disconnectPassiveEffect(finishedWork: Fiber): void {
         HookPassive,
       );
       // When disconnecting passive effects, we fire the effects in the same
-      // order as during a deletiong: parent before child
+      // order as during a deletion: parent before child
       recursivelyTraverseDisconnectPassiveEffects(finishedWork);
       break;
     }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1710,7 +1710,7 @@ function updateSyncExternalStore<T>(
   if (
     inst.getSnapshot !== getSnapshot ||
     snapshotChanged ||
-    // Check if the susbcribe function changed. We can save some memory by
+    // Check if the subscribe function changed. We can save some memory by
     // checking whether we scheduled a subscription effect above.
     (workInProgressHook !== null &&
       workInProgressHook.memoizedState.tag & HookHasEffect)
@@ -2477,7 +2477,7 @@ function mountId(): string {
   if (getIsHydrating()) {
     const treeId = getTreeId();
 
-    // Use a captial R prefix for server-generated ids.
+    // Use a capital R prefix for server-generated ids.
     id = ':' + identifierPrefix + 'R' + treeId;
 
     // Unless this is the first id at this level, append a number at the end

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -92,7 +92,7 @@ let hydrationParentFiber: null | Fiber = null;
 let nextHydratableInstance: null | HydratableInstance = null;
 let isHydrating: boolean = false;
 
-// This flag allows for warning supression when we expect there to be mismatches
+// This flag allows for warning suppression when we expect there to be mismatches
 // due to earlier mismatches or a suspended fiber.
 let didSuspendOrErrorDEV: boolean = false;
 

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -691,7 +691,19 @@ export function readContext<T>(context: ReactContext<T>): T {
   return readContextForConsumer(currentlyRenderingFiber, context);
 }
 
+/**
+ * @deprecated This is function is deprecated and will be removed in a future release.
+ * Please use `readContextDuringReconciliation(...)` instead.
+ */
 export function readContextDuringReconcilation<T>(
+  consumer: Fiber,
+  context: ReactContext<T>,
+  renderLanes: Lanes,
+): T {
+  return readContextDuringReconciliation(consumer, context, renderLanes);
+}
+
+export function readContextDuringReconciliation<T>(
   consumer: Fiber,
   context: ReactContext<T>,
   renderLanes: Lanes,

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -378,7 +378,7 @@ function throwException(
               renderDidSuspendDelayIfPossible();
             } else {
               // If we suspended deeper than the shell, we don't need to delay
-              // the commmit. However, we still call renderDidSuspend if this is
+              // the commit. However, we still call renderDidSuspend if this is
               // a new boundary, to tell the work loop that a new fallback has
               // appeared during this render.
               // TODO: Theoretically we should be able to delete this branch.

--- a/packages/react-reconciler/src/ReactFiberTreeContext.js
+++ b/packages/react-reconciler/src/ReactFiberTreeContext.js
@@ -109,7 +109,7 @@ export function pushTreeFork(
 ): void {
   // This is called right after we reconcile an array (or iterator) of child
   // fibers, because that's the only place where we know how many children in
-  // the whole set without doing extra work later, or storing addtional
+  // the whole set without doing extra work later, or storing additional
   // information on the fiber.
   //
   // That's why this function is separate from pushTreeId — it's called during

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -2441,7 +2441,7 @@ function performUnitOfWork(unitOfWork: Fiber): void {
 }
 
 function replaySuspendedUnitOfWork(unitOfWork: Fiber): void {
-  // This is a fork of performUnitOfWork specifcally for replaying a fiber that
+  // This is a fork of performUnitOfWork specifically for replaying a fiber that
   // just suspended.
   //
   const current = unitOfWork.alternate;
@@ -2533,7 +2533,7 @@ function replaySuspendedUnitOfWork(unitOfWork: Fiber): void {
 }
 
 function unwindSuspendedUnitOfWork(unitOfWork: Fiber, thrownValue: mixed) {
-  // This is a fork of performUnitOfWork specifcally for unwinding a fiber
+  // This is a fork of performUnitOfWork specifically for unwinding a fiber
   // that threw an exception.
   //
   // Return to the normal work loop. This will unwind the stack, and potentially

--- a/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
@@ -1539,7 +1539,7 @@ describe('ReactOffscreen', () => {
 
       expect(offscreenRef.current).not.toBeNull();
 
-      // Offscreen is attached by default. State updates from offscreen are **not defered**.
+      // Offscreen is attached by default. State updates from offscreen are **not deferred**.
       await act(async () => {
         updateChildState(1);
         updateHighPriorityComponentState(1);
@@ -1556,7 +1556,7 @@ describe('ReactOffscreen', () => {
         offscreenRef.current.detach();
       });
 
-      // Offscreen is detached. State updates from offscreen are **defered**.
+      // Offscreen is detached. State updates from offscreen are **deferred**.
       await act(async () => {
         updateChildState(2);
         updateHighPriorityComponentState(2);
@@ -1581,7 +1581,7 @@ describe('ReactOffscreen', () => {
         offscreenRef.current.attach();
       });
 
-      // Offscreen is attached. State updates from offscreen are **not defered**.
+      // Offscreen is attached. State updates from offscreen are **not deferred**.
       await act(async () => {
         updateChildState(3);
         updateHighPriorityComponentState(3);
@@ -1659,7 +1659,7 @@ describe('ReactOffscreen', () => {
       nextRenderTriggerDetach = true;
 
       // Offscreen is attached and gets detached inside useLayoutEffect.
-      // State updates from offscreen are **defered**.
+      // State updates from offscreen are **deferred**.
       await act(async () => {
         updateChildState(1);
         updateHighPriorityComponentState(1);
@@ -1686,7 +1686,7 @@ describe('ReactOffscreen', () => {
 
       nextRenderTriggerAttach = true;
 
-      // Offscreen is detached. State updates from offscreen are **defered**.
+      // Offscreen is detached. State updates from offscreen are **deferred**.
       // Offscreen is attached inside useLayoutEffect;
       await act(async () => {
         updateChildState(3);

--- a/packages/react-reconciler/src/__tests__/ReactUse-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUse-test.js
@@ -715,7 +715,7 @@ describe('ReactUse', () => {
     });
     assertLog(['Async text requested [Will never resolve]']);
 
-    // Calling a hook should error because we're oustide of a component.
+    // Calling a hook should error because we're outside of a component.
     expect(useState).toThrow(
       'Invalid hook call. Hooks can only be called inside of the body of a ' +
         'function component.',
@@ -1251,7 +1251,7 @@ describe('ReactUse', () => {
 
   test('async children are recursively unwrapped', async () => {
     // This is a Usable of a Usable. `use` would only unwrap a single level, but
-    // when passed as a child, the reconciler recurisvely unwraps until it
+    // when passed as a child, the reconciler recursively unwraps until it
     // resolves to a non-Usable value.
     const thenable = {
       then() {},
@@ -1439,10 +1439,10 @@ describe('ReactUse', () => {
 
       // TODO: We shouldn't have to re-render the parent of the context node.
       // This happens because we need to reconcile the parent's children again.
-      // However, we should be able to skip directly to reconcilation without
+      // However, we should be able to skip directly to reconciliation without
       // evaluating the component. One way to do this might be to mark the
       // context dependency with a flag that says it was added
-      // during reconcilation.
+      // during reconciliation.
       'ParentOfContextNode',
 
       // Notice that this was an update, not a remount.

--- a/packages/react-reconciler/src/__tests__/useSyncExternalStore-test.js
+++ b/packages/react-reconciler/src/__tests__/useSyncExternalStore-test.js
@@ -105,7 +105,7 @@ describe('useSyncExternalStore', () => {
         const refC = useRef(null);
         useLayoutEffect(() => {
           // This layout effect reads children that depend on an external store.
-          // This demostrates whether the children are consistent when the
+          // This demonstrates whether the children are consistent when the
           // layout phase runs.
           const aText = refA.current;
           const bText = refB.current;

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -2310,7 +2310,7 @@ describe('ReactFresh', () => {
       render(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
-          const tranformed = React.useMemo(() => val * 2, [val]);
+          const transformed = React.useMemo(() => val * 2, [val]);
           const handleClick = React.useCallback(() => setVal(v => v + 1), []);
 
           React.useEffect(() => {
@@ -2319,7 +2319,7 @@ describe('ReactFresh', () => {
 
           return (
             <p style={{color: 'blue'}} onClick={handleClick}>
-              {tranformed}
+              {transformed}
             </p>
           );
         }
@@ -2343,7 +2343,7 @@ describe('ReactFresh', () => {
         patch(() => {
           function Hello() {
             const [val, setVal] = React.useState(0);
-            const tranformed = React.useMemo(() => val * 10, [val]);
+            const transformed = React.useMemo(() => val * 10, [val]);
             const handleClick = React.useCallback(() => setVal(v => v - 1), []);
 
             React.useEffect(() => {
@@ -2352,7 +2352,7 @@ describe('ReactFresh', () => {
 
             return (
               <p style={{color: 'red'}} onClick={handleClick}>
-                {tranformed}
+                {transformed}
               </p>
             );
           }

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -227,7 +227,7 @@ export opaque type Request = {
   partialBoundaries: Array<SuspenseBoundary>, // Partially completed boundaries that can flush its segments early.
   // onError is called when an error happens anywhere in the tree. It might recover.
   // The return string is used in production  primarily to avoid leaking internals, secondarily to save bytes.
-  // Returning null/undefined will cause a defualt error message in production
+  // Returning null/undefined will cause a default error message in production
   onError: (error: mixed) => ?string,
   // onAllReady is called when all pending task is done but it may not have flushed yet.
   // This is a good time to start writing if you want only HTML and no intermediate steps.
@@ -1424,7 +1424,7 @@ function renderNodeDestructiveImpl(
       const iterator = iteratorFn.call(node);
       if (iterator) {
         // We need to know how many total children are in this set, so that we
-        // can allocate enough id slots to acommodate them. So we must exhaust
+        // can allocate enough id slots to accommodate them. So we must exhaust
         // the iterator before we start recursively rendering the children.
         // TODO: This is not great but I think it's inherent to the id
         // generation algorithm.

--- a/packages/react-server/src/ReactServerStreamConfigBrowser.js
+++ b/packages/react-server/src/ReactServerStreamConfigBrowser.js
@@ -101,7 +101,7 @@ export function writeChunkAndReturn(
   chunk: PrecomputedChunk | Chunk,
 ): boolean {
   writeChunk(destination, chunk);
-  // in web streams there is no backpressure so we can alwas write more
+  // in web streams there is no backpressure so we can always write more
   return true;
 }
 

--- a/packages/react-server/src/ReactServerStreamConfigEdge.js
+++ b/packages/react-server/src/ReactServerStreamConfigEdge.js
@@ -102,7 +102,7 @@ export function writeChunkAndReturn(
   chunk: PrecomputedChunk | Chunk,
 ): boolean {
   writeChunk(destination, chunk);
-  // in web streams there is no backpressure so we can alwas write more
+  // in web streams there is no backpressure so we can always write more
   return true;
 }
 

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -2677,23 +2677,23 @@ describe(`onNestedUpdateScheduled`, () => {
   it('is called when a class component schedules an update from the componentDidUpdate lifecycles', async () => {
     class Component extends React.Component {
       state = {
-        nestedUpdateSheduled: false,
+        nestedUpdateScheduled: false,
       };
       componentDidUpdate(prevProps, prevState) {
         if (
           this.props.scheduleNestedUpdate &&
-          !this.state.nestedUpdateSheduled
+          !this.state.nestedUpdateScheduled
         ) {
-          this.setState({nestedUpdateSheduled: true});
+          this.setState({nestedUpdateScheduled: true});
         }
       }
       render() {
         const {scheduleNestedUpdate} = this.props;
-        const {nestedUpdateSheduled} = this.state;
+        const {nestedUpdateScheduled: nestedUpdateScheduled} = this.state;
         Scheduler.log(
-          `Component:${scheduleNestedUpdate}:${nestedUpdateSheduled}`,
+          `Component:${scheduleNestedUpdate}:${nestedUpdateScheduled}`,
         );
-        return nestedUpdateSheduled;
+        return nestedUpdateScheduled;
       }
     }
 

--- a/packages/shared/CheckStringCoercion.js
+++ b/packages/shared/CheckStringCoercion.js
@@ -62,7 +62,7 @@ function testStringCoercion(value: mixed) {
   // To find which value is throwing, check the browser or debugger console.
   // Before this exception was thrown, there should be `console.error` output
   // that shows the type (Symbol, Temporal.PlainDate, etc.) that caused the
-  // problem and how that type was used: key, atrribute, input value prop, etc.
+  // problem and how that type was used: key, attribute, input value prop, etc.
   // In most cases, this console output also shows the component and its
   // ancestor components where the exception happened.
   //

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -169,7 +169,7 @@ module.exports = [
       'react-dom',
       'react-dom-bindings',
       'react-server-dom-webpack',
-      'react-dom/src/server/ReactDOMLegacyServerImpl.js', // not an entrypoint, but only usable in *Brower and *Node files
+      'react-dom/src/server/ReactDOMLegacyServerImpl.js', // not an entrypoint, but only usable in *Browser and *Node files
       'react-dom/src/server/ReactDOMLegacyServerBrowser.js', // react-dom/server.browser
       'react-dom/src/server/ReactDOMLegacyServerNode.js', // react-dom/server.node
       'react-dom/src/server/ReactDOMLegacyServerNode.classic.fb.js',


### PR DESCRIPTION
## Summary

This diff fixes various (`~140`) **typos** across react codebase :)

## How did you test this change?

This diff fixes various typos across react including all of the packages and the remaining codebase.

I came across an excellent tool named [**typos**](https://github.com/crate-ci/typos) and used it to find the typos, _yet I fixed all the typos manually_ to take into account the context of the words (e.g. React uses some string hashing algo and it provides the name of the algo which seems german, so basically it's kept as it).

For all of the changes, I assumed the `en-us` locale.

>**NOTE**: I did **not** use `--write-changes` flag while running the tool; hence, all changes are done manually.

Finally ran:
- `yarn prettier`
- `yarn test` _takes lot of time..._ ;)