### PR TITLE
Improve render() function error messages

### DIFF
--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -116,7 +116,7 @@ ReactDOMHydrationRoot.prototype.render = ReactDOMRoot.prototype.render =
           'You passed a container to the second argument of root.render(...). ' +
             "You don't need to pass it again since you already passed it to create the root.",
         );
-      } else if (typeof arguments[1] !== 'undefined') {
+      } else if (arguments.length >= 2) {
         console.error(
           'You passed a second argument to root.render(...) but it only accepts ' +
             'one argument.',


### PR DESCRIPTION
This not displaying error, because the function only checks if second argument is undefined.

<img width="559" alt="Captura de Pantalla 2023-03-18 a las 22 05 58" src="https://user-images.githubusercontent.com/42542864/226140399-0d81ff7c-af14-4f5f-a45e-b9074bcc6278.png">

Original function:

<img width="802" alt="Captura de Pantalla 2023-03-18 a las 22 14 26" src="https://user-images.githubusercontent.com/42542864/226140538-614d2b45-24c3-47cc-9eaa-1e4350b5bb1f.png">


Now checks the length property of the arguments object to ensure that no more than one argument is passed to root.render(). If there are more than two arguments, an error message is displayed.

Now:

<img width="817" alt="Captura de Pantalla 2023-03-18 a las 22 14 05" src="https://user-images.githubusercontent.com/42542864/226140500-59cf6bb2-c3e2-4027-beca-295be7b6398f.png">
