### PR TITLE
clear effect event update queue after committing

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -719,13 +719,16 @@ function commitHookEffectListMount(flags: HookFlags, finishedWork: Fiber) {
 function commitUseEffectEventMount(finishedWork: Fiber) {
   const updateQueue: FunctionComponentUpdateQueue | null =
     (finishedWork.updateQueue: any);
-  const eventPayloads = updateQueue !== null ? updateQueue.events : null;
-  if (eventPayloads !== null) {
-    for (let ii = 0; ii < eventPayloads.length; ii++) {
-      const {ref, nextImpl} = eventPayloads[ii];
-      ref.impl = nextImpl;
-    }
+  if (updateQueue !== null) {
+    const eventPayloads = updateQueue.events;
     updateQueue.events = null;
+
+    if (eventPayloads !== null) {
+      for (let ii = 0; ii < eventPayloads.length; ii++) {
+        const {ref, nextImpl} = eventPayloads[ii];
+        ref.impl = nextImpl;
+      }
+    }
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -725,6 +725,7 @@ function commitUseEffectEventMount(finishedWork: Fiber) {
       const {ref, nextImpl} = eventPayloads[ii];
       ref.impl = nextImpl;
     }
+    updateQueue.events = null;
   }
 }
 


### PR DESCRIPTION
## Summary

while looking at the implementation of `useEffectEvent()`, I noticed that the `updateQueque.events` should(?) be cleared after committing

## How did you test this change?

```
> yarn flow
> yarn test
> yarn test --prod
```
