### PR TITLE
Generate sourcemaps for production build artifacts

### DIFF
--- a/scripts/rollup/plugins/closure-plugin.js
+++ b/scripts/rollup/plugins/closure-plugin.js
@@ -19,15 +19,25 @@ function compile(flags) {
   });
 }
 
-module.exports = function closure(flags = {}) {
+module.exports = function closure(flags = {}, {needsSourcemaps}) {
   return {
     name: 'scripts/rollup/plugins/closure-plugin',
-    async renderChunk(code) {
+    async renderChunk(code, chunk, options) {
       const inputFile = tmp.fileSync();
-      const tempPath = inputFile.name;
-      flags = Object.assign({}, flags, {js: tempPath});
-      await writeFileAsync(tempPath, code, 'utf8');
-      const compiledCode = await compile(flags);
+
+      // Use a path like `node_modules/react/cjs/react.production.min.js.map` for the sourcemap file
+      const sourcemapPath = options.file.replace('.js', '.js.map');
+
+      // Tell Closure what JS source file to read, and optionally what sourcemap file to write
+      const finalFlags = {
+        ...flags,
+        js: inputFile.name,
+        ...(needsSourcemaps && {create_source_map: sourcemapPath}),
+      };
+
+      await writeFileAsync(inputFile.name, code, 'utf8');
+      const compiledCode = await compile(finalFlags);
+
       inputFile.removeCallback();
       return {code: compiledCode};
     },

--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -192,6 +192,7 @@ ${source}`;
   /****************** FB_WWW_DEV ******************/
   [FB_WWW_DEV](source, globalName, filename, moduleType) {
     return `/**
+ * @preserve
 ${license}
  *
  * @noflow
@@ -212,6 +213,7 @@ ${source}
   /****************** FB_WWW_PROD ******************/
   [FB_WWW_PROD](source, globalName, filename, moduleType) {
     return `/**
+ * @preserve
 ${license}
  *
  * @noflow
@@ -226,6 +228,7 @@ ${source}`;
   /****************** FB_WWW_PROFILING ******************/
   [FB_WWW_PROFILING](source, globalName, filename, moduleType) {
     return `/**
+ * @preserve
 ${license}
  *
  * @noflow
@@ -240,6 +243,7 @@ ${source}`;
   /****************** RN_OSS_DEV ******************/
   [RN_OSS_DEV](source, globalName, filename, moduleType) {
     return signFile(`/**
+ * @preserve
 ${license}
  *
  * @noflow
@@ -261,6 +265,7 @@ ${source}
   /****************** RN_OSS_PROD ******************/
   [RN_OSS_PROD](source, globalName, filename, moduleType) {
     return signFile(`/**
+ * @preserve
 ${license}
  *
  * @noflow
@@ -276,6 +281,7 @@ ${source}`);
   /****************** RN_OSS_PROFILING ******************/
   [RN_OSS_PROFILING](source, globalName, filename, moduleType) {
     return signFile(`/**
+ * @preserve
 ${license}
  *
  * @noflow
@@ -291,6 +297,7 @@ ${source}`);
   /****************** RN_FB_DEV ******************/
   [RN_FB_DEV](source, globalName, filename, moduleType) {
     return signFile(`/**
+ * @preserve
 ${license}
  *
  * @noflow
@@ -311,6 +318,7 @@ ${source}
   /****************** RN_FB_PROD ******************/
   [RN_FB_PROD](source, globalName, filename, moduleType) {
     return signFile(`/**
+ * @preserve
 ${license}
  *
  * @noflow
@@ -325,6 +333,7 @@ ${source}`);
   /****************** RN_FB_PROFILING ******************/
   [RN_FB_PROFILING](source, globalName, filename, moduleType) {
     return signFile(`/**
+ * @preserve
 ${license}
  *
  * @noflow


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

This PR updates the Rollup build pipeline to generate sourcemaps for production build artifacts like `react-dom.production.min.js`.
 
It requires the Rollup v3 changes that were just merged in #26442 .

Sourcemaps are currently _only_ generated for build artifacts that are _truly_ "production" - no sourcemaps will be generated for development, profiling, UMD, or `shouldStayReadable` artifacts.

The generated sourcemaps contain the bundled source contents right before that chunk was minified by Closure, and _not_ the original source files like `react-reconciler/src/*`.  This better reflects the actual code that is running as part of the bundle, with all the feature flags and transformations that were applied to the source files to generate that bundle.  The sourcemaps _do_ still show comments and original function names, thus improving debuggability for production usage.

Fixes #20186 .




<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

This allows React users to actually debug a readable version of the React bundle in production scenarios.  It also allows other tools like [Replay](https://replay.io) to do a better job inspecting the React source when stepping through.

## How did you test this change?

- Generated numerous sourcemaps with various combinations of the React bundle selections
- Viewed those sourcemaps in https://evanw.github.io/source-map-visualization/ and confirmed via the visualization that the generated mappings appear to be correct

I've attached a set of production files + their sourcemaps here:

[react-sourcemap-examples.zip](https://github.com/facebook/react/files/11023466/react-sourcemap-examples.zip)

You can drag JS+sourcemap file pairs into https://evanw.github.io/source-map-visualization/ for viewing.

Examples:

- `react.production.min.js`:

![image](https://user-images.githubusercontent.com/1128784/226478247-e5cbdee0-83fd-4a19-bcf1-09961d3c7da4.png)

- `react-dom.production.min.js`:

![image](https://user-images.githubusercontent.com/1128784/226478433-b5ccbf0f-8f68-42fe-9db9-9ecb97770d46.png)

- `use-sync-external-store/with-selector.production.min.js`:

![image](https://user-images.githubusercontent.com/1128784/226478565-bc74699d-db14-4c39-9e2d-b775f8755561.png)


<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
