### PR TITLE
Make InternalInstanceHandle type opaque in ReactNativeTypes

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -213,7 +213,7 @@ export type ReactNativeType = {
 };
 
 export opaque type Node = mixed;
-type InternalInstanceHandle = mixed;
+export opaque type InternalInstanceHandle = mixed;
 type PublicInstance = mixed;
 
 export type ReactFabricType = {


### PR DESCRIPTION
## Summary

This type was defined as `mixed` to avoid bringing the whole definition from React to React Native, but its definition is visible to RN. This type should be opaque to RN, so this makes it explicit.

## How did you test this change?

Applied the same changes in the React Native repository and could use the type without issues.