### PR TITLE
Fix Flow types of useEffectEvent

### DIFF
--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -383,9 +383,7 @@ export type Dispatcher = {
     create: () => (() => void) | void,
     deps: Array<mixed> | void | null,
   ): void,
-  useEffectEvent?: <Args, Return, F: (...Array<Args>) => Return>(
-    callback: F,
-  ) => F,
+  useEffectEvent?: <Args, F: (...Array<Args>) => mixed>(callback: F) => F,
   useInsertionEffect(
     create: () => (() => void) | void,
     deps: Array<mixed> | void | null,

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -218,19 +218,19 @@ export function useSyncExternalStore<T>(
 
 export function useCacheRefresh(): <T>(?() => T, ?T) => void {
   const dispatcher = resolveDispatcher();
-  // $FlowFixMe This is unstable, thus optional
+  // $FlowFixMe[not-a-function] This is unstable, thus optional
   return dispatcher.useCacheRefresh();
 }
 
 export function use<T>(usable: Usable<T>): T {
   const dispatcher = resolveDispatcher();
-  // $FlowFixMe This is unstable, thus optional
+  // $FlowFixMe[not-a-function] This is unstable, thus optional
   return dispatcher.use(usable);
 }
 
 export function useMemoCache(size: number): Array<any> {
   const dispatcher = resolveDispatcher();
-  // $FlowFixMe This is unstable, thus optional
+  // $FlowFixMe[not-a-function] This is unstable, thus optional
   return dispatcher.useMemoCache(size);
 }
 

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -234,7 +234,7 @@ export function useMemoCache(size: number): Array<any> {
   return dispatcher.useMemoCache(size);
 }
 
-export function useEffectEvent<Args, Return, F: (...Array<Args>) => Return>(
+export function useEffectEvent<Args, F: (...Array<Args>) => mixed>(
   callback: F,
 ): F {
   const dispatcher = resolveDispatcher();

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -234,8 +234,10 @@ export function useMemoCache(size: number): Array<any> {
   return dispatcher.useMemoCache(size);
 }
 
-export function useEffectEvent<T>(callback: T): void {
+export function useEffectEvent<Args, Return, F: (...Array<Args>) => Return>(
+  callback: F,
+): F {
   const dispatcher = resolveDispatcher();
-  // $FlowFixMe[not-a-function]
+  // $FlowFixMe[not-a-function] This is unstable, thus optional
   return dispatcher.useEffectEvent(callback);
 }

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -236,6 +236,6 @@ export function useMemoCache(size: number): Array<any> {
 
 export function useEffectEvent<T>(callback: T): void {
   const dispatcher = resolveDispatcher();
-  // $FlowFixMe This is unstable, thus optional
+  // $FlowFixMe[not-a-function]
   return dispatcher.useEffectEvent(callback);
 }


### PR DESCRIPTION
## Summary

Just copied the types over from the internal types. Type error was hidden by overly broad FlowFixMe. With `$FlowFixMe[not-a-function]` we would've seen the actual issue: 
```
Cannot return `dispatcher.useEffectEvent(...)` because  `T` [1] is incompatible with  undefined [2].Flow(incompatible-return)
```

## How did you test this change?

- [x] yarn flow dom-node
- [x] CI
