### PR TITLE
Fix remaining CommonJS imports after Rollup upgrade

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -182,12 +182,16 @@ let getRollupInteropValue = id => {
   // Specifying `interop: 'default'` instead will have Rollup use the imported variable as-is,
   // without adding a `.default` to the reference.
   const modulesWithCommonJsExports = [
-    'JSResourceReferenceImpl',
-    'error-stack-parser',
     'art/core/transform',
     'art/modes/current',
     'art/modes/fast-noSideEffects',
     'art/modes/svg',
+    'JSResourceReferenceImpl',
+    'error-stack-parser',
+    'neo-async',
+    'webpack/lib/dependencies/ModuleDependency',
+    'webpack/lib/dependencies/NullDependency',
+    'webpack/lib/Template',
   ];
 
   if (modulesWithCommonJsExports.includes(id)) {


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/26442.

It looks like we missed a few cases where we default import a CommonJS module, which leads to Rollup adding `.default` access, e.g. `require('webpack/lib/Template').default` in the output.

To fix, add the remaining cases to the list of exceptions. Verified by going through all `externals` in the bundle list, and manually checking the webpack plugin.