### PR TITLE
[flow] make Flow suppressions explicit on the error

### DIFF
--- a/packages/internal-test-utils/internalAct.js
+++ b/packages/internal-test-utils/internalAct.js
@@ -35,7 +35,7 @@ export async function act<T>(scope: () => Thenable<T>): Thenable<T> {
     );
   }
 
-  // $FlowFixMe: Flow doesn't know about global Jest object
+  // $FlowFixMe[cannot-resolve-name]: Flow doesn't know about global Jest object
   if (!jest.isMockFunction(setTimeout)) {
     throw Error(
       "This version of `act` requires Jest's timer mocks " +
@@ -70,7 +70,7 @@ export async function act<T>(scope: () => Thenable<T>): Thenable<T> {
       // Wait until end of current task/microtask.
       await waitForMicrotasks();
 
-      // $FlowFixMe: Flow doesn't know about global Jest object
+      // $FlowFixMe[cannot-resolve-name]: Flow doesn't know about global Jest object
       if (jest.isEnvironmentTornDown()) {
         error.message =
           'The Jest environment was torn down before `act` completed. This ' +
@@ -79,7 +79,7 @@ export async function act<T>(scope: () => Thenable<T>): Thenable<T> {
       }
 
       if (!Scheduler.unstable_hasPendingWork()) {
-        // $FlowFixMe: Flow doesn't know about global Jest object
+        // $FlowFixMe[cannot-resolve-name]: Flow doesn't know about global Jest object
         jest.runOnlyPendingTimers();
         if (Scheduler.unstable_hasPendingWork()) {
           // Committing a fallback scheduled additional work. Continue flushing.

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -189,12 +189,12 @@ export function getRoot<T>(response: Response): Thenable<T> {
 }
 
 function createPendingChunk<T>(response: Response): PendingChunk<T> {
-  // $FlowFixMe Flow doesn't support functions as constructors
+  // $FlowFixMe[invalid-constructor] Flow doesn't support functions as constructors
   return new Chunk(PENDING, null, null, response);
 }
 
 function createBlockedChunk<T>(response: Response): BlockedChunk<T> {
-  // $FlowFixMe Flow doesn't support functions as constructors
+  // $FlowFixMe[invalid-constructor] Flow doesn't support functions as constructors
   return new Chunk(BLOCKED, null, null, response);
 }
 
@@ -202,7 +202,7 @@ function createErrorChunk<T>(
   response: Response,
   error: ErrorWithDigest,
 ): ErroredChunk<T> {
-  // $FlowFixMe Flow doesn't support functions as constructors
+  // $FlowFixMe[invalid-constructor] Flow doesn't support functions as constructors
   return new Chunk(ERRORED, null, error, response);
 }
 
@@ -253,7 +253,7 @@ function createResolvedModelChunk<T>(
   response: Response,
   value: UninitializedModel,
 ): ResolvedModelChunk<T> {
-  // $FlowFixMe Flow doesn't support functions as constructors
+  // $FlowFixMe[invalid-constructor] Flow doesn't support functions as constructors
   return new Chunk(RESOLVED_MODEL, value, null, response);
 }
 
@@ -261,7 +261,7 @@ function createResolvedModuleChunk<T>(
   response: Response,
   value: ClientReference<T>,
 ): ResolvedModuleChunk<T> {
-  // $FlowFixMe Flow doesn't support functions as constructors
+  // $FlowFixMe[invalid-constructor] Flow doesn't support functions as constructors
   return new Chunk(RESOLVED_MODULE, value, null, response);
 }
 

--- a/packages/react-client/src/ReactFlightReplyClient.js
+++ b/packages/react-client/src/ReactFlightReplyClient.js
@@ -103,7 +103,7 @@ export function processReply(
   ): ReactJSONValue {
     const parent = this;
     if (__DEV__) {
-      // $FlowFixMe
+      // $FlowFixMe[incompatible-use]
       const originalValue = this[key];
       if (typeof originalValue === 'object' && originalValue !== value) {
         if (objectName(originalValue) !== 'Object') {
@@ -212,7 +212,7 @@ export function processReply(
         }
       }
 
-      // $FlowFixMe
+      // $FlowFixMe[incompatible-return]
       return value;
     }
 
@@ -249,13 +249,13 @@ export function processReply(
     }
 
     if (typeof value === 'symbol') {
-      // $FlowFixMe `description` might be undefined
+      // $FlowFixMe[incompatible-type] `description` might be undefined
       const name: string = value.description;
       if (Symbol.for(name) !== value) {
         throw new Error(
           'Only global symbols received from Symbol.for(...) can be passed to Server Functions. ' +
             `The symbol Symbol.for(${
-              // $FlowFixMe `description` might be undefined
+              // $FlowFixMe[incompatible-type] `description` might be undefined
               value.description
             }) cannot be found among global symbols.`,
         );

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -123,7 +123,7 @@ function useState<S>(
     hook !== null
       ? hook.memoizedState
       : typeof initialState === 'function'
-      ? // $FlowFixMe: Flow doesn't like mixed types
+      ? // $FlowFixMe[incompatible-use]: Flow doesn't like mixed types
         initialState()
       : initialState;
   hookLog.push({primitive: 'State', stackError: new Error(), value: state});
@@ -674,7 +674,7 @@ function handleRenderFunctionError(error: any): void {
   // that the error is caused by user's code in renderFunction.
   // In this case, we should wrap the original error inside a custom error
   // so that devtools can give a clear message about it.
-  // $FlowFixMe: Flow doesn't know about 2nd argument of Error constructor
+  // $FlowFixMe[extra-arg]: Flow doesn't know about 2nd argument of Error constructor
   const wrapperError = new Error('Error rendering inspected component', {
     cause: error,
   });
@@ -682,7 +682,7 @@ function handleRenderFunctionError(error: any): void {
   // TODO: refactor this if we ever combine the devtools and debug tools packages
   wrapperError.name = 'ReactDebugToolsRenderError';
   // this stage-4 proposal is not supported by all environments yet.
-  // $FlowFixMe Flow doesn't have this type yet.
+  // $FlowFixMe[prop-missing] Flow doesn't have this type yet.
   wrapperError.cause = error;
   throw wrapperError;
 }

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -1841,7 +1841,6 @@ describe('InspectedElement', () => {
         xyz: 1,
       },
     });
-    // $FlowFixMe
     const bigInt = BigInt(123); // eslint-disable-line no-undef
 
     await utils.actAsync(() =>

--- a/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
@@ -873,7 +873,6 @@ describe('InspectedElementContext', () => {
         xyz: 1,
       },
     });
-    // $FlowFixMe
     const bigInt = BigInt(123); // eslint-disable-line no-undef
 
     act(() =>

--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -80,7 +80,6 @@ beforeEach(() => {
   }
 
   const originalConsoleError = console.error;
-  // $FlowFixMe
   console.error = (...args) => {
     const firstArg = args[0];
     if (
@@ -111,7 +110,6 @@ beforeEach(() => {
     originalConsoleError.apply(console, args);
   };
   const originalConsoleWarn = console.warn;
-  // $FlowFixMe
   console.warn = (...args) => {
     if (shouldIgnoreConsoleErrorOrWarn(args)) {
       // Allows testing how DevTools behaves when it encounters console.warn without cluttering the test output.

--- a/packages/react-devtools-shared/src/__tests__/storeStressTestConcurrent-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeStressTestConcurrent-test.js
@@ -67,7 +67,6 @@ describe('StoreStressConcurrent', () => {
 
     // 1. Render a normal version of [a, b, c, d, e].
     let container = document.createElement('div');
-    // $FlowFixMe
     let root = ReactDOMClient.createRoot(container);
     act(() => root.render(<Parent>{[a, b, c, d, e]}</Parent>));
     expect(store).toMatchInlineSnapshot(
@@ -151,7 +150,6 @@ describe('StoreStressConcurrent', () => {
     for (let i = 0; i < cases.length; i++) {
       // Ensure fresh mount.
       container = document.createElement('div');
-      // $FlowFixMe
       root = ReactDOMClient.createRoot(container);
 
       // Verify mounting 'abcde'.
@@ -181,7 +179,6 @@ describe('StoreStressConcurrent', () => {
     // 6. Verify *updates* by reusing the container between iterations.
     // There'll be no unmounting until the very end.
     container = document.createElement('div');
-    // $FlowFixMe
     root = ReactDOMClient.createRoot(container);
     for (let i = 0; i < cases.length; i++) {
       // Verify mounting 'abcde'.
@@ -249,7 +246,6 @@ describe('StoreStressConcurrent', () => {
     const snapshots = [];
     let container = document.createElement('div');
     for (let i = 0; i < steps.length; i++) {
-      // $FlowFixMe
       const root = ReactDOMClient.createRoot(container);
       act(() => root.render(<Root>{steps[i]}</Root>));
       // We snapshot each step once so it doesn't regress.
@@ -321,7 +317,6 @@ describe('StoreStressConcurrent', () => {
     for (let i = 0; i < steps.length; i++) {
       for (let j = 0; j < steps.length; j++) {
         container = document.createElement('div');
-        // $FlowFixMe
         const root = ReactDOMClient.createRoot(container);
         act(() => root.render(<Root>{steps[i]}</Root>));
         expect(print(store)).toMatch(snapshots[i]);
@@ -338,7 +333,6 @@ describe('StoreStressConcurrent', () => {
     for (let i = 0; i < steps.length; i++) {
       for (let j = 0; j < steps.length; j++) {
         container = document.createElement('div');
-        // $FlowFixMe
         const root = ReactDOMClient.createRoot(container);
         act(() =>
           root.render(
@@ -412,7 +406,6 @@ describe('StoreStressConcurrent', () => {
     const snapshots = [];
     let container = document.createElement('div');
     for (let i = 0; i < steps.length; i++) {
-      // $FlowFixMe
       const root = ReactDOMClient.createRoot(container);
       act(() =>
         root.render(
@@ -515,7 +508,6 @@ describe('StoreStressConcurrent', () => {
 
     // 2. Verify check Suspense can render same steps as initial fallback content.
     for (let i = 0; i < steps.length; i++) {
-      // $FlowFixMe
       const root = ReactDOMClient.createRoot(container);
       act(() =>
         root.render(
@@ -540,7 +532,6 @@ describe('StoreStressConcurrent', () => {
       for (let j = 0; j < steps.length; j++) {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
-        // $FlowFixMe
         const root = ReactDOMClient.createRoot(container);
         act(() =>
           root.render(
@@ -586,7 +577,6 @@ describe('StoreStressConcurrent', () => {
       for (let j = 0; j < steps.length; j++) {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
-        // $FlowFixMe
         const root = ReactDOMClient.createRoot(container);
         act(() =>
           root.render(
@@ -644,7 +634,6 @@ describe('StoreStressConcurrent', () => {
       for (let j = 0; j < steps.length; j++) {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
-        // $FlowFixMe
         const root = ReactDOMClient.createRoot(container);
         act(() =>
           root.render(
@@ -694,7 +683,6 @@ describe('StoreStressConcurrent', () => {
       for (let j = 0; j < steps.length; j++) {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
-        // $FlowFixMe
         const root = ReactDOMClient.createRoot(container);
         act(() =>
           root.render(
@@ -748,7 +736,6 @@ describe('StoreStressConcurrent', () => {
       for (let j = 0; j < steps.length; j++) {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
-        // $FlowFixMe
         const root = ReactDOMClient.createRoot(container);
         act(() =>
           root.render(
@@ -904,7 +891,6 @@ describe('StoreStressConcurrent', () => {
     const snapshots = [];
     let container = document.createElement('div');
     for (let i = 0; i < steps.length; i++) {
-      // $FlowFixMe
       const root = ReactDOMClient.createRoot(container);
       act(() =>
         root.render(
@@ -928,7 +914,6 @@ describe('StoreStressConcurrent', () => {
     // which is different from the snapshots above. So we take more snapshots.
     const fallbackSnapshots = [];
     for (let i = 0; i < steps.length; i++) {
-      // $FlowFixMe
       const root = ReactDOMClient.createRoot(container);
       act(() =>
         root.render(
@@ -1062,7 +1047,6 @@ describe('StoreStressConcurrent', () => {
       for (let j = 0; j < steps.length; j++) {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
-        // $FlowFixMe
         const root = ReactDOMClient.createRoot(container);
         act(() =>
           root.render(
@@ -1114,7 +1098,6 @@ describe('StoreStressConcurrent', () => {
       for (let j = 0; j < steps.length; j++) {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
-        // $FlowFixMe
         const root = ReactDOMClient.createRoot(container);
         act(() =>
           root.render(
@@ -1181,7 +1164,6 @@ describe('StoreStressConcurrent', () => {
       for (let j = 0; j < steps.length; j++) {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
-        // $FlowFixMe
         const root = ReactDOMClient.createRoot(container);
         act(() =>
           root.render(
@@ -1233,7 +1215,6 @@ describe('StoreStressConcurrent', () => {
       for (let j = 0; j < steps.length; j++) {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
-        // $FlowFixMe
         const root = ReactDOMClient.createRoot(container);
         act(() =>
           root.render(
@@ -1285,7 +1266,6 @@ describe('StoreStressConcurrent', () => {
       for (let j = 0; j < steps.length; j++) {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
-        // $FlowFixMe
         const root = ReactDOMClient.createRoot(container);
         act(() =>
           root.render(

--- a/packages/react-devtools-shared/src/__tests__/utils.js
+++ b/packages/react-devtools-shared/src/__tests__/utils.js
@@ -46,7 +46,6 @@ export async function actAsync(
   const {act: actTestRenderer} = require('react-test-renderer');
   const {act: actDOM} = require('react-dom/test-utils');
 
-  // $FlowFixMe Flow doesn't know about "await act()" yet
   await actDOM(async () => {
     await actTestRenderer(async () => {
       await cb();
@@ -55,7 +54,6 @@ export async function actAsync(
 
   if (recursivelyFlush) {
     while (jest.getTimerCount() > 0) {
-      // $FlowFixMe Flow doesn't know about "await act()" yet
       await actDOM(async () => {
         await actTestRenderer(async () => {
           jest.runAllTimers();
@@ -63,7 +61,6 @@ export async function actAsync(
       });
     }
   } else {
-    // $FlowFixMe Flow doesn't know about "await act()" yet
     await actDOM(async () => {
       await actTestRenderer(async () => {
         jest.runOnlyPendingTimers();

--- a/packages/react-devtools-shared/src/backend/DevToolsComponentStackFrame.js
+++ b/packages/react-devtools-shared/src/backend/DevToolsComponentStackFrame.js
@@ -77,7 +77,7 @@ export function describeNativeComponentFrame(
   let control;
 
   const previousPrepareStackTrace = Error.prepareStackTrace;
-  // $FlowFixMe It does accept undefined.
+  // $FlowFixMe[incompatible-type] It does accept undefined.
   Error.prepareStackTrace = undefined;
 
   reentry = true;
@@ -98,7 +98,7 @@ export function describeNativeComponentFrame(
       const Fake = function () {
         throw Error();
       };
-      // $FlowFixMe
+      // $FlowFixMe[prop-missing]
       Object.defineProperty(Fake.prototype, 'props', {
         set: function () {
           // We use a throwing setter instead of frozen or non-writable props

--- a/packages/react-devtools-shared/src/backend/DevToolsConsolePatching.js
+++ b/packages/react-devtools-shared/src/backend/DevToolsConsolePatching.js
@@ -45,7 +45,7 @@ export function disableLogs(): void {
       value: disabledLog,
       writable: true,
     };
-    // $FlowFixMe Flow thinks console is immutable.
+    // $FlowFixMe[cannot-write] Flow thinks console is immutable.
     Object.defineProperties(console, {
       info: props,
       log: props,
@@ -69,7 +69,7 @@ export function reenableLogs(): void {
       enumerable: true,
       writable: true,
     };
-    // $FlowFixMe Flow thinks console is immutable.
+    // $FlowFixMe[cannot-write] Flow thinks console is immutable.
     Object.defineProperties(console, {
       log: {...props, value: prevLog},
       info: {...props, value: prevInfo},

--- a/packages/react-devtools-shared/src/backend/profilingHooks.js
+++ b/packages/react-devtools-shared/src/backend/profilingHooks.js
@@ -64,7 +64,7 @@ if (supportsUserTiming) {
   });
 
   try {
-    // $FlowFixMe: Flow expects the User Timing level 2 API.
+    // $FlowFixMe[extra-arg]: Flow expects the User Timing level 2 API.
     performance.mark(CHECK_V3_MARK, markOptions);
   } catch (error) {
     // Ignore
@@ -281,7 +281,7 @@ export function createProfilingHooks({
       );
     }
 
-    // $FlowFixMe This property should not be writable outside of this function.
+    // $FlowFixMe[cannot-write] This property should not be writable outside of this function.
     top.duration = currentTime - top.timestamp;
 
     if (currentTimelineData) {
@@ -590,7 +590,7 @@ export function createProfilingHooks({
 
   const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
 
-  // $FlowFixMe: Flow cannot handle polymorphic WeakMaps
+  // $FlowFixMe[incompatible-type]: Flow cannot handle polymorphic WeakMaps
   const wakeableIDs: WeakMap<Wakeable, number> = new PossiblyWeakMap();
   let wakeableID: number = 0;
   function getWakeableID(wakeable: Wakeable): number {

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -384,7 +384,7 @@ export function getInternalReactConstants(version: string): {
       typeof type === 'object' && type !== null ? type.$$typeof : type;
 
     return typeof symbolOrNumber === 'symbol'
-      ? // $FlowFixMe `toString()` doesn't match the type signature?
+      ? // $FlowFixMe[incompatible-return] `toString()` doesn't match the type signature?
         symbolOrNumber.toString()
       : symbolOrNumber;
   }

--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -72,7 +72,7 @@ export function copyWithDelete(
       delete updated[key];
     }
   } else {
-    // $FlowFixMe number or string is fine here
+    // $FlowFixMe[incompatible-use] number or string is fine here
     updated[key] = copyWithDelete(obj[key], path, index + 1);
   }
   return updated;
@@ -90,7 +90,7 @@ export function copyWithRename(
   const updated = isArray(obj) ? obj.slice() : {...obj};
   if (index + 1 === oldPath.length) {
     const newKey = newPath[index];
-    // $FlowFixMe number or string is fine here
+    // $FlowFixMe[incompatible-use] number or string is fine here
     updated[newKey] = updated[oldKey];
     if (isArray(updated)) {
       updated.splice(((oldKey: any): number), 1);
@@ -98,7 +98,7 @@ export function copyWithRename(
       delete updated[oldKey];
     }
   } else {
-    // $FlowFixMe number or string is fine here
+    // $FlowFixMe[incompatible-use] number or string is fine here
     updated[oldKey] = copyWithRename(obj[oldKey], oldPath, newPath, index + 1);
   }
   return updated;
@@ -115,7 +115,7 @@ export function copyWithSet(
   }
   const key = path[index];
   const updated = isArray(obj) ? obj.slice() : {...obj};
-  // $FlowFixMe number or string is fine here
+  // $FlowFixMe[incompatible-use] number or string is fine here
   updated[key] = copyWithSet(obj[key], path, value, index + 1);
   return updated;
 }

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -339,9 +339,9 @@ class Bridge<
     this._isShutdown = true;
 
     // Disable the API inherited from EventEmitter that can add more listeners and send more messages.
-    // $FlowFixMe This property is not writable.
+    // $FlowFixMe[cannot-write] This property is not writable.
     this.addListener = function () {};
-    // $FlowFixMe This property is not writable.
+    // $FlowFixMe[cannot-write] This property is not writable.
     this.emit = function () {};
     // NOTE: There's also EventEmitter API like `on` and `prependListener` that we didn't add to our Flow type of EventEmitter.
 

--- a/packages/react-devtools-shared/src/devtools/views/Button.js
+++ b/packages/react-devtools-shared/src/devtools/views/Button.js
@@ -28,7 +28,7 @@ export default function Button({
   ...rest
 }: Props): React.Node {
   let button = (
-    // $FlowFixMe unsafe spread
+    // $FlowFixMe[cannot-spread-inexact] unsafe spread
     <button
       className={`${styles.Button} ${className}`}
       data-testname={testName}

--- a/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/AutoSizeInput.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/AutoSizeInput.js
@@ -43,7 +43,7 @@ export default function AutoSizeInput({
   const isEmpty = value === '' || value === '""';
 
   return (
-    // $FlowFixMe unsafe rest spread
+    // $FlowFixMe[cannot-spread-inexact] unsafe rest spread
     <input
       className={[styles.Input, className].join(' ')}
       data-testname={testName}

--- a/packages/react-devtools-shared/src/devtools/views/Components/reach-ui/menu-button.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/reach-ui/menu-button.js
@@ -25,7 +25,7 @@ const MenuList = ({
 }): React.Node => {
   const style = useThemeStyles();
   return (
-    // $FlowFixMe unsafe spread
+    // $FlowFixMe[cannot-spread-inexact] unsafe spread
     <ReachMenuList style={style} {...props}>
       {children}
     </ReachMenuList>

--- a/packages/react-devtools-shared/src/devtools/views/Components/reach-ui/tooltip.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/reach-ui/tooltip.js
@@ -23,7 +23,7 @@ const Tooltip = ({
 }): React.Node => {
   const style = useThemeStyles();
   return (
-    // $FlowFixMe unsafe spread
+    // $FlowFixMe[cannot-spread-inexact] unsafe spread
     <ReachTooltip
       className={`${tooltipStyles.Tooltip} ${className}`}
       style={style}

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -290,7 +290,7 @@ export function updateThemeVariables(
   // but it makes a significant UI improvement in dark mode.
   // https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color
   documentElements.forEach(documentElement => {
-    // $FlowFixMe scrollbarColor is missing in CSSStyleDeclaration
+    // $FlowFixMe[prop-missing] scrollbarColor is missing in CSSStyleDeclaration
     documentElement.style.scrollbarColor = `var(${`--${theme}-color-scroll-thumb`}) var(${`--${theme}-color-scroll-track`})`;
   });
 }

--- a/packages/react-devtools-shared/src/devtools/views/utils.js
+++ b/packages/react-devtools-shared/src/devtools/views/utils.js
@@ -133,7 +133,7 @@ export function serializeDataForCopy(props: Object): string {
 }
 
 export function serializeHooksForCopy(hooks: HooksTree | null): string {
-  // $FlowFixMe "HooksTree is not an object"
+  // $FlowFixMe[not-an-object] "HooksTree is not an object"
   const cloned = Object.assign(([]: Array<any>), hooks);
 
   const queue = [...cloned];

--- a/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
+++ b/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
@@ -31,7 +31,8 @@ export function registerDevToolsEventLogger(
         let metadata = null;
         if (event.metadata != null) {
           metadata = event.metadata;
-          // $FlowFixMe: metadata is not writable and nullable
+          // $FlowFixMe[cannot-write]: metadata is not writable and nullable
+          // $FlowFixMe[prop-missing]
           delete event.metadata;
         }
         loggingIFrame.contentWindow.postMessage(
@@ -43,7 +44,7 @@ export function registerDevToolsEventLogger(
               version: process.env.DEVTOOLS_VERSION,
               metadata: metadata !== null ? JSON.stringify(metadata) : '',
               ...(fetchAdditionalContext != null
-                ? // $FlowFixMe
+                ? // $FlowFixMe[not-an-object]
                   await fetchAdditionalContext()
                 : {}),
             },

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -93,7 +93,7 @@ export function getAllEnumerableKeys(
     ];
     const descriptors = Object.getOwnPropertyDescriptors(current);
     currentKeys.forEach(key => {
-      // $FlowFixMe: key can be a Symbol https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor
+      // $FlowFixMe[incompatible-type]: key can be a Symbol https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor
       if (descriptors[key].enumerable) {
         keys.add(key);
       }

--- a/packages/react-devtools-shell/src/app/InspectableElements/CustomHooks.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/CustomHooks.js
@@ -107,7 +107,7 @@ function wrapWithHoc(Component: (props: any, ref: React$Ref<any>) => any) {
   function Hoc() {
     return <Component />;
   }
-  // $FlowFixMe
+  // $FlowFixMe[prop-missing]
   const displayName = Component.displayName || Component.name;
   // $FlowFixMe[incompatible-type] found when upgrading Flow
   Hoc.displayName = `withHoc(${displayName})`;

--- a/packages/react-devtools-shell/src/app/ReactNativeWeb/index.js
+++ b/packages/react-devtools-shell/src/app/ReactNativeWeb/index.js
@@ -9,7 +9,6 @@
 
 import * as React from 'react';
 import {Fragment, useState} from 'react';
-// $FlowFixMe
 import {Button, Text, View} from 'react-native-web';
 
 export default function ReactNativeWeb(): React.Node {

--- a/packages/react-devtools-shell/src/app/devtools.js
+++ b/packages/react-devtools-shell/src/app/devtools.js
@@ -11,7 +11,7 @@ import {initDevTools} from 'react-devtools-shared/src/devtools';
 
 // This is a pretty gross hack to make the runtime loaded named-hooks-code work.
 // TODO (Webpack 5) Hoepfully we can remove this once we upgrade to Webpack 5.
-// $FlowFixMe
+// $FlowFixMe[cannot-resolve-name]
 __webpack_public_path__ = '/dist/'; // eslint-disable-line no-undef
 
 const iframe = ((document.getElementById('target'): any): HTMLIFrameElement);

--- a/packages/react-devtools-shell/src/e2e-regression/devtools.js
+++ b/packages/react-devtools-shell/src/e2e-regression/devtools.js
@@ -9,7 +9,6 @@ import {initialize as createDevTools} from 'react-devtools-inline/frontend';
 
 // This is a pretty gross hack to make the runtime loaded named-hooks-code work.
 // TODO (Webpack 5) Hoepfully we can remove this once we upgrade to Webpack 5.
-// $FlowFixMe
 __webpack_public_path__ = '/dist/'; // eslint-disable-line no-undef
 
 // TODO (Webpack 5) Hopefully we can remove this prop after the Webpack 5 migration.
@@ -33,7 +32,6 @@ function init(appIframe, devtoolsContainer, appSource) {
   const DevTools = createDevTools(contentWindow);
 
   inject(contentDocument, appSource, () => {
-    // $FlowFixMe Flow doesn't know about createRoot() yet.
     createRoot(devtoolsContainer).render(
       <DevTools
         hookNamesModuleLoaderFunction={hookNamesModuleLoaderFunction}

--- a/packages/react-devtools-shell/src/e2e/devtools.js
+++ b/packages/react-devtools-shell/src/e2e/devtools.js
@@ -18,7 +18,6 @@ import {initialize as createDevTools} from 'react-devtools-inline/frontend';
 
 // This is a pretty gross hack to make the runtime loaded named-hooks-code work.
 // TODO (Webpack 5) Hoepfully we can remove this once we upgrade to Webpack 5.
-// $FlowFixMe
 __webpack_public_path__ = '/dist/'; // eslint-disable-line no-undef
 
 // TODO (Webpack 5) Hopefully we can remove this prop after the Webpack 5 migration.
@@ -42,7 +41,6 @@ function init(appIframe, devtoolsContainer, appSource) {
   const DevTools = createDevTools(contentWindow);
 
   inject(contentDocument, appSource, () => {
-    // $FlowFixMe Flow doesn't know about createRoot() yet.
     createRoot(devtoolsContainer).render(
       <DevTools
         hookNamesModuleLoaderFunction={hookNamesModuleLoaderFunction}

--- a/packages/react-devtools-shell/src/perf-regression/devtools.js
+++ b/packages/react-devtools-shell/src/perf-regression/devtools.js
@@ -8,7 +8,6 @@ import {initialize as createDevTools} from 'react-devtools-inline/frontend';
 
 // This is a pretty gross hack to make the runtime loaded named-hooks-code work.
 // TODO (Webpack 5) Hoepfully we can remove this once we upgrade to Webpack 5.
-// $FlowFixMe
 __webpack_public_path__ = '/dist/'; // eslint-disable-line no-undef
 
 // TODO (Webpack 5) Hopefully we can remove this prop after the Webpack 5 migration.

--- a/packages/react-devtools-timeline/src/content-views/NativeEventsView.js
+++ b/packages/react-devtools-timeline/src/content-views/NativeEventsView.js
@@ -65,7 +65,7 @@ export class NativeEventsView extends View {
       if (!this._depthToNativeEvent.has(depth)) {
         this._depthToNativeEvent.set(depth, [event]);
       } else {
-        // $FlowFixMe This is unnecessary.
+        // $FlowFixMe[incompatible-use] This is unnecessary.
         this._depthToNativeEvent.get(depth).push(event);
       }
     });

--- a/packages/react-devtools-timeline/src/content-views/NetworkMeasuresView.js
+++ b/packages/react-devtools-timeline/src/content-views/NetworkMeasuresView.js
@@ -68,7 +68,7 @@ export class NetworkMeasuresView extends View {
       if (!this._depthToNetworkMeasure.has(depth)) {
         this._depthToNetworkMeasure.set(depth, [event]);
       } else {
-        // $FlowFixMe This is unnecessary.
+        // $FlowFixMe[incompatible-use] This is unnecessary.
         this._depthToNetworkMeasure.get(depth).push(event);
       }
     });

--- a/packages/react-devtools-timeline/src/content-views/SnapshotsView.js
+++ b/packages/react-devtools-timeline/src/content-views/SnapshotsView.js
@@ -166,7 +166,7 @@ export class SnapshotsView extends View {
       imageRect.size.height,
     );
 
-    // $FlowFixMe Flow doesn't know about the 9 argument variant of drawImage()
+    // $FlowFixMe[incompatible-call] Flow doesn't know about the 9 argument variant of drawImage()
     context.drawImage(
       snapshot.image,
 

--- a/packages/react-devtools-timeline/src/content-views/SuspenseEventsView.js
+++ b/packages/react-devtools-timeline/src/content-views/SuspenseEventsView.js
@@ -72,7 +72,7 @@ export class SuspenseEventsView extends View {
       if (!this._depthToSuspenseEvent.has(depth)) {
         this._depthToSuspenseEvent.set(depth, [event]);
       } else {
-        // $FlowFixMe This is unnecessary.
+        // $FlowFixMe[incompatible-use] This is unnecessary.
         this._depthToSuspenseEvent.get(depth).push(event);
       }
     });

--- a/packages/react-devtools-timeline/src/import-worker/preprocessData.js
+++ b/packages/react-devtools-timeline/src/import-worker/preprocessData.js
@@ -207,7 +207,7 @@ function markWorkCompleted(
     console.error('Could not find matching measure for type "%s".', type);
   }
 
-  // $FlowFixMe This property should not be writable outside of this function.
+  // $FlowFixMe[cannot-write] This property should not be writable outside of this function.
   measure.duration = stopTime - startTime;
 }
 
@@ -370,7 +370,7 @@ function processScreenshot(
   fetch(snapshot.imageSource)
     .then(response => response.blob())
     .then(blob => {
-      // $FlowFixMe createImageBitmap
+      // $FlowFixMe[cannot-resolve-name] createImageBitmap
       createImageBitmap(blob).then(bitmap => {
         snapshot.height = bitmap.height;
         snapshot.width = bitmap.width;

--- a/packages/react-dom-bindings/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom-bindings/src/client/DOMPropertyOperations.js
@@ -480,7 +480,7 @@ export function setValueForPropertyOnCustomComponent(
           node.removeAttribute(name);
         }
       }
-      // $FlowFixMe value can't be casted to EventListener.
+      // $FlowFixMe[incompatible-cast] value can't be casted to EventListener.
       node.addEventListener(eventName, (value: EventListener), useCapture);
       return;
     }

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -1182,7 +1182,6 @@ function diffHydratedCustomComponent(
         }
         continue;
       case 'style':
-        // $FlowFixMe - Should be inferred as not undefined.
         extraAttributeNames.delete(propKey);
         diffHydratedStyles(domElement, nextProp);
         continue;
@@ -1195,7 +1194,6 @@ function diffHydratedCustomComponent(
       case 'outerText':
       case 'outerHTML':
         if (enableCustomElementPropertySupport) {
-          // $FlowFixMe - Should be inferred as not undefined.
           extraAttributeNames.delete(propKey.toLowerCase());
           if (__DEV__) {
             console.error(
@@ -1212,10 +1210,8 @@ function diffHydratedCustomComponent(
           ownNamespaceDev = getIntrinsicNamespace(tag);
         }
         if (ownNamespaceDev === HTML_NAMESPACE) {
-          // $FlowFixMe - Should be inferred as not undefined.
           extraAttributeNames.delete(propKey.toLowerCase());
         } else {
-          // $FlowFixMe - Should be inferred as not undefined.
           extraAttributeNames.delete(propKey);
         }
         const serverValue = getValueForAttributeOnCustomComponent(
@@ -1280,7 +1276,6 @@ function diffHydratedGenericElement(
         }
         continue;
       case 'style':
-        // $FlowFixMe - Should be inferred as not undefined.
         extraAttributeNames.delete(propKey);
         diffHydratedStyles(domElement, nextProp);
         continue;
@@ -1299,7 +1294,6 @@ function diffHydratedGenericElement(
         let isMismatchDueToBadCasing = false;
         let serverValue;
         if (propertyInfo !== null) {
-          // $FlowFixMe - Should be inferred as not undefined.
           extraAttributeNames.delete(propertyInfo.attributeName);
           serverValue = getValueForProperty(
             domElement,
@@ -1313,7 +1307,6 @@ function diffHydratedGenericElement(
             ownNamespaceDev = getIntrinsicNamespace(tag);
           }
           if (ownNamespaceDev === HTML_NAMESPACE) {
-            // $FlowFixMe - Should be inferred as not undefined.
             extraAttributeNames.delete(propKey.toLowerCase());
           } else {
             const standardName = getPossibleStandardName(propKey);
@@ -1324,10 +1317,8 @@ function diffHydratedGenericElement(
               // However, we already warn about bad casing elsewhere.
               // So we'll skip the misleading extra mismatch warning in this case.
               isMismatchDueToBadCasing = true;
-              // $FlowFixMe - Should be inferred as not undefined.
               extraAttributeNames.delete(standardName);
             }
-            // $FlowFixMe - Should be inferred as not undefined.
             extraAttributeNames.delete(propKey);
           }
           serverValue = getValueForAttribute(domElement, propKey, nextProp);
@@ -1484,11 +1475,9 @@ export function diffHydratedProperties(
       );
     }
     if (
-      // $FlowFixMe - Should be inferred as not undefined.
       extraAttributeNames.size > 0 &&
       rawProps.suppressHydrationWarning !== true
     ) {
-      // $FlowFixMe - Should be inferred as not undefined.
       warnForExtraAttributes(extraAttributeNames);
     }
   }

--- a/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
@@ -641,7 +641,7 @@ function dispatchBeforeDetachedBlur(
     // Dispatch "beforeblur" directly on the target,
     // so it gets picked up by the event system and
     // can propagate through the React internal tree.
-    // $FlowFixMe: internal field
+    // $FlowFixMe[prop-missing]: internal field
     event._detachedInterceptFiber = internalInstanceHandle;
     target.dispatchEvent(event);
   }
@@ -1324,7 +1324,7 @@ export function didNotHydrateInstanceWithinSuspenseInstance(
   instance: HydratableInstance,
 ) {
   if (__DEV__) {
-    // $FlowFixMe: Only Element or Document can be parent nodes.
+    // $FlowFixMe[incompatible-type]: Only Element or Document can be parent nodes.
     const parentNode: Element | Document | null = parentInstance.parentNode;
     if (parentNode !== null) {
       if (instance.nodeType === ELEMENT_NODE) {
@@ -1391,7 +1391,7 @@ export function didNotFindHydratableInstanceWithinSuspenseInstance(
   props: Props,
 ) {
   if (__DEV__) {
-    // $FlowFixMe: Only Element or Document can be parent nodes.
+    // $FlowFixMe[incompatible-type]: Only Element or Document can be parent nodes.
     const parentNode: Element | Document | null = parentInstance.parentNode;
     if (parentNode !== null)
       warnForInsertedHydratedElement(parentNode, type, props);
@@ -1403,7 +1403,7 @@ export function didNotFindHydratableTextInstanceWithinSuspenseInstance(
   text: string,
 ) {
   if (__DEV__) {
-    // $FlowFixMe: Only Element or Document can be parent nodes.
+    // $FlowFixMe[incompatible-type]: Only Element or Document can be parent nodes.
     const parentNode: Element | Document | null = parentInstance.parentNode;
     if (parentNode !== null) warnForInsertedHydratedText(parentNode, text);
   }

--- a/packages/react-dom-bindings/src/events/SyntheticEvent.js
+++ b/packages/react-dom-bindings/src/events/SyntheticEvent.js
@@ -94,7 +94,7 @@ function createSyntheticEvent(Interface: EventInterfaceType) {
 
       if (event.preventDefault) {
         event.preventDefault();
-        // $FlowFixMe - flow is not aware of `unknown` in IE
+        // $FlowFixMe[illegal-typeof] - flow is not aware of `unknown` in IE
       } else if (typeof event.returnValue !== 'unknown') {
         event.returnValue = false;
       }
@@ -110,7 +110,7 @@ function createSyntheticEvent(Interface: EventInterfaceType) {
 
       if (event.stopPropagation) {
         event.stopPropagation();
-        // $FlowFixMe - flow is not aware of `unknown` in IE
+        // $FlowFixMe[illegal-typeof] - flow is not aware of `unknown` in IE
       } else if (typeof event.cancelBubble !== 'unknown') {
         // The ChangeEventPlugin registers a "propertychange" event for
         // IE. This event does not support bubbling or cancelling, and
@@ -173,9 +173,9 @@ let lastMouseEvent;
 function updateMouseMovementPolyfillState(event: {[propName: string]: mixed}) {
   if (event !== lastMouseEvent) {
     if (lastMouseEvent && event.type === 'mousemove') {
-      // $FlowFixMe assuming this is a number
+      // $FlowFixMe[unsafe-arithmetic] assuming this is a number
       lastMovementX = event.screenX - lastMouseEvent.screenX;
-      // $FlowFixMe assuming this is a number
+      // $FlowFixMe[unsafe-arithmetic] assuming this is a number
       lastMovementY = event.screenY - lastMouseEvent.screenY;
     } else {
       lastMovementX = 0;
@@ -380,7 +380,7 @@ function getEventKey(nativeEvent: {[propName: string]: mixed}) {
     // FireFox implements `key` but returns `MozPrintableKey` for all
     // printable characters (normalized to `Unidentified`), ignore it.
     const key =
-      // $FlowFixMe unable to index with a `mixed` value
+      // $FlowFixMe[invalid-computed-prop] unable to index with a `mixed` value
       normalizeKey[nativeEvent.key] || nativeEvent.key;
     if (key !== 'Unidentified') {
       return key;
@@ -390,7 +390,7 @@ function getEventKey(nativeEvent: {[propName: string]: mixed}) {
   // Browser does not implement `key`, polyfill as much of it as we can.
   if (nativeEvent.type === 'keypress') {
     const charCode = getEventCharCode(
-      // $FlowFixMe unable to narrow to `KeyboardEvent`
+      // $FlowFixMe[incompatible-call] unable to narrow to `KeyboardEvent`
       nativeEvent,
     );
 
@@ -401,7 +401,7 @@ function getEventKey(nativeEvent: {[propName: string]: mixed}) {
   if (nativeEvent.type === 'keydown' || nativeEvent.type === 'keyup') {
     // While user keyboard layout determines the actual meaning of each
     // `keyCode` value, almost all function keys have a universal value.
-    // $FlowFixMe unable to index with a `mixed` value
+    // $FlowFixMe[invalid-computed-prop] unable to index with a `mixed` value
     return translateToKey[nativeEvent.keyCode] || 'Unidentified';
   }
   return '';
@@ -462,7 +462,7 @@ const KeyboardEventInterface = {
     // implemented in any major browser. Only KeyPress has charCode.
     if (event.type === 'keypress') {
       return getEventCharCode(
-        // $FlowFixMe unable to narrow to `KeyboardEvent`
+        // $FlowFixMe[incompatible-call] unable to narrow to `KeyboardEvent`
         event,
       );
     }
@@ -486,7 +486,7 @@ const KeyboardEventInterface = {
     // type of the event.
     if (event.type === 'keypress') {
       return getEventCharCode(
-        // $FlowFixMe unable to narrow to `KeyboardEvent`
+        // $FlowFixMe[incompatible-call] unable to narrow to `KeyboardEvent`
         event,
       );
     }
@@ -565,7 +565,7 @@ const WheelEventInterface = {
       ? event.deltaX
       : // Fallback to `wheelDeltaX` for Webkit and normalize (right is positive).
       'wheelDeltaX' in event
-      ? // $FlowFixMe assuming this is a number
+      ? // $FlowFixMe[unsafe-arithmetic] assuming this is a number
         -event.wheelDeltaX
       : 0;
   },
@@ -574,11 +574,11 @@ const WheelEventInterface = {
       ? event.deltaY
       : // Fallback to `wheelDeltaY` for Webkit and normalize (down is positive).
       'wheelDeltaY' in event
-      ? // $FlowFixMe assuming this is a number
+      ? // $FlowFixMe[unsafe-arithmetic] assuming this is a number
         -event.wheelDeltaY
       : // Fallback to `wheelDelta` for IE<9 and normalize (down is positive).
       'wheelDelta' in event
-      ? // $FlowFixMe assuming this is a number
+      ? // $FlowFixMe[unsafe-arithmetic] assuming this is a number
         -event.wheelDelta
       : 0;
   },

--- a/packages/react-dom-bindings/src/server/ReactDOMLegacyServerStreamConfig.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMLegacyServerStreamConfig.js
@@ -61,6 +61,6 @@ export function clonePrecomputedChunk(
 }
 
 export function closeWithError(destination: Destination, error: mixed): void {
-  // $FlowFixMe: This is an Error object or the destination accepts other types.
+  // $FlowFixMe[incompatible-call]: This is an Error object or the destination accepts other types.
   destination.destroy(error);
 }

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -65,11 +65,11 @@ export {
 if (__DEV__) {
   if (
     typeof Map !== 'function' ||
-    // $FlowFixMe Flow incorrectly thinks Map has no prototype
+    // $FlowFixMe[prop-missing] Flow incorrectly thinks Map has no prototype
     Map.prototype == null ||
     typeof Map.prototype.forEach !== 'function' ||
     typeof Set !== 'function' ||
-    // $FlowFixMe Flow incorrectly thinks Set has no prototype
+    // $FlowFixMe[prop-missing] Flow incorrectly thinks Set has no prototype
     Set.prototype == null ||
     typeof Set.prototype.clear !== 'function' ||
     typeof Set.prototype.forEach !== 'function'
@@ -91,7 +91,7 @@ function createPortal(
   }
 
   // TODO: pass ReactDOM portal implementation as third argument
-  // $FlowFixMe The Flow type is opaque but there's no way to actually create it.
+  // $FlowFixMe[incompatible-return] The Flow type is opaque but there's no way to actually create it.
   return createPortalImpl(children, container, null, key);
 }
 

--- a/packages/react-dom/src/client/ReactDOMLegacy.js
+++ b/packages/react-dom/src/client/ReactDOMLegacy.js
@@ -420,7 +420,7 @@ export function unmountComponentAtNode(container: Container): boolean {
     // Unmount should not be batched.
     flushSync(() => {
       legacyRenderSubtreeIntoContainer(null, null, container, false, () => {
-        // $FlowFixMe This should probably use `delete container._reactRootContainer`
+        // $FlowFixMe[incompatible-type] This should probably use `delete container._reactRootContainer`
         container._reactRootContainer = null;
         unmarkContainerAsRoot(container);
       });

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -65,7 +65,7 @@ function renderToReadableStream(
             abort(request);
           },
         },
-        // $FlowFixMe size() methods are not allowed on byte streams.
+        // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
         {highWaterMark: 0},
       ): any);
       // TODO: Move to sub-classing ReadableStream.

--- a/packages/react-dom/src/server/ReactDOMFizzServerBun.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBun.js
@@ -66,7 +66,7 @@ function renderToReadableStream(
             abort(request);
           },
         },
-        // $FlowFixMe size() methods are not allowed on byte streams.
+        // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
         {highWaterMark: 2048},
       ): any);
       // TODO: Move to sub-classing ReadableStream.

--- a/packages/react-dom/src/server/ReactDOMFizzServerEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerEdge.js
@@ -65,7 +65,7 @@ function renderToReadableStream(
             abort(request);
           },
         },
-        // $FlowFixMe size() methods are not allowed on byte streams.
+        // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
         {highWaterMark: 0},
       ): any);
       // TODO: Move to sub-classing ReadableStream.

--- a/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
@@ -55,7 +55,7 @@ function prerender(
             startFlowing(request, controller);
           },
         },
-        // $FlowFixMe size() methods are not allowed on byte streams.
+        // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
         {highWaterMark: 0},
       );
 

--- a/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
@@ -55,7 +55,7 @@ function prerender(
             startFlowing(request, controller);
           },
         },
-        // $FlowFixMe size() methods are not allowed on byte streams.
+        // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
         {highWaterMark: 0},
       );
 

--- a/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
@@ -43,7 +43,6 @@ class ReactMarkupReadableStream extends Readable {
   // $FlowFixMe[missing-local-annot]
   _destroy(err, callback) {
     abort(this.request);
-    // $FlowFixMe: The type definition for the callback should allow undefined and null.
     callback(err);
   }
 

--- a/packages/react-interactions/events/src/dom/create-event-handle/Focus.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/Focus.js
@@ -288,7 +288,7 @@ export function useFocusWithin<T>(
         // Handle focus visible
         setFocusVisibleListeners(
           focusVisibleHandles,
-          // $FlowFixMe focusWithinTarget is not null here
+          // $FlowFixMe[incompatible-call] focusWithinTarget is not null here
           focusWithinTarget,
           isFocusVisible => {
             if (state.isFocused && state.isFocusVisible !== isFocusVisible) {
@@ -301,7 +301,7 @@ export function useFocusWithin<T>(
         );
 
         // Handle focus
-        // $FlowFixMe focusWithinTarget is not null here
+        // $FlowFixMe[incompatible-call] focusWithinTarget is not null here
         focusHandle.setListener(focusWithinTarget, (event: FocusEvent) => {
           if (disabled) {
             return;
@@ -328,7 +328,7 @@ export function useFocusWithin<T>(
         });
 
         // Handle blur
-        // $FlowFixMe focusWithinTarget is not null here
+        // $FlowFixMe[incompatible-call] focusWithinTarget is not null here
         blurHandle.setListener(focusWithinTarget, (event: FocusEvent) => {
           if (disabled) {
             return;
@@ -354,7 +354,7 @@ export function useFocusWithin<T>(
 
         // Handle before blur. This is a special
         // React provided event.
-        // $FlowFixMe focusWithinTarget is not null here
+        // $FlowFixMe[incompatible-call] focusWithinTarget is not null here
         beforeBlurHandle.setListener(focusWithinTarget, (event: FocusEvent) => {
           if (disabled) {
             return;

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -74,7 +74,6 @@ function render(
   }
   updateContainer(element, root, null, callback);
 
-  // $FlowFixMe Flow has hardcoded values for React DOM that don't work with RN
   return getPublicRootInstance(root);
 }
 

--- a/packages/react-native-renderer/src/ReactNativeAttributePayload.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayload.js
@@ -186,9 +186,7 @@ function diffNestedProperty(
   if (isArray(prevProp)) {
     return diffProperties(
       updatePayload,
-      // $FlowFixMe - We know that this is always an object when the input is.
       flattenStyle(prevProp),
-      // $FlowFixMe - We know that this isn't an array because of above flow.
       nextProp,
       validAttributes,
     );
@@ -197,7 +195,6 @@ function diffNestedProperty(
   return diffProperties(
     updatePayload,
     prevProp,
-    // $FlowFixMe - We know that this is always an object when the input is.
     flattenStyle(nextProp),
     validAttributes,
   );

--- a/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
+++ b/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
@@ -183,7 +183,7 @@ const ReactNativeBridgeEventPlugin = {
 
     if (!bubbleDispatchConfig && !directDispatchConfig) {
       throw new Error(
-        // $FlowFixMe - Flow doesn't like this string coercion because DOMTopLevelEventType is opaque
+        // $FlowFixMe[incompatible-type] - Flow doesn't like this string coercion because DOMTopLevelEventType is opaque
         `Unsupported top level event type "${topLevelType}" dispatched`,
       );
     }

--- a/packages/react-native-renderer/src/ReactNativeEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactNativeEventEmitter.js
@@ -235,7 +235,7 @@ export function receiveTouches(
         rootNodeID = target;
       }
     }
-    // $FlowFixMe Shouldn't we *not* call it if rootNodeID is null?
+    // $FlowFixMe[incompatible-call] Shouldn't we *not* call it if rootNodeID is null?
     _receiveRootNodeIDEvent(rootNodeID, eventTopLevelType, nativeEvent);
   }
 }

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -77,7 +77,6 @@ function render(
   }
   updateContainer(element, root, null, callback);
 
-  // $FlowFixMe Flow has hardcoded values for React DOM that don't work with RN
   return getPublicRootInstance(root);
 }
 

--- a/packages/react-native-renderer/src/legacy-events/accumulateInto.js
+++ b/packages/react-native-renderer/src/legacy-events/accumulateInto.js
@@ -40,11 +40,12 @@ function accumulateInto<T>(
   // certain that x is an Array (x could be a string with concat method).
   if (isArray(current)) {
     if (isArray(next)) {
-      // $FlowFixMe `isArray` does not ensure array is mutable
+      // $FlowFixMe[prop-missing] `isArray` does not ensure array is mutable
+      // $FlowFixMe[method-unbinding]
       current.push.apply(current, next);
       return current;
     }
-    // $FlowFixMe `isArray` does not ensure array is mutable
+    // $FlowFixMe[prop-missing] `isArray` does not ensure array is mutable
     current.push(next);
     return current;
   }

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -830,7 +830,6 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       if (child.length === 1) {
         return childToJSX(child[0], null);
       }
-      // $FlowFixMe
       const children = child.map(c => childToJSX(c, null));
       if (children.every(c => typeof c === 'string' || typeof c === 'number')) {
         return children.join('');
@@ -1269,9 +1268,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           if (typeof child.text === 'string') {
             log(indent + '- ' + child.text);
           } else {
-            // $FlowFixMe - The child should've been refined now.
             log(indent + '- ' + child.type + '#' + child.id);
-            // $FlowFixMe - The child should've been refined now.
             logHostInstances(child.children, depth + 1);
           }
         }

--- a/packages/react-reconciler/src/DebugTracing.js
+++ b/packages/react-reconciler/src/DebugTracing.js
@@ -84,7 +84,7 @@ export function logCommitStopped(): void {
 }
 
 const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
-// $FlowFixMe: Flow cannot handle polymorphic WeakMaps
+// $FlowFixMe[incompatible-type]: Flow cannot handle polymorphic WeakMaps
 const wakeableIDs: WeakMap<Wakeable, number> = new PossiblyWeakMap();
 let wakeableID: number = 0;
 function getWakeableID(wakeable: Wakeable): number {

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -86,7 +86,7 @@ if (__DEV__) {
       );
     }
 
-    // $FlowFixMe unable to narrow type from mixed to writable object
+    // $FlowFixMe[cannot-write] unable to narrow type from mixed to writable object
     child._store.validated = true;
 
     const componentName = getComponentNameFromFiber(returnFiber) || 'Component';
@@ -1022,7 +1022,7 @@ function createChildReconciler(
       // See https://github.com/facebook/react/issues/12995
       if (
         typeof Symbol === 'function' &&
-        // $FlowFixMe Flow doesn't know about toStringTag
+        // $FlowFixMe[prop-missing] Flow doesn't know about toStringTag
         newChildrenIterable[Symbol.toStringTag] === 'Generator'
       ) {
         if (!didWarnAboutGenerators) {

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -230,7 +230,7 @@ function createFiber(
   key: null | string,
   mode: TypeOfMode,
 ): Fiber {
-  // $FlowFixMe: the shapes are exact here but Flow doesn't like constructors
+  // $FlowFixMe[invalid-constructor]: the shapes are exact here but Flow doesn't like constructors
   return new FiberNode(tag, pendingProps, key, mode);
 }
 

--- a/packages/react-reconciler/src/ReactFiberAct.js
+++ b/packages/react-reconciler/src/ReactFiberAct.js
@@ -29,7 +29,7 @@ export function isLegacyActEnvironment(fiber: Fiber): boolean {
           IS_REACT_ACT_ENVIRONMENT
         : undefined;
 
-    // $FlowFixMe - Flow doesn't know about jest
+    // $FlowFixMe[cannot-resolve-name] - Flow doesn't know about jest
     const jestIsDefined = typeof jest !== 'undefined';
     return (
       warnsIfNotActing && jestIsDefined && isReactActEnvironmentGlobal !== false

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -347,7 +347,7 @@ function safelyDetachRef(current: Fiber, nearestMountedAncestor: Fiber | null) {
         }
       }
     } else {
-      // $FlowFixMe unable to narrow type to RefObject
+      // $FlowFixMe[incompatible-use] unable to narrow type to RefObject
       ref.current = null;
     }
   }
@@ -1633,7 +1633,7 @@ function commitAttachRef(finishedWork: Fiber) {
         }
       }
 
-      // $FlowFixMe unable to narrow type to the non-function case
+      // $FlowFixMe[incompatible-use] unable to narrow type to the non-function case
       ref.current = instanceToUse;
     }
   }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -910,7 +910,7 @@ function completeDehydratedSuspenseBoundary(
             // Don't count time spent in a timed out Suspense subtree as part of the base duration.
             const primaryChildFragment = workInProgress.child;
             if (primaryChildFragment !== null) {
-              // $FlowFixMe Flow doesn't support type casting in combination with the -= operator
+              // $FlowFixMe[unsafe-arithmetic] Flow doesn't support type casting in combination with the -= operator
               workInProgress.treeBaseDuration -=
                 ((primaryChildFragment.treeBaseDuration: any): number);
             }
@@ -940,7 +940,7 @@ function completeDehydratedSuspenseBoundary(
             // Don't count time spent in a timed out Suspense subtree as part of the base duration.
             const primaryChildFragment = workInProgress.child;
             if (primaryChildFragment !== null) {
-              // $FlowFixMe Flow doesn't support type casting in combination with the -= operator
+              // $FlowFixMe[unsafe-arithmetic] Flow doesn't support type casting in combination with the -= operator
               workInProgress.treeBaseDuration -=
                 ((primaryChildFragment.treeBaseDuration: any): number);
             }
@@ -1484,7 +1484,7 @@ function completeWork(
             // Don't count time spent in a timed out Suspense subtree as part of the base duration.
             const primaryChildFragment = workInProgress.child;
             if (primaryChildFragment !== null) {
-              // $FlowFixMe Flow doesn't support type casting in combination with the -= operator
+              // $FlowFixMe[unsafe-arithmetic] Flow doesn't support type casting in combination with the -= operator
               workInProgress.treeBaseDuration -=
                 ((primaryChildFragment.treeBaseDuration: any): number);
             }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1036,7 +1036,7 @@ function useMemoCache(size: number): Array<any> {
 }
 
 function basicStateReducer<S>(state: S, action: BasicStateAction<S>): S {
-  // $FlowFixMe: Flow doesn't like mixed types
+  // $FlowFixMe[incompatible-use]: Flow doesn't like mixed types
   return typeof action === 'function' ? action(state) : action;
 }
 
@@ -1828,7 +1828,7 @@ function mountState<S>(
 ): [S, Dispatch<BasicStateAction<S>>] {
   const hook = mountWorkInProgressHook();
   if (typeof initialState === 'function') {
-    // $FlowFixMe: Flow doesn't like mixed types
+    // $FlowFixMe[incompatible-use]: Flow doesn't like mixed types
     initialState = initialState();
   }
   hook.memoizedState = hook.baseState = initialState;

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -563,7 +563,7 @@ if (__DEV__) {
       }
       return updated;
     }
-    // $FlowFixMe number or string is fine here
+    // $FlowFixMe[incompatible-use] number or string is fine here
     updated[key] = copyWithDeleteImpl(obj[key], path, index + 1);
     return updated;
   };
@@ -585,7 +585,7 @@ if (__DEV__) {
     const updated = isArray(obj) ? obj.slice() : {...obj};
     if (index + 1 === oldPath.length) {
       const newKey = newPath[index];
-      // $FlowFixMe number or string is fine here
+      // $FlowFixMe[incompatible-use] number or string is fine here
       updated[newKey] = updated[oldKey];
       if (isArray(updated)) {
         updated.splice(((oldKey: any): number), 1);
@@ -593,9 +593,9 @@ if (__DEV__) {
         delete updated[oldKey];
       }
     } else {
-      // $FlowFixMe number or string is fine here
+      // $FlowFixMe[incompatible-use] number or string is fine here
       updated[oldKey] = copyWithRenameImpl(
-        // $FlowFixMe number or string is fine here
+        // $FlowFixMe[incompatible-use] number or string is fine here
         obj[oldKey],
         oldPath,
         newPath,
@@ -637,7 +637,7 @@ if (__DEV__) {
     }
     const key = path[index];
     const updated = isArray(obj) ? obj.slice() : {...obj};
-    // $FlowFixMe number or string is fine here
+    // $FlowFixMe[incompatible-use] number or string is fine here
     updated[key] = copyWithSetImpl(obj[key], path, index + 1, value);
     return updated;
   };

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1797,7 +1797,7 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes): Fiber {
     // The root previous suspended and scheduled a timeout to commit a fallback
     // state. Now that we have additional work, cancel the timeout.
     root.timeoutHandle = noTimeout;
-    // $FlowFixMe Complains noTimeout is not a TimeoutID, despite the check above
+    // $FlowFixMe[incompatible-call] Complains noTimeout is not a TimeoutID, despite the check above
     cancelTimeout(timeoutHandle);
   }
   const cancelPendingCommit = root.cancelPendingCommit;

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -25,25 +25,31 @@ export {createResponse, close, getRoot};
 
 export function resolveRow(response: Response, chunk: RowEncoding): void {
   if (chunk[0] === 'O') {
-    // $FlowFixMe unable to refine on array indices
+    // $FlowFixMe[incompatible-call] unable to refine on array indices
     resolveModel(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'I') {
-    // $FlowFixMe unable to refine on array indices
+    // $FlowFixMe[incompatible-call] unable to refine on array indices
     resolveModule(response, chunk[1], chunk[2]);
   } else {
     if (__DEV__) {
       resolveErrorDev(
         response,
         chunk[1],
-        // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+        // $FlowFixMe[incompatible-call]: Flow doesn't support disjoint unions on tuples.
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-use]
         chunk[2].digest,
-        // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+        // $FlowFixMe[incompatible-call]: Flow doesn't support disjoint unions on tuples.
+        // $FlowFixMe[incompatible-use]
         chunk[2].message || '',
-        // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+        // $FlowFixMe[incompatible-call]: Flow doesn't support disjoint unions on tuples.
+        // $FlowFixMe[incompatible-use]
         chunk[2].stack || '',
       );
     } else {
-      // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+      // $FlowFixMe[incompatible-call]: Flow doesn't support disjoint unions on tuples.
+      // $FlowFixMe[prop-missing]
+      // $FlowFixMe[incompatible-use]
       resolveErrorProd(response, chunk[1], chunk[2].digest);
     }
   }

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -148,8 +148,6 @@ function convertModelToJSON(
       }
       return jsonArray;
     } else {
-      /* $FlowFixMe the old version of Flow doesn't have a good way to define
-       * an empty exact object. */
       const jsonObj: {[key: string]: JSONValue} = {};
       for (const nextKey in json) {
         if (hasOwnProperty.call(json, nextKey)) {
@@ -172,7 +170,6 @@ export function processModelChunk(
   id: number,
   model: ReactClientValue,
 ): Chunk {
-  // $FlowFixMe no good way to define an empty exact object
   const json = convertModelToJSON(request, {}, '', model);
   return ['O', id, json];
 }
@@ -207,7 +204,7 @@ export const requestStorage: AsyncLocalStorage<Map<Function, mixed>> =
 export function beginWriting(destination: Destination) {}
 
 export function writeChunk(destination: Destination, chunk: Chunk): void {
-  // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
+  // $FlowFixMe[incompatible-call] `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
   emitRow(destination, chunk);
 }
 
@@ -215,7 +212,7 @@ export function writeChunkAndReturn(
   destination: Destination,
   chunk: Chunk,
 ): boolean {
-  // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
+  // $FlowFixMe[incompatible-call] `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
   emitRow(destination, chunk);
   return true;
 }

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -69,7 +69,7 @@ function renderToReadableStream(
       },
       cancel: (reason): ?Promise<void> => {},
     },
-    // $FlowFixMe size() methods are not allowed on byte streams.
+    // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
     {highWaterMark: 0},
   );
   return stream;

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
@@ -69,7 +69,7 @@ function renderToReadableStream(
       },
       cancel: (reason): ?Promise<void> => {},
     },
-    // $FlowFixMe size() methods are not allowed on byte streams.
+    // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
     {highWaterMark: 0},
   );
   return stream;

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
@@ -25,25 +25,31 @@ export {createResponse, close, getRoot};
 
 export function resolveRow(response: Response, chunk: RowEncoding): void {
   if (chunk[0] === 'O') {
-    // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
+    // $FlowFixMe[incompatible-call] `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
     resolveModel(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'I') {
-    // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
+    // $FlowFixMe[incompatible-call] `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
     resolveModule(response, chunk[1], chunk[2]);
   } else {
     if (__DEV__) {
       resolveErrorDev(
         response,
         chunk[1],
-        // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+        // $FlowFixMe[incompatible-call]: Flow doesn't support disjoint unions on tuples.
+        // $FlowFixMe[incompatible-use]
+        // $FlowFixMe[prop-missing]
         chunk[2].digest,
-        // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+        // $FlowFixMe[incompatible-call]: Flow doesn't support disjoint unions on tuples.
+        // $FlowFixMe[incompatible-use]
         chunk[2].message || '',
-        // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+        // $FlowFixMe[incompatible-call]: Flow doesn't support disjoint unions on tuples.
+        // $FlowFixMe[incompatible-use]
         chunk[2].stack || '',
       );
     } else {
-      // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+      // $FlowFixMe[incompatible-call]: Flow doesn't support disjoint unions on tuples.
+      // $FlowFixMe[incompatible-use]
+      // $FlowFixMe[prop-missing]
       resolveErrorProd(response, chunk[1], chunk[2].digest);
     }
   }

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -144,7 +144,6 @@ function convertModelToJSON(
       }
       return jsonArray;
     } else {
-      // $FlowFixMe no good way to define an empty exact object
       const jsonObj: {[key: string]: JSONValue} = {};
       for (const nextKey in json) {
         if (hasOwnProperty.call(json, nextKey)) {
@@ -167,7 +166,6 @@ export function processModelChunk(
   id: number,
   model: ReactClientValue,
 ): Chunk {
-  // $FlowFixMe no good way to define an empty exact object
   const json = convertModelToJSON(request, {}, '', model);
   return ['O', id, json];
 }
@@ -202,7 +200,7 @@ export const requestStorage: AsyncLocalStorage<Map<Function, mixed>> =
 export function beginWriting(destination: Destination) {}
 
 export function writeChunk(destination: Destination, chunk: Chunk): void {
-  // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
+  // $FlowFixMe[incompatible-call] `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
   emitRow(destination, chunk);
 }
 
@@ -210,7 +208,7 @@ export function writeChunkAndReturn(
   destination: Destination,
   chunk: Chunk,
 ): boolean {
-  // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
+  // $FlowFixMe[incompatible-call] `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
   emitRow(destination, chunk);
   return true;
 }

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -291,7 +291,7 @@ function useContext<T>(context: ReactContext<T>): T {
 }
 
 function basicStateReducer<S>(state: S, action: BasicStateAction<S>): S {
-  // $FlowFixMe: Flow doesn't like mixed types
+  // $FlowFixMe[incompatible-use]: Flow doesn't like mixed types
   return typeof action === 'function' ? action(state) : action;
 }
 

--- a/packages/react-server/src/ReactFizzNewContext.js
+++ b/packages/react-server/src/ReactFizzNewContext.js
@@ -163,7 +163,7 @@ export function switchContext(newSnapshot: ContextSnapshot): void {
   const next = newSnapshot;
   if (prev !== next) {
     if (prev === null) {
-      // $FlowFixMe: This has to be non-null since it's not equal to prev.
+      // $FlowFixMe[incompatible-call]: This has to be non-null since it's not equal to prev.
       pushAllNext(next);
     } else if (next === null) {
       popAllPrevious(prev);

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -1292,7 +1292,6 @@ function validateIterable(iterable, iteratorFn: Function): void {
     // See https://github.com/facebook/react/issues/12995
     if (
       typeof Symbol === 'function' &&
-      // $FlowFixMe Flow doesn't know about toStringTag
       iterable[Symbol.toStringTag] === 'Generator'
     ) {
       if (!didWarnAboutGenerators) {

--- a/packages/react-server/src/ReactFlightNewContext.js
+++ b/packages/react-server/src/ReactFlightNewContext.js
@@ -165,7 +165,7 @@ export function switchContext(newSnapshot: ContextSnapshot): void {
   const next = newSnapshot;
   if (prev !== next) {
     if (prev === null) {
-      // $FlowFixMe: This has to be non-null since it's not equal to prev.
+      // $FlowFixMe[incompatible-call]: This has to be non-null since it's not equal to prev.
       pushAllNext(next);
     } else if (next === null) {
       popAllPrevious(prev);

--- a/packages/react-server/src/ReactFlightReplyServer.js
+++ b/packages/react-server/src/ReactFlightReplyServer.js
@@ -141,7 +141,7 @@ export function getRoot<T>(response: Response): Thenable<T> {
 }
 
 function createPendingChunk<T>(response: Response): PendingChunk<T> {
-  // $FlowFixMe Flow doesn't support functions as constructors
+  // $FlowFixMe[invalid-constructor] Flow doesn't support functions as constructors
   return new Chunk(PENDING, null, null, response);
 }
 
@@ -192,7 +192,7 @@ function createResolvedModelChunk<T>(
   response: Response,
   value: string,
 ): ResolvedModelChunk<T> {
-  // $FlowFixMe Flow doesn't support functions as constructors
+  // $FlowFixMe[invalid-constructor] Flow doesn't support functions as constructors
   return new Chunk(RESOLVED_MODEL, value, null, response);
 }
 

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -666,7 +666,7 @@ export function resolveModelToJSON(
   value: ReactClientValue,
 ): ReactJSONValue {
   if (__DEV__) {
-    // $FlowFixMe
+    // $FlowFixMe[incompatible-use]
     const originalValue = parent[key];
     if (typeof originalValue === 'object' && originalValue !== value) {
       if (objectName(originalValue) !== 'Object') {
@@ -865,7 +865,7 @@ export function resolveModelToJSON(
       }
     }
 
-    // $FlowFixMe
+    // $FlowFixMe[incompatible-return]
     return value;
   }
 
@@ -909,14 +909,14 @@ export function resolveModelToJSON(
     if (existingId !== undefined) {
       return serializeByValueID(existingId);
     }
-    // $FlowFixMe `description` might be undefined
+    // $FlowFixMe[incompatible-type] `description` might be undefined
     const name: string = value.description;
 
     if (Symbol.for(name) !== value) {
       throw new Error(
         'Only global symbols received from Symbol.for(...) can be passed to Client Components. ' +
           `The symbol Symbol.for(${
-            // $FlowFixMe `description` might be undefined
+            // $FlowFixMe[incompatible-type] `description` might be undefined
             value.description
           }) cannot be found among global symbols.` +
           describeObjectForErrorMessage(parent, key),

--- a/packages/react-server/src/ReactServerStreamConfigBrowser.js
+++ b/packages/react-server/src/ReactServerStreamConfigBrowser.js
@@ -146,7 +146,7 @@ export function clonePrecomputedChunk(
 export function closeWithError(destination: Destination, error: mixed): void {
   // $FlowFixMe[method-unbinding]
   if (typeof destination.error === 'function') {
-    // $FlowFixMe: This is an Error object or the destination accepts other types.
+    // $FlowFixMe[incompatible-call]: This is an Error object or the destination accepts other types.
     destination.error(error);
   } else {
     // Earlier implementations doesn't support this method. In that environment you're

--- a/packages/react-server/src/ReactServerStreamConfigBun.js
+++ b/packages/react-server/src/ReactServerStreamConfigBun.js
@@ -72,7 +72,7 @@ export function clonePrecomputedChunk(
 
 export function closeWithError(destination: Destination, error: mixed): void {
   if (typeof destination.error === 'function') {
-    // $FlowFixMe: This is an Error object or the destination accepts other types.
+    // $FlowFixMe[incompatible-call]: This is an Error object or the destination accepts other types.
     destination.error(error);
   } else {
     // Earlier implementations doesn't support this method. In that environment you're

--- a/packages/react-server/src/ReactServerStreamConfigEdge.js
+++ b/packages/react-server/src/ReactServerStreamConfigEdge.js
@@ -147,7 +147,7 @@ export function clonePrecomputedChunk(
 export function closeWithError(destination: Destination, error: mixed): void {
   // $FlowFixMe[method-unbinding]
   if (typeof destination.error === 'function') {
-    // $FlowFixMe: This is an Error object or the destination accepts other types.
+    // $FlowFixMe[incompatible-call]: This is an Error object or the destination accepts other types.
     destination.error(error);
   } else {
     // Earlier implementations doesn't support this method. In that environment you're

--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -220,6 +220,6 @@ export function clonePrecomputedChunk(
 }
 
 export function closeWithError(destination: Destination, error: mixed): void {
-  // $FlowFixMe: This is an Error object or the destination accepts other types.
+  // $FlowFixMe[incompatible-call]: This is an Error object or the destination accepts other types.
   destination.destroy(error);
 }

--- a/packages/react/src/ReactCache.js
+++ b/packages/react/src/ReactCache.js
@@ -57,7 +57,7 @@ export function cache<A: Iterable<mixed>, T>(fn: (...A) => T): (...A) => T {
     const dispatcher = ReactCurrentCache.current;
     if (!dispatcher) {
       // If there is no dispatcher, then we treat this as not being cached.
-      // $FlowFixMe: We don't want to use rest arguments since we transpile the code.
+      // $FlowFixMe[incompatible-call]: We don't want to use rest arguments since we transpile the code.
       return fn.apply(null, arguments);
     }
     const fnMap: WeakMap<any, CacheNode<T>> = dispatcher.getCacheForType(
@@ -111,7 +111,7 @@ export function cache<A: Iterable<mixed>, T>(fn: (...A) => T): (...A) => T {
       throw cacheNode.v;
     }
     try {
-      // $FlowFixMe: We don't want to use rest arguments since we transpile the code.
+      // $FlowFixMe[incompatible-call]: We don't want to use rest arguments since we transpile the code.
       const result = fn.apply(null, arguments);
       const terminatedNode: TerminatedCacheNode<T> = (cacheNode: any);
       terminatedNode.s = TERMINATED;

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -125,7 +125,7 @@ function mapIntoArray(
         if (__DEV__) {
           // The `if` statement here prevents auto-disabling of the safe
           // coercion ESLint rule, so we must manually disable it below.
-          // $FlowFixMe Flow incorrectly thinks React.Portal doesn't have a key
+          // $FlowFixMe[incompatible-type] Flow incorrectly thinks React.Portal doesn't have a key
           if (mappedChild.key && (!child || child.key !== mappedChild.key)) {
             checkKeyStringCoercion(mappedChild.key);
           }
@@ -135,7 +135,7 @@ function mapIntoArray(
           // Keep both the (mapped) and old keys if they differ, just as
           // traverseAllChildren used to do for objects as children
           escapedPrefix +
-            // $FlowFixMe Flow incorrectly thinks React.Portal doesn't have a key
+            // $FlowFixMe[incompatible-type] Flow incorrectly thinks React.Portal doesn't have a key
             (mappedChild.key && (!child || child.key !== mappedChild.key)
               ? escapeUserProvidedKey(
                   // $FlowFixMe[unsafe-addition]
@@ -191,7 +191,7 @@ function mapIntoArray(
       const iterator = iteratorFn.call(iterableChildren);
       let step;
       let ii = 0;
-      // $FlowFixMe `iteratorFn` might return null according to typing.
+      // $FlowFixMe[incompatible-use] `iteratorFn` might return null according to typing.
       while (!(step = iterator.next()).done) {
         child = step.value;
         nextName = nextNamePrefix + getElementKey(child, ii++);

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -54,7 +54,7 @@ export function createContext<T>(defaultValue: T): ReactContext<T> {
       $$typeof: REACT_CONTEXT_TYPE,
       _context: context,
     };
-    // $FlowFixMe: Flow complains about not setting a value, which is intentional here
+    // $FlowFixMe[prop-missing]: Flow complains about not setting a value, which is intentional here
     Object.defineProperties(Consumer, {
       Provider: {
         get() {
@@ -123,7 +123,7 @@ export function createContext<T>(defaultValue: T): ReactContext<T> {
         },
       },
     });
-    // $FlowFixMe: Flow complains about missing properties because it doesn't understand defineProperty
+    // $FlowFixMe[prop-missing]: Flow complains about missing properties because it doesn't understand defineProperty
     context.Consumer = Consumer;
   } else {
     context.Consumer = context;

--- a/packages/react/src/ReactFetch.js
+++ b/packages/react/src/ReactFetch.js
@@ -77,7 +77,7 @@ if (enableCache && enableFetchInstrumentation) {
         const request = new Request(resource, options);
         if (
           (request.method !== 'GET' && request.method !== 'HEAD') ||
-          // $FlowFixMe: keepalive is real
+          // $FlowFixMe[prop-missing]: keepalive is real
           request.keepalive
         ) {
           // We currently don't dedupe requests that might have side-effects. Those

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -137,7 +137,7 @@ export function lazy<T>(
     // In production, this would just set it on the object.
     let defaultProps;
     let propTypes;
-    // $FlowFixMe
+    // $FlowFixMe[prop-missing]
     Object.defineProperties(lazyType, {
       defaultProps: {
         configurable: true,
@@ -153,7 +153,7 @@ export function lazy<T>(
           );
           defaultProps = newDefaultProps;
           // Match production behavior more closely:
-          // $FlowFixMe
+          // $FlowFixMe[prop-missing]
           Object.defineProperty(lazyType, 'defaultProps', {
             enumerable: true,
           });
@@ -173,7 +173,7 @@ export function lazy<T>(
           );
           propTypes = newPropTypes;
           // Match production behavior more closely:
-          // $FlowFixMe
+          // $FlowFixMe[prop-missing]
           Object.defineProperty(lazyType, 'propTypes', {
             enumerable: true,
           });

--- a/packages/shared/CheckStringCoercion.js
+++ b/packages/shared/CheckStringCoercion.js
@@ -17,7 +17,7 @@
  * of the `value` object).
  */
 
-// $FlowFixMe only called in DEV, so void return is not possible.
+// $FlowFixMe[incompatible-return] only called in DEV, so void return is not possible.
 function typeName(value: mixed): string {
   if (__DEV__) {
     // toStringTag is needed for namespaced types like Temporal.Instant
@@ -26,12 +26,12 @@ function typeName(value: mixed): string {
       (hasToStringTag && (value: any)[Symbol.toStringTag]) ||
       (value: any).constructor.name ||
       'Object';
-    // $FlowFixMe
+    // $FlowFixMe[incompatible-return]
     return type;
   }
 }
 
-// $FlowFixMe only called in DEV, so void return is not possible.
+// $FlowFixMe[incompatible-return] only called in DEV, so void return is not possible.
 function willCoercionThrow(value: mixed): boolean {
   if (__DEV__) {
     try {

--- a/packages/shared/ConsolePatchingDev.js
+++ b/packages/shared/ConsolePatchingDev.js
@@ -42,7 +42,7 @@ export function disableLogs(): void {
         value: disabledLog,
         writable: true,
       };
-      // $FlowFixMe Flow thinks console is immutable.
+      // $FlowFixMe[cannot-write] Flow thinks console is immutable.
       Object.defineProperties(console, {
         info: props,
         log: props,
@@ -68,7 +68,7 @@ export function reenableLogs(): void {
         enumerable: true,
         writable: true,
       };
-      // $FlowFixMe Flow thinks console is immutable.
+      // $FlowFixMe[cannot-write] Flow thinks console is immutable.
       Object.defineProperties(console, {
         log: {...props, value: prevLog},
         info: {...props, value: prevInfo},

--- a/packages/shared/ReactComponentStackFrame.js
+++ b/packages/shared/ReactComponentStackFrame.js
@@ -83,7 +83,7 @@ export function describeNativeComponentFrame(
 
   reentry = true;
   const previousPrepareStackTrace = Error.prepareStackTrace;
-  // $FlowFixMe It does accept undefined.
+  // $FlowFixMe[incompatible-type] It does accept undefined.
   Error.prepareStackTrace = undefined;
   let previousDispatcher;
   if (__DEV__) {
@@ -100,7 +100,7 @@ export function describeNativeComponentFrame(
       const Fake = function () {
         throw Error();
       };
-      // $FlowFixMe
+      // $FlowFixMe[prop-missing]
       Object.defineProperty(Fake.prototype, 'props', {
         set: function () {
           // We use a throwing setter instead of frozen or non-writable props

--- a/packages/shared/ReactServerContextRegistry.js
+++ b/packages/shared/ReactServerContextRegistry.js
@@ -21,7 +21,7 @@ export function getOrCreateServerContext(
   if (!ContextRegistry[globalName]) {
     ContextRegistry[globalName] = createServerContext(
       globalName,
-      // $FlowFixMe function signature doesn't reflect the symbol value
+      // $FlowFixMe[incompatible-call] function signature doesn't reflect the symbol value
       REACT_SERVER_CONTEXT_DEFAULT_VALUE_NOT_LOADED,
     );
   }

--- a/packages/shared/checkPropTypes.js
+++ b/packages/shared/checkPropTypes.js
@@ -40,7 +40,7 @@ export default function checkPropTypes(
   element?: any,
 ): void {
   if (__DEV__) {
-    // $FlowFixMe This is okay but Flow doesn't know it.
+    // $FlowFixMe[incompatible-use] This is okay but Flow doesn't know it.
     const has = Function.call.bind(hasOwnProperty);
     for (const typeSpecName in typeSpecs) {
       if (has(typeSpecs, typeSpecName)) {


### PR DESCRIPTION
Added an explicit type to all $FlowFixMe suppressions to reduce over-suppressions of new errors that might be caused on the same lines.

Also removes suppressions that aren't used (e.g. in a `@noflow` file as they're purely misleading)

Test Plan:
yarn flow-ci