### PR TITLE
[DevTools] browser extension: improve script injection logic

### DIFF
--- a/packages/react-devtools-extensions/chrome/manifest.json
+++ b/packages/react-devtools-extensions/chrome/manifest.json
@@ -4,7 +4,7 @@
   "description": "Adds React debugging tools to the Chrome Developer Tools.",
   "version": "4.27.4",
   "version_name": "4.27.4",
-  "minimum_chrome_version": "88",
+  "minimum_chrome_version": "102",
   "icons": {
     "16": "icons/16-production.png",
     "32": "icons/32-production.png",

--- a/packages/react-devtools-extensions/edge/manifest.json
+++ b/packages/react-devtools-extensions/edge/manifest.json
@@ -4,7 +4,7 @@
   "description": "Adds React debugging tools to the Microsoft Edge Developer Tools.",
   "version": "4.27.4",
   "version_name": "4.27.4",
-  "minimum_chrome_version": "88",
+  "minimum_chrome_version": "102",
   "icons": {
     "16": "icons/16-production.png",
     "32": "icons/32-production.png",

--- a/packages/react-devtools-extensions/src/background.js
+++ b/packages/react-devtools-extensions/src/background.js
@@ -6,7 +6,7 @@ import {IS_FIREFOX} from './utils';
 
 const ports = {};
 
-if (!IS_FIREFOX) {
+if (!IS_FIREFOX) { // equivalent logic for Firefox is in prepareInjection.js
   // Manifest V3 method of injecting content scripts (not yet supported in Firefox)
   // Note: the "world" option in registerContentScripts is only available in Chrome v102+
   // It's critical since it allows us to directly run scripts on the "main" world on the page
@@ -180,6 +180,18 @@ chrome.runtime.onMessage.addListener((request, sender) => {
             devtools.postMessage(request);
           }
           break;
+      }
+    }
+  } else if (request.payload?.tabId) {
+    const tabId = request.payload?.tabId;
+    // This is sent from the devtools page when it is ready for injecting the backend
+    if (request.payload.type === 'react-devtools-inject-backend') {
+      if (!IS_FIREFOX) { // equivalent logic for Firefox is in prepareInjection.js
+        chrome.scripting.executeScript({
+          target: {tabId},
+          files: ['/build/react_devtools_backend.js'],
+          world: chrome.scripting.ExecutionWorld.MAIN
+        });
       }
     }
   }

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -5,7 +5,7 @@ import {flushSync} from 'react-dom';
 import {createRoot} from 'react-dom/client';
 import Bridge from 'react-devtools-shared/src/bridge';
 import Store from 'react-devtools-shared/src/devtools/store';
-import {getBrowserName, getBrowserTheme} from './utils';
+import {IS_FIREFOX, IS_CHROME, IS_EDGE, getBrowserTheme} from './utils';
 import {LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY} from 'react-devtools-shared/src/constants';
 import {registerDevToolsEventLogger} from 'react-devtools-shared/src/registerDevToolsEventLogger';
 import {
@@ -26,9 +26,6 @@ import {logEvent} from 'react-devtools-shared/src/Logger';
 
 const LOCAL_STORAGE_SUPPORTS_PROFILING_KEY =
   'React::DevTools::supportsProfiling';
-
-const isChrome = getBrowserName() === 'Chrome';
-const isEdge = getBrowserName() === 'Edge';
 
 // rAF never fires on devtools_page (because it's in the background)
 // https://bugs.chromium.org/p/chromium/issues/detail?id=1241986#c31
@@ -176,10 +173,10 @@ function createPanelIfReactLoaded() {
 
         store = new Store(bridge, {
           isProfiling,
-          supportsReloadAndProfile: isChrome || isEdge,
+          supportsReloadAndProfile: IS_CHROME || IS_EDGE,
           supportsProfiling,
           // At this time, the timeline can only parse Chrome performance profiles.
-          supportsTimeline: isChrome,
+          supportsTimeline: IS_CHROME,
           supportsTraceUpdates: true,
         });
         if (!isProfiling) {
@@ -188,14 +185,26 @@ function createPanelIfReactLoaded() {
 
         // Initialize the backend only once the Store has been initialized.
         // Otherwise the Store may miss important initial tree op codes.
-        chrome.devtools.inspectedWindow.eval(
-          `window.postMessage({ source: 'react-devtools-inject-backend' }, '*');`,
-          function (response, evalError) {
-            if (evalError) {
-              console.error(evalError);
-            }
-          },
-        );
+        if (IS_CHROME | IS_EDGE) {
+          chrome.runtime.sendMessage({
+            source: 'react-devtools-main',
+            payload: {
+              type: 'react-devtools-inject-backend',
+              tabId,
+            },
+          });
+        } else {
+          // Firefox does not support executing script in MAIN wolrd from content script.
+          // see prepareInjection.js
+          chrome.devtools.inspectedWindow.eval(
+            `window.postMessage({ source: 'react-devtools-inject-backend' }, '*');`,
+            function (response, evalError) {
+              if (evalError) {
+                console.error(evalError);
+              }
+            },
+          );
+        }
 
         const viewAttributeSourceFunction = (id, path) => {
           const rendererID = store.getRendererIDForElement(id);
@@ -255,7 +264,7 @@ function createPanelIfReactLoaded() {
         // For some reason in Firefox, chrome.runtime.sendMessage() from a content script
         // never reaches the chrome.runtime.onMessage event listener.
         let fetchFileWithCaching = null;
-        if (isChrome) {
+        if (IS_CHROME) {
           const fetchFromNetworkCache = (url, resolve, reject) => {
             // Debug ID allows us to avoid re-logging (potentially long) URL strings below,
             // while also still associating (potentially) interleaved logs with the original request.
@@ -463,7 +472,7 @@ function createPanelIfReactLoaded() {
       let needsToSyncElementSelection = false;
 
       chrome.devtools.panels.create(
-        isChrome || isEdge ? '⚛️ Components' : 'Components',
+        IS_CHROME || IS_EDGE ? '⚛️ Components' : 'Components',
         '',
         'panel.html',
         extensionPanel => {
@@ -494,7 +503,7 @@ function createPanelIfReactLoaded() {
       );
 
       chrome.devtools.panels.create(
-        isChrome || isEdge ? '⚛️ Profiler' : 'Profiler',
+        IS_CHROME || IS_EDGE ? '⚛️ Profiler' : 'Profiler',
         '',
         'panel.html',
         extensionPanel => {


### PR DESCRIPTION
## Summary

- Drop extension support for Chrome / Edge <v102 since they have less than 0.1% usage ([see data](https://caniuse.com/usage-table))
- Improve script injection logic when possible so that the scripts injected by the extension are no longer shown in Network (which caused a lot of confusion in the past)

## How did you test this change?

Built and tested locally, works as usual on Firefox.

For Chrome/Edge

**Before:**
Scripts shown in Network tab
<img width="1279" alt="Untitled 2" src="https://user-images.githubusercontent.com/1001890/228074363-1d00d503-d4b5-4339-8dd6-fd0467e36e3e.png">

**After:**
No scripts shown
<img width="1329" alt="image" src="https://user-images.githubusercontent.com/1001890/228074596-2084722b-bf3c-495e-a852-15f122233155.png">
