### PR TITLE
Refactor DOM special cases per tags including controlled fields

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type {InputWithWrapperState} from './ReactDOMInput';
+
 import {
   registrationNameDependencies,
   possibleRegistrationNames,
@@ -25,7 +27,6 @@ import {
 } from './DOMPropertyOperations';
 import {
   initWrapperState as ReactDOMInputInitWrapperState,
-  getHostProps as ReactDOMInputGetHostProps,
   postMountWrapper as ReactDOMInputPostMountWrapper,
   updateChecked as ReactDOMInputUpdateChecked,
   updateWrapper as ReactDOMInputUpdateWrapper,
@@ -37,14 +38,12 @@ import {
 } from './ReactDOMOption';
 import {
   initWrapperState as ReactDOMSelectInitWrapperState,
-  getHostProps as ReactDOMSelectGetHostProps,
   postMountWrapper as ReactDOMSelectPostMountWrapper,
   restoreControlledState as ReactDOMSelectRestoreControlledState,
   postUpdateWrapper as ReactDOMSelectPostUpdateWrapper,
 } from './ReactDOMSelect';
 import {
   initWrapperState as ReactDOMTextareaInitWrapperState,
-  getHostProps as ReactDOMTextareaGetHostProps,
   postMountWrapper as ReactDOMTextareaPostMountWrapper,
   updateWrapper as ReactDOMTextareaUpdateWrapper,
   restoreControlledState as ReactDOMTextareaRestoreControlledState,
@@ -369,6 +368,16 @@ function setProp(
       }
       break;
     }
+    case 'onClick': {
+      // TODO: This cast may not be sound for SVG, MathML or custom elements.
+      if (value != null) {
+        if (__DEV__ && typeof value !== 'function') {
+          warnForInvalidEventListener(key, value);
+        }
+        trapClickOnNonInteractiveElement(((domElement: any): HTMLElement));
+      }
+      break;
+    }
     case 'suppressContentEditableWarning':
     case 'suppressHydrationWarning':
     case 'defaultValue': // Reserved
@@ -539,124 +548,194 @@ export function createTextNode(
 export function setInitialProperties(
   domElement: Element,
   tag: string,
-  rawProps: Object,
+  props: Object,
 ): void {
-  const isCustomComponentTag = isCustomComponent(tag, rawProps);
   if (__DEV__) {
-    validatePropertiesInDevelopment(tag, rawProps);
+    validatePropertiesInDevelopment(tag, props);
   }
 
   // TODO: Make sure that we check isMounted before firing any of these events.
-  let props: Object;
+
   switch (tag) {
-    case 'dialog':
+    case 'input': {
+      ReactDOMInputInitWrapperState(domElement, props);
+      // We listen to this event in case to ensure emulated bubble
+      // listeners still fire for the invalid event.
+      listenToNonDelegatedEvent('invalid', domElement);
+      for (const propKey in props) {
+        if (!props.hasOwnProperty(propKey)) {
+          continue;
+        }
+        const propValue = props[propKey];
+        if (propValue == null) {
+          continue;
+        }
+        switch (propKey) {
+          case 'checked': {
+            const node = ((domElement: any): InputWithWrapperState);
+            const checked =
+              propValue != null ? propValue : node._wrapperState.initialChecked;
+            node.checked =
+              !!checked &&
+              typeof checked !== 'function' &&
+              checked !== 'symbol';
+            break;
+          }
+          case 'value': {
+            // This is handled by updateWrapper below.
+            break;
+          }
+          case 'children':
+          case 'dangerouslySetInnerHTML': {
+            if (propValue != null) {
+              throw new Error(
+                `${tag} is a void element tag and must neither have \`children\` nor ` +
+                  'use `dangerouslySetInnerHTML`.',
+              );
+            }
+            break;
+          }
+          // defaultChecked and defaultValue are ignored by setProp
+          default: {
+            setProp(domElement, tag, propKey, propValue, false, props);
+          }
+        }
+      }
+      // TODO: Make sure we check if this is still unmounted or do any clean
+      // up necessary since we never stop tracking anymore.
+      track((domElement: any));
+      ReactDOMInputPostMountWrapper(domElement, props, false);
+      return;
+    }
+    case 'select': {
+      ReactDOMSelectInitWrapperState(domElement, props);
+      // We listen to this event in case to ensure emulated bubble
+      // listeners still fire for the invalid event.
+      listenToNonDelegatedEvent('invalid', domElement);
+      for (const propKey in props) {
+        if (!props.hasOwnProperty(propKey)) {
+          continue;
+        }
+        const propValue = props[propKey];
+        if (propValue == null) {
+          continue;
+        }
+        switch (propKey) {
+          case 'value': {
+            // This is handled by updateWrapper below.
+            break;
+          }
+          // defaultValue are ignored by setProp
+          default: {
+            setProp(domElement, tag, propKey, propValue, false, props);
+          }
+        }
+      }
+      ReactDOMSelectPostMountWrapper(domElement, props);
+      return;
+    }
+    case 'textarea': {
+      ReactDOMTextareaInitWrapperState(domElement, props);
+      // We listen to this event in case to ensure emulated bubble
+      // listeners still fire for the invalid event.
+      listenToNonDelegatedEvent('invalid', domElement);
+      for (const propKey in props) {
+        if (!props.hasOwnProperty(propKey)) {
+          continue;
+        }
+        const propValue = props[propKey];
+        if (propValue == null) {
+          continue;
+        }
+        switch (propKey) {
+          case 'value': {
+            // This is handled by updateWrapper below.
+            break;
+          }
+          case 'children': {
+            // TODO: Handled by initWrapperState above.
+            break;
+          }
+          case 'dangerouslySetInnerHTML': {
+            if (propValue != null) {
+              // TODO: Do we really need a special error message for this. It's also pretty blunt.
+              throw new Error(
+                '`dangerouslySetInnerHTML` does not make sense on <textarea>.',
+              );
+            }
+            break;
+          }
+          // defaultValue is ignored by setProp
+          default: {
+            setProp(domElement, tag, propKey, propValue, false, props);
+          }
+        }
+      }
+      // TODO: Make sure we check if this is still unmounted or do any clean
+      // up necessary since we never stop tracking anymore.
+      track((domElement: any));
+      ReactDOMTextareaPostMountWrapper(domElement, props);
+      return;
+    }
+    case 'option': {
+      ReactDOMOptionValidateProps(domElement, props);
+      for (const propKey in props) {
+        if (!props.hasOwnProperty(propKey)) {
+          continue;
+        }
+        const propValue = props[propKey];
+        if (propValue == null) {
+          continue;
+        }
+        setProp(domElement, tag, propKey, propValue, false, props);
+      }
+      ReactDOMOptionPostMountWrapper(domElement, props);
+      return;
+    }
+    case 'dialog': {
       listenToNonDelegatedEvent('cancel', domElement);
       listenToNonDelegatedEvent('close', domElement);
-      props = rawProps;
       break;
-    case 'embed':
-      if (
-        rawProps.children != null ||
-        rawProps.dangerouslySetInnerHTML != null
-      ) {
-        // TODO: Can we make this a DEV warning to avoid this deny list?
-        throw new Error(
-          `${tag} is a void element tag and must neither have \`children\` nor ` +
-            'use `dangerouslySetInnerHTML`.',
-        );
-      }
-    // eslint-disable-next-line no-fallthrough
+    }
     case 'iframe':
-    case 'object':
+    case 'object': {
       // We listen to this event in case to ensure emulated bubble
       // listeners still fire for the load event.
       listenToNonDelegatedEvent('load', domElement);
-      props = rawProps;
       break;
+    }
     case 'video':
-    case 'audio':
+    case 'audio': {
       // We listen to these events in case to ensure emulated bubble
       // listeners still fire for all the media events.
       for (let i = 0; i < mediaEventTypes.length; i++) {
         listenToNonDelegatedEvent(mediaEventTypes[i], domElement);
       }
-      props = rawProps;
       break;
-    case 'source':
-      if (
-        rawProps.children != null ||
-        rawProps.dangerouslySetInnerHTML != null
-      ) {
-        // TODO: Can we make this a DEV warning to avoid this deny list?
-        throw new Error(
-          `${tag} is a void element tag and must neither have \`children\` nor ` +
-            'use `dangerouslySetInnerHTML`.',
-        );
-      }
-      // We listen to this event in case to ensure emulated bubble
-      // listeners still fire for the error event.
-      listenToNonDelegatedEvent('error', domElement);
-      props = rawProps;
-      break;
-    case 'img':
-    case 'link':
-      if (
-        rawProps.children != null ||
-        rawProps.dangerouslySetInnerHTML != null
-      ) {
-        throw new Error(
-          `${tag} is a void element tag and must neither have \`children\` nor ` +
-            'use `dangerouslySetInnerHTML`.',
-        );
-      }
-    // eslint-disable-next-line no-fallthrough
-    case 'image':
+    }
+    case 'image': {
       // We listen to these events in case to ensure emulated bubble
       // listeners still fire for error and load events.
       listenToNonDelegatedEvent('error', domElement);
       listenToNonDelegatedEvent('load', domElement);
-      props = rawProps;
       break;
-    case 'details':
+    }
+    case 'details': {
       // We listen to this event in case to ensure emulated bubble
       // listeners still fire for the toggle event.
       listenToNonDelegatedEvent('toggle', domElement);
-      props = rawProps;
       break;
-    case 'input':
-      if (
-        rawProps.children != null ||
-        rawProps.dangerouslySetInnerHTML != null
-      ) {
-        throw new Error(
-          `${tag} is a void element tag and must neither have \`children\` nor ` +
-            'use `dangerouslySetInnerHTML`.',
-        );
-      }
-      ReactDOMInputInitWrapperState(domElement, rawProps);
-      props = ReactDOMInputGetHostProps(domElement, rawProps);
-      // We listen to this event in case to ensure emulated bubble
-      // listeners still fire for the invalid event.
-      listenToNonDelegatedEvent('invalid', domElement);
-      break;
-    case 'option':
-      ReactDOMOptionValidateProps(domElement, rawProps);
-      props = rawProps;
-      break;
-    case 'select':
-      ReactDOMSelectInitWrapperState(domElement, rawProps);
-      props = ReactDOMSelectGetHostProps(domElement, rawProps);
-      // We listen to this event in case to ensure emulated bubble
-      // listeners still fire for the invalid event.
-      listenToNonDelegatedEvent('invalid', domElement);
-      break;
-    case 'textarea':
-      ReactDOMTextareaInitWrapperState(domElement, rawProps);
-      props = ReactDOMTextareaGetHostProps(domElement, rawProps);
-      // We listen to this event in case to ensure emulated bubble
-      // listeners still fire for the invalid event.
-      listenToNonDelegatedEvent('invalid', domElement);
-      break;
+    }
+    case 'embed':
+    case 'source':
+    case 'img':
+    case 'link': {
+      // These are void elements that also need delegated events.
+      listenToNonDelegatedEvent('error', domElement);
+      listenToNonDelegatedEvent('load', domElement);
+      // We fallthrough to the return of the void elements
+    }
+    // eslint-disable-next-line no-fallthrough
     case 'area':
     case 'base':
     case 'br':
@@ -668,63 +747,45 @@ export function setInitialProperties(
     case 'track':
     case 'wbr':
     case 'menuitem': {
-      if (
-        rawProps.children != null ||
-        rawProps.dangerouslySetInnerHTML != null
-      ) {
-        // TODO: Can we make this a DEV warning to avoid this deny list?
-        throw new Error(
-          `${tag} is a void element tag and must neither have \`children\` nor ` +
-            'use `dangerouslySetInnerHTML`.',
-        );
+      // Void elements
+      for (const propKey in props) {
+        if (!props.hasOwnProperty(propKey)) {
+          continue;
+        }
+        const propValue = props[propKey];
+        if (propValue == null) {
+          continue;
+        }
+        switch (propKey) {
+          case 'children':
+          case 'dangerouslySetInnerHTML': {
+            // TODO: Can we make this a DEV warning to avoid this deny list?
+            throw new Error(
+              `${tag} is a void element tag and must neither have \`children\` nor ` +
+                'use `dangerouslySetInnerHTML`.',
+            );
+          }
+          // defaultChecked and defaultValue are ignored by setProp
+          default: {
+            // TODO: If the `is` prop is specified, this should go through the isCustomComponentTag flow.
+            setProp(domElement, tag, propKey, propValue, false, props);
+          }
+        }
       }
+      return;
     }
-    // eslint-disable-next-line no-fallthrough
-    default:
-      props = rawProps;
   }
 
+  const isCustomComponentTag = isCustomComponent(tag, props);
   for (const propKey in props) {
-    if (props.hasOwnProperty(propKey)) {
-      const nextProp = props[propKey];
-      if (nextProp != null) {
-        setProp(
-          domElement,
-          tag,
-          propKey,
-          nextProp,
-          isCustomComponentTag,
-          props,
-        );
-      }
+    if (!props.hasOwnProperty(propKey)) {
+      continue;
     }
-  }
-
-  switch (tag) {
-    case 'input':
-      // TODO: Make sure we check if this is still unmounted or do any clean
-      // up necessary since we never stop tracking anymore.
-      track((domElement: any));
-      ReactDOMInputPostMountWrapper(domElement, rawProps, false);
-      break;
-    case 'textarea':
-      // TODO: Make sure we check if this is still unmounted or do any clean
-      // up necessary since we never stop tracking anymore.
-      track((domElement: any));
-      ReactDOMTextareaPostMountWrapper(domElement, rawProps);
-      break;
-    case 'option':
-      ReactDOMOptionPostMountWrapper(domElement, rawProps);
-      break;
-    case 'select':
-      ReactDOMSelectPostMountWrapper(domElement, rawProps);
-      break;
-    default:
-      if (typeof props.onClick === 'function') {
-        // TODO: This cast may not be sound for SVG, MathML or custom elements.
-        trapClickOnNonInteractiveElement(((domElement: any): HTMLElement));
-      }
-      break;
+    const propValue = props[propKey];
+    if (propValue == null) {
+      continue;
+    }
+    setProp(domElement, tag, propKey, propValue, isCustomComponentTag, props);
   }
 }
 
@@ -732,79 +793,23 @@ export function setInitialProperties(
 export function diffProperties(
   domElement: Element,
   tag: string,
-  lastRawProps: Object,
-  nextRawProps: Object,
+  lastProps: Object,
+  nextProps: Object,
 ): null | Array<mixed> {
   if (__DEV__) {
-    validatePropertiesInDevelopment(tag, nextRawProps);
+    validatePropertiesInDevelopment(tag, nextProps);
   }
 
   let updatePayload: null | Array<any> = null;
 
-  let lastProps: Object;
-  let nextProps: Object;
   switch (tag) {
     case 'input':
-      if (
-        nextRawProps.children != null ||
-        nextRawProps.dangerouslySetInnerHTML != null
-      ) {
-        throw new Error(
-          `${tag} is a void element tag and must neither have \`children\` nor ` +
-            'use `dangerouslySetInnerHTML`.',
-        );
-      }
-      lastProps = ReactDOMInputGetHostProps(domElement, lastRawProps);
-      nextProps = ReactDOMInputGetHostProps(domElement, nextRawProps);
-      updatePayload = [];
-      break;
     case 'select':
-      lastProps = ReactDOMSelectGetHostProps(domElement, lastRawProps);
-      nextProps = ReactDOMSelectGetHostProps(domElement, nextRawProps);
-      updatePayload = [];
-      break;
     case 'textarea':
-      lastProps = ReactDOMTextareaGetHostProps(domElement, lastRawProps);
-      nextProps = ReactDOMTextareaGetHostProps(domElement, nextRawProps);
+      // Schedule to ensure the commit phase happens
+      // TODO: Figure out if this is actually really necessary or if all scenarios
+      // will have changed props.
       updatePayload = [];
-      break;
-    case 'img':
-    case 'link':
-    case 'area':
-    case 'base':
-    case 'br':
-    case 'col':
-    case 'embed':
-    case 'hr':
-    case 'keygen':
-    case 'meta':
-    case 'param':
-    case 'source':
-    case 'track':
-    case 'wbr':
-    case 'menuitem': {
-      if (
-        nextRawProps.children != null ||
-        nextRawProps.dangerouslySetInnerHTML != null
-      ) {
-        // TODO: Can we make this a DEV warning to avoid this deny list?
-        throw new Error(
-          `${tag} is a void element tag and must neither have \`children\` nor ` +
-            'use `dangerouslySetInnerHTML`.',
-        );
-      }
-    }
-    // eslint-disable-next-line no-fallthrough
-    default:
-      lastProps = lastRawProps;
-      nextProps = nextRawProps;
-      if (
-        typeof lastProps.onClick !== 'function' &&
-        typeof nextProps.onClick === 'function'
-      ) {
-        // TODO: This cast may not be sound for SVG, MathML or custom elements.
-        trapClickOnNonInteractiveElement(((domElement: any): HTMLElement));
-      }
       break;
   }
 
@@ -906,23 +911,153 @@ export function updateProperties(
   domElement: Element,
   updatePayload: Array<any>,
   tag: string,
-  lastRawProps: Object,
-  nextRawProps: Object,
+  lastProps: Object,
+  nextProps: Object,
 ): void {
-  // Update checked *before* name.
-  // In the middle of an update, it is possible to have multiple checked.
-  // When a checked radio tries to change name, browser makes another radio's checked false.
-  if (
-    tag === 'input' &&
-    nextRawProps.type === 'radio' &&
-    nextRawProps.name != null
-  ) {
-    ReactDOMInputUpdateChecked(domElement, nextRawProps);
+  switch (tag) {
+    case 'input': {
+      // Update checked *before* name.
+      // In the middle of an update, it is possible to have multiple checked.
+      // When a checked radio tries to change name, browser makes another radio's checked false.
+      if (nextProps.type === 'radio' && nextProps.name != null) {
+        ReactDOMInputUpdateChecked(domElement, nextProps);
+      }
+      for (let i = 0; i < updatePayload.length; i += 2) {
+        const propKey = updatePayload[i];
+        const propValue = updatePayload[i + 1];
+        switch (propKey) {
+          case 'checked': {
+            const node = ((domElement: any): InputWithWrapperState);
+            const checked =
+              propValue != null ? propValue : node._wrapperState.initialChecked;
+            node.checked =
+              !!checked &&
+              typeof checked !== 'function' &&
+              checked !== 'symbol';
+            break;
+          }
+          case 'value': {
+            // This is handled by updateWrapper below.
+            break;
+          }
+          case 'children':
+          case 'dangerouslySetInnerHTML': {
+            if (propValue != null) {
+              throw new Error(
+                `${tag} is a void element tag and must neither have \`children\` nor ` +
+                  'use `dangerouslySetInnerHTML`.',
+              );
+            }
+            break;
+          }
+          // defaultChecked and defaultValue are ignored by setProp
+          default: {
+            setProp(domElement, tag, propKey, propValue, false, nextProps);
+          }
+        }
+      }
+      // Update the wrapper around inputs *after* updating props. This has to
+      // happen after updating the rest of props. Otherwise HTML5 input validations
+      // raise warnings and prevent the new value from being assigned.
+      ReactDOMInputUpdateWrapper(domElement, nextProps);
+      return;
+    }
+    case 'select': {
+      for (let i = 0; i < updatePayload.length; i += 2) {
+        const propKey = updatePayload[i];
+        const propValue = updatePayload[i + 1];
+        switch (propKey) {
+          case 'value': {
+            // This is handled by updateWrapper below.
+            break;
+          }
+          // defaultValue are ignored by setProp
+          default: {
+            setProp(domElement, tag, propKey, propValue, false, nextProps);
+          }
+        }
+      }
+      // <select> value update needs to occur after <option> children
+      // reconciliation
+      ReactDOMSelectPostUpdateWrapper(domElement, nextProps);
+      return;
+    }
+    case 'textarea': {
+      for (let i = 0; i < updatePayload.length; i += 2) {
+        const propKey = updatePayload[i];
+        const propValue = updatePayload[i + 1];
+        switch (propKey) {
+          case 'value': {
+            // This is handled by updateWrapper below.
+            break;
+          }
+          case 'children': {
+            // TODO: This doesn't actually do anything if it updates.
+            break;
+          }
+          case 'dangerouslySetInnerHTML': {
+            if (propValue != null) {
+              // TODO: Do we really need a special error message for this. It's also pretty blunt.
+              throw new Error(
+                '`dangerouslySetInnerHTML` does not make sense on <textarea>.',
+              );
+            }
+            break;
+          }
+          // defaultValue is ignored by setProp
+          default: {
+            setProp(domElement, tag, propKey, propValue, false, nextProps);
+          }
+        }
+      }
+      ReactDOMTextareaUpdateWrapper(domElement, nextProps);
+      return;
+    }
+    case 'img':
+    case 'link':
+    case 'area':
+    case 'base':
+    case 'br':
+    case 'col':
+    case 'embed':
+    case 'hr':
+    case 'keygen':
+    case 'meta':
+    case 'param':
+    case 'source':
+    case 'track':
+    case 'wbr':
+    case 'menuitem': {
+      // Void elements
+      for (let i = 0; i < updatePayload.length; i += 2) {
+        const propKey = updatePayload[i];
+        const propValue = updatePayload[i + 1];
+        switch (propKey) {
+          case 'children':
+          case 'dangerouslySetInnerHTML': {
+            if (propValue != null) {
+              // TODO: Can we make this a DEV warning to avoid this deny list?
+              throw new Error(
+                `${tag} is a void element tag and must neither have \`children\` nor ` +
+                  'use `dangerouslySetInnerHTML`.',
+              );
+            }
+            break;
+          }
+          // defaultChecked and defaultValue are ignored by setProp
+          default: {
+            // TODO: If the `is` prop is specified, this should go through the isCustomComponentTag flow.
+            setProp(domElement, tag, propKey, propValue, false, nextProps);
+          }
+        }
+      }
+      return;
+    }
   }
 
-  // TODO: Handle wasCustomComponentTag
-  // const wasCustomComponentTag = isCustomComponent(tag, lastRawProps);
-  const isCustomComponentTag = isCustomComponent(tag, nextRawProps);
+  // TODO: Handle wasCustomComponentTag. Changing "is" isn't valid.
+  // const wasCustomComponentTag = isCustomComponent(tag, lastProps);
+  const isCustomComponentTag = isCustomComponent(tag, nextProps);
   // Apply the diff.
   for (let i = 0; i < updatePayload.length; i += 2) {
     const propKey = updatePayload[i];
@@ -933,27 +1068,8 @@ export function updateProperties(
       propKey,
       propValue,
       isCustomComponentTag,
-      nextRawProps,
+      nextProps,
     );
-  }
-
-  // TODO: Ensure that an update gets scheduled if any of the special props
-  // changed.
-  switch (tag) {
-    case 'input':
-      // Update the wrapper around inputs *after* updating props. This has to
-      // happen after `updateDOMProperties`. Otherwise HTML5 input validations
-      // raise warnings and prevent the new value from being assigned.
-      ReactDOMInputUpdateWrapper(domElement, nextRawProps);
-      break;
-    case 'textarea':
-      ReactDOMTextareaUpdateWrapper(domElement, nextRawProps);
-      break;
-    case 'select':
-      // <select> value update needs to occur after <option> children
-      // reconciliation
-      ReactDOMSelectPostUpdateWrapper(domElement, nextRawProps);
-      break;
   }
 }
 

--- a/packages/react-dom-bindings/src/client/ReactDOMInput.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMInput.js
@@ -15,19 +15,22 @@ import {getToStringValue, toString} from './ToStringValue';
 import {checkControlledValueProps} from '../shared/ReactControlledValuePropTypes';
 import {updateValueIfChanged} from './inputValueTracking';
 import getActiveElement from './getActiveElement';
-import assign from 'shared/assign';
 import {disableInputAttributeSyncing} from 'shared/ReactFeatureFlags';
 import {checkAttributeStringCoercion} from 'shared/CheckStringCoercion';
 
 import type {ToStringValue} from './ToStringValue';
 
-type InputWithWrapperState = HTMLInputElement & {
+export type InputWithWrapperState = HTMLInputElement & {
   _wrapperState: {
     initialValue: ToStringValue,
     initialChecked: ?boolean,
     controlled?: boolean,
     ...
   },
+  checked: boolean,
+  value: string,
+  defaultChecked: boolean,
+  defaultValue: string,
   ...
 };
 
@@ -57,20 +60,6 @@ function isControlled(props: any) {
  *
  * See http://www.w3.org/TR/2012/WD-html5-20121025/the-input-element.html
  */
-
-export function getHostProps(element: Element, props: Object): Object {
-  const node = ((element: any): InputWithWrapperState);
-  const checked = props.checked;
-
-  const hostProps = assign({}, props, {
-    defaultChecked: undefined,
-    defaultValue: undefined,
-    value: undefined,
-    checked: checked != null ? checked : node._wrapperState.initialChecked,
-  });
-
-  return hostProps;
-}
 
 export function initWrapperState(element: Element, props: Object) {
   if (__DEV__) {
@@ -114,7 +103,6 @@ export function initWrapperState(element: Element, props: Object) {
 
   const node = ((element: any): InputWithWrapperState);
   const defaultValue = props.defaultValue == null ? '' : props.defaultValue;
-
   node._wrapperState = {
     initialChecked:
       props.checked != null ? props.checked : props.defaultChecked,
@@ -312,15 +300,16 @@ export function postMountWrapper(
     node.name = '';
   }
 
-  if (disableInputAttributeSyncing) {
-    // When not syncing the checked attribute, the checked property
-    // never gets assigned. It must be manually set. We don't want
-    // to do this when hydrating so that existing user input isn't
-    // modified
-    if (!isHydrating) {
-      updateChecked(element, props);
-    }
+  // The checked property never gets assigned. It must be manually set.
+  // We don't want to do this when hydrating so that existing user input isn't
+  // modified
+  // TODO: I'm pretty sure this is a bug because initialValueTracking won't be
+  // correct for the hydration case then.
+  if (!isHydrating) {
+    node.checked = !!node._wrapperState.initialChecked;
+  }
 
+  if (disableInputAttributeSyncing) {
     // Only assign the checked attribute if it is defined. This saves
     // a DOM write when controlling the checked attribute isn't needed
     // (text inputs, submit/reset)

--- a/packages/react-dom-bindings/src/client/ReactDOMSelect.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMSelect.js
@@ -12,7 +12,6 @@ import {getCurrentFiberOwnerNameInDevOrNull} from 'react-reconciler/src/ReactCur
 
 import {checkControlledValueProps} from '../shared/ReactControlledValuePropTypes';
 import {getToStringValue, toString} from './ToStringValue';
-import assign from 'shared/assign';
 import isArray from 'shared/isArray';
 
 let didWarnValueDefaultValue;
@@ -129,12 +128,6 @@ function updateOptions(
  * If `defaultValue` is provided, any options with the supplied values will be
  * selected.
  */
-
-export function getHostProps(element: Element, props: Object): Object {
-  return assign({}, props, {
-    value: undefined,
-  });
-}
 
 export function initWrapperState(element: Element, props: Object) {
   const node = ((element: any): SelectWithWrapperState);

--- a/packages/react-dom-bindings/src/client/ReactDOMTextarea.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMTextarea.js
@@ -17,7 +17,7 @@ import {disableTextareaChildren} from 'shared/ReactFeatureFlags';
 
 let didWarnValDefaultVal = false;
 
-type TextAreaWithWrapperState = HTMLTextAreaElement & {
+export type TextAreaWithWrapperState = HTMLTextAreaElement & {
   _wrapperState: {initialValue: ToStringValue},
 };
 
@@ -36,31 +36,6 @@ type TextAreaWithWrapperState = HTMLTextAreaElement & {
  * The rendered element will be initialized with an empty value, the prop
  * `defaultValue` if specified, or the children content (deprecated).
  */
-
-export function getHostProps(element: Element, props: Object): Object {
-  const node = ((element: any): TextAreaWithWrapperState);
-
-  if (props.dangerouslySetInnerHTML != null) {
-    throw new Error(
-      '`dangerouslySetInnerHTML` does not make sense on <textarea>.',
-    );
-  }
-
-  // Always set children to the same thing. In IE9, the selection range will
-  // get reset if `textContent` is mutated.  We could add a check in setTextContent
-  // to only set the value if/when the value differs from the node value (which would
-  // completely solve this IE9 bug), but Sebastian+Sophie seemed to like this
-  // solution. The value can be a boolean or object so that's why it's forced
-  // to be a string.
-  const hostProps = {
-    ...props,
-    value: undefined,
-    defaultValue: undefined,
-    children: toString(node._wrapperState.initialValue),
-  };
-
-  return hostProps;
-}
 
 export function initWrapperState(element: Element, props: Object) {
   const node = ((element: any): TextAreaWithWrapperState);
@@ -120,8 +95,10 @@ export function initWrapperState(element: Element, props: Object) {
     initialValue = defaultValue;
   }
 
+  const stringValue = getToStringValue(initialValue);
+  node.defaultValue = (stringValue: any); // This will be toString:ed.
   node._wrapperState = {
-    initialValue: getToStringValue(initialValue),
+    initialValue: stringValue,
   };
 }
 

--- a/packages/react-dom/src/events/plugins/__tests__/ChangeEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/ChangeEventPlugin-test.js
@@ -133,6 +133,42 @@ describe('ChangeEventPlugin', () => {
     }
   });
 
+  it('should not invoke a change event for textarea same value', () => {
+    let called = 0;
+
+    function cb(e) {
+      called++;
+      expect(e.type).toBe('change');
+    }
+
+    const node = ReactDOM.render(
+      <textarea onChange={cb} defaultValue="initial" />,
+      container,
+    );
+    node.dispatchEvent(new Event('input', {bubbles: true, cancelable: true}));
+    node.dispatchEvent(new Event('change', {bubbles: true, cancelable: true}));
+    // There should be no React change events because the value stayed the same.
+    expect(called).toBe(0);
+  });
+
+  it('should not invoke a change event for textarea same value (capture)', () => {
+    let called = 0;
+
+    function cb(e) {
+      called++;
+      expect(e.type).toBe('change');
+    }
+
+    const node = ReactDOM.render(
+      <textarea onChangeCapture={cb} defaultValue="initial" />,
+      container,
+    );
+    node.dispatchEvent(new Event('input', {bubbles: true, cancelable: true}));
+    node.dispatchEvent(new Event('change', {bubbles: true, cancelable: true}));
+    // There should be no React change events because the value stayed the same.
+    expect(called).toBe(0);
+  });
+
   it('should consider initial checkbox checked=true to be current', () => {
     let called = 0;
 


### PR DESCRIPTION
I use a shared helper when setting properties into a helper whether it's initial or update.

I moved the special cases per tag to commit phase so we can check it only once. This also effectively inlines getHostProps which can be done in a single check per prop key.