### PR TITLE
Implement public instances for text nodes in Fabric

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -47,18 +47,22 @@ const {get: getViewConfigForType} = ReactNativeViewConfigRegistry;
 // This means that they never overlap.
 let nextReactTag = 2;
 
+type InternalInstanceHandle = Object;
 type Node = Object;
 export type Type = string;
 export type Props = Object;
 export type Instance = {
   // Reference to the shadow node.
   node: Node,
+  // This object is shared by all the clones of the instance.
+  // We use it to access their shared public instance (exposed through refs)
+  // and to access its committed state for events, etc.
   canonical: {
     nativeTag: number,
     viewConfig: ViewConfig,
     currentProps: Props,
     // Reference to the React handle (the fiber)
-    internalInstanceHandle: Object,
+    internalInstanceHandle: InternalInstanceHandle,
     // Exposed through refs.
     publicInstance: PublicInstance,
   },
@@ -115,7 +119,7 @@ export function createInstance(
   props: Props,
   rootContainerInstance: Container,
   hostContext: HostContext,
-  internalInstanceHandle: Object,
+  internalInstanceHandle: InternalInstanceHandle,
 ): Instance {
   const tag = nextReactTag;
   nextReactTag += 2;
@@ -162,7 +166,7 @@ export function createTextInstance(
   text: string,
   rootContainerInstance: Container,
   hostContext: HostContext,
-  internalInstanceHandle: Object,
+  internalInstanceHandle: InternalInstanceHandle,
 ): TextInstance {
   if (__DEV__) {
     if (!hostContext.isInAParentText) {
@@ -240,7 +244,7 @@ export function getPublicInstance(instance: Instance): null | PublicInstance {
 }
 
 export function getPublicInstanceFromInternalInstanceHandle(
-  internalInstanceHandle: Object,
+  internalInstanceHandle: InternalInstanceHandle,
 ): null | PublicInstance {
   const instance: Instance = internalInstanceHandle.stateNode;
   return getPublicInstance(instance);
@@ -321,7 +325,7 @@ export function cloneInstance(
   type: string,
   oldProps: Props,
   newProps: Props,
-  internalInstanceHandle: Object,
+  internalInstanceHandle: InternalInstanceHandle,
   keepChildren: boolean,
   recyclableInstance: null | Instance,
 ): Instance {
@@ -350,7 +354,7 @@ export function cloneHiddenInstance(
   instance: Instance,
   type: string,
   props: Props,
-  internalInstanceHandle: Object,
+  internalInstanceHandle: InternalInstanceHandle,
 ): Instance {
   const viewConfig = instance.canonical.viewConfig;
   const node = instance.node;
@@ -367,7 +371,7 @@ export function cloneHiddenInstance(
 export function cloneHiddenTextInstance(
   instance: Instance,
   text: string,
-  internalInstanceHandle: Object,
+  internalInstanceHandle: InternalInstanceHandle,
 ): TextInstance {
   throw new Error('Not yet implemented.');
 }
@@ -399,7 +403,9 @@ export function getInstanceFromNode(node: any): empty {
   throw new Error('Not yet implemented.');
 }
 
-export function beforeActiveInstanceBlur(internalInstanceHandle: Object) {
+export function beforeActiveInstanceBlur(
+  internalInstanceHandle: InternalInstanceHandle,
+) {
   // noop
 }
 

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -215,6 +215,7 @@ export type ReactNativeType = {
 export opaque type Node = mixed;
 export opaque type InternalInstanceHandle = mixed;
 type PublicInstance = mixed;
+type PublicTextInstance = mixed;
 
 export type ReactFabricType = {
   findHostInstance_DEPRECATED<TElementType: ElementType>(
@@ -244,7 +245,7 @@ export type ReactFabricType = {
   ): ?Node,
   getPublicInstanceFromInternalInstanceHandle(
     internalInstanceHandle: InternalInstanceHandle,
-  ): PublicInstance,
+  ): PublicInstance | PublicTextInstance,
   ...
 };
 

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -8,6 +8,7 @@
  */
 
 export opaque type PublicInstance = mixed;
+export opaque type PublicTextInstance = mixed;
 
 module.exports = {
   get BatchedBridge() {
@@ -54,5 +55,8 @@ module.exports = {
   },
   get createPublicInstance() {
     return require('./createPublicInstance').default;
+  },
+  get createPublicTextInstance() {
+    return require('./createPublicTextInstance').default;
   },
 };

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/createPublicTextInstance.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/createPublicTextInstance.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {PublicInstance} from './ReactNativePrivateInterface';
+
+export default function createPublicTextInstance(
+  internalInstanceHandle: mixed,
+): PublicInstance {
+  return {
+    __internalInstanceHandle: internalInstanceHandle,
+  };
+}

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -16,8 +16,6 @@ let ReactNativePrivateInterface;
 let createReactNativeComponentClass;
 let StrictMode;
 let act;
-let getNativeTagFromPublicInstance;
-let getNodeFromPublicInstance;
 
 const DISPATCH_COMMAND_REQUIRES_HOST_COMPONENT =
   "Warning: dispatchCommand was called with a ref that isn't a " +
@@ -44,11 +42,6 @@ describe('ReactFabric', () => {
     createReactNativeComponentClass =
       require('react-native/Libraries/ReactPrivate/ReactNativePrivateInterface')
         .ReactNativeViewConfigRegistry.register;
-    getNativeTagFromPublicInstance =
-      require('react-native/Libraries/ReactPrivate/ReactNativePrivateInterface').getNativeTagFromPublicInstance;
-    getNodeFromPublicInstance =
-      require('react-native/Libraries/ReactPrivate/ReactNativePrivateInterface').getNodeFromPublicInstance;
-
     act = require('internal-test-utils').act;
   });
 
@@ -939,7 +932,7 @@ describe('ReactFabric', () => {
         '\n    in RCTView (at **)' +
         '\n    in ContainsStrictModeChild (at **)',
     ]);
-    expect(match).toBe(getNativeTagFromPublicInstance(child));
+    expect(match).toBe(ReactNativePrivateInterface.getNativeTagFromPublicInstance(child));
   });
 
   it('findNodeHandle should warn if passed a component that is inside StrictMode', async () => {
@@ -976,7 +969,7 @@ describe('ReactFabric', () => {
         '\n    in RCTView (at **)' +
         '\n    in IsInStrictMode (at **)',
     ]);
-    expect(match).toBe(getNativeTagFromPublicInstance(child));
+    expect(match).toBe(ReactNativePrivateInterface.getNativeTagFromPublicInstance(child));
   });
 
   it('should no-op if calling sendAccessibilityEvent on unmounted refs', async () => {
@@ -1030,11 +1023,14 @@ describe('ReactFabric', () => {
       );
     });
 
+    const internalInstanceHandle = nativeFabricUIManager.createNode.mock.calls[0][4];
+    expect(internalInstanceHandle).toEqual(expect.any(Object));
+
     const expectedShadowNode =
       nativeFabricUIManager.createNode.mock.results[0].value;
     expect(expectedShadowNode).toEqual(expect.any(Object));
 
-    const node = getNodeFromPublicInstance(viewRef);
+    const node = ReactFabric.getNodeFromInternalInstanceHandle(internalInstanceHandle);
     expect(node).toBe(expectedShadowNode);
   });
 

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -932,7 +932,9 @@ describe('ReactFabric', () => {
         '\n    in RCTView (at **)' +
         '\n    in ContainsStrictModeChild (at **)',
     ]);
-    expect(match).toBe(ReactNativePrivateInterface.getNativeTagFromPublicInstance(child));
+    expect(match).toBe(
+      ReactNativePrivateInterface.getNativeTagFromPublicInstance(child),
+    );
   });
 
   it('findNodeHandle should warn if passed a component that is inside StrictMode', async () => {
@@ -969,7 +971,9 @@ describe('ReactFabric', () => {
         '\n    in RCTView (at **)' +
         '\n    in IsInStrictMode (at **)',
     ]);
-    expect(match).toBe(ReactNativePrivateInterface.getNativeTagFromPublicInstance(child));
+    expect(match).toBe(
+      ReactNativePrivateInterface.getNativeTagFromPublicInstance(child),
+    );
   });
 
   it('should no-op if calling sendAccessibilityEvent on unmounted refs', async () => {
@@ -1010,27 +1014,21 @@ describe('ReactFabric', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    let viewRef;
     await act(() => {
-      ReactFabric.render(
-        <View
-          foo="test"
-          ref={ref => {
-            viewRef = ref;
-          }}
-        />,
-        1,
-      );
+      ReactFabric.render(<View foo="test" />, 1);
     });
 
-    const internalInstanceHandle = nativeFabricUIManager.createNode.mock.calls[0][4];
+    const internalInstanceHandle =
+      nativeFabricUIManager.createNode.mock.calls[0][4];
     expect(internalInstanceHandle).toEqual(expect.any(Object));
 
     const expectedShadowNode =
       nativeFabricUIManager.createNode.mock.results[0].value;
     expect(expectedShadowNode).toEqual(expect.any(Object));
 
-    const node = ReactFabric.getNodeFromInternalInstanceHandle(internalInstanceHandle);
+    const node = ReactFabric.getNodeFromInternalInstanceHandle(
+      internalInstanceHandle,
+    );
     expect(node).toBe(expectedShadowNode);
   });
 
@@ -1053,10 +1051,14 @@ describe('ReactFabric', () => {
       );
     });
 
-    const internalInstanceHandle = nativeFabricUIManager.createNode.mock.calls[0][4];
+    const internalInstanceHandle =
+      nativeFabricUIManager.createNode.mock.calls[0][4];
     expect(internalInstanceHandle).toEqual(expect.any(Object));
 
-    const publicInstance = ReactFabric.getPublicInstanceFromInternalInstanceHandle(internalInstanceHandle);
+    const publicInstance =
+      ReactFabric.getPublicInstanceFromInternalInstanceHandle(
+        internalInstanceHandle,
+      );
     expect(publicInstance).toBe(viewRef);
   });
 
@@ -1069,26 +1071,35 @@ describe('ReactFabric', () => {
     }));
 
     await act(() => {
-      ReactFabric.render(
-        <RCTText>Text content</RCTText>,
-        1,
-      );
+      ReactFabric.render(<RCTText>Text content</RCTText>, 1);
     });
 
     // Access the internal instance handle used to create the text node.
-    const internalInstanceHandle = nativeFabricUIManager.createNode.mock.calls[0][4];
+    const internalInstanceHandle =
+      nativeFabricUIManager.createNode.mock.calls[0][4];
     expect(internalInstanceHandle).toEqual(expect.any(Object));
 
     // Text public instances should be created lazily.
-    expect(ReactNativePrivateInterface.createPublicTextInstance).not.toHaveBeenCalled();
+    expect(
+      ReactNativePrivateInterface.createPublicTextInstance,
+    ).not.toHaveBeenCalled();
 
-    const publicInstance = ReactFabric.getPublicInstanceFromInternalInstanceHandle(internalInstanceHandle);
+    const publicInstance =
+      ReactFabric.getPublicInstanceFromInternalInstanceHandle(
+        internalInstanceHandle,
+      );
 
     // We just requested the text public instance, so it should have been created at this point.
-    expect(ReactNativePrivateInterface.createPublicTextInstance).toHaveBeenCalledTimes(1);
-    expect(ReactNativePrivateInterface.createPublicTextInstance).toHaveBeenCalledWith(internalInstanceHandle);
+    expect(
+      ReactNativePrivateInterface.createPublicTextInstance,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      ReactNativePrivateInterface.createPublicTextInstance,
+    ).toHaveBeenCalledWith(internalInstanceHandle);
 
-    const expectedPublicInstance = ReactNativePrivateInterface.createPublicTextInstance.mock.results[0].value;
+    const expectedPublicInstance =
+      ReactNativePrivateInterface.createPublicTextInstance.mock.results[0]
+        .value;
     expect(publicInstance).toBe(expectedPublicInstance);
   });
 });

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -145,6 +145,7 @@ declare module 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface'
     ...
   };
   declare export opaque type PublicInstance;
+  declare export opaque type PublicTextInstance;
   declare export function getNodeFromPublicInstance(
     publicInstance: PublicInstance,
   ): Object;
@@ -156,6 +157,9 @@ declare module 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface'
     viewConfig: __ViewConfig,
     internalInstanceHandle: mixed,
   ): PublicInstance;
+  declare export function createPublicTextInstance(
+    internalInstanceHandle: mixed,
+  ): PublicTextInstance;
 }
 
 declare module 'react-native/Libraries/ReactPrivate/ReactNativePrivateInitializeCore' {


### PR DESCRIPTION
## Summary

This adds the ability to create public instances for text nodes in Fabric. The implementation for the public instances lives in React Native (as it does for host components after #26437). The logic here just handles their lazy instantiation when requested via `getPublicInstanceFromInternalInstanceHandle`, which is called by Fabric with information coming from the shadow tree.

It's important that the creation of public instances for text nodes is done lazily to avoid regressing memory usage when unused. Instances for text nodes are left intact if the public instance is never accessed.

This is necessary to implement access to text nodes in React Native as explained in https://github.com/react-native-community/discussions-and-proposals/pull/607

## How did you test this change?

Added unit tests (also fixed a test that was only testing the logic in a mock :S).