### PR TITLE
Add Circle CI API token to request header if available

### DIFF
--- a/scripts/release/shared-commands/download-build-artifacts.js
+++ b/scripts/release/shared-commands/download-build-artifacts.js
@@ -22,9 +22,15 @@ const run = async ({build, cwd, releaseChannel}) => {
   }
 
   // Download and extract artifact
+  const {CIRCLE_CI_API_TOKEN} = process.env;
+  let header = '';
+  // Add Circle CI API token to request header if available.
+  if (CIRCLE_CI_API_TOKEN != null) {
+    header = '-H "Circle-Token: ${CIRCLE_CI_API_TOKEN}" ';
+  }
   await exec(`rm -rf ./build`, {cwd});
   await exec(
-    `curl -L $(fwdproxy-config curl) ${buildArtifacts.url} | tar -xvz`,
+    `curl -L $(fwdproxy-config curl) ${buildArtifacts.url} ${header}| tar -xvz`,
     {
       cwd,
     }

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -59,8 +59,13 @@ const extractCommitFromVersionNumber = version => {
 };
 
 const getArtifactsList = async buildID => {
+  const headers = {};
+  const {CIRCLE_CI_API_TOKEN} = process.env;
+  if (CIRCLE_CI_API_TOKEN != null) {
+    headers['Circle-Token'] = CIRCLE_CI_API_TOKEN;
+  }
   const jobArtifactsURL = `https://circleci.com/api/v1.1/project/github/facebook/react/${buildID}/artifacts`;
-  const jobArtifacts = await fetch(jobArtifactsURL);
+  const jobArtifacts = await fetch(jobArtifactsURL, {headers});
   return jobArtifacts.json();
 };
 


### PR DESCRIPTION
Follow up of #26499
A Circle CI team member got back to me. It is indeed not necessary, but they had a regression not long ago on fetching without token.
https://discuss.circleci.com/t/is-api-token-required-when-fetching-artifacts/47606/5

To mitigate the impact of this kind of issues, let's add this token to requests' header when it's available.