### PR TITLE
Warn for ARIA typos on custom elements

### DIFF
--- a/packages/react-dom-bindings/src/shared/ReactDOMInvalidARIAHook.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMInvalidARIAHook.js
@@ -6,7 +6,6 @@
  */
 
 import {ATTRIBUTE_NAME_CHAR} from './isAttributeNameSafe';
-import isCustomComponent from './isCustomComponent';
 import validAriaProperties from './validAriaProperties';
 import hasOwnProperty from 'shared/hasOwnProperty';
 
@@ -76,7 +75,7 @@ function validateProperty(tagName, name) {
   return true;
 }
 
-function warnInvalidARIAProps(type, props) {
+export function validateProperties(type, props) {
   if (__DEV__) {
     const invalidProps = [];
 
@@ -107,11 +106,4 @@ function warnInvalidARIAProps(type, props) {
       );
     }
   }
-}
-
-export function validateProperties(type, props) {
-  if (isCustomComponent(type, props)) {
-    return;
-  }
-  warnInvalidARIAProps(type, props);
 }


### PR DESCRIPTION
Normally we allow any attribute/property on custom elements. However it's a shared namespace. The `aria-` namespace applies to all generic elements which are shared with custom elements. So arguably adding custom extensions there is a really bad idea since it can conflict with future additions.

It's possible there is a new standard one that's polyfilled by a custom element but the same issue applies to React in general that we might warn for very new additions so we just have to be quick on that.

cc @josepharhar 