### PR TITLE
Fix logic around attribute seralization

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
@@ -3928,6 +3928,10 @@ function writeStyleResourceAttributeInJS(
     // Attribute renames
     case 'className':
       attributeName = 'class';
+      if (__DEV__) {
+        checkAttributeStringCoercion(value, attributeName);
+      }
+      attributeValue = '' + (value: any);
       break;
 
     // Booleans
@@ -3941,33 +3945,32 @@ function writeStyleResourceAttributeInJS(
     // Santized URLs
     case 'src':
     case 'href': {
+      value = sanitizeURL(value);
       if (__DEV__) {
         checkAttributeStringCoercion(value, attributeName);
       }
-      value = sanitizeURL(value);
+      attributeValue = '' + (value: any);
       break;
     }
     default: {
+      if (
+        // shouldIgnoreAttribute
+        // We have already filtered out null/undefined and reserved words.
+        name.length > 2 &&
+        (name[0] === 'o' || name[0] === 'O') &&
+        (name[1] === 'n' || name[1] === 'N')
+      ) {
+        return;
+      }
       if (!isAttributeNameSafe(name)) {
         return;
       }
+      if (__DEV__) {
+        checkAttributeStringCoercion(value, attributeName);
+      }
+      attributeValue = '' + (value: any);
     }
   }
-
-  if (
-    // shouldIgnoreAttribute
-    // We have already filtered out null/undefined and reserved words.
-    name.length > 2 &&
-    (name[0] === 'o' || name[0] === 'O') &&
-    (name[1] === 'n' || name[1] === 'N')
-  ) {
-    return;
-  }
-
-  if (__DEV__) {
-    checkAttributeStringCoercion(value, attributeName);
-  }
-  attributeValue = '' + (value: any);
   writeChunk(destination, arrayInterstitial);
   writeChunk(
     destination,
@@ -4121,6 +4124,10 @@ function writeStyleResourceAttributeInAttr(
     // Attribute renames
     case 'className':
       attributeName = 'class';
+      if (__DEV__) {
+        checkAttributeStringCoercion(value, attributeName);
+      }
+      attributeValue = '' + (value: any);
       break;
 
     // Booleans
@@ -4134,33 +4141,32 @@ function writeStyleResourceAttributeInAttr(
     // Santized URLs
     case 'src':
     case 'href': {
+      value = sanitizeURL(value);
       if (__DEV__) {
         checkAttributeStringCoercion(value, attributeName);
       }
-      value = sanitizeURL(value);
+      attributeValue = '' + (value: any);
       break;
     }
     default: {
+      if (
+        // shouldIgnoreAttribute
+        // We have already filtered out null/undefined and reserved words.
+        name.length > 2 &&
+        (name[0] === 'o' || name[0] === 'O') &&
+        (name[1] === 'n' || name[1] === 'N')
+      ) {
+        return;
+      }
       if (!isAttributeNameSafe(name)) {
         return;
       }
+      if (__DEV__) {
+        checkAttributeStringCoercion(value, attributeName);
+      }
+      attributeValue = '' + (value: any);
     }
   }
-
-  if (
-    // shouldIgnoreAttribute
-    // We have already filtered out null/undefined and reserved words.
-    name.length > 2 &&
-    (name[0] === 'o' || name[0] === 'O') &&
-    (name[1] === 'n' || name[1] === 'N')
-  ) {
-    return;
-  }
-
-  if (__DEV__) {
-    checkAttributeStringCoercion(value, attributeName);
-  }
-  attributeValue = '' + (value: any);
   writeChunk(destination, arrayInterstitial);
   writeChunk(
     destination,


### PR DESCRIPTION
There was a bug in the attribute seralization for stylesheet resources injected by the Fizz runtime. For boolean properties the attribute value was set to an empty string but later immediately set to a string coerced value. This PR fixes that bug and refactors the code paths to be clearer