### PR TITLE
Allow transitions to interrupt Suspensey commits

### DIFF
--- a/packages/react-reconciler/src/ReactFiberRootScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberRootScheduler.js
@@ -18,7 +18,6 @@ import {
   SyncLane,
   getHighestPriorityLane,
   getNextLanes,
-  includesOnlyNonUrgentLanes,
   includesSyncLane,
   markStarvedLanesAsExpired,
 } from './ReactFiberLane';
@@ -292,14 +291,16 @@ function scheduleTaskForRootDuringMicrotask(
 
   const existingCallbackNode = root.callbackNode;
   if (
+    // Check if there's nothing to work on
     nextLanes === NoLanes ||
     // If this root is currently suspended and waiting for data to resolve, don't
     // schedule a task to render it. We'll either wait for a ping, or wait to
     // receive an update.
-    (isWorkLoopSuspendedOnData() && root === workInProgressRoot) ||
-    // We should only interrupt a pending commit if the new update
-    // is urgent.
-    (root.cancelPendingCommit !== null && includesOnlyNonUrgentLanes(nextLanes))
+    //
+    // Suspended render phase
+    (root === workInProgressRoot && isWorkLoopSuspendedOnData()) ||
+    // Suspended commit phase
+    root.cancelPendingCommit !== null
   ) {
     // Fast path: There's nothing to work on.
     if (existingCallbackNode !== null) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -725,8 +725,11 @@ export function scheduleUpdateOnFiber(
   // Check if the work loop is currently suspended and waiting for data to
   // finish loading.
   if (
-    workInProgressSuspendedReason === SuspendedOnData &&
-    root === workInProgressRoot
+    // Suspended render phase
+    (root === workInProgressRoot &&
+      workInProgressSuspendedReason === SuspendedOnData) ||
+    // Suspended commit phase
+    root.cancelPendingCommit !== null
   ) {
     // The incoming update might unblock the current render. Interrupt the
     // current attempt and restart from the top.

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseyCommitPhase-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseyCommitPhase-test.js
@@ -137,7 +137,7 @@ describe('ReactSuspenseyCommitPhase', () => {
     // Nothing showing yet.
     expect(root).toMatchRenderedOutput(null);
 
-    // If there's an urgent update, it should interrupt the suspended commit.
+    // If there's an update, it should interrupt the suspended commit.
     await act(() => {
       root.render(<Text text="Something else" />);
     });
@@ -145,7 +145,7 @@ describe('ReactSuspenseyCommitPhase', () => {
     expect(root).toMatchRenderedOutput('Something else');
   });
 
-  test('a non-urgent update does not interrupt a suspended commit', async () => {
+  test('a transition update interrupts a suspended commit', async () => {
     const root = ReactNoop.createRoot();
 
     // Mount an image. This transition will suspend because it's not inside a
@@ -159,26 +159,12 @@ describe('ReactSuspenseyCommitPhase', () => {
     // Nothing showing yet.
     expect(root).toMatchRenderedOutput(null);
 
-    // If there's another transition update, it should not interrupt the
-    // suspended commit.
+    // If there's an update, it should interrupt the suspended commit.
     await act(() => {
       startTransition(() => {
         root.render(<Text text="Something else" />);
       });
     });
-    // Still suspended.
-    expect(root).toMatchRenderedOutput(null);
-
-    await act(() => {
-      // Resolving the image should result in an immediate, synchronous commit.
-      resolveSuspenseyThing('A');
-      expect(root).toMatchRenderedOutput(<suspensey-thing src="A" />);
-    });
-    // Then the second transition is unblocked.
-    // TODO: Right now the only way to unsuspend a commit early is to proceed
-    // with the commit even if everything isn't ready. Maybe there should also
-    // be a way to abort a commit so that it can be interrupted by
-    // another transition.
     assertLog(['Something else']);
     expect(root).toMatchRenderedOutput('Something else');
   });


### PR DESCRIPTION
I originally made it so that a Suspensey commit — i.e. a commit that's waiting for a stylesheet, image, or font to load before proceeding — could not be interrupted by transitions. My reasoning was that Suspensey commits always time out after a short interval, anyway, so if the incoming update isn't urgent, it's better to wait to commit the current frame instead of throwing it away.

I don't think this rationale was correct, for a few reasons. There are some cases where we'll suspend for a longer duration, like stylesheets — it's nearly always a bad idea to show content before its styles have loaded, so we're going to be extend this timeout to be really long.

But even in the case where the timeout is shorter, like fonts, if you get a new update, it's possible (even likely) that update will allow us to avoid showing a fallback, like by navigating to a different page. So we might as well try.

The behavior now matches our behavior for interrupting a suspended render phase (i.e. `use`), which makes sense because they're not that conceptually different.