### PR TITLE
Failing test for effect unmount issue

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -358,6 +358,11 @@ function safelyCallDestroy(
   nearestMountedAncestor: Fiber | null,
   destroy: () => void,
 ) {
+  if (destroy.CALLED) {
+    throw new Error('CALLED');
+  }
+  destroy.CALLED = true;
+
   try {
     destroy();
   } catch (error) {

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1863,6 +1863,9 @@ function pushEffect(
   destroy: (() => void) | void,
   deps: Array<mixed> | void | null,
 ): Effect {
+  if (destroy && destroy.CALLED) {
+    throw new Error('CALLED ' + destroy.NAME);
+  }
   const effect: Effect = {
     tag,
     create,

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
@@ -445,5 +445,57 @@ Random seed is ${SEED}
         </React.Suspense>,
       );
     });
+
+    it('6', async () => {
+      const {Text, Container, testResolvedOutput} = createFuzzer();
+      try {
+        await testResolvedOutput(
+          <React.Fragment>
+            <Text
+              initialDelay={0}
+              text="A"
+              updates={[
+                {
+                  beginAfter: 0,
+                  suspendFor: 1,
+                },
+              ]}
+            />
+            <Container
+              name="X"
+              updates={[
+                {
+                  remountAfter: 0,
+                },
+                {
+                  remountAfter: 0,
+                },
+              ]}>
+              <Container
+                name="Y"
+                updates={[
+                  {
+                    remountAfter: 0,
+                  },
+                ]}>
+                <Text
+                  initialDelay={0}
+                  text="B"
+                  updates={[
+                    {
+                      beginAfter: 0,
+                      suspendFor: 1,
+                    },
+                  ]}
+                />
+              </Container>
+            </Container>
+          </React.Fragment>,
+        );
+      } catch (e) {
+        console.log(Scheduler.unstable_clearLog());
+        throw e;
+      }
+    });
   });
 });


### PR DESCRIPTION
## Overview

This test fails because an effect destroy function is called twice. 

Note: the component that calls destroy twice is the top most Container component (with name="x")

The Scheduler log is:

```
      '[A:0]',
      '[B:0]',
      '[A:1]',
      '[B:0]',
      '[B:0]',
      '[B:1]',
      '[A:0]',
      '[B:0]',
      'Suspended! [[A:1]]',
      'Promise resolved [[A:1]]',
      'Promise resolved [[A:1]]',
      '[A:1]',
      '[B:0]',
      '[A:1]',
      '[B:0]',
      'Suspended! [[B:1]]',
      'Promise resolved [[B:1]]',
      'Promise resolved [[B:1]]',
      '[B:1]',
      '[A:1]',
      '[A:1]'
```

If it helps, I also added additional logging for the containers and effects:

```
'[A:0]',
      '[B:0]',
      'Text [A] mounted',
      'Text [B] mounted',
      'Remount children of Y after 0ms',
      'Remount children of X after 0ms',
      'Remount children of X after 0ms',
      '[A:1]',
      '[B:0]',
      'Text [B] unmounted',
      'Text [B] mounted',
      'Remount children of Y after 0ms',
      '[B:0]',
      'Text [B] unmounted',
      'Text [B] mounted',
      '[B:1]',
      '[A:0]',
      '[B:0]',
      'Text [A] mounted',
      'Text [B] mounted',
      'Remount children of Y after 0ms',
      'Remount children of X after 0ms',
      'Remount children of X after 0ms',
      'Suspended! [[A:1]]',
      'Promise resolved [[A:1]]',
      'Text [A] unmounted',
      'Text [B] unmounted',
      'Promise resolved [[A:1]]',
      '[A:1]',
      '[B:0]',
      'Text [A] mounted',
      'Text [B] mounted',
      'Remount children of Y after 0ms',
      'Remount children of X after 0ms',
      'Remount children of X after 0ms',
      '[A:1]',
      '[B:0]',
      'Text [B] unmounted',
      'Text [B] mounted',
      'Suspended! [[B:1]]',
      'Promise resolved [[B:1]]',
      'Text [A] unmounted',
      'Text [B] unmounted',
      'Promise resolved [[B:1]]',
      '[B:1]',
      'Text [A] mounted',
      'Text [B] mounted',
      'Remount children of Y after 0ms',
      'Remount children of X after 0ms',
      'Remount children of X after 0ms',
      '[A:1]',
      '[A:1]',
      'Text [A] unmounted',
      'Text [B] unmounted'
```

