### PR TITLE
fix[devtools]: use native clipboard api instead of clipboard-js

### DIFF
--- a/packages/react-devtools-extensions/firefox/manifest.json
+++ b/packages/react-devtools-extensions/firefox/manifest.json
@@ -6,7 +6,7 @@
   "applications": {
     "gecko": {
       "id": "@react-devtools",
-      "strict_min_version": "55.0"
+      "strict_min_version": "63.0"
     }
   },
   "icons": {

--- a/packages/react-devtools-shared/package.json
+++ b/packages/react-devtools-shared/package.json
@@ -17,7 +17,6 @@
     "@babel/traverse": "^7.12.5",
     "@reach/menu-button": "^0.16.1",
     "@reach/tooltip": "^0.16.0",
-    "clipboard-js": "^0.3.6",
     "compare-versions": "^5.0.3",
     "json5": "^2.1.3",
     "local-storage-fallback": "^4.1.1",

--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -33,12 +33,10 @@ if (compactConsole) {
 }
 
 beforeEach(() => {
+  // Storing this mock, so it can be accessed to reset its state
+  // Used inside inspectElement-test
   global.mockClipboardCopy = jest.fn();
-
-  // Test environment doesn't support document methods like execCommand()
-  // Also once the backend components below have been required,
-  // it's too late for a test to mock the clipboard-js modules.
-  jest.mock('clipboard-js', () => ({copy: global.mockClipboardCopy}));
+  global.navigator.clipboard = {writeText: global.mockClipboardCopy};
 
   // These files should be required (and re-required) before each test,
   // rather than imported at the head of the module.

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -14,20 +14,22 @@ import {
   ElementTypeHostComponent,
   ElementTypeOtherOrUnknown,
 } from 'react-devtools-shared/src/types';
-import {getUID, utfEncodeString, printOperationsArray} from '../../utils';
 import {
   cleanForBridge,
-  copyToClipboard,
   copyWithDelete,
   copyWithRename,
   copyWithSet,
-} from '../utils';
+} from 'react-devtools-shared/src/backend/utils';
 import {
   deletePathInObject,
   getDisplayName,
   getInObject,
-  renamePathInObject,
+  serializeAndCopyToClipboard,
   setInObject,
+  renamePathInObject,
+  getUID,
+  utfEncodeString,
+  printOperationsArray,
 } from 'react-devtools-shared/src/utils';
 import {
   __DEBUG__,
@@ -704,7 +706,7 @@ export function attach(
   function copyElementPath(id: number, path: Array<string | number>): void {
     const inspectedElement = inspectElementRaw(id);
     if (inspectedElement !== null) {
-      copyToClipboard(getInObject(inspectedElement, path));
+      serializeAndCopyToClipboard(getInObject(inspectedElement, path));
     }
   }
 

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -34,19 +34,20 @@ import {
   getInObject,
   getUID,
   renamePathInObject,
+  serializeAndCopyToClipboard,
   setInObject,
   utfEncodeString,
 } from 'react-devtools-shared/src/utils';
 import {sessionStorageGetItem} from 'react-devtools-shared/src/storage';
-import {gt, gte} from 'react-devtools-shared/src/backend/utils';
 import {
   cleanForBridge,
-  copyToClipboard,
   copyWithDelete,
   copyWithRename,
   copyWithSet,
+  gt,
+  gte,
   getEffectDurations,
-} from './utils';
+} from 'react-devtools-shared/src/backend/utils';
 import {
   __DEBUG__,
   PROFILING_FLAG_BASIC_SUPPORT,
@@ -3546,7 +3547,7 @@ export function attach(
 
   function copyElementPath(id: number, path: Array<string | number>): void {
     if (isMostRecentlyInspectedElement(id)) {
-      copyToClipboard(
+      serializeAndCopyToClipboard(
         getInObject(
           ((mostRecentlyInspectedElement: any): InspectedElement),
           path,

--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -8,7 +8,6 @@
  * @flow
  */
 
-import {copy} from 'clipboard-js';
 import {compareVersions} from 'compare-versions';
 import {dehydrate} from '../hydration';
 import isArray from 'shared/isArray';
@@ -38,23 +37,6 @@ export function cleanForBridge(
     };
   } else {
     return null;
-  }
-}
-
-export function copyToClipboard(value: any): void {
-  const safeToCopy = serializeToString(value);
-  const text = safeToCopy === undefined ? 'undefined' : safeToCopy;
-  const {clipboardCopyText} = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-
-  // On Firefox navigator.clipboard.writeText has to be called from
-  // the content script js code (because it requires the clipboardWrite
-  // permission to be allowed out of a "user handling" callback),
-  // clipboardCopyText is an helper injected into the page from.
-  // injectGlobalHook.
-  if (typeof clipboardCopyText === 'function') {
-    clipboardCopyText(text).catch(err => {});
-  } else {
-    copy(text);
   }
 }
 
@@ -141,23 +123,6 @@ export function getEffectDurations(root: Object): {
     }
   }
   return {effectDuration, passiveEffectDuration};
-}
-
-export function serializeToString(data: any): string {
-  const cache = new Set<mixed>();
-  // Use a custom replacer function to protect against circular references.
-  return JSON.stringify(data, (key, value) => {
-    if (typeof value === 'object' && value !== null) {
-      if (cache.has(value)) {
-        return;
-      }
-      cache.add(value);
-    }
-    if (typeof value === 'bigint') {
-      return value.toString() + 'n';
-    }
-    return value;
-  });
 }
 
 // Formats an array of args with a style for console methods, using

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContextTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContextTree.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import {copy} from 'clipboard-js';
 import * as React from 'react';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
@@ -19,6 +18,7 @@ import {
   ElementTypeClass,
   ElementTypeFunction,
 } from 'react-devtools-shared/src/types';
+import {copyToClipboard} from 'react-devtools-shared/src/utils';
 
 import type {InspectedElement} from './types';
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
@@ -48,7 +48,7 @@ export default function InspectedElementContextTree({
 
   const isEmpty = entries === null || entries.length === 0;
 
-  const handleCopy = () => copy(serializeDataForCopy(((context: any): Object)));
+  const handleCopy = () => copyToClipboard(serializeDataForCopy(context));
 
   // We add an object with a "value" key as a wrapper around Context data
   // so that we can use the shared <KeyValue> component to display it.

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementHooksTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementHooksTree.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import {copy} from 'clipboard-js';
 import * as React from 'react';
 import {useCallback, useContext, useRef, useState} from 'react';
 import {BridgeContext, StoreContext} from '../context';
@@ -28,6 +27,7 @@ import {
 } from 'react-devtools-feature-flags';
 import HookNamesModuleLoaderContext from 'react-devtools-shared/src/devtools/views/Components/HookNamesModuleLoaderContext';
 import isArray from 'react-devtools-shared/src/isArray';
+import {copyToClipboard} from 'react-devtools-shared/src/utils';
 
 import type {InspectedElement} from './types';
 import type {HooksNode, HooksTree} from 'react-debug-tools/src/ReactDebugHooks';
@@ -79,7 +79,7 @@ export function InspectedElementHooksTree({
     toggleTitle = 'Parse hook names (may be slow)';
   }
 
-  const handleCopy = () => copy(serializeHooksForCopy(hooks));
+  const handleCopy = () => copyToClipboard(serializeHooksForCopy(hooks));
 
   if (hooks === null) {
     return null;

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementPropsTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementPropsTree.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import {copy} from 'clipboard-js';
 import * as React from 'react';
 import {OptionsContext} from '../context';
 import Button from '../Button';
@@ -18,6 +17,7 @@ import {alphaSortEntries, serializeDataForCopy} from '../utils';
 import Store from '../../store';
 import styles from './InspectedElementSharedStyles.css';
 import {ElementTypeClass} from 'react-devtools-shared/src/types';
+import {copyToClipboard} from 'react-devtools-shared/src/utils';
 
 import type {InspectedElement} from './types';
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
@@ -59,8 +59,7 @@ export default function InspectedElementPropsTree({
   }
 
   const isEmpty = entries === null || entries.length === 0;
-
-  const handleCopy = () => copy(serializeDataForCopy(((props: any): Object)));
+  const handleCopy = () => copyToClipboard(serializeDataForCopy(props));
 
   return (
     <div

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementStateTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementStateTree.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import {copy} from 'clipboard-js';
 import * as React from 'react';
 import {ElementTypeHostComponent} from 'react-devtools-shared/src/types';
 import Button from '../Button';
@@ -16,6 +15,7 @@ import KeyValue from './KeyValue';
 import {alphaSortEntries, serializeDataForCopy} from '../utils';
 import Store from '../../store';
 import styles from './InspectedElementSharedStyles.css';
+import {copyToClipboard} from 'react-devtools-shared/src/utils';
 
 import type {InspectedElement} from './types';
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
@@ -50,7 +50,7 @@ export default function InspectedElementStateTree({
     entries.sort(alphaSortEntries);
   }
 
-  const handleCopy = () => copy(serializeDataForCopy(((state: any): Object)));
+  const handleCopy = () => copyToClipboard(serializeDataForCopy(state));
 
   return (
     <div className={styles.InspectedElementTree}>

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import {copy} from 'clipboard-js';
 import * as React from 'react';
 import {Fragment, useCallback, useContext} from 'react';
 import {TreeDispatcherContext} from './TreeContext';
@@ -34,6 +33,7 @@ import {
 } from 'react-devtools-shared/src/backendAPI';
 import {enableStyleXFeatures} from 'react-devtools-feature-flags';
 import {logEvent} from 'react-devtools-shared/src/Logger';
+import {copyToClipboard} from 'react-devtools-shared/src/utils';
 
 import styles from './InspectedElementView.css';
 
@@ -260,7 +260,7 @@ type SourceProps = {
 };
 
 function Source({fileName, lineNumber}: SourceProps) {
-  const handleCopy = () => copy(`${fileName}:${lineNumber}`);
+  const handleCopy = () => copyToClipboard(`${fileName}:${lineNumber}`);
   return (
     <div className={styles.Source} data-testname="InspectedElementView-Source">
       <div className={styles.SourceHeaderRow}>

--- a/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/StyleEditor.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/StyleEditor.js
@@ -10,11 +10,11 @@
 import * as React from 'react';
 import {useContext, useMemo, useRef, useState} from 'react';
 import {unstable_batchedUpdates as batchedUpdates} from 'react-dom';
-import {copy} from 'clipboard-js';
 import {
   BridgeContext,
   StoreContext,
 } from 'react-devtools-shared/src/devtools/views/context';
+import {copyToClipboard} from 'react-devtools-shared/src/utils';
 import Button from '../../Button';
 import ButtonIcon from '../../ButtonIcon';
 import {serializeDataForCopy} from '../../utils';
@@ -63,7 +63,7 @@ export default function StyleEditor({id, style}: Props): React.Node {
 
   const keys = useMemo(() => Array.from(Object.keys(style)), [style]);
 
-  const handleCopy = () => copy(serializeDataForCopy(style));
+  const handleCopy = () => copyToClipboard(serializeDataForCopy(style));
 
   return (
     <div className={styles.StyleEditor}>

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarEventInfo.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarEventInfo.js
@@ -21,7 +21,7 @@ import {
   getSchedulingEventLabel,
 } from 'react-devtools-timeline/src/utils/formatting';
 import {stackToComponentSources} from 'react-devtools-shared/src/devtools/utils';
-import {copy} from 'clipboard-js';
+import {copyToClipboard} from 'react-devtools-shared/src/utils';
 
 import styles from './SidebarEventInfo.css';
 
@@ -58,7 +58,7 @@ function SchedulingEventInfo({eventInfo}: SchedulingEventProps) {
               <div className={styles.Row}>
                 <label className={styles.Label}>Rendered by</label>
                 <Button
-                  onClick={() => copy(componentStack)}
+                  onClick={() => copyToClipboard(componentStack)}
                   title="Copy component stack to clipboard">
                   <ButtonIcon type="copy" />
                 </Button>

--- a/packages/react-devtools-shared/src/devtools/views/UnsupportedBridgeProtocolDialog.js
+++ b/packages/react-devtools-shared/src/devtools/views/UnsupportedBridgeProtocolDialog.js
@@ -14,8 +14,8 @@ import {StoreContext} from './context';
 import {currentBridgeProtocol} from 'react-devtools-shared/src/bridge';
 import Button from './Button';
 import ButtonIcon from './ButtonIcon';
-import {copy} from 'clipboard-js';
 import styles from './UnsupportedBridgeProtocolDialog.css';
+import {copyToClipboard} from 'react-devtools-shared/src/utils';
 
 import type {BridgeProtocol} from 'react-devtools-shared/src/bridge';
 
@@ -82,7 +82,7 @@ function DialogContent({
         <pre className={styles.NpmCommand}>
           {upgradeInstructions}
           <Button
-            onClick={() => copy(upgradeInstructions)}
+            onClick={() => copyToClipboard(upgradeInstructions)}
             title="Copy upgrade command to clipboard">
             <ButtonIcon type="copy" />
           </Button>
@@ -99,7 +99,7 @@ function DialogContent({
         <pre className={styles.NpmCommand}>
           {downgradeInstructions}
           <Button
-            onClick={() => copy(downgradeInstructions)}
+            onClick={() => copyToClipboard(downgradeInstructions)}
             title="Copy downgrade command to clipboard">
             <ButtonIcon type="copy" />
           </Button>

--- a/packages/react-devtools-timeline/package.json
+++ b/packages/react-devtools-timeline/package.json
@@ -5,7 +5,6 @@
   "license": "MIT",
   "dependencies": {
     "@elg/speedscope": "1.9.0-a6f84db",
-    "clipboard-js": "^0.3.6",
     "memoize-one": "^5.1.1",
     "nullthrows": "^1.1.1",
     "pretty-ms": "^7.0.0",

--- a/packages/react-devtools-timeline/src/CanvasPage.js
+++ b/packages/react-devtools-timeline/src/CanvasPage.js
@@ -26,7 +26,6 @@ import {
   useCallback,
 } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import {copy} from 'clipboard-js';
 import prettyMilliseconds from 'pretty-ms';
 
 import {
@@ -60,6 +59,7 @@ import {RegistryContext} from 'react-devtools-shared/src/devtools/ContextMenu/Co
 import ContextMenu from 'react-devtools-shared/src/devtools/ContextMenu/ContextMenu';
 import ContextMenuItem from 'react-devtools-shared/src/devtools/ContextMenu/ContextMenuItem';
 import useContextMenu from 'react-devtools-shared/src/devtools/ContextMenu/useContextMenu';
+import {copyToClipboard} from 'react-devtools-shared/src/utils';
 import {getBatchRange} from './utils/getBatchRange';
 import {MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL} from './view-base/constants';
 import {TimelineSearchContext} from './TimelineSearchContext';
@@ -98,7 +98,7 @@ const copySummary = (data: TimelineData, measure: ReactMeasure) => {
 
   const [startTime, stopTime] = getBatchRange(batchUID, data);
 
-  copy(
+  copyToClipboard(
     JSON.stringify({
       type,
       timestamp: prettyMilliseconds(timestamp),
@@ -741,28 +741,30 @@ function AutoSizedCanvas({
             <Fragment>
               {componentMeasure !== null && (
                 <ContextMenuItem
-                  onClick={() => copy(componentMeasure.componentName)}
+                  onClick={() =>
+                    copyToClipboard(componentMeasure.componentName)
+                  }
                   title="Copy component name">
                   Copy component name
                 </ContextMenuItem>
               )}
               {networkMeasure !== null && (
                 <ContextMenuItem
-                  onClick={() => copy(networkMeasure.url)}
+                  onClick={() => copyToClipboard(networkMeasure.url)}
                   title="Copy URL">
                   Copy URL
                 </ContextMenuItem>
               )}
               {schedulingEvent !== null && (
                 <ContextMenuItem
-                  onClick={() => copy(schedulingEvent.componentName)}
+                  onClick={() => copyToClipboard(schedulingEvent.componentName)}
                   title="Copy component name">
                   Copy component name
                 </ContextMenuItem>
               )}
               {suspenseEvent !== null && (
                 <ContextMenuItem
-                  onClick={() => copy(suspenseEvent.componentName)}
+                  onClick={() => copyToClipboard(suspenseEvent.componentName)}
                   title="Copy component name">
                   Copy component name
                 </ContextMenuItem>
@@ -785,7 +787,9 @@ function AutoSizedCanvas({
               )}
               {flamechartStackFrame !== null && (
                 <ContextMenuItem
-                  onClick={() => copy(flamechartStackFrame.scriptUrl)}
+                  onClick={() =>
+                    copyToClipboard(flamechartStackFrame.scriptUrl)
+                  }
                   title="Copy file path">
                   Copy file path
                 </ContextMenuItem>
@@ -793,7 +797,7 @@ function AutoSizedCanvas({
               {flamechartStackFrame !== null && (
                 <ContextMenuItem
                   onClick={() =>
-                    copy(
+                    copyToClipboard(
                       `line ${
                         flamechartStackFrame.locationLine ?? ''
                       }, column ${flamechartStackFrame.locationColumn ?? ''}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5394,11 +5394,6 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
   integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
 
-clipboard-js@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/clipboard-js/-/clipboard-js-0.3.6.tgz#6260add69b5318fde40b80f9d3c8c863efdaf339"
-  integrity sha512-hyrmvbrYCeRBHdiR3KrEz0tmrUTXXEU8HLeGW0Y0icUSwYmAsmc+d6wfE4EDb/TxZmAVJG0eTfMlulCIT+ecfw==
-
 cliui@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/26500

## Summary
- Bumping min version for Firefox to 63, the version in which Clipboard API is fully supported
- Using Clipboard API instead of `clipboard-js` lib

## How did you test this change?
- Tested electron app
- Tested `react-devtools-inline` app


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204324267013502