### PR TITLE
Testing: remove resetModules() where it doesn't cause errors

### DIFF
--- a/fixtures/dom/src/__tests__/nested-act-test.js
+++ b/fixtures/dom/src/__tests__/nested-act-test.js
@@ -18,7 +18,6 @@ expect.extend(require('../toWarnDev'));
 
 describe('unmocked scheduler', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     DOMAct = require('react-dom/test-utils').act;
     TestRenderer = require('react-test-renderer');
@@ -56,7 +55,6 @@ describe('unmocked scheduler', () => {
 
 describe('mocked scheduler', () => {
   beforeEach(() => {
-    jest.resetModules();
     jest.mock('scheduler', () =>
       require.requireActual('scheduler/unstable_mock')
     );

--- a/packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js
@@ -34,8 +34,6 @@ describe('React hooks DevTools integration', () => {
       onCommitFiberUnmount: () => {},
     };
 
-    jest.resetModules();
-
     React = require('react');
     ReactDebugTools = require('react-debug-tools');
     ReactTestRenderer = require('react-test-renderer');

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -15,7 +15,6 @@ let ReactDebugTools;
 
 describe('ReactHooksInspection', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDebugTools = require('react-debug-tools');
   });

--- a/packages/react-devtools-shared/src/__tests__/FastRefreshDevToolsIntegration-test.js
+++ b/packages/react-devtools-shared/src/__tests__/FastRefreshDevToolsIntegration-test.js
@@ -19,9 +19,7 @@ describe('Fast Refresh', () => {
   let store;
   let withErrorsOrWarningsIgnored;
 
-  afterEach(() => {
-    jest.resetModules();
-  });
+  afterEach(() => {});
 
   beforeEach(() => {
     exportsObj = undefined;

--- a/packages/react-devtools-shared/src/__tests__/console-test.js
+++ b/packages/react-devtools-shared/src/__tests__/console-test.js
@@ -784,8 +784,6 @@ describe('console', () => {
 
 describe('console error', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     const Console = require('react-devtools-shared/src/backend/console');
     patchConsole = Console.patch;
     unpatchConsole = Console.unpatch;

--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -173,5 +173,4 @@ afterEach(() => {
   // Without this, ReactDOM won't re-inject itself into the new hook.
   // It's also important to reset after tests, rather than before,
   // so that we don't disconnect the ReactCurrentDispatcher ref.
-  jest.resetModules();
 });

--- a/packages/react-devtools-shared/src/hooks/__tests__/parseHookNames-test.js
+++ b/packages/react-devtools-shared/src/hooks/__tests__/parseHookNames-test.js
@@ -48,8 +48,6 @@ describe('parseHookNames', () => {
   let parseHookNames;
 
   beforeEach(() => {
-    jest.resetModules();
-
     jest.mock('source-map-support', () => {
       console.trace('source-map-support');
     });
@@ -941,7 +939,6 @@ describe('parseHookNames worker', () => {
     window.Worker = true;
 
     // Reset module so mocked worker instance can be updated.
-    jest.resetModules();
     parseHookNames = require('../parseHookNames').parseHookNames;
 
     await getHookNamesForComponent(Component);

--- a/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
@@ -20,7 +20,6 @@ describe('DOMPropertyOperations', () => {
   let ReactDOM;
 
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
   });

--- a/packages/react-dom/src/__tests__/InvalidEventListeners-test.js
+++ b/packages/react-dom/src/__tests__/InvalidEventListeners-test.js
@@ -17,7 +17,6 @@ describe('InvalidEventListeners', () => {
   let container;
 
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
 

--- a/packages/react-dom/src/__tests__/ReactBrowserEventEmitter-test.js
+++ b/packages/react-dom/src/__tests__/ReactBrowserEventEmitter-test.js
@@ -43,7 +43,6 @@ let container;
 // It should probably be rewritten but we're keeping it for some extra coverage.
 describe('ReactBrowserEventEmitter', () => {
   beforeEach(() => {
-    jest.resetModules();
     LISTENER.mockClear();
 
     React = require('react');

--- a/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
+++ b/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
@@ -17,8 +17,6 @@ let ReactTestUtils;
 
 describe('ReactChildReconciler', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactTestUtils = require('react-dom/test-utils');
   });

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -61,7 +61,6 @@ describe('ReactCompositeComponent', () => {
   }
 
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
     ReactCurrentOwner =

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -16,7 +16,6 @@ let ReactTestUtils;
 
 describe('ReactDOM', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
@@ -374,7 +373,6 @@ describe('ReactDOM', () => {
         onCommitFiberUnmount: function () {},
         supportsFiber: true,
       };
-      jest.resetModules();
       React = require('react');
       ReactDOM = require('react-dom');
       class Component extends React.Component {

--- a/packages/react-dom/src/__tests__/ReactDOMConsoleErrorReporting-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMConsoleErrorReporting-test.js
@@ -20,7 +20,6 @@ describe('ReactDOMConsoleErrorReporting', () => {
   let waitForThrow;
 
   beforeEach(() => {
-    jest.resetModules();
     act = require('internal-test-utils').act;
     React = require('react');
     ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
@@ -7,25 +7,25 @@
 
 'use strict';
 
+let React;
+let OuterReactDOM;
+let InnerReactDOM;
+let container;
+
+window.TextEvent = function () {};
+jest.isolateModules(() => {
+  React = require('react');
+  OuterReactDOM = require('react-dom');
+});
+jest.isolateModules(() => {
+  InnerReactDOM = require('react-dom');
+});
+
+test('separate React instances', () => {
+  expect(OuterReactDOM).not.toBe(InnerReactDOM);
+});
+
 describe('ReactDOMEventListener', () => {
-  let React;
-  let OuterReactDOM;
-  let InnerReactDOM;
-  let container;
-
-  beforeEach(() => {
-    window.TextEvent = function () {};
-    jest.resetModules();
-    jest.isolateModules(() => {
-      React = require('react');
-      OuterReactDOM = require('react-dom');
-    });
-    jest.isolateModules(() => {
-      InnerReactDOM = require('react-dom');
-    });
-    expect(OuterReactDOM).not.toBe(InnerReactDOM);
-  });
-
   afterEach(() => {
     cleanup();
   });

--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
@@ -27,7 +27,6 @@ describe('ReactDOMFiberAsync', () => {
   let container;
 
   beforeEach(() => {
-    jest.resetModules();
     container = document.createElement('div');
     React = require('react');
     ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -20,7 +20,6 @@ let Suspense;
 
 describe('ReactDOMFizzServerBrowser', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOMFizzServer = require('react-dom/server.browser');
     Suspense = React.Suspense;

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -17,7 +17,6 @@ let Suspense;
 
 describe('ReactDOMFizzServerNode', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOMFizzServer = require('react-dom/server');
     Stream = require('stream');

--- a/packages/react-dom/src/__tests__/ReactDOMFizzShellHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzShellHydration-test.js
@@ -27,7 +27,6 @@ let assertLog;
 
 describe('ReactDOMFizzShellHydration', () => {
   beforeEach(() => {
-    jest.resetModules();
     JSDOM = require('jsdom').JSDOM;
     React = require('react');
     ReactDOMClient = require('react-dom/client');

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStatic-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStatic-test.js
@@ -26,7 +26,6 @@ let fatalError = undefined;
 
 describe('ReactDOMFizzStatic', () => {
   beforeEach(() => {
-    jest.resetModules();
     JSDOM = require('jsdom').JSDOM;
     React = require('react');
     ReactDOMClient = require('react-dom/client');

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
@@ -20,7 +20,6 @@ let Suspense;
 
 describe('ReactDOMFizzStaticBrowser', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     if (__EXPERIMENTAL__) {
       ReactDOMFizzStatic = require('react-dom/static.browser');

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticNode-test.js
@@ -16,7 +16,6 @@ let Suspense;
 
 describe('ReactDOMFizzStaticNode', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     if (__EXPERIMENTAL__) {
       ReactDOMFizzStatic = require('react-dom/static');

--- a/packages/react-dom/src/__tests__/ReactDOMHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHooks-test.js
@@ -19,8 +19,6 @@ describe('ReactDOMHooks', () => {
   let container;
 
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMClient = require('react-dom/client');

--- a/packages/react-dom/src/__tests__/ReactDOMImageLoad-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMImageLoad-test.internal.js
@@ -90,7 +90,6 @@ function loadImage(element) {
 
 describe('ReactDOMImageLoad', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     Scheduler = require('scheduler');
     // ReactCache = require('react-cache');

--- a/packages/react-dom/src/__tests__/ReactDOMInReactServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInReactServer-test.js
@@ -11,7 +11,6 @@
 
 describe('ReactDOMInReactServer', () => {
   beforeEach(() => {
-    jest.resetModules();
     jest.mock('react', () => require('react/react.shared-subset'));
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMNativeEventHeuristic-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMNativeEventHeuristic-test.js
@@ -22,7 +22,6 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
   let container;
 
   beforeEach(() => {
-    jest.resetModules();
     container = document.createElement('div');
     React = require('react');
     ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactDOMNestedEvents-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMNestedEvents-test.js
@@ -18,7 +18,6 @@ describe('ReactDOMNestedEvents', () => {
   let assertLog;
 
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOMClient = require('react-dom/client');
     Scheduler = require('scheduler');

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -24,7 +24,6 @@ describe('ReactDOMRoot', () => {
   let container;
 
   beforeEach(() => {
-    jest.resetModules();
     container = document.createElement('div');
     React = require('react');
     ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -20,7 +20,6 @@ let ReactDOMServer;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationCheckbox-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationCheckbox-test.js
@@ -21,7 +21,6 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationInput-test.js
@@ -21,7 +21,6 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContext-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContext-test.js
@@ -20,7 +20,6 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModules();
   PropTypes = require('prop-types');
   React = require('react');
   ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationReconnecting-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationReconnecting-test.js
@@ -18,7 +18,6 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModules();
 
   React = require('react');
   ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationRefs-test.js
@@ -18,7 +18,6 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUserInteraction-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUserInteraction-test.js
@@ -18,7 +18,6 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
@@ -21,7 +21,6 @@ let SuspenseList;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModules();
 
   React = require('react');
   ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactDOMShorthandCSSPropertyCollision-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMShorthandCSSPropertyCollision-test.js
@@ -14,7 +14,6 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
   let ReactDOM;
 
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
   });

--- a/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
@@ -26,7 +26,6 @@ let waitForAll;
 
 describe('ReactDOM HostSingleton', () => {
   beforeEach(() => {
-    jest.resetModules();
     JSDOM = require('jsdom').JSDOM;
     React = require('react');
     ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.js
@@ -20,7 +20,6 @@ describe('ReactDOMSuspensePlaceholder', () => {
   let container;
 
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
     Scheduler = require('scheduler');

--- a/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.js
@@ -28,8 +28,6 @@ describe('ReactDOMTestSelectors', () => {
   let container;
 
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     act = React.unstable_act;
 

--- a/packages/react-dom/src/__tests__/ReactEmptyComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactEmptyComponent-test.js
@@ -18,8 +18,6 @@ let log;
 
 describe('ReactEmptyComponent', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactDOM = require('react-dom');
     ReactTestUtils = require('react-dom/test-utils');

--- a/packages/react-dom/src/__tests__/ReactErrorBoundariesHooks-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundariesHooks-test.internal.js
@@ -14,7 +14,6 @@ let ReactDOM;
 
 describe('ReactErrorBoundariesHooks', () => {
   beforeEach(() => {
-    jest.resetModules();
     ReactDOM = require('react-dom');
     React = require('react');
   });

--- a/packages/react-dom/src/__tests__/ReactEventIndependence-test.js
+++ b/packages/react-dom/src/__tests__/ReactEventIndependence-test.js
@@ -14,8 +14,6 @@ let ReactDOM;
 
 describe('ReactEventIndependence', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactDOM = require('react-dom');
   });

--- a/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
@@ -20,7 +20,6 @@ function FunctionComponent(props) {
 
 describe('ReactFunctionComponent', () => {
   beforeEach(() => {
-    jest.resetModules();
     PropTypes = require('prop-types');
     React = require('react');
     ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactIdentity-test.js
+++ b/packages/react-dom/src/__tests__/ReactIdentity-test.js
@@ -15,7 +15,6 @@ let ReactTestUtils;
 
 describe('ReactIdentity', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
     ReactTestUtils = require('react-dom/test-utils');

--- a/packages/react-dom/src/__tests__/ReactLegacyContextDisabled-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyContextDisabled-test.internal.js
@@ -16,8 +16,6 @@ let ReactFeatureFlags;
 
 describe('ReactLegacyContextDisabled', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
@@ -37,7 +37,6 @@ describe('ReactLegacyErrorBoundaries', () => {
   let Normal;
 
   beforeEach(() => {
-    jest.resetModules();
     PropTypes = require('prop-types');
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;

--- a/packages/react-dom/src/__tests__/ReactLegacyRootWarnings-test.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyRootWarnings-test.js
@@ -4,7 +4,6 @@ describe('ReactDOMRoot', () => {
   let container;
 
   beforeEach(() => {
-    jest.resetModules();
     container = document.createElement('div');
     ReactDOM = require('react-dom');
   });

--- a/packages/react-dom/src/__tests__/ReactMultiChild-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChild-test.js
@@ -14,7 +14,6 @@ describe('ReactMultiChild', () => {
   let ReactDOM;
 
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
   });

--- a/packages/react-dom/src/__tests__/ReactMultiChildReconcile-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChildReconcile-test.js
@@ -287,9 +287,7 @@ function testPropsSequence(sequence) {
 }
 
 describe('ReactMultiChildReconcile', () => {
-  beforeEach(() => {
-    jest.resetModules();
-  });
+  beforeEach(() => {});
 
   it('should reset internal state if removed then readded in an array', () => {
     // Test basics.

--- a/packages/react-dom/src/__tests__/ReactServerRenderingBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingBrowser-test.js
@@ -16,11 +16,9 @@ let ReactDOMServerBrowser;
 
 describe('ReactServerRenderingBrowser', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOMServer = require('react-dom/server');
     // For extra isolation between what would be two bundles on npm
-    jest.resetModules();
     ReactDOMServerBrowser = require('react-dom/server.browser');
   });
 

--- a/packages/react-dom/src/__tests__/ReactTestUtilsActUnmockedScheduler-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsActUnmockedScheduler-test.js
@@ -32,7 +32,6 @@ function unmount(dom) {
 }
 
 beforeEach(() => {
-  jest.resetModules();
   jest.unmock('scheduler');
   yields = [];
   React = require('react');

--- a/packages/react-dom/src/__tests__/escapeTextForBrowser-test.js
+++ b/packages/react-dom/src/__tests__/escapeTextForBrowser-test.js
@@ -14,7 +14,6 @@ let ReactDOMServer;
 
 describe('escapeTextForBrowser', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOMServer = require('react-dom/server');
   });

--- a/packages/react-dom/src/__tests__/quoteAttributeValueForBrowser-test.js
+++ b/packages/react-dom/src/__tests__/quoteAttributeValueForBrowser-test.js
@@ -14,7 +14,6 @@ let ReactDOMServer;
 
 describe('quoteAttributeValueForBrowser', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOMServer = require('react-dom/server');
   });

--- a/packages/react-dom/src/__tests__/refs-destruction-test.js
+++ b/packages/react-dom/src/__tests__/refs-destruction-test.js
@@ -17,8 +17,6 @@ let TestComponent;
 
 describe('refs-destruction', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactDOM = require('react-dom');
     ReactTestUtils = require('react-dom/test-utils');

--- a/packages/react-dom/src/__tests__/refs-test.js
+++ b/packages/react-dom/src/__tests__/refs-test.js
@@ -21,7 +21,6 @@ describe('reactiverefs', () => {
   let container;
 
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
@@ -216,7 +215,6 @@ if (!ReactFeatureFlags.disableModulePatternComponents) {
 describe('ref swapping', () => {
   let RefHopsAround;
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
@@ -522,7 +520,6 @@ describe('strings refs across renderers', () => {
     class Indirection extends React.Component {
       componentDidUpdate() {
         // One ref is being rendered later using another renderer copy.
-        jest.resetModules();
         const AnotherCopyOfReactDOM = require('react-dom');
         AnotherCopyOfReactDOM.render(this.props.child2, div2);
       }

--- a/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
+++ b/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
@@ -18,7 +18,6 @@ describe('when Trusted Types are available in global object', () => {
   let ttObject2;
 
   beforeEach(() => {
-    jest.resetModules();
     container = document.createElement('div');
     const fakeTTObjects = new Set();
     window.trustedTypes = {

--- a/packages/react-dom/src/events/__tests__/SyntheticFocusEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticFocusEvent-test.js
@@ -13,7 +13,6 @@ describe('SyntheticFocusEvent', () => {
   let container;
 
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
 

--- a/packages/react-dom/src/events/plugins/__tests__/ChangeEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/ChangeEventPlugin-test.js
@@ -38,7 +38,6 @@ describe('ChangeEventPlugin', () => {
   let container;
 
   beforeEach(() => {
-    jest.resetModules();
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
     // TODO pull this into helper method, reduce repetition.
     // mock the browser APIs which are used in schedule:

--- a/packages/react-dom/src/events/plugins/__tests__/EnterLeaveEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/EnterLeaveEventPlugin-test.js
@@ -16,8 +16,6 @@ describe('EnterLeaveEventPlugin', () => {
   let container;
 
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactDOM = require('react-dom');
 

--- a/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
@@ -39,7 +39,6 @@ describe('SimpleEventPlugin', function () {
   }
 
   beforeEach(function () {
-    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMClient = require('react-dom/client');
@@ -239,8 +238,6 @@ describe('SimpleEventPlugin', function () {
 
   describe('interactive events, in concurrent mode', () => {
     beforeEach(() => {
-      jest.resetModules();
-
       React = require('react');
       ReactDOM = require('react-dom');
       ReactDOMClient = require('react-dom/client');

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -16,8 +16,6 @@ let SuspenseList;
 
 describe('ReactIs', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactDOM = require('react-dom');
     ReactIs = require('react-is');

--- a/packages/react-native-renderer/src/__tests__/ReactNativeError-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeError-test.internal.js
@@ -26,8 +26,6 @@ function normalizeCodeLocInfo(str) {
 
 describe('ReactNativeError', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNative = require('react-native-renderer');
     createReactNativeComponentClass =

--- a/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
@@ -24,8 +24,6 @@ describe('DebugTracing', () => {
   global.IS_REACT_ACT_ENVIRONMENT = true;
 
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactTestRenderer = require('react-test-renderer');
     const InternalTestUtils = require('internal-test-utils');

--- a/packages/react-reconciler/src/__tests__/ErrorBoundaryReconciliation-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ErrorBoundaryReconciliation-test.internal.js
@@ -9,8 +9,6 @@ describe('ErrorBoundaryReconciliation', () => {
   let act;
 
   beforeEach(() => {
-    jest.resetModules();
-
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
     ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;

--- a/packages/react-reconciler/src/__tests__/ReactBatching-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactBatching-test.internal.js
@@ -10,7 +10,6 @@ let TextResource;
 
 describe('ReactBlockingMode', () => {
   beforeEach(() => {
-    jest.resetModules();
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
     ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;

--- a/packages/react-reconciler/src/__tests__/ReactCPUSuspense-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactCPUSuspense-test.js
@@ -15,8 +15,6 @@ let waitForPaint;
 
 describe('ReactSuspenseWithNoopRenderer', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactCache-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactCache-test.js
@@ -18,8 +18,6 @@ let seededCache;
 
 describe('ReactCache', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Cache = React.unstable_Cache;

--- a/packages/react-reconciler/src/__tests__/ReactClassSetStateCallback-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactClassSetStateCallback-test.js
@@ -6,8 +6,6 @@ let assertLog;
 
 describe('ReactClassSetStateCallback', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactConcurrentErrorRecovery-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactConcurrentErrorRecovery-test.js
@@ -12,8 +12,6 @@ let seededCache;
 
 describe('ReactConcurrentErrorRecovery', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
@@ -13,8 +13,6 @@ let assertLog;
 
 describe('ReactLazyContextPropagation', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
@@ -20,8 +20,6 @@ let waitForPaint;
 
 describe('ReactDeferredValue', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactEffectOrdering-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactEffectOrdering-test.js
@@ -22,7 +22,6 @@ let assertLog;
 
 describe('ReactEffectOrdering', () => {
   beforeEach(() => {
-    jest.resetModules();
     jest.useFakeTimers();
 
     React = require('react');

--- a/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
@@ -18,7 +18,6 @@ let DefaultEventPriority;
 
 describe('ReactFiberHostContext', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     act = React.unstable_act;
     ReactFiberReconciler = require('react-reconciler');

--- a/packages/react-reconciler/src/__tests__/ReactFlushSync-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFlushSync-test.js
@@ -12,8 +12,6 @@ let waitForPaint;
 
 describe('ReactFlushSync', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactFlushSyncNoAggregateError-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFlushSyncNoAggregateError-test.js
@@ -11,8 +11,6 @@ let flushFakeMicrotasks;
 
 describe('ReactFlushSync (AggregateError not available)', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     global.AggregateError = undefined;
 
     // When AggregateError is not available, the errors are rethrown in a

--- a/packages/react-reconciler/src/__tests__/ReactFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFragment-test.js
@@ -15,8 +15,6 @@ let waitForAll;
 
 describe('ReactFragment', () => {
   beforeEach(function () {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
 

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
@@ -21,7 +21,6 @@ let assertLog;
 
 describe('ReactIncremental', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');
@@ -2718,7 +2717,6 @@ describe('ReactIncremental', () => {
 
     // First, verify that this code path normally receives Fibers as keys,
     // and that they're not extensible.
-    jest.resetModules();
     let receivedNonExtensibleObjects;
     // eslint-disable-next-line no-extend-native
     Map.prototype.set = function (key) {
@@ -2753,7 +2751,6 @@ describe('ReactIncremental', () => {
 
     // Next, verify that a Map polyfill that "writes" to keys
     // doesn't cause a failure.
-    jest.resetModules();
     // eslint-disable-next-line no-extend-native
     Map.prototype.set = function (key, value) {
       if (typeof key === 'object' && key !== null) {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
@@ -18,7 +18,6 @@ let waitForThrow;
 
 describe('ReactIncrementalErrorLogging', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.js
@@ -17,7 +17,6 @@ let waitForThrow;
 
 describe('ReactIncrementalErrorReplay', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactNoop = require('react-noop-renderer');
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
@@ -18,8 +18,6 @@ let waitForAll;
 
 describe('ReactIncrementalReflection', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
@@ -21,8 +21,6 @@ let assertLog;
 
 describe('ReactIncrementalUpdates', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdatesMinimalism-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdatesMinimalism-test.js
@@ -16,7 +16,6 @@ let act;
 
 describe('ReactIncrementalUpdatesMinimalism', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactNoop = require('react-noop-renderer');
 

--- a/packages/react-reconciler/src/__tests__/ReactInterleavedUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactInterleavedUpdates-test.js
@@ -11,8 +11,6 @@ let waitForPaint;
 
 describe('ReactInterleavedUpdates', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
@@ -16,8 +16,6 @@ let assertLog;
 
 describe('ReactOffscreen', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactOffscreenStrictMode-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreenStrictMode-test.js
@@ -6,7 +6,6 @@ let log;
 
 describe('ReactOffscreenStrictMode', () => {
   beforeEach(() => {
-    jest.resetModules();
     log = [];
 
     React = require('react');

--- a/packages/react-reconciler/src/__tests__/ReactPersistent-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactPersistent-test.js
@@ -16,8 +16,6 @@ let waitForAll;
 
 describe('ReactPersistent', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoopPersistent = require('react-noop-renderer/persistent');
     const InternalTestUtils = require('internal-test-utils');

--- a/packages/react-reconciler/src/__tests__/ReactPersistentUpdatesMinimalism-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactPersistentUpdatesMinimalism-test.js
@@ -16,7 +16,6 @@ let act;
 
 describe('ReactPersistentUpdatesMinimalism', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactNoopPersistent = require('react-noop-renderer/persistent');
     act = require('internal-test-utils').act;

--- a/packages/react-reconciler/src/__tests__/ReactSubtreeFlagsWarning-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSubtreeFlagsWarning-test.js
@@ -12,8 +12,6 @@ let assertLog;
 
 describe('ReactSuspenseWithNoopRenderer', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -13,7 +13,6 @@ let waitFor;
 
 describe('ReactSuspense', () => {
   beforeEach(() => {
-    jest.resetModules();
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
     ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemanticsDOM-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemanticsDOM-test.js
@@ -21,8 +21,6 @@ let fakeModuleCache;
 
 describe('ReactSuspenseEffectsSemanticsDOM', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMClient = require('react-dom/client');

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseFallback-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseFallback-test.js
@@ -17,8 +17,6 @@ let waitForAll;
 
 describe('ReactSuspenseFallback', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
@@ -20,7 +20,6 @@ function prettyFormat(thing) {
 
 describe('ReactSuspenseFuzz', () => {
   beforeEach(() => {
-    jest.resetModules();
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
     ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;

--- a/packages/react-reconciler/src/__tests__/ReactTopLevelFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTopLevelFragment-test.js
@@ -18,7 +18,6 @@ let waitForAll;
 // probably move to one of the other test files once it is official.
 describe('ReactTopLevelFragment', function () {
   beforeEach(function () {
-    jest.resetModules();
     React = require('react');
     ReactNoop = require('react-noop-renderer');
 

--- a/packages/react-reconciler/src/__tests__/ReactTopLevelText-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTopLevelText-test.js
@@ -18,7 +18,6 @@ let waitForAll;
 // probably move to one of the other test files once it is official.
 describe('ReactTopLevelText', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactNoop = require('react-noop-renderer');
 

--- a/packages/react-reconciler/src/__tests__/ReactTransition-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransition-test.js
@@ -30,7 +30,6 @@ let seededCache;
 
 describe('ReactTransition', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactUpdatePriority-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUpdatePriority-test.js
@@ -12,8 +12,6 @@ let assertLog;
 
 describe('ReactUpdatePriority', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
+++ b/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
@@ -17,7 +17,6 @@ let assertLog;
 
 describe('StrictEffectsMode', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactTestRenderer = require('react-test-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/useMemoCache-test.js
+++ b/packages/react-reconciler/src/__tests__/useMemoCache-test.js
@@ -18,8 +18,6 @@ let ErrorBoundary;
 
 describe('useMemoCache()', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     act = require('internal-test-utils').act;

--- a/packages/react-reconciler/src/__tests__/useSyncExternalStore-test.js
+++ b/packages/react-reconciler/src/__tests__/useSyncExternalStore-test.js
@@ -31,8 +31,6 @@ let assertLog;
 // React DOM versions (16, 17, etc) instead of React Noop.
 describe('useSyncExternalStore', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-server-dom-relay/src/__tests__/ReactDOMServerFB-test.internal.js
+++ b/packages/react-server-dom-relay/src/__tests__/ReactDOMServerFB-test.internal.js
@@ -15,7 +15,6 @@ let Suspense;
 
 describe('ReactDOMServerFB', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOMServer = require('../ReactDOMServerFB');
     Suspense = React.Suspense;

--- a/packages/react-server-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
+++ b/packages/react-server-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
@@ -17,8 +17,6 @@ let SuspenseList;
 
 describe('ReactFlightDOMRelay', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     act = require('internal-test-utils').act;
     React = require('react');
     ReactDOMClient = require('react-dom/client');

--- a/packages/react-server/src/__tests__/ReactServer-test.js
+++ b/packages/react-server/src/__tests__/ReactServer-test.js
@@ -15,8 +15,6 @@ let ReactNoopServer;
 
 describe('ReactServer', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactNoopServer = require('react-noop-renderer/server');
   });

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -17,7 +17,6 @@ const ReactTestRenderer = require('react-test-renderer');
 const {format: prettyFormat} = require('pretty-format');
 
 // Isolate noop renderer
-jest.resetModules();
 const ReactNoop = require('react-noop-renderer');
 
 const InternalTestUtils = require('internal-test-utils');

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererAct-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererAct-test.js
@@ -8,7 +8,6 @@ let assertLog;
 
 describe('ReactTestRenderer.act()', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactTestRenderer = require('react-test-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
@@ -18,8 +18,6 @@ let waitFor;
 
 describe('ReactTestRendererAsync', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactTestRenderer = require('react-test-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
@@ -19,7 +19,6 @@ const View = props => <RCTView {...props} />;
 
 describe('ReactTestRendererTraversal', () => {
   beforeEach(() => {
-    jest.resetModules();
     ReactTestRenderer = require('react-test-renderer');
     Context = React.createContext(null);
   });

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -14,7 +14,6 @@ describe('ReactChildren', () => {
   let ReactTestUtils;
 
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactTestUtils = require('react-dom/test-utils');
   });

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -23,8 +23,6 @@ let ReactTestUtils;
 
 describe('ReactContextValidator', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     PropTypes = require('prop-types');
     React = require('react');
     ReactDOM = require('react-dom');

--- a/packages/react/src/__tests__/ReactCreateRef-test.js
+++ b/packages/react/src/__tests__/ReactCreateRef-test.js
@@ -14,8 +14,6 @@ let ReactTestRenderer;
 
 describe('ReactCreateRef', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactTestRenderer = require('react-test-renderer');
   });

--- a/packages/react/src/__tests__/ReactFetch-test.js
+++ b/packages/react/src/__tests__/ReactFetch-test.js
@@ -39,7 +39,6 @@ let cache;
 
 describe('ReactFetch', () => {
   beforeEach(() => {
-    jest.resetModules();
     fetchCount = 0;
     global.fetch = fetchMock;
 

--- a/packages/react/src/__tests__/ReactFetchEdge-test.js
+++ b/packages/react/src/__tests__/ReactFetchEdge-test.js
@@ -44,7 +44,6 @@ let use;
 
 describe('ReactFetch', () => {
   beforeEach(() => {
-    jest.resetModules();
     fetchCount = 0;
     global.fetch = fetchMock;
 

--- a/packages/react/src/__tests__/ReactJSXElement-test.js
+++ b/packages/react/src/__tests__/ReactJSXElement-test.js
@@ -17,8 +17,6 @@ describe('ReactJSXElement', () => {
   let Component;
 
   beforeEach(() => {
-    jest.resetModules();
-
     React = require('react');
     ReactDOM = require('react-dom');
     ReactTestUtils = require('react-dom/test-utils');

--- a/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
@@ -28,8 +28,6 @@ describe('ReactProfiler DevTools integration', () => {
       supportsFiber: true,
     };
 
-    jest.resetModules();
-
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.enableProfilerTimer = true;
     Scheduler = require('scheduler');

--- a/packages/react/src/__tests__/ReactStartTransition-test.js
+++ b/packages/react/src/__tests__/ReactStartTransition-test.js
@@ -19,7 +19,6 @@ const SUSPICIOUS_NUMBER_OF_FIBERS_UPDATED = 10;
 
 describe('ReactStartTransition', () => {
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactTestRenderer = require('react-test-renderer');
     act = require('internal-test-utils').act;

--- a/packages/react/src/__tests__/ReactStrictMode-test.internal.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.internal.js
@@ -15,7 +15,6 @@ describe('ReactStrictMode', () => {
   let act;
 
   beforeEach(() => {
-    jest.resetModules();
     React = require('react');
     ReactDOMClient = require('react-dom/client');
 

--- a/packages/react/src/__tests__/forwardRef-test.internal.js
+++ b/packages/react/src/__tests__/forwardRef-test.internal.js
@@ -17,7 +17,6 @@ describe('forwardRef', () => {
   let waitForAll;
 
   beforeEach(() => {
-    jest.resetModules();
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
     ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;

--- a/packages/scheduler/src/__tests__/SchedulerSetTimeout-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerSetTimeout-test.js
@@ -20,7 +20,6 @@ describe('SchedulerNoDOM', () => {
   // Scheduler falls back to a naive implementation using setTimeout.
   // This is only meant to be used for testing purposes, like with jest's fake timer API.
   beforeEach(() => {
-    jest.resetModules();
     jest.useFakeTimers();
     delete global.setImmediate;
     delete global.MessageChannel;
@@ -100,7 +99,6 @@ describe('SchedulerNoDOM', () => {
 // See: https://github.com/facebook/react/pull/13088
 describe('does not crash non-node SSR environments', () => {
   it('if setTimeout is undefined', () => {
-    jest.resetModules();
     const originalSetTimeout = global.setTimeout;
     try {
       delete global.setTimeout;
@@ -114,7 +112,6 @@ describe('does not crash non-node SSR environments', () => {
   });
 
   it('if clearTimeout is undefined', () => {
-    jest.resetModules();
     const originalClearTimeout = global.clearTimeout;
     try {
       delete global.clearTimeout;

--- a/packages/scheduler/src/__tests__/SchedulerUMDBundle-test.internal.js
+++ b/packages/scheduler/src/__tests__/SchedulerUMDBundle-test.internal.js
@@ -20,7 +20,6 @@ describe('Scheduling UMD bundle', () => {
     // Fool SECRET_INTERNALS object into including UMD forwarding methods.
     global.__UMD__ = true;
 
-    jest.resetModules();
     jest.unmock('scheduler');
 
     global.MessageChannel = MockMessageChannel;

--- a/packages/shared/ReactVersion.js
+++ b/packages/shared/ReactVersion.js
@@ -1,16 +1,1 @@
-/**
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-// TODO: this is special because it gets imported during build.
-//
-// TODO: 18.0.0 has not been released to NPM;
-// It exists as a placeholder so that DevTools can support work tag changes between releases.
-// When we next publish a release, update the matching TODO in backend/renderer.js
-// TODO: This module is used both by the release scripts and to expose a version
-// at runtime. We should instead inject the version number as part of the build
-// process, and use the ReactVersions.js module as the single source of truth.
-export default '18.2.0';
+export default '18.3.0-PLACEHOLDER';

--- a/packages/shared/__tests__/ReactDOMFrameScheduling-test.js
+++ b/packages/shared/__tests__/ReactDOMFrameScheduling-test.js
@@ -11,8 +11,6 @@
 
 describe('ReactDOMFrameScheduling', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     jest.unmock('scheduler');
   });
 
@@ -23,7 +21,6 @@ describe('ReactDOMFrameScheduling', () => {
     try {
       // Simulate the Node environment:
       delete global.window;
-      jest.resetModules();
       expect(() => {
         require('react-dom');
       }).not.toThrow();

--- a/packages/shared/__tests__/ReactError-test.internal.js
+++ b/packages/shared/__tests__/ReactError-test.internal.js
@@ -25,7 +25,6 @@ describe('ReactError', () => {
       global.Error = globalErrorMock.OriginalError;
       expect(typeof global.Error).toBe('function');
     }
-    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
   });

--- a/packages/shared/__tests__/ReactErrorProd-test.internal.js
+++ b/packages/shared/__tests__/ReactErrorProd-test.internal.js
@@ -12,7 +12,6 @@ let formatProdErrorMessage;
 
 describe('ReactErrorProd', () => {
   beforeEach(() => {
-    jest.resetModules();
     formatProdErrorMessage = require('shared/formatProdErrorMessage').default;
   });
 

--- a/packages/use-subscription/src/__tests__/useSubscription-test.js
+++ b/packages/use-subscription/src/__tests__/useSubscription-test.js
@@ -22,7 +22,6 @@ let waitFor;
 
 describe('useSubscription', () => {
   beforeEach(() => {
-    jest.resetModules();
     jest.mock('scheduler', () => require('scheduler/unstable_mock'));
 
     useSubscription = require('use-subscription').useSubscription;

--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreNative-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreNative-test.js
@@ -23,8 +23,6 @@ let assertLog;
 // (Node) environment
 describe('useSyncExternalStore (userspace shim, server rendering)', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     // Remove useSyncExternalStore from the React imports so that we use the
     // shim instead. Also removing startTransition, since we use that to detect
     // outdated 18 alphas that don't yet include useSyncExternalStore.

--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShimServer-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShimServer-test.js
@@ -22,8 +22,6 @@ let assertLog;
 // (Node) environment
 describe('useSyncExternalStore (userspace shim, server rendering)', () => {
   beforeEach(() => {
-    jest.resetModules();
-
     // Remove useSyncExternalStore from the React imports so that we use the
     // shim instead. Also removing startTransition, since we use that to detect
     // outdated 18 alphas that don't yet include useSyncExternalStore.


### PR DESCRIPTION
This PR simply removes `jest.removeModules()` in all tests where it doesn't cause errors. I suspect this might speed up tests.

A benefit besides speed is that accidental top level requires are not creating references to a different instance to other modules anymore.

A downside is that tests are less isolated.

Created this PR by simply removing all `jest.resetModules()` running all tests and reverting the failing ones.