### PR TITLE
Remove revertRemovalOfSiblingPrerendering killswitch

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -2577,6 +2577,10 @@ function unwindUnitOfWork(unitOfWork: Fiber): void {
       returnFiber.deletions = null;
     }
 
+    // NOTE: If we re-enable sibling prerendering in some cases, here we
+    // would switch to the normal completion path: check if a sibling
+    // exists, and if so, begin work on it.
+
     // Otherwise, return to the parent
     // $FlowFixMe[incompatible-type] we bail out when we get a null
     incompleteWork = returnFiber;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -38,7 +38,6 @@ import {
   enableCache,
   enableTransitionTracing,
   useModernStrictMode,
-  revertRemovalOfSiblingPrerendering,
   disableLegacyContext,
 } from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -2467,28 +2466,14 @@ function completeUnitOfWork(unitOfWork: Fiber): void {
   // sibling. If there are no more siblings, return to the parent fiber.
   let completedWork: Fiber = unitOfWork;
   do {
-    if (revertRemovalOfSiblingPrerendering) {
+    if (__DEV__) {
       if ((completedWork.flags & Incomplete) !== NoFlags) {
-        // This fiber did not complete, because one of its children did not
-        // complete. Switch to unwinding the stack instead of completing it.
-        //
-        // The reason "unwind" and "complete" is interleaved is because when
-        // something suspends, we continue rendering the siblings even though
-        // they will be replaced by a fallback.
-        // TODO: Disable sibling prerendering, then remove this branch.
-        unwindUnitOfWork(completedWork);
-        return;
-      }
-    } else {
-      if (__DEV__) {
-        if ((completedWork.flags & Incomplete) !== NoFlags) {
-          // NOTE: If we re-enable sibling prerendering in some cases, this branch
-          // is where we would switch to the unwinding path.
-          console.error(
-            'Internal React error: Expected this fiber to be complete, but ' +
-              "it isn't. It should have been unwound. This is a bug in React.",
-          );
-        }
+        // NOTE: If we re-enable sibling prerendering in some cases, this branch
+        // is where we would switch to the unwinding path.
+        console.error(
+          'Internal React error: Expected this fiber to be complete, but ' +
+            "it isn't. It should have been unwound. This is a bug in React.",
+        );
       }
     }
 
@@ -2590,25 +2575,6 @@ function unwindUnitOfWork(unitOfWork: Fiber): void {
       returnFiber.flags |= Incomplete;
       returnFiber.subtreeFlags = NoFlags;
       returnFiber.deletions = null;
-    }
-
-    if (revertRemovalOfSiblingPrerendering) {
-      // If there are siblings, work on them now even though they're going to be
-      // replaced by a fallback. We're "prerendering" them. Historically our
-      // rationale for this behavior has been to initiate any lazy data requests
-      // in the siblings, and also to warm up the CPU cache.
-      // TODO: Don't prerender siblings. With `use`, we suspend the work loop
-      // until the data has resolved, anyway.
-      const siblingFiber = incompleteWork.sibling;
-      if (siblingFiber !== null) {
-        // This branch will return us to the normal work loop.
-        workInProgress = siblingFiber;
-        return;
-      }
-    } else {
-      // NOTE: If we re-enable sibling prerendering in some cases, this branch
-      // is where we would switch to the normal completion path: check if a
-      // sibling exists, and if so, begin work on it.
     }
 
     // Otherwise, return to the parent

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -22,11 +22,6 @@ export const enableComponentStackLocations = true;
 // when it rolls out to prod. We should remove these as soon as possible.
 // -----------------------------------------------------------------------------
 
-// This is phrased as a negative so that if someone forgets to add a GK, the
-// default is to enable the feature. It should only be overridden if there's
-// a regression in prod.
-export const revertRemovalOfSiblingPrerendering = false;
-
 // -----------------------------------------------------------------------------
 // Land or remove (moderate effort)
 //

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -43,7 +43,6 @@ export const enableScopeAPI = false;
 export const enableCreateEventHandleAPI = false;
 export const enableSuspenseCallback = false;
 export const disableLegacyContext = false;
-export const revertRemovalOfSiblingPrerendering = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
 export const disableModulePatternComponents = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -32,7 +32,6 @@ export const enableScopeAPI = false;
 export const enableCreateEventHandleAPI = false;
 export const enableSuspenseCallback = false;
 export const disableLegacyContext = false;
-export const revertRemovalOfSiblingPrerendering = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
 export const disableModulePatternComponents = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -32,7 +32,6 @@ export const enableScopeAPI = false;
 export const enableCreateEventHandleAPI = false;
 export const enableSuspenseCallback = false;
 export const disableLegacyContext = false;
-export const revertRemovalOfSiblingPrerendering = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
 export const disableModulePatternComponents = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -32,7 +32,6 @@ export const enableScopeAPI = false;
 export const enableCreateEventHandleAPI = false;
 export const enableSuspenseCallback = false;
 export const disableLegacyContext = false;
-export const revertRemovalOfSiblingPrerendering = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
 export const disableModulePatternComponents = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -32,7 +32,6 @@ export const enableScopeAPI = true;
 export const enableCreateEventHandleAPI = false;
 export const enableSuspenseCallback = true;
 export const disableLegacyContext = false;
-export const revertRemovalOfSiblingPrerendering = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
 export const disableModulePatternComponents = true;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -39,12 +39,6 @@ export const enableSchedulingProfiler = __VARIANT__;
 // so we don't need to use __VARIANT__ to get extra coverage.
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 
-// This flag only exists so it can be connected to a www GK that acts as a
-// killswitch. We don't run our tests against the `true` value because 1) it
-// affects too many tests 2) it shouldn't break anything. But it is mildly
-// risky, hence this extra precaution.
-export const revertRemovalOfSiblingPrerendering = false;
-
 // TODO: These flags are hard-coded to the default values used in open source.
 // Update the tests so that they pass in either mode, then set these
 // to __VARIANT__.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -18,7 +18,6 @@ export const {
   disableInputAttributeSyncing,
   disableIEWorkarounds,
   enableTrustedTypesIntegration,
-  revertRemovalOfSiblingPrerendering,
   replayFailedUnitOfWorkWithInvokeGuardedCallback,
   enableLegacyFBSupport,
   enableDebugTracing,


### PR DESCRIPTION
removal of sibling prerendering has been rolled out at Meta. We can delete the flag now.