### PR TITLE
[DevTools] Replace deprecated `new-window` with `webContents.setWindowOpenHandler()`

### DIFF
--- a/packages/react-devtools/app.js
+++ b/packages/react-devtools/app.js
@@ -40,9 +40,9 @@ app.on('ready', function () {
   }
 
   // https://stackoverflow.com/questions/32402327/
-  mainWindow.webContents.on('new-window', function (event, url) {
-    event.preventDefault();
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     require('electron').shell.openExternal(url);
+    return { action: 'deny' };
   });
 
   // and load the index.html of the app.

--- a/packages/react-devtools/app.js
+++ b/packages/react-devtools/app.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {app, BrowserWindow} = require('electron'); // Module to create native browser window.
+const {app, BrowserWindow, shell} = require('electron'); // Module to create native browser window.
 const {join} = require('path');
 const os = require('os');
 
@@ -40,9 +40,9 @@ app.on('ready', function () {
   }
 
   // https://stackoverflow.com/questions/32402327/
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    require('electron').shell.openExternal(url);
-    return { action: 'deny' };
+  mainWindow.webContents.setWindowOpenHandler(({url}) => {
+    shell.openExternal(url);
+    return {action: 'deny'};
   });
 
   // and load the index.html of the app.


### PR DESCRIPTION
## Summary

The electron package was recently upgraded from ^11.1.0 to ^23.1.2 (#26337). However, the WebContents `new-window` event – that is used in the react-devtools project – was deprecated in [v12.0.0](https://releases.electronjs.org/release/v12.0.0) and removed in [v22.2.0](https://releases.electronjs.org/release/v22.2.0). The event was replaced by `webContents.setWindowOpenHandler()`. This PR replaces the `new-window` event with `webContents.setWindowOpenHandler()`.

## How did you test this change?

I created a simple electron application with similar functionality:

```
const { app, BrowserWindow, shell } = require('electron')

const createWindow = () => {
  const mainWindow = new BrowserWindow({
    width: 800,
    height: 600
  })

  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
    shell.openExternal(url)
    return { action: 'deny' }
  })

  mainWindow.loadFile('index.html')
}

app.whenReady().then(() => {
  createWindow()
})
```