### PR TITLE
Bugfix: Don't run Effect cleanup twice after bailing out

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -748,6 +748,7 @@ export function bailoutHooks(
   workInProgress: Fiber,
   lanes: Lanes,
 ): void {
+  workInProgress.memoizedState = current.memoizedState;
   workInProgress.updateQueue = current.updateQueue;
   // TODO: Don't need to reset the flags here, because they're reset in the
   // complete phase (bubbleProperties).


### PR DESCRIPTION
This is a bug originally extracted from internal tools at Meta. I further reduced it from the repro @kassens found and @rickhanlonii reduced in https://github.com/facebook/react/pull/26533. The fix was suggested by @acdlite.
