### PR TITLE
[DevTools] Replace `constructor.name` checks with `constructor` checks

### DIFF
--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -596,7 +596,7 @@ export function getDataType(data: Object): DataType {
         return hasOwnProperty.call(data.constructor, 'BYTES_PER_ELEMENT')
           ? 'typed_array'
           : 'data_view';
-      } else if (data instanceof ArrayBuffer) {
+      } else if (data.constructor && data.constructor === ArrayBuffer) {
         return 'array_buffer';
       } else if (typeof data[Symbol.iterator] === 'function') {
         const iterator = data[Symbol.iterator]();
@@ -606,7 +606,7 @@ export function getDataType(data: Object): DataType {
         } else {
           return iterator === data ? 'opaque_iterator' : 'iterator';
         }
-      } else if (data instanceof RegExp) {
+      } else if (data.constructor && data.constructor === RegExp) {
         return 'regexp';
       } else {
         // $FlowFixMe[method-unbinding]

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -596,11 +596,7 @@ export function getDataType(data: Object): DataType {
         return hasOwnProperty.call(data.constructor, 'BYTES_PER_ELEMENT')
           ? 'typed_array'
           : 'data_view';
-      } else if (data.constructor && data.constructor.name === 'ArrayBuffer') {
-        // HACK This ArrayBuffer check is gross; is there a better way?
-        // We could try to create a new DataView with the value.
-        // If it doesn't error, we know it's an ArrayBuffer,
-        // but this seems kind of awkward and expensive.
+      } else if (data instanceof ArrayBuffer) {
         return 'array_buffer';
       } else if (typeof data[Symbol.iterator] === 'function') {
         const iterator = data[Symbol.iterator]();
@@ -610,7 +606,7 @@ export function getDataType(data: Object): DataType {
         } else {
           return iterator === data ? 'opaque_iterator' : 'iterator';
         }
-      } else if (data.constructor && data.constructor.name === 'RegExp') {
+      } else if (data instanceof RegExp) {
         return 'regexp';
       } else {
         // $FlowFixMe[method-unbinding]


### PR DESCRIPTION
## Summary

There is a question in the code of `utils.js` asking for a better way to check for an `ArrayBuffer`:

> HACK This ArrayBuffer check is gross; is there a better way?

Replacing the current check (`data.constructor && data.constructor.name === 'ArrayBuffer'`) with `data.constructor && data.constructor === ArrayBuffer` is arguably a better and more efficient way.

## How did you test this change?

In addition to running the existing tests, I compared the speeds of the checks:
```
let data = new ArrayBuffer(1000000);

// Measure the performance of using constructor
console.time('constructor check');
for (let i = 0; i < 1000000; i++) {
  if (data.constructor && data.constructor === ArrayBuffer) {
    // Do something
  }
}
console.timeEnd('constructor check');

// Measure the performance of using constructor.name
console.time('constructor.name check');
for (let i = 0; i < 1000000; i++) {
  if (data.constructor && data.constructor.name === 'ArrayBuffer') {
    // Do something
  }
}
console.timeEnd('constructor.name check');
```

This resulted in significant speed differences:

> constructor check: 4.143798828125 ms
> constructor.name check: 29.721923828125 ms