### PR TITLE
[Tests] `waitForThrow` should diff strings

### DIFF
--- a/packages/internal-test-utils/ReactInternalTestUtils.js
+++ b/packages/internal-test-utils/ReactInternalTestUtils.js
@@ -141,10 +141,18 @@ export async function waitForThrow(expectedError: mixed): mixed {
         typeof expectedError === 'string' &&
         typeof x === 'object' &&
         x !== null &&
-        typeof x.message === 'string' &&
-        x.message.includes(expectedError)
+        typeof x.message === 'string'
       ) {
-        return x;
+        if (x.message.includes(expectedError)) {
+          return x;
+        } else {
+          error.message = `
+Expected error was not thrown.
+
+${diff(expectedError, x.message)}
+`;
+          throw error;
+        }
       }
       error.message = `
 Expected error was not thrown.


### PR DESCRIPTION
Currently, `waitForThrow` tries to diff the expected value against the thrown value if it doesn't match. However if the expectation is a string, we are not diffing against the thrown message. This commit makes it so if we are matching against message we also diff against message.
