### PR TITLE
Diff properties in the commit phase instead of generating an update payload

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -50,6 +50,7 @@ import setInnerHTML from './setInnerHTML';
 import setTextContent from './setTextContent';
 import {
   createDangerousStringForStyles,
+  clearPreviousStyles,
   setValueForStyles,
   validateShorthandPropertyCollisionInDev,
 } from './CSSPropertyOperations';
@@ -69,6 +70,7 @@ import {
   disableIEWorkarounds,
   enableTrustedTypesIntegration,
   enableFilterEmptyStringAttributesDOM,
+  diffInCommitPhase,
 } from 'shared/ReactFeatureFlags';
 import {
   mediaEventTypes,
@@ -273,6 +275,7 @@ function setProp(
   key: string,
   value: mixed,
   props: any,
+  prevValue: mixed,
 ): void {
   switch (key) {
     case 'children': {
@@ -314,6 +317,12 @@ function setProp(
       break;
     }
     case 'style': {
+      if (diffInCommitPhase && prevValue != null) {
+        if (__DEV__) {
+          validateShorthandPropertyCollisionInDev(prevValue, value);
+        }
+        clearPreviousStyles(domElement, prevValue, value);
+      }
       setValueForStyles(domElement, value);
       break;
     }
@@ -689,6 +698,7 @@ function setPropOnCustomElement(
   key: string,
   value: mixed,
   props: any,
+  prevValue: mixed,
 ): void {
   switch (key) {
     case 'style': {
@@ -859,7 +869,7 @@ export function setInitialProperties(
           }
           // defaultChecked and defaultValue are ignored by setProp
           default: {
-            setProp(domElement, tag, propKey, propValue, props);
+            setProp(domElement, tag, propKey, propValue, props, null);
           }
         }
       }
@@ -892,7 +902,7 @@ export function setInitialProperties(
           }
           // defaultValue are ignored by setProp
           default: {
-            setProp(domElement, tag, propKey, propValue, props);
+            setProp(domElement, tag, propKey, propValue, props, null);
           }
         }
       }
@@ -1047,7 +1057,7 @@ export function setInitialProperties(
           }
           // defaultChecked and defaultValue are ignored by setProp
           default: {
-            setProp(domElement, tag, propKey, propValue, props);
+            setProp(domElement, tag, propKey, propValue, props, null);
           }
         }
       }
@@ -1063,7 +1073,14 @@ export function setInitialProperties(
           if (propValue == null) {
             continue;
           }
-          setPropOnCustomElement(domElement, tag, propKey, propValue, props);
+          setPropOnCustomElement(
+            domElement,
+            tag,
+            propKey,
+            propValue,
+            props,
+            null,
+          );
         }
         return;
       }
@@ -1078,7 +1095,7 @@ export function setInitialProperties(
     if (propValue == null) {
       continue;
     }
-    setProp(domElement, tag, propKey, propValue, props);
+    setProp(domElement, tag, propKey, propValue, props, null);
   }
 }
 
@@ -1188,15 +1205,415 @@ export function diffProperties(
   }
   if (styleUpdates) {
     if (__DEV__) {
-      validateShorthandPropertyCollisionInDev(styleUpdates, nextProps.style);
+      validateShorthandPropertyCollisionInDev(lastProps.style, nextProps.style);
     }
     (updatePayload = updatePayload || []).push('style', styleUpdates);
   }
   return updatePayload;
 }
 
-// Apply the diff.
 export function updateProperties(
+  domElement: Element,
+  tag: string,
+  lastProps: Object,
+  nextProps: Object,
+): void {
+  if (__DEV__) {
+    validatePropertiesInDevelopment(tag, nextProps);
+  }
+
+  switch (tag) {
+    case 'div':
+    case 'span':
+    case 'svg':
+    case 'path':
+    case 'a':
+    case 'g':
+    case 'p':
+    case 'li': {
+      // Fast track the most common tag types
+      break;
+    }
+    case 'input': {
+      // Update checked *before* name.
+      // In the middle of an update, it is possible to have multiple checked.
+      // When a checked radio tries to change name, browser makes another radio's checked false.
+      if (nextProps.type === 'radio' && nextProps.name != null) {
+        updateInputChecked(domElement, nextProps);
+      }
+      for (const propKey in lastProps) {
+        const lastProp = lastProps[propKey];
+        if (
+          lastProps.hasOwnProperty(propKey) &&
+          lastProp != null &&
+          !nextProps.hasOwnProperty(propKey)
+        ) {
+          switch (propKey) {
+            case 'checked': {
+              const checked = nextProps.defaultChecked;
+              const inputElement: HTMLInputElement = (domElement: any);
+              inputElement.checked =
+                !!checked &&
+                typeof checked !== 'function' &&
+                checked !== 'symbol';
+              break;
+            }
+            case 'value': {
+              // This is handled by updateWrapper below.
+              break;
+            }
+            // defaultChecked and defaultValue are ignored by setProp
+            default: {
+              setProp(domElement, tag, propKey, null, nextProps, lastProp);
+            }
+          }
+        }
+      }
+      for (const propKey in nextProps) {
+        const nextProp = nextProps[propKey];
+        const lastProp = lastProps[propKey];
+        if (
+          nextProps.hasOwnProperty(propKey) &&
+          nextProp !== lastProp &&
+          (nextProp != null || lastProp != null)
+        ) {
+          switch (propKey) {
+            case 'checked': {
+              const checked =
+                nextProp != null ? nextProp : nextProps.defaultChecked;
+              const inputElement: HTMLInputElement = (domElement: any);
+              inputElement.checked =
+                !!checked &&
+                typeof checked !== 'function' &&
+                checked !== 'symbol';
+              break;
+            }
+            case 'value': {
+              // This is handled by updateWrapper below.
+              break;
+            }
+            case 'children':
+            case 'dangerouslySetInnerHTML': {
+              if (nextProp != null) {
+                throw new Error(
+                  `${tag} is a void element tag and must neither have \`children\` nor ` +
+                    'use `dangerouslySetInnerHTML`.',
+                );
+              }
+              break;
+            }
+            // defaultChecked and defaultValue are ignored by setProp
+            default: {
+              setProp(domElement, tag, propKey, nextProp, nextProps, lastProp);
+            }
+          }
+        }
+      }
+
+      if (__DEV__) {
+        const wasControlled =
+          lastProps.type === 'checkbox' || lastProps.type === 'radio'
+            ? lastProps.checked != null
+            : lastProps.value != null;
+        const isControlled =
+          nextProps.type === 'checkbox' || nextProps.type === 'radio'
+            ? nextProps.checked != null
+            : nextProps.value != null;
+
+        if (
+          !wasControlled &&
+          isControlled &&
+          !didWarnUncontrolledToControlled
+        ) {
+          console.error(
+            'A component is changing an uncontrolled input to be controlled. ' +
+              'This is likely caused by the value changing from undefined to ' +
+              'a defined value, which should not happen. ' +
+              'Decide between using a controlled or uncontrolled input ' +
+              'element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components',
+          );
+          didWarnUncontrolledToControlled = true;
+        }
+        if (
+          wasControlled &&
+          !isControlled &&
+          !didWarnControlledToUncontrolled
+        ) {
+          console.error(
+            'A component is changing a controlled input to be uncontrolled. ' +
+              'This is likely caused by the value changing from a defined to ' +
+              'undefined, which should not happen. ' +
+              'Decide between using a controlled or uncontrolled input ' +
+              'element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components',
+          );
+          didWarnControlledToUncontrolled = true;
+        }
+      }
+      // Update the wrapper around inputs *after* updating props. This has to
+      // happen after updating the rest of props. Otherwise HTML5 input validations
+      // raise warnings and prevent the new value from being assigned.
+      updateInput(domElement, nextProps);
+      return;
+    }
+    case 'select': {
+      for (const propKey in lastProps) {
+        const lastProp = lastProps[propKey];
+        if (
+          lastProps.hasOwnProperty(propKey) &&
+          lastProp != null &&
+          !nextProps.hasOwnProperty(propKey)
+        ) {
+          switch (propKey) {
+            case 'value': {
+              // This is handled by updateWrapper below.
+              break;
+            }
+            // defaultValue are ignored by setProp
+            default: {
+              setProp(domElement, tag, propKey, null, nextProps, lastProp);
+            }
+          }
+        }
+      }
+      for (const propKey in nextProps) {
+        const nextProp = nextProps[propKey];
+        const lastProp = lastProps[propKey];
+        if (
+          nextProps.hasOwnProperty(propKey) &&
+          nextProp !== lastProp &&
+          (nextProp != null || lastProp != null)
+        ) {
+          switch (propKey) {
+            case 'value': {
+              // This is handled by updateWrapper below.
+              break;
+            }
+            // defaultValue are ignored by setProp
+            default: {
+              setProp(domElement, tag, propKey, nextProp, nextProps, lastProp);
+            }
+          }
+        }
+      }
+      // <select> value update needs to occur after <option> children
+      // reconciliation
+      updateSelect(domElement, lastProps, nextProps);
+      return;
+    }
+    case 'textarea': {
+      for (const propKey in lastProps) {
+        const lastProp = lastProps[propKey];
+        if (
+          lastProps.hasOwnProperty(propKey) &&
+          lastProp != null &&
+          !nextProps.hasOwnProperty(propKey)
+        ) {
+          switch (propKey) {
+            case 'value': {
+              // This is handled by updateWrapper below.
+              break;
+            }
+            // defaultValue is ignored by setProp
+            default: {
+              setProp(domElement, tag, propKey, null, nextProps, lastProp);
+            }
+          }
+        }
+      }
+      for (const propKey in nextProps) {
+        const nextProp = nextProps[propKey];
+        const lastProp = lastProps[propKey];
+        if (
+          nextProps.hasOwnProperty(propKey) &&
+          nextProp !== lastProp &&
+          (nextProp != null || lastProp != null)
+        ) {
+          switch (propKey) {
+            case 'value': {
+              // This is handled by updateWrapper below.
+              break;
+            }
+            case 'children': {
+              // TODO: This doesn't actually do anything if it updates.
+              break;
+            }
+            case 'dangerouslySetInnerHTML': {
+              if (nextProp != null) {
+                // TODO: Do we really need a special error message for this. It's also pretty blunt.
+                throw new Error(
+                  '`dangerouslySetInnerHTML` does not make sense on <textarea>.',
+                );
+              }
+              break;
+            }
+            // defaultValue is ignored by setProp
+            default: {
+              setProp(domElement, tag, propKey, nextProp, nextProps, lastProp);
+            }
+          }
+        }
+      }
+      updateTextarea(domElement, nextProps);
+      return;
+    }
+    case 'option': {
+      for (const propKey in lastProps) {
+        const lastProp = lastProps[propKey];
+        if (
+          lastProps.hasOwnProperty(propKey) &&
+          lastProp != null &&
+          !nextProps.hasOwnProperty(propKey)
+        ) {
+          setProp(domElement, tag, propKey, null, nextProps, lastProp);
+        }
+      }
+      for (const propKey in nextProps) {
+        const nextProp = nextProps[propKey];
+        const lastProp = lastProps[propKey];
+        if (
+          nextProps.hasOwnProperty(propKey) &&
+          nextProp !== lastProp &&
+          (nextProp != null || lastProp != null)
+        ) {
+          switch (propKey) {
+            case 'selected': {
+              // TODO: Remove support for selected on option.
+              (domElement: any).selected =
+                nextProp &&
+                typeof nextProp !== 'function' &&
+                typeof nextProp !== 'symbol';
+              break;
+            }
+            default: {
+              setProp(domElement, tag, propKey, nextProp, nextProps, lastProp);
+            }
+          }
+        }
+      }
+      return;
+    }
+    case 'img':
+    case 'link':
+    case 'area':
+    case 'base':
+    case 'br':
+    case 'col':
+    case 'embed':
+    case 'hr':
+    case 'keygen':
+    case 'meta':
+    case 'param':
+    case 'source':
+    case 'track':
+    case 'wbr':
+    case 'menuitem': {
+      // Void elements
+      for (const propKey in lastProps) {
+        const lastProp = lastProps[propKey];
+        if (
+          lastProps.hasOwnProperty(propKey) &&
+          lastProp != null &&
+          !nextProps.hasOwnProperty(propKey)
+        ) {
+          setProp(domElement, tag, propKey, null, nextProps, lastProp);
+        }
+      }
+      for (const propKey in nextProps) {
+        const nextProp = nextProps[propKey];
+        const lastProp = lastProps[propKey];
+        if (
+          nextProps.hasOwnProperty(propKey) &&
+          nextProp !== lastProp &&
+          (nextProp != null || lastProp != null)
+        ) {
+          switch (propKey) {
+            case 'children':
+            case 'dangerouslySetInnerHTML': {
+              if (nextProp != null) {
+                // TODO: Can we make this a DEV warning to avoid this deny list?
+                throw new Error(
+                  `${tag} is a void element tag and must neither have \`children\` nor ` +
+                    'use `dangerouslySetInnerHTML`.',
+                );
+              }
+              break;
+            }
+            // defaultChecked and defaultValue are ignored by setProp
+            default: {
+              setProp(domElement, tag, propKey, nextProp, nextProps, lastProp);
+            }
+          }
+        }
+      }
+      return;
+    }
+    default: {
+      if (isCustomElement(tag, nextProps)) {
+        for (const propKey in lastProps) {
+          const lastProp = lastProps[propKey];
+          if (
+            lastProps.hasOwnProperty(propKey) &&
+            lastProp != null &&
+            !nextProps.hasOwnProperty(propKey)
+          ) {
+            setPropOnCustomElement(
+              domElement,
+              tag,
+              propKey,
+              null,
+              nextProps,
+              lastProp,
+            );
+          }
+        }
+        for (const propKey in nextProps) {
+          const nextProp = nextProps[propKey];
+          const lastProp = lastProps[propKey];
+          if (
+            nextProps.hasOwnProperty(propKey) &&
+            nextProp !== lastProp &&
+            (nextProp != null || lastProp != null)
+          ) {
+            setPropOnCustomElement(
+              domElement,
+              tag,
+              propKey,
+              nextProp,
+              nextProps,
+              lastProp,
+            );
+          }
+        }
+        return;
+      }
+    }
+  }
+
+  for (const propKey in lastProps) {
+    const lastProp = lastProps[propKey];
+    if (
+      lastProps.hasOwnProperty(propKey) &&
+      lastProp != null &&
+      !nextProps.hasOwnProperty(propKey)
+    ) {
+      setProp(domElement, tag, propKey, null, nextProps, lastProp);
+    }
+  }
+  for (const propKey in nextProps) {
+    const nextProp = nextProps[propKey];
+    const lastProp = lastProps[propKey];
+    if (
+      nextProps.hasOwnProperty(propKey) &&
+      nextProp !== lastProp &&
+      (nextProp != null || lastProp != null)
+    ) {
+      setProp(domElement, tag, propKey, nextProp, nextProps, lastProp);
+    }
+  }
+}
+
+// Apply the diff.
+export function updatePropertiesWithDiff(
   domElement: Element,
   updatePayload: Array<any>,
   tag: string,
@@ -1252,7 +1669,7 @@ export function updateProperties(
           }
           // defaultChecked and defaultValue are ignored by setProp
           default: {
-            setProp(domElement, tag, propKey, propValue, nextProps);
+            setProp(domElement, tag, propKey, propValue, nextProps, null);
           }
         }
       }
@@ -1313,7 +1730,7 @@ export function updateProperties(
           }
           // defaultValue are ignored by setProp
           default: {
-            setProp(domElement, tag, propKey, propValue, nextProps);
+            setProp(domElement, tag, propKey, propValue, nextProps, null);
           }
         }
       }
@@ -1346,7 +1763,7 @@ export function updateProperties(
           }
           // defaultValue is ignored by setProp
           default: {
-            setProp(domElement, tag, propKey, propValue, nextProps);
+            setProp(domElement, tag, propKey, propValue, nextProps, null);
           }
         }
       }
@@ -1367,7 +1784,7 @@ export function updateProperties(
             break;
           }
           default: {
-            setProp(domElement, tag, propKey, propValue, nextProps);
+            setProp(domElement, tag, propKey, propValue, nextProps, null);
           }
         }
       }
@@ -1406,7 +1823,7 @@ export function updateProperties(
           }
           // defaultChecked and defaultValue are ignored by setProp
           default: {
-            setProp(domElement, tag, propKey, propValue, nextProps);
+            setProp(domElement, tag, propKey, propValue, nextProps, null);
           }
         }
       }
@@ -1423,6 +1840,7 @@ export function updateProperties(
             propKey,
             propValue,
             nextProps,
+            null,
           );
         }
         return;
@@ -1434,7 +1852,7 @@ export function updateProperties(
   for (let i = 0; i < updatePayload.length; i += 2) {
     const propKey = updatePayload[i];
     const propValue = updatePayload[i + 1];
-    setProp(domElement, tag, propKey, propValue, nextProps);
+    setProp(domElement, tag, propKey, propValue, nextProps, null);
   }
 }
 
@@ -2377,7 +2795,18 @@ export function diffHydratedProperties(
         );
       }
       if (!isConcurrentMode || !enableClientRenderFallbackOnTextMismatch) {
-        updatePayload = ['children', children];
+        if (diffInCommitPhase) {
+          // We really should be patching this in the commit phase but since
+          // this only affects legacy mode hydration which is deprecated anyway
+          // we can get away with it.
+          // Host singletons get their children appended and don't use the text
+          // content mechanism.
+          if (!enableHostSingletons || tag !== 'body') {
+            domElement.textContent = (children: any);
+          }
+        } else {
+          updatePayload = ['children', children];
+        }
       }
     }
   }

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -657,6 +657,21 @@ function setProp(
       );
       break;
     // Properties that should not be allowed on custom elements.
+    case 'is': {
+      if (__DEV__) {
+        if (prevValue != null) {
+          console.error(
+            'Cannot update the "is" prop after it has been initialized.',
+          );
+        }
+      }
+      // TODO: We shouldn't actually set this attribute, because we've already
+      // passed it to createElement. We don't also need the attribute.
+      // However, our tests currently query for it so it's plausible someone
+      // else does too so it's break.
+      setValueForAttribute(domElement, 'is', value);
+      break;
+    }
     case 'innerText':
     case 'textContent':
       if (enableCustomElementPropertySupport) {

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -47,6 +47,7 @@ import {
   setInitialProperties,
   diffProperties,
   updateProperties,
+  updatePropertiesWithDiff,
   diffHydratedProperties,
   diffHydratedText,
   trapClickOnNonInteractiveElement,
@@ -86,6 +87,7 @@ import {
   enableFloat,
   enableHostSingletons,
   enableTrustedTypesIntegration,
+  diffInCommitPhase,
 } from 'shared/ReactFeatureFlags';
 import {
   HostComponent,
@@ -485,6 +487,10 @@ export function prepareUpdate(
   newProps: Props,
   hostContext: HostContext,
 ): null | Array<mixed> {
+  if (diffInCommitPhase) {
+    // TODO: Figure out how to validateDOMNesting when children turn into a string.
+    return null;
+  }
   if (__DEV__) {
     const hostContextDev = ((hostContext: any): HostContextDev);
     if (
@@ -642,14 +648,26 @@ export function commitMount(
 
 export function commitUpdate(
   domElement: Instance,
-  updatePayload: Array<mixed>,
+  updatePayload: any,
   type: string,
   oldProps: Props,
   newProps: Props,
   internalInstanceHandle: Object,
 ): void {
-  // Apply the diff to the DOM node.
-  updateProperties(domElement, updatePayload, type, oldProps, newProps);
+  if (diffInCommitPhase) {
+    // Diff and update the properties.
+    updateProperties(domElement, type, oldProps, newProps);
+  } else {
+    // Apply the diff to the DOM node.
+    updatePropertiesWithDiff(
+      domElement,
+      updatePayload,
+      type,
+      oldProps,
+      newProps,
+    );
+  }
+
   // Update the props handle so that we know which props are the ones with
   // with current event handlers.
   updateFiberProps(domElement, newProps);

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -88,7 +88,6 @@ if (__DEV__) {
 
 function createReactNoop(reconciler: Function, useMutation: boolean) {
   let instanceCounter = 0;
-  let hostDiffCounter = 0;
   let hostUpdateCounter = 0;
   let hostCloneCounter = 0;
 
@@ -458,16 +457,12 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       oldProps: Props,
       newProps: Props,
     ): null | {...} {
-      if (type === 'errorInCompletePhase') {
-        throw new Error('Error in host config.');
-      }
       if (oldProps === null) {
         throw new Error('Should have old props');
       }
       if (newProps === null) {
         throw new Error('Should have new props');
       }
-      hostDiffCounter++;
       return UPDATE_SIGNAL;
     },
 
@@ -1186,30 +1181,24 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     },
 
     startTrackingHostCounters(): void {
-      hostDiffCounter = 0;
       hostUpdateCounter = 0;
       hostCloneCounter = 0;
     },
 
     stopTrackingHostCounters():
       | {
-          hostDiffCounter: number,
           hostUpdateCounter: number,
         }
       | {
-          hostDiffCounter: number,
           hostCloneCounter: number,
         } {
       const result = useMutation
         ? {
-            hostDiffCounter,
             hostUpdateCounter,
           }
         : {
-            hostDiffCounter,
             hostCloneCounter,
           };
-      hostDiffCounter = 0;
       hostUpdateCounter = 0;
       hostCloneCounter = 0;
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -54,6 +54,7 @@ import {
   enableFloat,
   enableLegacyHidden,
   enableHostSingletons,
+  diffInCommitPhase,
 } from 'shared/ReactFeatureFlags';
 import {
   FunctionComponent,
@@ -2774,7 +2775,7 @@ function commitMutationEffectsOnFiber(
             const updatePayload: null | UpdatePayload =
               (finishedWork.updateQueue: any);
             finishedWork.updateQueue = null;
-            if (updatePayload !== null) {
+            if (updatePayload !== null || diffInCommitPhase) {
               try {
                 commitUpdate(
                   instance,

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -39,6 +39,7 @@ import {
   enableHostSingletons,
   enableFloat,
   enableClientRenderFallbackOnTextMismatch,
+  diffInCommitPhase,
 } from 'shared/ReactFeatureFlags';
 
 import {
@@ -687,12 +688,15 @@ function prepareToHydrateHostInstance(
     fiber,
     shouldWarnIfMismatchDev,
   );
+
   // TODO: Type this specific to this type of component.
-  fiber.updateQueue = (updatePayload: any);
-  // If the update payload indicates that there is a change or if there
-  // is a new ref we mark this as an update.
-  if (updatePayload !== null) {
-    return true;
+  if (!diffInCommitPhase) {
+    fiber.updateQueue = (updatePayload: any);
+    // If the update payload indicates that there is a change or if there
+    // is a new ref we mark this as an update.
+    if (updatePayload !== null) {
+      return true;
+    }
   }
   return false;
 }

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdatesMinimalism-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdatesMinimalism-test.js
@@ -35,14 +35,12 @@ describe('ReactIncrementalUpdatesMinimalism', () => {
     ReactNoop.startTrackingHostCounters();
     await act(() => ReactNoop.render(<Parent />));
     expect(ReactNoop.stopTrackingHostCounters()).toEqual({
-      hostDiffCounter: 0,
       hostUpdateCounter: 0,
     });
 
     ReactNoop.startTrackingHostCounters();
     await act(() => ReactNoop.render(<Parent />));
     expect(ReactNoop.stopTrackingHostCounters()).toEqual({
-      hostDiffCounter: 1,
       hostUpdateCounter: 1,
     });
   });
@@ -75,14 +73,12 @@ describe('ReactIncrementalUpdatesMinimalism', () => {
     ReactNoop.startTrackingHostCounters();
     await act(() => ReactNoop.render(<Parent />));
     expect(ReactNoop.stopTrackingHostCounters()).toEqual({
-      hostDiffCounter: 0,
       hostUpdateCounter: 0,
     });
 
     ReactNoop.startTrackingHostCounters();
     await act(() => ReactNoop.render(<Parent />));
     expect(ReactNoop.stopTrackingHostCounters()).toEqual({
-      hostDiffCounter: 0,
       hostUpdateCounter: 0,
     });
   });
@@ -128,17 +124,12 @@ describe('ReactIncrementalUpdatesMinimalism', () => {
     ReactNoop.startTrackingHostCounters();
     await act(() => ReactNoop.render(<Parent />));
     expect(ReactNoop.stopTrackingHostCounters()).toEqual({
-      hostDiffCounter: 0,
       hostUpdateCounter: 0,
     });
 
     ReactNoop.startTrackingHostCounters();
     await act(() => childInst.setState({name: 'Robin'}));
     expect(ReactNoop.stopTrackingHostCounters()).toEqual({
-      // Child > div
-      // Child > Leaf > span
-      // Child > Leaf > span > b
-      hostDiffCounter: 3,
       // Child > div
       // Child > Leaf > span
       // Child > Leaf > span > b
@@ -159,7 +150,6 @@ describe('ReactIncrementalUpdatesMinimalism', () => {
       // Parent > section > div > hr
       // Parent > section > div > Leaf > span
       // Parent > section > div > Leaf > span > b
-      hostDiffCounter: 10,
       hostUpdateCounter: 10,
     });
   });

--- a/packages/react-reconciler/src/__tests__/ReactPersistentUpdatesMinimalism-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactPersistentUpdatesMinimalism-test.js
@@ -34,14 +34,12 @@ describe('ReactPersistentUpdatesMinimalism', () => {
     ReactNoopPersistent.startTrackingHostCounters();
     await act(() => ReactNoopPersistent.render(<Parent />));
     expect(ReactNoopPersistent.stopTrackingHostCounters()).toEqual({
-      hostDiffCounter: 0,
       hostCloneCounter: 0,
     });
 
     ReactNoopPersistent.startTrackingHostCounters();
     await act(() => ReactNoopPersistent.render(<Parent />));
     expect(ReactNoopPersistent.stopTrackingHostCounters()).toEqual({
-      hostDiffCounter: 1,
       hostCloneCounter: 1,
     });
   });
@@ -74,14 +72,12 @@ describe('ReactPersistentUpdatesMinimalism', () => {
     ReactNoopPersistent.startTrackingHostCounters();
     await act(() => ReactNoopPersistent.render(<Parent />));
     expect(ReactNoopPersistent.stopTrackingHostCounters()).toEqual({
-      hostDiffCounter: 0,
       hostCloneCounter: 0,
     });
 
     ReactNoopPersistent.startTrackingHostCounters();
     await act(() => ReactNoopPersistent.render(<Parent />));
     expect(ReactNoopPersistent.stopTrackingHostCounters()).toEqual({
-      hostDiffCounter: 0,
       hostCloneCounter: 0,
     });
   });
@@ -127,17 +123,12 @@ describe('ReactPersistentUpdatesMinimalism', () => {
     ReactNoopPersistent.startTrackingHostCounters();
     await act(() => ReactNoopPersistent.render(<Parent />));
     expect(ReactNoopPersistent.stopTrackingHostCounters()).toEqual({
-      hostDiffCounter: 0,
       hostCloneCounter: 0,
     });
 
     ReactNoopPersistent.startTrackingHostCounters();
     await act(() => childInst.setState({name: 'Robin'}));
     expect(ReactNoopPersistent.stopTrackingHostCounters()).toEqual({
-      // section > div > Child > div
-      // section > div > Child > Leaf > span
-      // section > div > Child > Leaf > span > b
-      hostDiffCounter: 3,
       // section
       // section > div
       // section > div > Child > div
@@ -159,7 +150,6 @@ describe('ReactPersistentUpdatesMinimalism', () => {
       // Parent > section > div > hr
       // Parent > section > div > Leaf > span
       // Parent > section > div > Leaf > span > b
-      hostDiffCounter: 10,
       hostCloneCounter: 10,
     });
   });

--- a/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
+++ b/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
@@ -230,7 +230,7 @@ export const supportsMutation = true;
 
 export function commitUpdate(
   instance: Instance,
-  updatePayload: {...},
+  updatePayload: null | {...},
   type: string,
   oldProps: Props,
   newProps: Props,

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -122,6 +122,9 @@ export const enableUseEffectEventHook = __EXPERIMENTAL__;
 // (handled with an MutationObserver) instead of inline-scripts
 export const enableFizzExternalRuntime = true;
 
+// Performance related test
+export const diffInCommitPhase = __EXPERIMENTAL__;
+
 // -----------------------------------------------------------------------------
 // Chopping Block
 //

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -82,5 +82,7 @@ export const enableHostSingletons = true;
 export const useModernStrictMode = false;
 export const enableFizzExternalRuntime = false;
 
+export const diffInCommitPhase = true;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -72,5 +72,7 @@ export const useModernStrictMode = false;
 export const enableFizzExternalRuntime = false;
 export const enableDeferRootSchedulingToMicrotask = true;
 
+export const diffInCommitPhase = true;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -72,5 +72,7 @@ export const useModernStrictMode = false;
 export const enableFizzExternalRuntime = false;
 export const enableDeferRootSchedulingToMicrotask = true;
 
+export const diffInCommitPhase = true;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -69,5 +69,7 @@ export const enableHostSingletons = true;
 export const useModernStrictMode = false;
 export const enableDeferRootSchedulingToMicrotask = true;
 
+export const diffInCommitPhase = true;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -74,5 +74,7 @@ export const useModernStrictMode = false;
 export const enableFizzExternalRuntime = false;
 export const enableDeferRootSchedulingToMicrotask = true;
 
+export const diffInCommitPhase = true;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -25,6 +25,7 @@ export const enableUnifiedSyncLane = __VARIANT__;
 export const enableTransitionTracing = __VARIANT__;
 export const enableCustomElementPropertySupport = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
+export const diffInCommitPhase = __VARIANT__;
 
 // Enable this flag to help with concurrent mode debugging.
 // It logs information to the console about React scheduling, rendering, and commit phases.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -29,6 +29,7 @@ export const {
   enableTransitionTracing,
   enableCustomElementPropertySupport,
   enableDeferRootSchedulingToMicrotask,
+  diffInCommitPhase,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.


### PR DESCRIPTION
This removes the concept of `prepareUpdate()`, behind a flag.

React Native already does everything in the commit phase, but generates a temporary update payload before applying it.

React Fabric does it both in the render phase. Now it just moves it to a single host config.

For DOM I forked updateProperties into one that does diffing and updating in one pass vs just applying a pre-diffed updatePayload.

There are a few downsides of this approach:

- If only "children" has changed, we end up scheduling an update to be done in the commit phase. Since we traverse through it anyway, it's probably not much extra.
- It does more work in the commit phase so for a large tree that is mostly unchanged, it'll stall longer.
- It does some extra work for special cases since that work happens if anything has changed. We no longer have a deep bailout.
- The special cases now have to each replicate the "clean up old props" loop, leading to extra code.

The benefit is that this doesn't allocate temporary extra objects (possibly multiple per element if the array has to resize). It's less work overall. It also gives us an option to reuse this function for a sync render optimization.

Another benefit is that if we do the loop in the commit phase I can do further optimizations by reading all props that I need for special cases in that loop instead of polymorphic reads from props. This is what I'd like to do in future refactors that would be stacked on top of this change.