### PR TITLE
Failing test for radio checked with changing names

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -1190,6 +1190,28 @@ describe('ReactDOMInput', () => {
     expect(firstRadioNode.checked).toBe(true);
   });
 
+  it("shouldn't get tricked by changing radio names, part 2", () => {
+    ReactDOM.render(
+      <div>
+        <input type="radio" name="a" value="1" checked={true} onChange={() => {}} />
+        <input type="radio" name="a" value="2" checked={false} onChange={() => {}} />
+      </div>,
+      container
+    );
+    expect(container.querySelector('input[name="a"][value="1"]').checked).toBe(true);
+    expect(container.querySelector('input[name="a"][value="2"]').checked).toBe(false);
+
+    ReactDOM.render(
+      <div>
+        <input type="radio" name="a" value="1" checked={true} onChange={() => {}} />
+        <input type="radio" name="b" value="2" checked={true} onChange={() => {}} />
+      </div>,
+      container
+    );
+    expect(container.querySelector('input[name="a"][value="1"]').checked).toBe(true);
+    expect(container.querySelector('input[name="b"][value="2"]').checked).toBe(true);
+  });
+
   it('should control radio buttons if the tree updates during render', () => {
     const sharedParent = container;
     const container1 = document.createElement('div');


### PR DESCRIPTION
```
 FAIL  packages/react-dom/src/__tests__/ReactDOMInput-test.js (8.01 s)
  ● ReactDOMInput › shouldn't get tricked by changing radio names, part 2

    expect(received).toBe(expected) // Object.is equality

    Expected: true
    Received: false

      1209 |       container
      1210 |     );
    > 1211 |     expect(container.querySelector('input[name="a"][value="1"]').checked).toBe(true);
           |                                                                               ^
      1212 |     expect(container.querySelector('input[name="b"][value="2"]').checked).toBe(true);
      1213 |   });
      1214 |

      at Object.<anonymous> (packages/react-dom/src/__tests__/ReactDOMInput-test.js:1211:79)
```
