### PR TITLE
Implements wiring for Flight to have it's own "HostConfig"

### DIFF
--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser.js
@@ -10,3 +10,4 @@
 export * from 'react-client/src/ReactFlightClientConfigBrowser';
 export * from 'react-client/src/ReactFlightClientConfigStream';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigWebpackBundler';
+export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-bun.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-bun.js
@@ -9,6 +9,7 @@
 
 export * from 'react-client/src/ReactFlightClientConfigBrowser';
 export * from 'react-client/src/ReactFlightClientConfigStream';
+export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';
 
 export type Response = any;
 export opaque type SSRManifest = mixed;

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-webpack.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-webpack.js
@@ -10,3 +10,4 @@
 export * from 'react-client/src/ReactFlightClientConfigBrowser';
 export * from 'react-client/src/ReactFlightClientConfigStream';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigWebpackBundler';
+export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-legacy.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-legacy.js
@@ -10,3 +10,4 @@
 export * from 'react-client/src/ReactFlightClientConfigBrowser';
 export * from 'react-client/src/ReactFlightClientConfigStream';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigWebpackBundler';
+export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-webpack.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-webpack.js
@@ -10,3 +10,4 @@
 export * from 'react-client/src/ReactFlightClientConfigNode';
 export * from 'react-client/src/ReactFlightClientConfigStream';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigWebpackBundler';
+export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-node.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-node.js
@@ -10,3 +10,4 @@
 export * from 'react-client/src/ReactFlightClientConfigNode';
 export * from 'react-client/src/ReactFlightClientConfigStream';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigNodeBundler';
+export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-relay.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-relay.js
@@ -9,3 +9,4 @@
 
 export * from 'react-server-dom-relay/src/ReactFlightClientConfigDOMRelay';
 export * from '../ReactFlightClientConfigNoStream';
+export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';

--- a/packages/react-dom-bindings/src/server/ReactFlightServerConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFlightServerConfigDOM.js
@@ -7,5 +7,6 @@
  * @flow
  */
 
-export * from 'react-server-dom-relay/src/ReactFlightServerConfigDOMRelay';
-export * from 'react-dom-bindings/src/server/ReactFlightServerConfigDOM';
+// Used to distinguish these contexts from ones used in other renderers.
+// E.g. this can be used to distinguish legacy renderers from this modern one.
+export const isPrimaryRenderer = true;

--- a/packages/react-dom-bindings/src/shared/ReactFlightClientConfigDOM.js
+++ b/packages/react-dom-bindings/src/shared/ReactFlightClientConfigDOM.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// This client file is in the shared folder because it applies to both SSR and browser contexts.
+// It is the configuraiton of the FlightClient behavior which can run in either environment.
+
+// In a future update this is where we will implement `dispatchDirective` such as for Float methods

--- a/packages/react-server/src/ReactFlightNewContext.js
+++ b/packages/react-server/src/ReactFlightNewContext.js
@@ -13,7 +13,7 @@ import type {
 } from 'shared/ReactTypes';
 
 import {REACT_SERVER_CONTEXT_DEFAULT_VALUE_NOT_LOADED} from 'shared/ReactSymbols';
-import {isPrimaryRenderer} from './ReactServerFormatConfig';
+import {isPrimaryRenderer} from './ReactFlightServerConfig';
 
 let rendererSigil;
 if (__DEV__) {

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser.js
@@ -9,3 +9,4 @@
 
 export * from '../ReactFlightServerConfigStream';
 export * from 'react-server-dom-webpack/src/ReactFlightServerConfigWebpackBundler';
+export * from 'react-dom-bindings/src/server/ReactFlightServerConfigDOM';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-bun.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-bun.js
@@ -9,3 +9,4 @@
 
 export * from '../ReactFlightServerConfigStream';
 export * from '../ReactFlightServerConfigBundlerCustom';
+export * from 'react-dom-bindings/src/server/ReactFlightServerConfigDOM';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge-webpack.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge-webpack.js
@@ -9,3 +9,4 @@
 
 export * from '../ReactFlightServerConfigStream';
 export * from 'react-server-dom-webpack/src/ReactFlightServerConfigWebpackBundler';
+export * from 'react-dom-bindings/src/server/ReactFlightServerConfigDOM';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-legacy.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-legacy.js
@@ -9,3 +9,4 @@
 
 export * from '../ReactFlightServerConfigStream';
 export * from 'react-server-dom-webpack/src/ReactFlightServerConfigWebpackBundler';
+export * from 'react-dom-bindings/src/server/ReactFlightServerConfigDOM';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-node-webpack.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-node-webpack.js
@@ -9,3 +9,4 @@
 
 export * from '../ReactFlightServerConfigStream';
 export * from 'react-server-dom-webpack/src/ReactFlightServerConfigWebpackBundler';
+export * from 'react-dom-bindings/src/server/ReactFlightServerConfigDOM';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-node.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-node.js
@@ -9,3 +9,4 @@
 
 export * from '../ReactFlightServerConfigStream';
 export * from 'react-server-dom-webpack/src/ReactFlightServerConfigWebpackBundler';
+export * from 'react-dom-bindings/src/server/ReactFlightServerConfigDOM';


### PR DESCRIPTION
Part of https://github.com/facebook/react/pull/26571

Implements wiring for Flight to have it's own "HostConfig" from Fizz.

Historically the ServerFormatConfigs were supposed to be generic enough to be used by Fizz and Flight. However with the addition of features like Float the configs have evolved to be more specific to the renderer. We may want to get back to a place where there is a pure FormatConfig which can be shared but for now we are embracing the fact that these runtimes need very different things and DCE cannot adequately remove the unused stuff for Fizz when pulling this dep into Flight so we are going to fork the configs and just maintain separate ones.

At first the Flight config will be almost empty but once Float support in Flight lands it will have a more complex implementation

Additionally this commit normalizes the component files which make up FlightServerConfig and FlightClientConfig. Now each file that participates starts with ReactFlightServerConfig... and ReactFlightClientConfig...
