### PR TITLE
rename $$$hostConfig to $$$config

### DIFF
--- a/packages/react-client/src/forks/ReactFlightClientConfig.custom.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.custom.js
@@ -23,7 +23,7 @@
 // So `$$$config` looks like a global variable, but it's
 // really an argument to a top-level wrapping function.
 
-declare var $$$hostConfig: any;
+declare var $$$config: any;
 
 export type Response = any;
 export opaque type SSRManifest = mixed;
@@ -31,19 +31,19 @@ export opaque type ServerManifest = mixed;
 export opaque type ServerReferenceId = string;
 export opaque type ClientReferenceMetadata = mixed;
 export opaque type ClientReference<T> = mixed; // eslint-disable-line no-unused-vars
-export const resolveClientReference = $$$hostConfig.resolveClientReference;
-export const resolveServerReference = $$$hostConfig.resolveServerReference;
-export const preloadModule = $$$hostConfig.preloadModule;
-export const requireModule = $$$hostConfig.requireModule;
+export const resolveClientReference = $$$config.resolveClientReference;
+export const resolveServerReference = $$$config.resolveServerReference;
+export const preloadModule = $$$config.preloadModule;
+export const requireModule = $$$config.requireModule;
 
 export opaque type Source = mixed;
 
 export type UninitializedModel = string;
-export const parseModel = $$$hostConfig.parseModel;
+export const parseModel = $$$config.parseModel;
 
 export opaque type StringDecoder = mixed; // eslint-disable-line no-undef
 
-export const supportsBinaryStreams = $$$hostConfig.supportsBinaryStreams;
-export const createStringDecoder = $$$hostConfig.createStringDecoder;
-export const readPartialStringChunk = $$$hostConfig.readPartialStringChunk;
-export const readFinalStringChunk = $$$hostConfig.readFinalStringChunk;
+export const supportsBinaryStreams = $$$config.supportsBinaryStreams;
+export const createStringDecoder = $$$config.createStringDecoder;
+export const readPartialStringChunk = $$$config.readPartialStringChunk;
+export const readFinalStringChunk = $$$config.readFinalStringChunk;

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
@@ -23,7 +23,7 @@
 // So `$$$config` looks like a global variable, but it's
 // really an argument to a top-level wrapping function.
 
-declare var $$$hostConfig: any;
+declare var $$$config: any;
 export opaque type Type = mixed; // eslint-disable-line no-undef
 export opaque type Props = mixed; // eslint-disable-line no-undef
 export opaque type Container = mixed; // eslint-disable-line no-undef
@@ -40,168 +40,163 @@ export opaque type NoTimeout = mixed; // eslint-disable-line no-undef
 export opaque type RendererInspectionConfig = mixed; // eslint-disable-line no-undef
 export type EventResponder = any;
 
-export const getPublicInstance = $$$hostConfig.getPublicInstance;
-export const getRootHostContext = $$$hostConfig.getRootHostContext;
-export const getChildHostContext = $$$hostConfig.getChildHostContext;
-export const prepareForCommit = $$$hostConfig.prepareForCommit;
-export const resetAfterCommit = $$$hostConfig.resetAfterCommit;
-export const createInstance = $$$hostConfig.createInstance;
-export const appendInitialChild = $$$hostConfig.appendInitialChild;
-export const finalizeInitialChildren = $$$hostConfig.finalizeInitialChildren;
-export const prepareUpdate = $$$hostConfig.prepareUpdate;
-export const shouldSetTextContent = $$$hostConfig.shouldSetTextContent;
-export const createTextInstance = $$$hostConfig.createTextInstance;
-export const scheduleTimeout = $$$hostConfig.scheduleTimeout;
-export const cancelTimeout = $$$hostConfig.cancelTimeout;
-export const noTimeout = $$$hostConfig.noTimeout;
-export const isPrimaryRenderer = $$$hostConfig.isPrimaryRenderer;
-export const warnsIfNotActing = $$$hostConfig.warnsIfNotActing;
-export const supportsMutation = $$$hostConfig.supportsMutation;
-export const supportsPersistence = $$$hostConfig.supportsPersistence;
-export const supportsHydration = $$$hostConfig.supportsHydration;
-export const getInstanceFromNode = $$$hostConfig.getInstanceFromNode;
-export const beforeActiveInstanceBlur = $$$hostConfig.beforeActiveInstanceBlur;
-export const afterActiveInstanceBlur = $$$hostConfig.afterActiveInstanceBlur;
-export const preparePortalMount = $$$hostConfig.preparePortalMount;
-export const prepareScopeUpdate = $$$hostConfig.prepareScopeUpdate;
-export const getInstanceFromScope = $$$hostConfig.getInstanceFromScope;
-export const getCurrentEventPriority = $$$hostConfig.getCurrentEventPriority;
-export const detachDeletedInstance = $$$hostConfig.detachDeletedInstance;
-export const requestPostPaintCallback = $$$hostConfig.requestPostPaintCallback;
-export const maySuspendCommit = $$$hostConfig.maySuspendCommit;
-export const preloadInstance = $$$hostConfig.preloadInstance;
-export const startSuspendingCommit = $$$hostConfig.startSuspendingCommit;
-export const suspendInstance = $$$hostConfig.suspendInstance;
-export const waitForCommitToBeReady = $$$hostConfig.waitForCommitToBeReady;
-export const prepareRendererToRender = $$$hostConfig.prepareRendererToRender;
-export const resetRendererAfterRender = $$$hostConfig.resetRendererAfterRender;
+export const getPublicInstance = $$$config.getPublicInstance;
+export const getRootHostContext = $$$config.getRootHostContext;
+export const getChildHostContext = $$$config.getChildHostContext;
+export const prepareForCommit = $$$config.prepareForCommit;
+export const resetAfterCommit = $$$config.resetAfterCommit;
+export const createInstance = $$$config.createInstance;
+export const appendInitialChild = $$$config.appendInitialChild;
+export const finalizeInitialChildren = $$$config.finalizeInitialChildren;
+export const prepareUpdate = $$$config.prepareUpdate;
+export const shouldSetTextContent = $$$config.shouldSetTextContent;
+export const createTextInstance = $$$config.createTextInstance;
+export const scheduleTimeout = $$$config.scheduleTimeout;
+export const cancelTimeout = $$$config.cancelTimeout;
+export const noTimeout = $$$config.noTimeout;
+export const isPrimaryRenderer = $$$config.isPrimaryRenderer;
+export const warnsIfNotActing = $$$config.warnsIfNotActing;
+export const supportsMutation = $$$config.supportsMutation;
+export const supportsPersistence = $$$config.supportsPersistence;
+export const supportsHydration = $$$config.supportsHydration;
+export const getInstanceFromNode = $$$config.getInstanceFromNode;
+export const beforeActiveInstanceBlur = $$$config.beforeActiveInstanceBlur;
+export const afterActiveInstanceBlur = $$$config.afterActiveInstanceBlur;
+export const preparePortalMount = $$$config.preparePortalMount;
+export const prepareScopeUpdate = $$$config.prepareScopeUpdate;
+export const getInstanceFromScope = $$$config.getInstanceFromScope;
+export const getCurrentEventPriority = $$$config.getCurrentEventPriority;
+export const detachDeletedInstance = $$$config.detachDeletedInstance;
+export const requestPostPaintCallback = $$$config.requestPostPaintCallback;
+export const maySuspendCommit = $$$config.maySuspendCommit;
+export const preloadInstance = $$$config.preloadInstance;
+export const startSuspendingCommit = $$$config.startSuspendingCommit;
+export const suspendInstance = $$$config.suspendInstance;
+export const waitForCommitToBeReady = $$$config.waitForCommitToBeReady;
+export const prepareRendererToRender = $$$config.prepareRendererToRender;
+export const resetRendererAfterRender = $$$config.resetRendererAfterRender;
 
 // -------------------
 //      Microtasks
 //     (optional)
 // -------------------
-export const supportsMicrotasks = $$$hostConfig.supportsMicrotasks;
-export const scheduleMicrotask = $$$hostConfig.scheduleMicrotask;
+export const supportsMicrotasks = $$$config.supportsMicrotasks;
+export const scheduleMicrotask = $$$config.scheduleMicrotask;
 
 // -------------------
 //      Test selectors
 //     (optional)
 // -------------------
-export const supportsTestSelectors = $$$hostConfig.supportsTestSelectors;
-export const findFiberRoot = $$$hostConfig.findFiberRoot;
-export const getBoundingRect = $$$hostConfig.getBoundingRect;
-export const getTextContent = $$$hostConfig.getTextContent;
-export const isHiddenSubtree = $$$hostConfig.isHiddenSubtree;
-export const matchAccessibilityRole = $$$hostConfig.matchAccessibilityRole;
-export const setFocusIfFocusable = $$$hostConfig.setFocusIfFocusable;
-export const setupIntersectionObserver =
-  $$$hostConfig.setupIntersectionObserver;
+export const supportsTestSelectors = $$$config.supportsTestSelectors;
+export const findFiberRoot = $$$config.findFiberRoot;
+export const getBoundingRect = $$$config.getBoundingRect;
+export const getTextContent = $$$config.getTextContent;
+export const isHiddenSubtree = $$$config.isHiddenSubtree;
+export const matchAccessibilityRole = $$$config.matchAccessibilityRole;
+export const setFocusIfFocusable = $$$config.setFocusIfFocusable;
+export const setupIntersectionObserver = $$$config.setupIntersectionObserver;
 
 // -------------------
 //      Mutation
 //     (optional)
 // -------------------
-export const appendChild = $$$hostConfig.appendChild;
-export const appendChildToContainer = $$$hostConfig.appendChildToContainer;
-export const commitTextUpdate = $$$hostConfig.commitTextUpdate;
-export const commitMount = $$$hostConfig.commitMount;
-export const commitUpdate = $$$hostConfig.commitUpdate;
-export const insertBefore = $$$hostConfig.insertBefore;
-export const insertInContainerBefore = $$$hostConfig.insertInContainerBefore;
-export const removeChild = $$$hostConfig.removeChild;
-export const removeChildFromContainer = $$$hostConfig.removeChildFromContainer;
-export const resetTextContent = $$$hostConfig.resetTextContent;
-export const hideInstance = $$$hostConfig.hideInstance;
-export const hideTextInstance = $$$hostConfig.hideTextInstance;
-export const unhideInstance = $$$hostConfig.unhideInstance;
-export const unhideTextInstance = $$$hostConfig.unhideTextInstance;
-export const clearContainer = $$$hostConfig.clearContainer;
+export const appendChild = $$$config.appendChild;
+export const appendChildToContainer = $$$config.appendChildToContainer;
+export const commitTextUpdate = $$$config.commitTextUpdate;
+export const commitMount = $$$config.commitMount;
+export const commitUpdate = $$$config.commitUpdate;
+export const insertBefore = $$$config.insertBefore;
+export const insertInContainerBefore = $$$config.insertInContainerBefore;
+export const removeChild = $$$config.removeChild;
+export const removeChildFromContainer = $$$config.removeChildFromContainer;
+export const resetTextContent = $$$config.resetTextContent;
+export const hideInstance = $$$config.hideInstance;
+export const hideTextInstance = $$$config.hideTextInstance;
+export const unhideInstance = $$$config.unhideInstance;
+export const unhideTextInstance = $$$config.unhideTextInstance;
+export const clearContainer = $$$config.clearContainer;
 
 // -------------------
 //     Persistence
 //     (optional)
 // -------------------
-export const cloneInstance = $$$hostConfig.cloneInstance;
-export const createContainerChildSet = $$$hostConfig.createContainerChildSet;
+export const cloneInstance = $$$config.cloneInstance;
+export const createContainerChildSet = $$$config.createContainerChildSet;
 export const appendChildToContainerChildSet =
-  $$$hostConfig.appendChildToContainerChildSet;
-export const finalizeContainerChildren =
-  $$$hostConfig.finalizeContainerChildren;
-export const replaceContainerChildren = $$$hostConfig.replaceContainerChildren;
-export const cloneHiddenInstance = $$$hostConfig.cloneHiddenInstance;
-export const cloneHiddenTextInstance = $$$hostConfig.cloneHiddenTextInstance;
+  $$$config.appendChildToContainerChildSet;
+export const finalizeContainerChildren = $$$config.finalizeContainerChildren;
+export const replaceContainerChildren = $$$config.replaceContainerChildren;
+export const cloneHiddenInstance = $$$config.cloneHiddenInstance;
+export const cloneHiddenTextInstance = $$$config.cloneHiddenTextInstance;
 
 // -------------------
 //     Hydration
 //     (optional)
 // -------------------
-export const isHydratableType = $$$hostConfig.isHydratableType;
-export const isHydratableText = $$$hostConfig.isHydratableText;
-export const isSuspenseInstancePending =
-  $$$hostConfig.isSuspenseInstancePending;
-export const isSuspenseInstanceFallback =
-  $$$hostConfig.isSuspenseInstanceFallback;
+export const isHydratableType = $$$config.isHydratableType;
+export const isHydratableText = $$$config.isHydratableText;
+export const isSuspenseInstancePending = $$$config.isSuspenseInstancePending;
+export const isSuspenseInstanceFallback = $$$config.isSuspenseInstanceFallback;
 export const getSuspenseInstanceFallbackErrorDetails =
-  $$$hostConfig.getSuspenseInstanceFallbackErrorDetails;
+  $$$config.getSuspenseInstanceFallbackErrorDetails;
 export const registerSuspenseInstanceRetry =
-  $$$hostConfig.registerSuspenseInstanceRetry;
-export const getNextHydratableSibling = $$$hostConfig.getNextHydratableSibling;
-export const getFirstHydratableChild = $$$hostConfig.getFirstHydratableChild;
+  $$$config.registerSuspenseInstanceRetry;
+export const getNextHydratableSibling = $$$config.getNextHydratableSibling;
+export const getFirstHydratableChild = $$$config.getFirstHydratableChild;
 export const getFirstHydratableChildWithinContainer =
-  $$$hostConfig.getFirstHydratableChildWithinContainer;
+  $$$config.getFirstHydratableChildWithinContainer;
 export const getFirstHydratableChildWithinSuspenseInstance =
-  $$$hostConfig.getFirstHydratableChildWithinSuspenseInstance;
+  $$$config.getFirstHydratableChildWithinSuspenseInstance;
 export const shouldSkipHydratableForInstance =
-  $$$hostConfig.shouldSkipHydratableForInstance;
+  $$$config.shouldSkipHydratableForInstance;
 export const shouldSkipHydratableForTextInstance =
-  $$$hostConfig.shouldSkipHydratableForTextInstance;
+  $$$config.shouldSkipHydratableForTextInstance;
 export const shouldSkipHydratableForSuspenseInstance =
-  $$$hostConfig.shouldSkipHydratableForSuspenseInstance;
-export const canHydrateInstance = $$$hostConfig.canHydrateInstance;
-export const canHydrateTextInstance = $$$hostConfig.canHydrateTextInstance;
-export const canHydrateSuspenseInstance =
-  $$$hostConfig.canHydrateSuspenseInstance;
-export const hydrateInstance = $$$hostConfig.hydrateInstance;
-export const hydrateTextInstance = $$$hostConfig.hydrateTextInstance;
-export const hydrateSuspenseInstance = $$$hostConfig.hydrateSuspenseInstance;
+  $$$config.shouldSkipHydratableForSuspenseInstance;
+export const canHydrateInstance = $$$config.canHydrateInstance;
+export const canHydrateTextInstance = $$$config.canHydrateTextInstance;
+export const canHydrateSuspenseInstance = $$$config.canHydrateSuspenseInstance;
+export const hydrateInstance = $$$config.hydrateInstance;
+export const hydrateTextInstance = $$$config.hydrateTextInstance;
+export const hydrateSuspenseInstance = $$$config.hydrateSuspenseInstance;
 export const getNextHydratableInstanceAfterSuspenseInstance =
-  $$$hostConfig.getNextHydratableInstanceAfterSuspenseInstance;
-export const commitHydratedContainer = $$$hostConfig.commitHydratedContainer;
+  $$$config.getNextHydratableInstanceAfterSuspenseInstance;
+export const commitHydratedContainer = $$$config.commitHydratedContainer;
 export const commitHydratedSuspenseInstance =
-  $$$hostConfig.commitHydratedSuspenseInstance;
-export const clearSuspenseBoundary = $$$hostConfig.clearSuspenseBoundary;
+  $$$config.commitHydratedSuspenseInstance;
+export const clearSuspenseBoundary = $$$config.clearSuspenseBoundary;
 export const clearSuspenseBoundaryFromContainer =
-  $$$hostConfig.clearSuspenseBoundaryFromContainer;
+  $$$config.clearSuspenseBoundaryFromContainer;
 export const shouldDeleteUnhydratedTailInstances =
-  $$$hostConfig.shouldDeleteUnhydratedTailInstances;
+  $$$config.shouldDeleteUnhydratedTailInstances;
 export const didNotMatchHydratedContainerTextInstance =
-  $$$hostConfig.didNotMatchHydratedContainerTextInstance;
+  $$$config.didNotMatchHydratedContainerTextInstance;
 export const didNotMatchHydratedTextInstance =
-  $$$hostConfig.didNotMatchHydratedTextInstance;
+  $$$config.didNotMatchHydratedTextInstance;
 export const didNotHydrateInstanceWithinContainer =
-  $$$hostConfig.didNotHydrateInstanceWithinContainer;
+  $$$config.didNotHydrateInstanceWithinContainer;
 export const didNotHydrateInstanceWithinSuspenseInstance =
-  $$$hostConfig.didNotHydrateInstanceWithinSuspenseInstance;
-export const didNotHydrateInstance = $$$hostConfig.didNotHydrateInstance;
+  $$$config.didNotHydrateInstanceWithinSuspenseInstance;
+export const didNotHydrateInstance = $$$config.didNotHydrateInstance;
 export const didNotFindHydratableInstanceWithinContainer =
-  $$$hostConfig.didNotFindHydratableInstanceWithinContainer;
+  $$$config.didNotFindHydratableInstanceWithinContainer;
 export const didNotFindHydratableTextInstanceWithinContainer =
-  $$$hostConfig.didNotFindHydratableTextInstanceWithinContainer;
+  $$$config.didNotFindHydratableTextInstanceWithinContainer;
 export const didNotFindHydratableSuspenseInstanceWithinContainer =
-  $$$hostConfig.didNotFindHydratableSuspenseInstanceWithinContainer;
+  $$$config.didNotFindHydratableSuspenseInstanceWithinContainer;
 export const didNotFindHydratableInstanceWithinSuspenseInstance =
-  $$$hostConfig.didNotFindHydratableInstanceWithinSuspenseInstance;
+  $$$config.didNotFindHydratableInstanceWithinSuspenseInstance;
 export const didNotFindHydratableTextInstanceWithinSuspenseInstance =
-  $$$hostConfig.didNotFindHydratableTextInstanceWithinSuspenseInstance;
+  $$$config.didNotFindHydratableTextInstanceWithinSuspenseInstance;
 export const didNotFindHydratableSuspenseInstanceWithinSuspenseInstance =
-  $$$hostConfig.didNotFindHydratableSuspenseInstanceWithinSuspenseInstance;
+  $$$config.didNotFindHydratableSuspenseInstanceWithinSuspenseInstance;
 export const didNotFindHydratableInstance =
-  $$$hostConfig.didNotFindHydratableInstance;
+  $$$config.didNotFindHydratableInstance;
 export const didNotFindHydratableTextInstance =
-  $$$hostConfig.didNotFindHydratableTextInstance;
+  $$$config.didNotFindHydratableTextInstance;
 export const didNotFindHydratableSuspenseInstance =
-  $$$hostConfig.didNotFindHydratableSuspenseInstance;
-export const errorHydratingContainer = $$$hostConfig.errorHydratingContainer;
+  $$$config.didNotFindHydratableSuspenseInstance;
+export const errorHydratingContainer = $$$config.errorHydratingContainer;
 
 // -------------------
 //     Resources
@@ -209,29 +204,28 @@ export const errorHydratingContainer = $$$hostConfig.errorHydratingContainer;
 // -------------------
 export type HoistableRoot = mixed;
 export type Resource = mixed; // eslint-disable-line no-undef
-export const supportsResources = $$$hostConfig.supportsResources;
-export const isHostHoistableType = $$$hostConfig.isHostHoistableType;
-export const getHoistableRoot = $$$hostConfig.getHoistableRoot;
-export const getResource = $$$hostConfig.getResource;
-export const acquireResource = $$$hostConfig.acquireResource;
-export const releaseResource = $$$hostConfig.releaseResource;
-export const hydrateHoistable = $$$hostConfig.hydrateHoistable;
-export const mountHoistable = $$$hostConfig.mountHoistable;
-export const unmountHoistable = $$$hostConfig.unmountHoistable;
-export const createHoistableInstance = $$$hostConfig.createHoistableInstance;
-export const prepareToCommitHoistables =
-  $$$hostConfig.prepareToCommitHoistables;
-export const mayResourceSuspendCommit = $$$hostConfig.mayResourceSuspendCommit;
-export const preloadResource = $$$hostConfig.preloadResource;
-export const suspendResource = $$$hostConfig.suspendResource;
+export const supportsResources = $$$config.supportsResources;
+export const isHostHoistableType = $$$config.isHostHoistableType;
+export const getHoistableRoot = $$$config.getHoistableRoot;
+export const getResource = $$$config.getResource;
+export const acquireResource = $$$config.acquireResource;
+export const releaseResource = $$$config.releaseResource;
+export const hydrateHoistable = $$$config.hydrateHoistable;
+export const mountHoistable = $$$config.mountHoistable;
+export const unmountHoistable = $$$config.unmountHoistable;
+export const createHoistableInstance = $$$config.createHoistableInstance;
+export const prepareToCommitHoistables = $$$config.prepareToCommitHoistables;
+export const mayResourceSuspendCommit = $$$config.mayResourceSuspendCommit;
+export const preloadResource = $$$config.preloadResource;
+export const suspendResource = $$$config.suspendResource;
 
 // -------------------
 //     Singletons
 //     (optional)
 // -------------------
-export const supportsSingletons = $$$hostConfig.supportsSingletons;
-export const resolveSingletonInstance = $$$hostConfig.resolveSingletonInstance;
-export const clearSingleton = $$$hostConfig.clearSingleton;
-export const acquireSingletonInstance = $$$hostConfig.acquireSingletonInstance;
-export const releaseSingletonInstance = $$$hostConfig.releaseSingletonInstance;
-export const isHostSingletonType = $$$hostConfig.isHostSingletonType;
+export const supportsSingletons = $$$config.supportsSingletons;
+export const resolveSingletonInstance = $$$config.resolveSingletonInstance;
+export const clearSingleton = $$$config.clearSingleton;
+export const acquireSingletonInstance = $$$config.acquireSingletonInstance;
+export const releaseSingletonInstance = $$$config.releaseSingletonInstance;
+export const isHostSingletonType = $$$config.isHostSingletonType;

--- a/packages/react-server/src/ReactFlightServerConfigBundlerCustom.js
+++ b/packages/react-server/src/ReactFlightServerConfigBundlerCustom.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-declare var $$$hostConfig: any;
+declare var $$$config: any;
 
 export opaque type ClientManifest = mixed;
 export opaque type ClientReference<T> = mixed; // eslint-disable-line no-unused-vars
@@ -15,11 +15,11 @@ export opaque type ServerReference<T> = mixed; // eslint-disable-line no-unused-
 export opaque type ClientReferenceMetadata: any = mixed;
 export opaque type ServerReferenceId: any = mixed;
 export opaque type ClientReferenceKey: any = mixed;
-export const isClientReference = $$$hostConfig.isClientReference;
-export const isServerReference = $$$hostConfig.isServerReference;
-export const getClientReferenceKey = $$$hostConfig.getClientReferenceKey;
+export const isClientReference = $$$config.isClientReference;
+export const isServerReference = $$$config.isServerReference;
+export const getClientReferenceKey = $$$config.getClientReferenceKey;
 export const resolveClientReferenceMetadata =
-  $$$hostConfig.resolveClientReferenceMetadata;
-export const getServerReferenceId = $$$hostConfig.getServerReferenceId;
+  $$$config.resolveClientReferenceMetadata;
+export const getServerReferenceId = $$$config.getServerReferenceId;
 export const getServerReferenceBoundArguments =
-  $$$hostConfig.getServerReferenceBoundArguments;
+  $$$config.getServerReferenceBoundArguments;

--- a/packages/react-server/src/forks/ReactFizzConfig.custom.js
+++ b/packages/react-server/src/forks/ReactFizzConfig.custom.js
@@ -23,7 +23,7 @@
 // So `$$$config` looks like a global variable, but it's
 // really an argument to a top-level wrapping function.
 
-declare var $$$hostConfig: any;
+declare var $$$config: any;
 export opaque type Destination = mixed; // eslint-disable-line no-undef
 export opaque type ResponseState = mixed;
 export opaque type Resources = mixed;
@@ -33,54 +33,53 @@ export opaque type SuspenseBoundaryID = mixed;
 
 export const isPrimaryRenderer = false;
 
-export const getChildFormatContext = $$$hostConfig.getChildFormatContext;
+export const getChildFormatContext = $$$config.getChildFormatContext;
 export const UNINITIALIZED_SUSPENSE_BOUNDARY_ID =
-  $$$hostConfig.UNINITIALIZED_SUSPENSE_BOUNDARY_ID;
-export const assignSuspenseBoundaryID = $$$hostConfig.assignSuspenseBoundaryID;
-export const makeId = $$$hostConfig.makeId;
-export const pushTextInstance = $$$hostConfig.pushTextInstance;
-export const pushStartInstance = $$$hostConfig.pushStartInstance;
-export const pushEndInstance = $$$hostConfig.pushEndInstance;
+  $$$config.UNINITIALIZED_SUSPENSE_BOUNDARY_ID;
+export const assignSuspenseBoundaryID = $$$config.assignSuspenseBoundaryID;
+export const makeId = $$$config.makeId;
+export const pushTextInstance = $$$config.pushTextInstance;
+export const pushStartInstance = $$$config.pushStartInstance;
+export const pushEndInstance = $$$config.pushEndInstance;
 export const pushStartCompletedSuspenseBoundary =
-  $$$hostConfig.pushStartCompletedSuspenseBoundary;
+  $$$config.pushStartCompletedSuspenseBoundary;
 export const pushEndCompletedSuspenseBoundary =
-  $$$hostConfig.pushEndCompletedSuspenseBoundary;
-export const pushSegmentFinale = $$$hostConfig.pushSegmentFinale;
-export const writeCompletedRoot = $$$hostConfig.writeCompletedRoot;
-export const writePlaceholder = $$$hostConfig.writePlaceholder;
+  $$$config.pushEndCompletedSuspenseBoundary;
+export const pushSegmentFinale = $$$config.pushSegmentFinale;
+export const writeCompletedRoot = $$$config.writeCompletedRoot;
+export const writePlaceholder = $$$config.writePlaceholder;
 export const writeStartCompletedSuspenseBoundary =
-  $$$hostConfig.writeStartCompletedSuspenseBoundary;
+  $$$config.writeStartCompletedSuspenseBoundary;
 export const writeStartPendingSuspenseBoundary =
-  $$$hostConfig.writeStartPendingSuspenseBoundary;
+  $$$config.writeStartPendingSuspenseBoundary;
 export const writeStartClientRenderedSuspenseBoundary =
-  $$$hostConfig.writeStartClientRenderedSuspenseBoundary;
+  $$$config.writeStartClientRenderedSuspenseBoundary;
 export const writeEndCompletedSuspenseBoundary =
-  $$$hostConfig.writeEndCompletedSuspenseBoundary;
+  $$$config.writeEndCompletedSuspenseBoundary;
 export const writeEndPendingSuspenseBoundary =
-  $$$hostConfig.writeEndPendingSuspenseBoundary;
+  $$$config.writeEndPendingSuspenseBoundary;
 export const writeEndClientRenderedSuspenseBoundary =
-  $$$hostConfig.writeEndClientRenderedSuspenseBoundary;
-export const writeStartSegment = $$$hostConfig.writeStartSegment;
-export const writeEndSegment = $$$hostConfig.writeEndSegment;
+  $$$config.writeEndClientRenderedSuspenseBoundary;
+export const writeStartSegment = $$$config.writeStartSegment;
+export const writeEndSegment = $$$config.writeEndSegment;
 export const writeCompletedSegmentInstruction =
-  $$$hostConfig.writeCompletedSegmentInstruction;
+  $$$config.writeCompletedSegmentInstruction;
 export const writeCompletedBoundaryInstruction =
-  $$$hostConfig.writeCompletedBoundaryInstruction;
+  $$$config.writeCompletedBoundaryInstruction;
 export const writeClientRenderBoundaryInstruction =
-  $$$hostConfig.writeClientRenderBoundaryInstruction;
-export const prepareToRender = $$$hostConfig.prepareToRender;
-export const cleanupAfterRender = $$$hostConfig.cleanupAfterRender;
+  $$$config.writeClientRenderBoundaryInstruction;
+export const prepareToRender = $$$config.prepareToRender;
+export const cleanupAfterRender = $$$config.cleanupAfterRender;
 
 // -------------------------
 //     Resources
 // -------------------------
-export const writePreamble = $$$hostConfig.writePreamble;
-export const writeHoistables = $$$hostConfig.writeHoistables;
-export const writePostamble = $$$hostConfig.writePostamble;
-export const hoistResources = $$$hostConfig.hoistResources;
-export const createResources = $$$hostConfig.createResources;
-export const createBoundaryResources = $$$hostConfig.createBoundaryResources;
+export const writePreamble = $$$config.writePreamble;
+export const writeHoistables = $$$config.writeHoistables;
+export const writePostamble = $$$config.writePostamble;
+export const hoistResources = $$$config.hoistResources;
+export const createResources = $$$config.createResources;
+export const createBoundaryResources = $$$config.createBoundaryResources;
 export const setCurrentlyRenderingBoundaryResourcesTarget =
-  $$$hostConfig.setCurrentlyRenderingBoundaryResourcesTarget;
-export const writeResourcesForBoundary =
-  $$$hostConfig.writeResourcesForBoundary;
+  $$$config.setCurrentlyRenderingBoundaryResourcesTarget;
+export const writeResourcesForBoundary = $$$config.writeResourcesForBoundary;

--- a/packages/react-server/src/forks/ReactServerStreamConfig.custom.js
+++ b/packages/react-server/src/forks/ReactServerStreamConfig.custom.js
@@ -23,22 +23,22 @@
 // So `$$$config` looks like a global variable, but it's
 // really an argument to a top-level wrapping function.
 
-declare var $$$hostConfig: any;
+declare var $$$config: any;
 export opaque type Destination = mixed; // eslint-disable-line no-undef
 
 export opaque type PrecomputedChunk = mixed; // eslint-disable-line no-undef
 export opaque type Chunk = mixed; // eslint-disable-line no-undef
 
-export const scheduleWork = $$$hostConfig.scheduleWork;
-export const beginWriting = $$$hostConfig.beginWriting;
-export const writeChunk = $$$hostConfig.writeChunk;
-export const writeChunkAndReturn = $$$hostConfig.writeChunkAndReturn;
-export const completeWriting = $$$hostConfig.completeWriting;
-export const flushBuffered = $$$hostConfig.flushBuffered;
-export const supportsRequestStorage = $$$hostConfig.supportsRequestStorage;
-export const requestStorage = $$$hostConfig.requestStorage;
-export const close = $$$hostConfig.close;
-export const closeWithError = $$$hostConfig.closeWithError;
-export const stringToChunk = $$$hostConfig.stringToChunk;
-export const stringToPrecomputedChunk = $$$hostConfig.stringToPrecomputedChunk;
-export const clonePrecomputedChunk = $$$hostConfig.clonePrecomputedChunk;
+export const scheduleWork = $$$config.scheduleWork;
+export const beginWriting = $$$config.beginWriting;
+export const writeChunk = $$$config.writeChunk;
+export const writeChunkAndReturn = $$$config.writeChunkAndReturn;
+export const completeWriting = $$$config.completeWriting;
+export const flushBuffered = $$$config.flushBuffered;
+export const supportsRequestStorage = $$$config.supportsRequestStorage;
+export const requestStorage = $$$config.requestStorage;
+export const close = $$$config.close;
+export const closeWithError = $$$config.closeWithError;
+export const stringToChunk = $$$config.stringToChunk;
+export const stringToPrecomputedChunk = $$$config.stringToPrecomputedChunk;
+export const clonePrecomputedChunk = $$$config.clonePrecomputedChunk;

--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -349,7 +349,7 @@ ${license}
 'use strict';
 
 if (process.env.NODE_ENV !== "production") {
-  module.exports = function $$$reconciler($$$hostConfig) {
+  module.exports = function $$$reconciler($$$config) {
     var exports = {};
 ${source}
     return exports;
@@ -368,7 +368,7 @@ ${source}
  *
 ${license}
  */
-module.exports = function $$$reconciler($$$hostConfig) {
+module.exports = function $$$reconciler($$$config) {
     
     var exports = {};
 ${source}
@@ -387,7 +387,7 @@ Object.defineProperty(module.exports, "__esModule", { value: true });
  *
 ${license}
  */
-module.exports = function $$$reconciler($$$hostConfig) {
+module.exports = function $$$reconciler($$$config) {
     var exports = {};
 ${source}
     return exports;


### PR DESCRIPTION
We have moved away from HostConfig since the name does not fully describe the configs we customize per runtime like FlightClient, FlightServer, Fizz, and Fiber. This commit generalizes $$$hostconfig to $$$config
