### PR TITLE
[Fizz] Fix incompatible type errors

### DIFF
--- a/packages/react-server/src/ReactFizzComponentStack.js
+++ b/packages/react-server/src/ReactFizzComponentStack.js
@@ -39,8 +39,8 @@ export function getStackByComponentStackNode(
 ): string {
   try {
     let info = '';
-    let node: ComponentStackNode = componentStack;
-    do {
+    let node: ComponentStackNode | null = componentStack;
+    while (node) {
       switch (node.tag) {
         case 0:
           info += describeBuiltInComponentFrame(node.type, null, null);
@@ -52,9 +52,8 @@ export function getStackByComponentStackNode(
           info += describeClassComponentFrame(node.type, null, null);
           break;
       }
-      // $FlowFixMe[incompatible-type] we bail out when we get a null
       node = node.parent;
-    } while (node);
+    }
     return info;
   } catch (x) {
     return '\nError generating stack: ' + x.message + '\n' + x.stack;

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -333,8 +333,8 @@ export function useReducer<S, I, A>(
         renderPhaseUpdates.delete(queue);
         // $FlowFixMe[incompatible-use] found when upgrading Flow
         let newState = workInProgressHook.memoizedState;
-        let update: Update<any> = firstRenderPhaseUpdate;
-        do {
+        let update: Update<any> | null = firstRenderPhaseUpdate;
+        while (update !== null) {
           // Process this render phase update. We don't have to check the
           // priority because it will always be the same as the current
           // render's.
@@ -346,9 +346,8 @@ export function useReducer<S, I, A>(
           if (__DEV__) {
             isInHookUserCodeInDev = false;
           }
-          // $FlowFixMe[incompatible-type] we bail out when we get a null
           update = update.next;
-        } while (update !== null);
+        }
 
         // $FlowFixMe[incompatible-use] found when upgrading Flow
         workInProgressHook.memoizedState = newState;


### PR DESCRIPTION
## Summary

There are these lines in `ReactFizzHooks.js`:

```
let update: Update<any> = firstRenderPhaseUpdate;

...

// $FlowFixMe[incompatible-type] we bail out when we get a null
update = update.next;
```

`Update` is defined as:

```
type Update<A> = {
  action: A,
  next: Update<A> | null,
};
```

Therefore, `update.next` can be `null`, but `let update: Update<any>` cannot. That is why Flow complains about `incompatible-type`, saying:

> Cannot assign `update.next` to `update` because null [1] is incompatible with `Update` [2].

This PR allows for `null` values in the `update` variable in `ReactFizzHooks.js` and in the `node` variable in `ReactFizzComponentStack.js` (similar case).

## How did you test this change?

I ran the existing tests.