### PR TITLE
[Fiber] Implement Basic Suspensey Font support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -505,6 +505,7 @@ module.exports = {
     trustedTypes: 'readonly',
     IS_REACT_ACT_ENVIRONMENT: 'readonly',
     AsyncLocalStorage: 'readonly',
+    FontFaceSet: 'readonly',
     globalThis: 'readonly',
   },
 };

--- a/packages/react-dom/src/__tests__/ReactDOMSuspenseyCommit-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSuspenseyCommit-test.js
@@ -1,0 +1,298 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment ./scripts/jest/ReactDOMServerIntegrationEnvironment
+ */
+
+'use strict';
+
+let JSDOM;
+let React;
+let ReactDOMClient;
+let Scheduler;
+let waitForAll;
+let assertLog;
+let currentFontReady;
+let resolveFontReady;
+let loadCache;
+let container;
+
+describe('ReactDOMSuspenseyCommit', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    JSDOM = require('jsdom').JSDOM;
+
+    const dom = new JSDOM(
+      '<!DOCTYPE html><html><head></head><body><div id="container">',
+      {runScripts: 'dangerously'},
+    );
+    global.window = dom.window;
+    global.document = dom.window.document;
+
+    container = document.getElementById('container');
+
+    currentFontReady = Promise.resolve();
+    resolveFontReady = null;
+
+    Object.defineProperty(document, 'fonts', {
+      enumerable: false,
+      configurable: false,
+      get() {
+        return {
+          ready: currentFontReady,
+          status: resolveFontReady ? 'loading' : 'loaded',
+        };
+      },
+    });
+
+    React = require('react');
+    ReactDOMClient = require('react-dom/client');
+    Scheduler = require('scheduler');
+
+    loadCache = new Set();
+
+    ({waitForAll, assertLog} = require('internal-test-utils'));
+  });
+
+  function startLoadingFonts() {
+    let previousResolveFontReady;
+    if (resolveFontReady) {
+      previousResolveFontReady = resolveFontReady;
+    }
+    currentFontReady = new Promise(resolve => {
+      resolveFontReady = () => {
+        if (previousResolveFontReady) {
+          previousResolveFontReady();
+        }
+        resolve();
+      };
+    });
+  }
+
+  async function finishLoadingFonts() {
+    if (resolveFontReady) {
+      const resolve = resolveFontReady;
+      resolveFontReady = null;
+      resolve();
+    }
+  }
+
+  function loadPreloads(hrefs) {
+    const event = new window.Event('load');
+    const nodes = document.querySelectorAll('link[rel="preload"]');
+    resolveLoadables(hrefs, nodes, event, href =>
+      Scheduler.log('load preload: ' + href),
+    );
+  }
+
+  // function errorPreloads(hrefs) {
+  //   const event = new window.Event('error');
+  //   const nodes = document.querySelectorAll('link[rel="preload"]');
+  //   resolveLoadables(hrefs, nodes, event, href =>
+  //     Scheduler.log('error preload: ' + href),
+  //   );
+  // }
+
+  function loadStylesheets(hrefs) {
+    const event = new window.Event('load');
+    const nodes = document.querySelectorAll('link[rel="stylesheet"]');
+    resolveLoadables(hrefs, nodes, event, href =>
+      Scheduler.log('load stylesheet: ' + href),
+    );
+  }
+
+  // function errorStylesheets(hrefs) {
+  //   const event = new window.Event('error');
+  //   const nodes = document.querySelectorAll('link[rel="stylesheet"]');
+  //   resolveLoadables(hrefs, nodes, event, href => {
+  //     Scheduler.log('error stylesheet: ' + href);
+  //   });
+  // }
+
+  function resolveLoadables(hrefs, nodes, event, onLoad) {
+    const hrefSet = hrefs ? new Set(hrefs) : null;
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+      if (loadCache.has(node)) {
+        continue;
+      }
+      const href = node.getAttribute('href');
+      if (!hrefSet || hrefSet.has(href)) {
+        loadCache.add(node);
+        onLoad(href);
+        node.dispatchEvent(event);
+      }
+    }
+  }
+
+  function getMeaningfulChildren(element) {
+    const children = [];
+    let node = element.firstChild;
+    while (node) {
+      if (node.nodeType === 1) {
+        if (
+          // some tags are ambiguous and might be hidden because they look like non-meaningful children
+          // so we have a global override where if this data attribute is included we also include the node
+          node.hasAttribute('data-meaningful') ||
+          (node.tagName !== 'SCRIPT' &&
+            node.tagName !== 'TEMPLATE' &&
+            node.tagName !== 'template' &&
+            !node.hasAttribute('hidden') &&
+            !node.hasAttribute('aria-hidden'))
+        ) {
+          const props = {};
+          const attributes = node.attributes;
+          for (let i = 0; i < attributes.length; i++) {
+            if (
+              attributes[i].name === 'id' &&
+              attributes[i].value.includes(':')
+            ) {
+              // We assume this is a React added ID that's a non-visual implementation detail.
+              continue;
+            }
+            props[attributes[i].name] = attributes[i].value;
+          }
+          props.children = getMeaningfulChildren(node);
+          children.push(React.createElement(node.tagName.toLowerCase(), props));
+        }
+      } else if (node.nodeType === 3) {
+        children.push(node.data);
+      }
+      node = node.nextSibling;
+    }
+    return children.length === 0
+      ? undefined
+      : children.length === 1
+      ? children[0]
+      : children;
+  }
+
+  it('should wait for fonts to load before committing', async () => {
+    const root = ReactDOMClient.createRoot(container);
+
+    React.startTransition(() => {
+      startLoadingFonts();
+      root.render(<div>hello</div>);
+    });
+    await waitForAll([]);
+    expect(getMeaningfulChildren(container)).toEqual(undefined);
+
+    await finishLoadingFonts();
+    expect(getMeaningfulChildren(container)).toEqual(<div>hello</div>);
+  });
+
+  it('should only wait for fonts for at most 100ms', async () => {
+    const root = ReactDOMClient.createRoot(container);
+
+    React.startTransition(() => {
+      startLoadingFonts();
+      root.render(<div>hello</div>);
+    });
+    await waitForAll([]);
+    expect(getMeaningfulChildren(container)).toEqual(undefined);
+
+    jest.advanceTimersByTime(100);
+    expect(getMeaningfulChildren(container)).toEqual(<div>hello</div>);
+  });
+
+  it('should only wait for stylesheets for at most 1 minute', async () => {
+    const root = ReactDOMClient.createRoot(container);
+
+    React.startTransition(() => {
+      startLoadingFonts();
+      root.render(
+        <div>
+          hello
+          <link rel="stylesheet" href="foo" precedence="default" />
+        </div>,
+      );
+    });
+    await waitForAll([]);
+    expect(getMeaningfulChildren(container)).toEqual(undefined);
+
+    jest.advanceTimersByTime(100);
+    expect(getMeaningfulChildren(container)).toEqual(undefined);
+
+    jest.advanceTimersByTime(1000 * 60);
+    expect(getMeaningfulChildren(container)).toEqual(<div>hello</div>);
+  });
+
+  it('should coordinate stylesheet insertions with completion of commit', async () => {
+    const root = ReactDOMClient.createRoot(container);
+
+    React.startTransition(() => {
+      startLoadingFonts();
+      root.render(
+        <div>
+          hello
+          <link rel="stylesheet" href="foo" precedence="default" />
+        </div>,
+      );
+    });
+    await waitForAll([]);
+    expect(getMeaningfulChildren(container)).toEqual(undefined);
+    expect(getMeaningfulChildren(document.head)).toEqual(
+      <link rel="preload" href="foo" as="style" />,
+    );
+
+    loadPreloads();
+    assertLog(['load preload: foo']);
+    expect(getMeaningfulChildren(container)).toEqual(undefined);
+    expect(getMeaningfulChildren(document.head)).toEqual(
+      <link rel="preload" href="foo" as="style" />,
+    );
+
+    await finishLoadingFonts();
+    expect(getMeaningfulChildren(container)).toEqual(undefined);
+    expect(getMeaningfulChildren(document.head)).toEqual([
+      <link rel="stylesheet" href="foo" data-precedence="default" />,
+      <link rel="preload" href="foo" as="style" />,
+    ]);
+
+    loadStylesheets();
+    assertLog(['load stylesheet: foo']);
+    expect(getMeaningfulChildren(container)).toEqual(<div>hello</div>);
+  });
+
+  it('should coordinate stylesheet insertions with completion of commit even when exceeding the font timeout', async () => {
+    const root = ReactDOMClient.createRoot(container);
+
+    React.startTransition(() => {
+      startLoadingFonts();
+      root.render(
+        <div>
+          hello
+          <link rel="stylesheet" href="foo" precedence="default" />
+        </div>,
+      );
+    });
+    await waitForAll([]);
+    expect(getMeaningfulChildren(container)).toEqual(undefined);
+    expect(getMeaningfulChildren(document.head)).toEqual(
+      <link rel="preload" href="foo" as="style" />,
+    );
+
+    loadPreloads();
+    assertLog(['load preload: foo']);
+    expect(getMeaningfulChildren(container)).toEqual(undefined);
+    expect(getMeaningfulChildren(document.head)).toEqual(
+      <link rel="preload" href="foo" as="style" />,
+    );
+
+    // advance timers to trigger commit timeout for fonts
+    jest.advanceTimersByTime(100);
+    expect(getMeaningfulChildren(container)).toEqual(undefined);
+    expect(getMeaningfulChildren(document.head)).toEqual([
+      <link rel="stylesheet" href="foo" data-precedence="default" />,
+      <link rel="preload" href="foo" as="style" />,
+    ]);
+
+    loadStylesheets();
+    assertLog(['load stylesheet: foo']);
+    expect(getMeaningfulChildren(container)).toEqual(<div>hello</div>);
+  });
+});

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -9,6 +9,7 @@
 
 import {REACT_STRICT_MODE_TYPE} from 'shared/ReactSymbols';
 
+import type {Container} from './ReactFiberConfig';
 import type {Wakeable, Thenable} from 'shared/ReactTypes';
 import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane';
@@ -1208,7 +1209,8 @@ function commitRootWhenReady(
     // At the end, ask the renderer if it's ready to commit, or if we should
     // suspend. If it's not ready, it will return a callback to subscribe to
     // a ready event.
-    const schedulePendingCommit = waitForCommitToBeReady();
+    const container: Container = root.containerInfo;
+    const schedulePendingCommit = waitForCommitToBeReady(container);
     if (schedulePendingCommit !== null) {
       // NOTE: waitForCommitToBeReady returns a subscribe function so that we
       // only allocate a function if the commit isn't ready yet. The other

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -281,3 +281,21 @@ declare module 'node:worker_threads' {
     port2: MessagePort;
   }
 }
+
+// To avoid having to spec the FontFace module (because currently we don't use it)
+// we alias FontFace to mixed.
+type FontFace = mixed;
+declare class FontFaceSet extends EventTarget {
+  +size: number;
+  +status: 'loading' | 'loaded';
+  +ready: Promise<FontFaceSet>;
+  add(fontFace: FontFace): void;
+  check(font: string, text?: string): boolean;
+  clear(): void;
+  delete(fontFace: FontFace): boolean;
+  has(fontFace: FontFace): boolean;
+  load(font: string, text?: string): Promise<Array<FontFace>>;
+  onloading: (event: Event) => void;
+  onloadingdone: (event: Event) => void;
+  onloadingerror: (event: Event) => void;
+}


### PR DESCRIPTION
Fonts are tricky. This PR implements a very basic form of Suspensey fonts that is probably only useful for SSR + hydration.

During a commit we might wait up to 100ms before committing to allow fonts that are currently loading to finish loading. We still maintain the 1 minute timeout for stylesheets so a commit could suspend for longer.

A more advanced Suspensey Font implementation will need to evaluate `document.fonts` after the commit phase and put suspense boundaries into fallback without restarting a render however this requires a change to the way suspense children are rendered and how we retain the fallback fibers even when children are unblocked.