### PR TITLE
[DevTools] use backend manager to support multiple backends in extension

### DIFF
--- a/packages/react-devtools-extensions/src/backend.js
+++ b/packages/react-devtools-extensions/src/backend.js
@@ -1,109 +1,37 @@
-// Do not use imports or top-level requires here!
-// Running module factories is intentionally delayed until we know the hook exists.
-// This is to avoid issues like: https://github.com/facebook/react-devtools/issues/1039
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
 
-// @flow strict-local
+import type {
+  DevToolsBackend,
+  DevToolsHook,
+  ReactRenderer,
+} from 'react-devtools-shared/src/backend/types';
 
-'use strict';
+import Agent from 'react-devtools-shared/src/backend/agent';
+import Bridge from 'react-devtools-shared/src/bridge';
+import {initBackend} from 'react-devtools-shared/src/backend';
+import setupNativeStyleEditor from 'react-devtools-shared/src/backend/NativeStyleEditor/setupNativeStyleEditor';
 
-let welcomeHasInitialized = false;
+import {COMPACT_VERSION_NAME} from './utils';
 
-// $FlowFixMe[missing-local-annot]
-function welcome(event: $FlowFixMe) {
-  if (
-    event.source !== window ||
-    event.data.source !== 'react-devtools-content-script'
-  ) {
-    return;
-  }
+setup(window.__REACT_DEVTOOLS_GLOBAL_HOOK__);
 
-  // In some circumstances, this method is called more than once for a single welcome message.
-  // The exact circumstances of this are unclear, though it seems related to 3rd party event batching code.
-  //
-  // Regardless, call this method multiple times can cause DevTools to add duplicate elements to the Store
-  // (and throw an error) or worse yet, choke up entirely and freeze the browser.
-  //
-  // The simplest solution is to ignore the duplicate events.
-  // To be clear, this SHOULD NOT BE NECESSARY, since we remove the event handler below.
-  //
-  // See https://github.com/facebook/react/issues/24162
-  if (welcomeHasInitialized) {
-    console.warn(
-      'React DevTools detected duplicate welcome "message" events from the content script.',
-    );
-    return;
-  }
-
-  welcomeHasInitialized = true;
-
-  window.removeEventListener('message', welcome);
-
-  setup(window.__REACT_DEVTOOLS_GLOBAL_HOOK__);
-}
-
-window.addEventListener('message', welcome);
-
-function setup(hook: any) {
+function setup(hook: ?DevToolsHook) {
   if (hook == null) {
-    // DevTools didn't get injected into this page (maybe b'c of the contentType).
     return;
   }
-  const Agent = require('react-devtools-shared/src/backend/agent').default;
-  const Bridge = require('react-devtools-shared/src/bridge').default;
-  const {initBackend} = require('react-devtools-shared/src/backend');
-  const setupNativeStyleEditor =
-    require('react-devtools-shared/src/backend/NativeStyleEditor/setupNativeStyleEditor').default;
 
-  const bridge = new Bridge<$FlowFixMe, $FlowFixMe>({
-    listen(fn) {
-      const listener = (event: $FlowFixMe) => {
-        if (
-          event.source !== window ||
-          !event.data ||
-          event.data.source !== 'react-devtools-content-script' ||
-          !event.data.payload
-        ) {
-          return;
-        }
-        fn(event.data.payload);
-      };
-      window.addEventListener('message', listener);
-      return () => {
-        window.removeEventListener('message', listener);
-      };
-    },
-    send(event: string, payload: any, transferable?: Array<any>) {
-      window.postMessage(
-        {
-          source: 'react-devtools-bridge',
-          payload: {event, payload},
-        },
-        '*',
-        transferable,
-      );
-    },
+  hook.backends.set(COMPACT_VERSION_NAME, {
+    Agent,
+    Bridge,
+    initBackend,
+    setupNativeStyleEditor,
   });
-
-  const agent = new Agent(bridge);
-  agent.addListener('shutdown', () => {
-    // If we received 'shutdown' from `agent`, we assume the `bridge` is already shutting down,
-    // and that caused the 'shutdown' event on the `agent`, so we don't need to call `bridge.shutdown()` here.
-    hook.emit('shutdown');
-  });
-
-  initBackend(hook, agent, window);
-
-  // Let the frontend know that the backend has attached listeners and is ready for messages.
-  // This covers the case of syncing saved values after reloading/navigating while DevTools remain open.
-  bridge.send('extensionBackendInitialized');
-
-  // Setup React Native style editor if a renderer like react-native-web has injected it.
-  if (hook.resolveRNStyle) {
-    setupNativeStyleEditor(
-      bridge,
-      agent,
-      hook.resolveRNStyle,
-      hook.nativeStyleEditorValidAttributes,
-    );
-  }
+  hook.emit('devtools-backend-installed', COMPACT_VERSION_NAME);
 }

--- a/packages/react-devtools-extensions/src/backendManager.js
+++ b/packages/react-devtools-extensions/src/backendManager.js
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {
+  DevToolsBackend,
+  DevToolsHook,
+  ReactRenderer,
+} from 'react-devtools-shared/src/backend/types';
+import {hasAssignedBackend} from 'react-devtools-shared/src/backend/utils';
+import {COMPACT_VERSION_NAME} from './utils';
+
+let welcomeHasInitialized = false;
+
+// $FlowFixMe[missing-local-annot]
+function welcome(event: $FlowFixMe) {
+  if (
+    event.source !== window ||
+    event.data.source !== 'react-devtools-content-script'
+  ) {
+    return;
+  }
+
+  // In some circumstances, this method is called more than once for a single welcome message.
+  // The exact circumstances of this are unclear, though it seems related to 3rd party event batching code.
+  //
+  // Regardless, call this method multiple times can cause DevTools to add duplicate elements to the Store
+  // (and throw an error) or worse yet, choke up entirely and freeze the browser.
+  //
+  // The simplest solution is to ignore the duplicate events.
+  // To be clear, this SHOULD NOT BE NECESSARY, since we remove the event handler below.
+  //
+  // See https://github.com/facebook/react/issues/24162
+  if (welcomeHasInitialized) {
+    console.warn(
+      'React DevTools detected duplicate welcome "message" events from the content script.',
+    );
+    return;
+  }
+
+  welcomeHasInitialized = true;
+
+  window.removeEventListener('message', welcome);
+
+  setup(window.__REACT_DEVTOOLS_GLOBAL_HOOK__);
+}
+
+window.addEventListener('message', welcome);
+
+function setup(hook: ?DevToolsHook) {
+  // this should not happen, but Chrome can be weird sometimes
+  if (hook == null) {
+    return;
+  }
+
+  // register renderers that have already injected themselves.
+  hook.renderers.forEach(renderer => {
+    registerRenderer(renderer);
+  });
+  updateRequiredBackends();
+
+  // register renderers that inject themselves later.
+  hook.sub('renderer', ({renderer}) => {
+    registerRenderer(renderer);
+    updateRequiredBackends();
+  });
+
+  // listen for backend installations.
+  hook.sub('devtools-backend-installed', version =>
+    activateBackend(version, hook),
+  );
+}
+
+const requiredBackends = new Set<string>();
+
+function registerRenderer(renderer: ReactRenderer) {
+  let version = renderer.version;
+  if (!hasAssignedBackend(renderer.version)) {
+    version = COMPACT_VERSION_NAME;
+  }
+  requiredBackends.add(version);
+}
+
+function activateBackend(version: string, hook: DevToolsHook) {
+  const backend = hook.backends.get(version);
+  if (!backend) {
+    throw new Error(`Could not find backend for version "${version}"`);
+  }
+  const {Agent, Bridge, initBackend, setupNativeStyleEditor} = backend;
+  const bridge = new Bridge({
+    listen(fn) {
+      const listener = (event: $FlowFixMe) => {
+        if (
+          event.source !== window ||
+          !event.data ||
+          event.data.source !== 'react-devtools-content-script' ||
+          !event.data.payload
+        ) {
+          return;
+        }
+        fn(event.data.payload);
+      };
+      window.addEventListener('message', listener);
+      return () => {
+        window.removeEventListener('message', listener);
+      };
+    },
+    send(event: string, payload: any, transferable?: Array<any>) {
+      window.postMessage(
+        {
+          source: 'react-devtools-bridge',
+          payload: {event, payload},
+        },
+        '*',
+        transferable,
+      );
+    },
+  });
+
+  const agent = new Agent(bridge);
+  agent.addListener('shutdown', () => {
+    // If we received 'shutdown' from `agent`, we assume the `bridge` is already shutting down,
+    // and that caused the 'shutdown' event on the `agent`, so we don't need to call `bridge.shutdown()` here.
+    hook.emit('shutdown');
+  });
+
+  initBackend(hook, agent, window);
+
+  // Setup React Native style editor if a renderer like react-native-web has injected it.
+  if (typeof setupNativeStyleEditor === 'function' && hook.resolveRNStyle) {
+    setupNativeStyleEditor(
+      bridge,
+      agent,
+      hook.resolveRNStyle,
+      hook.nativeStyleEditorValidAttributes,
+    );
+  }
+
+  // Let the frontend know that the backend has attached listeners and is ready for messages.
+  // This covers the case of syncing saved values after reloading/navigating while DevTools remain open.
+  bridge.send('extensionBackendInitialized');
+
+  // this backend is activated
+  requiredBackends.delete(version);
+}
+
+// tell the service worker which versions of backends are needed for the current page
+function updateRequiredBackends() {
+  window.postMessage(
+    {
+      source: 'react-devtools-backend-manager',
+      payload: {
+        type: 'react-devtools-required-backends',
+        versions: Array.from(requiredBackends),
+      },
+    },
+    '*',
+  );
+}

--- a/packages/react-devtools-extensions/src/background.js
+++ b/packages/react-devtools-extensions/src/background.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-import {IS_FIREFOX} from './utils';
+import {IS_FIREFOX, EXTENSION_CONTAINED_VERSIONS} from './utils';
 
 const ports = {};
 
@@ -179,26 +179,50 @@ chrome.runtime.onMessage.addListener((request, sender) => {
     if (request.hasDetectedReact) {
       setIconAndPopup(request.reactBuildType, id);
     } else {
+      const devtools = ports[id]?.devtools;
       switch (request.payload?.type) {
         case 'fetch-file-with-cache-complete':
         case 'fetch-file-with-cache-error':
           // Forward the result of fetch-in-page requests back to the extension.
-          const devtools = ports[id]?.devtools;
-          if (devtools) {
-            devtools.postMessage(request);
-          }
+          devtools?.postMessage(request);
+          break;
+        // This is sent from the backend manager running on a page
+        case 'react-devtools-required-backends':
+          const backendsToDownload = [];
+          request.payload.versions.forEach(version => {
+            if (EXTENSION_CONTAINED_VERSIONS.includes(version)) {
+              if (!IS_FIREFOX) {
+                // TODO: add equivalent logic for Firefox is in prepareInjection.js
+                chrome.scripting.executeScript({
+                  target: {tabId: id},
+                  files: [`/build/react_devtools_backend_${version}.js`],
+                  world: chrome.scripting.ExecutionWorld.MAIN,
+                });
+              }
+            } else {
+              backendsToDownload.push(version);
+            }
+          });
+          // Request the necessary backends in the extension DevTools UI
+          // TODO: handle this message in main.js
+          devtools?.postMessage({
+            payload: {
+              type: 'react-devtools-additional-backends',
+              versions: backendsToDownload,
+            },
+          });
           break;
       }
     }
   } else if (request.payload?.tabId) {
     const tabId = request.payload?.tabId;
     // This is sent from the devtools page when it is ready for injecting the backend
-    if (request.payload.type === 'react-devtools-inject-backend') {
+    if (request.payload.type === 'react-devtools-inject-backend-manager') {
       if (!IS_FIREFOX) {
         // equivalent logic for Firefox is in prepareInjection.js
         chrome.scripting.executeScript({
           target: {tabId},
-          files: ['/build/react_devtools_backend.js'],
+          files: [`/build/backendManager.js`],
           world: chrome.scripting.ExecutionWorld.MAIN,
         });
       }

--- a/packages/react-devtools-extensions/src/contentScripts/prepareInjection.js
+++ b/packages/react-devtools-extensions/src/contentScripts/prepareInjection.js
@@ -90,11 +90,9 @@ window.addEventListener('message', function onMessage({data, source}) {
         );
       }
       break;
-    case 'react-devtools-inject-backend':
+    case 'react-devtools-inject-backend-manager':
       if (IS_FIREFOX) {
-        injectScriptSync(
-          chrome.runtime.getURL('build/react_devtools_backend.js'),
-        );
+        injectScriptSync(chrome.runtime.getURL('build/backendManager.js'));
       }
       break;
   }

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -191,7 +191,7 @@ function createPanelIfReactLoaded() {
           chrome.runtime.sendMessage({
             source: 'react-devtools-main',
             payload: {
-              type: 'react-devtools-inject-backend',
+              type: 'react-devtools-inject-backend-manager',
               tabId,
             },
           });
@@ -199,7 +199,7 @@ function createPanelIfReactLoaded() {
           // Firefox does not support executing script in ExecutionWorld.MAIN from content script.
           // see prepareInjection.js
           chrome.devtools.inspectedWindow.eval(
-            `window.postMessage({ source: 'react-devtools-inject-backend' }, '*');`,
+            `window.postMessage({ source: 'react-devtools-inject-backend-manager' }, '*');`,
             function (response, evalError) {
               if (evalError) {
                 console.error(evalError);

--- a/packages/react-devtools-extensions/src/utils.js
+++ b/packages/react-devtools-extensions/src/utils.js
@@ -41,3 +41,6 @@ export function getBrowserTheme(): BrowserTheme {
     }
   }
 }
+
+export const COMPACT_VERSION_NAME = 'compact';
+export const EXTENSION_CONTAINED_VERSIONS = [COMPACT_VERSION_NAME];

--- a/packages/react-devtools-extensions/webpack.backend.js
+++ b/packages/react-devtools-extensions/webpack.backend.js
@@ -42,7 +42,7 @@ module.exports = {
   },
   output: {
     path: __dirname + '/build',
-    filename: 'react_devtools_backend.js',
+    filename: 'react_devtools_backend_compact.js',
   },
   node: {
     // Don't define a polyfill on window.setImmediate

--- a/packages/react-devtools-extensions/webpack.config.js
+++ b/packages/react-devtools-extensions/webpack.config.js
@@ -51,6 +51,7 @@ module.exports = {
   devtool: __DEV__ ? 'cheap-module-source-map' : false,
   entry: {
     background: './src/background.js',
+    backendManager: './src/backendManager.js',
     main: './src/main.js',
     panel: './src/panel.js',
     proxy: './src/contentScripts/proxy.js',

--- a/packages/react-devtools-shared/src/backend/NativeStyleEditor/setupNativeStyleEditor.js
+++ b/packages/react-devtools-shared/src/backend/NativeStyleEditor/setupNativeStyleEditor.js
@@ -16,6 +16,7 @@ import type {RendererID} from '../types';
 import type {StyleAndLayout} from './types';
 
 export type ResolveNativeStyle = (stylesheetID: any) => ?Object;
+export type SetupNativeStyleEditor = typeof setupNativeStyleEditor;
 
 export default function setupNativeStyleEditor(
   bridge: BackendBridge,

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -22,9 +22,15 @@ import type {
   ElementType,
   Plugins,
 } from 'react-devtools-shared/src/types';
-import type {ResolveNativeStyle} from 'react-devtools-shared/src/backend/NativeStyleEditor/setupNativeStyleEditor';
+import type {
+  ResolveNativeStyle,
+  SetupNativeStyleEditor,
+} from 'react-devtools-shared/src/backend/NativeStyleEditor/setupNativeStyleEditor';
+import type {InitBackend} from 'react-devtools-shared/src/backend';
 import type {TimelineDataExport} from 'react-devtools-timeline/src/types';
 import type {BrowserTheme} from 'react-devtools-shared/src/types';
+import type {BackendBridge} from 'react-devtools-shared/src/bridge';
+import type Agent from './agent';
 
 type BundleType =
   | 0 // PROD
@@ -165,6 +171,8 @@ export type ReactRenderer = {
   // 18.0+
   injectProfilingHooks?: (profilingHooks: DevToolsProfilingHooks) => void,
   getLaneLabelMap?: () => Map<Lane, string> | null,
+  // set by backend after successful attaching
+  attached?: boolean,
   ...
 };
 
@@ -464,10 +472,18 @@ export type DevToolsProfilingHooks = {
   markComponentPassiveEffectUnmountStopped: () => void,
 };
 
+export type DevToolsBackend = {
+  Agent: Class<Agent>,
+  Bridge: Class<BackendBridge>,
+  initBackend: InitBackend,
+  setupNativeStyleEditor?: SetupNativeStyleEditor,
+};
+
 export type DevToolsHook = {
   listeners: {[key: string]: Array<Handler>, ...},
   rendererInterfaces: Map<RendererID, RendererInterface>,
   renderers: Map<RendererID, ReactRenderer>,
+  backends: Map<string, DevToolsBackend>,
 
   emit: (event: string, data: any) => void,
   getFiberRoots: (rendererID: RendererID) => Set<Object>,

--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -14,6 +14,12 @@ import isArray from 'shared/isArray';
 
 import type {DehydratedData} from 'react-devtools-shared/src/devtools/views/Components/types';
 
+// TODO: update this to the first React version that has a corresponding DevTools backend
+const FIRST_DEVTOOLS_BACKEND_LOCKSTEP_VER = '999.9.9';
+export function hasAssignedBackend(version: string): boolean {
+  return gte(version, FIRST_DEVTOOLS_BACKEND_LOCKSTEP_VER);
+}
+
 export function cleanForBridge(
   data: Object | null,
   isPathAllowed: (path: Array<string | number>) => boolean,

--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -15,6 +15,7 @@ import type {
   ReactRenderer,
   RendererID,
   RendererInterface,
+  DevToolsBackend,
 } from './backend/types';
 
 declare var window: any;
@@ -506,10 +507,13 @@ export function installHook(target: any): DevToolsHook | null {
   const rendererInterfaces = new Map<RendererID, RendererInterface>();
   const listeners: {[string]: Array<Handler>} = {};
   const renderers = new Map<RendererID, ReactRenderer>();
+  const backends = new Map<string, DevToolsBackend>();
 
   const hook: DevToolsHook = {
     rendererInterfaces,
     listeners,
+
+    backends,
 
     // Fast Refresh for web relies on this.
     renderers,


### PR DESCRIPTION
In the extension, currently we do the following:
1. check whether there's at least one React renderer on the page
2. if yes, load the backend to the page
3. initialize the backend 

To support multiple versions of backends, we are changing it to:
1. check the versions of React renders on the page
2. load corresponding React DevTools backends that are shipped with the extension; if they are not contained (usually prod builds of prereleases), show a UI to allow users to load them from UI 
3. initialize each of the backends

To enable this workflow, a backend will ignore React renderers that does not match its version

This PR adds a new file "backendManager" in the extension for this purpose. 
