### PR TITLE
Post-process build files for React Native to add generated signature and @nolint

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "rollup-plugin-prettier": "^3.0.0",
     "rollup-plugin-strip-banner": "^3.0.0",
     "semver": "^7.1.1",
+    "signedsource": "^2.0.0",
     "targz": "^1.0.1",
     "through2": "^3.0.1",
     "tmp": "^0.1.0",

--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -2,6 +2,7 @@
 
 const {resolve} = require('path');
 const {readFileSync} = require('fs');
+const {signFile, getSigningToken} = require('signedsource');
 const {bundleTypes, moduleTypes} = require('./bundles');
 
 const {
@@ -238,14 +239,14 @@ ${source}`;
 
   /****************** RN_OSS_DEV ******************/
   [RN_OSS_DEV](source, globalName, filename, moduleType) {
-    return `/**
+    return signFile(`/**
 ${license}
  *
  * @noflow
  * @nolint
  * @providesModule ${globalName}-dev
  * @preventMunge
- * ${'@gen' + 'erated'}
+ * ${getSigningToken()}
  */
 
 'use strict';
@@ -254,48 +255,48 @@ if (__DEV__) {
   (function() {
 ${source}
   })();
-}`;
+}`);
   },
 
   /****************** RN_OSS_PROD ******************/
   [RN_OSS_PROD](source, globalName, filename, moduleType) {
-    return `/**
+    return signFile(`/**
 ${license}
  *
  * @noflow
  * @nolint
  * @providesModule ${globalName}-prod
  * @preventMunge
- * ${'@gen' + 'erated'}
+ * ${getSigningToken()}
  */
 
-${source}`;
+${source}`);
   },
 
   /****************** RN_OSS_PROFILING ******************/
   [RN_OSS_PROFILING](source, globalName, filename, moduleType) {
-    return `/**
+    return signFile(`/**
 ${license}
  *
  * @noflow
  * @nolint
  * @providesModule ${globalName}-profiling
  * @preventMunge
- * ${'@gen' + 'erated'}
+ * ${getSigningToken()}
  */
 
-${source}`;
+${source}`);
   },
 
   /****************** RN_FB_DEV ******************/
   [RN_FB_DEV](source, globalName, filename, moduleType) {
-    return `/**
+    return signFile(`/**
 ${license}
  *
  * @noflow
  * @nolint
  * @preventMunge
- * ${'@gen' + 'erated'}
+ * ${getSigningToken()}
  */
 
 'use strict';
@@ -304,35 +305,35 @@ if (__DEV__) {
   (function() {
 ${source}
   })();
-}`;
+}`);
   },
 
   /****************** RN_FB_PROD ******************/
   [RN_FB_PROD](source, globalName, filename, moduleType) {
-    return `/**
+    return signFile(`/**
 ${license}
  *
  * @noflow
  * @nolint
  * @preventMunge
- * ${'@gen' + 'erated'}
+ * ${getSigningToken()}
  */
 
-${source}`;
+${source}`);
   },
 
   /****************** RN_FB_PROFILING ******************/
   [RN_FB_PROFILING](source, globalName, filename, moduleType) {
-    return `/**
+    return signFile(`/**
 ${license}
  *
  * @noflow
  * @nolint
  * @preventMunge
- * ${'@gen' + 'erated'}
+ * ${getSigningToken()}
  */
 
-${source}`;
+${source}`);
   },
 };
 
@@ -369,7 +370,7 @@ ${source}
 ${license}
  */
 module.exports = function $$$reconciler($$$config) {
-    
+
     var exports = {};
 ${source}
     return exports;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14872,6 +14872,11 @@ signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+signedsource@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-2.0.0.tgz#f72dc0f98f5bca2763b464a555511a84a4da8eee"
+  integrity sha512-MscTxXbMij5JVgrW1xDiMIc+vFa0+H0+HP+rRrFjwa7ef2VAxIP/4L/E75I5H4xvyb4l1X+a9ch+6Zy5uFu7Fg==
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"


### PR DESCRIPTION
## Summary

We're enabling a new mechanism to synchronize build files from `react` to `react-native`. That new mechanism doesn't post-process files, so we need to add that post-processing somewhere. This PR does that when generating the files in the first place, so the generated files in the `build` directory are ready to be committed in the `react-native` repository directly.

This makes use of `signedsource` to avoid direct modifications of these files in the `react-native` repository, as well as `@noformat` and `@nolint` to prevent unactionable CI failures in that repository.

## How did you test this change?

Generated build files for `react-native` before and after this change:
```
node ./scripts/rollup/build-all-release-channels.js react-native
```

Checked new contents. Relevant changes:

```diff
diff --color -r build-before/react-native/implementations/ReactFabric-dev.fb.js build-after/react-native/implementations/ReactFabric-dev.fb.js
10c10
<  * @generated
---
>  * @generated SignedSource<<03cef14e77b8250b567dfdf3b066085e>>
diff --color -r build-before/react-native/implementations/ReactFabric-dev.js build-after/react-native/implementations/ReactFabric-dev.js
11c11
<  * @generated
---
>  * @generated SignedSource<<e39eed38a363846ca9ee9b59a225683c>>
diff --color -r build-before/react-native/implementations/ReactFabric-prod.fb.js build-after/react-native/implementations/ReactFabric-prod.fb.js
10c10
<  * @generated
---
>  * @generated SignedSource<<f65efcd6a469d5f6fef1ce647e5ec09a>>
diff --color -r build-before/react-native/implementations/ReactFabric-prod.js build-after/react-native/implementations/ReactFabric-prod.js
11c11
<  * @generated
---
>  * @generated SignedSource<<cdd582aa889b1054b2c5faf412622b18>>
diff --color -r build-before/react-native/implementations/ReactFabric-profiling.fb.js build-after/react-native/implementations/ReactFabric-profiling.fb.js
10c10
<  * @generated
---
>  * @generated SignedSource<<81e74849b24f104882bd298f062be0fa>>
diff --color -r build-before/react-native/implementations/ReactFabric-profiling.js build-after/react-native/implementations/ReactFabric-profiling.js
11c11
<  * @generated
---
>  * @generated SignedSource<<c050b7fa1453dc21ac1c5b98146210a8>>
diff --color -r build-before/react-native/implementations/ReactNativeRenderer-dev.fb.js build-after/react-native/implementations/ReactNativeRenderer-dev.fb.js
10c10
<  * @generated
---
>  * @generated SignedSource<<9c03464b489b41c06a065aeba8619263>>
diff --color -r build-before/react-native/implementations/ReactNativeRenderer-dev.js build-after/react-native/implementations/ReactNativeRenderer-dev.js
11c11
<  * @generated
---
>  * @generated SignedSource<<18b34c037544949dcf9b28f945921ba8>>
diff --color -r build-before/react-native/implementations/ReactNativeRenderer-prod.fb.js build-after/react-native/implementations/ReactNativeRenderer-prod.fb.js
10c10
<  * @generated
---
>  * @generated SignedSource<<592e9654c584d1da523378b119bd8bd7>>
diff --color -r build-before/react-native/implementations/ReactNativeRenderer-prod.js build-after/react-native/implementations/ReactNativeRenderer-prod.js
11c11
<  * @generated
---
>  * @generated SignedSource<<91c894db99e2d76f8a32708ad6ad1bde>>
diff --color -r build-before/react-native/implementations/ReactNativeRenderer-profiling.fb.js build-after/react-native/implementations/ReactNativeRenderer-profiling.fb.js
10c10
<  * @generated
---
>  * @generated SignedSource<<5ce378a9216ea747d91b208b9fd1ebd5>>
diff --color -r build-before/react-native/implementations/ReactNativeRenderer-profiling.js build-after/react-native/implementations/ReactNativeRenderer-profiling.js
11c11
<  * @generated
---
>  * @generated SignedSource<<1c7564f446ee83142976035b2884dcfd>>
diff --color -r build-before/react-native/shims/ReactFabric.js build-after/react-native/shims/ReactFabric.js
7c7
<  * @format
---
>  * @noformat
8a9,10
>  * @nolint
>  * @generated SignedSource<<cece19ddbec9f287c995721f49c68977>>
diff --color -r build-before/react-native/shims/ReactFeatureFlags.js build-after/react-native/shims/ReactFeatureFlags.js
7c7
<  * @format
---
>  * @noformat
8a9,10
>  * @nolint
>  * @generated SignedSource<<2881c8e89ef0f73f4cf6612cb518b197>>
diff --color -r build-before/react-native/shims/ReactNative.js build-after/react-native/shims/ReactNative.js
7c7
<  * @format
---
>  * @noformat
8a9,10
>  * @nolint
>  * @generated SignedSource<<0debd6e5a17dc037cb4661315a886de6>>
diff --color -r build-before/react-native/shims/ReactNativeTypes.js build-after/react-native/shims/ReactNativeTypes.js
7c7
<  * @format
---
>  * @noformat
8a9,10
>  * @nolint
>  * @generated SignedSource<<652b117c94307244bcf5e4af18928903>>
diff --color -r build-before/react-native/shims/ReactNativeViewConfigRegistry.js build-after/react-native/shims/ReactNativeViewConfigRegistry.js
7c7
<  * @format
---
>  * @noformat
8a9,10
>  * @nolint
>  * @generated SignedSource<<ce82e8957367bee7d11379ab88e3f7c5>>
diff --color -r build-before/react-native/shims/createReactNativeComponentClass.js build-after/react-native/shims/createReactNativeComponentClass.js
7c7
<  * @format
---
>  * @noformat
8a9,10
>  * @nolint
>  * @generated SignedSource<<ede54ac2fa1b9a09e234cdf098048989>>
```