### PR TITLE
Initial (client-only) async actions support

### DIFF
--- a/packages/react-reconciler/src/ReactFiberAsyncAction.js
+++ b/packages/react-reconciler/src/ReactFiberAsyncAction.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Wakeable} from 'shared/ReactTypes';
+import type {Lane} from './ReactFiberLane';
+import {requestTransitionLane} from './ReactFiberRootScheduler';
+
+interface AsyncActionImpl {
+  lane: Lane;
+  listeners: Array<(false) => mixed>;
+  count: number;
+  then(
+    onFulfill: (value: boolean) => mixed,
+    onReject: (error: mixed) => mixed,
+  ): void;
+}
+
+interface PendingAsyncAction extends AsyncActionImpl {
+  status: 'pending';
+}
+
+interface FulfilledAsyncAction extends AsyncActionImpl {
+  status: 'fulfilled';
+  value: boolean;
+}
+
+interface RejectedAsyncAction extends AsyncActionImpl {
+  status: 'rejected';
+  reason: mixed;
+}
+
+type AsyncAction =
+  | PendingAsyncAction
+  | FulfilledAsyncAction
+  | RejectedAsyncAction;
+
+let currentAsyncAction: AsyncAction | null = null;
+
+export function requestAsyncActionContext(
+  actionReturnValue: mixed,
+): AsyncAction | false {
+  if (
+    actionReturnValue !== null &&
+    typeof actionReturnValue === 'object' &&
+    typeof actionReturnValue.then === 'function'
+  ) {
+    // This is an async action.
+    //
+    // Return a thenable that resolves once the action scope (i.e. the async
+    // function passed to startTransition) has finished running. The fulfilled
+    // value is `false` to represent that the action is not pending.
+    const thenable: Wakeable = (actionReturnValue: any);
+    if (currentAsyncAction === null) {
+      // There's no outer async action scope. Create a new one.
+      const asyncAction: AsyncAction = {
+        lane: requestTransitionLane(),
+        listeners: [],
+        count: 0,
+        status: 'pending',
+        value: false,
+        reason: undefined,
+        then(resolve: boolean => mixed) {
+          asyncAction.listeners.push(resolve);
+        },
+      };
+      attachPingListeners(thenable, asyncAction);
+      currentAsyncAction = asyncAction;
+      return asyncAction;
+    } else {
+      // Inherit the outer scope.
+      const asyncAction: AsyncAction = (currentAsyncAction: any);
+      attachPingListeners(thenable, asyncAction);
+      return asyncAction;
+    }
+  } else {
+    // This is not an async action, but it may be part of an outer async action.
+    if (currentAsyncAction === null) {
+      // There's no outer async action scope.
+      return false;
+    } else {
+      // Inherit the outer scope.
+      return currentAsyncAction;
+    }
+  }
+}
+
+export function peekAsyncActionContext(): AsyncAction | null {
+  return currentAsyncAction;
+}
+
+function attachPingListeners(thenable: Wakeable, asyncAction: AsyncAction) {
+  asyncAction.count++;
+  thenable.then(
+    () => {
+      if (--asyncAction.count === 0) {
+        const fulfilledAsyncAction: FulfilledAsyncAction = (asyncAction: any);
+        fulfilledAsyncAction.status = 'fulfilled';
+        completeAsyncActionScope(asyncAction);
+      }
+    },
+    (error: mixed) => {
+      if (--asyncAction.count === 0) {
+        const rejectedAsyncAction: RejectedAsyncAction = (asyncAction: any);
+        rejectedAsyncAction.status = 'rejected';
+        rejectedAsyncAction.reason = error;
+        completeAsyncActionScope(asyncAction);
+      }
+    },
+  );
+  return asyncAction;
+}
+
+function completeAsyncActionScope(action: AsyncAction) {
+  if (currentAsyncAction === action) {
+    currentAsyncAction = null;
+  }
+
+  const listeners = action.listeners;
+  action.listeners = [];
+  for (let i = 0; i < listeners.length; i++) {
+    const listener = listeners[i];
+    listener(false);
+  }
+}

--- a/packages/react-reconciler/src/ReactFiberRootScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberRootScheduler.js
@@ -22,6 +22,7 @@ import {
   markStarvedLanesAsExpired,
   markRootEntangled,
   mergeLanes,
+  claimNextTransitionLane,
 } from './ReactFiberLane';
 import {
   CommitContext,
@@ -78,7 +79,7 @@ let mightHavePendingSyncWork: boolean = false;
 
 let isFlushingWork: boolean = false;
 
-let currentEventTransitionLane: Lane = NoLanes;
+let currentEventTransitionLane: Lane = NoLane;
 
 export function ensureRootIsScheduled(root: FiberRoot): void {
   // This function is called whenever a root receives an update. It does two
@@ -491,10 +492,17 @@ function scheduleImmediateTask(cb: () => mixed) {
   }
 }
 
-export function getCurrentEventTransitionLane(): Lane {
+export function requestTransitionLane(): Lane {
+  // The algorithm for assigning an update to a lane should be stable for all
+  // updates at the same priority within the same event. To do this, the
+  // inputs to the algorithm must be the same.
+  //
+  // The trick we use is to cache the first of each of these inputs within an
+  // event. Then reset the cached values once we can be sure the event is
+  // over. Our heuristic for that is whenever we enter a concurrent work loop.
+  if (currentEventTransitionLane === NoLane) {
+    // All transitions within the same event are assigned the same lane.
+    currentEventTransitionLane = claimNextTransitionLane();
+  }
   return currentEventTransitionLane;
-}
-
-export function setCurrentEventTransitionLane(lane: Lane): void {
-  currentEventTransitionLane = lane;
 }

--- a/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
@@ -1,0 +1,530 @@
+let React;
+let ReactNoop;
+let Scheduler;
+let act;
+let assertLog;
+let useTransition;
+let useState;
+let textCache;
+
+describe('ReactAsyncActions', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    React = require('react');
+    ReactNoop = require('react-noop-renderer');
+    Scheduler = require('scheduler');
+    act = require('internal-test-utils').act;
+    assertLog = require('internal-test-utils').assertLog;
+    useTransition = React.useTransition;
+    useState = React.useState;
+
+    textCache = new Map();
+  });
+
+  function resolveText(text) {
+    const record = textCache.get(text);
+    if (record === undefined) {
+      const newRecord = {
+        status: 'resolved',
+        value: text,
+      };
+      textCache.set(text, newRecord);
+    } else if (record.status === 'pending') {
+      const thenable = record.value;
+      record.status = 'resolved';
+      record.value = text;
+      thenable.pings.forEach(t => t());
+    }
+  }
+
+  function readText(text) {
+    const record = textCache.get(text);
+    if (record !== undefined) {
+      switch (record.status) {
+        case 'pending':
+          Scheduler.log(`Suspend! [${text}]`);
+          throw record.value;
+        case 'rejected':
+          throw record.value;
+        case 'resolved':
+          return record.value;
+      }
+    } else {
+      Scheduler.log(`Suspend! [${text}]`);
+      const thenable = {
+        pings: [],
+        then(resolve) {
+          if (newRecord.status === 'pending') {
+            thenable.pings.push(resolve);
+          } else {
+            Promise.resolve().then(() => resolve(newRecord.value));
+          }
+        },
+      };
+
+      const newRecord = {
+        status: 'pending',
+        value: thenable,
+      };
+      textCache.set(text, newRecord);
+
+      throw thenable;
+    }
+  }
+
+  function getText(text) {
+    const record = textCache.get(text);
+    if (record === undefined) {
+      const thenable = {
+        pings: [],
+        then(resolve) {
+          if (newRecord.status === 'pending') {
+            thenable.pings.push(resolve);
+          } else {
+            Promise.resolve().then(() => resolve(newRecord.value));
+          }
+        },
+      };
+      const newRecord = {
+        status: 'pending',
+        value: thenable,
+      };
+      textCache.set(text, newRecord);
+      return thenable;
+    } else {
+      switch (record.status) {
+        case 'pending':
+          return record.value;
+        case 'rejected':
+          return Promise.reject(record.value);
+        case 'resolved':
+          return Promise.resolve(record.value);
+      }
+    }
+  }
+
+  function Text({text}) {
+    Scheduler.log(text);
+    return text;
+  }
+
+  function AsyncText({text}) {
+    readText(text);
+    Scheduler.log(text);
+    return text;
+  }
+
+  // @gate enableAsyncActions
+  test('isPending remains true until async action finishes', async () => {
+    let startTransition;
+    function App() {
+      const [isPending, _start] = useTransition();
+      startTransition = _start;
+      return <Text text={'Pending: ' + isPending} />;
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(() => {
+      root.render(<App />);
+    });
+    assertLog(['Pending: false']);
+    expect(root).toMatchRenderedOutput('Pending: false');
+
+    // At the start of an async action, isPending is set to true.
+    await act(() => {
+      startTransition(async () => {
+        Scheduler.log('Async action started');
+        await getText('Wait');
+        Scheduler.log('Async action ended');
+      });
+    });
+    assertLog(['Async action started', 'Pending: true']);
+    expect(root).toMatchRenderedOutput('Pending: true');
+
+    // Once the action finishes, isPending is set back to false.
+    await act(() => resolveText('Wait'));
+    assertLog(['Async action ended', 'Pending: false']);
+    expect(root).toMatchRenderedOutput('Pending: false');
+  });
+
+  // @gate enableAsyncActions
+  test('multiple updates in an async action scope are entangled together', async () => {
+    let startTransition;
+    function App({text}) {
+      const [isPending, _start] = useTransition();
+      startTransition = _start;
+      return (
+        <>
+          <span>
+            <Text text={'Pending: ' + isPending} />
+          </span>
+          <span>
+            <Text text={text} />
+          </span>
+        </>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(() => {
+      root.render(<App text="A" />);
+    });
+    assertLog(['Pending: false', 'A']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span>Pending: false</span>
+        <span>A</span>
+      </>,
+    );
+
+    await act(() => {
+      startTransition(async () => {
+        Scheduler.log('Async action started');
+        await getText('Yield before updating');
+        Scheduler.log('Async action ended');
+        startTransition(() => root.render(<App text="B" />));
+      });
+    });
+    assertLog(['Async action started', 'Pending: true', 'A']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span>Pending: true</span>
+        <span>A</span>
+      </>,
+    );
+
+    await act(() => resolveText('Yield before updating'));
+    assertLog(['Async action ended', 'Pending: false', 'B']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span>Pending: false</span>
+        <span>B</span>
+      </>,
+    );
+  });
+
+  // @gate enableAsyncActions
+  test('multiple async action updates in the same scope are entangled together', async () => {
+    let setStepA;
+    function A() {
+      const [step, setStep] = useState(0);
+      setStepA = setStep;
+      return <AsyncText text={'A' + step} />;
+    }
+
+    let setStepB;
+    function B() {
+      const [step, setStep] = useState(0);
+      setStepB = setStep;
+      return <AsyncText text={'B' + step} />;
+    }
+
+    let setStepC;
+    function C() {
+      const [step, setStep] = useState(0);
+      setStepC = setStep;
+      return <AsyncText text={'C' + step} />;
+    }
+
+    let startTransition;
+    function App() {
+      const [isPending, _start] = useTransition();
+      startTransition = _start;
+      return (
+        <>
+          <span>
+            <Text text={'Pending: ' + isPending} />
+          </span>
+          <span>
+            <A />, <B />, <C />
+          </span>
+        </>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    resolveText('A0');
+    resolveText('B0');
+    resolveText('C0');
+    await act(() => {
+      root.render(<App text="A" />);
+    });
+    assertLog(['Pending: false', 'A0', 'B0', 'C0']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span>Pending: false</span>
+        <span>A0, B0, C0</span>
+      </>,
+    );
+
+    await act(() => {
+      startTransition(async () => {
+        Scheduler.log('Async action started');
+        setStepA(1);
+        await getText('Wait before updating B');
+        startTransition(() => setStepB(1));
+        await getText('Wait before updating C');
+        startTransition(() => setStepC(1));
+        Scheduler.log('Async action ended');
+      });
+    });
+    assertLog(['Async action started', 'Pending: true', 'A0', 'B0', 'C0']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span>Pending: true</span>
+        <span>A0, B0, C0</span>
+      </>,
+    );
+
+    // This will schedule an update on B, but nothing will render yet because
+    // the async action scope hasn't finished.
+    await act(() => resolveText('Wait before updating B'));
+    assertLog([]);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span>Pending: true</span>
+        <span>A0, B0, C0</span>
+      </>,
+    );
+
+    // This will schedule an update on C, and also the async action scope
+    // will end. This will allow React to attempt to render the updates.
+    await act(() => resolveText('Wait before updating C'));
+    assertLog(['Async action ended', 'Pending: false', 'Suspend! [A1]']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span>Pending: true</span>
+        <span>A0, B0, C0</span>
+      </>,
+    );
+
+    // Progressively load the all the data. Because they are all entangled
+    // together, only when the all of A, B, and C updates are unblocked is the
+    // render allowed to proceed.
+    await act(() => resolveText('A1'));
+    assertLog(['Pending: false', 'A1', 'Suspend! [B1]']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span>Pending: true</span>
+        <span>A0, B0, C0</span>
+      </>,
+    );
+    await act(() => resolveText('B1'));
+    assertLog(['Pending: false', 'A1', 'B1', 'Suspend! [C1]']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span>Pending: true</span>
+        <span>A0, B0, C0</span>
+      </>,
+    );
+
+    // Finally, all the data has loaded and the transition is complete.
+    await act(() => resolveText('C1'));
+    assertLog(['Pending: false', 'A1', 'B1', 'C1']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span>Pending: false</span>
+        <span>A1, B1, C1</span>
+      </>,
+    );
+  });
+
+  // @gate enableAsyncActions
+  test('urgent updates are not blocked during an async action', async () => {
+    let setStepA;
+    function A() {
+      const [step, setStep] = useState(0);
+      setStepA = setStep;
+      return <Text text={'A' + step} />;
+    }
+
+    let setStepB;
+    function B() {
+      const [step, setStep] = useState(0);
+      setStepB = setStep;
+      return <Text text={'B' + step} />;
+    }
+
+    let startTransition;
+    function App() {
+      const [isPending, _start] = useTransition();
+      startTransition = _start;
+      return (
+        <>
+          <span>
+            <Text text={'Pending: ' + isPending} />
+          </span>
+          <span>
+            <A />, <B />
+          </span>
+        </>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(() => {
+      root.render(<App text="A" />);
+    });
+    assertLog(['Pending: false', 'A0', 'B0']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span>Pending: false</span>
+        <span>A0, B0</span>
+      </>,
+    );
+
+    await act(() => {
+      startTransition(async () => {
+        Scheduler.log('Async action started');
+        startTransition(() => setStepA(1));
+        await getText('Wait');
+        Scheduler.log('Async action ended');
+      });
+    });
+    assertLog(['Async action started', 'Pending: true', 'A0', 'B0']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span>Pending: true</span>
+        <span>A0, B0</span>
+      </>,
+    );
+
+    // Update B at urgent priority. This should be allowed to finish.
+    await act(() => setStepB(1));
+    assertLog(['B1']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span>Pending: true</span>
+        <span>A0, B1</span>
+      </>,
+    );
+
+    // Finish the async action.
+    await act(() => resolveText('Wait'));
+    assertLog(['Async action ended', 'Pending: false', 'A1', 'B1']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span>Pending: false</span>
+        <span>A1, B1</span>
+      </>,
+    );
+  });
+
+  // @gate enableAsyncActions
+  test("if a sync action throws, it's rethrown from the `useTransition`", async () => {
+    class ErrorBoundary extends React.Component {
+      state = {error: null};
+      static getDerivedStateFromError(error) {
+        return {error};
+      }
+      render() {
+        if (this.state.error) {
+          return <Text text={this.state.error.message} />;
+        }
+        return this.props.children;
+      }
+    }
+
+    let startTransition;
+    function App() {
+      const [isPending, _start] = useTransition();
+      startTransition = _start;
+      return <Text text={'Pending: ' + isPending} />;
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(() => {
+      root.render(
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>,
+      );
+    });
+    assertLog(['Pending: false']);
+    expect(root).toMatchRenderedOutput('Pending: false');
+
+    await act(() => {
+      startTransition(() => {
+        throw new Error('Oops!');
+      });
+    });
+    assertLog(['Pending: true', 'Oops!', 'Oops!']);
+    expect(root).toMatchRenderedOutput('Oops!');
+  });
+
+  // @gate enableAsyncActions
+  test("if an async action throws, it's rethrown from the `useTransition`", async () => {
+    class ErrorBoundary extends React.Component {
+      state = {error: null};
+      static getDerivedStateFromError(error) {
+        return {error};
+      }
+      render() {
+        if (this.state.error) {
+          return <Text text={this.state.error.message} />;
+        }
+        return this.props.children;
+      }
+    }
+
+    let startTransition;
+    function App() {
+      const [isPending, _start] = useTransition();
+      startTransition = _start;
+      return <Text text={'Pending: ' + isPending} />;
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(() => {
+      root.render(
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>,
+      );
+    });
+    assertLog(['Pending: false']);
+    expect(root).toMatchRenderedOutput('Pending: false');
+
+    await act(() => {
+      startTransition(async () => {
+        Scheduler.log('Async action started');
+        await getText('Wait');
+        throw new Error('Oops!');
+      });
+    });
+    assertLog(['Async action started', 'Pending: true']);
+    expect(root).toMatchRenderedOutput('Pending: true');
+
+    await act(() => resolveText('Wait'));
+    assertLog(['Oops!', 'Oops!']);
+    expect(root).toMatchRenderedOutput('Oops!');
+  });
+
+  // @gate !enableAsyncActions
+  test('when enableAsyncActions is disabled, and a sync action throws, `isPending` is turned off', async () => {
+    let startTransition;
+    function App() {
+      const [isPending, _start] = useTransition();
+      startTransition = _start;
+      return <Text text={'Pending: ' + isPending} />;
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(() => {
+      root.render(<App />);
+    });
+    assertLog(['Pending: false']);
+    expect(root).toMatchRenderedOutput('Pending: false');
+
+    await act(() => {
+      expect(() => {
+        startTransition(() => {
+          throw new Error('Oops!');
+        });
+      }).toThrow('Oops!');
+    });
+    assertLog(['Pending: true', 'Pending: false']);
+    expect(root).toMatchRenderedOutput('Pending: false');
+  });
+});

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -120,6 +120,8 @@ export const enableFizzExternalRuntime = true;
 // Performance related test
 export const diffInCommitPhase = __EXPERIMENTAL__;
 
+export const enableAsyncActions = __EXPERIMENTAL__;
+
 // -----------------------------------------------------------------------------
 // Chopping Block
 //

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -82,6 +82,7 @@ export const useModernStrictMode = false;
 export const enableFizzExternalRuntime = false;
 
 export const diffInCommitPhase = true;
+export const enableAsyncActions = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -72,6 +72,7 @@ export const enableFizzExternalRuntime = false;
 export const enableDeferRootSchedulingToMicrotask = true;
 
 export const diffInCommitPhase = true;
+export const enableAsyncActions = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -72,6 +72,7 @@ export const enableFizzExternalRuntime = false;
 export const enableDeferRootSchedulingToMicrotask = true;
 
 export const diffInCommitPhase = true;
+export const enableAsyncActions = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -69,6 +69,7 @@ export const useModernStrictMode = false;
 export const enableDeferRootSchedulingToMicrotask = true;
 
 export const diffInCommitPhase = true;
+export const enableAsyncActions = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -74,6 +74,7 @@ export const enableFizzExternalRuntime = false;
 export const enableDeferRootSchedulingToMicrotask = true;
 
 export const diffInCommitPhase = true;
+export const enableAsyncActions = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -26,6 +26,7 @@ export const enableTransitionTracing = __VARIANT__;
 export const enableCustomElementPropertySupport = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const diffInCommitPhase = __VARIANT__;
+export const enableAsyncActions = __VARIANT__;
 
 // Enable this flag to help with concurrent mode debugging.
 // It logs information to the console about React scheduling, rendering, and commit phases.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -29,6 +29,7 @@ export const {
   enableCustomElementPropertySupport,
   enableDeferRootSchedulingToMicrotask,
   diffInCommitPhase,
+  enableAsyncActions,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.


### PR DESCRIPTION
Implements initial (client-only) support for async actions behind a flag. This is an experimental feature and the design isn't completely finalized but we're getting closer. It will be layered alongside other features we're working on, so it may not feel complete when considered in isolation.

The basic description is you can pass an async function to `startTransition` and all the transition updates that are scheduled inside that async function will be grouped together. The `isPending` flag will be set to true immediately, and only set back to false once the async action has completed (as well as all the updates that it triggers).

The ideal behavior would be that all updates spawned by the async action are automatically inferred and grouped together; however, doing this properly requires the upcoming (stage 2) Async Context API, which is not yet implemented by browsers. In the meantime, we will fake this by grouping together all transition updates that occur until the async function has terminated. This can lead to overgrouping between unrelated actions, which is not wrong per se, just not ideal.

If the `useTransition` hook is removed from the UI before an async action has completed — for example, if the user navigates to a new page — subsequent transitions will no longer be grouped with together with that action.

Another consequence of the lack of Async Context is that if you call `setState` inside an action but after an `await`, it must be wrapped in `startTransition` in order to be grouped properly. If we didn't require this, then there would be no way to distinguish action updates from urgent updates caused by user input, too. This is an unfortunate footgun but we can likely detect the most common mistakes using a lint rule.

Once Async Context lands in browsers, we can start warning in dev if we detect an update that hasn't been wrapped in `startTransition`. Then, longer term, once the feature is ubiquitous, we can rely on it for real and allow you to call `setState` without the additional wrapper.

Things that are _not_ yet implemented in this PR, but will be added as follow ups:

- Support for non-hook form of `startTransition`
- Canceling the async action scope if the `useTransition` hook is deleted from the UI
- Anything related to server actions