### PR TITLE
refactor: code redundance

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -769,6 +769,7 @@ function bubbleProperties(completedWork: Fiber) {
   let newChildLanes = NoLanes;
   let subtreeFlags = NoFlags;
 
+  let child = completedWork.child;
   // Bubble up the earliest expiration time.
   if (enableProfilerTimer && (completedWork.mode & ProfileMode) !== NoMode) {
     // In profiling mode, resetChildExpirationTime is also used to reset
@@ -776,7 +777,6 @@ function bubbleProperties(completedWork: Fiber) {
     let actualDuration = completedWork.actualDuration;
     let treeBaseDuration = ((completedWork.selfBaseDuration: any): number);
 
-    let child = completedWork.child;
     while (child !== null) {
       newChildLanes = mergeLanes(
         newChildLanes,
@@ -796,13 +796,12 @@ function bubbleProperties(completedWork: Fiber) {
       // render. In that case it should not bubble. We determine whether it was
       // cloned by comparing the child pointer.
       // $FlowFixMe[unsafe-addition] addition with possible null/undefined value
-      if (!didBailout && actualDuration) {
+      if (!didBailout) {
         actualDuration += child.actualDuration;
       }
 
       // $FlowFixMe[unsafe-addition] addition with possible null/undefined value
       treeBaseDuration += child.treeBaseDuration;
-
       child = child.sibling;
     }
 
@@ -811,12 +810,12 @@ function bubbleProperties(completedWork: Fiber) {
     }
     completedWork.treeBaseDuration = treeBaseDuration;
   } else {
-    let child = completedWork.child;
     while (child !== null) {
       newChildLanes = mergeLanes(
         newChildLanes,
         mergeLanes(child.lanes, child.childLanes),
       );
+
       // "Static" flags share the lifetime of the fiber/hook they belong to,
       // so we should bubble those up even during a bailout. All the other
       // flags have a lifetime only of a single render + commit, so we should
@@ -825,10 +824,12 @@ function bubbleProperties(completedWork: Fiber) {
         ? child.subtreeFlags
         : child.subtreeFlags & StaticMask;
       subtreeFlags |= !didBailout ? child.flags : child.flags & StaticMask;
+
       // Update the return pointer so the tree is consistent. This is a code
       // smell because it assumes the commit phase is never concurrent with
       // the render phase. Will address during refactor to alternate model.
       child.return = completedWork;
+
       child = child.sibling;
     }
   }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -774,7 +774,10 @@ function bubbleProperties(completedWork: Fiber) {
   if (enableProfilerTimer && (completedWork.mode & ProfileMode) !== NoMode) {
     // In profiling mode, resetChildExpirationTime is also used to reset
     // profiler durations.
-    let actualDuration = completedWork.actualDuration;
+
+    // It is reset to 0 each time we render and only updated when we don't bailout.
+    // So temporarily set it to 0.
+    let actualDuration = completedWork.actualDuration ?? 0;
     let treeBaseDuration = ((completedWork.selfBaseDuration: any): number);
 
     while (child !== null) {
@@ -797,7 +800,7 @@ function bubbleProperties(completedWork: Fiber) {
       // cloned by comparing the child pointer.
       // $FlowFixMe[unsafe-addition] addition with possible null/undefined value
       if (!didBailout) {
-        actualDuration += child.actualDuration;
+        actualDuration += child.actualDuration ?? 0;
       }
 
       // $FlowFixMe[unsafe-addition] addition with possible null/undefined value

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -769,116 +769,71 @@ function bubbleProperties(completedWork: Fiber) {
   let newChildLanes = NoLanes;
   let subtreeFlags = NoFlags;
 
-  if (!didBailout) {
-    // Bubble up the earliest expiration time.
-    if (enableProfilerTimer && (completedWork.mode & ProfileMode) !== NoMode) {
-      // In profiling mode, resetChildExpirationTime is also used to reset
-      // profiler durations.
-      let actualDuration = completedWork.actualDuration;
-      let treeBaseDuration = ((completedWork.selfBaseDuration: any): number);
+  // Bubble up the earliest expiration time.
+  if (enableProfilerTimer && (completedWork.mode & ProfileMode) !== NoMode) {
+    // In profiling mode, resetChildExpirationTime is also used to reset
+    // profiler durations.
+    let actualDuration = completedWork.actualDuration;
+    let treeBaseDuration = ((completedWork.selfBaseDuration: any): number);
 
-      let child = completedWork.child;
-      while (child !== null) {
-        newChildLanes = mergeLanes(
-          newChildLanes,
-          mergeLanes(child.lanes, child.childLanes),
-        );
+    let child = completedWork.child;
+    while (child !== null) {
+      newChildLanes = mergeLanes(
+        newChildLanes,
+        mergeLanes(child.lanes, child.childLanes),
+      );
 
-        subtreeFlags |= child.subtreeFlags;
-        subtreeFlags |= child.flags;
+      subtreeFlags |= !didBailout
+        ? child.subtreeFlags
+        : child.subtreeFlags & StaticMask;
+      subtreeFlags |= !didBailout ? child.flags : child.flags & StaticMask;
 
-        // When a fiber is cloned, its actualDuration is reset to 0. This value will
-        // only be updated if work is done on the fiber (i.e. it doesn't bailout).
-        // When work is done, it should bubble to the parent's actualDuration. If
-        // the fiber has not been cloned though, (meaning no work was done), then
-        // this value will reflect the amount of time spent working on a previous
-        // render. In that case it should not bubble. We determine whether it was
-        // cloned by comparing the child pointer.
-        // $FlowFixMe[unsafe-addition] addition with possible null/undefined value
+      // When a fiber is cloned, its actualDuration is reset to 0. This value will
+      // only be updated if work is done on the fiber (i.e. it doesn't bailout).
+      // When work is done, it should bubble to the parent's actualDuration. If
+      // the fiber has not been cloned though, (meaning no work was done), then
+      // this value will reflect the amount of time spent working on a previous
+      // render. In that case it should not bubble. We determine whether it was
+      // cloned by comparing the child pointer.
+      // $FlowFixMe[unsafe-addition] addition with possible null/undefined value
+      if (!didBailout && actualDuration) {
         actualDuration += child.actualDuration;
-
-        // $FlowFixMe[unsafe-addition] addition with possible null/undefined value
-        treeBaseDuration += child.treeBaseDuration;
-        child = child.sibling;
       }
 
+      // $FlowFixMe[unsafe-addition] addition with possible null/undefined value
+      treeBaseDuration += child.treeBaseDuration;
+
+      child = child.sibling;
+    }
+
+    if (!didBailout) {
       completedWork.actualDuration = actualDuration;
-      completedWork.treeBaseDuration = treeBaseDuration;
-    } else {
-      let child = completedWork.child;
-      while (child !== null) {
-        newChildLanes = mergeLanes(
-          newChildLanes,
-          mergeLanes(child.lanes, child.childLanes),
-        );
-
-        subtreeFlags |= child.subtreeFlags;
-        subtreeFlags |= child.flags;
-
-        // Update the return pointer so the tree is consistent. This is a code
-        // smell because it assumes the commit phase is never concurrent with
-        // the render phase. Will address during refactor to alternate model.
-        child.return = completedWork;
-
-        child = child.sibling;
-      }
     }
-
-    completedWork.subtreeFlags |= subtreeFlags;
+    completedWork.treeBaseDuration = treeBaseDuration;
   } else {
-    // Bubble up the earliest expiration time.
-    if (enableProfilerTimer && (completedWork.mode & ProfileMode) !== NoMode) {
-      // In profiling mode, resetChildExpirationTime is also used to reset
-      // profiler durations.
-      let treeBaseDuration = ((completedWork.selfBaseDuration: any): number);
-
-      let child = completedWork.child;
-      while (child !== null) {
-        newChildLanes = mergeLanes(
-          newChildLanes,
-          mergeLanes(child.lanes, child.childLanes),
-        );
-
-        // "Static" flags share the lifetime of the fiber/hook they belong to,
-        // so we should bubble those up even during a bailout. All the other
-        // flags have a lifetime only of a single render + commit, so we should
-        // ignore them.
-        subtreeFlags |= child.subtreeFlags & StaticMask;
-        subtreeFlags |= child.flags & StaticMask;
-
-        // $FlowFixMe[unsafe-addition] addition with possible null/undefined value
-        treeBaseDuration += child.treeBaseDuration;
-        child = child.sibling;
-      }
-
-      completedWork.treeBaseDuration = treeBaseDuration;
-    } else {
-      let child = completedWork.child;
-      while (child !== null) {
-        newChildLanes = mergeLanes(
-          newChildLanes,
-          mergeLanes(child.lanes, child.childLanes),
-        );
-
-        // "Static" flags share the lifetime of the fiber/hook they belong to,
-        // so we should bubble those up even during a bailout. All the other
-        // flags have a lifetime only of a single render + commit, so we should
-        // ignore them.
-        subtreeFlags |= child.subtreeFlags & StaticMask;
-        subtreeFlags |= child.flags & StaticMask;
-
-        // Update the return pointer so the tree is consistent. This is a code
-        // smell because it assumes the commit phase is never concurrent with
-        // the render phase. Will address during refactor to alternate model.
-        child.return = completedWork;
-
-        child = child.sibling;
-      }
+    let child = completedWork.child;
+    while (child !== null) {
+      newChildLanes = mergeLanes(
+        newChildLanes,
+        mergeLanes(child.lanes, child.childLanes),
+      );
+      // "Static" flags share the lifetime of the fiber/hook they belong to,
+      // so we should bubble those up even during a bailout. All the other
+      // flags have a lifetime only of a single render + commit, so we should
+      // ignore them.
+      subtreeFlags |= !didBailout
+        ? child.subtreeFlags
+        : child.subtreeFlags & StaticMask;
+      subtreeFlags |= !didBailout ? child.flags : child.flags & StaticMask;
+      // Update the return pointer so the tree is consistent. This is a code
+      // smell because it assumes the commit phase is never concurrent with
+      // the render phase. Will address during refactor to alternate model.
+      child.return = completedWork;
+      child = child.sibling;
     }
-
-    completedWork.subtreeFlags |= subtreeFlags;
   }
 
+  completedWork.subtreeFlags |= subtreeFlags;
   completedWork.childLanes = newChildLanes;
 
   return didBailout;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
refactor `bubbleProperties` method in file `ReactFiberCompleteWork.js`. handle code redundance problem.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
Just handle code redundance problem, so no test code added.
![image](https://user-images.githubusercontent.com/65998645/233304670-5a29ff39-0dd0-4ee6-8152-9041e29908be.png)

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
