### PR TITLE
Add `alwaysThrottleRetries` flag

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -39,6 +39,7 @@ import {
   enableTransitionTracing,
   useModernStrictMode,
   disableLegacyContext,
+  alwaysThrottleRetries,
 } from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import is from 'shared/objectIs';
@@ -1115,7 +1116,10 @@ function finishConcurrentRender(
       workInProgressTransitions,
     );
   } else {
-    if (includesOnlyRetries(lanes)) {
+    if (
+      includesOnlyRetries(lanes) &&
+      (alwaysThrottleRetries || exitStatus === RootSuspended)
+    ) {
       // This render only included retries, no updates. Throttle committing
       // retries so that we don't show too many loading states too quickly.
       const msUntilTimeout =

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -124,6 +124,8 @@ export const diffInCommitPhase = __EXPERIMENTAL__;
 
 export const enableAsyncActions = __EXPERIMENTAL__;
 
+export const alwaysThrottleRetries = true;
+
 // -----------------------------------------------------------------------------
 // Chopping Block
 //

--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -22,6 +22,7 @@ import typeof * as DynamicFlagsType from 'ReactNativeInternalFeatureFlags';
 
 export const enableUseRefAccessWarning = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
+export const alwaysThrottleRetries = __VARIANT__;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): DynamicFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -17,8 +17,11 @@ import * as dynamicFlags from 'ReactNativeInternalFeatureFlags';
 
 // We destructure each value before re-exporting to avoid a dynamic look-up on
 // the exports object every time a flag is read.
-export const {enableUseRefAccessWarning, enableDeferRootSchedulingToMicrotask} =
-  dynamicFlags;
+export const {
+  enableUseRefAccessWarning,
+  enableDeferRootSchedulingToMicrotask,
+  alwaysThrottleRetries,
+} = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.
 export const enableDebugTracing = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -75,5 +75,7 @@ export const enableDeferRootSchedulingToMicrotask = true;
 export const diffInCommitPhase = true;
 export const enableAsyncActions = false;
 
+export const alwaysThrottleRetries = true;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -75,5 +75,7 @@ export const enableDeferRootSchedulingToMicrotask = true;
 export const diffInCommitPhase = true;
 export const enableAsyncActions = false;
 
+export const alwaysThrottleRetries = true;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -72,5 +72,7 @@ export const enableDeferRootSchedulingToMicrotask = true;
 export const diffInCommitPhase = true;
 export const enableAsyncActions = false;
 
+export const alwaysThrottleRetries = true;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -77,5 +77,7 @@ export const enableDeferRootSchedulingToMicrotask = true;
 export const diffInCommitPhase = true;
 export const enableAsyncActions = false;
 
+export const alwaysThrottleRetries = true;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -27,6 +27,7 @@ export const enableCustomElementPropertySupport = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const diffInCommitPhase = __VARIANT__;
 export const enableAsyncActions = __VARIANT__;
+export const alwaysThrottleRetries = __VARIANT__;
 
 // Enable this flag to help with concurrent mode debugging.
 // It logs information to the console about React scheduling, rendering, and commit phases.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -30,6 +30,7 @@ export const {
   enableDeferRootSchedulingToMicrotask,
   diffInCommitPhase,
   enableAsyncActions,
+  alwaysThrottleRetries,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.

--- a/scripts/flow/xplat.js
+++ b/scripts/flow/xplat.js
@@ -10,4 +10,5 @@
 declare module 'ReactNativeInternalFeatureFlags' {
   declare export var enableUseRefAccessWarning: boolean;
   declare export var enableDeferRootSchedulingToMicrotask: boolean;
+  declare export var alwaysThrottleRetries: boolean;
 }


### PR DESCRIPTION
This puts the change introduced by #26611 behind a flag until Meta is able to roll it out. Disabling the flag reverts back to the old behavior, where retries are throttled if there's still data remaining in the tree, but not if all the data has finished loading.

The new behavior is still enabled in the public builds.