### PR TITLE
Rethrow errors from form actions

### DIFF
--- a/packages/react-dom-bindings/src/events/plugins/FormActionEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/FormActionEventPlugin.js
@@ -14,6 +14,7 @@ import type {EventSystemFlags} from '../EventSystemFlags';
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 
 import {getFiberCurrentPropsFromNode} from '../../client/ReactDOMComponentTree';
+import {startFormAction} from 'react-reconciler/src/ReactFiberReconciler';
 
 import {SyntheticEvent} from '../SyntheticEvent';
 
@@ -94,8 +95,8 @@ function extractEvents(
     } else {
       formData = new FormData(form);
     }
-    // TODO: Deal with errors and pending state.
-    action(formData);
+
+    startFormAction(action, formData);
   }
 
   dispatchQueue.push({

--- a/packages/react-dom-bindings/src/events/plugins/FormActionEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/FormActionEventPlugin.js
@@ -14,7 +14,7 @@ import type {EventSystemFlags} from '../EventSystemFlags';
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 
 import {getFiberCurrentPropsFromNode} from '../../client/ReactDOMComponentTree';
-import {startFormAction} from 'react-reconciler/src/ReactFiberReconciler';
+import {startHostTransition} from 'react-reconciler/src/ReactFiberReconciler';
 
 import {SyntheticEvent} from '../SyntheticEvent';
 
@@ -25,7 +25,7 @@ import {SyntheticEvent} from '../SyntheticEvent';
 function extractEvents(
   dispatchQueue: DispatchQueue,
   domEventName: DOMEventName,
-  targetInst: null | Fiber,
+  maybeTargetInst: null | Fiber,
   nativeEvent: AnyNativeEvent,
   nativeEventTarget: null | EventTarget,
   eventSystemFlags: EventSystemFlags,
@@ -34,11 +34,12 @@ function extractEvents(
   if (domEventName !== 'submit') {
     return;
   }
-  if (!targetInst || targetInst.stateNode !== nativeEventTarget) {
+  if (!maybeTargetInst || maybeTargetInst.stateNode !== nativeEventTarget) {
     // If we're inside a parent root that itself is a parent of this root, then
     // its deepest target won't be the actual form that's being submitted.
     return;
   }
+  const formInst = maybeTargetInst;
   const form: HTMLFormElement = (nativeEventTarget: any);
   let action = (getFiberCurrentPropsFromNode(form): any).action;
   const submitter: null | HTMLInputElement | HTMLButtonElement =
@@ -96,7 +97,7 @@ function extractEvents(
       formData = new FormData(form);
     }
 
-    startFormAction(action, formData);
+    startHostTransition(formInst, action, formData);
   }
 
   dispatchQueue.push({

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -81,7 +81,7 @@ import {
   higherEventPriority,
 } from './ReactEventPriorities';
 import {readContext, checkIfContextChanged} from './ReactFiberNewContext';
-import {HostRoot, CacheComponent} from './ReactWorkTags';
+import {HostRoot, CacheComponent, HostComponent} from './ReactWorkTags';
 import {
   LayoutStatic as LayoutStaticEffect,
   Passive as PassiveEffect,
@@ -752,6 +752,33 @@ function renderWithHooksAgain<Props, SecondArg>(
     children = Component(props, secondArg);
   } while (didScheduleRenderPhaseUpdateDuringThisPass);
   return children;
+}
+
+export function renderTransitionAwareHostComponentWithHooks(
+  current: Fiber | null,
+  workInProgress: Fiber,
+  lanes: Lanes,
+): boolean {
+  if (!(enableFormActions && enableAsyncActions)) {
+    return false;
+  }
+  return renderWithHooks(
+    current,
+    workInProgress,
+    TransitionAwareHostComponent,
+    null,
+    null,
+    lanes,
+  );
+}
+
+export function TransitionAwareHostComponent(): boolean {
+  if (!(enableFormActions && enableAsyncActions)) {
+    return false;
+  }
+  const dispatcher = ReactCurrentDispatcher.current;
+  const [isPending] = dispatcher.useTransition();
+  return isPending;
 }
 
 export function checkDidRenderIdHook(): boolean {
@@ -2484,13 +2511,89 @@ function startTransition(
   }
 }
 
-export function startFormAction<F>(callback: F => mixed, formData: F): void {
+export function startHostTransition<F>(
+  formFiber: Fiber,
+  callback: F => mixed,
+  formData: F,
+): void {
   if (!enableFormActions) {
     // Not implemented.
     return;
   }
-  // TODO: Implement pending and error states.
-  const setPending = () => {};
+
+  if (!enableAsyncActions) {
+    // Form actions are enabled, but async actions are not. Call the function,
+    // but don't handle any pending or error states.
+    callback(formData);
+    return;
+  }
+
+  if (formFiber.tag !== HostComponent) {
+    throw new Error(
+      'Expected the form instance to be a HostComponent. This ' +
+        'is a bug in React.',
+    );
+  }
+
+  let setPending;
+  if (formFiber.memoizedState === null) {
+    // Upgrade this host component fiber to be stateful. We're going to pretend
+    // it was stateful all along so we can reuse most of the implementation
+    // for function components and useTransition.
+    //
+    // Create the initial hooks used by useTransition. This is essentially an
+    // inlined version of mountTransition.
+    const queue: UpdateQueue<
+      Thenable<boolean> | boolean,
+      Thenable<boolean> | boolean,
+    > = {
+      pending: null,
+      lanes: NoLanes,
+      dispatch: null,
+      lastRenderedReducer: basicStateReducer,
+      lastRenderedState: false,
+    };
+    const stateHook: Hook = {
+      memoizedState: false,
+      baseState: false,
+      baseQueue: null,
+      queue: queue,
+      next: null,
+    };
+
+    const dispatch: (Thenable<boolean> | boolean) => void =
+      (dispatchSetState.bind(null, formFiber, queue): any);
+    setPending = queue.dispatch = dispatch;
+
+    // TODO: The only reason this second hook exists is to save a reference to
+    // the `dispatch` function. But we already store this on the state hook. So
+    // we can cheat and read it from there. Need to make this change to the
+    // regular `useTransition` implementation, too.
+    const transitionHook: Hook = {
+      memoizedState: dispatch,
+      baseState: null,
+      baseQueue: null,
+      queue: null,
+      next: null,
+    };
+
+    stateHook.next = transitionHook;
+
+    // Add the initial list of hooks to both fiber alternates. The idea is that
+    // the fiber had these hooks all along.
+    formFiber.memoizedState = stateHook;
+    const alternate = formFiber.alternate;
+    if (alternate !== null) {
+      alternate.memoizedState = stateHook;
+    }
+  } else {
+    // This fiber was already upgraded to be stateful.
+    const transitionHook: Hook = formFiber.memoizedState.next;
+    const dispatch: (Thenable<boolean> | boolean) => void =
+      transitionHook.memoizedState;
+    setPending = dispatch;
+  }
+
   startTransition(
     setPending,
     // TODO: We can avoid this extra wrapper, somehow. Figure out layering

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -43,6 +43,7 @@ import {
   enableLegacyCache,
   debugRenderPhaseSideEffectsForStrictMode,
   enableAsyncActions,
+  enableFormActions,
 } from 'shared/ReactFeatureFlags';
 import {
   REACT_CONTEXT_TYPE,
@@ -2481,6 +2482,21 @@ function startTransition(
       }
     }
   }
+}
+
+export function startFormAction<F>(callback: F => mixed, formData: F): void {
+  if (!enableFormActions) {
+    // Not implemented.
+    return;
+  }
+  // TODO: Implement pending and error states.
+  const setPending = () => {};
+  startTransition(
+    setPending,
+    // TODO: We can avoid this extra wrapper, somehow. Figure out layering
+    // once more of this function is implemented.
+    () => callback(formData),
+  );
 }
 
 function mountTransition(): [

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -111,6 +111,7 @@ export {
   focusWithin,
   observeVisibleRects,
 } from './ReactTestSelectors';
+export {startFormAction} from './ReactFiberHooks';
 
 type OpaqueRoot = FiberRoot;
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -111,7 +111,7 @@ export {
   focusWithin,
   observeVisibleRects,
 } from './ReactTestSelectors';
-export {startFormAction} from './ReactFiberHooks';
+export {startHostTransition} from './ReactFiberHooks';
 
 type OpaqueRoot = FiberRoot;
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -2330,6 +2330,16 @@ function replaySuspendedUnitOfWork(unitOfWork: Fiber): void {
       );
       break;
     }
+    case HostComponent: {
+      // Some host components are stateful (that's how we implement form
+      // actions) but we don't bother to reuse the memoized state because it's
+      // not worth the extra code. The main reason to reuse the previous hooks
+      // is to reuse uncached promises, but we happen to know that the only
+      // promises that a host component might suspend on are definitely cached
+      // because they are controlled by us. So don't bother.
+      resetHooksOnUnwind();
+      // Fallthrough to the next branch.
+    }
     default: {
       // Other types besides function components are reset completely before
       // being replayed. Currently this only happens when a Usable type is

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -460,5 +460,6 @@
   "472": "Type %s is not supported as an argument to a Server Function.",
   "473": "React doesn't accept base64 encoded file uploads because we don't except form data passed from a browser to ever encode data that way. If that's the wrong assumption, we can easily fix it.",
   "474": "Suspense Exception: This is not a real error, and should not leak into userspace. If you're seeing this, it's likely a bug in React.",
-  "475": "Internal React Error: suspendedState null when it was expected to exists. Please report this as a React bug."
+  "475": "Internal React Error: suspendedState null when it was expected to exists. Please report this as a React bug.",
+  "476": "Expected the form instance to be a HostComponent. This is a bug in React."
 }


### PR DESCRIPTION
This is the next step toward full support for async form actions.

Errors thrown inside form actions should cause the form to re-render and throw the error so it can be captured by an error boundary. The behavior is the same if the `<form />` had an internal useTransition hook, which is pretty much exactly how we implement it, too.

The first time an action is called, the form's HostComponent is "upgraded" to become stateful, by lazily mounting a list of hooks. The rest of the implementation for function components can be shared.

Because the error handling behavior added in this commit is just using useTransition under-the-hood, it also handles pending states, too. However, this pending state can't be observed until we add a new hook for that purpose. I'll add this next.
