### PR TITLE
Allow Node.js 20 to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "yargs": "^15.3.1"
   },
   "devEngines": {
-    "node": "16.x || 18.x || 19.x"
+    "node": "16.x || 18.x || 19.x || 20.x"
   },
   "jest": {
     "testRegex": "/scripts/jest/dont-run-jest-directly\\.js$"


### PR DESCRIPTION
This is stable and appears to build w/o problem. I don't see why we should disallow it.