### PR TITLE
Change DOM HostContext to number instead of string

### DIFF
--- a/packages/react-dom-bindings/src/client/DOMNamespaces.js
+++ b/packages/react-dom-bindings/src/client/DOMNamespaces.js
@@ -7,34 +7,5 @@
  * @flow
  */
 
-export const HTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
 export const MATH_NAMESPACE = 'http://www.w3.org/1998/Math/MathML';
 export const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
-
-// Assumes there is no parent namespace.
-export function getIntrinsicNamespace(type: string): string {
-  switch (type) {
-    case 'svg':
-      return SVG_NAMESPACE;
-    case 'math':
-      return MATH_NAMESPACE;
-    default:
-      return HTML_NAMESPACE;
-  }
-}
-
-export function getChildNamespace(
-  parentNamespace: string | null,
-  type: string,
-): string {
-  if (parentNamespace == null || parentNamespace === HTML_NAMESPACE) {
-    // No (or default) parent namespace: potential entry point.
-    return getIntrinsicNamespace(type);
-  }
-  if (parentNamespace === SVG_NAMESPACE && type === 'foreignObject') {
-    // We're leaving SVG.
-    return HTML_NAMESPACE;
-  }
-  // By default, pass namespace below.
-  return parentNamespace;
-}


### PR DESCRIPTION
In React DOM, we use HostContext to represent the namespace of whatever is currently rendering — SVG, Math, or HTML. Because there is a fixed set of possible values, we can switch this to be a number instead. My motivation is that I want to start tracking additional information in this type, and I want to pack all of it into a single number instead of turning it into an object. For better performance.

(In dev, the host context type is already an object that includes additional information, but that's dev so who cares.)

Technically, before this change, the host context could be any namespace URI string, but any value other than SVG or Math was treated the same way. Only SVG and Math have special behavior. So in the new structure, there are three enum values: SVG, Math, or None, which represents the HTML namespace as well as all other possible namespaces.