### PR TITLE
[Flight] Fix File Upload in Node.js

### DIFF
--- a/fixtures/flight/src/Form.js
+++ b/fixtures/flight/src/Form.js
@@ -20,8 +20,14 @@ export default function Form({action, children}) {
             React.startTransition(() => setIsPending(false));
           }
         }}>
-        <input name="name" />
+        <label>
+          Name: <input name="name" />
+        </label>
+        <label>
+          File: <input type="file" name="file" />
+        </label>
         <button>Say Hi</button>
+        {isPending ? 'Saving...' : null}
       </form>
     </ErrorBoundary>
   );

--- a/fixtures/flight/src/actions.js
+++ b/fixtures/flight/src/actions.js
@@ -5,5 +5,12 @@ export async function like() {
 }
 
 export async function greet(formData) {
-  return 'Hi ' + formData.get('name') + '!';
+  const name = formData.get('name') || 'you';
+  const file = formData.get('file');
+  if (file) {
+    return `Ok, ${name}, here is ${file.name}:
+      ${(await file.text()).toUpperCase()}
+    `;
+  }
+  return 'Hi ' + name + '!';
 }

--- a/packages/react-server/src/ReactFlightReplyServer.js
+++ b/packages/react-server/src/ReactFlightReplyServer.js
@@ -564,8 +564,11 @@ export function resolveFileComplete(
   handle: FileHandle,
 ): void {
   // Add this file to the backing store.
-  const file = new File(handle.chunks, handle.filename, {type: handle.mime});
-  response._formData.append(key, file);
+  // Node.js doesn't expose a global File constructor so we need to use
+  // the append() form that takes the file name as the third argument,
+  // to create a File object.
+  const blob = new Blob(handle.chunks, {type: handle.mime});
+  response._formData.append(key, blob, handle.filename);
 }
 
 export function close(response: Response): void {


### PR DESCRIPTION
Use the Blob constructor + append with filename instead of File constructor. Node.js doesn't expose a global File constructor but does support it in this form.

Queue fields until we get the 'end' event from the previous file. We rely on previous files being available by the time a field is resolved. However, since the 'end' event in Readable is fired after two micro-tasks, these are not resolved in order.

I use a queue of the fields while we're still waiting on files to finish. This still doesn't resolve files and fields in order relative to each other but that doesn't matter for our usage.