### PR TITLE
[DRAFT] Use gate pragmas in ReactDOMForm tests

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMForm-test.js
@@ -686,13 +686,8 @@ describe('ReactDOMForm', () => {
     expect(container.textContent).toBe('Initial');
   });
 
+  // @gate enableFormActions && enableAsyncActions
   it('sync errors in form actions can be captured by an error boundary', async () => {
-    if (gate(flags => !(flags.enableFormActions && flags.enableAsyncActions))) {
-      // TODO: Uncaught JSDOM errors fail the test after the scope has finished
-      // so don't work with the `gate` mechanism.
-      return;
-    }
-
     class ErrorBoundary extends React.Component {
       state = {error: null};
       static getDerivedStateFromError(error) {
@@ -732,13 +727,8 @@ describe('ReactDOMForm', () => {
     expect(container.textContent).toBe('Oh no!');
   });
 
+  // @gate enableFormActions && enableAsyncActions
   it('async errors in form actions can be captured by an error boundary', async () => {
-    if (gate(flags => !(flags.enableFormActions && flags.enableAsyncActions))) {
-      // TODO: Uncaught JSDOM errors fail the test after the scope has finished
-      // so don't work with the `gate` mechanism.
-      return;
-    }
-
     class ErrorBoundary extends React.Component {
       state = {error: null};
       static getDerivedStateFromError(error) {


### PR DESCRIPTION


## Summary

Use static gate pragmas instead of dynamic gates.

## How did you test this change?

- [x] Ran test with stable (applies gates) and experimental (no gates) release channel
- [ ] CI (suspecting that prod might be the issue)