### PR TITLE
build: use ReactDOM.createRoot instead of ReactDOM.render

### DIFF
--- a/fixtures/packaging/babel-standalone/dev.html
+++ b/fixtures/packaging/babel-standalone/dev.html
@@ -5,10 +5,7 @@
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
     <div id="container"></div>
     <script type="text/babel">
-      ReactDOM.render(
-        <h1>Hello World!</h1>,
-        document.getElementById('container')
-      );
+      ReactDOM.createRoot(document.getElementById('container')).render(<h1>Hello World!</h1>);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Update dev.html based on new api.

## How did you test this change?

I just changed from `render` to `createRoot` and run it locally, no need to add test case.