### PR TITLE
Update Flight fixture to use use() instead of Promise as a child

### DIFF
--- a/fixtures/flight/src/index.js
+++ b/fixtures/flight/src/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Suspense} from 'react';
+import {use, Suspense} from 'react';
 import ReactDOM from 'react-dom/client';
 import {createFromFetch, encodeReply} from 'react-server-dom-webpack/client';
 
@@ -27,7 +27,8 @@ let data = createFromFetch(
   }
 );
 
-// TODO: This transition shouldn't really be necessary but it is for now.
-React.startTransition(() => {
-  ReactDOM.hydrateRoot(document, data);
-});
+function Shell({data}) {
+  return use(data);
+}
+
+ReactDOM.hydrateRoot(document, <Shell data={data} />);


### PR DESCRIPTION
The Promise as a child case seems buggy. It ends up throwing the Promise as fatal when used in Sync rendering.