### PR TITLE
Use require() to implement script src in tests

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -64,7 +64,11 @@ describe('ReactDOMFizzServer', () => {
     });
     streamingContainer = null;
     global.window = jsdom.window;
-    global.document = jsdom.window.document;
+    global.document = global.window.document;
+    global.navigator = global.window.navigator;
+    global.Node = global.window.Node;
+    global.addEventListener = global.window.addEventListener;
+    global.MutationObserver = global.window.MutationObserver;
     container = document.getElementById('container');
 
     Scheduler = require('scheduler');

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -59,7 +59,11 @@ describe('ReactDOMFloat', () => {
     });
     streamingContainer = null;
     global.window = jsdom.window;
-    global.document = jsdom.window.document;
+    global.document = global.window.document;
+    global.navigator = global.window.navigator;
+    global.Node = global.window.Node;
+    global.addEventListener = global.window.addEventListener;
+    global.MutationObserver = global.window.MutationObserver;
     container = document.getElementById('container');
 
     React = require('react');
@@ -95,7 +99,7 @@ describe('ReactDOMFloat', () => {
     renderOptions = {};
     if (gate(flags => flags.enableFizzExternalRuntime)) {
       renderOptions.unstable_externalRuntimeSrc =
-        'react-dom-bindings/src/server/ReactDOMServerExternalRuntime.js';
+        'react-dom/unstable_server-external-runtime';
     }
   });
 

--- a/scripts/jest/ReactDOMServerIntegrationEnvironment.js
+++ b/scripts/jest/ReactDOMServerIntegrationEnvironment.js
@@ -16,6 +16,8 @@ class ReactDOMServerIntegrationEnvironment extends NodeEnvironment {
     this.global.document = this.global.window.document;
     this.global.navigator = this.global.window.navigator;
     this.global.Node = this.global.window.Node;
+    this.global.addEventListener = this.global.window.addEventListener;
+    this.global.MutationObserver = this.global.window.MutationObserver;
   }
 
   async setup() {


### PR DESCRIPTION
We currently use rollup to make an adhoc bundle from the file system when we're testing an import of an external file.

This doesn't follow all the interception rules that we use in jest and in our actual builds.

This switches to just using jest require() to load these. This means that they effectively have to load into the global document so this only works with global document tests which is all we have now anyway.
