### PR TITLE
Go through the toString path for booleanish strings and .name property

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -685,7 +685,10 @@ function setProp(
         if (__DEV__) {
           checkAttributeStringCoercion(value, key);
         }
-        domElement.setAttribute(key, (value: any));
+        domElement.setAttribute(
+          key,
+          enableTrustedTypesIntegration ? (value: any) : '' + (value: any),
+        );
       } else {
         domElement.removeAttribute(key);
       }

--- a/packages/react-dom-bindings/src/client/ReactDOMInput.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMInput.js
@@ -188,7 +188,7 @@ export function updateInput(
     if (__DEV__) {
       checkAttributeStringCoercion(name, 'name');
     }
-    node.name = name;
+    node.name = toString(getToStringValue(name));
   } else {
     node.removeAttribute('name');
   }


### PR DESCRIPTION
This is consistent with what we used to do but not what we want to do.

