### PR TITLE
Handle line endings correctly on Windows in build script for RN

### DIFF
--- a/scripts/rollup/packaging.js
+++ b/scripts/rollup/packaging.js
@@ -148,9 +148,9 @@ function processGenerated(directory) {
     const originalContents = readFileSync(file, 'utf8');
     const contents = originalContents
       // Replace {@}format with {@}noformat
-      .replace(/(\n\s*\*\s*)@format\b.*(\n)/, '$1@noformat$2')
+      .replace(/(\r?\n\s*\*\s*)@format\b.*(\n)/, '$1@noformat$2')
       // Add {@}nolint and {@}generated
-      .replace(' */\n', ` * @nolint\n * ${getSigningToken()}\n */\n`);
+      .replace(/(\r?\n\s*\*)\//, `$1 @nolint$1 ${getSigningToken()}$1/`);
     const signedContents = signFile(contents);
     writeFileSync(file, signedContents, 'utf8');
   });


### PR DESCRIPTION
## Summary

We added some post-processing in the build for RN in #26616 that broke for users on Windows due to how line endings were handled to the regular expression to insert some directives in the docblock. This fixes that problem, reported in #26697 as well.

## How did you test this change?

Verified files are still built correctly on Mac/Linux. Will ask for help to test on Windows.