### PR TITLE
Add nonce support to bootstrap scripts and external runtime

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -163,14 +163,8 @@ const startInlineScript = stringToPrecomputedChunk('<script>');
 const endInlineScript = stringToPrecomputedChunk('</script>');
 
 const startScriptSrc = stringToPrecomputedChunk('<script src="');
-const startScriptSrcWithNonce = stringToPrecomputedChunk('<script nonce="');
-const middleScriptSrcWithNonce = stringToPrecomputedChunk('" src="');
-
 const startModuleSrc = stringToPrecomputedChunk('<script type="module" src="');
-const startModuleSrcWithNonce = stringToPrecomputedChunk('<script nonce="');
-const middleModuleSrcWithNonce = stringToPrecomputedChunk(
-  '" type="module" src="',
-);
+const scriptNonce = stringToPrecomputedChunk('" nonce="');
 const scriptIntegirty = stringToPrecomputedChunk('" integrity="');
 const endAsyncScript = stringToPrecomputedChunk('" async=""></script>');
 
@@ -255,17 +249,15 @@ export function createResponseState(
         typeof scriptConfig === 'string' ? scriptConfig : scriptConfig.src;
       const integrity =
         typeof scriptConfig === 'string' ? undefined : scriptConfig.integrity;
-      if (nonce === undefined) {
+
+      bootstrapChunks.push(
+        startScriptSrc,
+        stringToChunk(escapeTextForBrowser(src)),
+      );
+      if (nonce) {
         bootstrapChunks.push(
-          startScriptSrc,
-          stringToChunk(escapeTextForBrowser(src)),
-        );
-      } else {
-        bootstrapChunks.push(
-          startScriptSrcWithNonce,
+          scriptNonce,
           stringToChunk(escapeTextForBrowser(nonce)),
-          middleScriptSrcWithNonce,
-          stringToChunk(escapeTextForBrowser(src)),
         );
       }
       if (integrity) {
@@ -284,17 +276,16 @@ export function createResponseState(
         typeof scriptConfig === 'string' ? scriptConfig : scriptConfig.src;
       const integrity =
         typeof scriptConfig === 'string' ? undefined : scriptConfig.integrity;
-      if (nonce === undefined) {
+
+      bootstrapChunks.push(
+        startModuleSrc,
+        stringToChunk(escapeTextForBrowser(src)),
+      );
+
+      if (nonce) {
         bootstrapChunks.push(
-          startModuleSrc,
-          stringToChunk(escapeTextForBrowser(src)),
-        );
-      } else {
-        bootstrapChunks.push(
-          startModuleSrcWithNonce,
+          scriptNonce,
           stringToChunk(escapeTextForBrowser(nonce)),
-          middleModuleSrcWithNonce,
-          stringToChunk(escapeTextForBrowser(src)),
         );
       }
       if (integrity) {

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -3033,6 +3033,14 @@ export function pushStartInstance(
         formatContext.noscriptTagInScope,
       );
     case 'script':
+      if (responseState.nonce) {
+        // add nonce to props, but allow override
+        props = {
+          nonce: responseState.nonce,
+          ...props,
+        };
+      }
+
       return enableFloat
         ? pushScript(
             target,

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -239,6 +239,9 @@ export function createResponseState(
     }
   }
   if (bootstrapScripts !== undefined) {
+
+    const startScriptWithNonce = nonce === undefined ? startScriptSrc : stringToPrecomputedChunk('<script nonce="' + escapeTextForBrowser(nonce) + '" src="');
+
     for (let i = 0; i < bootstrapScripts.length; i++) {
       const scriptConfig = bootstrapScripts[i];
       const src =
@@ -246,7 +249,7 @@ export function createResponseState(
       const integrity =
         typeof scriptConfig === 'string' ? undefined : scriptConfig.integrity;
       bootstrapChunks.push(
-        startScriptSrc,
+        startScriptWithNonce,
         stringToChunk(escapeTextForBrowser(src)),
       );
       if (integrity) {
@@ -259,6 +262,9 @@ export function createResponseState(
     }
   }
   if (bootstrapModules !== undefined) {
+
+    const startModuleWithNonce = nonce === undefined ? startModuleSrc : stringToPrecomputedChunk('<script type="module" nonce="' + escapeTextForBrowser(nonce) + '" src="');
+
     for (let i = 0; i < bootstrapModules.length; i++) {
       const scriptConfig = bootstrapModules[i];
       const src =
@@ -266,7 +272,7 @@ export function createResponseState(
       const integrity =
         typeof scriptConfig === 'string' ? undefined : scriptConfig.integrity;
       bootstrapChunks.push(
-        startModuleSrc,
+        startModuleWithNonce,
         stringToChunk(escapeTextForBrowser(src)),
       );
       if (integrity) {

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -163,7 +163,14 @@ const startInlineScript = stringToPrecomputedChunk('<script>');
 const endInlineScript = stringToPrecomputedChunk('</script>');
 
 const startScriptSrc = stringToPrecomputedChunk('<script src="');
+const startScriptSrcWithNonce = stringToPrecomputedChunk('<script nonce="');
+const middleScriptSrcWithNonce = stringToPrecomputedChunk('" src="');
+
 const startModuleSrc = stringToPrecomputedChunk('<script type="module" src="');
+const startModuleSrcWithNonce = stringToPrecomputedChunk('<script nonce="');
+const middleModuleSrcWithNonce = stringToPrecomputedChunk(
+  '" type="module" src="',
+);
 const scriptIntegirty = stringToPrecomputedChunk('" integrity="');
 const endAsyncScript = stringToPrecomputedChunk('" async=""></script>');
 
@@ -242,23 +249,25 @@ export function createResponseState(
     }
   }
   if (bootstrapScripts !== undefined) {
-    const startScriptWithNonce =
-      nonce === undefined
-        ? startScriptSrc
-        : stringToPrecomputedChunk(
-            '<script nonce="' + escapeTextForBrowser(nonce) + '" src="',
-          );
-
     for (let i = 0; i < bootstrapScripts.length; i++) {
       const scriptConfig = bootstrapScripts[i];
       const src =
         typeof scriptConfig === 'string' ? scriptConfig : scriptConfig.src;
       const integrity =
         typeof scriptConfig === 'string' ? undefined : scriptConfig.integrity;
-      bootstrapChunks.push(
-        startScriptWithNonce,
-        stringToChunk(escapeTextForBrowser(src)),
-      );
+      if (nonce === undefined) {
+        bootstrapChunks.push(
+          startScriptSrc,
+          stringToChunk(escapeTextForBrowser(src)),
+        );
+      } else {
+        bootstrapChunks.push(
+          startScriptSrcWithNonce,
+          stringToChunk(escapeTextForBrowser(nonce)),
+          middleScriptSrcWithNonce,
+          stringToChunk(escapeTextForBrowser(src)),
+        );
+      }
       if (integrity) {
         bootstrapChunks.push(
           scriptIntegirty,
@@ -269,25 +278,25 @@ export function createResponseState(
     }
   }
   if (bootstrapModules !== undefined) {
-    const startModuleWithNonce =
-      nonce === undefined
-        ? startModuleSrc
-        : stringToPrecomputedChunk(
-            '<script nonce="' +
-              escapeTextForBrowser(nonce) +
-              '" type="module" src="',
-          );
-
     for (let i = 0; i < bootstrapModules.length; i++) {
       const scriptConfig = bootstrapModules[i];
       const src =
         typeof scriptConfig === 'string' ? scriptConfig : scriptConfig.src;
       const integrity =
         typeof scriptConfig === 'string' ? undefined : scriptConfig.integrity;
-      bootstrapChunks.push(
-        startModuleWithNonce,
-        stringToChunk(escapeTextForBrowser(src)),
-      );
+      if (nonce === undefined) {
+        bootstrapChunks.push(
+          startModuleSrc,
+          stringToChunk(escapeTextForBrowser(src)),
+        );
+      } else {
+        bootstrapChunks.push(
+          startModuleSrcWithNonce,
+          stringToChunk(escapeTextForBrowser(nonce)),
+          middleModuleSrcWithNonce,
+          stringToChunk(escapeTextForBrowser(src)),
+        );
+      }
       if (integrity) {
         bootstrapChunks.push(
           scriptIntegirty,

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -3042,14 +3042,6 @@ export function pushStartInstance(
         formatContext.noscriptTagInScope,
       );
     case 'script':
-      if (responseState.nonce) {
-        // add nonce to props, but allow override
-        props = {
-          nonce: responseState.nonce,
-          ...props,
-        };
-      }
-
       return enableFloat
         ? pushScript(
             target,

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -270,9 +270,9 @@ export function createResponseState(
       nonce === undefined
         ? startModuleSrc
         : stringToPrecomputedChunk(
-            '<script type="module" nonce="' +
+            '<script nonce="' +
               escapeTextForBrowser(nonce) +
-              '" src="',
+              '" type="module" src="',
           );
 
     for (let i = 0; i < bootstrapModules.length; i++) {

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -130,6 +130,9 @@ export type ResponseState = {
   startInlineScript: PrecomputedChunk,
   instructions: InstructionState,
 
+  // state for outputting CSP nonce
+  nonce: string | void,
+
   // state for data streaming format
   externalRuntimeConfig: BootstrapScriptDescriptor | null,
 
@@ -313,6 +316,7 @@ export function createResponseState(
     preloadChunks: [],
     hoistableChunks: [],
     stylesToHoist: false,
+    nonce,
   };
 }
 
@@ -4082,7 +4086,7 @@ export function writePreamble(
     // (User code could choose to send this even earlier by calling
     //  preinit(...), if they know they will suspend).
     const {src, integrity} = responseState.externalRuntimeConfig;
-    internalPreinitScript(resources, src, integrity);
+    internalPreinitScript(resources, src, integrity, responseState.nonce);
   }
 
   const htmlChunks = responseState.htmlChunks;
@@ -5364,6 +5368,7 @@ function internalPreinitScript(
   resources: Resources,
   src: string,
   integrity: ?string,
+  nonce: ?string,
 ): void {
   const key = getResourceKey('script', src);
   let resource = resources.scriptsMap.get(key);
@@ -5380,6 +5385,7 @@ function internalPreinitScript(
       async: true,
       src,
       integrity,
+      nonce,
     });
   }
   return;

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -239,8 +239,12 @@ export function createResponseState(
     }
   }
   if (bootstrapScripts !== undefined) {
-
-    const startScriptWithNonce = nonce === undefined ? startScriptSrc : stringToPrecomputedChunk('<script nonce="' + escapeTextForBrowser(nonce) + '" src="');
+    const startScriptWithNonce =
+      nonce === undefined
+        ? startScriptSrc
+        : stringToPrecomputedChunk(
+            '<script nonce="' + escapeTextForBrowser(nonce) + '" src="',
+          );
 
     for (let i = 0; i < bootstrapScripts.length; i++) {
       const scriptConfig = bootstrapScripts[i];
@@ -262,8 +266,14 @@ export function createResponseState(
     }
   }
   if (bootstrapModules !== undefined) {
-
-    const startModuleWithNonce = nonce === undefined ? startModuleSrc : stringToPrecomputedChunk('<script type="module" nonce="' + escapeTextForBrowser(nonce) + '" src="');
+    const startModuleWithNonce =
+      nonce === undefined
+        ? startModuleSrc
+        : stringToPrecomputedChunk(
+            '<script type="module" nonce="' +
+              escapeTextForBrowser(nonce) +
+              '" src="',
+          );
 
     for (let i = 0; i < bootstrapModules.length; i++) {
       const scriptConfig = bootstrapModules[i];

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
@@ -57,6 +57,7 @@ export type ResponseState = {
   preloadChunks: Array<Chunk | PrecomputedChunk>,
   hoistableChunks: Array<Chunk | PrecomputedChunk>,
   stylesToHoist: boolean,
+  nonce: string | void,
   // This is an extra field for the legacy renderer
   generateStaticMarkup: boolean,
 };
@@ -94,6 +95,7 @@ export function createResponseState(
     preloadChunks: responseState.preloadChunks,
     hoistableChunks: responseState.hoistableChunks,
     stylesToHoist: responseState.stylesToHoist,
+    nonce: responseState.nonce,
 
     // This is an extra field for the legacy renderer
     generateStaticMarkup,

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -574,7 +574,7 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  it('should support nonce for inline scripts', async () => {
+  it('should support nonce for bootstrap and runtime scripts', async () => {
     CSPnonce = 'R4nd0m';
     try {
       let resolve;
@@ -591,11 +591,26 @@ describe('ReactDOMFizzServer', () => {
               <Lazy text="Hello" />
             </Suspense>
           </div>,
-          {nonce: 'R4nd0m'},
+          {
+            nonce: 'R4nd0m',
+            bootstrapScriptContent: 'INIT();',
+            bootstrapScripts: ['init.js'],
+            bootstrapModules: ['init.mjs'],
+          },
         );
         pipe(writable);
       });
+
       expect(getVisibleChildren(container)).toEqual(<div>Loading...</div>);
+
+      // check that there are 4 scripts with a matching nonce:
+      // The runtime script, an inline bootstrap script, and two src scripts
+      expect(
+        Array.from(container.getElementsByTagName('script')).filter(
+          node => node.getAttribute('nonce') === CSPnonce,
+        ).length,
+      ).toEqual(4);
+
       await act(() => {
         resolve({default: Text});
       });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -593,7 +593,7 @@ describe('ReactDOMFizzServer', () => {
           </div>,
           {
             nonce: 'R4nd0m',
-            bootstrapScriptContent: 'INIT();',
+            bootstrapScriptContent: 'function noop(){}',
             bootstrapScripts: ['init.js'],
             bootstrapModules: ['init.mjs'],
           },

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -5727,4 +5727,46 @@ describe('ReactDOMFizzServer', () => {
       console.error = originalConsoleError;
     }
   });
+
+  it('can render scripts with nonce added', async () => {
+    CSPnonce = 'R4nd0m';
+    try {
+      await act(async () => {
+        const {pipe} = renderToPipeableStream(
+          <html>
+            <body>
+              <script>{'try { foo() } catch (e) {} ;'}</script>
+              <script src="foo" />
+              <script src="bar" />
+              <script src="baz" integrity="qux" />
+              <script type="module" src="quux" />
+              <script type="module" src="corge" />
+              <script type="module" src="grault" integrity="garply" />
+            </body>
+          </html>,
+          {
+            nonce: CSPnonce,
+          },
+        );
+        pipe(writable);
+      });
+
+      expect(
+        stripExternalRuntimeInNodes(
+          document.getElementsByTagName('script'),
+          renderOptions.unstable_externalRuntimeSrc,
+        ).map(n => n.outerHTML),
+      ).toEqual([
+        `<script nonce="${CSPnonce}">try { foo() } catch (e) {} ;</script>`,
+        `<script nonce="${CSPnonce}" src="foo"></script>`,
+        `<script nonce="${CSPnonce}" src="bar"></script>`,
+        `<script nonce="${CSPnonce}" src="baz" integrity="qux"></script>`,
+        `<script nonce="${CSPnonce}" type="module" src="quux"></script>`,
+        `<script nonce="${CSPnonce}" type="module" src="corge"></script>`,
+        `<script nonce="${CSPnonce}" type="module" src="grault" integrity="garply"></script>`,
+      ]);
+    } finally {
+      CSPnonce = null;
+    }
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -574,7 +574,7 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  it('should support nonce scripts', async () => {
+  it('should support nonce for inline scripts', async () => {
     CSPnonce = 'R4nd0m';
     try {
       let resolve;

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -628,12 +628,17 @@ describe('ReactDOMFizzServer', () => {
           <html>
             <body>
               <script>{'try { foo() } catch (e) {} ;'}</script>
-              <script src="foo" />
+              <script src="foo" async={true} />
               <script src="bar" />
-              <script src="baz" integrity="qux" />
-              <script type="module" src="quux" />
-              <script type="module" src="corge" />
-              <script type="module" src="grault" integrity="garply" />
+              <script src="baz" integrity="qux" async={true} />
+              <script type="module" src="quux" async={true} />
+              <script type="module" src="corge" async={true} />
+              <script
+                type="module"
+                src="grault"
+                integrity="garply"
+                async={true}
+              />
             </body>
           </html>,
           {
@@ -649,13 +654,14 @@ describe('ReactDOMFizzServer', () => {
           renderOptions.unstable_externalRuntimeSrc,
         ).map(n => n.outerHTML),
       ).toEqual([
+        // async scripts get inserted first in render
+        `<script nonce="${CSPnonce}" src="foo" async=""></script>`,
+        `<script nonce="${CSPnonce}" src="baz" integrity="qux" async=""></script>`,
+        `<script nonce="${CSPnonce}" type="module" src="quux" async=""></script>`,
+        `<script nonce="${CSPnonce}" type="module" src="corge" async=""></script>`,
+        `<script nonce="${CSPnonce}" type="module" src="grault" integrity="garply" async=""></script>`,
         `<script nonce="${CSPnonce}">try { foo() } catch (e) {} ;</script>`,
-        `<script nonce="${CSPnonce}" src="foo"></script>`,
         `<script nonce="${CSPnonce}" src="bar"></script>`,
-        `<script nonce="${CSPnonce}" src="baz" integrity="qux"></script>`,
-        `<script nonce="${CSPnonce}" type="module" src="quux"></script>`,
-        `<script nonce="${CSPnonce}" type="module" src="corge"></script>`,
-        `<script nonce="${CSPnonce}" type="module" src="grault" integrity="garply"></script>`,
       ]);
     } finally {
       CSPnonce = null;

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -620,15 +620,15 @@ describe('ReactDOMFizzServer', () => {
     }
   });
 
-  it('should render scripts with nonce added', async () => {
+  it('should not automatically add nonce to rendered scripts', async () => {
     CSPnonce = 'R4nd0m';
     try {
       await act(async () => {
         const {pipe} = renderToPipeableStream(
           <html>
             <body>
-              <script>{'try { foo() } catch (e) {} ;'}</script>
-              <script src="foo" async={true} />
+              <script nonce={CSPnonce}>{'try { foo() } catch (e) {} ;'}</script>
+              <script nonce={CSPnonce} src="foo" async={true} />
               <script src="bar" />
               <script src="baz" integrity="qux" async={true} />
               <script type="module" src="quux" async={true} />
@@ -654,14 +654,13 @@ describe('ReactDOMFizzServer', () => {
           renderOptions.unstable_externalRuntimeSrc,
         ).map(n => n.outerHTML),
       ).toEqual([
-        // async scripts get inserted first in render
         `<script nonce="${CSPnonce}" src="foo" async=""></script>`,
-        `<script nonce="${CSPnonce}" src="baz" integrity="qux" async=""></script>`,
-        `<script nonce="${CSPnonce}" type="module" src="quux" async=""></script>`,
-        `<script nonce="${CSPnonce}" type="module" src="corge" async=""></script>`,
-        `<script nonce="${CSPnonce}" type="module" src="grault" integrity="garply" async=""></script>`,
+        `<script src="baz" integrity="qux" async=""></script>`,
+        `<script type="module" src="quux" async=""></script>`,
+        `<script type="module" src="corge" async=""></script>`,
+        `<script type="module" src="grault" integrity="garply" async=""></script>`,
         `<script nonce="${CSPnonce}">try { foo() } catch (e) {} ;</script>`,
-        `<script nonce="${CSPnonce}" src="bar"></script>`,
+        `<script src="bar"></script>`,
       ]);
     } finally {
       CSPnonce = null;

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -486,4 +486,21 @@ describe('ReactDOMFizzServerBrowser', () => {
       '<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>',
     );
   });
+
+  it('should support nonce attribute for bootstrap scripts', async () => {
+    const nonce = 'R4nd0m';
+    const stream = await ReactDOMFizzServer.renderToReadableStream(
+      <div>hello world</div>,
+      {
+        nonce,
+        bootstrapScriptContent: 'INIT();',
+        bootstrapScripts: ['init.js'],
+        bootstrapModules: ['init.mjs'],
+      },
+    );
+    const result = await readResult(stream);
+    expect(result).toMatchInlineSnapshot(
+      `"<div>hello world</div><script nonce="${nonce}">INIT();</script><script nonce="${nonce}" src="init.js" async=""></script><script nonce="${nonce}" type="module" src="init.mjs" async=""></script>"`,
+    );
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -500,7 +500,7 @@ describe('ReactDOMFizzServerBrowser', () => {
     );
     const result = await readResult(stream);
     expect(result).toMatchInlineSnapshot(
-      `"<div>hello world</div><script nonce="${nonce}">INIT();</script><script nonce="${nonce}" src="init.js" async=""></script><script nonce="${nonce}" type="module" src="init.mjs" async=""></script>"`,
+      `"<div>hello world</div><script nonce="${nonce}">INIT();</script><script src="init.js" nonce="${nonce}" async=""></script><script type="module" src="init.mjs" nonce="${nonce}" async=""></script>"`,
     );
   });
 });

--- a/packages/react-dom/src/test-utils/FizzTestUtils.js
+++ b/packages/react-dom/src/test-utils/FizzTestUtils.js
@@ -103,6 +103,12 @@ async function executeScript(script: Element) {
   } else {
     const newScript = ownerDocument.createElement('script');
     newScript.textContent = script.textContent;
+    // make sure to add nonce back to script if it exists
+    const scriptNonce = script.getAttribute('nonce');
+    if (scriptNonce) {
+      newScript.setAttribute('nonce', scriptNonce);
+    }
+
     parent.insertBefore(newScript, script);
     parent.removeChild(script);
   }


### PR DESCRIPTION
## Summary

When using a Content Security Policy with [the `strict-dynamic` source list keyword](https://content-security-policy.com/strict-dynamic/), all other non-nonce keywords and sources are ignored, specifically `'self'`. This means that scripts that are inserted via `<script src=... />` into the HTML violate the content security policy.

This fix also supports CSPs that are _not_ using `strict-dynamic`, but _are_ using [`nonce-xxx` sources](https://content-security-policy.com/nonce/)

Right now the render functions (`renderToReadableStream`, `renderToPipeableStream` etc) via `createResponseState` add the nonce attribute to inline scripts set in `bootstrapScriptContent`, but not scripts via `bootstrapScripts` and `bootstrapModules`. Also missing the nonce value are external runtime scripts, as well as scripts rendered at runtime that could be rendered on the server.

Adding nonce support to those scripts will allow them to pass a `content-security-policy` that uses `strict-dynamic`.

### Related issues:
- closes #24883
- Discussion and related issue in: #26026
- https://github.com/vercel/next.js/issues/43743

### Changes:

- Add `nonce` to bootstrap scripts/modules in `ReactFizzConfigDOM -> createResponseState()`
- Add `nonce` property to the return object for `createResponseState()`
- Pass `nonce` prop to `internalPreinitScript()` (external runtime scripts)
- ~Inject `nonce` prop in `pushStartInstance()` where `type=='script'` if it exists in `responseState`~ (removed based on https://github.com/facebook/react/pull/26738#issuecomment-1527902527)
- Updated `FizzTestUtils.js` to re-add nonce attribute after executing inline scripts


## How did you test this change?

I added the following tests:
- `ReactDOMFizzServer-test - it should render scripts with nonce added`
  Test that `nonce` values are applied correctly in rendered scripts 
- `ReactDOMFizzServer-test - it should support nonce for bootstrap and runtime scripts`
  Update the existing nonce test to test all bootstrap scripts, as well as the runtime script
