### PR TITLE
Implement experimental_useOptimisticState

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
+++ b/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
@@ -1243,10 +1243,9 @@ describe('Timeline profiler', () => {
         function Example() {
           const setHigh = React.useState(0)[1];
           const setLow = React.useState(0)[1];
-          const startTransition = React.useTransition()[1];
 
           updaterFn = () => {
-            startTransition(() => {
+            React.startTransition(() => {
               setLow(prevLow => prevLow + 1);
             });
             setHigh(prevHigh => prevHigh + 1);
@@ -1265,24 +1264,6 @@ describe('Timeline profiler', () => {
         const timelineData = stopProfilingAndGetTimelineData();
         expect(timelineData.schedulingEvents).toMatchInlineSnapshot(`
           [
-            {
-              "componentName": "Example",
-              "componentStack": "
-              in Example (at **)",
-              "lanes": "0b0000000000000000000000000001000",
-              "timestamp": 10,
-              "type": "schedule-state-update",
-              "warning": null,
-            },
-            {
-              "componentName": "Example",
-              "componentStack": "
-              in Example (at **)",
-              "lanes": "0b0000000000000000000000010000000",
-              "timestamp": 10,
-              "type": "schedule-state-update",
-              "warning": null,
-            },
             {
               "componentName": "Example",
               "componentStack": "

--- a/packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js
@@ -22,6 +22,7 @@ let React;
 let ReactDOMServer;
 let ReactDOMClient;
 let useFormStatus;
+let useOptimisticState;
 
 describe('ReactDOMFizzForm', () => {
   beforeEach(() => {
@@ -30,6 +31,7 @@ describe('ReactDOMFizzForm', () => {
     ReactDOMServer = require('react-dom/server.browser');
     ReactDOMClient = require('react-dom/client');
     useFormStatus = require('react-dom').experimental_useFormStatus;
+    useOptimisticState = require('react').experimental_useOptimisticState;
     act = require('internal-test-utils').act;
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -452,5 +454,22 @@ describe('ReactDOMFizzForm', () => {
     expect(savedTitle).toBe('Hello');
     expect(deletedTitle).toBe('Hello');
     expect(rootActionCalled).toBe(false);
+  });
+
+  // @gate enableAsyncActions
+  it('useOptimisticState returns passthrough value', async () => {
+    function App() {
+      const [optimisticState] = useOptimisticState('hi');
+      return optimisticState;
+    }
+
+    const stream = await ReactDOMServer.renderToReadableStream(<App />);
+    await readIntoContainer(stream);
+    expect(container.textContent).toBe('hi');
+
+    await act(async () => {
+      ReactDOMClient.hydrateRoot(container, <App />);
+    });
+    expect(container.textContent).toBe('hi');
   });
 });

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1918,6 +1918,30 @@ function rerenderState<S>(
   return rerenderReducer(basicStateReducer, (initialState: any));
 }
 
+function mountOptimisticState<S, A>(
+  passthrough: S,
+  reducer: ?(S, A) => S,
+): [S, (A) => void] {
+  // $FlowFixMe - TODO: Actual implementation
+  return mountState(passthrough);
+}
+
+function updateOptimisticState<S, A>(
+  passthrough: S,
+  reducer: ?(S, A) => S,
+): [S, (A) => void] {
+  // $FlowFixMe - TODO: Actual implementation
+  return updateState(passthrough);
+}
+
+function rerenderOptimisticState<S, A>(
+  passthrough: S,
+  reducer: ?(S, A) => S,
+): [S, (A) => void] {
+  // $FlowFixMe - TODO: Actual implementation
+  return rerenderState(passthrough);
+}
+
 function pushEffect(
   tag: HookFlags,
   create: () => (() => void) | void,
@@ -2989,6 +3013,10 @@ if (enableFormActions && enableAsyncActions) {
   (ContextOnlyDispatcher: Dispatcher).useHostTransitionStatus =
     throwInvalidHookError;
 }
+if (enableAsyncActions) {
+  (ContextOnlyDispatcher: Dispatcher).useOptimisticState =
+    throwInvalidHookError;
+}
 
 const HooksDispatcherOnMount: Dispatcher = {
   readContext,
@@ -3024,6 +3052,11 @@ if (enableFormActions && enableAsyncActions) {
   (HooksDispatcherOnMount: Dispatcher).useHostTransitionStatus =
     useHostTransitionStatus;
 }
+if (enableAsyncActions) {
+  (HooksDispatcherOnMount: Dispatcher).useOptimisticState =
+    mountOptimisticState;
+}
+
 const HooksDispatcherOnUpdate: Dispatcher = {
   readContext,
 
@@ -3057,6 +3090,10 @@ if (enableUseEffectEventHook) {
 if (enableFormActions && enableAsyncActions) {
   (HooksDispatcherOnUpdate: Dispatcher).useHostTransitionStatus =
     useHostTransitionStatus;
+}
+if (enableAsyncActions) {
+  (HooksDispatcherOnUpdate: Dispatcher).useOptimisticState =
+    updateOptimisticState;
 }
 
 const HooksDispatcherOnRerender: Dispatcher = {
@@ -3092,6 +3129,10 @@ if (enableUseEffectEventHook) {
 if (enableFormActions && enableAsyncActions) {
   (HooksDispatcherOnRerender: Dispatcher).useHostTransitionStatus =
     useHostTransitionStatus;
+}
+if (enableAsyncActions) {
+  (HooksDispatcherOnRerender: Dispatcher).useOptimisticState =
+    rerenderOptimisticState;
 }
 
 let HooksDispatcherOnMountInDEV: Dispatcher | null = null;
@@ -3283,6 +3324,17 @@ if (__DEV__) {
     (HooksDispatcherOnMountInDEV: Dispatcher).useHostTransitionStatus =
       useHostTransitionStatus;
   }
+  if (enableAsyncActions) {
+    (HooksDispatcherOnMountInDEV: Dispatcher).useOptimisticState =
+      function useOptimisticState<S, A>(
+        passthrough: S,
+        reducer: ?(S, A) => S,
+      ): [S, (A) => void] {
+        currentHookNameInDev = 'useOptimisticState';
+        mountHookTypesDev();
+        return mountOptimisticState(passthrough, reducer);
+      };
+  }
 
   HooksDispatcherOnMountWithHookTypesInDEV = {
     readContext<T>(context: ReactContext<T>): T {
@@ -3440,6 +3492,17 @@ if (__DEV__) {
   if (enableFormActions && enableAsyncActions) {
     (HooksDispatcherOnMountWithHookTypesInDEV: Dispatcher).useHostTransitionStatus =
       useHostTransitionStatus;
+  }
+  if (enableAsyncActions) {
+    (HooksDispatcherOnMountWithHookTypesInDEV: Dispatcher).useOptimisticState =
+      function useOptimisticState<S, A>(
+        passthrough: S,
+        reducer: ?(S, A) => S,
+      ): [S, (A) => void] {
+        currentHookNameInDev = 'useOptimisticState';
+        updateHookTypesDev();
+        return mountOptimisticState(passthrough, reducer);
+      };
   }
 
   HooksDispatcherOnUpdateInDEV = {
@@ -3601,6 +3664,17 @@ if (__DEV__) {
     (HooksDispatcherOnUpdateInDEV: Dispatcher).useHostTransitionStatus =
       useHostTransitionStatus;
   }
+  if (enableAsyncActions) {
+    (HooksDispatcherOnUpdateInDEV: Dispatcher).useOptimisticState =
+      function useOptimisticState<S, A>(
+        passthrough: S,
+        reducer: ?(S, A) => S,
+      ): [S, (A) => void] {
+        currentHookNameInDev = 'useOptimisticState';
+        updateHookTypesDev();
+        return updateOptimisticState(passthrough, reducer);
+      };
+  }
 
   HooksDispatcherOnRerenderInDEV = {
     readContext<T>(context: ReactContext<T>): T {
@@ -3760,6 +3834,17 @@ if (__DEV__) {
   if (enableFormActions && enableAsyncActions) {
     (HooksDispatcherOnRerenderInDEV: Dispatcher).useHostTransitionStatus =
       useHostTransitionStatus;
+  }
+  if (enableAsyncActions) {
+    (HooksDispatcherOnRerenderInDEV: Dispatcher).useOptimisticState =
+      function useOptimisticState<S, A>(
+        passthrough: S,
+        reducer: ?(S, A) => S,
+      ): [S, (A) => void] {
+        currentHookNameInDev = 'useOptimisticState';
+        updateHookTypesDev();
+        return rerenderOptimisticState(passthrough, reducer);
+      };
   }
 
   InvalidNestedHooksDispatcherOnMountInDEV = {
@@ -3942,6 +4027,18 @@ if (__DEV__) {
   if (enableFormActions && enableAsyncActions) {
     (InvalidNestedHooksDispatcherOnMountInDEV: Dispatcher).useHostTransitionStatus =
       useHostTransitionStatus;
+  }
+  if (enableAsyncActions) {
+    (InvalidNestedHooksDispatcherOnMountInDEV: Dispatcher).useOptimisticState =
+      function useOptimisticState<S, A>(
+        passthrough: S,
+        reducer: ?(S, A) => S,
+      ): [S, (A) => void] {
+        currentHookNameInDev = 'useOptimisticState';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return mountOptimisticState(passthrough, reducer);
+      };
   }
 
   InvalidNestedHooksDispatcherOnUpdateInDEV = {
@@ -4128,6 +4225,18 @@ if (__DEV__) {
     (InvalidNestedHooksDispatcherOnUpdateInDEV: Dispatcher).useHostTransitionStatus =
       useHostTransitionStatus;
   }
+  if (enableAsyncActions) {
+    (InvalidNestedHooksDispatcherOnUpdateInDEV: Dispatcher).useOptimisticState =
+      function useOptimisticState<S, A>(
+        passthrough: S,
+        reducer: ?(S, A) => S,
+      ): [S, (A) => void] {
+        currentHookNameInDev = 'useOptimisticState';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return updateOptimisticState(passthrough, reducer);
+      };
+  }
 
   InvalidNestedHooksDispatcherOnRerenderInDEV = {
     readContext<T>(context: ReactContext<T>): T {
@@ -4312,5 +4421,17 @@ if (__DEV__) {
   if (enableFormActions && enableAsyncActions) {
     (InvalidNestedHooksDispatcherOnRerenderInDEV: Dispatcher).useHostTransitionStatus =
       useHostTransitionStatus;
+  }
+  if (enableAsyncActions) {
+    (InvalidNestedHooksDispatcherOnRerenderInDEV: Dispatcher).useOptimisticState =
+      function useOptimisticState<S, A>(
+        passthrough: S,
+        reducer: ?(S, A) => S,
+      ): [S, (A) => void] {
+        currentHookNameInDev = 'useOptimisticState';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return rerenderOptimisticState(passthrough, reducer);
+      };
   }
 }

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -57,7 +57,8 @@ export type HookType =
   | 'useMutableSource'
   | 'useSyncExternalStore'
   | 'useId'
-  | 'useCacheRefresh';
+  | 'useCacheRefresh'
+  | 'useOptimisticState';
 
 export type ContextDependency<T> = {
   context: ReactContext<T>,
@@ -423,6 +424,10 @@ export type Dispatcher = {
   useCacheRefresh?: () => <T>(?() => T, ?T) => void,
   useMemoCache?: (size: number) => Array<any>,
   useHostTransitionStatus?: () => TransitionStatus,
+  useOptimisticState?: <S, A>(
+    passthrough: S,
+    reducer: ?(S, A) => S,
+  ) => [S, (A) => void],
 };
 
 export type CacheDispatcher = {

--- a/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
@@ -648,17 +648,430 @@ describe('ReactAsyncActions', () => {
   });
 
   // @gate enableAsyncActions
-  test('useOptimisticState exists', async () => {
-    // This API isn't implemented yet. This just tests that it's wired
-    // up correctly.
+  test('useOptimisticState can be used to implement a pending state', async () => {
+    const startTransition = React.startTransition;
+
+    let setIsPending;
+    function App({text}) {
+      const [isPending, _setIsPending] = useOptimisticState(false);
+      setIsPending = _setIsPending;
+      return (
+        <>
+          <Text text={'Pending: ' + isPending} />
+          <AsyncText text={text} />
+        </>
+      );
+    }
+
+    // Initial render
+    const root = ReactNoop.createRoot();
+    resolveText('A');
+    await act(() => root.render(<App text="A" />));
+    assertLog(['Pending: false', 'A']);
+    expect(root).toMatchRenderedOutput('Pending: falseA');
+
+    // Start a transition
+    await act(() =>
+      startTransition(() => {
+        setIsPending(true);
+        root.render(<App text="B" />);
+      }),
+    );
+    assertLog([
+      // Render the pending state immediately
+      'Pending: true',
+      'A',
+
+      // Then attempt to render the transition. The pending state will be
+      // automatically reverted.
+      'Pending: false',
+      'Suspend! [B]',
+    ]);
+
+    // Resolve the transition
+    await act(() => resolveText('B'));
+    assertLog([
+      // Render the pending state immediately
+      'Pending: false',
+      'B',
+    ]);
+  });
+
+  // @gate enableAsyncActions
+  test('useOptimisticState rebases pending updates on top of passthrough value', async () => {
+    let serverCart = ['A'];
+
+    async function submitNewItem(item) {
+      await getText('Adding item ' + item);
+      serverCart = [...serverCart, item];
+      React.startTransition(() => {
+        root.render(<App cart={serverCart} />);
+      });
+    }
+
+    let addItemToCart;
+    function App({cart}) {
+      const [isPending, startTransition] = useTransition();
+
+      const savedCartSize = cart.length;
+      const [optimisticCartSize, setOptimisticCartSize] =
+        useOptimisticState(savedCartSize);
+
+      addItemToCart = item => {
+        startTransition(async () => {
+          setOptimisticCartSize(n => n + 1);
+          await submitNewItem(item);
+        });
+      };
+
+      return (
+        <>
+          <div>
+            <Text text={'Pending: ' + isPending} />
+          </div>
+          <div>
+            <Text text={'Items in cart: ' + optimisticCartSize} />
+          </div>
+          <ul>
+            {cart.map(item => (
+              <li key={item}>
+                <Text text={'Item ' + item} />
+              </li>
+            ))}
+          </ul>
+        </>
+      );
+    }
+
+    // Initial render
+    const root = ReactNoop.createRoot();
+    await act(() => root.render(<App cart={serverCart} />));
+    assertLog(['Pending: false', 'Items in cart: 1', 'Item A']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <div>Pending: false</div>
+        <div>Items in cart: 1</div>
+        <ul>
+          <li>Item A</li>
+        </ul>
+      </>,
+    );
+
+    // The cart size is incremented even though B hasn't been added yet.
+    await act(() => addItemToCart('B'));
+    assertLog(['Pending: true', 'Items in cart: 2', 'Item A']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <div>Pending: true</div>
+        <div>Items in cart: 2</div>
+        <ul>
+          <li>Item A</li>
+        </ul>
+      </>,
+    );
+
+    // While B is still pending, another item gets added to the cart
+    // out-of-band.
+    serverCart = [...serverCart, 'C'];
+    // NOTE: This is a synchronous update only because we don't yet support
+    // parallel transitions; all transitions are entangled together. Once we add
+    // support for parallel transitions, we can update this test.
+    ReactNoop.flushSync(() => root.render(<App cart={serverCart} />));
+    assertLog([
+      'Pending: true',
+      // Note that the optimistic cart size is still correct, because the
+      // pending update was rebased on top new value.
+      'Items in cart: 3',
+      'Item A',
+      'Item C',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <div>Pending: true</div>
+        <div>Items in cart: 3</div>
+        <ul>
+          <li>Item A</li>
+          <li>Item C</li>
+        </ul>
+      </>,
+    );
+
+    // Finish loading B. The optimistic state is reverted.
+    await act(() => resolveText('Adding item B'));
+    assertLog([
+      'Pending: false',
+      'Items in cart: 3',
+      'Item A',
+      'Item C',
+      'Item B',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <div>Pending: false</div>
+        <div>Items in cart: 3</div>
+        <ul>
+          <li>Item A</li>
+          <li>Item C</li>
+          <li>Item B</li>
+        </ul>
+      </>,
+    );
+  });
+
+  // @gate enableAsyncActions
+  test('useOptimisticState accepts a custom reducer', async () => {
+    let serverCart = ['A'];
+
+    async function submitNewItem(item) {
+      await getText('Adding item ' + item);
+      serverCart = [...serverCart, item];
+      React.startTransition(() => {
+        root.render(<App cart={serverCart} />);
+      });
+    }
+
+    let addItemToCart;
+    function App({cart}) {
+      const [isPending, startTransition] = useTransition();
+
+      const savedCartSize = cart.length;
+      const [optimisticCartSize, addToOptimisticCart] = useOptimisticState(
+        savedCartSize,
+        (prevSize, newItem) => {
+          Scheduler.log('Increment optimistic cart size for ' + newItem);
+          return prevSize + 1;
+        },
+      );
+
+      addItemToCart = item => {
+        startTransition(async () => {
+          addToOptimisticCart(item);
+          await submitNewItem(item);
+        });
+      };
+
+      return (
+        <>
+          <div>
+            <Text text={'Pending: ' + isPending} />
+          </div>
+          <div>
+            <Text text={'Items in cart: ' + optimisticCartSize} />
+          </div>
+          <ul>
+            {cart.map(item => (
+              <li key={item}>
+                <Text text={'Item ' + item} />
+              </li>
+            ))}
+          </ul>
+        </>
+      );
+    }
+
+    // Initial render
+    const root = ReactNoop.createRoot();
+    await act(() => root.render(<App cart={serverCart} />));
+    assertLog(['Pending: false', 'Items in cart: 1', 'Item A']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <div>Pending: false</div>
+        <div>Items in cart: 1</div>
+        <ul>
+          <li>Item A</li>
+        </ul>
+      </>,
+    );
+
+    // The cart size is incremented even though B hasn't been added yet.
+    await act(() => addItemToCart('B'));
+    assertLog([
+      'Increment optimistic cart size for B',
+      'Pending: true',
+      'Items in cart: 2',
+      'Item A',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <div>Pending: true</div>
+        <div>Items in cart: 2</div>
+        <ul>
+          <li>Item A</li>
+        </ul>
+      </>,
+    );
+
+    // While B is still pending, another item gets added to the cart
+    // out-of-band.
+    serverCart = [...serverCart, 'C'];
+    // NOTE: This is a synchronous update only because we don't yet support
+    // parallel transitions; all transitions are entangled together. Once we add
+    // support for parallel transitions, we can update this test.
+    ReactNoop.flushSync(() => root.render(<App cart={serverCart} />));
+    assertLog([
+      'Increment optimistic cart size for B',
+      'Pending: true',
+      // Note that the optimistic cart size is still correct, because the
+      // pending update was rebased on top new value.
+      'Items in cart: 3',
+      'Item A',
+      'Item C',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <div>Pending: true</div>
+        <div>Items in cart: 3</div>
+        <ul>
+          <li>Item A</li>
+          <li>Item C</li>
+        </ul>
+      </>,
+    );
+
+    // Finish loading B. The optimistic state is reverted.
+    await act(() => resolveText('Adding item B'));
+    assertLog([
+      'Pending: false',
+      'Items in cart: 3',
+      'Item A',
+      'Item C',
+      'Item B',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <div>Pending: false</div>
+        <div>Items in cart: 3</div>
+        <ul>
+          <li>Item A</li>
+          <li>Item C</li>
+          <li>Item B</li>
+        </ul>
+      </>,
+    );
+  });
+
+  // @gate enableAsyncActions
+  test('useOptimisticState rebases if the passthrough is updated during a render phase update', async () => {
+    // This is kind of an esoteric case where it's hard to come up with a
+    // realistic real-world scenario but it should still work.
+    let increment;
+    let setCount;
     function App() {
-      const [text] = useOptimisticState('Hi');
-      return <Text text={text} />;
+      const [isPending, startTransition] = useTransition(2);
+      const [count, _setCount] = useState(0);
+      setCount = _setCount;
+
+      const [optimisticCount, setOptimisticCount] = useOptimisticState(
+        count,
+        prev => {
+          Scheduler.log('Increment optimistic count');
+          return prev + 1;
+        },
+      );
+
+      if (count === 1) {
+        Scheduler.log('Render phase update count from 1 to 2');
+        setCount(2);
+      }
+
+      increment = () =>
+        startTransition(async () => {
+          setOptimisticCount(n => n + 1);
+          await getText('Wait to increment');
+          React.startTransition(() => setCount(n => n + 1));
+        });
+
+      return (
+        <>
+          <div>
+            <Text text={'Count: ' + count} />
+          </div>
+          {isPending ? (
+            <div>
+              <Text text={'Optimistic count: ' + optimisticCount} />
+            </div>
+          ) : null}
+        </>
+      );
     }
 
     const root = ReactNoop.createRoot();
     await act(() => root.render(<App />));
-    assertLog(['Hi']);
-    expect(root).toMatchRenderedOutput('Hi');
+    assertLog(['Count: 0']);
+    expect(root).toMatchRenderedOutput(<div>Count: 0</div>);
+
+    await act(() => increment());
+    assertLog([
+      'Increment optimistic count',
+      'Count: 0',
+      'Optimistic count: 1',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <div>Count: 0</div>
+        <div>Optimistic count: 1</div>
+      </>,
+    );
+
+    await act(() => setCount(1));
+    assertLog([
+      'Increment optimistic count',
+      'Render phase update count from 1 to 2',
+      // The optimistic update is rebased on top of the new passthrough value.
+      'Increment optimistic count',
+      'Count: 2',
+      'Optimistic count: 3',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <div>Count: 2</div>
+        <div>Optimistic count: 3</div>
+      </>,
+    );
+
+    // Finish the action
+    await act(() => resolveText('Wait to increment'));
+    assertLog(['Count: 3']);
+    expect(root).toMatchRenderedOutput(<div>Count: 3</div>);
+  });
+
+  // @gate enableAsyncActions
+  test('useOptimisticState rebases if the passthrough is updated during a render phase update (initial mount)', async () => {
+    // This is kind of an esoteric case where it's hard to come up with a
+    // realistic real-world scenario but it should still work.
+    function App() {
+      const [count, setCount] = useState(0);
+      const [optimisticCount] = useOptimisticState(count);
+
+      if (count === 0) {
+        Scheduler.log('Render phase update count from 1 to 2');
+        setCount(1);
+      }
+
+      return (
+        <>
+          <div>
+            <Text text={'Count: ' + count} />
+          </div>
+          <div>
+            <Text text={'Optimistic count: ' + optimisticCount} />
+          </div>
+        </>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(() => root.render(<App />));
+    assertLog([
+      'Render phase update count from 1 to 2',
+      'Count: 1',
+      'Optimistic count: 1',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <div>Count: 1</div>
+        <div>Optimistic count: 1</div>
+      </>,
+    );
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
@@ -5,6 +5,7 @@ let act;
 let assertLog;
 let useTransition;
 let useState;
+let useOptimisticState;
 let textCache;
 
 describe('ReactAsyncActions', () => {
@@ -18,6 +19,7 @@ describe('ReactAsyncActions', () => {
     assertLog = require('internal-test-utils').assertLog;
     useTransition = React.useTransition;
     useState = React.useState;
+    useOptimisticState = React.experimental_useOptimisticState;
 
     textCache = new Map();
   });
@@ -643,5 +645,20 @@ describe('ReactAsyncActions', () => {
         <div>Oops C!</div>
       </>,
     );
+  });
+
+  // @gate enableAsyncActions
+  test('useOptimisticState exists', async () => {
+    // This API isn't implemented yet. This just tests that it's wired
+    // up correctly.
+    function App() {
+      const [text] = useOptimisticState('Hi');
+      return <Text text={text} />;
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(() => root.render(<App />));
+    assertLog(['Hi']);
+    expect(root).toMatchRenderedOutput('Hi');
   });
 });

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -553,6 +553,18 @@ function useHostTransitionStatus(): TransitionStatus {
   return NotPendingTransition;
 }
 
+function unsupportedSetOptimisticState() {
+  throw new Error('Cannot update optimistic state while rendering.');
+}
+
+function useOptimisticState<S, A>(
+  passthrough: S,
+  reducer: ?(S, A) => S,
+): [S, (A) => void] {
+  resolveCurrentlyRenderingComponent();
+  return [passthrough, unsupportedSetOptimisticState];
+}
+
 function useId(): string {
   const task: Task = (currentlyRenderingTask: any);
   const treeId = getTreeId(task.treeContext);
@@ -651,6 +663,9 @@ if (enableUseMemoCacheHook) {
 }
 if (enableFormActions && enableAsyncActions) {
   HooksDispatcher.useHostTransitionStatus = useHostTransitionStatus;
+}
+if (enableAsyncActions) {
+  HooksDispatcher.useOptimisticState = useOptimisticState;
 }
 
 export let currentResponseState: null | ResponseState = (null: any);

--- a/packages/react/index.classic.fb.js
+++ b/packages/react/index.classic.fb.js
@@ -59,6 +59,7 @@ export {
   useMemo,
   useMutableSource,
   useMutableSource as unstable_useMutableSource,
+  experimental_useOptimisticState,
   useReducer,
   useRef,
   useState,

--- a/packages/react/index.experimental.js
+++ b/packages/react/index.experimental.js
@@ -49,6 +49,7 @@ export {
   useInsertionEffect,
   useLayoutEffect,
   useMemo,
+  experimental_useOptimisticState,
   useReducer,
   useRef,
   useState,

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -77,6 +77,7 @@ export {
   useLayoutEffect,
   useMemo,
   useMutableSource,
+  experimental_useOptimisticState,
   useSyncExternalStore,
   useReducer,
   useRef,

--- a/packages/react/index.modern.fb.js
+++ b/packages/react/index.modern.fb.js
@@ -57,6 +57,7 @@ export {
   useMemo,
   useMutableSource,
   useMutableSource as unstable_useMutableSource,
+  experimental_useOptimisticState,
   useReducer,
   useRef,
   useState,

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -59,6 +59,7 @@ import {
   useCacheRefresh,
   use,
   useMemoCache,
+  useOptimisticState,
 } from './ReactHooks';
 import {
   createElementWithValidation,
@@ -112,6 +113,7 @@ export {
   useLayoutEffect,
   useMemo,
   useMutableSource,
+  useOptimisticState as experimental_useOptimisticState,
   useSyncExternalStore,
   useReducer,
   useRef,

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -241,3 +241,12 @@ export function useEffectEvent<Args, F: (...Array<Args>) => mixed>(
   // $FlowFixMe[not-a-function] This is unstable, thus optional
   return dispatcher.useEffectEvent(callback);
 }
+
+export function useOptimisticState<S, A>(
+  passthrough: S,
+  reducer: ?(S, A) => S,
+): [S, (A) => void] {
+  const dispatcher = resolveDispatcher();
+  // $FlowFixMe[not-a-function] This is unstable, thus optional
+  return dispatcher.useOptimisticState(passthrough, reducer);
+}

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -463,5 +463,6 @@
   "475": "Internal React Error: suspendedState null when it was expected to exists. Please report this as a React bug.",
   "476": "Expected the form instance to be a HostComponent. This is a bug in React.",
   "477": "React Internal Error: processHintChunk is not implemented for Native-Relay. The fact that this method was called means there is a bug in React.",
-  "478": "Thenable should have already resolved. This is a bug in React."
+  "478": "Thenable should have already resolved. This is a bug in React.",
+  "479": "Cannot update optimistic state while rendering."
 }


### PR DESCRIPTION
This adds an experimental hook tentatively called useOptimisticState. (The actual name needs some bikeshedding.)

The headline feature is that you can use it to implement optimistic updates. If you set some optimistic state during a transition/action, the state will be automatically reverted once the transition completes.

Another feature is that the optimistic updates will be continually rebased on top of the latest state.

It's easiest to explain with examples; we'll publish documentation as the API gets closer to stabilizing. See tests for now.

Technically the use cases for this hook are broader than just optimistic updates; you could use it implement any sort of "pending" state, such as the ones exposed by useTransition and useFormStatus. But we expect people will most often reach for this hook to implement the optimistic update pattern; simpler cases are covered by those other hooks.