### PR TITLE
Change `yarn test` to default to experimental

### DIFF
--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -45,7 +45,7 @@ const argv = yargs
       describe: 'Run with the given release channel.',
       requiresArg: true,
       type: 'string',
-      default: 'www-modern',
+      default: 'experimental',
       choices: ['experimental', 'stable', 'www-classic', 'www-modern'],
     },
     env: {


### PR DESCRIPTION
The idea is that the default `yarn test` command should be the one that includes the most bleeding edge features, because during development you probably want as many features enabled as possible.

That used to be `www-modern` but nowadays it's `experimental` because we've landed a bunch of async actions stuff in experimental but it isn't yet being tested at Meta.

So this switches the default to `experimental`.