### PR TITLE
Gate DevTools test to fix CI

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/profilingCache-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilingCache-test.js
@@ -938,8 +938,10 @@ describe('ProfilingCache', () => {
     }
   });
 
-  // @reactVersion >= 18.0
+  // @reactVersion = 17.0
   it('should handle unexpectedly shallow suspense trees', () => {
+    // This test only runs in v17 because it's a regression test for legacy
+    // Suspense behavior, and the implementation details changed in v18.
     const container = document.createElement('div');
 
     utils.act(() => store.profilerStore.startProfiling());
@@ -965,15 +967,7 @@ describe('ProfilingCache', () => {
           "passiveEffectDuration": null,
           "priorityLevel": "Normal",
           "timestamp": 0,
-          "updaters": [
-            {
-              "displayName": "render()",
-              "hocDisplayNames": null,
-              "id": 1,
-              "key": null,
-              "type": 11,
-            },
-          ],
+          "updaters": null,
         },
       ]
     `);

--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -16,6 +16,8 @@ const devToolsConfig = './scripts/jest/config.build-devtools.js';
 const persistentConfig = './scripts/jest/config.source-persistent.js';
 const buildConfig = './scripts/jest/config.build.js';
 
+const {ReactVersion} = require('../../ReactVersions');
+
 const argv = yargs
   .parserConfiguration({
     // Important: This option tells yargs to move all other options not
@@ -179,9 +181,13 @@ function validateOptions() {
       success = false;
     }
 
-    if (argv.reactVersion && !semver.validRange(argv.reactVersion)) {
-      success = false;
-      logError('please specify a valid version range for --reactVersion');
+    if (argv.reactVersion) {
+      if (!semver.validRange(argv.reactVersion)) {
+        success = false;
+        logError('please specify a valid version range for --reactVersion');
+      }
+    } else {
+      argv.reactVersion = ReactVersion;
     }
   } else {
     if (argv.compactConsole) {


### PR DESCRIPTION
This test started failing recently in older versions of React because the Scheduler priority inside a microtask is Normal instead of Immediate. This is expected because microtasks are not Scheduler tasks; it's an implementation detail.

I gated the test to only run in v17 because it's a regression test for legacy Suspense behavior, and the implementation details of the snapshot changed in v18.

Test plan
---------

Using latest:

```
yarn test --build --project devtools --release-channel=experimental profilingcache
```

Using v17 (typically runs in a timed CI workflow):

```
/scripts/circleci/download_devtools_regression_build.js 17.0 --replaceBuild
yarn test --build --project devtools --release-channel=experimental --reactVersion 17.0 profilingcache
```