### PR TITLE
Remove unused `initialStatus` parameter from `useHostTransitionStatus`

### DIFF
--- a/packages/react-dom-bindings/src/shared/ReactDOMFormActions.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMFormActions.js
@@ -70,7 +70,7 @@ export function useFormStatus(): FormStatus {
     throw new Error('Not implemented.');
   } else {
     const dispatcher = resolveDispatcher();
-    // $FlowFixMe We know this exists because of the feature check above.
+    // $FlowFixMe[not-a-function] We know this exists because of the feature check above.
     return dispatcher.useHostTransitionStatus();
   }
 }

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -422,9 +422,7 @@ export type Dispatcher = {
   useId(): string,
   useCacheRefresh?: () => <T>(?() => T, ?T) => void,
   useMemoCache?: (size: number) => Array<any>,
-  useHostTransitionStatus?: (
-    initialStatus: TransitionStatus,
-  ) => TransitionStatus,
+  useHostTransitionStatus?: () => TransitionStatus,
 };
 
 export type CacheDispatcher = {


### PR DESCRIPTION


## Summary

An unlimited `$FlowFixme` was masking an incompatible call of `useHostTransition` without arguments. Looks like `useHostTransition` never uses any arguments so this seems save to remove.

Feel free to close if this is planned, but not implemented yet. 

## How did you test this change?

- `yarn flow dom-node`
