### PR TITLE
fix(checkControlledValueProps): do not suggest setting readOnly for select component

### DIFF
--- a/packages/react-dom-bindings/src/shared/ReactControlledValuePropTypes.js
+++ b/packages/react-dom-bindings/src/shared/ReactControlledValuePropTypes.js
@@ -35,8 +35,8 @@ export function checkControlledValueProps(
       console.error(
         'You provided a `value` prop to a form field without an ' +
           '`onChange` handler. This will render a read-only field. If ' +
-          'the field should be mutable use `defaultValue`. Otherwise, ' +
-          'set either `onChange` or `readOnly`.',
+          'the field should be mutable use `defaultValue`. Otherwise, set %s.',
+        tagName === 'select' ? '`onChange`' : 'either `onChange` or `readOnly`',
       );
     }
 

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -65,7 +65,10 @@ describe('ReactDOMInput', () => {
     expect(() => {
       ReactDOM.render(<input type="text" value={0} />, container);
     }).toErrorDev(
-      'Warning: You provided a `value` prop to a form field without an `onChange` handler.',
+      'Warning: You provided a `value` prop to a form ' +
+        'field without an `onChange` handler. This will render a read-only ' +
+        'field. If the field should be mutable use `defaultValue`. ' +
+        'Otherwise, set either `onChange` or `readOnly`.',
     );
   });
 
@@ -73,7 +76,10 @@ describe('ReactDOMInput', () => {
     expect(() => {
       ReactDOM.render(<input type="text" value="" />, container);
     }).toErrorDev(
-      'Warning: You provided a `value` prop to a form field without an `onChange` handler.',
+      'Warning: You provided a `value` prop to a form ' +
+        'field without an `onChange` handler. This will render a read-only ' +
+        'field. If the field should be mutable use `defaultValue`. ' +
+        'Otherwise, set either `onChange` or `readOnly`.',
     );
   });
 
@@ -81,7 +87,10 @@ describe('ReactDOMInput', () => {
     expect(() => {
       ReactDOM.render(<input type="text" value="0" />, container);
     }).toErrorDev(
-      'Warning: You provided a `value` prop to a form field without an `onChange` handler.',
+      'Warning: You provided a `value` prop to a form ' +
+        'field without an `onChange` handler. This will render a read-only ' +
+        'field. If the field should be mutable use `defaultValue`. ' +
+        'Otherwise, set either `onChange` or `readOnly`.',
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -1034,6 +1034,7 @@ describe('ReactDOMSelect', () => {
         // See https://tc39.es/proposal-temporal/docs/plaindate.html#valueOf
         throw new TypeError('prod message');
       }
+
       toString() {
         return '2020-01-01';
       }
@@ -1287,6 +1288,116 @@ describe('ReactDOMSelect', () => {
       ).toErrorDev(
         'The provided `value` attribute is an unsupported type TemporalLike.' +
           ' This value must be coerced to a string before before using it here.',
+      );
+    });
+
+    it('should not warn about missing onChange if value is not set', () => {
+      ReactTestUtils.renderIntoDocument(
+        <select>
+          <option value="monkey">A monkey!</option>
+          <option value="giraffe">A giraffe!</option>
+          <option value="gorilla">A gorilla!</option>
+        </select>,
+      );
+    });
+
+    it('should not warn about missing onChange if value is undefined', () => {
+      ReactTestUtils.renderIntoDocument(
+        <select value={undefined}>
+          <option value="monkey">A monkey!</option>
+          <option value="giraffe">A giraffe!</option>
+          <option value="gorilla">A gorilla!</option>
+        </select>,
+      );
+    });
+
+    it('should not warn about missing onChange if onChange is set', () => {
+      const change = jest.fn();
+
+      ReactTestUtils.renderIntoDocument(
+        <select value="monkey" onChange={change}>
+          <option value="monkey">A monkey!</option>
+          <option value="giraffe">A giraffe!</option>
+          <option value="gorilla">A gorilla!</option>
+        </select>,
+      );
+    });
+
+    it('should not warn about missing onChange if disabled is true', () => {
+      ReactTestUtils.renderIntoDocument(
+        <select value="monkey" disabled={true}>
+          <option value="monkey">A monkey!</option>
+          <option value="giraffe">A giraffe!</option>
+          <option value="gorilla">A gorilla!</option>
+        </select>,
+      );
+    });
+
+    it('should warn about missing onChange if value is false', () => {
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(
+          <select value={false}>
+            <option value="monkey">A monkey!</option>
+            <option value="giraffe">A giraffe!</option>
+            <option value="gorilla">A gorilla!</option>
+          </select>,
+        ),
+      ).toErrorDev(
+        'Warning: You provided a `value` prop to a form ' +
+          'field without an `onChange` handler. This will render a read-only ' +
+          'field. If the field should be mutable use `defaultValue`. ' +
+          'Otherwise, set `onChange`.',
+      );
+    });
+
+    it('should warn about missing onChange if value is 0', () => {
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(
+          <select value={0}>
+            <option value="monkey">A monkey!</option>
+            <option value="giraffe">A giraffe!</option>
+            <option value="gorilla">A gorilla!</option>
+          </select>,
+        ),
+      ).toErrorDev(
+        'Warning: You provided a `value` prop to a form ' +
+          'field without an `onChange` handler. This will render a read-only ' +
+          'field. If the field should be mutable use `defaultValue`. ' +
+          'Otherwise, set `onChange`.',
+      );
+    });
+
+    it('should warn about missing onChange if value is "0"', () => {
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(
+          <select value="0">
+            <option value="monkey">A monkey!</option>
+            <option value="giraffe">A giraffe!</option>
+            <option value="gorilla">A gorilla!</option>
+          </select>,
+        ),
+      ).toErrorDev(
+        'Warning: You provided a `value` prop to a form ' +
+          'field without an `onChange` handler. This will render a read-only ' +
+          'field. If the field should be mutable use `defaultValue`. ' +
+          'Otherwise, set `onChange`.',
+      );
+    });
+
+    it('should warn about missing onChange if value is ""', () => {
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(
+          <select value="">
+            <option value="monkey">A monkey!</option>
+            <option value="giraffe">A giraffe!</option>
+            <option value="gorilla">A gorilla!</option>
+          </select>,
+        ),
+      ).toErrorDev(
+        'Warning: You provided a `value` prop to a form ' +
+          'field without an `onChange` handler. This will render a read-only ' +
+          'field. If the field should be mutable use `defaultValue`. ' +
+          'Otherwise, set `onChange`.',
       );
     });
   });

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -232,10 +232,12 @@ describe('ReactDOMTextarea', () => {
         // See https://tc39.es/proposal-temporal/docs/plaindate.html#valueOf
         throw new TypeError('prod message');
       }
+
       toString() {
         return '2020-01-01';
       }
     }
+
     const container = document.createElement('div');
     const stub = <textarea value="giraffe" onChange={emptyFunction} />;
     const node = renderTextarea(stub, container);
@@ -590,11 +592,14 @@ describe('ReactDOMTextarea', () => {
     const get = jest.fn(value => {
       return defaultValue;
     });
+
     class App extends React.Component {
       state = {count: 0, text: 'foo'};
+
       componentDidMount() {
         instance = this;
       }
+
       render() {
         return (
           <div>
@@ -609,6 +614,7 @@ describe('ReactDOMTextarea', () => {
         );
       }
     }
+
     ReactDOM.render(<App />, container);
     defaultValue = node.defaultValue;
     Object.defineProperty(node, 'defaultValue', {get, set});
@@ -758,5 +764,76 @@ describe('ReactDOMTextarea', () => {
 
     ReactDOM.render(<textarea defaultValue={null} />, container);
     expect(node.defaultValue).toBe('');
+  });
+
+  it('should not warn about missing onChange if value is not set', () => {
+    ReactTestUtils.renderIntoDocument(<textarea />);
+  });
+
+  it('should not warn about missing onChange if value is undefined', () => {
+    ReactTestUtils.renderIntoDocument(<textarea value={undefined} />);
+  });
+
+  it('should not warn about missing onChange if onChange is set', () => {
+    const change = jest.fn();
+    ReactTestUtils.renderIntoDocument(
+      <textarea value="something" onChange={change} />,
+    );
+  });
+
+  it('should not warn about missing onChange if disabled is true', () => {
+    ReactTestUtils.renderIntoDocument(
+      <textarea value="something" disabled={true} />,
+    );
+  });
+
+  it('should not warn about missing onChange if readOnly is true', () => {
+    ReactTestUtils.renderIntoDocument(
+      <textarea value="something" readOnly={true} />,
+    );
+  });
+
+  it('should warn about missing onChange if value is false', () => {
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<textarea value={false} />),
+    ).toErrorDev(
+      'Warning: You provided a `value` prop to a form ' +
+        'field without an `onChange` handler. This will render a read-only ' +
+        'field. If the field should be mutable use `defaultValue`. ' +
+        'Otherwise, set either `onChange` or `readOnly`.',
+    );
+  });
+
+  it('should warn about missing onChange if value is 0', () => {
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<textarea value={0} />),
+    ).toErrorDev(
+      'Warning: You provided a `value` prop to a form ' +
+        'field without an `onChange` handler. This will render a read-only ' +
+        'field. If the field should be mutable use `defaultValue`. ' +
+        'Otherwise, set either `onChange` or `readOnly`.',
+    );
+  });
+
+  it('should warn about missing onChange if value is "0"', () => {
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<textarea value="0" />),
+    ).toErrorDev(
+      'Warning: You provided a `value` prop to a form ' +
+        'field without an `onChange` handler. This will render a read-only ' +
+        'field. If the field should be mutable use `defaultValue`. ' +
+        'Otherwise, set either `onChange` or `readOnly`.',
+    );
+  });
+
+  it('should warn about missing onChange if value is ""', () => {
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<textarea value="" />),
+    ).toErrorDev(
+      'Warning: You provided a `value` prop to a form ' +
+        'field without an `onChange` handler. This will render a read-only ' +
+        'field. If the field should be mutable use `defaultValue`. ' +
+        'Otherwise, set either `onChange` or `readOnly`.',
+    );
   });
 });


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

### Motivation:
I encountered a warning in React when writing a select component:
```
Warning: You provided a `value` prop
to a form field without an `onChange` handler. This will render
a read-only field. If the field should be mutable use `defaultValue`. 
Otherwise, set either `onChange` or `readOnly`.
```
This warning is misleading because it suggests setting readOnly as a possible solution when in reality the select component [does not support it](https://react.dev/reference/react-dom/components/select).

### What my fix consists of:
I added a check in `checkControlledValueProps` to distinguish whether the mounted component is a select component.

Now, if you write:

```
<select value="avalue">
    <option value="avalue">avalue</option>
</select>
```

You will receive the following warning:
```
Warning: You provided a `value` prop
to a form field without an `onChange` handler. This will render
a read-only field. If the field should be mutable use `defaultValue`. 
Otherwise, set `onChange`.
```

Whereas if you write either of the following:

```
<input type="text" value="avalue"></select>

<textarea value="avalue"></select>
```

You will receive the old warning:
```
Warning: You provided a `value` prop
to a form field without an `onChange` handler. This will render
a read-only field. If the field should be mutable use `defaultValue`. 
Otherwise, set either `onChange` or `readOnly`.
```

## How did you test this change?
- I added extensive unit tests to `ReactDOMSelect-test.js` to ensure the correct behavior of the warning message.
- I edited existing related unit tests in `ReactDOMInput-test.js` to test the entire warning message which is now relevant.
- I added unit tests to `ReactDOMTextarea-test.js` to ensure correct behavior in that component, as they were missing.
- I performed some tests in `/fixtures/packaging/babel-standalone`.
- I run the entire test suite, with production flag as well.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
