### PR TITLE
Failing unit test for infinite render issue

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactFiberRootScheduler-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberRootScheduler-test.js
@@ -1,0 +1,63 @@
+let _doFlushWork;
+const shimHostConfigPath = 'react-reconciler/src/ReactFiberConfig';
+
+jest.mock(shimHostConfigPath, () => {
+  return jest.requireActual(
+    'react-dom-bindings/src/client/ReactFiberConfigDOM.js',
+  );
+});
+beforeAll(() => {
+  _doFlushWork = require('../ReactFiberRootScheduler')._doFlushWork;
+});
+
+test('does not hang', () => {
+  const root = {
+    tag: 1,
+    pendingChildren: null,
+    pingCache: {},
+    finishedWork: null,
+    timeoutHandle: -1,
+    cancelPendingCommit: null,
+    context: {},
+    pendingContext: null,
+    next: null,
+    callbackNode: null,
+    callbackPriority: 0,
+    expirationTimes: [
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 278303.90000000596,
+      278417.1999999881, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1,
+    ],
+    pendingLanes: 6176,
+    suspendedLanes: 0,
+    pingedLanes: 0,
+    expiredLanes: 0,
+    mutableReadLanes: 0,
+    finishedLanes: 0,
+    errorRecoveryDisabledLanes: 0,
+    entangledLanes: 6144,
+    entanglements: [
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6144, 6144, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0,
+    ],
+    hiddenUpdates: [],
+    identifierPrefix: '',
+    pooledCache: null,
+    pooledCacheLanes: 0,
+    mutableSourceEagerHydrationData: null,
+    hydrationCallbacks: {
+      unstable_concurrentUpdatesByDefault: true,
+      unstable_strictMode: true,
+    },
+    incompleteTransitions: {},
+    effectDuration: 0,
+    passiveEffectDuration: 0,
+    memoizedUpdaters: {},
+    pendingUpdatersLaneMap: [],
+    _debugRootType: 'hydrateRoot()',
+  };
+
+  expect(() => {
+    _doFlushWork(root, root, 2, false);
+  }).not.toThrow();
+});


### PR DESCRIPTION
I can't figure out what reproduces this via e2e tests, but this is the root data structure that causes it so I wrote a unit test to demonstrate it. It happens when `root === workInProgress` and the `workInProgressRootRenderLanes` is the sync lane. 

In that case, the `nextLane` is the sync lane for the work in progress, so we go into `performSyncWorkOnRoot`:

```js
// paraphrased
do {
  let = didPerformSomeWork = false
  const nextLanes = getNextLanes(
    root,
    root === workInProgressRoot ? workInProgressRootRenderLanes : NoLanes,
    );
    if (includesSyncLane(nextLanes)) {
      // TODO: Pass nextLanes as an argument instead of computing it again
      // inside performSyncWorkOnRoot.
      didPerformSomeWork = true;
      performSyncWorkOnRoot(root);
    }
    // ...  
} while (didPerformSomeWork)
```
But inside `performSyncWorkOnRoot`, these lines early return and do not account for the work in progress lanes:

```js
  // TODO: This was already computed in the caller. Pass it as an argument.
  let lanes = getNextLanes(root, NoLanes);
  if (!includesSyncLane(lanes)) {
    // There's no remaining sync work left.
    ensureRootIsScheduled(root);
    return null;
  }
```

So the do/while loop never ends, we just keep detecting that there's sync work to do in the outter function but early returning without doing any work in the inner function.

I think the fix is to complete the TODOs and ensure the same `nextLanes` are used to flush the sync work.