### PR TITLE
Rename "next" prerelease channel to "canary"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -605,10 +605,20 @@ workflows:
     when: << pipeline.parameters.prerelease_commit_sha >>
     jobs:
       - publish_prerelease:
-          name: Publish to Next channel
+          name: Publish to Canary channel
           commit_sha: << pipeline.parameters.prerelease_commit_sha >>
           release_channel: stable
-          dist_tag: "next"
+          # The tags to use when publishing canaries. The main one we should
+          # always include is "canary" but we can use multiple (e.g. alpha,
+          # beta, rc). To declare multiple, use a comma-separated string, like
+          # this:
+          #   dist_tag: "canary,alpha,beta,rc"
+          #
+          # TODO: We currently tag canaries with "next" in addition to "canary"
+          # because this used to be called the "next" channel and some
+          # downstream consumers might still expect that tag. We can remove this
+          # after some time has elapsed and the change has been communicated.
+          dist_tag: "canary,next"
       - publish_prerelease:
           name: Publish to Experimental channel
           requires:
@@ -616,7 +626,7 @@ workflows:
             # will sometimes fail if you try to concurrently publish two
             # different versions of the same package, even if they use different
             # dist tags.
-            - Publish to Next channel
+            - Publish to Canary channel
           commit_sha: << pipeline.parameters.prerelease_commit_sha >>
           release_channel: experimental
           dist_tag: experimental
@@ -634,7 +644,7 @@ workflows:
                 - main
     jobs:
       - publish_prerelease:
-          name: Publish to Next channel
+          name: Publish to Canary channel
           commit_sha: << pipeline.git.revision >>
           release_channel: stable
           dist_tag: "next"
@@ -645,7 +655,7 @@ workflows:
             # will sometimes fail if you try to concurrently publish two
             # different versions of the same package, even if they use different
             # dist tags.
-            - Publish to Next channel
+            - Publish to Canary channel
           commit_sha: << pipeline.git.revision >>
           release_channel: experimental
           dist_tag: experimental

--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -7,12 +7,12 @@
 //
 // The @latest channel uses the version as-is, e.g.:
 //
-//   18.0.0
+//   18.3.0
 //
-// The @next channel appends additional information, with the scheme
+// The @canary channel appends additional information, with the scheme
 // <version>-<label>-<commit_sha>, e.g.:
 //
-//   18.0.0-alpha-a1c2d3e4
+//   18.3.0-canary-a1c2d3e4
 //
 // The @experimental channel doesn't include a version, only a date and a sha, e.g.:
 //
@@ -20,9 +20,13 @@
 
 const ReactVersion = '18.3.0';
 
-// The label used by the @next channel. Represents the upcoming release's
-// stability. Could be "alpha", "beta", "rc", etc.
-const nextChannelLabel = 'next';
+// The label used by the @canary channel. Represents the upcoming release's
+// stability. Most of the time, this will be "canary", but we may temporarily
+// choose to change it to "alpha", "beta", "rc", etc.
+//
+// It only affects the label used in the version string. To customize the
+// npm dist tags used during publish, refer to .circleci/config.yml.
+const canaryChannelLabel = 'canary';
 
 const stablePackages = {
   'eslint-plugin-react-hooks': '5.0.0',
@@ -40,14 +44,14 @@ const stablePackages = {
   scheduler: '0.24.0',
 };
 
-// These packages do not exist in the @next or @latest channel, only
+// These packages do not exist in the @canary or @latest channel, only
 // @experimental. We don't use semver, just the commit sha, so this is just a
 // list of package names instead of a map.
 const experimentalPackages = [];
 
 module.exports = {
   ReactVersion,
-  nextChannelLabel,
+  canaryChannelLabel,
   stablePackages,
   experimentalPackages,
 };

--- a/fixtures/devtools/regression/canary.html
+++ b/fixtures/devtools/regression/canary.html
@@ -15,8 +15,8 @@
     <script src="https://unpkg.com/scheduler@canary/umd/scheduler-tracing.development.js"></script>
     <script src="https://unpkg.com/react@canary/umd/react.development.js"></script>
     <script src="https://unpkg.com/react-dom@canary/umd/react-dom.development.js"></script>
-    <script src="https://unpkg.com/react-cache@next/umd/react-cache.development.js"></script>
-    
+    <script src="https://unpkg.com/react-cache@canary/umd/react-cache.development.js"></script>
+
     <!-- Don't use this in production: -->
     <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   </head>

--- a/fixtures/devtools/regression/next.html
+++ b/fixtures/devtools/regression/next.html
@@ -11,12 +11,12 @@
       __REACT_DEVTOOLS_GLOBAL_HOOK__ = parent.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     </script>
 
-    <script src="https://unpkg.com/scheduler@next/umd/scheduler.development.js"></script>
-    <script src="https://unpkg.com/scheduler@next/umd/scheduler-tracing.development.js"></script>
-    <script src="https://unpkg.com/react@next/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@next/umd/react-dom.development.js"></script>
-    <script src="https://unpkg.com/react-cache@next/umd/react-cache.development.js"></script>
-    
+    <script src="https://unpkg.com/scheduler@canary/umd/scheduler.development.js"></script>
+    <script src="https://unpkg.com/scheduler@canary/umd/scheduler-tracing.development.js"></script>
+    <script src="https://unpkg.com/react@canary/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@canary/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/react-cache@canary/umd/react-cache.development.js"></script>
+
     <!-- Don't use this in production: -->
     <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   </head>

--- a/scripts/release/prepare-release-from-npm-commands/get-latest-next-version.js
+++ b/scripts/release/prepare-release-from-npm-commands/get-latest-next-version.js
@@ -5,11 +5,11 @@
 const {execRead, logPromise} = require('../utils');
 
 const run = async () => {
-  const version = await execRead('npm info react@next version');
+  const version = await execRead('npm info react@canary version');
 
   return version;
 };
 
 module.exports = async params => {
-  return logPromise(run(params), 'Determining latest "next" release version');
+  return logPromise(run(params), 'Determining latest "canary" release version');
 };

--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -13,7 +13,7 @@ const {
   ReactVersion,
   stablePackages,
   experimentalPackages,
-  nextChannelLabel,
+  canaryChannelLabel,
 } = require('../../ReactVersions');
 
 // Runs the build script for both stable and experimental release channels,
@@ -127,7 +127,7 @@ function processStable(buildDir) {
       const version = stablePackages[moduleName];
       versionsMap.set(
         moduleName,
-        version + '-' + nextChannelLabel + '-' + sha + '-' + dateString,
+        version + '-' + canaryChannelLabel + '-' + sha + '-' + dateString,
         defaultVersionIfNotFound
       );
     }
@@ -140,7 +140,7 @@ function processStable(buildDir) {
     fs.renameSync(buildDir + '/node_modules', buildDir + '/oss-stable');
     updatePlaceholderReactVersionInCompiledArtifacts(
       buildDir + '/oss-stable',
-      ReactVersion + '-' + nextChannelLabel + '-' + sha + '-' + dateString
+      ReactVersion + '-' + canaryChannelLabel + '-' + sha + '-' + dateString
     );
 
     // Now do the semver ones
@@ -191,16 +191,16 @@ function processStable(buildDir) {
       reactNativeBuildDir,
       ReactVersion +
         '-' +
-        nextChannelLabel +
+        canaryChannelLabel +
         '-' +
         hash.digest('hex').slice(0, 8)
     );
   }
 
-  // Update remaining placeholders with next channel version
+  // Update remaining placeholders with canary channel version
   updatePlaceholderReactVersionInCompiledArtifacts(
     buildDir,
-    ReactVersion + '-' + nextChannelLabel + '-' + sha + '-' + dateString
+    ReactVersion + '-' + canaryChannelLabel + '-' + sha + '-' + dateString
   );
 
   if (fs.existsSync(buildDir + '/sizes')) {
@@ -251,10 +251,10 @@ function processExperimental(buildDir, version) {
     );
   }
 
-  // Update remaining placeholders with next channel version
+  // Update remaining placeholders with canary channel version
   updatePlaceholderReactVersionInCompiledArtifacts(
     buildDir,
-    ReactVersion + '-' + nextChannelLabel + '-' + sha + '-' + dateString
+    ReactVersion + '-' + canaryChannelLabel + '-' + sha + '-' + dateString
   );
 
   if (fs.existsSync(buildDir + '/sizes')) {


### PR DESCRIPTION
The "next" prerelease channel represents what will be published the next time we do a stable release. We publish a new "next" release every day using a timed CI workflow.

When we introduced this prerelease channel a few years ago, another name we considered was "canary". But I proposed "next" instead to create a greater distinction between this channel and the "experimental" channel (which is published at the same cadence, but includes extra experimental features), because some other projects use "canary" to refer to releases that are more unstable than how we would use it.

The main downside of "next" is someone might mistakenly assume the name refers to Next.js. We were aware of this risk at the time but didn't think it would be an issue in practice.

However, colloquially, we've ended up referring to this as the "canary" channel anyway to avoid precisely that confusion.

So after further discussion, we've agreed to rename to "canary".

This affects the label used in the version string (e.g. `18.3.0-next-a1c2d3e4` becomes `18.3.0-canary-a1c2d3e4`) as well as the npm dist tags used to publish the releases. For now, I've chosen to publish the canaries using both `@canary` and `@next` dist tags, so that downstream consumers who might depend on `@next` have time to adjust. We can remove that later after the change has been communicated.