### PR TITLE
Remove deprecated workflow key from Circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,6 @@ jobs:
             scripts/release/publish.js --ci --tags << parameters.dist_tag >>
 
 workflows:
-  version: 2
 
   build_and_test:
     unless: << pipeline.parameters.prerelease_commit_sha >>


### PR DESCRIPTION
This key was only valid during the 2.0 beta period so we can remove it.