### PR TITLE
Add "canary" to list of allowed npm dist tags

### DIFF
--- a/scripts/release/publish-commands/parse-params.js
+++ b/scripts/release/publish-commands/parse-params.js
@@ -41,6 +41,7 @@ module.exports = () => {
   params.tags.forEach(tag => {
     switch (tag) {
       case 'latest':
+      case 'canary':
       case 'next':
       case 'experimental':
       case 'alpha':


### PR DESCRIPTION
Forgot this allowlist existed. It's an extra safeguard, in case we mess up the configuration somehow.