### PR TITLE
Small flowconfig fixes

### DIFF
--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -18,11 +18,6 @@
 
 %REACT_RENDERER_FLOW_IGNORES%
 
-[include]
-./node_modules/
-./packages/
-./scripts/
-
 [libs]
 ./node_modules/fbjs/flow/lib/dev.js
 ./scripts/flow/environment.js

--- a/scripts/flow/createFlowConfigs.js
+++ b/scripts/flow/createFlowConfigs.js
@@ -37,7 +37,7 @@ function writeConfig(renderer, rendererInfo, isServerSupported) {
 
     if (otherRenderer.shortName !== serverRenderer) {
       ignoredPaths.push(
-        `.*/packages/.*/forks/.*.${otherRenderer.shortName}.js`,
+        `.*/packages/.*/forks/.*\\.${otherRenderer.shortName}.js`,
       );
     }
   });


### PR DESCRIPTION
- The whole project root is included by default anyway, the include section should be redundant and just misleading.
- The generated ignore paths ignore more than intended as they didn't escape the `.` for regex.

Test Plan:
- wait for CI
- tested the ignore pattern change with renaming files and seeing the expected files ignored for flow