### PR TITLE
Allow non-latin characters in hook and component names

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -479,6 +479,22 @@ const tests = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        // Valid because hook names can include non-latin characters.
+        function ComponentWithHook() {
+          useÞursakóði();
+        };
+      `,
+    },
+    {
+      code: normalizeIndent`
+        // Valid because component names can include non-latin characters.
+        function ÆðiÞurs() {
+          useÞursakóði();
+        };
+      `,
+    },
   ],
   invalid: [
     {
@@ -1041,6 +1057,24 @@ const tests = {
         (class {i() { useState(); }});
       `,
       errors: [classError('useState')],
+    },
+    {
+      code: normalizeIndent`
+        // Valid because it is not a real hook (lowercased).
+        Hook.useþursaæði();
+        // Invalid in the top-level scope because it is a hook.
+        Hook.useÞursaÆði();
+      `,
+      errors: [topLevelError('Hook.useÞursaÆði')],
+    },
+    {
+      code: normalizeIndent`
+        // Invalid because this is not a component.
+        function æðiÞurs() {
+          useÞursakóði();
+        };
+      `,
+      errors: [functionError('useÞursakóði', 'æðiÞurs')],
     },
   ],
 };

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -17,9 +17,9 @@
 
 function isHookName(s) {
   if (__EXPERIMENTAL__) {
-    return s === 'use' || /^use[A-Z0-9]/.test(s);
+    return s === 'use' || /^use(\p{Lu}|\p{N})/u.test(s);
   }
-  return /^use[A-Z0-9]/.test(s);
+  return /^use(\p{Lu}|\p{N})/u.test(s);
 }
 
 /**
@@ -36,7 +36,7 @@ function isHook(node) {
     isHook(node.property)
   ) {
     const obj = node.object;
-    const isPascalCaseNameSpace = /^[A-Z].*/;
+    const isPascalCaseNameSpace = /^\p{Lu}/u;
     return obj.type === 'Identifier' && isPascalCaseNameSpace.test(obj.name);
   } else {
     return false;
@@ -49,7 +49,7 @@ function isHook(node) {
  */
 
 function isComponentName(node) {
-  return node.type === 'Identifier' && /^[A-Z]/.test(node.name);
+  return node.type === 'Identifier' && /^\p{Lu}/u.test(node.name);
 }
 
 function isReactFunction(node, functionName) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Currently, `react-hooks/rules-of-hooks` will emit an error that a hook is not valid if it starts with a non-latin character after `use`. I've updated the regular expressions to use [unicode property escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape), allowing people to write code in their native language if they wish to do so.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

I tested the code with two symbols that are part of the Icelandic alphabet, ash and thorn. Before these changes, hooks like `useÞursakóði` or `useÆði` would fail. I also wrote tests to make sure that the lowercase form of the two would not be detected as hooks (`useþursakóði` and `useæði`).