### PR TITLE
Fix nightly job to publish to "canary" channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -646,7 +646,7 @@ workflows:
           name: Publish to Canary channel
           commit_sha: << pipeline.git.revision >>
           release_channel: stable
-          dist_tag: "next"
+          dist_tag: "canary,next"
       - publish_prerelease:
           name: Publish to Experimental channel
           requires:


### PR DESCRIPTION
When I was renaming the next channel to canary, I updated the `publish_preleases` workflow correctly, but I skipped over `publish_preleases_nightly`. Oops.