### PR TITLE
fix[devtools]: fixed duplicated backend activation with multiple renderers

### DIFF
--- a/packages/react-devtools-extensions/src/backend.js
+++ b/packages/react-devtools-extensions/src/backend.js
@@ -29,5 +29,6 @@ function setup(hook: ?DevToolsHook) {
     initBackend,
     setupNativeStyleEditor,
   });
+
   hook.emit('devtools-backend-installed', COMPACT_VERSION_NAME);
 }


### PR DESCRIPTION
## Summary
Initially reported in https://github.com/facebook/react/issues/26797. Was not able to reproduce the exact same problem, but found this case:

1. Open corresponding codepen from the issue in debug mode
2. Open components tab of the extension
3. Refresh the page

Received multiple errors:
- Warning in the Console tab: Invalid renderer id "2".
- Error in the Components tab: Uncaught Error: Cannot add node "3" because a node with that id is already in the Store.

This problem has occurred after landing a fix in https://github.com/facebook/react/pull/26779. Looks like Chrome is keeping the injected scripts (the backend in this case) and we start backend twice.


