### PR TITLE
[react-native] Always set RN$stopSurface

### DIFF
--- a/scripts/rollup/shims/react-native/ReactFabric.js
+++ b/scripts/rollup/shims/react-native/ReactFabric.js
@@ -22,9 +22,9 @@ if (__DEV__) {
   ReactFabric = require('../implementations/ReactFabric-prod');
 }
 
-if (global.RN$Bridgeless) {
-  global.RN$stopSurface = ReactFabric.stopSurface;
-} else {
+global.RN$stopSurface = ReactFabric.stopSurface;
+
+if (global.RN$Bridgeless !== true) {
   BatchedBridge.registerCallableModule('ReactFabric', ReactFabric);
 }
 


### PR DESCRIPTION
## Summary
To support incremental adoption of bridgeless logic we want to default to using these globals whenever they're available.

## How did you test this change?
https://github.com/facebook/react-native/pull/37410