### PR TITLE
Example of missing case for dependency analysis

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1452,6 +1452,25 @@ const tests = {
         }
       `,
     },
+    // TODO
+    {
+      code: normalizeIndent`
+        function Foo() {
+          let tab = "foo";
+          useEffect(() => {
+            // Closure captures the binding, sees value at time of call ('bar')
+            if (tab === "foo") {
+              return;
+            }
+            log(tab);
+            // dependency array captures value at time of render ('foo')
+          }, [tab]);
+          // TODO: it should be an error to capture a non-constant value
+          tab = "bar"; 
+          return <Tab tab={tab} />;
+        }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1452,7 +1452,6 @@ const tests = {
         }
       `,
     },
-    ,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1452,25 +1452,7 @@ const tests = {
         }
       `,
     },
-    // TODO
-    {
-      code: normalizeIndent`
-        function Foo() {
-          let tab = "foo";
-          useEffect(() => {
-            // Closure captures the binding, sees value at time of call ('bar')
-            if (tab === "foo") {
-              return;
-            }
-            log(tab);
-            // dependency array captures value at time of render ('foo')
-          }, [tab]);
-          // TODO: it should be an error to capture a non-constant value
-          tab = "bar"; 
-          return <Tab tab={tab} />;
-        }
-      `,
-    },
+    ,
   ],
   invalid: [
     {
@@ -7623,6 +7605,26 @@ const tests = {
           suggestions: undefined,
         },
       ],
+    },
+    {
+      // TODO: add validation for this case
+      skip: true,
+      code: normalizeIndent`
+        function Foo() {
+          let tab = "foo";
+          useEffect(() => {
+            // Closure captures the binding, sees value at time of call ('bar')
+            if (tab === "foo") {
+              return;
+            }
+            log(tab);
+            // dependency array captures value at time of render ('foo')
+          }, [tab]);
+          // TODO: it should be an error to capture a non-constant value
+          tab = "bar"; 
+          return <Tab tab={tab} />;
+        }
+      `,
     },
   ],
 };


### PR DESCRIPTION
## Summary

I discovered this case while exploring optimizations for callbacks in React Forget:

```javascript
function Foo() {
  let tab = "foo";
  useEffect(() => {
    // Closure captures the binding, sees value at time of call ('bar')
    if (tab === "foo") {
      return;
    }
    log(tab);
    // dependency array captures value at time of render ('foo')
  }, [tab]);
  // TODO: it should be an error to capture a non-constant value
  tab = "bar"; 
  return <Tab tab={tab} />;
}
```

In addition to checking that dependencies are exhaustive, we also need to ensure that the bindings are _effectively_ constant as of the creation of the closure. In the above example, the problem isn't that `tab` is a `let` binding, but that `tab` is reassigned after the closure. Note, however, that you can't simply look for reassignments of `tab` that are "after" the closure in source code order. A correct analysis would find any possible reassignment of `tab` (including in other closures) which could occur after the creation of the closure _at runtime_. This requires a sophisticated static analysis such as what we have in Forget. So for now we can't really fix this (except maybe obvious cases like the one here). I'm adding just so we have it documented somewhere, i'm not sure if there's a way to skip eslint examples.

## How did you test this change?

`yarn test`