### PR TITLE
Bump update-notifier to 6.0.2

### DIFF
--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -28,6 +28,6 @@
     "ip": "^1.1.4",
     "minimist": "^1.2.3",
     "react-devtools-core": "4.27.7",
-    "update-notifier": "^2.1.0"
+    "update-notifier": "^6.0.2"
   }
 }


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Updates `react-devtools` to use the latest version of `update-notifier`, which was transitively dependent on a vulnerable version of `got`

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
