### PR TITLE
Fix strict mode badge URL

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElement.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElement.js
@@ -237,7 +237,7 @@ export default function InspectedElementWrapper(_: Props): React.Node {
     strictModeBadge = (
       <a
         className={styles.StrictModeNonCompliant}
-        href="https://fb.me/devtools-strict-mode"
+        href="https://react.dev/reference/react/StrictMode"
         rel="noopener noreferrer"
         target="_blank"
         title="This component is not running in StrictMode. Click to learn more.">


### PR DESCRIPTION
## Summary
Closes https://github.com/facebook/react/issues/26821

[[Fix #26821]](https://github.com/facebook/react/issues/26821) Update strict mode badge URL


Updated the URL in the strict mode badge to point to the correct React documentation for StrictMode. The previous URL was outdated. Now, when a component is not running in StrictMode, the badge links to https://react.dev/reference/react/StrictMode for more information.


## How did you test this change?

I verified that the strict mode badge now correctly links to the updated URL. Previously, it pointed to the outdated URL (https://fb.me/devtools-strict-mode). After the update, it correctly points to the React Dev documentation for StrictMode (https://react.dev/reference/react/StrictMode).


_Since its my first contribution here, i have completed the CLA_ 
 