### PR TITLE
Remove XHR support from Flight

### DIFF
--- a/fixtures/flight-browser/index.html
+++ b/fixtures/flight-browser/index.html
@@ -73,12 +73,6 @@
         let data = ReactServerDOMClient.createFromFetch(
           fetch(url)
         );
-        // The client also supports XHR streaming.
-        // var xhr = new XMLHttpRequest();
-        // xhr.open('GET', url);
-        // let data = ReactServerDOMClient.createFromXHR(xhr);
-        // xhr.send();
-
         renderResult(data);
       }
 

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js
@@ -17,7 +17,6 @@ import {
   createResponse,
   getRoot,
   reportGlobalError,
-  processStringChunk,
   processBinaryChunk,
   close,
 } from 'react-client/src/ReactFlightClientStream';
@@ -92,32 +91,6 @@ function createFromFetch<T>(
   return getRoot(response);
 }
 
-function createFromXHR<T>(
-  request: XMLHttpRequest,
-  options?: Options,
-): Thenable<T> {
-  const response: FlightResponse = createResponseFromOptions(options);
-  let processedLength = 0;
-  function progress(e: ProgressEvent): void {
-    const chunk = request.responseText;
-    processStringChunk(response, chunk, processedLength);
-    processedLength = chunk.length;
-  }
-  function load(e: ProgressEvent): void {
-    progress(e);
-    close(response);
-  }
-  function error(e: ProgressEvent): void {
-    reportGlobalError(response, new TypeError('Network error'));
-  }
-  request.addEventListener('progress', progress);
-  request.addEventListener('load', load);
-  request.addEventListener('error', error);
-  request.addEventListener('abort', error);
-  request.addEventListener('timeout', error);
-  return getRoot(response);
-}
-
 function encodeReply(
   value: ReactServerValue,
 ): Promise<
@@ -129,7 +102,6 @@ function encodeReply(
 }
 
 export {
-  createFromXHR,
   createFromFetch,
   createFromReadableStream,
   encodeReply,


### PR DESCRIPTION
We currently support passing an XHR request to Flight for broader compat and possibly better perf than `fetch()`. However, it's a little tricky because ideally the RSC protocol is really meant to support binary data too. XHR does support binary but it doesn't support it while also streaming.

We could maybe support this only when you know it's going to be only text streams but it has some limitations in how we can encode separators if we can't use binary.

Nobody is really asking for this so we might as well delete it.