### PR TITLE
Make scheduleHydration awaitable

### DIFF
--- a/packages/react-dom-bindings/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom-bindings/src/events/ReactDOMEventReplaying.js
@@ -349,9 +349,7 @@ function attemptExplicitHydrationTarget(
   }
 }
 
-export async function queueExplicitHydrationTarget(
-  target: Node,
-): Promise<void> {
+export function queueExplicitHydrationTarget(target: Node): Promise<void> {
   return new Promise((resolve, reject) => {
     if (!target) {
       reject(new Error('Cannot schedule hydration, target is undefined.'));

--- a/packages/react-dom-bindings/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom-bindings/src/events/ReactDOMEventReplaying.js
@@ -80,6 +80,7 @@ type QueuedHydrationTarget = {
   blockedOn: null | Container | SuspenseInstance,
   target: Node,
   priority: EventPriority,
+  callback: null | (true => void),
 };
 const queuedExplicitHydrationTargets: Array<QueuedHydrationTarget> = [];
 
@@ -337,7 +338,9 @@ function attemptExplicitHydrationTarget(
   }
 }
 
-export async function queueExplicitHydrationTarget(target: Node): void {
+export async function queueExplicitHydrationTarget(
+  target: Node,
+): Promise<true> {
   return new Promise(resolve => {
     // TODO: This will read the priority if it's dispatched by the React
     // event system but not native events. Should read window.event.type, like

--- a/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
@@ -238,7 +238,7 @@ describe('ReactDOMServerScheduleHydration', () => {
       }
 
       function App() {
-        const [setText] = React.useState('UNSET');
+        const [, setText] = React.useState('UNSET');
         Scheduler.log('App');
         return (
           <div>
@@ -335,8 +335,7 @@ describe('ReactDOMServerScheduleHydration', () => {
         // For sync by default, hydration is immediately observable.
         await root.unstable_scheduleHydration(spanA);
 
-        const resultA = dispatchClickEvent(spanA);
-        expect(resultA).toBe(true);
+        dispatchClickEvent(spanA);
 
         assertLog(['Clicked A']);
 

--- a/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
@@ -17,6 +17,29 @@ let Suspense;
 let assertLog;
 let waitForAll;
 let waitFor;
+let act;
+
+function dispatchClickEvent(target) {
+  const mouseOutEvent = document.createEvent('MouseEvents');
+  mouseOutEvent.initMouseEvent(
+    'click',
+    true,
+    true,
+    window,
+    0,
+    50,
+    50,
+    50,
+    50,
+    false,
+    false,
+    false,
+    false,
+    0,
+    target,
+  );
+  return target.dispatchEvent(mouseOutEvent);
+}
 
 describe('ReactDOMServerScheduleHydration', () => {
   beforeEach(() => {
@@ -33,20 +56,28 @@ describe('ReactDOMServerScheduleHydration', () => {
     assertLog = InternalTestUtils.assertLog;
     waitForAll = InternalTestUtils.waitForAll;
     waitFor = InternalTestUtils.waitFor;
+    act = InternalTestUtils.act;
   });
 
   describe('with no boundary', () => {
     it('resolves immediately for already hydrated content with no boundary', async () => {
-      function Child({text}) {
+      function Child({text, onClick}) {
         Scheduler.log(text);
-        return <span>{text}</span>;
+        return <span onClick={onClick}>{text}</span>;
       }
 
       function App() {
+        const [text, setText] = React.useState('A');
         Scheduler.log('App');
         return (
           <div>
-            <Child text="A" />
+            <Child
+              text={text}
+              onClick={() => {
+                Scheduler.log('Clicked ' + text);
+                setText('B');
+              }}
+            />
           </div>
         );
       }
@@ -66,8 +97,16 @@ describe('ReactDOMServerScheduleHydration', () => {
       // Hydrate everything
       await waitForAll(['App', 'A']);
 
-      const hydrated = await root.unstable_scheduleHydration(spanA);
-      expect(hydrated).toBe(true);
+      await root.unstable_scheduleHydration(spanA);
+
+      await act(() => {
+        const result = dispatchClickEvent(spanA);
+        expect(result).toBe(true);
+
+        assertLog(['Clicked A']);
+      });
+
+      assertLog(['App', 'B']);
     });
 
     it('resolves after content is hydrated with no boundary', async () => {
@@ -144,7 +183,7 @@ describe('ReactDOMServerScheduleHydration', () => {
       await waitForAll(['App', 'A']);
 
       const hydrated = await root.unstable_scheduleHydration(spanA);
-      expect(hydrated).toBe(true);
+      expect(hydrated).toBe(undefined);
     });
 
     it('resolves after content is hydrated', async () => {
@@ -229,16 +268,16 @@ describe('ReactDOMServerScheduleHydration', () => {
       await waitFor(['App', 'A']);
 
       const hydratedA = await root.unstable_scheduleHydration(spanA);
-      expect(hydratedA).toBe(true);
+      expect(hydratedA).toBe(undefined);
 
       // Hydrate everything else
       await waitForAll(['B', 'C']);
 
       const hydratedB = await root.unstable_scheduleHydration(spanB);
-      expect(hydratedB).toBe(true);
+      expect(hydratedB).toBe(undefined);
 
       const hydratedC = await root.unstable_scheduleHydration(spanC);
-      expect(hydratedC).toBe(true);
+      expect(hydratedC).toBe(undefined);
     });
 
     it('resolve after content is hydrated', async () => {
@@ -281,7 +320,6 @@ describe('ReactDOMServerScheduleHydration', () => {
       const scheduleHydrationB = root
         .unstable_scheduleHydration(spanB)
         .then(() => {
-          console.log('A');
           hydratedB = true;
         });
       const scheduleHydrationC = root
@@ -372,6 +410,174 @@ describe('ReactDOMServerScheduleHydration', () => {
       expect(hydratedA).toBe(true);
       expect(hydratedB).toBe(true);
       expect(hydratedC).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('rejects if target node is undefined', async () => {
+      function Child({text}) {
+        Scheduler.log(text);
+        return <span>{text}</span>;
+      }
+
+      function App() {
+        Scheduler.log('App');
+        return (
+          <div>
+            <Child text="A" />
+          </div>
+        );
+      }
+
+      const finalHTML = ReactDOMServer.renderToString(<App />);
+      assertLog(['App', 'A']);
+
+      const container = document.createElement('div');
+      container.innerHTML = finalHTML;
+
+      const root = ReactDOMClient.hydrateRoot(container, <App />);
+
+      // Nothing has been hydrated so far.
+      assertLog([]);
+
+      try {
+        await root.unstable_scheduleHydration(undefined);
+      } catch (e) {
+        expect(e).toMatch('Cannot schedule hydration, target is undefined.');
+      }
+
+      expect.assertions(1);
+    });
+
+    it('rejects if target node is not in this root', async () => {
+      function Child({text}) {
+        Scheduler.log(text);
+        return <span>{text}</span>;
+      }
+
+      function App() {
+        Scheduler.log('App');
+        return (
+          <div>
+            <Child text="A" />
+          </div>
+        );
+      }
+
+      const finalHTML = ReactDOMServer.renderToString(<App />);
+      assertLog(['App', 'A']);
+
+      const nodeOutsideContainer = document.createElement('span');
+      const container = document.createElement('div');
+      container.innerHTML = finalHTML;
+
+      const root = ReactDOMClient.hydrateRoot(container, <App />);
+
+      // Nothing has been hydrated so far.
+      assertLog([]);
+
+      try {
+        await root.unstable_scheduleHydration(nodeOutsideContainer);
+      } catch (e) {
+        expect(e).toMatch(
+          'Cannot schedule hydration, target is not a React component.',
+        );
+      }
+
+      expect.assertions(1);
+    });
+
+    it('rejects if target node is deleted before successfully hydrated', async () => {
+      // Ignore hydration errors.
+      spyOnDev(console, 'error').mockImplementation(() => {});
+      spyOnDev(console, 'warn').mockImplementation(() => {});
+
+      function Child({text}) {
+        Scheduler.log(text);
+        return <span>{text}</span>;
+      }
+
+      function App() {
+        Scheduler.log('App');
+        return (
+          <div>
+            <Suspense fallback="Loading...">
+              <Child text="A" />
+            </Suspense>
+            <Suspense fallback="Loading...">
+              <Child text="B" />
+            </Suspense>
+          </div>
+        );
+      }
+
+      const finalHTML = ReactDOMServer.renderToString(<App />);
+
+      assertLog(['App', 'A', 'B']);
+
+      const container = document.createElement('div');
+      container.innerHTML = finalHTML;
+
+      const spanA = container.getElementsByTagName('span')[0];
+      const spanB = container.getElementsByTagName('span')[1];
+
+      const root = ReactDOMClient.hydrateRoot(container, <App />);
+
+      // Nothing has been hydrated so far.
+      assertLog([]);
+
+      await waitFor(['App', 'A']);
+
+      let hydrationError = null;
+      const hydrationPromise = root
+        .unstable_scheduleHydration(spanB)
+        .catch(e => (hydrationError = e));
+
+      spanB.remove();
+
+      await waitForAll(['B', 'B', 'A']);
+
+      await hydrationPromise;
+
+      expect(hydrationError).toMatch('Target was removed before hydration.');
+    });
+
+    it('resolves if target node is inside dangerouslySetInnerHTML', async () => {
+      function App() {
+        Scheduler.log('App');
+        return <div dangerouslySetInnerHTML={{__html: '<span>A</span>'}}></div>;
+      }
+
+      const finalHTML = ReactDOMServer.renderToString(<App />);
+
+      assertLog(['App']);
+
+      const container = document.createElement('div');
+      container.innerHTML = finalHTML;
+
+      const spanA = container.getElementsByTagName('span')[0];
+
+      const root = ReactDOMClient.hydrateRoot(container, <App />);
+
+      // Nothing has been hydrated so far.
+      assertLog([]);
+
+      await waitFor(['App']);
+
+      let hydrated;
+      const hydrate = root
+        .unstable_scheduleHydration(spanA)
+        .then(() => (hydrated = true));
+
+      try {
+        await waitForAll(['B', 'B']);
+      } catch (e) {
+        //
+      }
+
+      await hydrate;
+
+      expect(hydrated).toBe(true);
     });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
@@ -48,19 +48,19 @@ describe('ReactDOMServerScheduleHydration', () => {
         Scheduler.log('App');
         return (
           <div>
-            <Child text="A"/>
+            <Child text="A" />
           </div>
         );
       }
 
-      const finalHTML = ReactDOMServer.renderToString(<App/>);
+      const finalHTML = ReactDOMServer.renderToString(<App />);
       assertLog(['App', 'A']);
 
       const container = document.createElement('div');
       container.innerHTML = finalHTML;
       const spanA = container.getElementsByTagName('span')[0];
 
-      const root = ReactDOMClient.hydrateRoot(container, <App/>);
+      const root = ReactDOMClient.hydrateRoot(container, <App />);
 
       // Nothing has been hydrated so far.
       assertLog([]);
@@ -82,12 +82,12 @@ describe('ReactDOMServerScheduleHydration', () => {
         Scheduler.log('App');
         return (
           <div>
-            <Child text="A"/>
+            <Child text="A" />
           </div>
         );
       }
 
-      const finalHTML = ReactDOMServer.renderToString(<App/>);
+      const finalHTML = ReactDOMServer.renderToString(<App />);
       assertLog(['App', 'A']);
 
       const container = document.createElement('div');
@@ -95,8 +95,10 @@ describe('ReactDOMServerScheduleHydration', () => {
       const spanA = container.getElementsByTagName('span')[0];
 
       let hydrated = false;
-      const root = ReactDOMClient.hydrateRoot(container, <App/>);
-      const scheduleHydrationA = root.unstable_scheduleHydration(spanA).then(() => hydrated = true);
+      const root = ReactDOMClient.hydrateRoot(container, <App />);
+      const scheduleHydrationA = root
+        .unstable_scheduleHydration(spanA)
+        .then(() => (hydrated = true));
 
       // Nothing has been hydrated so far.
       assertLog([]);
@@ -122,20 +124,20 @@ describe('ReactDOMServerScheduleHydration', () => {
         return (
           <div>
             <Suspense fallback="Loading...">
-              <Child text="A"/>
+              <Child text="A" />
             </Suspense>
           </div>
         );
       }
 
-      const finalHTML = ReactDOMServer.renderToString(<App/>);
+      const finalHTML = ReactDOMServer.renderToString(<App />);
       assertLog(['App', 'A']);
 
       const container = document.createElement('div');
       container.innerHTML = finalHTML;
       const spanA = container.getElementsByTagName('span')[0];
 
-      const root = ReactDOMClient.hydrateRoot(container, <App/>);
+      const root = ReactDOMClient.hydrateRoot(container, <App />);
 
       // Nothing has been hydrated so far.
       assertLog([]);
@@ -143,9 +145,9 @@ describe('ReactDOMServerScheduleHydration', () => {
       // Hydrate everything
       await waitForAll(['App', 'A']);
 
-      const hydrated = await root.unstable_scheduleHydration(spanA)
+      const hydrated = await root.unstable_scheduleHydration(spanA);
       expect(hydrated).toBe(true);
-    })
+    });
 
     it('resolves after content is hydrated', async () => {
       function Child({text}) {
@@ -158,13 +160,13 @@ describe('ReactDOMServerScheduleHydration', () => {
         return (
           <div>
             <Suspense fallback="Loading...">
-              <Child text="A"/>
+              <Child text="A" />
             </Suspense>
           </div>
         );
       }
 
-      const finalHTML = ReactDOMServer.renderToString(<App/>);
+      const finalHTML = ReactDOMServer.renderToString(<App />);
       assertLog(['App', 'A']);
 
       const container = document.createElement('div');
@@ -172,8 +174,10 @@ describe('ReactDOMServerScheduleHydration', () => {
       const spanA = container.getElementsByTagName('span')[0];
 
       let hydrated = false;
-      const root = ReactDOMClient.hydrateRoot(container, <App/>);
-      const scheduleHydrationA = root.unstable_scheduleHydration(spanA).then(() => hydrated = true);
+      const root = ReactDOMClient.hydrateRoot(container, <App />);
+      const scheduleHydrationA = root
+        .unstable_scheduleHydration(spanA)
+        .then(() => (hydrated = true));
 
       // Nothing has been hydrated so far.
       assertLog([]);
@@ -273,12 +277,18 @@ describe('ReactDOMServerScheduleHydration', () => {
       let hydratedA = false;
       let hydratedB = false;
       let hydratedC = false;
-      const scheduleHydrationA = root.unstable_scheduleHydration(spanA).then(() => hydratedA = true);
-      const scheduleHydrationB = root.unstable_scheduleHydration(spanB).then(() => {
-        console.log('A');
-        hydratedB = true;
-      });
-      const scheduleHydrationC = root.unstable_scheduleHydration(spanC).then(() => hydratedC = true);
+      const scheduleHydrationA = root
+        .unstable_scheduleHydration(spanA)
+        .then(() => (hydratedA = true));
+      const scheduleHydrationB = root
+        .unstable_scheduleHydration(spanB)
+        .then(() => {
+          console.log('A');
+          hydratedB = true;
+        });
+      const scheduleHydrationC = root
+        .unstable_scheduleHydration(spanC)
+        .then(() => (hydratedC = true));
 
       // Nothing has been hydrated so far.
       assertLog([]);
@@ -310,7 +320,7 @@ describe('ReactDOMServerScheduleHydration', () => {
         return (
           <div>
             <Suspense fallback="Loading...">
-              <Child text ="A" />
+              <Child text="A" />
             </Suspense>
             <Suspense fallback="Loading...">
               <Child text="B" />
@@ -338,9 +348,15 @@ describe('ReactDOMServerScheduleHydration', () => {
       let hydratedB = false;
       let hydratedC = false;
 
-      const scheduleHydrationB = root.unstable_scheduleHydration(spanB).then(() => hydratedB = true);
-      const scheduleHydrationC = root.unstable_scheduleHydration(spanC).then(() => hydratedC = true);
-      const scheduleHydrationA = root.unstable_scheduleHydration(spanA).then(() => hydratedA = true);
+      const scheduleHydrationB = root
+        .unstable_scheduleHydration(spanB)
+        .then(() => (hydratedB = true));
+      const scheduleHydrationC = root
+        .unstable_scheduleHydration(spanC)
+        .then(() => (hydratedC = true));
+      const scheduleHydrationA = root
+        .unstable_scheduleHydration(spanA)
+        .then(() => (hydratedA = true));
 
       // Nothing has been hydrated so far.
       assertLog([]);
@@ -360,5 +376,4 @@ describe('ReactDOMServerScheduleHydration', () => {
       expect(hydratedC).toBe(true);
     });
   });
-
 });

--- a/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
@@ -1,0 +1,364 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOM;
+let ReactDOMClient;
+let ReactDOMServer;
+let Scheduler;
+let Suspense;
+let assertLog;
+let waitForAll;
+let waitFor;
+
+describe('ReactDOMServerScheduleHydration', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    React = require('react');
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactDOMClient = require('react-dom/client');
+    ReactDOMServer = require('react-dom/server');
+    Scheduler = require('scheduler');
+    Suspense = React.Suspense;
+
+    const InternalTestUtils = require('internal-test-utils');
+    assertLog = InternalTestUtils.assertLog;
+    waitForAll = InternalTestUtils.waitForAll;
+    waitFor = InternalTestUtils.waitFor;
+  });
+
+  describe('with no boundary', () => {
+    it('resolves immediately for already hydrated content with no boundary', async () => {
+      function Child({text}) {
+        Scheduler.log(text);
+        return <span>{text}</span>;
+      }
+
+      function App() {
+        Scheduler.log('App');
+        return (
+          <div>
+            <Child text="A"/>
+          </div>
+        );
+      }
+
+      const finalHTML = ReactDOMServer.renderToString(<App/>);
+      assertLog(['App', 'A']);
+
+      const container = document.createElement('div');
+      container.innerHTML = finalHTML;
+      const spanA = container.getElementsByTagName('span')[0];
+
+      const root = ReactDOMClient.hydrateRoot(container, <App/>);
+
+      // Nothing has been hydrated so far.
+      assertLog([]);
+
+      // Hydrate everything
+      await waitForAll(['App', 'A']);
+
+      const hydrated = await root.unstable_scheduleHydration(spanA);
+      expect(hydrated).toBe(true);
+    });
+
+    it('resolves after content is hydrated with no boundary', async () => {
+      function Child({text}) {
+        Scheduler.log(text);
+        return <span>{text}</span>;
+      }
+
+      function App() {
+        Scheduler.log('App');
+        return (
+          <div>
+            <Child text="A"/>
+          </div>
+        );
+      }
+
+      const finalHTML = ReactDOMServer.renderToString(<App/>);
+      assertLog(['App', 'A']);
+
+      const container = document.createElement('div');
+      container.innerHTML = finalHTML;
+      const spanA = container.getElementsByTagName('span')[0];
+
+      let hydrated = false;
+      const root = ReactDOMClient.hydrateRoot(container, <App/>);
+      const scheduleHydrationA = root.unstable_scheduleHydration(spanA).then(() => hydrated = true);
+
+      // Nothing has been hydrated so far.
+      assertLog([]);
+      expect(hydrated).toBe(false);
+
+      // Hydrate everything
+      await waitForAll(['App', 'A']);
+      await scheduleHydrationA;
+
+      expect(hydrated).toBe(true);
+    });
+  });
+
+  describe('with a boundary', () => {
+    it('resolves immediately for already hydrated content', async () => {
+      function Child({text}) {
+        Scheduler.log(text);
+        return <span>{text}</span>;
+      }
+
+      function App() {
+        Scheduler.log('App');
+        return (
+          <div>
+            <Suspense fallback="Loading...">
+              <Child text="A"/>
+            </Suspense>
+          </div>
+        );
+      }
+
+      const finalHTML = ReactDOMServer.renderToString(<App/>);
+      assertLog(['App', 'A']);
+
+      const container = document.createElement('div');
+      container.innerHTML = finalHTML;
+      const spanA = container.getElementsByTagName('span')[0];
+
+      const root = ReactDOMClient.hydrateRoot(container, <App/>);
+
+      // Nothing has been hydrated so far.
+      assertLog([]);
+
+      // Hydrate everything
+      await waitForAll(['App', 'A']);
+
+      const hydrated = await root.unstable_scheduleHydration(spanA)
+      expect(hydrated).toBe(true);
+    })
+
+    it('resolves after content is hydrated', async () => {
+      function Child({text}) {
+        Scheduler.log(text);
+        return <span>{text}</span>;
+      }
+
+      function App() {
+        Scheduler.log('App');
+        return (
+          <div>
+            <Suspense fallback="Loading...">
+              <Child text="A"/>
+            </Suspense>
+          </div>
+        );
+      }
+
+      const finalHTML = ReactDOMServer.renderToString(<App/>);
+      assertLog(['App', 'A']);
+
+      const container = document.createElement('div');
+      container.innerHTML = finalHTML;
+      const spanA = container.getElementsByTagName('span')[0];
+
+      let hydrated = false;
+      const root = ReactDOMClient.hydrateRoot(container, <App/>);
+      const scheduleHydrationA = root.unstable_scheduleHydration(spanA).then(() => hydrated = true);
+
+      // Nothing has been hydrated so far.
+      assertLog([]);
+      expect(hydrated).toBe(false);
+
+      // Hydrate everything
+      await waitForAll(['App', 'A']);
+      await scheduleHydrationA;
+
+      expect(hydrated).toBe(true);
+    });
+  });
+
+  describe('with multiple boundaries', () => {
+    it('resolve immediately for already hydrated content', async () => {
+      function Child({text}) {
+        Scheduler.log(text);
+        return <span>{text}</span>;
+      }
+
+      function App() {
+        Scheduler.log('App');
+        return (
+          <div>
+            <Child text="A" />
+            <Suspense fallback="Loading...">
+              <Child text="B" />
+            </Suspense>
+            <Suspense fallback="Loading...">
+              <Child text="C" />
+            </Suspense>
+          </div>
+        );
+      }
+
+      const finalHTML = ReactDOMServer.renderToString(<App />);
+      assertLog(['App', 'A', 'B', 'C']);
+
+      const container = document.createElement('div');
+      container.innerHTML = finalHTML;
+      const spanA = container.getElementsByTagName('span')[0];
+      const spanB = container.getElementsByTagName('span')[1];
+      const spanC = container.getElementsByTagName('span')[2];
+
+      const root = ReactDOMClient.hydrateRoot(container, <App />);
+
+      // Nothing has been hydrated so far.
+      assertLog([]);
+
+      // Hydrate just A
+      await waitFor(['App', 'A']);
+
+      const hydratedA = await root.unstable_scheduleHydration(spanA);
+      expect(hydratedA).toBe(true);
+
+      // Hydrate everything else
+      await waitForAll(['B', 'C']);
+
+      const hydratedB = await root.unstable_scheduleHydration(spanB);
+      expect(hydratedB).toBe(true);
+
+      const hydratedC = await root.unstable_scheduleHydration(spanC);
+      expect(hydratedC).toBe(true);
+    });
+
+    it('resolve after content is hydrated', async () => {
+      function Child({text}) {
+        Scheduler.log(text);
+        return <span>{text}</span>;
+      }
+
+      function App() {
+        Scheduler.log('App');
+        return (
+          <div>
+            <Child text="A" />
+            <Suspense fallback="Loading...">
+              <Child text="B" />
+            </Suspense>
+            <Suspense fallback="Loading...">
+              <Child text="C" />
+            </Suspense>
+          </div>
+        );
+      }
+
+      const finalHTML = ReactDOMServer.renderToString(<App />);
+      assertLog(['App', 'A', 'B', 'C']);
+
+      const container = document.createElement('div');
+      container.innerHTML = finalHTML;
+      const spanA = container.getElementsByTagName('span')[0];
+      const spanB = container.getElementsByTagName('span')[1];
+      const spanC = container.getElementsByTagName('span')[2];
+
+      const root = ReactDOMClient.hydrateRoot(container, <App />);
+      let hydratedA = false;
+      let hydratedB = false;
+      let hydratedC = false;
+      const scheduleHydrationA = root.unstable_scheduleHydration(spanA).then(() => hydratedA = true);
+      const scheduleHydrationB = root.unstable_scheduleHydration(spanB).then(() => {
+        console.log('A');
+        hydratedB = true;
+      });
+      const scheduleHydrationC = root.unstable_scheduleHydration(spanC).then(() => hydratedC = true);
+
+      // Nothing has been hydrated so far.
+      assertLog([]);
+      expect(hydratedA).toBe(false);
+      expect(hydratedB).toBe(false);
+      expect(hydratedC).toBe(false);
+
+      // Hydrate just A
+      await waitForAll(['App', 'A', 'C', 'B']);
+
+      await scheduleHydrationA;
+      await scheduleHydrationB;
+      await scheduleHydrationC;
+
+      // Increase priority of B and then C.
+      expect(hydratedA).toBe(true);
+      expect(hydratedB).toBe(true);
+      expect(hydratedC).toBe(true);
+    });
+
+    it('resolve out of order content', async () => {
+      function Child({text}) {
+        Scheduler.log(text);
+        return <span>{text}</span>;
+      }
+
+      function App() {
+        Scheduler.log('App');
+        return (
+          <div>
+            <Suspense fallback="Loading...">
+              <Child text ="A" />
+            </Suspense>
+            <Suspense fallback="Loading...">
+              <Child text="B" />
+            </Suspense>
+            <Suspense fallback="Loading...">
+              <Child text="C" />
+            </Suspense>
+          </div>
+        );
+      }
+
+      const finalHTML = ReactDOMServer.renderToString(<App />);
+
+      assertLog(['App', 'A', 'B', 'C']);
+
+      const container = document.createElement('div');
+      container.innerHTML = finalHTML;
+
+      const spanA = container.getElementsByTagName('span')[0];
+      const spanB = container.getElementsByTagName('span')[1];
+      const spanC = container.getElementsByTagName('span')[2];
+
+      const root = ReactDOMClient.hydrateRoot(container, <App />);
+      let hydratedA = false;
+      let hydratedB = false;
+      let hydratedC = false;
+
+      const scheduleHydrationB = root.unstable_scheduleHydration(spanB).then(() => hydratedB = true);
+      const scheduleHydrationC = root.unstable_scheduleHydration(spanC).then(() => hydratedC = true);
+      const scheduleHydrationA = root.unstable_scheduleHydration(spanA).then(() => hydratedA = true);
+
+      // Nothing has been hydrated so far.
+      assertLog([]);
+
+      expect(hydratedA).toBe(false);
+      expect(hydratedB).toBe(false);
+      expect(hydratedC).toBe(false);
+
+      await waitForAll(['App', 'A', 'C', 'B']);
+
+      await scheduleHydrationA;
+      await scheduleHydrationB;
+      await scheduleHydrationC;
+
+      expect(hydratedA).toBe(true);
+      expect(hydratedB).toBe(true);
+      expect(hydratedC).toBe(true);
+    });
+  });
+
+});

--- a/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
@@ -10,7 +10,6 @@
 'use strict';
 
 let React;
-let ReactDOM;
 let ReactDOMClient;
 let ReactDOMServer;
 let Scheduler;
@@ -25,7 +24,6 @@ describe('ReactDOMServerScheduleHydration', () => {
 
     React = require('react');
     React = require('react');
-    ReactDOM = require('react-dom');
     ReactDOMClient = require('react-dom/client');
     ReactDOMServer = require('react-dom/server');
     Scheduler = require('scheduler');

--- a/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
@@ -18,6 +18,7 @@ let assertLog;
 let waitForAll;
 let waitFor;
 let act;
+let container;
 
 function dispatchClickEvent(target) {
   const mouseOutEvent = document.createEvent('MouseEvents');
@@ -57,6 +58,13 @@ describe('ReactDOMServerScheduleHydration', () => {
     waitForAll = InternalTestUtils.waitForAll;
     waitFor = InternalTestUtils.waitFor;
     act = InternalTestUtils.act;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
   });
 
   describe('with no boundary', () => {
@@ -87,7 +95,6 @@ describe('ReactDOMServerScheduleHydration', () => {
       const finalHTML = ReactDOMServer.renderToString(<App />);
       assertLog(['App', 'A']);
 
-      const container = document.createElement('div');
       container.innerHTML = finalHTML;
       const spanA = container.getElementsByTagName('span')[0];
 
@@ -138,7 +145,6 @@ describe('ReactDOMServerScheduleHydration', () => {
       const finalHTML = ReactDOMServer.renderToString(<App />);
       assertLog(['App', 'A']);
 
-      const container = document.createElement('div');
       container.innerHTML = finalHTML;
       const spanA = container.getElementsByTagName('span')[0];
 
@@ -200,7 +206,6 @@ describe('ReactDOMServerScheduleHydration', () => {
       const finalHTML = ReactDOMServer.renderToString(<App />);
       assertLog(['App', 'A']);
 
-      const container = document.createElement('div');
       container.innerHTML = finalHTML;
       const spanA = container.getElementsByTagName('span')[0];
 
@@ -252,7 +257,6 @@ describe('ReactDOMServerScheduleHydration', () => {
       const finalHTML = ReactDOMServer.renderToString(<App />);
       assertLog(['App', 'A']);
 
-      const container = document.createElement('div');
       container.innerHTML = finalHTML;
       const spanA = container.getElementsByTagName('span')[0];
 
@@ -317,7 +321,6 @@ describe('ReactDOMServerScheduleHydration', () => {
       const finalHTML = ReactDOMServer.renderToString(<App />);
       assertLog(['App', 'A', 'B', 'C']);
 
-      const container = document.createElement('div');
       container.innerHTML = finalHTML;
       const spanA = container.getElementsByTagName('span')[0];
       const spanB = container.getElementsByTagName('span')[1];
@@ -405,7 +408,6 @@ describe('ReactDOMServerScheduleHydration', () => {
       const finalHTML = ReactDOMServer.renderToString(<App />);
       assertLog(['App', 'A', 'B', 'C']);
 
-      const container = document.createElement('div');
       container.innerHTML = finalHTML;
       const spanA = container.getElementsByTagName('span')[0];
       const spanB = container.getElementsByTagName('span')[1];
@@ -495,7 +497,6 @@ describe('ReactDOMServerScheduleHydration', () => {
 
       assertLog(['App', 'A', 'B', 'C']);
 
-      const container = document.createElement('div');
       container.innerHTML = finalHTML;
 
       const spanC = container.getElementsByTagName('span')[2];
@@ -541,7 +542,6 @@ describe('ReactDOMServerScheduleHydration', () => {
       const finalHTML = ReactDOMServer.renderToString(<App />);
       assertLog(['App', 'A']);
 
-      const container = document.createElement('div');
       container.innerHTML = finalHTML;
 
       const root = ReactDOMClient.hydrateRoot(container, <App />);
@@ -624,7 +624,6 @@ describe('ReactDOMServerScheduleHydration', () => {
 
       assertLog(['App', 'A', 'B']);
 
-      const container = document.createElement('div');
       container.innerHTML = finalHTML;
 
       const spanB = container.getElementsByTagName('span')[1];
@@ -667,7 +666,6 @@ describe('ReactDOMServerScheduleHydration', () => {
 
       assertLog(['App']);
 
-      const container = document.createElement('div');
       container.innerHTML = finalHTML;
 
       const spanA = container.getElementsByTagName('span')[0];

--- a/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
@@ -10,7 +10,6 @@
 'use strict';
 
 let React;
-let ReactDOM;
 let ReactDOMClient;
 let ReactDOMServer;
 let Scheduler;
@@ -48,7 +47,6 @@ describe('ReactDOMServerScheduleHydration', () => {
 
     React = require('react');
     React = require('react');
-    ReactDOM = require('react-dom');
     ReactDOMClient = require('react-dom/client');
     ReactDOMServer = require('react-dom/server');
     Scheduler = require('scheduler');
@@ -77,7 +75,7 @@ describe('ReactDOMServerScheduleHydration', () => {
       }
 
       function App() {
-        const [_, setText] = React.useState('UNSET');
+        const [, setText] = React.useState('UNSET');
         Scheduler.log('App');
         return (
           <div>
@@ -128,7 +126,7 @@ describe('ReactDOMServerScheduleHydration', () => {
       }
 
       function App() {
-        const [_, setText] = React.useState('UNSET');
+        const [, setText] = React.useState('UNSET');
         Scheduler.log('App');
         return (
           <div>
@@ -188,7 +186,7 @@ describe('ReactDOMServerScheduleHydration', () => {
       }
 
       function App() {
-        const [text, setText] = React.useState('UNSET');
+        const [, setText] = React.useState('UNSET');
         Scheduler.log('App');
         return (
           <div>
@@ -240,7 +238,7 @@ describe('ReactDOMServerScheduleHydration', () => {
       }
 
       function App() {
-        const [text, setText] = React.useState('UNSET');
+        const [setText] = React.useState('UNSET');
         Scheduler.log('App');
         return (
           <div>
@@ -301,7 +299,7 @@ describe('ReactDOMServerScheduleHydration', () => {
       }
 
       function App() {
-        const [_, setText] = React.useState('UNSET');
+        const [, setText] = React.useState('UNSET');
         Scheduler.log('App');
         return (
           <div>
@@ -390,7 +388,7 @@ describe('ReactDOMServerScheduleHydration', () => {
       }
 
       function App() {
-        const [_, setText] = React.useState('UNSET');
+        const [, setText] = React.useState('UNSET');
         Scheduler.log('App');
         return (
           <div>
@@ -465,10 +463,6 @@ describe('ReactDOMServerScheduleHydration', () => {
     });
 
     it('resolve out of order content', async () => {
-      '' +
-        gate(flags => {
-          console.log(flags);
-        });
       function Child({text, onClick}) {
         Scheduler.log(text);
         return (
@@ -483,7 +477,7 @@ describe('ReactDOMServerScheduleHydration', () => {
       }
 
       function App() {
-        const [_, setText] = React.useState('UNSET');
+        const [, setText] = React.useState('UNSET');
         Scheduler.log('App');
         return (
           <div>
@@ -667,7 +661,7 @@ describe('ReactDOMServerScheduleHydration', () => {
     it('resolves if target node is inside dangerouslySetInnerHTML', async () => {
       function App() {
         Scheduler.log('App');
-        return <div dangerouslySetInnerHTML={{__html: '<span>A</span>'}}></div>;
+        return <div dangerouslySetInnerHTML={{__html: '<span>A</span>'}} />;
       }
 
       const finalHTML = ReactDOMServer.renderToString(<App />);

--- a/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerScheduleHydration-test.internal.js
@@ -578,7 +578,6 @@ describe('ReactDOMServerScheduleHydration', () => {
       assertLog(['App', 'A']);
 
       const nodeOutsideContainer = document.createElement('span');
-      const container = document.createElement('div');
       container.innerHTML = finalHTML;
 
       const root = ReactDOMClient.hydrateRoot(container, <App />);

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -267,9 +267,9 @@ export function createRoot(
 function ReactDOMHydrationRoot(internalRoot: FiberRoot) {
   this._internalRoot = internalRoot;
 }
-function scheduleHydration(target: Node) {
+async function scheduleHydration(target: Node) {
   if (target) {
-    queueExplicitHydrationTarget(target);
+    return queueExplicitHydrationTarget(target);
   }
 }
 // $FlowFixMe[prop-missing] found when upgrading Flow

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -268,9 +268,7 @@ function ReactDOMHydrationRoot(internalRoot: FiberRoot) {
   this._internalRoot = internalRoot;
 }
 async function scheduleHydration(target: Node) {
-  if (target) {
-    return queueExplicitHydrationTarget(target);
-  }
+  return queueExplicitHydrationTarget(target);
 }
 // $FlowFixMe[prop-missing] found when upgrading Flow
 ReactDOMHydrationRoot.prototype.unstable_scheduleHydration = scheduleHydration;

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -267,7 +267,7 @@ export function createRoot(
 function ReactDOMHydrationRoot(internalRoot: FiberRoot) {
   this._internalRoot = internalRoot;
 }
-async function scheduleHydration(target: Node) {
+function scheduleHydration(target: Node) {
   return queueExplicitHydrationTarget(target);
 }
 // $FlowFixMe[prop-missing] found when upgrading Flow

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -466,5 +466,8 @@
   "478": "Thenable should have already resolved. This is a bug in React.",
   "479": "Cannot update optimistic state while rendering.",
   "480": "File/Blob fields are not yet supported in progressive forms. It probably means you are closing over binary data or FormData in a Server Action.",
-  "481": "Tried to encode a Server Action from a different instance than the encoder is from. This is a bug in React."
+  "481": "Tried to encode a Server Action from a different instance than the encoder is from. This is a bug in React.",
+  "482": "Target was removed before hydration.",
+  "483": "Cannot schedule hydration, target is not a React component.",
+  "484": "Cannot schedule hydration, target is undefined."
 }


### PR DESCRIPTION
## Overview

End-to-end tests in server rendered environments need the ability to click on items after hydration. Since hydration is lazy, and may never complete, it doesn't make sense to add an API that waits just for hydration, which we might not even be working on.

We already have an unstable API to opt-in to trying to hydrate to a node, `unstable_scheduleHydration`. By making this function awaitable, E2E tests will be able to schedule hydration on a node, and wait for hydration on that node to complete. 