### PR TITLE
Add $FlowFixMe to fix React Native DiffTrain

### DIFF
--- a/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
+++ b/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
@@ -106,6 +106,7 @@ exports.get = function (name: string): ViewConfig {
         'View config getter callback for component `%s` must be a function (received `%s`).%s',
         name,
         callback === null ? 'null' : typeof callback,
+        // $FlowFixMe[recursive-definition]
         typeof name[0] === 'string' && /[a-z]/.test(name[0])
           ? ' Make sure to start component names with a capital letter.'
           : '',


### PR DESCRIPTION
Flow errors for 0.206 were suppressed in fbsource. This adds the suppression in React code.