### PR TITLE
Move enableSyncDefaultUpdates to test config

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -23,7 +23,6 @@ export const {
   enableDebugTracing,
   enableUseRefAccessWarning,
   enableLazyContextPropagation,
-  enableSyncDefaultUpdates,
   enableUnifiedSyncLane,
   enableTransitionTracing,
   enableCustomElementPropertySupport,
@@ -105,6 +104,9 @@ export const enableUseMutableSource = true;
 
 export const useModernStrictMode = false;
 export const enableFizzExternalRuntime = true;
+
+// This is only used in VARIANT tests, setting it to true does nothing.
+export const enableSyncDefaultUpdates = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/scripts/jest/setupTests.www.js
+++ b/scripts/jest/setupTests.www.js
@@ -6,7 +6,12 @@ jest.mock('shared/ReactFeatureFlags', () => {
     () => jest.requireActual('shared/forks/ReactFeatureFlags.www-dynamic'),
     {virtual: true}
   );
-  return jest.requireActual('shared/forks/ReactFeatureFlags.www');
+  const actual = jest.requireActual('shared/forks/ReactFeatureFlags.www');
+
+  // This flag is only used by tests, it should never be set elsewhere.
+  actual.enableSyncDefaultUpdates = __VARIANT__;
+
+  return actual;
 });
 
 jest.mock('scheduler/src/SchedulerFeatureFlags', () => {


### PR DESCRIPTION
# Overview

The only reason this needs imported from dynamic flags is for the variant tests, so let's set the variant in the test config directly instead.