### PR TITLE
run SchedulerFeatureFlags with variant flags again

### DIFF
--- a/scripts/jest/setupTests.www.js
+++ b/scripts/jest/setupTests.www.js
@@ -24,9 +24,18 @@ jest.mock('scheduler/src/SchedulerFeatureFlags', () => {
       ),
     {virtual: true}
   );
-  return jest.requireActual(
+  const actual = jest.requireActual(
     schedulerSrcPath + '/src/forks/SchedulerFeatureFlags.www'
   );
+
+  // These flags are not a dynamic on www, but we still want to run
+  // tests in both versions.
+  actual.enableIsInputPending = __VARIANT__;
+  actual.enableIsInputPendingContinuous = __VARIANT__;
+  actual.enableProfiling = __VARIANT__;
+  actual.enableSchedulerDebugging = __VARIANT__;
+
+  return actual;
 });
 
 global.__WWW__ = true;


### PR DESCRIPTION
With df12d7eac40c87bd5fdde0aa5a739bce9e7dce27 I accidentally made it so that tests aren't run with the 2 variant modes for most SchedulerFeatureFlags anymore. This fixes it with the same approach as ee4233bdbc71a7e09395a613c7dde01194d2a830.

Test Plan:
Run and notice the boolean flags follow the variant:
```
yarn test-www --variant=true
yarn test-www --variant=false
```