### PR TITLE
Fix concurrentUpdatesByDefaultOverride option not being used

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -459,11 +459,12 @@ export function createHostRootFiber(
       mode |= StrictLegacyMode | StrictEffectsMode;
     }
     if (
-      // We only use this flag for our repo tests to check both behaviors.
-      // TODO: Flip this flag and rename it something like "forceConcurrentByDefaultForTesting"
-      !enableSyncDefaultUpdates ||
-      // Only for internal experiments.
-      (allowConcurrentByDefault && concurrentUpdatesByDefaultOverride)
+      allowConcurrentByDefault && concurrentUpdatesByDefaultOverride !== null
+        ? // Only for internal experiments.
+          concurrentUpdatesByDefaultOverride
+        : // We only use this flag for our repo tests to check both behaviors.
+          // TODO: Flip this flag and rename it something like "forceConcurrentByDefaultForTesting"
+          !enableSyncDefaultUpdates
     ) {
       mode |= ConcurrentUpdatesByDefaultMode;
     }


### PR DESCRIPTION
If `enableSyncDefaultUpdates` was `false`,  we would always set `ConcurrentUpdatesByDefaultMode` and `concurrentUpdatesByDefaultOverride` was ignored.
This PR makes it that if `concurrentUpdatesByDefaultOverride` is set, use its value, otherwise use `enableSyncDefaultUpdates` for tests. 