### PR TITLE
Update enableSyncDefaultUpdates for www

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -105,8 +105,7 @@ export const enableUseMutableSource = true;
 export const useModernStrictMode = false;
 export const enableFizzExternalRuntime = true;
 
-// This is only used in VARIANT tests, setting it to true does nothing.
-export const enableSyncDefaultUpdates = false;
+export const enableSyncDefaultUpdates = true;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);


### PR DESCRIPTION
If this is false, it dead code eliminates the path to use the root flag. Will follow up to clean this up.