### PR TITLE
[Fizz][Float] stop automatically preloading scripts that are not script resources

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -1036,19 +1036,6 @@ export function bindInstance(
 
 export const supportsHydration = true;
 
-// With Resources, some HostComponent types will never be server rendered and need to be
-// inserted without breaking hydration
-export function isHydratableType(type: string, props: Props): boolean {
-  if (enableFloat) {
-    if (type === 'script') {
-      const {async, onLoad, onError} = (props: any);
-      return !(async && (onLoad || onError));
-    }
-    return true;
-  } else {
-    return true;
-  }
-}
 export function isHydratableText(text: string): boolean {
   return text !== '';
 }
@@ -1164,21 +1151,22 @@ export function canHydrateInstance(
           // if we learn it is problematic
           const srcAttr = element.getAttribute('src');
           if (
-            srcAttr &&
-            element.hasAttribute('async') &&
-            !element.hasAttribute('itemprop')
-          ) {
-            // This is an async script resource
-            break;
-          } else if (
             srcAttr !== (anyProps.src == null ? null : anyProps.src) ||
             element.getAttribute('type') !==
               (anyProps.type == null ? null : anyProps.type) ||
             element.getAttribute('crossorigin') !==
               (anyProps.crossOrigin == null ? null : anyProps.crossOrigin)
           ) {
-            // This script is for a different src
-            break;
+            // This script is for a different src/type/crossOrigin. It may be a script resource
+            // or it may just be a mistmatch
+            if (
+              srcAttr &&
+              element.hasAttribute('async') &&
+              !element.hasAttribute('itemprop')
+            ) {
+              // This is an async script resource
+              break;
+            }
           }
           return element;
         }

--- a/packages/react-reconciler/src/ReactFiberConfigWithNoHydration.js
+++ b/packages/react-reconciler/src/ReactFiberConfigWithNoHydration.js
@@ -21,7 +21,6 @@ function shim(...args: any): empty {
 // Hydration (when unsupported)
 export type SuspenseInstance = mixed;
 export const supportsHydration = false;
-export const isHydratableType = shim;
 export const isHydratableText = shim;
 export const isSuspenseInstancePending = shim;
 export const isSuspenseInstanceFallback = shim;

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -37,7 +37,6 @@ import {
 } from './ReactFiberFlags';
 import {
   enableHostSingletons,
-  enableFloat,
   enableClientRenderFallbackOnTextMismatch,
   diffInCommitPhase,
 } from 'shared/ReactFeatureFlags';
@@ -77,7 +76,6 @@ import {
   canHydrateInstance,
   canHydrateTextInstance,
   canHydrateSuspenseInstance,
-  isHydratableType,
   isHydratableText,
 } from './ReactFiberConfig';
 import {OffscreenLane} from './ReactFiberLane';
@@ -449,15 +447,6 @@ function claimHydratableSingleton(fiber: Fiber): void {
 function tryToClaimNextHydratableInstance(fiber: Fiber): void {
   if (!isHydrating) {
     return;
-  }
-  if (enableFloat) {
-    if (!isHydratableType(fiber.type, fiber.pendingProps)) {
-      // This fiber never hydrates from the DOM and always does an insert
-      fiber.flags = (fiber.flags & ~Hydrating) | Placement;
-      isHydrating = false;
-      hydrationParentFiber = fiber;
-      return;
-    }
   }
   const initialInstance = nextHydratableInstance;
   const nextInstance = nextHydratableInstance;

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
@@ -135,7 +135,6 @@ export const cloneHiddenTextInstance = $$$config.cloneHiddenTextInstance;
 //     Hydration
 //     (optional)
 // -------------------
-export const isHydratableType = $$$config.isHydratableType;
 export const isHydratableText = $$$config.isHydratableText;
 export const isSuspenseInstancePending = $$$config.isSuspenseInstancePending;
 export const isSuspenseInstanceFallback = $$$config.isSuspenseInstanceFallback;


### PR DESCRIPTION
Currently we preload all scripts that are not hoisted. One of the original reasons for this is we stopped SSR rendering async scripts that had an onLoad/onError because we needed to be able to distinguish between Float scripts and non-Float scripts during hydration. Hydration has been refactored a bit and we can not get around this limitation so we can just emit the async script in place. However, sync and defer scripts are also preloaded. While this is sometimes desirable it is not universally so and there are issues with conveying priority properly (see fetchpriority) so with this change we remove the automatic preloading of non-Float scripts altogether.

For this change to make sense we also need to emit async scripts with loading handlers during SSR. we previously only preloaded them during SSR because it was necessary to keep async scripts as unambiguously resources when hydrating. One ancillary benefit was that load handlers would always fire b/c there was no chance the script would run before hydration. With this change we go back to having the ability to have load handlers fired before hydration. This is already a problem with images and we don't have a generalized solution for it however our likely approach to this sort of thing where you need to wait for a script to load is to use something akin to `importScripts()` rather than rendering a script with onLoad.