### PR TITLE
Add a warning to useEffect if no deps

### DIFF
--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -118,6 +118,9 @@ export function useEffect(
   create: () => (() => void) | void,
   deps: Array<mixed> | void | null,
 ): void {
+  if (typeof deps === "undefined") {
+    console.warn("Missing dependency array in useEffect. This will lead to an infinite loop. To fix, please add a dependency array to useEffect. Docs: https://react.dev/reference/react/useEffect");
+  }
   const dispatcher = resolveDispatcher();
   return dispatcher.useEffect(create, deps);
 }


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
I've heard a lot of the community complain about `useEffect` causing an infinite loop if the second argument is omitted, so I am trying to help by proposing something in this direction.

Inspired by https://twitter.com/tlakomy/status/1501574622839463936 and others.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
This is a fairly minimal change (or at least appears to be), so I didn't test it outside of "brain compilation". The pull request is more intended to spark a discussion instead of be merged immediately, so I hope this is enough to meet that end.
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
