### PR TITLE
Added Filter to allow skip re-render in context consumers

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -3374,10 +3374,10 @@ if (__DEV__) {
       checkDepsAreArrayDev(deps);
       return mountCallback(callback, deps);
     },
-    useContext<T>(context: ReactContext<T>): T {
+    useContext<T>(context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
       currentHookNameInDev = 'useContext';
       mountHookTypesDev();
-      return readContext(context);
+      return readContext(context, filterCallback);
     },
     useEffect(
       create: () => (() => void) | void,
@@ -3547,10 +3547,10 @@ if (__DEV__) {
       updateHookTypesDev();
       return mountCallback(callback, deps);
     },
-    useContext<T>(context: ReactContext<T>): T {
+    useContext<T>(context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
       currentHookNameInDev = 'useContext';
       updateHookTypesDev();
-      return readContext(context);
+      return readContext(context, filterCallback);
     },
     useEffect(
       create: () => (() => void) | void,
@@ -3716,10 +3716,10 @@ if (__DEV__) {
       updateHookTypesDev();
       return updateCallback(callback, deps);
     },
-    useContext<T>(context: ReactContext<T>): T {
+    useContext<T>(context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
       currentHookNameInDev = 'useContext';
       updateHookTypesDev();
-      return readContext(context);
+      return readContext(context, filterCallback);
     },
     useEffect(
       create: () => (() => void) | void,
@@ -3887,10 +3887,10 @@ if (__DEV__) {
       updateHookTypesDev();
       return updateCallback(callback, deps);
     },
-    useContext<T>(context: ReactContext<T>): T {
+    useContext<T>(context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
       currentHookNameInDev = 'useContext';
       updateHookTypesDev();
-      return readContext(context);
+      return readContext(context, filterCallback);
     },
     useEffect(
       create: () => (() => void) | void,
@@ -4063,11 +4063,11 @@ if (__DEV__) {
       mountHookTypesDev();
       return mountCallback(callback, deps);
     },
-    useContext<T>(context: ReactContext<T>): T {
+    useContext<T>(context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
       currentHookNameInDev = 'useContext';
       warnInvalidHookAccess();
       mountHookTypesDev();
-      return readContext(context);
+      return readContext(context, filterCallback);
     },
     useEffect(
       create: () => (() => void) | void,
@@ -4257,11 +4257,11 @@ if (__DEV__) {
       updateHookTypesDev();
       return updateCallback(callback, deps);
     },
-    useContext<T>(context: ReactContext<T>): T {
+    useContext<T>(context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
       currentHookNameInDev = 'useContext';
       warnInvalidHookAccess();
       updateHookTypesDev();
-      return readContext(context);
+      return readContext(context, filterCallback);
     },
     useEffect(
       create: () => (() => void) | void,
@@ -4454,11 +4454,11 @@ if (__DEV__) {
       updateHookTypesDev();
       return updateCallback(callback, deps);
     },
-    useContext<T>(context: ReactContext<T>): T {
+    useContext<T>(context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
       currentHookNameInDev = 'useContext';
       warnInvalidHookAccess();
       updateHookTypesDev();
-      return readContext(context);
+      return readContext(context, filterCallback);
     },
     useEffect(
       create: () => (() => void) | void,

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -3376,7 +3376,10 @@ if (__DEV__) {
     },
     useContext<T>(
       context: ReactContext<T>,
-      filterCallback: (prevState: any, nextState: any) => boolean,
+      filterCallback:
+        | ((prevState: any, nextState: any) => boolean)
+        | void
+        | null,
     ): T {
       currentHookNameInDev = 'useContext';
       mountHookTypesDev();
@@ -3552,7 +3555,10 @@ if (__DEV__) {
     },
     useContext<T>(
       context: ReactContext<T>,
-      filterCallback: (prevState: any, nextState: any) => boolean,
+      filterCallback:
+        | ((prevState: any, nextState: any) => boolean)
+        | void
+        | null,
     ): T {
       currentHookNameInDev = 'useContext';
       updateHookTypesDev();
@@ -3724,7 +3730,10 @@ if (__DEV__) {
     },
     useContext<T>(
       context: ReactContext<T>,
-      filterCallback: (prevState: any, nextState: any) => boolean,
+      filterCallback:
+        | ((prevState: any, nextState: any) => boolean)
+        | void
+        | null,
     ): T {
       currentHookNameInDev = 'useContext';
       updateHookTypesDev();
@@ -3898,7 +3907,10 @@ if (__DEV__) {
     },
     useContext<T>(
       context: ReactContext<T>,
-      filterCallback: (prevState: any, nextState: any) => boolean,
+      filterCallback:
+        | ((prevState: any, nextState: any) => boolean)
+        | void
+        | null,
     ): T {
       currentHookNameInDev = 'useContext';
       updateHookTypesDev();
@@ -4077,7 +4089,10 @@ if (__DEV__) {
     },
     useContext<T>(
       context: ReactContext<T>,
-      filterCallback: (prevState: any, nextState: any) => boolean,
+      filterCallback:
+        | ((prevState: any, nextState: any) => boolean)
+        | void
+        | null,
     ): T {
       currentHookNameInDev = 'useContext';
       warnInvalidHookAccess();
@@ -4274,7 +4289,10 @@ if (__DEV__) {
     },
     useContext<T>(
       context: ReactContext<T>,
-      filterCallback: (prevState: any, nextState: any) => boolean,
+      filterCallback:
+        | ((prevState: any, nextState: any) => boolean)
+        | void
+        | null,
     ): T {
       currentHookNameInDev = 'useContext';
       warnInvalidHookAccess();
@@ -4474,7 +4492,10 @@ if (__DEV__) {
     },
     useContext<T>(
       context: ReactContext<T>,
-      filterCallback: (prevState: any, nextState: any) => boolean,
+      filterCallback:
+        | ((prevState: any, nextState: any) => boolean)
+        | void
+        | null,
     ): T {
       currentHookNameInDev = 'useContext';
       warnInvalidHookAccess();

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -3374,7 +3374,10 @@ if (__DEV__) {
       checkDepsAreArrayDev(deps);
       return mountCallback(callback, deps);
     },
-    useContext<T>(context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
+    useContext<T>(
+      context: ReactContext<T>,
+      filterCallback: (prevState: any, nextState: any) => boolean,
+    ): T {
       currentHookNameInDev = 'useContext';
       mountHookTypesDev();
       return readContext(context, filterCallback);
@@ -3547,7 +3550,10 @@ if (__DEV__) {
       updateHookTypesDev();
       return mountCallback(callback, deps);
     },
-    useContext<T>(context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
+    useContext<T>(
+      context: ReactContext<T>,
+      filterCallback: (prevState: any, nextState: any) => boolean,
+    ): T {
       currentHookNameInDev = 'useContext';
       updateHookTypesDev();
       return readContext(context, filterCallback);
@@ -3716,7 +3722,10 @@ if (__DEV__) {
       updateHookTypesDev();
       return updateCallback(callback, deps);
     },
-    useContext<T>(context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
+    useContext<T>(
+      context: ReactContext<T>,
+      filterCallback: (prevState: any, nextState: any) => boolean,
+    ): T {
       currentHookNameInDev = 'useContext';
       updateHookTypesDev();
       return readContext(context, filterCallback);
@@ -3887,7 +3896,10 @@ if (__DEV__) {
       updateHookTypesDev();
       return updateCallback(callback, deps);
     },
-    useContext<T>(context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
+    useContext<T>(
+      context: ReactContext<T>,
+      filterCallback: (prevState: any, nextState: any) => boolean,
+    ): T {
       currentHookNameInDev = 'useContext';
       updateHookTypesDev();
       return readContext(context, filterCallback);
@@ -4063,7 +4075,10 @@ if (__DEV__) {
       mountHookTypesDev();
       return mountCallback(callback, deps);
     },
-    useContext<T>(context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
+    useContext<T>(
+      context: ReactContext<T>,
+      filterCallback: (prevState: any, nextState: any) => boolean,
+    ): T {
       currentHookNameInDev = 'useContext';
       warnInvalidHookAccess();
       mountHookTypesDev();
@@ -4257,7 +4272,10 @@ if (__DEV__) {
       updateHookTypesDev();
       return updateCallback(callback, deps);
     },
-    useContext<T>(context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
+    useContext<T>(
+      context: ReactContext<T>,
+      filterCallback: (prevState: any, nextState: any) => boolean,
+    ): T {
       currentHookNameInDev = 'useContext';
       warnInvalidHookAccess();
       updateHookTypesDev();
@@ -4454,7 +4472,10 @@ if (__DEV__) {
       updateHookTypesDev();
       return updateCallback(callback, deps);
     },
-    useContext<T>(context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
+    useContext<T>(
+      context: ReactContext<T>,
+      filterCallback: (prevState: any, nextState: any) => boolean,
+    ): T {
       currentHookNameInDev = 'useContext';
       warnInvalidHookAccess();
       updateHookTypesDev();

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -278,13 +278,13 @@ function propagateContextChange_eager<T>(
       while (dependency !== null) {
         // Check if the context matches.
         if (
-          (dependency.context === context &&
-            typeof dependency.filterCallback === 'function' &&
+          dependency.context === context &&
+          ((typeof dependency.filterCallback === 'function' &&
             dependency.filterCallback(
               dependency.memoizedValue,
               readContextValue(dependency.context),
             ) !== false) ||
-          typeof dependency.filterCallback !== 'function'
+            typeof dependency.filterCallback !== 'function')
         ) {
           // Match! Schedule an update on this fiber.
           if (fiber.tag === ClassComponent) {
@@ -430,13 +430,13 @@ function propagateContextChanges<T>(
           // Check if the context matches.
           // TODO: Compare selected values to bail out early.
           if (
-            (dependency.context === context &&
-              typeof dependency.filterCallback === 'function' &&
+            dependency.context === context &&
+            ((typeof dependency.filterCallback === 'function' &&
               dependency.filterCallback(
                 dependency.memoizedValue,
                 readContextValue(dependency.context),
               ) !== false) ||
-            typeof dependency.filterCallback !== 'function'
+              typeof dependency.filterCallback !== 'function')
           ) {
             // Match! Schedule an update on this fiber.
 

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -273,7 +273,15 @@ function propagateContextChange_eager<T>(
       let dependency = list.firstContext;
       while (dependency !== null) {
         // Check if the context matches.
-        if (dependency.context === context && (typeof dependency.filterCallback === 'function' && dependency.filterCallback(dependency.memoizedValue, workInProgress.pendingProps.value) !== false) || typeof dependency.filterCallback !== 'function') {
+        if (
+          (dependency.context === context &&
+            typeof dependency.filterCallback === 'function' &&
+            dependency.filterCallback(
+              dependency.memoizedValue,
+              workInProgress.pendingProps.value,
+            ) !== false) ||
+          typeof dependency.filterCallback !== 'function'
+        ) {
           // Match! Schedule an update on this fiber.
           if (fiber.tag === ClassComponent) {
             // Schedule a force update on the work-in-progress.
@@ -710,7 +718,10 @@ export function prepareToReadContext(
   }
 }
 
-export function readContext<T>(context: ReactContext<T>, filterContext: any): T {
+export function readContext<T>(
+  context: ReactContext<T>,
+  filterContext: any,
+): T {
   if (__DEV__) {
     // This warning would fire if you read context inside a Hook like useMemo.
     // Unlike the class check below, it's not enforced in production for perf.
@@ -723,7 +734,11 @@ export function readContext<T>(context: ReactContext<T>, filterContext: any): T 
       );
     }
   }
-  return readContextForConsumer(currentlyRenderingFiber, context, filterContext);
+  return readContextForConsumer(
+    currentlyRenderingFiber,
+    context,
+    filterContext,
+  );
 }
 
 export function readContextDuringReconcilation<T>(

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -273,7 +273,7 @@ function propagateContextChange_eager<T>(
       let dependency = list.firstContext;
       while (dependency !== null) {
         // Check if the context matches.
-        if (dependency.context === context) {
+        if (dependency.context === context && (typeof dependency.filterCallback === 'function' && dependency.filterCallback(dependency.memoizedValue, workInProgress.pendingProps.value) !== false) || typeof dependency.filterCallback !== 'function') {
           // Match! Schedule an update on this fiber.
           if (fiber.tag === ClassComponent) {
             // Schedule a force update on the work-in-progress.
@@ -710,7 +710,7 @@ export function prepareToReadContext(
   }
 }
 
-export function readContext<T>(context: ReactContext<T>): T {
+export function readContext<T>(context: ReactContext<T>, filterContext: any): T {
   if (__DEV__) {
     // This warning would fire if you read context inside a Hook like useMemo.
     // Unlike the class check below, it's not enforced in production for perf.
@@ -723,7 +723,7 @@ export function readContext<T>(context: ReactContext<T>): T {
       );
     }
   }
-  return readContextForConsumer(currentlyRenderingFiber, context);
+  return readContextForConsumer(currentlyRenderingFiber, context, filterContext);
 }
 
 export function readContextDuringReconcilation<T>(
@@ -740,6 +740,7 @@ export function readContextDuringReconcilation<T>(
 function readContextForConsumer<T>(
   consumer: Fiber | null,
   context: ReactContext<T>,
+  filterCallback: any,
 ): T {
   const value = isPrimaryRenderer
     ? context._currentValue
@@ -752,6 +753,7 @@ function readContextForConsumer<T>(
       context: ((context: any): ReactContext<mixed>),
       memoizedValue: value,
       next: null,
+      filterCallback: filterCallback,
     };
 
     if (lastContextDependency === null) {

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -227,6 +227,10 @@ export function scheduleContextWorkOnParentPath(
   }
 }
 
+const readContextValue = (context: ReactContext<T>) => {
+  return isPrimaryRenderer ? context._currentValue : context._currentValue2;
+};
+
 export function propagateContextChange<T>(
   workInProgress: Fiber,
   context: ReactContext<T>,
@@ -278,7 +282,7 @@ function propagateContextChange_eager<T>(
             typeof dependency.filterCallback === 'function' &&
             dependency.filterCallback(
               dependency.memoizedValue,
-              workInProgress.pendingProps.value,
+              readContextValue(dependency.context),
             ) !== false) ||
           typeof dependency.filterCallback !== 'function'
         ) {
@@ -425,7 +429,15 @@ function propagateContextChanges<T>(
           const context: ReactContext<T> = contexts[i];
           // Check if the context matches.
           // TODO: Compare selected values to bail out early.
-          if (dependency.context === context) {
+          if (
+            (dependency.context === context &&
+              typeof dependency.filterCallback === 'function' &&
+              dependency.filterCallback(
+                dependency.memoizedValue,
+                readContextValue(dependency.context),
+              ) !== false) ||
+            typeof dependency.filterCallback !== 'function'
+          ) {
             // Match! Schedule an update on this fiber.
 
             // In the lazy implementation, don't mark a dirty flag on the

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -229,7 +229,7 @@ export function scheduleContextWorkOnParentPath(
 
 function readContextValue<T>(context: ReactContext<T>): any {
   return isPrimaryRenderer ? context._currentValue : context._currentValue2;
-};
+}
 
 export function propagateContextChange<T>(
   workInProgress: Fiber,
@@ -732,7 +732,7 @@ export function prepareToReadContext(
 
 export function readContext<T>(
   context: ReactContext<T>,
-  filterContext: any,
+  filterCallback: any,
 ): T {
   if (__DEV__) {
     // This warning would fire if you read context inside a Hook like useMemo.
@@ -749,7 +749,7 @@ export function readContext<T>(
   return readContextForConsumer(
     currentlyRenderingFiber,
     context,
-    filterContext,
+    filterCallback,
   );
 }
 

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -755,7 +755,7 @@ export function readContextDuringReconcilation<T>(
 function readContextForConsumer<T>(
   consumer: Fiber | null,
   context: ReactContext<T>,
-  filterCallback: any,
+  filterCallback: ((prevState: any, nextState: any) => boolean) | void | null,
 ): T {
   const value = isPrimaryRenderer
     ? context._currentValue

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -227,7 +227,7 @@ export function scheduleContextWorkOnParentPath(
   }
 }
 
-const readContextValue = (context: ReactContext<T>) => {
+function readContextValue<T>(context: ReactContext<T>): any {
   return isPrimaryRenderer ? context._currentValue : context._currentValue2;
 };
 

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -64,6 +64,7 @@ export type ContextDependency<T> = {
   context: ReactContext<T>,
   next: ContextDependency<mixed> | null,
   memoizedValue: T,
+  filterCallback: ((prevState: any, nextState: any) => boolean) | void | null,
   ...
 };
 
@@ -382,7 +383,7 @@ export type Dispatcher = {
     initialArg: I,
     init?: (I) => S,
   ): [S, Dispatch<A>],
-  useContext<T>(context: ReactContext<T>): T,
+  useContext<T>(context: ReactContext<T>, filterCallback: ((prevState: any, nextState: any) => boolean) | void | null): T,
   useRef<T>(initialValue: T): {current: T},
   useEffect(
     create: () => (() => void) | void,

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -383,7 +383,10 @@ export type Dispatcher = {
     initialArg: I,
     init?: (I) => S,
   ): [S, Dispatch<A>],
-  useContext<T>(context: ReactContext<T>, filterCallback: ((prevState: any, nextState: any) => boolean) | void | null): T,
+  useContext<T>(
+    context: ReactContext<T>,
+    filterCallback: ((prevState: any, nextState: any) => boolean) | void | null,
+  ): T,
   useRef<T>(initialValue: T): {current: T},
   useEffect(
     create: () => (() => void) | void,

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -1890,10 +1890,7 @@ Context fuzz tester error! Copy and paste the following line into the test suite
 
     // Update
     ReactNoop.render(<Component value="Good Bye" valueStatic="Static Value" />);
-    await waitForAll([
-      'Component',
-      'Component#ComponentToRender-value',
-    ]);
+    await waitForAll(['Component', 'Component#ComponentToRender-value']);
     expect(ReactNoop).toMatchRenderedOutput(
       <div>
         <div>Good Bye</div>

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -1748,7 +1748,6 @@ Context fuzz tester error! Copy and paste the following line into the test suite
       const {name} = props;
       // const filterCallback = React.useCallback(
       //   (prevState, nextState) => {
-      //     console.log('called', name, prevState, nextState);
 
       //     return prevState[name] !== nextState[name];
       //   },
@@ -1831,7 +1830,6 @@ Context fuzz tester error! Copy and paste the following line into the test suite
       const {name} = props;
       const filterCallback = React.useCallback(
         (prevState, nextState) => {
-          console.log('called', name, prevState, nextState);
 
           return prevState[name] !== nextState[name];
         },

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -1843,6 +1843,8 @@ Context fuzz tester error! Copy and paste the following line into the test suite
     };
 
     const ComponentParentToRender = () => {
+      Scheduler.log('Component#ComponentParentToRender');
+
       return (
         <div>
           <ComponentToRender name="value" />
@@ -1875,6 +1877,7 @@ Context fuzz tester error! Copy and paste the following line into the test suite
     );
     await waitForAll([
       'Component',
+      'Component#ComponentParentToRender',
       'Component#ComponentToRender-value',
       'Component#ComponentToRender-valueStatic',
     ]);
@@ -1887,7 +1890,10 @@ Context fuzz tester error! Copy and paste the following line into the test suite
 
     // Update
     ReactNoop.render(<Component value="Good Bye" valueStatic="Static Value" />);
-    await waitForAll(['Component', 'Component#ComponentToRender-value']);
+    await waitForAll([
+      'Component',
+      'Component#ComponentToRender-value',
+    ]);
     expect(ReactNoop).toMatchRenderedOutput(
       <div>
         <div>Good Bye</div>

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -1829,8 +1829,7 @@ Context fuzz tester error! Copy and paste the following line into the test suite
     const ComponentToRender = props => {
       const {name} = props;
       const filterCallback = React.useCallback(
-        (prevState, nextState) => {
-
+        (prevState = {}, nextState = {}) => {
           return prevState[name] !== nextState[name];
         },
         [name],

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -72,7 +72,10 @@ export function getCacheForType<T>(resourceType: () => T): T {
   return dispatcher.getCacheForType(resourceType);
 }
 
-export function useContext<T>(Context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
+export function useContext<T>(
+  Context: ReactContext<T>,
+  filterCallback: (prevState: any, nextState: any) => boolean,
+): T {
   const dispatcher = resolveDispatcher();
   if (__DEV__) {
     // TODO: add a more generic warning for invalid values.

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -72,7 +72,7 @@ export function getCacheForType<T>(resourceType: () => T): T {
   return dispatcher.getCacheForType(resourceType);
 }
 
-export function useContext<T>(Context: ReactContext<T>): T {
+export function useContext<T>(Context: ReactContext<T>, filterCallback: (prevState: any, nextState: any) => boolean): T {
   const dispatcher = resolveDispatcher();
   if (__DEV__) {
     // TODO: add a more generic warning for invalid values.
@@ -93,7 +93,7 @@ export function useContext<T>(Context: ReactContext<T>): T {
       }
     }
   }
-  return dispatcher.useContext(Context);
+  return dispatcher.useContext(Context, filterCallback);
 }
 
 export function useState<S>(

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -74,7 +74,7 @@ export function getCacheForType<T>(resourceType: () => T): T {
 
 export function useContext<T>(
   Context: ReactContext<T>,
-  filterCallback: (prevState: any, nextState: any) => boolean,
+  filterCallback: ((prevState: any, nextState: any) => boolean) | void | null,
 ): T {
   const dispatcher = resolveDispatcher();
   if (__DEV__) {


### PR DESCRIPTION
## Summary

The reason of this change is to have a way to skip re-renders in some consumers based on the previous state and new state or in case that i just want to re-render if a specific sub value inside the context changes

This allow to improve the performance in large applications without be making many context just to parse the value trying to avoid re-renders

![image](https://github.com/facebook/react/assets/35545218/6c8406f9-3999-4d09-9a62-b0b33159ebde)

i tested the implementation with an existing react application (small) where using devTools i was able to confirm that the elements that i was specting to be skipped were skipped

## How did you test this change?

https://github.com/facebook/react/issues/26890 in this ticket i left a codesandbox example about the proposal implementation

just will require to run it locally and replace `react` and `react-dom` to be able to test the changes and verified using devTools

in my case i was using this command `yarn build react/index,react-dom/index,react/jsx-runtime,react-dom/src/server --type=NODE_DEV`

![image](https://github.com/facebook/react/assets/35545218/2b1d64dc-f8dd-4115-8d64-054e67b645d8)
