### PR TITLE
Delete processStringChunk

### DIFF
--- a/packages/react-client/src/ReactFlightClientConfigBrowser.js
+++ b/packages/react-client/src/ReactFlightClientConfigBrowser.js
@@ -9,8 +9,6 @@
 
 export type StringDecoder = TextDecoder;
 
-export const supportsBinaryStreams = true;
-
 export function createStringDecoder(): StringDecoder {
   return new TextDecoder();
 }

--- a/packages/react-client/src/ReactFlightClientConfigNode.js
+++ b/packages/react-client/src/ReactFlightClientConfigNode.js
@@ -11,8 +11,6 @@ import {TextDecoder} from 'util';
 
 export type StringDecoder = TextDecoder;
 
-export const supportsBinaryStreams = true;
-
 export function createStringDecoder(): StringDecoder {
   return new TextDecoder();
 }

--- a/packages/react-client/src/forks/ReactFlightClientConfig.custom.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.custom.js
@@ -40,7 +40,6 @@ export opaque type Source = mixed;
 
 export opaque type StringDecoder = mixed; // eslint-disable-line no-undef
 
-export const supportsBinaryStreams = $$$config.supportsBinaryStreams;
 export const createStringDecoder = $$$config.createStringDecoder;
 export const readPartialStringChunk = $$$config.readPartialStringChunk;
 export const readFinalStringChunk = $$$config.readFinalStringChunk;

--- a/packages/react-noop-renderer/src/ReactNoopFlightServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightServer.js
@@ -21,7 +21,9 @@ import {saveModule} from 'react-noop-renderer/flight-modules';
 
 import ReactFlightServer from 'react-server/flight';
 
-type Destination = Array<string>;
+type Destination = Array<Uint8Array>;
+
+const textEncoder = new TextEncoder();
 
 const ReactNoopFlightServer = ReactFlightServer({
   scheduleWork(callback: () => void) {
@@ -39,13 +41,13 @@ const ReactNoopFlightServer = ReactFlightServer({
   close(destination: Destination): void {},
   closeWithError(destination: Destination, error: mixed): void {},
   flushBuffered(destination: Destination): void {},
-  stringToChunk(content: string): string {
-    return content;
+  stringToChunk(content: string): Uint8Array {
+    return textEncoder.encode(content);
   },
-  stringToPrecomputedChunk(content: string): string {
-    return content;
+  stringToPrecomputedChunk(content: string): Uint8Array {
+    return textEncoder.encode(content);
   },
-  clonePrecomputedChunk(chunk: string): string {
+  clonePrecomputedChunk(chunk: Uint8Array): Uint8Array {
     return chunk;
   },
   isClientReference(reference: Object): boolean {

--- a/packages/react-server-dom-esm/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-esm/src/ReactFlightDOMClientNode.js
@@ -20,7 +20,6 @@ import {
   processBinaryChunk,
   close,
 } from 'react-client/src/ReactFlightClient';
-import {processStringChunk} from '../../react-client/src/ReactFlightClient';
 
 function noServerCall() {
   throw new Error(
@@ -44,11 +43,7 @@ function createFromNodeStream<T>(
 ): Thenable<T> {
   const response: Response = createResponse(moduleRootPath, noServerCall);
   stream.on('data', chunk => {
-    if (typeof chunk === 'string') {
-      processStringChunk(response, chunk, 0);
-    } else {
-      processBinaryChunk(response, chunk);
-    }
+    processBinaryChunk(response, chunk);
   });
   stream.on('error', error => {
     reportGlobalError(response, error);

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientNode.js
@@ -22,7 +22,6 @@ import {
   processBinaryChunk,
   close,
 } from 'react-client/src/ReactFlightClient';
-import {processStringChunk} from '../../react-client/src/ReactFlightClient';
 
 function noServerCall() {
   throw new Error(
@@ -45,11 +44,7 @@ function createFromNodeStream<T>(
 ): Thenable<T> {
   const response: Response = createResponse(moduleMap, noServerCall);
   stream.on('data', chunk => {
-    if (typeof chunk === 'string') {
-      processStringChunk(response, chunk, 0);
-    } else {
-      processBinaryChunk(response, chunk);
-    }
+    processBinaryChunk(response, chunk);
   });
   stream.on('error', error => {
     reportGlobalError(response, error);


### PR DESCRIPTION
Follow up to #26827.

These can't include binary data and we don't really have any use cases that really require these to already be strings.

When the stream is encoded inside another protocol - such as HTML we need a different format that encode binary offsets and binary data.
