### PR TITLE
Feat:-Added command shortcut to inspect react dev tools

### DIFF
--- a/packages/react-devtools-extensions/chrome/manifest.json
+++ b/packages/react-devtools-extensions/chrome/manifest.json
@@ -57,5 +57,14 @@
       ],
       "run_at": "document_start"
     }
-  ]
+  ],
+  "commands": {
+    "inspect_node": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+X",
+        "mac": "Command+Shift+X"
+      },
+      "description": "Toggle on element/node inspector on React Devtools Component"
+    }
+  }
 }

--- a/packages/react-devtools-extensions/firefox/manifest.json
+++ b/packages/react-devtools-extensions/firefox/manifest.json
@@ -53,5 +53,14 @@
       ],
       "run_at": "document_start"
     }
-  ]
+  ],
+  "commands": {
+    "inspect_node": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+X",
+        "mac": "Command+Shift+X"
+      },
+      "description": "Toggle on element/node inspector on React Devtools Component"
+    }
+  } 
 }

--- a/packages/react-devtools-extensions/src/backendManager.js
+++ b/packages/react-devtools-extensions/src/backendManager.js
@@ -152,6 +152,35 @@ function activateBackend(version: string, hook: DevToolsHook) {
     );
   }
 
+  let inspectModeEnabled = false;
+
+  window.addEventListener('message', event => {
+    const { data } = event;
+    const { source, payload } = data || {};
+  
+    if (
+      source !== 'react-devtools-content-script' ||
+      !payload ||
+      payload.type !== 'command' ||
+      !payload.command
+    ) {
+      return;
+    }
+  
+    if (payload.command === 'inspect_node') {
+      inspectModeEnabled = !inspectModeEnabled;
+  
+      if (inspectModeEnabled) {
+        agent.startInspectingNative();
+      } else {
+        agent.stopInspectingNative();
+      }
+    }
+  });
+  
+  
+  
+
   // Let the frontend know that the backend has attached listeners and is ready for messages.
   // This covers the case of syncing saved values after reloading/navigating while DevTools remain open.
   bridge.send('extensionBackendInitialized');

--- a/packages/react-devtools-extensions/src/backendManager.js
+++ b/packages/react-devtools-extensions/src/backendManager.js
@@ -155,9 +155,9 @@ function activateBackend(version: string, hook: DevToolsHook) {
   let inspectModeEnabled = false;
 
   window.addEventListener('message', event => {
-    const { data } = event;
-    const { source, payload } = data || {};
-  
+    const {data} = event;
+    const {source, payload} = data || {};
+
     if (
       source !== 'react-devtools-content-script' ||
       !payload ||
@@ -166,10 +166,10 @@ function activateBackend(version: string, hook: DevToolsHook) {
     ) {
       return;
     }
-  
+
     if (payload.command === 'inspect_node') {
       inspectModeEnabled = !inspectModeEnabled;
-  
+
       if (inspectModeEnabled) {
         agent.startInspectingNative();
       } else {
@@ -177,9 +177,6 @@ function activateBackend(version: string, hook: DevToolsHook) {
       }
     }
   });
-  
-  
-  
 
   // Let the frontend know that the backend has attached listeners and is ready for messages.
   // This covers the case of syncing saved values after reloading/navigating while DevTools remain open.

--- a/packages/react-devtools-extensions/src/background.js
+++ b/packages/react-devtools-extensions/src/background.js
@@ -246,8 +246,7 @@ chrome.runtime.onMessage.addListener((request, sender) => {
 
 chrome.commands.onCommand.addListener(async command => {
   if (command === 'inspect_node') {
-    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    chrome.tabs.sendMessage(tab.id, { command: 'inspect_node' });
+    const [tab] = await chrome.tabs.query({active: true, currentWindow: true});
+    chrome.tabs.sendMessage(tab.id, {command: 'inspect_node'});
   }
 });
-

--- a/packages/react-devtools-extensions/src/background.js
+++ b/packages/react-devtools-extensions/src/background.js
@@ -243,3 +243,11 @@ chrome.runtime.onMessage.addListener((request, sender) => {
     }
   }
 });
+
+chrome.commands.onCommand.addListener(async command => {
+  if (command === 'inspect_node') {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    chrome.tabs.sendMessage(tab.id, { command: 'inspect_node' });
+  }
+});
+

--- a/packages/react-devtools-extensions/src/contentScripts/proxy.js
+++ b/packages/react-devtools-extensions/src/contentScripts/proxy.js
@@ -82,3 +82,16 @@ if (!backendInitialized) {
     }
   }, 500);
 }
+
+chrome.runtime.onMessage.addListener(({ command }) => {
+  if (command) {
+    window.postMessage({
+      source: 'react-devtools-content-script',
+      payload: {
+        type: 'command',
+        command,
+      },
+    }, '*');
+  }
+});
+

--- a/packages/react-devtools-extensions/src/contentScripts/proxy.js
+++ b/packages/react-devtools-extensions/src/contentScripts/proxy.js
@@ -83,15 +83,17 @@ if (!backendInitialized) {
   }, 500);
 }
 
-chrome.runtime.onMessage.addListener(({ command }) => {
+chrome.runtime.onMessage.addListener(({command}) => {
   if (command) {
-    window.postMessage({
-      source: 'react-devtools-content-script',
-      payload: {
-        type: 'command',
-        command,
+    window.postMessage(
+      {
+        source: 'react-devtools-content-script',
+        payload: {
+          type: 'command',
+          command,
+        },
       },
-    }, '*');
+      '*',
+    );
   }
 });
-

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -161,6 +161,8 @@ export default class Agent extends EventEmitter<{
   _persistedSelection: PersistedSelection | null = null;
   _persistedSelectionMatch: PathMatch | null = null;
   _traceUpdatesEnabled: boolean = false;
+  startInspectingNative: () => void;
+  stopInspectingNative: () => void;
 
   constructor(bridge: BackendBridge) {
     super();

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
@@ -34,6 +34,9 @@ export default function setupHighlighter(
   bridge.addListener('startInspectingNative', startInspectingNative);
   bridge.addListener('stopInspectingNative', stopInspectingNative);
 
+  agent.startInspectingNative = startInspectingNative;
+  agent.stopInspectingNative = stopInspectingNative;
+
   function startInspectingNative() {
     registerListenersOnWindow(window);
   }

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectHostNodesToggle.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectHostNodesToggle.js
@@ -43,7 +43,7 @@ export default function InspectHostNodesToggle(): React.Node {
     <Toggle
       onChange={handleChange}
       isChecked={isInspecting}
-      title="Select an element in the page to inspect it">
+      title="Select an element in the page to inspect it (Cmd/Ctrl Shift X)">
       <ButtonIcon type="search" />
     </Toggle>
   );


### PR DESCRIPTION
While tinkering with the devtools, I managed to write some code to create a custom shortcut to inspect the react devtools for chrome! on pressing `cmd+shift+x` on mac the inspect mode gets activated and again pressing it deactivates it!
this could be a handy feature to add!

@hoxyq  thoughts!

https://github.com/facebook/react/assets/72331432/6a94ce0b-e906-4316-81c7-0a42d5037164

