### PR TITLE
Feat:- Inspect react devtools keyboard shortcut added for chrome

### DIFF
--- a/packages/react-devtools-extensions/chrome/manifest.json
+++ b/packages/react-devtools-extensions/chrome/manifest.json
@@ -57,5 +57,14 @@
       ],
       "run_at": "document_start"
     }
-  ]
+  ],
+  "commands": {
+    "inspect_node": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+X",
+        "mac": "Command+Shift+X"
+      },
+      "description": "Toggle the element/node inspector on React Devtools Component"
+    }
+  }
 }

--- a/packages/react-devtools-extensions/firefox/manifest.json
+++ b/packages/react-devtools-extensions/firefox/manifest.json
@@ -53,5 +53,14 @@
       ],
       "run_at": "document_start"
     }
-  ]
+  ],
+  "commands": {
+    "inspect_node": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+X",
+        "mac": "Command+Shift+X"
+      },
+      "description": "Toggle the element/node inspector on React Devtools Component"
+    }
+  } 
 }

--- a/packages/react-devtools-extensions/src/backendManager.js
+++ b/packages/react-devtools-extensions/src/backendManager.js
@@ -152,6 +152,32 @@ function activateBackend(version: string, hook: DevToolsHook) {
     );
   }
 
+  let inspectModeEnabled = false;
+
+  window.addEventListener('message', event => {
+    const {data} = event;
+    const {source, payload} = data || {};
+
+    if (
+      source !== 'react-devtools-content-script' ||
+      !payload ||
+      payload.type !== 'command' ||
+      !payload.command
+    ) {
+      return;
+    }
+
+    if (payload.command === 'inspect_node') {
+      inspectModeEnabled = !inspectModeEnabled;
+
+      if (inspectModeEnabled) {
+        agent.startInspectingNative();
+      } else {
+        agent.stopInspectingNative(true);
+      }
+    }
+  });
+
   // Let the frontend know that the backend has attached listeners and is ready for messages.
   // This covers the case of syncing saved values after reloading/navigating while DevTools remain open.
   bridge.send('extensionBackendInitialized');

--- a/packages/react-devtools-extensions/src/background.js
+++ b/packages/react-devtools-extensions/src/background.js
@@ -243,3 +243,16 @@ chrome.runtime.onMessage.addListener((request, sender) => {
     }
   }
 });
+
+chrome.commands.onCommand.addListener(command => {
+  switch (command) {
+    case 'inspect_node': {
+      chrome.tabs.query({active: true, currentWindow: true}, tabs => {
+        chrome.tabs.sendMessage(tabs[0].id, {command: 'inspect_node'});
+      });
+      return;
+    }
+    default:
+      return;
+  }
+});

--- a/packages/react-devtools-extensions/src/contentScripts/proxy.js
+++ b/packages/react-devtools-extensions/src/contentScripts/proxy.js
@@ -82,3 +82,18 @@ if (!backendInitialized) {
     }
   }, 500);
 }
+
+chrome.runtime.onMessage.addListener(({command}) => {
+  if (command) {
+    window.postMessage(
+      {
+        source: 'react-devtools-content-script',
+        payload: {
+          type: 'command',
+          command,
+        },
+      },
+      '*',
+    );
+  }
+});

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -161,6 +161,7 @@ export default class Agent extends EventEmitter<{
   _persistedSelection: PersistedSelection | null = null;
   _persistedSelectionMatch: PathMatch | null = null;
   _traceUpdatesEnabled: boolean = false;
+  startInspectingNative: () => void;
 
   constructor(bridge: BackendBridge) {
     super();

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
@@ -34,6 +34,9 @@ export default function setupHighlighter(
   bridge.addListener('startInspectingNative', startInspectingNative);
   bridge.addListener('stopInspectingNative', stopInspectingNative);
 
+  agent.startInspectingNative = startInspectingNative;
+  agent.stopInspectingNative = stopInspectingNative;
+
   function startInspectingNative() {
     registerListenersOnWindow(window);
   }

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectHostNodesToggle.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectHostNodesToggle.js
@@ -43,7 +43,7 @@ export default function InspectHostNodesToggle(): React.Node {
     <Toggle
       onChange={handleChange}
       isChecked={isInspecting}
-      title="Select an element in the page to inspect it">
+      title="Select an element in the page to inspect it or Press Ctrl/cmd + Shift + X ">
       <ButtonIcon type="search" />
     </Toggle>
   );


### PR DESCRIPTION
While Tinkering with the Devtools, i sort of come out with this shortcut key command to inspect react dev tools element directly, cmd/ctrl +shift+x works , on pressing it activates the inspect mode and on pressing again it deactivates the same!
This can come very handy while working with dev tools!

Demo below!

https://github.com/facebook/react/assets/72331432/af579c82-ec74-463a-9d5c-869a486a75a8

