### PR TITLE
Update ReadMe file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ You can use React as a `<script>` tag from a [CDN](https://reactjs.org/docs/cdn-
 
 You can find the React documentation [on the website](https://reactjs.org/).  
 
-Check out the [Getting Started](https://reactjs.org/docs/getting-started.html) page for a quick overview.
+Check out the [Getting Started](https://reactjs.org/docs/getting-started.html) (Legacy) page for a quick overview.
+
+Check out the [Quick Start](https://react.dev/learn) (Updated) guide for a quick start.
 
 The documentation is divided into several sections:
 


### PR DESCRIPTION
Added Link to Quick Start page of the new Site and added '(Legacy)' after the old link.

Reason:
As a Reader, it annoyed me that the link to a quickstart of the updated docs was missing.
The reader will have access to both new and old links from the get-go. no need to go to the old site to visit the new one.