### PR TITLE
[Float][Fizz][Fiber] support imagesrcset and imagesizes for `ReactDOM.preload()`

### DIFF
--- a/packages/react-dom-bindings/src/shared/ReactDOMResourceValidation.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMResourceValidation.js
@@ -62,60 +62,6 @@ function propNamesListJoin(
   }
 }
 
-export function validatePreloadArguments(href: mixed, options: mixed) {
-  if (__DEV__) {
-    if (!href || typeof href !== 'string') {
-      const typeOfArg = getValueDescriptorExpectingObjectForWarning(href);
-      console.error(
-        'ReactDOM.preload() expected the first argument to be a string representing an href but found %s instead.',
-        typeOfArg,
-      );
-    } else if (typeof options !== 'object' || options === null) {
-      const typeOfArg = getValueDescriptorExpectingObjectForWarning(options);
-      console.error(
-        'ReactDOM.preload() expected the second argument to be an options argument containing at least an "as" property' +
-          ' specifying the Resource type. It found %s instead. The href for the preload call where this warning originated is "%s".',
-        typeOfArg,
-        href,
-      );
-    } else {
-      const as = options.as;
-      switch (as) {
-        // Font specific validation of options
-        case 'font': {
-          if (options.crossOrigin === 'use-credentials') {
-            console.error(
-              'ReactDOM.preload() was called with an "as" type of "font" and with a "crossOrigin" option of "use-credentials".' +
-                ' Fonts preloading must use crossOrigin "anonymous" to be functional. Please update your font preload to omit' +
-                ' the crossOrigin option or change it to any other value than "use-credentials" (Browsers default all other values' +
-                ' to anonymous mode). The href for the preload call where this warning originated is "%s"',
-              href,
-            );
-          }
-          break;
-        }
-        case 'script':
-        case 'style': {
-          break;
-        }
-
-        // We have an invalid as type and need to warn
-        default: {
-          const typeOfAs = getValueDescriptorExpectingEnumForWarning(as);
-          console.error(
-            'ReactDOM.preload() expected a valid "as" type in the options (second) argument but found %s instead.' +
-              ' Please use one of the following valid values instead: %s. The href for the preload call where this' +
-              ' warning originated is "%s".',
-            typeOfAs,
-            '"style", "font", or "script"',
-            href,
-          );
-        }
-      }
-    }
-  }
-}
-
 export function validatePreinitArguments(href: mixed, options: mixed) {
   if (__DEV__) {
     if (!href || typeof href !== 'string') {

--- a/packages/react-dom/src/shared/ReactDOMTypes.js
+++ b/packages/react-dom/src/shared/ReactDOMTypes.js
@@ -16,6 +16,8 @@ export type PreloadOptions = {
   type?: string,
   nonce?: string,
   fetchPriority?: 'high' | 'low' | 'auto',
+  imageSrcSet?: string,
+  imageSizes?: string,
 };
 export type PreinitOptions = {
   as: string,

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -1190,8 +1190,8 @@ describe('ReactFlightDOM', () => {
       root.render(<App />);
     });
     expect(document.head.innerHTML).toBe(
-      '<link href="before" rel="preload" as="style">' +
-        '<link href="after" rel="preload" as="style">',
+      '<link rel="preload" as="style" href="before">' +
+        '<link rel="preload" as="style" href="after">',
     );
     expect(container.innerHTML).toBe('<p>hello world</p>');
   });

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -1101,7 +1101,7 @@ describe('ReactFlightDOMBrowser', () => {
       root.render(<App />);
     });
     expect(document.head.innerHTML).toBe(
-      '<link href="before" rel="preload" as="style">',
+      '<link rel="preload" as="style" href="before">',
     );
     expect(container.innerHTML).toBe('<p>hello world</p>');
   });


### PR DESCRIPTION
For float methods the href argument is usually all we need to uniquely key the request. However when preloading responsive images it is possible that you may need more than one preload for differing imagesizes attributes. When using imagesrcset for preloads the href attribute acts more like a fallback href. For keying purposes the imagesrcset becomes the primary key conceptually.

This change updates the keying logic for `ReactDOM.preload()` when you pass `{as: "image"}`

1. If `options.imageSrcSet` is a non-emtpy string the key is defined as `options.imageSrcSet + options.imageSizes`. The `href` argument is still required but does not participate in keying.
2. If `options.imageSrcSet` is empty, missing, or an invalid format the key is defined as the `href`. Changing the `options.imageSizes` does not affect the key as this option is inert when not using `options.imageSrcSet`

Additionally, currently there is a bug in webkit (Safari) that causes preload links to fail to use imageSrcSet and fallback to href even when the browser will correctly resolve srcset on an `<img>` tag. Because the drawbacks of preloading the wrong image (href over imagesrcset) in a modern browser outweight the drawbacks of not preloading anything for responsive images in browsers that do not support srcset at all we will omit the `href` attribute whenever `options.imageSrcSet` is provided. We still require you provide an href since we want to be able to revert this behavior once all major browsers support it

bug link: https://bugs.webkit.org/show_bug.cgi?id=231150