### PR TITLE
fix[devtools]: display NaN as string in values

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
@@ -255,6 +255,8 @@ export default function KeyValue({
       displayValue = 'null';
     } else if (value === undefined) {
       displayValue = 'undefined';
+    } else if (isNaN(value)) {
+      displayValue = 'NaN';
     }
 
     let shouldDisplayValueAsLink = false;


### PR DESCRIPTION
## Summary

>Warning: Received NaN for the `children` attribute. If this is expected, cast the value to a string.

Fixes this warning, when we try to display NaN as NaN in key-value list.