### PR TITLE
[eslint-plugin-react-hooks] fix handling of local type aliases

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -7681,8 +7681,10 @@ const testsFlow = {
       code: normalizeIndent`
         function Component() {
           type LocalTypeAlias = string;
+          opaque type LocalOpaqueType = string;
           useEffect(() => {
             const foo: LocalTypeAlias = "foo";
+            const bar: LocalOpaqueType = "bar";
           }, []);
         }
       `,

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -7677,6 +7677,16 @@ const testsFlow = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        function Component() {
+          type LocalTypeAlias = string;
+          useEffect(() => {
+            const foo: LocalTypeAlias = "foo";
+          }, []);
+        }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -446,7 +446,7 @@ export default {
           if (def.node != null && def.node.init === node.parent) {
             continue;
           }
-          // Ignore Flow type parameters
+          // Ignore Flow type parameters and local type aliases
           if (def.type === 'TypeParameter' || def.node.type === 'TypeAlias') {
             continue;
           }

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -447,7 +447,7 @@ export default {
             continue;
           }
           // Ignore Flow type parameters
-          if (def.type === 'TypeParameter') {
+          if (def.type === 'TypeParameter' || def.node.type === 'TypeAlias') {
             continue;
           }
 


### PR DESCRIPTION
The added test case is okay as the binding refers to a local type alias, not a value.
