### PR TITLE
fix[devtools/standalone]: update webpack configurations

### DIFF
--- a/packages/react-devtools-core/package.json
+++ b/packages/react-devtools-core/package.json
@@ -29,6 +29,10 @@
     "ws": "^7"
   },
   "devDependencies": {
-    "cross-env": "^3.1.4"
+    "cross-env": "^3.1.4",
+    "process": "0.11.10",
+    "webpack": "^5.82.1",
+    "webpack-cli": "^5.1.1",
+    "workerize-loader": "^2.0.2"
   }
 }

--- a/packages/react-devtools-core/webpack.backend.js
+++ b/packages/react-devtools-core/webpack.backend.js
@@ -39,7 +39,7 @@ process.env.BABEL_CONFIG_ADDITIONAL_TARGETS = JSON.stringify({
 
 module.exports = {
   mode: __DEV__ ? 'development' : 'production',
-  devtool: __DEV__ ? 'cheap-module-eval-source-map' : 'source-map',
+  devtool: __DEV__ ? 'eval-cheap-module-source-map' : 'source-map',
   entry: {
     backend: './src/backend.js',
   },

--- a/packages/react-devtools-core/webpack.standalone.js
+++ b/packages/react-devtools-core/webpack.standalone.js
@@ -47,7 +47,7 @@ const babelOptions = {
 
 module.exports = {
   mode: __DEV__ ? 'development' : 'production',
-  devtool: __DEV__ ? 'cheap-module-eval-source-map' : 'source-map',
+  devtool: __DEV__ ? 'eval-cheap-module-source-map' : 'source-map',
   target: 'electron-main',
   entry: {
     standalone: './src/standalone.js',
@@ -56,8 +56,13 @@ module.exports = {
     path: __dirname + '/dist',
     filename: '[name].js',
     chunkFilename: '[name].chunk.js',
-    library: '[name]',
-    libraryTarget: 'commonjs2',
+    library: {
+      type: 'commonjs2',
+    },
+  },
+  externals: {
+    bufferutil: 'commonjs bufferutil',
+    'utf-8-validate': 'commonjs utf-8-validate',
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
Overlooked when was working on https://github.com/facebook/react/pull/26887.

- Added `webpack` packages as dev dependencies to `react-devtools-core`, because it calls webpack to build
- Added `process` package as dev dependency, because it is injected with `ProvidePlugin` (otherwise fails with Safari usage)
- Updated rule for sourcemaps
- Listed required externals for `standalone` build

Tested on RN application & Safari