### PR TITLE
[Fizz] Allow passing a reason to `abortStream`

### DIFF
--- a/packages/react-server-dom-fb/src/ReactDOMServerFB.js
+++ b/packages/react-server-dom-fb/src/ReactDOMServerFB.js
@@ -79,8 +79,8 @@ function renderToStream(children: ReactNodeList, options: Options): Stream {
   };
 }
 
-function abortStream(stream: Stream): void {
-  abort(stream.request);
+function abortStream(stream: Stream, reason: mixed): void {
+  abort(stream.request, reason);
 }
 
 function renderNextChunk(stream: Stream): string {

--- a/packages/react-server-dom-fb/src/__tests__/ReactDOMServerFB-test.internal.js
+++ b/packages/react-server-dom-fb/src/__tests__/ReactDOMServerFB-test.internal.js
@@ -195,4 +195,23 @@ describe('ReactDOMServerFB', () => {
       'The render was aborted by the server without a reason.',
     ]);
   });
+
+  it('should allow setting an abort reason', () => {
+    const errors = [];
+    const stream = ReactDOMServer.renderToStream(
+      <div>
+        <Suspense fallback={<div>Loading</div>}>
+          <InfiniteSuspend />
+        </Suspense>
+      </div>,
+      {
+        onError(x) {
+          errors.push(x.message);
+        },
+      },
+    );
+    const reason = 'Test abort reason';
+    ReactDOMServer.abortStream(stream, new Error(reason));
+    expect(errors).toEqual([reason]);
+  });
 });


### PR DESCRIPTION
## Summary

Currently `ReactFizzServer.abort` allows you to pass in the a `reason` error, which then gets passed to the `onError` handler for each task that ends up getting aborted. This adds in the ability to pass down that same `reason` error to `ReactDOMServerFB.abortStream` as well.

## How did you test this change?

Added a test case to ReactDOMServerFB-test.internal.js
