### PR TITLE
Fix react checkbox input synthetic event

### DIFF
--- a/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
@@ -272,6 +272,18 @@ function processDispatchQueueItemsInOrder(
   }
 }
 
+function checkEventValidation(event: ReactSyntheticEvent) {
+  if (
+    event.type === 'change' &&
+    event.nativeEvent.type === 'click' &&
+    event.nativeEvent.defaultPrevented
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
 export function processDispatchQueue(
   dispatchQueue: DispatchQueue,
   eventSystemFlags: EventSystemFlags,
@@ -279,10 +291,13 @@ export function processDispatchQueue(
   const inCapturePhase = (eventSystemFlags & IS_CAPTURE_PHASE) !== 0;
   for (let i = 0; i < dispatchQueue.length; i++) {
     const {event, listeners} = dispatchQueue[i];
-    processDispatchQueueItemsInOrder(event, listeners, inCapturePhase);
-    //  event system doesn't use pooling.
+    if (checkEventValidation(event)) {
+      processDispatchQueueItemsInOrder(event, listeners, inCapturePhase);
+      // event system doesn't use pooling.
+    }
   }
   // This would be a good time to rethrow if any of the event handlers threw.
+
   rethrowCaughtError();
 }
 

--- a/packages/react-dom/src/events/plugins/__tests__/ChangeEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/ChangeEventPlugin-test.js
@@ -235,6 +235,30 @@ describe('ChangeEventPlugin', () => {
     expect(called).toBe(2);
   });
 
+  it('should not trigger change event for checkbox input when preventDefault is called in onClick', () => {
+    const handleReactChange = jest.fn();
+    const handleNativeChange = jest.fn();
+
+    const node = ReactDOM.render(
+      <input
+        type="checkbox"
+        defaultChecked={true}
+        onClick={event => {
+          event.preventDefault();
+        }}
+        onChange={handleReactChange}
+      />,
+      container,
+    );
+
+    node.addEventListener('change', handleNativeChange);
+
+    node.click();
+
+    expect(handleNativeChange).toHaveBeenCalledTimes(0);
+    expect(handleReactChange).toHaveBeenCalledTimes(0);
+  });
+
   it('should not fire change setting the value programmatically', () => {
     let called = 0;
 


### PR DESCRIPTION
Closes https://github.com/facebook/react/issues/27128

Been weeks, i Discovered a strange activity of React while we try to render a input type of `checkbox`, when i have both an `onClick` handler and as well as an `onChange` handler, if i have added a `preventDefault` function, that should behave as it should not allow the onChange event to kick in! strangely it is not the behaviour it is producing, to confirm the same, i tried to reproduce the same Behaviour with Vanilla JavaScript and it did not behaved the same as of React. 

**Behaviour with Current React version**
on the Initial render, the OnChange event function gets called up , which should not be the case 

https://github.com/facebook/react/assets/72331432/7e6a3627-6f29-461a-bc74-fb68f6a5ca28



**Codesandboxlink below for the error reproduction**
https://codesandbox.io/s/bitter-forest-gytgph?file=/src/App.js


**Behaviour with Vanilla JavaScript**

https://github.com/facebook/react/assets/72331432/13d6ba5d-796b-4986-8d3e-8f9d77911690




The conclusion that i came to after seeing this, React is sort of trying to retrieve the checked value of the Node, even before our `preventDefault` function, is called.

In my mental model,  Initially the value of the `node.checked` seems to be true, As soon as we hit the first click this seem to generate something like:-

```
prevValue = false,
nextValue = true,
```
and on next subsequent clicks on the checkbox, our `change` event does not get fired since the value looks like
```
prevValue = true,
nextValue = true,
```

The solution seems to be pretty straight forward i went on to just add a condition to check for such when the prevent is there to just ignore the `onChange` event, I have tested the behaviour across chrome, safari and firefox and it seemed to work consistently across all! the test according to me is also passing as you can see below from the test snapshot
<img width="1435" alt="webstorm test pass image" src="https://github.com/facebook/react/assets/72331432/84c0a3fe-fceb-4c68-8ef1-2b40e5d82e52">

Working preview of the same across different Browsers

**Chrome**

https://github.com/facebook/react/assets/72331432/eb24b801-6ad5-4497-ab6a-c4b5d8ba9909

**Firefox**

https://github.com/facebook/react/assets/72331432/e9c0a512-ab52-4e7e-94ff-4327feaaa5ea

**Safari**


https://github.com/facebook/react/assets/72331432/bca07e0b-e1f1-4f61-9696-d86e40649fb4


