### PR TITLE
Fix: update other radios tracked value in one group when one is updated to be checked

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -2358,4 +2358,82 @@ describe('ReactDOMInput', () => {
     expect(log).toEqual(['']);
     expect(node.value).toBe('a');
   });
+
+  it('#26876: After the `checked` props updated not in the event handler task, `onChange` should still be called when the unchecked radio clicked', async () => {
+    const eventHandler = jest.fn();
+    ReactDOM.render(
+      <div>
+        <input
+          type="radio"
+          name="a"
+          value="1"
+          checked={true}
+          onChange={eventHandler}
+        />
+        <input
+          type="radio"
+          name="a"
+          value="2"
+          checked={false}
+          onChange={eventHandler}
+        />
+      </div>,
+      container,
+    );
+
+    ReactDOM.render(
+      <div>
+        <input
+          type="radio"
+          name="a"
+          value="1"
+          checked={false}
+          onChange={eventHandler}
+        />
+        <input
+          type="radio"
+          name="a"
+          value="2"
+          checked={true}
+          onChange={eventHandler}
+        />
+      </div>,
+      container,
+    );
+
+    ReactDOM.render(
+      <div>
+        <input
+          type="radio"
+          name="a"
+          value="1"
+          checked={true}
+          onChange={eventHandler}
+        />
+        <input
+          type="radio"
+          name="a"
+          value="2"
+          checked={false}
+          onChange={eventHandler}
+        />
+      </div>,
+      container,
+    );
+
+    const radio1 = container.querySelector('input[name="a"][value="1"]');
+    const radio2 = container.querySelector('input[name="a"][value="2"]');
+
+    expect(eventHandler).not.toHaveBeenCalled();
+
+    // This next line isn't necessary in a proper browser environment, but
+    // jsdom doesn't uncheck the others in a group (because they are not yet
+    // sharing a parent), which makes this whole test a little less effective.
+    setUntrackedChecked.call(radio1, false);
+    setUntrackedChecked.call(radio2, true);
+
+    dispatchEventOnNode(radio2, 'click');
+
+    expect(eventHandler).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Fix #26876, which is caused by not updating tracked values. Please see [here](https://github.com/facebook/react/issues/26876#issuecomment-1611037027) for the investigation details. 

The root is, when one radio is changed to be checked (by updating the `checked` prop), the previously checked one won't update its tracked value (will be still  `'true'`) if it's one of the previous siblings. 

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

Testing Steps (refer to but not exactly follow the steps of reproduction):
- Two radios with the same name, initially, radio1 is checked, and radio2 is unchecked. (radio1 is the previous sibling of radio2)
- Update the `checked` props to make radio1 unchecked, and radio2 checked.
- Then update the `checked` props to make radio1 checked, and radio2 unchecked.
- Click radio2, the `onChange` handler should be called after fixing the issue.

Any feedback and suggestions will be appreciated. cc @eps1lon @sebmarkbage @acdlite 