### PR TITLE
Revert "Fix: Detect infinite update loops caused by render phase updates (#26625)"

### DIFF
--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1620,64 +1620,6 @@ describe('ReactUpdates', () => {
     });
   });
 
-  it("does not infinite loop if there's a synchronous render phase update on another component", () => {
-    let setState;
-    function App() {
-      const [, _setState] = React.useState(0);
-      setState = _setState;
-      return <Child />;
-    }
-
-    function Child(step) {
-      // This will cause an infinite update loop, and a warning in dev.
-      setState(n => n + 1);
-      return null;
-    }
-
-    const container = document.createElement('div');
-    const root = ReactDOMClient.createRoot(container);
-
-    expect(() => {
-      expect(() => ReactDOM.flushSync(() => root.render(<App />))).toThrow(
-        'Maximum update depth exceeded',
-      );
-    }).toErrorDev(
-      'Warning: Cannot update a component (`App`) while rendering a different component (`Child`)',
-    );
-  });
-
-  it("does not infinite loop if there's an async render phase update on another component", async () => {
-    let setState;
-    function App() {
-      const [, _setState] = React.useState(0);
-      setState = _setState;
-      return <Child />;
-    }
-
-    function Child(step) {
-      // This will cause an infinite update loop, and a warning in dev.
-      setState(n => n + 1);
-      return null;
-    }
-
-    const container = document.createElement('div');
-    const root = ReactDOMClient.createRoot(container);
-
-    await expect(async () => {
-      let error;
-      try {
-        await act(() => {
-          React.startTransition(() => root.render(<App />));
-        });
-      } catch (e) {
-        error = e;
-      }
-      expect(error.message).toMatch('Maximum update depth exceeded');
-    }).toErrorDev(
-      'Warning: Cannot update a component (`App`) while rendering a different component (`Child`)',
-    );
-  });
-
   // TODO: Replace this branch with @gate pragmas
   if (__DEV__) {
     it('warns about a deferred infinite update loop with useEffect', async () => {

--- a/packages/react-reconciler/src/ReactFiberRootScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberRootScheduler.js
@@ -139,18 +139,6 @@ export function ensureRootIsScheduled(root: FiberRoot): void {
   }
 }
 
-function unscheduleAllRoots() {
-  // This is only done in a fatal error situation, as a last resort to prevent
-  // an infinite render loop.
-  let root = firstScheduledRoot;
-  while (root !== null) {
-    const next = root.next;
-    root.next = null;
-    root = next;
-  }
-  firstScheduledRoot = lastScheduledRoot = null;
-}
-
 export function flushSyncWorkOnAllRoots() {
   // This is allowed to be called synchronously, but the caller should check
   // the execution context first.
@@ -181,47 +169,10 @@ function flushSyncWorkAcrossRoots_impl(onlyLegacy: boolean) {
 
   // There may or may not be synchronous work scheduled. Let's check.
   let didPerformSomeWork;
-  let nestedUpdatePasses = 0;
   let errors: Array<mixed> | null = null;
   isFlushingWork = true;
   do {
     didPerformSomeWork = false;
-
-    // This outer loop re-runs if performing sync work on a root spawns
-    // additional sync work. If it happens too many times, it's very likely
-    // caused by some sort of infinite update loop. We already have a loop guard
-    // in place that will trigger an error on the n+1th update, but it's
-    // possible for that error to get swallowed if the setState is called from
-    // an unexpected place, like during the render phase. So as an added
-    // precaution, we also use a guard here.
-    //
-    // Ideally, there should be no known way to trigger this synchronous loop.
-    // It's really just here as a safety net.
-    //
-    // This limit is slightly larger than the one that throws inside setState,
-    // because that one is preferable because it includes a componens stack.
-    if (++nestedUpdatePasses > 60) {
-      // This is a fatal error, so we'll unschedule all the roots.
-      unscheduleAllRoots();
-      // TODO: Change this error message to something different to distinguish
-      // it from the one that is thrown from setState. Those are less fatal
-      // because they usually will result in the bad component being unmounted,
-      // and an error boundary being triggered, rather than us having to
-      // forcibly stop the entire scheduler.
-      const infiniteUpdateError = new Error(
-        'Maximum update depth exceeded. This can happen when a component ' +
-          'repeatedly calls setState inside componentWillUpdate or ' +
-          'componentDidUpdate. React limits the number of nested updates to ' +
-          'prevent infinite loops.',
-      );
-      if (errors === null) {
-        errors = [infiniteUpdateError];
-      } else {
-        errors.push(infiniteUpdateError);
-      }
-      break;
-    }
-
     let root = firstScheduledRoot;
     while (root !== null) {
       if (onlyLegacy && root.tag !== LegacyRoot) {

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -69,16 +69,12 @@ const createMatcherFor = (consoleMethod, matcherName) =>
         (message.includes('\n    in ') || message.includes('\n    at '));
 
       const consoleSpy = (format, ...args) => {
+        // Ignore uncaught errors reported by jsdom
+        // and React addendums because they're too noisy.
         if (
-          // Ignore uncaught errors reported by jsdom
-          // and React addendums because they're too noisy.
-          (!logAllErrors &&
-            consoleMethod === 'error' &&
-            shouldIgnoreConsoleError(format, args)) ||
-          // Ignore error objects passed to console.error, which we sometimes
-          // use as a fallback behavior, like when reportError
-          // isn't available.
-          typeof format !== 'string'
+          !logAllErrors &&
+          consoleMethod === 'error' &&
+          shouldIgnoreConsoleError(format, args)
         ) {
           return;
         }


### PR DESCRIPTION
This reverts commit 822386f252fd1f0e949efa904a1ed790133329f7.

This broke a number of tests when synced internally. We'll need to investigate the breakages before relanding this.