### PR TITLE
[DOM] Add unstable_batchedUpdates to server-rendering-stub

### DIFF
--- a/packages/react-dom/server-rendering-stub.js
+++ b/packages/react-dom/server-rendering-stub.js
@@ -23,4 +23,5 @@ export {
   preload,
   preinit,
   experimental_useFormStatus,
+  unstable_batchedUpdates,
 } from './src/server/ReactDOMServerRenderingStub';

--- a/packages/react-dom/src/__tests__/react-dom-server-rendering-stub-test.js
+++ b/packages/react-dom/src/__tests__/react-dom-server-rendering-stub-test.js
@@ -33,7 +33,6 @@ describe('react-dom-server-rendering-stub', () => {
     expect(ReactDOM.hydrate).toBe(undefined);
     expect(ReactDOM.render).toBe(undefined);
     expect(ReactDOM.unmountComponentAtNode).toBe(undefined);
-    expect(ReactDOM.unstable_batchedUpdates).toBe(undefined);
     expect(ReactDOM.unstable_createEventHandle).toBe(undefined);
     expect(ReactDOM.unstable_renderSubtreeIntoContainer).toBe(undefined);
     expect(ReactDOM.unstable_runWithPriority).toBe(undefined);

--- a/packages/react-dom/src/server/ReactDOMServerRenderingStub.js
+++ b/packages/react-dom/src/server/ReactDOMServerRenderingStub.js
@@ -31,3 +31,13 @@ export function flushSync() {
       ' to not call flushSync no the server.',
   );
 }
+
+// on the server we just call the callback because there is
+// not update mechanism. Really this should not be called on the
+// server but since the semantics are generally clear enough we
+// can provide this trivial implementation.
+function batchedUpdates<A, R>(fn: A => R, a: A): R {
+  return fn(a);
+}
+
+export {batchedUpdates as unstable_batchedUpdates};


### PR DESCRIPTION
`unstable_batchedUpdates` shouldn't really be called on the server but the semantics are clear enough and we can provide a trivial implementation that calls the provided callback so we are adding it to the server-rendering-stub.

This means we will also keep it around when we make the top level react-dom exports match the server-rendering-stub in the next major