### PR TITLE
Don't transpile async/await in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@babel/plugin-syntax-jsx": "^7.10.4",
     "@babel/plugin-syntax-typescript": "^7.14.5",
     "@babel/plugin-transform-arrow-functions": "^7.10.4",
-    "@babel/plugin-transform-async-to-generator": "^7.10.4",
     "@babel/plugin-transform-block-scoped-functions": "^7.10.4",
     "@babel/plugin-transform-block-scoping": "^7.11.1",
     "@babel/plugin-transform-classes": "^7.10.4",

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -17,9 +17,6 @@ const pathToBabel = path.join(
 const pathToBabelPluginReplaceConsoleCalls = require.resolve(
   '../babel/transform-replace-console-calls'
 );
-const pathToBabelPluginAsyncToGenerator = require.resolve(
-  '@babel/plugin-transform-async-to-generator'
-);
 const pathToTransformInfiniteLoops = require.resolve(
   '../babel/transform-prevent-infinite-loops'
 );
@@ -78,7 +75,7 @@ module.exports = {
       const isInDevToolsPackages = !!filePath.match(
         /\/packages\/react-devtools.*\//
       );
-      const testOnlyPlugins = [pathToBabelPluginAsyncToGenerator];
+      const testOnlyPlugins = [];
       const sourceOnlyPlugins = [];
       if (process.env.NODE_ENV === 'development' && !isInDevToolsPackages) {
         sourceOnlyPlugins.push(pathToBabelPluginReplaceConsoleCalls);


### PR DESCRIPTION
Modern runtimes support native async/await, as does the version of Node we use for our tests. To match how most of our users run React, this disables the transpilation of async/await in our test suite.