### PR TITLE
When selecting a package variant from an export map we should favor n…

### DIFF
--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -50,11 +50,12 @@
     "./client": "./client.js",
     "./server": {
       "workerd": "./server.edge.js",
-      "edge-light": "./server.edge.js",
       "bun": "./server.bun.js",
       "deno": "./server.browser.js",
       "worker": "./server.browser.js",
       "browser": "./server.browser.js",
+      "node": "./server.node.js",
+      "edge-light": "./server.edge.js",
       "default": "./server.node.js"
     },
     "./server.browser": "./server.browser.js",
@@ -63,10 +64,11 @@
     "./server.node": "./server.node.js",
     "./static": {
       "workerd": "./static.edge.js",
-      "edge-light": "./static.edge.js",
       "deno": "./static.browser.js",
       "worker": "./static.browser.js",
       "browser": "./static.browser.js",
+      "node": "./static.node.js",
+      "edge-light": "./static.edge.js",
       "default": "./static.node.js"
     },
     "./static.browser": "./static.browser.js",

--- a/packages/react-server-dom-webpack/package.json
+++ b/packages/react-server-dom-webpack/package.json
@@ -33,13 +33,13 @@
     "./plugin": "./plugin.js",
     "./client": {
       "workerd": "./client.edge.js",
-      "edge-light": "./client.edge.js",
       "deno": "./client.edge.js",
       "worker": "./client.edge.js",
       "node": {
         "webpack": "./client.node.js",
         "default": "./client.node.unbundled.js"
       },
+      "edge-light": "./client.edge.js",
       "browser": "./client.browser.js",
       "default": "./client.browser.js"
     },
@@ -50,12 +50,12 @@
     "./server": {
       "react-server": {
         "workerd": "./server.edge.js",
-        "edge-light": "./server.edge.js",
         "deno": "./server.browser.js",
         "node": {
           "webpack": "./server.node.js",
           "default": "./server.node.unbundled.js"
         },
+        "edge-light": "./server.edge.js",
         "browser": "./server.browser.js"
       },
       "default": "./server.js"


### PR DESCRIPTION
When selecting a package variant from an export map we should favor node over edge-light

edge-light represents a runtime with some minimal set of web apis generally found across edge runtimes. However some environments might be both edge-light compatible and node compatible and (node is adding many web APIs) and when both conditions exist we want to favor the node implementations. A followup to this change will add the web streams APIs to Flight and Fizz so the node version exports the same interfaces for web streams that edge does in addition to the node specific implementations.