### PR TITLE
Detect and warn about native async function components in development

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactUse-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUse-test.js
@@ -1639,13 +1639,20 @@ describe('ReactUse', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(() => {
-      root.render(
-        <ErrorBoundary>
-          <AsyncClientComponent />
-        </ErrorBoundary>,
-      );
-    });
+    await expect(async () => {
+      await act(() => {
+        root.render(
+          <ErrorBoundary>
+            <AsyncClientComponent />
+          </ErrorBoundary>,
+        );
+      });
+    }).toErrorDev([
+      'async/await is not yet supported in Client Components, only ' +
+        'Server Components. This error is often caused by accidentally ' +
+        "adding `'use client'` to a module that was originally written " +
+        'for the server.',
+    ]);
     assertLog([
       'async/await is not yet supported in Client Components, only Server ' +
         'Components. This error is often caused by accidentally adding ' +
@@ -1685,13 +1692,20 @@ describe('ReactUse', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(() => {
-      root.render(
-        <ErrorBoundary>
-          <AsyncClientComponent />
-        </ErrorBoundary>,
-      );
-    });
+    await expect(async () => {
+      await act(() => {
+        root.render(
+          <ErrorBoundary>
+            <AsyncClientComponent />
+          </ErrorBoundary>,
+        );
+      });
+    }).toErrorDev([
+      'async/await is not yet supported in Client Components, only ' +
+        'Server Components. This error is often caused by accidentally ' +
+        "adding `'use client'` to a module that was originally written " +
+        'for the server.',
+    ]);
     assertLog([
       'async/await is not yet supported in Client Components, only Server ' +
         'Components. This error is often caused by accidentally adding ' +
@@ -1708,5 +1722,47 @@ describe('ReactUse', () => {
         "`'use client'` to a module that was originally written for " +
         'the server.',
     );
+  });
+
+  test('warn if async client component calls a hook (e.g. useState)', async () => {
+    async function AsyncClientComponent() {
+      useState();
+      return <Text text="Hi" />;
+    }
+
+    const root = ReactNoop.createRoot();
+    await expect(async () => {
+      await act(() => {
+        startTransition(() => {
+          root.render(<AsyncClientComponent />);
+        });
+      });
+    }).toErrorDev([
+      'Hooks are not supported inside an async component. This ' +
+        "error is often caused by accidentally adding `'use client'` " +
+        'to a module that was originally written for the server.',
+    ]);
+  });
+
+  test('warn if async client component calls a hook (e.g. use)', async () => {
+    const promise = Promise.resolve();
+
+    async function AsyncClientComponent() {
+      use(promise);
+      return <Text text="Hi" />;
+    }
+
+    const root = ReactNoop.createRoot();
+    await expect(async () => {
+      await act(() => {
+        startTransition(() => {
+          root.render(<AsyncClientComponent />);
+        });
+      });
+    }).toErrorDev([
+      'Hooks are not supported inside an async component. This ' +
+        "error is often caused by accidentally adding `'use client'` " +
+        'to a module that was originally written for the server.',
+    ]);
   });
 });

--- a/packages/shared/ReactComponentStackFrame.js
+++ b/packages/shared/ReactComponentStackFrame.js
@@ -132,7 +132,15 @@ export function describeNativeComponentFrame(
       // TODO(luna): This will currently only throw if the function component
       // tries to access React/ReactDOM/props. We should probably make this throw
       // in simple components too
-      fn();
+      const maybePromise = fn();
+
+      // If the function component returns a promise, it's likely an async
+      // component, which we don't yet support. Attach a noop catch handler to
+      // silence the error.
+      // TODO: Implement component stacks for async client components?
+      if (maybePromise && typeof maybePromise.catch === 'function') {
+        maybePromise.catch(() => {});
+      }
     }
   } catch (sample) {
     // This is inlined manually because closure doesn't do it for us.

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -467,5 +467,6 @@
   "479": "Cannot update optimistic state while rendering.",
   "480": "File/Blob fields are not yet supported in progressive forms. It probably means you are closing over binary data or FormData in a Server Action.",
   "481": "Tried to encode a Server Action from a different instance than the encoder is from. This is a bug in React.",
-  "482": "async/await is not yet supported in Client Components, only Server Components. This error is often caused by accidentally adding `'use client'` to a module that was originally written for the server."
+  "482": "async/await is not yet supported in Client Components, only Server Components. This error is often caused by accidentally adding `'use client'` to a module that was originally written for the server.",
+  "483": "Hooks are not supported inside an async component. This error is often caused by accidentally adding `'use client'` to a module that was originally written for the server."
 }


### PR DESCRIPTION
Adds a development warning to complement the error introduced by https://github.com/facebook/react/pull/27019.

We can detect and warn about async client components by checking the prototype of the function. This won't work for environments where async functions are transpiled, but for native async functions, it allows us to log an earlier warning during development, including in cases that don't trigger the infinite loop guard added in https://github.com/facebook/react/pull/27019. It does not supersede the infinite loop guard, though, because that mechanism also prevents the app from crashing.

I also added a warning for calling a hook inside an async function. This one fires even during a transition. We could add a corresponding warning to Flight, since hooks are not allowed in async Server Components, either. (Though in both environments, this is better handled by a lint rule.)