### PR TITLE
updated getting started link to dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ React is a JavaScript library for building user interfaces.
 * **Component-Based:** Build encapsulated components that manage their own state, then compose them to make complex UIs. Since component logic is written in JavaScript instead of templates, you can easily pass rich data through your app and keep the state out of the DOM.
 * **Learn Once, Write Anywhere:** We don't make assumptions about the rest of your technology stack, so you can develop new features in React without rewriting existing code. React can also render on the server using Node and power mobile apps using [React Native](https://reactnative.dev/).
 
-[Learn how to use React in your project](https://reactjs.org/docs/getting-started.html).
+[Learn how to use React in your project](https://create-react-app.dev/docs/getting-started/).
 
 ## Installation
 


### PR DESCRIPTION


## Summary

Getting started link now directs to create-react-app.dev.

## How did you test this change?

Added the link to new React-dev docs rather than legacy.
