### PR TITLE
fix[devtools/inspect]: null check memoized props before trying to call hasOwnProperty

### DIFF
--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -3280,7 +3280,7 @@ export function attach(
     };
 
     if (enableStyleXFeatures) {
-      if (memoizedProps.hasOwnProperty('xstyle')) {
+      if (memoizedProps != null && memoizedProps.hasOwnProperty('xstyle')) {
         plugins.stylex = getStyleXData(memoizedProps.xstyle);
       }
     }


### PR DESCRIPTION
Simple check to avoid `TypeError`, quite rare case, but still.