### PR TITLE
fix #27092 - Get the installed proxy in HTMLInputElement.prototype.value before calling it

### DIFF
--- a/packages/react-dom-bindings/src/client/inputValueTracking.js
+++ b/packages/react-dom-bindings/src/client/inputValueTracking.js
@@ -104,6 +104,7 @@ function trackValueOnNode(node: any): ?ValueTracker {
         valueField,
       );
 
+      // Fall back to descriptor stored at installation time when there is no current descriptor
       if (!currentDescriptor || !currentDescriptor.set) {
         set.call(this, value);
         return;

--- a/packages/react-dom-bindings/src/client/inputValueTracking.js
+++ b/packages/react-dom-bindings/src/client/inputValueTracking.js
@@ -87,7 +87,7 @@ function trackValueOnNode(node: any): ?ValueTracker {
 
       // Fall back to descriptor stored at installation time when there is no current descriptor
       if (!currentGetter) {
-        return get.call(this)
+        return get.call(this);
       }
 
       return currentGetter.call(this);

--- a/packages/react-dom-bindings/src/client/inputValueTracking.js
+++ b/packages/react-dom-bindings/src/client/inputValueTracking.js
@@ -75,12 +75,15 @@ function trackValueOnNode(node: any): ?ValueTracker {
   ) {
     return;
   }
-  const {get, set} = descriptor;
   Object.defineProperty(node, valueField, {
     configurable: true,
     // $FlowFixMe[missing-this-annot]
     get: function () {
-      return get.call(this);
+      const descriptor = Object.getOwnPropertyDescriptor(
+        node.constructor.prototype,
+        valueField,
+      );
+      return descriptor.get.call(this);
     },
     // $FlowFixMe[missing-local-annot]
     // $FlowFixMe[missing-this-annot]
@@ -89,7 +92,11 @@ function trackValueOnNode(node: any): ?ValueTracker {
         checkFormFieldValueStringCoercion(value);
       }
       currentValue = '' + value;
-      set.call(this, value);
+      const descriptor = Object.getOwnPropertyDescriptor(
+        node.constructor.prototype,
+        valueField,
+      );
+      descriptor.set.call(this, value);
     },
   });
   // We could've passed this the first time

--- a/packages/react-dom-bindings/src/client/inputValueTracking.js
+++ b/packages/react-dom-bindings/src/client/inputValueTracking.js
@@ -79,11 +79,11 @@ function trackValueOnNode(node: any): ?ValueTracker {
     configurable: true,
     // $FlowFixMe[missing-this-annot]
     get: function () {
-      const descriptor = Object.getOwnPropertyDescriptor(
+      const currentDescriptor = Object.getOwnPropertyDescriptor(
         node.constructor.prototype,
         valueField,
       );
-      return descriptor.get.call(this);
+      return currentDescriptor.get.call(this);
     },
     // $FlowFixMe[missing-local-annot]
     // $FlowFixMe[missing-this-annot]
@@ -92,11 +92,11 @@ function trackValueOnNode(node: any): ?ValueTracker {
         checkFormFieldValueStringCoercion(value);
       }
       currentValue = '' + value;
-      const descriptor = Object.getOwnPropertyDescriptor(
+      const currentDescriptor = Object.getOwnPropertyDescriptor(
         node.constructor.prototype,
         valueField,
       );
-      descriptor.set.call(this, value);
+      currentDescriptor.set.call(this, value);
     },
   });
   // We could've passed this the first time

--- a/packages/react-dom-bindings/src/client/inputValueTracking.js
+++ b/packages/react-dom-bindings/src/client/inputValueTracking.js
@@ -80,17 +80,17 @@ function trackValueOnNode(node: any): ?ValueTracker {
     configurable: true,
     // $FlowFixMe[missing-this-annot]
     get: function () {
-      const currentGetter = Object.getOwnPropertyDescriptor(
+      const currentDescriptor = Object.getOwnPropertyDescriptor(
         node.constructor.prototype,
         valueField,
-      )?.get;
+      );
 
       // Fall back to descriptor stored at installation time when there is no current descriptor
-      if (!currentGetter) {
+      if (!currentDescriptor || !currentDescriptor.get) {
         return get.call(this);
       }
 
-      return currentGetter.call(this);
+      return currentDescriptor.get.call(this);
     },
     // $FlowFixMe[missing-local-annot]
     // $FlowFixMe[missing-this-annot]
@@ -99,17 +99,17 @@ function trackValueOnNode(node: any): ?ValueTracker {
         checkFormFieldValueStringCoercion(value);
       }
       currentValue = '' + value;
-      const currentSetter = Object.getOwnPropertyDescriptor(
+      const currentDescriptor = Object.getOwnPropertyDescriptor(
         node.constructor.prototype,
         valueField,
-      )?.set;
+      );
 
-      if (!currentSetter) {
+      if (!currentDescriptor || !currentDescriptor.set) {
         set.call(this, value);
         return;
       }
 
-      currentSetter.call(this, value);
+      currentDescriptor.set.call(this, value);
     },
   });
   // We could've passed this the first time

--- a/packages/react-dom/src/__tests__/inputValueTracking-test.js
+++ b/packages/react-dom/src/__tests__/inputValueTracking-test.js
@@ -25,22 +25,22 @@ describe('input value tracking', () => {
 
     Object.defineProperty(HTMLInputElement.prototype, 'value', {
       configurable: true,
-      get: function() {
+      get: function () {
         getterInterceptor();
         return get.call(this);
       },
-      set: function(value) {
+      set: function (value) {
         set.call(this, value);
-      }
+      },
     });
 
     class MyForm extends React.Component {
       render() {
         return (
           <form>
-            <input type='text'></input>
+            <input type="text"></input>
           </form>
-        )
+        );
       }
     }
 
@@ -48,10 +48,9 @@ describe('input value tracking', () => {
     const myForm = ReactDOM.findDOMNode(myNode);
     const myInput = myForm.firstElementChild;
 
-
     // Access input value to trigger the descriptor above
     myInput.value;
-  
+
     expect(getterInterceptor).toHaveBeenCalled();
   });
 
@@ -60,16 +59,15 @@ describe('input value tracking', () => {
       render() {
         return (
           <form>
-            <input type='text'></input>
+            <input type="text"></input>
           </form>
-        )
+        );
       }
     }
 
     const myNode = ReactTestUtils.renderIntoDocument(<MyForm />);
     const myForm = ReactDOM.findDOMNode(myNode);
     const myInput = myForm.firstElementChild;
-
 
     const descriptor = Object.getOwnPropertyDescriptor(
       HTMLInputElement.prototype,
@@ -81,18 +79,18 @@ describe('input value tracking', () => {
 
     Object.defineProperty(HTMLInputElement.prototype, 'value', {
       configurable: true,
-      get: function() {
+      get: function () {
         getterInterceptor();
         return get.call(this);
       },
-      set: function(value) {
+      set: function (value) {
         set.call(this, value);
-      }
+      },
     });
 
     // Access input value to trigger the descriptor above
     myInput.value;
-  
+
     expect(getterInterceptor).toHaveBeenCalled();
   });
 
@@ -104,13 +102,13 @@ describe('input value tracking', () => {
     const {get, set} = descriptor;
     Object.defineProperty(HTMLInputElement.prototype, 'value', {
       configurable: true,
-      get: function() {
+      get: function () {
         getterInterceptor();
         return get.call(this);
       },
-      set: function(value) {
+      set: function (value) {
         set.call(this, value);
-      }
+      },
     });
 
     const getterInterceptor = jest.fn();
@@ -119,9 +117,9 @@ describe('input value tracking', () => {
       render() {
         return (
           <form>
-            <input type='text'></input>
+            <input type="text"></input>
           </form>
-        )
+        );
       }
     }
 
@@ -129,11 +127,11 @@ describe('input value tracking', () => {
     const myForm = ReactDOM.findDOMNode(myNode);
     const myInput = myForm.firstElementChild;
 
-    delete HTMLInputElement.prototype.value
+    delete HTMLInputElement.prototype.value;
 
     // Access input value to trigger the descriptor above
     myInput.value;
-  
+
     expect(getterInterceptor).toHaveBeenCalled();
   });
 });

--- a/packages/react-dom/src/__tests__/inputValueTracking-test.js
+++ b/packages/react-dom/src/__tests__/inputValueTracking-test.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+const ReactTestUtils = require('react-dom/test-utils');
+
+describe('input value tracking', () => {
+  it('triggers descriptor installed before react', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value',
+    );
+    const {get, set} = descriptor;
+
+    const getterInterceptor = jest.fn();
+
+    Object.defineProperty(HTMLInputElement.prototype, 'value', {
+      configurable: true,
+      get: function() {
+        getterInterceptor();
+        return get.call(this);
+      },
+      set: function(value) {
+        set.call(this, value);
+      }
+    });
+
+    class MyForm extends React.Component {
+      render() {
+        return (
+          <form>
+            <input type='text'></input>
+          </form>
+        )
+      }
+    }
+
+    const myNode = ReactTestUtils.renderIntoDocument(<MyForm />);
+    const myForm = ReactDOM.findDOMNode(myNode);
+    const myInput = myForm.firstElementChild;
+
+
+    // Access input value to trigger the descriptor above
+    myInput.value;
+  
+    expect(getterInterceptor).toHaveBeenCalled();
+  });
+
+  it('triggers descriptor installed after react', () => {
+    class MyForm extends React.Component {
+      render() {
+        return (
+          <form>
+            <input type='text'></input>
+          </form>
+        )
+      }
+    }
+
+    const myNode = ReactTestUtils.renderIntoDocument(<MyForm />);
+    const myForm = ReactDOM.findDOMNode(myNode);
+    const myInput = myForm.firstElementChild;
+
+
+    const descriptor = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value',
+    );
+    const {get, set} = descriptor;
+
+    const getterInterceptor = jest.fn();
+
+    Object.defineProperty(HTMLInputElement.prototype, 'value', {
+      configurable: true,
+      get: function() {
+        getterInterceptor();
+        return get.call(this);
+      },
+      set: function(value) {
+        set.call(this, value);
+      }
+    });
+
+    // Access input value to trigger the descriptor above
+    myInput.value;
+  
+    expect(getterInterceptor).toHaveBeenCalled();
+  });
+
+  it('triggers original descriptor when the current one has been deleted', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value',
+    );
+    const {get, set} = descriptor;
+    Object.defineProperty(HTMLInputElement.prototype, 'value', {
+      configurable: true,
+      get: function() {
+        getterInterceptor();
+        return get.call(this);
+      },
+      set: function(value) {
+        set.call(this, value);
+      }
+    });
+
+    const getterInterceptor = jest.fn();
+
+    class MyForm extends React.Component {
+      render() {
+        return (
+          <form>
+            <input type='text'></input>
+          </form>
+        )
+      }
+    }
+
+    const myNode = ReactTestUtils.renderIntoDocument(<MyForm />);
+    const myForm = ReactDOM.findDOMNode(myNode);
+    const myInput = myForm.firstElementChild;
+
+    delete HTMLInputElement.prototype.value
+
+    // Access input value to trigger the descriptor above
+    myInput.value;
+  
+    expect(getterInterceptor).toHaveBeenCalled();
+  });
+});

--- a/packages/react-dom/src/__tests__/inputValueTracking-test.js
+++ b/packages/react-dom/src/__tests__/inputValueTracking-test.js
@@ -38,7 +38,7 @@ describe('input value tracking', () => {
       render() {
         return (
           <form>
-            <input type="text"></input>
+            <input type="text" />
           </form>
         );
       }
@@ -49,6 +49,7 @@ describe('input value tracking', () => {
     const myInput = myForm.firstElementChild;
 
     // Access input value to trigger the descriptor above
+    // eslint-disable-next-line ft-flow/no-unused-expressions
     myInput.value;
 
     expect(getterInterceptor).toHaveBeenCalled();
@@ -59,7 +60,7 @@ describe('input value tracking', () => {
       render() {
         return (
           <form>
-            <input type="text"></input>
+            <input type="text" />
           </form>
         );
       }
@@ -89,6 +90,7 @@ describe('input value tracking', () => {
     });
 
     // Access input value to trigger the descriptor above
+    // eslint-disable-next-line ft-flow/no-unused-expressions
     myInput.value;
 
     expect(getterInterceptor).toHaveBeenCalled();
@@ -117,7 +119,7 @@ describe('input value tracking', () => {
       render() {
         return (
           <form>
-            <input type="text"></input>
+            <input type="text" />
           </form>
         );
       }
@@ -130,6 +132,7 @@ describe('input value tracking', () => {
     delete HTMLInputElement.prototype.value;
 
     // Access input value to trigger the descriptor above
+    // eslint-disable-next-line ft-flow/no-unused-expressions
     myInput.value;
 
     expect(getterInterceptor).toHaveBeenCalled();


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

The motivation is fixing [https://github.com/facebook/react/issues/27092](https://github.com/facebook/react/issues/27092), which is fully described in the issue

## How did you test this change?

1. By following the instructions at [https://legacy.reactjs.org/docs/how-to-contribute.html](https://legacy.reactjs.org/docs/how-to-contribute.html) I was able to link react and react-dom packages to the repository which has the error reproducible: [https://github.com/SF97/react-input-element-bug](https://github.com/SF97/react-input-element-bug) 
2. I tried to reproduce the bug with the changes, and I was not able to do it

## Important decision

I've added a fallback to the current implementation when the descriptor has been deleted during the web page execution. This was mainly to fall back to the old implementation in the case there are any caveats I've missed, but I'm not opposed to removing it if necessary
