### PR TITLE
Add `referrerPolicy` option to `ReactDOM.preload()`

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2284,6 +2284,7 @@ function preloadPropsFromPreloadOptions(
     fetchPriority: options.fetchPriority,
     imageSrcSet: options.imageSrcSet,
     imageSizes: options.imageSizes,
+    referrerPolicy: options.referrerPolicy,
   };
 }
 

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -5564,6 +5564,7 @@ function preloadPropsFromPreloadOptions(
     fetchPriority: options.fetchPriority,
     imageSrcSet: options.imageSrcSet,
     imageSizes: options.imageSizes,
+    referrerPolicy: options.referrerPolicy,
   };
 }
 

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -3585,6 +3585,13 @@ body {
         imageSizes: 'makes no sense',
       });
 
+      ReactDOM.preload('rp', {
+        as: 'image',
+        imageSrcSet: 'rpsrcset',
+        imageSizes: 'rpsizes',
+        referrerPolicy: 'no-referrer',
+      });
+
       if (isClient) {
         // Will key off href in absense of imageSrcSet
         ReactDOM.preload('client', {as: 'image'});
@@ -3634,6 +3641,13 @@ body {
             imagesizes="foosizes"
           />
           <link rel="preload" as="somethingelse" href="bar" />
+          <link
+            rel="preload"
+            as="image"
+            imagesrcset="rpsrcset"
+            imagesizes="rpsizes"
+            referrerpolicy="no-referrer"
+          />
         </head>
         <body>hello</body>
       </html>,
@@ -3653,6 +3667,13 @@ body {
             imagesizes="foosizes"
           />
           <link rel="preload" as="somethingelse" href="bar" />
+          <link
+            rel="preload"
+            as="image"
+            imagesrcset="rpsrcset"
+            imagesizes="rpsizes"
+            referrerpolicy="no-referrer"
+          />
         </head>
         <body>hello</body>
       </html>,
@@ -3672,6 +3693,13 @@ body {
             imagesizes="foosizes"
           />
           <link rel="preload" as="somethingelse" href="bar" />
+          <link
+            rel="preload"
+            as="image"
+            imagesrcset="rpsrcset"
+            imagesizes="rpsizes"
+            referrerpolicy="no-referrer"
+          />
           <link rel="preload" as="image" href="client" />
           <link rel="preload" as="image" imagesrcset="clientset" />
           <link

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -3585,13 +3585,6 @@ body {
         imageSizes: 'makes no sense',
       });
 
-      ReactDOM.preload('rp', {
-        as: 'image',
-        imageSrcSet: 'rpsrcset',
-        imageSizes: 'rpsizes',
-        referrerPolicy: 'no-referrer',
-      });
-
       if (isClient) {
         // Will key off href in absense of imageSrcSet
         ReactDOM.preload('client', {as: 'image'});
@@ -3641,13 +3634,6 @@ body {
             imagesizes="foosizes"
           />
           <link rel="preload" as="somethingelse" href="bar" />
-          <link
-            rel="preload"
-            as="image"
-            imagesrcset="rpsrcset"
-            imagesizes="rpsizes"
-            referrerpolicy="no-referrer"
-          />
         </head>
         <body>hello</body>
       </html>,
@@ -3667,13 +3653,6 @@ body {
             imagesizes="foosizes"
           />
           <link rel="preload" as="somethingelse" href="bar" />
-          <link
-            rel="preload"
-            as="image"
-            imagesrcset="rpsrcset"
-            imagesizes="rpsizes"
-            referrerpolicy="no-referrer"
-          />
         </head>
         <body>hello</body>
       </html>,
@@ -3693,13 +3672,6 @@ body {
             imagesizes="foosizes"
           />
           <link rel="preload" as="somethingelse" href="bar" />
-          <link
-            rel="preload"
-            as="image"
-            imagesrcset="rpsrcset"
-            imagesizes="rpsizes"
-            referrerpolicy="no-referrer"
-          />
           <link rel="preload" as="image" href="client" />
           <link rel="preload" as="image" imagesrcset="clientset" />
           <link
@@ -3707,6 +3679,91 @@ body {
             as="image"
             imagesrcset="clientset"
             imagesizes="clientsizes"
+          />
+        </head>
+        <body>hello</body>
+      </html>,
+    );
+  });
+
+  it('should handle referrerPolicy on image preload', async () => {
+    function App({isClient}) {
+      ReactDOM.preload('/server', {
+        as: 'image',
+        imageSrcSet: '/server',
+        imageSizes: '100vw',
+        referrerPolicy: 'no-referrer',
+      });
+
+      if (isClient) {
+        ReactDOM.preload('/client', {
+          as: 'image',
+          imageSrcSet: '/client',
+          imageSizes: '100vw',
+          referrerPolicy: 'no-referrer',
+        });
+      }
+
+      return (
+        <html>
+          <body>hello</body>
+        </html>
+      );
+    }
+
+    await act(() => {
+      renderToPipeableStream(<App />).pipe(writable);
+    });
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <link
+            rel="preload"
+            as="image"
+            imagesrcset="/server"
+            imagesizes="100vw"
+            referrerpolicy="no-referrer"
+          />
+        </head>
+        <body>hello</body>
+      </html>,
+    );
+
+    const root = ReactDOMClient.hydrateRoot(document, <App />);
+    await waitForAll([]);
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <link
+            rel="preload"
+            as="image"
+            imagesrcset="/server"
+            imagesizes="100vw"
+            referrerpolicy="no-referrer"
+          />
+        </head>
+        <body>hello</body>
+      </html>,
+    );
+
+    root.render(<App isClient={true} />);
+    await waitForAll([]);
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <link
+            rel="preload"
+            as="image"
+            imagesrcset="/server"
+            imagesizes="100vw"
+            referrerpolicy="no-referrer"
+          />
+          <link
+            rel="preload"
+            as="image"
+            imagesrcset="/client"
+            imagesizes="100vw"
+            referrerpolicy="no-referrer"
           />
         </head>
         <body>hello</body>

--- a/packages/react-dom/src/shared/ReactDOMTypes.js
+++ b/packages/react-dom/src/shared/ReactDOMTypes.js
@@ -18,6 +18,7 @@ export type PreloadOptions = {
   fetchPriority?: 'high' | 'low' | 'auto',
   imageSrcSet?: string,
   imageSizes?: string,
+  referrerPolicy?: string,
 };
 export type PreinitOptions = {
   as: string,


### PR DESCRIPTION
## Summary

We started using `ReactDOM.preload()` in Next.js but found the `referrerPolicy` option was missing.

- Related https://github.com/vercel/next.js/pull/52425

## How did you test this change?

```
yarn test packages/react-dom/src/__tests__/ReactDOMFloat-test.js
```
