### PR TITLE
Add `media` option to ReactDOM.preload()

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -3935,6 +3935,91 @@ body {
     );
   });
 
+  it('should handle media on image preload', async () => {
+    function App({isClient}) {
+      ReactDOM.preload('/server', {
+        as: 'image',
+        imageSrcSet: '/server',
+        imageSizes: '100vw',
+        media: 'print and (min-width: 768px)',
+      });
+
+      if (isClient) {
+        ReactDOM.preload('/client', {
+          as: 'image',
+          imageSrcSet: '/client',
+          imageSizes: '100vw',
+          media: 'screen and (max-width: 480px)',
+        });
+      }
+
+      return (
+        <html>
+          <body>hello</body>
+        </html>
+      );
+    }
+
+    await act(() => {
+      renderToPipeableStream(<App />).pipe(writable);
+    });
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <link
+            rel="preload"
+            as="image"
+            imagesrcset="/server"
+            imagesizes="100vw"
+            media="print and (min-width: 768px)"
+          />
+        </head>
+        <body>hello</body>
+      </html>,
+    );
+
+    const root = ReactDOMClient.hydrateRoot(document, <App />);
+    await waitForAll([]);
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <link
+            rel="preload"
+            as="image"
+            imagesrcset="/server"
+            imagesizes="100vw"
+            media="print and (min-width: 768px)"
+          />
+        </head>
+        <body>hello</body>
+      </html>,
+    );
+
+    root.render(<App isClient={true} />);
+    await waitForAll([]);
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <link
+            rel="preload"
+            as="image"
+            imagesrcset="/server"
+            imagesizes="100vw"
+            media="print and (min-width: 768px)"
+          />
+          <link
+            rel="preload"
+            as="image"
+            imagesrcset="/client"
+            imagesizes="100vw"
+            media="screen and (max-width: 480px)"
+          />
+        </head>
+        <body>hello</body>
+      </html>,
+    );
+  });
+
   it('can emit preloads for non-lazy images that are rendered', async () => {
     function App() {
       ReactDOM.preload('script', {as: 'script'});

--- a/packages/react-dom/src/shared/ReactDOMTypes.js
+++ b/packages/react-dom/src/shared/ReactDOMTypes.js
@@ -21,6 +21,7 @@ export type PreloadOptions = {
   imageSrcSet?: string,
   imageSizes?: string,
   referrerPolicy?: string,
+  media?: string,
 };
 export type PreloadModuleOptions = {
   as?: string,


### PR DESCRIPTION
## Summary

Similar to https://github.com/facebook/react/pull/27096, we've encountered an issue in Next.js while using ReactDOM.preload(), where adding a `media` attribute does nothing.

I've not contributed to OSS before and am not familiar with the React core codebase, so I've followed the example set by the author of the https://github.com/facebook/react/pull/27096 pull request as a basis for this change.

## How did you test this change?
I wrote the test within `ReactDOMFloat-test.js` before making any functional changes, and ran:
```
yarn test packages/react-dom/src/__tests__/ReactDOMFloat-test.js
```
both before and after making the functional changes to verify that the test *failed* before the change, and *passed* after.
