### PR TITLE
Add a server.browser version for react-server-dom-esm

### DIFF
--- a/packages/react-server-dom-esm/package.json
+++ b/packages/react-server-dom-esm/package.json
@@ -17,6 +17,7 @@
     "client.node.js",
     "server.js",
     "server.node.js",
+    "server.browser.js",
     "cjs/",
     "esm/"
   ],
@@ -32,6 +33,7 @@
       "react-server": "./server.node.js",
       "default": "./server.js"
     },
+    "./server.browser": "./server.browser.js",
     "./server.node": "./server.node.js",
     "./node-loader": "./esm/react-server-dom-esm-node-loader.production.min.js",
     "./src/*": "./src/*.js",

--- a/packages/react-server-dom-esm/server.browser.js
+++ b/packages/react-server-dom-esm/server.browser.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from './src/ReactFlightDOMServerBrowser';

--- a/packages/react-server-dom-esm/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-esm/src/ReactFlightDOMServerBrowser.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
+import type {ClientManifest} from './ReactFlightServerConfigESMBundler';
+import type {ServerContextJSONValue, Thenable} from 'shared/ReactTypes';
+
+import {
+  createRequest,
+  startWork,
+  startFlowing,
+  abort,
+} from 'react-server/src/ReactFlightServer';
+
+export {
+  registerServerReference,
+  registerClientReference,
+} from './ReactFlightESMReferences';
+
+type Options = {
+  identifierPrefix?: string,
+  signal?: AbortSignal,
+  context?: Array<[string, ServerContextJSONValue]>,
+  onError?: (error: mixed) => void,
+};
+
+function renderToReadableStream(
+  model: ReactClientValue,
+  moduleBasePath: ClientManifest,
+  options?: Options,
+): ReadableStream {
+  const request = createRequest(
+    model,
+    moduleBasePath,
+    options ? options.onError : undefined,
+    options ? options.context : undefined,
+    options ? options.identifierPrefix : undefined,
+  );
+
+  if (options && options.signal) {
+    const signal = options.signal;
+    if (signal.aborted) {
+      abort(request, (signal: any).reason);
+    } else {
+      const listener = () => {
+        abort(request, (signal: any).reason);
+        signal.removeEventListener('abort', listener);
+      };
+      signal.addEventListener('abort', listener);
+    }
+  }
+  const stream = new ReadableStream(
+    {
+      type: 'bytes',
+      start: (controller): ?Promise<void> => {
+        startWork(request);
+      },
+      pull: (controller): ?Promise<void> => {
+        startFlowing(request, controller);
+      },
+      cancel: (reason): ?Promise<void> => {},
+    },
+    // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
+    {highWaterMark: 0},
+  );
+  return stream;
+}
+
+export {renderToReadableStream};


### PR DESCRIPTION

## Summary

Trying to use this to test out codesandbox RSC integration

## How did you test this change?

