### PR TITLE
bugfix: useSyncExternalStore() seems to be not solid in avoiding tearing

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1618,7 +1618,6 @@ function updateSyncExternalStore<T>(
       null,
     );
   }
-  
   // Unless we're rendering a blocking lane, schedule a consistency check.
   // Right before committing, we will walk the tree and check if any of the
   // stores were mutated.

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1617,21 +1617,21 @@ function updateSyncExternalStore<T>(
       createEffectInstance(),
       null,
     );
+  }
+  
+  // Unless we're rendering a blocking lane, schedule a consistency check.
+  // Right before committing, we will walk the tree and check if any of the
+  // stores were mutated.
+  const root: FiberRoot | null = getWorkInProgressRoot();
 
-    // Unless we're rendering a blocking lane, schedule a consistency check.
-    // Right before committing, we will walk the tree and check if any of the
-    // stores were mutated.
-    const root: FiberRoot | null = getWorkInProgressRoot();
+  if (root === null) {
+    throw new Error(
+      'Expected a work-in-progress root. This is a bug in React. Please file an issue.',
+    );
+  }
 
-    if (root === null) {
-      throw new Error(
-        'Expected a work-in-progress root. This is a bug in React. Please file an issue.',
-      );
-    }
-
-    if (!isHydrating && !includesBlockingLane(root, renderLanes)) {
-      pushStoreConsistencyCheck(fiber, getSnapshot, nextSnapshot);
-    }
+  if (!isHydrating && !includesBlockingLane(root, renderLanes)) {
+    pushStoreConsistencyCheck(fiber, getSnapshot, nextSnapshot);
   }
 
   return nextSnapshot;

--- a/packages/react-reconciler/src/__tests__/useSyncExternalStore-test.js
+++ b/packages/react-reconciler/src/__tests__/useSyncExternalStore-test.js
@@ -16,6 +16,7 @@ let Scheduler;
 let act;
 let useLayoutEffect;
 let forwardRef;
+let useEffect;
 let useImperativeHandle;
 let useRef;
 let useState;
@@ -39,6 +40,7 @@ describe('useSyncExternalStore', () => {
     useLayoutEffect = React.useLayoutEffect;
     useImperativeHandle = React.useImperativeHandle;
     forwardRef = React.forwardRef;
+    useEffect = React.useEffect;
     useRef = React.useRef;
     useState = React.useState;
     useSyncExternalStore = React.useSyncExternalStore;
@@ -66,6 +68,9 @@ describe('useSyncExternalStore', () => {
         ReactNoop.batchedUpdates(() => {
           listeners.forEach(listener => listener());
         });
+      },
+      setWithoutEmit(text) {
+        currentState = text;
       },
       subscribe(listener) {
         listeners.add(listener);
@@ -164,6 +169,94 @@ describe('useSyncExternalStore', () => {
 
         // During an interleaved event, the store is mutated.
         store2.set(1);
+
+        // Then we continue rendering.
+        await waitForAll([
+          // C reads a newer value from the store than A or B, which means they
+          // are inconsistent.
+          'C1',
+
+          // Before committing the layout effects, React detects that the store
+          // has been mutated. So it throws out the entire completed tree and
+          // re-renders the new values.
+          'A1',
+          'B1',
+          'C1',
+          // The layout effects reads consistent children.
+          'Children observed during layout: A1B1C1',
+        ]);
+      });
+    },
+  );
+
+  test(
+    'detects interleaved mutations(without emitting) during a concurrent read before ' +
+      'layout effects fire',
+    async () => {
+      const store1 = createExternalStore(0);
+
+      const Child = forwardRef(({store, label}, ref) => {
+        const value = useSyncExternalStore(store.subscribe, store.getState);
+        useImperativeHandle(
+          ref,
+          () => {
+            return value;
+          },
+          [value],
+        );
+        return <Text text={label + value} />;
+      });
+
+      function App({store}) {
+        // eslint-disabxle-next-line no-unused-vars
+        const [, setCount] = useState(0);
+        const refA = useRef(null);
+        const refB = useRef(null);
+        const refC = useRef(null);
+        useLayoutEffect(() => {
+          // This layout effect reads children that depend on an external store.
+          // This demostrates whether the children are consistent when the
+          // layout phase runs.
+          const aText = refA.current;
+          const bText = refB.current;
+          const cText = refC.current;
+          Scheduler.log(
+            `Children observed during layout: A${aText}B${bText}C${cText}`,
+          );
+        });
+
+        // trigger re-render in concurrent mode
+        useEffect(() => {
+          startTransition(() => {
+            setCount(count => count + 1);
+          });
+        }, []);
+
+        return (
+          <>
+            <Child store={store} ref={refA} label="A" />
+            <Child store={store} ref={refB} label="B" />
+            <Child store={store} ref={refC} label="C" />
+          </>
+        );
+      }
+
+      const root = ReactNoop.createRoot();
+      await act(async () => {
+        // Start a mount in legacy mode
+        root.render(<App store={store1} />);
+
+        await waitFor([
+          'A0',
+          'B0',
+          'C0',
+          'Children observed during layout: A0B0C0',
+          'A0', // re-render starts
+          'B0',
+        ]);
+
+        // During an interleaved event, the store is mutated without emitting
+        store1.setWithoutEmit(1);
 
         // Then we continue rendering.
         await waitForAll([


### PR DESCRIPTION
## Summary

Currently the update branch of `useSyncExternalStore()` - `updateSyncExternalStore()` sets up consistency check conditionally, while for `mountSyncExternalStore()` it is unconditionally.

This results in tearing still being possible when store mutates during rendering in concurrent mode, 
if the mutation is not with emitting(which is possible considering the throttling of continuous events).

Here is the [repro on stackblitz](https://stackblitz.com/edit/react-ts-quih5c?file=App.tsx)

<img width="448" alt="Screenshot 2023-08-03 at 02 24 57" src="https://github.com/facebook/react/assets/69352453/3c782ded-c2dc-42aa-b96f-742d968b795c">

## Proposed Fix

Same as `mountSyncExternalStore()`, we should add consistency check without condition.


## How did you test this change?

Added one more test case, which didn't pass before the fix

![Screenshot 2023-08-03 at 02 27 06](https://github.com/facebook/react/assets/69352453/973cbbb9-6e1e-45a7-a9b4-e63a29a35765)

> we see 'A0B0C1' being flushed - tearing happened
