### PR TITLE
grammatical correction 'a unique' to 'an unique'

### DIFF
--- a/fixtures/legacy-jsx-runtimes/react-14/cjs/react-jsx-dev-runtime.development.js
+++ b/fixtures/legacy-jsx-runtimes/react-14/cjs/react-jsx-dev-runtime.development.js
@@ -641,7 +641,7 @@ function validateExplicitKey(element, parentType) {
 
     setCurrentlyValidatingElement$1(element);
 
-    error('Each child in a list should have a unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
+    error('Each child in a list should have an unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
 
     setCurrentlyValidatingElement$1(null);
   }

--- a/fixtures/legacy-jsx-runtimes/react-14/cjs/react-jsx-runtime.development.js
+++ b/fixtures/legacy-jsx-runtimes/react-14/cjs/react-jsx-runtime.development.js
@@ -645,7 +645,7 @@ function validateExplicitKey(element, parentType) {
 
     setCurrentlyValidatingElement$1(element);
 
-    error('Each child in a list should have a unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
+    error('Each child in a list should have an unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
 
     setCurrentlyValidatingElement$1(null);
   }

--- a/fixtures/legacy-jsx-runtimes/react-14/react-14.test.js
+++ b/fixtures/legacy-jsx-runtimes/react-14/react-14.test.js
@@ -221,7 +221,7 @@ it('warns for keys for arrays of elements in children position', () => {
     ReactTestUtils.renderIntoDocument(
       <Component>{[<Component />, <Component />]}</Component>
     )
-  ).toErrorDev('Each child in a list should have a unique "key" prop.', {
+  ).toErrorDev('Each child in a list should have an unique "key" prop.', {
     withoutStack: true,
   });
 });
@@ -242,7 +242,7 @@ it('warns for keys for arrays of elements with owner info', () => {
   expect(() =>
     ReactTestUtils.renderIntoDocument(<ComponentWrapper />)
   ).toErrorDev(
-    'Each child in a list should have a unique "key" prop.' +
+    'Each child in a list should have an unique "key" prop.' +
       '\n\nCheck the render method of `InnerComponent`. ' +
       'It was passed a child from ComponentWrapper. ',
     {withoutStack: true}

--- a/fixtures/legacy-jsx-runtimes/react-15/cjs/react-jsx-dev-runtime.development.js
+++ b/fixtures/legacy-jsx-runtimes/react-15/cjs/react-jsx-dev-runtime.development.js
@@ -646,7 +646,7 @@ function validateExplicitKey(element, parentType) {
 
     setCurrentlyValidatingElement$1(element);
 
-    error('Each child in a list should have a unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
+    error('Each child in a list should have an unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
 
     setCurrentlyValidatingElement$1(null);
   }

--- a/fixtures/legacy-jsx-runtimes/react-15/cjs/react-jsx-runtime.development.js
+++ b/fixtures/legacy-jsx-runtimes/react-15/cjs/react-jsx-runtime.development.js
@@ -650,7 +650,7 @@ function validateExplicitKey(element, parentType) {
 
     setCurrentlyValidatingElement$1(element);
 
-    error('Each child in a list should have a unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
+    error('Each child in a list should have an unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
 
     setCurrentlyValidatingElement$1(null);
   }

--- a/fixtures/legacy-jsx-runtimes/react-15/react-15.test.js
+++ b/fixtures/legacy-jsx-runtimes/react-15/react-15.test.js
@@ -221,7 +221,7 @@ it('warns for keys for arrays of elements in children position', () => {
     ReactTestUtils.renderIntoDocument(
       <Component>{[<Component />, <Component />]}</Component>
     )
-  ).toErrorDev('Each child in a list should have a unique "key" prop.');
+  ).toErrorDev('Each child in a list should have an unique "key" prop.');
 });
 
 it('warns for keys for arrays of elements with owner info', () => {
@@ -240,7 +240,7 @@ it('warns for keys for arrays of elements with owner info', () => {
   expect(() =>
     ReactTestUtils.renderIntoDocument(<ComponentWrapper />)
   ).toErrorDev(
-    'Each child in a list should have a unique "key" prop.' +
+    'Each child in a list should have an unique "key" prop.' +
       '\n\nCheck the render method of `InnerComponent`. ' +
       'It was passed a child from ComponentWrapper. '
   );

--- a/fixtures/legacy-jsx-runtimes/react-16/cjs/react-jsx-dev-runtime.development.js
+++ b/fixtures/legacy-jsx-runtimes/react-16/cjs/react-jsx-dev-runtime.development.js
@@ -669,7 +669,7 @@ function validateExplicitKey(element, parentType) {
 
     setCurrentlyValidatingElement$1(element);
 
-    error('Each child in a list should have a unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
+    error('Each child in a list should have an unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
 
     setCurrentlyValidatingElement$1(null);
   }

--- a/fixtures/legacy-jsx-runtimes/react-16/cjs/react-jsx-runtime.development.js
+++ b/fixtures/legacy-jsx-runtimes/react-16/cjs/react-jsx-runtime.development.js
@@ -673,7 +673,7 @@ function validateExplicitKey(element, parentType) {
 
     setCurrentlyValidatingElement$1(element);
 
-    error('Each child in a list should have a unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
+    error('Each child in a list should have an unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
 
     setCurrentlyValidatingElement$1(null);
   }

--- a/fixtures/legacy-jsx-runtimes/react-16/react-16.test.js
+++ b/fixtures/legacy-jsx-runtimes/react-16/react-16.test.js
@@ -221,7 +221,7 @@ it('warns for keys for arrays of elements in children position', () => {
     ReactTestUtils.renderIntoDocument(
       <Component>{[<Component />, <Component />]}</Component>
     )
-  ).toErrorDev('Each child in a list should have a unique "key" prop.');
+  ).toErrorDev('Each child in a list should have an unique "key" prop.');
 });
 
 it('warns for keys for arrays of elements with owner info', () => {
@@ -240,7 +240,7 @@ it('warns for keys for arrays of elements with owner info', () => {
   expect(() =>
     ReactTestUtils.renderIntoDocument(<ComponentWrapper />)
   ).toErrorDev(
-    'Each child in a list should have a unique "key" prop.' +
+    'Each child in a list should have an unique "key" prop.' +
       '\n\nCheck the render method of `InnerComponent`. ' +
       'It was passed a child from ComponentWrapper. '
   );

--- a/fixtures/legacy-jsx-runtimes/react-17/cjs/react-jsx-dev-runtime.development.js
+++ b/fixtures/legacy-jsx-runtimes/react-17/cjs/react-jsx-dev-runtime.development.js
@@ -983,7 +983,7 @@ function validateExplicitKey(element, parentType) {
 
     setCurrentlyValidatingElement$1(element);
 
-    error('Each child in a list should have a unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
+    error('Each child in a list should have an unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
 
     setCurrentlyValidatingElement$1(null);
   }

--- a/fixtures/legacy-jsx-runtimes/react-17/cjs/react-jsx-runtime.development.js
+++ b/fixtures/legacy-jsx-runtimes/react-17/cjs/react-jsx-runtime.development.js
@@ -983,7 +983,7 @@ function validateExplicitKey(element, parentType) {
 
     setCurrentlyValidatingElement$1(element);
 
-    error('Each child in a list should have a unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
+    error('Each child in a list should have an unique "key" prop.' + '%s%s See https://reactjs.org/link/warning-keys for more information.', currentComponentErrorInfo, childOwner);
 
     setCurrentlyValidatingElement$1(null);
   }

--- a/fixtures/legacy-jsx-runtimes/react-17/react-17.test.js
+++ b/fixtures/legacy-jsx-runtimes/react-17/react-17.test.js
@@ -221,7 +221,7 @@ it('warns for keys for arrays of elements in children position', () => {
     ReactTestUtils.renderIntoDocument(
       <Component>{[<Component />, <Component />]}</Component>
     )
-  ).toErrorDev('Each child in a list should have a unique "key" prop.');
+  ).toErrorDev('Each child in a list should have an unique "key" prop.');
 });
 
 it('warns for keys for arrays of elements with owner info', () => {
@@ -240,7 +240,7 @@ it('warns for keys for arrays of elements with owner info', () => {
   expect(() =>
     ReactTestUtils.renderIntoDocument(<ComponentWrapper />)
   ).toErrorDev(
-    'Each child in a list should have a unique "key" prop.' +
+    'Each child in a list should have an unique "key" prop.' +
       '\n\nCheck the render method of `InnerComponent`. ' +
       'It was passed a child from ComponentWrapper. '
   );

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -2484,7 +2484,7 @@ describe('InspectedElement', () => {
 
       const container = document.createElement('div');
       await utils.withErrorsOrWarningsIgnored(
-        ['Warning: Each child in a list should have a unique "key" prop.'],
+        ['Warning: Each child in a list should have an unique "key" prop.'],
         async () => {
           await utils.actAsync(() =>
             legacyRender(<Example repeatWarningCount={1} />, container),
@@ -2497,7 +2497,7 @@ describe('InspectedElement', () => {
         {
           "errors": [
             [
-              "Warning: Each child in a list should have a unique "key" prop. See https://reactjs.org/link/warning-keys for more information.
+              "Warning: Each child in a list should have an unique "key" prop. See https://reactjs.org/link/warning-keys for more information.
             at Example",
               1,
             ],

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1799,7 +1799,7 @@ describe('ReactDOMFizzServer', () => {
 
       if (__DEV__) {
         expect(mockError).toHaveBeenCalledWith(
-          'Warning: Each child in a list should have a unique "key" prop.%s%s' +
+          'Warning: Each child in a list should have an unique "key" prop.%s%s' +
             ' See https://reactjs.org/link/warning-keys for more information.%s',
           '\n\nCheck the top-level render call using <div>.',
           '',

--- a/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
@@ -355,7 +355,7 @@ describe('ReactFunctionComponent', () => {
     }
 
     expect(() => ReactTestUtils.renderIntoDocument(<Child />)).toErrorDev(
-      'Each child in a list should have a unique "key" prop.\n\n' +
+      'Each child in a list should have an unique "key" prop.\n\n' +
         'Check the render method of `Child`.',
     );
   });

--- a/packages/react-dom/src/__tests__/ReactMultiChildText-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChildText-test.js
@@ -169,8 +169,8 @@ describe('ReactMultiChildText', () => {
         ['', 'foo', <div>{true}{<div />}{1.2}{''}</div>, 'foo'], ['', 'foo', <div />, 'foo'],
       ]);
     }).toErrorDev([
-      'Warning: Each child in a list should have a unique "key" prop.',
-      'Warning: Each child in a list should have a unique "key" prop.',
+      'Warning: Each child in a list should have an unique "key" prop.',
+      'Warning: Each child in a list should have an unique "key" prop.',
     ]);
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFragment-test.js
@@ -741,7 +741,7 @@ describe('ReactFragment', () => {
 
     ReactNoop.render(<Foo condition={false} />);
     await expect(async () => await waitForAll([])).toErrorDev(
-      'Each child in a list should have a unique "key" prop.',
+      'Each child in a list should have an unique "key" prop.',
     );
 
     expect(ops).toEqual([]);
@@ -938,7 +938,7 @@ describe('ReactFragment', () => {
 
     ReactNoop.render(<Foo condition={true} />);
     await expect(async () => await waitForAll([])).toErrorDev(
-      'Each child in a list should have a unique "key" prop.',
+      'Each child in a list should have an unique "key" prop.',
     );
 
     ReactNoop.render(<Foo condition={false} />);

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -148,7 +148,7 @@ function validateExplicitKey(element, parentType) {
   if (__DEV__) {
     setCurrentlyValidatingElement(element);
     console.error(
-      'Each child in a list should have a unique "key" prop.' +
+      'Each child in a list should have an unique "key" prop.' +
         '%s%s See https://reactjs.org/link/warning-keys for more information.',
       currentComponentErrorInfo,
       childOwner,

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -320,7 +320,7 @@ describe('ReactChildren', () => {
 
     let instance;
     expect(() => (instance = <div>{threeDivIterable}</div>)).toErrorDev(
-      'Warning: Each child in a list should have a unique "key" prop.',
+      'Warning: Each child in a list should have an unique "key" prop.',
     );
 
     function assertCalls() {
@@ -973,7 +973,7 @@ describe('ReactChildren', () => {
         ReactTestUtils.renderIntoDocument(<ComponentReturningArray />),
       ).toErrorDev(
         'Warning: ' +
-          'Each child in a list should have a unique "key" prop.' +
+          'Each child in a list should have an unique "key" prop.' +
           ' See https://reactjs.org/link/warning-keys for more information.' +
           '\n    in ComponentReturningArray (at **)',
       );
@@ -994,7 +994,7 @@ describe('ReactChildren', () => {
         ReactTestUtils.renderIntoDocument([<div />, <div />]),
       ).toErrorDev(
         'Warning: ' +
-          'Each child in a list should have a unique "key" prop.' +
+          'Each child in a list should have an unique "key" prop.' +
           ' See https://reactjs.org/link/warning-keys for more information.',
         {withoutStack: true}, // There's nothing on the stack
       );

--- a/packages/react/src/__tests__/ReactElementClone-test.js
+++ b/packages/react/src/__tests__/ReactElementClone-test.js
@@ -272,7 +272,7 @@ describe('ReactElementClone', () => {
   it('warns for keys for arrays of elements in rest args', () => {
     expect(() =>
       React.cloneElement(<div />, null, [<div />, <div />]),
-    ).toErrorDev('Each child in a list should have a unique "key" prop.');
+    ).toErrorDev('Each child in a list should have an unique "key" prop.');
   });
 
   it('does not warns for arrays of elements with keys', () => {

--- a/packages/react/src/__tests__/ReactElementJSX-test.js
+++ b/packages/react/src/__tests__/ReactElementJSX-test.js
@@ -255,7 +255,7 @@ describe('ReactElement.jsx', () => {
     expect(() =>
       ReactDOM.render(JSXRuntime.jsx(Parent, {}), container),
     ).toErrorDev(
-      'Warning: Each child in a list should have a unique "key" prop.\n\n' +
+      'Warning: Each child in a list should have an unique "key" prop.\n\n' +
         'Check the render method of `Parent`. See https://reactjs.org/link/warning-keys for more information.\n' +
         '    in Child (at **)\n' +
         '    in Parent (at **)',

--- a/packages/react/src/__tests__/ReactElementValidator-test.internal.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.internal.js
@@ -44,7 +44,7 @@ describe('ReactElementValidator', () => {
         React.createElement(ComponentClass),
         React.createElement(ComponentClass),
       ]);
-    }).toErrorDev('Each child in a list should have a unique "key" prop.');
+    }).toErrorDev('Each child in a list should have an unique "key" prop.');
   });
 
   it('warns for keys for arrays of elements with owner info', () => {
@@ -68,7 +68,7 @@ describe('ReactElementValidator', () => {
     expect(() => {
       ReactTestUtils.renderIntoDocument(React.createElement(ComponentWrapper));
     }).toErrorDev(
-      'Each child in a list should have a unique "key" prop.' +
+      'Each child in a list should have an unique "key" prop.' +
         '\n\nCheck the render method of `InnerClass`. ' +
         'It was passed a child from ComponentWrapper. ',
     );
@@ -164,7 +164,7 @@ describe('ReactElementValidator', () => {
 
     expect(() =>
       React.createElement(ComponentClass, null, iterable),
-    ).toErrorDev('Each child in a list should have a unique "key" prop.');
+    ).toErrorDev('Each child in a list should have an unique "key" prop.');
   });
 
   it('does not warns for arrays of elements with keys', () => {

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -48,7 +48,7 @@ describe('ReactJSXElementValidator', () => {
       ReactTestUtils.renderIntoDocument(
         <Component>{[<Component />, <Component />]}</Component>,
       ),
-    ).toErrorDev('Each child in a list should have a unique "key" prop.');
+    ).toErrorDev('Each child in a list should have an unique "key" prop.');
   });
 
   it('warns for keys for arrays of elements with owner info', () => {
@@ -67,7 +67,7 @@ describe('ReactJSXElementValidator', () => {
     expect(() =>
       ReactTestUtils.renderIntoDocument(<ComponentWrapper />),
     ).toErrorDev(
-      'Each child in a list should have a unique "key" prop.' +
+      'Each child in a list should have an unique "key" prop.' +
         '\n\nCheck the render method of `InnerComponent`. ' +
         'It was passed a child from ComponentWrapper. ',
     );
@@ -88,7 +88,7 @@ describe('ReactJSXElementValidator', () => {
 
     expect(() =>
       ReactTestUtils.renderIntoDocument(<Component>{iterable}</Component>),
-    ).toErrorDev('Each child in a list should have a unique "key" prop.');
+    ).toErrorDev('Each child in a list should have an unique "key" prop.');
   });
 
   it('does not warn for arrays of elements with keys', () => {

--- a/packages/react/src/jsx/ReactJSXElementValidator.js
+++ b/packages/react/src/jsx/ReactJSXElementValidator.js
@@ -161,7 +161,7 @@ function validateExplicitKey(element, parentType) {
 
     setCurrentlyValidatingElement(element);
     console.error(
-      'Each child in a list should have a unique "key" prop.' +
+      'Each child in a list should have an unique "key" prop.' +
         '%s%s See https://reactjs.org/link/warning-keys for more information.',
       currentComponentErrorInfo,
       childOwner,


### PR DESCRIPTION
## Change

Previously : Each child in a list should have a unique "key" prop.

Updated : Each child in a list should have an unique "key" prop.


## Summary

The changes makes the error grammatically correct.

## How did you test this change?

Few tests are failing as they are expecting 'a' and getting 'an' after update.
