### PR TITLE
Updating fixtures/packaging/babel-standalone/dev.html to use createRoot

### DIFF
--- a/fixtures/packaging/babel-standalone/dev.html
+++ b/fixtures/packaging/babel-standalone/dev.html
@@ -5,10 +5,8 @@
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
     <div id="container"></div>
     <script type="text/babel">
-      ReactDOM.render(
-        <h1>Hello World!</h1>,
-        document.getElementById('container')
-      );
+      const root = ReactDOM.createRoot(document.getElementById('container'));
+      root.render(<h1>Hello World!</h1>);
     </script>
   </body>
 </html>


### PR DESCRIPTION
Fixes: #27196 

## Summary

Following the process in the How to Contribute documentation, after the first build, to test it says to open the file: `fixtures/packaging/babel-standalone/dev.html`

When I opened this file, the console had this error:

`react-dom.development.js:81 Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot`

This change updates the code in that file from `ReactDOM.render` to `ReactDOM.createRoot` to fix the problem causing the error.

## How did you test this change?

I made this change, then looked at the console to verify the error was gone, and the rendered page to verify it was the same as before the change.  Here are screenshots:

Before:
![image](https://github.com/facebook/react/assets/479664/75628eab-8325-4f5a-a80d-7481f4fec5fb)

After:
![image](https://github.com/facebook/react/assets/479664/7193588d-bafd-4107-ab01-cc368e3f4915)

Note:  I could not find an existing issue for this, so following the request in the How to Contribute document, I have added one here: https://github.com/facebook/react/issues/27196
