### PR TITLE
[Fizz][Float] emit viewport meta before preloads

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -1920,6 +1920,9 @@ function pushMeta(
 
       if (typeof props.charSet === 'string') {
         return pushSelfClosing(responseState.charsetChunks, props, 'meta');
+      } else if (props.name === 'viewport') {
+        // "viewport" isn't related to preconnect but it has the right priority
+        return pushSelfClosing(responseState.preconnectChunks, props, 'meta');
       } else {
         return pushSelfClosing(responseState.hoistableChunks, props, 'meta');
       }


### PR DESCRIPTION
Fixes: #27200 

preloads for images that appear before the viewport meta may be loaded twice because the proper device image information is not used with the preload but is with the image itself. The viewport meta should be emitted earlier than all preloads to avoid this.

this change moves the queue for the viewport meta to preconnects which already has the right priority for this tag