### PR TITLE
feat: replace name with displayName in errorboundary componentStack

### DIFF
--- a/packages/shared/ReactComponentStackFrame.js
+++ b/packages/shared/ReactComponentStackFrame.js
@@ -186,6 +186,12 @@ export function describeNativeComponentFrame(
                   frame = frame.replace('<anonymous>', fn.displayName);
                 }
 
+                // If component has displayName,
+                // replace name with displayName in errorboundary componentStack
+                if (fn.displayName && fn.name && frame.includes(fn.name)) {
+                  frame = frame.replace(fn.name, fn.displayName);
+                }
+
                 if (__DEV__) {
                   if (typeof fn === 'function') {
                     componentFrameCache.set(fn, frame);


### PR DESCRIPTION
## Summary

In React16, while component throw error, developer can get component displayName from ErrorBoundary componentStack, if error component has displayName. For production debug or monitor, displayName is useful.


## How did you test this change?
run `yarn test --prod`
<img width="464" alt="image" src="https://github.com/facebook/react/assets/23349174/712d01d8-25c5-4492-8fbd-b2991d03ca09">


