### PR TITLE
Update README.md by new react site url

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ root.render(<HelloMessage name="Taylor" />);
 
 This example will render "Hello Taylor" into a container on the page.
 
-You'll notice that we used an HTML-like syntax; [we call it JSX](https://reactjs.org/docs/introducing-jsx.html). JSX is not required to use React, but it makes code more readable, and writing it feels like writing HTML. If you're using React as a `<script>` tag, read [this section](https://reactjs.org/docs/add-react-to-a-website.html#optional-try-react-with-jsx) on integrating JSX; otherwise, the [recommended JavaScript toolchains](https://reactjs.org/docs/create-a-new-react-app.html) handle it automatically.
+You'll notice that we used an HTML-like syntax; [we call it JSX](https://react.dev/learn/writing-markup-with-jsx). JSX is not required to use React, but it makes code more readable, and writing it feels like writing HTML. If you're using React as a `<script>` tag, read [this section](https://react.dev/learn/add-react-to-an-existing-project#optional-try-react-with-jsx) on integrating JSX; otherwise, the [recommended JavaScript toolchains](https://react.dev/learn/start-a-new-react-project) handle it automatically.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
Update README.md by new react site url in JSX section

## How did you test this change?
https://reactjs.org/docs/introducing-jsx.html -> https://react.dev/learn/writing-markup-with-jsx

Different page but the links should be on the new site. The new one also introduces the JSX.
https://reactjs.org/docs/add-react-to-a-website.html#optional-try-react-with-jsx -> https://react.dev/learn/add-react-to-an-existing-project#optional-try-react-with-jsx

There was a redirect, but more appropriate to change the new site URL.
https://reactjs.org/docs/create-a-new-react-app.html -> https://react.dev/learn/start-a-new-react-project

Same as above, there was a redirect, but change to the new site URL