### PR TITLE
[Float][Flight][Fizz][Fiber] Implement `preloadModule` and `preinitModule`

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactDOMFlightServerHostDispatcher.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMFlightServerHostDispatcher.js
@@ -12,7 +12,9 @@ import type {
   PrefetchDNSOptions,
   PreconnectOptions,
   PreloadOptions,
+  PreloadModuleOptions,
   PreinitOptions,
+  PreinitModuleOptions,
 } from 'react-dom/src/shared/ReactDOMTypes';
 
 import {enableFloat} from 'shared/ReactFeatureFlags';
@@ -27,7 +29,9 @@ export const ReactDOMFlightServerDispatcher: HostDispatcher = {
   prefetchDNS,
   preconnect,
   preload,
+  preloadModule,
   preinit,
+  preinitModule,
 };
 
 function prefetchDNS(href: string, options?: ?PrefetchDNSOptions) {
@@ -99,6 +103,28 @@ function preload(href: string, options: PreloadOptions) {
   }
 }
 
+function preloadModule(href: string, options?: ?PreloadModuleOptions) {
+  if (enableFloat) {
+    if (typeof href === 'string') {
+      const request = resolveRequest();
+      if (request) {
+        const hints = getHints(request);
+        const key = 'm' + href;
+        if (hints.has(key)) {
+          // duplicate hint
+          return;
+        }
+        hints.add(key);
+        if (options) {
+          emitHint(request, 'm', [href, options]);
+        } else {
+          emitHint(request, 'm', href);
+        }
+      }
+    }
+  }
+}
+
 function preinit(href: string, options: PreinitOptions) {
   if (enableFloat) {
     if (typeof href === 'string') {
@@ -112,6 +138,28 @@ function preinit(href: string, options: PreinitOptions) {
         }
         hints.add(key);
         emitHint(request, 'I', [href, options]);
+      }
+    }
+  }
+}
+
+function preinitModule(href: string, options?: ?PreinitModuleOptions) {
+  if (enableFloat) {
+    if (typeof href === 'string') {
+      const request = resolveRequest();
+      if (request) {
+        const hints = getHints(request);
+        const key = 'M' + href;
+        if (hints.has(key)) {
+          // duplicate hint
+          return;
+        }
+        hints.add(key);
+        if (options) {
+          emitHint(request, 'M', [href, options]);
+        } else {
+          emitHint(request, 'M', href);
+        }
       }
     }
   }

--- a/packages/react-dom-bindings/src/server/ReactFlightServerConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFlightServerConfigDOM.js
@@ -11,7 +11,9 @@ import type {
   PrefetchDNSOptions,
   PreconnectOptions,
   PreloadOptions,
+  PreloadModuleOptions,
   PreinitOptions,
+  PreinitModuleOptions,
 } from 'react-dom/src/shared/ReactDOMTypes';
 
 import ReactDOMSharedInternals from 'shared/ReactDOMSharedInternals';
@@ -31,7 +33,14 @@ export type HintModel =
   | string
   | [
       string,
-      PrefetchDNSOptions | PreconnectOptions | PreloadOptions | PreinitOptions,
+      (
+        | PrefetchDNSOptions
+        | PreconnectOptions
+        | PreloadOptions
+        | PreloadModuleOptions
+        | PreinitOptions
+        | PreinitModuleOptions
+      ),
     ];
 
 export type Hints = Set<string>;

--- a/packages/react-dom-bindings/src/shared/ReactFlightClientConfigDOM.js
+++ b/packages/react-dom-bindings/src/shared/ReactFlightClientConfigDOM.js
@@ -42,10 +42,22 @@ export function dispatchHint(code: string, model: HintModel): void {
         dispatcher.preload(href, options);
         return;
       }
+      case 'm': {
+        // $FlowFixMe[prop-missing] options are not refined to their types by code
+        // $FlowFixMe[incompatible-call] options are not refined to their types by code
+        dispatcher.preloadModule(href, options);
+        return;
+      }
       case 'I': {
         // $FlowFixMe[prop-missing] options are not refined to their types by code
         // $FlowFixMe[incompatible-call] options are not refined to their types by code
         dispatcher.preinit(href, options);
+        return;
+      }
+      case 'M': {
+        // $FlowFixMe[prop-missing] options are not refined to their types by code
+        // $FlowFixMe[incompatible-call] options are not refined to their types by code
+        dispatcher.preinitModule(href, options);
         return;
       }
     }

--- a/packages/react-dom/index.classic.fb.js
+++ b/packages/react-dom/index.classic.fb.js
@@ -35,7 +35,9 @@ export {
   prefetchDNS,
   preconnect,
   preload,
+  preloadModule,
   preinit,
+  preinitModule,
   version,
 } from './src/client/ReactDOM';
 

--- a/packages/react-dom/index.experimental.js
+++ b/packages/react-dom/index.experimental.js
@@ -24,6 +24,8 @@ export {
   prefetchDNS,
   preconnect,
   preload,
+  preloadModule,
   preinit,
+  preinitModule,
   version,
 } from './src/client/ReactDOM';

--- a/packages/react-dom/index.js
+++ b/packages/react-dom/index.js
@@ -27,6 +27,8 @@ export {
   prefetchDNS,
   preconnect,
   preload,
+  preloadModule,
   preinit,
+  preinitModule,
   version,
 } from './src/client/ReactDOM';

--- a/packages/react-dom/index.modern.fb.js
+++ b/packages/react-dom/index.modern.fb.js
@@ -20,6 +20,8 @@ export {
   prefetchDNS,
   preconnect,
   preload,
+  preloadModule,
   preinit,
+  preinitModule,
   version,
 } from './src/client/ReactDOM';

--- a/packages/react-dom/index.stable.js
+++ b/packages/react-dom/index.stable.js
@@ -22,6 +22,8 @@ export {
   prefetchDNS,
   preconnect,
   preload,
+  preloadModule,
   preinit,
+  preinitModule,
   version,
 } from './src/client/ReactDOM';

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -59,7 +59,9 @@ export {
   prefetchDNS,
   preconnect,
   preload,
+  preloadModule,
   preinit,
+  preinitModule,
 } from '../shared/ReactDOMFloat';
 export {useFormStatus} from 'react-dom-bindings/src/shared/ReactDOMFormActions';
 

--- a/packages/react-dom/src/shared/ReactDOMFloat.js
+++ b/packages/react-dom/src/shared/ReactDOMFloat.js
@@ -9,7 +9,9 @@
 import type {
   PreconnectOptions,
   PreloadOptions,
+  PreloadModuleOptions,
   PreinitOptions,
+  PreinitModuleOptions,
 } from './ReactDOMTypes';
 
 import ReactDOMSharedInternals from 'shared/ReactDOMSharedInternals';
@@ -63,10 +65,30 @@ export function preload(href: string, options: PreloadOptions) {
   // so we favor silent bailout over warning or erroring.
 }
 
+export function preloadModule(href: string, options?: ?PreloadModuleOptions) {
+  const dispatcher = Dispatcher.current;
+  if (dispatcher) {
+    dispatcher.preloadModule(href, options);
+  }
+  // We don't error because preload needs to be resilient to being called in a variety of scopes
+  // and the runtime may not be capable of responding. The function is optimistic and not critical
+  // so we favor silent bailout over warning or erroring.
+}
+
 export function preinit(href: string, options: PreinitOptions) {
   const dispatcher = Dispatcher.current;
   if (dispatcher) {
     dispatcher.preinit(href, options);
+  }
+  // We don't error because preinit needs to be resilient to being called in a variety of scopes
+  // and the runtime may not be capable of responding. The function is optimistic and not critical
+  // so we favor silent bailout over warning or erroring.
+}
+
+export function preinitModule(href: string, options?: ?PreinitModuleOptions) {
+  const dispatcher = Dispatcher.current;
+  if (dispatcher) {
+    dispatcher.preinitModule(href, options);
   }
   // We don't error because preinit needs to be resilient to being called in a variety of scopes
   // and the runtime may not be capable of responding. The function is optimistic and not critical

--- a/packages/react-dom/src/shared/ReactDOMTypes.js
+++ b/packages/react-dom/src/shared/ReactDOMTypes.js
@@ -20,6 +20,11 @@ export type PreloadOptions = {
   imageSizes?: string,
   referrerPolicy?: string,
 };
+export type PreloadModuleOptions = {
+  as?: string,
+  crossOrigin?: string,
+  integrity?: string,
+};
 export type PreinitOptions = {
   as: string,
   precedence?: string,
@@ -28,10 +33,17 @@ export type PreinitOptions = {
   nonce?: string,
   fetchPriority?: 'high' | 'low' | 'auto',
 };
+export type PreinitModuleOptions = {
+  as?: string,
+  crossOrigin?: string,
+  integrity?: string,
+};
 
 export type HostDispatcher = {
   prefetchDNS: (href: string, options?: ?PrefetchDNSOptions) => void,
-  preconnect: (href: string, options: ?PreconnectOptions) => void,
+  preconnect: (href: string, options?: ?PreconnectOptions) => void,
   preload: (href: string, options: PreloadOptions) => void,
+  preloadModule: (href: string, options?: ?PreloadModuleOptions) => void,
   preinit: (href: string, options: PreinitOptions) => void,
+  preinitModule: (href: string, options?: ?PreinitModuleOptions) => void,
 };


### PR DESCRIPTION
Stacked on #27224 

### Implements `ReactDOM.preloadModule()`
`preloadModule` is a function to preload modules of various types. Similar to `preload` this is useful when you expect to use a Resource soon but can't render that resource directly. At the moment the only sensible module to preload is script modules along with some other `as` variants such as `as="serviceworker"`. In the future when there is some notion of how to preload style module script or json module scripts this API will be extended to support those as well.

##### Arguments
1. `href: string` -> the href or src value you want to preload.
2. `options?: {...}` -> 
2.1. `options.as?: string` -> the `as` property the modulepreload link should render with. If not provided it will be omitted which will cause the modulepreload to be treated like a script module
2.2. `options.crossOrigin?: string` -> modules always load with CORS but you can provide `use-credentials` if you want to change the default behavior
2.3. `options.integrity?: string` -> an integrity hash for subresource integrity APIs
  
##### Rendering
each preloaded module will emit a `<link rel="modulepreload" href="..." />`
if `as` is specified and is something other than `"script"` the as attribute will also be included
if crossOrigin or integrity as specified their attributes will also be included

During SSR these script tags will be emitted before content. If we have not yet flushed the document head they will be emitted there after things that block paint such as font preloads, img preloads, and stylesheets.

On the client these link tags will be appended to the document.head.
  
### Implements `ReactDOM.preinitModule()`
`preinitModule` is a function to loading module scripts before they are required. It has the same use cases as `preinit`. 

During SSR you would use this to tell the browsers to start fetching code that will be used without having to wait for bootstrapping to initiate module fetches.

ON the client you would use this to start fetching a module script early for an anticipated navigation or other event that is likely to depend on this module script.

the `as` property for Float methods drew inspiration from the `as` attribute of the `<link rel="preload" ... >` tag but it is used as a sort of tag for the kind of thing being targetted by Float methods. For `preinitModule` we currently only support `as: "script"` and this is also the assumed default type so you current never need to specify this `as` value. In the future `preinitModule` will support additional module script types such as `style` or `json`. The support of these types will correspond to [Module Import Attributes](https://github.com/tc39/proposal-import-attributes).

##### Arguments
1. `href: string` -> the href or src value you want to preinitialize
2. `options?: {...}` ->
2.1 `options.as?: string` -> only supports `script` and this is the default behavior. Until we support import attributes such as `json` and `style` there will not be much reason to provide an `as` option.
2.2. `options.crossOrigin?: string`: modules always load with CORS but you can provide `use-credentials` if you want to change the default behavior
2.3 `options.integrity?: string` -> an integrity hash for subresource integrity APIs

##### Rendering
each preinitialized `script` module will emit a `<script type="module" async="" src"...">` During SSR these will appear behind display blocking resources such as font preloads, img preloads, and stylesheets. In the browser these will be appende to the head.

Note that for other `as` types the rendered output will be slightly different. `<script type="module">import "..." with {type: "json" }</script>`. Since this tag is an inline script variants of React that do not use inline scripts will simply omit these preinitialization tags from the SSR output. This is not implemented in this PR but will appear in a future update.