### PR TITLE
Jest: remove haste config

### DIFF
--- a/scripts/jest/config.base.js
+++ b/scripts/jest/config.base.js
@@ -2,9 +2,6 @@
 
 module.exports = {
   globalSetup: require.resolve('./setupGlobal.js'),
-  haste: {
-    hasteImplModulePath: require.resolve('./noHaste.js'),
-  },
   modulePathIgnorePatterns: [
     '<rootDir>/scripts/rollup/shims/',
     '<rootDir>/scripts/bench/',

--- a/scripts/jest/noHaste.js
+++ b/scripts/jest/noHaste.js
@@ -1,8 +1,0 @@
-'use strict';
-
-module.exports = {
-  getHasteName() {
-    // We never want Haste.
-    return null;
-  },
-};


### PR DESCRIPTION
Since we're not using haste at all, we can just remove the config to disable haste instead of enabling, just to inject an implementation that blocks any haste modules from being recognized.

Test Plan:
Creating a module and required it to get the expected error that the module doesn't exist.