### PR TITLE
Fix: Stylesheet in error UI suspends indefinitely

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -3385,7 +3385,6 @@ body {
     );
   });
 
-  // @gate FIXME
   it('loading a stylesheet as part of an error boundary UI, during initial render', async () => {
     class ErrorBoundary extends React.Component {
       state = {error: null};

--- a/packages/react-reconciler/src/ReactFiberThenable.js
+++ b/packages/react-reconciler/src/ReactFiberThenable.js
@@ -42,7 +42,16 @@ export const SuspenseyCommitException: mixed = new Error(
 // TODO: It would be better to refactor throwException into multiple functions
 // so we can trigger a fallback directly without having to check the type. But
 // for now this will do.
-export const noopSuspenseyCommitThenable = {then() {}};
+export const noopSuspenseyCommitThenable = {
+  then() {
+    if (__DEV__) {
+      console.error(
+        'Internal React error: A listener was unexpectedly attached to a ' +
+          '"noop" thenable. This is a bug in React. Please file an issue.',
+      );
+    }
+  },
+};
 
 export function createThenableState(): ThenableState {
   // The ThenableState is created the first time a component suspends. If it

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -438,8 +438,15 @@ function throwException(
               } else {
                 retryQueue.add(wakeable);
               }
+
+              // We only attach ping listeners in concurrent mode. Legacy
+              // Suspense always commits fallbacks synchronously, so there are
+              // no pings.
+              if (suspenseBoundary.mode & ConcurrentMode) {
+                attachPingListener(root, wakeable, rootRenderLanes);
+              }
             }
-            break;
+            return;
           }
           case OffscreenComponent: {
             if (suspenseBoundary.mode & ConcurrentMode) {
@@ -466,24 +473,17 @@ function throwException(
                     retryQueue.add(wakeable);
                   }
                 }
+
+                attachPingListener(root, wakeable, rootRenderLanes);
               }
-              break;
+              return;
             }
-            // Fall through
-          }
-          default: {
-            throw new Error(
-              `Unexpected Suspense handler tag (${suspenseBoundary.tag}). This ` +
-                'is a bug in React.',
-            );
           }
         }
-        // We only attach ping listeners in concurrent mode. Legacy Suspense always
-        // commits fallbacks synchronously, so there are no pings.
-        if (suspenseBoundary.mode & ConcurrentMode) {
-          attachPingListener(root, wakeable, rootRenderLanes);
-        }
-        return;
+        throw new Error(
+          `Unexpected Suspense handler tag (${suspenseBoundary.tag}). This ` +
+            'is a bug in React.',
+        );
       } else {
         // No boundary was found. Unless this is a sync update, this is OK.
         // We can suspend and wait for more data to arrive.


### PR DESCRIPTION
This fixes the regression test added in the previous commit. The "Suspensey commit" implementation relies on the `shouldRemainOnPreviousScreen` function to determine whether to 1) suspend the commit 2) activate a parent fallback and schedule a retry. The issue was that we were sometimes attempting option 2 even when there was no parent fallback.

Part of the reason this bug landed is due to how `throwException` is structured. In the case of Suspensey commits, we pass a special "noop" thenable to `throwException` as a way to trigger the Suspense path. This special thenable must never have a listener attached to it. This is not a great way to structure the logic, it's just a consequence of how the code evolved over time. We should refactor it into multiple functions so we can trigger a fallback directly without having to check the type. In the meantime, I added an internal warning to help detect similar mistakes in the future.