### PR TITLE
[Fizz] Split ResponseState/Resources into RenderState/ResumableState

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -492,7 +492,6 @@ module.exports = {
     ReadableStreamController: 'readonly',
     RequestInfo: 'readonly',
     RequestOptions: 'readonly',
-    ResponseState: 'readonly',
     StoreAsGlobal: 'readonly',
     symbol: 'readonly',
     SyntheticEvent: 'readonly',

--- a/packages/react-dom/npm/server.browser.js
+++ b/packages/react-dom/npm/server.browser.js
@@ -15,3 +15,6 @@ exports.renderToStaticMarkup = l.renderToStaticMarkup;
 exports.renderToNodeStream = l.renderToNodeStream;
 exports.renderToStaticNodeStream = l.renderToStaticNodeStream;
 exports.renderToReadableStream = s.renderToReadableStream;
+if (s.resume) {
+  exports.resume = s.resume;
+}

--- a/packages/react-dom/npm/server.bun.js
+++ b/packages/react-dom/npm/server.bun.js
@@ -12,6 +12,9 @@ if (process.env.NODE_ENV === 'production') {
 
 exports.version = b.version;
 exports.renderToReadableStream = b.renderToReadableStream;
+if (b.resume) {
+  exports.resume = b.resume;
+}
 exports.renderToNodeStream = b.renderToNodeStream;
 exports.renderToStaticNodeStream = b.renderToStaticNodeStream;
 exports.renderToString = l.renderToString;

--- a/packages/react-dom/npm/server.edge.js
+++ b/packages/react-dom/npm/server.edge.js
@@ -16,3 +16,6 @@ exports.renderToNodeStream = b.renderToNodeStream;
 exports.renderToStaticNodeStream = b.renderToStaticNodeStream;
 exports.renderToString = l.renderToString;
 exports.renderToStaticMarkup = l.renderToStaticMarkup;
+if (b.resume) {
+  exports.resume = b.resume;
+}

--- a/packages/react-dom/npm/server.node.js
+++ b/packages/react-dom/npm/server.node.js
@@ -15,3 +15,6 @@ exports.renderToStaticMarkup = l.renderToStaticMarkup;
 exports.renderToNodeStream = l.renderToNodeStream;
 exports.renderToStaticNodeStream = l.renderToStaticNodeStream;
 exports.renderToPipeableStream = s.renderToPipeableStream;
+if (s.resume) {
+  exports.resume = s.resume;
+}

--- a/packages/react-dom/server.browser.js
+++ b/packages/react-dom/server.browser.js
@@ -37,7 +37,14 @@ export function renderToStaticNodeStream() {
 }
 
 export function renderToReadableStream() {
-  return require('./src/server/ReactDOMFizzServerBrowser').renderToReadableStream.apply(
+  return require('./src/server/react-dom-server.browser').renderToReadableStream.apply(
+    this,
+    arguments,
+  );
+}
+
+export function resume() {
+  return require('./src/server/react-dom-server.browser').resume.apply(
     this,
     arguments,
   );

--- a/packages/react-dom/server.bun.js
+++ b/packages/react-dom/server.bun.js
@@ -12,21 +12,21 @@ import ReactVersion from 'shared/ReactVersion';
 export {ReactVersion as version};
 
 export function renderToReadableStream() {
-  return require('./src/server/ReactDOMFizzServerBun').renderToReadableStream.apply(
+  return require('./src/server/react-dom-server.bun').renderToReadableStream.apply(
     this,
     arguments,
   );
 }
 
 export function renderToNodeStream() {
-  return require('./src/server/ReactDOMFizzServerBun').renderToNodeStream.apply(
+  return require('./src/server/react-dom-server.bun').renderToNodeStream.apply(
     this,
     arguments,
   );
 }
 
 export function renderToStaticNodeStream() {
-  return require('./src/server/ReactDOMFizzServerBun').renderToStaticNodeStream.apply(
+  return require('./src/server/react-dom-server.bun').renderToStaticNodeStream.apply(
     this,
     arguments,
   );
@@ -41,6 +41,13 @@ export function renderToString() {
 
 export function renderToStaticMarkup() {
   return require('./src/server/ReactDOMLegacyServerBrowser').renderToStaticMarkup.apply(
+    this,
+    arguments,
+  );
+}
+
+export function resume() {
+  return require('./src/server/react-dom-server.bun').resume.apply(
     this,
     arguments,
   );

--- a/packages/react-dom/server.edge.js
+++ b/packages/react-dom/server.edge.js
@@ -12,21 +12,21 @@ import ReactVersion from 'shared/ReactVersion';
 export {ReactVersion as version};
 
 export function renderToReadableStream() {
-  return require('./src/server/ReactDOMFizzServerEdge').renderToReadableStream.apply(
+  return require('./src/server/react-dom-server.edge').renderToReadableStream.apply(
     this,
     arguments,
   );
 }
 
 export function renderToNodeStream() {
-  return require('./src/server/ReactDOMFizzServerEdge').renderToNodeStream.apply(
+  return require('./src/server/react-dom-server.edge').renderToNodeStream.apply(
     this,
     arguments,
   );
 }
 
 export function renderToStaticNodeStream() {
-  return require('./src/server/ReactDOMFizzServerEdge').renderToStaticNodeStream.apply(
+  return require('./src/server/react-dom-server.edge').renderToStaticNodeStream.apply(
     this,
     arguments,
   );
@@ -41,6 +41,13 @@ export function renderToString() {
 
 export function renderToStaticMarkup() {
   return require('./src/server/ReactDOMLegacyServerBrowser').renderToStaticMarkup.apply(
+    this,
+    arguments,
+  );
+}
+
+export function resume() {
+  return require('./src/server/react-dom-server.edge').resume.apply(
     this,
     arguments,
   );

--- a/packages/react-dom/server.node.js
+++ b/packages/react-dom/server.node.js
@@ -37,7 +37,14 @@ export function renderToStaticNodeStream() {
 }
 
 export function renderToPipeableStream() {
-  return require('./src/server/ReactDOMFizzServerNode').renderToPipeableStream.apply(
+  return require('./src/server/react-dom-server.node').renderToPipeableStream.apply(
+    this,
+    arguments,
+  );
+}
+
+export function resume() {
+  return require('./src/server/react-dom-server.node').resume.apply(
     this,
     arguments,
   );

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStatic-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStatic-test.js
@@ -224,6 +224,8 @@ describe('ReactDOMFizzStatic', () => {
 
     const result = await promise;
 
+    expect(result.postponed).toBe(null);
+
     await act(async () => {
       result.prelude.pipe(writable);
     });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStatic-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStatic-test.js
@@ -218,7 +218,7 @@ describe('ReactDOMFizzStatic', () => {
       );
     }
 
-    const promise = ReactDOMFizzStatic.prerenderToNodeStreams(<App />);
+    const promise = ReactDOMFizzStatic.prerenderToNodeStream(<App />);
 
     resolveText('Hello');
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticNode-test.js
@@ -47,8 +47,8 @@ describe('ReactDOMFizzStaticNode', () => {
   }
 
   // @gate experimental
-  it('should call prerenderToNodeStreams', async () => {
-    const result = await ReactDOMFizzStatic.prerenderToNodeStreams(
+  it('should call prerenderToNodeStream', async () => {
+    const result = await ReactDOMFizzStatic.prerenderToNodeStream(
       <div>hello world</div>,
     );
     const prelude = await readContent(result.prelude);
@@ -57,7 +57,7 @@ describe('ReactDOMFizzStaticNode', () => {
 
   // @gate experimental
   it('should emit DOCTYPE at the root of the document', async () => {
-    const result = await ReactDOMFizzStatic.prerenderToNodeStreams(
+    const result = await ReactDOMFizzStatic.prerenderToNodeStream(
       <html>
         <body>hello world</body>
       </html>,
@@ -76,7 +76,7 @@ describe('ReactDOMFizzStaticNode', () => {
 
   // @gate experimental
   it('should emit bootstrap script src at the end', async () => {
-    const result = await ReactDOMFizzStatic.prerenderToNodeStreams(
+    const result = await ReactDOMFizzStatic.prerenderToNodeStream(
       <div>hello world</div>,
       {
         bootstrapScriptContent: 'INIT();',
@@ -101,7 +101,7 @@ describe('ReactDOMFizzStaticNode', () => {
       }
       return 'Done';
     }
-    const resultPromise = ReactDOMFizzStatic.prerenderToNodeStreams(
+    const resultPromise = ReactDOMFizzStatic.prerenderToNodeStream(
       <div>
         <Suspense fallback="Loading">
           <Wait />
@@ -127,7 +127,7 @@ describe('ReactDOMFizzStaticNode', () => {
     const reportedErrors = [];
     let caughtError = null;
     try {
-      await ReactDOMFizzStatic.prerenderToNodeStreams(
+      await ReactDOMFizzStatic.prerenderToNodeStream(
         <div>
           <Throw />
         </div>,
@@ -149,7 +149,7 @@ describe('ReactDOMFizzStaticNode', () => {
     const reportedErrors = [];
     let caughtError = null;
     try {
-      await ReactDOMFizzStatic.prerenderToNodeStreams(
+      await ReactDOMFizzStatic.prerenderToNodeStream(
         <div>
           <Suspense fallback={<Throw />}>
             <InfiniteSuspend />
@@ -171,7 +171,7 @@ describe('ReactDOMFizzStaticNode', () => {
   // @gate experimental
   it('should not error the stream when an error is thrown inside suspense boundary', async () => {
     const reportedErrors = [];
-    const result = await ReactDOMFizzStatic.prerenderToNodeStreams(
+    const result = await ReactDOMFizzStatic.prerenderToNodeStream(
       <div>
         <Suspense fallback={<div>Loading</div>}>
           <Throw />
@@ -193,7 +193,7 @@ describe('ReactDOMFizzStaticNode', () => {
   it('should be able to complete by aborting even if the promise never resolves', async () => {
     const errors = [];
     const controller = new AbortController();
-    const resultPromise = ReactDOMFizzStatic.prerenderToNodeStreams(
+    const resultPromise = ReactDOMFizzStatic.prerenderToNodeStream(
       <div>
         <Suspense fallback={<div>Loading</div>}>
           <InfiniteSuspend />
@@ -223,7 +223,7 @@ describe('ReactDOMFizzStaticNode', () => {
   it('should reject if aborting before the shell is complete', async () => {
     const errors = [];
     const controller = new AbortController();
-    const promise = ReactDOMFizzStatic.prerenderToNodeStreams(
+    const promise = ReactDOMFizzStatic.prerenderToNodeStream(
       <div>
         <InfiniteSuspend />
       </div>,
@@ -262,7 +262,7 @@ describe('ReactDOMFizzStaticNode', () => {
         </Suspense>
       );
     }
-    const streamPromise = ReactDOMFizzStatic.prerenderToNodeStreams(
+    const streamPromise = ReactDOMFizzStatic.prerenderToNodeStream(
       <div>
         <App />
       </div>,
@@ -291,7 +291,7 @@ describe('ReactDOMFizzStaticNode', () => {
     const theReason = new Error('aborted for reasons');
     controller.abort(theReason);
 
-    const promise = ReactDOMFizzStatic.prerenderToNodeStreams(
+    const promise = ReactDOMFizzStatic.prerenderToNodeStream(
       <div>
         <Suspense fallback={<div>Loading</div>}>
           <InfiniteSuspend />
@@ -342,7 +342,7 @@ describe('ReactDOMFizzStaticNode', () => {
 
     const errors = [];
     const controller = new AbortController();
-    const resultPromise = ReactDOMFizzStatic.prerenderToNodeStreams(<App />, {
+    const resultPromise = ReactDOMFizzStatic.prerenderToNodeStream(<App />, {
       signal: controller.signal,
       onError(x) {
         errors.push(x);
@@ -384,7 +384,7 @@ describe('ReactDOMFizzStaticNode', () => {
 
     const errors = [];
     const controller = new AbortController();
-    const resultPromise = ReactDOMFizzStatic.prerenderToNodeStreams(<App />, {
+    const resultPromise = ReactDOMFizzStatic.prerenderToNodeStream(<App />, {
       signal: controller.signal,
       onError(x) {
         errors.push(x.message);

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -15,7 +15,6 @@ import ReactVersion from 'shared/ReactVersion';
 
 import {
   createRequest,
-  resumeRequest,
   startWork,
   startFlowing,
   abort,
@@ -166,13 +165,15 @@ function resume(
       allReady.catch(() => {});
       reject(error);
     }
-    const request = resumeRequest(
+    const request = createRequest(
       children,
-      postponedState,
+      postponedState.resumableState,
       createRenderState(
         postponedState.resumableState,
         options ? options.nonce : undefined,
       ),
+      postponedState.rootFormatContext,
+      postponedState.progressiveChunkSize,
       options ? options.onError : undefined,
       onAllReady,
       onShellReady,

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -196,4 +196,4 @@ function resume(
   });
 }
 
-export {renderToReadableStream, ReactVersion as version};
+export {renderToReadableStream, resume, ReactVersion as version};

--- a/packages/react-dom/src/server/ReactDOMFizzServerBun.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBun.js
@@ -20,8 +20,8 @@ import {
 } from 'react-server/src/ReactFizzServer';
 
 import {
-  createResources,
-  createResponseState,
+  createResumableState,
+  createRenderState,
   createRootFormatContext,
 } from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 
@@ -82,19 +82,18 @@ function renderToReadableStream(
       allReady.catch(() => {});
       reject(error);
     }
-    const resources = createResources();
+    const resumableState = createResumableState(
+      options ? options.identifierPrefix : undefined,
+      options ? options.nonce : undefined,
+      options ? options.bootstrapScriptContent : undefined,
+      options ? options.bootstrapScripts : undefined,
+      options ? options.bootstrapModules : undefined,
+      options ? options.unstable_externalRuntimeSrc : undefined,
+    );
     const request = createRequest(
       children,
-      resources,
-      createResponseState(
-        resources,
-        options ? options.identifierPrefix : undefined,
-        options ? options.nonce : undefined,
-        options ? options.bootstrapScriptContent : undefined,
-        options ? options.bootstrapScripts : undefined,
-        options ? options.bootstrapModules : undefined,
-        options ? options.unstable_externalRuntimeSrc : undefined,
-      ),
+      resumableState,
+      createRenderState(resumableState, options ? options.nonce : undefined),
       createRootFormatContext(options ? options.namespaceURI : undefined),
       options ? options.progressiveChunkSize : undefined,
       options ? options.onError : undefined,

--- a/packages/react-dom/src/server/ReactDOMFizzServerEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerEdge.js
@@ -15,7 +15,6 @@ import ReactVersion from 'shared/ReactVersion';
 
 import {
   createRequest,
-  resumeRequest,
   startWork,
   startFlowing,
   abort,
@@ -166,13 +165,15 @@ function resume(
       allReady.catch(() => {});
       reject(error);
     }
-    const request = resumeRequest(
+    const request = createRequest(
       children,
-      postponedState,
+      postponedState.resumableState,
       createRenderState(
         postponedState.resumableState,
         options ? options.nonce : undefined,
       ),
+      postponedState.rootFormatContext,
+      postponedState.progressiveChunkSize,
       options ? options.onError : undefined,
       onAllReady,
       onShellReady,

--- a/packages/react-dom/src/server/ReactDOMFizzServerEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerEdge.js
@@ -196,4 +196,4 @@ function resume(
   });
 }
 
-export {renderToReadableStream, ReactVersion as version};
+export {renderToReadableStream, resume, ReactVersion as version};

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -188,4 +188,8 @@ function resumeToPipeableStream(
   };
 }
 
-export {renderToPipeableStream, ReactVersion as version};
+export {
+  renderToPipeableStream,
+  resumeToPipeableStream,
+  ReactVersion as version,
+};

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Request} from 'react-server/src/ReactFizzServer';
+import type {Request, ResumableState} from 'react-server/src/ReactFizzServer';
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {Writable} from 'stream';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
@@ -17,6 +17,7 @@ import ReactVersion from 'shared/ReactVersion';
 
 import {
   createRequest,
+  resumeRequest,
   startWork,
   startFlowing,
   abort,
@@ -51,6 +52,15 @@ type Options = {
   onError?: (error: mixed) => ?string,
   onPostpone?: (reason: string) => void,
   unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor,
+};
+
+type ResumeOptions = {
+  nonce?: string,
+  onShellReady?: () => void,
+  onShellError?: (error: mixed) => void,
+  onAllReady?: () => void,
+  onError?: (error: mixed) => ?string,
+  onPostpone?: (reason: string) => void,
 };
 
 type PipeableStream = {
@@ -90,6 +100,59 @@ function renderToPipeableStream(
   options?: Options,
 ): PipeableStream {
   const request = createRequestImpl(children, options);
+  let hasStartedFlowing = false;
+  startWork(request);
+  return {
+    pipe<T: Writable>(destination: T): T {
+      if (hasStartedFlowing) {
+        throw new Error(
+          'React currently only supports piping to one writable stream.',
+        );
+      }
+      hasStartedFlowing = true;
+      startFlowing(request, destination);
+      destination.on('drain', createDrainHandler(destination, request));
+      destination.on(
+        'error',
+        createAbortHandler(
+          request,
+          'The destination stream errored while writing data.',
+        ),
+      );
+      destination.on(
+        'close',
+        createAbortHandler(request, 'The destination stream closed early.'),
+      );
+      return destination;
+    },
+    abort(reason: mixed) {
+      abort(request, reason);
+    },
+  };
+}
+
+function resumeRequestImpl(children: ReactNodeList,
+  resumableState: ResumableState,
+  options: void | ResumeOptions) {
+  return resumeRequest(
+    children,
+    resumableState, // TODO: How to pass nonce?
+    options ? options.onError : undefined,
+    options ? options.onAllReady : undefined,
+    options ? options.onShellReady : undefined,
+    options ? options.onShellError : undefined,
+    undefined,
+    options ? options.onPostpone : undefined,
+  );
+}
+
+
+function resumeToPipeableStream(
+  children: ReactNodeList,
+  resumableState: ResumableState,
+  options?: ResumeOptions,
+): PipeableStream {
+  const request = resumeRequestImpl(children, resumableState, options);
   let hasStartedFlowing = false;
   startWork(request);
   return {

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -17,7 +17,6 @@ import ReactVersion from 'shared/ReactVersion';
 
 import {
   createRequest,
-  resumeRequest,
   startWork,
   startFlowing,
   abort,
@@ -135,13 +134,15 @@ function resumeRequestImpl(
   postponedState: PostponedState,
   options: void | ResumeOptions,
 ) {
-  return resumeRequest(
+  return createRequest(
     children,
-    postponedState,
+    postponedState.resumableState,
     createRenderState(
       postponedState.resumableState,
       options ? options.nonce : undefined,
     ),
+    postponedState.rootFormatContext,
+    postponedState.progressiveChunkSize,
     options ? options.onError : undefined,
     options ? options.onAllReady : undefined,
     options ? options.onShellReady : undefined,

--- a/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
@@ -14,7 +14,7 @@ import type {PostponedState} from 'react-server/src/ReactFizzServer';
 import ReactVersion from 'shared/ReactVersion';
 
 import {
-  createPrerenderRequest,
+  createRequest,
   startWork,
   startFlowing,
   abort,
@@ -78,7 +78,7 @@ function prerender(
       options ? options.bootstrapModules : undefined,
       options ? options.unstable_externalRuntimeSrc : undefined,
     );
-    const request = createPrerenderRequest(
+    const request = createRequest(
       children,
       resources,
       createRenderState(resources, undefined),
@@ -86,6 +86,8 @@ function prerender(
       options ? options.progressiveChunkSize : undefined,
       options ? options.onError : undefined,
       onAllReady,
+      undefined,
+      undefined,
       onFatalError,
       options ? options.onPostpone : undefined,
     );

--- a/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
@@ -9,7 +9,7 @@
 
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
-import type {ResumableState} from 'react-server/src/ReactFizzServer';
+import type {PostponedState} from 'react-server/src/ReactFizzServer';
 
 import ReactVersion from 'shared/ReactVersion';
 
@@ -22,8 +22,8 @@ import {
 } from 'react-server/src/ReactFizzServer';
 
 import {
-  createResources,
-  createResponseState,
+  createResumableState,
+  createRenderState,
   createRootFormatContext,
 } from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 
@@ -41,7 +41,7 @@ type Options = {
 };
 
 type StaticResult = {
-  postponed: null | ResumableState,
+  postponed: null | PostponedState,
   prelude: ReadableStream,
 };
 
@@ -70,19 +70,18 @@ function prerender(
       };
       resolve(result);
     }
-    const resources = createResources();
+    const resources = createResumableState(
+      options ? options.identifierPrefix : undefined,
+      undefined, // nonce is not compatible with prerendered bootstrap scripts
+      options ? options.bootstrapScriptContent : undefined,
+      options ? options.bootstrapScripts : undefined,
+      options ? options.bootstrapModules : undefined,
+      options ? options.unstable_externalRuntimeSrc : undefined,
+    );
     const request = createPrerenderRequest(
       children,
       resources,
-      createResponseState(
-        resources,
-        options ? options.identifierPrefix : undefined,
-        undefined,
-        options ? options.bootstrapScriptContent : undefined,
-        options ? options.bootstrapScripts : undefined,
-        options ? options.bootstrapModules : undefined,
-        options ? options.unstable_externalRuntimeSrc : undefined,
-      ),
+      createRenderState(resources, undefined),
       createRootFormatContext(options ? options.namespaceURI : undefined),
       options ? options.progressiveChunkSize : undefined,
       options ? options.onError : undefined,

--- a/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
@@ -9,14 +9,16 @@
 
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
+import type {ResumableState} from 'react-server/src/ReactFizzServer';
 
 import ReactVersion from 'shared/ReactVersion';
 
 import {
-  createRequest,
+  createPrerenderRequest,
   startWork,
   startFlowing,
   abort,
+  getPostponedState,
 } from 'react-server/src/ReactFizzServer';
 
 import {
@@ -39,6 +41,7 @@ type Options = {
 };
 
 type StaticResult = {
+  postponed: null | ResumableState,
   prelude: ReadableStream,
 };
 
@@ -62,12 +65,13 @@ function prerender(
       );
 
       const result = {
+        postponed: getPostponedState(request),
         prelude: stream,
       };
       resolve(result);
     }
     const resources = createResources();
-    const request = createRequest(
+    const request = createPrerenderRequest(
       children,
       resources,
       createResponseState(
@@ -83,8 +87,6 @@ function prerender(
       options ? options.progressiveChunkSize : undefined,
       options ? options.onError : undefined,
       onAllReady,
-      undefined,
-      undefined,
       onFatalError,
       options ? options.onPostpone : undefined,
     );

--- a/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
@@ -14,7 +14,7 @@ import type {PostponedState} from 'react-server/src/ReactFizzServer';
 import ReactVersion from 'shared/ReactVersion';
 
 import {
-  createPrerenderRequest,
+  createRequest,
   startWork,
   startFlowing,
   abort,
@@ -78,7 +78,7 @@ function prerender(
       options ? options.bootstrapModules : undefined,
       options ? options.unstable_externalRuntimeSrc : undefined,
     );
-    const request = createPrerenderRequest(
+    const request = createRequest(
       children,
       resources,
       createRenderState(resources, undefined),
@@ -86,6 +86,8 @@ function prerender(
       options ? options.progressiveChunkSize : undefined,
       options ? options.onError : undefined,
       onAllReady,
+      undefined,
+      undefined,
       onFatalError,
       options ? options.onPostpone : undefined,
     );

--- a/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
@@ -9,7 +9,7 @@
 
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
-import type {ResumableState} from 'react-server/src/ReactFizzServer';
+import type {PostponedState} from 'react-server/src/ReactFizzServer';
 
 import ReactVersion from 'shared/ReactVersion';
 
@@ -22,8 +22,8 @@ import {
 } from 'react-server/src/ReactFizzServer';
 
 import {
-  createResources,
-  createResponseState,
+  createResumableState,
+  createRenderState,
   createRootFormatContext,
 } from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 
@@ -41,7 +41,7 @@ type Options = {
 };
 
 type StaticResult = {
-  postponed: null | ResumableState,
+  postponed: null | PostponedState,
   prelude: ReadableStream,
 };
 
@@ -70,19 +70,18 @@ function prerender(
       };
       resolve(result);
     }
-    const resources = createResources();
+    const resources = createResumableState(
+      options ? options.identifierPrefix : undefined,
+      undefined, // nonce is not compatible with prerendered bootstrap scripts
+      options ? options.bootstrapScriptContent : undefined,
+      options ? options.bootstrapScripts : undefined,
+      options ? options.bootstrapModules : undefined,
+      options ? options.unstable_externalRuntimeSrc : undefined,
+    );
     const request = createPrerenderRequest(
       children,
       resources,
-      createResponseState(
-        resources,
-        options ? options.identifierPrefix : undefined,
-        undefined,
-        options ? options.bootstrapScriptContent : undefined,
-        options ? options.bootstrapScripts : undefined,
-        options ? options.bootstrapModules : undefined,
-        options ? options.unstable_externalRuntimeSrc : undefined,
-      ),
+      createRenderState(resources, undefined),
       createRootFormatContext(options ? options.namespaceURI : undefined),
       options ? options.progressiveChunkSize : undefined,
       options ? options.onError : undefined,

--- a/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
@@ -9,14 +9,16 @@
 
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
+import type {ResumableState} from 'react-server/src/ReactFizzServer';
 
 import ReactVersion from 'shared/ReactVersion';
 
 import {
-  createRequest,
+  createPrerenderRequest,
   startWork,
   startFlowing,
   abort,
+  getPostponedState,
 } from 'react-server/src/ReactFizzServer';
 
 import {
@@ -39,6 +41,7 @@ type Options = {
 };
 
 type StaticResult = {
+  postponed: null | ResumableState,
   prelude: ReadableStream,
 };
 
@@ -62,12 +65,13 @@ function prerender(
       );
 
       const result = {
+        postponed: getPostponedState(request),
         prelude: stream,
       };
       resolve(result);
     }
     const resources = createResources();
-    const request = createRequest(
+    const request = createPrerenderRequest(
       children,
       resources,
       createResponseState(
@@ -83,8 +87,6 @@ function prerender(
       options ? options.progressiveChunkSize : undefined,
       options ? options.onError : undefined,
       onAllReady,
-      undefined,
-      undefined,
       onFatalError,
       options ? options.onPostpone : undefined,
     );

--- a/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
@@ -9,7 +9,7 @@
 
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
-import type {ResumableState} from 'react-server/src/ReactFizzServer';
+import type {PostponedState} from 'react-server/src/ReactFizzServer';
 
 import {Writable, Readable} from 'stream';
 
@@ -24,8 +24,8 @@ import {
 } from 'react-server/src/ReactFizzServer';
 
 import {
-  createResources,
-  createResponseState,
+  createResumableState,
+  createRenderState,
   createRootFormatContext,
 } from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 
@@ -43,7 +43,7 @@ type Options = {
 };
 
 type StaticResult = {
-  postponed: null | ResumableState,
+  postponed: null | PostponedState,
   prelude: Readable,
 };
 
@@ -84,19 +84,18 @@ function prerenderToNodeStream(
       };
       resolve(result);
     }
-    const resources = createResources();
+    const resumableState = createResumableState(
+      options ? options.identifierPrefix : undefined,
+      undefined, // nonce is not compatible with prerendered bootstrap scripts
+      options ? options.bootstrapScriptContent : undefined,
+      options ? options.bootstrapScripts : undefined,
+      options ? options.bootstrapModules : undefined,
+      options ? options.unstable_externalRuntimeSrc : undefined,
+    );
     const request = createPrerenderRequest(
       children,
-      resources,
-      createResponseState(
-        resources,
-        options ? options.identifierPrefix : undefined,
-        undefined,
-        options ? options.bootstrapScriptContent : undefined,
-        options ? options.bootstrapScripts : undefined,
-        options ? options.bootstrapModules : undefined,
-        options ? options.unstable_externalRuntimeSrc : undefined,
-      ),
+      resumableState,
+      createRenderState(resumableState, undefined),
       createRootFormatContext(options ? options.namespaceURI : undefined),
       options ? options.progressiveChunkSize : undefined,
       options ? options.onError : undefined,

--- a/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
@@ -16,7 +16,7 @@ import {Writable, Readable} from 'stream';
 import ReactVersion from 'shared/ReactVersion';
 
 import {
-  createPrerenderRequest,
+  createRequest,
   startWork,
   startFlowing,
   abort,
@@ -92,7 +92,7 @@ function prerenderToNodeStream(
       options ? options.bootstrapModules : undefined,
       options ? options.unstable_externalRuntimeSrc : undefined,
     );
-    const request = createPrerenderRequest(
+    const request = createRequest(
       children,
       resumableState,
       createRenderState(resumableState, undefined),
@@ -100,6 +100,8 @@ function prerenderToNodeStream(
       options ? options.progressiveChunkSize : undefined,
       options ? options.onError : undefined,
       onAllReady,
+      undefined,
+      undefined,
       onFatalError,
       options ? options.onPostpone : undefined,
     );

--- a/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
@@ -9,16 +9,18 @@
 
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
+import type {ResumableState} from 'react-server/src/ReactFizzServer';
 
 import {Writable, Readable} from 'stream';
 
 import ReactVersion from 'shared/ReactVersion';
 
 import {
-  createRequest,
+  createPrerenderRequest,
   startWork,
   startFlowing,
   abort,
+  getPostponedState,
 } from 'react-server/src/ReactFizzServer';
 
 import {
@@ -41,6 +43,7 @@ type Options = {
 };
 
 type StaticResult = {
+  postponed: null | ResumableState,
   prelude: Readable,
 };
 
@@ -76,12 +79,13 @@ function prerenderToNodeStreams(
       const writable = createFakeWritable(readable);
 
       const result = {
+        postponed: getPostponedState(request),
         prelude: readable,
       };
       resolve(result);
     }
     const resources = createResources();
-    const request = createRequest(
+    const request = createPrerenderRequest(
       children,
       resources,
       createResponseState(
@@ -97,8 +101,6 @@ function prerenderToNodeStreams(
       options ? options.progressiveChunkSize : undefined,
       options ? options.onError : undefined,
       onAllReady,
-      undefined,
-      undefined,
       onFatalError,
       options ? options.onPostpone : undefined,
     );

--- a/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
@@ -63,7 +63,7 @@ function createFakeWritable(readable: any): Writable {
   }: any);
 }
 
-function prerenderToNodeStreams(
+function prerenderToNodeStream(
   children: ReactNodeList,
   options?: Options,
 ): Promise<StaticResult> {
@@ -120,4 +120,4 @@ function prerenderToNodeStreams(
   });
 }
 
-export {prerenderToNodeStreams, ReactVersion as version};
+export {prerenderToNodeStream, ReactVersion as version};

--- a/packages/react-dom/src/server/ReactDOMLegacyServerImpl.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerImpl.js
@@ -10,7 +10,6 @@
 import ReactVersion from 'shared/ReactVersion';
 
 import type {ReactNodeList} from 'shared/ReactTypes';
-import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 
 import {
   createRequest,
@@ -20,8 +19,8 @@ import {
 } from 'react-server/src/ReactFizzServer';
 
 import {
-  createResources,
-  createResponseState,
+  createResumableState,
+  createRenderState,
   createRootFormatContext,
 } from 'react-dom-bindings/src/server/ReactFizzConfigDOMLegacy';
 
@@ -38,7 +37,6 @@ function renderToStringImpl(
   options: void | ServerOptions,
   generateStaticMarkup: boolean,
   abortReason: string,
-  unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor,
 ): string {
   let didFatal = false;
   let fatalError = null;
@@ -62,16 +60,18 @@ function renderToStringImpl(
   function onShellReady() {
     readyToStream = true;
   }
-  const resources = createResources();
+  const resumableState = createResumableState(
+    options ? options.identifierPrefix : undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  );
   const request = createRequest(
     children,
-    resources,
-    createResponseState(
-      resources,
-      generateStaticMarkup,
-      options ? options.identifierPrefix : undefined,
-      unstable_externalRuntimeSrc,
-    ),
+    resumableState,
+    createRenderState(resumableState, undefined, generateStaticMarkup),
     createRootFormatContext(),
     Infinity,
     onError,

--- a/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
@@ -19,8 +19,8 @@ import {
 } from 'react-server/src/ReactFizzServer';
 
 import {
-  createResources,
-  createResponseState,
+  createResumableState,
+  createRenderState,
   createRootFormatContext,
 } from 'react-dom-bindings/src/server/ReactFizzConfigDOMLegacy';
 
@@ -71,15 +71,18 @@ function renderToNodeStreamImpl(
     startFlowing(request, destination);
   }
   const destination = new ReactMarkupReadableStream();
-  const resources = createResources();
+  const resumableState = createResumableState(
+    options ? options.identifierPrefix : undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  );
   const request = createRequest(
     children,
-    resources,
-    createResponseState(
-      resources,
-      false,
-      options ? options.identifierPrefix : undefined,
-    ),
+    resumableState,
+    createRenderState(resumableState, undefined, false),
     createRootFormatContext(),
     Infinity,
     onError,

--- a/packages/react-dom/src/server/react-dom-server.browser.js
+++ b/packages/react-dom/src/server/react-dom-server.browser.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from './ReactDOMFizzServerBrowser.js';

--- a/packages/react-dom/src/server/react-dom-server.browser.stable.js
+++ b/packages/react-dom/src/server/react-dom-server.browser.stable.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export {renderToReadableStream, version} from './ReactDOMFizzServerBrowser.js';

--- a/packages/react-dom/src/server/react-dom-server.bun.js
+++ b/packages/react-dom/src/server/react-dom-server.bun.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from './ReactDOMFizzServerBun.js';

--- a/packages/react-dom/src/server/react-dom-server.bun.stable.js
+++ b/packages/react-dom/src/server/react-dom-server.bun.stable.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export {
+  renderToReadableStream,
+  renderToNodeStream,
+  renderToStaticNodeStream,
+  version,
+} from './ReactDOMFizzServerBun.js';

--- a/packages/react-dom/src/server/react-dom-server.edge.js
+++ b/packages/react-dom/src/server/react-dom-server.edge.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from './ReactDOMFizzServerEdge.js';

--- a/packages/react-dom/src/server/react-dom-server.edge.stable.js
+++ b/packages/react-dom/src/server/react-dom-server.edge.stable.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export {renderToReadableStream, version} from './ReactDOMFizzServerEdge.js';

--- a/packages/react-dom/src/server/react-dom-server.node.js
+++ b/packages/react-dom/src/server/react-dom-server.node.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from './ReactDOMFizzServerNode.js';

--- a/packages/react-dom/src/server/react-dom-server.node.stable.js
+++ b/packages/react-dom/src/server/react-dom-server.node.stable.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export {renderToPipeableStream, version} from './ReactDOMFizzServerNode.js';

--- a/packages/react-dom/static.node.js
+++ b/packages/react-dom/static.node.js
@@ -8,6 +8,6 @@
  */
 
 export {
-  prerenderToNodeStreams,
+  prerenderToNodeStream,
   version,
 } from './src/server/ReactDOMFizzStaticNode';

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -51,7 +51,7 @@ type Destination = {
   stack: Array<Segment | Instance | SuspenseInstance>,
 };
 
-type Resources = null;
+type RenderState = null;
 type BoundaryResources = null;
 
 const POP = Buffer.from('/', 'utf8');
@@ -104,7 +104,7 @@ const ReactNoopServer = ReactFizzServer({
   pushTextInstance(
     target: Array<Uint8Array>,
     text: string,
-    responseState: ResponseState,
+    renderState: RenderState,
     textEmbedded: boolean,
   ): boolean {
     const textInstance: TextInstance = {
@@ -140,21 +140,21 @@ const ReactNoopServer = ReactFizzServer({
   // This is a noop in ReactNoop
   pushSegmentFinale(
     target: Array<Uint8Array>,
-    responseState: ResponseState,
+    renderState: RenderState,
     lastPushedText: boolean,
     textEmbedded: boolean,
   ): void {},
 
   writeCompletedRoot(
     destination: Destination,
-    responseState: ResponseState,
+    renderState: RenderState,
   ): boolean {
     return true;
   },
 
   writePlaceholder(
     destination: Destination,
-    responseState: ResponseState,
+    renderState: RenderState,
     id: number,
   ): boolean {
     const parent = destination.stack[destination.stack.length - 1];
@@ -166,7 +166,7 @@ const ReactNoopServer = ReactFizzServer({
 
   writeStartCompletedSuspenseBoundary(
     destination: Destination,
-    responseState: ResponseState,
+    renderState: RenderState,
     suspenseInstance: SuspenseInstance,
   ): boolean {
     suspenseInstance.state = 'complete';
@@ -176,7 +176,7 @@ const ReactNoopServer = ReactFizzServer({
   },
   writeStartPendingSuspenseBoundary(
     destination: Destination,
-    responseState: ResponseState,
+    renderState: RenderState,
     suspenseInstance: SuspenseInstance,
   ): boolean {
     suspenseInstance.state = 'pending';
@@ -186,7 +186,7 @@ const ReactNoopServer = ReactFizzServer({
   },
   writeStartClientRenderedSuspenseBoundary(
     destination: Destination,
-    responseState: ResponseState,
+    renderState: RenderState,
     suspenseInstance: SuspenseInstance,
   ): boolean {
     suspenseInstance.state = 'client-render';
@@ -206,7 +206,7 @@ const ReactNoopServer = ReactFizzServer({
 
   writeStartSegment(
     destination: Destination,
-    responseState: ResponseState,
+    renderState: RenderState,
     formatContext: null,
     id: number,
   ): boolean {
@@ -225,7 +225,7 @@ const ReactNoopServer = ReactFizzServer({
 
   writeCompletedSegmentInstruction(
     destination: Destination,
-    responseState: ResponseState,
+    renderState: RenderState,
     contentSegmentID: number,
   ): boolean {
     const segment = destination.segments.get(contentSegmentID);
@@ -245,7 +245,7 @@ const ReactNoopServer = ReactFizzServer({
 
   writeCompletedBoundaryInstruction(
     destination: Destination,
-    responseState: ResponseState,
+    renderState: RenderState,
     boundary: SuspenseInstance,
     contentSegmentID: number,
   ): boolean {
@@ -259,7 +259,7 @@ const ReactNoopServer = ReactFizzServer({
 
   writeClientRenderBoundaryInstruction(
     destination: Destination,
-    responseState: ResponseState,
+    renderState: RenderState,
     boundary: SuspenseInstance,
   ): boolean {
     boundary.status = 'client-render';
@@ -268,10 +268,6 @@ const ReactNoopServer = ReactFizzServer({
   writePreamble() {},
   writeHoistables() {},
   writePostamble() {},
-
-  createResources(): Resources {
-    return null;
-  },
 
   createBoundaryResources(): BoundaryResources {
     return null;

--- a/packages/react-server-dom-fb/src/ReactDOMServerFB.js
+++ b/packages/react-server-dom-fb/src/ReactDOMServerFB.js
@@ -23,8 +23,8 @@ import {
 } from 'react-server/src/ReactFizzServer';
 
 import {
-  createResources,
-  createResponseState,
+  createResumableState,
+  createRenderState,
   createRootFormatContext,
 } from 'react-server/src/ReactFizzConfig';
 
@@ -50,19 +50,18 @@ function renderToStream(children: ReactNodeList, options: Options): Stream {
     fatal: false,
     error: null,
   };
-  const resources = createResources();
+  const resumableState = createResumableState(
+    options ? options.identifierPrefix : undefined,
+    undefined,
+    options ? options.bootstrapScriptContent : undefined,
+    options ? options.bootstrapScripts : undefined,
+    options ? options.bootstrapModules : undefined,
+    options ? options.unstable_externalRuntimeSrc : undefined,
+  );
   const request = createRequest(
     children,
-    resources,
-    createResponseState(
-      resources,
-      options ? options.identifierPrefix : undefined,
-      undefined,
-      options ? options.bootstrapScriptContent : undefined,
-      options ? options.bootstrapScripts : undefined,
-      options ? options.bootstrapModules : undefined,
-      options ? options.unstable_externalRuntimeSrc : undefined,
-    ),
+    resumableState,
+    createRenderState(resumableState, undefined),
     createRootFormatContext(undefined),
     options ? options.progressiveChunkSize : undefined,
     options.onError,

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -16,7 +16,7 @@ import type {
   Usable,
 } from 'shared/ReactTypes';
 
-import type {ResponseState} from './ReactFizzConfig';
+import type {ResumableState} from './ReactFizzConfig';
 import type {Task} from './ReactFizzServer';
 import type {ThenableState} from './ReactFizzThenable';
 import type {TransitionStatus} from './ReactFizzConfig';
@@ -554,15 +554,15 @@ function useId(): string {
   const task: Task = (currentlyRenderingTask: any);
   const treeId = getTreeId(task.treeContext);
 
-  const responseState = currentResponseState;
-  if (responseState === null) {
+  const resumableState = currentResumableState;
+  if (resumableState === null) {
     throw new Error(
       'Invalid hook call. Hooks can only be called inside of the body of a function component.',
     );
   }
 
   const localId = localIdCounter++;
-  return makeId(responseState, treeId, localId);
+  return makeId(resumableState, treeId, localId);
 }
 
 function use<T>(usable: Usable<T>): T {
@@ -652,9 +652,9 @@ if (enableAsyncActions) {
   HooksDispatcher.useOptimistic = useOptimistic;
 }
 
-export let currentResponseState: null | ResponseState = (null: any);
-export function setCurrentResponseState(
-  responseState: null | ResponseState,
+export let currentResumableState: null | ResumableState = (null: any);
+export function setCurrentResumableState(
+  resumableState: null | ResumableState,
 ): void {
-  currentResponseState = responseState;
+  currentResumableState = resumableState;
 }

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -281,7 +281,7 @@ function defaultErrorHandler(error: mixed) {
 
 function noop(): void {}
 
-function createRequestImpl(
+export function createRequest(
   children: ReactNodeList,
   resumableState: ResumableState,
   renderState: RenderState,
@@ -350,86 +350,6 @@ function createRequestImpl(
   );
   pingedTasks.push(rootTask);
   return request;
-}
-
-export function createRequest(
-  children: ReactNodeList,
-  resumableState: ResumableState,
-  renderState: RenderState,
-  rootFormatContext: FormatContext,
-  progressiveChunkSize: void | number,
-  onError: void | ((error: mixed) => ?string),
-  onAllReady: void | (() => void),
-  onShellReady: void | (() => void),
-  onShellError: void | ((error: mixed) => void),
-  onFatalError: void | ((error: mixed) => void),
-  onPostpone: void | ((reason: string) => void),
-): Request {
-  return createRequestImpl(
-    children,
-    resumableState,
-    renderState,
-    rootFormatContext,
-    progressiveChunkSize,
-    onError,
-    onAllReady,
-    onShellReady,
-    onShellError,
-    onFatalError,
-    onPostpone,
-  );
-}
-
-export function createPrerenderRequest(
-  children: ReactNodeList,
-  resumableState: ResumableState,
-  renderState: RenderState,
-  rootFormatContext: FormatContext,
-  progressiveChunkSize: void | number,
-  onError: void | ((error: mixed) => ?string),
-  onAllReady: void | (() => void),
-  onFatalError: void | ((error: mixed) => void),
-  onPostpone: void | ((reason: string) => void),
-): Request {
-  return createRequestImpl(
-    children,
-    resumableState,
-    renderState,
-    rootFormatContext,
-    progressiveChunkSize,
-    onError,
-    onAllReady,
-    undefined,
-    undefined,
-    onFatalError,
-    onPostpone,
-  );
-}
-
-export function resumeRequest(
-  children: ReactNodeList,
-  postponedState: PostponedState,
-  renderState: RenderState,
-  onError: void | ((error: mixed) => ?string),
-  onAllReady: void | (() => void),
-  onShellReady: void | (() => void),
-  onShellError: void | ((error: mixed) => void),
-  onFatalError: void | ((error: mixed) => void),
-  onPostpone: void | ((reason: string) => void),
-): Request {
-  return createRequestImpl(
-    children,
-    postponedState.resumableState,
-    renderState,
-    postponedState.rootFormatContext,
-    postponedState.progressiveChunkSize,
-    onError,
-    onAllReady,
-    onShellReady,
-    onShellError,
-    onFatalError,
-    onPostpone,
-  );
 }
 
 let currentRequest: null | Request = null;

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -281,7 +281,7 @@ function defaultErrorHandler(error: mixed) {
 
 function noop(): void {}
 
-export function createRequest(
+function createRequestImpl(
   children: ReactNodeList,
   resources: Resources,
   responseState: ResponseState,
@@ -350,6 +350,85 @@ export function createRequest(
   );
   pingedTasks.push(rootTask);
   return request;
+}
+
+export function createRequest(
+  children: ReactNodeList,
+  resources: Resources,
+  responseState: ResponseState,
+  rootFormatContext: FormatContext,
+  progressiveChunkSize: void | number,
+  onError: void | ((error: mixed) => ?string),
+  onAllReady: void | (() => void),
+  onShellReady: void | (() => void),
+  onShellError: void | ((error: mixed) => void),
+  onFatalError: void | ((error: mixed) => void),
+  onPostpone: void | ((reason: string) => void),
+): Request {
+  return createRequestImpl(
+    children,
+    resources,
+    responseState,
+    rootFormatContext,
+    progressiveChunkSize,
+    onError,
+    onAllReady,
+    onShellReady,
+    onShellError,
+    onFatalError,
+    onPostpone,
+  );
+}
+
+export function createPrerenderRequest(
+  children: ReactNodeList,
+  resources: Resources,
+  responseState: ResponseState,
+  rootFormatContext: FormatContext,
+  progressiveChunkSize: void | number,
+  onError: void | ((error: mixed) => ?string),
+  onAllReady: void | (() => void),
+  onFatalError: void | ((error: mixed) => void),
+  onPostpone: void | ((reason: string) => void),
+): Request {
+  return createRequestImpl(
+    children,
+    resources,
+    responseState,
+    rootFormatContext,
+    progressiveChunkSize,
+    onError,
+    onAllReady,
+    undefined,
+    undefined,
+    onFatalError,
+    onPostpone,
+  );
+}
+
+export function resumeRequest(
+  children: ReactNodeList,
+  resumableState: ResumableState,
+  onError: void | ((error: mixed) => ?string),
+  onAllReady: void | (() => void),
+  onShellReady: void | (() => void),
+  onShellError: void | ((error: mixed) => void),
+  onFatalError: void | ((error: mixed) => void),
+  onPostpone: void | ((reason: string) => void),
+): Request {
+  return createRequestImpl(
+    children,
+    resumableState.resources,
+    resumableState.responseState,
+    resumableState.rootFormatContext,
+    resumableState.progressiveChunkSize,
+    onError,
+    onAllReady,
+    onShellReady,
+    onShellError,
+    onFatalError,
+    onPostpone,
+  );
 }
 
 let currentRequest: null | Request = null;
@@ -2612,4 +2691,17 @@ export function flushResources(request: Request): void {
 
 export function getResources(request: Request): Resources {
   return request.resources;
+}
+
+export type ResumableState = {
+  nextSegmentId: number,
+  rootFormatContext: FormatContext,
+  progressiveChunkSize: number,
+  responseState: ResponseState,
+  resources: Resources,
+};
+
+// Returns the state of a postponed request or null if nothing was postponed.
+export function getPostponedState(request: Request): null | ResumableState {
+  return null;
 }

--- a/packages/react-server/src/forks/ReactFizzConfig.custom.js
+++ b/packages/react-server/src/forks/ReactFizzConfig.custom.js
@@ -28,8 +28,8 @@ import type {TransitionStatus} from 'react-reconciler/src/ReactFiberConfig';
 
 declare var $$$config: any;
 export opaque type Destination = mixed; // eslint-disable-line no-undef
-export opaque type ResponseState = mixed;
-export opaque type Resources = mixed;
+export opaque type RenderState = mixed;
+export opaque type ResumableState = mixed;
 export opaque type BoundaryResources = mixed;
 export opaque type FormatContext = mixed;
 export opaque type SuspenseBoundaryID = mixed;

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -233,7 +233,7 @@ const bundles = [
   {
     bundleTypes: [NODE_DEV, NODE_PROD, UMD_DEV, UMD_PROD],
     moduleType: RENDERER,
-    entry: 'react-dom/src/server/ReactDOMFizzServerBrowser.js',
+    entry: 'react-dom/src/server/react-dom-server.browser.js',
     name: 'react-dom-server.browser',
     global: 'ReactDOMServer',
     minifyWithProdErrorCodes: true,
@@ -243,7 +243,7 @@ const bundles = [
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
-    entry: 'react-dom/src/server/ReactDOMFizzServerNode.js',
+    entry: 'react-dom/src/server/react-dom-server.node.js',
     name: 'react-dom-server.node',
     global: 'ReactDOMServer',
     minifyWithProdErrorCodes: false,
@@ -264,7 +264,7 @@ const bundles = [
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
-    entry: 'react-dom/src/server/ReactDOMFizzServerEdge.js',
+    entry: 'react-dom/src/server/react-dom-server.edge.js',
     name: 'react-dom-server.edge', // 'node_modules/react/*.js',
 
     global: 'ReactDOMServer',
@@ -277,7 +277,7 @@ const bundles = [
   {
     bundleTypes: [BUN_DEV, BUN_PROD],
     moduleType: RENDERER,
-    entry: 'react-dom/src/server/ReactDOMFizzServerBun.js',
+    entry: 'react-dom/src/server/react-dom-server.bun.js',
     name: 'react-dom-server.bun', // 'node_modules/react/*.js',
 
     global: 'ReactDOMServer',

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -12,7 +12,7 @@ module.exports = [
     entryPoints: [
       'react-dom',
       'react-dom/unstable_testing',
-      'react-dom/src/server/ReactDOMFizzServerNode.js',
+      'react-dom/src/server/react-dom-server.node.js',
       'react-dom/static.node',
       'react-dom/server-rendering-stub',
       'react-dom/unstable_server-external-runtime',
@@ -27,6 +27,7 @@ module.exports = [
       'react-dom/server.node',
       'react-dom/static',
       'react-dom/static.node',
+      'react-dom/src/server/react-dom-server.node',
       'react-dom/src/server/ReactDOMFizzServerNode.js', // react-dom/server.node
       'react-dom/src/server/ReactDOMFizzStaticNode.js',
       'react-server-dom-webpack',
@@ -46,10 +47,11 @@ module.exports = [
   },
   {
     shortName: 'dom-bun',
-    entryPoints: ['react-dom', 'react-dom/src/server/ReactDOMFizzServerBun.js'],
+    entryPoints: ['react-dom', 'react-dom/src/server/react-dom-server.bun.js'],
     paths: [
       'react-dom',
       'react-dom/server.bun',
+      'react-dom/src/server/react-dom-server.bun',
       'react-dom/src/server/ReactDOMFizzServerBun.js',
       'react-dom-bindings',
       'shared/ReactDOMSharedInternals',
@@ -62,7 +64,7 @@ module.exports = [
     entryPoints: [
       'react-dom',
       'react-dom/unstable_testing',
-      'react-dom/src/server/ReactDOMFizzServerBrowser.js',
+      'react-dom/src/server/react-dom-server.browser.js',
       'react-dom/static.browser',
       'react-dom/server-rendering-stub',
       'react-dom/unstable_server-external-runtime',
@@ -76,6 +78,7 @@ module.exports = [
       'react-dom/server.browser',
       'react-dom/static.browser',
       'react-dom/unstable_testing',
+      'react-dom/src/server/react-dom-server.browser',
       'react-dom/src/server/ReactDOMFizzServerBrowser.js', // react-dom/server.browser
       'react-dom/src/server/ReactDOMFizzStaticBrowser.js',
       'react-server-dom-webpack',
@@ -118,7 +121,7 @@ module.exports = [
   {
     shortName: 'dom-edge-webpack',
     entryPoints: [
-      'react-dom/src/server/ReactDOMFizzServerEdge.js',
+      'react-dom/src/server/react-dom-server.edge.js',
       'react-dom/static.edge',
       'react-server-dom-webpack/server.edge',
       'react-server-dom-webpack/client.edge',
@@ -130,6 +133,7 @@ module.exports = [
       'react-dom/server.edge',
       'react-dom/static.edge',
       'react-dom/unstable_testing',
+      'react-dom/src/server/react-dom-server.edge',
       'react-dom/src/server/ReactDOMFizzServerEdge.js', // react-dom/server.edge
       'react-dom/src/server/ReactDOMFizzStaticEdge.js',
       'react-server-dom-webpack',
@@ -160,6 +164,7 @@ module.exports = [
       'react-dom/server.node',
       'react-dom/static',
       'react-dom/static.node',
+      'react-dom/src/server/react-dom-server.node',
       'react-dom/src/server/ReactDOMFizzServerNode.js', // react-dom/server.node
       'react-dom/src/server/ReactDOMFizzStaticNode.js',
       'react-server-dom-webpack',
@@ -193,6 +198,7 @@ module.exports = [
       'react-dom/server.node',
       'react-dom/static',
       'react-dom/static.node',
+      'react-dom/src/server/react-dom-server.node',
       'react-dom/src/server/ReactDOMFizzServerNode.js', // react-dom/server.node
       'react-dom/src/server/ReactDOMFizzStaticNode.js',
       'react-server-dom-esm',


### PR DESCRIPTION
This exposes a `resume()` API to go with the `prerender()` (only in experimental). It doesn't work yet since we don't yet emit the postponed state so not yet tested.

The main thing this does is rename ResponseState->RenderState and Resources->ResumableState. We separated out resources into a separate concept preemptively since it seemed like separate enough but probably doesn't warrant being a separate concept. The result is that we have a per RenderState in the Config which is really just temporary state and things that must be flushed completely in the prerender. Most things should be ResumableState.

Most options are specified in the `prerender()` and transferred into the `resume()` but certain options that are unique per request can't be. Notably `nonce` is special. This means that bootstrap scripts and external runtime can't use `nonce` in this mode. They need to have a CSP configured to deal with external scripts, but not inline.

We need to be able to restore state of things that we've already emitted in the prerender. We could have separate snapshot/restore methods that does this work when it happens but that means we have to explicitly do that work. This design is trying to keep to the principle that we just work with resumable data structures instead so that we're designing for it with every feature. It also makes restoring faster since it's just straight into the data structure.

This is not yet a serializable format. That can be done in a follow up.

We also need to vet that each step makes sense. Notably stylesToHoist is a bit unclear how it'll work.