### PR TITLE
Fix escaping in action error URL

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -501,7 +501,7 @@ function setProp(
             // eslint-disable-next-line no-script-url
             "javascript:throw new Error('" +
               'A React form was unexpectedly submitted. If you called form.submit() manually, ' +
-              "consider using form.requestSubmit() instead. If you're trying to use " +
+              "consider using form.requestSubmit() instead. If you\\'re trying to use " +
               'event.stopPropagation() in a submit event handler, consider also calling ' +
               'event.preventDefault().' +
               "')",


### PR DESCRIPTION
This URL is generated on the client (there's an equivalent but shorter SSR version too) when a function is used as an action. It should never happen but it'll be invoked if a form is manually submitted or event is stopped early.

The `'` wasn't escaped so this yielded invalid syntax. Which is an error too but much less helpful. `missing ) after argument list`. Added a test that evals to make sure it's correct syntax.
