### PR TITLE
Feat:-Add summary component instances

### DIFF
--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -1444,12 +1444,13 @@ export default class Store extends EventEmitter<{
     copy(text);
   };
 
-  getAllElements = () => Array<{id: number, displayName: string | null}> = () =>  {
-    return Array.from(this._idToElement, ([, value]) => ({
-      id: value.id,
-      displayName: value.displayName,
-    })).filter(value => !!value.displayName);
-  };
+  getAllElements: () => Array<{id: number, displayName: string | null}> =
+    () => {
+      return Array.from(this._idToElement, ([, value]) => ({
+        id: value.id,
+        displayName: value.displayName,
+      })).filter(value => !!value.displayName);
+    };
   // The Store should never throw an Error without also emitting an event.
   // Otherwise Store errors will be invisible to users,
   // but the downstream errors they cause will be reported as bugs.
@@ -1458,7 +1459,7 @@ export default class Store extends EventEmitter<{
   _throwAndEmitError(error: Error): empty {
     this.emit('error', error);
 
-    // Throwing is still valuable for local development
+    // Throwing is still valuuable for local development
     // and for unit testing the Store itself.
     throw error;
   }

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -1444,7 +1444,7 @@ export default class Store extends EventEmitter<{
     copy(text);
   };
 
-  getAllElements = (): Array<{|id: number, displayName: null | string|}> => {
+  getAllElements = (): Array<{id: number, displayName: string | null}> => {
     return Array.from(this._idToElement, ([, value]) => ({
       id: value.id,
       displayName: value.displayName,

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -1444,6 +1444,12 @@ export default class Store extends EventEmitter<{
     copy(text);
   };
 
+  getAllElements = (): Array<{|id: number, displayName: null | string|}> => {
+    return Array.from(this._idToElement, ([, value]) => ({
+      id: value.id,
+      displayName: value.displayName,
+    })).filter(value => !!value.displayName);
+  };
   // The Store should never throw an Error without also emitting an event.
   // Otherwise Store errors will be invisible to users,
   // but the downstream errors they cause will be reported as bugs.

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -1444,7 +1444,7 @@ export default class Store extends EventEmitter<{
     copy(text);
   };
 
-  getAllElements = (): Array<{id: number, displayName: string | null}> => {
+  getAllElements = () => Array<{id: number, displayName: string | null}> = () =>  {
     return Array.from(this._idToElement, ([, value]) => ({
       id: value.id,
       displayName: value.displayName,

--- a/packages/react-devtools-shared/src/devtools/views/Components/ComponentSummary.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/ComponentSummary.css
@@ -1,0 +1,37 @@
+  .Container {
+    width: 100%;
+    overflow: hidden;
+    flex: 1 0 auto;
+  }
+  
+  .Container:focus {
+    outline: none;
+  }
+  
+  .SummaryList {
+    font-family: var(--font-family-monospace);
+    font-size: var(--font-size-monospace-normal);
+    line-height: var(--line-height-data);
+  }
+  
+  .ComponentLine {
+    display: flex;
+    align-items: center;
+    padding-right: 2rem;
+  }
+  
+  .ComponentName {
+    width: calc(100% - 1rem);
+    color: var(--color-component-name);
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    pointer-events: none;
+    white-space: nowrap;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+  }
+  
+  .InstanceCount {
+    width: 1rem;
+    text-align: right;
+  }

--- a/packages/react-devtools-shared/src/devtools/views/Components/ComponentSummary.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/ComponentSummary.js
@@ -1,0 +1,116 @@
+import React, {useContext, useMemo} from 'react';
+import {FixedSizeList} from 'react-window';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import Tooltip from '@reach/tooltip';
+import {StoreContext} from '../context';
+import {SettingsContext} from '../Settings/SettingsContext';
+import {useSubscription} from '../hooks';
+import styles from './ComponentSummary.css';
+import tooltipStyles from '../Components/reach-ui/Tooltip.css';
+
+type ListItem = {|
+  componentName: string,
+  instanceCount: number,
+|};
+
+export default function ComponentSummary(props: Props) {
+  const store = useContext(StoreContext);
+
+  const allElementsSubscription = useMemo(
+    () => ({
+      getCurrentValue: () => {
+        const components = store
+          .getAllElements()
+          .reduce((allComponents, element) => {
+            const component = allComponents.find(
+              ({componentName}) => componentName === element.displayName,
+            );
+            if (component) {
+              component.instanceCount += 1;
+            } else {
+              allComponents.push({
+                componentName: element.displayName,
+                instanceCount: 1,
+              });
+            }
+
+            return allComponents;
+          }, []);
+
+        components.sort(
+          (
+            {instanceCount: count1, componentName: componentName1},
+            {instanceCount: count2, componentName: componentName2},
+          ) =>
+            count1 === count2
+              ? componentName1.localeCompare(componentName2)
+              : count2 - count1,
+        );
+
+        return components;
+      },
+      subscribe: (callback: Function) => {
+        store.addListener('mutated', callback);
+        return () => store.removeListener('mutated', callback);
+      },
+    }),
+    [store],
+  );
+
+  const items = useSubscription(allElementsSubscription);
+
+  return (
+    <div className={styles.Container}>
+      <AutoSizer>
+        {({height, width}) => (
+          <ComponentInstanceList items={items} height={height} width={width} />
+        )}
+      </AutoSizer>
+    </div>
+  );
+}
+
+type ListProps = {|
+  height: number,
+  width: number,
+  items: Array<ListItem>,
+|};
+
+function ComponentInstanceList({height, width, items}: ListProps) {
+  const {lineHeight} = useContext(SettingsContext);
+  return (
+    <FixedSizeList
+      className={styles.SummaryList}
+      height={height}
+      innerElementType="div"
+      itemCount={items.length}
+      itemData={items}
+      itemSize={lineHeight}
+      width={width}>
+      {ComponentInstanceListItem}
+    </FixedSizeList>
+  );
+}
+
+type ListItemProps = {
+  data: Array<ListItem>,
+  index: number,
+  style: Object,
+};
+
+function ComponentInstanceListItem(props: ListItemProps) {
+  const {index, data, style} = props;
+  const {componentName, instanceCount} = data[index];
+  const title = `${componentName} has ${instanceCount} instance${
+    instanceCount > 1 ? 's' : ''
+  } mounted`;
+
+  return (
+    <div className={styles.ComponentLine} style={style}>
+      <div className={styles.ComponentName}>{componentName}</div>
+      <Tooltip label={title} className={tooltipStyles.Tooltip}>
+        <span className={styles.InstanceCount}>{instanceCount}</span>
+      </Tooltip>
+    </div>
+  );
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/ComponentSummary.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/ComponentSummary.js
@@ -13,6 +13,8 @@ type ListItem = {|
   instanceCount: number,
 |};
 
+type Props = {};
+
 export default function ComponentSummary(props: Props) {
   const store = useContext(StoreContext);
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
@@ -357,9 +357,27 @@ export default function Tree(props: Props): React.Node {
     clearErrorsAndWarningsAPI({bridge, store});
   };
 
+  const zeroElementsNotice = (
+    <div className={styles.ZeroElementsNotice}>
+      <p>Loading React Element Tree...</p>
+      <p>
+        If this seems stuck, please follow the{' '}
+        <a
+          className={styles.Link}
+          href="https://github.com/facebook/react/blob/main/packages/react-devtools/README.md#the-react-tab-shows-no-components"
+          target="_blank">
+          troubleshooting instructions
+        </a>
+        .
+      </p>
+    </div>
+  );
+
   const content =
     selectedTabID === 'summary' ? (
       <ComponentSummary />
+    ) : numElements === 0 ? (
+      zeroElementsNotice
     ) : (
       <div
         className={styles.AutoSizerWrapper}
@@ -372,7 +390,6 @@ export default function Tree(props: Props): React.Node {
         tabIndex={0}>
         <AutoSizer>
           {({height, width}) => (
-            // $FlowFixMe https://github.com/facebook/flow/issues/7341
             <FixedSizeList
               className={styles.List}
               height={height}
@@ -389,22 +406,6 @@ export default function Tree(props: Props): React.Node {
         </AutoSizer>
       </div>
     );
-
-  const zeroElementsNotice = (
-    <div className={styles.ZeroElementsNotice}>
-      <p>Loading React Element Tree...</p>
-      <p>
-        If this seems stuck, please follow the{' '}
-        <a
-          className={styles.Link}
-          href="https://github.com/facebook/react/blob/main/packages/react-devtools/README.md#the-react-tab-shows-no-components"
-          target="_blank">
-          troubleshooting instructions
-        </a>
-        .
-      </p>
-    </div>
-  );
 
   return (
     <TreeFocusedContext.Provider value={treeFocused}>

--- a/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
@@ -36,6 +36,8 @@ import {clearErrorsAndWarnings as clearErrorsAndWarningsAPI} from 'react-devtool
 import styles from './Tree.css';
 import ButtonIcon from '../ButtonIcon';
 import Button from '../Button';
+import ComponentSummary from './ComponentSummary';
+import TabBar from '../TabBar';
 import {logEvent} from 'react-devtools-shared/src/Logger';
 
 // Never indent more than this number of pixels (even if we have the room).
@@ -50,6 +52,19 @@ export type ItemData = {
 };
 
 type Props = {};
+
+const tabs = [
+  {
+    id: 'tree',
+    label: 'Tree',
+    title: 'Component tree',
+  },
+  {
+    id: 'summary',
+    label: 'Summary',
+    title: 'Component summary',
+  },
+];
 
 export default function Tree(props: Props): React.Node {
   const dispatch = useContext(TreeDispatcherContext);
@@ -66,6 +81,7 @@ export default function Tree(props: Props): React.Node {
   const {hideSettings} = useContext(OptionsContext);
   const [isNavigatingWithKeyboard, setIsNavigatingWithKeyboard] =
     useState(false);
+  const [selectedTabID, setSelectedTabID] = useState('tree');
   const {highlightNativeElement, clearHighlightNativeElement} =
     useHighlightNativeElement();
   const treeRef = useRef<HTMLDivElement | null>(null);
@@ -341,6 +357,39 @@ export default function Tree(props: Props): React.Node {
     clearErrorsAndWarningsAPI({bridge, store});
   };
 
+  const content =
+    selectedTabID === 'summary' ? (
+      <ComponentSummary />
+    ) : (
+      <div
+        className={styles.AutoSizerWrapper}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
+        onKeyPress={handleKeyPress}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+        ref={focusTargetRef}
+        tabIndex={0}>
+        <AutoSizer>
+          {({height, width}) => (
+            // $FlowFixMe https://github.com/facebook/flow/issues/7341
+            <FixedSizeList
+              className={styles.List}
+              height={height}
+              innerElementType={InnerElementType}
+              itemCount={numElements}
+              itemData={itemData}
+              itemKey={itemKey}
+              itemSize={lineHeight}
+              ref={listCallbackRef}
+              width={width}>
+              {Element}
+            </FixedSizeList>
+          )}
+        </AutoSizer>
+      </div>
+    );
+
   const zeroElementsNotice = (
     <div className={styles.ZeroElementsNotice}>
       <p>Loading React Element Tree...</p>
@@ -404,6 +453,13 @@ export default function Tree(props: Props): React.Node {
                 </Button>
               </React.Fragment>
             )}
+          <TabBar
+            currentTab={selectedTabID}
+            id="Components"
+            selectTab={setSelectedTabID}
+            tabs={tabs}
+            type="components"
+          />
           {!hideSettings && (
             <Fragment>
               <div className={styles.VRule} />
@@ -411,36 +467,7 @@ export default function Tree(props: Props): React.Node {
             </Fragment>
           )}
         </div>
-        {numElements === 0 ? (
-          zeroElementsNotice
-        ) : (
-          <div
-            className={styles.AutoSizerWrapper}
-            onBlur={handleBlur}
-            onFocus={handleFocus}
-            onKeyPress={handleKeyPress}
-            onMouseMove={handleMouseMove}
-            onMouseLeave={handleMouseLeave}
-            ref={focusTargetRef}
-            tabIndex={0}>
-            <AutoSizer>
-              {({height, width}) => (
-                <FixedSizeList
-                  className={styles.List}
-                  height={height}
-                  innerElementType={InnerElementType}
-                  itemCount={numElements}
-                  itemData={itemData}
-                  itemKey={itemKey}
-                  itemSize={lineHeight}
-                  ref={listCallbackRef}
-                  width={width}>
-                  {Element}
-                </FixedSizeList>
-              )}
-            </AutoSizer>
-          </div>
-        )}
+        {content}
       </div>
     </TreeFocusedContext.Provider>
   );

--- a/packages/react-devtools-shared/src/devtools/views/TabBar.css
+++ b/packages/react-devtools-shared/src/devtools/views/TabBar.css
@@ -46,6 +46,10 @@
   font-size: var(--font-size-sans-normal);
   padding: 0.25rem 0.5rem;
 }
+.TabSizeComponents {
+  font-size: var(--font-size-sans-normal);
+  padding: 0.25rem 0.5rem;
+}
 
 .Input {
   width: 0;
@@ -80,9 +84,15 @@
   height: 1rem;
 }
 
+.IconSizeComponents {
+  display: none;
+}
+
 .TabLabelNavigation,
 .TabLabelProfiler,
-.TabLabelSettings {
+.TabLabelSettings,
+.TabLabelComponents
+{
 }
 
 .VRule {

--- a/packages/react-devtools-shared/src/devtools/views/TabBar.js
+++ b/packages/react-devtools-shared/src/devtools/views/TabBar.js
@@ -29,7 +29,7 @@ export type Props = {
   id: string,
   selectTab: (tabID: any) => void,
   tabs: Array<TabInfo | null>,
-  type: 'navigation' | 'profiler' | 'settings',
+  type: 'navigation' | 'profiler' | 'settings' | 'components',
 };
 
 export default function TabBar({
@@ -81,6 +81,11 @@ export default function TabBar({
       iconSizeClassName = styles.IconSizeSettings;
       tabLabelClassName = styles.TabLabelSettings;
       tabSizeClassName = styles.TabSizeSettings;
+      break;
+    case 'components':
+      iconSizeClassName = styles.IconSizeComponents;
+      tabLabelClassName = styles.TabLabelComponents;
+      tabSizeClassName = styles.TabSizeComponents;
       break;
     default:
       throw Error(`Unsupported type "${type}"`);


### PR DESCRIPTION
Its just a small POC and if it gets some good response and is actually useful then makes sense
Currently we have our tree View in the React Devtools, rendering the components instances in a tree structure 

How about a new tab which sort of acts like a summary  of components, like showing the number of instances of a particular component is mounted at a particular render cycle.

thoughts @hoxyq 

https://github.com/facebook/react/assets/72331432/628e3c2c-2f0f-4372-b9a0-717e7f5c7532


we can do some sort of vote in twitter or somewhere what people think about this

