### PR TITLE
[Fizz] Move /static build into /server builds

### DIFF
--- a/packages/react-dom/npm/static.browser.js
+++ b/packages/react-dom/npm/static.browser.js
@@ -1,7 +1,11 @@
 'use strict';
 
+var s;
 if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./cjs/react-dom-static.browser.production.min.js');
+  s = require('./cjs/react-dom-server.browser.production.min.js');
 } else {
-  module.exports = require('./cjs/react-dom-static.browser.development.js');
+  s = require('./cjs/react-dom-server.browser.development.js');
 }
+
+exports.version = s.version;
+exports.prerender = s.prerender;

--- a/packages/react-dom/npm/static.edge.js
+++ b/packages/react-dom/npm/static.edge.js
@@ -1,7 +1,11 @@
 'use strict';
 
+var s;
 if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./cjs/react-dom-static.edge.production.min.js');
+  s = require('./cjs/react-dom-server.edge.production.min.js');
 } else {
-  module.exports = require('./cjs/react-dom-static.edge.development.js');
+  s = require('./cjs/react-dom-server.edge.development.js');
 }
+
+exports.version = s.version;
+exports.prerender = s.prerender;

--- a/packages/react-dom/npm/static.node.js
+++ b/packages/react-dom/npm/static.node.js
@@ -1,7 +1,11 @@
 'use strict';
 
+var s;
 if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./cjs/react-dom-static.node.production.min.js');
+  s = require('./cjs/react-dom-server.node.production.min.js');
 } else {
-  module.exports = require('./cjs/react-dom-static.node.development.js');
+  s = require('./cjs/react-dom-server.node.development.js');
 }
+
+exports.version = s.version;
+exports.prerenderToNodeStream = s.prerenderToNodeStream;

--- a/packages/react-dom/src/server/react-dom-server.browser.js
+++ b/packages/react-dom/src/server/react-dom-server.browser.js
@@ -8,3 +8,4 @@
  */
 
 export * from './ReactDOMFizzServerBrowser.js';
+export {prerender} from './ReactDOMFizzStaticBrowser.js';

--- a/packages/react-dom/src/server/react-dom-server.edge.js
+++ b/packages/react-dom/src/server/react-dom-server.edge.js
@@ -8,3 +8,4 @@
  */
 
 export * from './ReactDOMFizzServerEdge.js';
+export {prerender} from './ReactDOMFizzStaticEdge.js';

--- a/packages/react-dom/src/server/react-dom-server.node.js
+++ b/packages/react-dom/src/server/react-dom-server.node.js
@@ -8,3 +8,4 @@
  */
 
 export * from './ReactDOMFizzServerNode.js';
+export {prerenderToNodeStream} from './ReactDOMFizzStaticNode.js';

--- a/packages/react-dom/static.browser.js
+++ b/packages/react-dom/static.browser.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export {prerender, version} from './src/server/ReactDOMFizzStaticBrowser';
+export {prerender, version} from './src/server/react-dom-server.browser';

--- a/packages/react-dom/static.edge.js
+++ b/packages/react-dom/static.edge.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export {prerender, version} from './src/server/ReactDOMFizzStaticEdge';
+export {prerender, version} from './src/server/react-dom-server.edge';

--- a/packages/react-dom/static.node.js
+++ b/packages/react-dom/static.node.js
@@ -10,4 +10,4 @@
 export {
   prerenderToNodeStream,
   version,
-} from './src/server/ReactDOMFizzStaticNode';
+} from './src/server/react-dom-server.node';

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -286,36 +286,6 @@ const bundles = [
     externals: ['react', 'react-dom'],
   },
 
-  /******* React DOM Fizz Static *******/
-  {
-    bundleTypes: __EXPERIMENTAL__ ? [NODE_DEV, NODE_PROD] : [],
-    moduleType: RENDERER,
-    entry: 'react-dom/static.browser',
-    global: 'ReactDOMStatic',
-    minifyWithProdErrorCodes: true,
-    wrapWithModuleBoundaries: false,
-    externals: ['react', 'react-dom'],
-  },
-  {
-    bundleTypes: __EXPERIMENTAL__ ? [NODE_DEV, NODE_PROD] : [],
-    moduleType: RENDERER,
-    entry: 'react-dom/static.node',
-    name: 'react-dom-static.node',
-    global: 'ReactDOMStatic',
-    minifyWithProdErrorCodes: false,
-    wrapWithModuleBoundaries: false,
-    externals: ['react', 'util', 'async_hooks', 'stream', 'react-dom'],
-  },
-  {
-    bundleTypes: __EXPERIMENTAL__ ? [NODE_DEV, NODE_PROD] : [],
-    moduleType: RENDERER,
-    entry: 'react-dom/static.edge',
-    global: 'ReactDOMStatic',
-    minifyWithProdErrorCodes: true,
-    wrapWithModuleBoundaries: false,
-    externals: ['react', 'react-dom'],
-  },
-
   /******* React DOM Fizz Server External Runtime *******/
   {
     bundleTypes: [BROWSER_SCRIPT],


### PR DESCRIPTION
This joins the static (prerender) builds with the server builds but doesn't change the public entry points.

The idea of two separate bundles is that we'd have a specialized build for Fizz just for the prerender that could do a lot more. However, in practice the code is implemented with a dynamic check so it's in both. It's also not a lot of code.

At the same time if you do have a set up that includes both the prerender and the render in the same build output, this just doubles the server bundle size for no reason.

So we might as well merge them into one build. However, I don't expose the `prerender` from `/server`. Instead it's just exposed from the public `/static` entry point. This leaves us with the option to go back to separate builds later if it diverges more in the future.