### PR TITLE
feat[devtools/extension]: add dark theme for popup

### DIFF
--- a/packages/react-devtools-extensions/popups/shared.css
+++ b/packages/react-devtools-extensions/popups/shared.css
@@ -5,3 +5,9 @@ html, body {
 body {
   margin: 8px;
 }
+
+@media (prefers-color-scheme: dark) {
+  html {
+    color-scheme: dark;
+  }
+}


### PR DESCRIPTION
## Summary

If the system/browser uses a dark theme, then the extension popup still remains with a light background. And so that the eyes do not hurt in a dark room, you need a dark theme.

## How did you test this change?

Make sure the dark theme is enabled on your system/browser.

**Before:**

![Screenshot 2023-09-02 at 22 20 56](https://github.com/facebook/react/assets/19418601/f7166ea7-f562-4d11-8851-be08fa9629a7)

**After:**

![Screenshot 2023-09-02 at 22 21 30](https://github.com/facebook/react/assets/19418601/e51ecd5f-3e71-4193-83ff-a548bce76bd4)