### PR TITLE
Add `server.edge` to `react-server-dom-esm`

### DIFF
--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-esm.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-esm.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from 'react-client/src/ReactFlightClientConfigBrowser';
+export * from 'react-server-dom-esm/src/ReactFlightClientConfigESMBundler';
+export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';
+export const usedWithSSR = true;

--- a/packages/react-server-dom-esm/npm/server.edge.js
+++ b/packages/react-server-dom-esm/npm/server.edge.js
@@ -1,0 +1,5 @@
+'use strict';
+
+throw new Error(
+  "'react-server-dom-esm/server.edge' cannot be imported directly. Instead, import from 'react-server-dom-esm/server'."
+);

--- a/packages/react-server-dom-esm/package.json
+++ b/packages/react-server-dom-esm/package.json
@@ -17,6 +17,7 @@
     "client.node.js",
     "server.js",
     "server.node.js",
+    "server.edge.js",
     "cjs/",
     "esm/"
   ],
@@ -29,9 +30,15 @@
     "./client.browser": "./client.browser.js",
     "./client.node": "./client.node.js",
     "./server": {
-      "react-server": "./server.node.js",
+      "react-server": {
+        "workerd": "./esm/react-server-dom-esm-server.edge.production.min.js",
+        "edge-light": "./esm/react-server-dom-esm-server.edge.production.min.js",
+        "node": "./server.node.js",
+        "default": "./server.node.js"
+      },
       "default": "./server.js"
     },
+    "./server.edge": "./server.edge.js",
     "./server.node": "./server.node.js",
     "./node-loader": "./esm/react-server-dom-esm-node-loader.production.min.js",
     "./src/*": "./src/*.js",

--- a/packages/react-server-dom-esm/server.edge.js
+++ b/packages/react-server-dom-esm/server.edge.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from './src/ReactFlightDOMServerEdge';

--- a/packages/react-server-dom-esm/src/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-esm/src/ReactFlightDOMServerEdge.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
+import type {ClientManifest} from './ReactFlightServerConfigESMBundler';
+import type {ServerManifest} from 'react-client/src/ReactFlightClientConfig';
+import type {ServerContextJSONValue, Thenable} from 'shared/ReactTypes';
+
+import {
+  createRequest,
+  startWork,
+  startFlowing,
+  abort,
+} from 'react-server/src/ReactFlightServer';
+
+import {
+  createResponse,
+  close,
+  getRoot,
+} from 'react-server/src/ReactFlightReplyServer';
+
+import {decodeAction} from 'react-server/src/ReactFlightActionServer';
+
+export {
+  registerServerReference,
+  registerClientReference,
+} from './ReactFlightESMReferences';
+
+type Options = {
+  identifierPrefix?: string,
+  signal?: AbortSignal,
+  context?: Array<[string, ServerContextJSONValue]>,
+  onError?: (error: mixed) => void,
+  onPostpone?: (reason: string) => void,
+};
+
+function renderToReadableStream(
+  model: ReactClientValue,
+  moduleBasePath: ClientManifest,
+  options?: Options,
+): ReadableStream {
+  const request = createRequest(
+    model,
+    moduleBasePath,
+    options ? options.onError : undefined,
+    options ? options.context : undefined,
+    options ? options.identifierPrefix : undefined,
+    options ? options.onPostpone : undefined,
+  );
+  if (options && options.signal) {
+    const signal = options.signal;
+    if (signal.aborted) {
+      abort(request, (signal: any).reason);
+    } else {
+      const listener = () => {
+        abort(request, (signal: any).reason);
+        signal.removeEventListener('abort', listener);
+      };
+      signal.addEventListener('abort', listener);
+    }
+  }
+  const stream = new ReadableStream(
+    {
+      type: 'bytes',
+      start: (controller): ?Promise<void> => {
+        startWork(request);
+      },
+      pull: (controller): ?Promise<void> => {
+        startFlowing(request, controller);
+      },
+      cancel: (reason): ?Promise<void> => {},
+    },
+    // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
+    {highWaterMark: 0},
+  );
+  return stream;
+}
+
+function decodeReply<T>(
+  body: string | FormData,
+  moduleBasePath: ServerManifest,
+): Thenable<T> {
+  if (typeof body === 'string') {
+    const form = new FormData();
+    form.append('0', body);
+    body = form;
+  }
+  const response = createResponse(moduleBasePath, '', body);
+  close(response);
+  return getRoot(response);
+}
+
+export {renderToReadableStream, decodeReply, decodeAction};

--- a/packages/react-server-dom-esm/src/ReactFlightESMNodeLoader.js
+++ b/packages/react-server-dom-esm/src/ReactFlightESMNodeLoader.js
@@ -329,9 +329,9 @@ async function transformClientModule(
       newSrc +=
         'throw new Error(' +
         JSON.stringify(
-          `Attempted to call the default export of ${url} from the server` +
+          `Attempted to call the default export of ${url} from the server ` +
             `but it's on the client. It's not possible to invoke a client function from ` +
-            `the server, it can only be rendered as a Component or passed to props of a` +
+            `the server, it can only be rendered as a Component or passed to props of a ` +
             `Client Component.`,
         ) +
         ');';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge-esm.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge-esm.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+import {AsyncLocalStorage} from 'async_hooks';
+
+import type {Request} from 'react-server/src/ReactFlightServer';
+
+export * from 'react-server-dom-esm/src/ReactFlightServerConfigESMBundler';
+export * from 'react-dom-bindings/src/server/ReactFlightServerConfigDOM';
+
+export const supportsRequestStorage = true;
+export const requestStorage: AsyncLocalStorage<Request> =
+  new AsyncLocalStorage();

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -420,7 +420,7 @@ const bundles = [
     externals: ['url', 'module', 'react-server-dom-webpack/server'],
   },
 
-  /******* React Server DOM ESM Server *******/
+  /******* React Server DOM ESM Node.js Server *******/
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
@@ -428,6 +428,16 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'util', 'async_hooks', 'react-dom'],
+  },
+
+  /******* React Server DOM ESM Edge Server *******/
+  {
+    bundleTypes: [NODE_DEV, NODE_PROD, ESM_DEV, ESM_PROD],
+    moduleType: RENDERER,
+    entry: 'react-server-dom-esm/server.edge',
+    minifyWithProdErrorCodes: false,
+    wrapWithModuleBoundaries: false,
+    externals: ['react', 'async_hooks', 'react-dom'],
   },
 
   /******* React Server DOM ESM Client *******/

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -185,6 +185,32 @@ module.exports = [
     isServerSupported: true,
   },
   {
+    shortName: 'dom-edge-esm',
+    entryPoints: ['react-server-dom-esm/server.edge'],
+    paths: [
+      'react-dom',
+      'react-dom-bindings',
+      'react-dom/client',
+      'react-dom/server.edge',
+      'react-dom/static.edge',
+      'react-dom/src/server/react-dom-server.edge',
+      'react-dom/src/server/ReactDOMFizzServerEdge.js', // react-dom/server.edge
+      'react-dom/src/server/ReactDOMFizzStaticEdge.js',
+      'react-server-dom-esm',
+      'react-server-dom-esm/server',
+      'react-server-dom-esm/server.edge',
+      'react-server-dom-esm/src/ReactFlightDOMServerEdge.js', // react-server-dom-esm/server.edge
+      'react-devtools',
+      'react-devtools-core',
+      'react-devtools-shell',
+      'react-devtools-shared',
+      'react-interactions',
+      'shared/ReactDOMSharedInternals',
+    ],
+    isFlowTyped: true,
+    isServerSupported: true,
+  },
+  {
     shortName: 'dom-node-esm',
     entryPoints: [
       'react-server-dom-esm/server.node',


### PR DESCRIPTION
## Summary

React Server DOM webpack has both a Node.js and a Edge server, but React Server DOM ESM only had a Node.js server. This PR adds a Edge server for React Server DOM ESM.

## How did you test this change?

Doesn't look like React Server DOM ESM has any tests yet. Happy to try adding some, but that might make more sense in a different PR. Let me know what y'all think.

Locally, I have a hacked together fixture based on flight-esm which shows this working in workerd (the Cloudflare Workers runtime). Also happy to share that if that helps validate this PR.