### PR TITLE
Track the key path difference between right before the first array

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
@@ -461,7 +461,7 @@ describe('ReactDOMFizzStaticBrowser', () => {
       if (prerendering) {
         React.unstable_postpone();
       }
-      return 'Hello';
+      return ['Hello', 'World'];
     }
 
     function App() {


### PR DESCRIPTION
There's a subtle difference if you suspend before the first array or after. In Fiber, we don't deal with this because we just suspend the parent and replay it if lazy() or Usable are used in its child slots. In Fizz we try to optimize this a bit more and enable resuming inside the component.

Semantically, it's different if you suspend/postpone before the first child array or inside that child array. Because when you resume the inner result might be another array and either that's part of the parent path or part of the inner slot.

There might be more clever way of structuring this but I just use -1 to indicate that we're not yet inside the array and is in the root child position. If that renders an element, then that's just the same as the 0 slot.

We need to also encode this in the resuming. I called that resuming the element or resuming the slot.