### PR TITLE
Add feature flag to use microtasks in the React Native Fabric renderer

### DIFF
--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -47,6 +47,8 @@ const {
   unstable_getCurrentEventPriority: fabricGetCurrentEventPriority,
 } = nativeFabricUIManager;
 
+import {useMicrotasksForSchedulingInFabric} from 'shared/ReactFeatureFlags';
+
 const {get: getViewConfigForType} = ReactNativeViewConfigRegistry;
 
 // Counter for uniquely identifying views.
@@ -119,7 +121,6 @@ export * from 'react-reconciler/src/ReactFiberConfigWithNoMutation';
 export * from 'react-reconciler/src/ReactFiberConfigWithNoHydration';
 export * from 'react-reconciler/src/ReactFiberConfigWithNoScopes';
 export * from 'react-reconciler/src/ReactFiberConfigWithNoTestSelectors';
-export * from 'react-reconciler/src/ReactFiberConfigWithNoMicrotasks';
 export * from 'react-reconciler/src/ReactFiberConfigWithNoResources';
 export * from 'react-reconciler/src/ReactFiberConfigWithNoSingletons';
 
@@ -470,3 +471,10 @@ export function waitForCommitToBeReady(): null {
 }
 
 export const NotPendingTransition: TransitionStatus = null;
+
+// -------------------
+//     Microtasks
+// -------------------
+export const supportsMicrotasks = useMicrotasksForSchedulingInFabric;
+export const scheduleMicrotask: any =
+  typeof queueMicrotask === 'function' ? queueMicrotask : scheduleTimeout;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -122,6 +122,8 @@ export const enableAsyncActions = __EXPERIMENTAL__;
 
 export const alwaysThrottleRetries = true;
 
+export const useMicrotasksForSchedulingInFabric = false;
+
 // -----------------------------------------------------------------------------
 // Chopping Block
 //

--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -23,6 +23,7 @@ import typeof * as DynamicFlagsType from 'ReactNativeInternalFeatureFlags';
 export const enableUseRefAccessWarning = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const alwaysThrottleRetries = __VARIANT__;
+export const useMicrotasksForSchedulingInFabric = __VARIANT__;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): DynamicFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -21,6 +21,7 @@ export const {
   enableUseRefAccessWarning,
   enableDeferRootSchedulingToMicrotask,
   alwaysThrottleRetries,
+  useMicrotasksForSchedulingInFabric,
 } = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -77,5 +77,7 @@ export const enableAsyncActions = false;
 
 export const alwaysThrottleRetries = true;
 
+export const useMicrotasksForSchedulingInFabric = false;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -77,5 +77,7 @@ export const enableAsyncActions = false;
 
 export const alwaysThrottleRetries = true;
 
+export const useMicrotasksForSchedulingInFabric = false;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -74,5 +74,7 @@ export const enableAsyncActions = false;
 
 export const alwaysThrottleRetries = true;
 
+export const useMicrotasksForSchedulingInFabric = false;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -77,5 +77,7 @@ export const enableAsyncActions = false;
 
 export const alwaysThrottleRetries = true;
 
+export const useMicrotasksForSchedulingInFabric = false;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -108,5 +108,7 @@ export const enableFizzExternalRuntime = true;
 
 export const forceConcurrentByDefaultForTesting = false;
 
+export const useMicrotasksForSchedulingInFabric = false;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/scripts/flow/xplat.js
+++ b/scripts/flow/xplat.js
@@ -11,4 +11,5 @@ declare module 'ReactNativeInternalFeatureFlags' {
   declare export var enableUseRefAccessWarning: boolean;
   declare export var enableDeferRootSchedulingToMicrotask: boolean;
   declare export var alwaysThrottleRetries: boolean;
+  declare export var useMicrotasksForSchedulingInFabric: boolean;
 }


### PR DESCRIPTION
## Summary

This is part of an effort to align the event loop in React Native with its behavior on the Web. In this case, we're going to test enabling microtasks in React Native (Fabric) and we need React to schedule work using microtasks if available there. This just adds a feature flag to configure that behavior at runtime.

## How did you test this change?

* Reviewed the generated code, which looks ok.
* Did a manual sync of this PR to Meta's internal infra and tested it with my changes to enable microtasks in RN/Hermes.