### PR TITLE
Fix: Initialize childIndex in Task constructor

### DIFF
--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -578,6 +578,7 @@ function createTask(
     context,
     treeContext,
     thenableState,
+    childIndex: -1,
   }: any);
   if (__DEV__) {
     task.componentStack = null;


### PR DESCRIPTION
This field was not being initialized. Although the property is part of the Flow type, the type error wasn't caught because the constructor itself is not covered by Flow, which is unfortunate. (I assume this is related to the dev-only componentStack property.)