### PR TITLE
fix[devtools/extension]: unregister dynamically injected content scripts instead of filtering

### DIFF
--- a/packages/react-devtools-extensions/src/background/dynamicallyInjectContentScripts.js
+++ b/packages/react-devtools-extensions/src/background/dynamicallyInjectContentScripts.js
@@ -11,7 +11,7 @@ const contentScriptsToInject = IS_FIREFOX
         js: ['build/proxy.js'],
         matches: ['<all_urls>'],
         persistAcrossSessions: true,
-        runAt: 'document_idle',
+        runAt: 'document_end',
       },
     ]
   : [
@@ -43,26 +43,19 @@ const contentScriptsToInject = IS_FIREFOX
 
 async function dynamicallyInjectContentScripts() {
   try {
-    const alreadyRegisteredContentScripts =
-      await chrome.scripting.getRegisteredContentScripts();
+    // Using this, instead of filtering registered scrips with `chrome.scripting.getRegisteredScripts`
+    // because of https://bugs.chromium.org/p/chromium/issues/detail?id=1393762
+    // This fixes registering proxy content script in incognito mode
+    await chrome.scripting.unregisterContentScripts();
 
-    const scriptsToInjectNow = contentScriptsToInject.filter(
-      scriptToInject =>
-        !alreadyRegisteredContentScripts.some(
-          registeredScript => registeredScript.id === scriptToInject.id,
-        ),
-    );
-
-    if (scriptsToInjectNow.length) {
-      // equivalent logic for Firefox is in prepareInjection.js
-      // Manifest V3 method of injecting content script
-      // TODO(hoxyq): migrate Firefox to V3 manifests
-      // Note: the "world" option in registerContentScripts is only available in Chrome v102+
-      // It's critical since it allows us to directly run scripts on the "main" world on the page
-      // "document_start" allows it to run before the page's scripts
-      // so the hook can be detected by react reconciler
-      await chrome.scripting.registerContentScripts(scriptsToInjectNow);
-    }
+    // equivalent logic for Firefox is in prepareInjection.js
+    // Manifest V3 method of injecting content script
+    // TODO(hoxyq): migrate Firefox to V3 manifests
+    // Note: the "world" option in registerContentScripts is only available in Chrome v102+
+    // It's critical since it allows us to directly run scripts on the "main" world on the page
+    // "document_start" allows it to run before the page's scripts
+    // so the hook can be detected by react reconciler
+    await chrome.scripting.registerContentScripts(contentScriptsToInject);
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
Same as https://github.com/facebook/react/pull/26765.
Related bug report - https://bugs.chromium.org/p/chromium/issues/detail?id=1393762.

This was changed in https://github.com/facebook/react/pull/27215, when I have refactored background logic in the extension. I've missed this case, because the extension was working in incognito mode.

Turns out, it stops working after the first reload, and it stops only in incognito mode, so I am rolling out back the previous workaround.

Tested on Chrome that it fixes the extension in incognito mode and that it doesn't affect default mode.
