### PR TITLE
Key types: Add bigint support to Key

### DIFF
--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -230,7 +230,7 @@ export type PathMatch = {
 export type SerializedElement = {
   displayName: string | null,
   id: number,
-  key: number | string | null,
+  key: number | bigint | string | null,
   type: ElementType,
 };
 
@@ -273,7 +273,7 @@ export type InspectedElement = {
   hooks: Object | null,
   props: Object | null,
   state: Object | null,
-  key: number | string | null,
+  key: number | bigint | string | null,
   errors: Array<[string, number]>,
   warnings: Array<[string, number]>,
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/types.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/types.js
@@ -24,7 +24,7 @@ export type Element = {
   children: Array<number>,
   type: ElementType,
   displayName: string | null,
-  key: number | string | null,
+  key: number | bigint | string | null,
 
   hocDisplayNames: null | Array<string>,
 
@@ -51,7 +51,7 @@ export type Element = {
 export type SerializedElement = {
   displayName: string | null,
   id: number,
-  key: number | string | null,
+  key: number | bigint | string | null,
   hocDisplayNames: Array<string> | null,
   type: ElementType,
 };
@@ -100,7 +100,7 @@ export type InspectedElement = {
   hooks: Object | null,
   props: Object | null,
   state: Object | null,
-  key: number | string | null,
+  key: number | bigint | string | null,
   errors: Array<[string, number]>,
   warnings: Array<[string, number]>,
 

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/types.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/types.js
@@ -19,7 +19,7 @@ export type CommitTreeNode = {
   children: Array<number>,
   displayName: string | null,
   hocDisplayNames: Array<string> | null,
-  key: number | string | null,
+  key: number | bigint | string | null,
   parentID: number,
   treeBaseDuration: number,
   type: ElementType,
@@ -35,7 +35,7 @@ export type SnapshotNode = {
   children: Array<number>,
   displayName: string | null,
   hocDisplayNames: Array<string> | null,
-  key: number | string | null,
+  key: number | bigint | string | null,
   type: ElementType,
 };
 

--- a/packages/react-devtools/OVERVIEW.md
+++ b/packages/react-devtools/OVERVIEW.md
@@ -203,7 +203,7 @@ The frontend stores its information about the tree in a map of id to objects wit
 * children: `Array<number>`
 * type: `number` (constant)
 * displayName: `string | null`
-* key: `number | string | null`
+* key: `number | bigint | string | null`
 * ownerID: `number`
 * depth: `number` <sup>1</sup>
 * weight: `number` <sup>2</sup>

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -162,7 +162,7 @@ const ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
 export type KeyNode = [
   Root | KeyNode /* parent */,
   string | null /* name */,
-  string | number /* key */,
+  string | number | bigint /* key */,
 ];
 
 const REPLAY_NODE = 0;
@@ -173,7 +173,7 @@ const RESUME_SLOT = 3;
 type ReplaySuspenseBoundary = [
   1, // REPLAY_SUSPENSE_BOUNDARY
   string | null /* name */,
-  string | number /* key */,
+  string | number | bigint /* key */,
   Array<ResumableNode> /* children */,
   SuspenseBoundaryID /* id */,
   number /* rootSegmentID */,
@@ -183,7 +183,7 @@ type ReplayNode =
   | [
       0, // REPLAY_NODE
       string | null /* name */,
-      string | number /* key */,
+      string | number | bigint /* key */,
       Array<ResumableNode> /* children */,
     ]
   | ReplaySuspenseBoundary;
@@ -191,7 +191,7 @@ type ReplayNode =
 type ResumeElement = [
   2, // RESUME_ELEMENT
   string | null /* name */,
-  string | number /* key */,
+  string | number | bigint /* key */,
   number /* segment id */,
 ];
 
@@ -1961,8 +1961,9 @@ function trackPostpone(
 
     const boundaryKeyPath = boundary.keyPath;
     if (boundaryKeyPath === null) {
+      // eslint-disable-next-line react-internal/prod-error-codes
       throw new Error(
-        'It should not be possible to postpone at the root. This is a bug in React.',
+        `React.trackPostpone(...): It should not be possible to postpone at the root. This is a bug in React.`,
       );
     }
     const children: Array<ResumableNode> = [];
@@ -1980,8 +1981,9 @@ function trackPostpone(
 
   const keyPath = task.keyPath;
   if (keyPath === null) {
+    // eslint-disable-next-line react-internal/prod-error-codes
     throw new Error(
-      'It should not be possible to postpone at the root. This is a bug in React.',
+      `React.trackPostpone(...): It should not be possible to postpone at the root. This is a bug in React.`,
     );
   }
 


### PR DESCRIPTION
## Summary
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

React accept `null`, `undefined`, `string` and `number` on the Key property. It seems strange for React to allow floats like `key={1.2}` but not `key={4n}`. Despite `key={bigint.toString()}` working as expected, we understand `key` should allow `key={bigint}` directly.

For example, the following code gives this error: "Type 'bigint' is not assignable to type 'Key | null | undefined'"
<div className="App" key={4n}>

For more information on the motivation, check the [Related Issue #27351](https://github.com/facebook/react/issues/27351).

## How did you test this change?
Ran the build and fixture examples adding `Bigint`s to the keys. Notice it works fine.
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
