### PR TITLE
perf: remove allocations in useReducer

### DIFF
--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -367,7 +367,7 @@ export function useReducer<S, I, A>(
         // $FlowFixMe[incompatible-use] found when upgrading Flow
         renderPhaseUpdates.delete(queue);
         // $FlowFixMe[incompatible-use] found when upgrading Flow
-        let newState = workInProgressHook.memoizedState;
+        let newState = workInProgressHook.memoizedState[0];
         let update: Update<any> = firstRenderPhaseUpdate;
         do {
           // Process this render phase update. We don't have to check the
@@ -386,13 +386,11 @@ export function useReducer<S, I, A>(
         } while (update !== null);
 
         // $FlowFixMe[incompatible-use] found when upgrading Flow
-        workInProgressHook.memoizedState = newState;
-
-        return [newState, dispatch];
+        workInProgressHook.memoizedState = [newState, dispatch];
       }
     }
     // $FlowFixMe[incompatible-use] found when upgrading Flow
-    return [workInProgressHook.memoizedState, dispatch];
+    return workInProgressHook.memoizedState;
   } else {
     if (__DEV__) {
       isInHookUserCodeInDev = true;
@@ -412,8 +410,6 @@ export function useReducer<S, I, A>(
       isInHookUserCodeInDev = false;
     }
     // $FlowFixMe[incompatible-use] found when upgrading Flow
-    workInProgressHook.memoizedState = initialState;
-    // $FlowFixMe[incompatible-use] found when upgrading Flow
     const queue: UpdateQueue<A> = (workInProgressHook.queue = {
       last: null,
       dispatch: null,
@@ -424,7 +420,9 @@ export function useReducer<S, I, A>(
       queue,
     ): any));
     // $FlowFixMe[incompatible-use] found when upgrading Flow
-    return [workInProgressHook.memoizedState, dispatch];
+    workInProgressHook.memoizedState = [initialState, dispatch];
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
+    return workInProgressHook.memoizedState;
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

### Summary

I was reading the source for `useReducer` and I noticed the returned array is always re-allocated. I figured it could be nice to reuse the value if there has been no change.

One possible concern is if the user is doing unholy things with the returned array, e.g.:

```jsx
function C() {
  const stateResult = useState(0)
  const [state, setState] = stateResult
  const arrayMineNow = stateResult
  arrayMineNow[0] = 42
  arrayMineNow[1] = 42
  return (<button onClick={() => setState(state + 1)}>{state}</button>)
}
```

But such abnormal usage could be caught by e.g. sealing the array in dev.

### How did you test this change?

`yarn test` and `yarn test --prod`