### PR TITLE
[Fizz] Don't bail out of flushing if we still have pending root tasks

### DIFF
--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -3778,9 +3778,6 @@ function flushCompletedQueues(
         // We haven't flushed the root yet so we don't need to check any other branches further down
         return;
       }
-    } else if (request.pendingRootTasks > 0) {
-      // We have not yet flushed the root segment so we early return
-      return;
     }
 
     if (enableFloat) {


### PR DESCRIPTION
The idea for this check is that we shouldn't flush anything before we flush the shell. That may or may not hold true in future formats like RN.

It is a problem for resuming because with resuming it's possible to have root tasks that are used from resuming but the shell was already flushed so we can have completed boundaries before the shell has fully resumed.

It's not technically necessary to bail early because there won't be anything in partialBoundaries or completedBoundaries because nothing gets added there unless the parent has already flushed.

It's not exactly slow to have to check the length of three arrays so it's probably not a big deal.

Flush partials in an early preamble needs further consideration regardless.

