### PR TITLE
[Fizz] Client render the nearest child or parent suspense boundary if replay errors or is aborted

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -6488,11 +6488,15 @@ describe('ReactDOMFizzServer', () => {
       });
     });
 
-    expect(recoverableErrors).toEqual([
-      'server error',
-      'replay error',
-      'server error',
-    ]);
+    expect(recoverableErrors).toEqual(
+      __DEV__
+        ? ['server error', 'replay error', 'server error']
+        : [
+            'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+            'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+            'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+          ],
+    );
     expect(getVisibleChildren(container)).toEqual(
       <div>
         {'Hello'}
@@ -6642,10 +6646,17 @@ describe('ReactDOMFizzServer', () => {
 
     expect(prerenderErrors).toEqual([]);
     expect(ssrErrors).toEqual(['aborted', 'aborted']);
-    expect(recoverableErrors).toEqual([
-      'The server did not finish this Suspense boundary: aborted',
-      'The server did not finish this Suspense boundary: aborted',
-    ]);
+    expect(recoverableErrors).toEqual(
+      __DEV__
+        ? [
+            'The server did not finish this Suspense boundary: aborted',
+            'The server did not finish this Suspense boundary: aborted',
+          ]
+        : [
+            'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+            'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+          ],
+    );
   });
 
   // @gate enablePostpone
@@ -6806,10 +6817,17 @@ describe('ReactDOMFizzServer', () => {
       'replay error',
       'replay error',
     ]);
-    expect(recoverableErrors).toEqual([
+    expect(recoverableErrors).toEqual(
       // It surfaced in two different suspense boundaries.
-      'The server did not finish this Suspense boundary: replay error',
-      'The server did not finish this Suspense boundary: replay error',
-    ]);
+      __DEV__
+        ? [
+            'The server did not finish this Suspense boundary: replay error',
+            'The server did not finish this Suspense boundary: replay error',
+          ]
+        : [
+            'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+            'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+          ],
+    );
   });
 });

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -3778,9 +3778,6 @@ function flushCompletedQueues(
         // We haven't flushed the root yet so we don't need to check any other branches further down
         return;
       }
-    } else if (request.pendingRootTasks > 0) {
-      // We have not yet flushed the root segment so we early return
-      return;
     }
 
     if (enableFloat) {

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -472,7 +472,7 @@
   "484": "A Server Component was postponed. The reason is omitted in production builds to avoid leaking sensitive details.",
   "485": "Cannot update form state while rendering.",
   "486": "It should not be possible to postpone at the root. This is a bug in React.",
-  "487": "Did not expect to see a Suspense boundary in this slot. The tree doesn't match so React will fallback to client rendering.",
+  "487": "We should not have any resumable nodes in the shell. This is a bug in React.",
   "488": "Couldn't find all resumable slots by key/index during replaying. The tree doesn't match so React will fallback to client rendering.",
   "489": "Expected to see a component of type \"%s\" in this slot. The tree doesn't match so React will fallback to client rendering.",
   "490": "Expected to see a Suspense boundary in this slot. The tree doesn't match so React will fallback to client rendering."


### PR DESCRIPTION
Based on #27385.

When we error or abort during replay, that doesn't actually error the component that errored because that has already rendered. The error only affects any child that is not yet completed. Therefore the error kind of gets thrown at the resumable point.

The resumable point might be a hole in the replay path, in which case throwing there errors the parent boundary just the same as if the replay component errored. If the hole is inside a deeper Suspense boundary though, then it's that Suspense boundary that gets client rendered. I.e. the child boundary. We can still finish any siblings.

In the shell all resumable points are inside a boundary since we must have finished the shell. Therefore if you error in the root, we just simply just turn all incomplete boundaries into client renders.
