### PR TITLE
[Fizz][Float] Refactor StyleResource

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
@@ -7,7 +7,11 @@
  * @flow
  */
 
-import type {ResumableState, BoundaryResources} from './ReactFizzConfigDOM';
+import type {
+  ResumableState,
+  BoundaryResources,
+  Precedence,
+} from './ReactFizzConfigDOM';
 
 import {
   createRenderState as createRenderStateImpl,
@@ -50,8 +54,7 @@ export type RenderState = {
   fontPreloads: Set<any>,
   highImagePreloads: Set<any>,
   // usedImagePreloads: Set<any>,
-  precedences: Map<string, Map<any, any>>,
-  stylePrecedences: Map<string, any>,
+  precedences: Map<string, Precedence>,
   bootstrapScripts: Set<any>,
   scripts: Set<any>,
   bulkPreloads: Set<any>,
@@ -95,7 +98,6 @@ export function createRenderState(
     highImagePreloads: renderState.highImagePreloads,
     // usedImagePreloads: renderState.usedImagePreloads,
     precedences: renderState.precedences,
-    stylePrecedences: renderState.stylePrecedences,
     bootstrapScripts: renderState.bootstrapScripts,
     scripts: renderState.scripts,
     bulkPreloads: renderState.bulkPreloads,


### PR DESCRIPTION
This change refactors the implementation of stylesheet resources and style tag resources. The style tag resource was already handled with special rules because it does not Flush is the same way as other resources do. This change reimagines the precedences as a combination of a style tag rules queue and a list of stylesheets.

This change eliminates a number of conditionals by embedding these variants in the data represenation itself.

This change also moves the binary encoding to work time rather than flush time.

Since style resources were the only type that actually used the `type` property I've removed this making resource object size slightly smaller
