### PR TITLE
Fix issue with eol when generating flow config

### DIFF
--- a/scripts/flow/createFlowConfigs.js
+++ b/scripts/flow/createFlowConfigs.js
@@ -15,7 +15,8 @@ const inlinedHostConfigs = require('../shared/inlinedHostConfigs');
 
 const configTemplate = fs
   .readFileSync(__dirname + '/config/flowconfig')
-  .toString();
+  .toString()
+  .replaceAll('\r\n', '\n');
 
 // stores all forks discovered during config generation
 const allForks = new Set();


### PR DESCRIPTION
## Summary

The generated `.flowconfig` is invalid if git config `core.autocrlf` is set to `true` (mainly Windows users).

```shell
$ node ./scripts/tasks/flow.js dom-node
Running Flow on the dom-node renderer...
.flowconfig:116 Unable to parse line.
Flow failed for the dom-node renderer

error Command failed with exit code 8.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This happens because of end of line behavior. Some of the code in createFlowConfig.js expects end of line to be `\n`, but it could be `\r\n` depending on the local git config.

## How did you test this change?

Ran `yarn flow dom-node` and verified that a valid `.flowconfig` is generated.