### PR TITLE
[Flight] Dedupe suspense boundaries when it has already been found earlier

### DIFF
--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -2490,15 +2490,23 @@ function trackPostpone(
       addToReplayParent(boundaryNode, boundaryKeyPath[0], trackedPostpones);
       return;
     } else {
-      const boundaryNode: ReplaySuspenseBoundary = [
-        boundaryKeyPath[1],
-        boundaryKeyPath[2],
-        children,
-        null,
-        boundary.rootSegmentID,
-      ];
-      trackedPostpones.workingMap.set(boundaryKeyPath, boundaryNode);
-      addToReplayParent(boundaryNode, boundaryKeyPath[0], trackedPostpones);
+      let boundaryNode: void | ReplayNode =
+        trackedPostpones.workingMap.get(boundaryKeyPath);
+      if (boundaryNode === undefined) {
+        boundaryNode = [
+          boundaryKeyPath[1],
+          boundaryKeyPath[2],
+          children,
+          null,
+          boundary.rootSegmentID,
+        ];
+        trackedPostpones.workingMap.set(boundaryKeyPath, boundaryNode);
+        addToReplayParent(boundaryNode, boundaryKeyPath[0], trackedPostpones);
+      } else {
+        // Upgrade to ReplaySuspenseBoundary.
+        ((boundaryNode: any): ReplaySuspenseBoundary)[4] =
+          boundary.rootSegmentID;
+      }
       // Fall through to add the child node.
     }
   }


### PR DESCRIPTION
If we track a postponed SuspenseBoundary parent that we have to replay through before it has postponed and it postpones itself later, we need to upgrade it to a postponed replay boundary instead of adding two.
