### PR TITLE
feat: support Micro-Frontend mode and Module Federation modules

### DIFF
--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -495,6 +495,7 @@ export function injectIntoGlobalHook(globalObject: any): void {
       ) {
         // This version supports React Refresh.
         helpersByRendererID.set(id, ((injected: any): RendererHelpers));
+        hook.renderers.set(id, ((injected: any): RendererHelpers));
       }
       return id;
     };


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Background:
Micro Frontend framework like garfish、qiankun and Module Federation are also need fast refresh.

Loading Progress:
Micro Frontend: 
Main App Fast Refresh -> Main App ReactDOM -> Sub App Fast Refresh -> Sub App ReactDOM.
This order has no trouble when perform refresh, but if Sub App external React and ReactDOM and using Main App's, it will Invalid to perform refresh, because Sub App ReactDOM will not init after Sub App Fast Refresh Runtime.

Module Federation:
Host App(like Main App) Fast Refresh -> Host App ReactDOM -> Sub App Fast Refresh -> Reuse Main App's ReactDOM(inited yet)
Since MF has shared to reuse loaded packages, ReactDOM is possible to reuse the inited package, so refresh is also invalid.

So we need to keep the **injected** into memory. This can make sure the Sub App can put the **injected** into its React Refresh Runtime
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
