### PR TITLE
[Fizz][Fiber] Support Suspense boundaries outside html, head, and body tags

### DIFF
--- a/packages/react-reconciler/src/ReactFiberConfigWithNoHydration.js
+++ b/packages/react-reconciler/src/ReactFiberConfigWithNoHydration.js
@@ -29,6 +29,7 @@ export const registerSuspenseInstanceRetry = shim;
 export const canHydrateFormStateMarker = shim;
 export const isFormStateMarkerMatching = shim;
 export const getNextHydratableSibling = shim;
+export const getNextHydratableInSingleton = shim;
 export const getFirstHydratableChild = shim;
 export const getFirstHydratableChildWithinContainer = shim;
 export const getFirstHydratableChildWithinSuspenseInstance = shim;

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
@@ -225,3 +225,5 @@ export const clearSingleton = $$$config.clearSingleton;
 export const acquireSingletonInstance = $$$config.acquireSingletonInstance;
 export const releaseSingletonInstance = $$$config.releaseSingletonInstance;
 export const isHostSingletonType = $$$config.isHostSingletonType;
+export const getNextHydratableInSingleton =
+  $$$config.getNextHydratableInSingleton;

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -439,7 +439,7 @@
   "451": "resolveSingletonInstance was called with an element type that is not supported. This is a bug in React.",
   "452": "React expected an <html> element (document.documentElement) to exist in the Document but one was not found. React never removes the documentElement for any Document it renders into so the cause is likely in some other script running on this page.",
   "453": "React expected a <head> element (document.head) to exist in the Document but one was not found. React never removes the head for any Document it renders into so the cause is likely in some other script running on this page.",
-  "454": "React expected a <body> element (document.body) to exist in the Document but one was not found. React never removes the body for any Document it renders into so the cause is likely in some other script running on this page.",
+  "454": "React expected a <%s> element (document.body) to exist in the Document but one was not found. React never removes the body for any Document it renders into so the cause is likely in some other script running on this page.",
   "455": "This CacheSignal was requested outside React which means that it is immediately aborted.",
   "456": "Calling Offscreen.detach before instance handle has been set.",
   "457": "acquireHeadResource encountered a resource type it did not expect: \"%s\". This is a bug in React.",


### PR DESCRIPTION
Today if you render a Suspense boundary outside `<body>` hydration doesn't really work correctly. This has to do with the nature of how we stream SSR content in from the server and parsing modes for browser HTML parsers.

While the document tags (html, head, and body) need to be part of the shell it should be possible to support suspending outside of these tags when the fallback content and the primary content contain no inlined data. This is useful for rendering hoistable elements such as stylesheets and scripts which are flushed via different means than rendering in place. It could also be useful for side effects and other components that have no visual output.

Technically there streaming mechanics actually work for other kinds of content such as divs but React's warnings about tag nesting still apply. Any support for hydrating non-empty content inside this hoisted suspense boundaries is entirely coincidental and would warn in Dev regardless.

Rather than trying to get the suspense boundary markers to emit around the premable/postamble tags like `<html>` and `<body>` instead we treat the root and singletons as a sort of shared hydration space. We start hydrating in the head always and then when we enter the body we switch to body mode. Now when we enter the head or body via rendering that tag we don't always pick up the first child of that element but use the shared cursor for the root if it exists. This is in someways ananlagous to how an HTML parser works where it assumes a context and then transitions when certain conditions are met.

In the course of implementing this feature it became apparent that we were not handling frameset correctly in a singletons world. Prior to this hydration change this was masked because the current method happened to work still. However with this hydration change I also had to convert frameset into a body-like singleton. I could remove this to save code size but that will require removing some tests and I wanted to first see how big an impact adding this support is. long term frameset is not really compatible with modern React because it breaks our streaming approach. Any support we try to maintain woudl only be for client only applications and I am skeptical that this is used by a meaningful amount of React projects.

One area that is still not supported for suspense boundaries is in between `<head>` and `<body>`.

```
<html>
  <head>...</head>
  <Suspense>...</Suspense>
  <body>...</body>
</html>
```

The comments end up after the closing `</head>` tag and the placeholder template ends up inside the `<head>`. This doesn't seems particularly critical to support so I will leave it as an edge case for now (it already is an edge case) and figure out how to warn effectively for this