### PR TITLE
publish `react-server-dom-turbopack` to canary channels

### DIFF
--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -35,6 +35,7 @@ const stablePackages = {
   'react-art': ReactVersion,
   'react-dom': ReactVersion,
   'react-server-dom-webpack': ReactVersion,
+  'react-server-dom-turbopack': ReactVersion,
   'react-is': ReactVersion,
   'react-reconciler': '0.30.0',
   'react-refresh': '0.15.0',


### PR DESCRIPTION
When I added react-server-dom-turbopack I failed to mark the package as stable so it did not get published with the canary release. This adds the package to the stable set so it will be published correctly