### PR TITLE
Revert "publish `react-server-dom-turbopack` to canary channels (#27427)

### DIFF
--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -35,7 +35,6 @@ const stablePackages = {
   'react-art': ReactVersion,
   'react-dom': ReactVersion,
   'react-server-dom-webpack': ReactVersion,
-  'react-server-dom-turbopack': ReactVersion,
   'react-is': ReactVersion,
   'react-reconciler': '0.30.0',
   'react-refresh': '0.15.0',


### PR DESCRIPTION
Build fails because the package does not exist. I've added the package to npm but we need the publishing account to be a collaborator. I'm reverting until we get that sorted so we don't block canaries