### PR TITLE
Restore "publish `react-server-dom-turbopack` to canary channels (#27427)"

### DIFF
--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -35,6 +35,7 @@ const stablePackages = {
   'react-art': ReactVersion,
   'react-dom': ReactVersion,
   'react-server-dom-webpack': ReactVersion,
+  'react-server-dom-turbopack': ReactVersion,
   'react-is': ReactVersion,
   'react-reconciler': '0.30.0',
   'react-refresh': '0.15.0',


### PR DESCRIPTION
Reverts facebook/react#27428 which restores facebook/react#27427

this will allow the publish script to publish `react-server-dom-turbopack`