### PR TITLE
Test fix: Add missing warning assertion

### DIFF
--- a/packages/react-server-dom-turbopack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-turbopack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -612,8 +612,22 @@ describe('ReactFlightDOMBrowser', () => {
   });
 
   it('basic use(context)', async () => {
-    const ContextA = React.createServerContext('ContextA', '');
-    const ContextB = React.createServerContext('ContextB', 'B');
+    let ContextA;
+    let ContextB;
+    expect(() => {
+      ContextA = React.createServerContext('ContextA', '');
+      ContextB = React.createServerContext('ContextB', 'B');
+    }).toErrorDev(
+      [
+        'Server Context is deprecated and will soon be removed. ' +
+          'It was never documented and we have found it not to be useful ' +
+          'enough to warrant the downside it imposes on all apps.',
+        'Server Context is deprecated and will soon be removed. ' +
+          'It was never documented and we have found it not to be useful ' +
+          'enough to warrant the downside it imposes on all apps.',
+      ],
+      {withoutStack: true},
+    );
 
     function ServerComponent() {
       return use(ContextA) + use(ContextB);


### PR DESCRIPTION
Adds a missing test assertion for Server Context deprecation.

The PR that added this warning was based on an older revision than the PR that added the test.