### PR TITLE
[Flight] Taint APIs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -506,6 +506,7 @@ module.exports = {
     Thenable: 'readonly',
     TimeoutID: 'readonly',
     WheelEventHandler: 'readonly',
+    FinalizationRegistry: 'readonly',
 
     spyOnDev: 'readonly',
     spyOnDevAndProd: 'readonly',

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -1475,7 +1475,7 @@ describe('ReactFlight', () => {
       name: 'Seb',
       age: 'rather not say',
     };
-    ReactServer.unstable_taintShallowObject(
+    ReactServer.experimental_taintObjectReference(
       "Don't pass the raw user object to the client",
       user,
     );
@@ -1497,7 +1497,7 @@ describe('ReactFlight', () => {
     const User = clientReference(UserClient);
 
     function change() {}
-    ReactServer.unstable_taintShallowObject(
+    ReactServer.experimental_taintObjectReference(
       'A change handler cannot be passed to a client component',
       change,
     );
@@ -1525,7 +1525,7 @@ describe('ReactFlight', () => {
         SECRET: '3e971ecc1485fe78625598bf9b6f85db',
       },
     };
-    ReactServer.unstable_taintValue(
+    ReactServer.experimental_taintUniqueValue(
       'Cannot pass a secret token to the client',
       process,
       process.env.SECRET,
@@ -1556,7 +1556,7 @@ describe('ReactFlight', () => {
       name: 'Seb',
       token: BigInt('0x3e971ecc1485fe78625598bf9b6f85dc'),
     };
-    ReactServer.unstable_taintValue(
+    ReactServer.experimental_taintUniqueValue(
       'Cannot pass a secret token to the client',
       currentUser,
       currentUser.token,
@@ -1587,7 +1587,7 @@ describe('ReactFlight', () => {
       name: 'Seb',
       token: new Uint32Array([0x3e971ecc, 0x1485fe78, 0x625598bf, 0x9b6f85dd]),
     };
-    ReactServer.unstable_taintValue(
+    ReactServer.experimental_taintUniqueValue(
       'Cannot pass a secret token to the client',
       currentUser,
       currentUser.token,
@@ -1620,7 +1620,7 @@ describe('ReactFlight', () => {
         name: 'Seb',
         token: '3e971ecc1485fe78625598bf9b6f85db',
       };
-      ReactServer.unstable_taintValue(
+      ReactServer.experimental_taintUniqueValue(
         'Cannot pass a secret token to the client',
         user,
         user.token,

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -1446,4 +1446,148 @@ describe('ReactFlight', () => {
       );
     });
   });
+
+  // @gate enableTaint
+  it('errors when a tainted object is serialized', async () => {
+    function UserClient({user}) {
+      return <span>{user.name}</span>;
+    }
+    const User = clientReference(UserClient);
+
+    const user = {
+      name: 'Seb',
+      age: 'rather not say',
+    };
+    ReactServer.unstable_taintShallowObject(
+      "Don't pass the raw user object to the client",
+      user,
+    );
+    const errors = [];
+    ReactNoopFlightServer.render(<User user={user} />, {
+      onError(x) {
+        errors.push(x.message);
+      },
+    });
+
+    expect(errors).toEqual(["Don't pass the raw user object to the client"]);
+  });
+
+  // @gate enableTaint
+  it('errors with a specific message when a tainted function is serialized', async () => {
+    function UserClient({user}) {
+      return <span>{user.name}</span>;
+    }
+    const User = clientReference(UserClient);
+
+    function change() {}
+    ReactServer.unstable_taintShallowObject(
+      'A change handler cannot be passed to a client component',
+      change,
+    );
+    const errors = [];
+    ReactNoopFlightServer.render(<User onChange={change} />, {
+      onError(x) {
+        errors.push(x.message);
+      },
+    });
+
+    expect(errors).toEqual([
+      'A change handler cannot be passed to a client component',
+    ]);
+  });
+
+  // @gate enableTaint
+  it('errors when a tainted string is serialized', async () => {
+    function UserClient({user}) {
+      return <span>{user.name}</span>;
+    }
+    const User = clientReference(UserClient);
+
+    const process = {
+      env: {
+        SECRET: '3e971ecc1485fe78625598bf9b6f85db',
+      },
+    };
+    ReactServer.unstable_taintValue(
+      'Cannot pass a secret token to the client',
+      process,
+      process.env.SECRET,
+    );
+
+    const errors = [];
+    ReactNoopFlightServer.render(<User token={process.env.SECRET} />, {
+      onError(x) {
+        errors.push(x.message);
+      },
+    });
+
+    expect(errors).toEqual(['Cannot pass a secret token to the client']);
+
+    // This just ensures the process object is kept alive for the life time of
+    // the test since we're simulating a global as an example.
+    expect(process.env.SECRET).toBe('3e971ecc1485fe78625598bf9b6f85db');
+  });
+
+  // @gate enableTaint
+  it('errors when a tainted bigint is serialized', async () => {
+    function UserClient({user}) {
+      return <span>{user.name}</span>;
+    }
+    const User = clientReference(UserClient);
+
+    const currentUser = {
+      name: 'Seb',
+      token: BigInt('0x3e971ecc1485fe78625598bf9b6f85dc'),
+    };
+    ReactServer.unstable_taintValue(
+      'Cannot pass a secret token to the client',
+      currentUser,
+      currentUser.token,
+    );
+
+    function App({user}) {
+      return <User token={user.token} />;
+    }
+
+    const errors = [];
+    ReactNoopFlightServer.render(<App user={currentUser} />, {
+      onError(x) {
+        errors.push(x.message);
+      },
+    });
+
+    expect(errors).toEqual(['Cannot pass a secret token to the client']);
+  });
+
+  // @gate enableTaint && enableBinaryFlight
+  it('errors when a tainted binary value is serialized', async () => {
+    function UserClient({user}) {
+      return <span>{user.name}</span>;
+    }
+    const User = clientReference(UserClient);
+
+    const currentUser = {
+      name: 'Seb',
+      token: new Uint32Array([0x3e971ecc, 0x1485fe78, 0x625598bf, 0x9b6f85dd]),
+    };
+    ReactServer.unstable_taintValue(
+      'Cannot pass a secret token to the client',
+      currentUser,
+      currentUser.token,
+    );
+
+    function App({user}) {
+      const clone = user.token.slice();
+      return <User token={clone} />;
+    }
+
+    const errors = [];
+    ReactNoopFlightServer.render(<App user={currentUser} />, {
+      onError(x) {
+        errors.push(x.message);
+      },
+    });
+
+    expect(errors).toEqual(['Cannot pass a secret token to the client']);
+  });
 });

--- a/packages/react/src/ReactServerSharedInternals.js
+++ b/packages/react/src/ReactServerSharedInternals.js
@@ -7,7 +7,11 @@
 
 import ReactCurrentDispatcher from './ReactCurrentDispatcher';
 import ReactCurrentCache from './ReactCurrentCache';
-import {TaintRegistryObjects, TaintRegistryValues} from './ReactTaintRegistry';
+import {
+  TaintRegistryObjects,
+  TaintRegistryValues,
+  TaintRegistryByteLengths,
+} from './ReactTaintRegistry';
 
 import {enableTaint} from 'shared/ReactFeatureFlags';
 
@@ -19,6 +23,8 @@ const ReactServerSharedInternals = {
 if (enableTaint) {
   ReactServerSharedInternals.TaintRegistryObjects = TaintRegistryObjects;
   ReactServerSharedInternals.TaintRegistryValues = TaintRegistryValues;
+  ReactServerSharedInternals.TaintRegistryByteLengths =
+    TaintRegistryByteLengths;
 }
 
 export default ReactServerSharedInternals;

--- a/packages/react/src/ReactServerSharedInternals.js
+++ b/packages/react/src/ReactServerSharedInternals.js
@@ -7,10 +7,18 @@
 
 import ReactCurrentDispatcher from './ReactCurrentDispatcher';
 import ReactCurrentCache from './ReactCurrentCache';
+import {TaintRegistryObjects, TaintRegistryValues} from './ReactTaintRegistry';
+
+import {enableTaint} from 'shared/ReactFeatureFlags';
 
 const ReactServerSharedInternals = {
   ReactCurrentDispatcher,
   ReactCurrentCache,
 };
+
+if (enableTaint) {
+  ReactServerSharedInternals.TaintRegistryObjects = TaintRegistryObjects;
+  ReactServerSharedInternals.TaintRegistryValues = TaintRegistryValues;
+}
 
 export default ReactServerSharedInternals;

--- a/packages/react/src/ReactServerSharedInternals.js
+++ b/packages/react/src/ReactServerSharedInternals.js
@@ -11,6 +11,7 @@ import {
   TaintRegistryObjects,
   TaintRegistryValues,
   TaintRegistryByteLengths,
+  TaintRegistryPendingRequests,
 } from './ReactTaintRegistry';
 
 import {enableTaint} from 'shared/ReactFeatureFlags';
@@ -25,6 +26,8 @@ if (enableTaint) {
   ReactServerSharedInternals.TaintRegistryValues = TaintRegistryValues;
   ReactServerSharedInternals.TaintRegistryByteLengths =
     TaintRegistryByteLengths;
+  ReactServerSharedInternals.TaintRegistryPendingRequests =
+    TaintRegistryPendingRequests;
 }
 
 export default ReactServerSharedInternals;

--- a/packages/react/src/ReactSharedInternalsClient.js
+++ b/packages/react/src/ReactSharedInternalsClient.js
@@ -11,8 +11,9 @@ import ReactCurrentBatchConfig from './ReactCurrentBatchConfig';
 import ReactCurrentActQueue from './ReactCurrentActQueue';
 import ReactCurrentOwner from './ReactCurrentOwner';
 import ReactDebugCurrentFrame from './ReactDebugCurrentFrame';
-import {enableServerContext} from 'shared/ReactFeatureFlags';
+import {enableServerContext, enableTaint} from 'shared/ReactFeatureFlags';
 import {ContextRegistry} from './ReactServerContextRegistry';
+import {TaintRegistry} from './ReactTaintRegistry';
 
 const ReactSharedInternals = {
   ReactCurrentDispatcher,
@@ -28,6 +29,10 @@ if (__DEV__) {
 
 if (enableServerContext) {
   ReactSharedInternals.ContextRegistry = ContextRegistry;
+}
+
+if (enableTaint) {
+  ReactSharedInternals.TaintRegistry = TaintRegistry;
 }
 
 export default ReactSharedInternals;

--- a/packages/react/src/ReactSharedInternalsClient.js
+++ b/packages/react/src/ReactSharedInternalsClient.js
@@ -11,9 +11,8 @@ import ReactCurrentBatchConfig from './ReactCurrentBatchConfig';
 import ReactCurrentActQueue from './ReactCurrentActQueue';
 import ReactCurrentOwner from './ReactCurrentOwner';
 import ReactDebugCurrentFrame from './ReactDebugCurrentFrame';
-import {enableServerContext, enableTaint} from 'shared/ReactFeatureFlags';
+import {enableServerContext} from 'shared/ReactFeatureFlags';
 import {ContextRegistry} from './ReactServerContextRegistry';
-import {TaintRegistry} from './ReactTaintRegistry';
 
 const ReactSharedInternals = {
   ReactCurrentDispatcher,
@@ -29,10 +28,6 @@ if (__DEV__) {
 
 if (enableServerContext) {
   ReactSharedInternals.ContextRegistry = ContextRegistry;
-}
-
-if (enableTaint) {
-  ReactSharedInternals.TaintRegistry = TaintRegistry;
 }
 
 export default ReactSharedInternals;

--- a/packages/react/src/ReactSharedSubset.experimental.js
+++ b/packages/react/src/ReactSharedSubset.experimental.js
@@ -16,8 +16,8 @@ export {default as __SECRET_SERVER_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED} fr
 
 // These are server-only
 export {
-  taintValue as unstable_taintValue,
-  taintShallowObject as unstable_taintShallowObject,
+  taintUniqueValue as experimental_taintUniqueValue,
+  taintObjectReference as experimental_taintObjectReference,
 } from './ReactTaint';
 
 export {

--- a/packages/react/src/ReactSharedSubset.experimental.js
+++ b/packages/react/src/ReactSharedSubset.experimental.js
@@ -14,6 +14,12 @@ export {default as __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED} from './R
 
 export {default as __SECRET_SERVER_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED} from './ReactServerSharedInternals';
 
+// These are server-only
+export {
+  taintValue as unstable_taintValue,
+  taintShallowObject as unstable_taintShallowObject,
+} from './ReactTaint';
+
 export {
   Children,
   Fragment,

--- a/packages/react/src/ReactTaint.js
+++ b/packages/react/src/ReactTaint.js
@@ -12,7 +12,8 @@ import {enableTaint, enableBinaryFlight} from 'shared/ReactFeatureFlags';
 import binaryToComparableString from 'shared/binaryToComparableString';
 
 import ReactServerSharedInternals from './ReactServerSharedInternals';
-const {TaintRegistryObjects, TaintRegistryValues} = ReactServerSharedInternals;
+const {TaintRegistryObjects, TaintRegistryValues, TaintRegistryByteLengths} =
+  ReactServerSharedInternals;
 
 interface Reference {}
 
@@ -74,6 +75,7 @@ export function taintValue(
     // hashing in the Map implementation. It doesn't really matter what form the string
     // take as long as it's the same when we look it up.
     // We're not too worried about collisions since this should be a high entropy value.
+    TaintRegistryByteLengths.add(value.byteLength);
     entryValue = binaryToComparableString(value);
   } else {
     const kind = value === null ? 'null' : typeof value;

--- a/packages/react/src/ReactTaint.js
+++ b/packages/react/src/ReactTaint.js
@@ -67,7 +67,7 @@ export function taintUniqueValue(
     (typeof lifetime !== 'object' && typeof lifetime !== 'function')
   ) {
     throw new Error(
-      'To taint a value, a life time must be defined by passing an object that holds ' +
+      'To taint a value, a lifetime must be defined by passing an object that holds ' +
         'the value.',
     );
   }
@@ -95,8 +95,7 @@ export function taintUniqueValue(
     throw new Error(
       'Cannot taint a ' +
         kind +
-        ' because the value is too general and cannot be ' +
-        'a secret by',
+        ' because the value is too general and not unique enough to block globally.',
     );
   }
   const existingEntry = TaintRegistryValues.get(entryValue);

--- a/packages/react/src/ReactTaint.js
+++ b/packages/react/src/ReactTaint.js
@@ -52,7 +52,7 @@ const finalizationRegistry =
     ? new FinalizationRegistry(cleanup)
     : null;
 
-export function taintValue(
+export function taintUniqueValue(
   message: ?string,
   lifetime: Reference,
   value: string | bigint | $ArrayBufferView,
@@ -89,7 +89,7 @@ export function taintValue(
     const kind = value === null ? 'null' : typeof value;
     if (kind === 'object' || kind === 'function') {
       throw new Error(
-        'taintValue cannot taint objects or functions. Try taintShallowObject instead.',
+        'taintUniqueValue cannot taint objects or functions. Try taintObjectReference instead.',
       );
     }
     throw new Error(
@@ -113,7 +113,10 @@ export function taintValue(
   }
 }
 
-export function taintShallowObject(message: ?string, object: Reference): void {
+export function taintObjectReference(
+  message: ?string,
+  object: Reference,
+): void {
   if (!enableTaint) {
     throw new Error('Not implemented.');
   }
@@ -121,7 +124,7 @@ export function taintShallowObject(message: ?string, object: Reference): void {
   message = '' + (message || defaultMessage);
   if (typeof object === 'string' || typeof object === 'bigint') {
     throw new Error(
-      'Only objects or functions can be passed to taintShallowObject. Try taintValue instead.',
+      'Only objects or functions can be passed to taintObjectReference. Try taintUniqueValue instead.',
     );
   }
   if (
@@ -129,7 +132,7 @@ export function taintShallowObject(message: ?string, object: Reference): void {
     (typeof object !== 'object' && typeof object !== 'function')
   ) {
     throw new Error(
-      'Only objects or functions can be passed to taintShallowObject.',
+      'Only objects or functions can be passed to taintObjectReference.',
     );
   }
   TaintRegistryObjects.set(object, message);

--- a/packages/react/src/ReactTaint.js
+++ b/packages/react/src/ReactTaint.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import {enableTaint} from 'shared/ReactFeatureFlags';
+import {enableTaint, enableBinaryFlight} from 'shared/ReactFeatureFlags';
 
 import binaryToComparableString from 'shared/binaryToComparableString';
 
@@ -67,8 +67,8 @@ export function taintValue(
     // Use as is.
     entryValue = value;
   } else if (
-    value instanceof TypedArrayConstructor ||
-    value instanceof DataView
+    enableBinaryFlight &&
+    (value instanceof TypedArrayConstructor || value instanceof DataView)
   ) {
     // For now, we just convert binary data to a string so that we can just use the native
     // hashing in the Map implementation. It doesn't really matter what form the string

--- a/packages/react/src/ReactTaint.js
+++ b/packages/react/src/ReactTaint.js
@@ -12,8 +12,12 @@ import {enableTaint, enableBinaryFlight} from 'shared/ReactFeatureFlags';
 import binaryToComparableString from 'shared/binaryToComparableString';
 
 import ReactServerSharedInternals from './ReactServerSharedInternals';
-const {TaintRegistryObjects, TaintRegistryValues, TaintRegistryByteLengths} =
-  ReactServerSharedInternals;
+const {
+  TaintRegistryObjects,
+  TaintRegistryValues,
+  TaintRegistryByteLengths,
+  TaintRegistryPendingRequests,
+} = ReactServerSharedInternals;
 
 interface Reference {}
 
@@ -29,6 +33,10 @@ const defaultMessage =
 function cleanup(entryValue: string | bigint): void {
   const entry = TaintRegistryValues.get(entryValue);
   if (entry !== undefined) {
+    TaintRegistryPendingRequests.forEach(function (requestQueue) {
+      requestQueue.push(entryValue);
+      entry.count++;
+    });
     if (entry.count === 1) {
       TaintRegistryValues.delete(entryValue);
     } else {

--- a/packages/react/src/ReactTaint.js
+++ b/packages/react/src/ReactTaint.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {enableTaint} from 'shared/ReactFeatureFlags';
+import ReactSharedInternals from 'shared/ReactSharedInternals';
+
+const TaintRegistry = ReactSharedInternals.TaintRegistry;
+
+interface Reference {}
+
+const TypedArrayConstructor = Object.getPrototypeOf(Uint8Array.prototype);
+
+const defaultMessage =
+  'A tainted value was attempted to be serialized to a Client Component or Action closure. ' +
+  'This would leak it to the client.';
+
+export function taintValue(
+  message: ?string,
+  lifetime: Reference,
+  value: string | bigint | $ArrayBufferView,
+): void {
+  if (!enableTaint) {
+    throw new Error('Not implemented.');
+  }
+  // eslint-disable-next-line react-internal/safe-string-coercion
+  message = '' + (message || defaultMessage);
+  if (
+    lifetime === null ||
+    (typeof lifetime !== 'object' && typeof lifetime !== 'function')
+  ) {
+    throw new Error(
+      'To taint a value, a life time must be defined by passing an object that holds ' +
+        'the value.',
+    );
+  }
+  if (typeof value === 'string') {
+    return;
+  }
+  if (typeof value === 'bigint') {
+    return;
+  }
+  if (value instanceof TypedArrayConstructor) {
+    return;
+  }
+  if (value instanceof DataView) {
+    return;
+  }
+  const kind = value === null ? 'null' : typeof value;
+  if (kind === 'object' || kind === 'function') {
+    throw new Error(
+      'taintValue cannot taint objects or functions. Try taintShallowObject instead.',
+    );
+  }
+  throw new Error(
+    'Cannot taint a ' +
+      kind +
+      ' because the value is too general and cannot be ' +
+      'a secret by',
+  );
+}
+
+export function taintShallowObject(message: ?string, object: Reference): void {
+  if (!enableTaint) {
+    throw new Error('Not implemented.');
+  }
+  // eslint-disable-next-line react-internal/safe-string-coercion
+  message = '' + (message || defaultMessage);
+  if (typeof object === 'string' || typeof object === 'bigint') {
+    throw new Error(
+      'Only objects or functions can be passed to taintShallowObject. Try taintValue instead.',
+    );
+  }
+  if (
+    object === null ||
+    (typeof object !== 'object' && typeof object !== 'function')
+  ) {
+    throw new Error(
+      'Only objects or functions can be passed to taintShallowObject.',
+    );
+  }
+  // TODO
+}

--- a/packages/react/src/ReactTaintRegistry.js
+++ b/packages/react/src/ReactTaintRegistry.js
@@ -16,3 +16,6 @@ type TaintEntry = {
 
 export const TaintRegistryObjects: WeakMap<Reference, string> = new WeakMap();
 export const TaintRegistryValues: Map<string | bigint, TaintEntry> = new Map();
+// Byte lengths of all binary values we've ever seen. We don't both refcounting this.
+// We expect to see only a few lengths here such as the length of token.
+export const TaintRegistryByteLengths: Set<number> = new Set();

--- a/packages/react/src/ReactTaintRegistry.js
+++ b/packages/react/src/ReactTaintRegistry.js
@@ -7,4 +7,12 @@
  * @flow
  */
 
-export const TaintRegistry: {} = {};
+interface Reference {}
+
+type TaintEntry = {
+  message: string,
+  count: number,
+};
+
+export const TaintRegistryObjects: WeakMap<Reference, string> = new WeakMap();
+export const TaintRegistryValues: Map<string | bigint, TaintEntry> = new Map();

--- a/packages/react/src/ReactTaintRegistry.js
+++ b/packages/react/src/ReactTaintRegistry.js
@@ -19,3 +19,9 @@ export const TaintRegistryValues: Map<string | bigint, TaintEntry> = new Map();
 // Byte lengths of all binary values we've ever seen. We don't both refcounting this.
 // We expect to see only a few lengths here such as the length of token.
 export const TaintRegistryByteLengths: Set<number> = new Set();
+
+// When a value is finalized, it means that it has been removed from any global caches.
+// No future requests can get a handle on it but any ongoing requests can still have
+// a handle on it. It's still tainted until that happens.
+type RequestCleanupQueue = Array<string | bigint>;
+export const TaintRegistryPendingRequests: Set<RequestCleanupQueue> = new Set();

--- a/packages/react/src/ReactTaintRegistry.js
+++ b/packages/react/src/ReactTaintRegistry.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export const TaintRegistry: {} = {};

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -86,6 +86,8 @@ export const enableFormActions = __EXPERIMENTAL__;
 
 export const enableBinaryFlight = __EXPERIMENTAL__;
 
+export const enableTaint = __EXPERIMENTAL__;
+
 export const enablePostpone = __EXPERIMENTAL__;
 
 export const enableTransitionTracing = false;

--- a/packages/shared/binaryToComparableString.js
+++ b/packages/shared/binaryToComparableString.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Turns a TypedArray or ArrayBuffer into a string that can be used for comparison
+// in a Map to see if the bytes are the same.
+export default function binaryToComparableString(
+  view: $ArrayBufferView,
+): string {
+  return String.fromCharCode.apply(
+    String,
+    new Uint8Array(view.buffer, view.byteOffset, view.byteLength),
+  );
+}

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -37,6 +37,7 @@ export const enableCacheElement = true;
 export const enableFetchInstrumentation = false;
 export const enableFormActions = true; // Doesn't affect Native
 export const enableBinaryFlight = true;
+export const enableTaint = true;
 export const enablePostpone = false;
 export const enableSchedulerDebugging = false;
 export const debugRenderPhaseSideEffectsForStrictMode = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -25,6 +25,7 @@ export const enableCacheElement = false;
 export const enableFetchInstrumentation = false;
 export const enableFormActions = true; // Doesn't affect Native
 export const enableBinaryFlight = true;
+export const enableTaint = true;
 export const enablePostpone = false;
 export const disableJavaScriptURLs = false;
 export const disableCommentsAsDOMContainers = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -25,6 +25,7 @@ export const enableCacheElement = __EXPERIMENTAL__;
 export const enableFetchInstrumentation = true;
 export const enableFormActions = true; // Doesn't affect Test Renderer
 export const enableBinaryFlight = true;
+export const enableTaint = true;
 export const enablePostpone = false;
 export const disableJavaScriptURLs = false;
 export const disableCommentsAsDOMContainers = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -25,6 +25,7 @@ export const enableCacheElement = true;
 export const enableFetchInstrumentation = false;
 export const enableFormActions = true; // Doesn't affect Test Renderer
 export const enableBinaryFlight = true;
+export const enableTaint = true;
 export const enablePostpone = false;
 export const disableJavaScriptURLs = false;
 export const disableCommentsAsDOMContainers = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -25,6 +25,7 @@ export const enableCacheElement = true;
 export const enableFetchInstrumentation = false;
 export const enableFormActions = true; // Doesn't affect Test Renderer
 export const enableBinaryFlight = true;
+export const enableTaint = true;
 export const enablePostpone = false;
 export const enableSchedulerDebugging = false;
 export const disableJavaScriptURLs = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -75,6 +75,7 @@ export const enableFetchInstrumentation = false;
 export const enableFormActions = false;
 
 export const enableBinaryFlight = true;
+export const enableTaint = false;
 
 export const enablePostpone = false;
 

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -478,9 +478,9 @@
   "490": "Expected to see a Suspense boundary in this slot. The tree doesn't match so React will fallback to client rendering.",
   "491": "It should not be possible to postpone both at the root of an element as well as a slot below. This is a bug in React.",
   "492": "The \"react\" package in this environment is not configured correctly. The \"react-server\" condition must be enabled in any environment that runs React Server Components.",
-  "493": "To taint a value, a life time must be defined by passing an object that holds the value.",
+  "493": "To taint a value, a lifetime must be defined by passing an object that holds the value.",
   "494": "taintUniqueValue cannot taint objects or functions. Try taintObjectReference instead.",
-  "495": "Cannot taint a %s because the value is too general and cannot be a secret by",
+  "495": "Cannot taint a %s because the value is too general and not unique enough to block globally.",
   "496": "Only objects or functions can be passed to taintObjectReference. Try taintUniqueValue instead.",
   "497": "Only objects or functions can be passed to taintObjectReference."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -479,8 +479,8 @@
   "491": "It should not be possible to postpone both at the root of an element as well as a slot below. This is a bug in React.",
   "492": "The \"react\" package in this environment is not configured correctly. The \"react-server\" condition must be enabled in any environment that runs React Server Components.",
   "493": "To taint a value, a life time must be defined by passing an object that holds the value.",
-  "494": "taintValue cannot taint objects or functions. Try taintShallowObject instead.",
+  "494": "taintUniqueValue cannot taint objects or functions. Try taintObjectReference instead.",
   "495": "Cannot taint a %s because the value is too general and cannot be a secret by",
-  "496": "Only objects or functions can be passed to taintShallowObject. Try taintValue instead.",
-  "497": "Only objects or functions can be passed to taintShallowObject."
+  "496": "Only objects or functions can be passed to taintObjectReference. Try taintUniqueValue instead.",
+  "497": "Only objects or functions can be passed to taintObjectReference."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -477,5 +477,10 @@
   "489": "Expected to see a component of type \"%s\" in this slot. The tree doesn't match so React will fallback to client rendering.",
   "490": "Expected to see a Suspense boundary in this slot. The tree doesn't match so React will fallback to client rendering.",
   "491": "It should not be possible to postpone both at the root of an element as well as a slot below. This is a bug in React.",
-  "492": "The \"react\" package in this environment is not configured correctly. The \"react-server\" condition must be enabled in any environment that runs React Server Components."
+  "492": "The \"react\" package in this environment is not configured correctly. The \"react-server\" condition must be enabled in any environment that runs React Server Components.",
+  "493": "To taint a value, a life time must be defined by passing an object that holds the value.",
+  "494": "taintValue cannot taint objects or functions. Try taintShallowObject instead.",
+  "495": "Cannot taint a %s because the value is too general and cannot be a secret by",
+  "496": "Only objects or functions can be passed to taintShallowObject. Try taintValue instead.",
+  "497": "Only objects or functions can be passed to taintShallowObject."
 }

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -24,6 +24,8 @@ declare var queueMicrotask: (fn: Function) => void;
 declare var reportError: (error: mixed) => void;
 declare var AggregateError: Class<Error>;
 
+declare var FinalizationRegistry: any;
+
 declare module 'create-react-class' {
   declare var exports: React$CreateClass;
 }

--- a/scripts/rollup/validate/eslintrc.cjs.js
+++ b/scripts/rollup/validate/eslintrc.cjs.js
@@ -31,6 +31,9 @@ module.exports = {
 
     Reflect: 'readonly',
     globalThis: 'readonly',
+
+    FinalizationRegistry: 'readonly',
+
     // Vendor specific
     MSApp: 'readonly',
     __REACT_DEVTOOLS_GLOBAL_HOOK__: 'readonly',

--- a/scripts/rollup/validate/eslintrc.cjs2015.js
+++ b/scripts/rollup/validate/eslintrc.cjs2015.js
@@ -31,6 +31,7 @@ module.exports = {
 
     Reflect: 'readonly',
     globalThis: 'readonly',
+    FinalizationRegistry: 'readonly',
     // Vendor specific
     MSApp: 'readonly',
     __REACT_DEVTOOLS_GLOBAL_HOOK__: 'readonly',

--- a/scripts/rollup/validate/eslintrc.esm.js
+++ b/scripts/rollup/validate/eslintrc.esm.js
@@ -31,6 +31,9 @@ module.exports = {
 
     Reflect: 'readonly',
     globalThis: 'readonly',
+
+    FinalizationRegistry: 'readonly',
+
     // Vendor specific
     MSApp: 'readonly',
     __REACT_DEVTOOLS_GLOBAL_HOOK__: 'readonly',

--- a/scripts/rollup/validate/eslintrc.fb.js
+++ b/scripts/rollup/validate/eslintrc.fb.js
@@ -31,6 +31,9 @@ module.exports = {
 
     Reflect: 'readonly',
     globalThis: 'readonly',
+
+    FinalizationRegistry: 'readonly',
+
     // Vendor specific
     MSApp: 'readonly',
     __REACT_DEVTOOLS_GLOBAL_HOOK__: 'readonly',

--- a/scripts/rollup/validate/eslintrc.rn.js
+++ b/scripts/rollup/validate/eslintrc.rn.js
@@ -31,6 +31,9 @@ module.exports = {
 
     Reflect: 'readonly',
     globalThis: 'readonly',
+
+    FinalizationRegistry: 'readonly',
+
     // Vendor specific
     MSApp: 'readonly',
     __REACT_DEVTOOLS_GLOBAL_HOOK__: 'readonly',

--- a/scripts/rollup/validate/eslintrc.umd.js
+++ b/scripts/rollup/validate/eslintrc.umd.js
@@ -30,6 +30,9 @@ module.exports = {
 
     Reflect: 'readonly',
     globalThis: 'readonly',
+
+    FinalizationRegistry: 'readonly',
+
     // Vendor specific
     MSApp: 'readonly',
     __REACT_DEVTOOLS_GLOBAL_HOOK__: 'readonly',


### PR DESCRIPTION
This lets a registered object or value be "tainted", which we block from crossing the serialization boundary. It's only allowed to stay in-memory.

This is an extra layer of protection against mistakes of transferring data from a data access layer to a client. It doesn't provide perfect protection, because it doesn't trace through derived values and substrings. So it shouldn't be used as the only security layer but more layers are better.

`taintObjectReference` is for specific object instances, not any nested objects or values inside that object. It's useful to avoid specific objects from getting passed as is. It ensures that you don't accidentally leak values in a specific context. It can be for security reasons like tokens, privacy reasons like personal data or performance reasons like avoiding passing large objects over the wire.

It might be privacy violation to leak the age of a specific user, but the number itself isn't blocked in any other context. As soon as the value is extracted and passed specifically without the object, it can therefore leak.

`taintUniqueValue` is useful for high entropy values such as hashes, tokens or crypto keys that are very unique values. In that case it can be useful to taint the actual primitive values themselves. These can be encoded as a string, bigint or typed array. We don't currently check for this value in a substring or inside other typed arrays.

Since values can be created from different sources they don't just follow garbage collection. In this case an additional object must be provided that defines the life time of this value for how long it should be blocked. It can be `globalThis` for essentially forever, but that risks leaking memory for ever when you're dealing with dynamic values like reading a token from a database. So in that case the idea is that you pass the object that might end up in cache.

A request is the only thing that is expected to do any work. The principle is that you can derive values from out of a tainted
entry during a request. Including stashing it in a per request cache. What you can't do is store a derived value in a global module level cache. At least not without also tainting the object.