### PR TITLE
Land enableCustomElementPropertySupport for React 19

### DIFF
--- a/packages/react-dom-bindings/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom-bindings/src/client/DOMPropertyOperations.js
@@ -8,10 +8,7 @@
  */
 
 import isAttributeNameSafe from '../shared/isAttributeNameSafe';
-import {
-  enableTrustedTypesIntegration,
-  enableCustomElementPropertySupport,
-} from 'shared/ReactFeatureFlags';
+import {enableTrustedTypesIntegration} from 'shared/ReactFeatureFlags';
 import {checkAttributeStringCoercion} from 'shared/CheckStringCoercion';
 import {getFiberCurrentPropsFromNode} from './ReactDOMComponentTree';
 
@@ -73,25 +70,18 @@ export function getValueForAttributeOnCustomComponent(
           // it would be expected that they end up not having an attribute.
           return expected;
         case 'function':
-          if (enableCustomElementPropertySupport) {
-            return expected;
-          }
-          break;
+          return expected;
         case 'boolean':
-          if (enableCustomElementPropertySupport) {
-            if (expected === false) {
-              return expected;
-            }
+          if (expected === false) {
+            return expected;
           }
       }
       return expected === undefined ? undefined : null;
     }
     const value = node.getAttribute(name);
 
-    if (enableCustomElementPropertySupport) {
-      if (value === '' && expected === true) {
-        return true;
-      }
+    if (value === '' && expected === true) {
+      return true;
     }
 
     if (__DEV__) {

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -67,7 +67,6 @@ import sanitizeURL from '../shared/sanitizeURL';
 
 import {
   enableBigIntSupport,
-  enableCustomElementPropertySupport,
   disableIEWorkarounds,
   enableTrustedTypesIntegration,
   enableFilterEmptyStringAttributesDOM,
@@ -870,9 +869,7 @@ function setProp(
     }
     case 'innerText':
     case 'textContent':
-      if (enableCustomElementPropertySupport) {
-        break;
-      }
+      break;
     // Fall through
     default: {
       if (
@@ -983,9 +980,7 @@ function setPropOnCustomElement(
     }
     case 'innerText': // Properties
     case 'textContent':
-      if (enableCustomElementPropertySupport) {
-        break;
-      }
+      break;
     // Fall through
     default: {
       if (registrationNameDependencies.hasOwnProperty(key)) {
@@ -993,15 +988,7 @@ function setPropOnCustomElement(
           warnForInvalidEventListener(key, value);
         }
       } else {
-        if (enableCustomElementPropertySupport) {
-          setValueForPropertyOnCustomComponent(domElement, key, value);
-        } else {
-          if (typeof value === 'boolean') {
-            // Special case before the new flag is on
-            value = '' + (value: any);
-          }
-          setValueForAttribute(domElement, key, value);
-        }
+        setValueForPropertyOnCustomComponent(domElement, key, value);
       }
     }
   }
@@ -2293,35 +2280,30 @@ function diffHydratedCustomComponent(
       case 'isContentEditable':
       case 'outerText':
       case 'outerHTML':
-        if (enableCustomElementPropertySupport) {
-          extraAttributes.delete(propKey.toLowerCase());
-          if (__DEV__) {
-            console.error(
-              'Assignment to read-only property will result in a no-op: `%s`',
-              propKey,
-            );
-          }
-          continue;
+        extraAttributes.delete(propKey.toLowerCase());
+        if (__DEV__) {
+          console.error(
+            'Assignment to read-only property will result in a no-op: `%s`',
+            propKey,
+          );
         }
+        continue;
       // Fall through
       case 'className':
-        if (enableCustomElementPropertySupport) {
-          // className is a special cased property on the server to render as an attribute.
-          extraAttributes.delete('class');
-          const serverValue = getValueForAttributeOnCustomComponent(
-            domElement,
-            'class',
-            value,
-          );
-          warnForPropDifference(
-            'className',
-            serverValue,
-            value,
-            serverDifferences,
-          );
-          continue;
-        }
-      // Fall through
+        // className is a special cased property on the server to render as an attribute.
+        extraAttributes.delete('class');
+        const serverValue = getValueForAttributeOnCustomComponent(
+          domElement,
+          'class',
+          value,
+        );
+        warnForPropDifference(
+          'className',
+          serverValue,
+          value,
+          serverDifferences,
+        );
+        continue;
       default: {
         // This is a DEV-only path
         const hostContextDev: HostContextDev = (hostContext: any);
@@ -2335,12 +2317,17 @@ function diffHydratedCustomComponent(
         } else {
           extraAttributes.delete(propKey);
         }
-        const serverValue = getValueForAttributeOnCustomComponent(
+        const valueOnCustomComponent = getValueForAttributeOnCustomComponent(
           domElement,
           propKey,
           value,
         );
-        warnForPropDifference(propKey, serverValue, value, serverDifferences);
+        warnForPropDifference(
+          propKey,
+          valueOnCustomComponent,
+          value,
+          serverDifferences,
+        );
       }
     }
   }

--- a/packages/react-dom-bindings/src/events/plugins/ChangeEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/ChangeEventPlugin.js
@@ -26,10 +26,7 @@ import {updateValueIfChanged} from '../../client/inputValueTracking';
 import {setDefaultValue} from '../../client/ReactDOMInput';
 import {enqueueStateRestore} from '../ReactDOMControlledComponent';
 
-import {
-  disableInputAttributeSyncing,
-  enableCustomElementPropertySupport,
-} from 'shared/ReactFeatureFlags';
+import {disableInputAttributeSyncing} from 'shared/ReactFeatureFlags';
 import {batchedUpdates} from '../ReactDOMUpdateBatching';
 import {
   processDispatchQueue,
@@ -311,7 +308,6 @@ function extractEvents(
   } else if (shouldUseClickEvent(targetNode)) {
     getTargetInstFunc = getTargetInstForClickEvent;
   } else if (
-    enableCustomElementPropertySupport &&
     targetInst &&
     isCustomElement(targetInst.elementType, targetInst.memoizedProps)
   ) {

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -30,7 +30,6 @@ import {Children} from 'react';
 import {
   enableBigIntSupport,
   enableFilterEmptyStringAttributesDOM,
-  enableCustomElementPropertySupport,
   enableFizzExternalRuntime,
   enableNewBooleanProps,
 } from 'shared/ReactFeatureFlags';
@@ -3342,11 +3341,9 @@ function pushStartCustomElement(
           // Ignored. These are built-in to React on the client.
           break;
         case 'className':
-          if (enableCustomElementPropertySupport) {
-            // className gets rendered as class on the client, so it should be
-            // rendered as class on the server.
-            attributeName = 'class';
-          }
+          // className gets rendered as class on the client, so it should be
+          // rendered as class on the server.
+          attributeName = 'class';
         // intentional fallthrough
         default:
           if (
@@ -3354,14 +3351,12 @@ function pushStartCustomElement(
             typeof propValue !== 'function' &&
             typeof propValue !== 'symbol'
           ) {
-            if (enableCustomElementPropertySupport) {
-              if (propValue === false) {
-                continue;
-              } else if (propValue === true) {
-                propValue = '';
-              } else if (typeof propValue === 'object') {
-                continue;
-              }
+            if (propValue === false) {
+              continue;
+            } else if (propValue === true) {
+              propValue = '';
+            } else if (typeof propValue === 'object') {
+              continue;
             }
             target.push(
               attributeSeparator,

--- a/packages/react-dom-bindings/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMUnknownPropertyHook.js
@@ -9,10 +9,7 @@ import {ATTRIBUTE_NAME_CHAR} from './isAttributeNameSafe';
 import isCustomElement from './isCustomElement';
 import possibleStandardNames from './possibleStandardNames';
 import hasOwnProperty from 'shared/hasOwnProperty';
-import {
-  enableCustomElementPropertySupport,
-  enableNewBooleanProps,
-} from 'shared/ReactFeatureFlags';
+import {enableNewBooleanProps} from 'shared/ReactFeatureFlags';
 
 const warnedProperties = {};
 const EVENT_NAME_REGEX = /^on./;
@@ -189,9 +186,7 @@ function validateProperty(tagName, name, value, eventRegistry) {
       }
       case 'innerText': // Properties
       case 'textContent':
-        if (enableCustomElementPropertySupport) {
-          return true;
-        }
+        return true;
     }
 
     switch (typeof value) {

--- a/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
@@ -10,10 +10,7 @@
 'use strict';
 
 // Set by `yarn test-fire`.
-const {
-  enableCustomElementPropertySupport,
-  disableInputAttributeSyncing,
-} = require('shared/ReactFeatureFlags');
+const {disableInputAttributeSyncing} = require('shared/ReactFeatureFlags');
 
 describe('DOMPropertyOperations', () => {
   let React;
@@ -234,7 +231,6 @@ describe('DOMPropertyOperations', () => {
       expect(container.firstChild.hasAttribute('value')).toBe(false);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('custom element custom events lowercase', async () => {
       const oncustomevent = jest.fn();
       function Test() {
@@ -251,7 +247,6 @@ describe('DOMPropertyOperations', () => {
       expect(oncustomevent).toHaveBeenCalledTimes(1);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('custom element custom events uppercase', async () => {
       const oncustomevent = jest.fn();
       function Test() {
@@ -268,7 +263,6 @@ describe('DOMPropertyOperations', () => {
       expect(oncustomevent).toHaveBeenCalledTimes(1);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('custom element custom event with dash in name', async () => {
       const oncustomevent = jest.fn();
       function Test() {
@@ -285,7 +279,6 @@ describe('DOMPropertyOperations', () => {
       expect(oncustomevent).toHaveBeenCalledTimes(1);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('custom element remove event handler', async () => {
       const oncustomevent = jest.fn();
       function Test(props) {
@@ -343,12 +336,8 @@ describe('DOMPropertyOperations', () => {
       expect(customElement.getAttribute('onstring')).toBe('hello');
       expect(customElement.getAttribute('onobj')).toBe('[object Object]');
       expect(customElement.getAttribute('onarray')).toBe('one,two');
-      expect(customElement.getAttribute('ontrue')).toBe(
-        enableCustomElementPropertySupport ? '' : 'true',
-      );
-      expect(customElement.getAttribute('onfalse')).toBe(
-        enableCustomElementPropertySupport ? null : 'false',
-      );
+      expect(customElement.getAttribute('ontrue')).toBe('');
+      expect(customElement.getAttribute('onfalse')).toBe(null);
 
       // Dispatch the corresponding event names to make sure that nothing crashes.
       customElement.dispatchEvent(new Event('string'));
@@ -385,7 +374,6 @@ describe('DOMPropertyOperations', () => {
       expect(syntheticClickEvent.nativeEvent).toBe(nativeClickEvent);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('custom elements should have working onChange event listeners', async () => {
       let reactChangeEvent = null;
       const eventHandler = jest.fn(event => (reactChangeEvent = event));
@@ -450,7 +438,6 @@ describe('DOMPropertyOperations', () => {
       expect(eventHandler).toHaveBeenCalledTimes(expectedHandlerCallCount);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('custom elements should have separate onInput and onChange handling', async () => {
       const container = document.createElement('div');
       document.body.appendChild(container);
@@ -476,7 +463,6 @@ describe('DOMPropertyOperations', () => {
       expect(changeEventHandler).toHaveBeenCalledTimes(1);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('custom elements should be able to remove and re-add custom event listeners', async () => {
       const container = document.createElement('div');
       document.body.appendChild(container);
@@ -758,7 +744,6 @@ describe('DOMPropertyOperations', () => {
       expect(customOnClickHandler).toHaveBeenCalledTimes(0);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('onChange/onInput/onClick on div with various types of children', async () => {
       const container = document.createElement('div');
       document.body.appendChild(container);
@@ -951,7 +936,6 @@ describe('DOMPropertyOperations', () => {
       expect(onClickHandler).toBeCalledTimes(1);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('custom element onChange/onInput/onClick with event target custom element child', async () => {
       const container = document.createElement('div');
       document.body.appendChild(container);
@@ -987,7 +971,6 @@ describe('DOMPropertyOperations', () => {
       expect(onClickHandler).toBeCalledTimes(1);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('custom elements should allow custom events with capture event listeners', async () => {
       const oncustomeventCapture = jest.fn();
       const oncustomevent = jest.fn();
@@ -1031,7 +1014,6 @@ describe('DOMPropertyOperations', () => {
       expect(customElement.hasChildNodes()).toBe(false);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('innerText should not work on custom elements', async () => {
       const container = document.createElement('div');
       const root = ReactDOMClient.createRoot(container);
@@ -1051,7 +1033,6 @@ describe('DOMPropertyOperations', () => {
       expect(customElement.hasChildNodes()).toBe(false);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('textContent should not work on custom elements', async () => {
       const container = document.createElement('div');
       const root = ReactDOMClient.createRoot(container);
@@ -1071,7 +1052,6 @@ describe('DOMPropertyOperations', () => {
       expect(customElement.hasChildNodes()).toBe(false);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('values should not be converted to booleans when assigning into custom elements', async () => {
       const container = document.createElement('div');
       document.body.appendChild(container);
@@ -1123,7 +1103,6 @@ describe('DOMPropertyOperations', () => {
       expect(customElement.foo).toBe(null);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('boolean props should not be stringified in attributes', async () => {
       const container = document.createElement('div');
       document.body.appendChild(container);
@@ -1143,7 +1122,6 @@ describe('DOMPropertyOperations', () => {
       expect(customElement.getAttribute('foo')).toBe(null);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('custom element custom event handlers assign multiple types', async () => {
       const container = document.createElement('div');
       document.body.appendChild(container);
@@ -1197,7 +1175,6 @@ describe('DOMPropertyOperations', () => {
       expect(customelement.getAttribute('oncustomevent')).toBe(null);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('custom element custom event handlers assign multiple types with setter', async () => {
       const container = document.createElement('div');
       document.body.appendChild(container);
@@ -1257,7 +1234,6 @@ describe('DOMPropertyOperations', () => {
       expect(customelement.getAttribute('oncustomevent')).toBe(null);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('assigning to a custom element property should not remove attributes', async () => {
       const container = document.createElement('div');
       document.body.appendChild(container);
@@ -1284,7 +1260,6 @@ describe('DOMPropertyOperations', () => {
       expect(customElement.getAttribute('foo')).toBe('one');
     });
 
-    // @gate enableCustomElementPropertySupport
     it('custom element properties should accept functions', async () => {
       const container = document.createElement('div');
       document.body.appendChild(container);

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -3549,15 +3549,11 @@ describe('ReactDOMComponent', () => {
         root.render(<some-custom-element foo={true} />);
       });
       const node = container.firstChild;
-      expect(node.getAttribute('foo')).toBe(
-        ReactFeatureFlags.enableCustomElementPropertySupport ? '' : 'true',
-      );
+      expect(node.getAttribute('foo')).toBe('');
       await act(() => {
         root.render(<some-custom-element foo={false} />);
       });
-      expect(node.getAttribute('foo')).toBe(
-        ReactFeatureFlags.enableCustomElementPropertySupport ? null : 'false',
-      );
+      expect(node.getAttribute('foo')).toBe(null);
       await act(() => {
         root.render(<some-custom-element />);
       });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -3603,7 +3603,7 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // bugfix: https://github.com/facebook/react/issues/27286 affecting enableCustomElementPropertySupport flag
+  // bugfix: https://github.com/facebook/react/issues/27286
   it('can render custom elements with children on ther server', async () => {
     await act(() => {
       renderToPipeableStream(

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -699,13 +699,8 @@ describe('ReactDOMServerIntegration', () => {
 
     itRenders('className for custom elements', async render => {
       const e = await render(<custom-element className="test" />, 0);
-      if (ReactFeatureFlags.enableCustomElementPropertySupport) {
-        expect(e.getAttribute('className')).toBe(null);
-        expect(e.getAttribute('class')).toBe('test');
-      } else {
-        expect(e.getAttribute('className')).toBe('test');
-        expect(e.getAttribute('class')).toBe(null);
-      }
+      expect(e.getAttribute('className')).toBe(null);
+      expect(e.getAttribute('class')).toBe('test');
     });
 
     itRenders('htmlFor property on is elements', async render => {
@@ -738,20 +733,12 @@ describe('ReactDOMServerIntegration', () => {
 
     itRenders('unknown boolean `true` attributes as strings', async render => {
       const e = await render(<custom-element foo={true} />);
-      if (ReactFeatureFlags.enableCustomElementPropertySupport) {
-        expect(e.getAttribute('foo')).toBe('');
-      } else {
-        expect(e.getAttribute('foo')).toBe('true');
-      }
+      expect(e.getAttribute('foo')).toBe('');
     });
 
     itRenders('unknown boolean `false` attributes as strings', async render => {
       const e = await render(<custom-element foo={false} />);
-      if (ReactFeatureFlags.enableCustomElementPropertySupport) {
-        expect(e.getAttribute('foo')).toBe(null);
-      } else {
-        expect(e.getAttribute('foo')).toBe('false');
-      }
+      expect(e.getAttribute('foo')).toBe(null);
     });
 
     itRenders('new boolean `true` attributes', async render => {

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -1085,7 +1085,6 @@ describe('ReactDOMServer', () => {
       expect(output).toBe(`<my-custom-element foo="5"></my-custom-element>`);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('Object properties should not be server rendered for custom elements', () => {
       const output = ReactDOMServer.renderToString(
         <my-custom-element foo={{foo: 'bar'}} />,
@@ -1093,7 +1092,6 @@ describe('ReactDOMServer', () => {
       expect(output).toBe(`<my-custom-element></my-custom-element>`);
     });
 
-    // @gate enableCustomElementPropertySupport
     it('Array properties should not be server rendered for custom elements', () => {
       const output = ReactDOMServer.renderToString(
         <my-custom-element foo={['foo', 'bar']} />,

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -593,23 +593,16 @@ describe('ReactDOMServerHydration', () => {
       const jsx = React.createElement('my-custom-element', props);
       const element = document.createElement('div');
       element.innerHTML = ReactDOMServer.renderToString(jsx);
-      if (gate(flags => flags.enableCustomElementPropertySupport)) {
-        await expect(async () => {
-          await act(() => {
-            ReactDOMClient.hydrateRoot(element, jsx);
-          });
-        }).toErrorDev(
-          `Warning: Assignment to read-only property will result in a no-op: \`${readOnlyProperty}\``,
-        );
-      } else {
+      await expect(async () => {
         await act(() => {
           ReactDOMClient.hydrateRoot(element, jsx);
         });
-      }
+      }).toErrorDev(
+        `Warning: Assignment to read-only property will result in a no-op: \`${readOnlyProperty}\``,
+      );
     }
   });
 
-  // @gate enableCustomElementPropertySupport
   it('should not re-assign properties on hydration', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -146,12 +146,6 @@ export const useModernStrictMode = __NEXT_MAJOR__;
 // Remove IE and MsApp specific workarounds for innerHTML
 export const disableIEWorkarounds = __NEXT_MAJOR__;
 
-// Changes the behavior for rendering custom elements in both server rendering
-// and client rendering, mostly to allow JSX attributes to apply to the custom
-// element's object properties instead of only HTML attributes.
-// https://github.com/facebook/react/issues/11347
-export const enableCustomElementPropertySupport = __NEXT_MAJOR__;
-
 // Filter certain DOM attributes (e.g. src, href) if their values are empty
 // strings. This prevents e.g. <img src=""> from making an unnecessary HTTP
 // request for certain browsers.

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -78,7 +78,6 @@ export const enableLazyContextPropagation = false;
 export const enableLegacyHidden = false;
 export const forceConcurrentByDefaultForTesting = false;
 export const allowConcurrentByDefault = false;
-export const enableCustomElementPropertySupport = true;
 export const enableNewBooleanProps = true;
 
 export const enableTransitionTracing = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -53,7 +53,6 @@ export const enableTaint = __NEXT_RN_MAJOR__;
 export const enableUnifiedSyncLane = __NEXT_RN_MAJOR__;
 export const enableFizzExternalRuntime = __NEXT_RN_MAJOR__; // DOM-only
 export const enableBinaryFlight = __NEXT_RN_MAJOR__; // DOM-only
-export const enableCustomElementPropertySupport = __NEXT_RN_MAJOR__; // DOM-only
 export const enableServerComponentKeys = __NEXT_RN_MAJOR__;
 export const enableServerComponentLogs = __NEXT_RN_MAJOR__;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -57,7 +57,6 @@ export const enableLegacyHidden = false;
 export const forceConcurrentByDefaultForTesting = false;
 export const enableUnifiedSyncLane = __EXPERIMENTAL__;
 export const allowConcurrentByDefault = false;
-export const enableCustomElementPropertySupport = false;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -59,7 +59,6 @@ export const enableLegacyHidden = false;
 export const forceConcurrentByDefaultForTesting = false;
 export const enableUnifiedSyncLane = true;
 export const allowConcurrentByDefault = true;
-export const enableCustomElementPropertySupport = true;
 export const enableNewBooleanProps = true;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -59,7 +59,6 @@ export const enableLegacyHidden = false;
 export const forceConcurrentByDefaultForTesting = false;
 export const enableUnifiedSyncLane = true;
 export const allowConcurrentByDefault = true;
-export const enableCustomElementPropertySupport = false;
 export const enableNewBooleanProps = false;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -54,7 +54,6 @@ export const enableUpdaterTracking = __PROFILE__;
 export const enableSuspenseAvoidThisFallback = true;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 
-export const enableCustomElementPropertySupport = true;
 export const enableCPUSuspense = true;
 export const enableUseMemoCacheHook = true;
 export const enableUseEffectEventHook = true;


### PR DESCRIPTION
We've rolled out this flag internally on WWW. This PR removed flag `enableCustomElementPropertySupport`

Test plan:
 -- `yarn test`
