### PR TITLE
Upgrade Server Actions to canary

### DIFF
--- a/fixtures/flight-esm/src/Button.js
+++ b/fixtures/flight-esm/src/Button.js
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import {experimental_useFormStatus as useFormStatus} from 'react-dom';
+import {useFormStatus} from 'react-dom';
 import ErrorBoundary from './ErrorBoundary.js';
 
 const h = React.createElement;

--- a/fixtures/flight-esm/src/Form.js
+++ b/fixtures/flight-esm/src/Form.js
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import {experimental_useFormStatus as useFormStatus} from 'react-dom';
+import {useFormStatus} from 'react-dom';
 import ErrorBoundary from './ErrorBoundary.js';
 
 const h = React.createElement;

--- a/fixtures/flight/src/Button.js
+++ b/fixtures/flight/src/Button.js
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import {experimental_useFormStatus as useFormStatus} from 'react-dom';
+import {useFormStatus} from 'react-dom';
 import ErrorBoundary from './ErrorBoundary.js';
 
 function ButtonDisabledWhilePending({action, children}) {

--- a/fixtures/flight/src/Counter.js
+++ b/fixtures/flight/src/Counter.js
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import {experimental_useFormState as useFormState} from 'react-dom';
+import {useFormState} from 'react-dom';
 
 import Container from './Container.js';
 

--- a/fixtures/flight/src/Form.js
+++ b/fixtures/flight/src/Form.js
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import {experimental_useFormStatus as useFormStatus} from 'react-dom';
+import {useFormStatus} from 'react-dom';
 import ErrorBoundary from './ErrorBoundary.js';
 
 function Status() {

--- a/packages/react-dom/index.classic.fb.js
+++ b/packages/react-dom/index.classic.fb.js
@@ -31,8 +31,8 @@ export {
   unstable_createEventHandle,
   unstable_renderSubtreeIntoContainer,
   unstable_runWithPriority, // DO NOT USE: Temporarily exposed to migrate off of Scheduler.runWithPriority.
-  useFormStatus as experimental_useFormStatus,
-  useFormState as experimental_useFormState,
+  useFormStatus,
+  useFormState,
   prefetchDNS,
   preconnect,
   preload,

--- a/packages/react-dom/index.experimental.js
+++ b/packages/react-dom/index.experimental.js
@@ -20,8 +20,8 @@ export {
   unstable_batchedUpdates,
   unstable_renderSubtreeIntoContainer,
   unstable_runWithPriority, // DO NOT USE: Temporarily exposed to migrate off of Scheduler.runWithPriority.
-  useFormStatus as experimental_useFormStatus,
-  useFormState as experimental_useFormState,
+  useFormStatus,
+  useFormState,
   prefetchDNS,
   preconnect,
   preload,

--- a/packages/react-dom/index.js
+++ b/packages/react-dom/index.js
@@ -23,8 +23,8 @@ export {
   unstable_createEventHandle,
   unstable_renderSubtreeIntoContainer,
   unstable_runWithPriority, // DO NOT USE: Temporarily exposed to migrate off of Scheduler.runWithPriority.
-  useFormStatus as experimental_useFormStatus,
-  useFormState as experimental_useFormState,
+  useFormStatus,
+  useFormState,
   prefetchDNS,
   preconnect,
   preload,

--- a/packages/react-dom/index.modern.fb.js
+++ b/packages/react-dom/index.modern.fb.js
@@ -16,8 +16,8 @@ export {
   unstable_batchedUpdates,
   unstable_createEventHandle,
   unstable_runWithPriority, // DO NOT USE: Temporarily exposed to migrate off of Scheduler.runWithPriority.
-  useFormStatus as experimental_useFormStatus,
-  useFormState as experimental_useFormState,
+  useFormStatus,
+  useFormState,
   prefetchDNS,
   preconnect,
   preload,

--- a/packages/react-dom/index.stable.js
+++ b/packages/react-dom/index.stable.js
@@ -19,6 +19,8 @@ export {
   unmountComponentAtNode,
   unstable_batchedUpdates,
   unstable_renderSubtreeIntoContainer,
+  useFormStatus,
+  useFormState,
   prefetchDNS,
   preconnect,
   preload,

--- a/packages/react-dom/server-rendering-stub.js
+++ b/packages/react-dom/server-rendering-stub.js
@@ -24,7 +24,7 @@ export {
   preloadModule,
   preinit,
   preinitModule,
-  experimental_useFormStatus,
-  experimental_useFormState,
+  useFormStatus,
+  useFormState,
   unstable_batchedUpdates,
 } from './src/server/ReactDOMServerRenderingStub';

--- a/packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js
@@ -31,9 +31,9 @@ describe('ReactDOMFizzForm', () => {
     React = require('react');
     ReactDOMServer = require('react-dom/server.browser');
     ReactDOMClient = require('react-dom/client');
-    useFormStatus = require('react-dom').experimental_useFormStatus;
-    useFormState = require('react-dom').experimental_useFormState;
-    useOptimistic = require('react').experimental_useOptimistic;
+    useFormStatus = require('react-dom').useFormStatus;
+    useFormState = require('react-dom').useFormState;
+    useOptimistic = require('react').useOptimistic;
     act = require('internal-test-utils').act;
     container = document.createElement('div');
     document.body.appendChild(container);

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -89,7 +89,7 @@ describe('ReactDOMFizzServer', () => {
     if (gate(flags => flags.enableSuspenseList)) {
       SuspenseList = React.unstable_SuspenseList;
     }
-    useFormState = ReactDOM.experimental_useFormState;
+    useFormState = ReactDOM.useFormState;
 
     PropTypes = require('prop-types');
 

--- a/packages/react-dom/src/__tests__/ReactDOMForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMForm-test.js
@@ -55,8 +55,8 @@ describe('ReactDOMForm', () => {
     useState = React.useState;
     Suspense = React.Suspense;
     startTransition = React.startTransition;
-    useFormStatus = ReactDOM.experimental_useFormStatus;
-    useFormState = ReactDOM.experimental_useFormState;
+    useFormStatus = ReactDOM.useFormStatus;
+    useFormState = ReactDOM.useFormState;
     container = document.createElement('div');
     document.body.appendChild(container);
 

--- a/packages/react-dom/src/__tests__/react-dom-server-rendering-stub-test.js
+++ b/packages/react-dom/src/__tests__/react-dom-server-rendering-stub-test.js
@@ -85,9 +85,9 @@ describe('react-dom-server-rendering-stub', () => {
 
   // @gate enableFormActions
   // @gate enableAsyncActions
-  it('exports experimental_useFormStatus', async () => {
+  it('exports useFormStatus', async () => {
     function App() {
-      const {pending} = ReactDOM.experimental_useFormStatus();
+      const {pending} = ReactDOM.useFormStatus();
       return 'Pending: ' + pending;
     }
 

--- a/packages/react-dom/src/server/ReactDOMServerRenderingStub.js
+++ b/packages/react-dom/src/server/ReactDOMServerRenderingStub.js
@@ -16,8 +16,8 @@ export {
   prefetchDNS,
 } from '../shared/ReactDOMFloat';
 export {
-  useFormStatus as experimental_useFormStatus,
-  useFormState as experimental_useFormState,
+  useFormStatus,
+  useFormState,
 } from 'react-dom-bindings/src/shared/ReactDOMFormActions';
 
 export function createPortal() {

--- a/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
@@ -19,7 +19,7 @@ describe('ReactAsyncActions', () => {
     assertLog = require('internal-test-utils').assertLog;
     useTransition = React.useTransition;
     useState = React.useState;
-    useOptimistic = React.experimental_useOptimistic;
+    useOptimistic = React.useOptimistic;
 
     textCache = new Map();
   });

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMForm-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMForm-test.js
@@ -55,7 +55,7 @@ describe('ReactFlightDOMForm', () => {
     ReactDOMServer = require('react-dom/server.edge');
     ReactDOMClient = require('react-dom/client');
     act = require('react-dom/test-utils').act;
-    useFormState = require('react-dom').experimental_useFormState;
+    useFormState = require('react-dom').useFormState;
     container = document.createElement('div');
     document.body.appendChild(container);
   });

--- a/packages/react/index.classic.fb.js
+++ b/packages/react/index.classic.fb.js
@@ -52,7 +52,7 @@ export {
   useLayoutEffect,
   useInsertionEffect,
   useMemo,
-  experimental_useOptimistic,
+  useOptimistic,
   useReducer,
   useRef,
   useState,

--- a/packages/react/index.experimental.js
+++ b/packages/react/index.experimental.js
@@ -50,7 +50,7 @@ export {
   useInsertionEffect,
   useLayoutEffect,
   useMemo,
-  experimental_useOptimistic,
+  useOptimistic,
   useReducer,
   useRef,
   useState,

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -75,7 +75,7 @@ export {
   useInsertionEffect,
   useLayoutEffect,
   useMemo,
-  experimental_useOptimistic,
+  useOptimistic,
   useSyncExternalStore,
   useReducer,
   useRef,

--- a/packages/react/index.modern.fb.js
+++ b/packages/react/index.modern.fb.js
@@ -50,7 +50,7 @@ export {
   useInsertionEffect,
   useLayoutEffect,
   useMemo,
-  experimental_useOptimistic,
+  useOptimistic,
   useReducer,
   useRef,
   useState,

--- a/packages/react/index.stable.js
+++ b/packages/react/index.stable.js
@@ -42,6 +42,7 @@ export {
   useLayoutEffect,
   useMemo,
   useReducer,
+  useOptimistic,
   useRef,
   useState,
   useSyncExternalStore,

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -111,7 +111,7 @@ export {
   useInsertionEffect,
   useLayoutEffect,
   useMemo,
-  useOptimistic as experimental_useOptimistic,
+  useOptimistic,
   useSyncExternalStore,
   useReducer,
   useRef,

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -31,6 +31,8 @@ export const enableComponentStackLocations = true;
 
 // TODO: Finish rolling out in www
 export const enableClientRenderFallbackOnTextMismatch = true;
+export const enableFormActions = true;
+export const enableAsyncActions = true;
 
 // Not sure if www still uses this. We don't have a replacement but whatever we
 // replace it with will likely be different than what's already there, so we
@@ -82,8 +84,6 @@ export const enableLegacyCache = __EXPERIMENTAL__;
 export const enableCacheElement = __EXPERIMENTAL__;
 export const enableFetchInstrumentation = true;
 
-export const enableFormActions = __EXPERIMENTAL__;
-
 export const enableBinaryFlight = __EXPERIMENTAL__;
 
 export const enableTaint = __EXPERIMENTAL__;
@@ -119,8 +119,6 @@ export const enableUseEffectEventHook = __EXPERIMENTAL__;
 // Enables DOM-server to stream its instruction set as data-attributes
 // (handled with an MutationObserver) instead of inline-scripts
 export const enableFizzExternalRuntime = true;
-
-export const enableAsyncActions = __EXPERIMENTAL__;
 
 export const alwaysThrottleRetries = true;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -74,7 +74,7 @@ export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
 export const enableFizzExternalRuntime = false;
 export const enableDeferRootSchedulingToMicrotask = true;
 
-export const enableAsyncActions = false;
+export const enableAsyncActions = true;
 
 export const alwaysThrottleRetries = true;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -71,7 +71,7 @@ export const useModernStrictMode = false;
 export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
 export const enableDeferRootSchedulingToMicrotask = true;
 
-export const enableAsyncActions = false;
+export const enableAsyncActions = true;
 
 export const alwaysThrottleRetries = true;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -74,7 +74,7 @@ export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
 export const enableFizzExternalRuntime = false;
 export const enableDeferRootSchedulingToMicrotask = true;
 
-export const enableAsyncActions = false;
+export const enableAsyncActions = true;
 
 export const alwaysThrottleRetries = true;
 


### PR DESCRIPTION
Upgrades the stability of Server Actions from experimental to canary.

- Turns on enableAsyncActions and enableFormActions
- Removes "experimental_" prefix from useOptimistic, useFormStatus, and useFormState