### PR TITLE
Move ReactCurrentDispatcher back to shared internals

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -108,6 +108,7 @@ import {
 } from 'shared/ReactSerializationErrors';
 
 import {getOrCreateServerContext} from 'shared/ReactServerContextRegistry';
+import ReactSharedInternals from 'shared/ReactSharedInternals';
 import ReactServerSharedInternals from './ReactServerSharedInternals';
 import isArray from 'shared/isArray';
 import binaryToComparableString from 'shared/binaryToComparableString';
@@ -209,9 +210,9 @@ const {
   TaintRegistryValues,
   TaintRegistryByteLengths,
   TaintRegistryPendingRequests,
-  ReactCurrentDispatcher,
   ReactCurrentCache,
 } = ReactServerSharedInternals;
+const ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
 
 function throwTaintViolation(message: string) {
   // eslint-disable-next-line react-internal/prod-error-codes

--- a/packages/react/src/ReactServerSharedInternals.js
+++ b/packages/react/src/ReactServerSharedInternals.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import ReactCurrentDispatcher from './ReactCurrentDispatcher';
 import ReactCurrentCache from './ReactCurrentCache';
 import {
   TaintRegistryObjects,
@@ -17,7 +16,6 @@ import {
 import {enableTaint} from 'shared/ReactFeatureFlags';
 
 const ReactServerSharedInternals = {
-  ReactCurrentDispatcher,
   ReactCurrentCache,
 };
 

--- a/packages/react/src/ReactSharedInternalsServer.js
+++ b/packages/react/src/ReactSharedInternalsServer.js
@@ -5,12 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import ReactCurrentDispatcher from './ReactCurrentDispatcher';
 import ReactCurrentOwner from './ReactCurrentOwner';
 import ReactDebugCurrentFrame from './ReactDebugCurrentFrame';
 import {enableServerContext} from 'shared/ReactFeatureFlags';
 import {ContextRegistry} from './ReactServerContextRegistry';
 
 const ReactSharedInternals = {
+  ReactCurrentDispatcher,
   ReactCurrentOwner,
 };
 


### PR DESCRIPTION
The jsx-runtime uses the ReactCurrentDispatcher from shared internals. Recently this was moved to ReactServerSharedInternals which broke jsx-runtime. This change moves it back to ReactSharedInternals until we can come up with a new forking mechanism.