### PR TITLE
Add failing ReactTestRenderer test

### DIFF
--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
@@ -14,6 +14,7 @@ let React;
 let ReactCache;
 let ReactTestRenderer;
 let waitForAll;
+let act;
 
 describe('ReactTestRenderer', () => {
   beforeEach(() => {
@@ -27,6 +28,7 @@ describe('ReactTestRenderer', () => {
     ReactTestRenderer = require('react-test-renderer');
     const InternalTestUtils = require('internal-test-utils');
     waitForAll = InternalTestUtils.waitForAll;
+    act = ReactTestRenderer.act;
   });
 
   it('should warn if used to render a ReactDOM portal', () => {
@@ -155,11 +157,17 @@ describe('ReactTestRenderer', () => {
         return <div>Selected Filters: {selectedFiltersString}</div>;
       }
 
-      const root = ReactTestRenderer.create(<Parent />);
-      await waitForAll([]);
-      expect(root.toJSON()).toEqual(
-        '<div>Selected Filters: _selected_all_filters_</div>',
-      );
+      let root;
+      act(() => {
+        root = ReactTestRenderer.create(<Parent />);
+      });
+
+      expect(root.toJSON()).toMatchInlineSnapshot(`
+        <div>
+          Selected Filters: 
+          _selected_all_filters_
+        </div>
+      `);
     });
   });
 });

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
@@ -120,5 +120,46 @@ describe('ReactTestRenderer', () => {
       await waitForAll([]);
       expect(root.toJSON().children).toEqual(['dynamic']);
     });
+
+    it('failing test', async () => {
+      const SELECT_ALL_FILTERS_VALUE = '_selected_all_filters_';
+      function Parent() {
+        const [selectedFilters, setSelectedFilters] = React.useState(null);
+        const filterList = ['green', 'red', 'gray'];
+        return (
+          <Child
+            selectedFilters={selectedFilters}
+            setSelectedFilters={setSelectedFilters}
+            filterList={filterList}
+          />
+        );
+      }
+
+      function Child({selectedFilters, setSelectedFilters, filterList}) {
+        const selectedFiltersString = React.useMemo(() => {
+          if (selectedFilters == null) {
+            return 'none';
+          }
+          if (selectedFilters.length === 1) {
+            return selectedFilters[0];
+          }
+          return SELECT_ALL_FILTERS_VALUE;
+        }, [selectedFilters]);
+
+        React.useEffect(() => {
+          if (selectedFilters == null) {
+            setSelectedFilters(SELECT_ALL_FILTERS_VALUE);
+          }
+        }, [selectedFilters]);
+
+        return <div>Selected Filters: {selectedFiltersString}</div>;
+      }
+
+      const root = ReactTestRenderer.create(<Parent />);
+      await waitForAll([]);
+      expect(root.toJSON()).toEqual(
+        '<div>Selected Filters: _selected_all_filters_</div>',
+      );
+    });
   });
 });


### PR DESCRIPTION
Interestingly this only seems to fail in ReactTestRenderer, in the codesandbox it correctly shows the right value

https://codesandbox.io/s/unruffled-platform-95l8w7?file=/src/App.js

```
  ● ReactTestRenderer › timed out Suspense hidden subtrees should not be observable via toJSON › failing test

    expect(received).toEqual(expected) // deep equality

    Expected: "<div>Selected Filters: _selected_all_filters_</div>"
    Received: <div>Selected Filters: none</div>

      157 |
      158 |       const root = ReactTestRenderer.create(<Parent />);
    > 159 |       expect(root.toJSON()).toEqual(
          |                             ^
      160 |         '<div>Selected Filters: _selected_all_filters_</div>',
      161 |       );
      162 |     });

      at Object.<anonymous> (packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js:159:29)
```