### PR TITLE
Reduce install network flake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,9 @@ commands:
             if [ $? -ne 0 ]; then
               yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
             fi
+          environment:
+          # If we start needing the Electron binary, please ensure the binary is cached in CI following https://www.electronjs.org/docs/latest/tutorial/installation
+            ELECTRON_SKIP_BINARY_DOWNLOAD: 1
       - save_cache:
           name: Save yarn cache
           key: v2-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
## Summary

Avoids potentially flaky network calls leading to failures such as https://app.circleci.com/pipelines/github/facebook/react/47096/workflows/b7966c1d-199c-4185-8d17-ac6485235c3a/jobs/727782. Also makes install faster since we don't need the binary in CI seemingly.

Electron itself is used to start the standalone binary.

## How did you test this change?

- [x] CI still passes without the binary downloaded. I'm just trusting [their docs](https://www.electronjs.org/docs/latest/tutorial/installation) here that setting this actually ensures the binary isn't downloaded.
