### PR TITLE
Disable ServerContext in canary

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -5608,6 +5608,7 @@ describe('ReactDOMFizzServer', () => {
     expect(getVisibleChildren(container)).toEqual('ABC');
   });
 
+  // @gate enableServerContext
   it('basic use(context)', async () => {
     const ContextA = React.createContext('default');
     const ContextB = React.createContext('B');

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -618,6 +618,7 @@ describe('ReactFlightDOMBrowser', () => {
     expect(container.innerHTML).toBe('ABC');
   });
 
+  // @gate enableServerContext
   it('basic use(context)', async () => {
     let ContextA;
     let ContextB;

--- a/packages/react/index.classic.fb.js
+++ b/packages/react/index.classic.fb.js
@@ -22,7 +22,6 @@ export {
   createElement,
   createFactory,
   createRef,
-  createServerContext,
   use,
   forwardRef,
   isValidElement,

--- a/packages/react/index.modern.fb.js
+++ b/packages/react/index.modern.fb.js
@@ -21,7 +21,6 @@ export {
   createContext,
   createElement,
   createRef,
-  createServerContext,
   use,
   forwardRef,
   isValidElement,

--- a/packages/react/index.stable.js
+++ b/packages/react/index.stable.js
@@ -22,7 +22,6 @@ export {
   createElement,
   createFactory,
   createRef,
-  createServerContext,
   use,
   forwardRef,
   isValidElement,

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -222,7 +222,7 @@ export const enableDebugTracing = false;
 // Track which Fiber(s) schedule render work.
 export const enableUpdaterTracking = __PROFILE__;
 
-export const enableServerContext = true;
+export const enableServerContext = __EXPERIMENTAL__;
 
 // Internal only.
 export const enableGetInspectorDataForInstanceInProduction = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -76,7 +76,7 @@ export const allowConcurrentByDefault = true;
 export const enableCustomElementPropertySupport = false;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;
-export const enableServerContext = true;
+export const enableServerContext = false;
 
 export const enableTransitionTracing = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -62,7 +62,7 @@ export const allowConcurrentByDefault = false;
 export const enableCustomElementPropertySupport = false;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;
-export const enableServerContext = true;
+export const enableServerContext = false;
 
 export const enableTransitionTracing = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -62,7 +62,7 @@ export const allowConcurrentByDefault = false;
 export const enableCustomElementPropertySupport = false;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;
-export const enableServerContext = true;
+export const enableServerContext = false;
 
 export const enableTransitionTracing = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -60,7 +60,7 @@ export const enableUnifiedSyncLane = false;
 export const allowConcurrentByDefault = true;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;
-export const enableServerContext = true;
+export const enableServerContext = false;
 
 export const enableTransitionTracing = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -62,7 +62,7 @@ export const allowConcurrentByDefault = true;
 export const enableCustomElementPropertySupport = false;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;
-export const enableServerContext = true;
+export const enableServerContext = false;
 
 export const enableTransitionTracing = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -102,7 +102,7 @@ export const disableTextareaChildren = __EXPERIMENTAL__;
 export const allowConcurrentByDefault = true;
 
 export const consoleManagedByDevToolsDuringStrictMode = true;
-export const enableServerContext = true;
+export const enableServerContext = false;
 
 export const useModernStrictMode = false;
 export const enableFizzExternalRuntime = true;


### PR DESCRIPTION
We previously added a warning in #27424. This just removes it from canary/stable channels but keeps it in experimental for now.
