### PR TITLE
[Fizz][Float] Only flush Hoistable Elements if their containing Boundary is complete

### DIFF
--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -220,7 +220,7 @@ export function getInternalReactConstants(version: string): {
       HostSingleton: 27, // Same as above
       HostText: 6,
       IncompleteClassComponent: 17,
-      IndeterminateComponent: 2,
+      IndeterminateComponent: 2, // removed in 19.0.0
       LazyComponent: 16,
       LegacyHiddenComponent: 23,
       MemoComponent: 14,

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
@@ -10,7 +10,6 @@
 import type {
   RenderState as BaseRenderState,
   ResumableState,
-  BoundaryResources,
   StyleQueue,
   Resource,
   HeadersDescriptor,
@@ -48,6 +47,7 @@ export type RenderState = {
   headChunks: null | Array<Chunk | PrecomputedChunk>,
   externalRuntimeScript: null | any,
   bootstrapChunks: Array<Chunk | PrecomputedChunk>,
+  importMapChunks: Array<Chunk | PrecomputedChunk>,
   onHeaders: void | ((headers: HeadersDescriptor) => void),
   headers: null | {
     preconnects: string,
@@ -56,11 +56,6 @@ export type RenderState = {
     remainingCapacity: number,
   },
   resets: BaseRenderState['resets'],
-  charsetChunks: Array<Chunk | PrecomputedChunk>,
-  preconnectChunks: Array<Chunk | PrecomputedChunk>,
-  importMapChunks: Array<Chunk | PrecomputedChunk>,
-  preloadChunks: Array<Chunk | PrecomputedChunk>,
-  hoistableChunks: Array<Chunk | PrecomputedChunk>,
   preconnects: Set<Resource>,
   fontPreloads: Set<Resource>,
   highImagePreloads: Set<Resource>,
@@ -75,7 +70,6 @@ export type RenderState = {
     scripts: Map<string, Resource>,
     moduleScripts: Map<string, Resource>,
   },
-  boundaryResources: ?BoundaryResources,
   stylesToHoist: boolean,
   // This is an extra field for the legacy renderer
   generateStaticMarkup: boolean,
@@ -103,14 +97,10 @@ export function createRenderState(
     headChunks: renderState.headChunks,
     externalRuntimeScript: renderState.externalRuntimeScript,
     bootstrapChunks: renderState.bootstrapChunks,
+    importMapChunks: renderState.importMapChunks,
     onHeaders: renderState.onHeaders,
     headers: renderState.headers,
     resets: renderState.resets,
-    charsetChunks: renderState.charsetChunks,
-    preconnectChunks: renderState.preconnectChunks,
-    importMapChunks: renderState.importMapChunks,
-    preloadChunks: renderState.preloadChunks,
-    hoistableChunks: renderState.hoistableChunks,
     preconnects: renderState.preconnects,
     fontPreloads: renderState.fontPreloads,
     highImagePreloads: renderState.highImagePreloads,
@@ -120,7 +110,6 @@ export function createRenderState(
     scripts: renderState.scripts,
     bulkPreloads: renderState.bulkPreloads,
     preloads: renderState.preloads,
-    boundaryResources: renderState.boundaryResources,
     stylesToHoist: renderState.stylesToHoist,
 
     // This is an extra field for the legacy renderer
@@ -138,6 +127,7 @@ export const doctypeChunk: PrecomputedChunk = stringToPrecomputedChunk('');
 
 export type {
   ResumableState,
+  HoistableState,
   BoundaryResources,
   FormatContext,
 } from './ReactFizzConfigDOM';
@@ -164,11 +154,12 @@ export {
   createRootFormatContext,
   createResumableState,
   createBoundaryResources,
+  createHoistableState,
   writePreamble,
   writeHoistables,
   writePostamble,
-  hoistResources,
-  setCurrentlyRenderingBoundaryResourcesTarget,
+  hoistBoundaryResources,
+  hoistHoistables,
   prepareHostDispatcher,
   resetResumableState,
   completeResumableState,

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -12,7 +12,6 @@
 let React;
 let ReactDOM;
 let ReactTestUtils;
-let PropTypes;
 
 const clone = function (o) {
   return JSON.parse(JSON.stringify(o));
@@ -91,7 +90,6 @@ describe('ReactComponentLifeCycle', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactTestUtils = require('react-dom/test-utils');
-    PropTypes = require('prop-types');
   });
 
   it('should not reuse an instance when it has been unmounted', () => {
@@ -982,67 +980,6 @@ describe('ReactComponentLifeCycle', () => {
       withoutStack: true,
     });
   });
-
-  if (!require('shared/ReactFeatureFlags').disableModulePatternComponents) {
-    it('calls effects on module-pattern component', function () {
-      const log = [];
-
-      function Parent() {
-        return {
-          render() {
-            expect(typeof this.props).toBe('object');
-            log.push('render');
-            return <Child />;
-          },
-          UNSAFE_componentWillMount() {
-            log.push('will mount');
-          },
-          componentDidMount() {
-            log.push('did mount');
-          },
-          componentDidUpdate() {
-            log.push('did update');
-          },
-          getChildContext() {
-            return {x: 2};
-          },
-        };
-      }
-      Parent.childContextTypes = {
-        x: PropTypes.number,
-      };
-      function Child(props, context) {
-        expect(context.x).toBe(2);
-        return <div />;
-      }
-      Child.contextTypes = {
-        x: PropTypes.number,
-      };
-
-      const div = document.createElement('div');
-      expect(() =>
-        ReactDOM.render(<Parent ref={c => c && log.push('ref')} />, div),
-      ).toErrorDev(
-        'Warning: The <Parent /> component appears to be a function component that returns a class instance. ' +
-          'Change Parent to a class that extends React.Component instead. ' +
-          "If you can't use a class try assigning the prototype on the function as a workaround. " +
-          '`Parent.prototype = React.Component.prototype`. ' +
-          "Don't use an arrow function since it cannot be called with `new` by React.",
-      );
-      ReactDOM.render(<Parent ref={c => c && log.push('ref')} />, div);
-
-      expect(log).toEqual([
-        'will mount',
-        'render',
-        'did mount',
-        'ref',
-
-        'render',
-        'did update',
-        'ref',
-      ]);
-    });
-  }
 
   it('should warn if getDerivedStateFromProps returns undefined', () => {
     class MyComponent extends React.Component {

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -111,53 +111,22 @@ describe('ReactCompositeComponent', () => {
     };
   });
 
-  if (require('shared/ReactFeatureFlags').disableModulePatternComponents) {
-    it('should not support module pattern components', () => {
-      function Child({test}) {
-        return {
-          render() {
-            return <div>{test}</div>;
-          },
-        };
-      }
+  it('should not support module pattern components', () => {
+    function Child({test}) {
+      return {
+        render() {
+          return <div>{test}</div>;
+        },
+      };
+    }
 
-      const el = document.createElement('div');
-      expect(() => {
-        expect(() => ReactDOM.render(<Child test="test" />, el)).toThrow(
-          'Objects are not valid as a React child (found: object with keys {render}).',
-        );
-      }).toErrorDev(
-        'Warning: The <Child /> component appears to be a function component that returns a class instance. ' +
-          'Change Child to a class that extends React.Component instead. ' +
-          "If you can't use a class try assigning the prototype on the function as a workaround. " +
-          '`Child.prototype = React.Component.prototype`. ' +
-          "Don't use an arrow function since it cannot be called with `new` by React.",
-      );
+    const el = document.createElement('div');
+    expect(() => ReactDOM.render(<Child test="test" />, el)).toThrow(
+      'Objects are not valid as a React child (found: object with keys {render}).',
+    );
 
-      expect(el.textContent).toBe('');
-    });
-  } else {
-    it('should support module pattern components', () => {
-      function Child({test}) {
-        return {
-          render() {
-            return <div>{test}</div>;
-          },
-        };
-      }
-
-      const el = document.createElement('div');
-      expect(() => ReactDOM.render(<Child test="test" />, el)).toErrorDev(
-        'Warning: The <Child /> component appears to be a function component that returns a class instance. ' +
-          'Change Child to a class that extends React.Component instead. ' +
-          "If you can't use a class try assigning the prototype on the function as a workaround. " +
-          '`Child.prototype = React.Component.prototype`. ' +
-          "Don't use an arrow function since it cannot be called with `new` by React.",
-      );
-
-      expect(el.textContent).toBe('test');
-    });
-  }
+    expect(el.textContent).toBe('');
+  });
 
   it('should support rendering to different child types over time', () => {
     const instance = ReactTestUtils.renderIntoDocument(<MorphingComponent />);

--- a/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
@@ -457,60 +457,6 @@ describe('ReactCompositeComponent-state', () => {
     ]);
   });
 
-  if (!require('shared/ReactFeatureFlags').disableModulePatternComponents) {
-    it('should support stateful module pattern components', () => {
-      function Child() {
-        return {
-          state: {
-            count: 123,
-          },
-          render() {
-            return <div>{`count:${this.state.count}`}</div>;
-          },
-        };
-      }
-
-      const el = document.createElement('div');
-      expect(() => ReactDOM.render(<Child />, el)).toErrorDev(
-        'Warning: The <Child /> component appears to be a function component that returns a class instance. ' +
-          'Change Child to a class that extends React.Component instead. ' +
-          "If you can't use a class try assigning the prototype on the function as a workaround. " +
-          '`Child.prototype = React.Component.prototype`. ' +
-          "Don't use an arrow function since it cannot be called with `new` by React.",
-      );
-
-      expect(el.textContent).toBe('count:123');
-    });
-
-    it('should support getDerivedStateFromProps for module pattern components', () => {
-      function Child() {
-        return {
-          state: {
-            count: 1,
-          },
-          render() {
-            return <div>{`count:${this.state.count}`}</div>;
-          },
-        };
-      }
-      Child.getDerivedStateFromProps = (props, prevState) => {
-        return {
-          count: prevState.count + props.incrementBy,
-        };
-      };
-
-      const el = document.createElement('div');
-      ReactDOM.render(<Child incrementBy={0} />, el);
-      expect(el.textContent).toBe('count:1');
-
-      ReactDOM.render(<Child incrementBy={2} />, el);
-      expect(el.textContent).toBe('count:3');
-
-      ReactDOM.render(<Child incrementBy={1} />, el);
-      expect(el.textContent).toBe('count:4');
-    });
-  }
-
   it('should support setState in componentWillUnmount', () => {
     let subscription;
     class A extends React.Component {

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
@@ -622,23 +622,9 @@ describe('ReactDOMServerIntegration', () => {
         checkFooDiv(await render(<ClassComponent />));
       });
 
-      if (require('shared/ReactFeatureFlags').disableModulePatternComponents) {
-        itThrowsWhenRendering(
-          'factory components',
-          async render => {
-            const FactoryComponent = () => {
-              return {
-                render: function () {
-                  return <div>foo</div>;
-                },
-              };
-            };
-            await render(<FactoryComponent />, 1);
-          },
-          'Objects are not valid as a React child (found: object with keys {render})',
-        );
-      } else {
-        itRenders('factory components', async render => {
+      itThrowsWhenRendering(
+        'factory components',
+        async render => {
           const FactoryComponent = () => {
             return {
               render: function () {
@@ -646,9 +632,10 @@ describe('ReactDOMServerIntegration', () => {
               },
             };
           };
-          checkFooDiv(await render(<FactoryComponent />, 1));
-        });
-      }
+          await render(<FactoryComponent />, 1);
+        },
+        'Objects are not valid as a React child (found: object with keys {render})',
+      );
     });
 
     describe('component hierarchies', function () {

--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
@@ -799,46 +799,6 @@ describe('ReactErrorBoundaries', () => {
     expect(container.firstChild.textContent).toBe('Caught an error: Hello.');
   });
 
-  // @gate !disableModulePatternComponents
-  // @gate !disableLegacyContext
-  it('renders an error state if module-style context provider throws in componentWillMount', () => {
-    function BrokenComponentWillMountWithContext() {
-      return {
-        getChildContext() {
-          return {foo: 42};
-        },
-        render() {
-          return <div>{this.props.children}</div>;
-        },
-        UNSAFE_componentWillMount() {
-          throw new Error('Hello');
-        },
-      };
-    }
-    BrokenComponentWillMountWithContext.childContextTypes = {
-      foo: PropTypes.number,
-    };
-
-    const container = document.createElement('div');
-    expect(() =>
-      ReactDOM.render(
-        <ErrorBoundary>
-          <BrokenComponentWillMountWithContext />
-        </ErrorBoundary>,
-        container,
-      ),
-    ).toErrorDev(
-      'Warning: The <BrokenComponentWillMountWithContext /> component appears to be a function component that ' +
-        'returns a class instance. ' +
-        'Change BrokenComponentWillMountWithContext to a class that extends React.Component instead. ' +
-        "If you can't use a class try assigning the prototype on the function as a workaround. " +
-        '`BrokenComponentWillMountWithContext.prototype = React.Component.prototype`. ' +
-        "Don't use an arrow function since it cannot be called with `new` by React.",
-    );
-
-    expect(container.firstChild.textContent).toBe('Caught an error: Hello.');
-  });
-
   it('mounts the error message if mounting fails', () => {
     function renderError(error) {
       return <ErrorMessage message={error.message} />;

--- a/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
@@ -825,45 +825,6 @@ describe('ReactLegacyErrorBoundaries', () => {
     expect(container.firstChild.textContent).toBe('Caught an error: Hello.');
   });
 
-  if (!require('shared/ReactFeatureFlags').disableModulePatternComponents) {
-    it('renders an error state if module-style context provider throws in componentWillMount', () => {
-      function BrokenComponentWillMountWithContext() {
-        return {
-          getChildContext() {
-            return {foo: 42};
-          },
-          render() {
-            return <div>{this.props.children}</div>;
-          },
-          UNSAFE_componentWillMount() {
-            throw new Error('Hello');
-          },
-        };
-      }
-      BrokenComponentWillMountWithContext.childContextTypes = {
-        foo: PropTypes.number,
-      };
-
-      const container = document.createElement('div');
-      expect(() =>
-        ReactDOM.render(
-          <ErrorBoundary>
-            <BrokenComponentWillMountWithContext />
-          </ErrorBoundary>,
-          container,
-        ),
-      ).toErrorDev(
-        'Warning: The <BrokenComponentWillMountWithContext /> component appears to be a function component that ' +
-          'returns a class instance. ' +
-          'Change BrokenComponentWillMountWithContext to a class that extends React.Component instead. ' +
-          "If you can't use a class try assigning the prototype on the function as a workaround. " +
-          '`BrokenComponentWillMountWithContext.prototype = React.Component.prototype`. ' +
-          "Don't use an arrow function since it cannot be called with `new` by React.",
-      );
-      expect(container.firstChild.textContent).toBe('Caught an error: Hello.');
-    });
-  }
-
   it('mounts the error message if mounting fails', () => {
     function renderError(error) {
       return <ErrorMessage message={error.message} />;

--- a/packages/react-dom/src/__tests__/refs-test.js
+++ b/packages/react-dom/src/__tests__/refs-test.js
@@ -11,7 +11,6 @@
 
 let React = require('react');
 let ReactDOM = require('react-dom');
-let ReactFeatureFlags = require('shared/ReactFeatureFlags');
 let ReactTestUtils = require('react-dom/test-utils');
 
 // This is testing if string refs are deleted from `instance.refs`
@@ -24,7 +23,6 @@ describe('reactiverefs', () => {
     jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
-    ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactTestUtils = require('react-dom/test-utils');
   });
 
@@ -183,33 +181,6 @@ describe('reactiverefs', () => {
   });
 });
 
-if (!ReactFeatureFlags.disableModulePatternComponents) {
-  describe('factory components', () => {
-    it('Should correctly get the ref', () => {
-      function Comp() {
-        return {
-          elemRef: React.createRef(),
-          render() {
-            return <div ref={this.elemRef} />;
-          },
-        };
-      }
-
-      let inst;
-      expect(
-        () => (inst = ReactTestUtils.renderIntoDocument(<Comp />)),
-      ).toErrorDev(
-        'Warning: The <Comp /> component appears to be a function component that returns a class instance. ' +
-          'Change Comp to a class that extends React.Component instead. ' +
-          "If you can't use a class try assigning the prototype on the function as a workaround. " +
-          '`Comp.prototype = React.Component.prototype`. ' +
-          "Don't use an arrow function since it cannot be called with `new` by React.",
-      );
-      expect(inst.elemRef.current.tagName).toBe('DIV');
-    });
-  });
-}
-
 /**
  * Tests that when a ref hops around children, we can track that correctly.
  */
@@ -219,7 +190,6 @@ describe('ref swapping', () => {
     jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
-    ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactTestUtils = require('react-dom/test-utils');
 
     RefHopsAround = class extends React.Component {

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -52,6 +52,7 @@ type Destination = {
 };
 
 type RenderState = null;
+type HoistableState = null;
 type BoundaryResources = null;
 
 const POP = Buffer.from('/', 'utf8');
@@ -269,7 +270,14 @@ const ReactNoopServer = ReactFizzServer({
     return null;
   },
 
-  setCurrentlyRenderingBoundaryResourcesTarget(resources: BoundaryResources) {},
+  createHoistableState(): HoistableState {
+    return null;
+  },
+
+  hoistHoistables(
+    parentHoistableState: HoistableState,
+    hoistableState: HoistableState,
+  ) {},
 
   prepareHostDispatcher() {},
   emitEarlyPreloads() {},

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -43,7 +43,6 @@ import {
 import {NoFlags, Placement, StaticMask} from './ReactFiberFlags';
 import {ConcurrentRoot} from './ReactRootTags';
 import {
-  IndeterminateComponent,
   ClassComponent,
   HostRoot,
   HostComponent,
@@ -249,19 +248,10 @@ export function isSimpleFunctionComponent(type: any): boolean {
   );
 }
 
-export function resolveLazyComponentTag(Component: Function): WorkTag {
-  if (typeof Component === 'function') {
-    return shouldConstruct(Component) ? ClassComponent : FunctionComponent;
-  } else if (Component !== undefined && Component !== null) {
-    const $$typeof = Component.$$typeof;
-    if ($$typeof === REACT_FORWARD_REF_TYPE) {
-      return ForwardRef;
-    }
-    if ($$typeof === REACT_MEMO_TYPE) {
-      return MemoComponent;
-    }
-  }
-  return IndeterminateComponent;
+export function isFunctionClassComponent(
+  type: (...args: Array<any>) => mixed,
+): boolean {
+  return shouldConstruct(type);
 }
 
 // This is used to create an alternate fiber to do work on.
@@ -352,7 +342,6 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
   if (__DEV__) {
     workInProgress._debugNeedsRemount = current._debugNeedsRemount;
     switch (workInProgress.tag) {
-      case IndeterminateComponent:
       case FunctionComponent:
       case SimpleMemoComponent:
         workInProgress.type = resolveFunctionForHotReloading(current.type);
@@ -494,7 +483,7 @@ export function createFiberFromTypeAndProps(
   mode: TypeOfMode,
   lanes: Lanes,
 ): Fiber {
-  let fiberTag = IndeterminateComponent;
+  let fiberTag = FunctionComponent;
   // The resolved type is set if we know what the final type will be. I.e. it's not lazy.
   let resolvedType = type;
   if (typeof type === 'function') {
@@ -881,7 +870,7 @@ export function assignFiberPropertiesInDEV(
   if (target === null) {
     // This Fiber's initial properties will always be overwritten.
     // We only use a Fiber to ensure the same hidden class so DEV isn't slow.
-    target = createFiber(IndeterminateComponent, null, null, NoMode);
+    target = createFiber(FunctionComponent, null, null, NoMode);
   }
 
   // This is intentionally written as a list of all properties.

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -47,7 +47,6 @@ import {
   setIsStrictModeForDevtools,
 } from './ReactFiberDevToolsHook';
 import {
-  IndeterminateComponent,
   FunctionComponent,
   ClassComponent,
   HostRoot,
@@ -95,7 +94,6 @@ import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {
   debugRenderPhaseSideEffectsForStrictMode,
   disableLegacyContext,
-  disableModulePatternComponents,
   enableProfilerCommitHooks,
   enableProfilerTimer,
   enableScopeAPI,
@@ -115,7 +113,12 @@ import shallowEqual from 'shared/shallowEqual';
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 import getComponentNameFromType from 'shared/getComponentNameFromType';
 import ReactStrictModeWarnings from './ReactStrictModeWarnings';
-import {REACT_LAZY_TYPE, getIteratorFn} from 'shared/ReactSymbols';
+import {
+  REACT_LAZY_TYPE,
+  REACT_FORWARD_REF_TYPE,
+  REACT_MEMO_TYPE,
+  getIteratorFn,
+} from 'shared/ReactSymbols';
 import {
   getCurrentFiberOwnerNameInDevOrNull,
   setIsRendering,
@@ -236,7 +239,6 @@ import {
   queueHydrationError,
 } from './ReactFiberHydrationContext';
 import {
-  adoptClassInstance,
   constructClassInstance,
   mountClassInstance,
   resumeMountClassInstance,
@@ -244,12 +246,12 @@ import {
 } from './ReactFiberClassComponent';
 import {resolveDefaultProps} from './ReactFiberLazyComponent';
 import {
-  resolveLazyComponentTag,
   createFiberFromTypeAndProps,
   createFiberFromFragment,
   createFiberFromOffscreen,
   createWorkInProgress,
   isSimpleFunctionComponent,
+  isFunctionClassComponent,
 } from './ReactFiber';
 import {
   retryDehydratedSuspenseBoundary,
@@ -301,7 +303,6 @@ export const SelectiveHydrationException: mixed = new Error(
 let didReceiveUpdate: boolean = false;
 
 let didWarnAboutBadClass;
-let didWarnAboutModulePatternComponent;
 let didWarnAboutContextTypeOnFunctionComponent;
 let didWarnAboutGetDerivedStateOnFunctionComponent;
 let didWarnAboutFunctionRefs;
@@ -312,7 +313,6 @@ let didWarnAboutDefaultPropsOnFunctionComponent;
 
 if (__DEV__) {
   didWarnAboutBadClass = ({}: {[string]: boolean});
-  didWarnAboutModulePatternComponent = ({}: {[string]: boolean});
   didWarnAboutContextTypeOnFunctionComponent = ({}: {[string]: boolean});
   didWarnAboutGetDerivedStateOnFunctionComponent = ({}: {[string]: boolean});
   didWarnAboutFunctionRefs = ({}: {[string]: boolean});
@@ -1096,6 +1096,27 @@ function updateFunctionComponent(
   renderLanes: Lanes,
 ) {
   if (__DEV__) {
+    if (
+      Component.prototype &&
+      typeof Component.prototype.render === 'function'
+    ) {
+      const componentName = getComponentNameFromType(Component) || 'Unknown';
+
+      if (!didWarnAboutBadClass[componentName]) {
+        console.error(
+          "The <%s /> component appears to have a render method, but doesn't extend React.Component. " +
+            'This is likely to cause errors. Change %s to extend React.Component instead.',
+          componentName,
+          componentName,
+        );
+        didWarnAboutBadClass[componentName] = true;
+      }
+    }
+
+    if (workInProgress.mode & StrictLegacyMode) {
+      ReactStrictModeWarnings.recordLegacyContextWarning(workInProgress, null);
+    }
+
     if (workInProgress.type !== workInProgress.elementType) {
       // Lazy component props can't be validated in createElement
       // because they're only guaranteed to be resolved here.
@@ -1106,6 +1127,20 @@ function updateFunctionComponent(
           nextProps, // Resolved props
           'prop',
           getComponentNameFromType(Component),
+        );
+      }
+    }
+
+    if (current === null) {
+      // Some validations were previously done in mountIndeterminateComponent however and are now run
+      // in updateFuntionComponent but only on mount
+      validateFunctionComponentInDev(workInProgress, workInProgress.type);
+
+      if (disableLegacyContext && Component.contextTypes) {
+        console.error(
+          '%s uses the legacy contextTypes API which is no longer supported. ' +
+            'Use React.createContext() with React.useContext() instead.',
+          getComponentNameFromType(Component) || 'Unknown',
         );
       }
     }
@@ -1758,54 +1793,54 @@ function mountLazyComponent(
   let Component = init(payload);
   // Store the unwrapped component in the type.
   workInProgress.type = Component;
-  const resolvedTag = (workInProgress.tag = resolveLazyComponentTag(Component));
+
   const resolvedProps = resolveDefaultProps(Component, props);
-  let child;
-  switch (resolvedTag) {
-    case FunctionComponent: {
+  if (typeof Component === 'function') {
+    if (isFunctionClassComponent(Component)) {
+      workInProgress.tag = ClassComponent;
+      if (__DEV__) {
+        workInProgress.type = Component =
+          resolveClassForHotReloading(Component);
+      }
+      return updateClassComponent(
+        null,
+        workInProgress,
+        Component,
+        resolvedProps,
+        renderLanes,
+      );
+    } else {
+      workInProgress.tag = FunctionComponent;
       if (__DEV__) {
         validateFunctionComponentInDev(workInProgress, Component);
         workInProgress.type = Component =
           resolveFunctionForHotReloading(Component);
       }
-      child = updateFunctionComponent(
+      return updateFunctionComponent(
         null,
         workInProgress,
         Component,
         resolvedProps,
         renderLanes,
       );
-      return child;
     }
-    case ClassComponent: {
-      if (__DEV__) {
-        workInProgress.type = Component =
-          resolveClassForHotReloading(Component);
-      }
-      child = updateClassComponent(
-        null,
-        workInProgress,
-        Component,
-        resolvedProps,
-        renderLanes,
-      );
-      return child;
-    }
-    case ForwardRef: {
+  } else if (Component !== undefined && Component !== null) {
+    const $$typeof = Component.$$typeof;
+    if ($$typeof === REACT_FORWARD_REF_TYPE) {
+      workInProgress.tag = ForwardRef;
       if (__DEV__) {
         workInProgress.type = Component =
           resolveForwardRefForHotReloading(Component);
       }
-      child = updateForwardRef(
+      return updateForwardRef(
         null,
         workInProgress,
         Component,
         resolvedProps,
         renderLanes,
       );
-      return child;
-    }
-    case MemoComponent: {
+    } else if ($$typeof === REACT_MEMO_TYPE) {
+      workInProgress.tag = MemoComponent;
       if (__DEV__) {
         if (workInProgress.type !== workInProgress.elementType) {
           const outerPropTypes = Component.propTypes;
@@ -1819,16 +1854,16 @@ function mountLazyComponent(
           }
         }
       }
-      child = updateMemoComponent(
+      return updateMemoComponent(
         null,
         workInProgress,
         Component,
         resolveDefaultProps(Component.type, resolvedProps), // The inner type can have defaults too
         renderLanes,
       );
-      return child;
     }
   }
+
   let hint = '';
   if (__DEV__) {
     if (
@@ -1886,194 +1921,6 @@ function mountIncompleteClassComponent(
     hasContext,
     renderLanes,
   );
-}
-
-function mountIndeterminateComponent(
-  _current: null | Fiber,
-  workInProgress: Fiber,
-  Component: $FlowFixMe,
-  renderLanes: Lanes,
-) {
-  resetSuspendedCurrentOnMountInLegacyMode(_current, workInProgress);
-
-  const props = workInProgress.pendingProps;
-  let context;
-  if (!disableLegacyContext) {
-    const unmaskedContext = getUnmaskedContext(
-      workInProgress,
-      Component,
-      false,
-    );
-    context = getMaskedContext(workInProgress, unmaskedContext);
-  }
-
-  prepareToReadContext(workInProgress, renderLanes);
-  let value;
-  let hasId;
-
-  if (enableSchedulingProfiler) {
-    markComponentRenderStarted(workInProgress);
-  }
-  if (__DEV__) {
-    if (
-      Component.prototype &&
-      typeof Component.prototype.render === 'function'
-    ) {
-      const componentName = getComponentNameFromType(Component) || 'Unknown';
-
-      if (!didWarnAboutBadClass[componentName]) {
-        console.error(
-          "The <%s /> component appears to have a render method, but doesn't extend React.Component. " +
-            'This is likely to cause errors. Change %s to extend React.Component instead.',
-          componentName,
-          componentName,
-        );
-        didWarnAboutBadClass[componentName] = true;
-      }
-    }
-
-    if (workInProgress.mode & StrictLegacyMode) {
-      ReactStrictModeWarnings.recordLegacyContextWarning(workInProgress, null);
-    }
-
-    setIsRendering(true);
-    ReactCurrentOwner.current = workInProgress;
-    value = renderWithHooks(
-      null,
-      workInProgress,
-      Component,
-      props,
-      context,
-      renderLanes,
-    );
-    hasId = checkDidRenderIdHook();
-    setIsRendering(false);
-  } else {
-    value = renderWithHooks(
-      null,
-      workInProgress,
-      Component,
-      props,
-      context,
-      renderLanes,
-    );
-    hasId = checkDidRenderIdHook();
-  }
-  if (enableSchedulingProfiler) {
-    markComponentRenderStopped();
-  }
-
-  // React DevTools reads this flag.
-  workInProgress.flags |= PerformedWork;
-
-  if (__DEV__) {
-    // Support for module components is deprecated and is removed behind a flag.
-    // Whether or not it would crash later, we want to show a good message in DEV first.
-    if (
-      typeof value === 'object' &&
-      value !== null &&
-      typeof value.render === 'function' &&
-      value.$$typeof === undefined
-    ) {
-      const componentName = getComponentNameFromType(Component) || 'Unknown';
-      if (!didWarnAboutModulePatternComponent[componentName]) {
-        console.error(
-          'The <%s /> component appears to be a function component that returns a class instance. ' +
-            'Change %s to a class that extends React.Component instead. ' +
-            "If you can't use a class try assigning the prototype on the function as a workaround. " +
-            "`%s.prototype = React.Component.prototype`. Don't use an arrow function since it " +
-            'cannot be called with `new` by React.',
-          componentName,
-          componentName,
-          componentName,
-        );
-        didWarnAboutModulePatternComponent[componentName] = true;
-      }
-    }
-  }
-
-  if (
-    // Run these checks in production only if the flag is off.
-    // Eventually we'll delete this branch altogether.
-    !disableModulePatternComponents &&
-    typeof value === 'object' &&
-    value !== null &&
-    typeof value.render === 'function' &&
-    value.$$typeof === undefined
-  ) {
-    if (__DEV__) {
-      const componentName = getComponentNameFromType(Component) || 'Unknown';
-      if (!didWarnAboutModulePatternComponent[componentName]) {
-        console.error(
-          'The <%s /> component appears to be a function component that returns a class instance. ' +
-            'Change %s to a class that extends React.Component instead. ' +
-            "If you can't use a class try assigning the prototype on the function as a workaround. " +
-            "`%s.prototype = React.Component.prototype`. Don't use an arrow function since it " +
-            'cannot be called with `new` by React.',
-          componentName,
-          componentName,
-          componentName,
-        );
-        didWarnAboutModulePatternComponent[componentName] = true;
-      }
-    }
-
-    // Proceed under the assumption that this is a class instance
-    workInProgress.tag = ClassComponent;
-
-    // Throw out any hooks that were used.
-    workInProgress.memoizedState = null;
-    workInProgress.updateQueue = null;
-
-    // Push context providers early to prevent context stack mismatches.
-    // During mounting we don't know the child context yet as the instance doesn't exist.
-    // We will invalidate the child context in finishClassComponent() right after rendering.
-    let hasContext = false;
-    if (isLegacyContextProvider(Component)) {
-      hasContext = true;
-      pushLegacyContextProvider(workInProgress);
-    } else {
-      hasContext = false;
-    }
-
-    workInProgress.memoizedState =
-      value.state !== null && value.state !== undefined ? value.state : null;
-
-    initializeUpdateQueue(workInProgress);
-
-    adoptClassInstance(workInProgress, value);
-    mountClassInstance(workInProgress, Component, props, renderLanes);
-    return finishClassComponent(
-      null,
-      workInProgress,
-      Component,
-      true,
-      hasContext,
-      renderLanes,
-    );
-  } else {
-    // Proceed under the assumption that this is a function component
-    workInProgress.tag = FunctionComponent;
-    if (__DEV__) {
-      if (disableLegacyContext && Component.contextTypes) {
-        console.error(
-          '%s uses the legacy contextTypes API which is no longer supported. ' +
-            'Use React.createContext() with React.useContext() instead.',
-          getComponentNameFromType(Component) || 'Unknown',
-        );
-      }
-    }
-
-    if (getIsHydrating() && hasId) {
-      pushMaterializedTreeId(workInProgress);
-    }
-
-    reconcileChildren(null, workInProgress, value, renderLanes);
-    if (__DEV__) {
-      validateFunctionComponentInDev(workInProgress, Component);
-    }
-    return workInProgress.child;
-  }
 }
 
 function validateFunctionComponentInDev(workInProgress: Fiber, Component: any) {
@@ -4095,14 +3942,6 @@ function beginWork(
   workInProgress.lanes = NoLanes;
 
   switch (workInProgress.tag) {
-    case IndeterminateComponent: {
-      return mountIndeterminateComponent(
-        current,
-        workInProgress,
-        workInProgress.type,
-        renderLanes,
-      );
-    }
     case LazyComponent: {
       const elementType = workInProgress.elementType;
       return mountLazyComponent(

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -569,16 +569,6 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
   }
 }
 
-function adoptClassInstance(workInProgress: Fiber, instance: any): void {
-  instance.updater = classComponentUpdater;
-  workInProgress.stateNode = instance;
-  // The instance needs access to the fiber so that it can schedule updates
-  setInstance(instance, workInProgress);
-  if (__DEV__) {
-    instance._reactInternalInstance = fakeInternalInstance;
-  }
-}
-
 function constructClassInstance(
   workInProgress: Fiber,
   ctor: any,
@@ -663,7 +653,13 @@ function constructClassInstance(
     instance.state !== null && instance.state !== undefined
       ? instance.state
       : null);
-  adoptClassInstance(workInProgress, instance);
+  instance.updater = classComponentUpdater;
+  workInProgress.stateNode = instance;
+  // The instance needs access to the fiber so that it can schedule updates
+  setInstance(instance, workInProgress);
+  if (__DEV__) {
+    instance._reactInternalInstance = fakeInternalInstance;
+  }
 
   if (__DEV__) {
     if (typeof ctor.getDerivedStateFromProps === 'function' && state === null) {
@@ -1231,7 +1227,6 @@ function updateClassInstance(
 }
 
 export {
-  adoptClassInstance,
   constructClassInstance,
   mountClassInstance,
   resumeMountClassInstance,

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -45,7 +45,6 @@ import {
 import {now} from './Scheduler';
 
 import {
-  IndeterminateComponent,
   FunctionComponent,
   ClassComponent,
   HostRoot,
@@ -967,7 +966,6 @@ function completeWork(
   // for hydration.
   popTreeContext(workInProgress);
   switch (workInProgress.tag) {
-    case IndeterminateComponent:
     case LazyComponent:
     case SimpleMemoComponent:
     case FunctionComponent:

--- a/packages/react-reconciler/src/ReactFiberComponentStack.js
+++ b/packages/react-reconciler/src/ReactFiberComponentStack.js
@@ -17,7 +17,6 @@ import {
   SuspenseComponent,
   SuspenseListComponent,
   FunctionComponent,
-  IndeterminateComponent,
   ForwardRef,
   SimpleMemoComponent,
   ClassComponent,
@@ -47,7 +46,6 @@ function describeFiber(fiber: Fiber): string {
     case SuspenseListComponent:
       return describeBuiltInComponentFrame('SuspenseList', source, owner);
     case FunctionComponent:
-    case IndeterminateComponent:
     case SimpleMemoComponent:
       return describeFunctionComponentFrame(fiber.type, source, owner);
     case ForwardRef:

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -97,7 +97,6 @@ import {
 } from './ReactTypeOfMode';
 import {
   HostRoot,
-  IndeterminateComponent,
   ClassComponent,
   SuspenseComponent,
   SuspenseListComponent,
@@ -2347,12 +2346,6 @@ function replaySuspendedUnitOfWork(unitOfWork: Fiber): void {
     startProfilerTimer(unitOfWork);
   }
   switch (unitOfWork.tag) {
-    case IndeterminateComponent: {
-      // Because it suspended with `use`, we can assume it's a
-      // function component.
-      unitOfWork.tag = FunctionComponent;
-      // Fallthrough to the next branch.
-    }
     case SimpleMemoComponent:
     case FunctionComponent: {
       // Resolve `defaultProps`. This logic is copied from `beginWork`.
@@ -3763,7 +3756,6 @@ export function warnAboutUpdateOnNotYetMountedFiberInDEV(fiber: Fiber) {
 
     const tag = fiber.tag;
     if (
-      tag !== IndeterminateComponent &&
       tag !== HostRoot &&
       tag !== ClassComponent &&
       tag !== FunctionComponent &&

--- a/packages/react-reconciler/src/ReactWorkTags.js
+++ b/packages/react-reconciler/src/ReactWorkTags.js
@@ -39,7 +39,6 @@ export type WorkTag =
 
 export const FunctionComponent = 0;
 export const ClassComponent = 1;
-export const IndeterminateComponent = 2; // Before we know whether it is function or class
 export const HostRoot = 3; // Root of a host tree. Could be nested inside another node.
 export const HostPortal = 4; // A subtree. Could be an entry point to a different renderer.
 export const HostComponent = 5;

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1208,16 +1208,6 @@ describe('ReactHooks', () => {
       return <div />;
     });
 
-    function Factory() {
-      return {
-        state: {},
-        render() {
-          renderCount++;
-          return <div />;
-        },
-      };
-    }
-
     const renderer = ReactTestRenderer.create(null);
 
     renderCount = 0;
@@ -1282,36 +1272,6 @@ describe('ReactHooks', () => {
       </StrictMode>,
     );
     expect(renderCount).toBe(__DEV__ ? 2 : 1);
-
-    if (!require('shared/ReactFeatureFlags').disableModulePatternComponents) {
-      renderCount = 0;
-      expect(() => renderer.update(<Factory />)).toErrorDev(
-        'Warning: The <Factory /> component appears to be a function component that returns a class instance. ' +
-          'Change Factory to a class that extends React.Component instead. ' +
-          "If you can't use a class try assigning the prototype on the function as a workaround. " +
-          '`Factory.prototype = React.Component.prototype`. ' +
-          "Don't use an arrow function since it cannot be called with `new` by React.",
-      );
-      expect(renderCount).toBe(1);
-      renderCount = 0;
-      renderer.update(<Factory />);
-      expect(renderCount).toBe(1);
-
-      renderCount = 0;
-      renderer.update(
-        <StrictMode>
-          <Factory />
-        </StrictMode>,
-      );
-      expect(renderCount).toBe(__DEV__ ? 2 : 1); // Treated like a class
-      renderCount = 0;
-      renderer.update(
-        <StrictMode>
-          <Factory />
-        </StrictMode>,
-      );
-      expect(renderCount).toBe(__DEV__ ? 2 : 1); // Treated like a class
-    }
 
     renderCount = 0;
     renderer.update(<HasHooks />);

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -227,44 +227,6 @@ describe('ReactHooksWithNoopRenderer', () => {
     await waitForAll([10]);
   });
 
-  // @gate !disableModulePatternComponents
-  it('throws inside module-style components', async () => {
-    function Counter() {
-      return {
-        render() {
-          const [count] = useState(0);
-          return <Text text={this.props.label + ': ' + count} />;
-        },
-      };
-    }
-    ReactNoop.render(<Counter />);
-    await expect(
-      async () =>
-        await waitForThrow(
-          'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen ' +
-            'for one of the following reasons:\n' +
-            '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
-            '2. You might be breaking the Rules of Hooks\n' +
-            '3. You might have more than one copy of React in the same app\n' +
-            'See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.',
-        ),
-    ).toErrorDev(
-      'Warning: The <Counter /> component appears to be a function component that returns a class instance. ' +
-        'Change Counter to a class that extends React.Component instead. ' +
-        "If you can't use a class try assigning the prototype on the function as a workaround. " +
-        '`Counter.prototype = React.Component.prototype`. ' +
-        "Don't use an arrow function since it cannot be called with `new` by React.",
-    );
-
-    // Confirm that a subsequent hook works properly.
-    function GoodCounter(props) {
-      const [count] = useState(props.initialCount);
-      return <Text text={count} />;
-    }
-    ReactNoop.render(<GoodCounter initialCount={10} />);
-    await waitForAll([10]);
-  });
-
   it('throws when called outside the render phase', async () => {
     expect(() => {
       expect(() => useState(0)).toThrow(

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
@@ -1864,48 +1864,6 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  // @gate !disableModulePatternComponents
-  // @gate !disableLegacyContext
-  it('does not leak own context into context provider (factory components)', async () => {
-    function Recurse(props, context) {
-      return {
-        getChildContext() {
-          return {n: (context.n || 3) - 1};
-        },
-        render() {
-          Scheduler.log('Recurse ' + JSON.stringify(context));
-          if (context.n === 0) {
-            return null;
-          }
-          return <Recurse />;
-        },
-      };
-    }
-    Recurse.contextTypes = {
-      n: PropTypes.number,
-    };
-    Recurse.childContextTypes = {
-      n: PropTypes.number,
-    };
-
-    ReactNoop.render(<Recurse />);
-    await expect(
-      async () =>
-        await waitForAll([
-          'Recurse {}',
-          'Recurse {"n":2}',
-          'Recurse {"n":1}',
-          'Recurse {"n":0}',
-        ]),
-    ).toErrorDev([
-      'Warning: The <Recurse /> component appears to be a function component that returns a class instance. ' +
-        'Change Recurse to a class that extends React.Component instead. ' +
-        "If you can't use a class try assigning the prototype on the function as a workaround. " +
-        '`Recurse.prototype = React.Component.prototype`. ' +
-        "Don't use an arrow function since it cannot be called with `new` by React.",
-    ]);
-  });
-
   // @gate www
   // @gate !disableLegacyContext
   it('provides context when reusing work', async () => {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1756,37 +1756,6 @@ describe('ReactIncrementalErrorHandling', () => {
     );
   });
 
-  // @gate !disableModulePatternComponents
-  it('handles error thrown inside getDerivedStateFromProps of a module-style context provider', async () => {
-    function Provider() {
-      return {
-        getChildContext() {
-          return {foo: 'bar'};
-        },
-        render() {
-          return 'Hi';
-        },
-      };
-    }
-    Provider.childContextTypes = {
-      x: () => {},
-    };
-    Provider.getDerivedStateFromProps = () => {
-      throw new Error('Oops!');
-    };
-
-    ReactNoop.render(<Provider />);
-    await expect(async () => {
-      await waitForThrow('Oops!');
-    }).toErrorDev([
-      'Warning: The <Provider /> component appears to be a function component that returns a class instance. ' +
-        'Change Provider to a class that extends React.Component instead. ' +
-        "If you can't use a class try assigning the prototype on the function as a workaround. " +
-        '`Provider.prototype = React.Component.prototype`. ' +
-        "Don't use an arrow function since it cannot be called with `new` by React.",
-    ]);
-  });
-
   it('uncaught errors should be discarded if the render is aborted', async () => {
     const root = ReactNoop.createRoot();
 

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -854,6 +854,7 @@ describe('ReactLazy', () => {
     }).toErrorDev(
       'Invalid prop `inner` of type `boolean` supplied to `Add`, expected `number`.',
     );
+
     expect(root).toMatchRenderedOutput('0');
   }
 

--- a/packages/react-reconciler/src/__tests__/ReactSubtreeFlagsWarning-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSubtreeFlagsWarning-test.js
@@ -132,11 +132,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
   // @gate experimental || www
   it('regression: false positive for legacy suspense', async () => {
-    // Wrapping in memo because regular function components go through the
-    // mountIndeterminateComponent path, which acts like there's no `current`
-    // fiber even though there is. `memo` is not indeterminate, so it goes
-    // through the update path.
-    const Child = React.memo(({text}) => {
+    const Child = ({text}) => {
       // If text hasn't resolved, this will throw and exit before the passive
       // static effect flag is added by the useEffect call below.
       readText(text);
@@ -147,7 +143,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       Scheduler.log(text);
       return text;
-    });
+    };
 
     function App() {
       return (

--- a/packages/react-reconciler/src/getComponentNameFromFiber.js
+++ b/packages/react-reconciler/src/getComponentNameFromFiber.js
@@ -15,7 +15,6 @@ import {enableLegacyHidden} from 'shared/ReactFeatureFlags';
 import {
   FunctionComponent,
   ClassComponent,
-  IndeterminateComponent,
   HostRoot,
   HostPortal,
   HostComponent,
@@ -115,7 +114,6 @@ export default function getComponentNameFromFiber(fiber: Fiber): string | null {
     case ClassComponent:
     case FunctionComponent:
     case IncompleteClassComponent:
-    case IndeterminateComponent:
     case MemoComponent:
     case SimpleMemoComponent:
       if (typeof type === 'function') {

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -1627,54 +1627,6 @@ describe('ReactFreshIntegration', () => {
       }
     });
 
-    if (!require('shared/ReactFeatureFlags').disableModulePatternComponents) {
-      it('remounts deprecated factory components', () => {
-        if (__DEV__) {
-          expect(() => {
-            render(`
-              function Parent() {
-                return {
-                  render() {
-                    return <Child prop="A" />;
-                  }
-                };
-              };
-
-              function Child({prop}) {
-                return <h1>{prop}1</h1>;
-              };
-
-              export default Parent;
-            `);
-          }).toErrorDev(
-            'The <Parent /> component appears to be a function component ' +
-              'that returns a class instance.',
-          );
-          const el = container.firstChild;
-          expect(el.textContent).toBe('A1');
-          patch(`
-            function Parent() {
-              return {
-                render() {
-                  return <Child prop="B" />;
-                }
-              };
-            };
-
-            function Child({prop}) {
-              return <h1>{prop}2</h1>;
-            };
-
-            export default Parent;
-          `);
-          // Like classes, factory components always remount.
-          expect(container.firstChild).not.toBe(el);
-          const newEl = container.firstChild;
-          expect(newEl.textContent).toBe('B2');
-        }
-      });
-    }
-
     describe('with inline requires', () => {
       beforeEach(() => {
         global.FakeModuleSystem = {};

--- a/packages/react-server/src/forks/ReactFizzConfig.custom.js
+++ b/packages/react-server/src/forks/ReactFizzConfig.custom.js
@@ -29,6 +29,7 @@ import type {TransitionStatus} from 'react-reconciler/src/ReactFiberConfig';
 declare var $$$config: any;
 export opaque type Destination = mixed; // eslint-disable-line no-undef
 export opaque type RenderState = mixed;
+export opaque type HoistableState = mixed;
 export opaque type ResumableState = mixed;
 export opaque type BoundaryResources = mixed;
 export opaque type FormatContext = mixed;
@@ -87,10 +88,9 @@ export const NotPendingTransition = $$$config.NotPendingTransition;
 export const writePreamble = $$$config.writePreamble;
 export const writeHoistables = $$$config.writeHoistables;
 export const writePostamble = $$$config.writePostamble;
-export const hoistResources = $$$config.hoistResources;
-export const createResources = $$$config.createResources;
+export const hoistBoundaryResources = $$$config.hoistBoundaryResources;
+export const hoistHoistables = $$$config.hoistHoistables;
+export const createHoistableState = $$$config.createHoistableState;
 export const createBoundaryResources = $$$config.createBoundaryResources;
-export const setCurrentlyRenderingBoundaryResourcesTarget =
-  $$$config.setCurrentlyRenderingBoundaryResourcesTarget;
 export const writeResourcesForBoundary = $$$config.writeResourcesForBoundary;
 export const emitEarlyPreloads = $$$config.emitEarlyPreloads;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -145,8 +145,6 @@ export const enableRetryLaneExpiration = false;
 // If FALSE, these trees will be StrictLegacyMode.
 export const createRootStrictEffectsByDefault = false;
 
-export const disableModulePatternComponents = false;
-
 export const disableLegacyContext = false;
 
 export const enableUseRefAccessWarning = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -21,7 +21,6 @@ import typeof * as DynamicFlagsType from 'ReactNativeInternalFeatureFlags';
 // update the test configuration.
 
 export const alwaysThrottleRetries = __VARIANT__;
-export const disableModulePatternComponents = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const enableUnifiedSyncLane = __VARIANT__;
 export const enableUseRefAccessWarning = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -19,7 +19,6 @@ import * as dynamicFlags from 'ReactNativeInternalFeatureFlags';
 // the exports object every time a flag is read.
 export const {
   alwaysThrottleRetries,
-  disableModulePatternComponents,
   enableDeferRootSchedulingToMicrotask,
   enableUnifiedSyncLane,
   enableUseRefAccessWarning,

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -38,7 +38,6 @@ export const enableSuspenseCallback = false;
 export const disableLegacyContext = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
-export const disableModulePatternComponents = false;
 export const enableSuspenseAvoidThisFallback = false;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -38,7 +38,6 @@ export const enableSuspenseCallback = false;
 export const disableLegacyContext = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
-export const disableModulePatternComponents = false;
 export const enableSuspenseAvoidThisFallback = false;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -38,7 +38,6 @@ export const enableSuspenseCallback = false;
 export const disableLegacyContext = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
-export const disableModulePatternComponents = false;
 export const enableComponentStackLocations = false;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -38,7 +38,6 @@ export const enableSuspenseCallback = true;
 export const disableLegacyContext = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
-export const disableModulePatternComponents = true;
 export const enableSuspenseAvoidThisFallback = true;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -86,8 +86,6 @@ export const disableJavaScriptURLs = true;
 // Need to remove it.
 export const disableCommentsAsDOMContainers = false;
 
-export const disableModulePatternComponents = true;
-
 export const enableCreateEventHandleAPI = true;
 
 export const enableScopeAPI = true;

--- a/scripts/flow/xplat.js
+++ b/scripts/flow/xplat.js
@@ -9,7 +9,6 @@
 
 declare module 'ReactNativeInternalFeatureFlags' {
   declare export var alwaysThrottleRetries: boolean;
-  declare export var disableModulePatternComponents: boolean;
   declare export var enableDeferRootSchedulingToMicrotask: boolean;
   declare export var enableUnifiedSyncLane: boolean;
   declare export var enableUseRefAccessWarning: boolean;


### PR DESCRIPTION
Currently Stacked on: #27742 

On the client Hoistable Elements act much like Host Components except they render into the document head instead of in their rendered position. On the server was previously not the case as any rendered hoistable would flush regardless of whether the boundary it was contained within was completed. This was even more egregious with fallbacks where if you rendered a hoistable in a fallback it would flush even if the suspense boundary never actually flushed the fallback because the primary content finished in time.

This change updates the flushing semantics of Hoistable Elements to bring them in line with the client.

What this means is that Hoistables are no longer an avenue to emit things like early preloads because if you do so within a Suspense Boundary the preload won't flush until the boundary completes making the preload likely not very useful. The general idea here is that Hoistables are not meant for things that have support in the imperative Float methods like `ReactDOM.preload` and `ReactDOM.preinit`. Given this we are going to simplify the flushing queue ordering to not prioritized any particular hoistables over others.

This PR however does not yet go all the way to a single queue for hoistables. First we have to deal with `charset`. Our plan is to make this a config or infer it from some encoding parameter passed to the render function. This generally is a better way to model charset since you can't reasonably emit this one late, it's either up front or broken and it's tied to some other aspect of the rendering namely the encoding format (note that for web API environments this may be limited to utf-8 only since TextEncoder can't encode other formats)

This PR also does not remove the privileged flushing for `viewport` meta tags. This is harder than charset b/c it is reasonably something you (or at least your meta-framework) might render and not know up front when you invoke the render method. If Hoistables have no privileged flushing queues then we need some means to support viewport from the imperative float methods since it emitting first before we flush things like image preloads is necessary for good performance.

This PR also refactors the Resource tracking to follow the patterns established for task local state values. This is a cleaner implementation though not functionally different. The reason this was not originally pursued is the boundary resources at one point were entanged with the Float imperative methods so it needed to be part of the resolvable resources object during dispatch. We've moved away from that by allowing these methods to be called outside of Render and no longer associate anyting to the Boundary state itself so we can not clean up the implementation here a bit.