### PR TITLE
[Fizz][Float] Do not write after closing the stream

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -15,6 +15,7 @@ global.ReadableStream =
 global.TextEncoder = require('util').TextEncoder;
 
 let React;
+let ReactDOM;
 let ReactDOMFizzServer;
 let Suspense;
 
@@ -22,6 +23,7 @@ describe('ReactDOMFizzServerBrowser', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
+    ReactDOM = require('react-dom');
     ReactDOMFizzServer = require('react-dom/server.browser');
     Suspense = React.Suspense;
   });
@@ -546,5 +548,38 @@ describe('ReactDOMFizzServerBrowser', () => {
     expect(postponed).toEqual(['testing postpone']);
     // However, it does error the shell.
     expect(caughtError.message).toEqual('testing postpone');
+  });
+
+  // https://github.com/facebook/react/issues/27540
+  // This test is not actually asserting much because in our test environment the Float method cannot find the request after
+  // an await and thus is a noop. If we fix our test environment to support AsyncLocalStorage we can assert that the
+  // stream does not write after closing.
+  it('does not try to write to the stream after it has been closed', async () => {
+    async function preloadLate() {
+      await 1;
+      ReactDOM.preconnect('foo');
+    }
+
+    function Preload() {
+      preloadLate();
+      return null;
+    }
+
+    function App() {
+      return (
+        <html>
+          <body>
+            <main>hello</main>
+            <Preload />
+          </body>
+        </html>
+      );
+    }
+    const stream = await ReactDOMFizzServer.renderToReadableStream(<App />);
+    const result = await readResult(stream);
+
+    expect(result).toMatchInlineSnapshot(
+      `"<!DOCTYPE html><html><head></head><body><main>hello</main></body></html>"`,
+    );
   });
 });


### PR DESCRIPTION
Float methods can hang on to a reference to a Request after the request is closed due to AsyncLocalStorage. If a Float method is called at this point we do not want to attempt to flush anything. This change updates the closing logic to also call `stopFlowing` which will ensure that any checks against the destination properly reflect that we cannot do any writes. In addition it updates the enqueueFlush logic to existence check the destination inside the work function since it can change across the work scheduling gap if it is async.

fixes: https://github.com/facebook/react/issues/27540
