### PR TITLE
Add additionalHigherOrderComponents option to rules-of-hooks to extend HOCs tracked by it

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -50,6 +50,8 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 
 ## Advanced Configuration
 
+### `exhaustive-deps`
+
 `exhaustive-deps` can be configured to validate dependencies of custom Hooks with the `additionalHooks` option.
 This option accepts a regex to match the names of custom Hooks that have dependencies.
 
@@ -65,6 +67,22 @@ This option accepts a regex to match the names of custom Hooks that have depende
 ```
 
 We suggest to use this option **very sparingly, if at all**. Generally saying, we recommend most custom Hooks to not use the dependencies argument, and instead provide a higher-level API that is more focused around a specific use case.
+
+### `rules-of-hooks`
+
+`rules-of-hooks` can be configured to validate anonymous components that are passed to higher-order components beyond the default of `React.memo` and `React.forwardRef`, by using the `additionalHigherOrderComponents` option.
+This option accepts a regex to match the names of custom higher-order components.
+
+```js
+{
+  "rules": {
+    // ...
+    "react-hooks/rules-of-hooks": ["error", {
+      "additionalHigherOrderComponents": "(myCustomHOC|myOtherCustomHOC)"
+    }]
+  }
+}
+```
 
 ## Valid and Invalid Examples
 

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -479,6 +479,17 @@ const tests = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        // Valid because hooks can be used in anonymous function arguments that
+        // are provided through the additionalHigherOrderComponents option.
+        const MemoizedFunction = customHOC(function (props) {
+          useHook();
+          return <button {...props} />
+        });
+      `,
+      options: [{additionalHigherOrderComponents: 'customHOC'}],
+    },
   ],
   invalid: [
     {
@@ -1057,6 +1068,34 @@ const tests = {
         }
       `,
       errors: [asyncComponentHookError('useState')],
+    },
+    {
+      code: normalizeIndent`
+        // Invalid because it's dangerous and might not warn otherwise.
+        // This *must* be invalid.
+        const FancyButton = customHOC((props, ref) => {
+          if (props.fancy) {
+            useCustomHook();
+          }
+          return <button ref={ref}>{props.children}</button>;
+        });
+      `,
+      options: [{additionalHigherOrderComponents: 'customHOC'}],
+      errors: [conditionalError('useCustomHook')],
+    },
+    {
+      code: normalizeIndent`
+        // Invalid because it's dangerous and might not warn otherwise.
+        // This *must* be invalid.
+        const FancyButton = customHOC(function(props, ref) {
+          if (props.fancy) {
+            useCustomHook();
+          }
+          return <button ref={ref}>{props.children}</button>;
+        });
+      `,
+      options: [{additionalHigherOrderComponents: 'customHOC'}],
+      errors: [conditionalError('useCustomHook')],
     },
   ],
 };


### PR DESCRIPTION
## Summary

At my workplace we use a theming library in our app that works through a higher-order component named `withTheme`, which wraps a lot of the components in the codebase. Example of what this sort of looks like:

```typescript
const SomeComponent = withTheme<SomeComponentProps>(({theme, ...props}) => {
  return (
    <View style={theme.container}>
      <Text>{props.text}</Text>
    </View>
  );
});
```

Recently we noticed that components that were wrapped with this HOC did not report `rules-of-hooks` violations, and as a result we had several violations in the codebase. We subsequently realized that the eslint rule assumed that anonymous components would only be wrapped in either `React.memo` or `React.forwardRef`.

In a similar vain to the `additionalHooks` option that the `exhaustive-deps` eslint rule exposes, this change adds an `additionalHigherOrderComponents` (possible the name is a bit verbose) option to `rules-of-hooks` which accepts a regex string in the same way, so that users can add any custom HOCs they use in their codebase to ensure the rule still enforces violations.

## How did you test this change?

Added new unit tests demonstrating the new rule option. Confirmed that the test cases failed when ran on `main`, and pass with the changes in this PR.

<details>
<summary>This section shows the output of running `ESLintRulesOfHooks-test.js` on `main` with the unit tests added in this PR.</summary>

```
 FAIL  packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
  ● react-hooks › invalid › 
// Invalid because it's dangerous and might not warn otherwise.
// This *must* be invalid.
const FancyButton = customHOC((props, ref) => {
  if (props.fancy) {
    useCustomHook();
  }
  return <button ref={ref}>{props.children}</button>;
});


    assert.strictEqual(received, expected)

    Expected value to strictly be equal to:
      1
    Received:
      0
    
    Message:
      Should have 1 error but had 0: []

      at testInvalidTemplate (node_modules/eslint/lib/rule-tester/rule-tester.js:724:24)
      at Object.<anonymous> (node_modules/eslint/lib/rule-tester/rule-tester.js:958:29)

  ● react-hooks › invalid › 
// Invalid because it's dangerous and might not warn otherwise.
// This *must* be invalid.
const FancyButton = customHOC(function(props, ref) {
  if (props.fancy) {
    useCustomHook();
  }
  return <button ref={ref}>{props.children}</button>;
});


    assert.strictEqual(received, expected)

    Expected value to strictly be equal to:
      1
    Received:
      0
    
    Message:
      Should have 1 error but had 0: []
```

</details>
