### PR TITLE
[Flight] Allow custom encoding of the form action

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -28,7 +28,10 @@ import type {
   HintModel,
 } from 'react-server/src/ReactFlightServerConfig';
 
-import type {CallServerCallback} from './ReactFlightReplyClient';
+import type {
+  CallServerCallback,
+  EncodeFormActionCallback,
+} from './ReactFlightReplyClient';
 
 import type {Postpone} from 'react/src/ReactPostpone';
 
@@ -53,7 +56,7 @@ import {
   REACT_POSTPONE_TYPE,
 } from 'shared/ReactSymbols';
 
-export type {CallServerCallback};
+export type {CallServerCallback, EncodeFormActionCallback};
 
 type UninitializedModel = string;
 
@@ -206,6 +209,7 @@ export type Response = {
   _bundlerConfig: SSRModuleMap,
   _moduleLoading: ModuleLoading,
   _callServer: CallServerCallback,
+  _encodeFormAction: void | EncodeFormActionCallback,
   _nonce: ?string,
   _chunks: Map<number, SomeChunk<any>>,
   _fromJSON: (key: string, value: JSONValue) => any,
@@ -592,7 +596,7 @@ function createServerReferenceProxy<A: Iterable<any>, T>(
       },
     );
   };
-  registerServerReference(proxy, metaData);
+  registerServerReference(proxy, metaData, response._encodeFormAction);
   return proxy;
 }
 
@@ -785,6 +789,7 @@ export function createResponse(
   bundlerConfig: SSRModuleMap,
   moduleLoading: ModuleLoading,
   callServer: void | CallServerCallback,
+  encodeFormAction: void | EncodeFormActionCallback,
   nonce: void | string,
 ): Response {
   const chunks: Map<number, SomeChunk<any>> = new Map();
@@ -792,6 +797,7 @@ export function createResponse(
     _bundlerConfig: bundlerConfig,
     _moduleLoading: moduleLoading,
     _callServer: callServer !== undefined ? callServer : missingCall,
+    _encodeFormAction: encodeFormAction,
     _nonce: nonce,
     _chunks: chunks,
     _stringDecoder: createStringDecoder(),

--- a/packages/react-server-dom-esm/src/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-esm/src/ReactFlightDOMClientBrowser.js
@@ -38,6 +38,7 @@ function createResponseFromOptions(options: void | Options) {
     options && options.moduleBaseURL ? options.moduleBaseURL : '',
     null,
     options && options.callServer ? options.callServer : undefined,
+    undefined, // encodeFormAction
     undefined, // nonce
   );
 }

--- a/packages/react-server-dom-esm/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-esm/src/ReactFlightDOMClientNode.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Thenable} from 'shared/ReactTypes.js';
+import type {Thenable, ReactCustomFormAction} from 'shared/ReactTypes.js';
 
 import type {Response} from 'react-client/src/ReactFlightClient';
 
@@ -38,8 +38,14 @@ export function createServerReference<A: Iterable<any>, T>(
   return createServerReferenceImpl(id, noServerCall);
 }
 
+type EncodeFormActionCallback = <A>(
+  id: any,
+  args: Promise<A>,
+) => ReactCustomFormAction;
+
 export type Options = {
   nonce?: string,
+  encodeFormAction?: EncodeFormActionCallback,
 };
 
 function createFromNodeStream<T>(
@@ -52,6 +58,7 @@ function createFromNodeStream<T>(
     moduleRootPath,
     moduleBaseURL,
     noServerCall,
+    options ? options.encodeFormAction : undefined,
     options && typeof options.nonce === 'string' ? options.nonce : undefined,
   );
   stream.on('data', chunk => {

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMClientBrowser.js
@@ -37,6 +37,7 @@ function createResponseFromOptions(options: void | Options) {
     null,
     null,
     options && options.callServer ? options.callServer : undefined,
+    undefined, // encodeFormAction
     undefined, // nonce
   );
 }

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMClientEdge.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Thenable} from 'shared/ReactTypes.js';
+import type {Thenable, ReactCustomFormAction} from 'shared/ReactTypes.js';
 
 import type {Response as FlightResponse} from 'react-client/src/ReactFlightClient';
 
@@ -51,9 +51,15 @@ export function createServerReference<A: Iterable<any>, T>(
   return createServerReferenceImpl(id, noServerCall);
 }
 
+type EncodeFormActionCallback = <A>(
+  id: any,
+  args: Promise<A>,
+) => ReactCustomFormAction;
+
 export type Options = {
   ssrManifest: SSRManifest,
   nonce?: string,
+  encodeFormAction?: EncodeFormActionCallback,
 };
 
 function createResponseFromOptions(options: Options) {
@@ -61,6 +67,7 @@ function createResponseFromOptions(options: Options) {
     options.ssrManifest.moduleMap,
     options.ssrManifest.moduleLoading,
     noServerCall,
+    options.encodeFormAction,
     typeof options.nonce === 'string' ? options.nonce : undefined,
   );
 }

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMClientNode.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Thenable} from 'shared/ReactTypes.js';
+import type {Thenable, ReactCustomFormAction} from 'shared/ReactTypes.js';
 
 import type {Response} from 'react-client/src/ReactFlightClient';
 
@@ -40,9 +40,6 @@ function noServerCall() {
       'to pass data to Client Components instead.',
   );
 }
-export type Options = {
-  nonce?: string,
-};
 
 export function createServerReference<A: Iterable<any>, T>(
   id: any,
@@ -50,6 +47,16 @@ export function createServerReference<A: Iterable<any>, T>(
 ): (...A) => Promise<T> {
   return createServerReferenceImpl(id, noServerCall);
 }
+
+type EncodeFormActionCallback = <A>(
+  id: any,
+  args: Promise<A>,
+) => ReactCustomFormAction;
+
+export type Options = {
+  nonce?: string,
+  encodeFormAction?: EncodeFormActionCallback,
+};
 
 function createFromNodeStream<T>(
   stream: Readable,
@@ -60,6 +67,7 @@ function createFromNodeStream<T>(
     ssrManifest.moduleMap,
     ssrManifest.moduleLoading,
     noServerCall,
+    options ? options.encodeFormAction : undefined,
     options && typeof options.nonce === 'string' ? options.nonce : undefined,
   );
   stream.on('data', chunk => {

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js
@@ -37,6 +37,7 @@ function createResponseFromOptions(options: void | Options) {
     null,
     null,
     options && options.callServer ? options.callServer : undefined,
+    undefined, // encodeFormAction
     undefined, // nonce
   );
 }

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Thenable} from 'shared/ReactTypes.js';
+import type {Thenable, ReactCustomFormAction} from 'shared/ReactTypes.js';
 
 import type {Response as FlightResponse} from 'react-client/src/ReactFlightClient';
 
@@ -51,9 +51,15 @@ export function createServerReference<A: Iterable<any>, T>(
   return createServerReferenceImpl(id, noServerCall);
 }
 
+type EncodeFormActionCallback = <A>(
+  id: any,
+  args: Promise<A>,
+) => ReactCustomFormAction;
+
 export type Options = {
   ssrManifest: SSRManifest,
   nonce?: string,
+  encodeFormAction?: EncodeFormActionCallback,
 };
 
 function createResponseFromOptions(options: Options) {
@@ -61,6 +67,7 @@ function createResponseFromOptions(options: Options) {
     options.ssrManifest.moduleMap,
     options.ssrManifest.moduleLoading,
     noServerCall,
+    options.encodeFormAction,
     typeof options.nonce === 'string' ? options.nonce : undefined,
   );
 }

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientNode.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Thenable} from 'shared/ReactTypes.js';
+import type {Thenable, ReactCustomFormAction} from 'shared/ReactTypes.js';
 
 import type {Response} from 'react-client/src/ReactFlightClient';
 
@@ -48,8 +48,14 @@ export function createServerReference<A: Iterable<any>, T>(
   return createServerReferenceImpl(id, noServerCall);
 }
 
+type EncodeFormActionCallback = <A>(
+  id: any,
+  args: Promise<A>,
+) => ReactCustomFormAction;
+
 export type Options = {
   nonce?: string,
+  encodeFormAction?: EncodeFormActionCallback,
 };
 
 function createFromNodeStream<T>(
@@ -61,6 +67,7 @@ function createFromNodeStream<T>(
     ssrManifest.moduleMap,
     ssrManifest.moduleLoading,
     noServerCall,
+    options ? options.encodeFormAction : undefined,
     options && typeof options.nonce === 'string' ? options.nonce : undefined,
   );
   stream.on('data', chunk => {


### PR DESCRIPTION
There are three parts to an RSC set up:

- React
- Bundler
- Endpoints

Most customizability is in the bundler configs. We deal with those as custom builds.

To create a full set up, you need to also configure ways to expose end points for example to call a Server Action. That's typically not something the bundler is responsible for even though it's responsible for gathering the end points that needs generation. Exposing which endpoints to generate is a responsibility for the bundler.

Typically a meta-framework is responsible for generating the end points.

There's two ways to "call" a Server Action. Through JS and through a Form. Through JS we expose the `callServer` callback so that the framework can call the end point.

Forms by default POST back to the current page with an action serialized into form data, which we have a decoder helper for. However, this is not something that React is really opinionated about just like we're not opinionated about the protocol used by callServer.

This exposes an option to configure the encoding of the form props. `encodeFormAction` is to the SSR is what `callServer` is to the Browser.