### PR TITLE
[Fizz] Postponing in the shell

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -576,6 +576,29 @@ export function createResumableState(
   };
 }
 
+export function resetResumableState(
+  resumableState: ResumableState,
+  renderState: RenderState,
+): void {
+  // Resets the resumable state based on what didn't manage to fully flush in the render state.
+  // This currently assumes nothing was flushed.
+  resumableState.nextFormID = 0;
+  resumableState.hasBody = false;
+  resumableState.hasHtml = false;
+  resumableState.unknownResources = {};
+  resumableState.dnsResources = {};
+  resumableState.connectResources = {
+    default: {},
+    anonymous: {},
+    credentials: {},
+  };
+  resumableState.imageResources = {};
+  resumableState.styleResources = {};
+  resumableState.scriptResources = {};
+  resumableState.moduleUnknownResources = {};
+  resumableState.moduleScriptResources = {};
+}
+
 // Constants for the insertion mode we're currently writing in. We don't encode all HTML5 insertion
 // modes. We only include the variants as they matter for the sake of our purposes.
 // We don't actually provide the namespace therefore we use constants instead of the string.

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
@@ -158,6 +158,7 @@ export {
   hoistResources,
   setCurrentlyRenderingBoundaryResourcesTarget,
   prepareHostDispatcher,
+  resetResumableState,
 } from './ReactFizzConfigDOM';
 
 import escapeTextForBrowser from './escapeTextForBrowser';

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -94,6 +94,8 @@ const ReactNoopServer = ReactFizzServer({
     return null;
   },
 
+  resetResumableState(): void {},
+
   pushTextInstance(
     target: Array<Uint8Array>,
     text: string,

--- a/packages/react-server/src/forks/ReactFizzConfig.custom.js
+++ b/packages/react-server/src/forks/ReactFizzConfig.custom.js
@@ -39,6 +39,7 @@ export const isPrimaryRenderer = false;
 export const supportsRequestStorage = false;
 export const requestStorage: AsyncLocalStorage<Request> = (null: any);
 
+export const resetResumableState = $$$config.resetResumableState;
 export const getChildFormatContext = $$$config.getChildFormatContext;
 export const makeId = $$$config.makeId;
 export const pushTextInstance = $$$config.pushTextInstance;


### PR DESCRIPTION
When we postpone a prerender in the shell, we should just leave an empty prelude and resume from the root. While preserving any options passed in.

Since we haven't flushed anything we can't assume we've already emitted html/body tags or any resources tracked in the resumable state. This introduces a resetResumableState function to reset anything we didn't flush.

This is a bit hacky. Ideally, we probably shouldn't have tracked it as already happened until it flushed or something like that.

Basically, it's like restarting the prerender with the same options and then immediately aborting. When we add the preload headers, we'd track those as preload() being emitted after the reset and so they get readded to the resumable state in that case.