### PR TITLE
Revert "Build: use content hash for facebook-react-native build"

### DIFF
--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -8,7 +8,6 @@ const fse = require('fs-extra');
 const {spawnSync} = require('child_process');
 const path = require('path');
 const tmp = require('tmp');
-const glob = require('glob');
 
 const {
   ReactVersion,
@@ -236,28 +235,19 @@ function processExperimental(buildDir, version) {
     );
   }
 
-  const facebookWwwDir = path.join(buildDir, 'facebook-www');
-  if (fs.existsSync(facebookWwwDir)) {
-    for (const fileName of fs.readdirSync(facebookWwwDir).sort()) {
-      const filePath = path.join(facebookWwwDir, fileName);
+  if (fs.existsSync(buildDir + '/facebook-www')) {
+    const hash = crypto.createHash('sha1');
+    for (const fileName of fs.readdirSync(buildDir + '/facebook-www').sort()) {
+      const filePath = buildDir + '/facebook-www/' + fileName;
       const stats = fs.statSync(filePath);
       if (!stats.isDirectory()) {
+        hash.update(fs.readFileSync(filePath));
         fs.renameSync(filePath, filePath.replace('.js', '.modern.js'));
       }
     }
-    const contentHash = hashJSFilesInDirectory(facebookWwwDir);
     updatePlaceholderReactVersionInCompiledArtifacts(
-      facebookWwwDir,
-      ReactVersion + '-www-modern-' + contentHash
-    );
-  }
-
-  const facebookReactNativeDir = path.join(buildDir, 'facebook-react-native');
-  if (fs.existsSync(facebookReactNativeDir)) {
-    const contentHash = hashJSFilesInDirectory(facebookReactNativeDir);
-    updatePlaceholderReactVersionInCompiledArtifacts(
-      facebookReactNativeDir,
-      ReactVersion + '-react-native-' + contentHash
+      buildDir + '/facebook-www',
+      ReactVersion + '-www-modern-' + hash.digest('hex').slice(0, 8)
     );
   }
 
@@ -354,14 +344,6 @@ function updatePackageVersions(
       fs.writeFileSync(packageJSONPath, JSON.stringify(packageInfo, null, 2));
     }
   }
-}
-
-function hashJSFilesInDirectory(directory) {
-  const hash = crypto.createHash('sha1');
-  for (const filePath of glob.sync(directory + '/**/*.js').sort()) {
-    hash.update(fs.readFileSync(filePath));
-  }
-  return hash.digest('hex').slice(0, 8);
 }
 
 function updatePlaceholderReactVersionInCompiledArtifacts(


### PR DESCRIPTION
Reverts facebook/react#27577.

We also sync React Native OSS bundles which means this didn't work as hoped unless we abandon the commit hash in OSS which seems useful.