### PR TITLE
Support Flow `as` expressions in ESLint rules

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -177,7 +177,7 @@ export default {
         if (init == null) {
           return false;
         }
-        while (init.type === 'TSAsExpression') {
+        while (init.type === 'TSAsExpression' || init.type === 'AsExpression') {
           init = init.expression;
         }
         // Detect primitive constants
@@ -1520,7 +1520,7 @@ function getConstructionExpressionType(node) {
       }
       return null;
     case 'TypeCastExpression':
-      return getConstructionExpressionType(node.expression);
+    case 'AsExpression':
     case 'TSAsExpression':
       return getConstructionExpressionType(node.expression);
   }

--- a/scripts/eslint-rules/safe-string-coercion.js
+++ b/scripts/eslint-rules/safe-string-coercion.js
@@ -291,7 +291,11 @@ function checkBinaryExpression(context, node) {
     (isEmptyLiteral(node.left) || isEmptyLiteral(node.right))
   ) {
     let valueToTest = isEmptyLiteral(node.left) ? node.right : node.left;
-    if (valueToTest.type === 'TypeCastExpression' && valueToTest.expression) {
+    if (
+      (valueToTest.type === 'TypeCastExpression' ||
+        valueToTest.type === 'AsExpression') &&
+      valueToTest.expression
+    ) {
       valueToTest = valueToTest.expression;
     }
 


### PR DESCRIPTION
Support Flow `as` expressions in ESLint rules, e.g. `<expr> as <type>`. This is the same syntax as TypeScript as expressions. I just looked for any place referencing `TSAsExpression` (the TS node) or `TypeCastExpression` (the previous Flow syntax) and added a case for `AsExpression` as well. 