### PR TITLE
[Fizz] Pass task.childIndex in retryReplayTask

### DIFF
--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -3476,7 +3476,13 @@ function retryReplayTask(request: Request, task: ReplayTask): void {
     const prevThenableState = task.thenableState;
     task.thenableState = null;
 
-    renderNodeDestructive(request, task, prevThenableState, task.node, -1);
+    renderNodeDestructive(
+      request,
+      task,
+      prevThenableState,
+      task.node,
+      task.childIndex,
+    );
 
     if (task.replay.pendingTasks === 1 && task.replay.nodes.length > 0) {
       throw new Error(


### PR DESCRIPTION
This was missed that we track the child index on the task. The equivalent in retryRenderTask already has this.

The effect is that a lazy node that suspends gets its child index reset to -1 even though it should resume in the index it left off.
