### PR TITLE
[Float][Fiber] Fixes incorrect boolean logic around loading states for stylesheets

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2337,7 +2337,7 @@ function preinitStyle(
       getStylesheetSelectorFromKey(key),
     );
     if (instance) {
-      state.loading = Loaded & Inserted;
+      state.loading = Loaded | Inserted;
     } else {
       // Construct a new instance and insert it
       const stylesheetProps = Object.assign(


### PR DESCRIPTION
the loading states of stylesheets found in the DOM during preinit should be assumed to be loaded