### PR TITLE
refactor[ReactDebugHooks]: support parsing stack frames when sourcemaps are available

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -24,3 +24,5 @@ packages/react-devtools-shared/src/hooks/__tests__/__source__/__untransformed__/
 packages/react-devtools-shell/dist
 packages/react-devtools-timeline/dist
 packages/react-devtools-timeline/static
+
+flow-typed

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,7 @@
 build
 
+flow-typed
+
 packages/react-devtools-core/dist
 packages/react-devtools-extensions/chrome/build
 packages/react-devtools-extensions/firefox/build

--- a/flow-typed/npm/error-stack-parser_v2.x.x.js
+++ b/flow-typed/npm/error-stack-parser_v2.x.x.js
@@ -1,0 +1,60 @@
+// flow-typed signature: 132e48034ef4756600e1d98681a166b5
+// flow-typed version: c6154227d1/error-stack-parser_v2.x.x/flow_>=v0.104.x
+
+declare module "error-stack-parser" {
+  declare interface StackFrame {
+    constructor(object: StackFrame): StackFrame;
+
+    isConstructor?: boolean;
+    getIsConstructor(): boolean;
+    setIsConstructor(): void;
+
+    isEval?: boolean;
+    getIsEval(): boolean;
+    setIsEval(): void;
+
+    isNative?: boolean;
+    getIsNative(): boolean;
+    setIsNative(): void;
+
+    isTopLevel?: boolean;
+    getIsTopLevel(): boolean;
+    setIsTopLevel(): void;
+
+    columnNumber?: number;
+    getColumnNumber(): number;
+    setColumnNumber(): void;
+
+    lineNumber?: number;
+    getLineNumber(): number;
+    setLineNumber(): void;
+
+    fileName?: string;
+    getFileName(): string;
+    setFileName(): void;
+
+    functionName?: string;
+    getFunctionName(): string;
+    setFunctionName(): void;
+
+    source?: string;
+    getSource(): string;
+    setSource(): void;
+
+    args?: any[];
+    getArgs(): any[];
+    setArgs(): void;
+
+    evalOrigin?: StackFrame;
+    getEvalOrigin(): StackFrame;
+    setEvalOrigin(): void;
+
+    toString(): string;
+  }
+
+  declare class ErrorStackParser {
+    parse(error: Error): Array<StackFrame>;
+  }
+
+  declare module.exports: ErrorStackParser;
+}

--- a/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
+++ b/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
@@ -662,24 +662,7 @@ describe('Timeline profiler', () => {
             "componentMeasures": [],
             "duration": 0.016,
             "flamechart": [],
-            "internalModuleSourceToRanges": Map {
-              undefined => [
-                [
-                  {
-                    "columnNumber": 0,
-                    "functionName": "filtered",
-                    "lineNumber": 0,
-                    "source": "  at filtered (<anonymous>:0:0)",
-                  },
-                  {
-                    "columnNumber": 1,
-                    "functionName": "filtered",
-                    "lineNumber": 1,
-                    "source": "  at filtered (<anonymous>:1:1)",
-                  },
-                ],
-              ],
-            },
+            "internalModuleSourceToRanges": Map {},
             "laneToLabelMap": Map {
               0 => "Sync",
               1 => "InputContinuousHydration",
@@ -938,24 +921,7 @@ describe('Timeline profiler', () => {
             ],
             "duration": 0.04,
             "flamechart": [],
-            "internalModuleSourceToRanges": Map {
-              undefined => [
-                [
-                  {
-                    "columnNumber": 0,
-                    "functionName": "filtered",
-                    "lineNumber": 0,
-                    "source": "  at filtered (<anonymous>:0:0)",
-                  },
-                  {
-                    "columnNumber": 1,
-                    "functionName": "filtered",
-                    "lineNumber": 1,
-                    "source": "  at filtered (<anonymous>:1:1)",
-                  },
-                ],
-              ],
-            },
+            "internalModuleSourceToRanges": Map {},
             "laneToLabelMap": Map {
               0 => "Sync",
               1 => "InputContinuousHydration",

--- a/packages/react-devtools-timeline/src/content-views/utils/moduleFilters.js
+++ b/packages/react-devtools-timeline/src/content-views/utils/moduleFilters.js
@@ -48,16 +48,26 @@ export function isInternalModule(
   const ranges = internalModuleSourceToRanges.get(scriptUrl);
   if (ranges != null) {
     for (let i = 0; i < ranges.length; i++) {
-      const [startStackFrame, stopStackFrame] = ranges[i];
+      const [
+        {lineNumber: startLineNumber, columnNumber: startColumnNumber},
+        {lineNumber: stopLineNumber, columnNumber: stopColumnNumber},
+      ] = ranges[i];
+
+      if (startLineNumber == null || stopLineNumber == null) {
+        return false;
+      }
 
       const isAfterStart =
-        locationLine > startStackFrame.lineNumber ||
-        (locationLine === startStackFrame.lineNumber &&
-          locationColumn >= startStackFrame.columnNumber);
+        locationLine > startLineNumber ||
+        (locationLine === startLineNumber &&
+          startColumnNumber != null &&
+          locationColumn >= startColumnNumber);
+
       const isBeforeStop =
-        locationLine < stopStackFrame.lineNumber ||
-        (locationLine === stopStackFrame.lineNumber &&
-          locationColumn <= stopStackFrame.columnNumber);
+        locationLine < stopLineNumber ||
+        (locationLine === stopLineNumber &&
+          stopColumnNumber != null &&
+          locationColumn <= stopColumnNumber);
 
       if (isAfterStart && isBeforeStop) {
         return true;

--- a/packages/react-devtools-timeline/src/types.js
+++ b/packages/react-devtools-timeline/src/types.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+import type {StackFrame} from 'error-stack-parser';
 import type {ScrollState} from './view-base/utils/scrollState';
 
 // Source: https://github.com/facebook/flow/issues/4002#issuecomment-323612798
@@ -16,13 +17,6 @@ type Return_<R, F: (...args: Array<any>) => R> = R;
 export type Return<T> = Return_<mixed, T>;
 
 // Project types
-
-export type ErrorStackFrame = {
-  fileName: string,
-  lineNumber: number,
-  columnNumber: number,
-};
-
 export type Milliseconds = number;
 
 export type ReactLane = number;
@@ -193,7 +187,7 @@ export type ViewState = {
 
 export type InternalModuleSourceToRanges = Map<
   string,
-  Array<[ErrorStackFrame, ErrorStackFrame]>,
+  Array<[StackFrame, StackFrame]>,
 >;
 
 export type LaneToLabelMap = Map<ReactLane, string>;
@@ -224,7 +218,7 @@ export type TimelineDataExport = {
   duration: number,
   flamechart: Flamechart,
   internalModuleSourceToRanges: Array<
-    [string, Array<[ErrorStackFrame, ErrorStackFrame]>],
+    [string, Array<[StackFrame, StackFrame]>],
   >,
   laneToLabelKeyValueArray: Array<[ReactLane, string]>,
   laneToReactMeasureKeyValueArray: Array<[ReactLane, ReactMeasure[]]>,


### PR DESCRIPTION
Unblocks https://github.com/facebook/react/pull/26446.

## TL;DR:
- The main difference is `isReactWrapper` function implementation. Previously, we would just look at hook stack trace entry and check if `functionName` ends with the corresponding hook primitive name. This doesn't work with the same setup, but with sourcemaps also being present. We use Proxy for handling custom errors, here is the implementation of the Proxy for Dispatcher
https://github.com/facebook/react/blob/666a6bc08589350f77e27d84b9ec26cce5500dd7/packages/react-debug-tools/src/ReactDebugHooks.js#L354-L373

For each supported hook, we have a stub, which saves the stack trace via `new Error()` call. Here is `useState`, for example:
https://github.com/facebook/react/blob/666a6bc08589350f77e27d84b9ec26cce5500dd7/packages/react-debug-tools/src/ReactDebugHooks.js#L142

At runtime, current dispatcher can be this Proxy object - `DispatcherProxy`, this will modify the stack trace. Here is how the corresponding stack frame looks like without sourcemaps:
```javascript
{
        columnNumber: 171,
        lineNumber: 16,
        fileName: '.../build/oss-stable/react-debug-tools/cjs/react-debug-tools.production.min.js',
        functionName: 'Proxy.useState',
        source: '    at Proxy.useState (.../react/build/oss-stable/react-debug-tools/cjs/react-debug-tools.production.min.js:16:171)'
}
```

When sourcemaps are present, this particular frame is different, it no longer mentions primitive hook name.
```javascript
{
        columnNumber: 21,
        lineNumber: 114,
        fileName: '.../build/oss-stable/react-debug-tools/cjs/react-debug-tools.production.js',
        functionName: 'Proxy.Error',
        source: '    at Proxy.Error (.../build/oss-stable/react-debug-tools/cjs/react-debug-tools.production.js:114:21)'
}
```

We do this parsing to skip React's frames, in this implementation we are only looking for user-defined hooks. In order to make this logic sourcemaps independent, instead of looking at stack trace of the error, which is created at runtime (basically once hook is called), we are also looking at primitive hook's stacktraces, which are defined here:
https://github.com/facebook/react/blob/666a6bc08589350f77e27d84b9ec26cce5500dd7/packages/react-debug-tools/src/ReactDebugHooks.js#L57-L99

Notice that we are using general Dispatcher here and not DispatcherProxy. Both with or without sourcemaps stack traces contain corresponding primitive hook name in the `functionName`.

## Also in these changes:
- Added Flow typings for `error-stack-parser` via `flow-typed`, updated other parts of the code which were using this library accordingly.