### PR TITLE
refactor[scripts/prettier]: respect .prettierignore when resolving js files via glob

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,9 @@
+build
+
 packages/react-devtools-core/dist
 packages/react-devtools-extensions/chrome/build
 packages/react-devtools-extensions/firefox/build
+packages/react-devtools-extensions/edge/build
 packages/react-devtools-extensions/shared/build
 packages/react-devtools-extensions/src/ErrorTesterCompiled.js
 packages/react-devtools-inline/dist


### PR DESCRIPTION
This script is used on CI in `yarn_lint` job. With current `glob` call settings, it includes a bunch of build files, which are actually ignored by listing them in `.prettierignore`. This check is not failing only because there is no build step before it.

If you run `node ./scripts/prettier/index` with build files present, you will see a bunch of files listed as non-formatted. These changes add a simple logic to include all paths listed in `.prettierignore` to ignore list of `glob` call with transforming them from gitignore-style to glob-style.

This should unblock CI for https://github.com/facebook/react/pull/27612, where `flow-typed` directory will be added, turned out that including it in `.prettierignore` is not enough.