### PR TITLE
Ensure close is called after getRoot in decodeReply

### DIFF
--- a/packages/react-server-dom-esm/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-esm/src/ReactFlightDOMServerNode.js
@@ -162,8 +162,9 @@ function decodeReply<T>(
     body = form;
   }
   const response = createResponse(moduleBasePath, '', body);
+  const root = getRoot(response);
   close(response);
-  return getRoot(response);
+  return root;
 }
 
 export {

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMServerBrowser.js
@@ -93,8 +93,9 @@ function decodeReply<T>(
     body = form;
   }
   const response = createResponse(turbopackMap, '', body);
+  const root = getRoot(response);
   close(response);
-  return getRoot(response);
+  return root;
 }
 
 export {renderToReadableStream, decodeReply, decodeAction};

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMServerEdge.js
@@ -93,8 +93,9 @@ function decodeReply<T>(
     body = form;
   }
   const response = createResponse(turbopackMap, '', body);
+  const root = getRoot(response);
   close(response);
-  return getRoot(response);
+  return root;
 }
 
 export {renderToReadableStream, decodeReply, decodeAction};

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMServerNode.js
@@ -158,8 +158,9 @@ function decodeReply<T>(
     body = form;
   }
   const response = createResponse(turbopackMap, '', body);
+  const root = getRoot(response);
   close(response);
-  return getRoot(response);
+  return root;
 }
 
 export {

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -100,8 +100,9 @@ function decodeReply<T>(
     body = form;
   }
   const response = createResponse(webpackMap, '', body);
+  const root = getRoot(response);
   close(response);
-  return getRoot(response);
+  return root;
 }
 
 export {renderToReadableStream, decodeReply, decodeAction, decodeFormState};

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
@@ -100,8 +100,9 @@ function decodeReply<T>(
     body = form;
   }
   const response = createResponse(webpackMap, '', body);
+  const root = getRoot(response);
   close(response);
-  return getRoot(response);
+  return root;
 }
 
 export {renderToReadableStream, decodeReply, decodeAction, decodeFormState};

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -181,8 +181,9 @@ function decodeReply<T>(
     body = form;
   }
   const response = createResponse(webpackMap, '', body);
+  const root = getRoot(response);
   close(response);
-  return getRoot(response);
+  return root;
 }
 
 export {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js
@@ -231,4 +231,14 @@ describe('ReactFlightDOMReply', () => {
     expect(s2.has('hi')).toBe(true);
     expect(s2).toEqual(s);
   });
+
+  it('does not hang indefinitely when calling decodeReply with FormData', async () => {
+    let error;
+    try {
+      await ReactServerDOMServer.decodeReply(new FormData(), webpackServerMap);
+    } catch (e) {
+      error = e;
+    }
+    expect(error.message).toBe('Connection closed.');
+  });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
`decodeReply` should be resilient to recieving FormData that doesn't match the expected payload. If `formData.get(0)` is missing, `close` should error. However if this is called before `getRoot`, it won't ever properly reject the promise because `getRoot` will create a pending chunk that is never resolved. 

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->


<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
