### PR TITLE
Fix minLength and maxLength constraints on textareas in Chrome

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMTextarea.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMTextarea.js
@@ -74,7 +74,14 @@ export function updateTextarea(
     }
     // TOOO: This should respect disableInputAttributeSyncing flag.
     if (defaultValue == null) {
-      if (node.defaultValue !== newValue) {
+      // Do not sync value and defaultValue if a minLength or maxLength constraint
+      // is set because this causes Chrome to skip validation.
+      // https://github.com/facebook/react/issues/19474
+      if (
+        node.defaultValue !== newValue &&
+        node.minLength === -1 &&
+        node.maxLength === -1
+      ) {
         node.defaultValue = newValue;
       }
       return;

--- a/packages/react-dom-bindings/src/client/ReactDOMTextarea.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMTextarea.js
@@ -79,7 +79,9 @@ export function updateTextarea(
       // https://github.com/facebook/react/issues/19474
       if (
         node.defaultValue !== newValue &&
+        // $FlowFixMe[prop-missing]
         node.minLength === -1 &&
+        // $FlowFixMe[prop-missing]
         node.maxLength === -1
       ) {
         node.defaultValue = newValue;

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -137,24 +137,24 @@ describe('ReactDOMTextarea', () => {
 
     let counter = 0;
     const originalCreateElement = document.createElement;
-    spyOnDevAndProd(document, 'createElement').mockImplementation(function (
-      type,
-    ) {
-      const el = originalCreateElement.apply(this, arguments);
-      let value = '';
-      if (type === 'textarea') {
-        Object.defineProperty(el, 'value', {
-          get: function () {
-            return value;
-          },
-          set: function (val) {
-            value = String(val);
-            counter++;
-          },
-        });
-      }
-      return el;
-    });
+    spyOnDevAndProd(document, 'createElement').mockImplementation(
+      function (type) {
+        const el = originalCreateElement.apply(this, arguments);
+        let value = '';
+        if (type === 'textarea') {
+          Object.defineProperty(el, 'value', {
+            get: function () {
+              return value;
+            },
+            set: function (val) {
+              value = String(val);
+              counter++;
+            },
+          });
+        }
+        return el;
+      },
+    );
 
     ReactDOM.render(<textarea value="" readOnly={true} />, container);
 

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -137,24 +137,24 @@ describe('ReactDOMTextarea', () => {
 
     let counter = 0;
     const originalCreateElement = document.createElement;
-    spyOnDevAndProd(document, 'createElement').mockImplementation(
-      function (type) {
-        const el = originalCreateElement.apply(this, arguments);
-        let value = '';
-        if (type === 'textarea') {
-          Object.defineProperty(el, 'value', {
-            get: function () {
-              return value;
-            },
-            set: function (val) {
-              value = String(val);
-              counter++;
-            },
-          });
-        }
-        return el;
-      },
-    );
+    spyOnDevAndProd(document, 'createElement').mockImplementation(function (
+      type,
+    ) {
+      const el = originalCreateElement.apply(this, arguments);
+      let value = '';
+      if (type === 'textarea') {
+        Object.defineProperty(el, 'value', {
+          get: function () {
+            return value;
+          },
+          set: function (val) {
+            value = String(val);
+            counter++;
+          },
+        });
+      }
+      return el;
+    });
 
     ReactDOM.render(<textarea value="" readOnly={true} />, container);
 
@@ -614,6 +614,32 @@ describe('ReactDOMTextarea', () => {
     Object.defineProperty(node, 'defaultValue', {get, set});
     instance.setState({count: 1});
     expect(set.mock.calls.length).toBe(0);
+  });
+
+  it('does not update defaultValue of DOM node if minLength or maxLength are set', () => {
+    const container = document.createElement('div');
+    let node;
+    ReactDOM.render(
+      <textarea
+        ref={n => (node = n)}
+        value="foo"
+        onChange={emptyFunction}
+        minLength={10}
+      />,
+      container,
+    );
+    expect(node.defaultValue).toBe('foo');
+
+    ReactDOM.render(
+      <textarea
+        ref={n => (node = n)}
+        value="food"
+        onChange={emptyFunction}
+        minLength={10}
+      />,
+      container,
+    );
+    expect(node.defaultValue).toBe('foo');
   });
 
   describe('When given a Symbol value', () => {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Fixes #19474

This fixes an issue that causes `<textarea>` with the `minLength` and `maxLength` props not to validate when the textarea has a controlled `value`. [This Codesandbox](https://codesandbox.io/s/react-textarea-issue-c3lp5w) has a minimal reproduction of the issue. Typing into the `<input>` element updates the `validity` of the input element correctly as shown in the console logs, but not the `<textarea>`.

This is caused by React syncing the controlled `value` prop into the native `textarea.defaultValue` property, which is equivalent to `textContent` (i.e. the children of the `<textarea>` element). When the children change, Chrome marks the change as a programmatic update rather than a user update [here](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/forms/html_text_area_element.cc;l=171?q=htmltextareaelement). Then, when checking validity, it skips the length constraint for programmatically set changes [here](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/forms/base_text_input_type.cc;l=80?q=lastchangewasuserEdit&ss=chromium%2Fchromium%2Fsrc:third_party%2Fblink%2Frenderer%2Fcore%2Fhtml%2Fforms%2F).

This issue is related to #11896. I'm not sure of the overall status of that effort, but I think since the `minLength` and `maxLength` props are currently broken entirely when a `<textarea>` is controlled, we could potentially consider changing the behavior for only that case for now without it being considered a breaking change. This PR disables updating the native `defaultValue` when a `minLength` or `maxLength` constraint is set. The idea is to make the minimal change possible to fix the issue until the larger refactor can be done in a major version. Open to feedback on this approach.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

Added a unit test. Created a small fixture locally and tested the build in Chrome.