### PR TITLE
[Fizz] implement `onHeaders` and `headersLengthHint` options

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
@@ -8,10 +8,12 @@
  */
 
 import type {
+  RenderState as BaseRenderState,
   ResumableState,
   BoundaryResources,
   StyleQueue,
   Resource,
+  HeadersDescriptor,
 } from './ReactFizzConfigDOM';
 
 import {
@@ -46,6 +48,14 @@ export type RenderState = {
   headChunks: null | Array<Chunk | PrecomputedChunk>,
   externalRuntimeScript: null | any,
   bootstrapChunks: Array<Chunk | PrecomputedChunk>,
+  onHeaders: void | ((headers: HeadersDescriptor) => void),
+  headers: null | {
+    preconnects: string,
+    fontPreloads: string,
+    highImagePreloads: string,
+    remainingCapacity: number,
+  },
+  resets: BaseRenderState['resets'],
   charsetChunks: Array<Chunk | PrecomputedChunk>,
   preconnectChunks: Array<Chunk | PrecomputedChunk>,
   importMapChunks: Array<Chunk | PrecomputedChunk>,
@@ -83,6 +93,7 @@ export function createRenderState(
     undefined,
     undefined,
     undefined,
+    undefined,
   );
   return {
     // Keep this in sync with ReactFizzConfigDOM
@@ -94,6 +105,9 @@ export function createRenderState(
     headChunks: renderState.headChunks,
     externalRuntimeScript: renderState.externalRuntimeScript,
     bootstrapChunks: renderState.bootstrapChunks,
+    onHeaders: renderState.onHeaders,
+    headers: renderState.headers,
+    resets: renderState.resets,
     charsetChunks: renderState.charsetChunks,
     preconnectChunks: renderState.preconnectChunks,
     importMapChunks: renderState.importMapChunks,
@@ -159,6 +173,7 @@ export {
   setCurrentlyRenderingBoundaryResourcesTarget,
   prepareHostDispatcher,
   resetResumableState,
+  emitEarlyPreloads,
 } from './ReactFizzConfigDOM';
 
 import escapeTextForBrowser from './escapeTextForBrowser';

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
@@ -18,6 +18,7 @@ import {
 global.ReadableStream =
   require('web-streams-polyfill/ponyfill/es6').ReadableStream;
 global.TextEncoder = require('util').TextEncoder;
+global.TextDecoder = require('util').TextDecoder;
 
 let React;
 let ReactDOM;
@@ -1314,6 +1315,108 @@ describe('ReactDOMFizzStaticBrowser', () => {
       '<!DOCTYPE html><html><head>' +
         '<link rel="stylesheet" href="my-style" data-precedence="high"/>' +
         '</head><body><div>Hello</div></body></html>',
+    );
+  });
+
+  // @gate enablePostpone
+  it('does not emit preloads during resume for Resources preloaded through onHeaders', async () => {
+    let prerendering = true;
+
+    let hasLoaded = false;
+    let resolve;
+    const promise = new Promise(r => (resolve = r));
+    function WaitIfResuming({children}) {
+      if (!prerendering && !hasLoaded) {
+        throw promise;
+      }
+      return children;
+    }
+
+    function Postpone() {
+      if (prerendering) {
+        React.unstable_postpone();
+      }
+      return null;
+    }
+
+    let headers;
+    function onHeaders(x) {
+      headers = x;
+    }
+
+    function App() {
+      ReactDOM.preload('image', {as: 'image', fetchPriority: 'high'});
+      return (
+        <html>
+          <body>
+            hello
+            <Suspense fallback={null}>
+              <WaitIfResuming>
+                world
+                <link rel="stylesheet" href="style" precedence="default" />
+              </WaitIfResuming>
+            </Suspense>
+            <Postpone />
+          </body>
+        </html>
+      );
+    }
+
+    const prerendered = await ReactDOMFizzStatic.prerender(<App />, {
+      onHeaders,
+    });
+    expect(prerendered.postponed).not.toBe(null);
+
+    prerendering = false;
+
+    expect(await readContent(prerendered.prelude)).toBe('');
+    expect(headers).toEqual(
+      new Headers({
+        Link: `
+<image>; rel=preload; as="image"; fetchpriority="high",
+ <style>; rel=preload; as="style"
+`
+          .replaceAll('\n', '')
+          .trim(),
+      }),
+    );
+
+    const content = await ReactDOMFizzServer.resume(
+      <App />,
+      JSON.parse(JSON.stringify(prerendered.postponed)),
+    );
+
+    const decoder = new TextDecoder();
+    const reader = content.getReader();
+    let {value, done} = await reader.read();
+    let result = decoder.decode(value, {stream: true});
+
+    expect(result).toBe(
+      '<!DOCTYPE html><html><head></head><body>hello<!--$?--><template id="B:1"></template><!--/$-->',
+    );
+
+    await 1;
+    hasLoaded = true;
+    resolve();
+
+    while (true) {
+      ({value, done} = await reader.read());
+      if (done) {
+        result += decoder.decode(value);
+        break;
+      }
+      result += decoder.decode(value, {stream: true});
+    }
+
+    // We are mostly just trying to assert that no preload for our stylesheet was emitted
+    // prior to sending the segment the stylesheet was for. This test is asserting this
+    // because the boundary complete instruction is sent when we are writing the
+    const instructionIndex = result.indexOf('$RC');
+    expect(instructionIndex > -1).toBe(true);
+    const slice = result.slice(0, instructionIndex + '$RC'.length);
+
+    expect(slice).toBe(
+      '<!DOCTYPE html><html><head></head><body>hello<!--$?--><template id="B:1"></template><!--/$--><div hidden id="S:1">world<!-- --></div><script>$RC',
     );
   });
 });

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -7,12 +7,12 @@
  * @flow
  */
 
-import type {
-  PostponedState,
-  HeadersDescriptor,
-} from 'react-server/src/ReactFizzServer';
+import type {PostponedState} from 'react-server/src/ReactFizzServer';
 import type {ReactNodeList, ReactFormState} from 'shared/ReactTypes';
-import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
+import type {
+  BootstrapScriptDescriptor,
+  HeadersDescriptor,
+} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 import type {ImportMap} from '../shared/ReactDOMTypes';
 
 import ReactVersion from 'shared/ReactVersion';
@@ -48,6 +48,7 @@ type Options = {
   importMap?: ImportMap,
   formState?: ReactFormState<any, any> | null,
   onHeaders?: (headers: Headers) => void,
+  maxHeadersLength?: number,
 };
 
 type ResumeOptions = {
@@ -125,6 +126,8 @@ function renderToReadableStream(
         options ? options.bootstrapModules : undefined,
         options ? options.unstable_externalRuntimeSrc : undefined,
         options ? options.importMap : undefined,
+        onHeadersImpl,
+        options ? options.maxHeadersLength : undefined,
       ),
       createRootFormatContext(options ? options.namespaceURI : undefined),
       options ? options.progressiveChunkSize : undefined,
@@ -135,7 +138,6 @@ function renderToReadableStream(
       onFatalError,
       options ? options.onPostpone : undefined,
       options ? options.formState : undefined,
-      onHeadersImpl,
     );
     if (options && options.signal) {
       const signal = options.signal;

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -7,7 +7,10 @@
  * @flow
  */
 
-import type {PostponedState} from 'react-server/src/ReactFizzServer';
+import type {
+  PostponedState,
+  HeadersDescriptor,
+} from 'react-server/src/ReactFizzServer';
 import type {ReactNodeList, ReactFormState} from 'shared/ReactTypes';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 import type {ImportMap} from '../shared/ReactDOMTypes';
@@ -44,6 +47,7 @@ type Options = {
   unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor,
   importMap?: ImportMap,
   formState?: ReactFormState<any, any> | null,
+  onHeaders?: (headers: Headers) => void,
 };
 
 type ResumeOptions = {
@@ -97,6 +101,15 @@ function renderToReadableStream(
       allReady.catch(() => {});
       reject(error);
     }
+
+    const onHeaders = options ? options.onHeaders : undefined;
+    let onHeadersImpl;
+    if (onHeaders) {
+      onHeadersImpl = (headersDescriptor: HeadersDescriptor) => {
+        onHeaders(new Headers(headersDescriptor));
+      };
+    }
+
     const resumableState = createResumableState(
       options ? options.identifierPrefix : undefined,
       options ? options.unstable_externalRuntimeSrc : undefined,
@@ -122,6 +135,7 @@ function renderToReadableStream(
       onFatalError,
       options ? options.onPostpone : undefined,
       options ? options.formState : undefined,
+      onHeadersImpl,
     );
     if (options && options.signal) {
       const signal = options.signal;

--- a/packages/react-dom/src/server/ReactDOMFizzServerBun.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBun.js
@@ -7,9 +7,11 @@
  * @flow
  */
 
-import type {HeadersDescriptor} from 'react-server/src/ReactFizzServer';
 import type {ReactNodeList, ReactFormState} from 'shared/ReactTypes';
-import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
+import type {
+  BootstrapScriptDescriptor,
+  HeadersDescriptor,
+} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 import type {ImportMap} from '../shared/ReactDOMTypes';
 
 import ReactVersion from 'shared/ReactVersion';
@@ -43,6 +45,7 @@ type Options = {
   importMap?: ImportMap,
   formState?: ReactFormState<any, any> | null,
   onHeaders?: (headers: Headers) => void,
+  maxHeadersLength?: number,
 };
 
 // TODO: Move to sub-classing ReadableStream.
@@ -113,6 +116,8 @@ function renderToReadableStream(
         options ? options.bootstrapModules : undefined,
         options ? options.unstable_externalRuntimeSrc : undefined,
         options ? options.importMap : undefined,
+        onHeadersImpl,
+        options ? options.maxHeadersLength : undefined,
       ),
       createRootFormatContext(options ? options.namespaceURI : undefined),
       options ? options.progressiveChunkSize : undefined,
@@ -123,7 +128,6 @@ function renderToReadableStream(
       onFatalError,
       options ? options.onPostpone : undefined,
       options ? options.formState : undefined,
-      onHeadersImpl,
     );
     if (options && options.signal) {
       const signal = options.signal;

--- a/packages/react-dom/src/server/ReactDOMFizzServerBun.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBun.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+import type {HeadersDescriptor} from 'react-server/src/ReactFizzServer';
 import type {ReactNodeList, ReactFormState} from 'shared/ReactTypes';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 import type {ImportMap} from '../shared/ReactDOMTypes';
@@ -41,6 +42,7 @@ type Options = {
   unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor,
   importMap?: ImportMap,
   formState?: ReactFormState<any, any> | null,
+  onHeaders?: (headers: Headers) => void,
 };
 
 // TODO: Move to sub-classing ReadableStream.
@@ -87,6 +89,15 @@ function renderToReadableStream(
       allReady.catch(() => {});
       reject(error);
     }
+
+    const onHeaders = options ? options.onHeaders : undefined;
+    let onHeadersImpl;
+    if (onHeaders) {
+      onHeadersImpl = (headersDescriptor: HeadersDescriptor) => {
+        onHeaders(new Headers(headersDescriptor));
+      };
+    }
+
     const resumableState = createResumableState(
       options ? options.identifierPrefix : undefined,
       options ? options.unstable_externalRuntimeSrc : undefined,
@@ -112,6 +123,7 @@ function renderToReadableStream(
       onFatalError,
       options ? options.onPostpone : undefined,
       options ? options.formState : undefined,
+      onHeadersImpl,
     );
     if (options && options.signal) {
       const signal = options.signal;

--- a/packages/react-dom/src/server/ReactDOMFizzServerEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerEdge.js
@@ -7,12 +7,12 @@
  * @flow
  */
 
-import type {
-  PostponedState,
-  HeadersDescriptor,
-} from 'react-server/src/ReactFizzServer';
+import type {PostponedState} from 'react-server/src/ReactFizzServer';
 import type {ReactNodeList, ReactFormState} from 'shared/ReactTypes';
-import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
+import type {
+  BootstrapScriptDescriptor,
+  HeadersDescriptor,
+} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 import type {ImportMap} from '../shared/ReactDOMTypes';
 
 import ReactVersion from 'shared/ReactVersion';
@@ -48,6 +48,7 @@ type Options = {
   importMap?: ImportMap,
   formState?: ReactFormState<any, any> | null,
   onHeaders?: (headers: Headers) => void,
+  maxHeadersLength?: number,
 };
 
 type ResumeOptions = {
@@ -125,6 +126,8 @@ function renderToReadableStream(
         options ? options.bootstrapModules : undefined,
         options ? options.unstable_externalRuntimeSrc : undefined,
         options ? options.importMap : undefined,
+        onHeadersImpl,
+        options ? options.maxHeadersLength : undefined,
       ),
       createRootFormatContext(options ? options.namespaceURI : undefined),
       options ? options.progressiveChunkSize : undefined,
@@ -135,7 +138,6 @@ function renderToReadableStream(
       onFatalError,
       options ? options.onPostpone : undefined,
       options ? options.formState : undefined,
-      onHeadersImpl,
     );
     if (options && options.signal) {
       const signal = options.signal;
@@ -204,7 +206,6 @@ function resume(
       onShellReady,
       onShellError,
       onFatalError,
-      undefined,
       options ? options.onPostpone : undefined,
     );
     if (options && options.signal) {

--- a/packages/react-dom/src/server/ReactDOMFizzServerEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerEdge.js
@@ -7,7 +7,10 @@
  * @flow
  */
 
-import type {PostponedState} from 'react-server/src/ReactFizzServer';
+import type {
+  PostponedState,
+  HeadersDescriptor,
+} from 'react-server/src/ReactFizzServer';
 import type {ReactNodeList, ReactFormState} from 'shared/ReactTypes';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 import type {ImportMap} from '../shared/ReactDOMTypes';
@@ -44,6 +47,7 @@ type Options = {
   unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor,
   importMap?: ImportMap,
   formState?: ReactFormState<any, any> | null,
+  onHeaders?: (headers: Headers) => void,
 };
 
 type ResumeOptions = {
@@ -97,6 +101,15 @@ function renderToReadableStream(
       allReady.catch(() => {});
       reject(error);
     }
+
+    const onHeaders = options ? options.onHeaders : undefined;
+    let onHeadersImpl;
+    if (onHeaders) {
+      onHeadersImpl = (headersDescriptor: HeadersDescriptor) => {
+        onHeaders(new Headers(headersDescriptor));
+      };
+    }
+
     const resumableState = createResumableState(
       options ? options.identifierPrefix : undefined,
       options ? options.unstable_externalRuntimeSrc : undefined,
@@ -122,6 +135,7 @@ function renderToReadableStream(
       onFatalError,
       options ? options.onPostpone : undefined,
       options ? options.formState : undefined,
+      onHeadersImpl,
     );
     if (options && options.signal) {
       const signal = options.signal;
@@ -190,6 +204,7 @@ function resume(
       onShellReady,
       onShellError,
       onFatalError,
+      undefined,
       options ? options.onPostpone : undefined,
     );
     if (options && options.signal) {

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -7,7 +7,11 @@
  * @flow
  */
 
-import type {Request, PostponedState} from 'react-server/src/ReactFizzServer';
+import type {
+  Request,
+  PostponedState,
+  HeadersDescriptor,
+} from 'react-server/src/ReactFizzServer';
 import type {ReactNodeList, ReactFormState} from 'shared/ReactTypes';
 import type {Writable} from 'stream';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
@@ -60,6 +64,7 @@ type Options = {
   unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor,
   importMap?: ImportMap,
   formState?: ReactFormState<any, any> | null,
+  onHeaders?: (headers: HeadersDescriptor) => void,
 };
 
 type ResumeOptions = {
@@ -104,6 +109,7 @@ function createRequestImpl(children: ReactNodeList, options: void | Options) {
     undefined,
     options ? options.onPostpone : undefined,
     options ? options.formState : undefined,
+    options ? options.onHeaders : undefined,
   );
 }
 

--- a/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
@@ -9,7 +9,10 @@
 
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
-import type {PostponedState} from 'react-server/src/ReactFizzServer';
+import type {
+  PostponedState,
+  HeadersDescriptor,
+} from 'react-server/src/ReactFizzServer';
 import type {ImportMap} from '../shared/ReactDOMTypes';
 
 import ReactVersion from 'shared/ReactVersion';
@@ -41,6 +44,7 @@ type Options = {
   onPostpone?: (reason: string) => void,
   unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor,
   importMap?: ImportMap,
+  onHeaders?: (headers: Headers) => void,
 };
 
 type StaticResult = {
@@ -77,6 +81,15 @@ function prerender(
       };
       resolve(result);
     }
+
+    const onHeaders = options ? options.onHeaders : undefined;
+    let onHeadersImpl;
+    if (onHeaders) {
+      onHeadersImpl = (headersDescriptor: HeadersDescriptor) => {
+        onHeaders(new Headers(headersDescriptor));
+      };
+    }
+
     const resources = createResumableState(
       options ? options.identifierPrefix : undefined,
       options ? options.unstable_externalRuntimeSrc : undefined,
@@ -101,6 +114,7 @@ function prerender(
       undefined,
       onFatalError,
       options ? options.onPostpone : undefined,
+      onHeadersImpl,
     );
     if (options && options.signal) {
       const signal = options.signal;

--- a/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
@@ -8,11 +8,11 @@
  */
 
 import type {ReactNodeList} from 'shared/ReactTypes';
-import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 import type {
-  PostponedState,
+  BootstrapScriptDescriptor,
   HeadersDescriptor,
-} from 'react-server/src/ReactFizzServer';
+} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
+import type {PostponedState} from 'react-server/src/ReactFizzServer';
 import type {ImportMap} from '../shared/ReactDOMTypes';
 
 import ReactVersion from 'shared/ReactVersion';
@@ -45,6 +45,7 @@ type Options = {
   unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor,
   importMap?: ImportMap,
   onHeaders?: (headers: Headers) => void,
+  maxHeadersLength?: number,
 };
 
 type StaticResult = {
@@ -105,6 +106,8 @@ function prerender(
         options ? options.bootstrapModules : undefined,
         options ? options.unstable_externalRuntimeSrc : undefined,
         options ? options.importMap : undefined,
+        onHeadersImpl,
+        options ? options.maxHeadersLength : undefined,
       ),
       createRootFormatContext(options ? options.namespaceURI : undefined),
       options ? options.progressiveChunkSize : undefined,
@@ -114,7 +117,6 @@ function prerender(
       undefined,
       onFatalError,
       options ? options.onPostpone : undefined,
-      onHeadersImpl,
     );
     if (options && options.signal) {
       const signal = options.signal;

--- a/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
@@ -8,11 +8,11 @@
  */
 
 import type {ReactNodeList} from 'shared/ReactTypes';
-import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 import type {
-  PostponedState,
+  BootstrapScriptDescriptor,
   HeadersDescriptor,
-} from 'react-server/src/ReactFizzServer';
+} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
+import type {PostponedState} from 'react-server/src/ReactFizzServer';
 import type {ImportMap} from '../shared/ReactDOMTypes';
 
 import ReactVersion from 'shared/ReactVersion';
@@ -45,6 +45,7 @@ type Options = {
   unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor,
   importMap?: ImportMap,
   onHeaders?: (headers: Headers) => void,
+  maxHeadersLength?: number,
 };
 
 type StaticResult = {
@@ -104,6 +105,8 @@ function prerender(
         options ? options.bootstrapModules : undefined,
         options ? options.unstable_externalRuntimeSrc : undefined,
         options ? options.importMap : undefined,
+        onHeadersImpl,
+        options ? options.maxHeadersLength : undefined,
       ),
       createRootFormatContext(options ? options.namespaceURI : undefined),
       options ? options.progressiveChunkSize : undefined,
@@ -113,7 +116,6 @@ function prerender(
       undefined,
       onFatalError,
       options ? options.onPostpone : undefined,
-      onHeadersImpl,
     );
     if (options && options.signal) {
       const signal = options.signal;

--- a/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
@@ -9,7 +9,10 @@
 
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
-import type {PostponedState} from 'react-server/src/ReactFizzServer';
+import type {
+  PostponedState,
+  HeadersDescriptor,
+} from 'react-server/src/ReactFizzServer';
 import type {ImportMap} from '../shared/ReactDOMTypes';
 
 import ReactVersion from 'shared/ReactVersion';
@@ -41,6 +44,7 @@ type Options = {
   onPostpone?: (reason: string) => void,
   unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor,
   importMap?: ImportMap,
+  onHeaders?: (headers: Headers) => void,
 };
 
 type StaticResult = {
@@ -77,6 +81,14 @@ function prerender(
       };
       resolve(result);
     }
+
+    const onHeaders = options ? options.onHeaders : undefined;
+    let onHeadersImpl;
+    if (onHeaders) {
+      onHeadersImpl = (headersDescriptor: HeadersDescriptor) => {
+        onHeaders(new Headers(headersDescriptor));
+      };
+    }
     const resources = createResumableState(
       options ? options.identifierPrefix : undefined,
       options ? options.unstable_externalRuntimeSrc : undefined,
@@ -101,6 +113,7 @@ function prerender(
       undefined,
       onFatalError,
       options ? options.onPostpone : undefined,
+      onHeadersImpl,
     );
     if (options && options.signal) {
       const signal = options.signal;

--- a/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
@@ -9,7 +9,10 @@
 
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
-import type {PostponedState} from 'react-server/src/ReactFizzServer';
+import type {
+  PostponedState,
+  HeadersDescriptor,
+} from 'react-server/src/ReactFizzServer';
 import type {ImportMap} from '../shared/ReactDOMTypes';
 
 import {Writable, Readable} from 'stream';
@@ -42,6 +45,7 @@ type Options = {
   onPostpone?: (reason: string) => void,
   unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor,
   importMap?: ImportMap,
+  onHeaders?: (headers: HeadersDescriptor) => void,
 };
 
 type StaticResult = {
@@ -110,6 +114,7 @@ function prerenderToNodeStream(
       undefined,
       onFatalError,
       options ? options.onPostpone : undefined,
+      options ? options.onHeaders : undefined,
     );
     if (options && options.signal) {
       const signal = options.signal;

--- a/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
@@ -8,11 +8,11 @@
  */
 
 import type {ReactNodeList} from 'shared/ReactTypes';
-import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 import type {
-  PostponedState,
+  BootstrapScriptDescriptor,
   HeadersDescriptor,
-} from 'react-server/src/ReactFizzServer';
+} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
+import type {PostponedState} from 'react-server/src/ReactFizzServer';
 import type {ImportMap} from '../shared/ReactDOMTypes';
 
 import {Writable, Readable} from 'stream';
@@ -46,6 +46,7 @@ type Options = {
   unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor,
   importMap?: ImportMap,
   onHeaders?: (headers: HeadersDescriptor) => void,
+  maxHeadersLength?: number,
 };
 
 type StaticResult = {
@@ -105,6 +106,8 @@ function prerenderToNodeStream(
         options ? options.bootstrapModules : undefined,
         options ? options.unstable_externalRuntimeSrc : undefined,
         options ? options.importMap : undefined,
+        options ? options.onHeaders : undefined,
+        options ? options.maxHeadersLength : undefined,
       ),
       createRootFormatContext(options ? options.namespaceURI : undefined),
       options ? options.progressiveChunkSize : undefined,
@@ -114,7 +117,6 @@ function prerenderToNodeStream(
       undefined,
       onFatalError,
       options ? options.onPostpone : undefined,
-      options ? options.onHeaders : undefined,
     );
     if (options && options.signal) {
       const signal = options.signal;

--- a/packages/react-dom/src/shared/ReactDOMTypes.js
+++ b/packages/react-dom/src/shared/ReactDOMTypes.js
@@ -17,7 +17,7 @@ export type PreloadOptions = {
   integrity?: string,
   type?: string,
   nonce?: string,
-  fetchPriority?: 'high' | 'low' | 'auto',
+  fetchPriority?: FetchPriorityEnum,
   imageSrcSet?: string,
   imageSizes?: string,
   referrerPolicy?: string,
@@ -34,7 +34,7 @@ export type PreinitOptions = {
   crossOrigin?: string,
   integrity?: string,
   nonce?: string,
-  fetchPriority?: 'high' | 'low' | 'auto',
+  fetchPriority?: FetchPriorityEnum,
 };
 export type PreinitModuleOptions = {
   as?: string,
@@ -51,10 +51,11 @@ export type PreloadImplOptions = {
   integrity?: ?string,
   nonce?: ?string,
   type?: ?string,
-  fetchPriority?: ?FetchPriorityEnum,
+  fetchPriority?: ?string,
   referrerPolicy?: ?string,
   imageSrcSet?: ?string,
   imageSizes?: ?string,
+  media?: ?string,
 };
 export type PreloadModuleImplOptions = {
   as?: ?string,
@@ -65,12 +66,12 @@ export type PreloadModuleImplOptions = {
 export type PreinitStyleOptions = {
   crossOrigin?: ?CrossOriginEnum,
   integrity?: ?string,
-  fetchPriority?: ?FetchPriorityEnum,
+  fetchPriority?: ?string,
 };
 export type PreinitScriptOptions = {
   crossOrigin?: ?CrossOriginEnum,
   integrity?: ?string,
-  fetchPriority?: ?FetchPriorityEnum,
+  fetchPriority?: ?string,
   nonce?: ?string,
 };
 export type PreinitModuleScriptOptions = {

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -271,6 +271,7 @@ const ReactNoopServer = ReactFizzServer({
   setCurrentlyRenderingBoundaryResourcesTarget(resources: BoundaryResources) {},
 
   prepareHostDispatcher() {},
+  emitEarlyPreloads() {},
 });
 
 type Options = {

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -77,6 +77,7 @@ import {
   pushFormStateMarkerIsMatching,
   pushFormStateMarkerIsNotMatching,
   resetResumableState,
+  emitEarlyPreloads,
 } from './ReactFizzConfig';
 import {
   constructClassInstance,
@@ -353,10 +354,6 @@ function defaultErrorHandler(error: mixed) {
 
 function noop(): void {}
 
-export type HeadersDescriptor = {
-  Link: string,
-};
-
 export function createRequest(
   children: ReactNodeList,
   resumableState: ResumableState,
@@ -370,7 +367,6 @@ export function createRequest(
   onFatalError: void | ((error: mixed) => void),
   onPostpone: void | ((reason: string) => void),
   formState: void | null | ReactFormState<any, any>,
-  onHeaders: void | ((headers: HeadersDescriptor) => void),
 ): Request {
   prepareHostDispatcher();
   const pingedTasks: Array<Task> = [];
@@ -447,7 +443,6 @@ export function createPrerenderRequest(
   onShellError: void | ((error: mixed) => void),
   onFatalError: void | ((error: mixed) => void),
   onPostpone: void | ((reason: string) => void),
-  onHeaders: void | ((headers: HeadersDescriptor) => void),
 ): Request {
   const request = createRequest(
     children,
@@ -462,7 +457,6 @@ export function createPrerenderRequest(
     onFatalError,
     onPostpone,
     undefined,
-    onHeaders,
   );
   // Start tracking postponed holes during this render.
   request.trackedPostpones = {
@@ -3024,8 +3018,7 @@ function erroredTask(
 
   request.allPendingTasks--;
   if (request.allPendingTasks === 0) {
-    const onAllReady = request.onAllReady;
-    onAllReady();
+    completeAll(request);
   }
 }
 
@@ -3173,9 +3166,7 @@ function abortTask(task: Task, request: Request, error: mixed): void {
         }
         request.pendingRootTasks--;
         if (request.pendingRootTasks === 0) {
-          request.onShellError = noop;
-          const onShellReady = request.onShellReady;
-          onShellReady();
+          completeShell(request);
         }
       }
     }
@@ -3217,9 +3208,52 @@ function abortTask(task: Task, request: Request, error: mixed): void {
 
   request.allPendingTasks--;
   if (request.allPendingTasks === 0) {
-    const onAllReady = request.onAllReady;
-    onAllReady();
+    completeAll(request);
   }
+}
+
+// I extracted this function out because we want to ensure we consistently emit preloads before
+// transitioning to the next request stage and this transition can happen in multiple places in this
+// implementation.
+function completeShell(request: Request) {
+  if (request.trackedPostpones === null) {
+    // We only emit early preloads on shell completion for renders. For prerenders
+    // we wait for the entire Request to finish because we are not responding to a
+    // live request and can wait for as much data as possible.
+
+    // we should only be calling completeShell when the shell is complete so we
+    // just use a literal here
+    const shellComplete = true;
+    emitEarlyPreloads(
+      request.renderState,
+      request.resumableState,
+      shellComplete,
+    );
+  }
+  // We have completed the shell so the shell can't error anymore.
+  request.onShellError = noop;
+  const onShellReady = request.onShellReady;
+  onShellReady();
+}
+
+// I extracted this function out because we want to ensure we consistently emit preloads before
+// transitioning to the next request stage and this transition can happen in multiple places in this
+// implementation.
+function completeAll(request: Request) {
+  // During a render the shell must be complete if the entire request is finished
+  // however during a Prerender it is possible that the shell is incomplete because
+  // it postponed. We cannot use rootPendingTasks in the prerender case because
+  // those hit zero even when the shell postpones. Instead we look at the completedRootSegment
+  const shellComplete =
+    request.trackedPostpones === null
+      ? // Render, we assume it is completed
+        true
+      : // Prerender Request, we use the state of the root segment
+        request.completedRootSegment === null ||
+        request.completedRootSegment.status !== POSTPONED;
+  emitEarlyPreloads(request.renderState, request.resumableState, shellComplete);
+  const onAllReady = request.onAllReady;
+  onAllReady();
 }
 
 function queueCompletedSegment(
@@ -3262,10 +3296,7 @@ function finishedTask(
     }
     request.pendingRootTasks--;
     if (request.pendingRootTasks === 0) {
-      // We have completed the shell so the shell can't error anymore.
-      request.onShellError = noop;
-      const onShellReady = request.onShellReady;
-      onShellReady();
+      completeShell(request);
     }
   } else {
     boundary.pendingTasks--;
@@ -3321,10 +3352,7 @@ function finishedTask(
 
   request.allPendingTasks--;
   if (request.allPendingTasks === 0) {
-    // This needs to be called at the very end so that we can synchronously write the result
-    // in the callback if needed.
-    const onAllReady = request.onAllReady;
-    onAllReady();
+    completeAll(request);
   }
 }
 
@@ -3536,14 +3564,11 @@ function retryReplayTask(request: Request, task: ReplayTask): void {
     );
     request.pendingRootTasks--;
     if (request.pendingRootTasks === 0) {
-      request.onShellError = noop;
-      const onShellReady = request.onShellReady;
-      onShellReady();
+      completeShell(request);
     }
     request.allPendingTasks--;
     if (request.allPendingTasks === 0) {
-      const onAllReady = request.onAllReady;
-      onAllReady();
+      completeAll(request);
     }
     return;
   } finally {
@@ -4064,6 +4089,33 @@ export function startWork(request: Request): void {
   } else {
     scheduleWork(() => performWork(request));
   }
+  if (request.trackedPostpones === null) {
+    // this is either a regular render or a resume. For regular render we want
+    // to call emitEarlyPreloads after the first performWork because we want
+    // are responding to a live request and need to balance sending something early
+    // (i.e. don't want for the shell to finish) but we need something to send.
+    // The only implementation of this is for DOM at the moment and during resumes nothing
+    // actually emits but the code paths here are the same.
+    // During a prerender we don't want to be too aggressive in emitting early preloads
+    // because we aren't responding to a live request and we can wait for the prerender to
+    // postpone before we emit anything.
+    if (supportsRequestStorage) {
+      scheduleWork(() =>
+        requestStorage.run(
+          request,
+          enqueueEarlyPreloadsAfterInitialWork,
+          request,
+        ),
+      );
+    } else {
+      scheduleWork(() => enqueueEarlyPreloadsAfterInitialWork(request));
+    }
+  }
+}
+
+function enqueueEarlyPreloadsAfterInitialWork(request: Request) {
+  const shellComplete = request.pendingRootTasks === 0;
+  emitEarlyPreloads(request.renderState, request.resumableState, shellComplete);
 }
 
 function enqueueFlush(request: Request): void {
@@ -4089,6 +4141,27 @@ function enqueueFlush(request: Request): void {
   }
 }
 
+// This function is intented to only be called during the pipe function for the Node builds.
+// The reason we need this is because `renderToPipeableStream` is the only API which allows
+// you to start flowing before the shell is complete and we've had a chance to emit early
+// preloads already. This is really just defensive programming to ensure that we give hosts an
+// opportunity to flush early preloads before streaming begins in case they are in an environment
+// that only supports a single call to emitEarlyPreloads like the DOM renderers. It's unfortunate
+// to put this Node only function directly in ReactFizzServer but it'd be more ackward to factor it
+// by moving the implementation into ReactServerStreamConfigNode and even then we may not be able to
+// eliminate all the wasted branching.
+export function prepareForStartFlowingIfBeforeAllReady(request: Request) {
+  const shellComplete =
+    request.trackedPostpones === null
+      ? // Render Request, we define shell complete by the pending root tasks
+        request.pendingRootTasks === 0
+      : // Prerender Request, we define shell complete by completedRootSegemtn
+      request.completedRootSegment === null
+      ? request.pendingRootTasks === 0
+      : request.completedRootSegment.status !== POSTPONED;
+  emitEarlyPreloads(request.renderState, request.resumableState, shellComplete);
+}
+
 export function startFlowing(request: Request, destination: Destination): void {
   if (request.status === CLOSING) {
     request.status = CLOSED;
@@ -4103,6 +4176,7 @@ export function startFlowing(request: Request, destination: Destination): void {
     return;
   }
   request.destination = destination;
+
   try {
     flushCompletedQueues(request, destination);
   } catch (error) {

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -353,6 +353,10 @@ function defaultErrorHandler(error: mixed) {
 
 function noop(): void {}
 
+export type HeadersDescriptor = {
+  Link: string,
+};
+
 export function createRequest(
   children: ReactNodeList,
   resumableState: ResumableState,
@@ -366,6 +370,7 @@ export function createRequest(
   onFatalError: void | ((error: mixed) => void),
   onPostpone: void | ((reason: string) => void),
   formState: void | null | ReactFormState<any, any>,
+  onHeaders: void | ((headers: HeadersDescriptor) => void),
 ): Request {
   prepareHostDispatcher();
   const pingedTasks: Array<Task> = [];
@@ -442,6 +447,7 @@ export function createPrerenderRequest(
   onShellError: void | ((error: mixed) => void),
   onFatalError: void | ((error: mixed) => void),
   onPostpone: void | ((reason: string) => void),
+  onHeaders: void | ((headers: HeadersDescriptor) => void),
 ): Request {
   const request = createRequest(
     children,
@@ -455,6 +461,8 @@ export function createPrerenderRequest(
     onShellError,
     onFatalError,
     onPostpone,
+    undefined,
+    onHeaders,
   );
   // Start tracking postponed holes during this render.
   request.trackedPostpones = {

--- a/packages/react-server/src/forks/ReactFizzConfig.custom.js
+++ b/packages/react-server/src/forks/ReactFizzConfig.custom.js
@@ -32,6 +32,7 @@ export opaque type RenderState = mixed;
 export opaque type ResumableState = mixed;
 export opaque type BoundaryResources = mixed;
 export opaque type FormatContext = mixed;
+export opaque type HeadersDescriptor = mixed;
 export type {TransitionStatus};
 
 export const isPrimaryRenderer = false;
@@ -91,3 +92,4 @@ export const createBoundaryResources = $$$config.createBoundaryResources;
 export const setCurrentlyRenderingBoundaryResourcesTarget =
   $$$config.setCurrentlyRenderingBoundaryResourcesTarget;
 export const writeResourcesForBoundary = $$$config.writeResourcesForBoundary;
+export const emitEarlyPreloads = $$$config.emitEarlyPreloads;

--- a/packages/shared/CheckStringCoercion.js
+++ b/packages/shared/CheckStringCoercion.js
@@ -117,6 +117,23 @@ export function checkPropStringCoercion(
   }
 }
 
+export function checkOptionStringCoercion(
+  value: mixed,
+  propName: string,
+): void | string {
+  if (__DEV__) {
+    if (willCoercionThrow(value)) {
+      console.error(
+        'The provided `%s` option is an unsupported type %s.' +
+          ' This value must be coerced to a string before using it here.',
+        propName,
+        typeName(value),
+      );
+      return testStringCoercion(value); // throw (to help callers find troubleshooting comments)
+    }
+  }
+}
+
 export function checkCSSPropertyStringCoercion(
   value: mixed,
   propName: string,

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -484,5 +484,6 @@
   "496": "Only objects or functions can be passed to taintObjectReference. Try taintUniqueValue instead.",
   "497": "Only objects or functions can be passed to taintObjectReference.",
   "498": "Only plain objects, and a few built-ins, can be passed to Client Components from Server Components. Classes or null prototypes are not supported.",
-  "499": "Only plain objects, and a few built-ins, can be passed to Server Actions. Classes or null prototypes are not supported."
+  "499": "Only plain objects, and a few built-ins, can be passed to Server Actions. Classes or null prototypes are not supported.",
+  "500": "React expected a headers state to exist when emitEarlyPreloads was called but did not find it. This suggests emitEarlyPreloads was called more than once per request. This is a bug in React."
 }


### PR DESCRIPTION
Adds a new option to `react-dom/server` entrypoints.

`onHeaders: (headers: Headers) => void` (non node envs)
`onHeaders: (headers: { Link?: string }) => void` (node envs)

When any `renderTo...` or `prerender...` function is called and this option is provided the supplied function will be called sometime on or before completion of the render with some preload link headers.

When provided during a `renderTo...` the callback will usually be called after the first pass at work. The idea here is we want to get a set of headers to start the browser loading well before the shell is ready. We don't wait for the shell because if we did we may as well send the preloads as tags in the HTML.

When provided during a `prerender...` the callback will be called after the entire prerender is complete. The idea here is we are not responding to a live request and it is preferable to capture as much as possible for preloading as Headers in case the prerender was unable to finish the shell.

Currently the following resources are always preloaded as headers when the option is provided
1. prefetchDNS and preconnects
2. font preloads
3. high priority image preloads

Additionally if we are providing headers when the shell is incomplete (regardless of whether it is render or prerender) we will also include any stylesheet Resources (ones with a precedence prop)

There is a second option `maxHeadersLength?: number` which allows you to specify the maximum length of the header content in unicode code units. This is what you get when you read the length property of a string in javascript. It's improtant to note that this is not the same as the utf-8 byte length when these headers are serialized in a Response. The utf8 representation may be the same size, or larger but it will never be smaller.

If you do not supply a `maxHeadersLength` we defaul to `2000`. This was chosen as half the value of the max headers length supported by commonly known web servers and CDNs. many browser and web server can support significantly more headers than this so you can use this option to increase the headers limit. You can also of course use it to be even more conservative. Again it is important to keep in mind there is no direct translation between the max length and the bytelength and so if you want to stay under a certain byte length you need to be potentially more aggressive in the maxHeadersLength you choose.

Conceptually `onHeaders` could be called more than once as new headers are discovered however if we haven't started flushing yet but since most APIs for the server including the web standard Response only allow you to set headers once the current implementation will only call it one time