### PR TITLE
Addition of Bad Polyfill warning TODO.

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -128,8 +128,8 @@ if (__DEV__) {
     new Set([nonExtensibleObject]);
     /* eslint-enable no-new */
   } catch (e) {
-    // TODO: Consider warning about bad polyfills
     hasBadMapPolyfill = true;
+    console.error('Warning: Bad Polyfill');
   }
 }
 


### PR DESCRIPTION
## Summary

This PR implements a Bad Polyfill warning suggested in 'react-reconciler/ReactFiber.js' TODO.

## How did you test this change?

This PR has no impactful changes, but tested with yarn test.
