### PR TITLE
refactor[react-devtools-shared]: minor parsing improvements and modifications

### DIFF
--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -439,7 +439,6 @@ export function getInternalReactConstants(version: string): {
         return 'Cache';
       case ClassComponent:
       case IncompleteClassComponent:
-        return getDisplayName(resolvedType);
       case FunctionComponent:
       case IndeterminateComponent:
         return getDisplayName(resolvedType);

--- a/packages/react-devtools-shared/src/devtools/views/Components/Element.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Element.js
@@ -122,7 +122,7 @@ export default function Element({data, index, style}: Props): React.Node {
     isStrictModeNonCompliant,
     key,
     type,
-  } = ((element: any): ElementType);
+  } = element;
 
   // Only show strict mode non-compliance badges for top level elements.
   // Showing an inline badge for every element in the tree would be noisy.
@@ -173,17 +173,16 @@ export default function Element({data, index, style}: Props): React.Node {
             "
           </Fragment>
         )}
+
         {hocDisplayNames !== null && hocDisplayNames.length > 0 ? (
           <Badge
             className={styles.Badge}
             hocDisplayNames={hocDisplayNames}
             type={type}>
-            <DisplayName
-              displayName={hocDisplayNames[0]}
-              id={((id: any): number)}
-            />
+            <DisplayName displayName={hocDisplayNames[0]} id={id} />
           </Badge>
         ) : null}
+
         {showInlineWarningsAndErrors && errorCount > 0 && (
           <Icon
             type="error"

--- a/packages/react-devtools-shared/src/devtools/views/Components/HocBadges.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/HocBadges.js
@@ -25,12 +25,11 @@ export default function HocBadges({element}: Props): React.Node {
 
   return (
     <div className={styles.HocBadges}>
-      {hocDisplayNames !== null &&
-        hocDisplayNames.map(hocDisplayName => (
-          <div key={hocDisplayName} className={styles.Badge}>
-            {hocDisplayName}
-          </div>
-        ))}
+      {hocDisplayNames.map(hocDisplayName => (
+        <div key={hocDisplayName} className={styles.Badge}>
+          {hocDisplayName}
+        </div>
+      ))}
     </div>
   );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitTreeBuilder.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitTreeBuilder.js
@@ -17,7 +17,7 @@ import {
   TREE_OPERATION_UPDATE_TREE_BASE_DURATION,
   TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS,
 } from 'react-devtools-shared/src/constants';
-import {utfDecodeString} from 'react-devtools-shared/src/utils';
+import {utfDecodeStringWithRanges} from 'react-devtools-shared/src/utils';
 import {ElementTypeRoot} from 'react-devtools-shared/src/frontend/types';
 import ProfilerStore from 'react-devtools-shared/src/devtools/ProfilerStore';
 
@@ -170,8 +170,10 @@ function updateTree(
   const stringTableEnd = i + stringTableSize;
   while (i < stringTableEnd) {
     const nextLength = operations[i++];
-    const nextString = utfDecodeString(
-      (operations.slice(i, i + nextLength): any),
+    const nextString = utfDecodeStringWithRanges(
+      operations,
+      i,
+      i + nextLength - 1,
     );
     stringTable.push(nextString);
     i += nextLength;

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -116,7 +116,7 @@ export function getWrappedDisplayName(
   wrapperName: string,
   fallbackName?: string,
 ): string {
-  const displayName = (outerType: any).displayName;
+  const displayName = (outerType: any)?.displayName;
   return (
     displayName || `${wrapperName}(${getDisplayName(innerType, fallbackName)})`
   );
@@ -152,15 +152,14 @@ export function getUID(): number {
   return ++uidCounter;
 }
 
-export function utfDecodeString(array: Array<number>): string {
-  // Avoid spreading the array (e.g. String.fromCodePoint(...array))
-  // Functions arguments are first placed on the stack before the function is called
-  // which throws a RangeError for large arrays.
-  // See github.com/facebook/react/issues/22293
+export function utfDecodeStringWithRanges(
+  array: Array<number>,
+  left: number,
+  right: number,
+): string {
   let string = '';
-  for (let i = 0; i < array.length; i++) {
-    const char = array[i];
-    string += String.fromCodePoint(char);
+  for (let i = left; i <= right; i++) {
+    string += String.fromCodePoint(array[i]);
   }
   return string;
 }
@@ -216,8 +215,10 @@ export function printOperationsArray(operations: Array<number>) {
   const stringTableEnd = i + stringTableSize;
   while (i < stringTableEnd) {
     const nextLength = operations[i++];
-    const nextString = utfDecodeString(
-      (operations.slice(i, i + nextLength): any),
+    const nextString = utfDecodeStringWithRanges(
+      operations,
+      i,
+      i + nextLength - 1,
     );
     stringTable.push(nextString);
     i += nextLength;


### PR DESCRIPTION
Had these stashed for some time, it includes:
- Some refactoring to remove unnecessary `FlowFixMe`s and type castings via `any`.
- Optimized version of parsing component names. We encode string names to utf8 and then pass it serialized from backend to frontend in a single array of numbers. Previously we would call `slice` to get the corresponding encoded string as a subarray and then parse each character. New implementation skips `slice` step and just receives `left` and `right` ranges for the string to parse.
- Early `break` instead of `continue` when Store receives unexpected operation, like removing an element from the Store, which is not registered yet.