### PR TITLE
refactor[ci/build]: support FB_WWW_BROWSER_SCRIPT bundle type

### DIFF
--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -133,10 +133,6 @@ jobs:
           mv build/oss-experimental/eslint-plugin-react-hooks/cjs/eslint-plugin-react-hooks.development.js \
             ./compiled/facebook-www/eslint-plugin-react-hooks.js
 
-          # Copy unstable_server-external-runtime.js into facebook-www
-          mv build/oss-stable/react-dom/unstable_server-external-runtime.js \
-            ./compiled/facebook-www/unstable_server-external-runtime.js
-
           # Copy react-refresh-babel.development.js into babel-plugin-react-refresh
           mv build/oss-experimental/react-refresh/cjs/react-refresh-babel.development.js \
             ./compiled/babel-plugin-react-refresh/index.js
@@ -148,7 +144,7 @@ jobs:
           mkdir -p ${BASE_FOLDER}/react-native-github/Libraries/Renderer/
           mkdir -p ${BASE_FOLDER}/RKJSModules/vendor/{scheduler,react,react-is,react-test-renderer}/
 
-          # Move React Native renderer 
+          # Move React Native renderer
           mv build/react-native/implementations/ $BASE_FOLDER/react-native-github/Libraries/Renderer/
           mv build/react-native/shims/ $BASE_FOLDER/react-native-github/Libraries/Renderer/
           mv build/facebook-react-native/scheduler/cjs/ $BASE_FOLDER/RKJSModules/vendor/scheduler/

--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -168,7 +168,10 @@ function processStable(buildDir) {
       const stats = fs.statSync(filePath);
       if (!stats.isDirectory()) {
         hash.update(fs.readFileSync(filePath));
-        fs.renameSync(filePath, filePath.replace('.js', '.classic.js'));
+
+        if (fileName !== 'unstable_server-external-runtime.js') {
+          fs.renameSync(filePath, filePath.replace('.js', '.classic.js'));
+        }
       }
     }
     updatePlaceholderReactVersionInCompiledArtifacts(
@@ -242,7 +245,9 @@ function processExperimental(buildDir, version) {
       const stats = fs.statSync(filePath);
       if (!stats.isDirectory()) {
         hash.update(fs.readFileSync(filePath));
-        fs.renameSync(filePath, filePath.replace('.js', '.modern.js'));
+        if (fileName !== 'unstable_server-external-runtime.js') {
+          fs.renameSync(filePath, filePath.replace('.js', '.modern.js'));
+        }
       }
     }
     updatePlaceholderReactVersionInCompiledArtifacts(

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -19,6 +19,7 @@ const bundleTypes = {
   NODE_PROFILING: 'NODE_PROFILING',
   BUN_DEV: 'BUN_DEV',
   BUN_PROD: 'BUN_PROD',
+  FB_WWW_BROWSER_SCRIPT: 'FB_WWW_BROWSER_SCRIPT',
   FB_WWW_DEV: 'FB_WWW_DEV',
   FB_WWW_PROD: 'FB_WWW_PROD',
   FB_WWW_PROFILING: 'FB_WWW_PROFILING',
@@ -43,6 +44,7 @@ const {
   NODE_PROFILING,
   BUN_DEV,
   BUN_PROD,
+  FB_WWW_BROWSER_SCRIPT,
   FB_WWW_DEV,
   FB_WWW_PROD,
   FB_WWW_PROFILING,
@@ -300,7 +302,7 @@ const bundles = [
 
   /******* React DOM Fizz Server External Runtime *******/
   {
-    bundleTypes: [BROWSER_SCRIPT],
+    bundleTypes: [BROWSER_SCRIPT, FB_WWW_BROWSER_SCRIPT],
     moduleType: RENDERER,
     entry: 'react-dom/unstable_server-external-runtime',
     outputPath: 'unstable_server-external-runtime.js',
@@ -1130,6 +1132,7 @@ function getFilename(bundle, bundleType) {
     case RN_FB_PROFILING:
     case RN_OSS_PROFILING:
       return `${globalName}-profiling.js`;
+    case FB_WWW_BROWSER_SCRIPT:
     case BROWSER_SCRIPT:
       return `${name}.js`;
   }

--- a/scripts/rollup/packaging.js
+++ b/scripts/rollup/packaging.js
@@ -29,6 +29,7 @@ const {
   NODE_PROFILING,
   BUN_DEV,
   BUN_PROD,
+  FB_WWW_BROWSER_SCRIPT,
   FB_WWW_DEV,
   FB_WWW_PROD,
   FB_WWW_PROFILING,
@@ -66,6 +67,23 @@ function getBundleOutputPath(bundle, bundleType, filename, packageName) {
     case UMD_PROD:
     case UMD_PROFILING:
       return `build/node_modules/${packageName}/umd/${filename}`;
+    case FB_WWW_BROWSER_SCRIPT: {
+      // Bundles that are served as browser scripts need to be able to be sent
+      // straight to the browser with any additional bundling. We shouldn't use
+      // a module to re-export. Depending on how they are served, they also may
+      // not go through package.json module resolution, so we shouldn't rely on
+      // that either. We should consider the output path as part of the public
+      // contract, and explicitly specify its location within the package's
+      // directory structure.
+      const outputPath = bundle.outputPath;
+      if (!outputPath) {
+        throw new Error(
+          'Bundles with type FB_WWW_BROWSER_SCRIPT must specific an explicit ' +
+          'output path.'
+        );
+      }
+      return `build/facebook-www/${outputPath}`;
+    }
     case FB_WWW_DEV:
     case FB_WWW_PROD:
     case FB_WWW_PROFILING:

--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -17,6 +17,7 @@ const {
   NODE_PROFILING,
   BUN_DEV,
   BUN_PROD,
+  FB_WWW_BROWSER_SCRIPT,
   FB_WWW_DEV,
   FB_WWW_PROD,
   FB_WWW_PROFILING,
@@ -442,7 +443,7 @@ function wrapBundle(
     }
   }
 
-  if (bundleType === BROWSER_SCRIPT) {
+  if (bundleType === BROWSER_SCRIPT || FB_WWW_BROWSER_SCRIPT) {
     // Bundles of type BROWSER_SCRIPT get sent straight to the browser without
     // additional processing. So we should exclude any extra wrapper comments.
     return source;


### PR DESCRIPTION
Follow-up on https://github.com/facebook/react/pull/26446.

Fixes 2 issues:
1. We are manually copying `unstable_server-external-runtime.js` into `facebook-www` when committing artifacts to Meta's monorepo.
    - This diverges from the local flow with just running `yarn build`: you will not get `build/facebook-www/unstable_server-external-runtime.js` in this case.
    - Because `build/oss-stable/react-dom/unstable_server-external-runtime.js` is actually included into `react-dom` npm package, we ship sourcemaps for it. We don't need sourcemaps for Meta's versions of these artifacts, though, it should be built separately with a different bundle type.
2. `unstable_server-external-runtime.js` doesn't have any effect on the `hash` that is created here https://github.com/facebook/react/blob/main/scripts/rollup/build-all-release-channels.js#L165-L173 or here 
https://github.com/facebook/react/blob/main/scripts/rollup/build-all-release-channels.js#L239-L247. I can double-check this, but it probably means that if only sources of this artifact change, it won't create a new react version identifier, which is based on `hash`.