### PR TITLE
refactor[ci/build]: dont generate sourcemaps for BROWSER_SCRIPT bundles

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -406,6 +406,10 @@ function getPlugins(
     // UMD builds are rarely used and not worth having sourcemaps.
     const needsSourcemaps =
       needsMinifiedByClosure &&
+      // This will only exclude `unstable_server-external-runtime.js` artifact
+      // To start generating sourcemaps for it, we should stop manually copying it to `facebook-www`
+      // and force `react-dom` to include .map files in npm-package at the root level
+      bundleType !== BROWSER_SCRIPT &&
       !isUMDBundle &&
       !sourcemapPackageExcludes.includes(entry) &&
       !shouldStayReadable;


### PR DESCRIPTION
Instead of https://github.com/facebook/react/pull/27664, we can just exclude `unstable_server-external-runtime.js` from having sourcemaps for now.

We should consider removing manual copying of this artifact in https://github.com/facebook/react/blob/52d542ad6d410008c495084f511247f43387055f/.github/workflows/commit_artifacts.yml#L136-L138


As described in  https://github.com/facebook/react/pull/27664, this artifact doesn't have any effect on the `hash`, which is used for generating React version identifier.