### PR TITLE
[Static][Fizz] bootstrap scripts should only emit once

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -690,6 +690,13 @@ export function resetResumableState(
   resumableState.moduleScriptResources = {};
 }
 
+export function completeResumableState(resumableState: ResumableState): void {
+  // This function is called when we have completed a prerender and there is a shell.
+  resumableState.bootstrapScriptContent = undefined;
+  resumableState.bootstrapScripts = undefined;
+  resumableState.bootstrapModules = undefined;
+}
+
 // Constants for the insertion mode we're currently writing in. We don't encode all HTML5 insertion
 // modes. We only include the variants as they matter for the sake of our purposes.
 // We don't actually provide the namespace therefore we use constants instead of the string.
@@ -3723,11 +3730,7 @@ export function pushEndInstance(
 function writeBootstrap(
   destination: Destination,
   renderState: RenderState,
-  resumableState: ResumableState,
 ): boolean {
-  resumableState.bootstrapScriptContent = undefined;
-  resumableState.bootstrapScripts = undefined;
-  resumableState.bootstrapModules = undefined;
   const bootstrapChunks = renderState.bootstrapChunks;
   let i = 0;
   for (; i < bootstrapChunks.length - 1; i++) {
@@ -3744,9 +3747,8 @@ function writeBootstrap(
 export function writeCompletedRoot(
   destination: Destination,
   renderState: RenderState,
-  resumableState: ResumableState,
 ): boolean {
-  return writeBootstrap(destination, renderState, resumableState);
+  return writeBootstrap(destination, renderState);
 }
 
 // Structural Nodes
@@ -4211,7 +4213,7 @@ export function writeCompletedBoundaryInstruction(
   } else {
     writeMore = writeChunkAndReturn(destination, completeBoundaryDataEnd);
   }
-  return writeBootstrap(destination, renderState, resumableState) && writeMore;
+  return writeBootstrap(destination, renderState) && writeMore;
 }
 
 const clientRenderScript1Full = stringToPrecomputedChunk(

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
@@ -171,6 +171,7 @@ export {
   setCurrentlyRenderingBoundaryResourcesTarget,
   prepareHostDispatcher,
   resetResumableState,
+  completeResumableState,
   emitEarlyPreloads,
 } from './ReactFizzConfigDOM';
 

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -95,6 +95,7 @@ const ReactNoopServer = ReactFizzServer({
   },
 
   resetResumableState(): void {},
+  completeResumableState(): void {},
 
   pushTextInstance(
     target: Array<Uint8Array>,

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -77,6 +77,7 @@ import {
   pushFormStateMarkerIsMatching,
   pushFormStateMarkerIsNotMatching,
   resetResumableState,
+  completeResumableState,
   emitEarlyPreloads,
 } from './ReactFizzConfig';
 import {
@@ -3968,11 +3969,7 @@ function flushCompletedQueues(
 
         flushSegment(request, destination, completedRootSegment);
         request.completedRootSegment = null;
-        writeCompletedRoot(
-          destination,
-          request.renderState,
-          request.resumableState,
-        );
+        writeCompletedRoot(destination, request.renderState);
       } else {
         // We haven't flushed the root yet so we don't need to check any other branches further down
         return;
@@ -4283,6 +4280,8 @@ export function getPostponedState(request: Request): null | PostponedState {
   ) {
     // We postponed the root so we didn't flush anything.
     resetResumableState(request.resumableState, request.renderState);
+  } else {
+    completeResumableState(request.resumableState);
   }
   return {
     nextSegmentId: request.nextSegmentId,

--- a/packages/react-server/src/forks/ReactFizzConfig.custom.js
+++ b/packages/react-server/src/forks/ReactFizzConfig.custom.js
@@ -41,6 +41,7 @@ export const supportsRequestStorage = false;
 export const requestStorage: AsyncLocalStorage<Request> = (null: any);
 
 export const resetResumableState = $$$config.resetResumableState;
+export const completeResumableState = $$$config.completeResumableState;
 export const getChildFormatContext = $$$config.getChildFormatContext;
 export const makeId = $$$config.makeId;
 export const pushTextInstance = $$$config.pushTextInstance;


### PR DESCRIPTION
I introduced a bug in a recent change to how bootstrap scripts are handled. Rather than clearing out the bootstrap script state from ResumableState on completion of the prerender I did it during the flushing phase which comes later after the postponed state has likely been serialized. We should freeze these objects in dev so this is not possible to do easily in test (nor in actual code in real systems).

This fixes the bug by eliminating the bootstrap config during getPostponedState which is before the state can be serialized.