### PR TITLE
[Flight] Bound server references should be able to be bound again

### DIFF
--- a/packages/react-server-dom-esm/src/ReactFlightESMReferences.js
+++ b/packages/react-server-dom-esm/src/ReactFlightESMReferences.js
@@ -47,15 +47,18 @@ export function registerClientReference<T>(
 const FunctionBind = Function.prototype.bind;
 // $FlowFixMe[method-unbinding]
 const ArraySlice = Array.prototype.slice;
-function bind(this: ServerReference<any>) {
+function bind(this: ServerReference<any>): any {
   // $FlowFixMe[unsupported-syntax]
   const newFn = FunctionBind.apply(this, arguments);
   if (this.$$typeof === SERVER_REFERENCE_TAG) {
     // $FlowFixMe[method-unbinding]
     const args = ArraySlice.call(arguments, 1);
-    newFn.$$typeof = SERVER_REFERENCE_TAG;
-    newFn.$$id = this.$$id;
-    newFn.$$bound = this.$$bound ? this.$$bound.concat(args) : args;
+    return Object.defineProperties((newFn: any), {
+      $$typeof: {value: SERVER_REFERENCE_TAG},
+      $$id: {value: this.$$id},
+      $$bound: {value: this.$$bound ? this.$$bound.concat(args) : args},
+      bind: {value: bind},
+    });
   }
   return newFn;
 }

--- a/packages/react-server-dom-turbopack/src/ReactFlightTurbopackReferences.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightTurbopackReferences.js
@@ -61,14 +61,17 @@ function registerClientReferenceImpl<T>(
 const FunctionBind = Function.prototype.bind;
 // $FlowFixMe[method-unbinding]
 const ArraySlice = Array.prototype.slice;
-function bind(this: ServerReference<any>) {
+function bind(this: ServerReference<any>): any {
   // $FlowFixMe[unsupported-syntax]
   const newFn = FunctionBind.apply(this, arguments);
   if (this.$$typeof === SERVER_REFERENCE_TAG) {
     const args = ArraySlice.call(arguments, 1);
-    newFn.$$typeof = SERVER_REFERENCE_TAG;
-    newFn.$$id = this.$$id;
-    newFn.$$bound = this.$$bound ? this.$$bound.concat(args) : args;
+    return Object.defineProperties((newFn: any), {
+      $$typeof: {value: SERVER_REFERENCE_TAG},
+      $$id: {value: this.$$id},
+      $$bound: {value: this.$$bound ? this.$$bound.concat(args) : args},
+      bind: {value: bind},
+    });
   }
   return newFn;
 }

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js
@@ -61,14 +61,17 @@ function registerClientReferenceImpl<T>(
 const FunctionBind = Function.prototype.bind;
 // $FlowFixMe[method-unbinding]
 const ArraySlice = Array.prototype.slice;
-function bind(this: ServerReference<any>) {
+function bind(this: ServerReference<any>): any {
   // $FlowFixMe[unsupported-syntax]
   const newFn = FunctionBind.apply(this, arguments);
   if (this.$$typeof === SERVER_REFERENCE_TAG) {
     const args = ArraySlice.call(arguments, 1);
-    newFn.$$typeof = SERVER_REFERENCE_TAG;
-    newFn.$$id = this.$$id;
-    newFn.$$bound = this.$$bound ? this.$$bound.concat(args) : args;
+    return Object.defineProperties((newFn: any), {
+      $$typeof: {value: SERVER_REFERENCE_TAG},
+      $$id: {value: this.$$id},
+      $$bound: {value: this.$$bound ? this.$$bound.concat(args) : args},
+      bind: {value: bind},
+    });
   }
   return newFn;
 }

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -1011,7 +1011,7 @@ describe('ReactFlightDOMBrowser', () => {
     const ClientRef = clientExports(Client);
 
     const stream = ReactServerDOMServer.renderToReadableStream(
-      <ClientRef action={greet.bind(null, 'Hello', 'World')} />,
+      <ClientRef action={greet.bind(null, 'Hello').bind(null, 'World')} />,
       webpackMap,
     );
 


### PR DESCRIPTION
Wasn't consistent. Probably should use a shared helper maybe.