### PR TITLE
Add sideEffects flag to react-is for tree shaking

### DIFF
--- a/packages/react-is/package.json
+++ b/packages/react-is/package.json
@@ -3,6 +3,7 @@
   "version": "18.2.0",
   "description": "Brand checking of React Elements.",
   "main": "index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/react.git",


### PR DESCRIPTION
## Summary

This PR:

- Adds the `"sideEffects": false` flag to the `react-is` package, to enable proper tree-shaking

## How did you test this change?

React-Redux v9 beta switches its artifacts from separate JS files to pre-bundled artifacts.  While testing builds locally, I noticed that our use of `react-is` was no longer getting tree-shaken from Vite builds, despite `react-is` only being used by our `connect` API and `connect` itself getting shaken out of the final bundle.

Hand-adding `"sideEffects": false` to the `react-is` package locally convinced Vite (+Rollup) to properly tree-shake `react-is` out of the bundle when it wasn't being used.

I'd love to see this published as v18.2.1 as soon as this PR is merged - we're hoping to release React-Redux v9 in the next few weeks!