### PR TITLE
Add a regression test for an infinite suspense + Fix

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -423,7 +423,9 @@ export function markStarvedLanesAsExpired(
   // We exclude retry lanes because those must always be time sliced, in order
   // to unwrap uncached promises.
   // TODO: Write a test for this
-  let lanes = pendingLanes & ~RetryLanes;
+  let lanes = enableRetryLaneExpiration
+    ? pendingLanes
+    : pendingLanes & ~RetryLanes;
   while (lanes > 0) {
     const index = pickArbitraryLaneIndex(lanes);
     const lane = 1 << index;

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -4008,4 +4008,76 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       );
     },
   );
+
+  // @gate enableLegacyCache
+  it('recurring updates in siblings should not block expensive content in suspense boundary from committing', async () => {
+    const {useState} = React;
+
+    let setText;
+    function UpdatingText() {
+      const [text, _setText] = useState('1');
+      setText = _setText;
+      return <Text text={text} />;
+    }
+
+    function ExpensiveText({text, ms}) {
+      Scheduler.log(text);
+      Scheduler.unstable_advanceTime(ms);
+      return <span prop={text} />;
+    }
+
+    function App() {
+      return (
+        <>
+          <UpdatingText />
+          <Suspense fallback={<Text text="Loading..." />}>
+            <AsyncText text="Async" />
+            <ExpensiveText text="A" ms={1000} />
+            <ExpensiveText text="B" ms={3999} />
+            <ExpensiveText text="C" ms={100000} />
+          </Suspense>
+        </>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    root.render(<App />);
+    await waitForAll(['1', 'Suspend! [Async]', 'Loading...']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span prop="1" />
+        <span prop="Loading..." />
+      </>,
+    );
+
+    await resolveText('Async');
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span prop="1" />
+        <span prop="Loading..." />
+      </>,
+    );
+
+    await waitFor(['Async', 'A', 'B']);
+    ReactNoop.expire(10000000);
+    await advanceTimers(10000000);
+    setText('2');
+    await waitForPaint(['2']);
+
+    await waitFor(['Async', 'A', 'B']);
+    ReactNoop.expire(10000000);
+    await advanceTimers(10000000);
+    setText('3');
+
+    // TODO: At this point we want "C" to commit
+    await waitForPaint(['3']);
+    await waitFor(['Async', 'A', 'B']);
+
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span prop="3" />
+        <span prop="Loading..." />
+      </>,
+    );
+  });
 });

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -5,7 +5,7 @@ let Scheduler;
 let act;
 let waitFor;
 let waitForAll;
-let unstable_waitForExpired;
+let waitForMicrotasks;
 let assertLog;
 let waitForPaint;
 let Suspense;
@@ -30,7 +30,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     waitFor = InternalTestUtils.waitFor;
     waitForAll = InternalTestUtils.waitForAll;
     waitForPaint = InternalTestUtils.waitForPaint;
-    unstable_waitForExpired = InternalTestUtils.unstable_waitForExpired;
+    waitForMicrotasks = InternalTestUtils.waitForMicrotasks;
     assertLog = InternalTestUtils.assertLog;
 
     getCacheForType = React.unstable_getCacheForType;
@@ -4011,8 +4011,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     },
   );
 
-  // @gate enableLegacyCache
-  // @gate enableRetryLaneExpiration
+  // @gate enableLegacyCache && enableRetryLaneExpiration
   it('recurring updates in siblings should not block expensive content in suspense boundary from committing', async () => {
     const {useState} = React;
 
@@ -4062,14 +4061,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     );
 
     await waitFor(['Async', 'A', 'B']);
-    ReactNoop.expire(10000000);
-    await advanceTimers(10000000);
+    ReactNoop.expire(100000);
+    await advanceTimers(100000);
     setText('2');
     await waitForPaint(['2']);
 
-    ReactNoop.expire(10000000);
-    await advanceTimers(10000000);
-    await unstable_waitForExpired(['Async', 'A', 'B', 'C']);
+    await waitForMicrotasks();
+    Scheduler.unstable_flushNumberOfYields(1);
+    assertLog(['Async', 'A', 'B', 'C']);
 
     expect(root).toMatchRenderedOutput(
       <>


### PR DESCRIPTION
Add a regression test for the [minimal repro](https://codesandbox.io/s/react-18-suspense-state-never-resolving-bug-hmlny5?file=/src/App.js) from @kassens 

And includes the fix from @acdlite: 
> This is another place we special-case Retry lanes to opt them out of
expiration. The reason is we rely on time slicing to unwrap uncached
promises (i.e. async functions during render). Since that ability is
still experimental, and enableRetryLaneExpiration is Meta-only, we can
remove the special case when enableRetryLaneExpiration is on, for now.