### PR TITLE
[Fizz] handle errors in `onHeaders`

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -6131,6 +6131,10 @@ export function emitEarlyPreloads(
   if (onHeaders) {
     const headers = renderState.headers;
     if (headers) {
+      // Even if onHeaders throws we don't want to call this again so
+      // we drop the headers state from this point onwards.
+      renderState.headers = null;
+
       let linkHeader = headers.preconnects;
       if (headers.fontPreloads) {
         if (linkHeader) {
@@ -6205,7 +6209,6 @@ export function emitEarlyPreloads(
         // it React will not provide any headers
         onHeaders({});
       }
-      renderState.headers = null;
       return;
     }
   }

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -3841,6 +3841,30 @@ describe('ReactDOMFizzServer', () => {
     });
   });
 
+  it('logs an error if onHeaders throws but continues the render', async () => {
+    const errors = [];
+    function onError(error) {
+      errors.push(error.message);
+    }
+
+    function onHeaders(x) {
+      throw new Error('bad onHeaders');
+    }
+
+    let pipe;
+    await act(() => {
+      ({pipe} = renderToPipeableStream(<div>hello</div>, {onHeaders, onError}));
+    });
+
+    expect(errors).toEqual(['bad onHeaders']);
+
+    await act(() => {
+      pipe(writable);
+    });
+
+    expect(getVisibleChildren(container)).toEqual(<div>hello</div>);
+  });
+
   describe('error escaping', () => {
     it('escapes error hash, message, and component stack values in directly flushed errors (html escaping)', async () => {
       window.__outlet = {};

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
@@ -1420,6 +1420,28 @@ describe('ReactDOMFizzStaticBrowser', () => {
     );
   });
 
+  // @gate experimental
+  it('logs an error if onHeaders throws but continues the prerender', async () => {
+    const errors = [];
+    function onError(error) {
+      errors.push(error.message);
+    }
+
+    function onHeaders(x) {
+      throw new Error('bad onHeaders');
+    }
+
+    const prerendered = await ReactDOMFizzStatic.prerender(<div>hello</div>, {
+      onHeaders,
+      onError,
+    });
+    expect(prerendered.postponed).toBe(null);
+    expect(errors).toEqual(['bad onHeaders']);
+
+    await readIntoContainer(prerendered.prelude);
+    expect(getVisibleChildren(container)).toEqual(<div>hello</div>);
+  });
+
   // @gate enablePostpone
   it('does not bootstrap again in a resume if it bootstraps', async () => {
     let prerendering = true;


### PR DESCRIPTION
`onHeaders` can throw however for now we can assume that headers are optimistic values since the only things we produce for them are preload links. This is a pragmatic decision because React could concievably have headers in the future which were not optimistic and thus non-optional however it is hard to imagine what these headers might be in practice. If we need to change this behavior to be fatal in the future it would be a breaking change.

This commit adds error logging when `onHeaders` throws and ensures the request can continue to render successfully.

