### PR TITLE
Update fork for ReactSharedInternalsClient export

### DIFF
--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -217,7 +217,7 @@ const forks = Object.freeze({
     }
   },
 
-  './packages/react/src/ReactSharedInternals.js': (bundleType, entry) => {
+  './packages/react/src/ReactSharedInternalsClient.js': (bundleType, entry) => {
     switch (bundleType) {
       case UMD_DEV:
       case UMD_PROD:


### PR DESCRIPTION
## Summary

After changes in https://github.com/facebook/react/pull/27436, UMD builds no longer expose Scheduler from ReactSharedInternals. This module is forked in rollup for UMD builds and the path no longer matches. This PR updates the path name to match the new module: ReactSharedInternalsClient. 

## How did you test this change?

- `yarn build`
- Inspect `react.development.js` UMD build, observe `Scheduler: Scheduler` is set in `ReactSharedInternals`, matching [18.2.0](https://unpkg.com/react@18.2.0/umd/react.development.js)
- ran attribute-behavior fixture app
- Observe no more error `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'unstable_cancelCallback')`
