### PR TITLE
Fix:- Replaced render with createRoot method to align with react-dom verison

### DIFF
--- a/fixtures/packaging/babel-standalone/dev.html
+++ b/fixtures/packaging/babel-standalone/dev.html
@@ -5,10 +5,8 @@
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
     <div id="container"></div>
     <script type="text/babel">
-      ReactDOM.render(
-        <h1>Hello World!</h1>,
-        document.getElementById('container')
-      );
+      ReactDOM.createRoot( document.getElementById('container')).render(
+      <h1>Hello World!</h1>)
     </script>
   </body>
 </html>


### PR DESCRIPTION
Seems weird to have the fixtures file using  `reactDOM.render()` since now we instead call `createRoot` method to instantiate  where to render.

also gets rid of the console error

@hoxyq #27717
just to ensure this file has no weird errors in future and can test stuff easily