### PR TITLE
Update .prettierrc.js

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -5,7 +5,7 @@ const {esNextPaths} = require('./scripts/shared/pathsByLanguageVersion');
 module.exports = {
   bracketSpacing: false,
   singleQuote: true,
-  jsxBracketSameLine: true,
+  bracketSameLine: true,
   trailingComma: 'es5',
   printWidth: 80,
   parser: 'flow',


### PR DESCRIPTION
jsxBracketSameLine deprecated in v2.4.0 of Prettier, replaced by bracketSameLine.

https://prettier.io/docs/en/options.html#deprecated-jsx-brackets

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

I've always wanted to contribute to open source, even if it's in the smallest way possible. Resolves deprecated feature with currently used version of Prettier (2.4+).  Those doing things like using React as a reference for their ".prettierrc" files will be using the non-deprecated versions.

## How did you test this change?

Modified line 969 of App.js to push </h1> to line 971, saved the file, then ran "yarn prettier" and formatting returned it to original position confirming that jsxBracketSameLine acts in the same fashion to bracketSameLine, but also is no longer deprecated that has additional features which may be useful in the future to the project.


<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

λ yarn prettier
yarn run v1.22.19
$ node ./scripts/prettier/index.js write-changed
> git merge-base HEAD main
> git diff --name-only --diff-filter=ACMRTUB bbb9cb116dbf7b6247721aa0c4bcb6ec249aa8af
> git ls-files --others --exclude-standard
Done in 1.52s.
