### PR TITLE
refactor[devtools]: highlight an array of elements for native

### DIFF
--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -283,3 +283,9 @@ export function gt(a: string = '', b: string = ''): boolean {
 export function gte(a: string = '', b: string = ''): boolean {
   return compareVersions(a, b) > -1;
 }
+
+export const isReactNativeEnvironment = (): boolean => {
+  // We've been relying on this for such a long time
+  // We should probably define the client for DevTools on the backend side and share it with the frontend
+  return window.document == null;
+};


### PR DESCRIPTION
We are currently just pass the first element, which diverges from the implementation for web. This is especially bad if you are inspecting something like a list, where host fiber can represent multiple elements.

This part runs on the backend of React DevTools, so it should not affect cases for React Native when frontend version can be more up-to-date than backend's. I will double-check it before merging.

Once version of `react-devtools-core` is updated in React Native, this should be supported, I will work on that later.