### PR TITLE
fix(dom): fix function error when element name is nodeName

### DIFF
--- a/packages/react-dom-bindings/src/events/plugins/ChangeEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/ChangeEventPlugin.js
@@ -80,7 +80,10 @@ let activeElementInst = null;
  * SECTION: handle `change` event
  */
 function shouldUseChangeEvent(elem: Instance | TextInstance) {
-  const nodeName = elem.nodeName && elem.nodeName.toLowerCase();
+  const nodeName =
+    elem.nodeName &&
+    typeof elem.nodeName === 'string' &&
+    elem.nodeName.toLowerCase();
   return (
     nodeName === 'select' ||
     (nodeName === 'input' && (elem: any).type === 'file')


### PR DESCRIPTION
## Summary
fix https://github.com/facebook/react/issues/23324

The `elem` itself of the `shouldUseChangeEvent` function in React is supposed to describe an element, and its `.nodeName` is the tag type of that element.
But if the label's name or id is named `nodeName`, then `elem.nodeName` hits the element called nodeName in the window. In this case,`elem.nodeName` is not a string, but an element, which does not have the `.toLowerCase()` method, resulting in an error.

## How did you test this change?
Determine the type of `elem.nodeName` before executing the `.toLowerCase()` method

Test Suites: 306 passed, 306 total
Tests:       32 skipped, 8057 passed, 8089 total
Snapshots:   177 passed, 177 total
Time:        474.908 s
