### PR TITLE
Add dynamic `disableModulePatternComponents` flag for native-fb

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -20,12 +20,13 @@ import typeof * as DynamicFlagsType from 'ReactNativeInternalFeatureFlags';
 // flag here but it won't be set to `true` in any of our test runs. Need to
 // update the test configuration.
 
-export const enableUseRefAccessWarning = __VARIANT__;
+export const alwaysThrottleRetries = __VARIANT__;
+export const disableModulePatternComponents = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const enableUnifiedSyncLane = __VARIANT__;
-export const alwaysThrottleRetries = __VARIANT__;
-export const useMicrotasksForSchedulingInFabric = __VARIANT__;
+export const enableUseRefAccessWarning = __VARIANT__;
 export const passChildrenWhenCloningPersistedNodes = __VARIANT__;
+export const useMicrotasksForSchedulingInFabric = __VARIANT__;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): DynamicFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -18,12 +18,13 @@ import * as dynamicFlags from 'ReactNativeInternalFeatureFlags';
 // We destructure each value before re-exporting to avoid a dynamic look-up on
 // the exports object every time a flag is read.
 export const {
-  enableUseRefAccessWarning,
+  alwaysThrottleRetries,
+  disableModulePatternComponents,
   enableDeferRootSchedulingToMicrotask,
   enableUnifiedSyncLane,
-  alwaysThrottleRetries,
-  useMicrotasksForSchedulingInFabric,
+  enableUseRefAccessWarning,
   passChildrenWhenCloningPersistedNodes,
+  useMicrotasksForSchedulingInFabric,
 } = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.
@@ -55,7 +56,6 @@ export const enableSuspenseCallback = false;
 export const disableLegacyContext = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
-export const disableModulePatternComponents = false;
 export const enableSuspenseAvoidThisFallback = false;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = true;

--- a/scripts/flow/xplat.js
+++ b/scripts/flow/xplat.js
@@ -8,10 +8,11 @@
  */
 
 declare module 'ReactNativeInternalFeatureFlags' {
-  declare export var enableUseRefAccessWarning: boolean;
+  declare export var alwaysThrottleRetries: boolean;
+  declare export var disableModulePatternComponents: boolean;
   declare export var enableDeferRootSchedulingToMicrotask: boolean;
   declare export var enableUnifiedSyncLane: boolean;
-  declare export var alwaysThrottleRetries: boolean;
-  declare export var useMicrotasksForSchedulingInFabric: boolean;
+  declare export var enableUseRefAccessWarning: boolean;
   declare export var passChildrenWhenCloningPersistedNodes: boolean;
+  declare export var useMicrotasksForSchedulingInFabric: boolean;
 }


### PR DESCRIPTION
Makes `disableModulePatternComponents` a flag to allow us a slow rollout for RN internally.