### PR TITLE
reduntant message word in file CheckStringCoercion under the shared p…

### DIFF
--- a/packages/shared/CheckStringCoercion.js
+++ b/packages/shared/CheckStringCoercion.js
@@ -12,7 +12,7 @@
  * and Temporal.* types. See https://github.com/facebook/react/pull/22064.
  *
  * The functions in this module will throw an easier-to-understand,
- * easier-to-debug exception with a clear errors message message explaining the
+ * easier-to-debug exception with a clear errors message explaining the
  * problem. (Instead of a confusing exception thrown inside the implementation
  * of the `value` object).
  */


### PR DESCRIPTION
Remove 'message' word from "easier-to-debug exception with a clear errors message message explaining the", since it's redundant.
