### PR TITLE
Rename fork ReactSharedInternals -> ReactSharedInternalsClient

### DIFF
--- a/packages/react/src/forks/ReactSharedInternalsClient.umd.js
+++ b/packages/react/src/forks/ReactSharedInternalsClient.umd.js
@@ -15,7 +15,7 @@ import ReactCurrentBatchConfig from '../ReactCurrentBatchConfig';
 import {enableServerContext} from 'shared/ReactFeatureFlags';
 import {ContextRegistry} from '../ReactServerContextRegistry';
 
-const ReactSharedInternals = {
+const ReactSharedInternalsClient = {
   ReactCurrentDispatcher,
   ReactCurrentCache,
   ReactCurrentOwner,
@@ -30,12 +30,12 @@ const ReactSharedInternals = {
 };
 
 if (__DEV__) {
-  ReactSharedInternals.ReactCurrentActQueue = ReactCurrentActQueue;
-  ReactSharedInternals.ReactDebugCurrentFrame = ReactDebugCurrentFrame;
+  ReactSharedInternalsClient.ReactCurrentActQueue = ReactCurrentActQueue;
+  ReactSharedInternalsClient.ReactDebugCurrentFrame = ReactDebugCurrentFrame;
 }
 
 if (enableServerContext) {
-  ReactSharedInternals.ContextRegistry = ContextRegistry;
+  ReactSharedInternalsClient.ContextRegistry = ContextRegistry;
 }
 
-export default ReactSharedInternals;
+export default ReactSharedInternalsClient;

--- a/packages/scheduler/src/__tests__/SchedulerUMDBundle-test.internal.js
+++ b/packages/scheduler/src/__tests__/SchedulerUMDBundle-test.internal.js
@@ -43,7 +43,7 @@ describe('Scheduling UMD bundle', () => {
     const umdAPIProd = require('../../npm/umd/scheduler.production.min');
     const umdAPIProfiling = require('../../npm/umd/scheduler.profiling.min');
     const secretAPI =
-      require('react/src/forks/ReactSharedInternals.umd').default;
+      require('react/src/forks/ReactSharedInternalsClient.umd').default;
     validateForwardedAPIs(api, [
       umdAPIDev,
       umdAPIProd,

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -225,7 +225,7 @@ const forks = Object.freeze({
       case UMD_DEV:
       case UMD_PROD:
       case UMD_PROFILING:
-        return './packages/react/src/forks/ReactSharedInternals.umd.js';
+        return './packages/react/src/forks/ReactSharedInternalsClient.umd.js';
       default:
         return null;
     }


### PR DESCRIPTION
## Summary

Follow up from #27717 based on feedback to rename the fork module itself

## How did you test this change?

- `yarn build`
- `yarn test packages/scheduler/src/__tests__/SchedulerUMDBundle-test.internal.js`