### PR TITLE
[lint] move use lint to non-experimental

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -479,6 +479,45 @@ const tests = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        function App() {
+          const text = use(Promise.resolve('A'));
+          return <Text text={text} />
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function App() {
+          if (shouldShowText) {
+            const text = use(query);
+            return <Text text={text} />
+          }
+          return <Text text={shouldFetchBackupText ? use(backupQuery) : "Nothing to see here"} />
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function App() {
+          let data = [];
+          for (const query of queries) {
+            const text = use(item);
+            data.push(text);
+          }
+          return <Child data={data} />
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function App() {
+          const data = someCallback((x) => use(x));
+          return <Child data={data} />
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -1058,6 +1097,58 @@ const tests = {
       `,
       errors: [asyncComponentHookError('useState')],
     },
+    {
+      code: normalizeIndent`
+        Hook.use();
+        Hook._use();
+        Hook.useState();
+        Hook._useState();
+        Hook.use42();
+        Hook.useHook();
+        Hook.use_hook();
+      `,
+      errors: [
+        topLevelError('Hook.use'),
+        topLevelError('Hook.useState'),
+        topLevelError('Hook.use42'),
+        topLevelError('Hook.useHook'),
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function notAComponent() {
+          use(promise);
+        }
+      `,
+      errors: [functionError('use', 'notAComponent')],
+    },
+    {
+      code: normalizeIndent`
+        const text = use(promise);
+        function App() {
+          return <Text text={text} />
+        }
+      `,
+      errors: [topLevelError('use')],
+    },
+    {
+      code: normalizeIndent`
+        class C {
+          m() {
+            use(promise);
+          }
+        }
+      `,
+      errors: [classError('use')],
+    },
+    {
+      code: normalizeIndent`
+        async function AsyncComponent() {
+          use();
+        }
+      `,
+      errors: [asyncComponentHookError('use')],
+    },
   ],
 };
 
@@ -1159,45 +1250,6 @@ if (__EXPERIMENTAL__) {
         }
       `,
     },
-    {
-      code: normalizeIndent`
-        function App() {
-          const text = use(Promise.resolve('A'));
-          return <Text text={text} />
-        }
-      `,
-    },
-    {
-      code: normalizeIndent`
-        function App() {
-          if (shouldShowText) {
-            const text = use(query);
-            return <Text text={text} />
-          }
-          return <Text text={shouldFetchBackupText ? use(backupQuery) : "Nothing to see here"} />
-        }
-      `,
-    },
-    {
-      code: normalizeIndent`
-        function App() {
-          let data = [];
-          for (const query of queries) {
-            const text = use(item);
-            data.push(text);
-          }
-          return <Child data={data} />
-        }
-      `,
-    },
-    {
-      code: normalizeIndent`
-        function App() {
-          const data = someCallback((x) => use(x));
-          return <Child data={data} />
-        }
-      `,
-    },
   ];
   tests.invalid = [
     ...tests.invalid,
@@ -1271,58 +1323,6 @@ if (__EXPERIMENTAL__) {
         }
       `,
       errors: [useEffectEventError('onClick')],
-    },
-    {
-      code: normalizeIndent`
-        Hook.use();
-        Hook._use();
-        Hook.useState();
-        Hook._useState();
-        Hook.use42();
-        Hook.useHook();
-        Hook.use_hook();
-      `,
-      errors: [
-        topLevelError('Hook.use'),
-        topLevelError('Hook.useState'),
-        topLevelError('Hook.use42'),
-        topLevelError('Hook.useHook'),
-      ],
-    },
-    {
-      code: normalizeIndent`
-        function notAComponent() {
-          use(promise);
-        }
-      `,
-      errors: [functionError('use', 'notAComponent')],
-    },
-    {
-      code: normalizeIndent`
-        const text = use(promise);
-        function App() {
-          return <Text text={text} />
-        }
-      `,
-      errors: [topLevelError('use')],
-    },
-    {
-      code: normalizeIndent`
-        class C {
-          m() {
-            use(promise);
-          }
-        }
-      `,
-      errors: [classError('use')],
-    },
-    {
-      code: normalizeIndent`
-        async function AsyncComponent() {
-          use();
-        }
-      `,
-      errors: [asyncComponentHookError('use')],
     },
   ];
 }

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -16,10 +16,7 @@
  */
 
 function isHookName(s) {
-  if (__EXPERIMENTAL__) {
-    return s === 'use' || /^use[A-Z0-9]/.test(s);
-  }
-  return /^use[A-Z0-9]/.test(s);
+  return s === 'use' || /^use[A-Z0-9]/.test(s);
 }
 
 /**
@@ -111,10 +108,7 @@ function isUseEffectEventIdentifier(node) {
 }
 
 function isUseIdentifier(node) {
-  if (__EXPERIMENTAL__) {
-    return node.type === 'Identifier' && node.name === 'use';
-  }
-  return false;
+  return node.type === 'Identifier' && node.name === 'use';
 }
 
 export default {


### PR DESCRIPTION
`use` is being stabilized, so let's make sure the lint is updated for the next release.