### PR TITLE
Fix useSyncExternalStoreWithSelector to not call selectors when snapshot hasn't changed

### DIFF
--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
@@ -651,9 +651,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
     const container = document.createElement('div');
     const root = createRoot(container);
     await act(() => root.render(<App />));
-
     assertLog(['App', 'Selector', 'A0']);
-    expect(container.textContent).toEqual('A0');
 
     await act(() => store.set(store.getState()));
     await act(() => store.set({a: 0}));

--- a/packages/use-sync-external-store/src/useSyncExternalStoreWithSelector.js
+++ b/packages/use-sync-external-store/src/useSyncExternalStoreWithSelector.js
@@ -93,6 +93,7 @@ export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
       // to React that the selections are conceptually equal, and we can bail
       // out of rendering.
       if (isEqual !== undefined && isEqual(prevSelection, nextSelection)) {
+        memoizedSnapshot = nextSnapshot;
         return prevSelection;
       }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Current implementation of `useSyncExternalStoreWithSelector` calls selectors even if snapshot hasn't changed.

## Details

Up to 50% of all dispatched actions in the apps that use `redux-saga` or `redux-thunk` could be ones that don't change the redux state but start some async logic.

Current `redux` implementation notifies listeners when any action is called, even if it does not change the state, and this behavior [won't change](https://github.com/reduxjs/redux/pull/4627).

Current `react-redux` implementation uses `useSyncExternalStoreWithSelector` from React, which [notifies](https://github.com/reduxjs/react-redux/issues/2089) subscribers for each such action even if state hasn't changed, causing all active selectors to be re-evaluated, which is actually a bug of `useSyncExternalStoreWithSelector`.

In huge apps there can be hundreds of subscribed selectors and dozens of actions per second, so this leads to additional CPU usage for no good reason. Especially noticable in `react-native` apps on old android devices.

## How did you test this change?

I added a test which fails in current version, and fixed it:

```javascript
    ...

    const container = document.createElement('div');
    const root = createRoot(container);
    await act(() => root.render(<App />));
    assertLog(['App', 'Selector', 'A0']);

    await act(() => store.set(store.getState()));
    await act(() => store.set({a: 0}));
    assertLog(['Selector']);

    await act(() => store.set(store.getState()));
    await act(() => store.set(store.getState()));
    assertLog([]);  // without the fix here we got ["Selector", "Selector"]
```
