### PR TITLE
feat[Fabric/Paper]: support isChildPublicInstance api method

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -39,6 +39,7 @@ import {
   dispatchCommand,
   sendAccessibilityEvent,
   getNodeFromInternalInstanceHandle,
+  isChildPublicInstance,
 } from './ReactNativePublicCompat';
 import {getPublicInstanceFromInternalInstanceHandle} from './ReactFiberConfigFabric';
 
@@ -128,6 +129,8 @@ export {
   // instance handles we use to dispatch events. This provides a way to access
   // the public instances we created from them (potentially created lazily).
   getPublicInstanceFromInternalInstanceHandle,
+  // DEV-only:
+  isChildPublicInstance,
 };
 
 injectIntoDevTools({

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -44,6 +44,7 @@ import {
   findNodeHandle,
   dispatchCommand,
   sendAccessibilityEvent,
+  isChildPublicInstance,
 } from './ReactNativePublicCompat';
 
 // $FlowFixMe[missing-local-annot]
@@ -137,6 +138,8 @@ export {
   // This export is typically undefined in production builds.
   // See the "enableGetInspectorDataForInstanceInProduction" flag.
   getInspectorDataForInstance,
+  // DEV-only:
+  isChildPublicInstance,
 };
 
 injectIntoDevTools({

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -159,6 +159,9 @@ declare module 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface'
   declare export function createPublicTextInstance(
     internalInstanceHandle: mixed,
   ): PublicTextInstance;
+  declare export function getInternalInstanceHandleFromPublicInstance(
+    publicInstance: PublicInstance,
+  ): ?Object;
 }
 
 declare module 'react-native/Libraries/ReactPrivate/ReactNativePrivateInitializeCore' {


### PR DESCRIPTION
Adds `isChildPublicInstance` method to both renderers (Fabric and Paper), which will receive 2 public instances and return if first argument is an ancestor of the second, based on fibers.

This will be used as a fallback when DOM node APIs are not available: for Paper renderer or for Fabric without DOM node APIs.

How it is going to be used: to determine which `AppContainer` component in RN is responsible for highlighting an inspected element on the screen.