### PR TITLE
convert circleci workflow devtools_regression_tests to github actions

### DIFF
--- a/.github/workflows/devtools_regression_tests.yml
+++ b/.github/workflows/devtools_regression_tests.yml
@@ -1,0 +1,137 @@
+name: facebook/react/devtools_regression_tests
+on:
+  schedule:
+  - cron: 0 0 * * *
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      prerelease_commit_sha:
+        required: false
+jobs:
+  download_build:
+    if: inputs.prerelease_commit_sha ==''
+    runs-on: ubuntu-latest
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+      revision: "${{ github.sha }}"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'yarn'
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+      env:
+        ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+      shell: bash
+    - name: Download artifacts for revision
+      run: |-
+        git fetch origin main
+        cd ./scripts/release && yarn && cd ../../
+        scripts/release/download-experimental-build.js --commit=${{ env.revision }} --allowBrokenCI
+    - uses: actions/upload-artifact@v3.1.3
+      with:
+        path: build
+  build_devtools_and_process_artifacts:
+    if: inputs.prerelease_commit_sha ==''
+    runs-on: ubuntu-latest
+    needs:
+    - download_build
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'yarn'
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: build
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+      env:
+        ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+      shell: bash
+    - run: "./scripts/circleci/pack_and_store_devtools_artifacts.sh"
+      env:
+        RELEASE_CHANNEL: experimental
+    - uses: actions/upload-artifact@v3.1.3
+      with:
+        path: build/devtools.tgz
+  run_devtools_tests_for_versions:
+    if: inputs.prerelease_commit_sha ==''
+    runs-on: ubuntu-latest
+    needs:
+    - build_devtools_and_process_artifacts
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    strategy:
+      matrix:
+        version:
+        - '16.0'
+        - '16.5'
+        - '16.8'
+        - '17.0'
+        - '18.0'
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'yarn'
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: build
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+      env:
+        ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+      shell: bash
+    - run: "./scripts/circleci/download_devtools_regression_build.js ${{ matrix.version }} --replaceBuild"
+    - run: node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion ${{ matrix.version }} --ci
+  run_devtools_e2e_tests_for_versions:
+    if: inputs.prerelease_commit_sha ==''
+    runs-on: ubuntu-latest
+    needs:
+    - build_devtools_and_process_artifacts
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    strategy:
+      matrix:
+        version:
+        - '16.0'
+        - '16.5'
+        - '16.8'
+        - '17.0'
+        - '18.0'
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'yarn'
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: "."
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+      env:
+        ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+      shell: bash
+    - name: Playwright install deps
+      run: |-
+        npx playwright install
+        sudo npx playwright install-deps
+    - run: "./scripts/circleci/download_devtools_regression_build.js ${{ matrix.version }}"
+    - run: "./scripts/circleci/run_devtools_e2e_tests.js ${{ matrix.version }}"
+      env:
+        RELEASE_CHANNEL: experimental
+    - name: Cleanup build regression folder
+      run: rm -r ./build-regression
+    - uses: actions/upload-artifact@v3.1.3
+      with:
+        path: tmp/screenshots


### PR DESCRIPTION
## Summary

This pull request converts the CircleCI workflows to GitHub actions workflows. [Github Actions Importer](https://github.com/github/gh-actions-importer) was used to convert the workflows initially, then I edited them manually to correct errors in translation.  

**Issues**
1. facebook/react/devtools_regression_tests  
The scripts that this workflow calls need to be modified.

## How did you test this change?

I tested these changes in a forked repo. You can [view the logs of this workflow in my fork](https://github.com/robandpdx/react/actions).

https://fburl.com/workplace/f6mz6tmw
