### PR TITLE
Update act references in tests

### DIFF
--- a/fixtures/dom/src/__tests__/nested-act-test.js
+++ b/fixtures/dom/src/__tests__/nested-act-test.js
@@ -20,7 +20,7 @@ describe('unmocked scheduler', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
-    DOMAct = require('react-dom/test-utils').act;
+    DOMAct = React.unstable_act;
     TestRenderer = require('react-test-renderer');
     TestAct = TestRenderer.act;
   });
@@ -61,7 +61,7 @@ describe('mocked scheduler', () => {
       require.requireActual('scheduler/unstable_mock')
     );
     React = require('react');
-    DOMAct = require('react-dom/test-utils').act;
+    DOMAct = React.unstable_act;
     TestRenderer = require('react-test-renderer');
     TestAct = TestRenderer.act;
   });

--- a/packages/react-devtools-shared/src/__tests__/utils.js
+++ b/packages/react-devtools-shared/src/__tests__/utils.js
@@ -19,7 +19,7 @@ export function act(
   recursivelyFlush: boolean = true,
 ): void {
   const {act: actTestRenderer} = require('react-test-renderer');
-  const {act: actDOM} = require('react-dom/test-utils');
+  const actDOM = require('react').unstable_act;
 
   actDOM(() => {
     actTestRenderer(() => {
@@ -44,7 +44,7 @@ export async function actAsync(
   recursivelyFlush: boolean = true,
 ): Promise<void> {
   const {act: actTestRenderer} = require('react-test-renderer');
-  const {act: actDOM} = require('react-dom/test-utils');
+  const actDOM = require('react').unstable_act;
 
   await actDOM(async () => {
     await actTestRenderer(async () => {

--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -25,7 +25,7 @@ describe('ReactDOMServerHydration', () => {
     React = require('react');
     ReactDOMClient = require('react-dom/client');
     ReactDOMServer = require('react-dom/server');
-    act = require('react-dom/test-utils').act;
+    act = React.unstable_act;
 
     console.error = jest.fn();
     container = document.createElement('div');

--- a/packages/react-dom/src/__tests__/ReactTestUtilsActUnmockedScheduler-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsActUnmockedScheduler-test.js
@@ -37,7 +37,7 @@ beforeEach(() => {
   yields = [];
   React = require('react');
   ReactDOM = require('react-dom');
-  act = require('react-dom/test-utils').act;
+  act = React.unstable_act;
   container = document.createElement('div');
   document.body.appendChild(container);
 });

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -34,7 +34,7 @@ describe('ReactFresh', () => {
       ReactDOM = require('react-dom');
       ReactDOMClient = require('react-dom/client');
       Scheduler = require('scheduler');
-      act = require('react-dom/test-utils').act;
+      act = React.unstable_act;
       internalAct = require('internal-test-utils').act;
 
       const InternalTestUtils = require('internal-test-utils');
@@ -3792,7 +3792,7 @@ describe('ReactFresh', () => {
       React = require('react');
       ReactDOM = require('react-dom');
       Scheduler = require('scheduler');
-      act = require('react-dom/test-utils').act;
+      act = React.unstable_act;
       internalAct = require('internal-test-utils').act;
 
       // Important! Inject into the global hook *after* ReactDOM runs:

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -31,7 +31,7 @@ describe('ReactFreshIntegration', () => {
       ReactFreshRuntime = require('react-refresh/runtime');
       ReactFreshRuntime.injectIntoGlobalHook(global);
       ReactDOM = require('react-dom');
-      act = require('react-dom/test-utils').act;
+      act = React.unstable_act;
       container = document.createElement('div');
       document.body.appendChild(container);
       exportsObj = undefined;

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMForm-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMForm-test.js
@@ -54,7 +54,7 @@ describe('ReactFlightDOMForm', () => {
     ReactServerDOMClient = require('react-server-dom-webpack/client.edge');
     ReactDOMServer = require('react-dom/server.edge');
     ReactDOMClient = require('react-dom/client');
-    act = require('react-dom/test-utils').act;
+    act = React.unstable_act;
     useFormState = require('react-dom').useFormState;
     container = document.createElement('div');
     document.body.appendChild(container);


### PR DESCRIPTION
As part of the process of removing the deprecated `react-dom/test-utils` package references to `act` from this module are replaced with references to `unstable_act` in `react`. It is likely that the unstable act implementation will be made stable. The test utils act is just a reexport of the unstable_act implementation in react itself.
