### PR TITLE
Enable flag disableModulePatternComponents for native-fb

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -21,7 +21,6 @@ import typeof * as DynamicFlagsType from 'ReactNativeInternalFeatureFlags';
 // update the test configuration.
 
 export const alwaysThrottleRetries = __VARIANT__;
-export const disableModulePatternComponents = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const enableUnifiedSyncLane = __VARIANT__;
 export const enableUseRefAccessWarning = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -19,7 +19,6 @@ import * as dynamicFlags from 'ReactNativeInternalFeatureFlags';
 // the exports object every time a flag is read.
 export const {
   alwaysThrottleRetries,
-  disableModulePatternComponents,
   enableDeferRootSchedulingToMicrotask,
   enableUnifiedSyncLane,
   enableUseRefAccessWarning,
@@ -28,6 +27,7 @@ export const {
 } = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.
+export const disableModulePatternComponents = true;
 export const enableDebugTracing = false;
 export const enableSchedulingProfiler = __PROFILE__;
 export const enableProfilerTimer = __PROFILE__;

--- a/scripts/flow/xplat.js
+++ b/scripts/flow/xplat.js
@@ -9,7 +9,6 @@
 
 declare module 'ReactNativeInternalFeatureFlags' {
   declare export var alwaysThrottleRetries: boolean;
-  declare export var disableModulePatternComponents: boolean;
   declare export var enableDeferRootSchedulingToMicrotask: boolean;
   declare export var enableUnifiedSyncLane: boolean;
   declare export var enableUseRefAccessWarning: boolean;


### PR DESCRIPTION
#27742 will remove this feature flag altogether, this just already removes the dynamic flag for the Meta React Native build ahead of time.