### PR TITLE
Remove WARNINGS file from FB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,7 @@ jobs:
       - run:
           command: |
             mkdir -p ./build/__test_utils__
-            node ./scripts/print-warnings/print-warnings.js > build/WARNINGS
-            node ./scripts/print-warnings/print-warnings.js --js > build/__test_utils__/ReactAllWarnings.js
+            node ./scripts/print-warnings/print-warnings.js > build/__test_utils__/ReactAllWarnings.js
       - persist_to_workspace:
           root: .
           paths:

--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -123,9 +123,8 @@ jobs:
           mkdir ./compiled
           mv build/facebook-www ./compiled
 
-          # Move WARNINGS to facebook-www
+          # Move ReactAllWarnings.js to facebook-www
           mkdir ./compiled/facebook-www/__test_utils__
-          mv build/WARNINGS ./compiled/facebook-www/WARNINGS
           mv build/__test_utils__/ReactAllWarnings.js ./compiled/facebook-www/__test_utils__/ReactAllWarnings.js
 
           # Move eslint-plugin-react-hooks into facebook-www

--- a/scripts/print-warnings/print-warnings.js
+++ b/scripts/print-warnings/print-warnings.js
@@ -75,11 +75,10 @@ gs([
   '!**/node_modules/**/*.js',
 ]).pipe(
   through.obj(transform, cb => {
-    if (process.argv[2] === '--js') {
-      const warningsArray = Array.from(warnings);
-      warningsArray.sort();
-      process.stdout.write(
-        `/**
+    const warningsArray = Array.from(warnings);
+    warningsArray.sort();
+    process.stdout.write(
+      `/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
@@ -92,14 +91,7 @@ gs([
 
 export default ${JSON.stringify(warningsArray, null, 2)};
 `
-      );
-    } else {
-      process.stdout.write(
-        Array.from(warnings, warning => JSON.stringify(warning))
-          .sort()
-          .join('\n') + '\n'
-      );
-    }
+    );
     cb();
   })
 );


### PR DESCRIPTION
The test was migrated to the generated JS file that allows Jest to track the dependencies, we can now remove this file generation.