### PR TITLE
enable isInputPending in Scheduler

### DIFF
--- a/packages/scheduler/src/SchedulerFeatureFlags.js
+++ b/packages/scheduler/src/SchedulerFeatureFlags.js
@@ -8,12 +8,9 @@
  */
 
 export const enableSchedulerDebugging = false;
-export const enableIsInputPending = false;
 export const enableProfiling = false;
-export const enableIsInputPendingContinuous = false;
 export const frameYieldMs = 5;
-export const continuousYieldMs = 50;
-export const maxYieldMs = 300;
+export const maxYieldMs = 10;
 
 export const userBlockingPriorityTimeout = 250;
 export const normalPriorityTimeout = 5000;

--- a/packages/scheduler/src/__tests__/Scheduler-test.js
+++ b/packages/scheduler/src/__tests__/Scheduler-test.js
@@ -342,12 +342,7 @@ describe('SchedulerBrowser', () => {
       // Even though there's no input, eventually Scheduler will yield
       // regardless in case there's a pending main thread task we don't know
       // about, like a network event.
-      gate(flags =>
-        flags.enableIsInputPending
-          ? 'Yield at 10ms'
-          : // When isInputPending is disabled, we always yield quickly
-            'Yield at 5ms',
-      ),
+      'Yield at 10ms',
     ]);
 
     runtime.resetTime();
@@ -396,12 +391,7 @@ describe('SchedulerBrowser', () => {
         // Even though there's no input, eventually Scheduler will yield
         // regardless in case there's a pending main thread task we don't know
         // about, like a network event.
-        gate(flags =>
-          flags.enableIsInputPending
-            ? 'Yield at 10ms'
-            : // When isInputPending is disabled, we always yield quickly
-              'Yield at 5ms',
-        ),
+        'Yield at 10ms',
       ]);
 
       runtime.resetTime();
@@ -421,12 +411,7 @@ describe('SchedulerBrowser', () => {
         'Task with continuous input',
         // This time we yielded quickly to unblock the continuous event. But not
         // as quickly as for a discrete event.
-        gate(flags =>
-          flags.enableIsInputPending
-            ? 'Yield at 10ms'
-            : // When isInputPending is disabled, we always yield quickly
-              'Yield at 5ms',
-        ),
+        'Yield at 10ms',
         'Continuous Event',
       ]);
     },
@@ -448,16 +433,7 @@ describe('SchedulerBrowser', () => {
     runtime.assertLog(['Post Message']);
 
     runtime.fireMessageEvent();
-    runtime.assertLog([
-      'Message Event',
-      'Task with no paint',
-      gate(flags =>
-        flags.enableIsInputPending
-          ? 'Yield at 10ms'
-          : // When isInputPending is disabled, we always yield quickly
-            'Yield at 5ms',
-      ),
-    ]);
+    runtime.assertLog(['Message Event', 'Task with no paint', 'Yield at 10ms']);
 
     runtime.resetTime();
 

--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
@@ -20,8 +20,5 @@ export const {
 export const enableSchedulerDebugging = true;
 export const enableProfiling: boolean =
   __PROFILE__ && enableProfilingFeatureFlag;
-export const enableIsInputPending = true;
-export const enableIsInputPendingContinuous = true;
 export const frameYieldMs = 5;
-export const continuousYieldMs = 10;
 export const maxYieldMs = 10;

--- a/scripts/jest/setupTests.www.js
+++ b/scripts/jest/setupTests.www.js
@@ -30,8 +30,6 @@ jest.mock('scheduler/src/SchedulerFeatureFlags', () => {
 
   // These flags are not a dynamic on www, but we still want to run
   // tests in both versions.
-  actual.enableIsInputPending = __VARIANT__;
-  actual.enableIsInputPendingContinuous = __VARIANT__;
   actual.enableProfiling = __VARIANT__;
   actual.enableSchedulerDebugging = __VARIANT__;
 


### PR DESCRIPTION
## Summary

This has been enabled at Meta for some time, but it looks like the changes were never published here. Enables isInputPending at a `maxYieldMs` of 10ms. Removes `enableIsInputPendingContinuous` flag and its corresponding yield interval, as we ended up landing on a configuration where it never got used.

## How did you test this change?
`yarn test packages/scheduler/src/__tests__/Scheduler-test.js`