### PR TITLE
feat:-test added to rcDOM for more coverage

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -482,6 +482,27 @@ describe('ReactDOMRoot', () => {
     );
   });
 
+  it('return ReactDOMRoot if container is element', () => {
+    const root = ReactDOMClient.createRoot(document.createElement('div'));
+    expect(root._internalRoot.containerInfo.constructor.name).toEqual(
+      'HTMLDivElement',
+    );
+  });
+
+  it('return ReactDOMRoot if container is document', () => {
+    const root = ReactDOMClient.createRoot(new Document());
+    expect(root._internalRoot.containerInfo.constructor.name).toEqual(
+      'Document',
+    );
+  });
+
+  it('return ReactDOMRoot if container is documentFragment', () => {
+    const root = ReactDOMClient.createRoot(new DocumentFragment());
+    expect(root._internalRoot.containerInfo.constructor.name).toEqual(
+      'DocumentFragment',
+    );
+  });
+
   // @gate disableCommentsAsDOMContainers
   it('errors if container is a comment node', () => {
     // This is an old feature used by www. Disabled in the open source build.


### PR DESCRIPTION
few test added to `reactDOMRoot` container on few cases
checking around:-
1. `container` being an `element` node
2. `container` being a `document` node
3.  `container` being a  `documentFragment` node