### PR TITLE
Export unstable_useMemoCache from ReactSharedSubset

### DIFF
--- a/packages/react/src/ReactSharedSubset.js
+++ b/packages/react/src/ReactSharedSubset.js
@@ -37,4 +37,5 @@ export {
   useDebugValue,
   useMemo,
   version,
+  unstable_useMemoCache,
 } from './React';

--- a/packages/react/src/ReactSharedSubset.js
+++ b/packages/react/src/ReactSharedSubset.js
@@ -37,5 +37,4 @@ export {
   useDebugValue,
   useMemo,
   version,
-  unstable_useMemoCache,
 } from './React';

--- a/packages/react/src/ReactSharedSubsetFB.js
+++ b/packages/react/src/ReactSharedSubsetFB.js
@@ -8,4 +8,5 @@
  */
 
 export * from './ReactSharedSubset';
+export {unstable_useMemoCache} from './React';
 export {jsx, jsxs, jsxDEV} from './jsx/ReactJSX';


### PR DESCRIPTION
Expose `unstable_useMemoCache` on `ReactSharedSubsetFB` in cases where forget is applied to RSC.