### PR TITLE
Disable legacy context

### DIFF
--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -1112,6 +1112,7 @@ describe('ReactComponentLifeCycle', () => {
   });
 
   if (!require('shared/ReactFeatureFlags').disableModulePatternComponents) {
+    // @gate !disableLegacyContext
     it('calls effects on module-pattern component', async () => {
       const log = [];
 

--- a/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
@@ -832,6 +832,7 @@ describe('ReactLegacyErrorBoundaries', () => {
   });
 
   if (!require('shared/ReactFeatureFlags').disableModulePatternComponents) {
+    // @gate !disableLegacyContext
     // @gate !disableLegacyMode
     it('renders an error state if module-style context provider throws in componentWillMount', () => {
       function BrokenComponentWillMountWithContext() {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1755,6 +1755,7 @@ describe('ReactIncrementalErrorHandling', () => {
   });
 
   // @gate !disableModulePatternComponents
+  // @gate !disableLegacyContext
   it('handles error thrown inside getDerivedStateFromProps of a module-style context provider', async () => {
     function Provider() {
       return {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -140,8 +140,8 @@ export const transitionLaneExpirationMs = 5000;
 // -----------------------------------------------------------------------------
 const __NEXT_MAJOR__ = __EXPERIMENTAL__;
 
-// Not ready to break experimental yet.
-export const disableLegacyContext = false;
+// Removes legacy style context
+export const disableLegacyContext = __NEXT_MAJOR__;
 
 // Not ready to break experimental yet.
 // Disable javascript: URL strings in href for XSS protection.

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -33,7 +33,6 @@ export const disableIEWorkarounds = true;
 export const enableScopeAPI = false;
 export const enableCreateEventHandleAPI = false;
 export const enableSuspenseCallback = false;
-export const disableLegacyContext = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
 export const disableModulePatternComponents = false;
@@ -100,6 +99,7 @@ export const disableStringRefs = __NEXT_MAJOR__;
 export const enableReactTestRendererWarning = false;
 export const enableBigIntSupport = __NEXT_MAJOR__;
 export const disableLegacyMode = __NEXT_MAJOR__;
+export const disableLegacyContext = __NEXT_MAJOR__;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);


### PR DESCRIPTION
Disables legacy context for the next major release. These have been deprecated for a long time now and have been warning.