### PR TITLE
[RSC @ Meta] Simplify implementation of isClientReference, getClientReferenceKey, resolveClientReferenceMetadata

### DIFF
--- a/packages/react-server-dom-fb/src/ReactFlightDOMServerFB.js
+++ b/packages/react-server-dom-fb/src/ReactFlightDOMServerFB.js
@@ -28,7 +28,7 @@ import {setByteLengthOfChunkImplementation} from 'react-server/src/ReactServerSt
 export {
   getRequestedClientReferencesKeys,
   clearRequestedClientReferencesKeysSet,
-  setClientReferenceInterface,
+  setClientReferenceImplementation,
 } from './ReactFlightReferencesFB';
 
 type Options = {

--- a/packages/react-server-dom-fb/src/ReactFlightDOMServerFB.js
+++ b/packages/react-server-dom-fb/src/ReactFlightDOMServerFB.js
@@ -14,7 +14,7 @@ import type {
   PrecomputedChunk,
 } from 'react-server/src/ReactServerStreamConfig';
 
-import {setClientReferenceImplementation} from './ReactFlightReferencesFB';
+import {setCheckIsClientReference} from './ReactFlightReferencesFB';
 
 import {
   createRequest,
@@ -27,7 +27,7 @@ import {setByteLengthOfChunkImplementation} from 'react-server/src/ReactServerSt
 export {
   getRequestedClientReferencesKeys,
   clearRequestedClientReferencesKeysSet,
-  setClientReferenceImplementation,
+  setCheckIsClientReference,
 } from './ReactFlightReferencesFB';
 
 type Options = {
@@ -55,14 +55,14 @@ function renderToDestination(
 
 type Config = {
   byteLength: (chunk: Chunk | PrecomputedChunk) => number,
-  ClientReferenceImplementation: {...},
+  isClientReference: (reference: mixed) => boolean,
 };
 
 let configured = false;
 
 function setConfig(config: Config): void {
   setByteLengthOfChunkImplementation(config.byteLength);
-  setClientReferenceImplementation(config.ClientReferenceImplementation);
+  setCheckIsClientReference(config.isClientReference);
   configured = true;
 }
 

--- a/packages/react-server-dom-fb/src/ReactFlightDOMServerFB.js
+++ b/packages/react-server-dom-fb/src/ReactFlightDOMServerFB.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import type {ClientReference} from './ReactFlightClientConfigFBBundler';
 import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
 import type {
   Destination,

--- a/packages/react-server-dom-fb/src/ReactFlightDOMServerFB.js
+++ b/packages/react-server-dom-fb/src/ReactFlightDOMServerFB.js
@@ -7,13 +7,15 @@
  * @flow
  */
 
+import type {ClientReference} from './ReactFlightClientConfigFBBundler';
 import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
 import type {
   Destination,
   Chunk,
   PrecomputedChunk,
 } from 'react-server/src/ReactServerStreamConfig';
-import type {ClientManifest} from './ReactFlightReferencesFB';
+
+import {setClientReferenceImplementation} from './ReactFlightReferencesFB';
 
 import {
   createRequest,
@@ -24,10 +26,9 @@ import {
 import {setByteLengthOfChunkImplementation} from 'react-server/src/ReactServerStreamConfig';
 
 export {
-  registerClientReference,
-  registerServerReference,
   getRequestedClientReferencesKeys,
   clearRequestedClientReferencesKeysSet,
+  setClientReferenceInterface,
 } from './ReactFlightReferencesFB';
 
 type Options = {
@@ -37,7 +38,6 @@ type Options = {
 function renderToDestination(
   destination: Destination,
   model: ReactClientValue,
-  bundlerConfig: ClientManifest,
   options?: Options,
 ): void {
   if (!configured) {
@@ -47,7 +47,7 @@ function renderToDestination(
   }
   const request = createRequest(
     model,
-    bundlerConfig,
+    null,
     options ? options.onError : undefined,
   );
   startWork(request);
@@ -56,12 +56,14 @@ function renderToDestination(
 
 type Config = {
   byteLength: (chunk: Chunk | PrecomputedChunk) => number,
+  ClientReferenceImplementation: {...},
 };
 
 let configured = false;
 
 function setConfig(config: Config): void {
   setByteLengthOfChunkImplementation(config.byteLength);
+  setClientReferenceImplementation(config.ClientReferenceImplementation);
   configured = true;
 }
 

--- a/packages/react-server-dom-fb/src/ReactFlightDOMServerFB.js
+++ b/packages/react-server-dom-fb/src/ReactFlightDOMServerFB.js
@@ -25,6 +25,8 @@ import {
 import {setByteLengthOfChunkImplementation} from 'react-server/src/ReactServerStreamConfig';
 
 export {
+  registerClientReference,
+  registerServerReference,
   getRequestedClientReferencesKeys,
   clearRequestedClientReferencesKeysSet,
   setCheckIsClientReference,

--- a/packages/react-server-dom-fb/src/ReactFlightReferencesFB.js
+++ b/packages/react-server-dom-fb/src/ReactFlightReferencesFB.js
@@ -27,18 +27,19 @@ export type ClientReferenceMetadata = {
 
 export type ServerReferenceId = string;
 
-let ClientReferenceImpl: {...} | null = null;
-export function setClientReferenceImplementation(clientReferenceImpl: {
-  ...
-}): void {
-  ClientReferenceImpl = clientReferenceImpl;
+let checkIsClientReference: (clientReference: mixed) => boolean;
+
+export function setCheckIsClientReference(
+  impl: (clientReference: mixed) => boolean,
+): void {
+  checkIsClientReference = impl;
 }
 
 export function isClientReference(reference: mixed): boolean {
-  if (ClientReferenceImpl == null) {
-    throw new Error('Expected ClientReferenceImpl.');
+  if (checkIsClientReference == null) {
+    throw new Error('Expected implementation for checkIsClientReference.');
   }
-  return reference instanceof ClientReferenceImpl;
+  return checkIsClientReference(reference);
 }
 
 export function getClientReferenceKey<T>(

--- a/packages/react-server-dom-fb/src/ReactFlightReferencesFB.js
+++ b/packages/react-server-dom-fb/src/ReactFlightReferencesFB.js
@@ -35,6 +35,10 @@ export function setCheckIsClientReference(
   checkIsClientReference = impl;
 }
 
+export function registerClientReference<T>(
+  clientReference: ClientReference<T>,
+): void {}
+
 export function isClientReference(reference: mixed): boolean {
   if (checkIsClientReference == null) {
     throw new Error('Expected implementation for checkIsClientReference.');
@@ -56,6 +60,14 @@ export function resolveClientReferenceMetadata<T>(
   clientReference: ClientReference<T>,
 ): ClientReferenceMetadata {
   return {moduleId: clientReference.getModuleId(), exportName: 'default'};
+}
+
+export function registerServerReference<T>(
+  serverReference: ServerReference<T>,
+  id: string,
+  exportName: null | string,
+): ServerReference<T> {
+  throw new Error('registerServerReference: Not Implemented.');
 }
 
 export function isServerReference<T>(reference: T): boolean {

--- a/packages/react-server-dom-fb/src/ReactFlightReferencesFB.js
+++ b/packages/react-server-dom-fb/src/ReactFlightReferencesFB.js
@@ -38,11 +38,7 @@ export function isClientReference(reference: mixed): boolean {
   if (ClientReferenceImpl == null) {
     throw new Error('Expected ClientReferenceImpl.');
   }
-  if (reference instanceof ClientReferenceImpl) {
-    return true;
-  }
-
-  return false;
+  return reference instanceof ClientReferenceImpl;
 }
 
 export function getClientReferenceKey<T>(

--- a/packages/react-server-dom-fb/src/__tests__/ReactFlightDOMServerFB-test.internal.js
+++ b/packages/react-server-dom-fb/src/__tests__/ReactFlightDOMServerFB-test.internal.js
@@ -28,7 +28,6 @@ let ReactDOMClient;
 let ReactServerDOMServer;
 let ReactServerDOMClient;
 let Suspense;
-let registerClientReference;
 
 class Destination {
   #buffer = '';
@@ -57,14 +56,22 @@ class Destination {
   onError() {}
 }
 
+class ClientReferenceImpl {
+  constructor(moduleId) {
+    this.moduleId = moduleId;
+  }
+
+  getModuleId() {
+    return this.moduleId;
+  }
+}
+
 describe('ReactFlightDOM for FB', () => {
   beforeEach(() => {
     // For this first reset we are going to load the dom-node version of react-server-dom-turbopack/server
     // This can be thought of as essentially being the React Server Components scope with react-server
     // condition
     jest.resetModules();
-    registerClientReference =
-      require('../ReactFlightReferencesFB').registerClientReference;
 
     jest.mock('react', () => require('react/src/ReactSharedSubsetFB'));
 
@@ -78,8 +85,7 @@ describe('ReactFlightDOM for FB', () => {
     });
 
     clientExports = value => {
-      registerClientReference(value, value.name);
-      return value;
+      return new ClientReferenceImpl(value.name);
     };
 
     moduleMap = {
@@ -91,6 +97,7 @@ describe('ReactFlightDOM for FB', () => {
     ReactServerDOMServer = require('../ReactFlightDOMServerFB');
     ReactServerDOMServer.setConfig({
       byteLength: str => Buffer.byteLength(str),
+      ClientReferenceImplementation: ClientReferenceImpl,
     });
 
     // This reset is to load modules for the SSR/Browser scope.

--- a/packages/react-server-dom-fb/src/__tests__/ReactFlightDOMServerFB-test.internal.js
+++ b/packages/react-server-dom-fb/src/__tests__/ReactFlightDOMServerFB-test.internal.js
@@ -97,7 +97,7 @@ describe('ReactFlightDOM for FB', () => {
     ReactServerDOMServer = require('../ReactFlightDOMServerFB');
     ReactServerDOMServer.setConfig({
       byteLength: str => Buffer.byteLength(str),
-      ClientReferenceImplementation: ClientReferenceImpl,
+      isClientReference: reference => reference instanceof ClientReferenceImpl,
     });
 
     // This reset is to load modules for the SSR/Browser scope.


### PR DESCRIPTION
For clientReferences we can just check the instance of the `clientReference`.
The implementation of `isClientReference` is provided via configuration. The class for ClientReference has to implement an interface that has `getModuleId() method.