### PR TITLE
fix[devtools/e2e]: add fallback for act in integration tests

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/utils.js
+++ b/packages/react-devtools-shared/src/__tests__/utils.js
@@ -19,7 +19,9 @@ export function act(
   recursivelyFlush: boolean = true,
 ): void {
   const {act: actTestRenderer} = require('react-test-renderer');
-  const actDOM = require('react').unstable_act;
+  // Use `require('react-dom/test-utils').act` as a fallback for React 17, which can be used in integration tests for React DevTools.
+  const actDOM =
+    require('react').unstable_act || require('react-dom/test-utils').act;
 
   actDOM(() => {
     actTestRenderer(() => {
@@ -44,7 +46,9 @@ export async function actAsync(
   recursivelyFlush: boolean = true,
 ): Promise<void> {
   const {act: actTestRenderer} = require('react-test-renderer');
-  const actDOM = require('react').unstable_act;
+  // Use `require('react-dom/test-utils').act` as a fallback for React 17, which can be used in integration tests for React DevTools.
+  const actDOM =
+    require('react').unstable_act || require('react-dom/test-utils').act;
 
   await actDOM(async () => {
     await actTestRenderer(async () => {


### PR DESCRIPTION
https://github.com/facebook/react/pull/27805 broke integration tests for React DevTools with React 17, these changes introduce a fallback for such case when `act` is not available in `react`, but available in `react-dom`, like before.