### PR TITLE
Fix for script yarn build-for-devtools-dev failing due to argument type

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -73,7 +73,7 @@ const {getFilename} = Bundles;
 function parseRequestedNames(names, toCase) {
   let result = [];
   for (let i = 0; i < names.length; i++) {
-    let splitNames = !Array.isArray(names[i])? names[i].split(',') : names[i];
+    let splitNames = !Array.isArray(names[i]) ? names[i].split(',') : names[i];
     for (let j = 0; j < splitNames.length; j++) {
       let name = splitNames[j].trim();
       if (!name) {

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -73,7 +73,7 @@ const {getFilename} = Bundles;
 function parseRequestedNames(names, toCase) {
   let result = [];
   for (let i = 0; i < names.length; i++) {
-    let splitNames = names[i].split(',');
+    let splitNames = !Array.isArray(names[i])? names[i].split(',') : names[i];
     for (let j = 0; j < splitNames.length; j++) {
       let name = splitNames[j].trim();
       if (!name) {


### PR DESCRIPTION
 The script yarn  **build-for-devtools-dev** fails due to the function parseRequestedNames in the build file is using the split on the names arguments and in this case since the arguments passed is of type array which doesn't support the prototype split.

<img width="841" alt="Screenshot 2023-12-25 at 10 24 11 AM" src="https://github.com/facebook/react/assets/14840130/6420f5d0-403e-472d-9c8c-b9a8135c2a30">
  

 Fix:
Added the fallback method in case the args passed to function is of type array then don't split the input. 
 

Yarn **build-for-devtools-dev** after these added changes resolve the issue.
