### PR TITLE
[churn] remove Node 19 from dev engines, add 21

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "yargs": "^15.3.1"
   },
   "devEngines": {
-    "node": "16.x || 18.x || 19.x || 20.x"
+    "node": "16.x || 18.x || 20.x || 21.x"
   },
   "jest": {
     "testRegex": "/scripts/jest/dont-run-jest-directly\\.js$"


### PR DESCRIPTION
This allows running `yarn` with Node 21 installed, also removes Node 19 which is no longer supported according to https://nodejs.org/en/about/previous-releases
