### PR TITLE
Failing lint case for compound components

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -521,6 +521,29 @@ const tests = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        const A = () => {
+          return 'A'
+        };
+        const B = () => {
+          useState(0);
+          return 'B';
+        };
+        A.B = B;
+      `,
+    },
+    {
+      code: normalizeIndent`
+        const A = () => {
+          return 'A'
+        }
+        A.B = () => {
+          useState(0);
+          return 'B';
+        }
+      `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
# Overview
This works:

```js
const A = () => {
  return 'A'
};
const B = () => {
  useState(0);
  return 'B';
};
A.B = B;
```

This doesn't:

```js
const A = () => {
  return 'A'
}
A.B = () => {
  useState(0);
  return 'B';
}

// 🚩 React Hook "useState" is called in function "A.B" that is neither a React function
// component nor a custom React Hook function. React component names must start
// with an uppercase letter. React Hook names must start with the word "use".
```