### PR TITLE
Bug: [Windows OS Only] yarn test returns stderr: file not found for 2 files

### DIFF
--- a/packages/react/src/__tests__/ReactClassEquivalence-test.js
+++ b/packages/react/src/__tests__/ReactClassEquivalence-test.js
@@ -31,7 +31,7 @@ function runJest(testFile) {
   const command = process.env.npm_lifecycle_event;
   const defaultReporter = '--reporters=default';
   const equivalenceReporter =
-    '--reporters=<rootDir>/scripts/jest/spec-equivalence-reporter/equivalenceReporter.js';
+    '--reporters=' + __dirname + '/../../../../scripts/jest/spec-equivalence-reporter/equivalenceReporter.js';
   if (!command.startsWith('test')) {
     throw new Error(
       'Expected this test to run as a result of one of test commands.',

--- a/packages/react/src/__tests__/ReactClassEquivalence-test.js
+++ b/packages/react/src/__tests__/ReactClassEquivalence-test.js
@@ -31,7 +31,9 @@ function runJest(testFile) {
   const command = process.env.npm_lifecycle_event;
   const defaultReporter = '--reporters=default';
   const equivalenceReporter =
-    '--reporters=' + __dirname + '/../../../../scripts/jest/spec-equivalence-reporter/equivalenceReporter.js';
+    '--reporters=' +
+    __dirname +
+    '/../../../../scripts/jest/spec-equivalence-reporter/equivalenceReporter.js';
   if (!command.startsWith('test')) {
     throw new Error(
       'Expected this test to run as a result of one of test commands.',


### PR DESCRIPTION
## Summary
Fixes a bug with running `yarn test` on a Windows OS #26212. I ran across the same issue on my Windows OS using PowerShell and Command Prompt.

Steps to reproduce:

- `git clone` the react repository `main` branch on Windows OS
- Run `yarn`
- Run `yarn test ReactClassEquivalence` or `yarn test`

## How did you test this change?
- Run `yarn test ReactClassEquivalence` or `yarn test`

![Screenshot_Error](https://github.com/facebook/react/assets/9804252/1a670c2e-469b-4396-8a82-954331b21d60)
Before the fix

![Screenshot](https://github.com/facebook/react/assets/9804252/742630d8-a2e2-4ef3-b531-3ebb5f6695a9)
After the fix