### PR TITLE
refactor[isChildPublicInstance]: don't leak ReactNativeFiberHostComponent to Fabric implementation

### DIFF
--- a/packages/react-native-renderer/src/ReactNativePublicCompat.js
+++ b/packages/react-native-renderer/src/ReactNativePublicCompat.js
@@ -27,8 +27,6 @@ import {doesFiberContain} from 'react-reconciler/src/ReactFiberTreeReflection';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import getComponentNameFromType from 'shared/getComponentNameFromType';
 
-import ReactNativeFiberHostComponent from './ReactNativeFiberHostComponent';
-
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
 export function findHostInstance_DEPRECATED<TElementType: ElementType>(
@@ -236,21 +234,19 @@ export function isChildPublicInstance(
   if (__DEV__) {
     // Paper
     if (
-      parentInstance instanceof ReactNativeFiberHostComponent ||
-      childInstance instanceof ReactNativeFiberHostComponent
+      // $FlowExpectedError[incompatible-type]
+      // $FlowExpectedError[prop-missing] Don't check via `instanceof ReactNativeFiberHostComponent`, so it won't be leaked to Fabric.
+      parentInstance._internalFiberInstanceHandleDEV &&
+      // $FlowExpectedError[incompatible-type]
+      // $FlowExpectedError[prop-missing] Don't check via `instanceof ReactNativeFiberHostComponent`, so it won't be leaked to Fabric.
+      childInstance._internalFiberInstanceHandleDEV
     ) {
-      if (
-        parentInstance instanceof ReactNativeFiberHostComponent &&
-        childInstance instanceof ReactNativeFiberHostComponent
-      ) {
-        return doesFiberContain(
-          parentInstance._internalFiberInstanceHandleDEV,
-          childInstance._internalFiberInstanceHandleDEV,
-        );
-      }
-
-      // Means that one instance is from Fabric and other is from Paper.
-      return false;
+      return doesFiberContain(
+        // $FlowExpectedError[incompatible-call]
+        parentInstance._internalFiberInstanceHandleDEV,
+        // $FlowExpectedError[incompatible-call]
+        childInstance._internalFiberInstanceHandleDEV,
+      );
     }
 
     const parentInternalInstanceHandle =
@@ -271,6 +267,7 @@ export function isChildPublicInstance(
       );
     }
 
+    // Means that one instance is from Fabric and other is from Paper.
     return false;
   } else {
     throw new Error('isChildPublicInstance() is not available in production.');


### PR DESCRIPTION
While inspecting the build artifacts for Fabric in https://www.internalfb.com/diff/D51816108, I've noticed it has some leaking implementation details from Paper, such as `ReactNativeFiberHostComponent`.

The reason for it is the single implementation of `isChildPublicInstance` in `ReactNativePublicCompat`, in which we were using `instanceof ReactNativeFiberHostComponent`.

This new implementation removes the `ReactNativeFiberHostComponent` leak, but decreases the Flow coverage.