### PR TITLE
fix: optimization code, modify if conditions

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -580,7 +580,7 @@ export function createFiberFromTypeAndProps(
         }
       // Fall through
       default: {
-        if (typeof type === 'object' && type !== null) {
+        if (type !== null && typeof type === 'object') {
           switch (type.$$typeof) {
             case REACT_PROVIDER_TYPE:
               fiberTag = ContextProvider;


### PR DESCRIPTION
## Summary

when reading code.
The conditions in the if branches are written in the opposite order than what is expected. The condition that should come first is placed last, and the condition that should come last is placed first.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

for example
The existing code looks like this.
```
if (typeof type === 'object' && type !== null)
```

now, variable （type）value is null. condition[typeof type === "object"] is true. execute the second condition [type !== null]

after modified:
```
if (type !== null && typeof type === 'object')
```
variable （type）value is null, two conditions will only execute one. that is to say `type !== null` .
avoided unnecessary execution

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
