### PR TITLE
refactor: leverage ES14 Array.prototype.toSorted method

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -8185,7 +8185,7 @@ describe('react-hooks', () => {
     ecmaFeatures: {
       jsx: true,
     },
-    ecmaVersion: 6,
+    ecmaVersion: 14,
     sourceType: 'module',
   };
 

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -855,8 +855,7 @@ export default {
           return true;
         }
         const declaredDepKeys = declaredDependencies.map(dep => dep.key);
-        const sortedDeclaredDepKeys = declaredDepKeys.slice().sort();
-        return declaredDepKeys.join(',') === sortedDeclaredDepKeys.join(',');
+        return declaredDepKeys.join(',') === declaredDepKeys.toSorted().join(',');
       }
       if (areDeclaredDepsAlphabetized()) {
         suggestedDeps.sort();

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -855,7 +855,9 @@ export default {
           return true;
         }
         const declaredDepKeys = declaredDependencies.map(dep => dep.key);
-        return declaredDepKeys.join(',') === declaredDepKeys.toSorted().join(',');
+        return (
+          declaredDepKeys.join(',') === declaredDepKeys.toSorted().join(',')
+        );
       }
       if (areDeclaredDepsAlphabetized()) {
         suggestedDeps.sort();


### PR DESCRIPTION
## Summary
Leverage ES14 feature - `Array.prototype.toSorted` 



## How did you test this change?

Since this PR is refactor of the existing code, no new tests are introduced. I have made sure that all existing test passes, by running `yarn test`
