### PR TITLE
feat(devtools): support reload and profile on Android Chrome

### DIFF
--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -43,7 +43,11 @@ import type {
   ComponentFilter,
   BrowserTheme,
 } from 'react-devtools-shared/src/frontend/types';
-import {isSynchronousXHRSupported} from './utils';
+import {
+  isSynchronousXHRSupported,
+  isLocationReloadSupported,
+  isReactNativeEnvironment,
+} from './utils';
 
 const debug = (methodName: string, ...args: Array<string>) => {
   if (__DEBUG__) {
@@ -250,6 +254,7 @@ export default class Agent extends EventEmitter<{
     } catch (error) {}
     bridge.send('isBackendStorageAPISupported', isBackendStorageAPISupported);
     bridge.send('isSynchronousXHRSupported', isSynchronousXHRSupported());
+    bridge.send('isLocationReloadSupported', isLocationReloadSupported());
 
     setupHighlighter(bridge, this);
     setupTraceUpdates(this);
@@ -587,6 +592,9 @@ export default class Agent extends EventEmitter<{
         SESSION_STORAGE_RECORD_CHANGE_DESCRIPTIONS_KEY,
         recordChangeDescriptions ? 'true' : 'false',
       );
+      if (!isReactNativeEnvironment()) {
+        window.location.reload(true);
+      }
 
       // This code path should only be hit if the shell has explicitly told the Store that it supports profiling.
       // In that case, the shell must also listen for this specific message to know when it needs to reload the app.

--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -276,6 +276,10 @@ export function isSynchronousXHRSupported(): boolean {
   );
 }
 
+export function isLocationReloadSupported(): boolean {
+  return typeof window?.location?.reload === 'function';
+}
+
 export function gt(a: string = '', b: string = ''): boolean {
   return compareVersions(a, b) === 1;
 }


### PR DESCRIPTION
feat(devtools): support reload and profile on Android Chrome

Summary:
This diff adds support for reload and profile on Android Chrome, using the
React standalone devtools.

Test plan:
1. Open React site in Android Chrome
2. Connect to standalone devtools
3. Click reload and profile

Note: I have had this flake a few times with errors about
"Could not find node with id n in commit tree", but 4/5 times it works
