### PR TITLE
Convert tests containing render to async

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "gzip-size": "^5.1.1",
     "hermes-eslint": "^0.18.2",
     "hermes-parser": "^0.18.2",
+    "hermes-transform": "^0.18.2",
     "jest": "^29.4.2",
     "jest-cli": "^29.4.2",
     "jest-diff": "^29.4.2",
@@ -130,6 +131,7 @@
     "download-build-for-head": "node ./scripts/release/download-experimental-build.js --commit=$(git rev-parse HEAD)",
     "download-build-in-codesandbox-ci": "cd scripts/release && yarn install && cd ../../ && yarn download-build-for-head || yarn build --type=node react/index react-dom/index react-dom/src/server react-dom/test-utils scheduler/index react/jsx-runtime react/jsx-dev-runtime",
     "check-release-dependencies": "node ./scripts/release/check-release-dependencies",
+    "codemod": "flow-node scripts/codemod/index.js",
     "generate-inline-fizz-runtime": "node ./scripts/rollup/generate-inline-fizz-runtime.js"
   },
   "resolutions": {

--- a/packages/react-art/src/__tests__/ReactART-test.js
+++ b/packages/react-art/src/__tests__/ReactART-test.js
@@ -169,7 +169,7 @@ describe('ReactART', () => {
     testDOMNodeStructure(realNode, expectedStructure);
   });
 
-  it('should be able to reorder components', () => {
+  it('should be able to reorder components', async () => {
     const instance = ReactDOM.render(
       <TestComponent flipped={false} />,
       container,
@@ -215,7 +215,7 @@ describe('ReactART', () => {
     testDOMNodeStructure(realNode, expectedNewStructure);
   });
 
-  it('should be able to reorder many components', () => {
+  it('should be able to reorder many components', async () => {
     class Component extends React.Component {
       render() {
         const chars = this.props.chars.split('');
@@ -297,7 +297,7 @@ describe('ReactART', () => {
     expect(ref.constructor).toBe(CustomShape);
   });
 
-  it('resolves refs before componentDidUpdate', () => {
+  it('resolves refs before componentDidUpdate', async () => {
     class CustomShape extends React.Component {
       render() {
         return <Shape />;
@@ -333,7 +333,7 @@ describe('ReactART', () => {
     expect(ref.constructor).toBe(CustomShape);
   });
 
-  it('adds and updates event handlers', () => {
+  it('adds and updates event handlers', async () => {
     function render(onClick) {
       return ReactDOM.render(
         <Surface>

--- a/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
@@ -729,7 +729,7 @@ describe('InspectedElementContext', () => {
   });
 
   // @reactVersion >= 16.0
-  it('should enable inspected values to be stored as global variables', () => {
+  it('should enable inspected values to be stored as global variables', async () => {
     const Example = () => null;
 
     const nestedObject = {
@@ -785,7 +785,7 @@ describe('InspectedElementContext', () => {
   });
 
   // @reactVersion >= 16.0
-  it('should enable inspected values to be copied to the clipboard', () => {
+  it('should enable inspected values to be copied to the clipboard', async () => {
     const Example = () => null;
 
     const nestedObject = {
@@ -842,7 +842,7 @@ describe('InspectedElementContext', () => {
   });
 
   // @reactVersion >= 16.0
-  it('should enable complex values to be copied to the clipboard', () => {
+  it('should enable complex values to be copied to the clipboard', async () => {
     const Immutable = require('immutable');
 
     const Example = () => null;

--- a/packages/react-devtools-shared/src/__tests__/legacy/storeLegacy-v15-test.js
+++ b/packages/react-devtools-shared/src/__tests__/legacy/storeLegacy-v15-test.js
@@ -32,7 +32,7 @@ describe('Store (legacy)', () => {
     ReactDOM = require('react-dom');
   });
 
-  it('should not allow a root node to be collapsed', () => {
+  it('should not allow a root node to be collapsed', async () => {
     const Component = () => <div>Hi</div>;
 
     act(() =>
@@ -58,7 +58,7 @@ describe('Store (legacy)', () => {
       store.collapseNodesByDefault = false;
     });
 
-    it('should support mount and update operations', () => {
+    it('should support mount and update operations', async () => {
       const Grandparent = ({count}) => (
         <div>
           <Parent count={count} />
@@ -126,7 +126,7 @@ describe('Store (legacy)', () => {
       expect(store).toMatchInlineSnapshot(``);
     });
 
-    it('should support mount and update operations for multiple roots', () => {
+    it('should support mount and update operations for multiple roots', async () => {
       const Parent = ({count}) => (
         <div>
           {new Array(count).fill(true).map((_, index) => (
@@ -204,7 +204,7 @@ describe('Store (legacy)', () => {
       expect(store).toMatchInlineSnapshot(``);
     });
 
-    it('should not filter DOM nodes from the store tree', () => {
+    it('should not filter DOM nodes from the store tree', async () => {
       const Grandparent = ({flip}) => (
         <div>
           <div>
@@ -268,7 +268,7 @@ describe('Store (legacy)', () => {
       expect(store).toMatchInlineSnapshot(``);
     });
 
-    it('should support collapsing parts of the tree', () => {
+    it('should support collapsing parts of the tree', async () => {
       const Grandparent = ({count}) => (
         <div>
           <Parent count={count} />
@@ -370,7 +370,7 @@ describe('Store (legacy)', () => {
       `);
     });
 
-    it('should support adding and removing children', () => {
+    it('should support adding and removing children', async () => {
       const Root = ({children}) => <div>{children}</div>;
       const Component = () => <div />;
 
@@ -428,7 +428,7 @@ describe('Store (legacy)', () => {
       `);
     });
 
-    it('should support reordering of children', () => {
+    it('should support reordering of children', async () => {
       const Root = ({children}) => <div>{children}</div>;
       const Component = () => <div />;
 
@@ -505,7 +505,7 @@ describe('Store (legacy)', () => {
       store.collapseNodesByDefault = true;
     });
 
-    it('should support mount and update operations', () => {
+    it('should support mount and update operations', async () => {
       const Parent = ({count}) => (
         <div>
           {new Array(count).fill(true).map((_, index) => (
@@ -549,7 +549,7 @@ describe('Store (legacy)', () => {
       expect(store).toMatchInlineSnapshot(``);
     });
 
-    it('should support mount and update operations for multiple roots', () => {
+    it('should support mount and update operations for multiple roots', async () => {
       const Parent = ({count}) => (
         <div>
           {new Array(count).fill(true).map((_, index) => (
@@ -594,7 +594,7 @@ describe('Store (legacy)', () => {
       expect(store).toMatchInlineSnapshot(``);
     });
 
-    it('should not filter DOM nodes from the store tree', () => {
+    it('should not filter DOM nodes from the store tree', async () => {
       const Grandparent = ({flip}) => (
         <div>
           <div>
@@ -657,7 +657,7 @@ describe('Store (legacy)', () => {
       expect(store).toMatchInlineSnapshot(``);
     });
 
-    it('should support expanding parts of the tree', () => {
+    it('should support expanding parts of the tree', async () => {
       const Grandparent = ({count}) => (
         <div>
           <Parent count={count} />
@@ -753,7 +753,7 @@ describe('Store (legacy)', () => {
       `);
     });
 
-    it('should support expanding deep parts of the tree', () => {
+    it('should support expanding deep parts of the tree', async () => {
       const Wrapper = ({forwardedRef}) => (
         <Nested depth={3} forwardedRef={forwardedRef} />
       );
@@ -833,7 +833,7 @@ describe('Store (legacy)', () => {
       `);
     });
 
-    it('should support reordering of children', () => {
+    it('should support reordering of children', async () => {
       const Root = ({children}) => <div>{children}</div>;
       const Component = () => <div />;
 
@@ -897,7 +897,7 @@ describe('Store (legacy)', () => {
   });
 
   describe('StrictMode compliance', () => {
-    it('should mark all elements as strict mode compliant', () => {
+    it('should mark all elements as strict mode compliant', async () => {
       const App = () => null;
 
       const container = document.createElement('div');

--- a/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
@@ -66,7 +66,7 @@ describe('CSSPropertyOperations', () => {
     expect(html).toContain('"--someColor:#000000"');
   });
 
-  it('should set style attribute when styles exist', () => {
+  it('should set style attribute when styles exist', async () => {
     const styles = {
       backgroundColor: '#000',
       display: 'none',
@@ -87,7 +87,7 @@ describe('CSSPropertyOperations', () => {
     expect(/style=/.test(html)).toBe(false);
   });
 
-  it('should warn when using hyphenated style names', () => {
+  it('should warn when using hyphenated style names', async () => {
     class Comp extends React.Component {
       static displayName = 'Comp';
 
@@ -105,7 +105,7 @@ describe('CSSPropertyOperations', () => {
     );
   });
 
-  it('should warn when updating hyphenated style names', () => {
+  it('should warn when updating hyphenated style names', async () => {
     class Comp extends React.Component {
       static displayName = 'Comp';
 
@@ -131,7 +131,7 @@ describe('CSSPropertyOperations', () => {
     ]);
   });
 
-  it('warns when miscapitalizing vendored style names', () => {
+  it('warns when miscapitalizing vendored style names', async () => {
     class Comp extends React.Component {
       static displayName = 'Comp';
 
@@ -163,7 +163,7 @@ describe('CSSPropertyOperations', () => {
     ]);
   });
 
-  it('should warn about style having a trailing semicolon', () => {
+  it('should warn about style having a trailing semicolon', async () => {
     class Comp extends React.Component {
       static displayName = 'Comp';
 
@@ -195,7 +195,7 @@ describe('CSSPropertyOperations', () => {
     ]);
   });
 
-  it('should warn about style containing a NaN value', () => {
+  it('should warn about style containing a NaN value', async () => {
     class Comp extends React.Component {
       static displayName = 'Comp';
 
@@ -213,7 +213,7 @@ describe('CSSPropertyOperations', () => {
     );
   });
 
-  it('should not warn when setting CSS custom properties', () => {
+  it('should not warn when setting CSS custom properties', async () => {
     class Comp extends React.Component {
       render() {
         return <div style={{'--foo-primary': 'red', backgroundColor: 'red'}} />;
@@ -224,7 +224,7 @@ describe('CSSPropertyOperations', () => {
     ReactDOM.render(<Comp />, root);
   });
 
-  it('should warn about style containing an Infinity value', () => {
+  it('should warn about style containing an Infinity value', async () => {
     class Comp extends React.Component {
       static displayName = 'Comp';
 
@@ -242,7 +242,7 @@ describe('CSSPropertyOperations', () => {
     );
   });
 
-  it('should not add units to CSS custom properties', () => {
+  it('should not add units to CSS custom properties', async () => {
     class Comp extends React.Component {
       render() {
         return <div style={{'--foo': '5'}} />;

--- a/packages/react-dom/src/__tests__/InvalidEventListeners-test.js
+++ b/packages/react-dom/src/__tests__/InvalidEventListeners-test.js
@@ -30,7 +30,7 @@ describe('InvalidEventListeners', () => {
     container = null;
   });
 
-  it('should prevent non-function listeners, at dispatch', () => {
+  it('should prevent non-function listeners, at dispatch', async () => {
     let node;
     expect(() => {
       node = ReactDOM.render(<div onClick="not a function" />, container);
@@ -77,7 +77,7 @@ describe('InvalidEventListeners', () => {
     }
   });
 
-  it('should not prevent null listeners, at dispatch', () => {
+  it('should not prevent null listeners, at dispatch', async () => {
     const node = ReactDOM.render(<div onClick={null} />, container);
     node.dispatchEvent(
       new MouseEvent('click', {

--- a/packages/react-dom/src/__tests__/ReactComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponent-test.js
@@ -24,7 +24,7 @@ describe('ReactComponent', () => {
     ReactTestUtils = require('react-dom/test-utils');
   });
 
-  it('should throw on invalid render targets', () => {
+  it('should throw on invalid render targets', async () => {
     const container = document.createElement('div');
     // jQuery objects are basically arrays; people often pass them in by mistake
     expect(function () {
@@ -300,7 +300,7 @@ describe('ReactComponent', () => {
     expect(mounted).toBe(true);
   });
 
-  it('should call refs at the correct time', () => {
+  it('should call refs at the correct time', async () => {
     const log = [];
 
     class Inner extends React.Component {
@@ -396,7 +396,7 @@ describe('ReactComponent', () => {
     /* eslint-enable indent */
   });
 
-  it('fires the callback after a component is rendered', () => {
+  it('fires the callback after a component is rendered', async () => {
     const callback = jest.fn();
     const container = document.createElement('div');
     ReactDOM.render(<div />, container, callback);
@@ -470,7 +470,7 @@ describe('ReactComponent', () => {
     );
   });
 
-  it('throws if a plain object is used as a child', () => {
+  it('throws if a plain object is used as a child', async () => {
     const children = {
       x: <span />,
       y: <span />,
@@ -486,7 +486,7 @@ describe('ReactComponent', () => {
     );
   });
 
-  it('throws if a plain object even if it is in an owner', () => {
+  it('throws if a plain object even if it is in an owner', async () => {
     class Foo extends React.Component {
       render() {
         const children = {
@@ -545,7 +545,7 @@ describe('ReactComponent', () => {
   });
 
   describe('with new features', () => {
-    it('warns on function as a return value from a function', () => {
+    it('warns on function as a return value from a function', async () => {
       function Foo() {
         return Foo;
       }
@@ -558,7 +558,7 @@ describe('ReactComponent', () => {
       );
     });
 
-    it('warns on function as a return value from a class', () => {
+    it('warns on function as a return value from a class', async () => {
       class Foo extends React.Component {
         render() {
           return Foo;
@@ -573,7 +573,7 @@ describe('ReactComponent', () => {
       );
     });
 
-    it('warns on function as a child to host component', () => {
+    it('warns on function as a child to host component', async () => {
       function Foo() {
         return (
           <div>
@@ -592,7 +592,7 @@ describe('ReactComponent', () => {
       );
     });
 
-    it('does not warn for function-as-a-child that gets resolved', () => {
+    it('does not warn for function-as-a-child that gets resolved', async () => {
       function Bar(props) {
         return props.children();
       }
@@ -604,7 +604,7 @@ describe('ReactComponent', () => {
       expect(container.innerHTML).toBe('Hello');
     });
 
-    it('deduplicates function type warnings based on component type', () => {
+    it('deduplicates function type warnings based on component type', async () => {
       class Foo extends React.PureComponent {
         constructor() {
           super();

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -112,7 +112,7 @@ describe('ReactCompositeComponent', () => {
   });
 
   if (require('shared/ReactFeatureFlags').disableModulePatternComponents) {
-    it('should not support module pattern components', () => {
+    it('should not support module pattern components', async () => {
       function Child({test}) {
         return {
           render() {
@@ -137,7 +137,7 @@ describe('ReactCompositeComponent', () => {
       expect(el.textContent).toBe('');
     });
   } else {
-    it('should support module pattern components', () => {
+    it('should support module pattern components', async () => {
       function Child({test}) {
         return {
           render() {
@@ -173,7 +173,7 @@ describe('ReactCompositeComponent', () => {
     expect(el.tagName).toBe('A');
   });
 
-  it('should react to state changes from callbacks', () => {
+  it('should react to state changes from callbacks', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     try {
@@ -198,7 +198,7 @@ describe('ReactCompositeComponent', () => {
     expect(instance.xRef.current.tagName).toBe('A');
   });
 
-  it('should not cache old DOM nodes when switching constructors', () => {
+  it('should not cache old DOM nodes when switching constructors', async () => {
     const container = document.createElement('div');
     const instance = ReactDOM.render(
       <ChildUpdates renderAnchor={true} anchorClassOn={false} />,
@@ -264,7 +264,7 @@ describe('ReactCompositeComponent', () => {
     expect(inputProps.prop).not.toBeDefined();
   });
 
-  it('should warn about `forceUpdate` on not-yet-mounted components', () => {
+  it('should warn about `forceUpdate` on not-yet-mounted components', async () => {
     class MyComponent extends React.Component {
       constructor(props) {
         super(props);
@@ -288,7 +288,7 @@ describe('ReactCompositeComponent', () => {
     ReactDOM.render(<MyComponent />, container2);
   });
 
-  it('should warn about `setState` on not-yet-mounted components', () => {
+  it('should warn about `setState` on not-yet-mounted components', async () => {
     class MyComponent extends React.Component {
       constructor(props) {
         super(props);
@@ -312,7 +312,7 @@ describe('ReactCompositeComponent', () => {
     ReactDOM.render(<MyComponent />, container2);
   });
 
-  it('should not warn about `forceUpdate` on unmounted components', () => {
+  it('should not warn about `forceUpdate` on unmounted components', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
 
@@ -334,7 +334,7 @@ describe('ReactCompositeComponent', () => {
     instance.forceUpdate();
   });
 
-  it('should not warn about `setState` on unmounted components', () => {
+  it('should not warn about `setState` on unmounted components', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
 
@@ -369,7 +369,7 @@ describe('ReactCompositeComponent', () => {
     expect(renders).toBe(2);
   });
 
-  it('should silently allow `setState`, not call cb on unmounting components', () => {
+  it('should silently allow `setState`, not call cb on unmounting components', async () => {
     let cbCalled = false;
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -397,7 +397,7 @@ describe('ReactCompositeComponent', () => {
     expect(cbCalled).toBe(false);
   });
 
-  it('should warn when rendering a class with a render method that does not extend React.Component', () => {
+  it('should warn when rendering a class with a render method that does not extend React.Component', async () => {
     const container = document.createElement('div');
     class ClassWithRenderNotExtended {
       render() {
@@ -420,7 +420,7 @@ describe('ReactCompositeComponent', () => {
     }).toThrow(TypeError);
   });
 
-  it('should warn about `setState` in render', () => {
+  it('should warn about `setState` in render', async () => {
     const container = document.createElement('div');
 
     let renderedState = -1;
@@ -484,7 +484,7 @@ describe('ReactCompositeComponent', () => {
     expect(ReactCurrentOwner.current).toBe(null);
   });
 
-  it('should call componentWillUnmount before unmounting', () => {
+  it('should call componentWillUnmount before unmounting', async () => {
     const container = document.createElement('div');
     let innerUnmounted = false;
 
@@ -629,7 +629,7 @@ describe('ReactCompositeComponent', () => {
     expect(ReactDOM.findDOMNode(component).innerHTML).toBe('bar');
   });
 
-  it('should skip update when rerendering element in container', () => {
+  it('should skip update when rerendering element in container', async () => {
     class Parent extends React.Component {
       render() {
         return <div>{this.props.children}</div>;
@@ -889,7 +889,7 @@ describe('ReactCompositeComponent', () => {
   });
 
   // @gate !disableLegacyContext
-  it('unmasked context propagates through updates', () => {
+  it('unmasked context propagates through updates', async () => {
     class Leaf extends React.Component {
       static contextTypes = {
         foo: PropTypes.string.isRequired,
@@ -953,7 +953,7 @@ describe('ReactCompositeComponent', () => {
   });
 
   // @gate !disableLegacyContext
-  it('should trigger componentWillReceiveProps for context changes', () => {
+  it('should trigger componentWillReceiveProps for context changes', async () => {
     let contextChanges = 0;
     let propChanges = 0;
 
@@ -1087,7 +1087,7 @@ describe('ReactCompositeComponent', () => {
     );
   });
 
-  it('only renders once if updated in componentWillReceiveProps', () => {
+  it('only renders once if updated in componentWillReceiveProps', async () => {
     let renders = 0;
 
     class Component extends React.Component {
@@ -1115,7 +1115,7 @@ describe('ReactCompositeComponent', () => {
     expect(instance.state.updated).toBe(true);
   });
 
-  it('only renders once if updated in componentWillReceiveProps when batching', () => {
+  it('only renders once if updated in componentWillReceiveProps when batching', async () => {
     let renders = 0;
 
     class Component extends React.Component {
@@ -1145,7 +1145,7 @@ describe('ReactCompositeComponent', () => {
     expect(instance.state.updated).toBe(true);
   });
 
-  it('should update refs if shouldComponentUpdate gives false', () => {
+  it('should update refs if shouldComponentUpdate gives false', async () => {
     class Static extends React.Component {
       shouldComponentUpdate() {
         return false;
@@ -1199,7 +1199,7 @@ describe('ReactCompositeComponent', () => {
     expect(ReactDOM.findDOMNode(comp.static1Ref.current).textContent).toBe('A');
   });
 
-  it('should allow access to findDOMNode in componentWillUnmount', () => {
+  it('should allow access to findDOMNode in componentWillUnmount', async () => {
     let a = null;
     let b = null;
 
@@ -1227,7 +1227,7 @@ describe('ReactCompositeComponent', () => {
   });
 
   // @gate !disableLegacyContext || !__DEV__
-  it('context should be passed down from the parent', () => {
+  it('context should be passed down from the parent', async () => {
     class Parent extends React.Component {
       static childContextTypes = {
         foo: PropTypes.string,
@@ -1329,7 +1329,7 @@ describe('ReactCompositeComponent', () => {
     expect(moo.state.amIImmutable).toBe(undefined);
   });
 
-  it('should not warn about unmounting during unmounting', () => {
+  it('should not warn about unmounting during unmounting', async () => {
     const container = document.createElement('div');
     const layer = document.createElement('div');
 
@@ -1362,7 +1362,7 @@ describe('ReactCompositeComponent', () => {
     ReactDOM.render(<Outer />, container);
   });
 
-  it('should warn when mutated props are passed', () => {
+  it('should warn when mutated props are passed', async () => {
     const container = document.createElement('div');
 
     class Foo extends React.Component {
@@ -1382,7 +1382,7 @@ describe('ReactCompositeComponent', () => {
     );
   });
 
-  it('should only call componentWillUnmount once', () => {
+  it('should only call componentWillUnmount once', async () => {
     let app;
     let count = 0;
 
@@ -1423,7 +1423,7 @@ describe('ReactCompositeComponent', () => {
     expect(count).toBe(1);
   });
 
-  it('prepares new child before unmounting old', () => {
+  it('prepares new child before unmounting old', async () => {
     const log = [];
 
     class Spy extends React.Component {
@@ -1464,7 +1464,7 @@ describe('ReactCompositeComponent', () => {
     ]);
   });
 
-  it('respects a shallow shouldComponentUpdate implementation', () => {
+  it('respects a shallow shouldComponentUpdate implementation', async () => {
     let renderCalls = 0;
     class PlasticWrap extends React.Component {
       constructor(props, context) {
@@ -1534,7 +1534,7 @@ describe('ReactCompositeComponent', () => {
     expect(renderCalls).toBe(4);
   });
 
-  it('does not do a deep comparison for a shallow shouldComponentUpdate implementation', () => {
+  it('does not do a deep comparison for a shallow shouldComponentUpdate implementation', async () => {
     function getInitialState() {
       return {
         foo: [1, 2, 3],
@@ -1595,7 +1595,7 @@ describe('ReactCompositeComponent', () => {
     expect(mockArgs.length).toEqual(0);
   });
 
-  it('this.state should be updated on setState callback inside componentWillMount', () => {
+  it('this.state should be updated on setState callback inside componentWillMount', async () => {
     const div = document.createElement('div');
     let stateSuccessfullyUpdated = false;
 
@@ -1623,7 +1623,7 @@ describe('ReactCompositeComponent', () => {
     expect(stateSuccessfullyUpdated).toBe(true);
   });
 
-  it('should call the setState callback even if shouldComponentUpdate = false', done => {
+  it('should call the setState callback even if shouldComponentUpdate = false', async () => {
     const mockFn = jest.fn().mockReturnValue(false);
     const div = document.createElement('div');
 
@@ -1688,7 +1688,7 @@ describe('ReactCompositeComponent', () => {
     ]);
   });
 
-  it('should warn about reassigning this.props while rendering', () => {
+  it('should warn about reassigning this.props while rendering', async () => {
     class Bad extends React.Component {
       componentDidMount() {}
       componentDidUpdate() {}
@@ -1726,7 +1726,7 @@ describe('ReactCompositeComponent', () => {
 
   // Regression test for accidental breaking change
   // https://github.com/facebook/react/issues/13580
-  it('should support classes shadowing isReactComponent', () => {
+  it('should support classes shadowing isReactComponent', async () => {
     class Shadow extends React.Component {
       isReactComponent() {}
       render() {
@@ -1738,7 +1738,7 @@ describe('ReactCompositeComponent', () => {
     expect(container.firstChild.tagName).toBe('DIV');
   });
 
-  it('should not warn on updating function component from componentWillMount', () => {
+  it('should not warn on updating function component from componentWillMount', async () => {
     let _setState;
     function A() {
       _setState = React.useState()[1];
@@ -1764,7 +1764,7 @@ describe('ReactCompositeComponent', () => {
     ReactDOM.render(<Parent />, container);
   });
 
-  it('should not warn on updating function component from componentWillUpdate', () => {
+  it('should not warn on updating function component from componentWillUpdate', async () => {
     let _setState;
     function A() {
       _setState = React.useState()[1];
@@ -1791,7 +1791,7 @@ describe('ReactCompositeComponent', () => {
     ReactDOM.render(<Parent />, container);
   });
 
-  it('should not warn on updating function component from componentWillReceiveProps', () => {
+  it('should not warn on updating function component from componentWillReceiveProps', async () => {
     let _setState;
     function A() {
       _setState = React.useState()[1];
@@ -1818,7 +1818,7 @@ describe('ReactCompositeComponent', () => {
     ReactDOM.render(<Parent />, container);
   });
 
-  it('should warn on updating function component from render', () => {
+  it('should warn on updating function component from render', async () => {
     let _setState;
     function A() {
       _setState = React.useState()[1];

--- a/packages/react-dom/src/__tests__/ReactCompositeComponentNestedState-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponentNestedState-test.js
@@ -18,7 +18,7 @@ describe('ReactCompositeComponentNestedState-state', () => {
     ReactDOM = require('react-dom');
   });
 
-  it('should provide up to date values for props', () => {
+  it('should provide up to date values for props', async () => {
     class ParentComponent extends React.Component {
       state = {color: 'blue'};
 

--- a/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
@@ -121,7 +121,7 @@ describe('ReactCompositeComponent-state', () => {
     };
   });
 
-  it('should support setting state', () => {
+  it('should support setting state', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
 
@@ -215,7 +215,7 @@ describe('ReactCompositeComponent-state', () => {
     expect(stateListener.mock.calls.join('\n')).toEqual(expected.join('\n'));
   });
 
-  it('should call componentDidUpdate of children first', () => {
+  it('should call componentDidUpdate of children first', async () => {
     const container = document.createElement('div');
 
     let ops = [];
@@ -282,7 +282,7 @@ describe('ReactCompositeComponent-state', () => {
     expect(ops).toEqual(['child did update', 'parent did update']);
   });
 
-  it('should batch unmounts', () => {
+  it('should batch unmounts', async () => {
     class Inner extends React.Component {
       render() {
         return <div />;
@@ -310,7 +310,7 @@ describe('ReactCompositeComponent-state', () => {
     }).not.toThrow();
   });
 
-  it('should update state when called from child cWRP', function () {
+  it('should update state when called from child cWRP', async () => {
     const log = [];
     class Parent extends React.Component {
       state = {value: 'one'};
@@ -350,7 +350,7 @@ describe('ReactCompositeComponent-state', () => {
     ]);
   });
 
-  it('should merge state when sCU returns false', function () {
+  it('should merge state when sCU returns false', async () => {
     const log = [];
     class Test extends React.Component {
       state = {a: 0};
@@ -377,7 +377,7 @@ describe('ReactCompositeComponent-state', () => {
     expect(log).toEqual(['scu from a to a,b', 'scu from a,b to a,b,c']);
   });
 
-  it('should treat assigning to this.state inside cWRP as a replaceState, with a warning', () => {
+  it('should treat assigning to this.state inside cWRP as a replaceState, with a warning', async () => {
     const ops = [];
     class Test extends React.Component {
       state = {step: 1, extra: true};
@@ -420,7 +420,7 @@ describe('ReactCompositeComponent-state', () => {
     ReactDOM.render(<Test />, container);
   });
 
-  it('should treat assigning to this.state inside cWM as a replaceState, with a warning', () => {
+  it('should treat assigning to this.state inside cWM as a replaceState, with a warning', async () => {
     const ops = [];
     class Test extends React.Component {
       state = {step: 1, extra: true};
@@ -458,7 +458,7 @@ describe('ReactCompositeComponent-state', () => {
   });
 
   if (!require('shared/ReactFeatureFlags').disableModulePatternComponents) {
-    it('should support stateful module pattern components', () => {
+    it('should support stateful module pattern components', async () => {
       function Child() {
         return {
           state: {
@@ -482,7 +482,7 @@ describe('ReactCompositeComponent-state', () => {
       expect(el.textContent).toBe('count:123');
     });
 
-    it('should support getDerivedStateFromProps for module pattern components', () => {
+    it('should support getDerivedStateFromProps for module pattern components', async () => {
       function Child() {
         return {
           state: {
@@ -511,7 +511,7 @@ describe('ReactCompositeComponent-state', () => {
     });
   }
 
-  it('should support setState in componentWillUnmount', () => {
+  it('should support setState in componentWillUnmount', async () => {
     let subscription;
     class A extends React.Component {
       componentWillUnmount() {

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -23,7 +23,7 @@ describe('ReactDOM', () => {
     ReactTestUtils = require('react-dom/test-utils');
   });
 
-  it('should bubble onSubmit', function () {
+  it('should bubble onSubmit', async () => {
     const container = document.createElement('div');
 
     let count = 0;
@@ -121,7 +121,7 @@ describe('ReactDOM', () => {
     expect(dog.className).toBe('bigdog');
   });
 
-  it('throws in render() if the mount callback is not a function', () => {
+  it('throws in render() if the mount callback is not a function', async () => {
     function Foo() {
       this.a = 1;
       this.b = 2;
@@ -173,7 +173,7 @@ describe('ReactDOM', () => {
     );
   });
 
-  it('throws in render() if the update callback is not a function', () => {
+  it('throws in render() if the update callback is not a function', async () => {
     function Foo() {
       this.a = 1;
       this.b = 2;
@@ -228,7 +228,7 @@ describe('ReactDOM', () => {
     );
   });
 
-  it('preserves focus', () => {
+  it('preserves focus', async () => {
     let input;
     let input2;
     class A extends React.Component {
@@ -288,7 +288,7 @@ describe('ReactDOM', () => {
     }
   });
 
-  it('calls focus() on autoFocus elements after they have been mounted to the DOM', () => {
+  it('calls focus() on autoFocus elements after they have been mounted to the DOM', async () => {
     const originalFocus = HTMLElement.prototype.focus;
 
     try {
@@ -321,7 +321,7 @@ describe('ReactDOM', () => {
     }
   });
 
-  it("shouldn't fire duplicate event handler while handling other nested dispatch", () => {
+  it("shouldn't fire duplicate event handler while handling other nested dispatch", async () => {
     const actual = [];
 
     class Wrapper extends React.Component {
@@ -366,7 +366,7 @@ describe('ReactDOM', () => {
     }
   });
 
-  it('should not crash with devtools installed', () => {
+  it('should not crash with devtools installed', async () => {
     try {
       global.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
         inject: function () {},
@@ -388,7 +388,7 @@ describe('ReactDOM', () => {
     }
   });
 
-  it('should not crash calling findDOMNode inside a function component', () => {
+  it('should not crash calling findDOMNode inside a function component', async () => {
     const container = document.createElement('div');
 
     class Component extends React.Component {
@@ -408,7 +408,7 @@ describe('ReactDOM', () => {
     }
   });
 
-  it('reports stacks with re-entrant renderToString() calls on the client', () => {
+  it('reports stacks with re-entrant renderToString() calls on the client', async () => {
     function Child2(props) {
       return <span ariaTypo3="no">{props.children}</span>;
     }

--- a/packages/react-dom/src/__tests__/ReactDOMAttribute-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMAttribute-test.js
@@ -51,7 +51,7 @@ describe('ReactDOM unknown attribute', () => {
       testUnknownAttributeAssignment(false, null);
     });
 
-    it('removes unknown attributes that were rendered but are now missing', () => {
+    it('removes unknown attributes that were rendered but are now missing', async () => {
       const el = document.createElement('div');
       ReactDOM.render(<div unknown="something" />, el);
       expect(el.firstChild.getAttribute('unknown')).toBe('something');
@@ -131,7 +131,7 @@ describe('ReactDOM unknown attribute', () => {
       );
     });
 
-    it('allows camelCase unknown attributes and warns', () => {
+    it('allows camelCase unknown attributes and warns', async () => {
       const el = document.createElement('div');
 
       expect(() =>

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -29,7 +29,7 @@ describe('ReactDOMComponent', () => {
   });
 
   describe('updateDOM', () => {
-    it('should handle className', () => {
+    it('should handle className', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<div style={{}} />, container);
 
@@ -41,7 +41,7 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.className).toEqual('');
     });
 
-    it('should gracefully handle various style value types', () => {
+    it('should gracefully handle various style value types', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<div style={{}} />, container);
       const stubStyle = container.firstChild.style;
@@ -68,7 +68,7 @@ describe('ReactDOMComponent', () => {
       expect(stubStyle.fontFamily).toEqual('');
     });
 
-    it('should not update styles when mutating a proxy style object', () => {
+    it('should not update styles when mutating a proxy style object', async () => {
       const styleStore = {
         display: 'none',
         fontFamily: 'Arial',
@@ -147,7 +147,7 @@ describe('ReactDOMComponent', () => {
       }
     });
 
-    it('should warn for unknown prop', () => {
+    it('should warn for unknown prop', async () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(<div foo={() => {}} />, container),
@@ -159,7 +159,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should group multiple unknown prop warnings together', () => {
+    it('should group multiple unknown prop warnings together', async () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(<div foo={() => {}} baz={() => {}} />, container),
@@ -171,7 +171,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should warn for onDblClick prop', () => {
+    it('should warn for onDblClick prop', async () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(<div onDblClick={() => {}} />, container),
@@ -180,7 +180,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should warn for unknown string event handlers', () => {
+    it('should warn for unknown string event handlers', async () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(<div onUnknown='alert("hack")' />, container),
@@ -205,7 +205,7 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild['on-unknown']).toBe(undefined);
     });
 
-    it('should warn for unknown function event handlers', () => {
+    it('should warn for unknown function event handlers', async () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(<div onUnknown={function () {}} />, container),
@@ -230,7 +230,7 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild['on-unknown']).toBe(undefined);
     });
 
-    it('should warn for badly cased React attributes', () => {
+    it('should warn for badly cased React attributes', async () => {
       const container = document.createElement('div');
       expect(() => ReactDOM.render(<div CHILDREN="5" />, container)).toErrorDev(
         'Warning: Invalid DOM property `CHILDREN`. Did you mean `children`?\n    in div (at **)',
@@ -248,7 +248,7 @@ describe('ReactDOMComponent', () => {
       ReactTestUtils.renderIntoDocument(<Component />);
     });
 
-    it('should warn nicely about NaN in style', () => {
+    it('should warn nicely about NaN in style', async () => {
       const style = {fontSize: NaN};
       const div = document.createElement('div');
       expect(() => ReactDOM.render(<span style={style} />, div)).toErrorDev(
@@ -258,7 +258,7 @@ describe('ReactDOMComponent', () => {
       ReactDOM.render(<span style={style} />, div);
     });
 
-    it('throws with Temporal-like objects as style values', () => {
+    it('throws with Temporal-like objects as style values', async () => {
       class TemporalLike {
         valueOf() {
           // Throwing here is the behavior of ECMAScript "Temporal" date/time API.
@@ -280,7 +280,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should update styles if initially null', () => {
+    it('should update styles if initially null', async () => {
       let styles = null;
       const container = document.createElement('div');
       ReactDOM.render(<div style={styles} />, container);
@@ -293,7 +293,7 @@ describe('ReactDOMComponent', () => {
       expect(stubStyle.display).toEqual('block');
     });
 
-    it('should update styles if updated to null multiple times', () => {
+    it('should update styles if updated to null multiple times', async () => {
       let styles = null;
       const container = document.createElement('div');
       ReactDOM.render(<div style={styles} />, container);
@@ -314,7 +314,7 @@ describe('ReactDOMComponent', () => {
       expect(stubStyle.display).toEqual('');
     });
 
-    it('should allow named slot projection on both web components and regular DOM elements', () => {
+    it('should allow named slot projection on both web components and regular DOM elements', async () => {
       const container = document.createElement('div');
 
       ReactDOM.render(
@@ -331,7 +331,7 @@ describe('ReactDOMComponent', () => {
       expect(lightDOM[1].getAttribute('slot')).toBe('second');
     });
 
-    it('should skip reserved props on web components', () => {
+    it('should skip reserved props on web components', async () => {
       const container = document.createElement('div');
 
       ReactDOM.render(
@@ -367,7 +367,7 @@ describe('ReactDOMComponent', () => {
       ).toBe(false);
     });
 
-    it('should skip dangerouslySetInnerHTML on web components', () => {
+    it('should skip dangerouslySetInnerHTML on web components', async () => {
       const container = document.createElement('div');
 
       ReactDOM.render(
@@ -387,7 +387,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should render null and undefined as empty but print other falsy values', () => {
+    it('should render null and undefined as empty but print other falsy values', async () => {
       const container = document.createElement('div');
 
       ReactDOM.render(
@@ -424,7 +424,7 @@ describe('ReactDOMComponent', () => {
       expect(container.textContent).toEqual('');
     });
 
-    it('should remove attributes', () => {
+    it('should remove attributes', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<img height="17" />, container);
 
@@ -433,7 +433,7 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.hasAttribute('height')).toBe(false);
     });
 
-    it('should remove properties', () => {
+    it('should remove properties', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<div className="monkey" />, container);
 
@@ -442,7 +442,7 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.className).toEqual('');
     });
 
-    it('should not set null/undefined attributes', () => {
+    it('should not set null/undefined attributes', async () => {
       const container = document.createElement('div');
       // Initial render.
       ReactDOM.render(<img src={null} data-foo={undefined} />, container);
@@ -468,7 +468,7 @@ describe('ReactDOMComponent', () => {
     });
 
     if (ReactFeatureFlags.enableFilterEmptyStringAttributesDOM) {
-      it('should not add an empty src attribute', () => {
+      it('should not add an empty src attribute', async () => {
         const container = document.createElement('div');
         expect(() => ReactDOM.render(<img src="" />, container)).toErrorDev(
           'An empty string ("") was passed to the src attribute. ' +
@@ -491,7 +491,7 @@ describe('ReactDOMComponent', () => {
         expect(node.hasAttribute('src')).toBe(false);
       });
 
-      it('should not add an empty href attribute', () => {
+      it('should not add an empty href attribute', async () => {
         const container = document.createElement('div');
         expect(() => ReactDOM.render(<link href="" />, container)).toErrorDev(
           'An empty string ("") was passed to the href attribute. ' +
@@ -512,7 +512,7 @@ describe('ReactDOMComponent', () => {
         expect(node.hasAttribute('href')).toBe(false);
       });
 
-      it('should allow an empty action attribute', () => {
+      it('should allow an empty action attribute', async () => {
         const container = document.createElement('div');
         ReactDOM.render(<form action="" />, container);
         const node = container.firstChild;
@@ -525,7 +525,7 @@ describe('ReactDOMComponent', () => {
         expect(node.getAttribute('action')).toBe('');
       });
 
-      it('allows empty string of a formAction to override the default of a parent', () => {
+      it('allows empty string of a formAction to override the default of a parent', async () => {
         const container = document.createElement('div');
         ReactDOM.render(
           <form action="hello">
@@ -538,7 +538,7 @@ describe('ReactDOMComponent', () => {
         expect(node.getAttribute('formaction')).toBe('');
       });
 
-      it('should not filter attributes for custom elements', () => {
+      it('should not filter attributes for custom elements', async () => {
         const container = document.createElement('div');
         ReactDOM.render(
           <some-custom-element action="" formAction="" href="" src="" />,
@@ -552,7 +552,7 @@ describe('ReactDOMComponent', () => {
       });
     }
 
-    it('should apply React-specific aliases to HTML elements', () => {
+    it('should apply React-specific aliases to HTML elements', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<form acceptCharset="foo" />, container);
       const node = container.firstChild;
@@ -585,7 +585,7 @@ describe('ReactDOMComponent', () => {
       expect(node.hasAttribute('acceptCharset')).toBe(false);
     });
 
-    it('should apply React-specific aliases to SVG elements', () => {
+    it('should apply React-specific aliases to SVG elements', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<svg arabicForm="foo" />, container);
       const node = container.firstChild;
@@ -618,7 +618,7 @@ describe('ReactDOMComponent', () => {
       expect(node.hasAttribute('arabicForm')).toBe(false);
     });
 
-    it('should properly update custom attributes on custom elements', () => {
+    it('should properly update custom attributes on custom elements', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<some-custom-element foo="bar" />, container);
       ReactDOM.render(<some-custom-element bar="buzz" />, container);
@@ -627,7 +627,7 @@ describe('ReactDOMComponent', () => {
       expect(node.getAttribute('bar')).toBe('buzz');
     });
 
-    it('should not apply React-specific aliases to custom elements', () => {
+    it('should not apply React-specific aliases to custom elements', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<some-custom-element arabicForm="foo" />, container);
       const node = container.firstChild;
@@ -646,7 +646,7 @@ describe('ReactDOMComponent', () => {
       expect(node.hasAttribute('accept-charset')).toBe(false);
     });
 
-    it('should clear a single style prop when changing `style`', () => {
+    it('should clear a single style prop when changing `style`', async () => {
       let styles = {display: 'none', color: 'red'};
       const container = document.createElement('div');
       ReactDOM.render(<div style={styles} />, container);
@@ -707,7 +707,7 @@ describe('ReactDOMComponent', () => {
       ]);
     });
 
-    it('should reject attribute key injection attack on mount for regular DOM', () => {
+    it('should reject attribute key injection attack on mount for regular DOM', async () => {
       expect(() => {
         for (let i = 0; i < 3; i++) {
           const container = document.createElement('div');
@@ -737,7 +737,7 @@ describe('ReactDOMComponent', () => {
       ]);
     });
 
-    it('should reject attribute key injection attack on mount for custom elements', () => {
+    it('should reject attribute key injection attack on mount for custom elements', async () => {
       expect(() => {
         for (let i = 0; i < 3; i++) {
           const container = document.createElement('div');
@@ -767,7 +767,7 @@ describe('ReactDOMComponent', () => {
       ]);
     });
 
-    it('should reject attribute key injection attack on update for regular DOM', () => {
+    it('should reject attribute key injection attack on update for regular DOM', async () => {
       expect(() => {
         for (let i = 0; i < 3; i++) {
           const container = document.createElement('div');
@@ -798,7 +798,7 @@ describe('ReactDOMComponent', () => {
       ]);
     });
 
-    it('should reject attribute key injection attack on update for custom elements', () => {
+    it('should reject attribute key injection attack on update for custom elements', async () => {
       expect(() => {
         for (let i = 0; i < 3; i++) {
           const container = document.createElement('div');
@@ -829,7 +829,7 @@ describe('ReactDOMComponent', () => {
       ]);
     });
 
-    it('should update arbitrary attributes for tags containing dashes', () => {
+    it('should update arbitrary attributes for tags containing dashes', async () => {
       const container = document.createElement('div');
 
       const beforeUpdate = React.createElement('x-foo-component', {}, null);
@@ -841,7 +841,7 @@ describe('ReactDOMComponent', () => {
       expect(container.childNodes[0].getAttribute('myattr')).toBe('myval');
     });
 
-    it('should clear all the styles when removing `style`', () => {
+    it('should clear all the styles when removing `style`', async () => {
       const styles = {display: 'none', color: 'red'};
       const container = document.createElement('div');
       ReactDOM.render(<div style={styles} />, container);
@@ -853,7 +853,7 @@ describe('ReactDOMComponent', () => {
       expect(stubStyle.color).toEqual('');
     });
 
-    it('should update styles when `style` changes from null to object', () => {
+    it('should update styles when `style` changes from null to object', async () => {
       const container = document.createElement('div');
       const styles = {color: 'red'};
       ReactDOM.render(<div style={styles} />, container);
@@ -864,7 +864,7 @@ describe('ReactDOMComponent', () => {
       expect(stubStyle.color).toEqual('red');
     });
 
-    it('should not reset innerHTML for when children is null', () => {
+    it('should not reset innerHTML for when children is null', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<div />, container);
       container.firstChild.innerHTML = 'bonjour';
@@ -874,7 +874,7 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.innerHTML).toEqual('bonjour');
     });
 
-    it('should reset innerHTML when switching from a direct text child to an empty child', () => {
+    it('should reset innerHTML when switching from a direct text child to an empty child', async () => {
       const transitionToValues = [null, undefined, false];
       transitionToValues.forEach(transitionToValue => {
         const container = document.createElement('div');
@@ -886,7 +886,7 @@ describe('ReactDOMComponent', () => {
       });
     });
 
-    it('should empty element when removing innerHTML', () => {
+    it('should empty element when removing innerHTML', async () => {
       const container = document.createElement('div');
       ReactDOM.render(
         <div dangerouslySetInnerHTML={{__html: ':)'}} />,
@@ -898,7 +898,7 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.innerHTML).toEqual('');
     });
 
-    it('should transition from string content to innerHTML', () => {
+    it('should transition from string content to innerHTML', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<div>hello</div>, container);
 
@@ -910,7 +910,7 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.innerHTML).toEqual('goodbye');
     });
 
-    it('should transition from innerHTML to string content', () => {
+    it('should transition from innerHTML to string content', async () => {
       const container = document.createElement('div');
       ReactDOM.render(
         <div dangerouslySetInnerHTML={{__html: 'bonjour'}} />,
@@ -922,7 +922,7 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.innerHTML).toEqual('adieu');
     });
 
-    it('should transition from innerHTML to children in nested el', () => {
+    it('should transition from innerHTML to children in nested el', async () => {
       const container = document.createElement('div');
       ReactDOM.render(
         <div>
@@ -943,7 +943,7 @@ describe('ReactDOMComponent', () => {
       expect(container.textContent).toEqual('adieu');
     });
 
-    it('should transition from children to innerHTML in nested el', () => {
+    it('should transition from children to innerHTML in nested el', async () => {
       const container = document.createElement('div');
       ReactDOM.render(
         <div>
@@ -964,7 +964,7 @@ describe('ReactDOMComponent', () => {
       expect(container.textContent).toEqual('bonjour');
     });
 
-    it('should not incur unnecessary DOM mutations for attributes', () => {
+    it('should not incur unnecessary DOM mutations for attributes', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<div id="" />, container);
 
@@ -1002,7 +1002,7 @@ describe('ReactDOMComponent', () => {
       expect(node.removeAttribute).toHaveBeenCalledTimes(2);
     });
 
-    it('should not incur unnecessary DOM mutations for string properties', () => {
+    it('should not incur unnecessary DOM mutations for string properties', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<div value="" />, container);
 
@@ -1035,7 +1035,7 @@ describe('ReactDOMComponent', () => {
       expect(nodeValueSetter).toHaveBeenCalledTimes(2);
     });
 
-    it('should not incur unnecessary DOM mutations for controlled string properties', () => {
+    it('should not incur unnecessary DOM mutations for controlled string properties', async () => {
       function onChange() {}
       const container = document.createElement('div');
       ReactDOM.render(<input value="" onChange={onChange} />, container);
@@ -1092,7 +1092,7 @@ describe('ReactDOMComponent', () => {
       expect(nodeValueSetter).toHaveBeenCalledTimes(2);
     });
 
-    it('should not incur unnecessary DOM mutations for boolean properties', () => {
+    it('should not incur unnecessary DOM mutations for boolean properties', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<audio muted={true} />, container);
 
@@ -1115,13 +1115,13 @@ describe('ReactDOMComponent', () => {
       expect(nodeValueSetter).toHaveBeenCalledTimes(1);
     });
 
-    it('should ignore attribute list for elements with the "is" attribute', () => {
+    it('should ignore attribute list for elements with the "is" attribute', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<button is="test" cowabunga="chevynova" />, container);
       expect(container.firstChild.hasAttribute('cowabunga')).toBe(true);
     });
 
-    it('should warn about non-string "is" attribute', () => {
+    it('should warn about non-string "is" attribute', async () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(<button is={function () {}} />, container),
@@ -1131,7 +1131,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should not update when switching between null/undefined', () => {
+    it('should not update when switching between null/undefined', async () => {
       const container = document.createElement('div');
       const node = ReactDOM.render(<div />, container);
 
@@ -1146,7 +1146,7 @@ describe('ReactDOMComponent', () => {
       expect(setter).toHaveBeenCalledTimes(1);
     });
 
-    it('handles multiple child updates without interference', () => {
+    it('handles multiple child updates without interference', async () => {
       // This test might look like it's just testing ReactMultiChild but the
       // last bug in this was actually in DOMChildrenOperations so this test
       // needs to be in some DOM-specific test file.
@@ -1254,7 +1254,7 @@ describe('ReactDOMComponent', () => {
       };
     });
 
-    it('should work error event on <source> element', () => {
+    it('should work error event on <source> element', async () => {
       spyOnDevAndProd(console, 'log');
       const container = document.createElement('div');
       ReactDOM.render(
@@ -1358,7 +1358,7 @@ describe('ReactDOMComponent', () => {
       }
     });
 
-    it('should throw on children for void elements', () => {
+    it('should throw on children for void elements', async () => {
       const container = document.createElement('div');
       expect(() => {
         ReactDOM.render(<input>children</input>, container);
@@ -1368,7 +1368,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should throw on dangerouslySetInnerHTML for void elements', () => {
+    it('should throw on dangerouslySetInnerHTML for void elements', async () => {
       const container = document.createElement('div');
       expect(() => {
         ReactDOM.render(
@@ -1381,7 +1381,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should treat menuitem as a void element but still create the closing tag', () => {
+    it('should treat menuitem as a void element but still create the closing tag', async () => {
       // menuitem is not implemented in jsdom, so this triggers the unknown warning error
       const container = document.createElement('div');
 
@@ -1482,7 +1482,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should throw for children on void elements', () => {
+    it('should throw for children on void elements', async () => {
       class X extends React.Component {
         render() {
           return <input>moo</input>;
@@ -1498,7 +1498,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should support custom elements which extend native elements', () => {
+    it('should support custom elements which extend native elements', async () => {
       const container = document.createElement('div');
       spyOnDevAndProd(document, 'createElement');
       ReactDOM.render(<div is="custom-div" />, container);
@@ -1507,7 +1507,7 @@ describe('ReactDOMComponent', () => {
       });
     });
 
-    it('should work load and error events on <image> element in SVG', () => {
+    it('should work load and error events on <image> element in SVG', async () => {
       spyOnDevAndProd(console, 'log');
       const container = document.createElement('div');
       ReactDOM.render(
@@ -1537,7 +1537,7 @@ describe('ReactDOMComponent', () => {
       }
     });
 
-    it('should receive a load event on <link> elements', () => {
+    it('should receive a load event on <link> elements', async () => {
       const container = document.createElement('div');
       const onLoad = jest.fn();
 
@@ -1555,7 +1555,7 @@ describe('ReactDOMComponent', () => {
       expect(onLoad).toHaveBeenCalledTimes(1);
     });
 
-    it('should receive an error event on <link> elements', () => {
+    it('should receive an error event on <link> elements', async () => {
       const container = document.createElement('div');
       const onError = jest.fn();
 
@@ -1581,7 +1581,7 @@ describe('ReactDOMComponent', () => {
       container = document.createElement('div');
     });
 
-    it('should warn against children for void elements', () => {
+    it('should warn against children for void elements', async () => {
       ReactDOM.render(<input />, container);
 
       expect(function () {
@@ -1592,7 +1592,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should warn against dangerouslySetInnerHTML for void elements', () => {
+    it('should warn against dangerouslySetInnerHTML for void elements', async () => {
       ReactDOM.render(<input />, container);
 
       expect(function () {
@@ -1606,7 +1606,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should validate against multiple children props', () => {
+    it('should validate against multiple children props', async () => {
       ReactDOM.render(<div />, container);
 
       expect(function () {
@@ -1619,7 +1619,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should warn about contentEditable and children', () => {
+    it('should warn about contentEditable and children', async () => {
       expect(() => {
         ReactDOM.render(
           <div contentEditable={true}>
@@ -1630,7 +1630,7 @@ describe('ReactDOMComponent', () => {
       }).toErrorDev('contentEditable');
     });
 
-    it('should validate against invalid styles', () => {
+    it('should validate against invalid styles', async () => {
       ReactDOM.render(<div />, container);
 
       expect(function () {
@@ -1642,7 +1642,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should report component containing invalid styles', () => {
+    it('should report component containing invalid styles', async () => {
       class Animal extends React.Component {
         render() {
           return <div style={1} />;
@@ -1681,7 +1681,7 @@ describe('ReactDOMComponent', () => {
   });
 
   describe('unmountComponent', () => {
-    it('unmounts children before unsetting DOM node info', () => {
+    it('unmounts children before unsetting DOM node info', async () => {
       class Inner extends React.Component {
         render() {
           return <span />;
@@ -1747,7 +1747,7 @@ describe('ReactDOMComponent', () => {
       ]);
     });
 
-    it('warns on invalid nesting at root', () => {
+    it('warns on invalid nesting at root', async () => {
       const p = document.createElement('p');
 
       expect(() => {
@@ -1805,7 +1805,7 @@ describe('ReactDOMComponent', () => {
       ]);
     });
 
-    it('warns nicely for updating table rows to use text', () => {
+    it('warns nicely for updating table rows to use text', async () => {
       const container = document.createElement('div');
 
       function Row({children}) {
@@ -2369,7 +2369,7 @@ describe('ReactDOMComponent', () => {
   });
 
   describe('whitespace', () => {
-    it('renders innerHTML and preserves whitespace', () => {
+    it('renders innerHTML and preserves whitespace', async () => {
       const container = document.createElement('div');
       const html = '\n  \t  <span>  \n  testContent  \t  </span>  \n  \t';
       const elem = <div dangerouslySetInnerHTML={{__html: html}} />;
@@ -2378,7 +2378,7 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.innerHTML).toBe(html);
     });
 
-    it('render and then updates innerHTML and preserves whitespace', () => {
+    it('render and then updates innerHTML and preserves whitespace', async () => {
       const container = document.createElement('div');
       const html = '\n  \t  <span>  \n  testContent1  \t  </span>  \n  \t';
       const elem = <div dangerouslySetInnerHTML={{__html: html}} />;
@@ -2447,7 +2447,7 @@ describe('ReactDOMComponent', () => {
       expect(el.getAttribute('class')).toBe('test');
     });
 
-    it('updates aliased attributes on custom elements', function () {
+    it('updates aliased attributes on custom elements', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<div is="custom-element" class="foo" />, container);
       ReactDOM.render(<div is="custom-element" class="bar" />, container);
@@ -2463,7 +2463,7 @@ describe('ReactDOMComponent', () => {
       expect(el.getAttribute('whatever')).toBe('30');
     });
 
-    it('removes custom attributes', function () {
+    it('removes custom attributes', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<div whatever="30" />, container);
 
@@ -2521,7 +2521,7 @@ describe('ReactDOMComponent', () => {
       expect(el.getAttribute('whatever')).toBe('[object Object]');
     });
 
-    it('allows Temporal-like objects as HTML (they are not coerced to strings first)', function () {
+    it('allows Temporal-like objects as HTML (they are not coerced to strings first)', async () => {
       class TemporalLike {
         valueOf() {
           // Throwing here is the behavior of ECMAScript "Temporal" date/time API.
@@ -2585,7 +2585,7 @@ describe('ReactDOMComponent', () => {
       expect(el.getAttribute('whatever')).toBe('NaN');
     });
 
-    it('removes a property when it becomes invalid', function () {
+    it('removes a property when it becomes invalid', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<div whatever={0} />, container);
       expect(() =>
@@ -2613,7 +2613,7 @@ describe('ReactDOMComponent', () => {
       expect(el.getAttribute('accept-charset')).toBe('[object Object]');
     });
 
-    it('should pass objects as attributes if they define toString', () => {
+    it('should pass objects as attributes if they define toString', async () => {
       const obj = {
         toString() {
           return 'hello';
@@ -2631,7 +2631,7 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.getAttribute('unknown')).toBe('hello');
     });
 
-    it('passes objects on known SVG attributes if they do not define toString', () => {
+    it('passes objects on known SVG attributes if they do not define toString', async () => {
       const obj = {};
       const container = document.createElement('div');
 
@@ -2641,7 +2641,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('passes objects on custom attributes if they do not define toString', () => {
+    it('passes objects on custom attributes if they do not define toString', async () => {
       const obj = {};
       const container = document.createElement('div');
 
@@ -2772,7 +2772,7 @@ describe('ReactDOMComponent', () => {
   // These tests mostly verify the existing behavior.
   // It may not always makes sense but we can't change it in minors.
   describe('Custom elements', () => {
-    it('does not strip unknown boolean attributes', () => {
+    it('does not strip unknown boolean attributes', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<some-custom-element foo={true} />, container);
       const node = container.firstChild;
@@ -2789,7 +2789,7 @@ describe('ReactDOMComponent', () => {
       expect(node.hasAttribute('foo')).toBe(true);
     });
 
-    it('does not strip the on* attributes', () => {
+    it('does not strip the on* attributes', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<some-custom-element onx="bar" />, container);
       const node = container.firstChild;
@@ -2803,7 +2803,7 @@ describe('ReactDOMComponent', () => {
     });
   });
 
-  it('receives events in specific order', () => {
+  it('receives events in specific order', async () => {
     const eventOrder = [];
     const track = tag => () => eventOrder.push(tag);
     const outerRef = React.createRef();
@@ -2868,7 +2868,7 @@ describe('ReactDOMComponent', () => {
   });
 
   describe('iOS Tap Highlight', () => {
-    it('adds onclick handler to elements with onClick prop', () => {
+    it('adds onclick handler to elements with onClick prop', async () => {
       const container = document.createElement('div');
 
       const elementRef = React.createRef();
@@ -2880,7 +2880,7 @@ describe('ReactDOMComponent', () => {
       expect(typeof elementRef.current.onclick).toBe('function');
     });
 
-    it('adds onclick handler to a portal root', () => {
+    it('adds onclick handler to a portal root', async () => {
       const container = document.createElement('div');
       const portalContainer = document.createElement('div');
 
@@ -2895,7 +2895,7 @@ describe('ReactDOMComponent', () => {
       expect(typeof portalContainer.onclick).toBe('function');
     });
 
-    it('does not add onclick handler to the React root', () => {
+    it('does not add onclick handler to the React root', async () => {
       const container = document.createElement('div');
 
       function Component() {

--- a/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
@@ -26,7 +26,7 @@ describe('ReactDOMComponentTree', () => {
     container = null;
   });
 
-  it('finds nodes for instances on events', () => {
+  it('finds nodes for instances on events', async () => {
     const mouseOverID = 'mouseOverID';
     const clickID = 'clickID';
     let currentTargetID = null;
@@ -63,7 +63,7 @@ describe('ReactDOMComponentTree', () => {
     expect(currentTargetID).toBe(clickID);
   });
 
-  it('finds closest instance for node when an event happens', () => {
+  it('finds closest instance for node when an event happens', async () => {
     const nonReactElemID = 'aID';
     const innerHTML = {__html: `<div id="${nonReactElemID}"></div>`};
     const closestInstanceID = 'closestInstance';
@@ -98,7 +98,7 @@ describe('ReactDOMComponentTree', () => {
     expect(currentTargetID).toBe(closestInstanceID);
   });
 
-  it('updates event handlers from fiber props', () => {
+  it('updates event handlers from fiber props', async () => {
     let action = '';
     let instance;
     const handlerA = () => (action = 'A');
@@ -140,7 +140,7 @@ describe('ReactDOMComponentTree', () => {
     expect(action).toEqual('B');
   });
 
-  it('finds a controlled instance from node and gets its current fiber props', () => {
+  it('finds a controlled instance from node and gets its current fiber props', async () => {
     const inputID = 'inputID';
     const startValue = undefined;
     const finishValue = 'finish';
@@ -187,7 +187,7 @@ describe('ReactDOMComponentTree', () => {
     );
   });
 
-  it('finds instance of node that is attempted to be unmounted', () => {
+  it('finds instance of node that is attempted to be unmounted', async () => {
     const component = <div />;
     const node = ReactDOM.render(<div>{component}</div>, container);
     expect(() => ReactDOM.unmountComponentAtNode(node)).toErrorDev(
@@ -199,7 +199,7 @@ describe('ReactDOMComponentTree', () => {
     );
   });
 
-  it('finds instance from node to stop rendering over other react rendered components', () => {
+  it('finds instance from node to stop rendering over other react rendered components', async () => {
     const component = (
       <div>
         <span>Hello</span>

--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -22,7 +22,7 @@ describe('ReactDOMEventListener', () => {
   });
 
   describe('Propagation', () => {
-    it('should propagate events one level down', () => {
+    it('should propagate events one level down', async () => {
       const mouseOut = jest.fn();
       const onMouseOut = event => mouseOut(event.currentTarget);
 
@@ -53,7 +53,7 @@ describe('ReactDOMEventListener', () => {
       }
     });
 
-    it('should propagate events two levels down', () => {
+    it('should propagate events two levels down', async () => {
       const mouseOut = jest.fn();
       const onMouseOut = event => mouseOut(event.currentTarget);
 
@@ -93,7 +93,7 @@ describe('ReactDOMEventListener', () => {
     });
 
     // Regression test for https://github.com/facebook/react/issues/1105
-    it('should not get confused by disappearing elements', () => {
+    it('should not get confused by disappearing elements', async () => {
       const container = document.createElement('div');
       document.body.appendChild(container);
 
@@ -131,7 +131,7 @@ describe('ReactDOMEventListener', () => {
       }
     });
 
-    it('should batch between handlers from different roots', () => {
+    it('should batch between handlers from different roots', async () => {
       const mock = jest.fn();
 
       const childContainer = document.createElement('div');
@@ -188,7 +188,7 @@ describe('ReactDOMEventListener', () => {
     });
   });
 
-  it('should not fire duplicate events for a React DOM tree', () => {
+  it('should not fire duplicate events for a React DOM tree', async () => {
     const mouseOut = jest.fn();
     const onMouseOut = event => mouseOut(event.target);
 
@@ -229,7 +229,7 @@ describe('ReactDOMEventListener', () => {
   });
 
   // Regression test for https://github.com/facebook/react/pull/12877
-  it('should not fire form events twice', () => {
+  it('should not fire form events twice', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
 
@@ -284,7 +284,7 @@ describe('ReactDOMEventListener', () => {
   // This tests an implementation detail that submit/reset events are listened to
   // at the document level, which is necessary for event replaying to work.
   // They bubble in all modern browsers.
-  it('should not receive submit events if native, interim DOM handler prevents it', () => {
+  it('should not receive submit events if native, interim DOM handler prevents it', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
 
@@ -326,7 +326,7 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
-  it('should dispatch loadstart only for media elements', () => {
+  it('should dispatch loadstart only for media elements', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
 
@@ -364,7 +364,7 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
-  it('should not attempt to listen to unnecessary events on the top level', () => {
+  it('should not attempt to listen to unnecessary events on the top level', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
 
@@ -478,7 +478,7 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
-  it('should dispatch load for embed elements', () => {
+  it('should dispatch load for embed elements', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
 
@@ -507,7 +507,7 @@ describe('ReactDOMEventListener', () => {
 
   // Unlike browsers, we delegate media events.
   // (This doesn't make a lot of sense but it would be a breaking change not to.)
-  it('should delegate media events even without a direct listener', () => {
+  it('should delegate media events even without a direct listener', async () => {
     const container = document.createElement('div');
     const ref = React.createRef();
     const handleVideoPlayDelegated = jest.fn();
@@ -533,7 +533,7 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
-  it('should delegate dialog events even without a direct listener', () => {
+  it('should delegate dialog events even without a direct listener', async () => {
     const container = document.createElement('div');
     const ref = React.createRef();
     const onCancel = jest.fn();
@@ -566,7 +566,7 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
-  it('should bubble non-native bubbling toggle events', () => {
+  it('should bubble non-native bubbling toggle events', async () => {
     const container = document.createElement('div');
     const ref = React.createRef();
     const onToggle = jest.fn();
@@ -589,7 +589,7 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
-  it('should bubble non-native bubbling cancel/close events', () => {
+  it('should bubble non-native bubbling cancel/close events', async () => {
     const container = document.createElement('div');
     const ref = React.createRef();
     const onCancel = jest.fn();
@@ -619,7 +619,7 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
-  it('should bubble non-native bubbling media events events', () => {
+  it('should bubble non-native bubbling media events events', async () => {
     const container = document.createElement('div');
     const ref = React.createRef();
     const onPlay = jest.fn();
@@ -642,7 +642,7 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
-  it('should bubble non-native bubbling invalid events', () => {
+  it('should bubble non-native bubbling invalid events', async () => {
     const container = document.createElement('div');
     const ref = React.createRef();
     const onInvalid = jest.fn();
@@ -665,7 +665,7 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
-  it('should handle non-bubbling capture events correctly', () => {
+  it('should handle non-bubbling capture events correctly', async () => {
     const container = document.createElement('div');
     const innerRef = React.createRef();
     const outerRef = React.createRef();
@@ -712,7 +712,7 @@ describe('ReactDOMEventListener', () => {
   // We're moving towards aligning more closely with the browser.
   // Currently we emulate bubbling for all non-bubbling events except scroll.
   // We may expand this list in the future, removing emulated bubbling altogether.
-  it('should not emulate bubbling of scroll events', () => {
+  it('should not emulate bubbling of scroll events', async () => {
     const container = document.createElement('div');
     const ref = React.createRef();
     const log = [];
@@ -783,7 +783,7 @@ describe('ReactDOMEventListener', () => {
   // We're moving towards aligning more closely with the browser.
   // Currently we emulate bubbling for all non-bubbling events except scroll.
   // We may expand this list in the future, removing emulated bubbling altogether.
-  it('should not emulate bubbling of scroll events (no own handler)', () => {
+  it('should not emulate bubbling of scroll events (no own handler)', async () => {
     const container = document.createElement('div');
     const ref = React.createRef();
     const log = [];
@@ -841,7 +841,7 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
-  it('should subscribe to scroll during updates', () => {
+  it('should subscribe to scroll during updates', async () => {
     const container = document.createElement('div');
     const ref = React.createRef();
     const log = [];
@@ -992,7 +992,7 @@ describe('ReactDOMEventListener', () => {
   });
 
   // Regression test.
-  it('should subscribe to scroll during hydration', () => {
+  it('should subscribe to scroll during hydration', async () => {
     const container = document.createElement('div');
     const ref = React.createRef();
     const log = [];
@@ -1083,7 +1083,7 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
-  it('should not subscribe to selectionchange twice', () => {
+  it('should not subscribe to selectionchange twice', async () => {
     const log = [];
 
     const originalDocAddEventListener = document.addEventListener;

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -27,14 +27,14 @@ describe('ReactDOMFiber', () => {
     jest.restoreAllMocks();
   });
 
-  it('should render strings as children', () => {
+  it('should render strings as children', async () => {
     const Box = ({value}) => <div>{value}</div>;
 
     ReactDOM.render(<Box value="foo" />, container);
     expect(container.textContent).toEqual('foo');
   });
 
-  it('should render numbers as children', () => {
+  it('should render numbers as children', async () => {
     const Box = ({value}) => <div>{value}</div>;
 
     ReactDOM.render(<Box value={10} />, container);
@@ -42,7 +42,7 @@ describe('ReactDOMFiber', () => {
     expect(container.textContent).toEqual('10');
   });
 
-  it('should be called a callback argument', () => {
+  it('should be called a callback argument', async () => {
     // mounting phase
     let called = false;
     ReactDOM.render(<div>Foo</div>, container, () => (called = true));
@@ -54,7 +54,7 @@ describe('ReactDOMFiber', () => {
     expect(called).toEqual(true);
   });
 
-  it('should call a callback argument when the same element is re-rendered', () => {
+  it('should call a callback argument when the same element is re-rendered', async () => {
     class Foo extends React.Component {
       render() {
         return <div>Foo</div>;
@@ -75,14 +75,14 @@ describe('ReactDOMFiber', () => {
     expect(called).toEqual(true);
   });
 
-  it('should render a component returning strings directly from render', () => {
+  it('should render a component returning strings directly from render', async () => {
     const Text = ({value}) => value;
 
     ReactDOM.render(<Text value="foo" />, container);
     expect(container.textContent).toEqual('foo');
   });
 
-  it('should render a component returning numbers directly from render', () => {
+  it('should render a component returning numbers directly from render', async () => {
     const Text = ({value}) => value;
 
     ReactDOM.render(<Text value={10} />, container);
@@ -90,7 +90,7 @@ describe('ReactDOMFiber', () => {
     expect(container.textContent).toEqual('10');
   });
 
-  it('finds the DOM Text node of a string child', () => {
+  it('finds the DOM Text node of a string child', async () => {
     class Text extends React.Component {
       render() {
         return this.props.value;
@@ -109,7 +109,7 @@ describe('ReactDOMFiber', () => {
     expect(textNode.nodeValue).toBe('foo');
   });
 
-  it('finds the first child when a component returns a fragment', () => {
+  it('finds the first child when a component returns a fragment', async () => {
     class Fragment extends React.Component {
       render() {
         return [<div key="a" />, <span key="b" />];
@@ -126,7 +126,7 @@ describe('ReactDOMFiber', () => {
     expect(firstNode.tagName).toBe('DIV');
   });
 
-  it('finds the first child even when fragment is nested', () => {
+  it('finds the first child even when fragment is nested', async () => {
     class Wrapper extends React.Component {
       render() {
         return this.props.children;
@@ -154,7 +154,7 @@ describe('ReactDOMFiber', () => {
     expect(firstNode.tagName).toBe('DIV');
   });
 
-  it('finds the first child even when first child renders null', () => {
+  it('finds the first child even when first child renders null', async () => {
     class NullComponent extends React.Component {
       render() {
         return null;
@@ -177,7 +177,7 @@ describe('ReactDOMFiber', () => {
     expect(firstNode.tagName).toBe('DIV');
   });
 
-  it('renders an empty fragment', () => {
+  it('renders an empty fragment', async () => {
     const Div = () => <div />;
     const EmptyFragment = () => <></>;
     const NonEmptyFragment = () => (
@@ -232,7 +232,7 @@ describe('ReactDOMFiber', () => {
     expect(testContainer.innerHTML).toBe('');
   };
 
-  it('should render one portal', () => {
+  it('should render one portal', async () => {
     const portalContainer = document.createElement('div');
 
     ReactDOM.render(
@@ -247,7 +247,7 @@ describe('ReactDOMFiber', () => {
     expect(container.innerHTML).toBe('');
   });
 
-  it('should render many portals', () => {
+  it('should render many portals', async () => {
     const portalContainer1 = document.createElement('div');
     const portalContainer2 = document.createElement('div');
 
@@ -347,7 +347,7 @@ describe('ReactDOMFiber', () => {
     ]);
   });
 
-  it('should render nested portals', () => {
+  it('should render nested portals', async () => {
     const portalContainer1 = document.createElement('div');
     const portalContainer2 = document.createElement('div');
     const portalContainer3 = document.createElement('div');
@@ -390,7 +390,7 @@ describe('ReactDOMFiber', () => {
     expect(container.innerHTML).toBe('');
   });
 
-  it('should reconcile portal children', () => {
+  it('should reconcile portal children', async () => {
     const portalContainer = document.createElement('div');
 
     ReactDOM.render(
@@ -436,7 +436,7 @@ describe('ReactDOMFiber', () => {
     expect(container.innerHTML).toBe('<div></div>');
   });
 
-  it('should unmount empty portal component wherever it appears', () => {
+  it('should unmount empty portal component wherever it appears', async () => {
     const portalContainer = document.createElement('div');
 
     class Wrapper extends React.Component {
@@ -719,7 +719,7 @@ describe('ReactDOMFiber', () => {
   });
 
   // @gate !disableLegacyContext
-  it('should pass portal context when rendering subtree elsewhere', () => {
+  it('should pass portal context when rendering subtree elsewhere', async () => {
     const portalContainer = document.createElement('div');
 
     class Component extends React.Component {
@@ -754,7 +754,7 @@ describe('ReactDOMFiber', () => {
   });
 
   // @gate !disableLegacyContext
-  it('should update portal context if it changes due to setState', () => {
+  it('should update portal context if it changes due to setState', async () => {
     const portalContainer = document.createElement('div');
 
     class Component extends React.Component {
@@ -799,7 +799,7 @@ describe('ReactDOMFiber', () => {
   });
 
   // @gate !disableLegacyContext
-  it('should update portal context if it changes due to re-render', () => {
+  it('should update portal context if it changes due to re-render', async () => {
     const portalContainer = document.createElement('div');
 
     class Component extends React.Component {
@@ -839,7 +839,7 @@ describe('ReactDOMFiber', () => {
     expect(container.innerHTML).toBe('');
   });
 
-  it('findDOMNode should find dom element after expanding a fragment', () => {
+  it('findDOMNode should find dom element after expanding a fragment', async () => {
     class MyNode extends React.Component {
       render() {
         return !this.props.flag
@@ -859,7 +859,7 @@ describe('ReactDOMFiber', () => {
     expect(b.tagName).toBe('SPAN');
   });
 
-  it('should bubble events from the portal to the parent', () => {
+  it('should bubble events from the portal to the parent', async () => {
     const portalContainer = document.createElement('div');
     document.body.appendChild(portalContainer);
     try {
@@ -890,7 +890,7 @@ describe('ReactDOMFiber', () => {
     }
   });
 
-  it('should not onMouseLeave when staying in the portal', () => {
+  it('should not onMouseLeave when staying in the portal', async () => {
     const portalContainer = document.createElement('div');
     document.body.appendChild(portalContainer);
 
@@ -966,7 +966,7 @@ describe('ReactDOMFiber', () => {
   });
 
   // Regression test for https://github.com/facebook/react/issues/19562
-  it('does not fire mouseEnter twice when relatedTarget is the root node', () => {
+  it('does not fire mouseEnter twice when relatedTarget is the root node', async () => {
     let ops = [];
     let target = null;
 
@@ -1016,7 +1016,7 @@ describe('ReactDOMFiber', () => {
     expect(ops).toEqual([]);
   });
 
-  it('listens to events that do not exist in the Portal subtree', () => {
+  it('listens to events that do not exist in the Portal subtree', async () => {
     const onClick = jest.fn();
 
     const ref = React.createRef();
@@ -1043,7 +1043,7 @@ describe('ReactDOMFiber', () => {
     }).toThrow('Target container is not a DOM element.');
   });
 
-  it('should warn for non-functional event listeners', () => {
+  it('should warn for non-functional event listeners', async () => {
     class Example extends React.Component {
       render() {
         return <div onClick="woops" />;
@@ -1056,7 +1056,7 @@ describe('ReactDOMFiber', () => {
     );
   });
 
-  it('should warn with a special message for `false` event listeners', () => {
+  it('should warn with a special message for `false` event listeners', async () => {
     class Example extends React.Component {
       render() {
         return <div onClick={false} />;
@@ -1071,7 +1071,7 @@ describe('ReactDOMFiber', () => {
     );
   });
 
-  it('should not update event handlers until commit', () => {
+  it('should not update event handlers until commit', async () => {
     spyOnDev(console, 'error');
 
     let ops = [];
@@ -1168,7 +1168,7 @@ describe('ReactDOMFiber', () => {
     }
   });
 
-  it('should not crash encountering low-priority tree', () => {
+  it('should not crash encountering low-priority tree', async () => {
     ReactDOM.render(
       <div hidden={true}>
         <div />
@@ -1177,7 +1177,7 @@ describe('ReactDOMFiber', () => {
     );
   });
 
-  it('should not warn when rendering into an empty container', () => {
+  it('should not warn when rendering into an empty container', async () => {
     ReactDOM.render(<div>foo</div>, container);
     expect(container.innerHTML).toBe('<div>foo</div>');
     ReactDOM.render(null, container);
@@ -1186,7 +1186,7 @@ describe('ReactDOMFiber', () => {
     expect(container.innerHTML).toBe('<div>bar</div>');
   });
 
-  it('should warn when replacing a container which was manually updated outside of React', () => {
+  it('should warn when replacing a container which was manually updated outside of React', async () => {
     // when not messing with the DOM outside of React
     ReactDOM.render(<div key="1">foo</div>, container);
     ReactDOM.render(<div key="1">bar</div>, container);
@@ -1210,7 +1210,7 @@ describe('ReactDOMFiber', () => {
     }).toThrowError();
   });
 
-  it('should warn when doing an update to a container manually updated outside of React', () => {
+  it('should warn when doing an update to a container manually updated outside of React', async () => {
     // when not messing with the DOM outside of React
     ReactDOM.render(<div>foo</div>, container);
     ReactDOM.render(<div>bar</div>, container);
@@ -1227,7 +1227,7 @@ describe('ReactDOMFiber', () => {
     );
   });
 
-  it('should warn when doing an update to a container manually cleared outside of React', () => {
+  it('should warn when doing an update to a container manually cleared outside of React', async () => {
     // when not messing with the DOM outside of React
     ReactDOM.render(<div>foo</div>, container);
     ReactDOM.render(<div>bar</div>, container);
@@ -1244,7 +1244,7 @@ describe('ReactDOMFiber', () => {
     );
   });
 
-  it('should render a text component with a text DOM node on the same document as the container', () => {
+  it('should render a text component with a text DOM node on the same document as the container', async () => {
     // 1. Create a new document through the use of iframe
     // 2. Set up the spy to make asserts when a text component
     //    is rendered inside the iframe container
@@ -1274,7 +1274,7 @@ describe('ReactDOMFiber', () => {
     expect(iframeContainer.appendChild).toHaveBeenCalledTimes(1);
   });
 
-  it('should mount into a document fragment', () => {
+  it('should mount into a document fragment', async () => {
     const fragment = document.createDocumentFragment();
     ReactDOM.render(<div>foo</div>, fragment);
     expect(container.innerHTML).toBe('');
@@ -1283,7 +1283,7 @@ describe('ReactDOMFiber', () => {
   });
 
   // Regression test for https://github.com/facebook/react/issues/12643#issuecomment-413727104
-  it('should not diff memoized host components', () => {
+  it('should not diff memoized host components', async () => {
     const inputRef = React.createRef();
     let didCallOnChange = false;
 
@@ -1341,7 +1341,7 @@ describe('ReactDOMFiber', () => {
     expect(didCallOnChange).toBe(true);
   });
 
-  it('unmounted legacy roots should never clear newer root content from a container', () => {
+  it('unmounted legacy roots should never clear newer root content from a container', async () => {
     const ref = React.createRef();
 
     function OldApp() {

--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
@@ -50,7 +50,7 @@ describe('ReactDOMFiberAsync', () => {
     document.body.removeChild(container);
   });
 
-  it('renders synchronously by default', () => {
+  it('renders synchronously by default', async () => {
     const ops = [];
     ReactDOM.render(<div>Hi</div>, container, () => {
       ops.push(container.textContent);
@@ -61,7 +61,7 @@ describe('ReactDOMFiberAsync', () => {
     expect(ops).toEqual(['Hi', 'Bye']);
   });
 
-  it('flushSync batches sync updates and flushes them at the end of the batch', () => {
+  it('flushSync batches sync updates and flushes them at the end of the batch', async () => {
     const ops = [];
     let instance;
 
@@ -99,7 +99,7 @@ describe('ReactDOMFiberAsync', () => {
     expect(ops).toEqual(['A', 'ABC', 'ABCD']);
   });
 
-  it('flushSync flushes updates even if nested inside another flushSync', () => {
+  it('flushSync flushes updates even if nested inside another flushSync', async () => {
     const ops = [];
     let instance;
 
@@ -141,7 +141,7 @@ describe('ReactDOMFiberAsync', () => {
     expect(ops).toEqual(['A', 'ABCD']);
   });
 
-  it('flushSync logs an error if already performing work', () => {
+  it('flushSync logs an error if already performing work', async () => {
     class Component extends React.Component {
       componentDidUpdate() {
         ReactDOM.flushSync();

--- a/packages/react-dom/src/__tests__/ReactDOMHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHooks-test.js
@@ -76,7 +76,7 @@ describe('ReactDOMHooks', () => {
     expect(container3.textContent).toBe('6');
   });
 
-  it('should not bail out when an update is scheduled from within an event handler', () => {
+  it('should not bail out when an update is scheduled from within an event handler', async () => {
     const {createRef, useCallback, useState} = React;
 
     const Example = ({inputRef, labelRef}) => {

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -106,7 +106,7 @@ describe('ReactDOMInput', () => {
     jest.restoreAllMocks();
   });
 
-  it('should warn for controlled value of 0 with missing onChange', () => {
+  it('should warn for controlled value of 0 with missing onChange', async () => {
     expect(() => {
       ReactDOM.render(<input type="text" value={0} />, container);
     }).toErrorDev(
@@ -117,7 +117,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn for controlled value of "" with missing onChange', () => {
+  it('should warn for controlled value of "" with missing onChange', async () => {
     expect(() => {
       ReactDOM.render(<input type="text" value="" />, container);
     }).toErrorDev(
@@ -128,7 +128,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn for controlled value of "0" with missing onChange', () => {
+  it('should warn for controlled value of "0" with missing onChange', async () => {
     expect(() => {
       ReactDOM.render(<input type="text" value="0" />, container);
     }).toErrorDev(
@@ -139,7 +139,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn for controlled value of false with missing onChange', () => {
+  it('should warn for controlled value of false with missing onChange', async () => {
     expect(() =>
       ReactDOM.render(<input type="checkbox" checked={false} />, container),
     ).toErrorDev(
@@ -147,7 +147,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn with checked and no onChange handler with readOnly specified', () => {
+  it('should warn with checked and no onChange handler with readOnly specified', async () => {
     ReactDOM.render(
       <input type="checkbox" checked={false} readOnly={true} />,
       container,
@@ -166,7 +166,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should not warn about missing onChange in uncontrolled inputs', () => {
+  it('should not warn about missing onChange in uncontrolled inputs', async () => {
     ReactDOM.render(<input />, container);
     ReactDOM.unmountComponentAtNode(container);
     ReactDOM.render(<input value={undefined} />, container);
@@ -180,11 +180,11 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(<input type="checkbox" checked={undefined} />, container);
   });
 
-  it('should not warn with value and onInput handler', () => {
+  it('should not warn with value and onInput handler', async () => {
     ReactDOM.render(<input value="..." onInput={() => {}} />, container);
   });
 
-  it('should properly control a value even if no event listener exists', () => {
+  it('should properly control a value even if no event listener exists', async () => {
     let node;
 
     expect(() => {
@@ -204,7 +204,7 @@ describe('ReactDOMInput', () => {
     expect(isValueDirty(node)).toBe(true);
   });
 
-  it('should control a value in reentrant events', () => {
+  it('should control a value in reentrant events', async () => {
     class ControlledInputs extends React.Component {
       state = {value: 'lion'};
       a = null;
@@ -256,7 +256,7 @@ describe('ReactDOMInput', () => {
     expect(instance.switchedFocus).toBe(true);
   });
 
-  it('should control values in reentrant events with different targets', () => {
+  it('should control values in reentrant events with different targets', async () => {
     class ControlledInputs extends React.Component {
       state = {value: 'lion'};
       a = null;
@@ -300,7 +300,7 @@ describe('ReactDOMInput', () => {
   });
 
   describe('switching text inputs between numeric and string numbers', () => {
-    it('does change the number 2 to "2.0" with no change handler', () => {
+    it('does change the number 2 to "2.0" with no change handler', async () => {
       const stub = <input type="text" value={2} onChange={jest.fn()} />;
       const node = ReactDOM.render(stub, container);
 
@@ -315,7 +315,7 @@ describe('ReactDOMInput', () => {
       }
     });
 
-    it('does change the string "2" to "2.0" with no change handler', () => {
+    it('does change the string "2" to "2.0" with no change handler', async () => {
       const stub = <input type="text" value={'2'} onChange={jest.fn()} />;
       const node = ReactDOM.render(stub, container);
 
@@ -330,7 +330,7 @@ describe('ReactDOMInput', () => {
       }
     });
 
-    it('changes the number 2 to "2.0" using a change handler', () => {
+    it('changes the number 2 to "2.0" using a change handler', async () => {
       class Stub extends React.Component {
         state = {
           value: 2,
@@ -360,7 +360,7 @@ describe('ReactDOMInput', () => {
     });
   });
 
-  it('does change the string ".98" to "0.98" with no change handler', () => {
+  it('does change the string ".98" to "0.98" with no change handler', async () => {
     class Stub extends React.Component {
       state = {
         value: '.98',
@@ -383,7 +383,7 @@ describe('ReactDOMInput', () => {
     expect(node.value).toEqual('0.98');
   });
 
-  it('performs a state change from "" to 0', () => {
+  it('performs a state change from "" to 0', async () => {
     class Stub extends React.Component {
       state = {
         value: '',
@@ -400,7 +400,7 @@ describe('ReactDOMInput', () => {
     expect(node.value).toEqual('0');
   });
 
-  it('updates the value on radio buttons from "" to 0', function () {
+  it('updates the value on radio buttons from "" to 0', async () => {
     ReactDOM.render(
       <input type="radio" value="" onChange={function () {}} />,
       container,
@@ -413,7 +413,7 @@ describe('ReactDOMInput', () => {
     expect(container.firstChild.getAttribute('value')).toBe('0');
   });
 
-  it('updates the value on checkboxes from "" to 0', function () {
+  it('updates the value on checkboxes from "" to 0', async () => {
     ReactDOM.render(
       <input type="checkbox" value="" onChange={function () {}} />,
       container,
@@ -426,7 +426,7 @@ describe('ReactDOMInput', () => {
     expect(container.firstChild.getAttribute('value')).toBe('0');
   });
 
-  it('distinguishes precision for extra zeroes in string number values', () => {
+  it('distinguishes precision for extra zeroes in string number values', async () => {
     class Stub extends React.Component {
       state = {
         value: '3.0000',
@@ -450,7 +450,7 @@ describe('ReactDOMInput', () => {
     expect(node.value).toEqual('3');
   });
 
-  it('should display `defaultValue` of number 0', () => {
+  it('should display `defaultValue` of number 0', async () => {
     const stub = <input type="text" defaultValue={0} />;
     const node = ReactDOM.render(stub, container);
 
@@ -458,7 +458,7 @@ describe('ReactDOMInput', () => {
     expect(node.value).toBe('0');
   });
 
-  it('only assigns defaultValue if it changes', () => {
+  it('only assigns defaultValue if it changes', async () => {
     class Test extends React.Component {
       render() {
         return <input defaultValue="0" />;
@@ -482,21 +482,21 @@ describe('ReactDOMInput', () => {
     component.forceUpdate();
   });
 
-  it('should display "true" for `defaultValue` of `true`', () => {
+  it('should display "true" for `defaultValue` of `true`', async () => {
     const stub = <input type="text" defaultValue={true} />;
     const node = ReactDOM.render(stub, container);
 
     expect(node.value).toBe('true');
   });
 
-  it('should display "false" for `defaultValue` of `false`', () => {
+  it('should display "false" for `defaultValue` of `false`', async () => {
     const stub = <input type="text" defaultValue={false} />;
     const node = ReactDOM.render(stub, container);
 
     expect(node.value).toBe('false');
   });
 
-  it('should update `defaultValue` for uncontrolled input', () => {
+  it('should update `defaultValue` for uncontrolled input', async () => {
     const node = ReactDOM.render(
       <input type="text" defaultValue="0" />,
       container,
@@ -523,7 +523,7 @@ describe('ReactDOMInput', () => {
     }
   });
 
-  it('should update `defaultValue` for uncontrolled date/time input', () => {
+  it('should update `defaultValue` for uncontrolled date/time input', async () => {
     const node = ReactDOM.render(
       <input type="date" defaultValue="1980-01-01" />,
       container,
@@ -545,7 +545,7 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(<input type="date" />, container);
   });
 
-  it('should take `defaultValue` when changing to uncontrolled input', () => {
+  it('should take `defaultValue` when changing to uncontrolled input', async () => {
     const node = ReactDOM.render(
       <input type="text" value="0" readOnly={true} />,
       container,
@@ -580,7 +580,7 @@ describe('ReactDOMInput', () => {
     expect(div.firstChild.getAttribute('defaultValue')).toBe(null);
   });
 
-  it('should render name attribute if it is supplied', () => {
+  it('should render name attribute if it is supplied', async () => {
     const node = ReactDOM.render(<input type="text" name="name" />, container);
     expect(node.name).toBe('name');
     expect(container.firstChild.getAttribute('name')).toBe('name');
@@ -594,7 +594,7 @@ describe('ReactDOMInput', () => {
     expect(div.firstChild.getAttribute('name')).toBe('name');
   });
 
-  it('should not render name attribute if it is not supplied', () => {
+  it('should not render name attribute if it is not supplied', async () => {
     ReactDOM.render(<input type="text" />, container);
     expect(container.firstChild.getAttribute('name')).toBe(null);
   });
@@ -607,7 +607,7 @@ describe('ReactDOMInput', () => {
     expect(div.firstChild.getAttribute('name')).toBe(null);
   });
 
-  it('should display "foobar" for `defaultValue` of `objToString`', () => {
+  it('should display "foobar" for `defaultValue` of `objToString`', async () => {
     const objToString = {
       toString: function () {
         return 'foobar';
@@ -620,7 +620,7 @@ describe('ReactDOMInput', () => {
     expect(node.value).toBe('foobar');
   });
 
-  it('should throw for date inputs if `defaultValue` is an object where valueOf() throws', () => {
+  it('should throw for date inputs if `defaultValue` is an object where valueOf() throws', async () => {
     class TemporalLike {
       valueOf() {
         // Throwing here is the behavior of ECMAScript "Temporal" date/time API.
@@ -644,7 +644,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should throw for text inputs if `defaultValue` is an object where valueOf() throws', () => {
+  it('should throw for text inputs if `defaultValue` is an object where valueOf() throws', async () => {
     class TemporalLike {
       valueOf() {
         // Throwing here is the behavior of ECMAScript "Temporal" date/time API.
@@ -668,7 +668,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should throw for date inputs if `value` is an object where valueOf() throws', () => {
+  it('should throw for date inputs if `value` is an object where valueOf() throws', async () => {
     class TemporalLike {
       valueOf() {
         // Throwing here is the behavior of ECMAScript "Temporal" date/time API.
@@ -692,7 +692,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should throw for text inputs if `value` is an object where valueOf() throws', () => {
+  it('should throw for text inputs if `value` is an object where valueOf() throws', async () => {
     class TemporalLike {
       valueOf() {
         // Throwing here is the behavior of ECMAScript "Temporal" date/time API.
@@ -716,14 +716,14 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should display `value` of number 0', () => {
+  it('should display `value` of number 0', async () => {
     const stub = <input type="text" value={0} onChange={emptyFunction} />;
     const node = ReactDOM.render(stub, container);
 
     expect(node.value).toBe('0');
   });
 
-  it('should allow setting `value` to `true`', () => {
+  it('should allow setting `value` to `true`', async () => {
     let stub = <input type="text" value="yolo" onChange={emptyFunction} />;
     const node = ReactDOM.render(stub, container);
 
@@ -736,7 +736,7 @@ describe('ReactDOMInput', () => {
     expect(node.value).toEqual('true');
   });
 
-  it('should allow setting `value` to `false`', () => {
+  it('should allow setting `value` to `false`', async () => {
     let stub = <input type="text" value="yolo" onChange={emptyFunction} />;
     const node = ReactDOM.render(stub, container);
 
@@ -749,7 +749,7 @@ describe('ReactDOMInput', () => {
     expect(node.value).toEqual('false');
   });
 
-  it('should allow setting `value` to `objToString`', () => {
+  it('should allow setting `value` to `objToString`', async () => {
     let stub = <input type="text" value="foo" onChange={emptyFunction} />;
     const node = ReactDOM.render(stub, container);
 
@@ -767,7 +767,7 @@ describe('ReactDOMInput', () => {
     expect(node.value).toEqual('foobar');
   });
 
-  it('should not incur unnecessary DOM mutations', () => {
+  it('should not incur unnecessary DOM mutations', async () => {
     ReactDOM.render(<input value="a" onChange={() => {}} />, container);
 
     const node = container.firstChild;
@@ -789,7 +789,7 @@ describe('ReactDOMInput', () => {
     expect(nodeValueSetter).toHaveBeenCalledTimes(1);
   });
 
-  it('should not incur unnecessary DOM mutations for numeric type conversion', () => {
+  it('should not incur unnecessary DOM mutations for numeric type conversion', async () => {
     ReactDOM.render(<input value="0" onChange={() => {}} />, container);
 
     const node = container.firstChild;
@@ -808,7 +808,7 @@ describe('ReactDOMInput', () => {
     expect(nodeValueSetter).toHaveBeenCalledTimes(0);
   });
 
-  it('should not incur unnecessary DOM mutations for the boolean type conversion', () => {
+  it('should not incur unnecessary DOM mutations for the boolean type conversion', async () => {
     ReactDOM.render(<input value="true" onChange={() => {}} />, container);
 
     const node = container.firstChild;
@@ -827,7 +827,7 @@ describe('ReactDOMInput', () => {
     expect(nodeValueSetter).toHaveBeenCalledTimes(0);
   });
 
-  it('should properly control a value of number `0`', () => {
+  it('should properly control a value of number `0`', async () => {
     const stub = <input type="text" value={0} onChange={emptyFunction} />;
     const node = ReactDOM.render(stub, container);
 
@@ -836,7 +836,7 @@ describe('ReactDOMInput', () => {
     expect(node.value).toBe('0');
   });
 
-  it('should properly control 0.0 for a text input', () => {
+  it('should properly control 0.0 for a text input', async () => {
     const stub = <input type="text" value={0} onChange={emptyFunction} />;
     const node = ReactDOM.render(stub, container);
 
@@ -845,7 +845,7 @@ describe('ReactDOMInput', () => {
     expect(node.value).toBe('0');
   });
 
-  it('should properly control 0.0 for a number input', () => {
+  it('should properly control 0.0 for a number input', async () => {
     const stub = <input type="number" value={0} onChange={emptyFunction} />;
     const node = ReactDOM.render(stub, container);
 
@@ -864,7 +864,7 @@ describe('ReactDOMInput', () => {
     }
   });
 
-  it('should properly transition from an empty value to 0', function () {
+  it('should properly transition from an empty value to 0', async () => {
     ReactDOM.render(
       <input type="text" value="" onChange={emptyFunction} />,
       container,
@@ -887,7 +887,7 @@ describe('ReactDOMInput', () => {
     }
   });
 
-  it('should properly transition from 0 to an empty value', function () {
+  it('should properly transition from 0 to an empty value', async () => {
     ReactDOM.render(
       <input type="text" value={0} onChange={emptyFunction} />,
       container,
@@ -905,7 +905,7 @@ describe('ReactDOMInput', () => {
     expect(isValueDirty(node)).toBe(true);
   });
 
-  it('should properly transition a text input from 0 to an empty 0.0', function () {
+  it('should properly transition a text input from 0 to an empty 0.0', async () => {
     ReactDOM.render(
       <input type="text" value={0} onChange={emptyFunction} />,
       container,
@@ -925,7 +925,7 @@ describe('ReactDOMInput', () => {
     }
   });
 
-  it('should properly transition a number input from "" to 0', function () {
+  it('should properly transition a number input from "" to 0', async () => {
     ReactDOM.render(
       <input type="number" value="" onChange={emptyFunction} />,
       container,
@@ -945,7 +945,7 @@ describe('ReactDOMInput', () => {
     }
   });
 
-  it('should properly transition a number input from "" to "0"', function () {
+  it('should properly transition a number input from "" to "0"', async () => {
     ReactDOM.render(
       <input type="number" value="" onChange={emptyFunction} />,
       container,
@@ -965,7 +965,7 @@ describe('ReactDOMInput', () => {
     }
   });
 
-  it('should have the correct target value', () => {
+  it('should have the correct target value', async () => {
     let handled = false;
     const handler = function (event) {
       expect(event.target.nodeName).toBe('INPUT');
@@ -981,7 +981,7 @@ describe('ReactDOMInput', () => {
     expect(handled).toBe(true);
   });
 
-  it('should restore uncontrolled inputs to last defaultValue upon reset', () => {
+  it('should restore uncontrolled inputs to last defaultValue upon reset', async () => {
     const inputRef = React.createRef();
     ReactDOM.render(
       <form>
@@ -1020,7 +1020,7 @@ describe('ReactDOMInput', () => {
     expect(isValueDirty(inputRef.current)).toBe(false);
   });
 
-  it('should not set a value for submit buttons unnecessarily', () => {
+  it('should not set a value for submit buttons unnecessarily', async () => {
     const stub = <input type="submit" />;
     ReactDOM.render(stub, container);
     const node = container.firstChild;
@@ -1032,7 +1032,7 @@ describe('ReactDOMInput', () => {
     expect(node.hasAttribute('value')).toBe(false);
   });
 
-  it('should remove the value attribute on submit inputs when value is updated to undefined', () => {
+  it('should remove the value attribute on submit inputs when value is updated to undefined', async () => {
     const stub = <input type="submit" value="foo" onChange={emptyFunction} />;
     ReactDOM.render(stub, container);
 
@@ -1051,7 +1051,7 @@ describe('ReactDOMInput', () => {
     expect(node.getAttribute('value')).toBe(null);
   });
 
-  it('should remove the value attribute on reset inputs when value is updated to undefined', () => {
+  it('should remove the value attribute on reset inputs when value is updated to undefined', async () => {
     const stub = <input type="reset" value="foo" onChange={emptyFunction} />;
     ReactDOM.render(stub, container);
 
@@ -1070,7 +1070,7 @@ describe('ReactDOMInput', () => {
     expect(node.getAttribute('value')).toBe(null);
   });
 
-  it('should set a value on a submit input', () => {
+  it('should set a value on a submit input', async () => {
     const stub = <input type="submit" value="banana" />;
     ReactDOM.render(stub, container);
     const node = container.firstChild;
@@ -1078,7 +1078,7 @@ describe('ReactDOMInput', () => {
     expect(node.getAttribute('value')).toBe('banana');
   });
 
-  it('should not set an undefined value on a submit input', () => {
+  it('should not set an undefined value on a submit input', async () => {
     const stub = <input type="submit" value={undefined} />;
     ReactDOM.render(stub, container);
     const node = container.firstChild;
@@ -1091,7 +1091,7 @@ describe('ReactDOMInput', () => {
     expect(node.getAttribute('value')).toBe(null);
   });
 
-  it('should not set an undefined value on a reset input', () => {
+  it('should not set an undefined value on a reset input', async () => {
     const stub = <input type="reset" value={undefined} />;
     ReactDOM.render(stub, container);
     const node = container.firstChild;
@@ -1104,7 +1104,7 @@ describe('ReactDOMInput', () => {
     expect(node.getAttribute('value')).toBe(null);
   });
 
-  it('should not set a null value on a submit input', () => {
+  it('should not set a null value on a submit input', async () => {
     const stub = <input type="submit" value={null} />;
     expect(() => {
       ReactDOM.render(stub, container);
@@ -1119,7 +1119,7 @@ describe('ReactDOMInput', () => {
     expect(node.getAttribute('value')).toBe(null);
   });
 
-  it('should not set a null value on a reset input', () => {
+  it('should not set a null value on a reset input', async () => {
     const stub = <input type="reset" value={null} />;
     expect(() => {
       ReactDOM.render(stub, container);
@@ -1134,7 +1134,7 @@ describe('ReactDOMInput', () => {
     expect(node.getAttribute('value')).toBe(null);
   });
 
-  it('should set a value on a reset input', () => {
+  it('should set a value on a reset input', async () => {
     const stub = <input type="reset" value="banana" />;
     ReactDOM.render(stub, container);
     const node = container.firstChild;
@@ -1142,7 +1142,7 @@ describe('ReactDOMInput', () => {
     expect(node.getAttribute('value')).toBe('banana');
   });
 
-  it('should set an empty string value on a submit input', () => {
+  it('should set an empty string value on a submit input', async () => {
     const stub = <input type="submit" value="" />;
     ReactDOM.render(stub, container);
     const node = container.firstChild;
@@ -1150,7 +1150,7 @@ describe('ReactDOMInput', () => {
     expect(node.getAttribute('value')).toBe('');
   });
 
-  it('should set an empty string value on a reset input', () => {
+  it('should set an empty string value on a reset input', async () => {
     const stub = <input type="reset" value="" />;
     ReactDOM.render(stub, container);
     const node = container.firstChild;
@@ -1158,7 +1158,7 @@ describe('ReactDOMInput', () => {
     expect(node.getAttribute('value')).toBe('');
   });
 
-  it('should control radio buttons', () => {
+  it('should control radio buttons', async () => {
     class RadioGroup extends React.Component {
       aRef = React.createRef();
       bRef = React.createRef();
@@ -1421,7 +1421,7 @@ describe('ReactDOMInput', () => {
     assertInputTrackingIsCurrent(container);
   });
 
-  it('should check the correct radio when the selected name moves', () => {
+  it('should check the correct radio when the selected name moves', async () => {
     class App extends React.Component {
       state = {
         updated: false,
@@ -1466,7 +1466,7 @@ describe('ReactDOMInput', () => {
     assertInputTrackingIsCurrent(container);
   });
 
-  it("shouldn't get tricked by changing radio names, part 2", () => {
+  it("shouldn't get tricked by changing radio names, part 2", async () => {
     ReactDOM.render(
       <div>
         <input
@@ -1520,7 +1520,7 @@ describe('ReactDOMInput', () => {
     assertInputTrackingIsCurrent(container);
   });
 
-  it('should control radio buttons if the tree updates during render', () => {
+  it('should control radio buttons if the tree updates during render', async () => {
     const sharedParent = container;
     const container1 = document.createElement('div');
     const container2 = document.createElement('div');
@@ -1600,7 +1600,7 @@ describe('ReactDOMInput', () => {
     assertInputTrackingIsCurrent(container);
   });
 
-  it('should control radio buttons if the tree updates during render (case 2; #26876)', () => {
+  it('should control radio buttons if the tree updates during render (case 2; #26876)', async () => {
     let thunk = null;
     function App() {
       const [disabled, setDisabled] = React.useState(false);
@@ -1677,7 +1677,7 @@ describe('ReactDOMInput', () => {
     assertInputTrackingIsCurrent(container);
   });
 
-  it('should warn with value and no onChange handler and readOnly specified', () => {
+  it('should warn with value and no onChange handler and readOnly specified', async () => {
     ReactDOM.render(
       <input type="text" value="zoink" readOnly={true} />,
       container,
@@ -1698,7 +1698,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should have a this value of undefined if bind is not used', () => {
+  it('should have a this value of undefined if bind is not used', async () => {
     expect.assertions(1);
     const unboundInputOnChange = function () {
       expect(this).toBe(undefined);
@@ -1711,7 +1711,7 @@ describe('ReactDOMInput', () => {
     dispatchEventOnNode(node, 'input');
   });
 
-  it('should update defaultValue to empty string', () => {
+  it('should update defaultValue to empty string', async () => {
     ReactDOM.render(<input type="text" defaultValue={'foo'} />, container);
     if (disableInputAttributeSyncing) {
       expect(isValueDirty(container.firstChild)).toBe(false);
@@ -1727,7 +1727,7 @@ describe('ReactDOMInput', () => {
     }
   });
 
-  it('should warn if value is null', () => {
+  it('should warn if value is null', async () => {
     expect(() =>
       ReactDOM.render(<input type="text" value={null} />, container),
     ).toErrorDev(
@@ -1740,7 +1740,7 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(<input type="text" value={null} />, container);
   });
 
-  it('should warn if checked and defaultChecked props are specified', () => {
+  it('should warn if checked and defaultChecked props are specified', async () => {
     expect(() =>
       ReactDOM.render(
         <input
@@ -1772,7 +1772,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if value and defaultValue props are specified', () => {
+  it('should warn if value and defaultValue props are specified', async () => {
     expect(() =>
       ReactDOM.render(
         <input type="text" value="foo" defaultValue="bar" readOnly={true} />,
@@ -1794,7 +1794,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if controlled input switches to uncontrolled (value is undefined)', () => {
+  it('should warn if controlled input switches to uncontrolled (value is undefined)', async () => {
     const stub = (
       <input type="text" value="controlled" onChange={emptyFunction} />
     );
@@ -1809,7 +1809,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if controlled input switches to uncontrolled (value is null)', () => {
+  it('should warn if controlled input switches to uncontrolled (value is null)', async () => {
     const stub = (
       <input type="text" value="controlled" onChange={emptyFunction} />
     );
@@ -1828,7 +1828,7 @@ describe('ReactDOMInput', () => {
     ]);
   });
 
-  it('should warn if controlled input switches to uncontrolled with defaultValue', () => {
+  it('should warn if controlled input switches to uncontrolled with defaultValue', async () => {
     const stub = (
       <input type="text" value="controlled" onChange={emptyFunction} />
     );
@@ -1848,7 +1848,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if uncontrolled input (value is undefined) switches to controlled', () => {
+  it('should warn if uncontrolled input (value is undefined) switches to controlled', async () => {
     const stub = <input type="text" />;
     ReactDOM.render(stub, container);
     expect(() =>
@@ -1863,7 +1863,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if uncontrolled input (value is null) switches to controlled', () => {
+  it('should warn if uncontrolled input (value is null) switches to controlled', async () => {
     const stub = <input type="text" value={null} />;
     expect(() => ReactDOM.render(stub, container)).toErrorDev(
       '`value` prop on `input` should not be null. ' +
@@ -1881,7 +1881,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if controlled checkbox switches to uncontrolled (checked is undefined)', () => {
+  it('should warn if controlled checkbox switches to uncontrolled (checked is undefined)', async () => {
     const stub = (
       <input type="checkbox" checked={true} onChange={emptyFunction} />
     );
@@ -1898,7 +1898,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if controlled checkbox switches to uncontrolled (checked is null)', () => {
+  it('should warn if controlled checkbox switches to uncontrolled (checked is null)', async () => {
     const stub = (
       <input type="checkbox" checked={true} onChange={emptyFunction} />
     );
@@ -1915,7 +1915,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if controlled checkbox switches to uncontrolled with defaultChecked', () => {
+  it('should warn if controlled checkbox switches to uncontrolled with defaultChecked', async () => {
     const stub = (
       <input type="checkbox" checked={true} onChange={emptyFunction} />
     );
@@ -1935,7 +1935,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if uncontrolled checkbox (checked is undefined) switches to controlled', () => {
+  it('should warn if uncontrolled checkbox (checked is undefined) switches to controlled', async () => {
     const stub = <input type="checkbox" />;
     ReactDOM.render(stub, container);
     expect(() =>
@@ -1950,7 +1950,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if uncontrolled checkbox (checked is null) switches to controlled', () => {
+  it('should warn if uncontrolled checkbox (checked is null) switches to controlled', async () => {
     const stub = <input type="checkbox" checked={null} />;
     ReactDOM.render(stub, container);
     expect(() =>
@@ -1965,7 +1965,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if controlled radio switches to uncontrolled (checked is undefined)', () => {
+  it('should warn if controlled radio switches to uncontrolled (checked is undefined)', async () => {
     const stub = <input type="radio" checked={true} onChange={emptyFunction} />;
     ReactDOM.render(stub, container);
     expect(() => ReactDOM.render(<input type="radio" />, container)).toErrorDev(
@@ -1978,7 +1978,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if controlled radio switches to uncontrolled (checked is null)', () => {
+  it('should warn if controlled radio switches to uncontrolled (checked is null)', async () => {
     const stub = <input type="radio" checked={true} onChange={emptyFunction} />;
     ReactDOM.render(stub, container);
     expect(() =>
@@ -1993,7 +1993,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if controlled radio switches to uncontrolled with defaultChecked', () => {
+  it('should warn if controlled radio switches to uncontrolled with defaultChecked', async () => {
     const stub = <input type="radio" checked={true} onChange={emptyFunction} />;
     ReactDOM.render(stub, container);
     expect(() =>
@@ -2008,7 +2008,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if uncontrolled radio (checked is undefined) switches to controlled', () => {
+  it('should warn if uncontrolled radio (checked is undefined) switches to controlled', async () => {
     const stub = <input type="radio" />;
     ReactDOM.render(stub, container);
     expect(() =>
@@ -2023,7 +2023,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should warn if uncontrolled radio (checked is null) switches to controlled', () => {
+  it('should warn if uncontrolled radio (checked is null) switches to controlled', async () => {
     const stub = <input type="radio" checked={null} />;
     ReactDOM.render(stub, container);
     expect(() =>
@@ -2038,7 +2038,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('should not warn if radio value changes but never becomes controlled', () => {
+  it('should not warn if radio value changes but never becomes controlled', async () => {
     ReactDOM.render(<input type="radio" value="value" />, container);
     ReactDOM.render(<input type="radio" />, container);
     ReactDOM.render(
@@ -2052,7 +2052,7 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(<input type="radio" />, container);
   });
 
-  it('should not warn if radio value changes but never becomes uncontrolled', () => {
+  it('should not warn if radio value changes but never becomes uncontrolled', async () => {
     ReactDOM.render(
       <input type="radio" checked={false} onChange={() => null} />,
       container,
@@ -2073,7 +2073,7 @@ describe('ReactDOMInput', () => {
     assertInputTrackingIsCurrent(container);
   });
 
-  it('should warn if radio checked false changes to become uncontrolled', () => {
+  it('should warn if radio checked false changes to become uncontrolled', async () => {
     ReactDOM.render(
       <input
         type="radio"
@@ -2095,7 +2095,7 @@ describe('ReactDOMInput', () => {
     );
   });
 
-  it('sets type, step, min, max before value always', () => {
+  it('sets type, step, min, max before value always', async () => {
     const log = [];
     const originalCreateElement = document.createElement;
     spyOnDevAndProd(document, 'createElement').mockImplementation(
@@ -2154,12 +2154,12 @@ describe('ReactDOMInput', () => {
     ]);
   });
 
-  it('sets value properly with type coming later in props', () => {
+  it('sets value properly with type coming later in props', async () => {
     const input = ReactDOM.render(<input value="hi" type="radio" />, container);
     expect(input.value).toBe('hi');
   });
 
-  it('does not raise a validation warning when it switches types', () => {
+  it('does not raise a validation warning when it switches types', async () => {
     class Input extends React.Component {
       state = {type: 'number', value: 1000};
 
@@ -2178,7 +2178,7 @@ describe('ReactDOMInput', () => {
     expect(node.value).toEqual('Test');
   });
 
-  it('resets value of date/time input to fix bugs in iOS Safari', () => {
+  it('resets value of date/time input to fix bugs in iOS Safari', async () => {
     function strify(x) {
       return JSON.stringify(x, null, 2);
     }
@@ -2289,7 +2289,7 @@ describe('ReactDOMInput', () => {
       };
     }
 
-    it('always sets the attribute when values change on text inputs', function () {
+    it('always sets the attribute when values change on text inputs', async () => {
       const Input = getTestInput();
       const stub = ReactDOM.render(<Input type="text" />, container);
       const node = ReactDOM.findDOMNode(stub);
@@ -2306,7 +2306,7 @@ describe('ReactDOMInput', () => {
       }
     });
 
-    it('does not set the value attribute on number inputs if focused', () => {
+    it('does not set the value attribute on number inputs if focused', async () => {
       const Input = getTestInput();
       const stub = ReactDOM.render(
         <Input type="number" value="1" />,
@@ -2328,7 +2328,7 @@ describe('ReactDOMInput', () => {
       }
     });
 
-    it('sets the value attribute on number inputs on blur', () => {
+    it('sets the value attribute on number inputs on blur', async () => {
       const Input = getTestInput();
       const stub = ReactDOM.render(
         <Input type="number" value="1" />,
@@ -2352,7 +2352,7 @@ describe('ReactDOMInput', () => {
       }
     });
 
-    it('an uncontrolled number input will not update the value attribute on blur', () => {
+    it('an uncontrolled number input will not update the value attribute on blur', async () => {
       const node = ReactDOM.render(
         <input type="number" defaultValue="1" />,
         container,
@@ -2372,7 +2372,7 @@ describe('ReactDOMInput', () => {
       expect(node.getAttribute('value')).toBe('1');
     });
 
-    it('an uncontrolled text input will not update the value attribute on blur', () => {
+    it('an uncontrolled text input will not update the value attribute on blur', async () => {
       const node = ReactDOM.render(
         <input type="text" defaultValue="1" />,
         container,
@@ -2494,7 +2494,7 @@ describe('ReactDOMInput', () => {
   });
 
   describe('When given a Symbol value', function () {
-    it('treats initial Symbol value as an empty string', function () {
+    it('treats initial Symbol value as an empty string', async () => {
       expect(() =>
         ReactDOM.render(
           <input value={Symbol('foobar')} onChange={() => {}} />,
@@ -2511,7 +2511,7 @@ describe('ReactDOMInput', () => {
       }
     });
 
-    it('treats updated Symbol value as an empty string', function () {
+    it('treats updated Symbol value as an empty string', async () => {
       ReactDOM.render(<input value="foo" onChange={() => {}} />, container);
       expect(() =>
         ReactDOM.render(
@@ -2529,7 +2529,7 @@ describe('ReactDOMInput', () => {
       }
     });
 
-    it('treats initial Symbol defaultValue as an empty string', function () {
+    it('treats initial Symbol defaultValue as an empty string', async () => {
       ReactDOM.render(<input defaultValue={Symbol('foobar')} />, container);
       const node = container.firstChild;
 
@@ -2538,7 +2538,7 @@ describe('ReactDOMInput', () => {
       // TODO: we should warn here.
     });
 
-    it('treats updated Symbol defaultValue as an empty string', function () {
+    it('treats updated Symbol defaultValue as an empty string', async () => {
       ReactDOM.render(<input defaultValue="foo" />, container);
       ReactDOM.render(<input defaultValue={Symbol('foobar')} />, container);
       const node = container.firstChild;
@@ -2554,7 +2554,7 @@ describe('ReactDOMInput', () => {
   });
 
   describe('When given a function value', function () {
-    it('treats initial function value as an empty string', function () {
+    it('treats initial function value as an empty string', async () => {
       expect(() =>
         ReactDOM.render(
           <input value={() => {}} onChange={() => {}} />,
@@ -2571,7 +2571,7 @@ describe('ReactDOMInput', () => {
       }
     });
 
-    it('treats updated function value as an empty string', function () {
+    it('treats updated function value as an empty string', async () => {
       ReactDOM.render(<input value="foo" onChange={() => {}} />, container);
       expect(() =>
         ReactDOM.render(
@@ -2589,7 +2589,7 @@ describe('ReactDOMInput', () => {
       }
     });
 
-    it('treats initial function defaultValue as an empty string', function () {
+    it('treats initial function defaultValue as an empty string', async () => {
       ReactDOM.render(<input defaultValue={() => {}} />, container);
       const node = container.firstChild;
 
@@ -2598,7 +2598,7 @@ describe('ReactDOMInput', () => {
       // TODO: we should warn here.
     });
 
-    it('treats updated function defaultValue as an empty string', function () {
+    it('treats updated function defaultValue as an empty string', async () => {
       ReactDOM.render(<input defaultValue="foo" />, container);
       ReactDOM.render(<input defaultValue={() => {}} />, container);
       const node = container.firstChild;
@@ -2619,7 +2619,7 @@ describe('ReactDOMInput', () => {
     // Between 16 and 16.2, we assigned a node's value to it's current
     // value in order to "dettach" it from defaultValue. This had the unfortunate
     // side-effect of assigning value="on" to radio and checkboxes
-    it('does not add "on" in absence of value on a checkbox', function () {
+    it('does not add "on" in absence of value on a checkbox', async () => {
       ReactDOM.render(
         <input type="checkbox" defaultChecked={true} />,
         container,
@@ -2630,7 +2630,7 @@ describe('ReactDOMInput', () => {
       expect(node.hasAttribute('value')).toBe(false);
     });
 
-    it('does not add "on" in absence of value on a radio', function () {
+    it('does not add "on" in absence of value on a radio', async () => {
       ReactDOM.render(<input type="radio" defaultChecked={true} />, container);
       const node = container.firstChild;
 
@@ -2639,7 +2639,7 @@ describe('ReactDOMInput', () => {
     });
   });
 
-  it('should remove previous `defaultValue`', () => {
+  it('should remove previous `defaultValue`', async () => {
     const node = ReactDOM.render(
       <input type="text" defaultValue="0" />,
       container,
@@ -2652,7 +2652,7 @@ describe('ReactDOMInput', () => {
     expect(node.defaultValue).toBe('');
   });
 
-  it('should treat `defaultValue={null}` as missing', () => {
+  it('should treat `defaultValue={null}` as missing', async () => {
     const node = ReactDOM.render(
       <input type="text" defaultValue="0" />,
       container,
@@ -2665,7 +2665,7 @@ describe('ReactDOMInput', () => {
     expect(node.defaultValue).toBe('');
   });
 
-  it('should notice input changes when reverting back to original value', () => {
+  it('should notice input changes when reverting back to original value', async () => {
     const log = [];
     function onChange(e) {
       log.push(e.target.value);

--- a/packages/react-dom/src/__tests__/ReactDOMOption-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMOption-test.js
@@ -182,7 +182,7 @@ describe('ReactDOMOption', () => {
     expect(node.innerHTML).toBe('foobar');
   });
 
-  it('should set attribute for empty value', () => {
+  it('should set attribute for empty value', async () => {
     const container = document.createElement('div');
     const option = ReactDOM.render(<option value="" />, container);
     expect(option.hasAttribute('value')).toBe(true);
@@ -193,7 +193,7 @@ describe('ReactDOMOption', () => {
     expect(option.getAttribute('value')).toBe('lava');
   });
 
-  it('should allow ignoring `value` on option', () => {
+  it('should allow ignoring `value` on option', async () => {
     const a = 'a';
     const stub = (
       <select value="giraffe" onChange={() => {}}>

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -321,7 +321,7 @@ describe('ReactDOMRoot', () => {
     expect(container.textContent).toEqual('');
   });
 
-  it('warns when passing legacy container to createRoot()', () => {
+  it('warns when passing legacy container to createRoot()', async () => {
     ReactDOM.render(<div>Hi</div>, container);
     expect(() => {
       ReactDOMClient.createRoot(container);
@@ -483,7 +483,7 @@ describe('ReactDOMRoot', () => {
   });
 
   // @gate disableCommentsAsDOMContainers
-  it('errors if container is a comment node', () => {
+  it('errors if container is a comment node', async () => {
     // This is an old feature used by www. Disabled in the open source build.
     const div = document.createElement('div');
     div.innerHTML = '<!-- react-mount-point-unstable -->';

--- a/packages/react-dom/src/__tests__/ReactDOMSVG-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSVG-test.js
@@ -29,7 +29,7 @@ describe('ReactDOMSVG', () => {
     expect(markup).toContain('xlink:href="http://i.imgur.com/w7GCRPb.png"');
   });
 
-  it('creates elements with SVG namespace inside SVG tag during mount', () => {
+  it('creates elements with SVG namespace inside SVG tag during mount', async () => {
     const node = document.createElement('div');
     let div,
       div2,
@@ -110,7 +110,7 @@ describe('ReactDOMSVG', () => {
     });
   });
 
-  it('creates elements with SVG namespace inside SVG tag during update', () => {
+  it('creates elements with SVG namespace inside SVG tag during update', async () => {
     let inst,
       div,
       div2,
@@ -193,7 +193,7 @@ describe('ReactDOMSVG', () => {
     });
   });
 
-  it('can render SVG into a non-React SVG tree', () => {
+  it('can render SVG into a non-React SVG tree', async () => {
     const outerSVGRoot = document.createElementNS(
       'http://www.w3.org/2000/svg',
       'svg',
@@ -209,7 +209,7 @@ describe('ReactDOMSVG', () => {
     expect(image.tagName).toBe('image');
   });
 
-  it('can render HTML into a foreignObject in non-React SVG tree', () => {
+  it('can render HTML into a foreignObject in non-React SVG tree', async () => {
     const outerSVGRoot = document.createElementNS(
       'http://www.w3.org/2000/svg',
       'svg',

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -32,7 +32,7 @@ describe('ReactDOMSelect', () => {
     ReactTestUtils = require('react-dom/test-utils');
   });
 
-  it('should allow setting `defaultValue`', () => {
+  it('should allow setting `defaultValue`', async () => {
     const stub = (
       <select defaultValue="giraffe">
         <option value="monkey">A monkey!</option>
@@ -62,7 +62,7 @@ describe('ReactDOMSelect', () => {
     }).not.toThrow();
   });
 
-  it('should not control when using `defaultValue`', () => {
+  it('should not control when using `defaultValue`', async () => {
     const el = (
       <select defaultValue="giraffe">
         <option value="monkey">A monkey!</option>
@@ -81,7 +81,7 @@ describe('ReactDOMSelect', () => {
     expect(node.value).toEqual('monkey');
   });
 
-  it('should allow setting `defaultValue` with multiple', () => {
+  it('should allow setting `defaultValue` with multiple', async () => {
     const stub = (
       <select multiple={true} defaultValue={['giraffe', 'gorilla']}>
         <option value="monkey">A monkey!</option>
@@ -110,7 +110,7 @@ describe('ReactDOMSelect', () => {
     expect(node.options[2].selected).toBe(true); // gorilla
   });
 
-  it('should allow setting `value`', () => {
+  it('should allow setting `value`', async () => {
     const stub = (
       <select value="giraffe" onChange={noop}>
         <option value="monkey">A monkey!</option>
@@ -134,7 +134,7 @@ describe('ReactDOMSelect', () => {
     expect(node.value).toEqual('gorilla');
   });
 
-  it('should default to the first non-disabled option', () => {
+  it('should default to the first non-disabled option', async () => {
     const stub = (
       <select defaultValue="">
         <option disabled={true}>Disabled</option>
@@ -149,7 +149,7 @@ describe('ReactDOMSelect', () => {
     expect(node.options[2].selected).toBe(true);
   });
 
-  it('should allow setting `value` to __proto__', () => {
+  it('should allow setting `value` to __proto__', async () => {
     const stub = (
       <select value="__proto__" onChange={noop}>
         <option value="monkey">A monkey!</option>
@@ -181,7 +181,7 @@ describe('ReactDOMSelect', () => {
     }).not.toThrow();
   });
 
-  it('should allow setting `value` with multiple', () => {
+  it('should allow setting `value` with multiple', async () => {
     const stub = (
       <select multiple={true} value={['giraffe', 'gorilla']} onChange={noop}>
         <option value="monkey">A monkey!</option>
@@ -210,7 +210,7 @@ describe('ReactDOMSelect', () => {
     expect(node.options[2].selected).toBe(false); // gorilla
   });
 
-  it('should allow setting `value` to __proto__ with multiple', () => {
+  it('should allow setting `value` to __proto__ with multiple', async () => {
     const stub = (
       <select multiple={true} value={['__proto__', 'gorilla']} onChange={noop}>
         <option value="monkey">A monkey!</option>
@@ -254,7 +254,7 @@ describe('ReactDOMSelect', () => {
     expect(node.options[2].selected).toBe(true); // twelve
   });
 
-  it('should reset child options selected when they are changed and `value` is set', () => {
+  it('should reset child options selected when they are changed and `value` is set', async () => {
     const stub = <select multiple={true} value={['a', 'b']} onChange={noop} />;
     const container = document.createElement('div');
     const node = ReactDOM.render(stub, container);
@@ -273,7 +273,7 @@ describe('ReactDOMSelect', () => {
     expect(node.options[2].selected).toBe(false); // c
   });
 
-  it('should allow setting `value` with `objectToString`', () => {
+  it('should allow setting `value` with `objectToString`', async () => {
     const objectToString = {
       animal: 'giraffe',
       toString: function () {
@@ -312,7 +312,7 @@ describe('ReactDOMSelect', () => {
     expect(node.options[2].selected).toBe(false); // gorilla
   });
 
-  it('should allow switching to multiple', () => {
+  it('should allow switching to multiple', async () => {
     const stub = (
       <select defaultValue="giraffe">
         <option value="monkey">A monkey!</option>
@@ -341,7 +341,7 @@ describe('ReactDOMSelect', () => {
     expect(node.options[2].selected).toBe(true); // gorilla
   });
 
-  it('should allow switching from multiple', () => {
+  it('should allow switching from multiple', async () => {
     const stub = (
       <select multiple={true} defaultValue={['giraffe', 'gorilla']}>
         <option value="monkey">A monkey!</option>
@@ -369,7 +369,7 @@ describe('ReactDOMSelect', () => {
     expect(node.options[2].selected).toBe(true); // gorilla
   });
 
-  it('does not select an item when size is initially set to greater than 1', () => {
+  it('does not select an item when size is initially set to greater than 1', async () => {
     const stub = (
       <select size="2">
         <option value="monkey">A monkey!</option>
@@ -388,7 +388,7 @@ describe('ReactDOMSelect', () => {
     expect(select.selectedIndex).toBe(-1);
   });
 
-  it('should remember value when switching to uncontrolled', () => {
+  it('should remember value when switching to uncontrolled', async () => {
     const stub = (
       <select value={'giraffe'} onChange={noop}>
         <option value="monkey">A monkey!</option>
@@ -411,7 +411,7 @@ describe('ReactDOMSelect', () => {
     expect(node.options[2].selected).toBe(false); // gorilla
   });
 
-  it('should remember updated value when switching to uncontrolled', () => {
+  it('should remember updated value when switching to uncontrolled', async () => {
     const stub = (
       <select value={'giraffe'} onChange={noop}>
         <option value="monkey">A monkey!</option>
@@ -534,7 +534,7 @@ describe('ReactDOMSelect', () => {
     expect(options[2].selected).toBe(true);
   });
 
-  it('should not control defaultValue if re-adding options', () => {
+  it('should not control defaultValue if re-adding options', async () => {
     const container = document.createElement('div');
 
     const node = ReactDOM.render(
@@ -591,7 +591,7 @@ describe('ReactDOMSelect', () => {
     expect(node.options[2].selected).toBe(false); // gorilla
   });
 
-  it('should support options with dynamic children', () => {
+  it('should support options with dynamic children', async () => {
     const container = document.createElement('div');
 
     let node;
@@ -682,7 +682,7 @@ describe('ReactDOMSelect', () => {
     );
   });
 
-  it('should refresh state on change', () => {
+  it('should refresh state on change', async () => {
     const stub = (
       <select value="giraffe" onChange={noop}>
         <option value="monkey">A monkey!</option>
@@ -732,14 +732,14 @@ describe('ReactDOMSelect', () => {
     );
   });
 
-  it('should not warn about missing onChange in uncontrolled textareas', () => {
+  it('should not warn about missing onChange in uncontrolled textareas', async () => {
     const container = document.createElement('div');
     ReactDOM.render(<select />, container);
     ReactDOM.unmountComponentAtNode(container);
     ReactDOM.render(<select value={undefined} />, container);
   });
 
-  it('should be able to safely remove select onChange', () => {
+  it('should be able to safely remove select onChange', async () => {
     function changeView() {
       ReactDOM.unmountComponentAtNode(container);
     }
@@ -757,7 +757,7 @@ describe('ReactDOMSelect', () => {
     expect(() => ReactTestUtils.Simulate.change(node)).not.toThrow();
   });
 
-  it('should select grandchild options nested inside an optgroup', () => {
+  it('should select grandchild options nested inside an optgroup', async () => {
     const stub = (
       <select value="b" onChange={noop}>
         <optgroup label="group">
@@ -775,7 +775,7 @@ describe('ReactDOMSelect', () => {
     expect(node.options[2].selected).toBe(false); // c
   });
 
-  it('should allow controlling `value` in a nested render', () => {
+  it('should allow controlling `value` in a nested render', async () => {
     let selectNode;
 
     class Parent extends React.Component {
@@ -839,7 +839,7 @@ describe('ReactDOMSelect', () => {
     document.body.removeChild(container);
   });
 
-  it('should not select first option by default when multiple is set and no defaultValue is set', () => {
+  it('should not select first option by default when multiple is set and no defaultValue is set', async () => {
     const stub = (
       <select multiple={true} onChange={noop}>
         <option value="a">a</option>

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.js
@@ -167,7 +167,7 @@ describe('ReactDOMServerIntegration - Untrusted URLs', () => {
     },
   );
 
-  it('rejects a javascript protocol href if it is added during an update', () => {
+  it('rejects a javascript protocol href if it is added during an update', async () => {
     const container = document.createElement('div');
     ReactDOM.render(<a href="thisisfine">click me</a>, container);
     expect(() => {
@@ -325,7 +325,7 @@ describe('ReactDOMServerIntegration - Untrusted URLs - disableJavaScriptURLs', (
     },
   );
 
-  it('rejects a javascript protocol href if it is added during an update', () => {
+  it('rejects a javascript protocol href if it is added during an update', async () => {
     const container = document.createElement('div');
     ReactDOM.render(<a href="http://thisisfine/">click me</a>, container);
     expect(container.firstChild.href).toBe('http://thisisfine/');
@@ -369,7 +369,7 @@ describe('ReactDOMServerIntegration - Untrusted URLs - disableJavaScriptURLs', (
     expect(e.href).toBe('https://reactjs.org/');
   });
 
-  it('rejects a javascript protocol href if it is added during an update twice', () => {
+  it('rejects a javascript protocol href if it is added during an update twice', async () => {
     const container = document.createElement('div');
     ReactDOM.render(<a href="http://thisisfine/">click me</a>, container);
     expect(container.firstChild.href).toBe('http://thisisfine/');

--- a/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.js
@@ -267,7 +267,7 @@ describe('ReactDOMSuspensePlaceholder', () => {
   });
 
   // Regression test for https://github.com/facebook/react/issues/14188
-  it('can call findDOMNode() in a suspended component commit phase (#2)', () => {
+  it('can call findDOMNode() in a suspended component commit phase (#2)', async () => {
     let suspendOnce = Promise.resolve();
     function Suspend() {
       if (suspendOnce) {

--- a/packages/react-dom/src/__tests__/ReactDOMTextComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextComponent-test.js
@@ -29,7 +29,7 @@ describe('ReactDOMTextComponent', () => {
     ReactDOMServer = require('react-dom/server');
   });
 
-  it('updates a mounted text component in place', () => {
+  it('updates a mounted text component in place', async () => {
     const el = document.createElement('div');
     let inst = ReactDOM.render(
       <div>
@@ -63,7 +63,7 @@ describe('ReactDOMTextComponent', () => {
     expect(bar.data).toBe('qux');
   });
 
-  it('can be toggled in and out of the markup', () => {
+  it('can be toggled in and out of the markup', async () => {
     const el = document.createElement('div');
     let inst = ReactDOM.render(
       <div>
@@ -285,7 +285,7 @@ describe('ReactDOMTextComponent', () => {
     expect(el.innerHTML).toBe('<div></div>');
   });
 
-  it('throws for Temporal-like text nodes', () => {
+  it('throws for Temporal-like text nodes', async () => {
     const el = document.createElement('div');
     class TemporalLike {
       valueOf() {

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -89,7 +89,7 @@ describe('ReactDOMTextarea', () => {
     expect(node.value).toBe('foobar');
   });
 
-  it('should set defaultValue', () => {
+  it('should set defaultValue', async () => {
     const container = document.createElement('div');
     ReactDOM.render(<textarea defaultValue="foo" />, container);
     ReactDOM.render(<textarea defaultValue="bar" />, container);
@@ -111,14 +111,14 @@ describe('ReactDOMTextarea', () => {
     expect(node.value).toBe('0');
   });
 
-  it('should update defaultValue to empty string', () => {
+  it('should update defaultValue to empty string', async () => {
     const container = document.createElement('div');
     ReactDOM.render(<textarea defaultValue={'foo'} />, container);
     ReactDOM.render(<textarea defaultValue={''} />, container);
     expect(container.firstChild.defaultValue).toBe('');
   });
 
-  it('should allow setting `value` to `giraffe`', () => {
+  it('should allow setting `value` to `giraffe`', async () => {
     const container = document.createElement('div');
     let stub = <textarea value="giraffe" onChange={emptyFunction} />;
     const node = renderTextarea(stub, container);
@@ -132,7 +132,7 @@ describe('ReactDOMTextarea', () => {
     expect(node.value).toEqual('gorilla');
   });
 
-  it('will not initially assign an empty value (covers case where firefox throws a validation error when required attribute is set)', () => {
+  it('will not initially assign an empty value (covers case where firefox throws a validation error when required attribute is set)', async () => {
     const container = document.createElement('div');
 
     let counter = 0;
@@ -178,7 +178,7 @@ describe('ReactDOMTextarea', () => {
     expect(div.firstChild.getAttribute('defaultValue')).toBe(null);
   });
 
-  it('should allow setting `value` to `true`', () => {
+  it('should allow setting `value` to `true`', async () => {
     const container = document.createElement('div');
     let stub = <textarea value="giraffe" onChange={emptyFunction} />;
     const node = renderTextarea(stub, container);
@@ -192,7 +192,7 @@ describe('ReactDOMTextarea', () => {
     expect(node.value).toEqual('true');
   });
 
-  it('should allow setting `value` to `false`', () => {
+  it('should allow setting `value` to `false`', async () => {
     const container = document.createElement('div');
     let stub = <textarea value="giraffe" onChange={emptyFunction} />;
     const node = renderTextarea(stub, container);
@@ -206,7 +206,7 @@ describe('ReactDOMTextarea', () => {
     expect(node.value).toEqual('false');
   });
 
-  it('should allow setting `value` to `objToString`', () => {
+  it('should allow setting `value` to `objToString`', async () => {
     const container = document.createElement('div');
     let stub = <textarea value="giraffe" onChange={emptyFunction} />;
     const node = renderTextarea(stub, container);
@@ -225,7 +225,7 @@ describe('ReactDOMTextarea', () => {
     expect(node.value).toEqual('foo');
   });
 
-  it('should throw when value is set to a Temporal-like object', () => {
+  it('should throw when value is set to a Temporal-like object', async () => {
     class TemporalLike {
       valueOf() {
         // Throwing here is the behavior of ECMAScript "Temporal" date/time API.
@@ -255,7 +255,7 @@ describe('ReactDOMTextarea', () => {
     );
   });
 
-  it('should take updates to `defaultValue` for uncontrolled textarea', () => {
+  it('should take updates to `defaultValue` for uncontrolled textarea', async () => {
     const container = document.createElement('div');
 
     const node = ReactDOM.render(<textarea defaultValue="0" />, container);
@@ -267,7 +267,7 @@ describe('ReactDOMTextarea', () => {
     expect(node.value).toBe('0');
   });
 
-  it('should take updates to children in lieu of `defaultValue` for uncontrolled textarea', () => {
+  it('should take updates to children in lieu of `defaultValue` for uncontrolled textarea', async () => {
     const container = document.createElement('div');
 
     const node = ReactDOM.render(<textarea defaultValue="0" />, container);
@@ -279,7 +279,7 @@ describe('ReactDOMTextarea', () => {
     expect(node.value).toBe('0');
   });
 
-  it('should not incur unnecessary DOM mutations', () => {
+  it('should not incur unnecessary DOM mutations', async () => {
     const container = document.createElement('div');
     ReactDOM.render(<textarea value="a" onChange={emptyFunction} />, container);
 
@@ -326,7 +326,7 @@ describe('ReactDOMTextarea', () => {
   });
 
   if (ReactFeatureFlags.disableTextareaChildren) {
-    it('should ignore children content', () => {
+    it('should ignore children content', async () => {
       const container = document.createElement('div');
       let stub = <textarea>giraffe</textarea>;
       let node;
@@ -359,7 +359,7 @@ describe('ReactDOMTextarea', () => {
   }
 
   if (!ReactFeatureFlags.disableTextareaChildren) {
-    it('should treat children like `defaultValue`', () => {
+    it('should treat children like `defaultValue`', async () => {
       const container = document.createElement('div');
       let stub = <textarea>giraffe</textarea>;
       let node;
@@ -378,7 +378,7 @@ describe('ReactDOMTextarea', () => {
     });
   }
 
-  it('should keep value when switching to uncontrolled element if not changed', () => {
+  it('should keep value when switching to uncontrolled element if not changed', async () => {
     const container = document.createElement('div');
 
     const node = renderTextarea(
@@ -393,7 +393,7 @@ describe('ReactDOMTextarea', () => {
     expect(node.value).toEqual('kitten');
   });
 
-  it('should keep value when switching to uncontrolled element if changed', () => {
+  it('should keep value when switching to uncontrolled element if changed', async () => {
     const container = document.createElement('div');
 
     const node = renderTextarea(
@@ -568,14 +568,14 @@ describe('ReactDOMTextarea', () => {
     ReactTestUtils.renderIntoDocument(<InvalidComponent />);
   });
 
-  it('should not warn about missing onChange in uncontrolled textareas', () => {
+  it('should not warn about missing onChange in uncontrolled textareas', async () => {
     const container = document.createElement('div');
     ReactDOM.render(<textarea />, container);
     ReactDOM.unmountComponentAtNode(container);
     ReactDOM.render(<textarea value={undefined} />, container);
   });
 
-  it('does not set textContent if value is unchanged', () => {
+  it('does not set textContent if value is unchanged', async () => {
     const container = document.createElement('div');
     let node;
     let instance;
@@ -617,7 +617,7 @@ describe('ReactDOMTextarea', () => {
   });
 
   describe('When given a Symbol value', () => {
-    it('treats initial Symbol value as an empty string', () => {
+    it('treats initial Symbol value as an empty string', async () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(
@@ -630,7 +630,7 @@ describe('ReactDOMTextarea', () => {
       expect(node.value).toBe('');
     });
 
-    it('treats initial Symbol children as an empty string', () => {
+    it('treats initial Symbol children as an empty string', async () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(
@@ -643,7 +643,7 @@ describe('ReactDOMTextarea', () => {
       expect(node.value).toBe('');
     });
 
-    it('treats updated Symbol value as an empty string', () => {
+    it('treats updated Symbol value as an empty string', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<textarea value="foo" onChange={() => {}} />, container);
       expect(() =>
@@ -657,7 +657,7 @@ describe('ReactDOMTextarea', () => {
       expect(node.value).toBe('');
     });
 
-    it('treats initial Symbol defaultValue as an empty string', () => {
+    it('treats initial Symbol defaultValue as an empty string', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<textarea defaultValue={Symbol('foobar')} />, container);
       const node = container.firstChild;
@@ -666,7 +666,7 @@ describe('ReactDOMTextarea', () => {
       expect(node.value).toBe('');
     });
 
-    it('treats updated Symbol defaultValue as an empty string', () => {
+    it('treats updated Symbol defaultValue as an empty string', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<textarea defaultValue="foo" />, container);
       ReactDOM.render(<textarea defaultValue={Symbol('foobar')} />, container);
@@ -678,7 +678,7 @@ describe('ReactDOMTextarea', () => {
   });
 
   describe('When given a function value', () => {
-    it('treats initial function value as an empty string', () => {
+    it('treats initial function value as an empty string', async () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(
@@ -691,7 +691,7 @@ describe('ReactDOMTextarea', () => {
       expect(node.value).toBe('');
     });
 
-    it('treats initial function children as an empty string', () => {
+    it('treats initial function children as an empty string', async () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(
@@ -704,7 +704,7 @@ describe('ReactDOMTextarea', () => {
       expect(node.value).toBe('');
     });
 
-    it('treats updated function value as an empty string', () => {
+    it('treats updated function value as an empty string', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<textarea value="foo" onChange={() => {}} />, container);
       expect(() =>
@@ -718,7 +718,7 @@ describe('ReactDOMTextarea', () => {
       expect(node.value).toBe('');
     });
 
-    it('treats initial function defaultValue as an empty string', () => {
+    it('treats initial function defaultValue as an empty string', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<textarea defaultValue={() => {}} />, container);
       const node = container.firstChild;
@@ -727,7 +727,7 @@ describe('ReactDOMTextarea', () => {
       expect(node.value).toBe('');
     });
 
-    it('treats updated function defaultValue as an empty string', () => {
+    it('treats updated function defaultValue as an empty string', async () => {
       const container = document.createElement('div');
       ReactDOM.render(<textarea defaultValue="foo" />, container);
       ReactDOM.render(<textarea defaultValue={() => {}} />, container);
@@ -738,7 +738,7 @@ describe('ReactDOMTextarea', () => {
     });
   });
 
-  it('should remove previous `defaultValue`', () => {
+  it('should remove previous `defaultValue`', async () => {
     const container = document.createElement('div');
     const node = ReactDOM.render(<textarea defaultValue="0" />, container);
 
@@ -749,7 +749,7 @@ describe('ReactDOMTextarea', () => {
     expect(node.defaultValue).toBe('');
   });
 
-  it('should treat `defaultValue={null}` as missing', () => {
+  it('should treat `defaultValue={null}` as missing', async () => {
     const container = document.createElement('div');
     const node = ReactDOM.render(<textarea defaultValue="0" />, container);
 

--- a/packages/react-dom/src/__tests__/ReactEmptyComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactEmptyComponent-test.js
@@ -58,7 +58,7 @@ describe('ReactEmptyComponent', () => {
       }).not.toThrowError();
     });
 
-    it('should not produce child DOM nodes for nullish and false', () => {
+    it('should not produce child DOM nodes for nullish and false', async () => {
       class Component1 extends React.Component {
         render() {
           return nullORUndefined;
@@ -222,7 +222,7 @@ describe('ReactEmptyComponent', () => {
       },
     );
 
-    it('works when switching components', () => {
+    it('works when switching components', async () => {
       let assertions = 0;
 
       class Inner extends React.Component {
@@ -269,7 +269,7 @@ describe('ReactEmptyComponent', () => {
       expect(assertions).toBe(3);
     });
 
-    it('can render nullish at the top level', () => {
+    it('can render nullish at the top level', async () => {
       const div = document.createElement('div');
       ReactDOM.render(nullORUndefined, div);
       expect(div.innerHTML).toBe('');
@@ -313,7 +313,7 @@ describe('ReactEmptyComponent', () => {
       }).not.toThrow();
     });
 
-    it('preserves the dom node during updates', () => {
+    it('preserves the dom node during updates', async () => {
       class Empty extends React.Component {
         render() {
           return nullORUndefined;

--- a/packages/react-dom/src/__tests__/ReactErrorLoggingRecovery-test.js
+++ b/packages/react-dom/src/__tests__/ReactErrorLoggingRecovery-test.js
@@ -58,7 +58,7 @@ describe('ReactErrorLoggingRecovery', () => {
     console.error = originalConsoleError;
   });
 
-  it('should recover from errors in console.error', function () {
+  it('should recover from errors in console.error', async () => {
     const div = document.createElement('div');
     let didCatch = false;
     try {

--- a/packages/react-dom/src/__tests__/ReactEventIndependence-test.js
+++ b/packages/react-dom/src/__tests__/ReactEventIndependence-test.js
@@ -20,7 +20,7 @@ describe('ReactEventIndependence', () => {
     ReactDOM = require('react-dom');
   });
 
-  it('does not crash with other react inside', () => {
+  it('does not crash with other react inside', async () => {
     let clicks = 0;
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -42,7 +42,7 @@ describe('ReactEventIndependence', () => {
     }
   });
 
-  it('does not crash with other react outside', () => {
+  it('does not crash with other react outside', async () => {
     let clicks = 0;
     const outer = document.createElement('div');
     document.body.appendChild(outer);
@@ -59,7 +59,7 @@ describe('ReactEventIndependence', () => {
     }
   });
 
-  it('does not when event fired on unmounted tree', () => {
+  it('does not when event fired on unmounted tree', async () => {
     let clicks = 0;
     const container = document.createElement('div');
     document.body.appendChild(container);

--- a/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
@@ -27,14 +27,14 @@ describe('ReactFunctionComponent', () => {
     ReactTestUtils = require('react-dom/test-utils');
   });
 
-  it('should render stateless component', () => {
+  it('should render stateless component', async () => {
     const el = document.createElement('div');
     ReactDOM.render(<FunctionComponent name="A" />, el);
 
     expect(el.textContent).toBe('A');
   });
 
-  it('should update stateless component', () => {
+  it('should update stateless component', async () => {
     class Parent extends React.Component {
       render() {
         return <FunctionComponent {...this.props} />;
@@ -49,7 +49,7 @@ describe('ReactFunctionComponent', () => {
     expect(el.textContent).toBe('B');
   });
 
-  it('should unmount stateless component', () => {
+  it('should unmount stateless component', async () => {
     const container = document.createElement('div');
 
     ReactDOM.render(<FunctionComponent name="A" />, container);
@@ -60,7 +60,7 @@ describe('ReactFunctionComponent', () => {
   });
 
   // @gate !disableLegacyContext
-  it('should pass context thru stateless component', () => {
+  it('should pass context thru stateless component', async () => {
     class Child extends React.Component {
       static contextTypes = {
         test: PropTypes.string.isRequired,
@@ -99,7 +99,7 @@ describe('ReactFunctionComponent', () => {
     expect(el.textContent).toBe('mest');
   });
 
-  it('should warn for getDerivedStateFromProps on a function component', () => {
+  it('should warn for getDerivedStateFromProps on a function component', async () => {
     function FunctionComponentWithChildContext() {
       return null;
     }
@@ -115,7 +115,7 @@ describe('ReactFunctionComponent', () => {
     );
   });
 
-  it('should warn for childContextTypes on a function component', () => {
+  it('should warn for childContextTypes on a function component', async () => {
     function FunctionComponentWithChildContext(props) {
       return <div>{props.name}</div>;
     }
@@ -378,7 +378,7 @@ describe('ReactFunctionComponent', () => {
   });
 
   // @gate !disableLegacyContext
-  it('should receive context', () => {
+  it('should receive context', async () => {
     class Parent extends React.Component {
       static childContextTypes = {
         lang: PropTypes.string,

--- a/packages/react-dom/src/__tests__/ReactIdentity-test.js
+++ b/packages/react-dom/src/__tests__/ReactIdentity-test.js
@@ -21,7 +21,7 @@ describe('ReactIdentity', () => {
     ReactTestUtils = require('react-dom/test-utils');
   });
 
-  it('should allow key property to express identity', () => {
+  it('should allow key property to express identity', async () => {
     let node;
     const Component = props => (
       <div ref={c => (node = c)}>
@@ -39,7 +39,7 @@ describe('ReactIdentity', () => {
     expect(origChildren[1]).toBe(newChildren[0]);
   });
 
-  it('should use composite identity', () => {
+  it('should use composite identity', async () => {
     class Wrapper extends React.Component {
       render() {
         return <a>{this.props.children}</a>;
@@ -209,7 +209,7 @@ describe('ReactIdentity', () => {
     }).not.toThrow();
   });
 
-  it('should retain key during updates in composite components', () => {
+  it('should retain key during updates in composite components', async () => {
     class TestComponent extends React.Component {
       render() {
         return <div>{this.props.children}</div>;
@@ -264,7 +264,7 @@ describe('ReactIdentity', () => {
     }).not.toThrow();
   });
 
-  it('should throw if key is a Temporal-like object', () => {
+  it('should throw if key is a Temporal-like object', async () => {
     class TemporalLike {
       valueOf() {
         // Throwing here is the behavior of ECMAScript "Temporal" date/time API.

--- a/packages/react-dom/src/__tests__/ReactMockedComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactMockedComponent-test.js
@@ -30,12 +30,12 @@ describe('ReactMockedComponent', () => {
     MockedComponent.prototype.render = jest.fn();
   });
 
-  it('should allow a mocked component to be rendered', () => {
+  it('should allow a mocked component to be rendered', async () => {
     const container = document.createElement('container');
     ReactDOM.render(<MockedComponent />, container);
   });
 
-  it('should allow a mocked component to be updated in dev', () => {
+  it('should allow a mocked component to be updated in dev', async () => {
     const container = document.createElement('container');
     ReactDOM.render(<MockedComponent />, container);
     ReactDOM.render(<MockedComponent />, container);

--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -43,7 +43,7 @@ describe('ReactMount', () => {
       expect(d.textContent).toBe('hellooo');
     });
 
-    it('returns true on React containers', () => {
+    it('returns true on React containers', async () => {
       const d = document.createElement('div');
       ReactDOM.render(<b>hellooo</b>, d);
       expect(d.textContent).toBe('hellooo');
@@ -67,7 +67,7 @@ describe('ReactMount', () => {
     );
   });
 
-  it('should render different components in same root', () => {
+  it('should render different components in same root', async () => {
     const container = document.createElement('container');
     document.body.appendChild(container);
 
@@ -78,7 +78,7 @@ describe('ReactMount', () => {
     expect(container.firstChild.nodeName).toBe('SPAN');
   });
 
-  it('should unmount and remount if the key changes', () => {
+  it('should unmount and remount if the key changes', async () => {
     const container = document.createElement('container');
 
     const mockMount = jest.fn();
@@ -113,7 +113,7 @@ describe('ReactMount', () => {
     expect(mockUnmount).toHaveBeenCalledTimes(1);
   });
 
-  it('should reuse markup if rendering to the same target twice', () => {
+  it('should reuse markup if rendering to the same target twice', async () => {
     const container = document.createElement('container');
     const instance1 = ReactDOM.render(<div />, container);
     const instance2 = ReactDOM.render(<div />, container);
@@ -138,14 +138,14 @@ describe('ReactMount', () => {
     );
   });
 
-  it('should not warn if mounting into non-empty node', () => {
+  it('should not warn if mounting into non-empty node', async () => {
     const container = document.createElement('container');
     container.innerHTML = '<div></div>';
 
     ReactDOM.render(<div />, container);
   });
 
-  it('should warn when mounting into document.body', () => {
+  it('should warn when mounting into document.body', async () => {
     const iFrame = document.createElement('iframe');
     document.body.appendChild(iFrame);
 
@@ -171,7 +171,7 @@ describe('ReactMount', () => {
     );
   });
 
-  it('should warn if render removes React-rendered children', () => {
+  it('should warn if render removes React-rendered children', async () => {
     const container = document.createElement('container');
 
     class Component extends React.Component {
@@ -198,7 +198,7 @@ describe('ReactMount', () => {
     );
   });
 
-  it('should warn if the unmounted node was rendered by another copy of React', () => {
+  it('should warn if the unmounted node was rendered by another copy of React', async () => {
     jest.resetModules();
     const ReactDOMOther = require('react-dom');
     const container = document.createElement('div');
@@ -227,7 +227,7 @@ describe('ReactMount', () => {
     ReactDOM.unmountComponentAtNode(container);
   });
 
-  it('passes the correct callback context', () => {
+  it('passes the correct callback context', async () => {
     const container = document.createElement('div');
     let calls = 0;
 
@@ -267,7 +267,7 @@ describe('ReactMount', () => {
     expect(calls).toBe(5);
   });
 
-  it('initial mount of legacy root is sync inside batchedUpdates, as if it were wrapped in flushSync', () => {
+  it('initial mount of legacy root is sync inside batchedUpdates, as if it were wrapped in flushSync', async () => {
     const container1 = document.createElement('div');
     const container2 = document.createElement('div');
 
@@ -313,7 +313,7 @@ describe('ReactMount', () => {
       expect(mountPoint.nodeType).toBe(COMMENT_NODE);
     });
 
-    it('renders at a comment node', () => {
+    it('renders at a comment node', async () => {
       function Char(props) {
         return props.children;
       }

--- a/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
+++ b/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
@@ -13,7 +13,7 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 
 describe('ReactMount', () => {
-  it('should destroy a react root upon request', () => {
+  it('should destroy a react root upon request', async () => {
     const mainContainerDiv = document.createElement('div');
     document.body.appendChild(mainContainerDiv);
 
@@ -38,7 +38,7 @@ describe('ReactMount', () => {
     expect(secondRootDiv.firstChild).toBeNull();
   });
 
-  it('should warn when unmounting a non-container root node', () => {
+  it('should warn when unmounting a non-container root node', async () => {
     const mainContainerDiv = document.createElement('div');
 
     const component = (
@@ -59,7 +59,7 @@ describe('ReactMount', () => {
     );
   });
 
-  it('should warn when unmounting a non-container, non-root node', () => {
+  it('should warn when unmounting a non-container, non-root node', async () => {
     const mainContainerDiv = document.createElement('div');
 
     const component = (

--- a/packages/react-dom/src/__tests__/ReactMultiChild-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChild-test.js
@@ -20,7 +20,7 @@ describe('ReactMultiChild', () => {
   });
 
   describe('reconciliation', () => {
-    it('should update children when possible', () => {
+    it('should update children when possible', async () => {
       const container = document.createElement('div');
 
       const mockMount = jest.fn();
@@ -63,7 +63,7 @@ describe('ReactMultiChild', () => {
       expect(mockUnmount).toHaveBeenCalledTimes(0);
     });
 
-    it('should replace children with different constructors', () => {
+    it('should replace children with different constructors', async () => {
       const container = document.createElement('div');
 
       const mockMount = jest.fn();
@@ -101,7 +101,7 @@ describe('ReactMultiChild', () => {
       expect(mockUnmount).toHaveBeenCalledTimes(1);
     });
 
-    it('should NOT replace children with different owners', () => {
+    it('should NOT replace children with different owners', async () => {
       const container = document.createElement('div');
 
       const mockMount = jest.fn();
@@ -140,7 +140,7 @@ describe('ReactMultiChild', () => {
       expect(mockUnmount).toHaveBeenCalledTimes(0);
     });
 
-    it('should replace children with different keys', () => {
+    it('should replace children with different keys', async () => {
       const container = document.createElement('div');
 
       const mockMount = jest.fn();
@@ -178,7 +178,7 @@ describe('ReactMultiChild', () => {
       expect(mockUnmount).toHaveBeenCalledTimes(1);
     });
 
-    it('should warn for duplicated array keys with component stack info', () => {
+    it('should warn for duplicated array keys with component stack info', async () => {
       const container = document.createElement('div');
 
       class WrapperComponent extends React.Component {
@@ -217,7 +217,7 @@ describe('ReactMultiChild', () => {
       );
     });
 
-    it('should warn for duplicated iterable keys with component stack info', () => {
+    it('should warn for duplicated iterable keys with component stack info', async () => {
       const container = document.createElement('div');
 
       class WrapperComponent extends React.Component {
@@ -278,7 +278,7 @@ describe('ReactMultiChild', () => {
     });
   });
 
-  it('should warn for using maps as children with owner info', () => {
+  it('should warn for using maps as children with owner info', async () => {
     class Parent extends React.Component {
       render() {
         return (
@@ -302,7 +302,7 @@ describe('ReactMultiChild', () => {
     );
   });
 
-  it('should warn for using generators as children', () => {
+  it('should warn for using generators as children', async () => {
     function* Foo() {
       yield <h1 key="1">Hello</h1>;
       yield <h1 key="2">World</h1>;
@@ -323,7 +323,7 @@ describe('ReactMultiChild', () => {
     ReactDOM.render(<Foo />, div);
   });
 
-  it('should not warn for using generators in legacy iterables', () => {
+  it('should not warn for using generators in legacy iterables', async () => {
     const fooIterable = {
       '@@iterator': function* () {
         yield <h1 key="1">Hello</h1>;
@@ -343,7 +343,7 @@ describe('ReactMultiChild', () => {
     expect(div.textContent).toBe('HelloWorld');
   });
 
-  it('should not warn for using generators in modern iterables', () => {
+  it('should not warn for using generators in modern iterables', async () => {
     const fooIterable = {
       [Symbol.iterator]: function* () {
         yield <h1 key="1">Hello</h1>;
@@ -363,7 +363,7 @@ describe('ReactMultiChild', () => {
     expect(div.textContent).toBe('HelloWorld');
   });
 
-  it('should reorder bailed-out children', () => {
+  it('should reorder bailed-out children', async () => {
     class LetterInner extends React.Component {
       render() {
         return <div>{this.props.char}</div>;
@@ -401,7 +401,7 @@ describe('ReactMultiChild', () => {
     expect(container.textContent).toBe('EHCjpdTUuiybDvhRJwZt');
   });
 
-  it('prepares new children before unmounting old', () => {
+  it('prepares new children before unmounting old', async () => {
     const log = [];
 
     class Spy extends React.Component {

--- a/packages/react-dom/src/__tests__/ReactMultiChildReconcile-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChildReconcile-test.js
@@ -291,7 +291,7 @@ describe('ReactMultiChildReconcile', () => {
     jest.resetModules();
   });
 
-  it('should reset internal state if removed then readded in an array', () => {
+  it('should reset internal state if removed then readded in an array', async () => {
     // Test basics.
     const props = {
       usernameToStatus: {
@@ -333,7 +333,7 @@ describe('ReactMultiChildReconcile', () => {
     );
   });
 
-  it('should reset internal state if removed then readded in a legacy iterable', () => {
+  it('should reset internal state if removed then readded in a legacy iterable', async () => {
     // Test basics.
     const props = {
       usernameToStatus: {
@@ -375,7 +375,7 @@ describe('ReactMultiChildReconcile', () => {
     );
   });
 
-  it('should reset internal state if removed then readded in a modern iterable', () => {
+  it('should reset internal state if removed then readded in a modern iterable', async () => {
     // Test basics.
     const props = {
       usernameToStatus: {

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -34,7 +34,7 @@ describe('ReactDOMServerHydration', () => {
     act = InternalTestUtils.act;
   });
 
-  it('should have the correct mounting behavior (new hydrate API)', () => {
+  it('should have the correct mounting behavior (new hydrate API)', async () => {
     let mountCount = 0;
     let numClicks = 0;
 
@@ -122,7 +122,7 @@ describe('ReactDOMServerHydration', () => {
   // We have a polyfill for autoFocus on the client, but we intentionally don't
   // want it to call focus() when hydrating because this can mess up existing
   // focus before the JS has loaded.
-  it('should emit autofocus on the server but not focus() when hydrating', () => {
+  it('should emit autofocus on the server but not focus() when hydrating', async () => {
     const element = document.createElement('div');
     element.innerHTML = ReactDOMServer.renderToString(
       <input autoFocus={true} />,
@@ -139,7 +139,7 @@ describe('ReactDOMServerHydration', () => {
     expect(element.firstChild.focus).not.toHaveBeenCalled();
   });
 
-  it('should not focus on either server or client with autofocus={false}', () => {
+  it('should not focus on either server or client with autofocus={false}', async () => {
     const element = document.createElement('div');
     element.innerHTML = ReactDOMServer.renderToString(
       <input autoFocus={false} />,

--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -30,7 +30,7 @@ describe('ReactTestUtils', () => {
     expect(Object.keys(ReactTestUtils.Simulate).sort()).toMatchSnapshot();
   });
 
-  it('gives Jest mocks a passthrough implementation with mockComponent()', () => {
+  it('gives Jest mocks a passthrough implementation with mockComponent()', async () => {
     class MockedComponent extends React.Component {
       render() {
         throw new Error('Should not get here.');
@@ -162,7 +162,7 @@ describe('ReactTestUtils', () => {
     expect(scryResults5.length).toBe(0);
   });
 
-  it('traverses children in the correct order', () => {
+  it('traverses children in the correct order', async () => {
     class Wrapper extends React.Component {
       render() {
         return <div>{this.props.children}</div>;
@@ -327,7 +327,7 @@ describe('ReactTestUtils', () => {
   });
 
   describe('Simulate', () => {
-    it('should change the value of an input field', () => {
+    it('should change the value of an input field', async () => {
       const obj = {
         handler: function (e) {
           e.persist();
@@ -348,7 +348,7 @@ describe('ReactTestUtils', () => {
       );
     });
 
-    it('should change the value of an input field in a component', () => {
+    it('should change the value of an input field in a component', async () => {
       class SomeComponent extends React.Component {
         inputRef = React.createRef();
         render() {
@@ -385,7 +385,7 @@ describe('ReactTestUtils', () => {
       );
     });
 
-    it('should not warn when used with extra properties', () => {
+    it('should not warn when used with extra properties', async () => {
       const CLIENT_X = 100;
 
       class Component extends React.Component {
@@ -405,7 +405,7 @@ describe('ReactTestUtils', () => {
       });
     });
 
-    it('should set the type of the event', () => {
+    it('should set the type of the event', async () => {
       let event;
       const stub = jest.fn().mockImplementation(e => {
         e.persist();

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -98,7 +98,7 @@ describe('ReactTestUtils.act()', () => {
       return null;
     }
 
-    it('does not warn in legacy mode', () => {
+    it('does not warn in legacy mode', async () => {
       expect(() => {
         ReactDOM.render(<App />, document.createElement('div'));
       }).toErrorDev([]);

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -113,7 +113,7 @@ describe('ReactUpdates', () => {
     expect(updateCount).toBe(1);
   });
 
-  it('should batch state and props together', () => {
+  it('should batch state and props together', async () => {
     let updateCount = 0;
 
     class Component extends React.Component {
@@ -686,7 +686,7 @@ describe('ReactUpdates', () => {
     /* eslint-enable indent */
   });
 
-  it('should flush updates in the correct order across roots', () => {
+  it('should flush updates in the correct order across roots', async () => {
     const instances = [];
     const updates = [];
 
@@ -816,7 +816,7 @@ describe('ReactUpdates', () => {
     expect(ReactDOM.findDOMNode(a).textContent).toBe('A1');
   });
 
-  it('calls componentWillReceiveProps setState callback properly', () => {
+  it('calls componentWillReceiveProps setState callback properly', async () => {
     let callbackCount = 0;
 
     class A extends React.Component {
@@ -1017,7 +1017,7 @@ describe('ReactUpdates', () => {
     });
   });
 
-  it('does not update one component twice in a batch (#6371)', () => {
+  it('does not update one component twice in a batch (#6371)', async () => {
     let callbacks = [];
     function emitChange() {
       callbacks.forEach(c => c());
@@ -1074,7 +1074,7 @@ describe('ReactUpdates', () => {
     expect(result).toEqual(42);
   });
 
-  it('unmounts and remounts a root in the same batch', () => {
+  it('unmounts and remounts a root in the same batch', async () => {
     const container = document.createElement('div');
     ReactDOM.render(<span>a</span>, container);
     ReactDOM.unstable_batchedUpdates(function () {
@@ -1084,7 +1084,7 @@ describe('ReactUpdates', () => {
     expect(container.textContent).toBe('b');
   });
 
-  it('handles reentrant mounting in synchronous mode', () => {
+  it('handles reentrant mounting in synchronous mode', async () => {
     let mounts = 0;
     class Editor extends React.Component {
       render() {
@@ -1121,7 +1121,7 @@ describe('ReactUpdates', () => {
     expect(mounts).toBe(1);
   });
 
-  it('mounts and unmounts are sync even in a batch', () => {
+  it('mounts and unmounts are sync even in a batch', async () => {
     const ops = [];
     const container = document.createElement('div');
     ReactDOM.unstable_batchedUpdates(() => {
@@ -1136,7 +1136,7 @@ describe('ReactUpdates', () => {
   it(
     'in legacy mode, updates in componentWillUpdate and componentDidUpdate ' +
       'should both flush in the immediately subsequent commit',
-    () => {
+    async () => {
       const ops = [];
       class Foo extends React.Component {
         state = {a: false, b: false};
@@ -1179,7 +1179,7 @@ describe('ReactUpdates', () => {
   it(
     'in legacy mode, updates in componentWillUpdate and componentDidUpdate ' +
       '(on a sibling) should both flush in the immediately subsequent commit',
-    () => {
+    async () => {
       const ops = [];
       class Foo extends React.Component {
         state = {a: false};
@@ -1247,7 +1247,7 @@ describe('ReactUpdates', () => {
     },
   );
 
-  it('uses correct base state for setState inside render phase', () => {
+  it('uses correct base state for setState inside render phase', async () => {
     const ops = [];
 
     class Foo extends React.Component {
@@ -1270,7 +1270,7 @@ describe('ReactUpdates', () => {
     expect(ops).toEqual(['base: 0, memoized: 0', 'base: 1, memoized: 1']);
   });
 
-  it('does not re-render if state update is null', () => {
+  it('does not re-render if state update is null', async () => {
     const container = document.createElement('div');
 
     let instance;
@@ -1290,7 +1290,7 @@ describe('ReactUpdates', () => {
   });
 
   // Will change once we switch to async by default
-  it('synchronously renders hidden subtrees', () => {
+  it('synchronously renders hidden subtrees', async () => {
     const container = document.createElement('div');
     let ops = [];
 
@@ -1383,7 +1383,7 @@ describe('ReactUpdates', () => {
     expect(hiddenDiv.innerHTML).toBe('<p>bar 1</p>');
   });
 
-  it('can render ridiculously large number of roots without triggering infinite update loop error', () => {
+  it('can render ridiculously large number of roots without triggering infinite update loop error', async () => {
     class Foo extends React.Component {
       componentDidMount() {
         const limit = 1200;
@@ -1407,7 +1407,7 @@ describe('ReactUpdates', () => {
     ReactDOM.render(<Foo />, container);
   });
 
-  it('resets the update counter for unrelated updates', () => {
+  it('resets the update counter for unrelated updates', async () => {
     const container = document.createElement('div');
     const ref = React.createRef();
 
@@ -1447,7 +1447,7 @@ describe('ReactUpdates', () => {
     expect(ref.current).toBe(null);
   });
 
-  it('does not fall into an infinite update loop', () => {
+  it('does not fall into an infinite update loop', async () => {
     class NonTerminating extends React.Component {
       state = {step: 0};
       componentDidMount() {
@@ -1472,7 +1472,7 @@ describe('ReactUpdates', () => {
     }).toThrow('Maximum');
   });
 
-  it('does not fall into an infinite update loop with useLayoutEffect', () => {
+  it('does not fall into an infinite update loop with useLayoutEffect', async () => {
     function NonTerminating() {
       const [step, setStep] = React.useState(0);
       React.useLayoutEffect(() => {
@@ -1487,7 +1487,7 @@ describe('ReactUpdates', () => {
     }).toThrow('Maximum');
   });
 
-  it('can recover after falling into an infinite update loop', () => {
+  it('can recover after falling into an infinite update loop', async () => {
     class NonTerminating extends React.Component {
       state = {step: 0};
       componentDidMount() {
@@ -1527,7 +1527,7 @@ describe('ReactUpdates', () => {
     expect(container.textContent).toBe('1');
   });
 
-  it('does not fall into mutually recursive infinite update loop with same container', () => {
+  it('does not fall into mutually recursive infinite update loop with same container', async () => {
     // Note: this test would fail if there were two or more different roots.
 
     class A extends React.Component {
@@ -1554,7 +1554,7 @@ describe('ReactUpdates', () => {
     }).toThrow('Maximum');
   });
 
-  it('does not fall into an infinite error loop', () => {
+  it('does not fall into an infinite error loop', async () => {
     function BadRender() {
       throw new Error('error');
     }
@@ -1587,7 +1587,7 @@ describe('ReactUpdates', () => {
     }).toThrow('Maximum');
   });
 
-  it('can schedule ridiculously many updates within the same batch without triggering a maximum update error', () => {
+  it('can schedule ridiculously many updates within the same batch without triggering a maximum update error', async () => {
     const subscribers = [];
 
     class Child extends React.Component {

--- a/packages/react-dom/src/__tests__/findDOMNode-test.js
+++ b/packages/react-dom/src/__tests__/findDOMNode-test.js
@@ -37,7 +37,7 @@ describe('findDOMNode', () => {
     expect(mySameDiv).toBe(myDiv);
   });
 
-  it('findDOMNode should find dom element after an update from null', () => {
+  it('findDOMNode should find dom element after an update from null', async () => {
     function Bar({flag}) {
       if (flag) {
         return <span>A</span>;
@@ -69,7 +69,7 @@ describe('findDOMNode', () => {
     }).toThrowError('Argument appears to not be a ReactComponent. Keys: foo');
   });
 
-  it('findDOMNode should reject unmounted objects with render func', () => {
+  it('findDOMNode should reject unmounted objects with render func', async () => {
     class Foo extends React.Component {
       render() {
         return <div />;

--- a/packages/react-dom/src/__tests__/refs-destruction-test.js
+++ b/packages/react-dom/src/__tests__/refs-destruction-test.js
@@ -55,7 +55,7 @@ describe('refs-destruction', () => {
     };
   });
 
-  it('should remove refs when destroying the parent', () => {
+  it('should remove refs when destroying the parent', async () => {
     const container = document.createElement('div');
     const testInstance = ReactDOM.render(<TestComponent />, container);
 
@@ -70,7 +70,7 @@ describe('refs-destruction', () => {
     expect(testInstance.theInnerClassComponentRef.current).toBe(null);
   });
 
-  it('should remove refs when destroying the child', () => {
+  it('should remove refs when destroying the child', async () => {
     const container = document.createElement('div');
     const testInstance = ReactDOM.render(<TestComponent />, container);
     expect(
@@ -84,7 +84,7 @@ describe('refs-destruction', () => {
     expect(testInstance.theInnerClassComponentRef.current).toBe(null);
   });
 
-  it('should remove refs when removing the child ref attribute', () => {
+  it('should remove refs when removing the child ref attribute', async () => {
     const container = document.createElement('div');
     const testInstance = ReactDOM.render(<TestComponent />, container);
 
@@ -99,7 +99,7 @@ describe('refs-destruction', () => {
     expect(testInstance.theInnerClassComponentRef.current).toBe(null);
   });
 
-  it('should not error when destroying child with ref asynchronously', () => {
+  it('should not error when destroying child with ref asynchronously', async () => {
     class Modal extends React.Component {
       componentDidMount() {
         this.div = document.createElement('div');

--- a/packages/react-dom/src/__tests__/refs-test.js
+++ b/packages/react-dom/src/__tests__/refs-test.js
@@ -396,7 +396,7 @@ describe('ref swapping', () => {
 });
 
 describe('root level refs', () => {
-  it('attaches and detaches root refs', () => {
+  it('attaches and detaches root refs', async () => {
     let inst = null;
 
     // host node
@@ -506,7 +506,7 @@ describe('creating element with string ref in constructor', () => {
 });
 
 describe('strings refs across renderers', () => {
-  it('does not break', () => {
+  it('does not break', async () => {
     class Parent extends React.Component {
       render() {
         // This component owns both refs.
@@ -571,7 +571,7 @@ describe('strings refs across renderers', () => {
 });
 
 describe('refs return clean up function', () => {
-  it('calls clean up function if it exists', () => {
+  it('calls clean up function if it exists', async () => {
     const container = document.createElement('div');
     let cleanUp = jest.fn();
     let setup = jest.fn();
@@ -635,7 +635,7 @@ describe('refs return clean up function', () => {
     expect(cleanUp).toHaveBeenCalledTimes(1);
   });
 
-  it('handles ref functions with stable identity', () => {
+  it('handles ref functions with stable identity', async () => {
     const container = document.createElement('div');
     const cleanUp = jest.fn();
     const setup = jest.fn();
@@ -664,7 +664,7 @@ describe('refs return clean up function', () => {
     expect(cleanUp).toHaveBeenCalledTimes(1);
   });
 
-  it('warns if clean up function is returned when called with null', () => {
+  it('warns if clean up function is returned when called with null', async () => {
     const container = document.createElement('div');
     const cleanUp = jest.fn();
     const setup = jest.fn();

--- a/packages/react-dom/src/__tests__/renderSubtreeIntoContainer-test.js
+++ b/packages/react-dom/src/__tests__/renderSubtreeIntoContainer-test.js
@@ -101,7 +101,7 @@ describe('renderSubtreeIntoContainer', () => {
   });
 
   // @gate !disableLegacyContext
-  it('should update context if it changes due to setState', () => {
+  it('should update context if it changes due to setState', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const portal = document.createElement('div');
@@ -162,7 +162,7 @@ describe('renderSubtreeIntoContainer', () => {
   });
 
   // @gate !disableLegacyContext
-  it('should update context if it changes due to re-render', () => {
+  it('should update context if it changes due to re-render', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const portal = document.createElement('div');
@@ -218,7 +218,7 @@ describe('renderSubtreeIntoContainer', () => {
     expect(portal.firstChild.innerHTML).toBe('changed-changed');
   });
 
-  it('should render portal with non-context-provider parent', () => {
+  it('should render portal with non-context-provider parent', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const portal = document.createElement('div');
@@ -242,7 +242,7 @@ describe('renderSubtreeIntoContainer', () => {
   });
 
   // @gate !disableLegacyContext
-  it('should get context through non-context-provider parent', () => {
+  it('should get context through non-context-provider parent', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const portal = document.createElement('div');
@@ -286,7 +286,7 @@ describe('renderSubtreeIntoContainer', () => {
   });
 
   // @gate !disableLegacyContext
-  it('should get context through middle non-context-provider layer', () => {
+  it('should get context through middle non-context-provider layer', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const portal1 = document.createElement('div');
@@ -337,7 +337,7 @@ describe('renderSubtreeIntoContainer', () => {
     expect(portal2.textContent).toBe('foo');
   });
 
-  it('fails gracefully when mixing React 15 and 16', () => {
+  it('fails gracefully when mixing React 15 and 16', async () => {
     class C extends React.Component {
       render() {
         return <div />;

--- a/packages/react-dom/src/client/__tests__/dangerouslySetInnerHTML-test.js
+++ b/packages/react-dom/src/client/__tests__/dangerouslySetInnerHTML-test.js
@@ -14,7 +14,7 @@ const ReactDOM = require('react-dom');
 
 describe('dangerouslySetInnerHTML', () => {
   describe('when the node has innerHTML property', () => {
-    it('sets innerHTML on it', () => {
+    it('sets innerHTML on it', async () => {
       const container = document.createElement('div');
       const node = ReactDOM.render(
         <div dangerouslySetInnerHTML={{__html: '<h1>Hello</h1>'}} />,
@@ -56,7 +56,7 @@ describe('dangerouslySetInnerHTML', () => {
     });
 
     // @gate !disableIEWorkarounds
-    it('sets innerHTML on it', () => {
+    it('sets innerHTML on it', async () => {
       const html = '<circle></circle>';
       const container = document.createElementNS(
         'http://www.w3.org/2000/svg',
@@ -71,7 +71,7 @@ describe('dangerouslySetInnerHTML', () => {
     });
 
     // @gate !disableIEWorkarounds
-    it('clears previous children', () => {
+    it('clears previous children', async () => {
       const firstHtml = '<rect></rect>';
       const secondHtml = '<circle></circle>';
 

--- a/packages/react-dom/src/events/__tests__/SyntheticClipboardEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticClipboardEvent-test.js
@@ -32,7 +32,7 @@ describe('SyntheticClipboardEvent', () => {
   describe('ClipboardEvent interface', () => {
     describe('clipboardData', () => {
       describe('when event has clipboardData', () => {
-        it("returns event's clipboardData", () => {
+        it("returns event's clipboardData", async () => {
           let expectedCount = 0;
 
           // Mock clipboardData since jsdom implementation doesn't have a constructor
@@ -79,7 +79,7 @@ describe('SyntheticClipboardEvent', () => {
   });
 
   describe('EventInterface', () => {
-    it('is able to `preventDefault` and `stopPropagation`', () => {
+    it('is able to `preventDefault` and `stopPropagation`', async () => {
       let expectedCount = 0;
 
       const eventHandler = event => {

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -28,7 +28,7 @@ describe('SyntheticEvent', () => {
     container = null;
   });
 
-  it('should be able to `preventDefault`', () => {
+  it('should be able to `preventDefault`', async () => {
     let expectedCount = 0;
 
     const eventHandler = syntheticEvent => {
@@ -48,7 +48,7 @@ describe('SyntheticEvent', () => {
     expect(expectedCount).toBe(1);
   });
 
-  it('should be prevented if nativeEvent is prevented', () => {
+  it('should be prevented if nativeEvent is prevented', async () => {
     let expectedCount = 0;
 
     const eventHandler = syntheticEvent => {
@@ -80,7 +80,7 @@ describe('SyntheticEvent', () => {
     expect(expectedCount).toBe(2);
   });
 
-  it('should be able to `stopPropagation`', () => {
+  it('should be able to `stopPropagation`', async () => {
     let expectedCount = 0;
 
     const eventHandler = syntheticEvent => {

--- a/packages/react-dom/src/events/__tests__/SyntheticKeyboardEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticKeyboardEvent-test.js
@@ -32,7 +32,7 @@ describe('SyntheticKeyboardEvent', () => {
     describe('charCode', () => {
       describe('when event is `keypress`', () => {
         describe('when charCode is present in nativeEvent', () => {
-          it('when charCode is 0 and keyCode is 13, returns 13', () => {
+          it('when charCode is 0 and keyCode is 13, returns 13', async () => {
             let charCode = null;
             const node = ReactDOM.render(
               <input
@@ -53,7 +53,7 @@ describe('SyntheticKeyboardEvent', () => {
             expect(charCode).toBe(13);
           });
 
-          it('when charCode is 32 or bigger and keyCode is missing, returns charCode', () => {
+          it('when charCode is 32 or bigger and keyCode is missing, returns charCode', async () => {
             let charCode = null;
             const node = ReactDOM.render(
               <input
@@ -73,7 +73,7 @@ describe('SyntheticKeyboardEvent', () => {
             expect(charCode).toBe(32);
           });
 
-          it('when charCode is 13 and keyCode is missing, returns charCode', () => {
+          it('when charCode is 13 and keyCode is missing, returns charCode', async () => {
             let charCode = null;
             const node = ReactDOM.render(
               <input
@@ -96,7 +96,7 @@ describe('SyntheticKeyboardEvent', () => {
           // Firefox creates a keypress event for function keys too. This removes
           // the unwanted keypress events. Enter is however both printable and
           // non-printable. One would expect Tab to be as well (but it isn't).
-          it('when charCode is smaller than 32 but is not 13, and keyCode is missing, ignores keypress', () => {
+          it('when charCode is smaller than 32 but is not 13, and keyCode is missing, ignores keypress', async () => {
             let called = false;
             const node = ReactDOM.render(
               <input
@@ -116,7 +116,7 @@ describe('SyntheticKeyboardEvent', () => {
             expect(called).toBe(false);
           });
 
-          it('when charCode is 10, returns 13', () => {
+          it('when charCode is 10, returns 13', async () => {
             let charCode = null;
             const node = ReactDOM.render(
               <input
@@ -136,7 +136,7 @@ describe('SyntheticKeyboardEvent', () => {
             expect(charCode).toBe(13);
           });
 
-          it('when charCode is 10 and ctrl is pressed, returns 13', () => {
+          it('when charCode is 10 and ctrl is pressed, returns 13', async () => {
             let charCode = null;
             const node = ReactDOM.render(
               <input
@@ -181,7 +181,7 @@ describe('SyntheticKeyboardEvent', () => {
             charCodeDescriptor = null;
           });
 
-          it('when keyCode is 32 or bigger, returns keyCode', () => {
+          it('when keyCode is 32 or bigger, returns keyCode', async () => {
             let charCode = null;
             const node = ReactDOM.render(
               <input
@@ -201,7 +201,7 @@ describe('SyntheticKeyboardEvent', () => {
             expect(charCode).toBe(32);
           });
 
-          it('when keyCode is 13, returns 13', () => {
+          it('when keyCode is 13, returns 13', async () => {
             let charCode = null;
             const node = ReactDOM.render(
               <input
@@ -221,7 +221,7 @@ describe('SyntheticKeyboardEvent', () => {
             expect(charCode).toBe(13);
           });
 
-          it('when keyCode is smaller than 32 and is not 13, ignores keypress', () => {
+          it('when keyCode is smaller than 32 and is not 13, ignores keypress', async () => {
             let called = false;
             const node = ReactDOM.render(
               <input
@@ -244,7 +244,7 @@ describe('SyntheticKeyboardEvent', () => {
       });
 
       describe('when event is not `keypress`', () => {
-        it('returns 0', () => {
+        it('returns 0', async () => {
           let charCodeDown = null;
           let charCodeUp = null;
           const node = ReactDOM.render(
@@ -277,7 +277,7 @@ describe('SyntheticKeyboardEvent', () => {
         });
       });
 
-      it('when charCode is smaller than 32 but is not 13, and keyCode is missing, charCode is 0', () => {
+      it('when charCode is smaller than 32 but is not 13, and keyCode is missing, charCode is 0', async () => {
         let charCode = null;
         const node = ReactDOM.render(
           <input
@@ -300,7 +300,7 @@ describe('SyntheticKeyboardEvent', () => {
 
     describe('keyCode', () => {
       describe('when event is `keydown` or `keyup`', () => {
-        it('returns a passed keyCode', () => {
+        it('returns a passed keyCode', async () => {
           let keyCodeDown = null;
           let keyCodeUp = null;
           const node = ReactDOM.render(
@@ -334,7 +334,7 @@ describe('SyntheticKeyboardEvent', () => {
       });
 
       describe('when event is `keypress`', () => {
-        it('returns 0', () => {
+        it('returns 0', async () => {
           let keyCode = null;
           const node = ReactDOM.render(
             <input
@@ -358,7 +358,7 @@ describe('SyntheticKeyboardEvent', () => {
 
     describe('which', () => {
       describe('when event is `keypress`', () => {
-        it('is consistent with `charCode`', () => {
+        it('is consistent with `charCode`', async () => {
           let calls = 0;
           const node = ReactDOM.render(
             <input
@@ -397,7 +397,7 @@ describe('SyntheticKeyboardEvent', () => {
       });
 
       describe('when event is `keydown` or `keyup`', () => {
-        it('is consistent with `keyCode`', () => {
+        it('is consistent with `keyCode`', async () => {
           let calls = 0;
           const node = ReactDOM.render(
             <input
@@ -453,7 +453,7 @@ describe('SyntheticKeyboardEvent', () => {
     });
 
     describe('code', () => {
-      it('returns code on `keydown`, `keyup` and `keypress`', () => {
+      it('returns code on `keydown`, `keyup` and `keypress`', async () => {
         let codeDown = null;
         let codeUp = null;
         let codePress = null;
@@ -501,7 +501,7 @@ describe('SyntheticKeyboardEvent', () => {
   });
 
   describe('EventInterface', () => {
-    it('is able to `preventDefault` and `stopPropagation`', () => {
+    it('is able to `preventDefault` and `stopPropagation`', async () => {
       let expectedCount = 0;
       const eventHandler = event => {
         expect(event.isDefaultPrevented()).toBe(false);

--- a/packages/react-dom/src/events/__tests__/SyntheticMouseEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticMouseEvent-test.js
@@ -30,7 +30,7 @@ describe('SyntheticMouseEvent', () => {
     container = null;
   });
 
-  it('should only use values from movementX/Y when event type is mousemove', () => {
+  it('should only use values from movementX/Y when event type is mousemove', async () => {
     const events = [];
     const onMouseMove = event => {
       events.push(event.movementX);
@@ -79,7 +79,7 @@ describe('SyntheticMouseEvent', () => {
     expect(events[2]).toBe(0); // mousedown event should have movementX at 0
   });
 
-  it('should correctly calculate movementX/Y for capture phase', () => {
+  it('should correctly calculate movementX/Y for capture phase', async () => {
     const events = [];
     const onMouseMove = event => {
       events.push(['move', false, event.movementX, event.movementY]);

--- a/packages/react-dom/src/events/__tests__/SyntheticWheelEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticWheelEvent-test.js
@@ -29,7 +29,7 @@ describe('SyntheticWheelEvent', () => {
     container = null;
   });
 
-  it('should normalize properties from the MouseEvent interface', () => {
+  it('should normalize properties from the MouseEvent interface', async () => {
     const events = [];
     const onWheel = event => {
       event.persist();
@@ -48,7 +48,7 @@ describe('SyntheticWheelEvent', () => {
     expect(events[0].button).toBe(1);
   });
 
-  it('should normalize properties from the WheelEvent interface', () => {
+  it('should normalize properties from the WheelEvent interface', async () => {
     const events = [];
     const onWheel = event => {
       event.persist();
@@ -83,7 +83,7 @@ describe('SyntheticWheelEvent', () => {
     expect(events[1].deltaY).toBe(-50);
   });
 
-  it('should be able to `preventDefault` and `stopPropagation`', () => {
+  it('should be able to `preventDefault` and `stopPropagation`', async () => {
     const events = [];
     const onWheel = event => {
       expect(event.isDefaultPrevented()).toBe(false);

--- a/packages/react-dom/src/events/__tests__/getEventKey-test.js
+++ b/packages/react-dom/src/events/__tests__/getEventKey-test.js
@@ -31,7 +31,7 @@ describe('getEventKey', () => {
 
   describe('when key is implemented in a browser', () => {
     describe('when key is not normalized', () => {
-      it('returns a normalized value', () => {
+      it('returns a normalized value', async () => {
         let key = null;
         class Comp extends React.Component {
           render() {
@@ -52,7 +52,7 @@ describe('getEventKey', () => {
     });
 
     describe('when key is normalized', () => {
-      it('returns a key', () => {
+      it('returns a key', async () => {
         let key = null;
         class Comp extends React.Component {
           render() {
@@ -76,7 +76,7 @@ describe('getEventKey', () => {
   describe('when key is not implemented in a browser', () => {
     describe('when event type is keypress', () => {
       describe('when charCode is 13', () => {
-        it('returns "Enter"', () => {
+        it('returns "Enter"', async () => {
           let key = null;
           class Comp extends React.Component {
             render() {
@@ -97,7 +97,7 @@ describe('getEventKey', () => {
       });
 
       describe('when charCode is not 13', () => {
-        it('returns a string from a charCode', () => {
+        it('returns a string from a charCode', async () => {
           let key = null;
           class Comp extends React.Component {
             render() {
@@ -120,7 +120,7 @@ describe('getEventKey', () => {
 
     describe('when event type is keydown or keyup', () => {
       describe('when keyCode is recognized', () => {
-        it('returns a translated key', () => {
+        it('returns a translated key', async () => {
           let key = null;
           class Comp extends React.Component {
             render() {
@@ -141,7 +141,7 @@ describe('getEventKey', () => {
       });
 
       describe('when keyCode is not recognized', () => {
-        it('returns Unidentified', () => {
+        it('returns Unidentified', async () => {
           let key = null;
           class Comp extends React.Component {
             render() {

--- a/packages/react-dom/src/events/plugins/__tests__/ChangeEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/ChangeEventPlugin-test.js
@@ -83,7 +83,7 @@ describe('ChangeEventPlugin', () => {
   // keep track of the "current" value and only fire events when it changes.
   // See https://github.com/facebook/react/pull/5746.
 
-  it('should consider initial text value to be current', () => {
+  it('should consider initial text value to be current', async () => {
     let called = 0;
 
     function cb(e) {
@@ -102,7 +102,7 @@ describe('ChangeEventPlugin', () => {
     expect(called).toBe(0);
   });
 
-  it('should consider initial text value to be current (capture)', () => {
+  it('should consider initial text value to be current (capture)', async () => {
     let called = 0;
 
     function cb(e) {
@@ -121,7 +121,7 @@ describe('ChangeEventPlugin', () => {
     expect(called).toBe(0);
   });
 
-  it('should not invoke a change event for textarea same value', () => {
+  it('should not invoke a change event for textarea same value', async () => {
     let called = 0;
 
     function cb(e) {
@@ -139,7 +139,7 @@ describe('ChangeEventPlugin', () => {
     expect(called).toBe(0);
   });
 
-  it('should not invoke a change event for textarea same value (capture)', () => {
+  it('should not invoke a change event for textarea same value (capture)', async () => {
     let called = 0;
 
     function cb(e) {
@@ -157,7 +157,7 @@ describe('ChangeEventPlugin', () => {
     expect(called).toBe(0);
   });
 
-  it('should consider initial checkbox checked=true to be current', () => {
+  it('should consider initial checkbox checked=true to be current', async () => {
     let called = 0;
 
     function cb(e) {
@@ -181,7 +181,7 @@ describe('ChangeEventPlugin', () => {
     expect(called).toBe(0);
   });
 
-  it('should consider initial checkbox checked=false to be current', () => {
+  it('should consider initial checkbox checked=false to be current', async () => {
     let called = 0;
 
     function cb(e) {
@@ -205,7 +205,7 @@ describe('ChangeEventPlugin', () => {
     expect(called).toBe(0);
   });
 
-  it('should fire change for checkbox input', () => {
+  it('should fire change for checkbox input', async () => {
     let called = 0;
 
     function cb(e) {
@@ -235,7 +235,7 @@ describe('ChangeEventPlugin', () => {
     expect(called).toBe(2);
   });
 
-  it('should not fire change setting the value programmatically', () => {
+  it('should not fire change setting the value programmatically', async () => {
     let called = 0;
 
     function cb(e) {
@@ -271,7 +271,7 @@ describe('ChangeEventPlugin', () => {
     expect(called).toBe(1);
   });
 
-  it('should not distinguish equal string and number values', () => {
+  it('should not distinguish equal string and number values', async () => {
     let called = 0;
 
     function cb(e) {
@@ -296,7 +296,7 @@ describe('ChangeEventPlugin', () => {
   });
 
   // See a similar input test above for a detailed description of why.
-  it('should not fire change when setting checked programmatically', () => {
+  it('should not fire change when setting checked programmatically', async () => {
     let called = 0;
 
     function cb(e) {
@@ -326,13 +326,13 @@ describe('ChangeEventPlugin', () => {
     expect(called).toBe(1);
   });
 
-  it('should unmount', () => {
+  it('should unmount', async () => {
     const input = ReactDOM.render(<input />, container);
 
     ReactDOM.unmountComponentAtNode(container);
   });
 
-  it('should only fire change for checked radio button once', () => {
+  it('should only fire change for checked radio button once', async () => {
     let called = 0;
 
     function cb(e) {
@@ -351,7 +351,7 @@ describe('ChangeEventPlugin', () => {
     expect(called).toBe(1);
   });
 
-  it('should track radio button cousins in a group', () => {
+  it('should track radio button cousins in a group', async () => {
     let called1 = 0;
     let called2 = 0;
 
@@ -392,7 +392,7 @@ describe('ChangeEventPlugin', () => {
     expect(called2).toBe(1);
   });
 
-  it('should deduplicate input value change events', () => {
+  it('should deduplicate input value change events', async () => {
     let called = 0;
 
     function cb(e) {
@@ -455,7 +455,7 @@ describe('ChangeEventPlugin', () => {
     });
   });
 
-  it('should listen for both change and input events when supported', () => {
+  it('should listen for both change and input events when supported', async () => {
     let called = 0;
 
     function cb(e) {
@@ -477,7 +477,7 @@ describe('ChangeEventPlugin', () => {
     expect(called).toBe(2);
   });
 
-  it('should only fire events when the value changes for range inputs', () => {
+  it('should only fire events when the value changes for range inputs', async () => {
     let called = 0;
 
     function cb(e) {
@@ -500,7 +500,7 @@ describe('ChangeEventPlugin', () => {
     expect(called).toBe(2);
   });
 
-  it('does not crash for nodes with custom value property', () => {
+  it('does not crash for nodes with custom value property', async () => {
     let originalCreateElement;
     // https://github.com/facebook/react/issues/10196
     try {

--- a/packages/react-dom/src/events/plugins/__tests__/EnterLeaveEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/EnterLeaveEventPlugin-test.js
@@ -31,7 +31,7 @@ describe('EnterLeaveEventPlugin', () => {
     container = null;
   });
 
-  it('should set onMouseLeave relatedTarget properly in iframe', () => {
+  it('should set onMouseLeave relatedTarget properly in iframe', async () => {
     const iframe = document.createElement('iframe');
     container.appendChild(iframe);
     const iframeDocument = iframe.contentDocument;
@@ -64,7 +64,7 @@ describe('EnterLeaveEventPlugin', () => {
     expect(leaveEvents[0].relatedTarget).toBe(iframe.contentWindow);
   });
 
-  it('should set onMouseEnter relatedTarget properly in iframe', () => {
+  it('should set onMouseEnter relatedTarget properly in iframe', async () => {
     const iframe = document.createElement('iframe');
     container.appendChild(iframe);
     const iframeDocument = iframe.contentDocument;
@@ -98,7 +98,7 @@ describe('EnterLeaveEventPlugin', () => {
   });
 
   // Regression test for https://github.com/facebook/react/issues/10906.
-  it('should find the common parent after updates', () => {
+  it('should find the common parent after updates', async () => {
     let parentEnterCalls = 0;
     let childEnterCalls = 0;
     let parent = null;
@@ -136,7 +136,7 @@ describe('EnterLeaveEventPlugin', () => {
   });
 
   // Test for https://github.com/facebook/react/issues/16763.
-  it('should call mouseEnter once from sibling rendered inside a rendered component', done => {
+  it('should call mouseEnter once from sibling rendered inside a rendered component', async () => {
     const mockFn = jest.fn();
 
     class Parent extends React.Component {
@@ -186,7 +186,7 @@ describe('EnterLeaveEventPlugin', () => {
     ReactDOM.render(<Parent />, container);
   });
 
-  it('should call mouseEnter when pressing a non tracked React node', done => {
+  it('should call mouseEnter when pressing a non tracked React node', async () => {
     const mockFn = jest.fn();
 
     class Parent extends React.Component {
@@ -237,7 +237,7 @@ describe('EnterLeaveEventPlugin', () => {
     ReactDOM.render(<Parent />, container);
   });
 
-  it('should work with portals outside of the root that has onMouseLeave', () => {
+  it('should work with portals outside of the root that has onMouseLeave', async () => {
     const divRef = React.createRef();
     const onMouseLeave = jest.fn();
 
@@ -263,7 +263,7 @@ describe('EnterLeaveEventPlugin', () => {
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
   });
 
-  it('should work with portals that have onMouseEnter outside of the root ', () => {
+  it('should work with portals that have onMouseEnter outside of the root ', async () => {
     const divRef = React.createRef();
     const otherDivRef = React.createRef();
     const onMouseEnter = jest.fn();

--- a/packages/react-dom/src/events/plugins/__tests__/SelectEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/SelectEventPlugin-test.js
@@ -29,7 +29,7 @@ describe('SelectEventPlugin', () => {
   });
 
   // See https://github.com/facebook/react/pull/3639 for details.
-  it('does not get confused when dependent events are registered independently', () => {
+  it('does not get confused when dependent events are registered independently', async () => {
     const select = jest.fn();
     const onSelect = event => {
       expect(typeof event).toBe('object');
@@ -74,7 +74,7 @@ describe('SelectEventPlugin', () => {
     expect(select).toHaveBeenCalledTimes(1);
   });
 
-  it('should fire `onSelect` when a listener is present', () => {
+  it('should fire `onSelect` when a listener is present', async () => {
     const select = jest.fn();
     const onSelect = event => {
       expect(typeof event).toBe('object');
@@ -108,7 +108,7 @@ describe('SelectEventPlugin', () => {
     expect(select).toHaveBeenCalledTimes(1);
   });
 
-  it('should fire `onSelectCapture` when a listener is present', () => {
+  it('should fire `onSelectCapture` when a listener is present', async () => {
     const select = jest.fn();
     const onSelectCapture = event => {
       expect(typeof event).toBe('object');
@@ -143,7 +143,7 @@ describe('SelectEventPlugin', () => {
   });
 
   // Regression test for https://github.com/facebook/react/issues/11379
-  it('should not wait for `mouseup` after receiving `dragend`', () => {
+  it('should not wait for `mouseup` after receiving `dragend`', async () => {
     const select = jest.fn();
     const onSelect = event => {
       expect(typeof event).toBe('object');
@@ -177,7 +177,7 @@ describe('SelectEventPlugin', () => {
     expect(select).toHaveBeenCalledTimes(1);
   });
 
-  it('should handle selectionchange events', function () {
+  it('should handle selectionchange events', async () => {
     const onSelect = jest.fn();
     const node = ReactDOM.render(
       <input type="text" onSelect={onSelect} />,

--- a/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
@@ -144,7 +144,7 @@ describe('SimpleEventPlugin', function () {
         expectNoClickThru(mounted(element));
       });
 
-      it('should forward clicks when it becomes not disabled', () => {
+      it('should forward clicks when it becomes not disabled', async () => {
         container = document.createElement('div');
         document.body.appendChild(container);
         let element = ReactDOM.render(
@@ -158,7 +158,7 @@ describe('SimpleEventPlugin', function () {
         expectClickThru(element);
       });
 
-      it('should not forward clicks when it becomes disabled', () => {
+      it('should not forward clicks when it becomes disabled', async () => {
         container = document.createElement('div');
         document.body.appendChild(container);
         let element = ReactDOM.render(
@@ -172,7 +172,7 @@ describe('SimpleEventPlugin', function () {
         expectNoClickThru(element);
       });
 
-      it('should work correctly if the listener is changed', () => {
+      it('should work correctly if the listener is changed', async () => {
         container = document.createElement('div');
         document.body.appendChild(container);
         let element = ReactDOM.render(
@@ -188,7 +188,7 @@ describe('SimpleEventPlugin', function () {
     });
   });
 
-  it('batches updates that occur as a result of a nested event dispatch', () => {
+  it('batches updates that occur as a result of a nested event dispatch', async () => {
     container = document.createElement('div');
     document.body.appendChild(container);
 
@@ -392,7 +392,7 @@ describe('SimpleEventPlugin', function () {
   describe('iOS bubbling click fix', function () {
     // See http://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
 
-    it('does not add a local click to interactive elements', function () {
+    it('does not add a local click to interactive elements', async () => {
       container = document.createElement('div');
 
       ReactDOM.render(<button onClick={onClick} />, container);
@@ -404,7 +404,7 @@ describe('SimpleEventPlugin', function () {
       expect(onClick).toHaveBeenCalledTimes(0);
     });
 
-    it('adds a local click listener to non-interactive elements', function () {
+    it('adds a local click listener to non-interactive elements', async () => {
       container = document.createElement('div');
 
       ReactDOM.render(<div onClick={onClick} />, container);
@@ -416,7 +416,7 @@ describe('SimpleEventPlugin', function () {
       expect(onClick).toHaveBeenCalledTimes(0);
     });
 
-    it('registers passive handlers for events affected by the intervention', () => {
+    it('registers passive handlers for events affected by the intervention', async () => {
       container = document.createElement('div');
 
       const passiveEvents = [];

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -1780,7 +1780,7 @@ describe('ReactFresh', () => {
     }
   });
 
-  it('keeps a valid tree when forcing remount', () => {
+  it('keeps a valid tree when forcing remount', async () => {
     if (__DEV__) {
       const HelloV1 = prepare(() => {
         function Hello() {
@@ -3019,7 +3019,7 @@ describe('ReactFresh', () => {
     }
   });
 
-  it('regression test: does not get into an infinite loop', () => {
+  it('regression test: does not get into an infinite loop', async () => {
     if (__DEV__) {
       const containerA = document.createElement('div');
       const containerB = document.createElement('div');
@@ -3481,7 +3481,7 @@ describe('ReactFresh', () => {
     });
   }
 
-  it('can update multiple roots independently', () => {
+  it('can update multiple roots independently', async () => {
     if (__DEV__) {
       // Declare the first version.
       const HelloV1 = () => {

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -72,7 +72,7 @@ describe('ReactContextValidator', () => {
   });
 
   // @gate !disableLegacyContext
-  it('should pass next context to lifecycles', () => {
+  it('should pass next context to lifecycles', async () => {
     let componentDidMountContext;
     let componentDidUpdateContext;
     let componentWillReceivePropsContext;
@@ -369,7 +369,7 @@ describe('ReactContextValidator', () => {
     expect(childContext.foo).toBe('FOO');
   });
 
-  it('should pass next context to lifecycles', () => {
+  it('should pass next context to lifecycles', async () => {
     let componentDidMountContext;
     let componentDidUpdateContext;
     let componentWillReceivePropsContext;
@@ -447,7 +447,7 @@ describe('ReactContextValidator', () => {
     }
   });
 
-  it('should re-render PureComponents when context Provider updates', () => {
+  it('should re-render PureComponents when context Provider updates', async () => {
     let renderedContext;
 
     const Context = React.createContext();

--- a/packages/react/src/__tests__/ReactElementJSX-test.js
+++ b/packages/react/src/__tests__/ReactElementJSX-test.js
@@ -48,7 +48,7 @@ describe('ReactElement.jsx', () => {
     expect(element.constructor).toBe(object.constructor);
   });
 
-  it('should use default prop value when removing a prop', () => {
+  it('should use default prop value when removing a prop', async () => {
     class Component extends React.Component {
       render() {
         return JSXRuntime.jsx('span', {});
@@ -114,7 +114,7 @@ describe('ReactElement.jsx', () => {
     }
   });
 
-  it('throws when adding a prop (in dev) after element creation', () => {
+  it('throws when adding a prop (in dev) after element creation', async () => {
     const container = document.createElement('div');
     class Outer extends React.Component {
       render() {
@@ -155,7 +155,7 @@ describe('ReactElement.jsx', () => {
     expect(test.props.value).toBeNaN();
   });
 
-  it('should warn when `key` is being accessed on composite element', () => {
+  it('should warn when `key` is being accessed on composite element', async () => {
     const container = document.createElement('div');
     class Child extends React.Component {
       render() {
@@ -183,7 +183,7 @@ describe('ReactElement.jsx', () => {
     );
   });
 
-  it('warns when a jsxs is passed something that is not an array', () => {
+  it('warns when a jsxs is passed something that is not an array', async () => {
     const container = document.createElement('div');
     expect(() =>
       ReactDOM.render(
@@ -209,7 +209,7 @@ describe('ReactElement.jsx', () => {
     );
   });
 
-  it('should warn when `ref` is being accessed', () => {
+  it('should warn when `ref` is being accessed', async () => {
     const container = document.createElement('div');
     class Child extends React.Component {
       render() {
@@ -233,7 +233,7 @@ describe('ReactElement.jsx', () => {
     );
   });
 
-  it('should warn when unkeyed children are passed to jsx', () => {
+  it('should warn when unkeyed children are passed to jsx', async () => {
     const container = document.createElement('div');
 
     class Child extends React.Component {
@@ -262,7 +262,7 @@ describe('ReactElement.jsx', () => {
     );
   });
 
-  it('should warn when keys are passed as part of props', () => {
+  it('should warn when keys are passed as part of props', async () => {
     const container = document.createElement('div');
     class Child extends React.Component {
       render() {
@@ -288,7 +288,7 @@ describe('ReactElement.jsx', () => {
     );
   });
 
-  it('should not warn when unkeyed children are passed to jsxs', () => {
+  it('should not warn when unkeyed children are passed to jsxs', async () => {
     const container = document.createElement('div');
     class Child extends React.Component {
       render() {

--- a/packages/react/src/__tests__/ReactJSXElement-test.js
+++ b/packages/react/src/__tests__/ReactJSXElement-test.js
@@ -172,7 +172,7 @@ describe('ReactJSXElement', () => {
     expect(element.constructor).toBe(object.constructor);
   });
 
-  it('should use default prop value when removing a prop', () => {
+  it('should use default prop value when removing a prop', async () => {
     Component.defaultProps = {fruit: 'persimmon'};
 
     const container = document.createElement('div');

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -172,7 +172,7 @@ describe('ReactJSXElementValidator', () => {
     );
   });
 
-  it('should update component stack after receiving next element', () => {
+  it('should update component stack after receiving next element', async () => {
     function MyComp() {
       return null;
     }

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -34,7 +34,7 @@ describe('ReactStrictMode', () => {
     useReducer = React.useReducer;
   });
 
-  it('should appear in the client component stack', () => {
+  it('should appear in the client component stack', async () => {
     function Foo() {
       return <div ariaTypo="" />;
     }
@@ -75,7 +75,7 @@ describe('ReactStrictMode', () => {
   });
 
   // @gate __DEV__
-  it('should invoke precommit lifecycle methods twice', () => {
+  it('should invoke precommit lifecycle methods twice', async () => {
     let log = [];
     let shouldComponentUpdate = false;
     class ClassComponent extends React.Component {
@@ -162,7 +162,7 @@ describe('ReactStrictMode', () => {
     ]);
   });
 
-  it('should invoke setState callbacks twice', () => {
+  it('should invoke setState callbacks twice', async () => {
     let instance;
     class ClassComponent extends React.Component {
       state = {
@@ -196,7 +196,7 @@ describe('ReactStrictMode', () => {
     expect(instance.state.count).toBe(2);
   });
 
-  it('should invoke precommit lifecycle methods twice in DEV', () => {
+  it('should invoke precommit lifecycle methods twice in DEV', async () => {
     const {StrictMode} = React;
 
     let log = [];
@@ -303,7 +303,7 @@ describe('ReactStrictMode', () => {
     }
   });
 
-  it('should invoke setState callbacks twice in DEV', () => {
+  it('should invoke setState callbacks twice in DEV', async () => {
     const {StrictMode} = React;
 
     let instance;
@@ -727,7 +727,7 @@ Please update the following components: Parent`,
     await act(() => root.render(<StrictRoot foo={false} />));
   });
 
-  it('should also warn inside of "strict" mode trees', () => {
+  it('should also warn inside of "strict" mode trees', async () => {
     const {StrictMode} = React;
 
     class SyncRoot extends React.Component {
@@ -783,7 +783,7 @@ describe('symbol checks', () => {
     ReactDOMClient = require('react-dom/client');
   });
 
-  it('should switch from StrictMode to a Fragment and reset state', () => {
+  it('should switch from StrictMode to a Fragment and reset state', async () => {
     const {Fragment, StrictMode} = React;
 
     function ParentComponent({useFragment}) {
@@ -819,7 +819,7 @@ describe('symbol checks', () => {
     expect(container.textContent).toBe('count:1');
   });
 
-  it('should switch from a Fragment to StrictMode and reset state', () => {
+  it('should switch from a Fragment to StrictMode and reset state', async () => {
     const {Fragment, StrictMode} = React;
 
     function ParentComponent({useFragment}) {
@@ -855,7 +855,7 @@ describe('symbol checks', () => {
     expect(container.textContent).toBe('count:1');
   });
 
-  it('should update with StrictMode without losing state', () => {
+  it('should update with StrictMode without losing state', async () => {
     const {StrictMode} = React;
 
     function ParentComponent() {
@@ -896,7 +896,7 @@ describe('string refs', () => {
     ReactDOMClient = require('react-dom/client');
   });
 
-  it('should warn within a strict tree', () => {
+  it('should warn within a strict tree', async () => {
     const {StrictMode} = React;
 
     class OuterComponent extends React.Component {
@@ -930,7 +930,7 @@ describe('string refs', () => {
     ReactDOM.render(<OuterComponent />, container);
   });
 
-  it('should warn within a strict tree', () => {
+  it('should warn within a strict tree', async () => {
     const {StrictMode} = React;
 
     class OuterComponent extends React.Component {
@@ -986,7 +986,7 @@ describe('context legacy', () => {
   });
 
   // @gate !disableLegacyContext || !__DEV__
-  it('should warn if the legacy context API have been used in strict mode', () => {
+  it('should warn if the legacy context API have been used in strict mode', async () => {
     class LegacyContextProvider extends React.Component {
       getChildContext() {
         return {color: 'purple'};
@@ -1067,7 +1067,7 @@ describe('context legacy', () => {
     });
 
     if (ReactFeatureFlags.consoleManagedByDevToolsDuringStrictMode) {
-      it('does not disable logs for class double render', () => {
+      it('does not disable logs for class double render', async () => {
         spyOnDevAndProd(console, 'log');
 
         let count = 0;
@@ -1095,7 +1095,7 @@ describe('context legacy', () => {
         expect(console.log).toBeCalledWith('foo 1');
       });
 
-      it('does not disable logs for class double ctor', () => {
+      it('does not disable logs for class double ctor', async () => {
         spyOnDevAndProd(console, 'log');
 
         let count = 0;
@@ -1126,7 +1126,7 @@ describe('context legacy', () => {
         expect(console.log).toBeCalledWith('foo 1');
       });
 
-      it('does not disable logs for class double getDerivedStateFromProps', () => {
+      it('does not disable logs for class double getDerivedStateFromProps', async () => {
         spyOnDevAndProd(console, 'log');
 
         let count = 0;
@@ -1158,7 +1158,7 @@ describe('context legacy', () => {
         expect(console.log).toBeCalledWith('foo 1');
       });
 
-      it('does not disable logs for class double shouldComponentUpdate', () => {
+      it('does not disable logs for class double shouldComponentUpdate', async () => {
         spyOnDevAndProd(console, 'log');
 
         let count = 0;
@@ -1197,7 +1197,7 @@ describe('context legacy', () => {
         expect(console.log).toBeCalledWith('foo 1');
       });
 
-      it('does not disable logs for class state updaters', () => {
+      it('does not disable logs for class state updaters', async () => {
         spyOnDevAndProd(console, 'log');
 
         let inst;
@@ -1231,7 +1231,7 @@ describe('context legacy', () => {
         expect(console.log).toBeCalledWith('foo 1');
       });
 
-      it('does not disable logs for function double render', () => {
+      it('does not disable logs for function double render', async () => {
         spyOnDevAndProd(console, 'log');
 
         let count = 0;
@@ -1257,7 +1257,7 @@ describe('context legacy', () => {
         expect(console.log).toBeCalledWith('foo 1');
       });
     } else {
-      it('disable logs for class double render', () => {
+      it('disable logs for class double render', async () => {
         spyOnDevAndProd(console, 'log');
 
         let count = 0;
@@ -1285,7 +1285,7 @@ describe('context legacy', () => {
         expect(console.log).toBeCalledWith('foo 1');
       });
 
-      it('disables logs for class double ctor', () => {
+      it('disables logs for class double ctor', async () => {
         spyOnDevAndProd(console, 'log');
 
         let count = 0;
@@ -1316,7 +1316,7 @@ describe('context legacy', () => {
         expect(console.log).toBeCalledWith('foo 1');
       });
 
-      it('disable logs for class double getDerivedStateFromProps', () => {
+      it('disable logs for class double getDerivedStateFromProps', async () => {
         spyOnDevAndProd(console, 'log');
 
         let count = 0;
@@ -1348,7 +1348,7 @@ describe('context legacy', () => {
         expect(console.log).toBeCalledWith('foo 1');
       });
 
-      it('disable logs for class double shouldComponentUpdate', () => {
+      it('disable logs for class double shouldComponentUpdate', async () => {
         spyOnDevAndProd(console, 'log');
 
         let count = 0;
@@ -1387,7 +1387,7 @@ describe('context legacy', () => {
         expect(console.log).toBeCalledWith('foo 1');
       });
 
-      it('disable logs for class state updaters', () => {
+      it('disable logs for class state updaters', async () => {
         spyOnDevAndProd(console, 'log');
 
         let inst;
@@ -1421,7 +1421,7 @@ describe('context legacy', () => {
         expect(console.log).toBeCalledWith('foo 1');
       });
 
-      it('disable logs for function double render', () => {
+      it('disable logs for function double render', async () => {
         spyOnDevAndProd(console, 'log');
 
         let count = 0;

--- a/packages/shared/__tests__/describeComponentFrame-test.js
+++ b/packages/shared/__tests__/describeComponentFrame-test.js
@@ -19,7 +19,7 @@ describe('Component stack trace displaying', () => {
   });
 
   // @gate !enableComponentStackLocations || !__DEV__
-  it('should provide filenames in stack traces', () => {
+  it('should provide filenames in stack traces', async () => {
     class Component extends React.Component {
       render() {
         return [<span>a</span>, <span>b</span>];

--- a/scripts/codemod/index.js
+++ b/scripts/codemod/index.js
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ESNode, CallExpression} from 'hermes-estree';
+import type {TransformContext} from 'hermes-transform';
+
+const {transform, t} = require('hermes-transform');
+const {SimpleTraverser} = require('hermes-parser');
+const Glob = require('glob');
+const {readFileSync, writeFileSync} = require('fs');
+const Prettier = require('prettier');
+
+/* eslint-disable no-for-of-loops/no-for-of-loops */
+
+function containsReactDOMRenderCall(func: ESNode): boolean {
+  if (
+    func.type !== 'ArrowFunctionExpression' &&
+    func.type !== 'FunctionExpression'
+  ) {
+    throw new Error('expected a function');
+  }
+  let result = false;
+  SimpleTraverser.traverse(func.body, {
+    enter(node: ESNode) {
+      if (
+        node.type === 'CallExpression' &&
+        node.callee.type === 'MemberExpression' &&
+        node.callee.object.type === 'Identifier' &&
+        node.callee.object.name === 'ReactDOM' &&
+        node.callee.property.type === 'Identifier' &&
+        node.callee.property.name === 'render'
+      ) {
+        result = true;
+        throw SimpleTraverser.Break;
+      }
+    },
+    leave() {},
+  });
+  return result;
+}
+
+function updateItToAsync(context: TransformContext) {
+  return {
+    CallExpression(node: CallExpression) {
+      if (
+        node.callee.type === 'Identifier' &&
+        node.callee.name === 'it' &&
+        node.arguments.length === 2
+      ) {
+        const fn = node.arguments[1];
+        if (
+          fn.type !== 'ArrowFunctionExpression' &&
+          fn.type !== 'FunctionExpression'
+        ) {
+          throw new Error('expected a function as argument to it()');
+        }
+        if (containsReactDOMRenderCall(fn)) {
+          context.replaceNode(
+            fn,
+            t.ArrowFunctionExpression({
+              params: [],
+              body: fn.body,
+              async: true,
+            }),
+          );
+        }
+      }
+    },
+  };
+}
+
+// function updateExpectToAsync(context: TransformContext) {
+//   return {
+//     CallExpression(node: CallExpression) {
+//       if (
+//         node.callee.type === 'MemberExpression' &&
+//         node.callee.object.type === 'CallExpression' &&
+//         node.callee.object.callee.type === 'Identifier' &&
+//         node.callee.object.callee.name === 'expect' &&
+//         node.callee.object.arguments.length === 1 &&
+//         (node.callee.object.arguments[0].type === 'ArrowFunctionExpression' ||
+//           node.callee.object.arguments[0].type === 'FunctionExpression') &&
+//         containsReactDOMRenderCall(node.callee.object.arguments[0])
+//       ) {
+//         const cloned = context.deepCloneNode(node);
+//         // $FlowFixMe
+//         cloned.callee.object.arguments[0] = t.ArrowFunctionExpression({
+//           params: [],
+//           body: t.BlockStatement({
+//             // $FlowFixMe
+//             body: [cloned.callee.object.arguments[0].body],
+//           }),
+//           async: true,
+//         });
+//         context.replaceNode(
+//           node,
+//           t.AwaitExpression({
+//             argument: cloned,
+//           })
+//         );
+//       }
+//     },
+//   };
+// }
+
+// function replaceReactDOMRender(context: TransformContext) {
+//   return {
+//     CallExpression(node: CallExpression) {
+//       if (
+//         node.callee.type === 'MemberExpression' &&
+//         node.callee.object.type === 'Identifier' &&
+//         node.callee.object.name === 'ReactDOM' &&
+//         node.callee.property.type === 'Identifier' &&
+//         node.callee.property.name === 'render'
+//       ) {
+//         const renderRoot = t.CallExpression({
+//           callee: t.MemberExpression({
+//             object: t.Identifier({name: 'root'}),
+//             property: t.Identifier({name: 'render'}),
+//             computed: false,
+//           }),
+//           arguments: [node.arguments[0]],
+//         });
+//         context.replaceNode(
+//           node,
+//           t.AwaitExpression({
+//             argument: t.CallExpression({
+//               callee: t.Identifier({name: 'act'}),
+//               arguments: [
+//                 t.ArrowFunctionExpression({
+//                   async: false,
+//                   params: [],
+//                   body: t.BlockStatement({
+//                     body: [
+//                       t.ExpressionStatement({
+//                         expression: renderRoot,
+//                       }),
+//                     ],
+//                   }),
+//                 }),
+//               ],
+//             }),
+//           })
+//         );
+//       }
+//     },
+//   };
+// }
+
+const visitors = [
+  updateItToAsync,
+  // updateExpectToAsync,
+  // replaceReactDOMRender,
+];
+
+async function transformFile(filename: string) {
+  const originalCode = readFileSync(filename, 'utf8');
+  const prettierConfig = await Prettier.resolveConfig(filename);
+  let transformedCode = originalCode;
+  for (const createVisitors of visitors) {
+    transformedCode = await transform(
+      transformedCode,
+      createVisitors,
+      prettierConfig,
+    );
+  }
+  if (originalCode !== transformedCode) {
+    writeFileSync(filename, transformedCode, 'utf8');
+    return true;
+  }
+  return false;
+}
+
+async function main(args: $ReadOnlyArray<string>) {
+  if (args.length !== 1) {
+    console.error('Usage: yarn codemod <PATTERN>');
+    process.exit(1);
+  }
+  const files = Glob.sync(args[0]);
+  let updatedCount = 0;
+  for (const file of files) {
+    const updated = await transformFile(file);
+    if (updated) {
+      updatedCount++;
+      console.log(`updated ${file}`);
+    }
+  }
+  console.log(`${files.length} processed, ${updatedCount} updated`);
+}
+
+main(process.argv.slice(2)).catch(err => {
+  console.error('Error while transforming:', err);
+});

--- a/scripts/shared/pathsByLanguageVersion.js
+++ b/scripts/shared/pathsByLanguageVersion.js
@@ -20,6 +20,7 @@ const esNextPaths = [
   'packages/react-interactions/**/*.js',
   'packages/shared/**/*.js',
   // Shims and Flow environment
+  'scripts/codemod/*.js',
   'scripts/flow/*.js',
   'scripts/rollup/shims/**/*.js',
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -7860,6 +7860,11 @@ flow-bin@^0.226.0:
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.226.0.tgz#b245847b749ab20756ef74c91d96619f68d18430"
   integrity sha512-q8hXSRhZ+I14jS0KGDDsPYCvPufvBexk6nJXSOsSP6DgCuXbvCOByWhsXRAjPtmXKmO8v9RKSJm1kRaWaf0fZw==
 
+flow-enums-runtime@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz#5bb0cd1b0a3e471330f4d109039b7eba5cb3e787"
+  integrity sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==
+
 flow-remove-types@^2.226.0:
   version "2.226.0"
   resolved "https://registry.yarnpkg.com/flow-remove-types/-/flow-remove-types-2.226.0.tgz#08ff7e195137ce43042e11bfa04303184971dac2"
@@ -8593,7 +8598,7 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hermes-eslint@^0.18.2:
+hermes-eslint@0.18.2, hermes-eslint@^0.18.2:
   version "0.18.2"
   resolved "https://registry.yarnpkg.com/hermes-eslint/-/hermes-eslint-0.18.2.tgz#af09ea1700eb32502caf135b181ffed6091ccb72"
   integrity sha512-FWKVoHyHaXRjOfjoTgoc4OTkC+KThYdhLFyggoXIYLMDHF9hkg5yHSih3cyK3hT73te6+aaGHePzwaOai69uoA==
@@ -8613,6 +8618,18 @@ hermes-parser@0.18.2, hermes-parser@^0.18.2:
   integrity sha512-1eQfvib+VPpgBZ2zYKQhpuOjw1tH+Emuib6QmjkJWJMhyjM8xnXMvA+76o9LhF0zOAJDZgPfQhg43cyXEyl5Ew==
   dependencies:
     hermes-estree "0.18.2"
+
+hermes-transform@^0.18.2:
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/hermes-transform/-/hermes-transform-0.18.2.tgz#ab0dbf586b76980dadc2b396ee7936b206cc1904"
+  integrity sha512-cM5J6cnC/9d7mIjUeUzv2/3nmGjbevA3FemPjevgWG5udEIhlJB5z5zwcrkVdp16W/Q6bVJdaT1pc4LPmlzsCA==
+  dependencies:
+    "@babel/code-frame" "^7.16.0"
+    esquery "^1.4.0"
+    flow-enums-runtime "^0.0.6"
+    hermes-eslint "0.18.2"
+    hermes-estree "0.18.2"
+    hermes-parser "0.18.2"
 
 homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
Convert tests containing render to async

This runs a simple codemod converting all `it` calls to async functions when they contain a `ReactDOM.render` call.
There's no real harm in doing it in bulk and the tests will need to be switched anyway when moving to `createRoot`.

This should reduce noise and manual changes needed.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/27994).
* __->__ #27994
* #27921