### PR TITLE
Convert describeComponentFrame to createRoot

### DIFF
--- a/packages/shared/__tests__/describeComponentFrame-test.js
+++ b/packages/shared/__tests__/describeComponentFrame-test.js
@@ -10,16 +10,18 @@
 'use strict';
 
 let React;
-let ReactDOM;
+let ReactDOMClient;
+let act;
 
 describe('Component stack trace displaying', () => {
   beforeEach(() => {
     React = require('react');
-    ReactDOM = require('react-dom');
+    ReactDOMClient = require('react-dom');
+    act = require('internal-test-utils').act;
   });
 
   // @gate !enableComponentStackLocations || !__DEV__
-  it('should provide filenames in stack traces', () => {
+  it('should provide filenames in stack traces', async () => {
     class Component extends React.Component {
       render() {
         return [<span>a</span>, <span>b</span>];
@@ -88,15 +90,21 @@ describe('Component stack trace displaying', () => {
       'C:\\funny long (path)/index.js': 'funny long (path)/index.js',
       'C:\\funny long (path)/index.jsx': 'funny long (path)/index.jsx',
     };
-    Object.keys(fileNames).forEach((fileName, i) => {
+
+    const root = ReactDOMClient.createRoot(container);
+
+    let i = 0;
+    for (const fileName in fileNames) {
       Component.displayName = 'Component ' + i;
-      ReactDOM.render(
-        <Component __source={{fileName, lineNumber: i}} />,
-        container,
-      );
-    });
+
+      await act(() => {
+        root.render(<Component __source={{fileName, lineNumber: i}} />);
+      });
+
+      i++;
+    }
     if (__DEV__) {
-      let i = 0;
+      i = 0;
       expect(console.error).toHaveBeenCalledTimes(
         Object.keys(fileNames).length,
       );


### PR DESCRIPTION
Not gated in `yarn test packages/shared/__tests__/describeComponentFrame-test.js --env production -r=www-classic`