### PR TITLE
Update ReactUpdates-test

### DIFF
--- a/packages/react-dom/src/__tests__/ReactLegacyUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyUpdates-test.js
@@ -14,8 +14,6 @@ let ReactDOM;
 let ReactTestUtils;
 let act;
 let Scheduler;
-let waitForAll;
-let waitFor;
 let assertLog;
 
 // Copy of ReactUpdates using ReactDOM.render and ReactDOM.unstable_batchedUpdates.
@@ -30,8 +28,6 @@ describe('ReactLegacyUpdates', () => {
     Scheduler = require('scheduler');
 
     const InternalTestUtils = require('internal-test-utils');
-    waitForAll = InternalTestUtils.waitForAll;
-    waitFor = InternalTestUtils.waitFor;
     assertLog = InternalTestUtils.assertLog;
   });
 

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -181,7 +181,6 @@ describe('ReactUpdates', () => {
   });
 
   it('should batch parent/child state updates together', async () => {
-    let parentRef;
     let childRef;
     let parentState;
     let childState;
@@ -198,10 +197,7 @@ describe('ReactUpdates', () => {
       });
 
       return (
-        <div
-          ref={ref => {
-            parentRef = ref;
-          }}>
+        <div>
           <Child prop={state} />
         </div>
       );
@@ -252,7 +248,6 @@ describe('ReactUpdates', () => {
   });
 
   it('should batch child/parent state updates together', async () => {
-    let parentRef;
     let childRef;
     let parentState;
     let childState;
@@ -269,10 +264,7 @@ describe('ReactUpdates', () => {
       });
 
       return (
-        <div
-          ref={ref => {
-            parentRef = ref;
-          }}>
+        <div>
           <Child prop={state} />
         </div>
       );


### PR DESCRIPTION
## Overview

These tests are important for `ReactDOM.render`, so instead of just re-writing them to `createRoot` and losing coverage:
- Moved the `.render` tests to `ReactLegacyUpdates`
- Re-wrote the tests in `ReactUpdates` to use `createRoot`
- Remove `unstable_batchedUpdates` from `ReactUpdates`

In a future PR, when I flag `batchedUpdates` with a Noop, I can add the gate to just the tests in `ReactLegacyUpdates`.