### PR TITLE
[Flight] Refactor the Render Loop to Behave More Like Fizz

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -242,6 +242,20 @@ describe('ReactFlightDOMEdge', () => {
     expect(result).toEqual(resolvedChildren);
   });
 
+  it('should execute repeated server components in a compact form', async () => {
+    async function ServerComponent({recurse}) {
+      if (recurse > 0) {
+        return <ServerComponent recurse={recurse - 1} />;
+      }
+      return <div>Fin</div>;
+    }
+    const stream = ReactServerDOMServer.renderToReadableStream(
+      <ServerComponent recurse={20} />,
+    );
+    const serializedContent = await readResult(stream);
+    expect(serializedContent.length).toBeLessThan(150);
+  });
+
   // @gate enableBinaryFlight
   it('should be able to serialize any kind of typed array', async () => {
     const buffer = new Uint8Array([

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -2201,8 +2201,12 @@ function renderNodeDestructive(
   task.node = node;
   task.childIndex = childIndex;
 
+  if (node === null) {
+    return;
+  }
+
   // Handle object types
-  if (typeof node === 'object' && node !== null) {
+  if (typeof node === 'object') {
     switch ((node: any).$$typeof) {
       case REACT_ELEMENT_TYPE: {
         const element: any = node;

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -504,7 +504,7 @@ function createLazyWrapperAroundWakeable(wakeable: Wakeable) {
   return lazyType;
 }
 
-function attemptResolveElement(
+function renderElement(
   request: Request,
   type: any,
   key: null | React$Key,
@@ -574,7 +574,7 @@ function attemptResolveElement(
         const payload = type._payload;
         const init = type._init;
         const wrappedType = init(payload);
-        return attemptResolveElement(
+        return renderElement(
           request,
           wrappedType,
           key,
@@ -589,7 +589,7 @@ function attemptResolveElement(
         return render(props, undefined);
       }
       case REACT_MEMO_TYPE: {
-        return attemptResolveElement(
+        return renderElement(
           request,
           type.type,
           key,
@@ -1018,7 +1018,7 @@ function resolveModelToJSON(
           // TODO: Concatenate keys of parents onto children.
           const element: React$Element<any> = (value: any);
           // Attempt to render the Server Component.
-          value = attemptResolveElement(
+          value = renderElement(
             request,
             element.type,
             element.key,
@@ -1551,7 +1551,7 @@ function retryTask(request: Request, task: Task): void {
       // Doing this here lets us reuse this same task if the next component
       // also suspends.
       task.model = value;
-      value = attemptResolveElement(
+      value = renderElement(
         request,
         element.type,
         element.key,
@@ -1576,7 +1576,7 @@ function retryTask(request: Request, task: Task): void {
         // TODO: Concatenate keys of parents onto children.
         const nextElement: React$Element<any> = (value: any);
         task.model = value;
-        value = attemptResolveElement(
+        value = renderElement(
           request,
           nextElement.type,
           nextElement.key,

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -614,7 +614,7 @@ function renderElement(
       }
       case REACT_PROVIDER_TYPE: {
         if (enableServerContext) {
-          pushProvider(type._context, props.value);
+          task.context = pushProvider(type._context, props.value);
           if (__DEV__) {
             const extraKeys = Object.keys(props).filter(value => {
               if (value === 'children' || value === 'value') {
@@ -1199,7 +1199,7 @@ function renderModelDestructive(
         }
         return serializeByValueID(providerId);
       } else if (value === POP) {
-        popProvider();
+        task.context = popProvider();
         if (__DEV__) {
           insideContextProps = null;
           isInsideContextValue = false;


### PR DESCRIPTION
This refactors the Flight render loop to behave more like Fizz with similar naming conventions. So it's easier to apply similar techniques across both. This is not necessarily better/faster - at least not yet.

This doesn't yet implement serialization by writing segments to chunks but we probably should do that since the built-in parts that `JSON.stringify` gets us isn't really much anymore (except serializing strings). When we switch to that it probably makes sense for the whole thing to be recursive.

Right now it's not technically fully recursive because each recursive render returns the next JSON value to encode. So it's kind of like a trampoline. This means we can't have many contextual things on the stack. It needs to use the Server Context `__POP` trick. However, it does work for things that are contextual only for one sequence of server component abstractions in a row. Since those are now recursive.

An interesting observation here is that `renderModel` means that anything can suspend while still serializing the outer siblings. Typically only Lazy or Components would suspend but in principle a Proxy can suspend/postpone too and now that is left serialized by reference to a future value. It's only if the thing that we rendered was something that can reduce to Lazy e.g. an Element that we can serialize it as a lazy.

Similarly to how Suspense boundaries in Fizz can catch errors, anything that can be reduced to Lazy can also catch an error rather than bubbling it. It only errors when the Lazy resolves. Unlike Suspense boundaries though, those things don't render anything so they're otherwise going to use the destructive form. To ensure that throwing in an Element can reuse the current task, this must be handled by `renderModel`, not for example `renderElement`.