### PR TITLE
Convert ReactMount to createRoot

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -114,6 +114,32 @@ describe('ReactDOMServerHydration', () => {
     });
 
     // @gate __DEV__
+    it('warns when escaping on a checksum mismatch', () => {
+      function Mismatch({isClient}) {
+        if (isClient) {
+          return (
+            <div>This markup contains an nbsp entity: &nbsp; client text</div>
+          );
+        }
+        return (
+          <div>This markup contains an nbsp entity: &nbsp; server text</div>
+        );
+      }
+
+      /* eslint-disable no-irregular-whitespace */
+      expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
+        [
+          "Warning: Text content did not match. Server: "This markup contains an nbsp entity:   server text" Client: "This markup contains an nbsp entity:   client text"
+            in div (at **)
+            in Mismatch (at **)",
+          "Warning: An error occurred during hydration. The server HTML was replaced with client content in <div>.",
+          "Caught [Text content does not match server-rendered HTML.]",
+          "Caught [There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.]",
+        ]
+      `);
+      /* eslint-enable no-irregular-whitespace */
+    });
+
     it('warns when client and server render different html', () => {
       function Mismatch({isClient}) {
         return (

--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -140,6 +140,7 @@ describe('ReactDOMServerHydration', () => {
       /* eslint-enable no-irregular-whitespace */
     });
 
+    // @gate __DEV__
     it('warns when client and server render different html', () => {
       function Mismatch({isClient}) {
         return (

--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -127,16 +127,26 @@ describe('ReactDOMServerHydration', () => {
       }
 
       /* eslint-disable no-irregular-whitespace */
-      expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
-        [
-          "Warning: Text content did not match. Server: "This markup contains an nbsp entity:   server text" Client: "This markup contains an nbsp entity:   client text"
-            in div (at **)
-            in Mismatch (at **)",
-          "Warning: An error occurred during hydration. The server HTML was replaced with client content in <div>.",
-          "Caught [Text content does not match server-rendered HTML.]",
-          "Caught [There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.]",
-        ]
-      `);
+      if (gate(flags => flags.enableClientRenderFallbackOnTextMismatch)) {
+        expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
+          [
+            "Warning: Text content did not match. Server: "This markup contains an nbsp entity:   server text" Client: "This markup contains an nbsp entity:   client text"
+              in div (at **)
+              in Mismatch (at **)",
+            "Warning: An error occurred during hydration. The server HTML was replaced with client content in <div>.",
+            "Caught [Text content does not match server-rendered HTML.]",
+            "Caught [There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.]",
+          ]
+        `);
+      } else {
+        expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
+          [
+            "Warning: Text content did not match. Server: "This markup contains an nbsp entity:   server text" Client: "This markup contains an nbsp entity:   client text"
+              in div (at **)
+              in Mismatch (at **)",
+          ]
+        `);
+      }
       /* eslint-enable no-irregular-whitespace */
     });
 

--- a/packages/react-dom/src/__tests__/ReactLegacyMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyMount-test.js
@@ -15,6 +15,10 @@ let React;
 let ReactDOM;
 let ReactDOMServer;
 let ReactTestUtils;
+let Scheduler = require('scheduler');
+const ReactDOMClient = require('react-dom/client');
+let assertLog;
+let waitForAll;
 
 describe('ReactMount', () => {
   beforeEach(() => {
@@ -24,6 +28,11 @@ describe('ReactMount', () => {
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
     ReactTestUtils = require('react-dom/test-utils');
+    Scheduler = require('scheduler');
+
+    const InternalTestUtils = require('internal-test-utils');
+    assertLog = InternalTestUtils.assertLog;
+    waitForAll = InternalTestUtils.waitForAll;
   });
 
   describe('unmountComponentAtNode', () => {
@@ -336,5 +345,128 @@ describe('ReactMount', () => {
         'A<!-- react-mount-point-unstable -->B',
       );
     });
+  });
+
+  it('clears existing children with legacy API', async () => {
+    const container = document.createElement('div');
+    container.innerHTML = '<div>a</div><div>b</div>';
+    ReactDOM.render(
+      <div>
+        <span>c</span>
+        <span>d</span>
+      </div>,
+      container,
+    );
+    expect(container.textContent).toEqual('cd');
+    ReactDOM.render(
+      <div>
+        <span>d</span>
+        <span>c</span>
+      </div>,
+      container,
+    );
+    await waitForAll([]);
+    expect(container.textContent).toEqual('dc');
+  });
+
+  it('warns when rendering with legacy API into createRoot() container', async () => {
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+    root.render(<div>Hi</div>);
+    await waitForAll([]);
+    expect(container.textContent).toEqual('Hi');
+    expect(() => {
+      ReactDOM.render(<div>Bye</div>, container);
+    }).toErrorDev(
+      [
+        // We care about this warning:
+        'You are calling ReactDOM.render() on a container that was previously ' +
+          'passed to ReactDOMClient.createRoot(). This is not supported. ' +
+          'Did you mean to call root.render(element)?',
+        // This is more of a symptom but restructuring the code to avoid it isn't worth it:
+        'Replacing React-rendered children with a new root component.',
+      ],
+      {withoutStack: true},
+    );
+    await waitForAll([]);
+    // This works now but we could disallow it:
+    expect(container.textContent).toEqual('Bye');
+  });
+
+  it('callback passed to legacy hydrate() API', () => {
+    const container = document.createElement('div');
+    container.innerHTML = '<div>Hi</div>';
+    ReactDOM.hydrate(<div>Hi</div>, container, () => {
+      Scheduler.log('callback');
+    });
+    expect(container.textContent).toEqual('Hi');
+    assertLog(['callback']);
+  });
+
+  it('warns when unmounting with legacy API (no previous content)', async () => {
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+    root.render(<div>Hi</div>);
+    await waitForAll([]);
+    expect(container.textContent).toEqual('Hi');
+    let unmounted = false;
+    expect(() => {
+      unmounted = ReactDOM.unmountComponentAtNode(container);
+    }).toErrorDev(
+      [
+        // We care about this warning:
+        'You are calling ReactDOM.unmountComponentAtNode() on a container that was previously ' +
+          'passed to ReactDOMClient.createRoot(). This is not supported. Did you mean to call root.unmount()?',
+        // This is more of a symptom but restructuring the code to avoid it isn't worth it:
+        "The node you're attempting to unmount was rendered by React and is not a top-level container.",
+      ],
+      {withoutStack: true},
+    );
+    expect(unmounted).toBe(false);
+    await waitForAll([]);
+    expect(container.textContent).toEqual('Hi');
+    root.unmount();
+    await waitForAll([]);
+    expect(container.textContent).toEqual('');
+  });
+
+  it('warns when unmounting with legacy API (has previous content)', async () => {
+    const container = document.createElement('div');
+    // Currently createRoot().render() doesn't clear this.
+    container.appendChild(document.createElement('div'));
+    // The rest is the same as test above.
+    const root = ReactDOMClient.createRoot(container);
+    root.render(<div>Hi</div>);
+    await waitForAll([]);
+    expect(container.textContent).toEqual('Hi');
+    let unmounted = false;
+    expect(() => {
+      unmounted = ReactDOM.unmountComponentAtNode(container);
+    }).toErrorDev(
+      [
+        'Did you mean to call root.unmount()?',
+        // This is more of a symptom but restructuring the code to avoid it isn't worth it:
+        "The node you're attempting to unmount was rendered by React and is not a top-level container.",
+      ],
+      {withoutStack: true},
+    );
+    expect(unmounted).toBe(false);
+    await waitForAll([]);
+    expect(container.textContent).toEqual('Hi');
+    root.unmount();
+    await waitForAll([]);
+    expect(container.textContent).toEqual('');
+  });
+
+  it('warns when passing legacy container to createRoot()', () => {
+    const container = document.createElement('div');
+    ReactDOM.render(<div>Hi</div>, container);
+    expect(() => {
+      ReactDOMClient.createRoot(container);
+    }).toErrorDev(
+      'You are calling ReactDOMClient.createRoot() on a container that was previously ' +
+        'passed to ReactDOM.render(). This is not supported.',
+      {withoutStack: true},
+    );
   });
 });

--- a/packages/react-dom/src/__tests__/ReactLegacyMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyMount-test.js
@@ -15,8 +15,8 @@ let React;
 let ReactDOM;
 let ReactDOMServer;
 let ReactTestUtils;
-let Scheduler = require('scheduler');
-const ReactDOMClient = require('react-dom/client');
+let Scheduler;
+let ReactDOMClient;
 let assertLog;
 let waitForAll;
 
@@ -26,6 +26,7 @@ describe('ReactMount', () => {
 
     React = require('react');
     ReactDOM = require('react-dom');
+    ReactDOMClient = require('react-dom/client');
     ReactDOMServer = require('react-dom/server');
     ReactTestUtils = require('react-dom/test-utils');
     Scheduler = require('scheduler');


### PR DESCRIPTION
To convert this file, I started replacing all the calls in line, and quickly realized that we already have most of these tests covered in other files. So I found the test that we didn't already have for `create/hydrateRoot` and added them, then renamed `ReactMount` to `ReactLegacyMount`.