### PR TITLE
Batch async actions even if useTransition is unmounted

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -53,6 +53,7 @@ import {
   ForceUpdate,
   initializeUpdateQueue,
   cloneUpdateQueue,
+  suspendIfUpdateReadFromEntangledAsyncAction,
 } from './ReactFiberClassUpdateQueue';
 import {NoLanes} from './ReactFiberLane';
 import {
@@ -892,6 +893,7 @@ function mountClassInstance(
     // If we had additional state updates during this life-cycle, let's
     // process them now.
     processUpdateQueue(workInProgress, newProps, instance, renderLanes);
+    suspendIfUpdateReadFromEntangledAsyncAction();
     instance.state = workInProgress.memoizedState;
   }
 
@@ -959,6 +961,7 @@ function resumeMountClassInstance(
   const oldState = workInProgress.memoizedState;
   let newState = (instance.state = oldState);
   processUpdateQueue(workInProgress, newProps, instance, renderLanes);
+  suspendIfUpdateReadFromEntangledAsyncAction();
   newState = workInProgress.memoizedState;
   if (
     oldProps === newProps &&
@@ -1109,6 +1112,7 @@ function updateClassInstance(
   const oldState = workInProgress.memoizedState;
   let newState = (instance.state = oldState);
   processUpdateQueue(workInProgress, newProps, instance, renderLanes);
+  suspendIfUpdateReadFromEntangledAsyncAction();
   newState = workInProgress.memoizedState;
 
   if (

--- a/packages/react-reconciler/src/ReactFiberClassUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactFiberClassUpdateQueue.js
@@ -125,6 +125,10 @@ import {
 import {setIsStrictModeForDevtools} from './ReactFiberDevToolsHook';
 
 import assign from 'shared/assign';
+import {
+  peekEntangledActionLane,
+  peekEntangledActionThenable,
+} from './ReactFiberAsyncAction';
 
 export type Update<State> = {
   lane: Lane,
@@ -463,12 +467,38 @@ function getStateFromUpdate<State>(
   return prevState;
 }
 
+let didReadFromEntangledAsyncAction: boolean = false;
+
+// Each call to processUpdateQueue should be accompanied by a call to this. It's
+// only in a separate function because in updateHostRoot, it must happen after
+// all the context stacks have been pushed to, to prevent a stack mismatch. A
+// bit unfortunate.
+export function suspendIfUpdateReadFromEntangledAsyncAction() {
+  // Check if this update is part of a pending async action. If so, we'll
+  // need to suspend until the action has finished, so that it's batched
+  // together with future updates in the same action.
+  // TODO: Once we support hooks inside useMemo (or an equivalent
+  // memoization boundary like Forget), hoist this logic so that it only
+  // suspends if the memo boundary produces a new value.
+  if (didReadFromEntangledAsyncAction) {
+    const entangledActionThenable = peekEntangledActionThenable();
+    if (entangledActionThenable !== null) {
+      // TODO: Instead of the throwing the thenable directly, throw a
+      // special object like `use` does so we can detect if it's captured
+      // by userspace.
+      throw entangledActionThenable;
+    }
+  }
+}
+
 export function processUpdateQueue<State>(
   workInProgress: Fiber,
   props: any,
   instance: any,
   renderLanes: Lanes,
 ): void {
+  didReadFromEntangledAsyncAction = false;
+
   // This is always non-null on a ClassComponent or HostRoot
   const queue: UpdateQueue<State> = (workInProgress.updateQueue: any);
 
@@ -570,6 +600,13 @@ export function processUpdateQueue<State>(
         newLanes = mergeLanes(newLanes, updateLane);
       } else {
         // This update does have sufficient priority.
+
+        // Check if this update is part of a pending async action. If so,
+        // we'll need to suspend until the action has finished, so that it's
+        // batched together with future updates in the same action.
+        if (updateLane !== NoLane && updateLane === peekEntangledActionLane()) {
+          didReadFromEntangledAsyncAction = true;
+        }
 
         if (newLastBaseUpdate !== null) {
           const clone: Update<State> = {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1994,7 +1994,7 @@ function renderRootSync(root: FiberRoot, lanes: Lanes) {
             // Unwind then continue with the normal work loop.
             workInProgressSuspendedReason = NotSuspended;
             workInProgressThrownValue = null;
-            throwAndUnwindWorkLoop(unitOfWork, thrownValue);
+            throwAndUnwindWorkLoop(root, unitOfWork, thrownValue);
             break;
           }
         }
@@ -2114,7 +2114,7 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
             // Unwind then continue with the normal work loop.
             workInProgressSuspendedReason = NotSuspended;
             workInProgressThrownValue = null;
-            throwAndUnwindWorkLoop(unitOfWork, thrownValue);
+            throwAndUnwindWorkLoop(root, unitOfWork, thrownValue);
             break;
           }
           case SuspendedOnData: {
@@ -2172,7 +2172,7 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
               // Otherwise, unwind then continue with the normal work loop.
               workInProgressSuspendedReason = NotSuspended;
               workInProgressThrownValue = null;
-              throwAndUnwindWorkLoop(unitOfWork, thrownValue);
+              throwAndUnwindWorkLoop(root, unitOfWork, thrownValue);
             }
             break;
           }
@@ -2229,7 +2229,7 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
             // Otherwise, unwind then continue with the normal work loop.
             workInProgressSuspendedReason = NotSuspended;
             workInProgressThrownValue = null;
-            throwAndUnwindWorkLoop(unitOfWork, thrownValue);
+            throwAndUnwindWorkLoop(root, unitOfWork, thrownValue);
             break;
           }
           case SuspendedOnDeprecatedThrowPromise: {
@@ -2239,7 +2239,7 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
             // always unwind.
             workInProgressSuspendedReason = NotSuspended;
             workInProgressThrownValue = null;
-            throwAndUnwindWorkLoop(unitOfWork, thrownValue);
+            throwAndUnwindWorkLoop(root, unitOfWork, thrownValue);
             break;
           }
           case SuspendedOnHydration: {
@@ -2464,7 +2464,11 @@ function replaySuspendedUnitOfWork(unitOfWork: Fiber): void {
   ReactCurrentOwner.current = null;
 }
 
-function throwAndUnwindWorkLoop(unitOfWork: Fiber, thrownValue: mixed) {
+function throwAndUnwindWorkLoop(
+  root: FiberRoot,
+  unitOfWork: Fiber,
+  thrownValue: mixed,
+) {
   // This is a fork of performUnitOfWork specifcally for unwinding a fiber
   // that threw an exception.
   //
@@ -2473,40 +2477,32 @@ function throwAndUnwindWorkLoop(unitOfWork: Fiber, thrownValue: mixed) {
   resetSuspendedWorkLoopOnUnwind(unitOfWork);
 
   const returnFiber = unitOfWork.return;
-  if (returnFiber === null || workInProgressRoot === null) {
-    // Expected to be working on a non-root fiber. This is a fatal error
-    // because there's no ancestor that can handle it; the root is
-    // supposed to capture all errors that weren't caught by an error
-    // boundary.
-    workInProgressRootExitStatus = RootFatalErrored;
-    workInProgressRootFatalError = thrownValue;
-    // Set `workInProgress` to null. This represents advancing to the next
-    // sibling, or the parent if there are no siblings. But since the root
-    // has no siblings nor a parent, we set it to null. Usually this is
-    // handled by `completeUnitOfWork` or `unwindWork`, but since we're
-    // intentionally not calling those, we need set it here.
-    // TODO: Consider calling `unwindWork` to pop the contexts.
-    workInProgress = null;
-    return;
-  }
-
   try {
     // Find and mark the nearest Suspense or error boundary that can handle
     // this "exception".
-    throwException(
-      workInProgressRoot,
+    const didFatal = throwException(
+      root,
       returnFiber,
       unitOfWork,
       thrownValue,
       workInProgressRootRenderLanes,
     );
+    if (didFatal) {
+      panicOnRootError(thrownValue);
+      return;
+    }
   } catch (error) {
     // We had trouble processing the error. An example of this happening is
     // when accessing the `componentDidCatch` property of an error boundary
     // throws an error. A weird edge case. There's a regression test for this.
     // To prevent an infinite loop, bubble the error up to the next parent.
-    workInProgress = returnFiber;
-    throw error;
+    if (returnFiber !== null) {
+      workInProgress = returnFiber;
+      throw error;
+    } else {
+      panicOnRootError(thrownValue);
+      return;
+    }
   }
 
   if (unitOfWork.flags & Incomplete) {
@@ -2524,6 +2520,22 @@ function throwAndUnwindWorkLoop(unitOfWork: Fiber, thrownValue: mixed) {
     // this particular path is how that would be implemented.
     completeUnitOfWork(unitOfWork);
   }
+}
+
+function panicOnRootError(error: mixed) {
+  // There's no ancestor that can handle this exception. This should never
+  // happen because the root is supposed to capture all errors that weren't
+  // caught by an error boundary. This is a fatal error, or panic condition,
+  // because we've run out of ways to recover.
+  workInProgressRootExitStatus = RootFatalErrored;
+  workInProgressRootFatalError = error;
+  // Set `workInProgress` to null. This represents advancing to the next
+  // sibling, or the parent if there are no siblings. But since the root
+  // has no siblings nor a parent, we set it to null. Usually this is
+  // handled by `completeUnitOfWork` or `unwindWork`, but since we're
+  // intentionally not calling those, we need set it here.
+  // TODO: Consider calling `unwindWork` to pop the contexts.
+  workInProgress = null;
 }
 
 function completeUnitOfWork(unitOfWork: Fiber): void {

--- a/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
@@ -1461,4 +1461,184 @@ describe('ReactAsyncActions', () => {
       expect(root).toMatchRenderedOutput(<span>C</span>);
     },
   );
+
+  // @gate enableAsyncActions
+  test(
+    'updates in an async action are entangled even if useTransition hook ' +
+      'is unmounted before it finishes (class component)',
+    async () => {
+      let startTransition;
+      function Updater() {
+        const [isPending, _start] = useTransition();
+        startTransition = _start;
+        return (
+          <span>
+            <Text text={'Pending: ' + isPending} />
+          </span>
+        );
+      }
+
+      let setText;
+      class Sibling extends React.Component {
+        state = {text: 'A'};
+        render() {
+          setText = text => this.setState({text});
+          return (
+            <span>
+              <Text text={this.state.text} />
+            </span>
+          );
+        }
+      }
+
+      function App({showUpdater}) {
+        return (
+          <>
+            {showUpdater ? <Updater /> : null}
+            <Sibling />
+          </>
+        );
+      }
+
+      const root = ReactNoop.createRoot();
+      await act(() => {
+        root.render(<App showUpdater={true} />);
+      });
+      assertLog(['Pending: false', 'A']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <span>Pending: false</span>
+          <span>A</span>
+        </>,
+      );
+
+      // Start an async action that has multiple updates with async
+      // operations in between.
+      await act(() => {
+        startTransition(async () => {
+          Scheduler.log('Async action started');
+          startTransition(() => setText('B'));
+
+          await getText('Wait before updating to C');
+
+          Scheduler.log('Async action ended');
+          startTransition(() => setText('C'));
+        });
+      });
+      assertLog(['Async action started', 'Pending: true']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <span>Pending: true</span>
+          <span>A</span>
+        </>,
+      );
+
+      // Delete the component that contains the useTransition hook. This
+      // component no longer blocks the transition from completing. But the
+      // pending update to Sibling should not be allowed to finish, because it's
+      // part of the async action.
+      await act(() => {
+        root.render(<App showUpdater={false} />);
+      });
+      assertLog(['A']);
+      expect(root).toMatchRenderedOutput(<span>A</span>);
+
+      // Finish the async action. Notice the intermediate B state was never
+      // shown, because it was batched with the update that came later in the
+      // same action.
+      await act(() => resolveText('Wait before updating to C'));
+      assertLog(['Async action ended', 'C']);
+      expect(root).toMatchRenderedOutput(<span>C</span>);
+
+      // Check that subsequent updates are unaffected.
+      await act(() => setText('D'));
+      assertLog(['D']);
+      expect(root).toMatchRenderedOutput(<span>D</span>);
+    },
+  );
+
+  // @gate enableAsyncActions
+  test(
+    'updates in an async action are entangled even if useTransition hook ' +
+      'is unmounted before it finishes (root update)',
+    async () => {
+      let startTransition;
+      function Updater() {
+        const [isPending, _start] = useTransition();
+        startTransition = _start;
+        return (
+          <span>
+            <Text text={'Pending: ' + isPending} />
+          </span>
+        );
+      }
+
+      let setShowUpdater;
+      function App({text}) {
+        const [showUpdater, _setShowUpdater] = useState(true);
+        setShowUpdater = _setShowUpdater;
+        return (
+          <>
+            {showUpdater ? <Updater /> : null}
+            <span>
+              <Text text={text} />
+            </span>
+          </>
+        );
+      }
+
+      const root = ReactNoop.createRoot();
+      await act(() => {
+        root.render(<App text="A" />);
+      });
+      assertLog(['Pending: false', 'A']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <span>Pending: false</span>
+          <span>A</span>
+        </>,
+      );
+
+      // Start an async action that has multiple updates with async
+      // operations in between.
+      await act(() => {
+        startTransition(async () => {
+          Scheduler.log('Async action started');
+          startTransition(() => root.render(<App text="B" />));
+
+          await getText('Wait before updating to C');
+
+          Scheduler.log('Async action ended');
+          startTransition(() => root.render(<App text="C" />));
+        });
+      });
+      assertLog(['Async action started', 'Pending: true']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <span>Pending: true</span>
+          <span>A</span>
+        </>,
+      );
+
+      // Delete the component that contains the useTransition hook. This
+      // component no longer blocks the transition from completing. But the
+      // pending update to Sibling should not be allowed to finish, because it's
+      // part of the async action.
+      await act(() => setShowUpdater(false));
+      assertLog(['A']);
+      expect(root).toMatchRenderedOutput(<span>A</span>);
+
+      // Finish the async action. Notice the intermediate B state was never
+      // shown, because it was batched with the update that came later in the
+      // same action.
+      await act(() => resolveText('Wait before updating to C'));
+      assertLog(['Async action ended', 'C']);
+      expect(root).toMatchRenderedOutput(<span>C</span>);
+
+      // Check that subsequent updates are unaffected.
+      await act(() => root.render(<App text="D" />));
+      assertLog(['D']);
+      expect(root).toMatchRenderedOutput(<span>D</span>);
+    },
+  );
 });

--- a/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
@@ -1270,4 +1270,195 @@ describe('ReactAsyncActions', () => {
     assertLog(['Loading... (25%)', 'A', 'B']);
     expect(root).toMatchRenderedOutput(<div>B</div>);
   });
+
+  // @gate enableAsyncActions
+  test(
+    'optimistic state is not reverted until async action finishes, even if ' +
+      'useTransition hook is unmounted',
+    async () => {
+      let startTransition;
+      function Updater() {
+        const [isPending, _start] = useTransition();
+        startTransition = _start;
+        return (
+          <span>
+            <Text text={'Pending: ' + isPending} />
+          </span>
+        );
+      }
+
+      let setText;
+      let setOptimisticText;
+      function Sibling() {
+        const [canonicalText, _setText] = useState('A');
+        setText = _setText;
+
+        const [text, _setOptimisticText] = useOptimistic(
+          canonicalText,
+          (_, optimisticText) => `${optimisticText} (loading...)`,
+        );
+        setOptimisticText = _setOptimisticText;
+
+        return (
+          <span>
+            <Text text={text} />
+          </span>
+        );
+      }
+
+      function App({showUpdater}) {
+        return (
+          <>
+            {showUpdater ? <Updater /> : null}
+            <Sibling />
+          </>
+        );
+      }
+
+      const root = ReactNoop.createRoot();
+      await act(() => {
+        root.render(<App showUpdater={true} />);
+      });
+      assertLog(['Pending: false', 'A']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <span>Pending: false</span>
+          <span>A</span>
+        </>,
+      );
+
+      // Start an async action that has multiple updates with async
+      // operations in between.
+      await act(() => {
+        startTransition(async () => {
+          Scheduler.log('Async action started');
+
+          setOptimisticText('C');
+
+          startTransition(() => setText('B'));
+
+          await getText('Wait before updating to C');
+
+          Scheduler.log('Async action ended');
+          startTransition(() => setText('C'));
+        });
+      });
+      assertLog([
+        'Async action started',
+        'Pending: true',
+        // Render an optimistic value
+        'C (loading...)',
+      ]);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <span>Pending: true</span>
+          <span>C (loading...)</span>
+        </>,
+      );
+
+      // Delete the component that contains the useTransition hook. This
+      // component no longer blocks the transition from completing. But the
+      // we're still showing an optimistic state, because the async action has
+      // not yet finished.
+      await act(() => {
+        root.render(<App showUpdater={false} />);
+      });
+      assertLog(['C (loading...)']);
+      expect(root).toMatchRenderedOutput(<span>C (loading...)</span>);
+
+      // Finish the async action. Now the optimistic state is reverted and we
+      // switch to the canonical value.
+      await act(() => resolveText('Wait before updating to C'));
+      assertLog(['Async action ended', 'C']);
+      expect(root).toMatchRenderedOutput(<span>C</span>);
+    },
+  );
+
+  // @gate enableAsyncActions
+  test(
+    'updates in an async action are entangled even if useTransition hook ' +
+      'is unmounted before it finishes',
+    async () => {
+      let startTransition;
+      function Updater() {
+        const [isPending, _start] = useTransition();
+        startTransition = _start;
+        return (
+          <span>
+            <Text text={'Pending: ' + isPending} />
+          </span>
+        );
+      }
+
+      let setText;
+      function Sibling() {
+        const [text, _setText] = useState('A');
+        setText = _setText;
+        return (
+          <span>
+            <Text text={text} />
+          </span>
+        );
+      }
+
+      function App({showUpdater}) {
+        return (
+          <>
+            {showUpdater ? <Updater /> : null}
+            <Sibling />
+          </>
+        );
+      }
+
+      const root = ReactNoop.createRoot();
+      await act(() => {
+        root.render(<App showUpdater={true} />);
+      });
+      assertLog(['Pending: false', 'A']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <span>Pending: false</span>
+          <span>A</span>
+        </>,
+      );
+
+      // Start an async action that has multiple updates with async
+      // operations in between.
+      await act(() => {
+        startTransition(async () => {
+          Scheduler.log('Async action started');
+          startTransition(() => setText('B'));
+
+          await getText('Wait before updating to C');
+
+          Scheduler.log('Async action ended');
+          startTransition(() => setText('C'));
+        });
+      });
+      assertLog(['Async action started', 'Pending: true']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <span>Pending: true</span>
+          <span>A</span>
+        </>,
+      );
+
+      // Delete the component that contains the useTransition hook. This
+      // component no longer blocks the transition from completing. But the
+      // pending update to Sibling should not be allowed to finish, because it's
+      // part of the async action.
+      await act(() => {
+        root.render(<App showUpdater={false} />);
+      });
+      assertLog(['A']);
+      expect(root).toMatchRenderedOutput(<span>A</span>);
+
+      // Finish the async action. Notice the intermediate B state was never
+      // shown, because it was batched with the update that came later in the
+      // same action.
+      await act(() => resolveText('Wait before updating to C'));
+      assertLog(['Async action ended', 'C']);
+      expect(root).toMatchRenderedOutput(<span>C</span>);
+    },
+  );
 });


### PR DESCRIPTION
If there are multiple updates inside an async action, they should all be rendered in the same batch, even if they are separate by an async operation (`await`). We currently implement this by suspending in the `useTransition` hook to block the update from committing until all possible updates have been scheduled by the action. The reason we did it this way is so you can "cancel" an action by navigating away from the UI that triggered it.

The problem with that approach, though, is that even if you navigate away from the `useTransition` hook, the action may have updated shared parts of the UI that are still in the tree. So we may need to continue suspending even after the `useTransition` hook is deleted.

In other words, the lifetime of an async action scope is longer than the lifetime of a particular `useTransition` hook.

The solution is to suspend whenever _any_ update that is part of the async action scope is unwrapped during render. So, inside useState and useReducer.

This fixes a related issue where an optimistic update is reverted before the async action has finished, because we were relying on the `useTransition` hook to prevent the optimistic update from finishing.

This also prepares us to support async actions being passed to the non-hook form of `startTransition` (though this isn't implemented yet).