### PR TITLE
Remove duplicate dynamic scheduler flags

### DIFF
--- a/scripts/jest/setupTests.www.js
+++ b/scripts/jest/setupTests.www.js
@@ -30,9 +30,6 @@ jest.mock('scheduler/src/SchedulerFeatureFlags', () => {
 
   // These flags are not a dynamic on www, but we still want to run
   // tests in both versions.
-  actual.enableIsInputPending = __VARIANT__;
-  actual.enableIsInputPendingContinuous = __VARIANT__;
-  actual.enableProfiling = __VARIANT__;
   actual.enableSchedulerDebugging = __VARIANT__;
 
   return actual;


### PR DESCRIPTION
These were made dynamic again in https://github.com/facebook/react/pull/27919, and already have the dynamic flags set. It's a bummer to push this around, we should come up with a better way.