### PR TITLE
Remove createRootStrictEffectsByDefault flag

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -776,14 +776,7 @@ describe('ReactDOMServerPartialHydration', () => {
     const span2 = container.getElementsByTagName('span')[0];
     // This is a new node.
     expect(span).not.toBe(span2);
-
-    if (gate(flags => flags.dfsEffectsRefactor)) {
-      // The effects list refactor causes this to be null because the Suspense Activity's child
-      // is null. However, since we can't hydrate Suspense in legacy this change in behavior is ok
-      expect(ref.current).toBe(null);
-    } else {
-      expect(ref.current).toBe(span2);
-    }
+    expect(ref.current).toBe(null);
 
     // Resolving the promise should render the final content.
     suspend = false;

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -28,7 +28,6 @@ import {
   isHostSingletonType,
 } from './ReactFiberConfig';
 import {
-  createRootStrictEffectsByDefault,
   enableCache,
   enableProfilerTimer,
   enableScopeAPI,
@@ -456,7 +455,7 @@ export function createHostRootFiber(
   let mode;
   if (tag === ConcurrentRoot) {
     mode = ConcurrentMode;
-    if (isStrictMode === true || createRootStrictEffectsByDefault) {
+    if (isStrictMode === true) {
       mode |= StrictLegacyMode | StrictEffectsMode;
     }
     if (

--- a/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
+++ b/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
@@ -14,6 +14,7 @@ let ReactTestRenderer;
 let Scheduler;
 let act;
 let assertLog;
+let StrictMode;
 
 describe('StrictEffectsMode', () => {
   beforeEach(() => {
@@ -26,15 +27,6 @@ describe('StrictEffectsMode', () => {
     const InternalTestUtils = require('internal-test-utils');
     assertLog = InternalTestUtils.assertLog;
   });
-
-  function supportsDoubleInvokeEffects() {
-    return gate(
-      flags =>
-        flags.build === 'development' &&
-        flags.createRootStrictEffectsByDefault &&
-        flags.dfsEffectsRefactor,
-    );
-  }
 
   it('should not double invoke effects in legacy mode', async () => {
     function App({text}) {
@@ -52,7 +44,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      ReactTestRenderer.create(<App text={'mount'} />);
+      ReactTestRenderer.create(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+      );
     });
 
     assertLog(['useLayoutEffect mount', 'useEffect mount']);
@@ -75,12 +71,17 @@ describe('StrictEffectsMode', () => {
 
     let renderer;
     await act(() => {
-      renderer = ReactTestRenderer.create(<App text={'mount'} />, {
-        isConcurrent: true,
-      });
+      renderer = ReactTestRenderer.create(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+        {
+          isConcurrent: true,
+        },
+      );
     });
 
-    if (supportsDoubleInvokeEffects()) {
+    if (__DEV__) {
       assertLog([
         'useLayoutEffect mount',
         'useEffect mount',
@@ -94,7 +95,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(<App text={'update'} />);
+      renderer.update(
+        <React.StrictMode>
+          <App text={'update'} />
+        </React.StrictMode>,
+      );
     });
 
     assertLog([
@@ -128,12 +133,17 @@ describe('StrictEffectsMode', () => {
 
     let renderer;
     await act(() => {
-      renderer = ReactTestRenderer.create(<App text={'mount'} />, {
-        isConcurrent: true,
-      });
+      renderer = ReactTestRenderer.create(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+        {
+          isConcurrent: true,
+        },
+      );
     });
 
-    if (supportsDoubleInvokeEffects()) {
+    if (__DEV__) {
       assertLog([
         'useEffect One mount',
         'useEffect Two mount',
@@ -147,7 +157,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(<App text={'update'} />);
+      renderer.update(
+        <React.StrictMode>
+          <App text={'update'} />
+        </React.StrictMode>,
+      );
     });
 
     assertLog([
@@ -181,12 +195,17 @@ describe('StrictEffectsMode', () => {
 
     let renderer;
     await act(() => {
-      renderer = ReactTestRenderer.create(<App text={'mount'} />, {
-        isConcurrent: true,
-      });
+      renderer = ReactTestRenderer.create(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+        {
+          isConcurrent: true,
+        },
+      );
     });
 
-    if (supportsDoubleInvokeEffects()) {
+    if (__DEV__) {
       assertLog([
         'useLayoutEffect One mount',
         'useLayoutEffect Two mount',
@@ -200,7 +219,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(<App text={'update'} />);
+      renderer.update(
+        <React.StrictMode>
+          <App text={'update'} />
+        </React.StrictMode>,
+      );
     });
 
     assertLog([
@@ -232,12 +255,17 @@ describe('StrictEffectsMode', () => {
 
     let renderer;
     await act(() => {
-      renderer = ReactTestRenderer.create(<App text={'mount'} />, {
-        isConcurrent: true,
-      });
+      renderer = ReactTestRenderer.create(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+        {
+          isConcurrent: true,
+        },
+      );
     });
 
-    if (supportsDoubleInvokeEffects()) {
+    if (__DEV__) {
       assertLog([
         'useLayoutEffect mount',
         'useEffect mount',
@@ -249,7 +277,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(<App text={'update'} />);
+      renderer.update(
+        <React.StrictMode>
+          <App text={'update'} />
+        </React.StrictMode>,
+      );
     });
 
     assertLog(['useLayoutEffect mount', 'useEffect mount']);
@@ -286,10 +318,15 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      ReactTestRenderer.create(<App />, {isConcurrent: true});
+      ReactTestRenderer.create(
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>,
+        {isConcurrent: true},
+      );
     });
 
-    if (supportsDoubleInvokeEffects()) {
+    if (__DEV__) {
       assertLog([
         'componentDidMount',
         'componentWillUnmount',
@@ -321,12 +358,17 @@ describe('StrictEffectsMode', () => {
 
     let renderer;
     await act(() => {
-      renderer = ReactTestRenderer.create(<App text={'mount'} />, {
-        isConcurrent: true,
-      });
+      renderer = ReactTestRenderer.create(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+        {
+          isConcurrent: true,
+        },
+      );
     });
 
-    if (supportsDoubleInvokeEffects()) {
+    if (__DEV__) {
       assertLog([
         'componentDidMount',
         'componentWillUnmount',
@@ -337,7 +379,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(<App text={'update'} />);
+      renderer.update(
+        <React.StrictMode>
+          <App text={'update'} />
+        </React.StrictMode>,
+      );
     });
 
     assertLog(['componentDidUpdate']);
@@ -366,19 +412,28 @@ describe('StrictEffectsMode', () => {
 
     let renderer;
     await act(() => {
-      renderer = ReactTestRenderer.create(<App text={'mount'} />, {
-        isConcurrent: true,
-      });
+      renderer = ReactTestRenderer.create(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+        {
+          isConcurrent: true,
+        },
+      );
     });
 
-    if (supportsDoubleInvokeEffects()) {
+    if (__DEV__) {
       assertLog(['componentWillUnmount']);
     } else {
       assertLog([]);
     }
 
     await act(() => {
-      renderer.update(<App text={'update'} />);
+      renderer.update(
+        <React.StrictMode>
+          <App text={'update'} />
+        </React.StrictMode>,
+      );
     });
 
     assertLog(['componentDidUpdate']);
@@ -410,7 +465,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      ReactTestRenderer.create(<App text={'mount'} />);
+      ReactTestRenderer.create(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+      );
     });
 
     assertLog(['componentDidMount']);
@@ -437,12 +496,17 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      ReactTestRenderer.create(<App text={'mount'} />, {
-        isConcurrent: true,
-      });
+      ReactTestRenderer.create(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+        {
+          isConcurrent: true,
+        },
+      );
     });
 
-    if (supportsDoubleInvokeEffects()) {
+    if (__DEV__) {
       assertLog([
         'mount',
         'useLayoutEffect mount',
@@ -502,10 +566,15 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      ReactTestRenderer.create(<App />, {isConcurrent: true});
+      ReactTestRenderer.create(
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>,
+        {isConcurrent: true},
+      );
     });
 
-    if (supportsDoubleInvokeEffects()) {
+    if (__DEV__) {
       assertLog([
         'App useLayoutEffect mount',
         'App useEffect mount',
@@ -522,7 +591,7 @@ describe('StrictEffectsMode', () => {
       _setShowChild(true);
     });
 
-    if (supportsDoubleInvokeEffects()) {
+    if (__DEV__) {
       assertLog([
         'App useLayoutEffect unmount',
         'Child useLayoutEffect mount',
@@ -585,12 +654,17 @@ describe('StrictEffectsMode', () => {
 
     let renderer;
     await act(() => {
-      renderer = ReactTestRenderer.create(<App text={'mount'} />, {
-        isConcurrent: true,
-      });
+      renderer = ReactTestRenderer.create(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+        {
+          isConcurrent: true,
+        },
+      );
     });
 
-    if (supportsDoubleInvokeEffects()) {
+    if (__DEV__) {
       assertLog([
         'componentDidMount',
         'useLayoutEffect mount',
@@ -611,7 +685,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(<App text={'mount'} />);
+      renderer.update(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+      );
     });
 
     assertLog([
@@ -666,12 +744,17 @@ describe('StrictEffectsMode', () => {
 
     let renderer;
     await act(() => {
-      renderer = ReactTestRenderer.create(<App text={'mount'} />, {
-        isConcurrent: true,
-      });
+      renderer = ReactTestRenderer.create(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+        {
+          isConcurrent: true,
+        },
+      );
     });
 
-    if (supportsDoubleInvokeEffects()) {
+    if (__DEV__) {
       assertLog([
         'useLayoutEffect mount',
         'useEffect mount',
@@ -686,7 +769,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(<App text={'mount'} />);
+      renderer.update(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+      );
     });
 
     assertLog([

--- a/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
+++ b/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
@@ -14,7 +14,6 @@ let ReactTestRenderer;
 let Scheduler;
 let act;
 let assertLog;
-let StrictMode;
 
 describe('StrictEffectsMode', () => {
   beforeEach(() => {

--- a/packages/react-reconciler/src/__tests__/StrictEffectsModeDefaults-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/StrictEffectsModeDefaults-test.internal.js
@@ -32,9 +32,6 @@ describe('StrictEffectsMode defaults', () => {
     waitForAll = InternalTestUtils.waitForAll;
     waitForPaint = InternalTestUtils.waitForPaint;
     assertLog = InternalTestUtils.assertLog;
-
-    const ReactFeatureFlags = require('shared/ReactFeatureFlags');
-    ReactFeatureFlags.createRootStrictEffectsByDefault = __DEV__;
   });
 
   it('should not double invoke effects in legacy mode', async () => {
@@ -53,7 +50,11 @@ describe('StrictEffectsMode defaults', () => {
     }
 
     await act(() => {
-      ReactNoop.renderLegacySyncRoot(<App text={'mount'} />);
+      ReactNoop.renderLegacySyncRoot(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+      );
     });
 
     assertLog(['useLayoutEffect mount', 'useEffect mount']);
@@ -79,7 +80,11 @@ describe('StrictEffectsMode defaults', () => {
     }
 
     await act(() => {
-      ReactNoop.renderLegacySyncRoot(<App text={'mount'} />);
+      ReactNoop.renderLegacySyncRoot(
+        <React.StrictMode>
+          <App text={'mount'} />
+        </React.StrictMode>,
+      );
     });
 
     assertLog(['componentDidMount']);
@@ -98,9 +103,9 @@ describe('StrictEffectsMode defaults', () => {
 
       await act(async () => {
         ReactNoop.render(
-          <>
+          <React.StrictMode>
             <ComponentWithEffects label={'one'} />
-          </>,
+          </React.StrictMode>,
         );
 
         await waitForPaint([
@@ -112,10 +117,10 @@ describe('StrictEffectsMode defaults', () => {
 
       await act(async () => {
         ReactNoop.render(
-          <>
+          <React.StrictMode>
             <ComponentWithEffects label={'one'} />
             <ComponentWithEffects label={'two'} />
-          </>,
+          </React.StrictMode>,
         );
 
         assertLog([]);
@@ -151,9 +156,9 @@ describe('StrictEffectsMode defaults', () => {
 
       await act(async () => {
         ReactNoop.render(
-          <>
+          <React.StrictMode>
             <ComponentWithEffects label={'one'} />
-          </>,
+          </React.StrictMode>,
         );
 
         await waitForAll([
@@ -168,10 +173,10 @@ describe('StrictEffectsMode defaults', () => {
 
       await act(async () => {
         ReactNoop.render(
-          <>
+          <React.StrictMode>
             <ComponentWithEffects label={'one'} />
             <ComponentWithEffects label={'two'} />
-          </>,
+          </React.StrictMode>,
         );
 
         await waitFor([
@@ -209,7 +214,11 @@ describe('StrictEffectsMode defaults', () => {
         return text;
       }
       await act(() => {
-        ReactNoop.render(<App text={'mount'} />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App text={'mount'} />
+          </React.StrictMode>,
+        );
       });
 
       assertLog([
@@ -222,7 +231,11 @@ describe('StrictEffectsMode defaults', () => {
       ]);
 
       await act(() => {
-        ReactNoop.render(<App text={'update'} />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App text={'update'} />
+          </React.StrictMode>,
+        );
       });
 
       assertLog([
@@ -255,7 +268,11 @@ describe('StrictEffectsMode defaults', () => {
       }
 
       await act(() => {
-        ReactNoop.render(<App text={'mount'} />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App text={'mount'} />
+          </React.StrictMode>,
+        );
       });
 
       assertLog([
@@ -268,7 +285,11 @@ describe('StrictEffectsMode defaults', () => {
       ]);
 
       await act(() => {
-        ReactNoop.render(<App text={'update'} />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App text={'update'} />
+          </React.StrictMode>,
+        );
       });
 
       assertLog([
@@ -301,7 +322,11 @@ describe('StrictEffectsMode defaults', () => {
       }
 
       await act(() => {
-        ReactNoop.render(<App text={'mount'} />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App text={'mount'} />
+          </React.StrictMode>,
+        );
       });
 
       assertLog([
@@ -314,7 +339,11 @@ describe('StrictEffectsMode defaults', () => {
       ]);
 
       await act(() => {
-        ReactNoop.render(<App text={'update'} />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App text={'update'} />
+          </React.StrictMode>,
+        );
       });
 
       assertLog([
@@ -345,7 +374,11 @@ describe('StrictEffectsMode defaults', () => {
       }
 
       await act(() => {
-        ReactNoop.render(<App text={'mount'} />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App text={'mount'} />
+          </React.StrictMode>,
+        );
       });
 
       assertLog([
@@ -356,7 +389,11 @@ describe('StrictEffectsMode defaults', () => {
       ]);
 
       await act(() => {
-        ReactNoop.render(<App text={'update'} />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App text={'update'} />
+          </React.StrictMode>,
+        );
       });
 
       assertLog(['useLayoutEffect mount', 'useEffect mount']);
@@ -383,7 +420,11 @@ describe('StrictEffectsMode defaults', () => {
       }
 
       await act(() => {
-        ReactNoop.render(<App text={'mount'} />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App text={'mount'} />
+          </React.StrictMode>,
+        );
       });
 
       expect(onRefMock.mock.calls.length).toBe(3);
@@ -417,7 +458,11 @@ describe('StrictEffectsMode defaults', () => {
       }
 
       await act(() => {
-        ReactNoop.render(<App />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App />
+          </React.StrictMode>,
+        );
       });
 
       assertLog([
@@ -447,7 +492,11 @@ describe('StrictEffectsMode defaults', () => {
       }
 
       await act(() => {
-        ReactNoop.render(<App text={'mount'} />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App text={'mount'} />
+          </React.StrictMode>,
+        );
       });
 
       assertLog([
@@ -457,7 +506,11 @@ describe('StrictEffectsMode defaults', () => {
       ]);
 
       await act(() => {
-        ReactNoop.render(<App text={'update'} />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App text={'update'} />
+          </React.StrictMode>,
+        );
       });
 
       assertLog(['componentDidUpdate']);
@@ -490,7 +543,11 @@ describe('StrictEffectsMode defaults', () => {
       }
 
       await act(() => {
-        ReactNoop.render(<App text={'mount'} />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App text={'mount'} />
+          </React.StrictMode>,
+        );
       });
 
       assertLog([
@@ -540,7 +597,11 @@ describe('StrictEffectsMode defaults', () => {
       }
 
       await act(() => {
-        ReactNoop.render(<App />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App />
+          </React.StrictMode>,
+        );
       });
 
       assertLog([
@@ -599,15 +660,19 @@ describe('StrictEffectsMode defaults', () => {
 
       function App({text}) {
         return (
-          <>
+          <React.StrictMode>
             <ClassChild text={text} />
             <FunctionChild text={text} />
-          </>
+          </React.StrictMode>
         );
       }
 
       await act(() => {
-        ReactNoop.render(<App text={'mount'} />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App text={'mount'} />
+          </React.StrictMode>,
+        );
       });
 
       assertLog([
@@ -623,7 +688,11 @@ describe('StrictEffectsMode defaults', () => {
       ]);
 
       await act(() => {
-        ReactNoop.render(<App text={'mount'} />);
+        ReactNoop.render(
+          <React.StrictMode>
+            <App text={'mount'} />
+          </React.StrictMode>,
+        );
       });
 
       assertLog([

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -141,13 +141,6 @@ export const transitionLaneExpirationMs = 5000;
 // when we plan to enable them.
 // -----------------------------------------------------------------------------
 
-// This flag enables Strict Effects by default. We're not turning this on until
-// after 18 because it requires migration work. Recommendation is to use
-// <StrictMode /> to gradually upgrade components.
-// If TRUE, trees rendered with createRoot will be StrictEffectsMode.
-// If FALSE, these trees will be StrictLegacyMode.
-export const createRootStrictEffectsByDefault = false;
-
 export const disableModulePatternComponents = false;
 
 export const disableLegacyContext = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -73,8 +73,6 @@ export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;
 
-export const createRootStrictEffectsByDefault = false;
-
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
 export const enableLegacyHidden = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -56,7 +56,6 @@ export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;
 
-export const createRootStrictEffectsByDefault = false;
 export const enableUseRefAccessWarning = false;
 
 export const disableSchedulerTimeoutInWorkLoop = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -56,7 +56,6 @@ export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;
 
-export const createRootStrictEffectsByDefault = false;
 export const enableUseRefAccessWarning = false;
 
 export const disableSchedulerTimeoutInWorkLoop = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -50,7 +50,6 @@ export const enableCPUSuspense = false;
 export const enableUseMemoCacheHook = true;
 export const enableUseEffectEventHook = false;
 export const enableClientRenderFallbackOnTextMismatch = true;
-export const createRootStrictEffectsByDefault = false;
 export const enableUseRefAccessWarning = false;
 
 export const enableRetryLaneExpiration = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -56,7 +56,6 @@ export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;
 
-export const createRootStrictEffectsByDefault = false;
 export const enableUseRefAccessWarning = false;
 
 export const disableSchedulerTimeoutInWorkLoop = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -49,7 +49,6 @@ export const enableProfilerNestedUpdateScheduledHook: boolean =
   __PROFILE__ && dynamicFeatureFlags.enableProfilerNestedUpdateScheduledHook;
 export const enableUpdaterTracking = __PROFILE__;
 
-export const createRootStrictEffectsByDefault = false;
 export const enableSuspenseAvoidThisFallback = true;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 

--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -50,9 +50,6 @@ const environmentFlags = {
   FIXME: false,
   TODO: false,
 
-  // Turn these flags back on (or delete) once the effect list is removed in
-  // favor of a depth-first traversal using `subtreeTags`.
-  dfsEffectsRefactor: true,
   enableUseJSStackToTrackPassiveDurations: false,
 };
 


### PR DESCRIPTION
There's no need to separate strict mode from strict effects mode any more.

I didn't clean up the `StrictEffectMode` fiber flag, because it's used to prevent strict effects in legacy mode. I could replace those checks with `LegacyMode` checks, but when we remove legacy mode, we can remove that flag and condense them into one StrictMode flag away.