### PR TITLE
Capture React.startTransition errors and pass to reportError

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1983,8 +1983,6 @@ function runFormStateAction<S, P>(
   }
   try {
     const returnValue = action(prevState, payload);
-    notifyTransitionCallbacks(currentTransition, returnValue);
-
     if (
       returnValue !== null &&
       typeof returnValue === 'object' &&
@@ -1992,6 +1990,7 @@ function runFormStateAction<S, P>(
       typeof returnValue.then === 'function'
     ) {
       const thenable = ((returnValue: any): Thenable<Awaited<S>>);
+      notifyTransitionCallbacks(currentTransition, thenable);
 
       // Attach a listener to read the return state of the action. As soon as
       // this resolves, we can run the next action in the sequence.
@@ -2854,7 +2853,6 @@ function startTransition<S>(
   try {
     if (enableAsyncActions) {
       const returnValue = callback();
-      notifyTransitionCallbacks(currentTransition, returnValue);
 
       // Check if we're inside an async action scope. If so, we'll entangle
       // this new action with the existing scope.
@@ -2870,6 +2868,7 @@ function startTransition<S>(
         typeof returnValue.then === 'function'
       ) {
         const thenable = ((returnValue: any): Thenable<mixed>);
+        notifyTransitionCallbacks(currentTransition, thenable);
         // Create a thenable that resolves to `finishedState` once the async
         // action has completed.
         const thenableForFinishedState = chainThenableValue(

--- a/packages/react-reconciler/src/ReactFiberTransition.js
+++ b/packages/react-reconciler/src/ReactFiberTransition.js
@@ -45,23 +45,17 @@ export function requestCurrentTransition(): BatchConfigTransition | null {
   if (transition !== null) {
     // Whenever a transition update is scheduled, register a callback on the
     // transition object so we can get the return value of the scope function.
-    transition._callbacks.add(handleTransitionScopeResult);
+    transition._callbacks.add(handleAsyncAction);
   }
   return transition;
 }
 
-function handleTransitionScopeResult(
+function handleAsyncAction(
   transition: BatchConfigTransition,
-  returnValue: mixed,
+  thenable: Thenable<mixed>,
 ): void {
-  if (
-    enableAsyncActions &&
-    returnValue !== null &&
-    typeof returnValue === 'object' &&
-    typeof returnValue.then === 'function'
-  ) {
+  if (enableAsyncActions) {
     // This is an async action.
-    const thenable: Thenable<mixed> = (returnValue: any);
     entangleAsyncAction(transition, thenable);
   }
 }


### PR DESCRIPTION
To make React.startTransition more consistent with the hook form of startTransition, we capture errors thrown by the scope function and pass them to the global reportError function. (This is also what we do as a default for onRecoverableError.)

This is a breaking change because it means that errors inside of startTransition will no longer bubble up to the caller. You can still catch the error by putting a try/catch block inside of the scope function itself.

We do the same for async actions to prevent "unhandled promise rejection" warnings.

The motivation is to avoid a refactor hazard when changing from a sync to an async action, or from useTransition to startTransition.