### PR TITLE
Add ReactDOMClient to ServerIntegration tests (minor fixes)

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -15,6 +15,7 @@ const ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
 let React;
 let ReactDOM;
+let ReactDOMClient;
 let ReactTestUtils;
 let ReactDOMServer;
 
@@ -23,12 +24,13 @@ function initModules() {
   jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
+  ReactDOMClient = require('react-dom/client');
   ReactDOMServer = require('react-dom/server');
   ReactTestUtils = require('react-dom/test-utils');
 
   // Make them available to the helpers.
   return {
-    ReactDOM,
+    ReactDOMClient,
     ReactDOMServer,
     ReactTestUtils,
   };
@@ -638,7 +640,12 @@ describe('ReactDOMServerIntegration', () => {
         // DOM nodes on the client side. We force it to fire early
         // so that it gets deduplicated later, and doesn't fail the test.
         expect(() => {
-          ReactDOM.render(<nonstandard />, document.createElement('div'));
+          ReactDOM.flushSync(() => {
+            const root = ReactDOMClient.createRoot(
+              document.createElement('div'),
+            );
+            root.render(<nonstandard />);
+          });
         }).toErrorDev('The tag <nonstandard> is unrecognized in this browser.');
 
         const e = await render(<nonstandard foo="bar" />);

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.js
@@ -15,7 +15,6 @@
 const ReactDOMServerIntegrationUtils = require('./utils/ReactDOMServerIntegrationTestUtils');
 
 let React;
-let ReactDOM;
 let ReactDOMClient;
 let ReactDOMServer;
 let ReactTestUtils;
@@ -35,7 +34,6 @@ describe('ReactDOMServerIntegration - Untrusted URLs', () => {
   function initModules() {
     jest.resetModules();
     React = require('react');
-    ReactDOM = require('react-dom');
     ReactDOMClient = require('react-dom/client');
     ReactDOMServer = require('react-dom/server');
     ReactTestUtils = require('react-dom/test-utils');
@@ -43,7 +41,7 @@ describe('ReactDOMServerIntegration - Untrusted URLs', () => {
 
     // Make them available to the helpers.
     return {
-      ReactDOM,
+      ReactDOMClient,
       ReactDOMServer,
       ReactTestUtils,
     };
@@ -204,7 +202,6 @@ describe('ReactDOMServerIntegration - Untrusted URLs - disableJavaScriptURLs', (
     ReactFeatureFlags.disableJavaScriptURLs = true;
 
     React = require('react');
-    ReactDOM = require('react-dom');
     ReactDOMClient = require('react-dom/client');
     ReactDOMServer = require('react-dom/server');
     ReactTestUtils = require('react-dom/test-utils');
@@ -212,7 +209,7 @@ describe('ReactDOMServerIntegration - Untrusted URLs - disableJavaScriptURLs', (
 
     // Make them available to the helpers.
     return {
-      ReactDOM,
+      ReactDOMClient,
       ReactDOMServer,
       ReactTestUtils,
     };


### PR DESCRIPTION
## Overview 

Branched off https://github.com/facebook/react/pull/28130

Converts to `createRoot`, with a few additional in-line conversions in each file.
