### PR TITLE
Add test for href without protocol

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -74,6 +74,15 @@ describe('ReactDOM', () => {
     expect(node.tagName).toBe('DIV');
   });
 
+  it('allows href to be set without protocol', () => {
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+    ReactDOM.flushSync(() => {
+      root.render(<a href="thisisfine">click me</a>);
+    });
+    expect(container.firstChild.href).toBe('http://thisisfine');
+  });
+
   it('should allow children to be passed as an argument', () => {
     const argNode = ReactTestUtils.renderIntoDocument(
       React.createElement('div', null, 'child'),


### PR DESCRIPTION
## Overview

I noticed that this changed between 18.2 and main, opening this to confirm whether it's expected.

Sandbox showing 18 behavior: https://codesandbox.io/p/sandbox/beautiful-tereshkova-lklwsl