### PR TITLE
eslint react-hooks/exhaustive-deps add ignoreUseEffect option

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -50,7 +50,7 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 
 ## Advanced Configuration
 
-`exhaustive-deps` can be configured to validate dependencies of custom Hooks with the `additionalHooks` option.
+`exhaustive-deps` can be configured to validate dependencies of custom Hooks with the `additionalHooks` or `ignoreUseEffect` options.
 This option accepts a regex to match the names of custom Hooks that have dependencies.
 
 ```js
@@ -58,7 +58,8 @@ This option accepts a regex to match the names of custom Hooks that have depende
   "rules": {
     // ...
     "react-hooks/exhaustive-deps": ["warn", {
-      "additionalHooks": "(useMyCustomHook|useMyOtherCustomHook)"
+      "additionalHooks": "(useMyCustomHook|useMyOtherCustomHook)",
+      "ignoreUseEffect": true, // not recommended; defaults to false
     }]
   }
 }

--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -59,7 +59,7 @@ This option accepts a regex to match the names of custom Hooks that have depende
     // ...
     "react-hooks/exhaustive-deps": ["warn", {
       "additionalHooks": "(useMyCustomHook|useMyOtherCustomHook)",
-      "ignoreUseEffect": true, // not recommended; defaults to false
+      "ignoreUseEffect": true // not recommended; defaults to false
     }]
   }
 }

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1461,6 +1461,18 @@ const tests = {
         }
       `,
     },
+    {
+      // normally invalid, but the ignoreUseEffect option has been specified
+      code: normalizeIndent`
+        function MyComponent() {
+          const local = someFunc();
+          useEffect(() => {
+            console.log(local);
+          }, []);
+        }
+      `,
+      options: [{ignoreUseEffect: true}],
+    },
   ],
   invalid: [
     {
@@ -2004,6 +2016,7 @@ const tests = {
           ],
         },
       ],
+      options: [{ignoreUseEffect: true}], // has no effect when testing useMemo
     },
     {
       code: normalizeIndent`

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -29,6 +29,9 @@ export default {
           additionalHooks: {
             type: 'string',
           },
+          ignoreUseEffect: {
+            type: 'boolean',
+          },
           enableDangerousAutofixThisMayCauseInfiniteLoops: {
             type: 'boolean',
           },
@@ -45,6 +48,12 @@ export default {
         ? new RegExp(context.options[0].additionalHooks)
         : undefined;
 
+    const ignoreUseEffect =
+      (context.options &&
+        context.options[0] &&
+        context.options[0].ignoreUseEffect) ||
+      false;
+
     const enableDangerousAutofixThisMayCauseInfiniteLoops =
       (context.options &&
         context.options[0] &&
@@ -53,6 +62,7 @@ export default {
 
     const options = {
       additionalHooks,
+      ignoreUseEffect,
       enableDangerousAutofixThisMayCauseInfiniteLoops,
     };
 
@@ -1747,6 +1757,7 @@ function getReactiveHookCallbackIndex(calleeNode, options) {
   switch (node.name) {
     case 'useEffect':
     case 'useLayoutEffect':
+      return options && options.ignoreUseEffect ? -1 : 0;
     case 'useCallback':
     case 'useMemo':
       // useEffect(fn)


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Problem: The library as-is allows two options:

1. Check `useMemo` and `useEffect`
2. don't check either (disable `react-hooks/exhaustive-deps` entirely)

And in our code base:
- `useMemo` missing deps is usually a bug
- We have many `useEffect` non-exhaustive deps that are required to be non-exhaustive.
  - This may be bad practice, but we don't have budget to refactor years of legacy code.

So, option 1 has been a no-go for us, so we were forced to pick option 2 and now we have bugs from time to time. :(

Solution:

This PR introduces an additional level of granularity

3. Check `useMemo` but ignore `useEffect` deps (enable, but with `ignoreUseEffect` option)

And we will use option 3, which will help us prevent bugs without a major refactor! (yay!)

## How did you test this change?

Added test to `packages\eslint-plugin-react-hooks\__tests__\ESLintRuleExhaustiveDeps-test.js`

Ran locally @ 83edda6d575419807d978c18e76e010cbc0cf307 and it is passing.

Do I need more tests? If so, please enumerate what I need to add so this can get merged.