### PR TITLE
Move modern strict to experimental

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -3792,12 +3792,9 @@ function commitDoubleInvokeEffectsInDEV(
   hasPassiveEffects: boolean,
 ) {
   if (__DEV__) {
-    if (useModernStrictMode) {
+    if (useModernStrictMode && root.tag !== LegacyRoot) {
       let doubleInvokeEffects = true;
 
-      if (root.tag === LegacyRoot && !(root.current.mode & StrictLegacyMode)) {
-        doubleInvokeEffects = false;
-      }
       if (
         root.tag === ConcurrentRoot &&
         !(root.current.mode & (StrictLegacyMode | StrictEffectsMode))

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -116,15 +116,29 @@ describe('ReactStrictMode', () => {
       container,
     );
 
-    expect(log).toEqual([
-      'constructor',
-      'constructor',
-      'getDerivedStateFromProps',
-      'getDerivedStateFromProps',
-      'render',
-      'render',
-      'componentDidMount',
-    ]);
+    if (gate(flags => flags.useModernStrictMode)) {
+      expect(log).toEqual([
+        'constructor',
+        'constructor',
+        'getDerivedStateFromProps',
+        'getDerivedStateFromProps',
+        'render',
+        'render',
+        'componentDidMount',
+        'componentWillUnmount',
+        'componentDidMount',
+      ]);
+    } else {
+      expect(log).toEqual([
+        'constructor',
+        'constructor',
+        'getDerivedStateFromProps',
+        'getDerivedStateFromProps',
+        'render',
+        'render',
+        'componentDidMount',
+      ]);
+    }
 
     log = [];
     shouldComponentUpdate = true;

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -116,29 +116,15 @@ describe('ReactStrictMode', () => {
       container,
     );
 
-    if (gate(flags => flags.useModernStrictMode)) {
-      expect(log).toEqual([
-        'constructor',
-        'constructor',
-        'getDerivedStateFromProps',
-        'getDerivedStateFromProps',
-        'render',
-        'render',
-        'componentDidMount',
-        'componentWillUnmount',
-        'componentDidMount',
-      ]);
-    } else {
-      expect(log).toEqual([
-        'constructor',
-        'constructor',
-        'getDerivedStateFromProps',
-        'getDerivedStateFromProps',
-        'render',
-        'render',
-        'componentDidMount',
-      ]);
-    }
+    expect(log).toEqual([
+      'constructor',
+      'constructor',
+      'getDerivedStateFromProps',
+      'getDerivedStateFromProps',
+      'render',
+      'render',
+      'componentDidMount',
+    ]);
 
     log = [];
     shouldComponentUpdate = true;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -147,7 +147,7 @@ export const disableJavaScriptURLs = false;
 // Modern <StrictMode /> behaviour aligns more with what components
 // components will encounter in production, especially when used With <Offscreen />.
 // TODO: clean up legacy <StrictMode /> once tests pass WWW.
-export const useModernStrictMode = false;
+export const useModernStrictMode = __NEXT_MAJOR__;
 
 // Not ready to break experimental yet.
 // Remove IE and MsApp specific workarounds for innerHTML


### PR DESCRIPTION
Turn this on 

Edited: ope, nvm
<details>
Looks like there's still an outstanding issue with this. The original PR turned off a strict effects test, which causes a stray `componentWillUnmount` to fire.

https://github.com/facebook/react/commit/5d1ce651393524639a3b4b1e861a0413a4d25629#diff-19df471970763c4790c2cc0811fd2726cc6a891b0e1d5dedbf6d0599240c127aR70


Before:
```js
expect(log).toEqual([
      'constructor',
      'constructor',
      'getDerivedStateFromProps',
      'getDerivedStateFromProps',
      'render',
      'render',
      'componentDidMount',
    ]);
```

After:

```js
expect(log).toEqual([
      'constructor',
      'constructor',
      'getDerivedStateFromProps',
      'getDerivedStateFromProps',
      'render',
      'render',
      'componentDidMount',
      'componentWillUnmount',
      'componentDidMount',
    ]);
```

So there's a bug somewhere
</details>