### PR TITLE
Always warn if client component suspends with an uncached promise

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactUse-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUse-test.js
@@ -1733,25 +1733,35 @@ describe('ReactUse', () => {
     );
   });
 
-  test('warn if async client component calls a hook (e.g. useState)', async () => {
-    async function AsyncClientComponent() {
-      useState();
-      return <Text text="Hi" />;
-    }
+  test(
+    'warn if async client component calls a hook (e.g. useState) ' +
+      'during a non-sync update',
+    async () => {
+      async function AsyncClientComponent() {
+        useState();
+        return <Text text="Hi" />;
+      }
 
-    const root = ReactNoop.createRoot();
-    await expect(async () => {
-      await act(() => {
-        startTransition(() => {
-          root.render(<AsyncClientComponent />);
+      const root = ReactNoop.createRoot();
+      await expect(async () => {
+        await act(() => {
+          startTransition(() => {
+            root.render(<AsyncClientComponent />);
+          });
         });
-      });
-    }).toErrorDev([
-      'Hooks are not supported inside an async component. This ' +
-        "error is often caused by accidentally adding `'use client'` " +
-        'to a module that was originally written for the server.',
-    ]);
-  });
+      }).toErrorDev([
+        // Note: This used to log a different warning about not using hooks
+        // inside async components, like we do on the server. Since then, we
+        // decided to warn for _any_ async client component regardless of
+        // whether the update is sync. But if we ever add back support for async
+        // client components, we should add back the hook warning.
+        'async/await is not yet supported in Client Components, only Server ' +
+          'Components. This error is often caused by accidentally adding ' +
+          "`'use client'` to a module that was originally written for " +
+          'the server.',
+      ]);
+    },
+  );
 
   test('warn if async client component calls a hook (e.g. use)', async () => {
     const promise = Promise.resolve();
@@ -1769,9 +1779,15 @@ describe('ReactUse', () => {
         });
       });
     }).toErrorDev([
-      'Hooks are not supported inside an async component. This ' +
-        "error is often caused by accidentally adding `'use client'` " +
-        'to a module that was originally written for the server.',
+      // Note: This used to log a different warning about not using hooks
+      // inside async components, like we do on the server. Since then, we
+      // decided to warn for _any_ async client component regardless of
+      // whether the update is sync. But if we ever add back support for async
+      // client components, we should add back the hook warning.
+      'async/await is not yet supported in Client Components, only Server ' +
+        'Components. This error is often caused by accidentally adding ' +
+        "`'use client'` to a module that was originally written for " +
+        'the server.',
     ]);
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactUse-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUse-test.js
@@ -230,11 +230,17 @@ describe('ReactUse', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(() => {
-      startTransition(() => {
-        root.render(<App />);
+    await expect(async () => {
+      await act(() => {
+        startTransition(() => {
+          root.render(<App />);
+        });
       });
-    });
+    }).toErrorDev([
+      'A component was suspended by an uncached promise. Creating ' +
+        'promises inside a Client Component or hook is not yet ' +
+        'supported, except via a Suspense-compatible library or framework.',
+    ]);
     assertLog(['ABC']);
     expect(root).toMatchRenderedOutput('ABC');
   });
@@ -394,11 +400,20 @@ describe('ReactUse', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(() => {
-      startTransition(() => {
-        root.render(<App />);
+    await expect(async () => {
+      await act(() => {
+        startTransition(() => {
+          root.render(<App />);
+        });
       });
-    });
+    }).toErrorDev([
+      'A component was suspended by an uncached promise. Creating ' +
+        'promises inside a Client Component or hook is not yet ' +
+        'supported, except via a Suspense-compatible library or framework.',
+      'A component was suspended by an uncached promise. Creating ' +
+        'promises inside a Client Component or hook is not yet ' +
+        'supported, except via a Suspense-compatible library or framework.',
+    ]);
     assertLog([
       // First attempt. The uncached promise suspends.
       'Suspend! [Async]',
@@ -1759,6 +1774,9 @@ describe('ReactUse', () => {
           'Components. This error is often caused by accidentally adding ' +
           "`'use client'` to a module that was originally written for " +
           'the server.',
+        'A component was suspended by an uncached promise. Creating ' +
+          'promises inside a Client Component or hook is not yet ' +
+          'supported, except via a Suspense-compatible library or framework.',
       ]);
     },
   );
@@ -1788,6 +1806,12 @@ describe('ReactUse', () => {
         'Components. This error is often caused by accidentally adding ' +
         "`'use client'` to a module that was originally written for " +
         'the server.',
+      'A component was suspended by an uncached promise. Creating ' +
+        'promises inside a Client Component or hook is not yet ' +
+        'supported, except via a Suspense-compatible library or framework.',
+      'A component was suspended by an uncached promise. Creating ' +
+        'promises inside a Client Component or hook is not yet ' +
+        'supported, except via a Suspense-compatible library or framework.',
     ]);
   });
 });


### PR DESCRIPTION
Previously we only warned during a synchronous update, because we eventually want to support async client components in controlled scenarios, like during navigations. However, we're going to warn in all cases for now until we figure out how that should work.