### PR TITLE
[DevTools] Add React Conf notification

### DIFF
--- a/packages/react-devtools-extensions/popups/deadcode.html
+++ b/packages/react-devtools-extensions/popups/deadcode.html
@@ -1,7 +1,8 @@
 <script src="shared.js"></script>
 <link rel="stylesheet" href="shared.css" />
 <style>
-  html, body {
+  html,
+  body {
     min-width: 460px;
     min-height: 133px;
   }
@@ -14,15 +15,24 @@
   <b>This page includes an extra development build of React. &#x1f6a7;</b>
 </p>
 <p>
-  The React build on this page includes both development and production versions because dead code elimination has not been applied correctly.
+  The React build on this page includes both development and production versions because dead code elimination has not
+  been applied correctly.
   <br />
   <br />
   This makes its size larger, and causes React to run slower.
   <br />
   <br />
-  Make sure to <a href="https://reactjs.org/docs/optimizing-performance.html#use-the-production-build">set up dead code elimination</a> before deployment.
+  Make sure to <a href="https://reactjs.org/docs/optimizing-performance.html#use-the-production-build">set up dead code
+    elimination</a> before deployment.
 </p>
 <hr />
 <p>
-  Open the developer tools, and  "Components" and "Profiler" tabs will appear to the right.
+  Open the developer tools, and "Components" and "Profiler" tabs will appear to the right.
 </p>
+<div id="message" style="display: none;">
+  <hr />
+  <p>
+    React Conf is on May 15-16! Grab your tickets, sign up for updates, and join the free livestream at <a
+      href="https://conf.react.dev">conf.react.dev</a>.
+  </p>
+</div>

--- a/packages/react-devtools-extensions/popups/development.html
+++ b/packages/react-devtools-extensions/popups/development.html
@@ -1,7 +1,8 @@
 <script src="shared.js"></script>
 <link rel="stylesheet" href="shared.css" />
 <style>
-  html, body {
+  html,
+  body {
     min-width: 460px;
     min-height: 101px;
   }
@@ -16,9 +17,17 @@
 <p>
   Note that the development build is not suitable for production.
   <br />
-  Make sure to <a href="https://reactjs.org/docs/optimizing-performance.html#use-the-production-build">use the production build</a> before deployment.
+  Make sure to <a href="https://reactjs.org/docs/optimizing-performance.html#use-the-production-build">use the
+    production build</a> before deployment.
 </p>
 <hr />
 <p>
-  Open the developer tools, and  "Components" and "Profiler" tabs will appear to the right.
+  Open the developer tools, and "Components" and "Profiler" tabs will appear to the right.
 </p>
+<div id="message" style="display: none;">
+  <hr />
+  <p>
+    React Conf is on May 15-16! Grab your tickets, sign up for updates, and join the free livestream at <a
+      href="https://conf.react.dev">conf.react.dev</a>.
+  </p>
+</div>

--- a/packages/react-devtools-extensions/popups/disabled.html
+++ b/packages/react-devtools-extensions/popups/disabled.html
@@ -1,7 +1,8 @@
 <script src="shared.js"></script>
 <link rel="stylesheet" href="shared.css" />
 <style>
-  html, body {
+  html,
+  body {
     min-width: 410px;
     min-height: 33px;
   }
@@ -13,5 +14,14 @@
 <p>
   <b>This page doesn&rsquo;t appear to be using React.</b>
   <br />
-  If this seems wrong, follow the <a href="https://github.com/facebook/react/tree/main/packages/react-devtools#the-react-tab-doesnt-show-up">troubleshooting instructions</a>.
+  If this seems wrong, follow the <a
+    href="https://github.com/facebook/react/tree/main/packages/react-devtools#the-react-tab-doesnt-show-up">troubleshooting
+    instructions</a>.
 </p>
+<div id="message" style="display: none;">
+  <hr />
+  <p>
+    React Conf is on May 15-16! Grab your tickets, sign up for updates, and join the free livestream at <a
+      href="https://conf.react.dev">conf.react.dev</a>.
+  </p>
+</div>

--- a/packages/react-devtools-extensions/popups/outdated.html
+++ b/packages/react-devtools-extensions/popups/outdated.html
@@ -1,7 +1,8 @@
 <script src="shared.js"></script>
 <link rel="stylesheet" href="shared.css" />
 <style>
-  html, body {
+  html,
+  body {
     min-width: 460px;
     min-height: 117px;
   }
@@ -21,5 +22,12 @@
 </p>
 <hr />
 <p>
-  Open the developer tools, and  "Components" and "Profiler" tabs will appear to the right.
+  Open the developer tools, and "Components" and "Profiler" tabs will appear to the right.
 </p>
+<div id="message" style="display: none;">
+  <hr />
+  <p>
+    React Conf is on May 15-16! Grab your tickets, sign up for updates, and join the free livestream at <a
+      href="https://conf.react.dev">conf.react.dev</a>.
+  </p>
+</div>

--- a/packages/react-devtools-extensions/popups/production.html
+++ b/packages/react-devtools-extensions/popups/production.html
@@ -1,7 +1,8 @@
 <script src="shared.js"></script>
 <link rel="stylesheet" href="shared.css" />
 <style>
-  html, body {
+  html,
+  body {
     min-width: 460px;
     min-height: 39px;
   }
@@ -13,5 +14,12 @@
 <p>
   <b>This page is using the production build of React. &#x2705;</b>
   <br />
-  Open the developer tools, and  "Components" and "Profiler" tabs will appear to the right.
+  Open the developer tools, and "Components" and "Profiler" tabs will appear to the right.
 </p>
+<div id="message" style="display: none;">
+  <hr />
+  <p>
+    React Conf is on May 15-16! Grab your tickets, sign up for updates, and join the free livestream at <a
+      href="https://conf.react.dev">conf.react.dev</a>.
+  </p>
+</div>

--- a/packages/react-devtools-extensions/popups/restricted.html
+++ b/packages/react-devtools-extensions/popups/restricted.html
@@ -1,14 +1,21 @@
 <script src="shared.js"></script>
 <link rel="stylesheet" href="shared.css" />
 <style>
-  html, body {
+  html,
+  body {
     min-width: 286px;
     min-height: 33px;
   }
-
 </style>
 <p>
   <b>This is a restricted browser page.</b>
   <br />
   React devtools cannot access this page.
 </p>
+<div id="message" style="display: none;">
+  <hr />
+  <p>
+    React Conf is on May 15-16! Grab your tickets, sign up for updates, and join the free livestream at <a
+      href="https://conf.react.dev">conf.react.dev</a>.
+  </p>
+</div>

--- a/packages/react-devtools-extensions/popups/shared.js
+++ b/packages/react-devtools-extensions/popups/shared.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const ln = links[i];
       const location = ln.href;
       ln.onclick = function () {
-        chrome.tabs.create({ active: true, url: location });
+        chrome.tabs.create({active: true, url: location});
         return false;
       };
     })();
@@ -34,8 +34,8 @@ document.addEventListener('DOMContentLoaded', function () {
   // Remove the notifiaction badge when the popup is opened
   chrome.storage.local.get(['notifications'], function (data) {
     if (data.notifications === undefined) {
-      chrome.action.setBadgeText({ text: "" });
-      chrome.storage.local.set({ 'notifications': false })
+      chrome.action.setBadgeText({text: ''});
+      chrome.storage.local.set({notifications: false});
     }
   });
 });

--- a/packages/react-devtools-extensions/popups/shared.js
+++ b/packages/react-devtools-extensions/popups/shared.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const ln = links[i];
       const location = ln.href;
       ln.onclick = function () {
-        chrome.tabs.create({active: true, url: location});
+        chrome.tabs.create({ active: true, url: location });
         return false;
       };
     })();
@@ -21,5 +21,21 @@ document.addEventListener('DOMContentLoaded', function () {
   document.body.style.transition = 'opacity ease-out .4s';
   requestAnimationFrame(function () {
     document.body.style.opacity = 1;
+  });
+
+  // Only show React Conf message in popup before and during
+  // the conference (May 15th-16th, 2024)
+  const today = new Date();
+  const may16 = new Date(2024, 4, 16); // May is month 5 in JavaScript
+  if (today < may16) {
+    document.getElementById('message').style.display = 'block';
+  }
+
+  // Remove the notifiaction badge when the popup is opened
+  chrome.storage.local.get(['notifications'], function (data) {
+    if (data.notifications === undefined) {
+      chrome.action.setBadgeText({ text: "" });
+      chrome.storage.local.set({ 'notifications': false })
+    }
   });
 });

--- a/packages/react-devtools-extensions/popups/unminified.html
+++ b/packages/react-devtools-extensions/popups/unminified.html
@@ -1,6 +1,7 @@
 <script src="shared.js"></script>
 <style>
-  html, body {
+  html,
+  body {
     font-size: 14px;
     min-width: 460px;
     min-height: 133px;
@@ -23,9 +24,17 @@
   This makes its size larger, and causes React to run slower.
   <br />
   <br />
-  Make sure to <a href="https://reactjs.org/docs/optimizing-performance.html#use-the-production-build">set up minification</a> before deployment.
+  Make sure to <a href="https://reactjs.org/docs/optimizing-performance.html#use-the-production-build">set up
+    minification</a> before deployment.
 </p>
 <hr />
 <p>
-  Open the developer tools, and  "Components" and "Profiler" tabs will appear to the right.
+  Open the developer tools, and "Components" and "Profiler" tabs will appear to the right.
 </p>
+<div id="message" style="display: none;">
+  <hr />
+  <p>
+    React Conf is on May 15-16! Grab your tickets, sign up for updates, and join the free livestream at <a
+      href="https://conf.react.dev">conf.react.dev</a>.
+  </p>
+</div>

--- a/packages/react-devtools-extensions/src/background/index.js
+++ b/packages/react-devtools-extensions/src/background/index.js
@@ -196,7 +196,7 @@ chrome.runtime.onMessage.addListener((message, sender) => {
   }
 });
 
-chrome.tabs.onActivated.addListener(({ tabId: activeTabId }) => {
+chrome.tabs.onActivated.addListener(({tabId: activeTabId}) => {
   for (const registeredTabId in ports) {
     if (
       ports[registeredTabId].proxy != null &&
@@ -208,7 +208,7 @@ chrome.tabs.onActivated.addListener(({ tabId: activeTabId }) => {
           ? 'resumeElementPolling'
           : 'pauseElementPolling';
 
-      ports[registeredTabId].extension.postMessage({ event });
+      ports[registeredTabId].extension.postMessage({event});
     }
   }
 });
@@ -226,8 +226,8 @@ chrome.runtime.onInstalled.addListener(() => {
   // only show the notification badge if the user hasn't clicked on the extension icon
   chrome.storage.local.get(['notifications'], function (data) {
     if (data.notifications === undefined || data.notifications === true) {
-      chrome.action.setBadgeBackgroundColor({ color: '#FF6F00' });
-      chrome.action.setBadgeText({ text: "1" });
+      chrome.action.setBadgeBackgroundColor({color: '#FF6F00'});
+      chrome.action.setBadgeText({text: '1'});
     }
   });
 });

--- a/packages/react-devtools-extensions/src/background/index.js
+++ b/packages/react-devtools-extensions/src/background/index.js
@@ -196,7 +196,7 @@ chrome.runtime.onMessage.addListener((message, sender) => {
   }
 });
 
-chrome.tabs.onActivated.addListener(({tabId: activeTabId}) => {
+chrome.tabs.onActivated.addListener(({ tabId: activeTabId }) => {
   for (const registeredTabId in ports) {
     if (
       ports[registeredTabId].proxy != null &&
@@ -208,7 +208,26 @@ chrome.tabs.onActivated.addListener(({tabId: activeTabId}) => {
           ? 'resumeElementPolling'
           : 'pauseElementPolling';
 
-      ports[registeredTabId].extension.postMessage({event});
+      ports[registeredTabId].extension.postMessage({ event });
     }
   }
+});
+
+// Show a notification badge when the extension is installed if:
+// 1. it is before or during the conference (May 15th-16th, 2024)
+// 2. the user has clicked on the extension icon to open the popup
+chrome.runtime.onInstalled.addListener(() => {
+  // skip the notificaiton if the conference is in the past
+  const today = new Date();
+  const may16 = new Date(2024, 4, 16); // May is month 5 in JavaScript
+  if (today > may16) {
+    return;
+  }
+  // only show the notification badge if the user hasn't clicked on the extension icon
+  chrome.storage.local.get(['notifications'], function (data) {
+    if (data.notifications === undefined || data.notifications === true) {
+      chrome.action.setBadgeBackgroundColor({ color: '#FF6F00' });
+      chrome.action.setBadgeText({ text: "1" });
+    }
+  });
 });


### PR DESCRIPTION
This PR creates notifies DevTools users of React Conf through:

1. Updating the text on the popup

<img width="803" alt="Screenshot 2024-01-31 at 3 45 45 PM" src="https://github.com/facebook/react/assets/7158882/081971f9-fca6-4975-b66e-2cd53d860359">

2.  a text "badge" notification on the extension icon 

<img width="258" alt="Screenshot 2024-01-31 at 3 44 41 PM" src="https://github.com/facebook/react/assets/7158882/37fb4bad-ff9c-4913-b458-8fa773faabe6">

The badge disappears after the user clicks on the icon or after React Conf ends.

Note: this only works on Chrome and hasn't been tested or written to work on Firefox or Edge yet.