### PR TITLE
convert ReactElementClone-test from renderIntoDocument

### DIFF
--- a/packages/react/src/__tests__/ReactElementClone-test.js
+++ b/packages/react/src/__tests__/ReactElementClone-test.js
@@ -275,12 +275,7 @@ describe('ReactElementClone', () => {
   });
 
   it('should overwrite props', async () => {
-    let component;
     class Component extends React.Component {
-      componentDidMount() {
-        component = this;
-      }
-
       render() {
         expect(this.props.myprop).toBe('xyz');
         return <div />;

--- a/packages/react/src/__tests__/ReactElementClone-test.js
+++ b/packages/react/src/__tests__/ReactElementClone-test.js
@@ -13,7 +13,6 @@ let act;
 let PropTypes;
 let React;
 let ReactDOMClient;
-let ReactTestUtils;
 
 describe('ReactElementClone', () => {
   let ComponentClass;
@@ -24,7 +23,6 @@ describe('ReactElementClone', () => {
     PropTypes = require('prop-types');
     React = require('react');
     ReactDOMClient = require('react-dom/client');
-    ReactTestUtils = require('react-dom/test-utils');
 
     // NOTE: We're explicitly not using JSX here. This is intended to test
     // classic JS without JSX.


### PR DESCRIPTION
## Summary

migrates to createRoot – renderIntoDocument uses ReactDOM.render

## How did you test this change?

yarn test ReactElementClone