### PR TITLE
fix(eslint-plugin-react-hooks): accepting `as` expression as a callback

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -7765,6 +7765,15 @@ const testsTypescript = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        function App(props) {
+          React.useEffect((() => {
+            console.log(props.test);
+          }) as any, [props.test]);
+        }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1223,6 +1223,15 @@ export default {
             isEffect,
           );
           return; // Handled
+        case 'TSAsExpression':
+          visitFunctionWithDependencies(
+            callback.expression,
+            declaredDependenciesNode,
+            reactiveHook,
+            reactiveHookName,
+            isEffect,
+          );
+          return; // Handled
         case 'Identifier':
           if (!declaredDependenciesNode) {
             // No deps, no problems.


### PR DESCRIPTION
## Summary

Closes #20750

## How did you test this change?

Added a test case
