### PR TITLE
add RSC entrypoint for jsx-runtime

### DIFF
--- a/packages/react/jsx-runtime.react-server.js
+++ b/packages/react/jsx-runtime.react-server.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+export {Fragment, jsx, jsxs} from './src/jsx/ReactJSXServer';

--- a/packages/react/npm/jsx-runtime.react-server.js
+++ b/packages/react/npm/jsx-runtime.react-server.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-jsx-runtime.react-server.production.min.js');
+} else {
+  module.exports = require('./cjs/react-jsx-runtime.react-server.development.js');
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,7 +25,10 @@
       "default": "./index.js"
     },
     "./package.json": "./package.json",
-    "./jsx-runtime": "./jsx-runtime.js",
+    "./jsx-runtime": {
+      "react-server": "./jsx-runtime.react-server.js",
+      "default": "./jsx-runtime.js"
+    },
     "./jsx-dev-runtime": "./jsx-dev-runtime.js",
     "./src/*": "./src/*"
   },

--- a/packages/react/src/jsx/ReactJSXServer.js
+++ b/packages/react/src/jsx/ReactJSXServer.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// These are implementations of the jsx APIs for React Server runtimes.
+import {REACT_FRAGMENT_TYPE} from 'shared/ReactSymbols';
+import {
+  jsxWithValidationStatic,
+  jsxWithValidationDynamic,
+} from './ReactJSXElementValidator';
+import {jsx as jsxProd} from './ReactJSXElement';
+const jsx: any = __DEV__ ? jsxWithValidationDynamic : jsxProd;
+// we may want to special case jsxs internally to take advantage of static children.
+// for now we can ship identical prod functions
+const jsxs: any = __DEV__ ? jsxWithValidationStatic : jsxProd;
+
+export {REACT_FRAGMENT_TYPE as Fragment, jsx, jsxs};

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -134,6 +134,18 @@ const bundles = [
     externals: ['react', 'ReactNativeInternalFeatureFlags'],
   },
 
+  /******* React JSX Runtime React Server *******/
+  {
+    bundleTypes: [NODE_DEV, NODE_PROD],
+    moduleType: ISOMORPHIC,
+    entry: 'react/src/jsx/ReactJSXServer.js',
+    name: 'react-jsx-runtime.react-server',
+    global: 'JSXRuntime',
+    minifyWithProdErrorCodes: false,
+    wrapWithModuleBoundaries: false,
+    externals: ['react', 'ReactNativeInternalFeatureFlags'],
+  },
+
   /******* React JSX DEV Runtime *******/
   {
     bundleTypes: [
@@ -176,7 +188,7 @@ const bundles = [
     externals: ['react'],
   },
 
-  /******* React DOM Shared Subset *******/
+  /******* React DOM React Server *******/
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,


### PR DESCRIPTION
Adds a new entrypoint for the production jsx-runtime when using react-server condition. Currently the entrypoints are the same but in the future we will potentially change the implementation of the runtime in ways that can only be optimized for react-server constraints and we want to have the entrypoint already separated so environments using it will be pulling in the right version
