### PR TITLE
[Fiber] Remove the digest property from errorInfo passed to onRecoverableError

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -3621,11 +3621,11 @@ describe('ReactDOMFizzServer', () => {
         onRecoverableError(error, errorInfo) {
           expect(() => {
             expect(error.digest).toBe('a digest');
-            expect(errorInfo.digest).toBe('a digest');
+            expect(errorInfo.digest).toBe(undefined);
           }).toErrorDev(
-            'Warning: You are accessing "digest" from the errorInfo object passed to onRecoverableError.' +
-              ' This property is deprecated and will be removed in a future version of React.' +
-              ' To access the digest of an Error look for this property on the Error instance itself.',
+            'You are accessing "digest" from the errorInfo object passed to onRecoverableError.' +
+              ' This property is no longer provided as part of errorInfo but can be accessed as a property' +
+              ' of the Error instance itself.',
             {withoutStack: true},
           );
         },

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -3001,10 +3001,7 @@ function commitRootImpl(
     const onRecoverableError = root.onRecoverableError;
     for (let i = 0; i < recoverableErrors.length; i++) {
       const recoverableError = recoverableErrors[i];
-      const errorInfo = makeErrorInfo(
-        recoverableError.digest,
-        recoverableError.stack,
-      );
+      const errorInfo = makeErrorInfo(recoverableError.stack);
       onRecoverableError(recoverableError.value, errorInfo);
     }
   }
@@ -3104,28 +3101,35 @@ function commitRootImpl(
   return null;
 }
 
-function makeErrorInfo(digest: ?string, componentStack: ?string) {
+function makeErrorInfo(componentStack: ?string) {
   if (__DEV__) {
     const errorInfo = {
       componentStack,
-      digest,
     };
-    Object.defineProperty(errorInfo, 'digest', {
-      configurable: false,
-      enumerable: true,
-      get() {
-        console.error(
-          'You are accessing "digest" from the errorInfo object passed to onRecoverableError.' +
-            ' This property is deprecated and will be removed in a future version of React.' +
-            ' To access the digest of an Error look for this property on the Error instance itself.',
-        );
-        return digest;
+    return new Proxy(errorInfo, {
+      get(target, prop, receiver) {
+        if (prop === 'digest') {
+          console.error(
+            'You are accessing "digest" from the errorInfo object passed to onRecoverableError.' +
+              ' This property is no longer provided as part of errorInfo but can be accessed as a property' +
+              ' of the Error instance itself.',
+          );
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+      has(target, prop) {
+        if (prop === 'digest') {
+          console.error(
+            'You are accessing "digest" from the errorInfo object passed to onRecoverableError.' +
+              ' This property is no longer provided as part of errorInfo but can be accessed as a property' +
+              ' of the Error instance itself.',
+          );
+        }
+        return Reflect.has(target, prop);
       },
     });
-    return errorInfo;
   } else {
     return {
-      digest,
       componentStack,
     };
   }


### PR DESCRIPTION
Removes the digest property from errorInfo passed to onRecoverableError when handling an error propagated from the server. Previously we warned in Dev but still provided the digest on the errorInfo object. This change removes digest from error info but continues to warn if it is accessed. The reason for retaining the warning is the version with the warning was not released as stable but we will include this deprecated removal in our next major so we should communicate this change at runtime.
