### PR TITLE
Remove deprecated methods from react-is

### DIFF
--- a/packages/react-is/index.experimental.js
+++ b/packages/react-is/index.experimental.js
@@ -24,8 +24,6 @@ export {
   StrictMode,
   Suspense,
   SuspenseList,
-  isAsyncMode,
-  isConcurrentMode,
   isContextConsumer,
   isContextProvider,
   isElement,

--- a/packages/react-is/index.stable.js
+++ b/packages/react-is/index.stable.js
@@ -24,8 +24,6 @@ export {
   StrictMode,
   Suspense,
   SuspenseList,
-  isAsyncMode,
-  isConcurrentMode,
   isContextConsumer,
   isContextProvider,
   isElement,

--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -78,36 +78,6 @@ export const SuspenseList = REACT_SUSPENSE_LIST_TYPE;
 
 export {isValidElementType};
 
-let hasWarnedAboutDeprecatedIsAsyncMode = false;
-let hasWarnedAboutDeprecatedIsConcurrentMode = false;
-
-// AsyncMode should be deprecated
-export function isAsyncMode(object: any): boolean {
-  if (__DEV__) {
-    if (!hasWarnedAboutDeprecatedIsAsyncMode) {
-      hasWarnedAboutDeprecatedIsAsyncMode = true;
-      // Using console['warn'] to evade Babel and ESLint
-      console['warn'](
-        'The ReactIs.isAsyncMode() alias has been deprecated, ' +
-          'and will be removed in React 18+.',
-      );
-    }
-  }
-  return false;
-}
-export function isConcurrentMode(object: any): boolean {
-  if (__DEV__) {
-    if (!hasWarnedAboutDeprecatedIsConcurrentMode) {
-      hasWarnedAboutDeprecatedIsConcurrentMode = true;
-      // Using console['warn'] to evade Babel and ESLint
-      console['warn'](
-        'The ReactIs.isConcurrentMode() alias has been deprecated, ' +
-          'and will be removed in React 18+.',
-      );
-    }
-  }
-  return false;
-}
 export function isContextConsumer(object: any): boolean {
   return typeOf(object) === REACT_CONTEXT_TYPE;
 }


### PR DESCRIPTION
These aren't being used anywhere and don't even correspond to real APIs.