### PR TITLE
DevTools: Add support for use(Context)

### DIFF
--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
@@ -1108,6 +1108,44 @@ describe('ReactHooksInspectionIntegration', () => {
     ]);
   });
 
+  it('should support use(Context) hook', () => {
+    const Context = React.createContext('default');
+    function Foo() {
+      const value = React.use(Context);
+      React.useMemo(() => 'memo', []);
+      React.useMemo(() => 'not used', []);
+
+      return value;
+    }
+
+    const renderer = ReactTestRenderer.create(<Foo />);
+    const childFiber = renderer.root.findByType(Foo)._currentFiber();
+    const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    expect(tree).toEqual([
+      {
+        id: null,
+        isStateEditable: false,
+        name: 'Use',
+        value: 'default',
+        subHooks: [],
+      },
+      {
+        id: 0,
+        isStateEditable: false,
+        name: 'Memo',
+        value: 'memo',
+        subHooks: [],
+      },
+      {
+        id: 1,
+        isStateEditable: false,
+        name: 'Memo',
+        value: 'not used',
+        subHooks: [],
+      },
+    ]);
+  });
+
   // @gate enableAsyncActions
   it('should support useOptimistic hook', () => {
     const useOptimistic = React.useOptimistic;

--- a/packages/react-devtools-shell/src/app/InspectableElements/CustomHooks.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/CustomHooks.js
@@ -19,6 +19,7 @@ import {
   useEffect,
   useOptimistic,
   useState,
+  use,
 } from 'react';
 import {useFormState} from 'react-dom';
 
@@ -76,6 +77,7 @@ function FunctionWithHooks(props: any, ref: React$Ref<any>) {
   // eslint-disable-next-line no-unused-vars
   const contextValueA = useContext(ContextA);
   useOptimistic<number, mixed>(1);
+  use(ContextA);
 
   // eslint-disable-next-line no-unused-vars
   const [_, __] = useState(object);


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/28232

## Summary

Add support for `use(Context)` Hook fixing "Support for `use()` not yet implemented in react-debug-tools." when inspecting components using `use(Context)`

`use(Promise)` will still throw: "Support for `use(Promise)` not yet implemented in react-debug-tools."

## How did you test this change?

- added test
- add usage to devtools-shell:
   ![Screenshot 2024-02-04 at 15 41 54](https://github.com/facebook/react/assets/12292047/33b55c74-8657-4689-b9dc-43912a81ec34)

