### PR TITLE
fix: partially revert jest setup config removal to fix regression tests

### DIFF
--- a/scripts/jest/devtools/config.build-devtools-regression.js
+++ b/scripts/jest/devtools/config.build-devtools-regression.js
@@ -31,6 +31,8 @@ if (REACT_VERSION) {
       '^react-dom/client$'
     ] = `<rootDir>/build/${NODE_MODULES_DIR}/react-dom`;
   }
+
+  setupFiles.push(require.resolve('./setupTests.build-devtools-regression'));
 }
 
 module.exports = {

--- a/scripts/jest/devtools/setupTests.build-devtools-regression.js
+++ b/scripts/jest/devtools/setupTests.build-devtools-regression.js
@@ -1,0 +1,7 @@
+'use strict';
+
+// Regression tests use a React DOM profiling, so we need
+// to replace these tests with scheduler/tracing-profiling
+jest.mock('scheduler/tracing', () => {
+  return jest.requireActual('scheduler/tracing-profiling');
+});


### PR DESCRIPTION
Partially reverting what has been removed in https://github.com/facebook/react/pull/28186.

We need `'scheduler/tracing'` mock for React >= 16.8.
The error:
```
Invariant Violation: It is not supported to run the profiling version of a renderer (for example, `react-dom/profiling`) without also replacing the `scheduler/tracing` module with `scheduler/tracing-profiling`. Your bundler might have a setting for aliasing both modules. Learn more at http://fb.me/react-profiling
```

Validated by running regression tests for the whole version matrix:
```
./scripts/circleci/download_devtools_regression_build.js 16.0 --replaceBuild && node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion 16.0 --ci && ./scripts/circleci/download_devtools_regression_build.js 16.5 --replaceBuild && node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion 16.5 --ci && ./scripts/circleci/download_devtools_regression_build.js 16.8 --replaceBuild && node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion 16.8 --ci && ./scripts/circleci/download_devtools_regression_build.js 17.0 --replaceBuild && node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion 17.0 --ci && ./scripts/circleci/download_devtools_regression_build.js 18.0 --replaceBuild && node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion 18.0 --ci
```