### PR TITLE
Ensure useState and useReducer initializer functions are double invoked in StrictMode

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1160,11 +1160,8 @@ function mountReducer<S, I, A>(
     initialState = init(initialArg);
     if (shouldDoubleInvokeUserFnsInHooksDEV) {
       setIsStrictModeForDevtools(true);
-      try {
-        init(initialArg);
-      } finally {
-        setIsStrictModeForDevtools(false);
-      }
+      init(initialArg);
+      setIsStrictModeForDevtools(false);
     }
   } else {
     initialState = ((initialArg: any): S);
@@ -1762,12 +1759,9 @@ function mountStateImpl<S>(initialState: (() => S) | S): Hook {
     initialState = initialStateInitializer();
     if (shouldDoubleInvokeUserFnsInHooksDEV) {
       setIsStrictModeForDevtools(true);
-      try {
-        // $FlowFixMe[incompatible-use]: Flow doesn't like mixed types
-        initialStateInitializer();
-      } finally {
-        setIsStrictModeForDevtools(false);
-      }
+      // $FlowFixMe[incompatible-use]: Flow doesn't like mixed types
+      initialStateInitializer();
+      setIsStrictModeForDevtools(false);
     }
   }
   hook.memoizedState = hook.baseState = initialState;

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1158,6 +1158,9 @@ function mountReducer<S, I, A>(
   let initialState;
   if (init !== undefined) {
     initialState = init(initialArg);
+    if (shouldDoubleInvokeUserFnsInHooksDEV) {
+      init(initialArg);
+    }
   } else {
     initialState = ((initialArg: any): S);
   }
@@ -1749,8 +1752,12 @@ function forceStoreRerender(fiber: Fiber) {
 function mountStateImpl<S>(initialState: (() => S) | S): Hook {
   const hook = mountWorkInProgressHook();
   if (typeof initialState === 'function') {
+    const initialStateInitializer = initialState;
     // $FlowFixMe[incompatible-use]: Flow doesn't like mixed types
-    initialState = initialState();
+    initialState = initialStateInitializer();
+    if (shouldDoubleInvokeUserFnsInHooksDEV) {
+      initialStateInitializer();
+    }
   }
   hook.memoizedState = hook.baseState = initialState;
   const queue: UpdateQueue<S, BasicStateAction<S>> = {

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1756,6 +1756,7 @@ function mountStateImpl<S>(initialState: (() => S) | S): Hook {
     // $FlowFixMe[incompatible-use]: Flow doesn't like mixed types
     initialState = initialStateInitializer();
     if (shouldDoubleInvokeUserFnsInHooksDEV) {
+      // $FlowFixMe[incompatible-use]: Flow doesn't like mixed types
       initialStateInitializer();
     }
   }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1159,7 +1159,12 @@ function mountReducer<S, I, A>(
   if (init !== undefined) {
     initialState = init(initialArg);
     if (shouldDoubleInvokeUserFnsInHooksDEV) {
-      init(initialArg);
+      setIsStrictModeForDevtools(true);
+      try {
+        init(initialArg);
+      } finally {
+        setIsStrictModeForDevtools(false);
+      }
     }
   } else {
     initialState = ((initialArg: any): S);
@@ -1756,8 +1761,13 @@ function mountStateImpl<S>(initialState: (() => S) | S): Hook {
     // $FlowFixMe[incompatible-use]: Flow doesn't like mixed types
     initialState = initialStateInitializer();
     if (shouldDoubleInvokeUserFnsInHooksDEV) {
-      // $FlowFixMe[incompatible-use]: Flow doesn't like mixed types
-      initialStateInitializer();
+      setIsStrictModeForDevtools(true);
+      try {
+        // $FlowFixMe[incompatible-use]: Flow doesn't like mixed types
+        initialStateInitializer();
+      } finally {
+        setIsStrictModeForDevtools(false);
+      }
     }
   }
   hook.memoizedState = hook.baseState = initialState;

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -202,6 +202,46 @@ describe('ReactStrictMode', () => {
     expect(instance.state.count).toBe(2);
   });
 
+  // @gate debugRenderPhaseSideEffectsForStrictMode
+  it('double invokes useState and useReducer initializers functions', async () => {
+    const log = [];
+
+    function App() {
+      React.useState(() => {
+        log.push('Compute initial count state: 1');
+        return 1;
+      });
+      React.useReducer(
+        s => s,
+        2,
+        s => {
+          log.push('Compute initial reducer state: 2');
+          return s;
+        },
+      );
+
+      return 3;
+    }
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => {
+      root.render(
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>,
+      );
+    });
+    expect(container.textContent).toBe('3');
+
+    expect(log).toEqual([
+      'Compute initial count state: 1',
+      'Compute initial count state: 1',
+      'Compute initial reducer state: 2',
+      'Compute initial reducer state: 2',
+    ]);
+  });
+
   it('should invoke only precommit lifecycle methods twice in DEV legacy roots', async () => {
     const {StrictMode} = React;
 

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -208,14 +208,14 @@ describe('ReactStrictMode', () => {
 
     function App() {
       React.useState(() => {
-        log.push('Compute initial count state: 1');
+        log.push('Compute initial state count: 1');
         return 1;
       });
       React.useReducer(
         s => s,
         2,
         s => {
-          log.push('Compute initial reducer state: 2');
+          log.push('Compute initial reducer count: 2');
           return s;
         },
       );
@@ -235,10 +235,10 @@ describe('ReactStrictMode', () => {
     expect(container.textContent).toBe('3');
 
     expect(log).toEqual([
-      'Compute initial count state: 1',
-      'Compute initial count state: 1',
-      'Compute initial reducer state: 2',
-      'Compute initial reducer state: 2',
+      'Compute initial state count: 1',
+      'Compute initial state count: 1',
+      'Compute initial reducer count: 2',
+      'Compute initial reducer count: 2',
     ]);
   });
 


### PR DESCRIPTION

## Summary

Fixes https://github.com/facebook/react/pull/25583#issuecomment-1899170319

In StrictMode we used to double invoke state initializer functions in StrictMode (I started bisecting from 17 where this was already the case). Our docs imply this:
> Functions that you pass to [useState](https://react.dev/reference/react/useState), [set functions](https://react.dev/reference/react/useState#setstate), [useMemo](https://react.dev/reference/react/useMemo), or [useReducer](https://react.dev/reference/react/useReducer)
-- https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-double-rendering-in-development

However, in https://github.com/facebook/react/pull/25583 we stopped doing that but likely because we never had a test. 

Now we double invoke again using the same pattern we use for double invoking updater functions.

## How did you test this change?

- added test for state initializer invocations
