### PR TITLE
Fix nodeName to UPPERCASE in insertStylesheetIntoRoot

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3414,7 +3414,7 @@ function insertStylesheetIntoRoot(
     for (let i = 0; i < nodes.length; i++) {
       const node = nodes[i];
       if (
-        node.nodeName === 'link' ||
+        node.nodeName === 'LINK' ||
         // We omit style tags with media="not all" because they are not in the right position
         // and will be hoisted by the Fizz runtime imminently.
         node.getAttribute('media') !== 'not all'


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

<img width="518" alt="image" src="https://github.com/facebook/react/assets/18693190/6d12df76-7dae-403b-b486-4940992abe8d">

The condition `node.nodeName === 'link'` is always `false`, because `node.nodeName` is Uppercase in specification. And the condition `node.nodeName === 'LINK'` is unnecessary, because Fizz hoists tags when it's `media` attribute is `"not all"`, whether it is a `link` or a `style` (line 36):

https://github.com/facebook/react/blob/18cbcbf783377c5a22277a63ae41af54504502e0/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetExternalRuntime.js#L30-L44

https://github.com/facebook/react/blob/18cbcbf783377c5a22277a63ae41af54504502e0/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetInlineSource.js#L30-L44

