### PR TITLE
fix: gate react/jsx-runtime upgrade only for React >= 17 tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.10.4",
     "@babel/plugin-transform-object-super": "^7.10.4",
     "@babel/plugin-transform-parameters": "^7.10.5",
+    "@babel/plugin-transform-react-jsx-source": "^7.10.5",
     "@babel/plugin-transform-react-jsx": "^7.23.4",
     "@babel/plugin-transform-react-jsx-development": "^7.22.5",
     "@babel/plugin-transform-shorthand-properties": "^7.10.4",

--- a/scripts/jest/devtools/setupEnv.js
+++ b/scripts/jest/devtools/setupEnv.js
@@ -31,9 +31,10 @@ global.process.env.LIGHT_MODE_DIMMED_ERROR_COLOR =
   LIGHT_MODE_DIMMED_ERROR_COLOR;
 global.process.env.LIGHT_MODE_DIMMED_LOG_COLOR = LIGHT_MODE_DIMMED_LOG_COLOR;
 
+const ReactVersionTestingAgainst = process.env.REACT_VERSION || ReactVersion;
+
 global._test_react_version = (range, testName, callback) => {
-  const reactVersion = process.env.REACT_VERSION || ReactVersion;
-  const shouldPass = semver.satisfies(reactVersion, range);
+  const shouldPass = semver.satisfies(ReactVersionTestingAgainst, range);
 
   if (shouldPass) {
     test(testName, callback);
@@ -43,8 +44,7 @@ global._test_react_version = (range, testName, callback) => {
 };
 
 global._test_react_version_focus = (range, testName, callback) => {
-  const reactVersion = process.env.REACT_VERSION || ReactVersion;
-  const shouldPass = semver.satisfies(reactVersion, range);
+  const shouldPass = semver.satisfies(ReactVersionTestingAgainst, range);
 
   if (shouldPass) {
     // eslint-disable-next-line jest/no-focused-tests
@@ -71,12 +71,14 @@ global._test_ignore_for_react_version = (testName, callback) => {
 // Longer term we should migrate all our tests away from using require() and
 // resetModules, and use import syntax instead so this kind of thing doesn't
 // happen.
-lazyRequireFunctionExports('react/jsx-dev-runtime');
+if (semver.gte(ReactVersionTestingAgainst, '17.0.0')) {
+  lazyRequireFunctionExports('react/jsx-dev-runtime');
 
-// TODO: We shouldn't need to do this in the production runtime, but until
-// we remove string refs they also depend on the shared state object. Remove
-// once we remove string refs.
-lazyRequireFunctionExports('react/jsx-runtime');
+  // TODO: We shouldn't need to do this in the production runtime, but until
+  // we remove string refs they also depend on the shared state object. Remove
+  // once we remove string refs.
+  lazyRequireFunctionExports('react/jsx-runtime');
+}
 
 function lazyRequireFunctionExports(moduleName) {
   jest.mock(moduleName, () => {


### PR DESCRIPTION
https://github.com/facebook/react/pull/28252 broke RDT tests with React 16.x.

These changes gate the `jsx-runtime` upgrade only for cases when we are testing against React >= 17.

Validated with:
```
 ./scripts/circleci/download_devtools_regression_build.js 16.0 --replaceBuild && node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion 16.0 --ci && ./scripts/circleci/download_devtools_regression_build.js 16.5 --replaceBuild && node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion 16.5 --ci && ./scripts/circleci/download_devtools_regression_build.js 16.8 --replaceBuild && node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion 16.8 --ci && ./scripts/circleci/download_devtools_regression_build.js 17.0 --replaceBuild && node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion 17.0 --ci && ./scripts/circleci/download_devtools_regression_build.js 18.0 --replaceBuild && node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion 18.0 --ci
 ```