### PR TITLE
Fixes typos

### DIFF
--- a/packages/scheduler/src/SchedulerMinHeap.js
+++ b/packages/scheduler/src/SchedulerMinHeap.js
@@ -17,7 +17,7 @@ type Node = {
 export function push<T: Node>(heap: Heap<T>, node: T): void {
   const index = heap.length;
   heap.push(node);
-  siftUp(heap, node, index);
+  shiftUp(heap, node, index);
 }
 
 export function peek<T: Node>(heap: Heap<T>): T | null {
@@ -32,12 +32,12 @@ export function pop<T: Node>(heap: Heap<T>): T | null {
   const last = heap.pop();
   if (last !== first) {
     heap[0] = last;
-    siftDown(heap, last, 0);
+    shiftDown(heap, last, 0);
   }
   return first;
 }
 
-function siftUp<T: Node>(heap: Heap<T>, node: T, i: number): void {
+function shiftUp<T: Node>(heap: Heap<T>, node: T, i: number): void {
   let index = i;
   while (index > 0) {
     const parentIndex = (index - 1) >>> 1;
@@ -54,7 +54,7 @@ function siftUp<T: Node>(heap: Heap<T>, node: T, i: number): void {
   }
 }
 
-function siftDown<T: Node>(heap: Heap<T>, node: T, i: number): void {
+function shiftDown<T: Node>(heap: Heap<T>, node: T, i: number): void {
   let index = i;
   const length = heap.length;
   const halfLength = length >>> 1;


### PR DESCRIPTION
## Summary

Fixes typo('sift') in the scheduler

## How did you test this change?

  4. `yarn test --prod --testPathPattern=packages/scheduler` - **Passed**
  5. `yarn test --prod --testPathPattern=packages/scheduler` - **Passed**
  7. `yarn prettier` - **Passed**
  8. `yarn linc` - **Passed**
  9. `yarn flow dom-node` - **Passed**
  