### PR TITLE
[WIP] Add transform to reset modules in tests

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -11,7 +11,7 @@
 'use strict';
 
 let Activity;
-let React = require('react');
+let React;
 let ReactDOM;
 let ReactDOMClient;
 let ReactDOMServer;
@@ -26,6 +26,7 @@ let waitForAll;
 let waitFor;
 let waitForPaint;
 let assertLog;
+let TestAppClass;
 
 function normalizeCodeLocInfo(strOrErr) {
   if (strOrErr && strOrErr.replace) {
@@ -87,17 +88,6 @@ function dispatchMouseEvent(to, from) {
   }
 }
 
-class TestAppClass extends React.Component {
-  render() {
-    return (
-      <div>
-        <>{''}</>
-        <>{'Hello'}</>
-      </div>
-    );
-  }
-}
-
 describe('ReactDOMServerPartialHydration', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -126,6 +116,17 @@ describe('ReactDOMServerPartialHydration', () => {
     waitFor = InternalTestUtils.waitFor;
 
     IdleEventPriority = require('react-reconciler/constants').IdleEventPriority;
+
+    TestAppClass = class extends React.Component {
+      render() {
+        return (
+          <div>
+            <>{''}</>
+            <>{'Hello'}</>
+          </div>
+        );
+      }
+    };
   });
 
   // Note: This is based on a similar component we use in www. We can delete

--- a/packages/react-dom/src/__tests__/ReactErrorLoggingRecovery-test.js
+++ b/packages/react-dom/src/__tests__/ReactErrorLoggingRecovery-test.js
@@ -15,34 +15,38 @@ if (global.window) {
   throw new Error('This test must run in a Node environment.');
 }
 
-// The issue only reproduced when React was loaded before JSDOM.
-const React = require('react');
-const ReactDOMClient = require('react-dom/client');
-const act = require('internal-test-utils').act;
-
-// Initialize JSDOM separately.
-// We don't use our normal JSDOM setup because we want to load React first.
-const {JSDOM} = require('jsdom');
-global.requestAnimationFrame = setTimeout;
-global.cancelAnimationFrame = clearTimeout;
-const jsdom = new JSDOM(`<div id="app-root"></div>`);
-global.window = jsdom.window;
-global.document = jsdom.window.document;
-global.navigator = jsdom.window.navigator;
-
-class Bad extends React.Component {
-  componentDidUpdate() {
-    throw new Error('no');
-  }
-  render() {
-    return null;
-  }
-}
+let React;
+let ReactDOMClient;
+let act;
+let Bad;
 
 describe('ReactErrorLoggingRecovery', () => {
   const originalConsoleError = console.error;
 
   beforeEach(() => {
+    // The issue only reproduced when React was loaded before JSDOM.
+    React = require('react');
+    ReactDOMClient = require('react-dom/client');
+    act = require('internal-test-utils').act;
+
+    // Initialize JSDOM separately.
+    // We don't use our normal JSDOM setup because we want to load React first.
+    const {JSDOM} = require('jsdom');
+    global.requestAnimationFrame = setTimeout;
+    global.cancelAnimationFrame = clearTimeout;
+    const jsdom = new JSDOM(`<div id="app-root"></div>`);
+    global.window = jsdom.window;
+    global.document = jsdom.window.document;
+    global.navigator = jsdom.window.navigator;
+
+    Bad = class extends React.Component {
+      componentDidUpdate() {
+        throw new Error('no');
+      }
+      render() {
+        return null;
+      }
+    };
     console.error = error => {
       throw new Error('Buggy console.error');
     };

--- a/packages/react-dom/src/__tests__/ReactMultiChildReconcile-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChildReconcile-test.js
@@ -13,297 +13,312 @@ const React = require('react');
 const ReactDOMClient = require('react-dom/client');
 const act = require('internal-test-utils').act;
 
-const stripEmptyValues = function (obj) {
-  const ret = {};
-  for (const name in obj) {
-    if (!obj.hasOwnProperty(name)) {
-      continue;
-    }
-    if (obj[name] !== null && obj[name] !== undefined) {
-      ret[name] = obj[name];
-    }
-  }
-  return ret;
-};
-
-let idCounter = 123;
-
-/**
- * Contains internal static internal state in order to test that updates to
- * existing children won't reinitialize components, when moving children -
- * reusing existing DOM/memory resources.
- */
-class StatusDisplay extends React.Component {
-  state = {internalState: idCounter++};
-
-  getStatus() {
-    return this.props.status;
-  }
-
-  getInternalState() {
-    return this.state.internalState;
-  }
-
-  componentDidMount() {
-    this.props.onFlush();
-  }
-
-  componentDidUpdate() {
-    this.props.onFlush();
-  }
-
-  render() {
-    return <div>{this.props.contentKey}</div>;
-  }
-}
-
-/**
- * Displays friends statuses.
- */
-class FriendsStatusDisplay extends React.Component {
-  displays = {};
-
-  /**
-   * Gets the order directly from each rendered child's `index` field.
-   * Refs are not maintained in the rendered order, and neither is
-   * `this._renderedChildren` (surprisingly).
-   */
-  getOriginalKeys() {
-    const originalKeys = [];
-    for (const key in this.props.usernameToStatus) {
-      if (this.props.usernameToStatus[key]) {
-        originalKeys.push(key);
-      }
-    }
-    return originalKeys;
-  }
-
-  /**
-   * Retrieves the rendered children in a nice format for comparing to the input
-   * `this.props.usernameToStatus`.
-   */
-  getStatusDisplays() {
-    const res = {};
-    const originalKeys = this.getOriginalKeys();
-    for (let i = 0; i < originalKeys.length; i++) {
-      const key = originalKeys[i];
-      res[key] = this.displays[key];
-    }
-    return res;
-  }
-
-  /**
-   * Verifies that by the time a child is flushed, the refs that appeared
-   * earlier have already been resolved.
-   * TODO: This assumption will likely break with incremental reconciler
-   * but our internal layer API depends on this assumption. We need to change
-   * it to be more declarative before making ref resolution indeterministic.
-   */
-  verifyPreviousRefsResolved(flushedKey) {
-    const originalKeys = this.getOriginalKeys();
-    for (let i = 0; i < originalKeys.length; i++) {
-      const key = originalKeys[i];
-      if (key === flushedKey) {
-        // We are only interested in children up to the current key.
-        return;
-      }
-      expect(this.displays[key]).toBeTruthy();
-    }
-  }
-
-  render() {
-    const children = [];
-    for (const key in this.props.usernameToStatus) {
-      const status = this.props.usernameToStatus[key];
-      children.push(
-        !status ? null : (
-          <StatusDisplay
-            key={key}
-            ref={current => {
-              this.displays[key] = current;
-            }}
-            contentKey={key}
-            onFlush={this.verifyPreviousRefsResolved.bind(this, key)}
-            status={status}
-          />
-        ),
-      );
-    }
-    const childrenToRender = this.props.prepareChildren(children);
-    return <div>{childrenToRender}</div>;
-  }
-}
-
-function getInternalStateByUserName(statusDisplays) {
-  return Object.keys(statusDisplays).reduce((acc, key) => {
-    acc[key] = statusDisplays[key].getInternalState();
-    return acc;
-  }, {});
-}
-
-/**
- * Verifies that the rendered `StatusDisplay` instances match the `props` that
- * were responsible for allocating them. Checks the content of the user's status
- * message as well as the order of them.
- */
-function verifyStatuses(statusDisplays, props) {
-  const nonEmptyStatusDisplays = stripEmptyValues(statusDisplays);
-  const nonEmptyStatusProps = stripEmptyValues(props.usernameToStatus);
-  let username;
-  expect(Object.keys(nonEmptyStatusDisplays).length).toEqual(
-    Object.keys(nonEmptyStatusProps).length,
-  );
-  for (username in nonEmptyStatusDisplays) {
-    if (!nonEmptyStatusDisplays.hasOwnProperty(username)) {
-      continue;
-    }
-    expect(nonEmptyStatusDisplays[username].getStatus()).toEqual(
-      nonEmptyStatusProps[username],
-    );
-  }
-
-  // now go the other way to make sure we got them all.
-  for (username in nonEmptyStatusProps) {
-    if (!nonEmptyStatusProps.hasOwnProperty(username)) {
-      continue;
-    }
-    expect(nonEmptyStatusDisplays[username].getStatus()).toEqual(
-      nonEmptyStatusProps[username],
-    );
-  }
-
-  expect(Object.keys(nonEmptyStatusDisplays)).toEqual(
-    Object.keys(nonEmptyStatusProps),
-  );
-}
-
-/**
- * For all statusDisplays that existed in the previous iteration of the
- * sequence, verify that the state has been preserved. `StatusDisplay` contains
- * a unique number that allows us to track internal state across ordering
- * movements.
- */
-function verifyStatesPreserved(lastInternalStates, statusDisplays) {
-  let key;
-  for (key in statusDisplays) {
-    if (!statusDisplays.hasOwnProperty(key)) {
-      continue;
-    }
-    if (lastInternalStates[key]) {
-      expect(lastInternalStates[key]).toEqual(
-        statusDisplays[key].getInternalState(),
-      );
-    }
-  }
-}
-
-/**
- * Verifies that the internal representation of a set of `renderedChildren`
- * accurately reflects what is in the DOM.
- */
-function verifyDomOrderingAccurate(outerContainer, statusDisplays) {
-  const containerNode = outerContainer.firstChild;
-  const statusDisplayNodes = containerNode.childNodes;
-  const orderedDomKeys = [];
-  for (let i = 0; i < statusDisplayNodes.length; i++) {
-    const contentKey = statusDisplayNodes[i].textContent;
-    orderedDomKeys.push(contentKey);
-  }
-
-  const orderedLogicalKeys = [];
-  let username;
-  for (username in statusDisplays) {
-    if (!statusDisplays.hasOwnProperty(username)) {
-      continue;
-    }
-    const statusDisplay = statusDisplays[username];
-    orderedLogicalKeys.push(statusDisplay.props.contentKey);
-  }
-  expect(orderedDomKeys).toEqual(orderedLogicalKeys);
-}
-
-async function testPropsSequenceWithPreparedChildren(
-  sequence,
-  prepareChildren,
-) {
-  const container = document.createElement('div');
-  const root = ReactDOMClient.createRoot(container);
-  let parentInstance;
-  await act(() => {
-    root.render(
-      <FriendsStatusDisplay
-        {...sequence[0]}
-        prepareChildren={prepareChildren}
-        ref={current => {
-          if (parentInstance === undefined) {
-            parentInstance = current;
-          }
-        }}
-      />,
-    );
-  });
-  let statusDisplays = parentInstance.getStatusDisplays();
-  let lastInternalStates = getInternalStateByUserName(statusDisplays);
-  verifyStatuses(statusDisplays, sequence[0]);
-
-  for (let i = 1; i < sequence.length; i++) {
-    await act(() => {
-      root.render(
-        <FriendsStatusDisplay
-          {...sequence[i]}
-          prepareChildren={prepareChildren}
-        />,
-      );
-    });
-
-    statusDisplays = parentInstance.getStatusDisplays();
-    verifyStatuses(statusDisplays, sequence[i]);
-    verifyStatesPreserved(lastInternalStates, statusDisplays);
-    verifyDomOrderingAccurate(container, statusDisplays);
-
-    lastInternalStates = getInternalStateByUserName(statusDisplays);
-  }
-}
-
-function prepareChildrenArray(childrenArray) {
-  return childrenArray;
-}
-
-function prepareChildrenLegacyIterable(childrenArray) {
-  return {
-    '@@iterator': function* () {
-      // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-      for (const child of childrenArray) {
-        yield child;
-      }
-    },
-  };
-}
-
-function prepareChildrenModernIterable(childrenArray) {
-  return {
-    [Symbol.iterator]: function* () {
-      // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-      for (const child of childrenArray) {
-        yield child;
-      }
-    },
-  };
-}
-
-async function testPropsSequence(sequence) {
-  await testPropsSequenceWithPreparedChildren(sequence, prepareChildrenArray);
-  await testPropsSequenceWithPreparedChildren(
-    sequence,
-    prepareChildrenLegacyIterable,
-  );
-  await testPropsSequenceWithPreparedChildren(
-    sequence,
-    prepareChildrenModernIterable,
-  );
-}
+let StatusDisplay;
+let FriendsStatusDisplay;
+let getInternalStateByUserName;
+let verifyStatuses;
+let verifyStatesPreserved;
+let verifyDomOrderingAccurate;
+let testPropsSequenceWithPreparedChildren;
+let prepareChildrenArray;
+let prepareChildrenLegacyIterable;
+let prepareChildrenModernIterable;
+let testPropsSequence;
 
 describe('ReactMultiChildReconcile', () => {
+  beforeEach(() => {
+    let idCounter = 123;
+    const stripEmptyValues = function (obj) {
+      const ret = {};
+      for (const name in obj) {
+        if (!obj.hasOwnProperty(name)) {
+          continue;
+        }
+        if (obj[name] !== null && obj[name] !== undefined) {
+          ret[name] = obj[name];
+        }
+      }
+      return ret;
+    };
+
+    /**
+     * Contains internal static internal state in order to test that updates to
+     * existing children won't reinitialize components, when moving children -
+     * reusing existing DOM/memory resources.
+     */
+    StatusDisplay = class extends React.Component {
+      state = {internalState: idCounter++};
+
+      getStatus() {
+        return this.props.status;
+      }
+
+      getInternalState() {
+        return this.state.internalState;
+      }
+
+      componentDidMount() {
+        this.props.onFlush();
+      }
+
+      componentDidUpdate() {
+        this.props.onFlush();
+      }
+
+      render() {
+        return <div>{this.props.contentKey}</div>;
+      }
+    };
+
+    /**
+     * Displays friends statuses.
+     */
+    FriendsStatusDisplay = class extends React.Component {
+      displays = {};
+
+      /**
+       * Gets the order directly from each rendered child's `index` field.
+       * Refs are not maintained in the rendered order, and neither is
+       * `this._renderedChildren` (surprisingly).
+       */
+      getOriginalKeys() {
+        const originalKeys = [];
+        for (const key in this.props.usernameToStatus) {
+          if (this.props.usernameToStatus[key]) {
+            originalKeys.push(key);
+          }
+        }
+        return originalKeys;
+      }
+
+      /**
+       * Retrieves the rendered children in a nice format for comparing to the input
+       * `this.props.usernameToStatus`.
+       */
+      getStatusDisplays() {
+        const res = {};
+        const originalKeys = this.getOriginalKeys();
+        for (let i = 0; i < originalKeys.length; i++) {
+          const key = originalKeys[i];
+          res[key] = this.displays[key];
+        }
+        return res;
+      }
+
+      /**
+       * Verifies that by the time a child is flushed, the refs that appeared
+       * earlier have already been resolved.
+       * TODO: This assumption will likely break with incremental reconciler
+       * but our internal layer API depends on this assumption. We need to change
+       * it to be more declarative before making ref resolution indeterministic.
+       */
+      verifyPreviousRefsResolved(flushedKey) {
+        const originalKeys = this.getOriginalKeys();
+        for (let i = 0; i < originalKeys.length; i++) {
+          const key = originalKeys[i];
+          if (key === flushedKey) {
+            // We are only interested in children up to the current key.
+            return;
+          }
+          expect(this.displays[key]).toBeTruthy();
+        }
+      }
+
+      render() {
+        const children = [];
+        for (const key in this.props.usernameToStatus) {
+          const status = this.props.usernameToStatus[key];
+          children.push(
+            !status ? null : (
+              <StatusDisplay
+                key={key}
+                ref={current => {
+                  this.displays[key] = current;
+                }}
+                contentKey={key}
+                onFlush={this.verifyPreviousRefsResolved.bind(this, key)}
+                status={status}
+              />
+            ),
+          );
+        }
+        const childrenToRender = this.props.prepareChildren(children);
+        return <div>{childrenToRender}</div>;
+      }
+    };
+
+    getInternalStateByUserName = function (statusDisplays) {
+      return Object.keys(statusDisplays).reduce((acc, key) => {
+        acc[key] = statusDisplays[key].getInternalState();
+        return acc;
+      }, {});
+    };
+
+    /**
+     * Verifies that the rendered `StatusDisplay` instances match the `props` that
+     * were responsible for allocating them. Checks the content of the user's status
+     * message as well as the order of them.
+     */
+    verifyStatuses = function (statusDisplays, props) {
+      const nonEmptyStatusDisplays = stripEmptyValues(statusDisplays);
+      const nonEmptyStatusProps = stripEmptyValues(props.usernameToStatus);
+      let username;
+      expect(Object.keys(nonEmptyStatusDisplays).length).toEqual(
+        Object.keys(nonEmptyStatusProps).length,
+      );
+      for (username in nonEmptyStatusDisplays) {
+        if (!nonEmptyStatusDisplays.hasOwnProperty(username)) {
+          continue;
+        }
+        expect(nonEmptyStatusDisplays[username].getStatus()).toEqual(
+          nonEmptyStatusProps[username],
+        );
+      }
+
+      // now go the other way to make sure we got them all.
+      for (username in nonEmptyStatusProps) {
+        if (!nonEmptyStatusProps.hasOwnProperty(username)) {
+          continue;
+        }
+        expect(nonEmptyStatusDisplays[username].getStatus()).toEqual(
+          nonEmptyStatusProps[username],
+        );
+      }
+
+      expect(Object.keys(nonEmptyStatusDisplays)).toEqual(
+        Object.keys(nonEmptyStatusProps),
+      );
+    };
+
+    /**
+     * For all statusDisplays that existed in the previous iteration of the
+     * sequence, verify that the state has been preserved. `StatusDisplay` contains
+     * a unique number that allows us to track internal state across ordering
+     * movements.
+     */
+    verifyStatesPreserved = function (lastInternalStates, statusDisplays) {
+      let key;
+      for (key in statusDisplays) {
+        if (!statusDisplays.hasOwnProperty(key)) {
+          continue;
+        }
+        if (lastInternalStates[key]) {
+          expect(lastInternalStates[key]).toEqual(
+            statusDisplays[key].getInternalState(),
+          );
+        }
+      }
+    };
+
+    /**
+     * Verifies that the internal representation of a set of `renderedChildren`
+     * accurately reflects what is in the DOM.
+     */
+    verifyDomOrderingAccurate = function (outerContainer, statusDisplays) {
+      const containerNode = outerContainer.firstChild;
+      const statusDisplayNodes = containerNode.childNodes;
+      const orderedDomKeys = [];
+      for (let i = 0; i < statusDisplayNodes.length; i++) {
+        const contentKey = statusDisplayNodes[i].textContent;
+        orderedDomKeys.push(contentKey);
+      }
+
+      const orderedLogicalKeys = [];
+      let username;
+      for (username in statusDisplays) {
+        if (!statusDisplays.hasOwnProperty(username)) {
+          continue;
+        }
+        const statusDisplay = statusDisplays[username];
+        orderedLogicalKeys.push(statusDisplay.props.contentKey);
+      }
+      expect(orderedDomKeys).toEqual(orderedLogicalKeys);
+    };
+
+    testPropsSequenceWithPreparedChildren = async function (
+      sequence,
+      prepareChildren,
+    ) {
+      const container = document.createElement('div');
+      const root = ReactDOMClient.createRoot(container);
+      let parentInstance;
+      await act(() => {
+        root.render(
+          <FriendsStatusDisplay
+            {...sequence[0]}
+            prepareChildren={prepareChildren}
+            ref={current => {
+              if (parentInstance === undefined) {
+                parentInstance = current;
+              }
+            }}
+          />,
+        );
+      });
+      let statusDisplays = parentInstance.getStatusDisplays();
+      let lastInternalStates = getInternalStateByUserName(statusDisplays);
+      verifyStatuses(statusDisplays, sequence[0]);
+
+      for (let i = 1; i < sequence.length; i++) {
+        await act(() => {
+          root.render(
+            <FriendsStatusDisplay
+              {...sequence[i]}
+              prepareChildren={prepareChildren}
+            />,
+          );
+        });
+
+        statusDisplays = parentInstance.getStatusDisplays();
+        verifyStatuses(statusDisplays, sequence[i]);
+        verifyStatesPreserved(lastInternalStates, statusDisplays);
+        verifyDomOrderingAccurate(container, statusDisplays);
+
+        lastInternalStates = getInternalStateByUserName(statusDisplays);
+      }
+    };
+
+    prepareChildrenArray = function (childrenArray) {
+      return childrenArray;
+    };
+
+    prepareChildrenLegacyIterable = function (childrenArray) {
+      return {
+        '@@iterator': function* () {
+          // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+          for (const child of childrenArray) {
+            yield child;
+          }
+        },
+      };
+    };
+
+    prepareChildrenModernIterable = function (childrenArray) {
+      return {
+        [Symbol.iterator]: function* () {
+          // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+          for (const child of childrenArray) {
+            yield child;
+          }
+        },
+      };
+    };
+
+    testPropsSequence = async function (sequence) {
+      await testPropsSequenceWithPreparedChildren(
+        sequence,
+        prepareChildrenArray,
+      );
+      await testPropsSequenceWithPreparedChildren(
+        sequence,
+        prepareChildrenLegacyIterable,
+      );
+      await testPropsSequenceWithPreparedChildren(
+        sequence,
+        prepareChildrenModernIterable,
+      );
+    };
+  });
   it('should reset internal state if removed then readded in an array', async () => {
     // Test basics.
     const props = {

--- a/packages/react-dom/src/__tests__/multiple-copies-of-react-test.js
+++ b/packages/react-dom/src/__tests__/multiple-copies-of-react-test.js
@@ -9,19 +9,26 @@
 
 'use strict';
 
-let React = require('react');
-const ReactDOMClient = require('react-dom/client');
-const act = require('internal-test-utils').act;
+let React;
+let ReactDOMClient;
+let act;
 
-class TextWithStringRef extends React.Component {
-  render() {
-    jest.resetModules();
-    React = require('react');
-    return <span ref="foo">Hello world!</span>;
-  }
-}
+let TextWithStringRef;
 
 describe('when different React version is used with string ref', () => {
+  beforeEach(() => {
+    React = require('react');
+    ReactDOMClient = require('react-dom/client');
+    act = require('internal-test-utils').act;
+
+    TextWithStringRef = class extends React.Component {
+      render() {
+        jest.resetModules();
+        React = require('react');
+        return <span ref="foo">Hello world!</span>;
+      }
+    };
+  });
   it('throws the "Refs must have owner" warning', async () => {
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);

--- a/packages/react-reconciler/src/__tests__/useEffectEvent-test.js
+++ b/packages/react-reconciler/src/__tests__/useEffectEvent-test.js
@@ -12,11 +12,12 @@
 
 'use strict';
 
+const React = require('react');
+const ReactNoop = require('react-noop-renderer');
+const Scheduler = require('scheduler');
+const act = require('internal-test-utils').act;
+
 describe('useEffectEvent', () => {
-  let React;
-  let ReactNoop;
-  let Scheduler;
-  let act;
   let createContext;
   let useContext;
   let useState;
@@ -30,11 +31,6 @@ describe('useEffectEvent', () => {
   let waitForThrow;
 
   beforeEach(() => {
-    React = require('react');
-    ReactNoop = require('react-noop-renderer');
-    Scheduler = require('scheduler');
-
-    act = require('internal-test-utils').act;
     createContext = React.createContext;
     useContext = React.useContext;
     useState = React.useState;

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-const ReactFeatureFlags = require('shared/ReactFeatureFlags');
-ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 const React = require('react');
 const ReactTestRenderer = require('react-test-renderer');
 const {format: prettyFormat} = require('pretty-format');
@@ -49,6 +47,11 @@ function cleanNodeOrArray(node) {
     cleanNodeOrArray(node.rendered);
   }
 }
+
+beforeEach(() => {
+  const ReactFeatureFlags = require('shared/ReactFeatureFlags');
+  ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
+});
 
 describe('ReactTestRenderer', () => {
   it('renders a simple component', () => {
@@ -288,7 +291,8 @@ describe('ReactTestRenderer', () => {
     expect(() => ReactTestRenderer.create(<Foo />)).toErrorDev(
       'Warning: Function components cannot be given refs. Attempts ' +
         'to access this ref will fail. ' +
-        'Did you mean to use React.forwardRef()?\n' +
+        'Did you mean to use React.forwardRef()?\n\n' +
+        'Check the render method of `Foo`.\n' +
         '    in Bar (at **)\n' +
         '    in Foo (at **)',
     );

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
@@ -18,54 +18,59 @@ const RCTView = 'RCTView';
 const View = props => <RCTView {...props} />;
 
 describe('ReactTestRendererTraversal', () => {
+  let Example;
+  let ExampleSpread;
+  let ExampleFn;
+  let ExampleNull;
+  let ExampleForwardRef;
   beforeEach(() => {
     ReactTestRenderer = require('react-test-renderer');
     Context = React.createContext(null);
-  });
 
-  class Example extends React.Component {
-    render() {
-      return (
-        <View>
-          <View foo="foo">
-            <View bar="bar" />
-            <View bar="bar" baz="baz" itself="itself" />
-            <View />
-            <ExampleSpread bar="bar" />
-            <ExampleFn bar="bar" bing="bing" />
-            <ExampleNull bar="bar" />
-            <ExampleNull null="null">
-              <View void="void" />
-              <View void="void" />
-            </ExampleNull>
-            <React.Profiler id="test" onRender={() => {}}>
-              <ExampleForwardRef qux="qux" />
-            </React.Profiler>
-            <>
+    Example = class extends React.Component {
+      render() {
+        return (
+          <View>
+            <View foo="foo">
+              <View bar="bar" />
+              <View bar="bar" baz="baz" itself="itself" />
+              <View />
+              <ExampleSpread bar="bar" />
+              <ExampleFn bar="bar" bing="bing" />
+              <ExampleNull bar="bar" />
+              <ExampleNull null="null">
+                <View void="void" />
+                <View void="void" />
+              </ExampleNull>
+              <React.Profiler id="test" onRender={() => {}}>
+                <ExampleForwardRef qux="qux" />
+              </React.Profiler>
               <>
-                <Context.Provider value={null}>
-                  <Context.Consumer>
-                    {() => <View nested={true} />}
-                  </Context.Consumer>
-                </Context.Provider>
+                <>
+                  <Context.Provider value={null}>
+                    <Context.Consumer>
+                      {() => <View nested={true} />}
+                    </Context.Consumer>
+                  </Context.Provider>
+                </>
+                <View nested={true} />
+                <View nested={true} />
               </>
-              <View nested={true} />
-              <View nested={true} />
-            </>
+            </View>
           </View>
-        </View>
-      );
-    }
-  }
-  class ExampleSpread extends React.Component {
-    render = () => <View {...this.props} />;
-  }
-  const ExampleFn = props => <View baz="baz" />;
-  const ExampleNull = props => null;
+        );
+      }
+    };
+    ExampleSpread = class extends React.Component {
+      render = () => <View {...this.props} />;
+    };
+    ExampleFn = props => <View baz="baz" />;
+    ExampleNull = props => null;
 
-  const ExampleForwardRef = React.forwardRef((props, ref) => (
-    <View {...props} ref={ref} />
-  ));
+    ExampleForwardRef = React.forwardRef((props, ref) => (
+      <View {...props} ref={ref} />
+    ));
+  });
 
   it('initializes', () => {
     const render = ReactTestRenderer.create(<Example />);

--- a/packages/react/src/__tests__/ReactCreateElement-test.js
+++ b/packages/react/src/__tests__/ReactCreateElement-test.js
@@ -9,10 +9,9 @@
 
 'use strict';
 
-let act;
-
-let React;
-let ReactDOMClient;
+const React = require('react');
+const ReactDOMClient = require('react-dom/client');
+const act = require('internal-test-utils').act;
 
 // NOTE: This module tests the old, "classic" JSX runtime, React.createElement.
 // Do not use JSX syntax in this module; call React.createElement directly.
@@ -20,10 +19,6 @@ describe('ReactCreateElement', () => {
   let ComponentClass;
 
   beforeEach(() => {
-    act = require('internal-test-utils').act;
-
-    React = require('react');
-    ReactDOMClient = require('react-dom/client');
     ComponentClass = class extends React.Component {
       render() {
         return React.createElement('div');

--- a/scripts/babel/__tests__/__snapshots__/transform-reset-requires-test.js.snap
+++ b/scripts/babel/__tests__/__snapshots__/transform-reset-requires-test.js.snap
@@ -1,0 +1,163 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`transformPlugin inserts before each at top 1`] = `
+"### Before
+
+const React = require('react');
+describe('test', () => {
+
+});
+
+
+### After
+let React;
+beforeEach(() => {
+  React = require("react");
+});
+describe('test', () => {});"
+`;
+
+exports[`transformPlugin transforms act correctly 1`] = `
+"### Before
+const act = require('internal-test-utils').act;
+
+### After
+let act;
+beforeEach(() => {
+  act = require("internal-test-utils").act;
+});"
+`;
+
+exports[`transformPlugin transforms all imports correctly 1`] = `
+"### Before
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+const ReactDOMClient = require('react-dom/client');
+const act = require('internal-test-utils').act;
+
+
+### After
+let act;
+let ReactDOMClient;
+let ReactDOM;
+let React;
+beforeEach(() => {
+  React = require("react");
+  ReactDOM = require("react-dom");
+  ReactDOMClient = require("react-dom/client");
+  act = require("internal-test-utils").act;
+});"
+`;
+
+exports[`transformPlugin transforms babel output correctly 1`] = `
+"### Before
+
+var React = require('react');var _React = React,
+startTransition = _React.startTransition,useDeferredValue = _React.useDeferredValue;
+var ReactNoop = require('react-noop-renderer');var _require = require('internal-test-utils'),waitFor = _require.waitFor,waitForAll = _require.waitForAll,waitForPaint = _require.waitForPaint,waitForThrow = _require.waitForThrow,assertLog = _require.assertLog;
+var act = require('internal-test-utils').act;
+
+
+### After
+let assertLog;
+let waitForThrow;
+let waitForPaint;
+let waitForAll;
+let waitFor;
+let useDeferredValue;
+let startTransition;
+let act;
+
+let _React;
+
+let _require;
+
+let ReactNoop;
+let React;
+beforeEach(() => {
+  React = require("react");
+  ReactNoop = require("react-noop-renderer");
+  _require = require("internal-test-utils");
+  _React = React;
+  act = require("internal-test-utils").act;
+  startTransition = _React.startTransition;
+  useDeferredValue = _React.useDeferredValue;
+  waitFor = _require.waitFor;
+  waitForAll = _require.waitForAll;
+  waitForPaint = _require.waitForPaint;
+  waitForThrow = _require.waitForThrow;
+  assertLog = _require.assertLog;
+});"
+`;
+
+exports[`transformPlugin transforms destructured imports correctly 1`] = `
+"### Before
+
+const React = require('react');
+const {startTransition, useDeferredValue} = React;
+const {
+  waitFor,
+  waitForAll,
+  waitForPaint,
+  waitForThrow,
+  assertLog,
+  act,
+} = require('internal-test-utils');
+
+
+### After
+let act;
+let assertLog;
+let waitForThrow;
+let waitForPaint;
+let waitForAll;
+let waitFor;
+let useDeferredValue;
+let startTransition;
+let React;
+beforeEach(() => {
+  React = require("react");
+  startTransition = React.startTransition;
+  useDeferredValue = React.useDeferredValue;
+  waitFor = require("internal-test-utils").waitFor;
+  waitForAll = require("internal-test-utils").waitForAll;
+  waitForPaint = require("internal-test-utils").waitForPaint;
+  waitForThrow = require("internal-test-utils").waitForThrow;
+  assertLog = require("internal-test-utils").assertLog;
+  act = require("internal-test-utils").act;
+});"
+`;
+
+exports[`transformPlugin transforms require('react') correctly 1`] = `
+"### Before
+const React = require('react');
+
+### After
+let React;
+beforeEach(() => {
+  React = require("react");
+});"
+`;
+
+exports[`transformPlugin transforms require('react-dom') correctly 1`] = `
+"### Before
+const ReactDOM = require('react-dom');
+
+### After
+let ReactDOM;
+beforeEach(() => {
+  ReactDOM = require("react-dom");
+});"
+`;
+
+exports[`transformPlugin transforms require('react-dom/client') correctly 1`] = `
+"### Before
+const ReactDOMClient = require('react-dom/client');
+
+### After
+let ReactDOMClient;
+beforeEach(() => {
+  ReactDOMClient = require("react-dom/client");
+});"
+`;

--- a/scripts/babel/__tests__/transform-reset-requires-test.js
+++ b/scripts/babel/__tests__/transform-reset-requires-test.js
@@ -1,0 +1,169 @@
+'use strict';
+
+const babel = require('@babel/core');
+const myPlugin = require('../transform-reset-requires'); // Adjust the path to where your plugin is located
+
+const transform = code => {
+  return babel.transform(code, {
+    configFile: false,
+    plugins: [
+      // require.resolve('@babel/plugin-transform-modules-commonjs'),
+      [
+        myPlugin,
+        {
+          moduleNames: [
+            'react',
+            'react-dom',
+            'react-dom/client',
+            'internal-test-utils',
+            'scheduler',
+            'react-noop-renderer',
+            'scheduler/unstable_mock',
+          ],
+        },
+      ],
+    ],
+  }).code;
+};
+
+function normalizeIndent(strings) {
+  const codeLines = strings[0].split('\n');
+  const leftPadding = codeLines[1].match(/\s+/)[0];
+  return codeLines.map(line => line.slice(leftPadding.length)).join('\n');
+}
+
+function formatSnapshot(inputCode) {
+  return `### Before\n${inputCode}\n\n### After\n${transform(inputCode)}`;
+}
+expect.extend({
+  toEqualIgnoringWhitespace(received, expected) {
+    const normalizeWhitespace = str => str.replace(/\s+/g, ' ').trim();
+    const normalizedReceived = normalizeWhitespace(received);
+    const normalizedExpected = normalizeWhitespace(expected);
+
+    if (normalizedReceived === normalizedExpected) {
+      return {
+        message: () =>
+          `expected ${received} not to equal (ignoring whitespace) ${expected}`,
+        pass: true,
+      };
+    } else {
+      return {
+        message: () =>
+          `expected ${received} to equal (ignoring whitespace) ${expected}`,
+        pass: false,
+      };
+    }
+  },
+});
+
+describe('transformPlugin', () => {
+  it("transforms require('react') correctly", () => {
+    const inputCode = `const React = require('react');`;
+
+    expect(formatSnapshot(inputCode)).toMatchSnapshot();
+  });
+
+  it("transforms require('react-dom') correctly", () => {
+    const inputCode = `const ReactDOM = require('react-dom');`;
+
+    expect(formatSnapshot(inputCode)).toMatchSnapshot();
+  });
+
+  it("transforms require('react-dom/client') correctly", () => {
+    const inputCode = `const ReactDOMClient = require('react-dom/client');`;
+
+    expect(formatSnapshot(inputCode)).toMatchSnapshot();
+  });
+
+  it('transforms act correctly', () => {
+    const inputCode = `const act = require('internal-test-utils').act;`;
+
+    expect(formatSnapshot(inputCode)).toMatchSnapshot();
+  });
+
+  it('transforms destructured imports correctly', () => {
+    const inputCode = normalizeIndent`
+      const React = require('react');
+      const {startTransition, useDeferredValue} = React;
+      const {
+        waitFor,
+        waitForAll,
+        waitForPaint,
+        waitForThrow,
+        assertLog,
+        act,
+      } = require('internal-test-utils');
+    `;
+
+    expect(formatSnapshot(inputCode)).toMatchSnapshot();
+  });
+
+  it('transforms babel output correctly', () => {
+    const inputCode = normalizeIndent`
+    var React = require('react');var _React = React,
+    startTransition = _React.startTransition,useDeferredValue = _React.useDeferredValue;
+    var ReactNoop = require('react-noop-renderer');var _require = require('internal-test-utils'),waitFor = _require.waitFor,waitForAll = _require.waitForAll,waitForPaint = _require.waitForPaint,waitForThrow = _require.waitForThrow,assertLog = _require.assertLog;
+    var act = require('internal-test-utils').act;
+    `;
+
+    expect(formatSnapshot(inputCode)).toMatchSnapshot();
+  });
+
+  it('transforms all imports correctly', () => {
+    const inputCode = normalizeIndent`
+      const React = require('react');
+      const ReactDOM = require('react-dom');
+      const ReactDOMClient = require('react-dom/client');
+      const act = require('internal-test-utils').act;
+    `;
+
+    expect(formatSnapshot(inputCode)).toMatchSnapshot();
+  });
+
+  it('inserts before each at top', () => {
+    const inputCode = normalizeIndent`
+      const React = require('react');
+      describe('test', () => {
+
+      });
+    `;
+
+    expect(formatSnapshot(inputCode)).toMatchSnapshot();
+  });
+
+  it('does not transform non-configured modules', () => {
+    const inputCode = `const moment = require('moment');`;
+    const outputCode = transform(inputCode);
+
+    expect(outputCode).toEqualIgnoringWhitespace(inputCode);
+  });
+
+  it('does not transform nested imports', () => {
+    const inputCode = normalizeIndent`
+      describe(() => {
+        const React = require('react');
+        const ReactDOM = require('react-dom');
+        const ReactDOMClient = require('react-dom/client');
+      });
+    `;
+    const outputCode = transform(inputCode);
+
+    expect(outputCode).toEqualIgnoringWhitespace(inputCode);
+  });
+
+  it('does not transform lets in the existing pattern', () => {
+    const inputCode = normalizeIndent`
+    let React;
+    let ReactDOM;
+    let ReactDOMClient;
+    beforeEach(() => {
+      React = require('react');
+      ReactDOM = require('react-dom');
+      ReactDOMClient = require('react-dom/client');
+    });`;
+    const outputCode = transform(inputCode);
+
+    expect(outputCode).toEqualIgnoringWhitespace(inputCode);
+  });
+});

--- a/scripts/babel/transform-reset-requires.js
+++ b/scripts/babel/transform-reset-requires.js
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+module.exports = function (babel) {
+  const {types: t} = babel;
+
+  return {
+    visitor: {
+      Program: {
+        enter(path, state) {
+          // Initialize state for different types of requires
+          state.requires = [];
+          state.propertyAccesses = [];
+          state.destructured = [];
+          state.destructuredDirectly = [];
+          state.assignments = [];
+          state.aliases = [];
+        },
+        exit(path, state) {
+          // Deduplicate and create let declarations for all identifiers
+          const allIdentifiers = new Set([
+            ...state.requires.map(req => req.varName),
+            ...state.aliases.map(alias => alias.alias),
+            ...state.propertyAccesses.map(access => access.varName),
+            ...state.destructured.flatMap(d => d.identifiers),
+            ...state.assignments.map(assignment => assignment.varName),
+            ...state.destructuredDirectly.flatMap(d =>
+              d.identifiers.map(id => id.varName)
+            ), // Adjusted
+          ]);
+
+          // Prepare and insert the beforeEach block
+          const assignments = [
+            ...state.requires.map(req =>
+              t.expressionStatement(
+                t.assignmentExpression(
+                  '=',
+                  t.identifier(req.varName),
+                  t.callExpression(t.identifier('require'), [
+                    t.stringLiteral(req.moduleName),
+                  ])
+                )
+              )
+            ),
+            ...state.aliases
+              .filter(alias =>
+                state.requires.find(imp => imp.varName === alias.original)
+              )
+              .map(alias =>
+                t.expressionStatement(
+                  t.assignmentExpression(
+                    '=',
+                    t.identifier(alias.alias),
+                    t.identifier(alias.original) // Assign the alias to the original imported module
+                  )
+                )
+              ),
+            ...state.propertyAccesses.map(access =>
+              t.expressionStatement(
+                t.assignmentExpression(
+                  '=',
+                  t.identifier(access.varName),
+                  t.memberExpression(
+                    t.callExpression(t.identifier('require'), [
+                      t.stringLiteral(access.moduleName),
+                    ]),
+                    t.identifier(access.property)
+                  )
+                )
+              )
+            ),
+            ...state.destructured.flatMap(d =>
+              d.identifiers.map(identifier =>
+                t.expressionStatement(
+                  t.assignmentExpression(
+                    '=',
+                    t.identifier(identifier),
+                    t.memberExpression(
+                      t.identifier(d.from),
+                      t.identifier(identifier)
+                    )
+                  )
+                )
+              )
+            ),
+            ...state.destructuredDirectly.flatMap(d =>
+              d.identifiers.map(({varName, property}) =>
+                t.expressionStatement(
+                  t.assignmentExpression(
+                    '=',
+                    t.identifier(varName),
+                    t.memberExpression(
+                      t.callExpression(t.identifier('require'), [
+                        t.stringLiteral(d.moduleName),
+                      ]),
+                      t.identifier(property)
+                    )
+                  )
+                )
+              )
+            ),
+            ...state.assignments.map(assignment =>
+              t.expressionStatement(
+                t.assignmentExpression(
+                  '=',
+                  t.identifier(assignment.varName),
+                  t.memberExpression(
+                    t.identifier(assignment.fromVarName),
+                    t.identifier(assignment.property)
+                  )
+                )
+              )
+            ),
+          ];
+
+          if (assignments.length > 0) {
+            const beforeEachBlock = t.expressionStatement(
+              t.callExpression(t.identifier('beforeEach'), [
+                t.arrowFunctionExpression([], t.blockStatement(assignments)),
+              ])
+            );
+            path.node.body.unshift(beforeEachBlock); // Add beforeEach after let declarations
+            allIdentifiers.forEach(varName => {
+              path.node.body.unshift(
+                t.variableDeclaration('let', [
+                  t.variableDeclarator(t.identifier(varName)),
+                ])
+              );
+            });
+          }
+        },
+      },
+      VariableDeclaration(path, state) {
+        if (path.parentPath.type === 'Program') {
+          path.node.declarations.forEach(declaration => {
+            // Handle direct require calls
+            if (
+              t.isObjectPattern(declaration.id) &&
+              t.isCallExpression(declaration.init) &&
+              t.isIdentifier(declaration.init.callee, {name: 'require'}) &&
+              declaration.init.arguments.length === 1 &&
+              t.isStringLiteral(declaration.init.arguments[0])
+            ) {
+              const moduleName = declaration.init.arguments[0].value;
+              const identifiers = declaration.id.properties.map(prop => ({
+                varName: prop.key.name, // Capture the variable name from the destructured property
+                property: prop.key.name, // Assuming property name matches variable name; adjust if needed
+              }));
+              state.destructuredDirectly.push({moduleName, identifiers});
+              path.remove();
+            } else if (
+              t.isCallExpression(declaration.init) &&
+              t.isIdentifier(declaration.init.callee, {name: 'require'}) &&
+              declaration.init.arguments.length === 1 &&
+              t.isStringLiteral(declaration.init.arguments[0])
+            ) {
+              const moduleName = declaration.init.arguments[0].value;
+              if (state.opts.moduleNames.includes(moduleName)) {
+                state.requires.push({
+                  varName: declaration.id.name,
+                  moduleName,
+                });
+                path.remove();
+              }
+            } else if (
+              t.isMemberExpression(declaration.init) &&
+              t.isCallExpression(declaration.init.object) &&
+              t.isIdentifier(declaration.init.object.callee, {
+                name: 'require',
+              }) &&
+              declaration.init.object.arguments.length === 1 &&
+              t.isStringLiteral(declaration.init.object.arguments[0])
+            ) {
+              // Handle require call with property access
+              const moduleName = declaration.init.object.arguments[0].value;
+              const property = declaration.init.property.name;
+              const varName = declaration.id.name;
+              if (state.opts.moduleNames.includes(moduleName)) {
+                state.propertyAccesses.push({varName, moduleName, property});
+                path.remove();
+              }
+            } else if (
+              t.isObjectPattern(declaration.id) &&
+              t.isIdentifier(declaration.init)
+            ) {
+              // Handle destructuring from a previously required variable
+              const fromVarName = declaration.init.name;
+              const identifiers = declaration.id.properties.map(
+                prop => prop.key.name
+              );
+              if (
+                state.requires.find(req => req.varName === fromVarName) ||
+                state.propertyAccesses.find(
+                  access => access.varName === fromVarName
+                )
+              ) {
+                state.destructured.push({from: fromVarName, identifiers});
+                path.remove();
+              }
+            } else if (t.isMemberExpression(declaration.init)) {
+              // Handle variable assignments from an imported module
+              const fromVarName = declaration.init.object.name;
+              const varName = declaration.id.name;
+              if (
+                state.requires.some(req => req.varName === fromVarName) ||
+                state.aliases.some(req => req.alias === fromVarName)
+              ) {
+                // Assume property name matches variable name; adjust if needed
+                state.assignments.push({
+                  fromVarName,
+                  varName,
+                  property: varName,
+                });
+                if (!path.removed) {
+                  path.remove();
+                }
+              }
+            } else if (
+              t.isIdentifier(declaration.init) &&
+              state.requires.find(imp => imp.varName === declaration.init.name)
+            ) {
+              // Aliases of those requires
+              const originalName = declaration.init.name;
+              const alias = declaration.id.name;
+              state.aliases.push({original: originalName, alias});
+            }
+          });
+        }
+      },
+    },
+  };
+};

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -19,6 +19,9 @@ const pathToBabel = path.join(
 const pathToBabelPluginReplaceConsoleCalls = require.resolve(
   '../babel/transform-replace-console-calls'
 );
+const pathToBabelPluginResetRequires = require.resolve(
+  '../babel/transform-reset-requires'
+);
 const pathToTransformInfiniteLoops = require.resolve(
   '../babel/transform-prevent-infinite-loops'
 );
@@ -73,7 +76,25 @@ module.exports = {
       const isInDevToolsPackages = !!filePath.match(
         /\/packages\/react-devtools.*\//
       );
-      const testOnlyPlugins = [];
+      const testOnlyPlugins = [
+        [
+          pathToBabelPluginResetRequires,
+          {
+            moduleNames: [
+              'react',
+              'react-dom',
+              'react-dom/client',
+              'internal-test-utils',
+              'scheduler',
+              'react-noop-renderer',
+              'scheduler/unstable_mock',
+              'react-dom/test-utils',
+              'shared/ReactFeatureFlags',
+              'react-test-renderer',
+            ],
+          },
+        ],
+      ];
       const sourceOnlyPlugins = [];
       if (process.env.NODE_ENV === 'development' && !isInDevToolsPackages) {
         sourceOnlyPlugins.push(pathToBabelPluginReplaceConsoleCalls);
@@ -104,7 +125,7 @@ module.exports = {
       }
 
       let sourceAst = hermesParser.parse(src, {babel: true});
-      return {
+      const result = {
         code: babel.transformFromAstSync(
           sourceAst,
           src,
@@ -120,6 +141,11 @@ module.exports = {
           )
         ).code,
       };
+      if (isTestFile) {
+        // console.log('test23', result.code);
+      }
+
+      return result;
     }
     return {code: src};
   },


### PR DESCRIPTION
## [WIP] Overview

Adds a transform that will transform imports like:

```js
const React = require('react');
```

to this:

```js
let React;
beforeEach(() => {
  React = require('react');
});
```

Combined with the last change to run `jest.resetModules()` between each test, this will reset the React/ReactDOM/etc import for each test. This means we can codemod the ugly manually way of doing this now, but it can result in some strange test failures.

