### PR TITLE
DevTools: Add support for use(Promise)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -450,6 +450,13 @@ module.exports = {
         __IS_EDGE__: 'readonly',
       },
     },
+    {
+      files: ['packages/react-devtools-shell/**/*.js'],
+      rules: {
+        // DevTools shell is an internal app not published to NPM
+        'react-internal/prod-error-codes': 'off',
+      },
+    },
   ],
 
   env: {


### PR DESCRIPTION
## Summary

Adds support for Devtools to display the fulfilled value of promises passed to `use`. 

The other cases would suspend so I don't think we need to handle them in devtools anyway.

## How did you test this change?

Added new cases to shell under `FunctionWithUse`:

https://github.com/facebook/react/assets/12292047/8e5c2be1-324b-4004-a683-1f7913d9b26b


