### PR TITLE
[Fiber] Transfer `_debugInfo` from Arrays, Lazy, Thenables and Elements to the inner Fibers.

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -12,7 +12,6 @@ import type {
   ReactDebugInfo,
   ReactComponentInfo,
   ReactAsyncInfo,
-  ReactConsoleInfo,
 } from 'shared/ReactTypes';
 import type {LazyComponent} from 'react/src/ReactLazy';
 
@@ -1017,7 +1016,7 @@ function resolveHint<Code: HintCode>(
 function resolveDebugInfo(
   response: Response,
   id: number,
-  debugInfo: ReactComponentInfo | ReactAsyncInfo | ReactConsoleInfo,
+  debugInfo: ReactComponentInfo | ReactAsyncInfo,
 ): void {
   if (!__DEV__) {
     // These errors should never make it into a build so we don't need to encode them in codes.json

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -7,7 +7,13 @@
  * @flow
  */
 
-import type {Thenable} from 'shared/ReactTypes';
+import type {
+  Thenable,
+  ReactDebugInfo,
+  ReactComponentInfo,
+  ReactAsyncInfo,
+  ReactConsoleInfo,
+} from 'shared/ReactTypes';
 import type {LazyComponent} from 'react/src/ReactLazy';
 
 import type {
@@ -75,9 +81,6 @@ const RESOLVED_MODEL = 'resolved_model';
 const RESOLVED_MODULE = 'resolved_module';
 const INITIALIZED = 'fulfilled';
 const ERRORED = 'rejected';
-
-// Dev-only
-type ReactDebugInfo = Array<{+name?: string, +env?: string}>;
 
 type PendingChunk<T> = {
   status: 'pending',
@@ -1014,7 +1017,7 @@ function resolveHint<Code: HintCode>(
 function resolveDebugInfo(
   response: Response,
   id: number,
-  debugInfo: {name: string},
+  debugInfo: ReactComponentInfo | ReactAsyncInfo | ReactConsoleInfo,
 ): void {
   if (!__DEV__) {
     // These errors should never make it into a build so we don't need to encode them in codes.json

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -201,7 +201,7 @@ function FiberNode(
 
   if (__DEV__) {
     // This isn't directly used but is handy for debugging internals:
-
+    this._debugInfo = null;
     this._debugOwner = null;
     this._debugNeedsRemount = false;
     this._debugHookTypes = null;
@@ -347,6 +347,7 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
   }
 
   if (__DEV__) {
+    workInProgress._debugInfo = current._debugInfo;
     workInProgress._debugNeedsRemount = current._debugNeedsRemount;
     switch (workInProgress.tag) {
       case IndeterminateComponent:
@@ -911,6 +912,7 @@ export function assignFiberPropertiesInDEV(
     target.treeBaseDuration = source.treeBaseDuration;
   }
 
+  target._debugInfo = source._debugInfo;
   target._debugOwner = source._debugOwner;
   target._debugNeedsRemount = source._debugNeedsRemount;
   target._debugHookTypes = source._debugHookTypes;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -3760,6 +3760,10 @@ function remountFiber(
     newWorkInProgress.return = oldWorkInProgress.return;
     newWorkInProgress.ref = oldWorkInProgress.ref;
 
+    if (__DEV__) {
+      newWorkInProgress._debugInfo = oldWorkInProgress._debugInfo;
+    }
+
     // Replace the child/sibling pointers above it.
     if (oldWorkInProgress === returnFiber.child) {
       returnFiber.child = newWorkInProgress;

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -15,6 +15,7 @@ import type {
   Usable,
   ReactFormState,
   Awaited,
+  ReactDebugInfo,
 } from 'shared/ReactTypes';
 import type {WorkTag} from './ReactWorkTags';
 import type {TypeOfMode} from './ReactTypeOfMode';
@@ -199,6 +200,7 @@ export type Fiber = {
   // to be the same as work in progress.
   // __DEV__ only
 
+  _debugInfo?: ReactDebugInfo | null,
   _debugOwner?: Fiber | null,
   _debugIsCurrentlyTiming?: boolean,
   _debugNeedsRemount?: boolean,

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -55,7 +55,6 @@ import type {
   ReactDebugInfo,
   ReactComponentInfo,
   ReactAsyncInfo,
-  ReactConsoleInfo,
 } from 'shared/ReactTypes';
 import type {LazyComponent} from 'react/src/ReactLazy';
 
@@ -1732,7 +1731,7 @@ function emitModelChunk(request: Request, id: number, json: string): void {
 function emitDebugChunk(
   request: Request,
   id: number,
-  debugInfo: ReactComponentInfo | ReactAsyncInfo | ReactConsoleInfo,
+  debugInfo: ReactComponentInfo | ReactAsyncInfo,
 ): void {
   if (!__DEV__) {
     // These errors should never make it into a build so we don't need to encode them in codes.json

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -52,6 +52,10 @@ import type {
   PendingThenable,
   FulfilledThenable,
   RejectedThenable,
+  ReactDebugInfo,
+  ReactComponentInfo,
+  ReactAsyncInfo,
+  ReactConsoleInfo,
 } from 'shared/ReactTypes';
 import type {LazyComponent} from 'react/src/ReactLazy';
 
@@ -106,9 +110,6 @@ import binaryToComparableString from 'shared/binaryToComparableString';
 import {SuspenseException, getSuspendedThenable} from './ReactFlightThenable';
 
 initAsyncDebugInfo();
-
-// Dev-only
-type ReactDebugInfo = Array<{+name?: string, +env?: string}>;
 
 const ObjectPrototype = Object.prototype;
 
@@ -1731,7 +1732,7 @@ function emitModelChunk(request: Request, id: number, json: string): void {
 function emitDebugChunk(
   request: Request,
   id: number,
-  debugInfo: {+name?: string, +env?: string},
+  debugInfo: ReactComponentInfo | ReactAsyncInfo | ReactConsoleInfo,
 ): void {
   if (!__DEV__) {
     // These errors should never make it into a build so we don't need to encode them in codes.json

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Wakeable, Thenable} from 'shared/ReactTypes';
+import type {Wakeable, Thenable, ReactDebugInfo} from 'shared/ReactTypes';
 
 import {REACT_LAZY_TYPE} from 'shared/ReactSymbols';
 
@@ -46,7 +46,7 @@ export type LazyComponent<T, P> = {
   $$typeof: symbol | number,
   _payload: P,
   _init: (payload: P) => T,
-  _debugInfo?: null | Array<{+name?: string, +env?: string}>,
+  _debugInfo?: null | ReactDebugInfo,
 };
 
 function lazyInitializer<T>(payload: Payload<T>): T {

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -111,20 +111,24 @@ interface ThenableImpl<T> {
 }
 interface UntrackedThenable<T> extends ThenableImpl<T> {
   status?: void;
+  _debugInfo?: null | ReactDebugInfo;
 }
 
 export interface PendingThenable<T> extends ThenableImpl<T> {
   status: 'pending';
+  _debugInfo?: null | ReactDebugInfo;
 }
 
 export interface FulfilledThenable<T> extends ThenableImpl<T> {
   status: 'fulfilled';
   value: T;
+  _debugInfo?: null | ReactDebugInfo;
 }
 
 export interface RejectedThenable<T> extends ThenableImpl<T> {
   status: 'rejected';
   reason: mixed;
+  _debugInfo?: null | ReactDebugInfo;
 }
 
 export type Thenable<T> =
@@ -185,6 +189,4 @@ export type ReactAsyncInfo = {
   +stack?: string,
 };
 
-export type ReactDebugInfo = Array<
-  ReactComponentInfo | ReactAsyncInfo,
->;
+export type ReactDebugInfo = Array<ReactComponentInfo | ReactAsyncInfo>;

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -173,3 +173,18 @@ export type Awaited<T> = T extends null | void
       : empty // the argument to `then` was not callable.
     : T // argument was not an object
   : T; // non-thenable
+
+export type ReactComponentInfo = {
+  +name?: string,
+  +env?: string,
+};
+
+export type ReactAsyncInfo = {
+  +started?: number,
+  +completed?: number,
+  +stack?: string,
+};
+
+export type ReactDebugInfo = Array<
+  ReactComponentInfo | ReactAsyncInfo,
+>;


### PR DESCRIPTION
That way we can use it for debug information like component stacks and DevTools. I used an extra stack argument in Child Fiber to track this as it's flowing down since it's not just elements where we have this info readily available but parent arrays and lazy can merge this into the Fiber too. It's not great that this is a dev-only argument and I could track it globally but seems more likely to make mistakes.

It is possible for the same debug info to appear for multiple child fibers like when it's attached to a fragment or a lazy that resolves to a fragment at the root. The object identity could be used in these scenarios to infer if that's really one server component that's a parent of all children or if each child has a server component with the same name.

This is effectively a public API because you can use it to stash information on Promises from a third-party service - not just Server Components. I started outline the types for this for some things I was planning to add but it's not final.

I was also planning on storing it from `use(thenable)` for when you suspend on a Promise. However, I realized that there's no Hook instance for those to stash it on. So it might need a separate data structure to stash the previous pass over of `use()` that resets each render.

No tests yet since I didn't want to test internals but it'll be covered once we have debugging features like component stacks.