### PR TITLE
[Fiber] Stash usables on _debugUsables for DevTools

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -77,7 +77,7 @@ const INITIALIZED = 'fulfilled';
 const ERRORED = 'rejected';
 
 // Dev-only
-type ReactDebugInfo = Array<{+name?: string}>;
+type ReactDebugInfo = Array<{+name?: string, +env?: string}>;
 
 type PendingChunk<T> = {
   status: 'pending',

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -7,7 +7,13 @@
  * @flow
  */
 
-import type {Thenable} from 'shared/ReactTypes';
+import type {
+  Thenable,
+  ReactDebugInfo,
+  ReactComponentInfo,
+  ReactAsyncInfo,
+  ReactConsoleInfo,
+} from 'shared/ReactTypes';
 import type {LazyComponent} from 'react/src/ReactLazy';
 
 import type {
@@ -75,9 +81,6 @@ const RESOLVED_MODEL = 'resolved_model';
 const RESOLVED_MODULE = 'resolved_module';
 const INITIALIZED = 'fulfilled';
 const ERRORED = 'rejected';
-
-// Dev-only
-type ReactDebugInfo = Array<{+name?: string, +env?: string}>;
 
 type PendingChunk<T> = {
   status: 'pending',
@@ -1014,7 +1017,7 @@ function resolveHint<Code: HintCode>(
 function resolveDebugInfo(
   response: Response,
   id: number,
-  debugInfo: {name: string},
+  debugInfo: ReactComponentInfo | ReactAsyncInfo | ReactConsoleInfo,
 ): void {
   if (!__DEV__) {
     // These errors should never make it into a build so we don't need to encode them in codes.json

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -1806,4 +1806,59 @@ describe('ReactFlight', () => {
 
     expect(ReactNoop).toMatchRenderedOutput(<div>Ba</div>);
   });
+
+  it('preserves debug info for server-to-server pass through', async () => {
+    function ThirdPartyLazyComponent() {
+      return <span>!</span>;
+    }
+
+    const lazy = React.lazy(async () => ({
+      default: <ThirdPartyLazyComponent />,
+    }));
+
+    function ThirdPartyComponent() {
+      return <span>stranger</span>;
+    }
+
+    function ServerComponent({transport}) {
+      // This is a Server Component that receives other Server Components from a third party.
+      const children = ReactNoopFlightClient.read(transport);
+      return <div>Hello, {children}</div>;
+    }
+
+    const promise = Promise.resolve(<ThirdPartyComponent />);
+
+    const thirdPartyTransport = ReactNoopFlightServer.render([promise, lazy]);
+
+    // Wait for the lazy component to initialize
+    await 0;
+
+    const transport = ReactNoopFlightServer.render(
+      <ServerComponent transport={thirdPartyTransport} />,
+    );
+
+    await act(async () => {
+      const promise = ReactNoopFlightClient.read(transport);
+      expect(promise._debugInfo).toEqual(
+        __DEV__ ? [{name: 'ServerComponent'}] : undefined,
+      );
+      const result = await promise;
+      const thirdPartyChildren = await result.props.children[1];
+      // We expect the debug info to be transferred from the inner stream to the outer.
+      expect(thirdPartyChildren[0]._debugInfo).toEqual(
+        __DEV__ ? [{name: 'ThirdPartyComponent'}] : undefined,
+      );
+      expect(thirdPartyChildren[1]._debugInfo).toEqual(
+        __DEV__ ? [{name: 'ThirdPartyLazyComponent'}] : undefined,
+      );
+      ReactNoop.render(result);
+    });
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <div>
+        Hello, <span>stranger</span>
+        <span>!</span>
+      </div>,
+    );
+  });
 });

--- a/packages/react-noop-renderer/src/ReactNoopFlightServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightServer.js
@@ -68,8 +68,10 @@ const ReactNoopFlightServer = ReactFlightServer({
 });
 
 type Options = {
-  onError?: (error: mixed) => void,
+  environmentName?: string,
   identifierPrefix?: string,
+  onError?: (error: mixed) => void,
+  onPostpone?: (reason: string) => void,
 };
 
 function render(model: ReactClientValue, options?: Options): Destination {
@@ -80,6 +82,8 @@ function render(model: ReactClientValue, options?: Options): Destination {
     bundlerConfig,
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
+    options ? options.onPostpone : undefined,
+    options ? options.environmentName : undefined,
   );
   ReactNoopFlightServer.startWork(request);
   ReactNoopFlightServer.startFlowing(request, destination);

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -201,7 +201,7 @@ function FiberNode(
 
   if (__DEV__) {
     // This isn't directly used but is handy for debugging internals:
-
+    this._debugInfo = null;
     this._debugOwner = null;
     this._debugNeedsRemount = false;
     this._debugHookTypes = null;
@@ -347,6 +347,7 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
   }
 
   if (__DEV__) {
+    workInProgress._debugInfo = current._debugInfo;
     workInProgress._debugNeedsRemount = current._debugNeedsRemount;
     switch (workInProgress.tag) {
       case IndeterminateComponent:
@@ -911,6 +912,7 @@ export function assignFiberPropertiesInDEV(
     target.treeBaseDuration = source.treeBaseDuration;
   }
 
+  target._debugInfo = source._debugInfo;
   target._debugOwner = source._debugOwner;
   target._debugNeedsRemount = source._debugNeedsRemount;
   target._debugHookTypes = source._debugHookTypes;

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -202,6 +202,7 @@ function FiberNode(
   if (__DEV__) {
     // This isn't directly used but is handy for debugging internals:
     this._debugInfo = null;
+    this._debugUsables = null;
     this._debugOwner = null;
     this._debugNeedsRemount = false;
     this._debugHookTypes = null;
@@ -348,6 +349,7 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
 
   if (__DEV__) {
     workInProgress._debugInfo = current._debugInfo;
+    workInProgress._debugUsables = current._debugUsables;
     workInProgress._debugNeedsRemount = current._debugNeedsRemount;
     switch (workInProgress.tag) {
       case IndeterminateComponent:
@@ -913,6 +915,7 @@ export function assignFiberPropertiesInDEV(
   }
 
   target._debugInfo = source._debugInfo;
+  target._debugUsables = source._debugUsables;
   target._debugOwner = source._debugOwner;
   target._debugNeedsRemount = source._debugNeedsRemount;
   target._debugHookTypes = source._debugHookTypes;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -3760,6 +3760,10 @@ function remountFiber(
     newWorkInProgress.return = oldWorkInProgress.return;
     newWorkInProgress.ref = oldWorkInProgress.ref;
 
+    if (__DEV__) {
+      newWorkInProgress._debugInfo = oldWorkInProgress._debugInfo;
+    }
+
     // Replace the child/sibling pointers above it.
     if (oldWorkInProgress === returnFiber.child) {
       returnFiber.child = newWorkInProgress;

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -15,6 +15,7 @@ import type {
   Usable,
   ReactFormState,
   Awaited,
+  ReactDebugInfo,
 } from 'shared/ReactTypes';
 import type {WorkTag} from './ReactWorkTags';
 import type {TypeOfMode} from './ReactTypeOfMode';
@@ -199,6 +200,7 @@ export type Fiber = {
   // to be the same as work in progress.
   // __DEV__ only
 
+  _debugInfo?: ReactDebugInfo | null,
   _debugOwner?: Fiber | null,
   _debugIsCurrentlyTiming?: boolean,
   _debugNeedsRemount?: boolean,

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -200,7 +200,11 @@ export type Fiber = {
   // to be the same as work in progress.
   // __DEV__ only
 
+  // DebugInfo for Virtual Parents used to render this Component.
   _debugInfo?: ReactDebugInfo | null,
+  // Usables use():ed inside this Component. These might themselves include DebugInfo.
+  _debugUsables?: Array<Usable<any>> | null,
+  // The Fiber that rendered the JSX which resulted in this Component.
   _debugOwner?: Fiber | null,
   _debugIsCurrentlyTiming?: boolean,
   _debugNeedsRemount?: boolean,

--- a/packages/react-server-dom-esm/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-esm/src/ReactFlightDOMServerNode.js
@@ -52,6 +52,7 @@ function createDrainHandler(destination: Destination, request: Request) {
 }
 
 type Options = {
+  environmentName?: string,
   onError?: (error: mixed) => void,
   onPostpone?: (reason: string) => void,
   identifierPrefix?: string,
@@ -73,6 +74,7 @@ function renderToPipeableStream(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
+    options ? options.environmentName : undefined,
   );
   let hasStartedFlowing = false;
   startWork(request);

--- a/packages/react-server-dom-fb/src/ReactFlightDOMServerFB.js
+++ b/packages/react-server-dom-fb/src/ReactFlightDOMServerFB.js
@@ -50,6 +50,8 @@ function renderToDestination(
     model,
     null,
     options ? options.onError : undefined,
+    undefined,
+    undefined,
   );
   startWork(request);
   startFlowing(request, destination);

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMServerBrowser.js
@@ -34,6 +34,7 @@ export {
 } from './ReactFlightTurbopackReferences';
 
 type Options = {
+  environmentName?: string,
   identifierPrefix?: string,
   signal?: AbortSignal,
   onError?: (error: mixed) => void,
@@ -51,6 +52,7 @@ function renderToReadableStream(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
+    options ? options.environmentName : undefined,
   );
   if (options && options.signal) {
     const signal = options.signal;

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMServerEdge.js
@@ -34,6 +34,7 @@ export {
 } from './ReactFlightTurbopackReferences';
 
 type Options = {
+  environmentName?: string,
   identifierPrefix?: string,
   signal?: AbortSignal,
   onError?: (error: mixed) => void,
@@ -51,6 +52,7 @@ function renderToReadableStream(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
+    options ? options.environmentName : undefined,
   );
   if (options && options.signal) {
     const signal = options.signal;

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMServerNode.js
@@ -49,6 +49,7 @@ function createDrainHandler(destination: Destination, request: Request) {
 }
 
 type Options = {
+  environmentName?: string,
   onError?: (error: mixed) => void,
   onPostpone?: (reason: string) => void,
   identifierPrefix?: string,
@@ -70,6 +71,7 @@ function renderToPipeableStream(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
+    options ? options.environmentName : undefined,
   );
   let hasStartedFlowing = false;
   startWork(request);

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -38,6 +38,7 @@ export {
 } from './ReactFlightWebpackReferences';
 
 type Options = {
+  environmentName?: string,
   identifierPrefix?: string,
   signal?: AbortSignal,
   onError?: (error: mixed) => void,
@@ -55,6 +56,7 @@ function renderToReadableStream(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
+    options ? options.environmentName : undefined,
   );
   if (options && options.signal) {
     const signal = options.signal;

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
@@ -38,6 +38,7 @@ export {
 } from './ReactFlightWebpackReferences';
 
 type Options = {
+  environmentName?: string,
   identifierPrefix?: string,
   signal?: AbortSignal,
   onError?: (error: mixed) => void,
@@ -55,6 +56,7 @@ function renderToReadableStream(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
+    options ? options.environmentName : undefined,
   );
   if (options && options.signal) {
     const signal = options.signal;

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -61,6 +61,7 @@ function createCancelHandler(request: Request, reason: string) {
 }
 
 type Options = {
+  environmentName?: string,
   onError?: (error: mixed) => void,
   onPostpone?: (reason: string) => void,
   identifierPrefix?: string,
@@ -82,6 +83,7 @@ function renderToPipeableStream(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
+    options ? options.environmentName : undefined,
   );
   let hasStartedFlowing = false;
   startWork(request);

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -286,7 +286,7 @@ describe('ReactFlightDOMEdge', () => {
       <ServerComponent recurse={20} />,
     );
     const serializedContent = await readResult(stream);
-    const expectedDebugInfoSize = __DEV__ ? 30 * 20 : 0;
+    const expectedDebugInfoSize = __DEV__ ? 42 * 20 : 0;
     expect(serializedContent.length).toBeLessThan(150 + expectedDebugInfoSize);
   });
 

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -52,6 +52,10 @@ import type {
   PendingThenable,
   FulfilledThenable,
   RejectedThenable,
+  ReactDebugInfo,
+  ReactComponentInfo,
+  ReactAsyncInfo,
+  ReactConsoleInfo,
 } from 'shared/ReactTypes';
 import type {LazyComponent} from 'react/src/ReactLazy';
 
@@ -106,9 +110,6 @@ import binaryToComparableString from 'shared/binaryToComparableString';
 import {SuspenseException, getSuspendedThenable} from './ReactFlightThenable';
 
 initAsyncDebugInfo();
-
-// Dev-only
-type ReactDebugInfo = Array<{+name?: string, +env?: string}>;
 
 const ObjectPrototype = Object.prototype;
 
@@ -1731,7 +1732,7 @@ function emitModelChunk(request: Request, id: number, json: string): void {
 function emitDebugChunk(
   request: Request,
   id: number,
-  debugInfo: {+name?: string, +env?: string},
+  debugInfo: ReactComponentInfo | ReactAsyncInfo | ReactConsoleInfo,
 ): void {
   if (!__DEV__) {
     // These errors should never make it into a build so we don't need to encode them in codes.json

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Wakeable, Thenable} from 'shared/ReactTypes';
+import type {Wakeable, Thenable, ReactDebugInfo} from 'shared/ReactTypes';
 
 import {REACT_LAZY_TYPE} from 'shared/ReactSymbols';
 
@@ -46,7 +46,7 @@ export type LazyComponent<T, P> = {
   $$typeof: symbol | number,
   _payload: P,
   _init: (payload: P) => T,
-  _debugInfo?: null | Array<{+name?: string, +env?: string}>,
+  _debugInfo?: null | ReactDebugInfo,
 };
 
 function lazyInitializer<T>(payload: Payload<T>): T {

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -46,7 +46,7 @@ export type LazyComponent<T, P> = {
   $$typeof: symbol | number,
   _payload: P,
   _init: (payload: P) => T,
-  _debugInfo?: null | Array<{+name?: string}>,
+  _debugInfo?: null | Array<{+name?: string, +env?: string}>,
 };
 
 function lazyInitializer<T>(payload: Payload<T>): T {

--- a/packages/react/src/__tests__/ReactFetch-test.js
+++ b/packages/react/src/__tests__/ReactFetch-test.js
@@ -85,7 +85,7 @@ describe('ReactFetch', () => {
     const promise = render(Component);
     expect(await promise).toMatchInlineSnapshot(`"GET world []"`);
     expect(promise._debugInfo).toEqual(
-      __DEV__ ? [{name: 'Component'}] : undefined,
+      __DEV__ ? [{name: 'Component', env: 'server'}] : undefined,
     );
     expect(fetchCount).toBe(1);
   });

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -173,3 +173,22 @@ export type Awaited<T> = T extends null | void
       : empty // the argument to `then` was not callable.
     : T // argument was not an object
   : T; // non-thenable
+
+export type ReactComponentInfo = {
+  +name?: string,
+  +env?: string,
+};
+
+export type ReactAsyncInfo = {
+  +started?: number,
+  +completed?: number,
+  +stack?: string,
+};
+
+export type ReactConsoleInfo = {
+  // TODO
+};
+
+export type ReactDebugInfo = Array<
+  ReactComponentInfo | ReactAsyncInfo | ReactConsoleInfo,
+>;

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -111,20 +111,24 @@ interface ThenableImpl<T> {
 }
 interface UntrackedThenable<T> extends ThenableImpl<T> {
   status?: void;
+  _debugInfo?: null | ReactDebugInfo;
 }
 
 export interface PendingThenable<T> extends ThenableImpl<T> {
   status: 'pending';
+  _debugInfo?: null | ReactDebugInfo;
 }
 
 export interface FulfilledThenable<T> extends ThenableImpl<T> {
   status: 'fulfilled';
   value: T;
+  _debugInfo?: null | ReactDebugInfo;
 }
 
 export interface RejectedThenable<T> extends ThenableImpl<T> {
   status: 'rejected';
   reason: mixed;
+  _debugInfo?: null | ReactDebugInfo;
 }
 
 export type Thenable<T> =


### PR DESCRIPTION
Stacked on #28286.

Stash usables on `_debugUsables` so that DevTools can pick up any `use()` calls. These can also include further `DebugInfo` on them such as what Server Component rendered the Promise or async debug info. This is nice just to see which `use()` calls were made in the side-panel but it can also be used to gather everything that might have suspended.

Together with #28286 we cover the case when a Promise was used a child and if it was unwrapped with `use()`. Notably we don't cover a Promise that was thrown (although we do support that in a Server Component which maybe we shouldn't). Throwing a Promise isn't officially supported though and that use case should move to the `use()` Hook.

The pattern of conditionally suspending based on cache also isn't really supported with the `use()` pattern. You should always call `use()` if you previously called `use()` with the same input. This also ensures that we can track what *might* have suspended rather than what actually did.