### PR TITLE
fix: define IS_ACT_ENVIRONMENT global for tests with concurrent mode and synchronous act

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/FastRefreshDevToolsIntegration-test.js
+++ b/packages/react-devtools-shared/src/__tests__/FastRefreshDevToolsIntegration-test.js
@@ -20,6 +20,8 @@ describe('Fast Refresh', () => {
   let withErrorsOrWarningsIgnored;
 
   beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+
     exportsObj = undefined;
 
     babel = require('@babel/core');

--- a/packages/react-devtools-shared/src/__tests__/profilerStore-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilerStore-test.js
@@ -17,6 +17,8 @@ describe('ProfilerStore', () => {
   let utils;
 
   beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+
     utils = require('./utils');
     utils.beforeEachProfiling();
 

--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -23,6 +23,8 @@ describe('Store', () => {
   let withErrorsOrWarningsIgnored;
 
   beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+
     agent = global.agent;
     bridge = global.bridge;
     store = global.store;

--- a/packages/react-devtools-shared/src/__tests__/storeStressTestConcurrent-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeStressTestConcurrent-test.js
@@ -17,6 +17,8 @@ describe('StoreStressConcurrent', () => {
   let print;
 
   beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+
     bridge = global.bridge;
     store = global.store;
     store.collapseNodesByDefault = false;
@@ -30,12 +32,6 @@ describe('StoreStressConcurrent', () => {
 
     print = require('./__serializers__/storeSerializer').print;
   });
-
-  // TODO: Remove this in favor of @gate pragma
-  if (!__EXPERIMENTAL__) {
-    it("empty test so Jest doesn't complain", () => {});
-    return;
-  }
 
   // This is a stress test for the tree mount/update/unmount traversal.
   // It renders different trees that should produce the same output.

--- a/packages/react-devtools-shared/src/__tests__/treeContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/treeContext-test.js
@@ -33,6 +33,8 @@ describe('TreeListContext', () => {
   let state: StateContext;
 
   beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+
     utils = require('./utils');
     utils.beforeEachProfiling();
 


### PR DESCRIPTION
Unblocks https://github.com/facebook/react/pull/28152 for landing.

While triaging why https://github.com/facebook/react/pull/28152 breaks some tests for DevTools, I've observed that using `act` from `internal-test-utils` is actually fixes the issue. One of the main differences between `act` from `react` and `act` from `internal-test-utils` is that later awaits for microtasks:
https://github.com/facebook/react/blob/d27c1ac1128327280607389c187e7db8dab06f84/packages/internal-test-utils/internalAct.js#L60-L64

All tests that were failing with modern strict mode enabled, using concurrent mode, but with a synchronous act. Following this, I am assuming that in order to avoid queueing microtask, we should define `IS_REACT_ACT_ENVIRONMENT` global.
https://github.com/facebook/react/blob/d27c1ac1128327280607389c187e7db8dab06f84/packages/react-reconciler/src/__tests__/ReactIsomorphicAct-test.js#L55-L77 

Validated with running tests on https://github.com/facebook/react/pull/28152 with these changes.
Also validated that it works for regression tests for previous versions of React.