### PR TITLE
Add jsx-runtime.react-server.js to file allowlist

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,8 +15,9 @@
     "cjs/",
     "umd/",
     "jsx-runtime.js",
+    "jsx-runtime.react-server.js",
     "jsx-dev-runtime.js",
-    "react.react-server.js"
+    "react.react-server.js",
   ],
   "main": "index.js",
   "exports": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,7 +17,7 @@
     "jsx-runtime.js",
     "jsx-runtime.react-server.js",
     "jsx-dev-runtime.js",
-    "react.react-server.js",
+    "react.react-server.js"
   ],
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
https://github.com/facebook/react/pull/28217 doesn't work without this since it's not included in the files list.

See https://github.com/dai-shi/waku/pull/467#issuecomment-1936965080.

This should fix that.