### PR TITLE
Thrown object in RSC to be shown as stringified text not [Object object] in client side (next.js)

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -1599,7 +1599,8 @@ function emitErrorChunk(
         message = String(error.message);
         // eslint-disable-next-line react-internal/safe-string-coercion
         stack = String(error.stack);
-      } else if (typeof error === "object") {
+      } else if (typeof error === 'object' && error !== null) {
+        // eslint-disable-next-line react-internal/safe-string-coercion
         message = String(error.message);
       } else {
         message = 'Error: ' + (error: any);

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -1599,6 +1599,8 @@ function emitErrorChunk(
         message = String(error.message);
         // eslint-disable-next-line react-internal/safe-string-coercion
         stack = String(error.stack);
+      } else if (typeof error === "object") {
+        message = 'Error: ' + stringify(error);
       } else {
         message = 'Error: ' + (error: any);
       }

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -1600,7 +1600,7 @@ function emitErrorChunk(
         // eslint-disable-next-line react-internal/safe-string-coercion
         stack = String(error.stack);
       } else if (typeof error === "object") {
-        message = 'Error: ' + stringify(error);
+        message = String(error.message);
       } else {
         message = 'Error: ' + (error: any);
       }


### PR DESCRIPTION
This is my first PR for `react` and I have completed CLA.

## Summary

`error.message` passed from a server component that throws object (normally Error) only displays [object Object] in client side.
see issue in Next.js below.
https://github.com/vercel/next.js/issues/61902

So I add conditional branch in [line 1680](https://github.com/facebook/react/blob/32df74dba67207300511cf9b7c5ef82dd708c0c1/packages/react-server/src/ReactFlightServer.js#L1680) of `react/packages/react-server/src/ReactFlightServer.js` so that not only thrown `Error` but also `object` can be stringified.

I am not sure how many people throw object (not Error, usually Error is better since Error can trace stacks) in server component in production, but it would help one user with the issue above.

## How did you test this change?

Clone https://github.com/carlos-dubon/nextjs-error-bug and `yarn install`. ( don't forget to install `next 14.1.1-canary.48` and `react 18.2.0` and `react-dom 18.2.0` ).
Then beatify `node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js` and edit line 14534.

```javascript
n instanceof Error ? (a = String(n.message), i = String(n.stack)) : typeof n == "object" ? a = n.message : a = "Error: " + n
```

<img width="840" alt="スクリーンショット 2024-02-13 19 30 13" src="https://github.com/facebook/react/assets/136598145/b81153eb-37f5-4a30-a7b0-1a2e28049780">

after that `yarn dev` and go to `/` page and, edit line 10 of [this file](https://github.com/carlos-dubon/nextjs-error-bug/blob/master/src/app/error.tsx) to 

```javascript
  return <div>Error: {JSON.stringify(error.message)}</div>;
```

and you can get the message.

Test cases `yarn test ReactServer` and `yarn test --prod ReactServer` was passed without fail.
