### PR TITLE
Devtools: Unwrap Promise in useFormState

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -94,17 +94,6 @@ function getPrimitiveStackCache(): Map<string, Array<any>> {
       if (typeof Dispatcher.useFormState === 'function') {
         // This type check is for Flow only.
         Dispatcher.useFormState((s: mixed, p: mixed) => s, null);
-        try {
-          // $FlowFixMe[not-a-function]: Already checked above.
-          Dispatcher.useFormState(
-            (s: mixed, p: mixed) => s,
-            // This isn't actually a valid call.
-            // We just simulate a pending promise here to exhaust all cases in the stackframe cache.
-            ({
-              then() {},
-            }: any),
-          );
-        } catch (x) {}
       }
       if (typeof Dispatcher.use === 'function') {
         // This type check is for Flow only.
@@ -504,6 +493,7 @@ function useFormState<S, P>(
 ): [Awaited<S>, (P) => void] {
   const hook = nextHook(); // FormState
   nextHook(); // ActionQueue
+  const stackError = new Error();
   let state;
   let debugInfo = null;
   if (hook !== null) {
@@ -531,7 +521,7 @@ function useFormState<S, P>(
           // but we can still emit anything up until this point.
           hookLog.push({
             primitive: 'FormState',
-            stackError: new Error(),
+            stackError: stackError,
             value: thenable,
             debugInfo:
               thenable._debugInfo === undefined ? null : thenable._debugInfo,
@@ -546,7 +536,7 @@ function useFormState<S, P>(
   }
   hookLog.push({
     primitive: 'FormState',
-    stackError: new Error(),
+    stackError: stackError,
     value: state,
     debugInfo: debugInfo,
   });

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -530,7 +530,7 @@ function useFormState<S, P>(
           // If this was an uncached Promise we have to abandon this attempt
           // but we can still emit anything up until this point.
           hookLog.push({
-            primitive: 'Unresolved',
+            primitive: 'FormState',
             stackError: new Error(),
             value: thenable,
             debugInfo:

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -94,6 +94,17 @@ function getPrimitiveStackCache(): Map<string, Array<any>> {
       if (typeof Dispatcher.useFormState === 'function') {
         // This type check is for Flow only.
         Dispatcher.useFormState((s: mixed, p: mixed) => s, null);
+        try {
+          // $FlowFixMe[not-a-function]: Already checked above.
+          Dispatcher.useFormState(
+            (s: mixed, p: mixed) => s,
+            // This isn't actually a valid call.
+            // We just simulate a pending promise here to exhaust all cases in the stackframe cache.
+            ({
+              then() {},
+            }: any),
+          );
+        } catch (x) {}
       }
       if (typeof Dispatcher.use === 'function') {
         // This type check is for Flow only.


### PR DESCRIPTION
## Summary

Instead of just showing plain "Promise" after an async action, we now unwrap the fulfilled value of the Promise.

## How did you test this change?

- added case to devtools fixture:  

  https://github.com/facebook/react/assets/12292047/4a37eef8-281a-4f54-9924-b29cd17aad60

