### PR TITLE
Remove non-JSX propTypes checks

### DIFF
--- a/packages/react-server/src/ReactFizzContext.js
+++ b/packages/react-server/src/ReactFizzContext.js
@@ -9,7 +9,6 @@
 
 import {disableLegacyContext} from 'shared/ReactFeatureFlags';
 import getComponentNameFromType from 'shared/getComponentNameFromType';
-import checkPropTypes from 'shared/checkPropTypes';
 
 let warnedAboutMissingGetChildContext;
 
@@ -34,11 +33,6 @@ export function getMaskedContext(type: any, unmaskedContext: Object): Object {
     const context: {[string]: $FlowFixMe} = {};
     for (const key in contextTypes) {
       context[key] = unmaskedContext[key];
-    }
-
-    if (__DEV__) {
-      const name = getComponentNameFromType(type) || 'Unknown';
-      checkPropTypes(contextTypes, context, 'context', name);
     }
 
     return context;
@@ -84,11 +78,6 @@ export function processChildContext(
         );
       }
     }
-    if (__DEV__) {
-      const name = getComponentNameFromType(type) || 'Unknown';
-      checkPropTypes(childContextTypes, childContext, 'child context', name);
-    }
-
     return {...parentContext, ...childContext};
   }
 }

--- a/packages/react/src/ReactForwardRef.js
+++ b/packages/react/src/ReactForwardRef.js
@@ -36,9 +36,9 @@ export function forwardRef<Props, ElementType: React$ElementType>(
     }
 
     if (render != null) {
-      if (render.defaultProps != null || render.propTypes != null) {
+      if (render.defaultProps != null) {
         console.error(
-          'forwardRef render functions do not support propTypes or defaultProps. ' +
+          'forwardRef render functions do not support defaultProps. ' +
             'Did you accidentally pass a React component?',
         );
       }

--- a/packages/react/src/__tests__/forwardRef-test.js
+++ b/packages/react/src/__tests__/forwardRef-test.js
@@ -10,14 +10,12 @@
 'use strict';
 
 describe('forwardRef', () => {
-  let PropTypes;
   let React;
   let ReactNoop;
   let waitForAll;
 
   beforeEach(() => {
     jest.resetModules();
-    PropTypes = require('prop-types');
     React = require('react');
     ReactNoop = require('react-noop-renderer');
 
@@ -76,7 +74,7 @@ describe('forwardRef', () => {
     expect(ref.current).toBe(null);
   });
 
-  it('should support propTypes and defaultProps', async () => {
+  it('should support defaultProps', async () => {
     function FunctionComponent({forwardedRef, optional, required}) {
       return (
         <div ref={forwardedRef}>
@@ -91,10 +89,6 @@ describe('forwardRef', () => {
         return <FunctionComponent {...props} forwardedRef={ref} />;
       },
     );
-    RefForwardingComponent.propTypes = {
-      optional: PropTypes.string,
-      required: PropTypes.string.isRequired,
-    };
     RefForwardingComponent.defaultProps = {
       optional: 'default',
     };
@@ -116,14 +110,6 @@ describe('forwardRef', () => {
       {text: 'default', hidden: false},
       {text: 'foo', hidden: false},
     ]);
-
-    expect(() =>
-      ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />),
-    ).toErrorDev(
-      'Warning: Failed prop type: The prop `required` is marked as required in ' +
-        '`ForwardRef(NamedFunction)`, but its value is `undefined`.\n' +
-        '    in NamedFunction (at **)',
-    );
   });
 
   it('should warn if not provided a callback during creation', () => {
@@ -150,24 +136,14 @@ describe('forwardRef', () => {
     );
   });
 
-  it('should warn if the render function provided has propTypes or defaultProps attributes', () => {
-    function renderWithPropTypes(props, ref) {
-      return null;
-    }
-    renderWithPropTypes.propTypes = {};
-
+  it('should warn if the render function provided has defaultProps attributes', () => {
     function renderWithDefaultProps(props, ref) {
       return null;
     }
     renderWithDefaultProps.defaultProps = {};
 
-    expect(() => React.forwardRef(renderWithPropTypes)).toErrorDev(
-      'forwardRef render functions do not support propTypes or defaultProps. ' +
-        'Did you accidentally pass a React component?',
-      {withoutStack: true},
-    );
     expect(() => React.forwardRef(renderWithDefaultProps)).toErrorDev(
-      'forwardRef render functions do not support propTypes or defaultProps. ' +
+      'forwardRef render functions do not support defaultProps. ' +
         'Did you accidentally pass a React component?',
       {withoutStack: true},
     );


### PR DESCRIPTION
Removes all `propTypes` validation called from outside the JSX factories. Haven't touched JSX.

Tests that verify related behavior are stripped down to the non-`propTypes` logic.