### PR TITLE
[Flight] Allow a Server Reference to be registered twice

### DIFF
--- a/packages/react-server-dom-esm/src/ReactFlightESMReferences.js
+++ b/packages/react-server-dom-esm/src/ReactFlightESMReferences.js
@@ -70,8 +70,8 @@ export function registerServerReference<T>(
 ): ServerReference<T> {
   return Object.defineProperties((reference: any), {
     $$typeof: {value: SERVER_REFERENCE_TAG},
-    $$id: {value: id + '#' + exportName},
-    $$bound: {value: null},
-    bind: {value: bind},
+    $$id: {value: id + '#' + exportName, configurable: true},
+    $$bound: {value: null, configurable: true},
+    bind: {value: bind, configurable: true},
   });
 }

--- a/packages/react-server-dom-turbopack/src/ReactFlightTurbopackReferences.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightTurbopackReferences.js
@@ -83,9 +83,12 @@ export function registerServerReference<T>(
 ): ServerReference<T> {
   return Object.defineProperties((reference: any), {
     $$typeof: {value: SERVER_REFERENCE_TAG},
-    $$id: {value: exportName === null ? id : id + '#' + exportName},
-    $$bound: {value: null},
-    bind: {value: bind},
+    $$id: {
+      value: exportName === null ? id : id + '#' + exportName,
+      configurable: true,
+    },
+    $$bound: {value: null, configurable: true},
+    bind: {value: bind, configurable: true},
   });
 }
 

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js
@@ -83,9 +83,12 @@ export function registerServerReference<T>(
 ): ServerReference<T> {
   return Object.defineProperties((reference: any), {
     $$typeof: {value: SERVER_REFERENCE_TAG},
-    $$id: {value: exportName === null ? id : id + '#' + exportName},
-    $$bound: {value: null},
-    bind: {value: bind},
+    $$id: {
+      value: exportName === null ? id : id + '#' + exportName,
+      configurable: true,
+    },
+    $$bound: {value: null, configurable: true},
+    bind: {value: bind, configurable: true},
   });
 }
 


### PR DESCRIPTION
It's possible for the same function instance to appear more than once in the same graph or even the same file.

Currently this errors on trying to reconfigure the property but it really doesn't matter which one wins. First or last.

Regardless there will be an entry point generated that can get them.

