### PR TITLE
Fix crash running `yarn flags --sort flag`

### DIFF
--- a/scripts/flags/flags.js
+++ b/scripts/flags/flags.js
@@ -318,11 +318,15 @@ for (const flag of allFlagsUniqueFlags) {
 let sorted = table;
 if (isDiff || argv.sort) {
   const sortChannel = argToHeader(isDiff ? argv.diff[0] : argv.sort);
-  sorted = Object.fromEntries(
-    Object.entries(table).sort(([, rowA], [, rowB]) =>
-      rowB[sortChannel].toString().localeCompare(rowA[sortChannel])
-    )
-  );
+  const sortBy =
+    sortChannel === 'flag'
+      ? ([flagA], [flagB]) => {
+          return flagA.localeCompare(flagB);
+        }
+      : ([, rowA], [, rowB]) => {
+          return rowB[sortChannel].toString().localeCompare(rowA[sortChannel]);
+        };
+  sorted = Object.fromEntries(Object.entries(table).sort(sortBy));
 }
 
 if (argv.csv) {


### PR DESCRIPTION


## Summary

Fixes

```
$ yarn flags                        
yarn run v1.22.10
$ node ./scripts/flags/flags.js
/Users/sebastian.silbermann/react/scripts/flags/flags.js:323
      rowB[sortChannel].toString().localeCompare(rowA[sortChannel])
                        ^

TypeError: Cannot read properties of undefined (reading 'toString')
    at /Users/sebastian.silbermann/react/scripts/flags/flags.js:323:25
    at Array.sort (<anonymous>)
    at Object.<anonymous> (/Users/sebastian.silbermann/react/scripts/flags/flags.js:322:27)
    at Module._compile (node:internal/modules/cjs/loader:1356:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1414:10)
    at Module.load (node:internal/modules/cjs/loader:1197:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1013:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:128:12)
    at node:internal/main/run_main_module:28:49

Node.js v18.19.1
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## How did you test this change?

- `yarn flags`
- `yarn flags --sort flags`
