### PR TITLE
Add smoke test for flight fixture

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,8 @@ jobs:
           command: ./scripts/circleci/run_devtools_e2e_tests.js
 
   run_fixtures_flight_tests:
-    docker: *docker
+    docker:
+      - image: cimg/openjdk:20.0-node
     environment: *environment
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ jobs:
             sudo npx playwright install-deps
       - run:
           working_directory: fixtures/flight
-          command: cp -r ../../build/oss-experimental/* ./node_modules/
+          command: yarn build
       - run:
           name: Run tests
           working_directory: fixtures/flight

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,12 +243,16 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      # Fixture copies some built packages from the workroot after install.
+      # That means dependencies of the built packages are not installed.
+      # We need to install dependencies of the workroot to fulfill all dependency constraints
+      - setup_node_modules
       - restore_cache:
-          name: Restore yarn cache
+          name: Restore yarn cache of fixture
           keys:
             - v2-yarn_cache_fixtures_flight-{{ arch }}-{{ checksum "yarn.lock" }}
       - run:
-          name: Install dependencies
+          name: Install fixture dependencies
           working_directory: fixtures/flight
           command: |
             yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
@@ -256,7 +260,7 @@ jobs:
               yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
             fi
       - save_cache:
-          name: Save yarn cache
+          name: Save yarn cache of fixture
           key: v2-yarn_cache_fixtures_flight-{{ arch }}-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ jobs:
       - run:
           name: Run tests
           working_directory: fixtures/flight
-          command: yarn test
+          command: yarn dev
       - store_artifacts:
           path: fixtures/flight/playwright-report
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,10 @@ jobs:
       - run:
           name: Run tests
           working_directory: fixtures/flight
-          command: yarn dev
+          command: yarn test
+          environment:
+          # Otherwise the webserver is a blackbox
+            DEBUG: pw:webserver
       - store_artifacts:
           path: fixtures/flight/playwright-report
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,11 @@ jobs:
             sudo npx playwright install-deps
       - run:
           working_directory: fixtures/flight
-          command: yarn build
+          name: yarn build
+          command: |
+            yarn build
+            # Need to build twice for unknown reasons
+            yarn build
       - run:
           name: Run tests
           working_directory: fixtures/flight

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,13 +272,6 @@ jobs:
             npx playwright install
             sudo npx playwright install-deps
       - run:
-          working_directory: fixtures/flight
-          name: yarn build
-          command: |
-            yarn build
-            # Need to build twice for unknown reasons
-            yarn build
-      - run:
           name: Run tests
           working_directory: fixtures/flight
           command: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,6 +236,48 @@ jobs:
             RELEASE_CHANNEL: experimental
           command: ./scripts/circleci/run_devtools_e2e_tests.js
 
+  run_fixtures_flight_tests:
+    docker: *docker
+    environment: *environment
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          name: Restore yarn cache
+          keys:
+            - v2-yarn_cache_fixtures_flight-{{ arch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: Install dependencies
+          working_directory: fixtures/flight
+          command: |
+            yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+            if [ $? -ne 0 ]; then
+              yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+            fi
+      - save_cache:
+          name: Save yarn cache
+          key: v2-yarn_cache_fixtures_flight-{{ arch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+      - run:
+          working_directory: fixtures/flight
+          name: Playwright install deps
+          command: |
+            npx playwright install
+            sudo npx playwright install-deps
+      - run:
+          working_directory: fixtures/flight
+          command: cp -r ../../build/oss-experimental/* ./node_modules/
+      - run:
+          name: Run tests
+          working_directory: fixtures/flight
+          command: yarn test
+      - store_artifacts:
+          path: fixtures/flight/playwright-report
+      - store_artifacts:
+          path: fixtures/flight/test-results
+
   run_devtools_tests_for_versions:
     docker: *docker
     environment: *environment
@@ -516,6 +558,9 @@ workflows:
       - run_devtools_e2e_tests:
           requires:
             - build_devtools_and_process_artifacts
+      - run_fixtures_flight_tests:
+          requires:
+            - yarn_build
 
   devtools_regression_tests:
     unless: << pipeline.parameters.prerelease_commit_sha >>

--- a/fixtures/flight/.gitignore
+++ b/fixtures/flight/.gitignore
@@ -7,6 +7,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # production
 /build

--- a/fixtures/flight/__tests__/__e2e__/smoke.test.js
+++ b/fixtures/flight/__tests__/__e2e__/smoke.test.js
@@ -13,6 +13,7 @@ test('smoke test', async ({page}) => {
     pageErrors.push(error.stack);
   });
   await page.goto('/');
+  await expect(page.locator('h1')).toHaveText('Hello World');
 
   await expect(consoleErrors).toEqual([]);
   await expect(pageErrors).toEqual([]);

--- a/fixtures/flight/__tests__/__e2e__/smoke.test.js
+++ b/fixtures/flight/__tests__/__e2e__/smoke.test.js
@@ -1,0 +1,19 @@
+import {test, expect} from '@playwright/test';
+
+test('smoke test', async ({page}) => {
+  const consoleErrors = [];
+  page.on('console', msg => {
+    const type = msg.type();
+    if (type === 'warn' || type === 'error') {
+      consoleErrors.push({type: type, text: msg.text()});
+    }
+  });
+  const pageErrors = [];
+  page.on('pageerror', error => {
+    pageErrors.push(error.stack);
+  });
+  await page.goto('/');
+
+  await expect(consoleErrors).toEqual([]);
+  await expect(pageErrors).toEqual([]);
+});

--- a/fixtures/flight/package.json
+++ b/fixtures/flight/package.json
@@ -3,6 +3,9 @@
   "type": "module",
   "version": "0.1.0",
   "private": true,
+  "devEngines": {
+    "node": "20.x || 21.x"
+  },
   "dependencies": {
     "@babel/core": "^7.16.0",
     "@babel/plugin-proposal-private-property-in-object": "^7.18.6",

--- a/fixtures/flight/package.json
+++ b/fixtures/flight/package.json
@@ -60,6 +60,9 @@
     "webpack-hot-middleware": "^2.25.3",
     "webpack-manifest-plugin": "^4.0.2"
   },
+  "devDependencies": {
+    "@playwright/test": "^1.41.2"
+  },
   "scripts": {
     "predev": "cp -r ../../build/oss-experimental/* ./node_modules/",
     "prebuild": "cp -r ../../build/oss-experimental/* ./node_modules/",
@@ -70,7 +73,7 @@
     "start:global": "NODE_ENV=production node --experimental-loader ./loader/global.js server/global",
     "start:region": "NODE_ENV=production node --experimental-loader ./loader/region.js --conditions=react-server server/region",
     "build": "node scripts/build.js",
-    "test": "node scripts/test.js --env=jsdom"
+    "test": "playwright test"
   },
   "browserslist": {
     "production": [

--- a/fixtures/flight/playwright.config.js
+++ b/fixtures/flight/playwright.config.js
@@ -1,0 +1,31 @@
+import {defineConfig, devices} from '@playwright/test';
+
+const isCI = process.env.CI === '1';
+
+export default defineConfig({
+  // relative to this configuration file.
+  testDir: '__tests__/__e2e__',
+  fullyParallel: true,
+  // Fail the build on CI if you accidentally left test.only in the source code.
+  forbidOnly: !isCI,
+  retries: isCI ? 2 : 0,
+  // Opt out of parallel tests on CI.
+  workers: isCI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {...devices['Desktop Chrome']},
+    },
+  ],
+  webServer: {
+    command: 'yarn dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !isCI,
+  },
+});

--- a/fixtures/flight/playwright.config.js
+++ b/fixtures/flight/playwright.config.js
@@ -1,6 +1,6 @@
 import {defineConfig, devices} from '@playwright/test';
 
-const isCI = process.env.CI === '1';
+const isCI = Boolean(process.env.CI);
 
 export default defineConfig({
   // relative to this configuration file.

--- a/fixtures/flight/playwright.config.js
+++ b/fixtures/flight/playwright.config.js
@@ -24,7 +24,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'yarn dev',
+    command: 'FAST_REFRESH=false yarn dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !isCI,
   },

--- a/fixtures/flight/yarn.lock
+++ b/fixtures/flight/yarn.lock
@@ -2689,6 +2689,13 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@playwright/test@^1.41.2":
+  version "1.41.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.41.2.tgz#bd9db40177f8fd442e16e14e0389d23751cdfc54"
+  integrity sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==
+  dependencies:
+    playwright "1.41.2"
+
 "@pmmmwh/react-refresh-webpack-plugin@0.5.7":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.7.tgz#58f8217ba70069cc6a73f5d7e05e85b458c150e2"
@@ -4885,7 +4892,7 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents@^2.3.2, fsevents@~2.3.2:
+fsevents@2.3.2, fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -6643,6 +6650,20 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+playwright-core@1.41.2:
+  version "1.41.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.41.2.tgz#db22372c708926c697acc261f0ef8406606802d9"
+  integrity sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==
+
+playwright@1.41.2:
+  version "1.41.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.41.2.tgz#4e760b1c79f33d9129a8c65cc27953be6dd35042"
+  integrity sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==
+  dependencies:
+    playwright-core "1.41.2"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 postcss-attribute-case-insensitive@^5.0.2:
   version "5.0.2"


### PR DESCRIPTION
Not working in CI yet. Needs Node.js 20

## Summary

The test just opens the page for now and asserts that no console errors or uncaught errors happens. This would've caught the breakage that was fixed in https://github.com/facebook/react/pull/28352

## How did you test this change?

- CI
- `yarn build && cd fixtures/flight && yarn && yarn build && yarn build && yarn test`
