### PR TITLE
Fix error handling when name is a Symbol

### DIFF
--- a/packages/react-server-dom-turbopack/src/ReactFlightTurbopackReferences.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightTurbopackReferences.js
@@ -229,7 +229,7 @@ const proxyHandlers = {
               `only be rendered as a Component or passed to props of a Client Component.`,
           );
         }: any),
-        target.$$id + '#' + name,
+        target.$$id + '#' + String(name),
         target.$$async,
       );
       Object.defineProperty((reference: any), 'name', {value: name});

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js
@@ -224,7 +224,7 @@ function getReference(target: Function, name: string): $FlowFixMe {
             `only be rendered as a Component or passed to props of a Client Component.`,
         );
       }: any),
-      target.$$id + '#' + name,
+      target.$$id + '#' + String(name),
       target.$$async,
     );
     Object.defineProperty((reference: any), 'name', {value: name});


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Error discovered in a next.js application.  Normal warning about complex types being passed to client components from a server component, but in this case the code that tries to render a warning/error message actually causes a different error/exception that masks the original error.
I initially filed the issue against next.js ( https://github.com/vercel/next.js/issues/61966 ) with a repro example ( https://github.com/jon-ressio/vercel-prop-warn-error ).

I now think this is just from 1 case of String() not being called on name, so trying to concatenate a string and a symbol.  I fixed the two places I saw the same pattern.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

I have not tested it yet.  I can figure out how to yarn link and build next against my build of react that includes the fix, but it would take me a bit.  This feels like a pretty safe change, but if you'd like me to validate I can definitely do that, just let me know.