### PR TITLE
Improve stack trace when gated test fails

### DIFF
--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -241,7 +241,7 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
     global.Error = ErrorProxy;
   }
 
-  const expectTestToFail = async (callback, errorMsg) => {
+  const expectTestToFail = async (callback, error) => {
     if (callback.length > 0) {
       throw Error(
         'Gated test helpers do not support the `done` callback. Return a ' +
@@ -261,12 +261,12 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
       // `afterEach` like we normally do. `afterEach` is too late because if it
       // throws, we won't have captured it.
       flushAllUnexpectedConsoleCalls();
-    } catch (error) {
+    } catch (testError) {
       // Failed as expected
       resetAllUnexpectedConsoleCalls();
       return;
     }
-    throw Error(errorMsg);
+    throw error;
   };
 
   const gatedErrorMessage = 'Gated test was expected to fail, but it passed.';
@@ -284,8 +284,10 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
     if (shouldPass) {
       test(testName, callback);
     } else {
+      const error = new Error(gatedErrorMessage);
+      Error.captureStackTrace(error, global._test_gate);
       test(`[GATED, SHOULD FAIL] ${testName}`, () =>
-        expectTestToFail(callback, gatedErrorMessage));
+        expectTestToFail(callback, error));
     }
   };
   global._test_gate_focus = (gateFn, testName, callback) => {
@@ -302,8 +304,10 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
     if (shouldPass) {
       test.only(testName, callback);
     } else {
+      const error = new Error(gatedErrorMessage);
+      Error.captureStackTrace(error, global._test_gate_focus);
       test.only(`[GATED, SHOULD FAIL] ${testName}`, () =>
-        expectTestToFail(callback, gatedErrorMessage));
+        expectTestToFail(callback, error));
     }
   };
 


### PR DESCRIPTION
## Summary

After:
```
  ● ReactDOMInput › [GATED, SHOULD FAIL] should render bigint value for SSR

    Gated test was expected to fail, but it passed.

      679 |
      680 |   // @gate enableBigIntSupport
    > 681 |   it('should render bigint value for SSR', () => {
          |   ^
      682 |     const element = <input type="text" value={5n} onChange={() => {}} />;
      683 |     const markup = ReactDOMServer.renderToString(element);
      684 |     const div = document.createElement('div');

      at packages/react-dom/src/__tests__/ReactDOMInput-test.js:681:3
      at Object.<anonymous> (packages/react-dom/src/__tests__/ReactDOMInput-test.js:17:1)

```

Before:
```
  ● ReactDOMInput › [GATED, SHOULD FAIL] should render bigint value for SSR

    Gated test was expected to fail, but it passed.

      267 |       return;
      268 |     }
    > 269 |     throw Error(errorMsg);
          |           ^
      270 |   };
      271 |
      272 |   const gatedErrorMessage = 'Gated test was expected to fail, but it passed.';

      at expectTestToFail (scripts/jest/setupTests.js:269:11)
      at Object.<anonymous> (scripts/jest/setupTests.js:288:11)
```

## How did you test this change?

- Gated a test that passed to see the new and improved stack trace
