### PR TITLE
Remove RTR from ReactCreateRef-test

### DIFF
--- a/packages/react/src/__tests__/ReactCreateRef-test.js
+++ b/packages/react/src/__tests__/ReactCreateRef-test.js
@@ -10,14 +10,16 @@
 'use strict';
 
 let React;
-let ReactTestRenderer;
+let ReactDOM;
+let ReactDOMClient;
 
 describe('ReactCreateRef', () => {
   beforeEach(() => {
     jest.resetModules();
 
     React = require('react');
-    ReactTestRenderer = require('react-test-renderer');
+    ReactDOM = require('react-dom');
+    ReactDOMClient = require('react-dom/client');
   });
 
   it('should warn in dev if an invalid ref object is provided', () => {
@@ -31,12 +33,15 @@ describe('ReactCreateRef', () => {
       }
     }
 
+    const root = ReactDOMClient.createRoot(document.createElement('div'));
     expect(() =>
-      ReactTestRenderer.create(
-        <Wrapper>
-          <div ref={{}} />
-        </Wrapper>,
-      ),
+      ReactDOM.flushSync(() => {
+        root.render(
+          <Wrapper>
+            <div ref={{}} />
+          </Wrapper>,
+        );
+      }),
     ).toErrorDev(
       'Unexpected ref object provided for div. ' +
         'Use either a ref-setter function or React.createRef().\n' +
@@ -45,11 +50,13 @@ describe('ReactCreateRef', () => {
     );
 
     expect(() =>
-      ReactTestRenderer.create(
-        <Wrapper>
-          <ExampleComponent ref={{}} />
-        </Wrapper>,
-      ),
+      ReactDOM.flushSync(() => {
+        root.render(
+          <Wrapper>
+            <ExampleComponent ref={{}} />
+          </Wrapper>,
+        );
+      }),
     ).toErrorDev(
       'Unexpected ref object provided for ExampleComponent. ' +
         'Use either a ref-setter function or React.createRef().\n' +


### PR DESCRIPTION
## Summary

Cleaning up internal usage of ReactTestRenderer

## How did you test this change?

`yarn test packages/react/src/__tests__/ReactCreateRef-test.js`
