### PR TITLE
Remove RTR from StrictEffectsMode-test

### DIFF
--- a/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
+++ b/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
@@ -10,12 +10,10 @@
 'use strict';
 
 let React;
-let ReactDOMClient;
-let ReactDOM;
+let ReactNoop;
 let Scheduler;
 let act;
 let assertLog;
-let container;
 
 describe('StrictEffectsMode', () => {
   beforeEach(() => {
@@ -26,9 +24,7 @@ describe('StrictEffectsMode', () => {
 
     React = require('react');
     Scheduler = require('scheduler');
-    ReactDOMClient = require('react-dom/client');
-    ReactDOM = require('react-dom');
-    container = document.createElement('div');
+    ReactNoop = require('react-noop-renderer');
   });
 
   it('should not double invoke effects in legacy mode', async () => {
@@ -46,12 +42,12 @@ describe('StrictEffectsMode', () => {
       return text;
     }
 
+    const root = ReactNoop.createLegacyRoot();
     await act(() => {
-      ReactDOM.render(
+      root.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
-        container,
       );
     });
 
@@ -73,12 +69,12 @@ describe('StrictEffectsMode', () => {
       return text;
     }
 
-    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
+        'root',
       );
     });
 
@@ -96,10 +92,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'update'} />
         </React.StrictMode>,
+        'root',
       );
     });
 
@@ -111,7 +108,7 @@ describe('StrictEffectsMode', () => {
     ]);
 
     await act(() => {
-      root.unmount();
+      ReactNoop.unmountRootWithID('root');
     });
 
     assertLog(['useLayoutEffect unmount', 'useEffect unmount']);
@@ -132,12 +129,12 @@ describe('StrictEffectsMode', () => {
       return text;
     }
 
-    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
+        'root',
       );
     });
 
@@ -155,10 +152,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'update'} />
         </React.StrictMode>,
+        'root',
       );
     });
 
@@ -170,7 +168,7 @@ describe('StrictEffectsMode', () => {
     ]);
 
     await act(() => {
-      root.unmount(null);
+      ReactNoop.unmountRootWithID('root');
     });
 
     assertLog(['useEffect One unmount', 'useEffect Two unmount']);
@@ -191,12 +189,12 @@ describe('StrictEffectsMode', () => {
       return text;
     }
 
-    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
+        'root',
       );
     });
 
@@ -214,10 +212,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'update'} />
         </React.StrictMode>,
+        'root',
       );
     });
 
@@ -229,7 +228,7 @@ describe('StrictEffectsMode', () => {
     ]);
 
     await act(() => {
-      root.unmount();
+      ReactNoop.unmountRootWithID('root');
     });
 
     assertLog(['useLayoutEffect One unmount', 'useLayoutEffect Two unmount']);
@@ -248,9 +247,8 @@ describe('StrictEffectsMode', () => {
       return text;
     }
 
-    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
@@ -269,7 +267,7 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'update'} />
         </React.StrictMode>,
@@ -279,7 +277,7 @@ describe('StrictEffectsMode', () => {
     assertLog(['useLayoutEffect mount', 'useEffect mount']);
 
     await act(() => {
-      root.unmount();
+      ReactNoop.unmountRootWithID('root');
     });
 
     assertLog([]);
@@ -309,9 +307,8 @@ describe('StrictEffectsMode', () => {
       }
     }
 
-    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App />
         </React.StrictMode>,
@@ -348,12 +345,12 @@ describe('StrictEffectsMode', () => {
       }
     }
 
-    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
+        'root',
       );
     });
 
@@ -368,17 +365,18 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'update'} />
         </React.StrictMode>,
+        'root',
       );
     });
 
     assertLog(['componentDidUpdate']);
 
     await act(() => {
-      root.unmount();
+      ReactNoop.unmountRootWithID('root');
     });
 
     assertLog(['componentWillUnmount']);
@@ -399,12 +397,12 @@ describe('StrictEffectsMode', () => {
       }
     }
 
-    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
+        'root',
       );
     });
 
@@ -415,17 +413,18 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'update'} />
         </React.StrictMode>,
+        'root',
       );
     });
 
     assertLog(['componentDidUpdate']);
 
     await act(() => {
-      root.unmount();
+      ReactNoop.unmountRootWithID('root');
     });
 
     assertLog(['componentWillUnmount']);
@@ -450,12 +449,12 @@ describe('StrictEffectsMode', () => {
       }
     }
 
+    const root = ReactNoop.createLegacyRoot();
     await act(() => {
-      ReactDOM.render(
+      root.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
-        container,
       );
     });
 
@@ -482,9 +481,8 @@ describe('StrictEffectsMode', () => {
       return text;
     }
 
-    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
@@ -550,12 +548,12 @@ describe('StrictEffectsMode', () => {
       return showChild && <Child />;
     }
 
-    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App />
         </React.StrictMode>,
+        'root',
       );
     });
 
@@ -637,12 +635,12 @@ describe('StrictEffectsMode', () => {
       );
     }
 
-    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
+        'root',
       );
     });
 
@@ -667,10 +665,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
+        'root',
       );
     });
 
@@ -682,7 +681,7 @@ describe('StrictEffectsMode', () => {
     ]);
 
     await act(() => {
-      root.unmount();
+      ReactNoop.unmountRootWithID('root');
     });
 
     assertLog([
@@ -724,12 +723,12 @@ describe('StrictEffectsMode', () => {
       );
     }
 
-    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
+        'root',
       );
     });
 
@@ -748,10 +747,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      root.render(
+      ReactNoop.renderToRootWithID(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
+        'root',
       );
     });
 
@@ -763,7 +763,7 @@ describe('StrictEffectsMode', () => {
     ]);
 
     await act(() => {
-      root.unmount();
+      ReactNoop.unmountRootWithID('root');
     });
 
     assertLog([

--- a/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
+++ b/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
@@ -10,21 +10,25 @@
 'use strict';
 
 let React;
-let ReactTestRenderer;
+let ReactDOMClient;
+let ReactDOM;
 let Scheduler;
 let act;
 let assertLog;
+let container;
 
 describe('StrictEffectsMode', () => {
   beforeEach(() => {
     jest.resetModules();
-    React = require('react');
-    ReactTestRenderer = require('react-test-renderer');
-    Scheduler = require('scheduler');
     act = require('internal-test-utils').act;
-
     const InternalTestUtils = require('internal-test-utils');
     assertLog = InternalTestUtils.assertLog;
+
+    React = require('react');
+    Scheduler = require('scheduler');
+    ReactDOMClient = require('react-dom/client');
+    ReactDOM = require('react-dom');
+    container = document.createElement('div');
   });
 
   it('should not double invoke effects in legacy mode', async () => {
@@ -43,10 +47,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      ReactTestRenderer.create(
+      ReactDOM.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
+        container,
       );
     });
 
@@ -68,15 +73,12 @@ describe('StrictEffectsMode', () => {
       return text;
     }
 
-    let renderer;
+    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      renderer = ReactTestRenderer.create(
+      root.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
-        {
-          isConcurrent: true,
-        },
       );
     });
 
@@ -94,7 +96,7 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(
+      root.render(
         <React.StrictMode>
           <App text={'update'} />
         </React.StrictMode>,
@@ -109,7 +111,7 @@ describe('StrictEffectsMode', () => {
     ]);
 
     await act(() => {
-      renderer.unmount();
+      root.unmount();
     });
 
     assertLog(['useLayoutEffect unmount', 'useEffect unmount']);
@@ -130,15 +132,12 @@ describe('StrictEffectsMode', () => {
       return text;
     }
 
-    let renderer;
+    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      renderer = ReactTestRenderer.create(
+      root.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
-        {
-          isConcurrent: true,
-        },
       );
     });
 
@@ -156,7 +155,7 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(
+      root.render(
         <React.StrictMode>
           <App text={'update'} />
         </React.StrictMode>,
@@ -171,7 +170,7 @@ describe('StrictEffectsMode', () => {
     ]);
 
     await act(() => {
-      renderer.unmount(null);
+      root.unmount(null);
     });
 
     assertLog(['useEffect One unmount', 'useEffect Two unmount']);
@@ -192,15 +191,12 @@ describe('StrictEffectsMode', () => {
       return text;
     }
 
-    let renderer;
+    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      renderer = ReactTestRenderer.create(
+      root.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
-        {
-          isConcurrent: true,
-        },
       );
     });
 
@@ -218,7 +214,7 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(
+      root.render(
         <React.StrictMode>
           <App text={'update'} />
         </React.StrictMode>,
@@ -233,7 +229,7 @@ describe('StrictEffectsMode', () => {
     ]);
 
     await act(() => {
-      renderer.unmount();
+      root.unmount();
     });
 
     assertLog(['useLayoutEffect One unmount', 'useLayoutEffect Two unmount']);
@@ -252,15 +248,12 @@ describe('StrictEffectsMode', () => {
       return text;
     }
 
-    let renderer;
+    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      renderer = ReactTestRenderer.create(
+      root.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
-        {
-          isConcurrent: true,
-        },
       );
     });
 
@@ -276,7 +269,7 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(
+      root.render(
         <React.StrictMode>
           <App text={'update'} />
         </React.StrictMode>,
@@ -286,7 +279,7 @@ describe('StrictEffectsMode', () => {
     assertLog(['useLayoutEffect mount', 'useEffect mount']);
 
     await act(() => {
-      renderer.unmount();
+      root.unmount();
     });
 
     assertLog([]);
@@ -316,12 +309,12 @@ describe('StrictEffectsMode', () => {
       }
     }
 
+    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      ReactTestRenderer.create(
+      root.render(
         <React.StrictMode>
           <App />
         </React.StrictMode>,
-        {isConcurrent: true},
       );
     });
 
@@ -355,15 +348,12 @@ describe('StrictEffectsMode', () => {
       }
     }
 
-    let renderer;
+    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      renderer = ReactTestRenderer.create(
+      root.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
-        {
-          isConcurrent: true,
-        },
       );
     });
 
@@ -378,7 +368,7 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(
+      root.render(
         <React.StrictMode>
           <App text={'update'} />
         </React.StrictMode>,
@@ -388,7 +378,7 @@ describe('StrictEffectsMode', () => {
     assertLog(['componentDidUpdate']);
 
     await act(() => {
-      renderer.unmount();
+      root.unmount();
     });
 
     assertLog(['componentWillUnmount']);
@@ -409,15 +399,12 @@ describe('StrictEffectsMode', () => {
       }
     }
 
-    let renderer;
+    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      renderer = ReactTestRenderer.create(
+      root.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
-        {
-          isConcurrent: true,
-        },
       );
     });
 
@@ -428,7 +415,7 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(
+      root.render(
         <React.StrictMode>
           <App text={'update'} />
         </React.StrictMode>,
@@ -438,7 +425,7 @@ describe('StrictEffectsMode', () => {
     assertLog(['componentDidUpdate']);
 
     await act(() => {
-      renderer.unmount();
+      root.unmount();
     });
 
     assertLog(['componentWillUnmount']);
@@ -464,10 +451,11 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      ReactTestRenderer.create(
+      ReactDOM.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
+        container,
       );
     });
 
@@ -494,14 +482,12 @@ describe('StrictEffectsMode', () => {
       return text;
     }
 
+    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      ReactTestRenderer.create(
+      root.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
-        {
-          isConcurrent: true,
-        },
       );
     });
 
@@ -564,12 +550,12 @@ describe('StrictEffectsMode', () => {
       return showChild && <Child />;
     }
 
+    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      ReactTestRenderer.create(
+      root.render(
         <React.StrictMode>
           <App />
         </React.StrictMode>,
-        {isConcurrent: true},
       );
     });
 
@@ -651,15 +637,12 @@ describe('StrictEffectsMode', () => {
       );
     }
 
-    let renderer;
+    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      renderer = ReactTestRenderer.create(
+      root.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
-        {
-          isConcurrent: true,
-        },
       );
     });
 
@@ -684,7 +667,7 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(
+      root.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
@@ -699,7 +682,7 @@ describe('StrictEffectsMode', () => {
     ]);
 
     await act(() => {
-      renderer.unmount();
+      root.unmount();
     });
 
     assertLog([
@@ -741,15 +724,12 @@ describe('StrictEffectsMode', () => {
       );
     }
 
-    let renderer;
+    const root = ReactDOMClient.createRoot(container);
     await act(() => {
-      renderer = ReactTestRenderer.create(
+      root.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
-        {
-          isConcurrent: true,
-        },
       );
     });
 
@@ -768,7 +748,7 @@ describe('StrictEffectsMode', () => {
     }
 
     await act(() => {
-      renderer.update(
+      root.render(
         <React.StrictMode>
           <App text={'mount'} />
         </React.StrictMode>,
@@ -783,7 +763,7 @@ describe('StrictEffectsMode', () => {
     ]);
 
     await act(() => {
-      renderer.unmount();
+      root.unmount();
     });
 
     assertLog([


### PR DESCRIPTION
## Summary

Cleaning up internal usage of ReactTestRenderer

## How did you test this change?

`yarn test packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js`
