### PR TITLE
[Flight] Prefix Replayed Console Logs with a Badge

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -1095,12 +1095,13 @@ function resolveConsoleEntry(
     );
   }
 
-  const payload: [string, string, mixed] = parseModel(response, value);
+  const payload: [string, string, string, mixed] = parseModel(response, value);
   const methodName = payload[0];
   // TODO: Restore the fake stack before logging.
   // const stackTrace = payload[1];
-  const args = payload.slice(2);
-  printToConsole(methodName, args);
+  const env = payload[2];
+  const args = payload.slice(3);
+  printToConsole(methodName, args, env);
 }
 
 function mergeBuffer(

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -50,6 +50,7 @@ import {
   readFinalStringChunk,
   createStringDecoder,
   prepareDestinationForModule,
+  printToConsole,
 } from './ReactFlightClientConfig';
 
 import {registerServerReference} from './ReactFlightReplyClient';
@@ -1099,8 +1100,7 @@ function resolveConsoleEntry(
   // TODO: Restore the fake stack before logging.
   // const stackTrace = payload[1];
   const args = payload.slice(2);
-  // eslint-disable-next-line react-internal/no-production-logging
-  console[methodName].apply(console, args);
+  printToConsole(methodName, args);
 }
 
 function mergeBuffer(

--- a/packages/react-client/src/ReactFlightClientConsoleConfigBrowser.js
+++ b/packages/react-client/src/ReactFlightClientConsoleConfigBrowser.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export function printToConsole(methodName: string, args: Array<any>): void {
+  switch (methodName) {
+    case 'dir':
+    case 'dirxml':
+    case 'groupEnd':
+    case 'table': {
+      // These methods cannot be colorized because they don't take a formatting string.
+      // eslint-disable-next-line react-internal/no-production-logging
+      console[methodName].apply(console, args);
+      return;
+    }
+    case 'assert': {
+      // assert takes formatting options as the second argument.
+      // eslint-disable-next-line react-internal/no-production-logging
+      console.assert.apply(console, args);
+      return;
+    }
+    default: {
+      // eslint-disable-next-line react-internal/no-production-logging
+      console[methodName].apply(console, args);
+      return;
+    }
+  }
+}

--- a/packages/react-client/src/ReactFlightClientConsoleConfigBrowser.js
+++ b/packages/react-client/src/ReactFlightClientConsoleConfigBrowser.js
@@ -7,7 +7,11 @@
  * @flow
  */
 
-export function printToConsole(methodName: string, args: Array<any>): void {
+export function printToConsole(
+  methodName: string,
+  args: Array<any>,
+  badgeName: string,
+): void {
   switch (methodName) {
     case 'dir':
     case 'dirxml':

--- a/packages/react-client/src/ReactFlightClientConsoleConfigBrowser.js
+++ b/packages/react-client/src/ReactFlightClientConsoleConfigBrowser.js
@@ -7,18 +7,17 @@
  * @flow
  */
 
-import normalizeConsoleFormat from 'shared/normalizeConsoleFormat';
-
-const badgeFormat = ' %c%s%c';
+const badgeFormat = '%c%s%c ';
 // Same badge styling as DevTools.
 const badgeStyle =
   // We use a fixed background if light-dark is not supported, otherwise
   // we use a transparent background.
   'background: #e6e6e6;' +
   'background: light-dark(rgba(0,0,0,0.1), rgba(255,255,255,0.25));' +
-  'color: #000000; ' +
-  'color: light-dark(#000000, #ffffff); ' +
+  'color: #000000;' +
+  'color: light-dark(#000000, #ffffff);' +
   'border-radius: 2px';
+const resetStyle = '';
 const pad = ' ';
 
 export function printToConsole(
@@ -26,6 +25,7 @@ export function printToConsole(
   args: Array<any>,
   badgeName: string,
 ): void {
+  let offset = 0;
   switch (methodName) {
     case 'dir':
     case 'dirxml':
@@ -38,33 +38,32 @@ export function printToConsole(
     }
     case 'assert': {
       // assert takes formatting options as the second argument.
-      const newArgs = args.slice(0);
-
-      if (typeof args[1] === 'string') {
-        newArgs[1] = normalizeConsoleFormat(args[1], args, 2) + badgeFormat;
-      } else {
-        newArgs.splice(1, 0, normalizeConsoleFormat('', args, 1) + badgeFormat);
-      }
-
-      newArgs.push(badgeStyle, pad + badgeName + pad, '');
-
-      // eslint-disable-next-line react-internal/no-production-logging
-      console.assert.apply(console, args);
-      return;
-    }
-    default: {
-      const newArgs = args.slice(0);
-      if (typeof args[0] === 'string') {
-        newArgs[0] = normalizeConsoleFormat(args[0], args, 1) + badgeFormat;
-      } else {
-        newArgs.unshift(normalizeConsoleFormat('', args, 0) + badgeFormat);
-      }
-
-      newArgs.push(badgeStyle, pad + badgeName + pad, '');
-
-      // eslint-disable-next-line react-internal/no-production-logging
-      console[methodName].apply(console, args);
-      return;
+      offset = 1;
     }
   }
+
+  const newArgs = args.slice(0);
+  if (typeof newArgs[offset] === 'string') {
+    newArgs.splice(
+      offset,
+      1,
+      badgeFormat + newArgs[offset],
+      badgeStyle,
+      pad + badgeName + pad,
+      resetStyle,
+    );
+  } else {
+    newArgs.splice(
+      offset,
+      0,
+      badgeFormat,
+      badgeStyle,
+      pad + badgeName + pad,
+      resetStyle,
+    );
+  }
+
+  // eslint-disable-next-line react-internal/no-production-logging
+  console[methodName].apply(console, newArgs);
+  return;
 }

--- a/packages/react-client/src/ReactFlightClientConsoleConfigBrowser.js
+++ b/packages/react-client/src/ReactFlightClientConsoleConfigBrowser.js
@@ -7,6 +7,20 @@
  * @flow
  */
 
+import normalizeConsoleFormat from 'shared/normalizeConsoleFormat';
+
+const badgeFormat = ' %c%s%c';
+// Same badge styling as DevTools.
+const badgeStyle =
+  // We use a fixed background if light-dark is not supported, otherwise
+  // we use a transparent background.
+  'background: #e6e6e6;' +
+  'background: light-dark(rgba(0,0,0,0.1), rgba(255,255,255,0.25));' +
+  'color: #000000; ' +
+  'color: light-dark(#000000, #ffffff); ' +
+  'border-radius: 2px';
+const pad = ' ';
+
 export function printToConsole(
   methodName: string,
   args: Array<any>,
@@ -24,11 +38,30 @@ export function printToConsole(
     }
     case 'assert': {
       // assert takes formatting options as the second argument.
+      const newArgs = args.slice(0);
+
+      if (typeof args[1] === 'string') {
+        newArgs[1] = normalizeConsoleFormat(args[1], args, 2) + badgeFormat;
+      } else {
+        newArgs.splice(1, 0, normalizeConsoleFormat('', args, 1) + badgeFormat);
+      }
+
+      newArgs.push(badgeStyle, pad + badgeName + pad, '');
+
       // eslint-disable-next-line react-internal/no-production-logging
       console.assert.apply(console, args);
       return;
     }
     default: {
+      const newArgs = args.slice(0);
+      if (typeof args[0] === 'string') {
+        newArgs[0] = normalizeConsoleFormat(args[0], args, 1) + badgeFormat;
+      } else {
+        newArgs.unshift(normalizeConsoleFormat('', args, 0) + badgeFormat);
+      }
+
+      newArgs.push(badgeStyle, pad + badgeName + pad, '');
+
       // eslint-disable-next-line react-internal/no-production-logging
       console[methodName].apply(console, args);
       return;

--- a/packages/react-client/src/ReactFlightClientConsoleConfigPlain.js
+++ b/packages/react-client/src/ReactFlightClientConsoleConfigPlain.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+const badgeFormat = '[%s] ';
+const pad = ' ';
+
+export function printToConsole(
+  methodName: string,
+  args: Array<any>,
+  badgeName: string,
+): void {
+  let offset = 0;
+  switch (methodName) {
+    case 'dir':
+    case 'dirxml':
+    case 'groupEnd':
+    case 'table': {
+      // These methods cannot be colorized because they don't take a formatting string.
+      // eslint-disable-next-line react-internal/no-production-logging
+      console[methodName].apply(console, args);
+      return;
+    }
+    case 'assert': {
+      // assert takes formatting options as the second argument.
+      offset = 1;
+    }
+  }
+
+  const newArgs = args.slice(0);
+  if (typeof newArgs[offset] === 'string') {
+    newArgs.splice(
+      offset,
+      1,
+      badgeFormat + newArgs[offset],
+      pad + badgeName + pad,
+    );
+  } else {
+    newArgs.splice(offset, 0, badgeFormat, pad + badgeName + pad);
+  }
+
+  // eslint-disable-next-line react-internal/no-production-logging
+  console[methodName].apply(console, newArgs);
+  return;
+}

--- a/packages/react-client/src/ReactFlightClientConsoleConfigServer.js
+++ b/packages/react-client/src/ReactFlightClientConsoleConfigServer.js
@@ -7,6 +7,21 @@
  * @flow
  */
 
+import normalizeConsoleFormat from 'shared/normalizeConsoleFormat';
+
+// This flips color using ANSI, then sets a color styling, then resets.
+const badgeFormat = ' \x1b[0m\x1b[7m%c%s\x1b[0m%c';
+// Same badge styling as DevTools.
+const badgeStyle =
+  // We use a fixed background if light-dark is not supported, otherwise
+  // we use a transparent background.
+  'background: #e6e6e6;' +
+  'background: light-dark(rgba(0,0,0,0.1), rgba(255,255,255,0.25));' +
+  'color: #000000; ' +
+  'color: light-dark(#000000, #ffffff); ' +
+  'border-radius: 2px';
+const pad = ' ';
+
 export function printToConsole(
   methodName: string,
   args: Array<any>,
@@ -24,11 +39,30 @@ export function printToConsole(
     }
     case 'assert': {
       // assert takes formatting options as the second argument.
+      const newArgs = args.slice(0);
+
+      if (typeof args[1] === 'string') {
+        newArgs[1] = normalizeConsoleFormat(args[1], args, 2) + badgeFormat;
+      } else {
+        newArgs.splice(1, 0, normalizeConsoleFormat('', args, 1) + badgeFormat);
+      }
+
+      newArgs.push(badgeStyle, pad + badgeName + pad, '');
+
       // eslint-disable-next-line react-internal/no-production-logging
       console.assert.apply(console, args);
       return;
     }
     default: {
+      const newArgs = args.slice(0);
+      if (typeof args[0] === 'string') {
+        newArgs[0] = normalizeConsoleFormat(args[0], args, 1) + badgeFormat;
+      } else {
+        newArgs.unshift(normalizeConsoleFormat('', args, 0) + badgeFormat);
+      }
+
+      newArgs.push(badgeStyle, pad + badgeName + pad, '');
+
       // eslint-disable-next-line react-internal/no-production-logging
       console[methodName].apply(console, args);
       return;

--- a/packages/react-client/src/ReactFlightClientConsoleConfigServer.js
+++ b/packages/react-client/src/ReactFlightClientConsoleConfigServer.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export function printToConsole(methodName: string, args: Array<any>): void {
+  switch (methodName) {
+    case 'dir':
+    case 'dirxml':
+    case 'groupEnd':
+    case 'table': {
+      // These methods cannot be colorized because they don't take a formatting string.
+      // eslint-disable-next-line react-internal/no-production-logging
+      console[methodName].apply(console, args);
+      return;
+    }
+    case 'assert': {
+      // assert takes formatting options as the second argument.
+      // eslint-disable-next-line react-internal/no-production-logging
+      console.assert.apply(console, args);
+      return;
+    }
+    default: {
+      // eslint-disable-next-line react-internal/no-production-logging
+      console[methodName].apply(console, args);
+      return;
+    }
+  }
+}

--- a/packages/react-client/src/ReactFlightClientConsoleConfigServer.js
+++ b/packages/react-client/src/ReactFlightClientConsoleConfigServer.js
@@ -7,7 +7,11 @@
  * @flow
  */
 
-export function printToConsole(methodName: string, args: Array<any>): void {
+export function printToConsole(
+  methodName: string,
+  args: Array<any>,
+  badgeName: string,
+): void {
   switch (methodName) {
     case 'dir':
     case 'dirxml':

--- a/packages/react-client/src/ReactFlightClientConsoleConfigServer.js
+++ b/packages/react-client/src/ReactFlightClientConsoleConfigServer.js
@@ -7,19 +7,18 @@
  * @flow
  */
 
-import normalizeConsoleFormat from 'shared/normalizeConsoleFormat';
-
 // This flips color using ANSI, then sets a color styling, then resets.
-const badgeFormat = ' \x1b[0m\x1b[7m%c%s\x1b[0m%c';
+const badgeFormat = '\x1b[0m\x1b[7m%c%s\x1b[0m%c ';
 // Same badge styling as DevTools.
 const badgeStyle =
   // We use a fixed background if light-dark is not supported, otherwise
   // we use a transparent background.
   'background: #e6e6e6;' +
   'background: light-dark(rgba(0,0,0,0.1), rgba(255,255,255,0.25));' +
-  'color: #000000; ' +
-  'color: light-dark(#000000, #ffffff); ' +
+  'color: #000000;' +
+  'color: light-dark(#000000, #ffffff);' +
   'border-radius: 2px';
+const resetStyle = '';
 const pad = ' ';
 
 export function printToConsole(
@@ -27,6 +26,7 @@ export function printToConsole(
   args: Array<any>,
   badgeName: string,
 ): void {
+  let offset = 0;
   switch (methodName) {
     case 'dir':
     case 'dirxml':
@@ -39,33 +39,32 @@ export function printToConsole(
     }
     case 'assert': {
       // assert takes formatting options as the second argument.
-      const newArgs = args.slice(0);
-
-      if (typeof args[1] === 'string') {
-        newArgs[1] = normalizeConsoleFormat(args[1], args, 2) + badgeFormat;
-      } else {
-        newArgs.splice(1, 0, normalizeConsoleFormat('', args, 1) + badgeFormat);
-      }
-
-      newArgs.push(badgeStyle, pad + badgeName + pad, '');
-
-      // eslint-disable-next-line react-internal/no-production-logging
-      console.assert.apply(console, args);
-      return;
-    }
-    default: {
-      const newArgs = args.slice(0);
-      if (typeof args[0] === 'string') {
-        newArgs[0] = normalizeConsoleFormat(args[0], args, 1) + badgeFormat;
-      } else {
-        newArgs.unshift(normalizeConsoleFormat('', args, 0) + badgeFormat);
-      }
-
-      newArgs.push(badgeStyle, pad + badgeName + pad, '');
-
-      // eslint-disable-next-line react-internal/no-production-logging
-      console[methodName].apply(console, args);
-      return;
+      offset = 1;
     }
   }
+
+  const newArgs = args.slice(0);
+  if (typeof newArgs[offset] === 'string') {
+    newArgs.splice(
+      offset,
+      1,
+      badgeFormat + newArgs[offset],
+      badgeStyle,
+      pad + badgeName + pad,
+      resetStyle,
+    );
+  } else {
+    newArgs.splice(
+      offset,
+      0,
+      badgeFormat,
+      badgeStyle,
+      pad + badgeName + pad,
+      resetStyle,
+    );
+  }
+
+  // eslint-disable-next-line react-internal/no-production-logging
+  console[methodName].apply(console, newArgs);
+  return;
 }

--- a/packages/react-client/src/forks/ReactFlightClientConfig.custom.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.custom.js
@@ -47,3 +47,5 @@ export opaque type StringDecoder = mixed; // eslint-disable-line no-undef
 export const createStringDecoder = $$$config.createStringDecoder;
 export const readPartialStringChunk = $$$config.readPartialStringChunk;
 export const readFinalStringChunk = $$$config.readFinalStringChunk;
+
+export const printToConsole = $$$config.printToConsole;

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser-esm.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser-esm.js
@@ -8,6 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
+export * from 'react-client/src/ReactFlightClientConsoleConfigBrowser';
 export * from 'react-server-dom-esm/src/ReactFlightClientConfigBundlerESM';
 export * from 'react-server-dom-esm/src/ReactFlightClientConfigTargetESMBrowser';
 export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser-turbopack.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser-turbopack.js
@@ -8,6 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
+export * from 'react-client/src/ReactFlightClientConsoleConfigBrowser';
 export * from 'react-server-dom-turbopack/src/ReactFlightClientConfigBundlerTurbopack';
 export * from 'react-server-dom-turbopack/src/ReactFlightClientConfigBundlerTurbopackBrowser';
 export * from 'react-server-dom-turbopack/src/ReactFlightClientConfigTargetTurbopackBrowser';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser.js
@@ -8,6 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
+export * from 'react-client/src/ReactFlightClientConsoleConfigBrowser';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpack';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpackBrowser';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigTargetWebpackBrowser';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-bun.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-bun.js
@@ -8,6 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
+export * from 'react-client/src/ReactFlightClientConsoleConfigServer';
 export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';
 
 export type Response = any;

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-bun.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-bun.js
@@ -8,7 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
-export * from 'react-client/src/ReactFlightClientConsoleConfigServer';
+export * from 'react-client/src/ReactFlightClientConsoleConfigPlain';
 export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';
 
 export type Response = any;

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-turbopack.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-turbopack.js
@@ -8,6 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
+export * from 'react-client/src/ReactFlightClientConsoleConfigServer';
 export * from 'react-server-dom-turbopack/src/ReactFlightClientConfigBundlerTurbopack';
 export * from 'react-server-dom-turbopack/src/ReactFlightClientConfigBundlerTurbopackServer';
 export * from 'react-server-dom-turbopack/src/ReactFlightClientConfigTargetTurbopackServer';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-webpack.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-webpack.js
@@ -8,6 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
+export * from 'react-client/src/ReactFlightClientConsoleConfigServer';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpack';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpackServer';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigTargetWebpackServer';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-fb-experimental.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-fb-experimental.js
@@ -8,7 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
-export * from 'react-client/src/ReactFlightClientConsoleConfigServer';
+export * from 'react-client/src/ReactFlightClientConsoleConfigPlain';
 export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';
 export * from 'react-server-dom-fb/src/ReactFlightClientConfigFBBundler';
 

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-fb-experimental.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-fb-experimental.js
@@ -8,6 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
+export * from 'react-client/src/ReactFlightClientConsoleConfigServer';
 export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';
 export * from 'react-server-dom-fb/src/ReactFlightClientConfigFBBundler';
 

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-legacy.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-legacy.js
@@ -8,6 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
+export * from 'react-client/src/ReactFlightClientConsoleConfigBrowser';
 export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';
 
 export type Response = any;

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-esm.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-esm.js
@@ -8,6 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigNode';
+export * from 'react-client/src/ReactFlightClientConsoleConfigServer';
 export * from 'react-server-dom-esm/src/ReactFlightClientConfigBundlerESM';
 export * from 'react-server-dom-esm/src/ReactFlightClientConfigTargetESMServer';
 export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-turbopack-bundled.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-turbopack-bundled.js
@@ -8,6 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigNode';
+export * from 'react-client/src/ReactFlightClientConsoleConfigServer';
 export * from 'react-server-dom-turbopack/src/ReactFlightClientConfigBundlerTurbopack';
 export * from 'react-server-dom-turbopack/src/ReactFlightClientConfigBundlerTurbopackServer';
 export * from 'react-server-dom-turbopack/src/ReactFlightClientConfigTargetTurbopackServer';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-turbopack.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-turbopack.js
@@ -8,6 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigNode';
+export * from 'react-client/src/ReactFlightClientConsoleConfigServer';
 export * from 'react-server-dom-turbopack/src/ReactFlightClientConfigBundlerNode';
 export * from 'react-server-dom-turbopack/src/ReactFlightClientConfigTargetTurbopackServer';
 export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-webpack.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-webpack.js
@@ -8,6 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigNode';
+export * from 'react-client/src/ReactFlightClientConsoleConfigServer';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpack';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpackServer';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigTargetWebpackServer';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-node.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-node.js
@@ -8,6 +8,7 @@
  */
 
 export * from 'react-client/src/ReactFlightClientStreamConfigNode';
+export * from 'react-client/src/ReactFlightClientConsoleConfigServer';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigBundlerNode';
 export * from 'react-server-dom-webpack/src/ReactFlightClientConfigTargetWebpackServer';
 export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';

--- a/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
@@ -43,6 +43,10 @@ const {createResponse, processBinaryChunk, getRoot, close} = ReactFlightClient({
   parseModel(response: Response, json) {
     return JSON.parse(json, response._fromJSON);
   },
+  printToConsole(methodName, args, badgeName) {
+    // eslint-disable-next-line react-internal/no-production-logging
+    console[methodName].apply(console, args);
+  },
 });
 
 function read<T>(source: Source): Thenable<T> {

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -2213,7 +2213,9 @@ function emitConsoleChunk(
     }
   }
 
-  const payload = [methodName, stackTrace];
+  // TODO: Don't double badge if this log came from another Flight Client.
+  const env = request.environmentName;
+  const payload = [methodName, stackTrace, env];
   // $FlowFixMe[method-unbinding]
   payload.push.apply(payload, args);
   // $FlowFixMe[incompatible-type] stringify can return null

--- a/packages/shared/__tests__/normalizeConsoleFormat-test.internal.js
+++ b/packages/shared/__tests__/normalizeConsoleFormat-test.internal.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let normalizeConsoleFormat;
+
+describe('normalizeConsoleFormat', () => {
+  beforeEach(() => {
+    normalizeConsoleFormat = require('shared/normalizeConsoleFormat').default;
+  });
+
+  it('normalize empty string', async () => {
+    expect(normalizeConsoleFormat('', [1, {}, 'foo'], 0)).toMatchInlineSnapshot(
+      `"%o %o %s"`,
+    );
+  });
+
+  it('normalize extra args', async () => {
+    expect(
+      normalizeConsoleFormat('%f', [1, {}, 'foo'], 0),
+    ).toMatchInlineSnapshot(`"%f %o %s"`);
+  });
+
+  it('normalize fewer than args', async () => {
+    expect(
+      normalizeConsoleFormat('%s %O %o %f', [1, {}, 'foo'], 0),
+    ).toMatchInlineSnapshot(`"%s %O %o %%f"`);
+  });
+
+  it('normalize escape sequences', async () => {
+    expect(
+      normalizeConsoleFormat('hel%lo %s %%s world', [1, 'foo'], 0),
+    ).toMatchInlineSnapshot(`"hel%lo %s %%s world %s"`);
+  });
+
+  it('normalize ending with escape', async () => {
+    expect(
+      normalizeConsoleFormat('hello %s world %', [1, {}, 'foo'], 0),
+    ).toMatchInlineSnapshot(`"hello %s world % %o %s"`);
+    expect(
+      normalizeConsoleFormat('hello %s world %', [], 0),
+    ).toMatchInlineSnapshot(`"hello %%s world %"`);
+  });
+});

--- a/packages/shared/normalizeConsoleFormat.js
+++ b/packages/shared/normalizeConsoleFormat.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Takes a format string (first argument to console) and returns a normalized
+// string that has the exact number of arguments as the args. That way it's safe
+// to prepend or append to it.
+export default function normalizeConsoleFormat(
+  formatString: string,
+  args: $ReadOnlyArray<mixed>,
+  firstArg: number,
+): string {
+  let j = firstArg;
+  let normalizedString = '';
+  let last = 0;
+  for (let i = 0; i < formatString.length - 1; i++) {
+    if (formatString.charCodeAt(i) !== 37 /* "%" */) {
+      continue;
+    }
+    switch (formatString.charCodeAt(++i)) {
+      case 79 /* "O" */:
+      case 99 /* "c" */:
+      case 100 /* "d" */:
+      case 102 /* "f" */:
+      case 105 /* "i" */:
+      case 111 /* "o" */:
+      case 115 /* "s" */: {
+        if (j < args.length) {
+          // We have a matching argument.
+          j++;
+        } else {
+          // We have more format specifiers than arguments.
+          // So we need to escape this to print the literal.
+          normalizedString += formatString.slice(last, (last = i)) + '%';
+        }
+      }
+    }
+  }
+  normalizedString += formatString.slice(last, formatString.length);
+  // Pad with extra format specifiers for the rest.
+  while (j < args.length) {
+    if (normalizedString !== '') {
+      normalizedString += ' ';
+    }
+    // Not every environment has the same default.
+    // This seems to be what Chrome DevTools defaults to.
+    normalizedString += typeof args[j] === 'string' ? '%s' : '%o';
+    j++;
+  }
+  return normalizedString;
+}


### PR DESCRIPTION
Builds on top of #28384.

This prefixes each log with a badge similar to how we badge built-ins like "ForwardRef" and "Memo" in the React DevTools. The idea is that we can add such badges in DevTools for Server Components too to carry on the consistency.

This puts the "environment" name in the badge which defaults to "Server". So you know which source it is coming from.

We try to use the same styling as the React DevTools. We use light-dark mode where available to support the two different color styles, but if it's not available I use a fixed background so that it's always readable even in dark mode.

In Terminals, instead of hard coding colors that might not look good with some themes, I use the ANSI color code to flip background/foreground colors in that case.

In earlier commits I had it on the end of the line similar to the DevTools badges but for multiline I found it better to prefix it. We could try various options tough.

In most cases we can use both ANSI and the `%c` CSS color specifier, because node will only use ANSI and hide the other. Chrome supports both but the color overrides ANSI if it comes later (and Chrome doesn't support color inverting anyway). Safari/Firefox prints the ANSI, so it can only use CSS colors.

Therefore in browser builds I exclude ANSI.

On the server I support both so if you use Chrome inspector on the server, you get nice colors on both terminal and in the inspector.

Since Bun uses WebKit inspector and it prints the ANSI we can't safely emit both there. However, we also can't emit just the color specifier because then it prints in the terminal. https://github.com/oven-sh/bun/issues/9021 So we just use a plain string prefix for now with a bracket until that's fixed.

Screen shots:

<img width="758" alt="Screenshot 2024-02-21 at 12 56 02 AM" src="https://github.com/facebook/react/assets/63648/4f887ffe-fffe-4402-bf2a-b7890986d60c">
<img width="759" alt="Screenshot 2024-02-21 at 12 56 24 AM" src="https://github.com/facebook/react/assets/63648/f32d432f-f738-4872-a700-ea0a78e6c745">
<img width="514" alt="Screenshot 2024-02-21 at 12 57 10 AM" src="https://github.com/facebook/react/assets/63648/205d2e82-75b7-4e2b-9d9c-aa9e2cbedf39">
<img width="489" alt="Screenshot 2024-02-21 at 12 57 34 AM" src="https://github.com/facebook/react/assets/63648/ea52d1e4-b9fa-431d-ae9e-ccb87631f399">
<img width="516" alt="Screenshot 2024-02-21 at 12 58 23 AM" src="https://github.com/facebook/react/assets/63648/52b50fac-bec0-471d-a457-1a10d8df9172">
<img width="956" alt="Screenshot 2024-02-21 at 12 58 56 AM" src="https://github.com/facebook/react/assets/63648/0096ed61-5eff-4aa9-8a8a-2204e754bd1f">
