### PR TITLE
Devtools: Add support for useFormStatus

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -49,11 +49,7 @@ type HookLogEntry = {
   value: mixed,
   debugInfo: ReactDebugInfo | null,
   dispatcherHookName: string,
-  /**
-   * A list of hook function names that may call this dispatcher method.
-   * If `null`, we assume that the wrapper name is equal to the dispatcher mthod name.
-   */
-  wrapperNames: Array<string> | null,
+  wrapperNames: Array<string>,
 };
 
 let hookLog: Array<HookLogEntry> = [];
@@ -222,7 +218,7 @@ function use<T>(usable: Usable<T>): T {
             debugInfo:
               thenable._debugInfo === undefined ? null : thenable._debugInfo,
             dispatcherHookName: 'Use',
-            wrapperNames: null,
+            wrapperNames: ['Use'],
           });
           return fulfilledValue;
         }
@@ -241,7 +237,7 @@ function use<T>(usable: Usable<T>): T {
         debugInfo:
           thenable._debugInfo === undefined ? null : thenable._debugInfo,
         dispatcherHookName: 'Use',
-        wrapperNames: null,
+        wrapperNames: ['Use'],
       });
       throw SuspenseException;
     } else if (usable.$$typeof === REACT_CONTEXT_TYPE) {
@@ -255,7 +251,7 @@ function use<T>(usable: Usable<T>): T {
         value,
         debugInfo: null,
         dispatcherHookName: 'Use',
-        wrapperNames: null,
+        wrapperNames: ['Use'],
       });
 
       return value;
@@ -275,7 +271,7 @@ function useContext<T>(context: ReactContext<T>): T {
     value: value,
     debugInfo: null,
     dispatcherHookName: 'Context',
-    wrapperNames: null,
+    wrapperNames: ['Context'],
   });
   return value;
 }
@@ -298,7 +294,7 @@ function useState<S>(
     value: state,
     debugInfo: null,
     dispatcherHookName: 'State',
-    wrapperNames: null,
+    wrapperNames: ['State'],
   });
   return [state, (action: BasicStateAction<S>) => {}];
 }
@@ -322,7 +318,7 @@ function useReducer<S, I, A>(
     value: state,
     debugInfo: null,
     dispatcherHookName: 'Reducer',
-    wrapperNames: null,
+    wrapperNames: ['Reducer'],
   });
   return [state, (action: A) => {}];
 }
@@ -337,7 +333,7 @@ function useRef<T>(initialValue: T): {current: T} {
     value: ref.current,
     debugInfo: null,
     dispatcherHookName: 'Ref',
-    wrapperNames: null,
+    wrapperNames: ['Ref'],
   });
   return ref;
 }
@@ -351,7 +347,7 @@ function useCacheRefresh(): () => void {
     value: hook !== null ? hook.memoizedState : function refresh() {},
     debugInfo: null,
     dispatcherHookName: 'CacheRefresh',
-    wrapperNames: null,
+    wrapperNames: ['CacheRefresh'],
   });
   return () => {};
 }
@@ -368,7 +364,7 @@ function useLayoutEffect(
     value: create,
     debugInfo: null,
     dispatcherHookName: 'LayoutEffect',
-    wrapperNames: null,
+    wrapperNames: ['LayoutEffect'],
   });
 }
 
@@ -384,7 +380,7 @@ function useInsertionEffect(
     value: create,
     debugInfo: null,
     dispatcherHookName: 'InsertionEffect',
-    wrapperNames: null,
+    wrapperNames: ['InsertionEffect'],
   });
 }
 
@@ -400,7 +396,7 @@ function useEffect(
     value: create,
     debugInfo: null,
     dispatcherHookName: 'Effect',
-    wrapperNames: null,
+    wrapperNames: ['Effect'],
   });
 }
 
@@ -425,7 +421,7 @@ function useImperativeHandle<T>(
     value: instance,
     debugInfo: null,
     dispatcherHookName: 'ImperativeHandle',
-    wrapperNames: null,
+    wrapperNames: ['ImperativeHandle'],
   });
 }
 
@@ -437,7 +433,7 @@ function useDebugValue(value: any, formatterFn: ?(value: any) => any) {
     value: typeof formatterFn === 'function' ? formatterFn(value) : value,
     debugInfo: null,
     dispatcherHookName: 'DebugValue',
-    wrapperNames: null,
+    wrapperNames: ['DebugValue'],
   });
 }
 
@@ -450,7 +446,7 @@ function useCallback<T>(callback: T, inputs: Array<mixed> | void | null): T {
     value: hook !== null ? hook.memoizedState[0] : callback,
     debugInfo: null,
     dispatcherHookName: 'Callback',
-    wrapperNames: null,
+    wrapperNames: ['Callback'],
   });
   return callback;
 }
@@ -468,7 +464,7 @@ function useMemo<T>(
     value,
     debugInfo: null,
     dispatcherHookName: 'Memo',
-    wrapperNames: null,
+    wrapperNames: ['Memo'],
   });
   return value;
 }
@@ -491,7 +487,7 @@ function useSyncExternalStore<T>(
     value,
     debugInfo: null,
     dispatcherHookName: 'SyncExternalStore',
-    wrapperNames: null,
+    wrapperNames: ['SyncExternalStore'],
   });
   return value;
 }
@@ -515,7 +511,7 @@ function useTransition(): [
     value: isPending,
     debugInfo: null,
     dispatcherHookName: 'Transition',
-    wrapperNames: null,
+    wrapperNames: ['Transition'],
   });
   return [isPending, () => {}];
 }
@@ -530,7 +526,7 @@ function useDeferredValue<T>(value: T, initialValue?: T): T {
     value: prevValue,
     debugInfo: null,
     dispatcherHookName: 'DeferredValue',
-    wrapperNames: null,
+    wrapperNames: ['DeferredValue'],
   });
   return prevValue;
 }
@@ -545,7 +541,7 @@ function useId(): string {
     value: id,
     debugInfo: null,
     dispatcherHookName: 'Id',
-    wrapperNames: null,
+    wrapperNames: ['Id'],
   });
   return id;
 }
@@ -597,7 +593,7 @@ function useOptimistic<S, A>(
     value: state,
     debugInfo: null,
     dispatcherHookName: 'Optimistic',
-    wrapperNames: null,
+    wrapperNames: ['Optimistic'],
   });
   return [state, (action: A) => {}];
 }
@@ -658,7 +654,7 @@ function useFormState<S, P>(
     value: value,
     debugInfo: debugInfo,
     dispatcherHookName: 'FormState',
-    wrapperNames: null,
+    wrapperNames: ['FormState'],
   });
 
   if (error !== null) {
@@ -729,7 +725,7 @@ function useActionState<S, P>(
     value: value,
     debugInfo: debugInfo,
     dispatcherHookName: 'ActionState',
-    wrapperNames: null,
+    wrapperNames: ['ActionState'],
   });
 
   if (error !== null) {
@@ -914,18 +910,8 @@ function findPrimitiveIndex(hookStack: any, hook: HookLogEntry) {
       ) {
         i++;
       }
-      if (hook.wrapperNames !== null) {
-        for (let j = 0; j < hook.wrapperNames.length; j++) {
-          const wrapperName = hook.wrapperNames[j];
-          if (
-            i < hookStack.length - 1 &&
-            isReactWrapper(hookStack[i].functionName, wrapperName)
-          ) {
-            i++;
-          }
-        }
-      } else {
-        const wrapperName = hook.dispatcherHookName;
+      for (let j = 0; j < hook.wrapperNames.length; j++) {
+        const wrapperName = hook.wrapperNames[j];
         if (
           i < hookStack.length - 1 &&
           isReactWrapper(hookStack[i].functionName, wrapperName)

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -882,7 +882,11 @@ function findPrimitiveIndex(hookStack: any, hook: HookLogEntry) {
         isReactWrapper(hookStack[i].functionName, hook.dispatcherHookName)
       ) {
         i++;
-        i++;
+        // Guard against the dispatcher call being inlined.
+        // At this point we wouldn't be able to recover the actual React Hook name.
+        if (i < hookStack.length - 1) {
+          i++;
+        }
       }
       return i;
     }

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -49,7 +49,6 @@ type HookLogEntry = {
   value: mixed,
   debugInfo: ReactDebugInfo | null,
   dispatcherHookName: string,
-  wrapperNames: Array<string>,
 };
 
 let hookLog: Array<HookLogEntry> = [];
@@ -218,7 +217,6 @@ function use<T>(usable: Usable<T>): T {
             debugInfo:
               thenable._debugInfo === undefined ? null : thenable._debugInfo,
             dispatcherHookName: 'Use',
-            wrapperNames: ['Use'],
           });
           return fulfilledValue;
         }
@@ -237,7 +235,6 @@ function use<T>(usable: Usable<T>): T {
         debugInfo:
           thenable._debugInfo === undefined ? null : thenable._debugInfo,
         dispatcherHookName: 'Use',
-        wrapperNames: ['Use'],
       });
       throw SuspenseException;
     } else if (usable.$$typeof === REACT_CONTEXT_TYPE) {
@@ -251,7 +248,6 @@ function use<T>(usable: Usable<T>): T {
         value,
         debugInfo: null,
         dispatcherHookName: 'Use',
-        wrapperNames: ['Use'],
       });
 
       return value;
@@ -271,7 +267,6 @@ function useContext<T>(context: ReactContext<T>): T {
     value: value,
     debugInfo: null,
     dispatcherHookName: 'Context',
-    wrapperNames: ['Context'],
   });
   return value;
 }
@@ -294,7 +289,6 @@ function useState<S>(
     value: state,
     debugInfo: null,
     dispatcherHookName: 'State',
-    wrapperNames: ['State'],
   });
   return [state, (action: BasicStateAction<S>) => {}];
 }
@@ -318,7 +312,6 @@ function useReducer<S, I, A>(
     value: state,
     debugInfo: null,
     dispatcherHookName: 'Reducer',
-    wrapperNames: ['Reducer'],
   });
   return [state, (action: A) => {}];
 }
@@ -333,7 +326,6 @@ function useRef<T>(initialValue: T): {current: T} {
     value: ref.current,
     debugInfo: null,
     dispatcherHookName: 'Ref',
-    wrapperNames: ['Ref'],
   });
   return ref;
 }
@@ -347,7 +339,6 @@ function useCacheRefresh(): () => void {
     value: hook !== null ? hook.memoizedState : function refresh() {},
     debugInfo: null,
     dispatcherHookName: 'CacheRefresh',
-    wrapperNames: ['CacheRefresh'],
   });
   return () => {};
 }
@@ -364,7 +355,6 @@ function useLayoutEffect(
     value: create,
     debugInfo: null,
     dispatcherHookName: 'LayoutEffect',
-    wrapperNames: ['LayoutEffect'],
   });
 }
 
@@ -380,7 +370,6 @@ function useInsertionEffect(
     value: create,
     debugInfo: null,
     dispatcherHookName: 'InsertionEffect',
-    wrapperNames: ['InsertionEffect'],
   });
 }
 
@@ -396,7 +385,6 @@ function useEffect(
     value: create,
     debugInfo: null,
     dispatcherHookName: 'Effect',
-    wrapperNames: ['Effect'],
   });
 }
 
@@ -421,7 +409,6 @@ function useImperativeHandle<T>(
     value: instance,
     debugInfo: null,
     dispatcherHookName: 'ImperativeHandle',
-    wrapperNames: ['ImperativeHandle'],
   });
 }
 
@@ -433,7 +420,6 @@ function useDebugValue(value: any, formatterFn: ?(value: any) => any) {
     value: typeof formatterFn === 'function' ? formatterFn(value) : value,
     debugInfo: null,
     dispatcherHookName: 'DebugValue',
-    wrapperNames: ['DebugValue'],
   });
 }
 
@@ -446,7 +432,6 @@ function useCallback<T>(callback: T, inputs: Array<mixed> | void | null): T {
     value: hook !== null ? hook.memoizedState[0] : callback,
     debugInfo: null,
     dispatcherHookName: 'Callback',
-    wrapperNames: ['Callback'],
   });
   return callback;
 }
@@ -464,7 +449,6 @@ function useMemo<T>(
     value,
     debugInfo: null,
     dispatcherHookName: 'Memo',
-    wrapperNames: ['Memo'],
   });
   return value;
 }
@@ -487,7 +471,6 @@ function useSyncExternalStore<T>(
     value,
     debugInfo: null,
     dispatcherHookName: 'SyncExternalStore',
-    wrapperNames: ['SyncExternalStore'],
   });
   return value;
 }
@@ -511,7 +494,6 @@ function useTransition(): [
     value: isPending,
     debugInfo: null,
     dispatcherHookName: 'Transition',
-    wrapperNames: ['Transition'],
   });
   return [isPending, () => {}];
 }
@@ -526,7 +508,6 @@ function useDeferredValue<T>(value: T, initialValue?: T): T {
     value: prevValue,
     debugInfo: null,
     dispatcherHookName: 'DeferredValue',
-    wrapperNames: ['DeferredValue'],
   });
   return prevValue;
 }
@@ -541,7 +522,6 @@ function useId(): string {
     value: id,
     debugInfo: null,
     dispatcherHookName: 'Id',
-    wrapperNames: ['Id'],
   });
   return id;
 }
@@ -593,7 +573,6 @@ function useOptimistic<S, A>(
     value: state,
     debugInfo: null,
     dispatcherHookName: 'Optimistic',
-    wrapperNames: ['Optimistic'],
   });
   return [state, (action: A) => {}];
 }
@@ -654,7 +633,6 @@ function useFormState<S, P>(
     value: value,
     debugInfo: debugInfo,
     dispatcherHookName: 'FormState',
-    wrapperNames: ['FormState'],
   });
 
   if (error !== null) {
@@ -725,7 +703,6 @@ function useActionState<S, P>(
     value: value,
     debugInfo: debugInfo,
     dispatcherHookName: 'ActionState',
-    wrapperNames: ['ActionState'],
   });
 
   if (error !== null) {
@@ -756,10 +733,6 @@ function useHostTransitionStatus(): TransitionStatus {
     value: status,
     debugInfo: null,
     dispatcherHookName: 'HostTransitionStatus',
-    wrapperNames: [
-      // react-dom
-      'FormStatus',
-    ],
   });
 
   return status;
@@ -909,15 +882,7 @@ function findPrimitiveIndex(hookStack: any, hook: HookLogEntry) {
         isReactWrapper(hookStack[i].functionName, hook.dispatcherHookName)
       ) {
         i++;
-      }
-      for (let j = 0; j < hook.wrapperNames.length; j++) {
-        const wrapperName = hook.wrapperNames[j];
-        if (
-          i < hookStack.length - 1 &&
-          isReactWrapper(hookStack[i].functionName, wrapperName)
-        ) {
-          i++;
-        }
+        i++;
       }
       return i;
     }

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -426,6 +426,150 @@ describe('ReactHooksInspection', () => {
     `);
   });
 
+  it('should not confuse built-in hooks with custom hooks that have the same name', () => {
+    function useState(value) {
+      React.useState(value);
+      React.useDebugValue('custom useState');
+    }
+    function useFormStatus() {
+      React.useState('custom useState');
+      React.useDebugValue('custom useFormStatus');
+    }
+    function Foo(props) {
+      useFormStatus();
+      useState('Hello, Dave!');
+      return null;
+    }
+    const tree = ReactDebugTools.inspectHooks(Foo, {});
+    if (__DEV__) {
+      expect(normalizeSourceLoc(tree)).toMatchInlineSnapshot(`
+        [
+          {
+            "debugInfo": null,
+            "hookSource": {
+              "columnNumber": 0,
+              "fileName": "**",
+              "functionName": "Foo",
+              "lineNumber": 0,
+            },
+            "id": null,
+            "isStateEditable": false,
+            "name": "FormStatus",
+            "subHooks": [
+              {
+                "debugInfo": null,
+                "hookSource": {
+                  "columnNumber": 0,
+                  "fileName": "**",
+                  "functionName": "useFormStatus",
+                  "lineNumber": 0,
+                },
+                "id": 0,
+                "isStateEditable": true,
+                "name": "State",
+                "subHooks": [],
+                "value": "custom useState",
+              },
+            ],
+            "value": "custom useFormStatus",
+          },
+          {
+            "debugInfo": null,
+            "hookSource": {
+              "columnNumber": 0,
+              "fileName": "**",
+              "functionName": "Foo",
+              "lineNumber": 0,
+            },
+            "id": null,
+            "isStateEditable": false,
+            "name": "State",
+            "subHooks": [
+              {
+                "debugInfo": null,
+                "hookSource": {
+                  "columnNumber": 0,
+                  "fileName": "**",
+                  "functionName": "useState",
+                  "lineNumber": 0,
+                },
+                "id": 1,
+                "isStateEditable": true,
+                "name": "State",
+                "subHooks": [],
+                "value": "Hello, Dave!",
+              },
+            ],
+            "value": "custom useState",
+          },
+        ]
+      `);
+    } else {
+      expect(normalizeSourceLoc(tree)).toMatchInlineSnapshot(`
+        [
+          {
+            "debugInfo": null,
+            "hookSource": {
+              "columnNumber": 0,
+              "fileName": "**",
+              "functionName": "Foo",
+              "lineNumber": 0,
+            },
+            "id": null,
+            "isStateEditable": false,
+            "name": "FormStatus",
+            "subHooks": [
+              {
+                "debugInfo": null,
+                "hookSource": {
+                  "columnNumber": 0,
+                  "fileName": "**",
+                  "functionName": "useFormStatus",
+                  "lineNumber": 0,
+                },
+                "id": 0,
+                "isStateEditable": true,
+                "name": "State",
+                "subHooks": [],
+                "value": "custom useState",
+              },
+            ],
+            "value": undefined,
+          },
+          {
+            "debugInfo": null,
+            "hookSource": {
+              "columnNumber": 0,
+              "fileName": "**",
+              "functionName": "Foo",
+              "lineNumber": 0,
+            },
+            "id": null,
+            "isStateEditable": false,
+            "name": "State",
+            "subHooks": [
+              {
+                "debugInfo": null,
+                "hookSource": {
+                  "columnNumber": 0,
+                  "fileName": "**",
+                  "functionName": "useState",
+                  "lineNumber": 0,
+                },
+                "id": 1,
+                "isStateEditable": true,
+                "name": "State",
+                "subHooks": [],
+                "value": "Hello, Dave!",
+              },
+            ],
+            "value": undefined,
+          },
+        ]
+      `);
+    }
+  });
+
   it('should inspect the default value using the useContext hook', () => {
     const MyContext = React.createContext('default');
     function Foo(props) {

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegrationDOM-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegrationDOM-test.js
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment jsdom
+ */
+
+'use strict';
+
+let React;
+let ReactDOM;
+let ReactDOMClient;
+let ReactDebugTools;
+let act;
+
+function normalizeSourceLoc(tree) {
+  tree.forEach(node => {
+    if (node.hookSource) {
+      node.hookSource.fileName = '**';
+      node.hookSource.lineNumber = 0;
+      node.hookSource.columnNumber = 0;
+    }
+    normalizeSourceLoc(node.subHooks);
+  });
+  return tree;
+}
+
+describe('ReactHooksInspectionIntegration', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactDOMClient = require('react-dom/client');
+    act = require('internal-test-utils').act;
+    ReactDebugTools = require('react-debug-tools');
+  });
+
+  it('should support useFormStatus hook', async () => {
+    function FormStatus() {
+      const status = ReactDOM.useFormStatus();
+      React.useMemo(() => 'memo', []);
+      React.useMemo(() => 'not used', []);
+
+      return JSON.stringify(status);
+    }
+
+    const treeWithoutFiber = ReactDebugTools.inspectHooks(FormStatus);
+    expect(normalizeSourceLoc(treeWithoutFiber)).toEqual([
+      {
+        debugInfo: null,
+        hookSource: {
+          columnNumber: 0,
+          fileName: '**',
+          functionName: 'FormStatus',
+          lineNumber: 0,
+        },
+        id: null,
+        isStateEditable: false,
+        name: 'FormStatus',
+        subHooks: [],
+        value: null,
+      },
+      {
+        debugInfo: null,
+        hookSource: {
+          columnNumber: 0,
+          fileName: '**',
+          functionName: 'FormStatus',
+          lineNumber: 0,
+        },
+        id: 0,
+        isStateEditable: false,
+        name: 'Memo',
+        subHooks: [],
+        value: 'memo',
+      },
+      {
+        debugInfo: null,
+        hookSource: {
+          columnNumber: 0,
+          fileName: '**',
+          functionName: 'FormStatus',
+          lineNumber: 0,
+        },
+        id: 1,
+        isStateEditable: false,
+        name: 'Memo',
+        subHooks: [],
+        value: 'not used',
+      },
+    ]);
+
+    const root = ReactDOMClient.createRoot(document.createElement('div'));
+
+    await act(() => {
+      root.render(
+        <form>
+          <FormStatus />
+        </form>,
+      );
+    });
+
+    // Implementation detail. Feel free to adjust the position of the Fiber in the tree.
+    const formStatusFiber = root._internalRoot.current.child.child;
+    const treeWithFiber = ReactDebugTools.inspectHooksOfFiber(formStatusFiber);
+    expect(normalizeSourceLoc(treeWithFiber)).toEqual([
+      {
+        debugInfo: null,
+        hookSource: {
+          columnNumber: 0,
+          fileName: '**',
+          functionName: 'FormStatus',
+          lineNumber: 0,
+        },
+        id: null,
+        isStateEditable: false,
+        name: 'FormStatus',
+        subHooks: [],
+        value: null,
+      },
+      {
+        debugInfo: null,
+        hookSource: {
+          columnNumber: 0,
+          fileName: '**',
+          functionName: 'FormStatus',
+          lineNumber: 0,
+        },
+        id: 0,
+        isStateEditable: false,
+        name: 'Memo',
+        subHooks: [],
+        value: 'memo',
+      },
+      {
+        debugInfo: null,
+        hookSource: {
+          columnNumber: 0,
+          fileName: '**',
+          functionName: 'FormStatus',
+          lineNumber: 0,
+        },
+        id: 1,
+        isStateEditable: false,
+        name: 'Memo',
+        subHooks: [],
+        value: 'not used',
+      },
+    ]);
+  });
+});

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegrationDOM-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegrationDOM-test.js
@@ -38,8 +38,6 @@ describe('ReactHooksInspectionIntegration', () => {
     ReactDebugTools = require('react-debug-tools');
   });
 
-  // Gating production, non-source builds only for Jest.
-  // @gate source || build === "development"
   it('should support useFormStatus hook', async () => {
     function FormStatus() {
       const status = ReactDOM.useFormStatus();

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegrationDOM-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegrationDOM-test.js
@@ -38,6 +38,8 @@ describe('ReactHooksInspectionIntegration', () => {
     ReactDebugTools = require('react-debug-tools');
   });
 
+  // Gating production, non-source builds only for Jest.
+  // @gate source || build === "development"
   it('should support useFormStatus hook', async () => {
     function FormStatus() {
       const status = ReactDOM.useFormStatus();

--- a/packages/react-devtools-shell/src/app/InspectableElements/CustomHooks.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/CustomHooks.js
@@ -21,7 +21,7 @@ import {
   useState,
   use,
 } from 'react';
-import {useFormState} from 'react-dom';
+import {useFormState, useFormStatus} from 'react-dom';
 
 const object = {
   string: 'abc',
@@ -164,6 +164,12 @@ function incrementWithDelay(previousState: number, formData: FormData) {
   });
 }
 
+function FormStatus() {
+  const status = useFormStatus();
+
+  return <pre>{JSON.stringify(status)}</pre>;
+}
+
 function Forms() {
   const [state, formAction] = useFormState<any, any>(incrementWithDelay, 0);
   return (
@@ -184,6 +190,7 @@ function Forms() {
         <input name="shouldReject" type="checkbox" />
       </label>
       <button formAction={formAction}>Increment</button>
+      <FormStatus />
     </form>
   );
 }


### PR DESCRIPTION
Stack:
1. https://github.com/facebook/react/pull/28593 
1. https://github.com/facebook/react/pull/28413 <--- You're here
1. https://github.com/facebook/react/pull/28728

Unfortunately, the initial value will be incorrect since that value specified in the Fiber config to which react-debug-tools has no access until we land https://github.com/facebook/react/pull/28728. 


## Test plan

- [x] `yarn test ReactHooksInspectionIntegrationDOM`
- [x] inspected components with hooks (`FormStatus`) in the shell
- [x] Backwards compat with 16.8: https://8qq2sv.csb.app/
- [x] Backwards compat with 17.0: https://g67r45.csb.app/
- [x] Backwards compat with 18.0: https://ydjfsq.csb.app/
- [x] Compat with Experimental: https://react-devtools-hook-inspection-experimental.vercel.app/


https://github.com/facebook/react/assets/12292047/780136d5-56ff-4848-9997-1043d11b0738


   