### PR TITLE
Add type to root, remove OpaqueRoot.

### DIFF
--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -217,7 +217,7 @@ export function createRoot(
     }
   }
 
-  const root: FiberRoot  = createContainer(
+  const root: FiberRoot = createContainer(
     container,
     ConcurrentRoot,
     null,
@@ -308,7 +308,7 @@ export function hydrateRoot(
     }
   }
 
-  const root = createHydrationContainer(
+  const root: FiberRoot = createHydrationContainer(
     initialChildren,
     null,
     container,

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -217,7 +217,7 @@ export function createRoot(
     }
   }
 
-  const root = createContainer(
+  const root: FiberRoot  = createContainer(
     container,
     ConcurrentRoot,
     null,

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -112,8 +112,6 @@ export {
 } from './ReactTestSelectors';
 export {startHostTransition} from './ReactFiberHooks';
 
-type OpaqueRoot = FiberRoot;
-
 // 0 is PROD, 1 is DEV.
 // Might add PROFILE later.
 type BundleType = 0 | 1;
@@ -251,7 +249,7 @@ export function createContainer(
   identifierPrefix: string,
   onRecoverableError: (error: mixed) => void,
   transitionCallbacks: null | TransitionTracingCallbacks,
-): OpaqueRoot {
+): FiberRoot {
   const hydrate = false;
   const initialChildren = null;
   return createFiberRoot(
@@ -282,7 +280,7 @@ export function createHydrationContainer(
   onRecoverableError: (error: mixed) => void,
   transitionCallbacks: null | TransitionTracingCallbacks,
   formState: ReactFormState<any, any> | null,
-): OpaqueRoot {
+): FiberRoot {
   const hydrate = true;
   const root = createFiberRoot(
     containerInfo,
@@ -320,7 +318,7 @@ export function createHydrationContainer(
 
 export function updateContainer(
   element: ReactNodeList,
-  container: OpaqueRoot,
+  container: FiberRoot,
   parentComponent: ?React$Component<any, any>,
   callback: ?Function,
 ): Lane {
@@ -396,7 +394,7 @@ export {
 };
 
 export function getPublicRootInstance(
-  container: OpaqueRoot,
+  container: FiberRoot,
 ): React$Component<any, any> | PublicInstance | null {
   const containerFiber = container.current;
   if (!containerFiber.child) {

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -166,7 +166,7 @@ export function createFiberRoot(
 
   // Cyclic construction. This cheats the type system right now because
   // stateNode is any.
-  const uninitializedFiber = createHostRootFiber(
+  const uninitializedFiber: Fiber = createHostRootFiber(
     tag,
     isStrictMode,
     concurrentUpdatesByDefaultOverride,
@@ -175,7 +175,7 @@ export function createFiberRoot(
   uninitializedFiber.stateNode = root;
 
   if (enableCache) {
-    const initialCache = createCache();
+    const initialCache: Cache = createCache();
     retainCache(initialCache);
 
     // The pooledCache is a fresh cache instance that is used temporarily

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -167,7 +167,7 @@ export function createFiberRoot(
 
   // Cyclic construction. This cheats the type system right now because
   // stateNode is any.
-  const uninitializedFiber = createHostRootFiber(
+  const uninitializedFiber: Fiber = createHostRootFiber(
     tag,
     isStrictMode,
     concurrentUpdatesByDefaultOverride,
@@ -176,7 +176,7 @@ export function createFiberRoot(
   uninitializedFiber.stateNode = root;
 
   if (enableCache) {
-    const initialCache = createCache();
+    const initialCache: Cache = createCache();
     retainCache(initialCache);
 
     // The pooledCache is a fresh cache instance that is used temporarily

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -16,6 +16,7 @@ import type {
 import type {RootTag} from './ReactRootTags';
 import type {Cache} from './ReactFiberCacheComponent';
 import type {Container} from './ReactFiberConfig';
+import type {Fiber} from './ReactInternalTypes';
 
 import {noTimeout} from './ReactFiberConfig';
 import {createHostRootFiber} from './ReactFiber';
@@ -166,7 +167,7 @@ export function createFiberRoot(
 
   // Cyclic construction. This cheats the type system right now because
   // stateNode is any.
-  const uninitializedFiber: Fiber = createHostRootFiber(
+  const uninitializedFiber = createHostRootFiber(
     tag,
     isStrictMode,
     concurrentUpdatesByDefaultOverride,
@@ -175,7 +176,7 @@ export function createFiberRoot(
   uninitializedFiber.stateNode = root;
 
   if (enableCache) {
-    const initialCache: Cache = createCache();
+    const initialCache = createCache();
     retainCache(initialCache);
 
     // The pooledCache is a fresh cache instance that is used temporarily


### PR DESCRIPTION
I recently read the React source code, and have a few suggestions to improve the reading experience. Hope you can consider them ~
1. Every time I see the root assignment in the createRoot function, I often can't remember the type of this value for a moment, so maybe adding a type here would be helpful.
2. OpaqueRoot is actually FiberRoot, so there's no need to define another name for it here, right? It's not very good for the reading experience~
