### PR TITLE
React DevTools 5.0.0 -> 5.0.1

### DIFF
--- a/packages/react-devtools-core/package.json
+++ b/packages/react-devtools-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-devtools-core",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Use react-devtools outside of the browser",
   "license": "MIT",
   "main": "./dist/backend.js",

--- a/packages/react-devtools-extensions/chrome/manifest.json
+++ b/packages/react-devtools-extensions/chrome/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "React Developer Tools",
   "description": "Adds React debugging tools to the Chrome Developer Tools.",
-  "version": "5.0.0",
-  "version_name": "5.0.0",
+  "version": "5.0.1",
+  "version_name": "5.0.1",
   "minimum_chrome_version": "102",
   "icons": {
     "16": "icons/16-production.png",

--- a/packages/react-devtools-extensions/edge/manifest.json
+++ b/packages/react-devtools-extensions/edge/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "React Developer Tools",
   "description": "Adds React debugging tools to the Microsoft Edge Developer Tools.",
-  "version": "5.0.0",
-  "version_name": "5.0.0",
+  "version": "5.0.1",
+  "version_name": "5.0.1",
   "minimum_chrome_version": "102",
   "icons": {
     "16": "icons/16-production.png",

--- a/packages/react-devtools-extensions/firefox/manifest.json
+++ b/packages/react-devtools-extensions/firefox/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "React Developer Tools",
   "description": "Adds React debugging tools to the Firefox Developer Tools.",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "applications": {
     "gecko": {
       "id": "@react-devtools",

--- a/packages/react-devtools-inline/package.json
+++ b/packages/react-devtools-inline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-devtools-inline",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Embed react-devtools within a website",
   "license": "MIT",
   "main": "./dist/backend.js",

--- a/packages/react-devtools-timeline/package.json
+++ b/packages/react-devtools-timeline/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "react-devtools-timeline",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "license": "MIT",
   "dependencies": {
     "@elg/speedscope": "1.9.0-a6f84db",

--- a/packages/react-devtools/CHANGELOG.md
+++ b/packages/react-devtools/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ---
 
+### 5.0.1
+February 22, 2024
+
+* feature[REMOVED][devtools]: turn off / hide location based component filters ([hoxyq](https://github.com/hoxyq) in [#28417](https://github.com/facebook/react/pull/28417))
+* Add useSyncExternalStore and useTransition to getPrimitiveStackCache ([jamesbvaughan](https://github.com/jamesbvaughan) in [#28399](https://github.com/facebook/react/pull/28399))
+* chore[devtools]: use react-window from npm and bump react-virtualized-auto-sizer to ^1.0.23 ([hoxyq](https://github.com/hoxyq) in [#28408](https://github.com/facebook/react/pull/28408))
+* [Debug Tools] Always use includeHooksSource option ([sebmarkbage](https://github.com/sebmarkbage) in [#28309](https://github.com/facebook/react/pull/28309))
+* [Debug Tools] Introspect Promises in use() ([sebmarkbage](https://github.com/sebmarkbage) in [#28297](https://github.com/facebook/react/pull/28297))
+* fix[devtools/useModalDismissSignal]: use getRootNode for shadow root case support ([hoxyq](https://github.com/hoxyq) in [#28145](https://github.com/facebook/react/pull/28145))
+* DevTools: Add support for use(Context) ([eps1lon](https://github.com/eps1lon) in [#28233](https://github.com/facebook/react/pull/28233))
+* Patch devtools before running useMemo function in strict mode ([gsathya](https://github.com/gsathya) in [#28249](https://github.com/facebook/react/pull/28249))
+* DevTools: Add support for useFormState ([eps1lon](https://github.com/eps1lon) in [#28232](https://github.com/facebook/react/pull/28232))
+* DevTools: Add support for useOptimistic Hook ([eps1lon](https://github.com/eps1lon) in [#27982](https://github.com/facebook/react/pull/27982))
+
+---
+
 ### 5.0.0
 November 29, 2023
 

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-devtools",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Use react-devtools outside of the browser",
   "license": "MIT",
   "repository": {
@@ -27,7 +27,7 @@
     "electron": "^23.1.2",
     "ip": "^1.1.4",
     "minimist": "^1.2.3",
-    "react-devtools-core": "5.0.0",
+    "react-devtools-core": "5.0.1",
     "update-notifier": "^2.1.0"
   }
 }


### PR DESCRIPTION
Full list of changes (not a public CHANGELOG):

* feature[REMOVED][devtools]: turn off / hide location based component filters ([hoxyq](https://github.com/hoxyq) in [#28417](https://github.com/facebook/react/pull/28417))
* Add useSyncExternalStore and useTransition to getPrimitiveStackCache ([jamesbvaughan](https://github.com/jamesbvaughan) in [#28399](https://github.com/facebook/react/pull/28399))
* chore[devtools]: use react-window from npm and bump react-virtualized-auto-sizer to ^1.0.23 ([hoxyq](https://github.com/hoxyq) in [#28408](https://github.com/facebook/react/pull/28408))
* Pass ref as normal prop ([acdlite](https://github.com/acdlite) in [#28348](https://github.com/facebook/react/pull/28348))
* Combine createElement and JSX modules ([acdlite](https://github.com/acdlite) in [#28320](https://github.com/facebook/react/pull/28320))
* [Debug Tools] Always use includeHooksSource option ([sebmarkbage](https://github.com/sebmarkbage) in [#28309](https://github.com/facebook/react/pull/28309))
* Revert "[Tests] Reset modules by default" ([acdlite](https://github.com/acdlite) in [#28318](https://github.com/facebook/react/pull/28318))
* Switch <Context> to mean <Context.Provider> ([gaearon](https://github.com/gaearon) in [#28226](https://github.com/facebook/react/pull/28226))
* [Debug Tools] Introspect Promises in use() ([sebmarkbage](https://github.com/sebmarkbage) in [#28297](https://github.com/facebook/react/pull/28297))
* fix[devtools/useModalDismissSignal]: use getRootNode for shadow root case support ([hoxyq](https://github.com/hoxyq) in [#28145](https://github.com/facebook/react/pull/28145))
* fix: define IS_ACT_ENVIRONMENT global for tests with concurrent mode and synchronous act ([hoxyq](https://github.com/hoxyq) in [#28296](https://github.com/facebook/react/pull/28296))
* chore: gate legacy apis for react-devtools-shell ([hoxyq](https://github.com/hoxyq) in [#28273](https://github.com/facebook/react/pull/28273))
* DevTools: Add support for use(Context) ([eps1lon](https://github.com/eps1lon) in [#28233](https://github.com/facebook/react/pull/28233))
* Remove __self and __source location from elements ([sebmarkbage](https://github.com/sebmarkbage) in [#28265](https://github.com/facebook/react/pull/28265))
* chore: use versioned render in inspectedElement test ([hoxyq](https://github.com/hoxyq) in [#28246](https://github.com/facebook/react/pull/28246))
* chore: use versioned render in TimelineProfiler test and gate some for legacy rendering ([hoxyq](https://github.com/hoxyq) in [#28218](https://github.com/facebook/react/pull/28218))
* [Tests] Reset modules by default ([rickhanlonii](https://github.com/rickhanlonii) in [#28254](https://github.com/facebook/react/pull/28254))
* chore: use versioned render in preprocessData test and gate some for … ([hoxyq](https://github.com/hoxyq) in [#28219](https://github.com/facebook/react/pull/28219))
* chore: use versioned render in storeStressSync test and gate them for legacy rendering ([hoxyq](https://github.com/hoxyq) in [#28216](https://github.com/facebook/react/pull/28216))
* Patch devtools before running useMemo function in strict mode ([gsathya](https://github.com/gsathya) in [#28249](https://github.com/facebook/react/pull/28249))
* chore: use versioned render in storeComponentFilters test ([hoxyq](https://github.com/hoxyq) in [#28241](https://github.com/facebook/react/pull/28241))
* chore: use versioned render in profilerContext test ([hoxyq](https://github.com/hoxyq) in [#28243](https://github.com/facebook/react/pull/28243))
* chore: use versioned render in profilingCommitTreeBuilder test and gate some for legacy rendering ([hoxyq](https://github.com/hoxyq) in [#28236](https://github.com/facebook/react/pull/28236))
* chore: use versioned render in profilingHostRoot test and gate some for legacy rendering ([hoxyq](https://github.com/hoxyq) in [#28237](https://github.com/facebook/react/pull/28237))
* chore: use versioned render in profilingCache test ([hoxyq](https://github.com/hoxyq) in [#28242](https://github.com/facebook/react/pull/28242))
* chore: use versioned render in ownersListContext test ([hoxyq](https://github.com/hoxyq) in [#28240](https://github.com/facebook/react/pull/28240))
* chore: use versioned render in editing test ([hoxyq](https://github.com/hoxyq) in [#28239](https://github.com/facebook/react/pull/28239))
* chore: use versioned render in treeContext test ([hoxyq](https://github.com/hoxyq) in [#28245](https://github.com/facebook/react/pull/28245))
* chore: use versioned render in store test ([hoxyq](https://github.com/hoxyq) in [#28244](https://github.com/facebook/react/pull/28244))
* chore: use versioned render in profilerStore test ([hoxyq](https://github.com/hoxyq) in [#28238](https://github.com/facebook/react/pull/28238))
* chore: use versioned render in profilingCharts test ([hoxyq](https://github.com/hoxyq) in [#28235](https://github.com/facebook/react/pull/28235))
* chore: use versioned render in profilerChangeDescriptions test ([hoxyq](https://github.com/hoxyq) in [#28221](https://github.com/facebook/react/pull/28221))
* chore: use versioned render in storeOwners test ([hoxyq](https://github.com/hoxyq) in [#28215](https://github.com/facebook/react/pull/28215))
* chore: use versioned render in componentStacks test ([hoxyq](https://github.com/hoxyq) in [#28214](https://github.com/facebook/react/pull/28214))
* chore: use versioned render in console test ([hoxyq](https://github.com/hoxyq) in [#28213](https://github.com/facebook/react/pull/28213))
* chore: use versioned render in useEditableValue test ([hoxyq](https://github.com/hoxyq) in [#28212](https://github.com/facebook/react/pull/28212))
* chore: use versioned render in FastRefreshDevToolsIntegration test ([hoxyq](https://github.com/hoxyq) in [#28211](https://github.com/facebook/react/pull/28211))
* chore: add versioned render implementation for DevTools tests ([hoxyq](https://github.com/hoxyq) in [#28210](https://github.com/facebook/react/pull/28210))
* chore: add single versioned implementation of act for DevTools tests ([hoxyq](https://github.com/hoxyq) in [#28186](https://github.com/facebook/react/pull/28186))
* DevTools: Add support for useFormState ([eps1lon](https://github.com/eps1lon) in [#28232](https://github.com/facebook/react/pull/28232))
* DevTools: Add support for useOptimistic Hook ([eps1lon](https://github.com/eps1lon) in [#27982](https://github.com/facebook/react/pull/27982))
* Add stable React.act export ([acdlite](https://github.com/acdlite) in [#28160](https://github.com/facebook/react/pull/28160))
* [flow] upgrade to 0.225.1 ([kassens](https://github.com/kassens) in [#27871](https://github.com/facebook/react/pull/27871))
* fix[devtools/e2e]: add fallback for act in integration tests ([hoxyq](https://github.com/hoxyq) in [#27842](https://github.com/facebook/react/pull/27842))
* Add stable concurrent option to react-test-renderer ([jackpope](https://github.com/jackpope) in [#27804](https://github.com/facebook/react/pull/27804))
* Update act references in tests ([gnoff](https://github.com/gnoff) in [#27805](https://github.com/facebook/react/pull/27805))
* Flow: make more objects exact ([kassens](https://github.com/kassens) in [#27790](https://github.com/facebook/react/pull/27790))