### PR TITLE
[RTR] Enable warning flag

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -129,7 +129,9 @@ beforeEach(() => {
   jest.useFakeTimers();
 
   // Use utils.js#withErrorsOrWarningsIgnored instead of directly mutating this array.
-  global._ignoredErrorOrWarningMessages = [];
+  global._ignoredErrorOrWarningMessages = [
+    'react-test-renderer is deprecated.',
+  ];
   function shouldIgnoreConsoleErrorOrWarn(args) {
     let firstArg = args[0];
     if (

--- a/packages/react-devtools-shared/src/__tests__/treeContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/treeContext-test.js
@@ -2586,14 +2586,14 @@ describe('TreeListContext', () => {
         utils.act(() => TestRenderer.create(<Contexts />));
 
         expect(store).toMatchInlineSnapshot(`
-          ✕ 1, ⚠ 0
+          ✕ 1, ⚠ 1
           [root]
               <ErrorBoundary> ✕
         `);
 
         selectNextErrorOrWarning();
         expect(state).toMatchInlineSnapshot(`
-          ✕ 1, ⚠ 0
+          ✕ 1, ⚠ 1
           [root]
           →    <ErrorBoundary> ✕
         `);
@@ -2648,14 +2648,14 @@ describe('TreeListContext', () => {
         utils.act(() => TestRenderer.create(<Contexts />));
 
         expect(store).toMatchInlineSnapshot(`
-          ✕ 1, ⚠ 0
+          ✕ 1, ⚠ 1
           [root]
               <ErrorBoundary> ✕
         `);
 
         selectNextErrorOrWarning();
         expect(state).toMatchInlineSnapshot(`
-          ✕ 1, ⚠ 0
+          ✕ 1, ⚠ 1
           [root]
           →    <ErrorBoundary> ✕
         `);
@@ -2705,7 +2705,7 @@ describe('TreeListContext', () => {
         utils.act(() => TestRenderer.create(<Contexts />));
 
         expect(store).toMatchInlineSnapshot(`
-          ✕ 2, ⚠ 0
+          ✕ 2, ⚠ 1
           [root]
             ▾ <ErrorBoundary> ✕
                 <Child> ✕
@@ -2713,7 +2713,7 @@ describe('TreeListContext', () => {
 
         selectNextErrorOrWarning();
         expect(state).toMatchInlineSnapshot(`
-          ✕ 2, ⚠ 0
+          ✕ 2, ⚠ 1
           [root]
           →  ▾ <ErrorBoundary> ✕
                  <Child> ✕

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -474,7 +474,10 @@ function create(
   unstable_flushSync: typeof flushSync,
 } {
   if (__DEV__) {
-    if (enableReactTestRendererWarning === true) {
+    if (
+      enableReactTestRendererWarning === true &&
+      global.IS_REACT_NATIVE_TEST_ENVIRONMENT !== true
+    ) {
       console.warn(
         'react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer',
       );

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -65,6 +65,19 @@ describe('ReactTestRenderer', () => {
     );
   });
 
+  // @gate __DEV__
+  it('should not warn if enableReactTestRendererWarning is enabled but the RN global is set', () => {
+    global.IS_REACT_NATIVE_TEST_ENVIRONMENT = true;
+    ReactFeatureFlags.enableReactTestRendererWarning = true;
+    expect(() => {
+      ReactTestRenderer.create(<div />);
+    }).not.toWarnDev(
+      'Warning: react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer',
+      {withoutStack: true},
+    );
+    global.IS_REACT_NATIVE_TEST_ENVIRONMENT = false;
+  });
+
   it('renders a simple component', () => {
     function Link() {
       return <a role="link" />;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -183,10 +183,8 @@ export const enableInfiniteRenderLoopDetection = true;
 export const enableRefAsProp = __NEXT_MAJOR__;
 export const disableStringRefs = __NEXT_MAJOR__;
 
-// Not ready to break experimental yet.
-// Needs more internal cleanup
 // Warn on any usage of ReactTestRenderer
-export const enableReactTestRendererWarning = false;
+export const enableReactTestRendererWarning = __NEXT_MAJOR__;
 
 // Disables legacy mode
 // This allows us to land breaking changes to remove legacy mode APIs in experimental builds

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -90,13 +90,13 @@ export const enableInfiniteRenderLoopDetection = false;
 const __NEXT_MAJOR__ = __EXPERIMENTAL__;
 export const enableRefAsProp = __NEXT_MAJOR__;
 export const disableStringRefs = __NEXT_MAJOR__;
-export const enableReactTestRendererWarning = false;
 export const enableBigIntSupport = __NEXT_MAJOR__;
 export const disableLegacyMode = __NEXT_MAJOR__;
 export const disableLegacyContext = __NEXT_MAJOR__;
 export const enableNewBooleanProps = __NEXT_MAJOR__;
 export const disableModulePatternComponents = __NEXT_MAJOR__;
 export const enableRenderableContext = __NEXT_MAJOR__;
+export const enableReactTestRendererWarning = __NEXT_MAJOR__;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -3,6 +3,7 @@
 const chalk = require('chalk');
 const util = require('util');
 const shouldIgnoreConsoleError = require('./shouldIgnoreConsoleError');
+const shouldIgnoreConsoleWarn = require('./shouldIgnoreConsoleWarn');
 const {getTestFlags} = require('./TestFlags');
 
 if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
@@ -68,6 +69,11 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
       // Ignore uncaught errors reported by jsdom
       // and React addendums because they're too noisy.
       if (methodName === 'error' && shouldIgnoreConsoleError(format, args)) {
+        return;
+      }
+
+      // Ignore certain React warnings causing test failures
+      if (methodName === 'warn' && shouldIgnoreConsoleWarn(format)) {
         return;
       }
 

--- a/scripts/jest/shouldIgnoreConsoleWarn.js
+++ b/scripts/jest/shouldIgnoreConsoleWarn.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function shouldIgnoreConsoleWarn(format) {
+  if (typeof format === 'string') {
+    if (format.indexOf('Warning: react-test-renderer is deprecated.') === 0) {
+      return true;
+    }
+  }
+
+  return false;
+};


### PR DESCRIPTION
## Summary

Based on
- https://github.com/facebook/react/pull/27903

This PR
- Silence warning in React tests
- Turn on flag

We want to finish cleaning up internal RTR usage, but let's prioritize the deprecation process. We do this by silencing the internal warning for now.

## How did you test this change?

`yarn build`
`yarn test ReactHooksInspectionIntegration -b`
