### PR TITLE
Add dynamic disablePropFilteringInViewConfigs flag for native-fb

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -125,6 +125,8 @@ export const enableRenderableContext = false;
 
 export const enableServerComponentLogs = __EXPERIMENTAL__;
 
+export const disablePropFilteringInViewConfigs = false;
+
 /**
  * Enables an expiration time for retry lanes to avoid starvation.
  */

--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -21,6 +21,7 @@ import typeof * as DynamicFlagsType from 'ReactNativeInternalFeatureFlags';
 // update the test configuration.
 
 export const alwaysThrottleRetries = __VARIANT__;
+export const disablePropFilteringInViewConfigs = __VARIANT__;
 export const enableComponentStackLocations = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const enableUseRefAccessWarning = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -19,6 +19,7 @@ import * as dynamicFlags from 'ReactNativeInternalFeatureFlags';
 // the exports object every time a flag is read.
 export const {
   alwaysThrottleRetries,
+  disablePropFilteringInViewConfigs,
   enableComponentStackLocations,
   enableDeferRootSchedulingToMicrotask,
   enableUseRefAccessWarning,

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -98,6 +98,7 @@ export const enableReactTestRendererWarning = false;
 
 export const enableBigIntSupport = false;
 export const disableLegacyMode = false;
+export const disablePropFilteringInViewConfigs = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -89,6 +89,7 @@ export const disableClientCache = true;
 export const enableServerComponentKeys = true;
 export const enableServerComponentLogs = true;
 export const enableInfiniteRenderLoopDetection = false;
+export const disablePropFilteringInViewConfigs = false;
 
 // TODO: This must be in sync with the main ReactFeatureFlags file because
 // the Test Renderer's value must be the same as the one used by the

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -94,6 +94,7 @@ export const enableReactTestRendererWarning = false;
 export const disableLegacyMode = false;
 
 export const enableBigIntSupport = false;
+export const disablePropFilteringInViewConfigs = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -97,6 +97,7 @@ export const enableReactTestRendererWarning = false;
 export const disableLegacyMode = false;
 
 export const enableBigIntSupport = false;
+export const disablePropFilteringInViewConfigs = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -127,6 +127,7 @@ export const enableBigIntSupport = false;
 export const disableStringRefs = false;
 
 export const disableLegacyMode = false;
+export const disablePropFilteringInViewConfigs = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/scripts/flow/xplat.js
+++ b/scripts/flow/xplat.js
@@ -9,6 +9,7 @@
 
 declare module 'ReactNativeInternalFeatureFlags' {
   declare export var alwaysThrottleRetries: boolean;
+  declare export var disablePropFilteringInViewConfigs: boolean;
   declare export var enableComponentStackLocations: boolean;
   declare export var enableDeferRootSchedulingToMicrotask: boolean;
   declare export var enableUseRefAccessWarning: boolean;


### PR DESCRIPTION
Adds the `disablePropFilteringInViewConfigs` flag to set up and experiment to see the performance implications of not filtering out invalid props in the `diffProperties` function.

If `disablePropFilteringInViewConfigs` is `true`, we skip prop diffing and prop filtering, and send all props to native.