### PR TITLE
fix[devtools]: fixed Tree indentation logic after updating react-windows

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
@@ -538,7 +538,7 @@ function updateIndentationSizeVar(
 }
 
 // $FlowFixMe[missing-local-annot]
-function InnerElementType({children, style, ...rest}) {
+function InnerElementType({children, style}) {
   const {ownerID} = useContext(TreeStateContext);
 
   const cachedChildWidths = useMemo<WeakMap<HTMLElement, number>>(
@@ -586,11 +586,7 @@ function InnerElementType({children, style, ...rest}) {
   // A lot of options were considered; this seemed the one that requires the least code.
   // See https://github.com/bvaughn/react-devtools-experimental/issues/9
   return (
-    <div
-      className={styles.InnerElementType}
-      ref={divRef}
-      style={style}
-      {...rest}>
+    <div className={styles.InnerElementType} ref={divRef} style={style}>
       <SelectedTreeHighlight />
       {children}
     </div>


### PR DESCRIPTION
Forward-fixing the indentation after landing https://github.com/facebook/react/pull/28408. Could potentially be related to `ref` changes in `react`, but haven't validated yet.

Haven't occured while testing the previous PR, but reproduced while testing the https://github.com/facebook/react/pull/28418, for which I've rebuilt all dependencies, including `react`.

This change basically removes the props passing from original parent, `rest` should include only `ref`: https://github.com/bvaughn/react-window/blob/efad3d8909753fd74aad7c47dc902b26f0919651/src/createListComponent.js#L382