### PR TITLE
Update RN dynamic flag types

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -7,9 +7,6 @@
  * @flow strict
  */
 
-import typeof * as ExportsType from './ReactFeatureFlags.native-fb-dynamic';
-import typeof * as DynamicFlagsType from 'ReactNativeInternalFeatureFlags';
-
 // In xplat, these flags are controlled by GKs. Because most GKs have some
 // population running in either mode, we should run our tests that way, too,
 //
@@ -18,7 +15,7 @@ import typeof * as DynamicFlagsType from 'ReactNativeInternalFeatureFlags';
 //
 // TODO: __VARIANT__ isn't supported for React Native flags yet. You can set the
 // flag here but it won't be set to `true` in any of our test runs. Need to
-// update the test configuration.
+// add a test configuration for React Native.
 
 export const alwaysThrottleDisappearingFallbacks = __VARIANT__;
 export const alwaysThrottleRetries = __VARIANT__;
@@ -32,6 +29,3 @@ export const enableUnifiedSyncLane = __VARIANT__;
 export const enableUseRefAccessWarning = __VARIANT__;
 export const passChildrenWhenCloningPersistedNodes = __VARIANT__;
 export const useModernStrictMode = __VARIANT__;
-
-// Flow magic to verify the exports of this file match the original version.
-((((null: any): ExportsType): DynamicFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -9,11 +9,12 @@
 
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as ExportsType from './ReactFeatureFlags.native-fb';
+import typeof * as DynamicExportsType from './ReactFeatureFlags.native-fb-dynamic';
 
-// NOTE: There are no flags, currently. Uncomment the stuff below if we add one.
-// Re-export dynamic flags from the internal module. Intentionally using *
-// because this import is compiled to a `require` call.
-import * as dynamicFlags from 'ReactNativeInternalFeatureFlags';
+// Re-export dynamic flags from the internal module.
+// Intentionally using * because this import is compiled to a `require` call.
+import * as dynamicFlagsUntyped from 'ReactNativeInternalFeatureFlags';
+const dynamicFlags: DynamicExportsType = (dynamicFlagsUntyped: any);
 
 // We destructure each value before re-exporting to avoid a dynamic look-up on
 // the exports object every time a flag is read.

--- a/scripts/flow/xplat.js
+++ b/scripts/flow/xplat.js
@@ -8,16 +8,5 @@
  */
 
 declare module 'ReactNativeInternalFeatureFlags' {
-  declare export const alwaysThrottleDisappearingFallbacks: boolean;
-  declare export const alwaysThrottleRetries: boolean;
-  declare export const consoleManagedByDevToolsDuringStrictMode: boolean;
-  declare export const enableAsyncActions: boolean;
-  declare export const enableComponentStackLocations: boolean;
-  declare export const enableDeferRootSchedulingToMicrotask: boolean;
-  declare export const enableInfiniteRenderLoopDetection: boolean;
-  declare export const enableRenderableContext: boolean;
-  declare export const enableUnifiedSyncLane: boolean;
-  declare export const enableUseRefAccessWarning: boolean;
-  declare export const passChildrenWhenCloningPersistedNodes: boolean;
-  declare export const useModernStrictMode: boolean;
+  declare module.exports: any;
 }


### PR DESCRIPTION
Updates the RN flag flow types to work like www does, so we can use the `.native-fb-dynamic.js` file as the type/shim for the dynamically imported file.