### PR TITLE
Delete use of `source` in JSX runtime

### DIFF
--- a/packages/react/src/__tests__/ReactElementValidator-test.internal.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.internal.js
@@ -310,12 +310,12 @@ describe('ReactElementValidator', () => {
     }).toErrorDev([
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
-        'components) but got: null.' +
-        '\n\nCheck the render method of `ParentComp`.\n    in ParentComp',
+        'components) but got: null.\n' +
+        '    in ParentComp (at **)',
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
-        'components) but got: null.' +
-        '\n\nCheck the render method of `ParentComp`.\n    in ParentComp',
+        'components) but got: null.\n' +
+        '    in ParentComp (at **)',
     ]);
   });
 
@@ -427,7 +427,7 @@ describe('ReactElementValidator', () => {
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: undefined. You likely forgot to export your ' +
         "component from the file it's defined in, or you might have mixed up " +
-        'default and named imports.\n\nCheck your code at **.',
+        'default and named imports.',
       {withoutStack: true},
     );
   });

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -170,22 +170,19 @@ describe('ReactJSXElementValidator', () => {
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: undefined. You likely forgot to export your ' +
         "component from the file it's defined in, or you might have mixed up " +
-        'default and named imports.' +
-        '\n\nCheck your code at **.',
+        'default and named imports.',
       {withoutStack: true},
     );
     expect(() => void (<Null />)).toErrorDev(
       'Warning: React.jsx: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
-        'components) but got: null.' +
-        '\n\nCheck your code at **.',
+        'components) but got: null.',
       {withoutStack: true},
     );
     expect(() => void (<True />)).toErrorDev(
       'Warning: React.jsx: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
-        'components) but got: boolean.' +
-        '\n\nCheck your code at **.',
+        'components) but got: boolean.',
       {withoutStack: true},
     );
     // No error expected

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -425,13 +425,6 @@ export function jsxDEV(type, config, maybeKey, isStaticChildren, source, self) {
           "it's defined in, or you might have mixed up default and named imports.";
       }
 
-      const sourceInfo = getSourceInfoErrorAddendum(source);
-      if (sourceInfo) {
-        info += sourceInfo;
-      } else {
-        info += getDeclarationErrorAddendum();
-      }
-
       let typeString;
       if (type === null) {
         typeString = 'null';
@@ -620,13 +613,6 @@ export function createElement(type, config, children) {
         info +=
           ' You likely forgot to export your component from the file ' +
           "it's defined in, or you might have mixed up default and named imports.";
-      }
-
-      const sourceInfo = getSourceInfoErrorAddendumForProps(config);
-      if (sourceInfo) {
-        info += sourceInfo;
-      } else {
-        info += getDeclarationErrorAddendum();
       }
 
       let typeString;
@@ -934,24 +920,6 @@ function getDeclarationErrorAddendum() {
       if (name) {
         return '\n\nCheck the render method of `' + name + '`.';
       }
-    }
-    return '';
-  }
-}
-
-function getSourceInfoErrorAddendumForProps(elementProps) {
-  if (elementProps !== null && elementProps !== undefined) {
-    return getSourceInfoErrorAddendum(elementProps.__source);
-  }
-  return '';
-}
-
-function getSourceInfoErrorAddendum(source) {
-  if (__DEV__) {
-    if (source !== undefined) {
-      const fileName = source.fileName.replace(/^.*[\\\/]/, '');
-      const lineNumber = source.lineNumber;
-      return '\n\nCheck your code at ' + fileName + ':' + lineNumber + '.';
     }
     return '';
   }


### PR DESCRIPTION
Only remaining place it was being used was in a warning message.