### PR TITLE
clean up isInputPending in Scheduler

### DIFF
--- a/packages/scheduler/src/SchedulerFeatureFlags.js
+++ b/packages/scheduler/src/SchedulerFeatureFlags.js
@@ -8,12 +8,8 @@
  */
 
 export const enableSchedulerDebugging = false;
-export const enableIsInputPending = false;
 export const enableProfiling = false;
-export const enableIsInputPendingContinuous = false;
 export const frameYieldMs = 5;
-export const continuousYieldMs = 50;
-export const maxYieldMs = 300;
 
 export const userBlockingPriorityTimeout = 250;
 export const normalPriorityTimeout = 5000;

--- a/packages/scheduler/src/__tests__/Scheduler-test.js
+++ b/packages/scheduler/src/__tests__/Scheduler-test.js
@@ -101,23 +101,6 @@ describe('SchedulerBrowser', () => {
       this.port2 = port2;
     };
 
-    const scheduling = {
-      isInputPending(options) {
-        if (this !== scheduling) {
-          throw new Error(
-            'isInputPending called with incorrect `this` context',
-          );
-        }
-
-        return (
-          hasPendingDiscreteEvent ||
-          (options && options.includeContinuous && hasPendingContinuousEvent)
-        );
-      },
-    };
-
-    global.navigator = {scheduling};
-
     function ensureLogIsEmpty() {
       if (eventLog.length !== 0) {
         throw Error('Log is not empty. Call assertLog before continuing.');
@@ -218,7 +201,7 @@ describe('SchedulerBrowser', () => {
     runtime.assertLog([
       'Message Event',
       'Task',
-      'Yield at 5ms',
+      gate(flags => (flags.www ? 'Yield at 10ms' : 'Yield at 5ms')),
       'Post Message',
     ]);
 
@@ -318,132 +301,6 @@ describe('SchedulerBrowser', () => {
     runtime.assertLog(['Post Message']);
     runtime.fireMessageEvent();
     runtime.assertLog(['Message Event', 'B']);
-  });
-
-  it('when isInputPending is available, we can wait longer before yielding', () => {
-    function blockUntilSchedulerAsksToYield() {
-      while (!Scheduler.unstable_shouldYield()) {
-        runtime.advanceTime(1);
-      }
-      runtime.log(`Yield at ${performance.now()}ms`);
-    }
-
-    // First show what happens when we don't request a paint
-    scheduleCallback(NormalPriority, () => {
-      runtime.log('Task with no pending input');
-      blockUntilSchedulerAsksToYield();
-    });
-    runtime.assertLog(['Post Message']);
-
-    runtime.fireMessageEvent();
-    runtime.assertLog([
-      'Message Event',
-      'Task with no pending input',
-      'Yield at 5ms',
-    ]);
-
-    runtime.resetTime();
-
-    // Now do the same thing, but while the task is running, simulate an
-    // input event.
-    scheduleCallback(NormalPriority, () => {
-      runtime.log('Task with pending input');
-      runtime.scheduleDiscreteEvent();
-      blockUntilSchedulerAsksToYield();
-    });
-    runtime.assertLog(['Post Message']);
-
-    runtime.fireMessageEvent();
-    runtime.assertLog([
-      'Message Event',
-      'Task with pending input',
-      // This time we yielded quickly to unblock the discrete event.
-      'Yield at 5ms',
-      'Discrete Event',
-    ]);
-  });
-
-  it(
-    'isInputPending will also check for continuous inputs, but after a ' +
-      'slightly larger threshold',
-    () => {
-      function blockUntilSchedulerAsksToYield() {
-        while (!Scheduler.unstable_shouldYield()) {
-          runtime.advanceTime(1);
-        }
-        runtime.log(`Yield at ${performance.now()}ms`);
-      }
-
-      // First show what happens when we don't request a paint
-      scheduleCallback(NormalPriority, () => {
-        runtime.log('Task with no pending input');
-        blockUntilSchedulerAsksToYield();
-      });
-      runtime.assertLog(['Post Message']);
-
-      runtime.fireMessageEvent();
-      runtime.assertLog([
-        'Message Event',
-        'Task with no pending input',
-        'Yield at 5ms',
-      ]);
-
-      runtime.resetTime();
-
-      // Now do the same thing, but while the task is running, simulate a
-      // continuous input event.
-      scheduleCallback(NormalPriority, () => {
-        runtime.log('Task with continuous input');
-        runtime.scheduleContinuousEvent();
-        blockUntilSchedulerAsksToYield();
-      });
-      runtime.assertLog(['Post Message']);
-
-      runtime.fireMessageEvent();
-      runtime.assertLog([
-        'Message Event',
-        'Task with continuous input',
-        'Yield at 5ms',
-        'Continuous Event',
-      ]);
-    },
-  );
-
-  it('requestPaint forces a yield at the end of the next frame interval', () => {
-    function blockUntilSchedulerAsksToYield() {
-      while (!Scheduler.unstable_shouldYield()) {
-        runtime.advanceTime(1);
-      }
-      runtime.log(`Yield at ${performance.now()}ms`);
-    }
-
-    // First show what happens when we don't request a paint
-    scheduleCallback(NormalPriority, () => {
-      runtime.log('Task with no paint');
-      blockUntilSchedulerAsksToYield();
-    });
-    runtime.assertLog(['Post Message']);
-
-    runtime.fireMessageEvent();
-    runtime.assertLog(['Message Event', 'Task with no paint', 'Yield at 5ms']);
-
-    runtime.resetTime();
-
-    // Now do the same thing, but call requestPaint inside the task
-    scheduleCallback(NormalPriority, () => {
-      runtime.log('Task with paint');
-      requestPaint();
-      blockUntilSchedulerAsksToYield();
-    });
-    runtime.assertLog(['Post Message']);
-
-    runtime.fireMessageEvent();
-    runtime.assertLog([
-      'Message Event',
-      'Task with paint',
-      // This time we yielded quickly (5ms) because we requested a paint.
-      'Yield at 5ms',
-    ]);
   });
 
   it('yielding continues in a new task regardless of how much time is remaining', () => {

--- a/packages/scheduler/src/__tests__/Scheduler-test.js
+++ b/packages/scheduler/src/__tests__/Scheduler-test.js
@@ -339,15 +339,7 @@ describe('SchedulerBrowser', () => {
     runtime.assertLog([
       'Message Event',
       'Task with no pending input',
-      // Even though there's no input, eventually Scheduler will yield
-      // regardless in case there's a pending main thread task we don't know
-      // about, like a network event.
-      gate(flags =>
-        flags.enableIsInputPending
-          ? 'Yield at 10ms'
-          : // When isInputPending is disabled, we always yield quickly
-            'Yield at 5ms',
-      ),
+      'Yield at 5ms',
     ]);
 
     runtime.resetTime();
@@ -393,15 +385,7 @@ describe('SchedulerBrowser', () => {
       runtime.assertLog([
         'Message Event',
         'Task with no pending input',
-        // Even though there's no input, eventually Scheduler will yield
-        // regardless in case there's a pending main thread task we don't know
-        // about, like a network event.
-        gate(flags =>
-          flags.enableIsInputPending
-            ? 'Yield at 10ms'
-            : // When isInputPending is disabled, we always yield quickly
-              'Yield at 5ms',
-        ),
+        'Yield at 5ms',
       ]);
 
       runtime.resetTime();
@@ -419,14 +403,7 @@ describe('SchedulerBrowser', () => {
       runtime.assertLog([
         'Message Event',
         'Task with continuous input',
-        // This time we yielded quickly to unblock the continuous event. But not
-        // as quickly as for a discrete event.
-        gate(flags =>
-          flags.enableIsInputPending
-            ? 'Yield at 10ms'
-            : // When isInputPending is disabled, we always yield quickly
-              'Yield at 5ms',
-        ),
+        'Yield at 5ms',
         'Continuous Event',
       ]);
     },
@@ -448,16 +425,7 @@ describe('SchedulerBrowser', () => {
     runtime.assertLog(['Post Message']);
 
     runtime.fireMessageEvent();
-    runtime.assertLog([
-      'Message Event',
-      'Task with no paint',
-      gate(flags =>
-        flags.enableIsInputPending
-          ? 'Yield at 10ms'
-          : // When isInputPending is disabled, we always yield quickly
-            'Yield at 5ms',
-      ),
-    ]);
+    runtime.assertLog(['Message Event', 'Task with no paint', 'Yield at 5ms']);
 
     runtime.resetTime();
 

--- a/packages/scheduler/src/__tests__/SchedulerSetImmediate-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerSetImmediate-test.js
@@ -173,7 +173,7 @@ describe('SchedulerDOMSetImmediate', () => {
     runtime.assertLog([
       'setImmediate Callback',
       'Task',
-      'Yield at 5ms',
+      gate(flags => (flags.www ? 'Yield at 10ms' : 'Yield at 5ms')),
       'Set Immediate',
     ]);
 

--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.www-dynamic.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.www-dynamic.js
@@ -13,8 +13,6 @@
 
 export const enableProfiling = __VARIANT__;
 
-export const frameYieldMs = 5;
-
 export const userBlockingPriorityTimeout = 250;
 export const normalPriorityTimeout = 5000;
 export const lowPriorityTimeout = 10000;

--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.www-dynamic.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.www-dynamic.js
@@ -13,11 +13,7 @@
 
 export const enableProfiling = __VARIANT__;
 
-export const enableIsInputPending = __VARIANT__;
-export const enableIsInputPendingContinuous = __VARIANT__;
 export const frameYieldMs = 5;
-export const continuousYieldMs = 10;
-export const maxYieldMs = 10;
 
 export const userBlockingPriorityTimeout = 250;
 export const normalPriorityTimeout = 5000;

--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
@@ -16,8 +16,9 @@ export const {
   userBlockingPriorityTimeout,
   normalPriorityTimeout,
   lowPriorityTimeout,
-  frameYieldMs,
 } = dynamicFeatureFlags;
+
+export const frameYieldMs = 10;
 export const enableSchedulerDebugging = true;
 export const enableProfiling: boolean =
   __PROFILE__ && enableProfilingFeatureFlag;

--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
@@ -16,11 +16,7 @@ export const {
   userBlockingPriorityTimeout,
   normalPriorityTimeout,
   lowPriorityTimeout,
-  enableIsInputPending,
-  enableIsInputPendingContinuous,
   frameYieldMs,
-  continuousYieldMs,
-  maxYieldMs,
 } = dynamicFeatureFlags;
 export const enableSchedulerDebugging = true;
 export const enableProfiling: boolean =

--- a/packages/scheduler/src/forks/SchedulerPostTask.js
+++ b/packages/scheduler/src/forks/SchedulerPostTask.js
@@ -57,8 +57,7 @@ let deadline = 0;
 
 let currentPriorityLevel_DEPRECATED = NormalPriority;
 
-// `isInputPending` is not available. Since we have no way of knowing if
-// there's pending input, always yield at the end of the frame.
+// Always yield at the end of the frame.
 export function unstable_shouldYield(): boolean {
   return getCurrentTime() >= deadline;
 }


### PR DESCRIPTION
## Summary

`isInputPending` is not in use. This PR cleans up the flags controlling its gating and parameters to simplify Scheduler.

Makes `frameYieldMs` feature flag static, set to 10ms in www, which we found built on the wins provided by a broader yield interval via `isInputPending`. Flag remains set to 5ms in OSS builds.

## How did you test this change?
`yarn test Scheduler`