### PR TITLE
Remove enableClientRenderFallbackOnTextMismatch flag

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -68,7 +68,6 @@ import sanitizeURL from '../shared/sanitizeURL';
 import {
   enableBigIntSupport,
   enableCustomElementPropertySupport,
-  enableClientRenderFallbackOnTextMismatch,
   disableIEWorkarounds,
   enableTrustedTypesIntegration,
   enableFilterEmptyStringAttributesDOM,
@@ -351,11 +350,9 @@ export function checkForUnmatchedText(
     }
   }
 
-  if (enableClientRenderFallbackOnTextMismatch) {
-    // In concurrent roots, we throw when there's a text mismatch and revert to
-    // client rendering, up to the nearest Suspense boundary.
-    throw new Error('Text content does not match server-rendered HTML.');
-  }
+  // In concurrent roots, we throw when there's a text mismatch and revert to
+  // client rendering, up to the nearest Suspense boundary.
+  throw new Error('Text content does not match server-rendered HTML.');
 }
 
 function noop() {}
@@ -2864,16 +2861,6 @@ export function diffHydratedProperties(
     if (domElement.textContent !== '' + children) {
       if (props.suppressHydrationWarning !== true) {
         checkForUnmatchedText(domElement.textContent, children, shouldWarnDev);
-      }
-      if (!enableClientRenderFallbackOnTextMismatch) {
-        // We really should be patching this in the commit phase but since
-        // this only affects legacy mode hydration which is deprecated anyway
-        // we can get away with it.
-        // Host singletons get their children appended and don't use the text
-        // content mechanism.
-        if (tag !== 'body') {
-          domElement.textContent = (children: any);
-        }
       }
     }
   }

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -4419,7 +4419,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate enableClientRenderFallbackOnTextMismatch
   it('#24384: Suspending should halt hydration warnings but still emit hydration warnings after unsuspending if mismatches are genuine', async () => {
     const makeApp = () => {
       let resolve, resolved;
@@ -4505,7 +4504,6 @@ describe('ReactDOMFizzServer', () => {
     await waitForAll([]);
   });
 
-  // @gate enableClientRenderFallbackOnTextMismatch
   it('only warns once on hydration mismatch while within a suspense boundary', async () => {
     const originalConsoleError = console.error;
     const mockError = jest.fn();

--- a/packages/react-dom/src/__tests__/ReactDOMFizzSuppressHydrationWarning-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzSuppressHydrationWarning-test.js
@@ -130,7 +130,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
       : children;
   }
 
-  // @gate enableClientRenderFallbackOnTextMismatch
   it('suppresses but does not fix text mismatches with suppressHydrationWarning', async () => {
     function App({isClient}) {
       return (
@@ -170,47 +169,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     );
   });
 
-  // @gate !enableClientRenderFallbackOnTextMismatch
-  it('suppresses and fixes text mismatches with suppressHydrationWarning', async () => {
-    function App({isClient}) {
-      return (
-        <div>
-          <span suppressHydrationWarning={true}>
-            {isClient ? 'Client Text' : 'Server Text'}
-          </span>
-          <span suppressHydrationWarning={true}>{isClient ? 2 : 1}</span>
-        </div>
-      );
-    }
-    await act(() => {
-      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
-        <App isClient={false} />,
-      );
-      pipe(writable);
-    });
-    expect(getVisibleChildren(container)).toEqual(
-      <div>
-        <span>Server Text</span>
-        <span>1</span>
-      </div>,
-    );
-    ReactDOMClient.hydrateRoot(container, <App isClient={true} />, {
-      onRecoverableError(error) {
-        // Don't miss a hydration error. There should be none.
-        Scheduler.log(error.message);
-      },
-    });
-    await waitForAll([]);
-    // The text mismatch should be *silently* fixed. Even in production.
-    expect(getVisibleChildren(container)).toEqual(
-      <div>
-        <span>Client Text</span>
-        <span>2</span>
-      </div>,
-    );
-  });
-
-  // @gate enableClientRenderFallbackOnTextMismatch
   it('suppresses but does not fix multiple text node mismatches with suppressHydrationWarning', async () => {
     function App({isClient}) {
       return (
@@ -247,48 +205,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         <span>
           {'Server1'}
           {'Server2'}
-        </span>
-      </div>,
-    );
-  });
-
-  // @gate !enableClientRenderFallbackOnTextMismatch
-  it('suppresses and fixes multiple text node mismatches with suppressHydrationWarning', async () => {
-    function App({isClient}) {
-      return (
-        <div>
-          <span suppressHydrationWarning={true}>
-            {isClient ? 'Client1' : 'Server1'}
-            {isClient ? 'Client2' : 'Server2'}
-          </span>
-        </div>
-      );
-    }
-    await act(() => {
-      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
-        <App isClient={false} />,
-      );
-      pipe(writable);
-    });
-    expect(getVisibleChildren(container)).toEqual(
-      <div>
-        <span>
-          {'Server1'}
-          {'Server2'}
-        </span>
-      </div>,
-    );
-    ReactDOMClient.hydrateRoot(container, <App isClient={true} />, {
-      onRecoverableError(error) {
-        Scheduler.log(error.message);
-      },
-    });
-    await waitForAll([]);
-    expect(getVisibleChildren(container)).toEqual(
-      <div>
-        <span>
-          {'Client1'}
-          {'Client2'}
         </span>
       </div>,
     );
@@ -345,7 +261,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     );
   });
 
-  // @gate enableClientRenderFallbackOnTextMismatch
   it('suppresses but does not fix client-only single text node mismatches with suppressHydrationWarning', async () => {
     function App({text}) {
       return (
@@ -382,41 +297,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     expect(getVisibleChildren(container)).toEqual(
       <div>
         <span>Client 2</span>
-      </div>,
-    );
-  });
-
-  // @gate !enableClientRenderFallbackOnTextMismatch
-  it('suppresses and fixes client-only single text node mismatches with suppressHydrationWarning', async () => {
-    function App({isClient}) {
-      return (
-        <div>
-          <span suppressHydrationWarning={true}>
-            {isClient ? 'Client' : null}
-          </span>
-        </div>
-      );
-    }
-    await act(() => {
-      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
-        <App isClient={false} />,
-      );
-      pipe(writable);
-    });
-    expect(getVisibleChildren(container)).toEqual(
-      <div>
-        <span />
-      </div>,
-    );
-    ReactDOMClient.hydrateRoot(container, <App isClient={true} />, {
-      onRecoverableError(error) {
-        Scheduler.log(error.message);
-      },
-    });
-    await waitForAll([]);
-    expect(getVisibleChildren(container)).toEqual(
-      <div>
-        <span>{'Client'}</span>
       </div>,
     );
   });

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -6446,7 +6446,6 @@ body {
       );
     });
 
-    // @gate enableClientRenderFallbackOnTextMismatch
     it('retains styles even when a new html, head, and/body mount', async () => {
       await act(() => {
         const {pipe} = renderToPipeableStream(
@@ -8232,7 +8231,6 @@ background-color: green;
       ]);
     });
 
-    // @gate enableClientRenderFallbackOnTextMismatch || !__DEV__
     it('can render a title before a singleton even if that singleton clears its contents', async () => {
       await act(() => {
         const {pipe} = renderToPipeableStream(

--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -80,28 +80,17 @@ describe('ReactDOMServerHydration', () => {
           </div>
         );
       }
-      if (gate(flags => flags.enableClientRenderFallbackOnTextMismatch)) {
-        expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
-          [
-            "Warning: Text content did not match. Server: "server" Client: "client"
-              in main (at **)
-              in div (at **)
-              in Mismatch (at **)",
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content in <div>.",
-            "Caught [Text content does not match server-rendered HTML.]",
-            "Caught [There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.]",
-          ]
-        `);
-      } else {
-        expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
-          [
-            "Warning: Text content did not match. Server: "server" Client: "client"
-              in main (at **)
-              in div (at **)
-              in Mismatch (at **)",
-          ]
-        `);
-      }
+      expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
+        [
+          "Warning: Text content did not match. Server: "server" Client: "client"
+            in main (at **)
+            in div (at **)
+            in Mismatch (at **)",
+          "Warning: An error occurred during hydration. The server HTML was replaced with client content in <div>.",
+          "Caught [Text content does not match server-rendered HTML.]",
+          "Caught [There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.]",
+        ]
+      `);
     });
 
     // @gate __DEV__
@@ -118,26 +107,16 @@ describe('ReactDOMServerHydration', () => {
       }
 
       /* eslint-disable no-irregular-whitespace */
-      if (gate(flags => flags.enableClientRenderFallbackOnTextMismatch)) {
-        expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
-          [
-            "Warning: Text content did not match. Server: "This markup contains an nbsp entity:   server text" Client: "This markup contains an nbsp entity:   client text"
-              in div (at **)
-              in Mismatch (at **)",
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content in <div>.",
-            "Caught [Text content does not match server-rendered HTML.]",
-            "Caught [There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.]",
-          ]
-        `);
-      } else {
-        expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
-          [
-            "Warning: Text content did not match. Server: "This markup contains an nbsp entity:   server text" Client: "This markup contains an nbsp entity:   client text"
-              in div (at **)
-              in Mismatch (at **)",
-          ]
-        `);
-      }
+      expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
+        [
+          "Warning: Text content did not match. Server: "This markup contains an nbsp entity:   server text" Client: "This markup contains an nbsp entity:   client text"
+            in div (at **)
+            in Mismatch (at **)",
+          "Warning: An error occurred during hydration. The server HTML was replaced with client content in <div>.",
+          "Caught [Text content does not match server-rendered HTML.]",
+          "Caught [There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.]",
+        ]
+      `);
       /* eslint-enable no-irregular-whitespace */
     });
 
@@ -388,26 +367,16 @@ describe('ReactDOMServerHydration', () => {
         function Mismatch({isClient}) {
           return <div className="parent">{isClient && 'only'}</div>;
         }
-        if (gate(flags => flags.enableClientRenderFallbackOnTextMismatch)) {
-          expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
-            [
-              "Warning: Text content did not match. Server: "" Client: "only"
-                in div (at **)
-                in Mismatch (at **)",
-              "Warning: An error occurred during hydration. The server HTML was replaced with client content in <div>.",
-              "Caught [Text content does not match server-rendered HTML.]",
-              "Caught [There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.]",
-            ]
-          `);
-        } else {
-          expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
-            [
-              "Warning: Text content did not match. Server: "" Client: "only"
-                in div (at **)
-                in Mismatch (at **)",
-            ]
-          `);
-        }
+        expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
+          [
+            "Warning: Text content did not match. Server: "" Client: "only"
+              in div (at **)
+              in Mismatch (at **)",
+            "Warning: An error occurred during hydration. The server HTML was replaced with client content in <div>.",
+            "Caught [Text content does not match server-rendered HTML.]",
+            "Caught [There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.]",
+          ]
+        `);
       });
 
       // @gate __DEV__

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
@@ -18,7 +18,6 @@ let React;
 let ReactDOM;
 let ReactDOMClient;
 let ReactDOMServer;
-let ReactFeatureFlags;
 
 function initModules() {
   jest.resetModules();
@@ -26,7 +25,6 @@ function initModules() {
   ReactDOM = require('react-dom');
   ReactDOMClient = require('react-dom/client');
   ReactDOMServer = require('react-dom/server');
-  ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
   // Make them available to the helpers.
   return {
@@ -843,16 +841,15 @@ describe('ReactDOMServerIntegration', () => {
           if (
             render === serverRender ||
             render === streamRender ||
-            (render === clientRenderOnServerString &&
-              ReactFeatureFlags.enableClientRenderFallbackOnTextMismatch)
+            render === clientRenderOnServerString
           ) {
             expect(e.childNodes.length).toBe(1);
-            // Everything becomes LF when parsed from server HTML or hydrated if enableClientRenderFallbackOnTextMismatch is on.
+            // Everything becomes LF when parsed from server HTML or hydrated.
             // Null character is ignored.
             expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\nbar\nbaz\nqux');
           } else {
             expect(e.childNodes.length).toBe(1);
-            // Client rendering (or hydration without enableClientRenderFallbackOnTextMismatch) uses JS value with CR.
+            // Client rendering uses JS value with CR.
             // Null character stays.
 
             expectNode(
@@ -876,19 +873,18 @@ describe('ReactDOMServerIntegration', () => {
           if (
             render === serverRender ||
             render === streamRender ||
-            (render === clientRenderOnServerString &&
-              ReactFeatureFlags.enableClientRenderFallbackOnTextMismatch)
+            render === clientRenderOnServerString
           ) {
             // We have three nodes because there is a comment between them.
             expect(e.childNodes.length).toBe(3);
-            // Everything becomes LF when parsed from server HTML or hydrated if enableClientRenderFallbackOnTextMismatch is on.
+            // Everything becomes LF when parsed from server HTML or hydrated.
             // Null character is ignored.
             expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\nbar');
             expectNode(e.childNodes[2], TEXT_NODE_TYPE, '\nbaz\nqux');
           } else if (render === clientRenderOnServerString) {
             // We have three nodes because there is a comment between them.
             expect(e.childNodes.length).toBe(3);
-            // Hydration without enableClientRenderFallbackOnTextMismatch uses JS value with CR and null character.
+            // Hydration uses JS value with CR and null character.
 
             expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\rbar');
             expectNode(e.childNodes[2], TEXT_NODE_TYPE, '\r\nbaz\nqux\u0000');

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -4059,7 +4059,6 @@ describe('ReactDOMServerPartialHydration', () => {
     );
   });
 
-  // @gate enableClientRenderFallbackOnTextMismatch
   it("falls back to client rendering when there's a text mismatch (direct text child)", async () => {
     function DirectTextChild({text}) {
       return <div>{text}</div>;
@@ -4091,7 +4090,6 @@ describe('ReactDOMServerPartialHydration', () => {
     ]);
   });
 
-  // @gate enableClientRenderFallbackOnTextMismatch
   it("falls back to client rendering when there's a text mismatch (text child with siblings)", async () => {
     function Sibling() {
       return 'Sibling';

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -265,9 +265,6 @@ describe('rendering React components at document', () => {
       );
       const testDocument = getTestDocument(markup);
 
-      const enableClientRenderFallbackOnTextMismatch = gate(
-        flags => flags.enableClientRenderFallbackOnTextMismatch,
-      );
       expect(() => {
         ReactDOM.flushSync(() => {
           ReactDOMClient.hydrateRoot(
@@ -281,25 +278,19 @@ describe('rendering React components at document', () => {
           );
         });
       }).toErrorDev(
-        enableClientRenderFallbackOnTextMismatch
-          ? [
-              'Warning: An error occurred during hydration. The server HTML was replaced with client content in <#document>.',
-              'Warning: Text content did not match.',
-            ]
-          : ['Warning: Text content did not match.'],
+        [
+          'Warning: An error occurred during hydration. The server HTML was replaced with client content in <#document>.',
+          'Warning: Text content did not match.',
+        ],
         {
-          withoutStack: enableClientRenderFallbackOnTextMismatch ? 1 : 0,
+          withoutStack: 1,
         },
       );
 
-      assertLog(
-        enableClientRenderFallbackOnTextMismatch
-          ? [
-              'Log recoverable error: Text content does not match server-rendered HTML.',
-              'Log recoverable error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.',
-            ]
-          : [],
-      );
+      assertLog([
+        'Log recoverable error: Text content does not match server-rendered HTML.',
+        'Log recoverable error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.',
+      ]);
       expect(testDocument.body.innerHTML).toBe('Hello world');
     });
 

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -123,9 +123,6 @@ describe('ReactDOMServerHydration', () => {
       // Now simulate a situation where the app is not idempotent. React should
       // warn but do the right thing.
       element.innerHTML = lastMarkup;
-      const enableClientRenderFallbackOnTextMismatch = gate(
-        flags => flags.enableClientRenderFallbackOnTextMismatch,
-      );
       await expect(async () => {
         root = await act(() => {
           return ReactDOMClient.hydrateRoot(
@@ -142,13 +139,11 @@ describe('ReactDOMServerHydration', () => {
           );
         });
       }).toErrorDev(
-        enableClientRenderFallbackOnTextMismatch
-          ? [
-              'An error occurred during hydration. The server HTML was replaced with client content in <div>.',
-              'Text content did not match. Server: "x" Client: "y"',
-            ]
-          : ['Text content did not match. Server: "x" Client: "y"'],
-        {withoutStack: enableClientRenderFallbackOnTextMismatch ? 1 : 0},
+        [
+          'An error occurred during hydration. The server HTML was replaced with client content in <div>.',
+          'Text content did not match. Server: "x" Client: "y"',
+        ],
+        {withoutStack: 1},
       );
       expect(mountCount).toEqual(4);
       expect(element.innerHTML.length > 0).toBe(true);
@@ -218,9 +213,6 @@ describe('ReactDOMServerHydration', () => {
     const onFocusAfterHydration = jest.fn();
     element.firstChild.focus = onFocusBeforeHydration;
 
-    const enableClientRenderFallbackOnTextMismatch = gate(
-      flags => flags.enableClientRenderFallbackOnTextMismatch,
-    );
     await expect(async () => {
       await act(() => {
         ReactDOMClient.hydrateRoot(
@@ -232,15 +224,11 @@ describe('ReactDOMServerHydration', () => {
         );
       });
     }).toErrorDev(
-      enableClientRenderFallbackOnTextMismatch
-        ? [
-            'An error occurred during hydration. The server HTML was replaced with client content in <div>.',
-            'Warning: Text content did not match. Server: "server" Client: "client"',
-          ]
-        : [
-            'Warning: Text content did not match. Server: "server" Client: "client"',
-          ],
-      {withoutStack: enableClientRenderFallbackOnTextMismatch ? 1 : 0},
+      [
+        'An error occurred during hydration. The server HTML was replaced with client content in <div>.',
+        'Warning: Text content did not match. Server: "server" Client: "client"',
+      ],
+      {withoutStack: 1},
     );
 
     expect(onFocusBeforeHydration).not.toHaveBeenCalled();
@@ -530,9 +518,6 @@ describe('ReactDOMServerHydration', () => {
     );
     domElement.innerHTML = markup;
 
-    const enableClientRenderFallbackOnTextMismatch = gate(
-      flags => flags.enableClientRenderFallbackOnTextMismatch,
-    );
     await expect(async () => {
       await act(() => {
         ReactDOMClient.hydrateRoot(
@@ -546,15 +531,11 @@ describe('ReactDOMServerHydration', () => {
 
       expect(domElement.innerHTML).not.toEqual(markup);
     }).toErrorDev(
-      enableClientRenderFallbackOnTextMismatch
-        ? [
-            'An error occurred during hydration. The server HTML was replaced with client content in <div>.',
-            'Warning: Text content did not match. Server: "server" Client: "client"',
-          ]
-        : [
-            'Warning: Text content did not match. Server: "server" Client: "client"',
-          ],
-      {withoutStack: enableClientRenderFallbackOnTextMismatch ? 1 : 0},
+      [
+        'An error occurred during hydration. The server HTML was replaced with client content in <div>.',
+        'Warning: Text content did not match. Server: "server" Client: "client"',
+      ],
+      {withoutStack: 1},
     );
   });
 

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -1306,9 +1306,7 @@ function completeWork(
         const currentHostContext = getHostContext();
         const wasHydrated = popHydrationState(workInProgress);
         if (wasHydrated) {
-          if (prepareToHydrateHostTextInstance(workInProgress)) {
-            markUpdate(workInProgress);
-          }
+          prepareToHydrateHostTextInstance(workInProgress);
         } else {
           workInProgress.stateNode = createTextInstance(
             newText,

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -27,7 +27,6 @@ import {
   HostRoot,
   SuspenseComponent,
 } from './ReactWorkTags';
-import {enableClientRenderFallbackOnTextMismatch} from 'shared/ReactFeatureFlags';
 
 import {createFiberFromDehydratedFragment} from './ReactFiber';
 import {
@@ -489,7 +488,7 @@ function prepareToHydrateHostInstance(
   );
 }
 
-function prepareToHydrateHostTextInstance(fiber: Fiber): boolean {
+function prepareToHydrateHostTextInstance(fiber: Fiber): void {
   if (!supportsHydration) {
     throw new Error(
       'Expected prepareToHydrateHostTextInstance() to never be called. ' +
@@ -500,13 +499,13 @@ function prepareToHydrateHostTextInstance(fiber: Fiber): boolean {
   const textInstance: TextInstance = fiber.stateNode;
   const textContent: string = fiber.memoizedProps;
   const shouldWarnIfMismatchDev = !didSuspendOrErrorDEV;
-  const shouldUpdate = hydrateTextInstance(
+  const textIsDifferent = hydrateTextInstance(
     textInstance,
     textContent,
     fiber,
     shouldWarnIfMismatchDev,
   );
-  if (shouldUpdate) {
+  if (textIsDifferent) {
     // We assume that prepareToHydrateHostTextInstance is called in a context where the
     // hydration parent is the parent host component of this host text.
     const returnFiber = hydrationParentFiber;
@@ -520,11 +519,6 @@ function prepareToHydrateHostTextInstance(fiber: Fiber): boolean {
             textContent,
             shouldWarnIfMismatchDev,
           );
-          if (enableClientRenderFallbackOnTextMismatch) {
-            // In concurrent mode we never update the mismatched text,
-            // even if the error was ignored.
-            return false;
-          }
           break;
         }
         case HostSingleton:
@@ -540,17 +534,11 @@ function prepareToHydrateHostTextInstance(fiber: Fiber): boolean {
             textContent,
             shouldWarnIfMismatchDev,
           );
-          if (enableClientRenderFallbackOnTextMismatch) {
-            // In concurrent mode we never update the mismatched text,
-            // even if the error was ignored.
-            return false;
-          }
           break;
         }
       }
     }
   }
-  return shouldUpdate;
 }
 
 function prepareToHydrateHostSuspenseInstance(fiber: Fiber): void {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -30,7 +30,6 @@ export const enableComponentStackLocations = true;
 // -----------------------------------------------------------------------------
 
 // TODO: Finish rolling out in www
-export const enableClientRenderFallbackOnTextMismatch = true;
 export const enableAsyncActions = true;
 
 // Need to remove didTimeout argument from Scheduler before landing

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -65,7 +65,6 @@ export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = true;
 export const enableUseMemoCacheHook = true;
 export const enableUseEffectEventHook = false;
-export const enableClientRenderFallbackOnTextMismatch = true;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = true;
 export const enableGetInspectorDataForInstanceInProduction = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -87,7 +87,6 @@ export const disableTextareaChildren = false;
 export const enableSuspenseAvoidThisFallback = false;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableUseEffectEventHook = false;
-export const enableClientRenderFallbackOnTextMismatch = true;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = true;
 export const enableGetInspectorDataForInstanceInProduction = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -39,7 +39,6 @@ export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = false;
 export const enableUseMemoCacheHook = true;
 export const enableUseEffectEventHook = false;
-export const enableClientRenderFallbackOnTextMismatch = true;
 export const enableComponentStackLocations = true;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -45,7 +45,6 @@ export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = false;
 export const enableUseMemoCacheHook = true;
 export const enableUseEffectEventHook = false;
-export const enableClientRenderFallbackOnTextMismatch = true;
 export const enableUseRefAccessWarning = false;
 export const enableInfiniteRenderLoopDetection = false;
 export const enableRenderableContext = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -41,7 +41,6 @@ export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = false;
 export const enableUseMemoCacheHook = true;
 export const enableUseEffectEventHook = false;
-export const enableClientRenderFallbackOnTextMismatch = true;
 export const enableComponentStackLocations = true;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = true;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -30,7 +30,6 @@ export const enableUseDeferredValueInitialArg = __VARIANT__;
 export const enableRenderableContext = __VARIANT__;
 export const useModernStrictMode = __VARIANT__;
 export const enableRefAsProp = __VARIANT__;
-export const enableClientRenderFallbackOnTextMismatch = __VARIANT__;
 export const enableNewBooleanProps = __VARIANT__;
 export const enableRetryLaneExpiration = __VARIANT__;
 export const retryLaneExpirationMs = 5000;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -39,7 +39,6 @@ export const {
   useModernStrictMode,
   enableRefAsProp,
   enableNewBooleanProps,
-  enableClientRenderFallbackOnTextMismatch,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.


### PR DESCRIPTION
Build on top of #28440.

This lets us remove the path where updates are tracked on differences in text.