### PR TITLE
DevTools: Read context values from context dependencies

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -1109,41 +1109,41 @@ export function inspectHooksOfFiber(
   currentHook = (fiber.memoizedState: Hook);
   currentFiber = fiber;
 
-  // Only used for versions of React without memoized context value in context dependencies.
-  const contextMap = new Map<ReactContext<any>, any>();
-  if (hasOwnProperty.call(currentFiber, 'dependencies')) {
-    // $FlowFixMe[incompatible-use]: Flow thinks hasOwnProperty might have nulled `currentFiber`
-    const dependencies = currentFiber.dependencies;
-    currentContextDependency =
-      dependencies !== null ? dependencies.firstContext : null;
-  } else if (hasOwnProperty.call(currentFiber, 'dependencies_old')) {
-    const dependencies: Dependencies = (currentFiber: any).dependencies_old;
-    currentContextDependency =
-      dependencies !== null ? dependencies.firstContext : null;
-    setupContexts(contextMap, fiber);
-  } else if (hasOwnProperty.call(currentFiber, 'dependencies_new')) {
-    const dependencies: Dependencies = (currentFiber: any).dependencies_new;
-    currentContextDependency =
-      dependencies !== null ? dependencies.firstContext : null;
-    setupContexts(contextMap, fiber);
-  } else if (hasOwnProperty.call(currentFiber, 'contextDependencies')) {
-    const contextDependencies = (currentFiber: any).contextDependencies;
-    currentContextDependency =
-      contextDependencies !== null ? contextDependencies.first : null;
-    setupContexts(contextMap, fiber);
-  } else {
-    throw new Error(
-      'Unsupported React version. This is a bug in React Debug Tools.',
-    );
-  }
-
   const type = fiber.type;
   let props = fiber.memoizedProps;
   if (type !== fiber.elementType) {
     props = resolveDefaultProps(type, props);
   }
 
+  // Only used for versions of React without memoized context value in context dependencies.
+  const contextMap = new Map<ReactContext<any>, any>();
   try {
+    if (hasOwnProperty.call(currentFiber, 'dependencies')) {
+      // $FlowFixMe[incompatible-use]: Flow thinks hasOwnProperty might have nulled `currentFiber`
+      const dependencies = currentFiber.dependencies;
+      currentContextDependency =
+        dependencies !== null ? dependencies.firstContext : null;
+    } else if (hasOwnProperty.call(currentFiber, 'dependencies_old')) {
+      const dependencies: Dependencies = (currentFiber: any).dependencies_old;
+      currentContextDependency =
+        dependencies !== null ? dependencies.firstContext : null;
+      setupContexts(contextMap, fiber);
+    } else if (hasOwnProperty.call(currentFiber, 'dependencies_new')) {
+      const dependencies: Dependencies = (currentFiber: any).dependencies_new;
+      currentContextDependency =
+        dependencies !== null ? dependencies.firstContext : null;
+      setupContexts(contextMap, fiber);
+    } else if (hasOwnProperty.call(currentFiber, 'contextDependencies')) {
+      const contextDependencies = (currentFiber: any).contextDependencies;
+      currentContextDependency =
+        contextDependencies !== null ? contextDependencies.first : null;
+      setupContexts(contextMap, fiber);
+    } else {
+      throw new Error(
+        'Unsupported React version. This is a bug in React Debug Tools.',
+      );
+    }
+
     if (fiber.tag === ForwardRef) {
       return inspectHooksOfForwardRef(
         type.render,

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -61,10 +61,6 @@ type Hook = {
   next: Hook | null,
 };
 
-const GetPrimitiveStackCacheContext: ReactContext<mixed> = ({
-  $$typeof: REACT_CONTEXT_TYPE,
-  _currentValue: null,
-}: any);
 function getPrimitiveStackCache(): Map<string, Array<any>> {
   // This initializes a cache of all primitive hooks so that the top
   // most stack frames added by calling the primitive hook can be removed.
@@ -73,7 +69,7 @@ function getPrimitiveStackCache(): Map<string, Array<any>> {
     let readHookLog;
     try {
       // Use all hooks here to add them to the hook log.
-      Dispatcher.useContext(GetPrimitiveStackCacheContext);
+      Dispatcher.useContext(({_currentValue: null}: any));
       Dispatcher.useState(null);
       Dispatcher.useReducer((s: mixed, a: mixed) => s, null);
       Dispatcher.useRef(null);
@@ -109,7 +105,12 @@ function getPrimitiveStackCache(): Map<string, Array<any>> {
       }
       if (typeof Dispatcher.use === 'function') {
         // This type check is for Flow only.
-        Dispatcher.use(GetPrimitiveStackCacheContext);
+        Dispatcher.use(
+          ({
+            $$typeof: REACT_CONTEXT_TYPE,
+            _currentValue: null,
+          }: any),
+        );
         Dispatcher.use({
           then() {},
           status: 'fulfilled',
@@ -149,13 +150,9 @@ function nextHook(): null | Hook {
 }
 
 function readContext<T>(context: ReactContext<T>): T {
-  if (context === GetPrimitiveStackCacheContext) {
-    // This is a read for filling the primitive stack cache.
-    // There's no sensible value to return.
-    return (null: any);
-  }
   if (currentFiber === null) {
-    // Hook inspection without access to the Fiber tree.
+    // Hook inspection without access to the Fiber tree
+    // e.g. when filling the primitive stack cache or during `ReactDebugTools.inspectHooks()`.
     return context._currentValue;
   }
   if (currentContextDependency === null) {

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -1109,6 +1109,29 @@ export function inspectHooksOfFiber(
   currentHook = (fiber.memoizedState: Hook);
   currentFiber = fiber;
 
+  if (hasOwnProperty.call(currentFiber, 'dependencies')) {
+    // $FlowFixMe[incompatible-use]: Flow thinks hasOwnProperty might have nulled `currentFiber`
+    const dependencies = currentFiber.dependencies;
+    currentContextDependency =
+      dependencies !== null ? dependencies.firstContext : null;
+  } else if (hasOwnProperty.call(currentFiber, 'dependencies_old')) {
+    const dependencies: Dependencies = (currentFiber: any).dependencies_old;
+    currentContextDependency =
+      dependencies !== null ? dependencies.firstContext : null;
+  } else if (hasOwnProperty.call(currentFiber, 'dependencies_new')) {
+    const dependencies: Dependencies = (currentFiber: any).dependencies_new;
+    currentContextDependency =
+      dependencies !== null ? dependencies.firstContext : null;
+  } else if (hasOwnProperty.call(currentFiber, 'contextDependencies')) {
+    const contextDependencies = (currentFiber: any).contextDependencies;
+    currentContextDependency =
+      contextDependencies !== null ? contextDependencies.first : null;
+  } else {
+    throw new Error(
+      'Unsupported React version. This is a bug in React Debug Tools.',
+    );
+  }
+
   const type = fiber.type;
   let props = fiber.memoizedProps;
   if (type !== fiber.elementType) {
@@ -1118,30 +1141,11 @@ export function inspectHooksOfFiber(
   // Only used for versions of React without memoized context value in context dependencies.
   const contextMap = new Map<ReactContext<any>, any>();
   try {
-    if (hasOwnProperty.call(currentFiber, 'dependencies')) {
-      // $FlowFixMe[incompatible-use]: Flow thinks hasOwnProperty might have nulled `currentFiber`
-      const dependencies = currentFiber.dependencies;
-      currentContextDependency =
-        dependencies !== null ? dependencies.firstContext : null;
-    } else if (hasOwnProperty.call(currentFiber, 'dependencies_old')) {
-      const dependencies: Dependencies = (currentFiber: any).dependencies_old;
-      currentContextDependency =
-        dependencies !== null ? dependencies.firstContext : null;
+    if (
+      currentContextDependency !== null &&
+      !hasOwnProperty.call(currentContextDependency, 'memoizedValue')
+    ) {
       setupContexts(contextMap, fiber);
-    } else if (hasOwnProperty.call(currentFiber, 'dependencies_new')) {
-      const dependencies: Dependencies = (currentFiber: any).dependencies_new;
-      currentContextDependency =
-        dependencies !== null ? dependencies.firstContext : null;
-      setupContexts(contextMap, fiber);
-    } else if (hasOwnProperty.call(currentFiber, 'contextDependencies')) {
-      const contextDependencies = (currentFiber: any).contextDependencies;
-      currentContextDependency =
-        contextDependencies !== null ? contextDependencies.first : null;
-      setupContexts(contextMap, fiber);
-    } else {
-      throw new Error(
-        'Unsupported React version. This is a bug in React Debug Tools.',
-      );
     }
 
     if (fiber.tag === ForwardRef) {

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -152,20 +152,21 @@ function nextHook(): null | Hook {
 function readContext<T>(context: ReactContext<T>): T {
   if (currentFiber === null) {
     // Hook inspection without access to the Fiber tree
-    // e.g. when filling the primitive stack cache or during `ReactDebugTools.inspectHooks()`.
+    // e.g. when warming up the primitive stack cache or during `ReactDebugTools.inspectHooks()`.
     return context._currentValue;
-  }
-  if (currentContextDependency === null) {
-    throw new Error(
-      'Context reads do not line up with context dependencies. This is a bug in React.',
-    );
-  }
+  } else {
+    if (currentContextDependency === null) {
+      throw new Error(
+        'Context reads do not line up with context dependencies. This is a bug in React.',
+      );
+    }
 
-  // For now we don't expose readContext usage in the hooks debugging info.
-  const value = ((currentContextDependency.memoizedValue: any): T);
-  currentContextDependency = currentContextDependency.next;
+    // For now we don't expose readContext usage in the hooks debugging info.
+    const value = ((currentContextDependency.memoizedValue: any): T);
+    currentContextDependency = currentContextDependency.next;
 
-  return value;
+    return value;
+  }
 }
 
 const SuspenseException: mixed = new Error(

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -154,9 +154,16 @@ function readContext<T>(context: ReactContext<T>): T {
     // There's no sensible value to return.
     return (null: any);
   }
-  if (currentContextDependency === null) {
+  if (currentFiber === null) {
+    // Hook inspection without access to the Fiber tree.
     return context._currentValue;
   }
+  if (currentContextDependency === null) {
+    throw new Error(
+      'Context reads do not line up with context dependencies. This is a bug in React.',
+    );
+  }
+
   // For now we don't expose readContext usage in the hooks debugging info.
   const value = ((currentContextDependency.memoizedValue: any): T);
   currentContextDependency = currentContextDependency.next;


### PR DESCRIPTION
## Summary

Instead of walking up the fiber tree to fill context values from the provider values we now move a cursor along the context dependencies whenever we read context.

This will allow us to read from host specific contexts where we don't have access to the context object e.g. `useFormStatus()`. 

For React versions prior to https://github.com/facebook/react/pull/20890 we still need to walk the fiber tree up to visit context providers since we don't have `memoizedValue` on the context dependency in this case.

## How did you test this change?

- [x] react-debug-tools tests
- [x] inspected components with context hooks (e.g. FunctionalContextConsumerWithUpdates) in the shell
- [x] Backwards compat with 16.8: https://codesandbox.io/p/sandbox/serverless-snowflake-ttrp8v 
- [x] Backwards compat with 17.0: https://codesandbox.io/p/sandbox/17-0-react-devtools-context-inspection-forked-rslrsq
- [x] Backwards compat with 18.0: https://codesandbox.io/p/sandbox/18-0-react-devtools-context-inspection-p8ntzj
- [x] Compat with Canary: https://codesandbox.io/p/sandbox/canary-react-devtools-context-inspection-9y5gkc
