### PR TITLE
Remove loose-envify dep and browserify configs

### DIFF
--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "art": "^0.10.1",
     "create-react-class": "^15.6.2",
-    "loose-envify": "^1.1.0",
     "scheduler": "^0.23.0"
   },
   "peerDependencies": {
@@ -39,10 +38,5 @@
     "Circle.js",
     "Rectangle.js",
     "Wedge.js"
-  ],
-  "browserify": {
-    "transform": [
-      "loose-envify"
-    ]
-  }
+  ]
 }

--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -25,13 +25,5 @@
   },
   "peerDependencies": {
     "react": "^17.0.0"
-  },
-  "dependencies": {
-    "loose-envify": "^1.1.0"
-  },
-  "browserify": {
-    "transform": [
-      "loose-envify"
-    ]
   }
 }

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -17,7 +17,6 @@
   },
   "homepage": "https://react.dev/",
   "dependencies": {
-    "loose-envify": "^1.1.0",
     "scheduler": "^0.23.0"
   },
   "peerDependencies": {
@@ -89,10 +88,5 @@
   "browser": {
     "./server.js": "./server.browser.js",
     "./static.js": "./static.browser.js"
-  },
-  "browserify": {
-    "transform": [
-      "loose-envify"
-    ]
   }
 }

--- a/packages/react-interactions/package.json
+++ b/packages/react-interactions/package.json
@@ -33,15 +33,7 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "dependencies": {
-    "loose-envify": "^1.1.0"
-  },
   "peerDependencies": {
     "react": "^17.0.0"
-  },
-  "browserify": {
-    "transform": [
-      "loose-envify"
-    ]
   }
 }

--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -29,12 +29,6 @@
     "react": "^18.2.0"
   },
   "dependencies": {
-    "loose-envify": "^1.1.0",
     "scheduler": "^0.23.0"
-  },
-  "browserify": {
-    "transform": [
-      "loose-envify"
-    ]
   }
 }

--- a/packages/react-server-dom-turbopack/package.json
+++ b/packages/react-server-dom-turbopack/package.json
@@ -84,12 +84,6 @@
   },
   "dependencies": {
     "acorn-loose": "^8.3.0",
-    "neo-async": "^2.6.1",
-    "loose-envify": "^1.1.0"
-  },
-  "browserify": {
-    "transform": [
-      "loose-envify"
-    ]
+    "neo-async": "^2.6.1"
   }
 }

--- a/packages/react-server-dom-webpack/package.json
+++ b/packages/react-server-dom-webpack/package.json
@@ -85,12 +85,6 @@
   },
   "dependencies": {
     "acorn-loose": "^8.3.0",
-    "neo-async": "^2.6.1",
-    "loose-envify": "^1.1.0"
-  },
-  "browserify": {
-    "transform": [
-      "loose-envify"
-    ]
+    "neo-async": "^2.6.1"
   }
 }

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -27,13 +27,5 @@
   },
   "peerDependencies": {
     "react": "^17.0.0"
-  },
-  "dependencies": {
-    "loose-envify": "^1.1.0"
-  },
-  "browserify": {
-    "transform": [
-      "loose-envify"
-    ]
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,13 +40,5 @@
   },
   "engines": {
     "node": ">=0.10.0"
-  },
-  "dependencies": {
-    "loose-envify": "^1.1.0"
-  },
-  "browserify": {
-    "transform": [
-      "loose-envify"
-    ]
   }
 }

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -15,9 +15,6 @@
     "url": "https://github.com/facebook/react/issues"
   },
   "homepage": "https://react.dev/",
-  "dependencies": {
-    "loose-envify": "^1.1.0"
-  },
   "files": [
     "LICENSE",
     "README.md",
@@ -27,10 +24,5 @@
     "unstable_post_task.js",
     "cjs/",
     "umd/"
-  ],
-  "browserify": {
-    "transform": [
-      "loose-envify"
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
Browserify isn't widely used, and at this point I don't think it makes sense to have a special config just for the sake of it. Let's remove it?