### PR TITLE
Remove unstable_concurrentUpdateByDefault option from RTR

### DIFF
--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -52,10 +52,7 @@ import {checkPropStringCoercion} from 'shared/CheckStringCoercion';
 
 import {getPublicInstance} from './ReactFiberConfigTestHost';
 import {ConcurrentRoot, LegacyRoot} from 'react-reconciler/src/ReactRootTags';
-import {
-  allowConcurrentByDefault,
-  enableReactTestRendererWarning,
-} from 'shared/ReactFeatureFlags';
+import {enableReactTestRendererWarning} from 'shared/ReactFeatureFlags';
 
 const act = React.act;
 
@@ -66,8 +63,6 @@ type TestRendererOptions = {
   isConcurrent: boolean,
   unstable_isConcurrent: boolean,
   unstable_strictMode: boolean,
-  unstable_concurrentUpdatesByDefault: boolean,
-  ...
 };
 
 type ReactTestRendererJSON = {
@@ -485,7 +480,6 @@ function create(
   let createNodeMock = defaultTestOptions.createNodeMock;
   let isConcurrent = false;
   let isStrictMode = false;
-  let concurrentUpdatesByDefault = null;
   if (typeof options === 'object' && options !== null) {
     if (typeof options.createNodeMock === 'function') {
       // $FlowFixMe[incompatible-type] found when upgrading Flow
@@ -500,12 +494,6 @@ function create(
     if (options.unstable_strictMode === true) {
       isStrictMode = true;
     }
-    if (allowConcurrentByDefault) {
-      if (options.unstable_concurrentUpdatesByDefault !== undefined) {
-        concurrentUpdatesByDefault =
-          options.unstable_concurrentUpdatesByDefault;
-      }
-    }
   }
   let container = {
     children: ([]: Array<Instance | TextInstance>),
@@ -517,7 +505,7 @@ function create(
     isConcurrent ? ConcurrentRoot : LegacyRoot,
     null,
     isStrictMode,
-    concurrentUpdatesByDefault,
+    false,
     '',
     onRecoverableError,
     null,

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -61,9 +61,9 @@ export const enableLazyContextPropagation = false;
 export const enableLegacyHidden = false;
 export const forceConcurrentByDefaultForTesting = false;
 export const enableUnifiedSyncLane = true;
-export const allowConcurrentByDefault = true;
 export const enableCustomElementPropertySupport = true;
 export const enableNewBooleanProps = true;
+export const allowConcurrentByDefault = false;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -61,7 +61,7 @@ export const enableLazyContextPropagation = false;
 export const enableLegacyHidden = false;
 export const forceConcurrentByDefaultForTesting = false;
 export const enableUnifiedSyncLane = true;
-export const allowConcurrentByDefault = true;
+export const allowConcurrentByDefault = false;
 export const enableCustomElementPropertySupport = false;
 export const enableNewBooleanProps = false;
 


### PR DESCRIPTION
Clean up unused ReactTestRenderer option: `unstable_concurrentUpdateByDefault`