### PR TITLE
fix: calling onblur event on unmount

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -16,6 +16,7 @@ let ReactDOMServer = require('react-dom/server');
 let Scheduler = require('scheduler');
 let act;
 let useEffect;
+let useState;
 let assertLog;
 let waitFor;
 let waitForAll;
@@ -33,6 +34,7 @@ describe('ReactDOMRoot', () => {
     Scheduler = require('scheduler');
     act = require('internal-test-utils').act;
     useEffect = React.useEffect;
+    useState = React.useState;
 
     const InternalTestUtils = require('internal-test-utils');
     assertLog = InternalTestUtils.assertLog;
@@ -506,5 +508,64 @@ describe('ReactDOMRoot', () => {
         '  root.render(Symbol(foo))',
       {withoutStack: true},
     );
+  });
+
+  it('should trigger the onBlur Event before the Component Unmount', async () => {
+    const handleBlur = jest.fn();
+    const handleBlur2 = jest.fn();
+    const handleBlur3 = jest.fn();
+    function App() {
+      const [mount1, setMount1] = useState(true);
+      const [mount2, setMount2] = useState(true);
+      const [mount3, setMount3] = useState(true);
+      return (
+        <>
+          {mount1 && (
+            <button
+              id="btn1"
+              onClick={() => setMount1(false)}
+              onBlur={handleBlur}>
+              click me
+            </button>
+          )}
+          <button id="btn2" onBlur={handleBlur2}>
+            click me2
+          </button>
+          {mount2 && (
+            <button id="btn3" onClick={() => setMount2(false)}>
+              click me3
+            </button>
+          )}
+          {mount3 && (
+            <div onBlur={handleBlur3}>
+              <button
+                id="btn4"
+                onClick={() => setMount3(false)}
+                onBlur={handleBlur3}>
+                click me4
+              </button>
+            </div>
+          )}
+        </>
+      );
+    }
+    document.body.appendChild(container);
+    ReactDOM.render(<App />, container);
+    // should call blur handler with emit unmount
+    const button = container.querySelector('#btn1');
+    button.click();
+    expect(handleBlur).toHaveBeenCalled();
+    // should call blur handler without emit unmount
+    const button2 = container.querySelector('#btn2');
+    button2.focus();
+    button2.blur();
+    expect(handleBlur2).toHaveBeenCalled();
+    const button3 = container.querySelector('#btn3');
+    button3.click();
+    expect(container.querySelector('#btn3')).toBe(null);
+    const button4 = container.querySelector('#btn4');
+    button4.click();
+    expect(container.querySelector('#btn4')).toBe(null);
+    expect(handleBlur3).toBeCalledTimes(2);
   });
 });

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2019,6 +2019,9 @@ function commitDeletionEffectsOnFiber(
   nearestMountedAncestor: Fiber,
   deletedFiber: Fiber,
 ) {
+  if (deletedFiber.memoizedProps && deletedFiber.memoizedProps.onBlur) {
+    deletedFiber.memoizedProps.onBlur(new Event('blur', {bubbles: true}));
+  }
   onCommitUnmount(deletedFiber);
 
   // The cases in this outer switch modify the stack before they traverse


### PR DESCRIPTION
Working wit React, there was a small bug i discovered, related to unmounting off a particular element in the DOM, in vanilla JS whenever a particular item gets removed from the DOM, an `onBlur` event is triggered automatically, as said in MDN 
<img width="837" alt="Screenshot 2024-03-05 at 6 30 36 PM" src="https://github.com/facebook/react/assets/72331432/90f95cd1-ce67-4867-a6e5-1ae9e03c9cbf">
[MDN LINK](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)
React simply does not seem to call this `onBlur` event when a particular element is unmounted, i might be wrong to judge why the same wasn't implemented in the context of react, anyways this would mean a learning opportunity for me to understand react design principles more better.

here is a Vanilla Js repro of the onBlur being called

https://github.com/facebook/react/assets/72331432/71764d95-8cf1-46f4-870c-7260496eb4ed

[Vanilla JS codesandbox repro](https://codesandbox.io/p/sandbox/thirsty-dew-m3c9rw?file=%2Fsrc%2Findex.js&layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522cltebycuk00063b7gmdoekmb7%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522cltebycuk00023b7gkqj1jfl5%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522cltebycuk00033b7g0lpr7ihd%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522cltebycuk00053b7giz3n0fay%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522cltebycuk00023b7gkqj1jfl5%2522%253A%257B%2522id%2522%253A%2522cltebycuk00023b7gkqj1jfl5%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cltecjrm500023b7gfcgihboa%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fsrc%252Findex.js%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522activeTabId%2522%253A%2522cltecjrm500023b7gfcgihboa%2522%257D%252C%2522cltebycuk00053b7giz3n0fay%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cltebycuk00043b7gf3vg0hzn%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522cltebycuk00053b7giz3n0fay%2522%252C%2522activeTabId%2522%253A%2522cltebycuk00043b7gf3vg0hzn%2522%257D%252C%2522cltebycuk00033b7g0lpr7ihd%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522cltebycuk00033b7g0lpr7ihd%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257Dl)


here is the React Codesandbox example, check console as the `onBlur` is not called

https://github.com/facebook/react/assets/72331432/f12b66bf-5bb9-4a0b-a0f5-aa37c57c3119


[React Sandbox Link](https://codesandbox.io/p/sandbox/react-blur-cyffzf?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522cltecd0id00063b7g9dw8muas%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522cltecd0ic00023b7gfaq73wrr%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522cltecd0ic00033b7gu9schf65%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522cltecd0ic00053b7gw8foqyy4%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B40%252C60%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522cltecd0ic00023b7gfaq73wrr%2522%253A%257B%2522id%2522%253A%2522cltecd0ic00023b7gfaq73wrr%2522%252C%2522tabs%2522%253A%255B%255D%257D%252C%2522cltecd0ic00053b7gw8foqyy4%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cltecd0ic00043b7gtgtst7qn%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522cltecd0ic00053b7gw8foqyy4%2522%252C%2522activeTabId%2522%253A%2522cltecd0ic00043b7gtgtst7qn%2522%257D%252C%2522cltecd0ic00033b7gu9schf65%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522cltecd0ic00033b7gu9schf65%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)


The fix i proposed here is  if the deletedFiber object has `memoizedProps` and if those `memoizedProps` contain an `onBlur` property. If both conditions are true, it calls the onBlur function with a new blur event.
I have added a test for the same, to not allow regression to occur


Tested on the fixtures file after running `yarn build` 
Passing Test
<img width="724" alt="Screenshot 2024-03-07 at 1 48 03 PM" src="https://github.com/facebook/react/assets/72331432/4ab2f6c5-1a3f-45ec-9021-0df18435cfb6">



https://github.com/facebook/react/assets/72331432/badedda2-94fa-46b0-a1e7-3c24e9dd26ae



This Behaviour falls under the category where React and Vanilla JS act differently , earlier i raised #27016 , reviewed by sophie , which concluded to refer away from custom event logic as of now, as the future of react seems to get rid of  React event system logic and rely on browser event system.

tagging @sebmarkbage @sophiebits @acdlite @rickhanlonii  , would love to know all of your thoughts and what you feel about this.
