### PR TITLE
Remove react-test-renderer/shallow export

### DIFF
--- a/packages/react-test-renderer/__tests__/shallow-test.js
+++ b/packages/react-test-renderer/__tests__/shallow-test.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+describe('shallow', () => {
+  it('throws an error on init', () => {
+    const ReactShallowRenderer = require('../shallow.js').default;
+    expect(() => {
+      // eslint-disable-next-line no-new
+      new ReactShallowRenderer();
+    }).toThrow(
+      'react-test-renderer/shallow has been removed. See https://react.dev/warnings/react-test-renderer.'
+    );
+  });
+});

--- a/packages/react-test-renderer/npm/shallow.js
+++ b/packages/react-test-renderer/npm/shallow.js
@@ -1,3 +1,9 @@
 'use strict';
 
-module.exports = require('react-shallow-renderer');
+function ReactShallowRenderer() {
+  throw new Error(
+    'react-test-renderer/shallow has been removed. See https://react.dev/warnings/react-test-renderer.'
+  );
+}
+
+module.exports = ReactShallowRenderer;

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -20,7 +20,6 @@
   "homepage": "https://react.dev/",
   "dependencies": {
     "react-is": "^18.2.0",
-    "react-shallow-renderer": "^16.15.0",
     "scheduler": "^0.23.0"
   },
   "peerDependencies": {

--- a/packages/react-test-renderer/shallow.js
+++ b/packages/react-test-renderer/shallow.js
@@ -7,4 +7,5 @@
  * @flow
  */
 
-export {default} from 'react-shallow-renderer';
+import ReactShallowRenderer from './npm/shallow.js';
+export default ReactShallowRenderer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13017,14 +13017,6 @@ react-native-web@0.0.0-26873b469:
     prop-types "^15.6.0"
     react-timer-mixin "^0.13.4"
 
-react-shallow-renderer@^16.15.0:
-  version "16.15.0"
-  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
-  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
-  dependencies:
-    object-assign "^4.1.1"
-    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
-
 react-timer-mixin@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz#75a00c3c94c13abe29b43d63b4c65a88fc8264d3"


### PR DESCRIPTION
Based on
- https://github.com/facebook/react/pull/28419

## Summary

The shallow renderer was extracted from the repo years ago and published by enzyme: https://github.com/enzymejs/react-shallow-renderer

We no longer need to reexport under the react-test-renderer namespace. People can import `react-shallow-renderer` as needed

## How did you test this change?

- Observe shallow.js in react-test-renderer package from standard build
- Run build with changes on this branch
- Observe no more shallow.js export in build output
