### PR TITLE
[DOM] move `flushSync` out of the reconciler

### DIFF
--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -10,9 +10,9 @@ import ReactVersion from 'shared/ReactVersion';
 import {LegacyRoot, ConcurrentRoot} from 'react-reconciler/src/ReactRootTags';
 import {
   createContainer,
-  updateContainer,
+  updateContainerSync,
   injectIntoDevTools,
-  flushSync,
+  flushSyncWork,
 } from 'react-reconciler/src/ReactFiberReconciler';
 import Transform from 'art/core/transform';
 import Mode from 'art/modes/current';
@@ -78,9 +78,8 @@ class Surface extends React.Component {
     );
     // We synchronously flush updates coming from above so that they commit together
     // and so that refs resolve before the parent life cycles.
-    flushSync(() => {
-      updateContainer(this.props.children, this._mountNode, this);
-    });
+    updateContainerSync(this.props.children, this._mountNode, this);
+    flushSyncWork();
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -92,9 +91,8 @@ class Surface extends React.Component {
 
     // We synchronously flush updates coming from above so that they commit together
     // and so that refs resolve before the parent life cycles.
-    flushSync(() => {
-      updateContainer(this.props.children, this._mountNode, this);
-    });
+    updateContainerSync(this.props.children, this._mountNode, this);
+    flushSyncWork();
 
     if (this._surface.render) {
       this._surface.render();
@@ -104,9 +102,8 @@ class Surface extends React.Component {
   componentWillUnmount() {
     // We synchronously flush updates coming from above so that they commit together
     // and so that refs resolve before the parent life cycles.
-    flushSync(() => {
-      updateContainer(null, this._mountNode, this);
-    });
+    updateContainerSync(null, this._mountNode, this);
+    flushSyncWork();
   }
 
   render() {

--- a/packages/react-dom-bindings/src/events/ReactDOMUpdateBatching.js
+++ b/packages/react-dom-bindings/src/events/ReactDOMUpdateBatching.js
@@ -13,7 +13,7 @@ import {
 import {
   batchedUpdates as batchedUpdatesImpl,
   discreteUpdates as discreteUpdatesImpl,
-  flushSync as flushSyncImpl,
+  flushSyncWork,
 } from 'react-reconciler/src/ReactFiberReconciler';
 
 // Used as a way to call batchedUpdates when we don't have a reference to
@@ -36,7 +36,9 @@ function finishEventHandler() {
     // bails out of the update without touching the DOM.
     // TODO: Restore state in the microtask, after the discrete updates flush,
     // instead of early flushing them here.
-    flushSyncImpl();
+    // @TODO Should move to flushSyncWork once legacy mode is removed but since this flushSync
+    // flushes passive effects we can't do this yet.
+    flushSyncWork();
     restoreStateIfNeeded();
   }
 }

--- a/packages/react-dom-bindings/src/server/ReactDOMFlightServerHostDispatcher.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMFlightServerHostDispatcher.js
@@ -28,6 +28,7 @@ const ReactDOMCurrentDispatcher =
 
 const previousDispatcher = ReactDOMCurrentDispatcher.current;
 ReactDOMCurrentDispatcher.current = {
+  flushSyncWork: previousDispatcher.flushSyncWork,
   prefetchDNS,
   preconnect,
   preload,

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -88,6 +88,7 @@ const ReactDOMCurrentDispatcher =
 
 const previousDispatcher = ReactDOMCurrentDispatcher.current;
 ReactDOMCurrentDispatcher.current = {
+  flushSyncWork: previousDispatcher.flushSyncWork,
   prefetchDNS,
   preconnect,
   preload,

--- a/packages/react-dom/src/ReactDOMSharedInternals.js
+++ b/packages/react-dom/src/ReactDOMSharedInternals.js
@@ -29,6 +29,7 @@ type InternalsType = {
 function noop() {}
 
 const DefaultDispatcher: HostDispatcher = {
+  flushSyncWork: noop,
   prefetchDNS: noop,
   preconnect: noop,
   preload: noop,

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -14,6 +14,7 @@ import type {
   CreateRootOptions,
 } from './ReactDOMRoot';
 
+import {disableLegacyMode} from 'shared/ReactFeatureFlags';
 import {
   createRoot as createRootImpl,
   hydrateRoot as hydrateRootImpl,
@@ -21,9 +22,10 @@ import {
 } from './ReactDOMRoot';
 import {createEventHandle} from 'react-dom-bindings/src/client/ReactDOMEventHandle';
 import {runWithPriority} from 'react-dom-bindings/src/client/ReactDOMUpdatePriority';
+import {flushSync as flushSyncIsomorphic} from '../shared/ReactDOMFlushSync';
 
 import {
-  flushSync as flushSyncWithoutWarningIfAlreadyRendering,
+  flushSyncFromReconciler as flushSyncWithoutWarningIfAlreadyRendering,
   isAlreadyRendering,
   injectIntoDevTools,
   findHostInstance,
@@ -123,11 +125,11 @@ function hydrateRoot(
 
 // Overload the definition to the two valid signatures.
 // Warning, this opts-out of checking the function body.
-declare function flushSync<R>(fn: () => R): R;
+declare function flushSyncFromReconciler<R>(fn: () => R): R;
 // eslint-disable-next-line no-redeclare
-declare function flushSync(): void;
+declare function flushSyncFromReconciler(): void;
 // eslint-disable-next-line no-redeclare
-function flushSync<R>(fn: (() => R) | void): R | void {
+function flushSyncFromReconciler<R>(fn: (() => R) | void): R | void {
   if (__DEV__) {
     if (isAlreadyRendering()) {
       console.error(
@@ -139,6 +141,10 @@ function flushSync<R>(fn: (() => R) | void): R | void {
   }
   return flushSyncWithoutWarningIfAlreadyRendering(fn);
 }
+
+const flushSync: typeof flushSyncIsomorphic = disableLegacyMode
+  ? flushSyncIsomorphic
+  : flushSyncFromReconciler;
 
 function findDOMNode(
   componentOrElement: React$Component<any, any>,

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -93,7 +93,8 @@ import {
   createContainer,
   createHydrationContainer,
   updateContainer,
-  flushSync,
+  updateContainerSync,
+  flushSyncWork,
   isAlreadyRendering,
   defaultOnUncaughtError,
   defaultOnCaughtError,
@@ -161,9 +162,8 @@ ReactDOMHydrationRoot.prototype.unmount = ReactDOMRoot.prototype.unmount =
           );
         }
       }
-      flushSync(() => {
-        updateContainer(null, root, null, null);
-      });
+      updateContainerSync(null, root, null, null);
+      flushSyncWork();
       unmarkContainerAsRoot(container);
     }
   };

--- a/packages/react-dom/src/shared/ReactDOMFlushSync.js
+++ b/packages/react-dom/src/shared/ReactDOMFlushSync.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {BatchConfig} from 'react/src/ReactCurrentBatchConfig';
+
+import {disableLegacyMode} from 'shared/ReactFeatureFlags';
+import {DiscreteEventPriority} from 'react-reconciler/src/ReactEventPriorities';
+
+import ReactSharedInternals from 'shared/ReactSharedInternals';
+const ReactCurrentBatchConfig: BatchConfig =
+  ReactSharedInternals.ReactCurrentBatchConfig;
+
+import ReactDOMSharedInternals from 'shared/ReactDOMSharedInternals';
+const ReactDOMCurrentDispatcher =
+  ReactDOMSharedInternals.ReactDOMCurrentDispatcher;
+
+declare function flushSyncImpl<R>(fn: () => R): R;
+declare function flushSyncImpl(void): void;
+function flushSyncImpl<R>(fn: (() => R) | void): R | void {
+  const previousTransition = ReactCurrentBatchConfig.transition;
+  const previousUpdatePriority =
+    ReactDOMSharedInternals.up; /* ReactDOMCurrentUpdatePriority */
+
+  try {
+    ReactCurrentBatchConfig.transition = null;
+    ReactDOMSharedInternals.up /* ReactDOMCurrentUpdatePriority */ =
+      DiscreteEventPriority;
+    if (fn) {
+      return fn();
+    } else {
+      return undefined;
+    }
+  } finally {
+    ReactCurrentBatchConfig.transition = previousTransition;
+    ReactDOMSharedInternals.up /* ReactDOMCurrentUpdatePriority */ =
+      previousUpdatePriority;
+    const wasInRender = ReactDOMCurrentDispatcher.current.flushSyncWork();
+    if (__DEV__) {
+      if (wasInRender) {
+        console.error(
+          'flushSync was called from inside a lifecycle method. React cannot ' +
+            'flush when React is already rendering. Consider moving this call to ' +
+            'a scheduler task or micro task.',
+        );
+      }
+    }
+  }
+}
+
+declare function flushSyncErrorInBuildsThatSupportLegacyMode<R>(fn: () => R): R;
+declare function flushSyncErrorInBuildsThatSupportLegacyMode(void): void;
+function flushSyncErrorInBuildsThatSupportLegacyMode() {
+  // eslint-disable-next-line react-internal/prod-error-codes
+  throw new Error(
+    'Expected this build of React to not support legacy mode but it does. This is a bug in React.',
+  );
+}
+
+export const flushSync: typeof flushSyncImpl = disableLegacyMode
+  ? flushSyncImpl
+  : flushSyncErrorInBuildsThatSupportLegacyMode;

--- a/packages/react-dom/src/shared/ReactDOMTypes.js
+++ b/packages/react-dom/src/shared/ReactDOMTypes.js
@@ -82,6 +82,7 @@ export type PreinitModuleScriptOptions = {
 };
 
 export type HostDispatcher = {
+  flushSyncWork: () => boolean | void,
   prefetchDNS: (href: string) => void,
   preconnect: (href: string, crossOrigin?: ?CrossOriginEnum) => void,
   preload: (href: string, as: string, options?: ?PreloadImplOptions) => void,

--- a/packages/react-reconciler/src/ReactFiberHotReloading.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.js
@@ -15,12 +15,12 @@ import type {Instance} from './ReactFiberConfig';
 import type {ReactNodeList} from 'shared/ReactTypes';
 
 import {
-  flushSync,
+  flushSyncWork,
   scheduleUpdateOnFiber,
   flushPassiveEffects,
 } from './ReactFiberWorkLoop';
 import {enqueueConcurrentRenderForLane} from './ReactFiberConcurrentUpdates';
-import {updateContainer} from './ReactFiberReconciler';
+import {updateContainerSync} from './ReactFiberReconciler';
 import {emptyContextObject} from './ReactFiberContext';
 import {SyncLane} from './ReactFiberLane';
 import {
@@ -241,13 +241,12 @@ export const scheduleRefresh: ScheduleRefresh = (
     }
     const {staleFamilies, updatedFamilies} = update;
     flushPassiveEffects();
-    flushSync(() => {
-      scheduleFibersWithFamiliesRecursively(
-        root.current,
-        updatedFamilies,
-        staleFamilies,
-      );
-    });
+    scheduleFibersWithFamiliesRecursively(
+      root.current,
+      updatedFamilies,
+      staleFamilies,
+    );
+    flushSyncWork();
   }
 };
 
@@ -262,10 +261,8 @@ export const scheduleRoot: ScheduleRoot = (
       // Just ignore. We'll delete this with _renderSubtree code path later.
       return;
     }
-    flushPassiveEffects();
-    flushSync(() => {
-      updateContainer(element, root, null, null);
-    });
+    updateContainerSync(element, root, null, null);
+    flushSyncWork();
   }
 };
 

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -20,7 +20,7 @@ import {
   getPublicRootInstance,
   createContainer,
   updateContainer,
-  flushSync,
+  flushSyncFromReconciler,
   injectIntoDevTools,
   batchedUpdates,
   defaultOnUncaughtError,
@@ -468,7 +468,7 @@ function create(
   update(newElement: React$Element<any>): any,
   unmount(): void,
   getInstance(): React$Component<any, any> | PublicInstance | null,
-  unstable_flushSync: typeof flushSync,
+  unstable_flushSync: typeof flushSyncFromReconciler,
 } {
   if (__DEV__) {
     if (
@@ -597,7 +597,7 @@ function create(
       return getPublicRootInstance(root);
     },
 
-    unstable_flushSync: flushSync,
+    unstable_flushSync: flushSyncFromReconciler,
   };
 
   Object.defineProperty(

--- a/packages/react/src/ReactCurrentBatchConfig.js
+++ b/packages/react/src/ReactCurrentBatchConfig.js
@@ -9,7 +9,7 @@
 
 import type {BatchConfigTransition} from 'react-reconciler/src/ReactFiberTracingMarkerComponent';
 
-type BatchConfig = {
+export type BatchConfig = {
   transition: BatchConfigTransition | null,
 };
 /**

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -505,5 +505,6 @@
   "517": "Symbols cannot be passed to a Server Function without a temporary reference set. Pass a TemporaryReferenceSet to the options.%s",
   "518": "Saw multiple hydration diff roots in a pass. This is a bug in React.",
   "519": "Hydration Mismatch Exception: This is not a real error, and should not leak into userspace. If you're seeing this, it's likely a bug in React.",
-  "520": "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."
+  "520": "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root.",
+  "521": "flushSyncWork should not be called from builds that support legacy mode. This is a bug in React."
 }


### PR DESCRIPTION
This PR moves `flushSync` out of the reconciler. there is still an internal implementation that is used when these semantics are needed for React methods such as `unmount` on roots.

This new isomorphic `flushSync` is only used in builds that no longer support legacy mode.

Additionally all the internal uses of flushSync in the reconciler have been replaced with more direct methods. There is a new `updateContainerSync` method which updates a container but forces it to the Sync lane and flushes passive effects if necessary. This combined with flushSyncWork can be used to replace flushSync for all instances of internal usage.

We still maintain the original flushSync implementation as `flushSyncFromReconciler` because it will be used as the flushSync implementation for FB builds. This is because it has special legacy mode handling that the new isomorphic implementation does not need to consider. It will be removed from production OSS builds by closure though