### PR TITLE
Add pending state to useFormState

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -521,8 +521,9 @@ function useFormState<S, P>(
   action: (Awaited<S>, P) => S,
   initialState: Awaited<S>,
   permalink?: string,
-): [Awaited<S>, (P) => void] {
+): [Awaited<S>, (P) => void, boolean] {
   const hook = nextHook(); // FormState
+  nextHook(); // PendingState
   nextHook(); // ActionQueue
   const stackError = new Error();
   let value;
@@ -580,7 +581,9 @@ function useFormState<S, P>(
   // value being a Thenable is equivalent to error being not null
   // i.e. we only reach this point with Awaited<S>
   const state = ((value: any): Awaited<S>);
-  return [state, (payload: P) => {}];
+
+  // TODO: support displaying pending value
+  return [state, (payload: P) => {}, false];
 }
 
 const Dispatcher: DispatcherType = {

--- a/packages/react-dom-bindings/src/shared/ReactDOMFormActions.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMFormActions.js
@@ -80,7 +80,7 @@ export function useFormState<S, P>(
   action: (Awaited<S>, P) => S,
   initialState: Awaited<S>,
   permalink?: string,
-): [Awaited<S>, (P) => void] {
+): [Awaited<S>, (P) => void, boolean] {
   if (!(enableFormActions && enableAsyncActions)) {
     throw new Error('Not implemented.');
   } else {

--- a/packages/react-dom/index.experimental.js
+++ b/packages/react-dom/index.experimental.js
@@ -45,7 +45,7 @@ export function experimental_useFormState<S, P>(
   action: (Awaited<S>, P) => S,
   initialState: Awaited<S>,
   permalink?: string,
-): [Awaited<S>, (P) => void] {
+): [Awaited<S>, (P) => void, boolean] {
   if (__DEV__) {
     console.error(
       'useFormState is now in canary. Remove the experimental_ prefix. ' +

--- a/packages/react-dom/server-rendering-stub.js
+++ b/packages/react-dom/server-rendering-stub.js
@@ -50,7 +50,7 @@ export function experimental_useFormState<S, P>(
   action: (Awaited<S>, P) => S,
   initialState: Awaited<S>,
   permalink?: string,
-): [Awaited<S>, (P) => void] {
+): [Awaited<S>, (P) => void, boolean] {
   if (__DEV__) {
     console.error(
       'useFormState is now in canary. Remove the experimental_ prefix. ' +

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -413,7 +413,7 @@ export type Dispatcher = {
     action: (Awaited<S>, P) => S,
     initialState: Awaited<S>,
     permalink?: string,
-  ) => [Awaited<S>, (P) => void],
+  ) => [Awaited<S>, (P) => void, boolean],
 };
 
 export type CacheDispatcher = {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMForm-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMForm-test.js
@@ -358,14 +358,16 @@ describe('ReactFlightDOMForm', () => {
 
     const initialState = {count: 1};
     function Client({action}) {
-      const [state, dispatch] = useFormState(action, initialState);
+      const [state, dispatch, isPending] = useFormState(action, initialState);
       return (
         <form action={dispatch}>
+          <span>{isPending ? 'Pending...' : ''}</span>
           <span>Count: {state.count}</span>
           <input type="text" name="incrementAmount" defaultValue="5" />
         </form>
       );
     }
+
     const ClientRef = await clientExports(Client);
 
     const rscStream = ReactServerDOMServer.renderToReadableStream(
@@ -382,8 +384,10 @@ describe('ReactFlightDOMForm', () => {
     await readIntoContainer(ssrStream);
 
     const form = container.getElementsByTagName('form')[0];
-    const span = container.getElementsByTagName('span')[0];
-    expect(span.textContent).toBe('Count: 1');
+    const pendingSpan = container.getElementsByTagName('span')[0];
+    const stateSpan = container.getElementsByTagName('span')[1];
+    expect(pendingSpan.textContent).toBe('');
+    expect(stateSpan.textContent).toBe('Count: 1');
 
     const {returnValue} = await submit(form);
     expect(await returnValue).toEqual({count: 6});
@@ -399,8 +403,13 @@ describe('ReactFlightDOMForm', () => {
     );
 
     function Form({action}) {
-      const [count, dispatch] = useFormState(action, 1);
-      return <form action={dispatch}>{count}</form>;
+      const [count, dispatch, isPending] = useFormState(action, 1);
+      return (
+        <form action={dispatch}>
+          {isPending ? 'Pending...' : ''}
+          {count}
+        </form>
+      );
     }
 
     function Client({action}) {
@@ -487,8 +496,13 @@ describe('ReactFlightDOMForm', () => {
       );
 
       function Form({action}) {
-        const [count, dispatch] = useFormState(action, 1);
-        return <form action={dispatch}>{count}</form>;
+        const [count, dispatch, isPending] = useFormState(action, 1);
+        return (
+          <form action={dispatch}>
+            {isPending ? 'Pending...' : ''}
+            {count}
+          </form>
+        );
       }
 
       function Client({action}) {
@@ -607,8 +621,13 @@ describe('ReactFlightDOMForm', () => {
     );
 
     function Form({action}) {
-      const [count, dispatch] = useFormState(action, 1);
-      return <form action={dispatch}>{count}</form>;
+      const [count, dispatch, isPending] = useFormState(action, 1);
+      return (
+        <form action={dispatch}>
+          {isPending ? 'Pending...' : ''}
+          {count}
+        </form>
+      );
     }
 
     function Client({action}) {
@@ -682,8 +701,13 @@ describe('ReactFlightDOMForm', () => {
     );
 
     function Form({action, permalink}) {
-      const [count, dispatch] = useFormState(action, 1, permalink);
-      return <form action={dispatch}>{count}</form>;
+      const [count, dispatch, isPending] = useFormState(action, 1, permalink);
+      return (
+        <form action={dispatch}>
+          {isPending ? 'Pending...' : ''}
+          {count}
+        </form>
+      );
     }
 
     function Page1({action, permalink}) {
@@ -783,17 +807,19 @@ describe('ReactFlightDOMForm', () => {
 
     const initialState = {count: 1};
     function Client({action}) {
-      const [state, dispatch] = useFormState(
+      const [state, dispatch, isPending] = useFormState(
         action,
         initialState,
         '/permalink',
       );
       return (
         <form action={dispatch}>
+          <span>{isPending ? 'Pending...' : ''}</span>
           <span>Count: {state.count}</span>
         </form>
       );
     }
+
     const ClientRef = await clientExports(Client);
 
     const rscStream = ReactServerDOMServer.renderToReadableStream(
@@ -810,8 +836,10 @@ describe('ReactFlightDOMForm', () => {
     await readIntoContainer(ssrStream);
 
     const form = container.getElementsByTagName('form')[0];
-    const span = container.getElementsByTagName('span')[0];
-    expect(span.textContent).toBe('Count: 1');
+    const pendingSpan = container.getElementsByTagName('span')[0];
+    const stateSpan = container.getElementsByTagName('span')[1];
+    expect(pendingSpan.textContent).toBe('');
+    expect(stateSpan.textContent).toBe('Count: 1');
 
     expect(form.action).toBe('http://localhost/permalink');
   });
@@ -833,13 +861,19 @@ describe('ReactFlightDOMForm', () => {
 
     const initialState = {count: 1};
     function Client({action}) {
-      const [state, dispatch] = useFormState(action, initialState, permalink);
+      const [state, dispatch, isPending] = useFormState(
+        action,
+        initialState,
+        permalink,
+      );
       return (
         <form action={dispatch}>
+          <span>{isPending ? 'Pending...' : ''}</span>
           <span>Count: {state.count}</span>
         </form>
       );
     }
+
     const ClientRef = await clientExports(Client);
 
     const rscStream = ReactServerDOMServer.renderToReadableStream(
@@ -856,8 +890,10 @@ describe('ReactFlightDOMForm', () => {
     await readIntoContainer(ssrStream);
 
     const form = container.getElementsByTagName('form')[0];
-    const span = container.getElementsByTagName('span')[0];
-    expect(span.textContent).toBe('Count: 1');
+    const pendingSpan = container.getElementsByTagName('span')[0];
+    const stateSpan = container.getElementsByTagName('span')[1];
+    expect(pendingSpan.textContent).toBe('');
+    expect(stateSpan.textContent).toBe('Count: 1');
 
     expect(form.action).toBe('http://localhost/permalink');
   });

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -615,7 +615,7 @@ function useFormState<S, P>(
   action: (Awaited<S>, P) => S,
   initialState: Awaited<S>,
   permalink?: string,
-): [Awaited<S>, (P) => void] {
+): [Awaited<S>, (P) => void, boolean] {
   resolveCurrentlyRenderingComponent();
 
   // Count the number of useFormState hooks per component. We also use this to
@@ -708,7 +708,7 @@ function useFormState<S, P>(
       };
     }
 
-    return [state, dispatch];
+    return [state, dispatch, false];
   } else {
     // This is not a server action, so the implementation is much simpler.
 
@@ -718,7 +718,7 @@ function useFormState<S, P>(
     const dispatch = (payload: P): void => {
       boundAction(payload);
     };
-    return [initialState, dispatch];
+    return [initialState, dispatch, false];
   }
 }
 


### PR DESCRIPTION
## Overview

Adds a `pending` state to useFormState, which will be replaced by `useActionState` in the next diff. We will keep `useFormState` around for backwards compatibility, but functionally it will work the same as `useActionState`, which has an `isPending` state returned.