### PR TITLE
Configure "Always On" Feature Flags for React Native

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -38,7 +38,7 @@ export const enableProfilerCommitHooks = __PROFILE__;
 export const enableProfilerNestedUpdatePhase = __PROFILE__;
 export const enableProfilerNestedUpdateScheduledHook = false;
 export const enableUpdaterTracking = __PROFILE__;
-export const enableCache = false;
+export const enableCache = true;
 export const enableLegacyCache = false;
 export const enableCacheElement = true;
 export const enableFetchInstrumentation = false;
@@ -79,7 +79,7 @@ export const enableLazyContextPropagation = false;
 export const enableLegacyHidden = false;
 export const forceConcurrentByDefaultForTesting = false;
 export const allowConcurrentByDefault = false;
-export const enableCustomElementPropertySupport = false;
+export const enableCustomElementPropertySupport = true;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -20,7 +20,7 @@ export const enableProfilerCommitHooks = __PROFILE__;
 export const enableProfilerNestedUpdatePhase = __PROFILE__;
 export const enableProfilerNestedUpdateScheduledHook = false;
 export const enableUpdaterTracking = __PROFILE__;
-export const enableCache = false;
+export const enableCache = true;
 export const enableLegacyCache = false;
 export const enableCacheElement = true;
 export const enableFetchInstrumentation = false;
@@ -35,7 +35,7 @@ export const disableIEWorkarounds = true;
 export const enableScopeAPI = false;
 export const enableCreateEventHandleAPI = false;
 export const enableSuspenseCallback = false;
-export const disableLegacyContext = false;
+export const disableLegacyContext = true;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
 export const disableModulePatternComponents = false;
@@ -64,7 +64,7 @@ export const enableLegacyHidden = false;
 export const forceConcurrentByDefaultForTesting = false;
 export const enableUnifiedSyncLane = true;
 export const allowConcurrentByDefault = false;
-export const enableCustomElementPropertySupport = false;
+export const enableCustomElementPropertySupport = true;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -38,7 +38,7 @@ export const enableSuspenseCallback = false;
 export const disableLegacyContext = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
-export const disableModulePatternComponents = false;
+export const disableModulePatternComponents = true;
 export const enableComponentStackLocations = false;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = true;
@@ -64,6 +64,7 @@ export const enableLegacyHidden = false;
 export const forceConcurrentByDefaultForTesting = false;
 export const enableUnifiedSyncLane = true;
 export const allowConcurrentByDefault = true;
+export const enableCustomElementPropertySupport = true;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;
 


### PR DESCRIPTION
## Summary

This PR is a subset of https://github.com/facebook/react/pull/28425, which only includes the feature flags that will be configured as "always on" (i.e. not "dynamic").

The following list summarizes the feature flag changes:

* RN FB
  * Always Enable
    * enableCache
    * enableCustomElementPropertySupport
* RN OSS
  * Always Enable
    * disableLegacyContext
    * enableCache
    * enableCustomElementPropertySupport
* RN Test
  * Always Enable
    * disableModulePatternComponents
    * enableCustomElementPropertySupport

## How did you test this change?

Ran the following successfully:

```
$ yarn test
$ yarn flow native
$ yarn flow fabric
```