### PR TITLE
Fix ReactHooksInspection-test.js

### DIFF
--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -584,24 +584,29 @@ describe('ReactHooksInspection', () => {
       return <div>{value}</div>;
     }
     const tree = ReactDebugTools.inspectHooks(Foo, {});
-    expect(normalizeSourceLoc(tree)).toMatchInlineSnapshot(`
-      [
-        {
-          "debugInfo": null,
-          "hookSource": {
-            "columnNumber": 0,
-            "fileName": "**",
-            "functionName": "Foo",
-            "lineNumber": 0,
-          },
-          "id": null,
-          "isStateEditable": false,
-          "name": "Unresolved",
-          "subHooks": [],
-          "value": Promise {},
+    const results = normalizeSourceLoc(tree);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchInlineSnapshot(
+      {
+        value: expect.any(Promise),
+      },
+      `
+      {
+        "debugInfo": null,
+        "hookSource": {
+          "columnNumber": 0,
+          "fileName": "**",
+          "functionName": "Foo",
+          "lineNumber": 0,
         },
-      ]
-    `);
+        "id": null,
+        "isStateEditable": false,
+        "name": "Unresolved",
+        "subHooks": [],
+        "value": Any<Promise>,
+      }
+    `,
+    );
   });
 
   describe('useDebugValue', () => {


### PR DESCRIPTION
## Summary

Currently, `ReactHooksInspection-test.js` fails because something is polluting the resulting `Promise` with symbol properties. This changes the unit test to be more resilient to such symbol properties.

## How did you test this change?

Ran the following successfully:

```
$ yarn test
```