### PR TITLE
Concurrent rendering in ReactDevToolsHooksIntegration-test

### DIFF
--- a/packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js
@@ -55,7 +55,12 @@ describe('React hooks DevTools integration', () => {
       return <div>count:{count}</div>;
     }
 
-    const renderer = ReactTestRenderer.create(<MyComponent />);
+    let renderer;
+    await act(() => {
+      renderer = ReactTestRenderer.create(<MyComponent />, {
+        unstable_isConcurrent: true,
+      });
+    });
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       props: {},
@@ -107,7 +112,12 @@ describe('React hooks DevTools integration', () => {
       );
     }
 
-    const renderer = ReactTestRenderer.create(<MyComponent />);
+    let renderer;
+    await act(() => {
+      renderer = ReactTestRenderer.create(<MyComponent />, {
+        unstable_isConcurrent: true,
+      });
+    });
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       props: {},
@@ -155,7 +165,12 @@ describe('React hooks DevTools integration', () => {
       return <div>count:{count}</div>;
     }
 
-    const renderer = ReactTestRenderer.create(<MyComponent />);
+    let renderer;
+    await act(() => {
+      renderer = ReactTestRenderer.create(<MyComponent />, {
+        unstable_isConcurrent: true,
+      });
+    });
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       props: {},
@@ -192,14 +207,17 @@ describe('React hooks DevTools integration', () => {
     function MyComponent() {
       return 'Done';
     }
-
-    const renderer = ReactTestRenderer.create(
-      <div>
-        <React.Suspense fallback={'Loading'}>
-          <MyComponent />
-        </React.Suspense>
-      </div>,
-    );
+    let renderer;
+    await act(() => {
+      renderer = ReactTestRenderer.create(
+        <div>
+          <React.Suspense fallback={'Loading'}>
+            <MyComponent />
+          </React.Suspense>
+        </div>,
+        {unstable_isConcurrent: true},
+      );
+    });
     const fiber = renderer.root._currentFiber().child;
     if (__DEV__) {
       // First render was locked
@@ -254,7 +272,7 @@ describe('React hooks DevTools integration', () => {
             <MyComponent />
           </React.Suspense>
         </div>,
-        {isConcurrent: true},
+        {unstable_isConcurrent: true},
       ),
     );
 

--- a/packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js
@@ -43,10 +43,9 @@ describe('React hooks DevTools integration', () => {
     const InternalTestUtils = require('internal-test-utils');
     waitForAll = InternalTestUtils.waitForAll;
 
-    act = ReactTestRenderer.act;
+    act = require('internal-test-utils').act;
   });
 
-  // @gate __DEV__
   it('should support editing useState hooks', async () => {
     let setCountFn;
 
@@ -90,7 +89,6 @@ describe('React hooks DevTools integration', () => {
     }
   });
 
-  // @gate __DEV__
   it('should support editable useReducer hooks', async () => {
     const initialData = {foo: 'abc', bar: 123};
 
@@ -150,7 +148,6 @@ describe('React hooks DevTools integration', () => {
 
   // This test case is based on an open source bug report:
   // https://github.com/facebookincubator/redux-react-hook/issues/34#issuecomment-466693787
-  // @gate __DEV__
   it('should handle interleaved stateful hooks (e.g. useState) and non-stateful hooks (e.g. useContext)', async () => {
     const MyContext = React.createContext(1);
 
@@ -201,7 +198,6 @@ describe('React hooks DevTools integration', () => {
     }
   });
 
-  // @gate __DEV__
   it('should support overriding suspense in legacy mode', async () => {
     if (__DEV__) {
       // Lock the first render
@@ -258,7 +254,6 @@ describe('React hooks DevTools integration', () => {
     }
   });
 
-  // @gate __DEV__
   it('should support overriding suspense in concurrent mode', async () => {
     if (__DEV__) {
       // Lock the first render

--- a/packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js
@@ -46,6 +46,7 @@ describe('React hooks DevTools integration', () => {
     act = ReactTestRenderer.act;
   });
 
+  // @gate __DEV__
   it('should support editing useState hooks', async () => {
     let setCountFn;
 
@@ -89,6 +90,7 @@ describe('React hooks DevTools integration', () => {
     }
   });
 
+  // @gate __DEV__
   it('should support editable useReducer hooks', async () => {
     const initialData = {foo: 'abc', bar: 123};
 
@@ -148,6 +150,7 @@ describe('React hooks DevTools integration', () => {
 
   // This test case is based on an open source bug report:
   // https://github.com/facebookincubator/redux-react-hook/issues/34#issuecomment-466693787
+  // @gate __DEV__
   it('should handle interleaved stateful hooks (e.g. useState) and non-stateful hooks (e.g. useContext)', async () => {
     const MyContext = React.createContext(1);
 
@@ -198,6 +201,7 @@ describe('React hooks DevTools integration', () => {
     }
   });
 
+  // @gate __DEV__
   it('should support overriding suspense in legacy mode', async () => {
     if (__DEV__) {
       // Lock the first render


### PR DESCRIPTION
## Summary

We need to unblock flipping the default for RTR to be concurrent rendering. Update ReactDevToolsHooksIntegration-test to use `unstable_isConcurrent` in place.

## How did you test this change?

`yarn test packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js`