### PR TITLE
Set didPerformSomeWork after performing work

### DIFF
--- a/packages/react-reconciler/src/ReactFiberRootScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberRootScheduler.js
@@ -185,8 +185,8 @@ function flushSyncWorkAcrossRoots_impl(onlyLegacy: boolean) {
         if (includesSyncLane(nextLanes)) {
           // This root has pending sync work. Flush it now.
           try {
-            didPerformSomeWork = true;
             performSyncWorkOnRoot(root, nextLanes);
+            didPerformSomeWork = true;
           } catch (error) {
             // Collect errors so we can rethrow them at the end
             if (errors === null) {


### PR DESCRIPTION
## Overview

Not sure if this fix is correct, but wanted to open to discuss. 

`performSyncWorkOnRoot` can immediately throw `'Should not already be working.'` without doing any work. When this happens, we catch the error and continue in the loop, which will throw again, and we're in an infinite loop.

Moving the check to after the work is complete will break the loop, but probably miss some work.

@yungsters and I found the loop when syncing the enableCache flag to RN. Turns out, RN internally is using mismatching versions of the renderer (main) and react (npm), so it's a busted setup that needs fixed, but exposed this hang.