### PR TITLE
Configure Dynamic Feature Flags for React Native

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -21,13 +21,17 @@ import typeof * as DynamicFlagsType from 'ReactNativeInternalFeatureFlags';
 // update the test configuration.
 
 export const alwaysThrottleRetries = __VARIANT__;
+export const consoleManagedByDevToolsDuringStrictMode = __VARIANT__;
+export const enableAsyncActions = __VARIANT__;
 export const enableComponentStackLocations = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
+export const enableInfiniteRenderLoopDetection = __VARIANT__;
+export const enableRenderableContext = __VARIANT__;
+export const enableUnifiedSyncLane = __VARIANT__;
 export const enableUseRefAccessWarning = __VARIANT__;
 export const passChildrenWhenCloningPersistedNodes = __VARIANT__;
 export const useMicrotasksForSchedulingInFabric = __VARIANT__;
-export const enableUnifiedSyncLane = __VARIANT__;
-export const enableInfiniteRenderLoopDetection = __VARIANT__;
+export const useModernStrictMode = __VARIANT__;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): DynamicFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -19,13 +19,17 @@ import * as dynamicFlags from 'ReactNativeInternalFeatureFlags';
 // the exports object every time a flag is read.
 export const {
   alwaysThrottleRetries,
+  consoleManagedByDevToolsDuringStrictMode,
+  enableAsyncActions,
   enableComponentStackLocations,
   enableDeferRootSchedulingToMicrotask,
+  enableInfiniteRenderLoopDetection,
+  enableRenderableContext,
+  enableUnifiedSyncLane,
   enableUseRefAccessWarning,
   passChildrenWhenCloningPersistedNodes,
   useMicrotasksForSchedulingInFabric,
-  enableUnifiedSyncLane,
-  enableInfiniteRenderLoopDetection,
+  useModernStrictMode,
 } = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.
@@ -67,7 +71,6 @@ export const enableClientRenderFallbackOnTextMismatch = true;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = true;
 export const enableGetInspectorDataForInstanceInProduction = true;
-export const enableRenderableContext = false;
 
 export const enableRetryLaneExpiration = false;
 export const retryLaneExpirationMs = 5000;
@@ -81,17 +84,13 @@ export const forceConcurrentByDefaultForTesting = false;
 export const allowConcurrentByDefault = false;
 export const enableCustomElementPropertySupport = true;
 
-export const consoleManagedByDevToolsDuringStrictMode = false;
-
 export const enableTransitionTracing = false;
 
 export const enableFloat = true;
 
-export const useModernStrictMode = false;
 export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
 export const enableFizzExternalRuntime = true;
 
-export const enableAsyncActions = false;
 export const enableUseDeferredValueInitialArg = true;
 export const disableClientCache = true;
 

--- a/scripts/flow/xplat.js
+++ b/scripts/flow/xplat.js
@@ -9,11 +9,15 @@
 
 declare module 'ReactNativeInternalFeatureFlags' {
   declare export var alwaysThrottleRetries: boolean;
+  declare export var consoleManagedByDevToolsDuringStrictMode: boolean;
+  declare export var enableAsyncActions: boolean;
   declare export var enableComponentStackLocations: boolean;
   declare export var enableDeferRootSchedulingToMicrotask: boolean;
+  declare export var enableInfiniteRenderLoopDetection: boolean;
+  declare export var enableRenderableContext: boolean;
+  declare export var enableUnifiedSyncLane: boolean;
   declare export var enableUseRefAccessWarning: boolean;
   declare export var passChildrenWhenCloningPersistedNodes: boolean;
   declare export var useMicrotasksForSchedulingInFabric: boolean;
-  declare export var enableUnifiedSyncLane: boolean;
-  declare export var enableInfiniteRenderLoopDetection: boolean;
+  declare export var useModernStrictMode: boolean;
 }


### PR DESCRIPTION
## Summary

This PR is a subset of https://github.com/facebook/react/pull/28425, which only includes the feature flags that will be configured as dynamic.

The following list summarizes the feature flag changes:

* RN FB
  * Change to Dynamic
    * consoleManagedByDevToolsDuringStrictMode
    * enableAsyncActions
    * enableDeferRootSchedulingToMicrotask
    * enableRenderableContext
    * useModernStrictMode

## How did you test this change?

Ran the following successfully:

```
$ yarn test
$ yarn flow native
$ yarn flow fabric
```