### PR TITLE
Remove ReactTestUtils from refs-destruction-test

### DIFF
--- a/packages/react-dom/src/__tests__/refs-destruction-test.js
+++ b/packages/react-dom/src/__tests__/refs-destruction-test.js
@@ -12,7 +12,6 @@
 let React;
 let ReactDOM;
 let ReactDOMClient;
-let ReactTestUtils;
 let TestComponent;
 let act;
 let theInnerDivRef;
@@ -25,7 +24,6 @@ describe('refs-destruction', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMClient = require('react-dom/client');
-    ReactTestUtils = require('react-dom/test-utils');
     act = require('internal-test-utils').act;
 
     class ClassComponent extends React.Component {
@@ -75,7 +73,7 @@ describe('refs-destruction', () => {
       root.render(<TestComponent />);
     });
 
-    expect(ReactTestUtils.isDOMComponent(theInnerDivRef.current)).toBe(true);
+    expect(theInnerDivRef.current).toBeInstanceOf(Element);
     expect(theInnerClassComponentRef.current).toBeTruthy();
 
     root.unmount();
@@ -91,7 +89,7 @@ describe('refs-destruction', () => {
       root.render(<TestComponent />);
     });
 
-    expect(ReactTestUtils.isDOMComponent(theInnerDivRef.current)).toBe(true);
+    expect(theInnerDivRef.current).toBeInstanceOf(Element);
     expect(theInnerClassComponentRef.current).toBeTruthy();
 
     await act(async () => {
@@ -109,7 +107,7 @@ describe('refs-destruction', () => {
       root.render(<TestComponent />);
     });
 
-    expect(ReactTestUtils.isDOMComponent(theInnerDivRef.current)).toBe(true);
+    expect(theInnerDivRef.current).toBeInstanceOf(Element);
     expect(theInnerClassComponentRef.current).toBeTruthy();
 
     await act(async () => {


### PR DESCRIPTION
```diff
-expect(ReactTestUtils.isDOMComponent(maybeElement)).toBe(true);
+expect(maybeElement).toBeInstanceOf(Element);
```

It's not equivalent since `isDOMComponent` checks `maybeElement.nodeType === Element.ELEMENT_NODE && !!maybeElement.tagName` but `instanceof` check seems sufficient here. Checking `nodeType` is mostly for cross-realm checks and checking falsy `tagName` seems like a check specifically for incomplete DOM implementations because tagName can't be empty by spec I believe.