### PR TITLE
Remove remaining usages of ReactTestUtils in tests unrelated to `react-dom/test-util`

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/profilingCache-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilingCache-test.js
@@ -1237,12 +1237,14 @@ describe('ProfilingCache', () => {
       );
     }
 
-    const {Simulate} = require('react-dom/test-utils');
-
     utils.act(() => render(<App />));
     expect(getContainer().textContent).toBe('Home');
     utils.act(() => store.profilerStore.startProfiling());
-    utils.act(() => Simulate.click(linkRef.current));
+    utils.act(() =>
+      linkRef.current.dispatchEvent(
+        new MouseEvent('click', {bubbles: true, cancelable: true}),
+      ),
+    );
     utils.act(() => store.profilerStore.stopProfiling());
     expect(getContainer().textContent).toBe('About');
   });

--- a/packages/react-dom/src/__tests__/ReactLegacyMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyMount-test.js
@@ -14,7 +14,6 @@ const {COMMENT_NODE} = require('react-dom-bindings/src/client/HTMLNodeType');
 let React;
 let ReactDOM;
 let ReactDOMServer;
-let ReactTestUtils;
 let Scheduler;
 let ReactDOMClient;
 let assertLog;
@@ -28,7 +27,6 @@ describe('ReactMount', () => {
     ReactDOM = require('react-dom');
     ReactDOMClient = require('react-dom/client');
     ReactDOMServer = require('react-dom/server');
-    ReactTestUtils = require('react-dom/test-utils');
     Scheduler = require('scheduler');
 
     const InternalTestUtils = require('internal-test-utils');
@@ -71,7 +69,10 @@ describe('ReactMount', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(Component)).toErrorDev(
+    expect(() => {
+      const container = document.createElement('div');
+      ReactDOM.render(Component, container);
+    }).toErrorDev(
       'Functions are not valid as a React child. ' +
         'This may happen if you return Component instead of <Component /> from render. ' +
         'Or maybe you meant to call this function rather than return it.\n' +

--- a/packages/react-dom/src/__tests__/findDOMNode-test.js
+++ b/packages/react-dom/src/__tests__/findDOMNode-test.js
@@ -11,7 +11,6 @@
 
 const React = require('react');
 const ReactDOM = require('react-dom');
-const ReactTestUtils = require('react-dom/test-utils');
 const StrictMode = React.StrictMode;
 
 describe('findDOMNode', () => {
@@ -31,7 +30,8 @@ describe('findDOMNode', () => {
       }
     }
 
-    const myNode = ReactTestUtils.renderIntoDocument(<MyNode />);
+    const container = document.createElement('div');
+    const myNode = ReactDOM.render(<MyNode />, container);
     const myDiv = ReactDOM.findDOMNode(myNode);
     const mySameDiv = ReactDOM.findDOMNode(myDiv);
     expect(myDiv.tagName).toBe('DIV');
@@ -99,7 +99,10 @@ describe('findDOMNode', () => {
         return <div />;
       }
     }
-    expect(() => ReactTestUtils.renderIntoDocument(<Bar />)).not.toThrow();
+    expect(() => {
+      const container = document.createElement('div');
+      ReactDOM.render(<Bar />, container);
+    }).not.toThrow();
   });
 
   // @gate !disableLegacyMode
@@ -117,8 +120,10 @@ describe('findDOMNode', () => {
       }
     }
 
-    ReactTestUtils.renderIntoDocument(
+    const container = document.createElement('div');
+    ReactDOM.render(
       <ContainsStrictModeChild ref={n => (parent = n)} />,
+      container,
     );
 
     let match;
@@ -145,10 +150,13 @@ describe('findDOMNode', () => {
       }
     }
 
-    ReactTestUtils.renderIntoDocument(
+    const container = document.createElement('div');
+
+    ReactDOM.render(
       <StrictMode>
         <IsInStrictMode ref={n => (parent = n)} />
       </StrictMode>,
+      container,
     );
 
     let match;

--- a/packages/react-dom/src/__tests__/renderSubtreeIntoContainer-test.js
+++ b/packages/react-dom/src/__tests__/renderSubtreeIntoContainer-test.js
@@ -13,7 +13,6 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const ReactDOM = require('react-dom');
 const ReactDOMClient = require('react-dom/client');
-const ReactTestUtils = require('react-dom/test-utils');
 const act = require('internal-test-utils').act;
 const renderSubtreeIntoContainer =
   require('react-dom').unstable_renderSubtreeIntoContainer;
@@ -60,7 +59,8 @@ describe('renderSubtreeIntoContainer', () => {
       }
     }
 
-    ReactTestUtils.renderIntoDocument(<Parent />);
+    const container = document.createElement('div');
+    ReactDOM.render(<Parent />, container);
     expect(portal.firstChild.innerHTML).toBe('bar');
   });
 

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -14,7 +14,6 @@
 import React = require('react');
 import ReactDOM = require('react-dom');
 import ReactDOMClient = require('react-dom/client');
-import ReactDOMTestUtils = require('react-dom/test-utils');
 import PropTypes = require('prop-types');
 import ReactFeatureFlags = require('shared/ReactFeatureFlags');
 


### PR DESCRIPTION
Batched the remaining usages since these were straight forward. Completes removal of `ReactTestUtils` from tests unrelated to `react-dom/test-util` together with:
- https://github.com/facebook/react/pull/28531
- https://github.com/facebook/react/pull/28532
- https://github.com/facebook/react/pull/28533