### PR TITLE
Fix scroll event type

### DIFF
--- a/packages/react-dom-bindings/src/events/plugins/SimpleEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/SimpleEventPlugin.js
@@ -23,7 +23,6 @@ import {
   SyntheticTouchEvent,
   SyntheticAnimationEvent,
   SyntheticTransitionEvent,
-  SyntheticUIEvent,
   SyntheticWheelEvent,
   SyntheticClipboardEvent,
   SyntheticPointerEvent,

--- a/packages/react-dom-bindings/src/events/plugins/SimpleEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/SimpleEventPlugin.js
@@ -139,10 +139,6 @@ function extractEvents(
     case TRANSITION_END:
       SyntheticEventCtor = SyntheticTransitionEvent;
       break;
-    case 'scroll':
-    case 'scrollend':
-      SyntheticEventCtor = SyntheticUIEvent;
-      break;
     case 'wheel':
       SyntheticEventCtor = SyntheticWheelEvent;
       break;


### PR DESCRIPTION
The scroll event type is Event, not UIEvent.

https://developer.mozilla.org/en-US/docs/Web/API/Element/scroll_event
https://drafts.csswg.org/cssom-view/#eventdef-document-scroll

https://github.com/facebook/react/blob/a4939017ffe2e04a94efca0f48b661bc778a6fa4/packages/react-dom-bindings/src/events/plugins/SimpleEventPlugin.js#L142-L144