### PR TITLE
fix: calling onblue event on unmount.

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2004,6 +2004,9 @@ function commitDeletionEffectsOnFiber(
   nearestMountedAncestor: Fiber,
   deletedFiber: Fiber,
 ) {
+  if (deletedFiber.memoizedProps && deletedFiber.memoizedProps.onBlur) {
+    deletedFiber.memoizedProps.onBlur(new Event('blur', {bubbles: true}));
+  }
   onCommitUnmount(deletedFiber);
 
   // The cases in this outer switch modify the stack before they traverse


### PR DESCRIPTION
Working wit React, there was a small bug i discovered, related to unmounting off a particular element in the DOM, in vanilla JS whenever a particular item gets removed from the DOM, an onBlur event is triggered automatically, as said in MDN.

React simply does not seem to call this onBlur event when a particular element is unmounted, i might be wrong to judge why the same wasn't implemented in the context of react, anyways this would mean a learning opportunity for me to understand react design principles more better.

here is a Vanilla Js repro of the onBlur being called.

This Behaviour falls under the category where React and Vanilla JS act differently , earlier i raised https://github.com/facebook/react/pull/27016 , reviewed by sophie , which concluded to refer away from custom event logic as of now, as the future of react seems to get rid of React event system logic and rely on browser event system.