### PR TITLE
Update isConcurrent RTR option usage

### DIFF
--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
@@ -1012,7 +1012,7 @@ describe('ReactHooksInspectionIntegration', () => {
       );
     }
     const renderer = await act(() => {
-      return ReactTestRenderer.create(<Foo />, {isConcurrent: true});
+      return ReactTestRenderer.create(<Foo />, {unstable_isConcurrent: true});
     });
     expect(renderer).toMatchRenderedOutput(null);
     let childFiber = renderer.root.findByType(Foo)._currentFiber();

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -77,7 +77,7 @@ describe('InspectedElement', () => {
     // Used by inspectElementAtIndex() helper function
     utils.act(() => {
       testRendererInstance = TestRenderer.create(null, {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       });
     });
 
@@ -356,7 +356,7 @@ describe('InspectedElement', () => {
         ['An update to %s inside a test was not wrapped in act'],
         () => {
           testRendererInstance = TestRenderer.create(null, {
-            isConcurrent: true,
+            unstable_isConcurrent: true,
           });
         },
       );
@@ -510,7 +510,7 @@ describe('InspectedElement', () => {
       ['An update to %s inside a test was not wrapped in act'],
       () => {
         testRendererInstance = TestRenderer.create(null, {
-          isConcurrent: true,
+          unstable_isConcurrent: true,
         });
       },
     );
@@ -2069,7 +2069,7 @@ describe('InspectedElement', () => {
       ['An update to %s inside a test was not wrapped in act'],
       () => {
         testRendererInstance = TestRenderer.create(null, {
-          isConcurrent: true,
+          unstable_isConcurrent: true,
         });
       },
     );
@@ -2129,7 +2129,7 @@ describe('InspectedElement', () => {
       ['An update to %s inside a test was not wrapped in act'],
       () => {
         testRendererInstance = TestRenderer.create(null, {
-          isConcurrent: true,
+          unstable_isConcurrent: true,
         });
       },
     );
@@ -2405,7 +2405,7 @@ describe('InspectedElement', () => {
               <Suspender target={id} />
             </React.Suspense>
           </Contexts>,
-          {isConcurrent: true},
+          {unstable_isConcurrent: true},
         );
       }, false);
       await utils.actAsync(() => {
@@ -2943,7 +2943,7 @@ describe('InspectedElement', () => {
           ['An update to %s inside a test was not wrapped in act'],
           () => {
             testRendererInstance = TestRenderer.create(null, {
-              isConcurrent: true,
+              unstable_isConcurrent: true,
             });
           },
         );

--- a/packages/react-reconciler/src/__tests__/ErrorBoundaryReconciliation-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ErrorBoundaryReconciliation-test.internal.js
@@ -59,7 +59,7 @@ describe('ErrorBoundaryReconciliation', () => {
           <ErrorBoundary fallbackTagName={fallbackTagName}>
             <BrokenRender fail={false} />
           </ErrorBoundary>,
-          {isConcurrent: isConcurrent},
+          {unstable_isConcurrent: isConcurrent},
         );
       });
       expect(renderer).toMatchRenderedOutput(<span prop="BrokenRender" />);

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -86,7 +86,7 @@ describe('ReactHooks', () => {
       return <Child text={text} />;
     }
 
-    const root = ReactTestRenderer.create(null, {isConcurrent: true});
+    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
     root.update(<Parent />);
     await waitForAll(['Parent: 0, 0', 'Child: 0, 0', 'Effect: 0, 0']);
     expect(root).toMatchRenderedOutput('0, 0');
@@ -174,7 +174,7 @@ describe('ReactHooks', () => {
 
     Parent = memo(Parent);
 
-    const root = ReactTestRenderer.create(null, {isConcurrent: true});
+    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
     root.update(<Parent theme="light" />);
     await waitForAll(['Parent: 0, 0 (light)', 'Child: 0, 0 (light)']);
     expect(root).toMatchRenderedOutput('0, 0 (light)');
@@ -232,7 +232,7 @@ describe('ReactHooks', () => {
       return counter;
     }
 
-    const root = ReactTestRenderer.create(null, {isConcurrent: true});
+    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
     root.update(<Counter />);
     await waitForAll(['Count: 0']);
     expect(root).toMatchRenderedOutput('0');
@@ -266,7 +266,7 @@ describe('ReactHooks', () => {
       return counter;
     }
 
-    const root = ReactTestRenderer.create(null, {isConcurrent: true});
+    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
     root.update(<Counter />);
     await waitForAll(['Count: 0']);
     expect(root).toMatchRenderedOutput('0');
@@ -322,7 +322,7 @@ describe('ReactHooks', () => {
       });
       return <Child text={text} />;
     }
-    const root = ReactTestRenderer.create(null, {isConcurrent: true});
+    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
     await act(() => {
       root.update(
         <ThemeProvider>
@@ -390,7 +390,7 @@ describe('ReactHooks', () => {
       return <Child text={counter} />;
     }
 
-    const root = ReactTestRenderer.create(null, {isConcurrent: true});
+    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
     root.update(<Parent />);
     await waitForAll(['Parent: 0', 'Child: 0', 'Effect: 0']);
     expect(root).toMatchRenderedOutput('0');
@@ -465,7 +465,7 @@ describe('ReactHooks', () => {
       return <Child text={counter} />;
     }
 
-    const root = ReactTestRenderer.create(null, {isConcurrent: true});
+    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
     root.update(<Parent />);
     await waitForAll(['Parent: 0', 'Child: 0']);
     expect(root).toMatchRenderedOutput('0');
@@ -523,7 +523,7 @@ describe('ReactHooks', () => {
       return <Child text={counter} />;
     }
 
-    const root = ReactTestRenderer.create(null, {isConcurrent: true});
+    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
     root.update(<Parent />);
     await waitForAll(['Parent: 1', 'Child: 1']);
     expect(root).toMatchRenderedOutput('1');

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -97,7 +97,7 @@ describe('ReactLazy', () => {
         <LazyText text="Hi" />
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
 
@@ -183,7 +183,7 @@ describe('ReactLazy', () => {
         <LazyBar />
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
 
@@ -206,7 +206,7 @@ describe('ReactLazy', () => {
     const LazyText = lazy(async () => Text);
 
     const root = ReactTestRenderer.create(null, {
-      isConcurrent: true,
+      unstable_isConcurrent: true,
     });
 
     let error;
@@ -240,7 +240,7 @@ describe('ReactLazy', () => {
     });
 
     const root = ReactTestRenderer.create(null, {
-      isConcurrent: true,
+      unstable_isConcurrent: true,
     });
 
     let error;
@@ -300,7 +300,7 @@ describe('ReactLazy', () => {
     }
 
     const root = ReactTestRenderer.create(<Parent swap={false} />, {
-      isConcurrent: true,
+      unstable_isConcurrent: true,
     });
 
     await waitForAll(['Suspend! [LazyChildA]', 'Loading...']);
@@ -335,7 +335,7 @@ describe('ReactLazy', () => {
         <LazyText />
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
 
@@ -392,7 +392,7 @@ describe('ReactLazy', () => {
         </Lazy>
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
     await waitForAll(['Loading...']);
@@ -438,7 +438,7 @@ describe('ReactLazy', () => {
         </Suspense>
       </>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
     await waitForAll(['Not lazy: 0', 'Loading...']);
@@ -483,7 +483,7 @@ describe('ReactLazy', () => {
         </Suspense>
       </>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
     await waitForAll(['Not lazy: 0', 'Loading...']);
@@ -559,7 +559,7 @@ describe('ReactLazy', () => {
         <LazyClass num={1} />
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
 
@@ -689,7 +689,7 @@ describe('ReactLazy', () => {
         <LazyText />
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
 
@@ -732,7 +732,7 @@ describe('ReactLazy', () => {
         <BadLazy />
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
 
@@ -759,7 +759,7 @@ describe('ReactLazy', () => {
         <Lazy2 text="Hello" />
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
 
@@ -792,7 +792,7 @@ describe('ReactLazy', () => {
         <LazyAdd inner="2" outer="2" />
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
 
@@ -939,7 +939,7 @@ describe('ReactLazy', () => {
         <LazyText />
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
 
@@ -977,7 +977,7 @@ describe('ReactLazy', () => {
         <LazyFoo />
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
 
@@ -1022,7 +1022,7 @@ describe('ReactLazy', () => {
         <LazyForwardRef ref={ref} />
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
 
@@ -1053,7 +1053,7 @@ describe('ReactLazy', () => {
         <LazyAdd outer={2} />
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
     await waitForAll(['Loading...']);
@@ -1140,7 +1140,7 @@ describe('ReactLazy', () => {
         <LazyAdd outer={2} />
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
     await waitForAll(['Loading...']);
@@ -1187,7 +1187,7 @@ describe('ReactLazy', () => {
         <LazyFoo ref={ref} />
       </Suspense>,
       {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       },
     );
 
@@ -1227,7 +1227,7 @@ describe('ReactLazy', () => {
           <LazyText text="Hi" />
         </Suspense>
       </ErrorBoundary>,
-      {isConcurrent: true},
+      {unstable_isConcurrent: true},
     );
 
     await waitForAll(['Loading...']);
@@ -1335,7 +1335,7 @@ describe('ReactLazy', () => {
     }
 
     const root = ReactTestRenderer.create(<Parent swap={false} />, {
-      isConcurrent: true,
+      unstable_isConcurrent: true,
     });
 
     await waitForAll(['Init A', 'Loading...']);
@@ -1420,7 +1420,7 @@ describe('ReactLazy', () => {
     }
 
     const root = ReactTestRenderer.create(<Parent swap={false} />, {
-      isConcurrent: false,
+      unstable_isConcurrent: false,
     });
 
     assertLog(['Init A', 'Init B', 'Loading...']);
@@ -1482,7 +1482,7 @@ describe('ReactLazy', () => {
     }
 
     const root = ReactTestRenderer.create(<Parent swap={false} />, {
-      isConcurrent: true,
+      unstable_isConcurrent: true,
     });
 
     await waitForAll(['Init A', 'Loading...']);
@@ -1551,7 +1551,7 @@ describe('ReactLazy', () => {
     }
 
     const root = ReactTestRenderer.create(<Parent swap={false} />, {
-      isConcurrent: false,
+      unstable_isConcurrent: false,
     });
 
     assertLog(['Init A', 'Loading...']);

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -63,7 +63,6 @@ const act = React.act;
 
 type TestRendererOptions = {
   createNodeMock: (element: React$Element<any>) => any,
-  isConcurrent: boolean,
   unstable_isConcurrent: boolean,
   unstable_strictMode: boolean,
   unstable_concurrentUpdatesByDefault: boolean,
@@ -491,10 +490,7 @@ function create(
       // $FlowFixMe[incompatible-type] found when upgrading Flow
       createNodeMock = options.createNodeMock;
     }
-    if (
-      options.unstable_isConcurrent === true ||
-      options.isConcurrent === true
-    ) {
+    if (options.unstable_isConcurrent === true) {
       isConcurrent = true;
     }
     if (options.unstable_strictMode === true) {

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
@@ -34,7 +34,7 @@ describe('ReactTestRendererAsync', () => {
       return props.children;
     }
     const renderer = ReactTestRenderer.create(<Foo>Hi</Foo>, {
-      isConcurrent: true,
+      unstable_isConcurrent: true,
     });
 
     // Before flushing, nothing has mounted.
@@ -68,7 +68,7 @@ describe('ReactTestRendererAsync', () => {
       );
     }
     const renderer = ReactTestRenderer.create(<Parent step={1} />, {
-      isConcurrent: true,
+      unstable_isConcurrent: true,
     });
 
     await waitForAll(['A:1', 'B:1', 'C:1']);
@@ -97,7 +97,7 @@ describe('ReactTestRendererAsync', () => {
     let renderer;
     React.startTransition(() => {
       renderer = ReactTestRenderer.create(<Parent step={1} />, {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       });
     });
 
@@ -137,7 +137,7 @@ describe('ReactTestRendererAsync', () => {
     let renderer;
     React.startTransition(() => {
       renderer = ReactTestRenderer.create(<Example step={1} />, {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       });
     });
 

--- a/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
@@ -154,7 +154,7 @@ describe('ReactProfiler DevTools integration', () => {
       return text;
     }
 
-    const root = ReactTestRenderer.create(null, {isConcurrent: true});
+    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
 
     // Commit something
     root.update(<Text text="A" />);

--- a/packages/react/src/__tests__/ReactStartTransition-test.js
+++ b/packages/react/src/__tests__/ReactStartTransition-test.js
@@ -49,7 +49,7 @@ describe('ReactStartTransition', () => {
 
     await act(() => {
       ReactTestRenderer.create(<Component level={0} />, {
-        isConcurrent: true,
+        unstable_isConcurrent: true,
       });
     });
 


### PR DESCRIPTION
Reverting some of https://github.com/facebook/react/pull/27804 which renamed this option to stable. This PR just replaces internal usage to make upcoming PRs cleaner.

Keeping isConcurrent unstable for the next major release in order to enable a broader deprecation of RTR and be consistent with concurrent rendering everywhere for next major. (https://github.com/facebook/react/pull/28498)
- Next major will use concurrent root
- The old behavior (legacy root by default, concurrent root with unstable option) will be preserved for React Native until new architecture is fully shipped. 
- Flag and legacy root usage can be removed after RN dependency is unblocked without an additional breaking change
