### PR TITLE
Ensure dispatch from `useFormState` works in `StrictMode`

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMForm-test.js
@@ -1295,4 +1295,48 @@ describe('ReactDOMForm', () => {
     assertLog(['B']);
     expect(container.textContent).toBe('B');
   });
+
+
+  // @gate enableFormActions
+  // @gate enableAsyncActions
+  test('useFormState works in StrictMode', async () => {
+    let actionCounter = 0;
+    async function action(state, type) {
+      actionCounter++;
+
+      Scheduler.log(`Async action started [${actionCounter}]`);
+      await getText(`Wait [${actionCounter}]`);
+
+      switch (type) {
+        case 'increment':
+          return state + 1;
+        case 'decrement':
+          return state - 1;
+        default:
+          return state;
+      }
+    }
+
+    let dispatch;
+    function App() {
+      const [state, _dispatch, isPending] = useFormState(action, 0);
+      dispatch = _dispatch;
+      const pending = isPending ? 'Pending ' : '';
+      return <Text text={pending + state} />;
+    }
+
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => root.render(<React.StrictMode><App /></React.StrictMode>));
+    assertLog(['0']);
+    expect(container.textContent).toBe('0');
+
+    await act(() => dispatch('increment'));
+    assertLog(['Async action started [1]', 'Pending 0']);
+    expect(container.textContent).toBe('Pending 0');
+
+
+    await act(() => resolveText('Wait [1]'));
+    assertLog(['1']);
+    expect(container.textContent).toBe('1');
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMForm-test.js
@@ -1296,7 +1296,6 @@ describe('ReactDOMForm', () => {
     expect(container.textContent).toBe('B');
   });
 
-
   // @gate enableFormActions
   // @gate enableAsyncActions
   test('useFormState works in StrictMode', async () => {
@@ -1326,14 +1325,19 @@ describe('ReactDOMForm', () => {
     }
 
     const root = ReactDOMClient.createRoot(container);
-    await act(() => root.render(<React.StrictMode><App /></React.StrictMode>));
+    await act(() =>
+      root.render(
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>,
+      ),
+    );
     assertLog(['0']);
     expect(container.textContent).toBe('0');
 
     await act(() => dispatch('increment'));
     assertLog(['Async action started [1]', 'Pending 0']);
     expect(container.textContent).toBe('Pending 0');
-
 
     await act(() => resolveText('Wait [1]'));
     assertLog(['1']);

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -2259,6 +2259,9 @@ function rerenderFormState<S, P>(
     );
   }
 
+  // For mount, pending is always false.
+  const [isPending] = rerenderState(false);
+
   // This is a mount. No updates to process.
   const state: Awaited<S> = stateHook.memoizedState;
 
@@ -2269,8 +2272,7 @@ function rerenderFormState<S, P>(
   // This may have changed during the rerender.
   actionQueueHook.memoizedState = action;
 
-  // For mount, pending is always false.
-  return [state, dispatch, false];
+  return [state, dispatch, isPending];
 }
 
 function pushEffect(

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -2259,8 +2259,7 @@ function rerenderFormState<S, P>(
     );
   }
 
-  // For mount, pending is always false.
-  const [isPending] = rerenderState(false);
+  updateWorkInProgressHook(); // State
 
   // This is a mount. No updates to process.
   const state: Awaited<S> = stateHook.memoizedState;
@@ -2272,7 +2271,8 @@ function rerenderFormState<S, P>(
   // This may have changed during the rerender.
   actionQueueHook.memoizedState = action;
 
-  return [state, dispatch, isPending];
+  // For mount, pending is always false.
+  return [state, dispatch, false];
 }
 
 function pushEffect(


### PR DESCRIPTION
## Summary

Closes https://github.com/facebook/react/issues/28556

We didn't follow the Rules of Hooks in the rerender implementation for mounts.

## Test plan

- Added test based on "useFormState updates state asynchronously and queues multiple actions" but with StrictMode and less dispatches (because it repros on the first attempt)