### PR TITLE
[Flight] Encode React Elements in Replies as Temporary References

### DIFF
--- a/packages/react-client/src/ReactFlightTemporaryReferences.js
+++ b/packages/react-client/src/ReactFlightTemporaryReferences.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+interface Reference {}
+
+export opaque type TemporaryReferenceSet = Array<Reference>;
+
+export function createTemporaryReferenceSet(): TemporaryReferenceSet {
+  return [];
+}
+
+export function writeTemporaryReference(
+  set: TemporaryReferenceSet,
+  object: Reference,
+): number {
+  // We always create a new entry regardless if we've already written the same
+  // object. This ensures that we always generate a deterministic encoding of
+  // each slot in the reply for cacheability.
+  const newId = set.length;
+  set.push(object);
+  return newId;
+}
+
+export function readTemporaryReference(
+  set: TemporaryReferenceSet,
+  id: number,
+): Reference {
+  if (id < 0 || id >= set.length) {
+    throw new Error(
+      "The RSC response contained a reference that doesn't exist in the temporary reference set. " +
+        'Always pass the matching set that was used to create the reply when parsing its response.',
+    );
+  }
+  return set[id];
+}

--- a/packages/react-server-dom-esm/src/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-esm/src/ReactFlightDOMClientBrowser.js
@@ -26,11 +26,18 @@ import {
   createServerReference,
 } from 'react-client/src/ReactFlightReplyClient';
 
+import type {TemporaryReferenceSet} from 'react-client/src/ReactFlightTemporaryReferences';
+
+export {createTemporaryReferenceSet} from 'react-client/src/ReactFlightTemporaryReferences';
+
+export type {TemporaryReferenceSet};
+
 type CallServerCallback = <A, T>(string, args: A) => Promise<T>;
 
 export type Options = {
   moduleBaseURL?: string,
   callServer?: CallServerCallback,
+  temporaryReferences?: TemporaryReferenceSet,
 };
 
 function createResponseFromOptions(options: void | Options) {
@@ -40,6 +47,9 @@ function createResponseFromOptions(options: void | Options) {
     options && options.callServer ? options.callServer : undefined,
     undefined, // encodeFormAction
     undefined, // nonce
+    options && options.temporaryReferences
+      ? options.temporaryReferences
+      : undefined,
   );
 }
 
@@ -97,11 +107,20 @@ function createFromFetch<T>(
 
 function encodeReply(
   value: ReactServerValue,
+  options?: {temporaryReferences?: TemporaryReferenceSet},
 ): Promise<
   string | URLSearchParams | FormData,
 > /* We don't use URLSearchParams yet but maybe */ {
   return new Promise((resolve, reject) => {
-    processReply(value, '', resolve, reject);
+    processReply(
+      value,
+      '',
+      options && options.temporaryReferences
+        ? options.temporaryReferences
+        : undefined,
+      resolve,
+      reject,
+    );
   });
 }
 

--- a/packages/react-server-dom-esm/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-esm/src/ReactFlightDOMClientNode.js
@@ -60,6 +60,7 @@ function createFromNodeStream<T>(
     noServerCall,
     options ? options.encodeFormAction : undefined,
     options && typeof options.nonce === 'string' ? options.nonce : undefined,
+    undefined, // TODO: If encodeReply is supported, this should support temporaryReferences
   );
   stream.on('data', chunk => {
     processBinaryChunk(response, chunk);

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMClientBrowser.js
@@ -26,10 +26,17 @@ import {
   createServerReference,
 } from 'react-client/src/ReactFlightReplyClient';
 
+import type {TemporaryReferenceSet} from 'react-client/src/ReactFlightTemporaryReferences';
+
+export {createTemporaryReferenceSet} from 'react-client/src/ReactFlightTemporaryReferences';
+
+export type {TemporaryReferenceSet};
+
 type CallServerCallback = <A, T>(string, args: A) => Promise<T>;
 
 export type Options = {
   callServer?: CallServerCallback,
+  temporaryReferences?: TemporaryReferenceSet,
 };
 
 function createResponseFromOptions(options: void | Options) {
@@ -39,6 +46,9 @@ function createResponseFromOptions(options: void | Options) {
     options && options.callServer ? options.callServer : undefined,
     undefined, // encodeFormAction
     undefined, // nonce
+    options && options.temporaryReferences
+      ? options.temporaryReferences
+      : undefined,
   );
 }
 
@@ -96,11 +106,20 @@ function createFromFetch<T>(
 
 function encodeReply(
   value: ReactServerValue,
+  options?: {temporaryReferences?: TemporaryReferenceSet},
 ): Promise<
   string | URLSearchParams | FormData,
 > /* We don't use URLSearchParams yet but maybe */ {
   return new Promise((resolve, reject) => {
-    processReply(value, '', resolve, reject);
+    processReply(
+      value,
+      '',
+      options && options.temporaryReferences
+        ? options.temporaryReferences
+        : undefined,
+      resolve,
+      reject,
+    );
   });
 }
 

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMClientEdge.js
@@ -36,6 +36,12 @@ import {
   createServerReference as createServerReferenceImpl,
 } from 'react-client/src/ReactFlightReplyClient';
 
+import type {TemporaryReferenceSet} from 'react-client/src/ReactFlightTemporaryReferences';
+
+export {createTemporaryReferenceSet} from 'react-client/src/ReactFlightTemporaryReferences';
+
+export type {TemporaryReferenceSet};
+
 function noServerCall() {
   throw new Error(
     'Server Functions cannot be called during initial render. ' +
@@ -60,6 +66,7 @@ export type Options = {
   ssrManifest: SSRManifest,
   nonce?: string,
   encodeFormAction?: EncodeFormActionCallback,
+  temporaryReferences?: TemporaryReferenceSet,
 };
 
 function createResponseFromOptions(options: Options) {
@@ -69,6 +76,9 @@ function createResponseFromOptions(options: Options) {
     noServerCall,
     options.encodeFormAction,
     typeof options.nonce === 'string' ? options.nonce : undefined,
+    options && options.temporaryReferences
+      ? options.temporaryReferences
+      : undefined,
   );
 }
 
@@ -126,11 +136,20 @@ function createFromFetch<T>(
 
 function encodeReply(
   value: ReactServerValue,
+  options?: {temporaryReferences?: TemporaryReferenceSet},
 ): Promise<
   string | URLSearchParams | FormData,
 > /* We don't use URLSearchParams yet but maybe */ {
   return new Promise((resolve, reject) => {
-    processReply(value, '', resolve, reject);
+    processReply(
+      value,
+      '',
+      options && options.temporaryReferences
+        ? options.temporaryReferences
+        : undefined,
+      resolve,
+      reject,
+    );
   });
 }
 

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMClientNode.js
@@ -69,6 +69,7 @@ function createFromNodeStream<T>(
     noServerCall,
     options ? options.encodeFormAction : undefined,
     options && typeof options.nonce === 'string' ? options.nonce : undefined,
+    undefined, // TODO: If encodeReply is supported, this should support temporaryReferences
   );
   stream.on('data', chunk => {
     processBinaryChunk(response, chunk);

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js
@@ -26,10 +26,17 @@ import {
   createServerReference,
 } from 'react-client/src/ReactFlightReplyClient';
 
+import type {TemporaryReferenceSet} from 'react-client/src/ReactFlightTemporaryReferences';
+
+export {createTemporaryReferenceSet} from 'react-client/src/ReactFlightTemporaryReferences';
+
+export type {TemporaryReferenceSet};
+
 type CallServerCallback = <A, T>(string, args: A) => Promise<T>;
 
 export type Options = {
   callServer?: CallServerCallback,
+  temporaryReferences?: TemporaryReferenceSet,
 };
 
 function createResponseFromOptions(options: void | Options) {
@@ -39,6 +46,9 @@ function createResponseFromOptions(options: void | Options) {
     options && options.callServer ? options.callServer : undefined,
     undefined, // encodeFormAction
     undefined, // nonce
+    options && options.temporaryReferences
+      ? options.temporaryReferences
+      : undefined,
   );
 }
 
@@ -96,11 +106,20 @@ function createFromFetch<T>(
 
 function encodeReply(
   value: ReactServerValue,
+  options?: {temporaryReferences?: TemporaryReferenceSet},
 ): Promise<
   string | URLSearchParams | FormData,
 > /* We don't use URLSearchParams yet but maybe */ {
   return new Promise((resolve, reject) => {
-    processReply(value, '', resolve, reject);
+    processReply(
+      value,
+      '',
+      options && options.temporaryReferences
+        ? options.temporaryReferences
+        : undefined,
+      resolve,
+      reject,
+    );
   });
 }
 

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
@@ -36,6 +36,12 @@ import {
   createServerReference as createServerReferenceImpl,
 } from 'react-client/src/ReactFlightReplyClient';
 
+import type {TemporaryReferenceSet} from 'react-client/src/ReactFlightTemporaryReferences';
+
+export {createTemporaryReferenceSet} from 'react-client/src/ReactFlightTemporaryReferences';
+
+export type {TemporaryReferenceSet};
+
 function noServerCall() {
   throw new Error(
     'Server Functions cannot be called during initial render. ' +
@@ -60,6 +66,7 @@ export type Options = {
   ssrManifest: SSRManifest,
   nonce?: string,
   encodeFormAction?: EncodeFormActionCallback,
+  temporaryReferences?: TemporaryReferenceSet,
 };
 
 function createResponseFromOptions(options: Options) {
@@ -69,6 +76,9 @@ function createResponseFromOptions(options: Options) {
     noServerCall,
     options.encodeFormAction,
     typeof options.nonce === 'string' ? options.nonce : undefined,
+    options && options.temporaryReferences
+      ? options.temporaryReferences
+      : undefined,
   );
 }
 
@@ -126,11 +136,20 @@ function createFromFetch<T>(
 
 function encodeReply(
   value: ReactServerValue,
+  options?: {temporaryReferences?: TemporaryReferenceSet},
 ): Promise<
   string | URLSearchParams | FormData,
 > /* We don't use URLSearchParams yet but maybe */ {
   return new Promise((resolve, reject) => {
-    processReply(value, '', resolve, reject);
+    processReply(
+      value,
+      '',
+      options && options.temporaryReferences
+        ? options.temporaryReferences
+        : undefined,
+      resolve,
+      reject,
+    );
   });
 }
 

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientNode.js
@@ -69,6 +69,7 @@ function createFromNodeStream<T>(
     noServerCall,
     options ? options.encodeFormAction : undefined,
     options && typeof options.nonce === 'string' ? options.nonce : undefined,
+    undefined, // TODO: If encodeReply is supported, this should support temporaryReferences
   );
   stream.on('data', chunk => {
     processBinaryChunk(response, chunk);

--- a/packages/react-server/src/ReactFlightReplyServer.js
+++ b/packages/react-server/src/ReactFlightReplyServer.js
@@ -24,6 +24,8 @@ import {
   requireModule,
 } from 'react-client/src/ReactFlightClientConfig';
 
+import {createTemporaryReference} from './ReactFlightServerTemporaryReferences';
+
 export type JSONValue =
   | number
   | null
@@ -412,6 +414,10 @@ function parseModelString(
           parentObject,
           key,
         );
+      }
+      case 'T': {
+        // Temporary Reference
+        return createTemporaryReference(value.slice(2));
       }
       case 'Q': {
         // Map

--- a/packages/react-server/src/ReactFlightServerTemporaryReferences.js
+++ b/packages/react-server/src/ReactFlightServerTemporaryReferences.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+const TEMPORARY_REFERENCE_TAG = Symbol.for('react.temporary.reference');
+
+// eslint-disable-next-line no-unused-vars
+export opaque type TemporaryReference<T> = {
+  $$typeof: symbol,
+  $$id: string,
+};
+
+export function isTemporaryReference(reference: Object): boolean {
+  return reference.$$typeof === TEMPORARY_REFERENCE_TAG;
+}
+
+export function resolveTemporaryReferenceID<T>(
+  temporaryReference: TemporaryReference<T>,
+): string {
+  return temporaryReference.$$id;
+}
+
+const proxyHandlers = {
+  get: function (
+    target: Function,
+    name: string | symbol,
+    receiver: Proxy<Function>,
+  ) {
+    switch (name) {
+      // These names are read by the Flight runtime if you end up using the exports object.
+      case '$$typeof':
+        // These names are a little too common. We should probably have a way to
+        // have the Flight runtime extract the inner target instead.
+        return target.$$typeof;
+      case '$$id':
+        return target.$$id;
+      case '$$async':
+        return target.$$async;
+      case 'name':
+        return undefined;
+      case 'displayName':
+        return undefined;
+      // We need to special case this because createElement reads it if we pass this
+      // reference.
+      case 'defaultProps':
+        return undefined;
+      // Avoid this attempting to be serialized.
+      case 'toJSON':
+        return undefined;
+      case Symbol.toPrimitive:
+        // $FlowFixMe[prop-missing]
+        return Object.prototype[Symbol.toPrimitive];
+      case Symbol.toStringTag:
+        // $FlowFixMe[prop-missing]
+        return Object.prototype[Symbol.toStringTag];
+      case 'Provider':
+        throw new Error(
+          `Cannot render a Client Context Provider on the Server. ` +
+            `Instead, you can export a Client Component wrapper ` +
+            `that itself renders a Client Context Provider.`,
+        );
+    }
+    throw new Error(
+      // eslint-disable-next-line react-internal/safe-string-coercion
+      `Cannot access ${String(name)} on the server. ` +
+        'You cannot dot into a temporary client reference from a server component. ' +
+        'You can only pass the value through to the client.',
+    );
+  },
+  set: function () {
+    throw new Error(
+      'Cannot assign to a temporary client reference from a server module.',
+    );
+  },
+};
+
+export function createTemporaryReference<T>(id: string): TemporaryReference<T> {
+  const reference: TemporaryReference<any> = Object.defineProperties(
+    (function () {
+      throw new Error(
+        // eslint-disable-next-line react-internal/safe-string-coercion
+        `Attempted to call a temporary Client Reference from the server but it is on the client. ` +
+          `It's not possible to invoke a client function from the server, it can ` +
+          `only be rendered as a Component or passed to props of a Client Component.`,
+      );
+    }: any),
+    {
+      $$typeof: {value: TEMPORARY_REFERENCE_TAG},
+      $$id: {value: id},
+    },
+  );
+
+  return new Proxy(reference, proxyHandlers);
+}

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -495,5 +495,11 @@
   "507": "Expected the last optional `callback` argument to be a function. Instead received: %s.",
   "508": "The first argument must be a React class instance. Instead received: %s.",
   "509": "ReactDOM: Unsupported Legacy Mode API.",
-  "510": "React Element cannot be passed to Server Functions from the Client.%s"
+  "510": "React Element cannot be passed to Server Functions from the Client without a temporary reference set. Pass a TemporaryReferenceSet to the options.%s",
+  "511": "Missing a temporary reference set but the RSC response returned a temporary reference. Pass a temporaryReference option with the set that was used with the reply.",
+  "512": "The RSC response contained a reference that doesn't exist in the temporary reference set. Always pass the matching set that was used to create the reply when parsing its response.",
+  "513": "Cannot render a Client Context Provider on the Server. Instead, you can export a Client Component wrapper that itself renders a Client Context Provider.",
+  "514": "Cannot access %s on the server. You cannot dot into a temporary client reference from a server component. You can only pass the value through to the client.",
+  "515": "Cannot assign to a temporary client reference from a server module.",
+  "516": "Attempted to call a temporary Client Reference from the server but it is on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -494,5 +494,6 @@
   "506": "Functions are not valid as a child of Client Components. This may happen if you return %s instead of <%s /> from render. Or maybe you meant to call this function rather than return it.%s",
   "507": "Expected the last optional `callback` argument to be a function. Instead received: %s.",
   "508": "The first argument must be a React class instance. Instead received: %s.",
-  "509": "ReactDOM: Unsupported Legacy Mode API."
+  "509": "ReactDOM: Unsupported Legacy Mode API.",
+  "510": "React Element cannot be passed to Server Functions from the Client.%s"
 }


### PR DESCRIPTION
Currently you can accidentally pass React Element to a Server Action. It warns but in prod it actually works because we can encode the symbol and otherwise it's mostly a plain object. It only works if you only pass host components and no function props etc. which makes it potentially error later. The first thing this does it just early hard error for elements.

I made Lazy work by unwrapping though since that will be replaced by Promises later which works.

Our protocol is not fully symmetric in that elements flow from Server -> Client. Only the Server can resolve Components and only the client should really be able to receive host components. It's not intended that a Server can actually do something with them other than passing them to the client.

In the case of a Reply, we expect the client to be stateful. It's waiting for a response. So anything we can't serialize we can still pass by reference to an in memory object. So I introduce the concept of a TemporaryReferenceSet which is an opaque object that you create before encoding the reply. This then stashes any unserializable values in this set and encode the slot by id. When a new response from the Action then returns we pass the same temporary set into the parser which can then restore the objects. This lets you pass a value by reference to the server and back into another slot.

For example it can be used to render children inside a parent tree from a server action:

```
export async function Component({ children }) {
  "use server";
  return <div>{children}</div>;
}
```

(You wouldn't normally do this due to the waterfalls but for advanced cases.)

A common scenario where this comes up accidentally today is in `useActionState`.

```
export function action(state, formData) {
  "use server";
   if (errored) {
     return <div>This action <strong>errored</strong></div>;
   }
   return null;
}
```

```
const [errors, formAction] = useActionState(action);
return <div>{errors}<div>;
```

It feels like I'm just passing the JSX from server to client. However, because `useActionState` also sends the previous state *back* to the server this should not actually be valid. Before this PR this actually worked accidentally. You get a DEV warning but it used to work in prod. Once you do something like pass a client reference it won't work tho. We could perhaps make client references work by stashing where we got them from but it wouldn't work with all possible JSX.

By adding temporary references to the action implementation this will work again - on the client. It'll also be more efficient since we don't send back the JSX content that you shouldn't introspect on the server anyway.

However, a flaw here is that the progressive enhancement of this case won't work because we can't use temporary references for progressive enhancement since there's no in memory stash. What is worse is that it won't error if you hydrate. ~It also will error late in the example above because the first state is "undefined" so invoking the form once works - it errors on the second attempt when it tries to send the error state back again.~ It actually errors on the first invocation because we need to eagerly serialize "previous state" into the form. So at least that's better.

I think maybe the solution to this particular pattern would be to allow JSX to serialize if you have no temporary reference set, and remember client references so that client references can be returned back to the server as client references. That way anything you could send from the server could also be returned to the server. But it would only deopt to serializing it for progressive enhancement. The consequence of that would be that there's a lot of JSX that might accidentally seem like it should work but it's only if you've gotten it from the server before that it works. This would have to have pair them somehow though since you can't take a client reference from one implementation of Flight and use it with another. 