### PR TITLE
Revert rollout state of enableCache in React Native to next major only

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -10,6 +10,13 @@
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as ExportsType from './ReactFeatureFlags.native-oss';
 
+// -----------------------------------------------------------------------------
+// Ready for next major.
+//
+// Alias __NEXT_MAJOR__ to false for easier skimming.
+// -----------------------------------------------------------------------------
+const __NEXT_MAJOR__ = false;
+
 export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 export const enableDebugTracing = false;
 export const enableAsyncDebugInfo = false;
@@ -18,7 +25,7 @@ export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = __PROFILE__;
 export const enableProfilerNestedUpdatePhase = __PROFILE__;
 export const enableUpdaterTracking = __PROFILE__;
-export const enableCache = true;
+export const enableCache = __NEXT_MAJOR__;
 export const enableLegacyCache = false;
 export const enableCacheElement = true;
 export const enableFetchInstrumentation = false;


### PR DESCRIPTION
## Summary

We're working on enabling the use of microtasks in React Native by default when using the new architecture. To enable this we need to synchronize the RN renderers from React, but doing this causes an error because the renderers now rely on an object defined in `React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` (`ReactCurrentCache`) that's hasn't been released as a stable version yet (cache).

This reverts the change done in #28519 to avoid enabling the cache API in RN until we release a new version of React in npm.

## How did you test this change?

Manually built the RN renderer, copied it to the RN repository and tested e2e in RNTester.