### PR TITLE
Remove excess `ms` prop from Suspense tests

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -107,7 +107,7 @@ describe('ReactSuspense', () => {
         <Suspense fallback={<Text text="Loading..." />}>
           {renderBar ? (
             <Bar>
-              <AsyncText text="A" ms={100} />
+              <AsyncText text="A" />
               <Text text="B" />
             </Bar>
           ) : null}
@@ -153,10 +153,10 @@ describe('ReactSuspense', () => {
     root.render(
       <>
         <Suspense fallback={<Text text="Loading A..." />}>
-          <AsyncText text="A" ms={5000} />
+          <AsyncText text="A" />
         </Suspense>
         <Suspense fallback={<Text text="Loading B..." />}>
-          <AsyncText text="B" ms={6000} />
+          <AsyncText text="B" />
         </Suspense>
       </>,
     );
@@ -258,9 +258,9 @@ describe('ReactSuspense', () => {
       Scheduler.log('Foo');
       return (
         <Suspense fallback={<Text text="Loading..." />}>
-          <AsyncText text="A" ms={200} />
+          <AsyncText text="A" />
           <Suspense fallback={<Text text="Loading more..." />}>
-            <AsyncText text="B" ms={300} />
+            <AsyncText text="B" />
           </Suspense>
         </Suspense>
       );
@@ -294,9 +294,9 @@ describe('ReactSuspense', () => {
       Scheduler.log('Foo');
       return (
         <Suspense fallback={<Text text="Loading..." />}>
-          <AsyncText text="A" ms={200} />
+          <AsyncText text="A" />
           <Suspense fallback={<Text text="Loading more..." />}>
-            <AsyncText text="B" ms={1200} />
+            <AsyncText text="B" />
           </Suspense>
         </Suspense>
       );
@@ -346,7 +346,7 @@ describe('ReactSuspense', () => {
           <>
             <Text text={`A${step}`} />
             <Suspense fallback={<Text text="Loading..." />}>
-              {shouldSuspend ? <AsyncText text="Async" ms={2000} /> : null}
+              {shouldSuspend ? <AsyncText text="Async" /> : null}
             </Suspense>
             <Text text={`B${step}`} />
             <Text text={`C${step}`} />
@@ -627,7 +627,7 @@ describe('ReactSuspense', () => {
       return (
         <Suspense fallback={<Text text="Loading..." />}>
           <TextWithLayout text="Child 1" />
-          {show && <AsyncText ms={1000} text="Child 2" />}
+          {show && <AsyncText text="Child 2" />}
         </Suspense>
       );
     }
@@ -722,7 +722,7 @@ describe('ReactSuspense', () => {
         return (
           <Suspense fallback={<TextWithLifecycle text="Loading..." />}>
             <TextWithLifecycle text="A" />
-            <AsyncTextWithLifecycle ms={100} text="B" ref={instance} />
+            <AsyncTextWithLifecycle text="B" ref={instance} />
             <TextWithLifecycle text="C" />
           </Suspense>
         );
@@ -776,7 +776,7 @@ describe('ReactSuspense', () => {
         return (
           <Suspense fallback={<Text text="Loading..." />}>
             <Stateful />
-            <AsyncText ms={1000} text={props.text} />
+            <AsyncText text={props.text} />
           </Suspense>
         );
       }
@@ -822,7 +822,7 @@ describe('ReactSuspense', () => {
             <Indirection>
               <Indirection>
                 <Indirection>
-                  <AsyncText ms={1000} text={props.text} />
+                  <AsyncText text={props.text} />
                 </Indirection>
               </Indirection>
             </Indirection>
@@ -872,7 +872,7 @@ describe('ReactSuspense', () => {
       function App({text}) {
         return (
           <Suspense fallback={<Text text="Loading..." />}>
-            <AsyncTextWithUnmount text={text} ms={100} />
+            <AsyncTextWithUnmount text={text} />
           </Suspense>
         );
       }
@@ -902,7 +902,7 @@ describe('ReactSuspense', () => {
       function App({text}) {
         return (
           <Suspense fallback={<Text text="Loading..." />}>
-            <AsyncTextWithEffect text={text} ms={100} />
+            <AsyncTextWithEffect text={text} />
           </Suspense>
         );
       }
@@ -920,7 +920,7 @@ describe('ReactSuspense', () => {
         state = {step: 1};
         render() {
           instance = this;
-          return <AsyncText ms={1000} text={`Step: ${this.state.step}`} />;
+          return <AsyncText text={`Step: ${this.state.step}`} />;
         }
       }
 
@@ -976,9 +976,9 @@ describe('ReactSuspense', () => {
       function App(props) {
         return (
           <Suspense fallback={<ShouldMountOnce />}>
-            <AsyncText ms={1000} text="Child 1" />
-            <AsyncText ms={2000} text="Child 2" />
-            <AsyncText ms={3000} text="Child 3" />
+            <AsyncText text="Child 1" />
+            <AsyncText text="Child 2" />
+            <AsyncText text="Child 3" />
           </Suspense>
         );
       }
@@ -1019,7 +1019,7 @@ describe('ReactSuspense', () => {
 
         return (
           <Suspense fallback={<Text text="Loading..." />}>
-            <AsyncText key={tab} text={'Tab: ' + tab} ms={1000} />
+            <AsyncText key={tab} text={'Tab: ' + tab} />
             <Text key={tab + 'sibling'} text=" + sibling" />
           </Suspense>
         );
@@ -1087,9 +1087,9 @@ describe('ReactSuspense', () => {
       function App() {
         return (
           <Suspense fallback={<Text text="Loading..." />}>
-            <AsyncText text="A" ms={1000} />
-            <AsyncText text="B" ms={2000} />
-            <AsyncText text="C" ms={3000} />
+            <AsyncText text="A" />
+            <AsyncText text="B" />
+            <AsyncText text="C" />
           </Suspense>
         );
       }

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemantics-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemantics-test.js
@@ -258,7 +258,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(() => {
         ReactNoop.render(
           <App>
-            <AsyncText text="Async" ms={1000} />
+            <AsyncText text="Async" />
           </App>,
         );
       });
@@ -376,7 +376,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(() => {
         ReactNoop.renderLegacySyncRoot(
           <App>
-            <AsyncText text="Async" ms={1000} />
+            <AsyncText text="Async" />
           </App>,
         );
       });
@@ -503,7 +503,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(() => {
         ReactNoop.renderLegacySyncRoot(
           <App>
-            <AsyncText text="Async" ms={1000} />
+            <AsyncText text="Async" />
           </App>,
         );
       });
@@ -633,7 +633,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(async () => {
         ReactNoop.render(
           <App>
-            <AsyncText text="Async" ms={1000} />
+            <AsyncText text="Async" />
           </App>,
         );
         await waitFor([
@@ -773,7 +773,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(async () => {
         ReactNoop.render(
           <App>
-            <AsyncText text="Async" ms={1000} />
+            <AsyncText text="Async" />
           </App>,
         );
 
@@ -885,7 +885,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(async () => {
         ReactNoop.render(
           <App>
-            <AsyncText text="Async" ms={1000} />
+            <AsyncText text="Async" />
           </App>,
         );
         await waitFor([
@@ -999,7 +999,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(async () => {
         ReactNoop.render(
           <App>
-            <AsyncText text="Async" ms={1000} />
+            <AsyncText text="Async" />
           </App>,
         );
         await waitFor([
@@ -1097,7 +1097,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       // Suspend the inner Suspense subtree (only inner effects should be destroyed)
       await act(() => {
         ReactNoop.render(
-          <App innerChildren={<AsyncText text="InnerAsync_1" ms={1000} />} />,
+          <App innerChildren={<AsyncText text="InnerAsync_1" />} />,
         );
       });
       assertLog([
@@ -1122,8 +1122,8 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(() => {
         ReactNoop.render(
           <App
-            outerChildren={<AsyncText text="OuterAsync_1" ms={1000} />}
-            innerChildren={<AsyncText text="InnerAsync_1" ms={1000} />}
+            outerChildren={<AsyncText text="OuterAsync_1" />}
+            innerChildren={<AsyncText text="InnerAsync_1" />}
           />,
         );
       });
@@ -1164,8 +1164,8 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(() => {
         ReactNoop.render(
           <App
-            outerChildren={<AsyncText text="OuterAsync_1" ms={1000} />}
-            innerChildren={<AsyncText text="InnerAsync_2" ms={1000} />}
+            outerChildren={<AsyncText text="OuterAsync_1" />}
+            innerChildren={<AsyncText text="InnerAsync_2" />}
           />,
         );
       });
@@ -1236,8 +1236,8 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(() => {
         ReactNoop.render(
           <App
-            outerChildren={<AsyncText text="OuterAsync_2" ms={1000} />}
-            innerChildren={<AsyncText text="InnerAsync_2" ms={1000} />}
+            outerChildren={<AsyncText text="OuterAsync_2" />}
+            innerChildren={<AsyncText text="InnerAsync_2" />}
           />,
         );
       });
@@ -1325,7 +1325,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       // Suspend the inner Suspense subtree (only inner effects should be destroyed)
       await act(() => {
         ReactNoop.render(
-          <App innerChildren={<AsyncText text="InnerAsync_1" ms={1000} />} />,
+          <App innerChildren={<AsyncText text="InnerAsync_1" />} />,
         );
       });
       assertLog([
@@ -1350,8 +1350,8 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(() => {
         ReactNoop.render(
           <App
-            outerChildren={<AsyncText text="OuterAsync_1" ms={1000} />}
-            innerChildren={<AsyncText text="InnerAsync_1" ms={1000} />}
+            outerChildren={<AsyncText text="OuterAsync_1" />}
+            innerChildren={<AsyncText text="InnerAsync_1" />}
           />,
         );
       });
@@ -1448,7 +1448,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       // Suspend the outer shell
       await act(async () => {
         ReactNoop.render(
-          <App outerChildren={<AsyncText text="OutsideAsync" ms={1000} />} />,
+          <App outerChildren={<AsyncText text="OutsideAsync" />} />,
         );
         await waitFor([
           'Text:Inside render',
@@ -1478,8 +1478,8 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(async () => {
         ReactNoop.render(
           <App
-            fallbackChildren={<AsyncText text="FallbackAsync" ms={1000} />}
-            outerChildren={<AsyncText text="OutsideAsync" ms={1000} />}
+            fallbackChildren={<AsyncText text="FallbackAsync" />}
+            outerChildren={<AsyncText text="OutsideAsync" />}
           />,
         );
         await waitFor([
@@ -1577,8 +1577,8 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(() => {
         ReactNoop.render(
           <App
-            outerChildren={<AsyncText text="OutsideAsync" ms={1000} />}
-            fallbackChildren={<AsyncText text="FallbackAsync" ms={1000} />}
+            outerChildren={<AsyncText text="OutsideAsync" />}
+            fallbackChildren={<AsyncText text="FallbackAsync" />}
           />,
         );
       });
@@ -1807,7 +1807,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App>
-                <AsyncText text="Async" ms={1000} />
+                <AsyncText text="Async" />
               </App>
             </ErrorBoundary>,
           );
@@ -1941,7 +1941,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App>
-                <AsyncText text="Async" ms={1000} />
+                <AsyncText text="Async" />
               </App>
             </ErrorBoundary>,
           );
@@ -2050,7 +2050,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App>
-                <AsyncText text="Async" ms={1000} />
+                <AsyncText text="Async" />
               </App>
             </ErrorBoundary>,
           );
@@ -2184,7 +2184,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App>
-                <AsyncText text="Async" ms={1000} />
+                <AsyncText text="Async" />
               </App>
             </ErrorBoundary>,
           );
@@ -2276,8 +2276,8 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(async () => {
         ReactNoop.render(
           <App>
-            <AsyncText text="Async_1" ms={1000} />
-            <AsyncText text="Async_2" ms={2000} />
+            <AsyncText text="Async_1" />
+            <AsyncText text="Async_2" />
           </App>,
         );
         await waitFor([
@@ -2581,7 +2581,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
       // Suspend the inner Suspense subtree (only inner effects should be destroyed)
       await act(() => {
         ReactNoop.renderLegacySyncRoot(
-          <App children={<AsyncText text="Async" ms={1000} />} />,
+          <App children={<AsyncText text="Async" />} />,
         );
       });
       await advanceTimers(1000);
@@ -2661,9 +2661,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
 
       // Suspend the inner Suspense subtree (only inner effects should be destroyed)
       await act(() => {
-        ReactNoop.render(
-          <App children={<AsyncText text="Async" ms={1000} />} />,
-        );
+        ReactNoop.render(<App children={<AsyncText text="Async" />} />);
       });
       await advanceTimers(1000);
       assertLog([
@@ -2764,9 +2762,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
 
       // Suspend the inner Suspense subtree (only inner effects should be destroyed)
       await act(() => {
-        ReactNoop.render(
-          <App children={<AsyncText text="Async" ms={1000} />} />,
-        );
+        ReactNoop.render(<App children={<AsyncText text="Async" />} />);
       });
       await advanceTimers(1000);
       assertLog([
@@ -2863,9 +2859,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
 
       // Suspend the inner Suspense subtree (only inner effects should be destroyed)
       await act(() => {
-        ReactNoop.render(
-          <App children={<AsyncText text="Async" ms={1000} />} />,
-        );
+        ReactNoop.render(<App children={<AsyncText text="Async" />} />);
       });
       await advanceTimers(1000);
       assertLog([
@@ -2967,9 +2961,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
 
       // Suspend the inner Suspense subtree (only inner effects should be destroyed)
       await act(() => {
-        ReactNoop.render(
-          <App children={<AsyncText text="Async" ms={1000} />} />,
-        );
+        ReactNoop.render(<App children={<AsyncText text="Async" />} />);
       });
       await advanceTimers(1000);
       assertLog([
@@ -3078,7 +3070,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
           ReactNoop.render(
             <ErrorBoundary fallback={<Text text="Error" />}>
               <App>
-                <AsyncText text="Async" ms={1000} />
+                <AsyncText text="Async" />
               </App>
             </ErrorBoundary>,
           );

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseFallback-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseFallback-test.js
@@ -135,7 +135,7 @@ describe('ReactSuspenseFallback', () => {
   it('suspends and shows fallback', async () => {
     ReactNoop.render(
       <Suspense fallback={<Text text="Loading..." />}>
-        <AsyncText text="A" ms={100} />
+        <AsyncText text="A" />
       </Suspense>,
     );
 
@@ -147,7 +147,7 @@ describe('ReactSuspenseFallback', () => {
   it('suspends and shows null fallback', async () => {
     ReactNoop.render(
       <Suspense fallback={null}>
-        <AsyncText text="A" ms={100} />
+        <AsyncText text="A" />
       </Suspense>,
     );
 
@@ -162,7 +162,7 @@ describe('ReactSuspenseFallback', () => {
   it('suspends and shows undefined fallback', async () => {
     ReactNoop.render(
       <Suspense>
-        <AsyncText text="A" ms={100} />
+        <AsyncText text="A" />
       </Suspense>,
     );
 
@@ -178,7 +178,7 @@ describe('ReactSuspenseFallback', () => {
     ReactNoop.render(
       <Suspense fallback={<Text text="Should not show..." />}>
         <Suspense fallback={<Text text="Loading..." />}>
-          <AsyncText text="A" ms={100} />
+          <AsyncText text="A" />
         </Suspense>
       </Suspense>,
     );
@@ -192,7 +192,7 @@ describe('ReactSuspenseFallback', () => {
     ReactNoop.render(
       <Suspense fallback={<Text text="Should not show..." />}>
         <Suspense>
-          <AsyncText text="A" ms={100} />
+          <AsyncText text="A" />
         </Suspense>
       </Suspense>,
     );
@@ -209,7 +209,7 @@ describe('ReactSuspenseFallback', () => {
     ReactNoop.render(
       <Suspense fallback={<Text text="Should not show..." />}>
         <Suspense fallback={null}>
-          <AsyncText text="A" ms={100} />
+          <AsyncText text="A" />
         </Suspense>
       </Suspense>,
     );

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -208,7 +208,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         <>
           <Suspense fallback={<Text text="Loading..." />}>
             <Bar>
-              <AsyncText text="A" ms={100} />
+              <AsyncText text="A" />
               <Text text="B" />
             </Bar>
           </Suspense>
@@ -422,7 +422,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         <Suspense fallback={<Text text="Loading..." />}>
           {renderContent ? (
             <ErrorBoundary ref={errorBoundary}>
-              <AsyncText text="Result" ms={1000} />
+              <AsyncText text="Result" />
             </ErrorBoundary>
           ) : null}
         </Suspense>
@@ -619,7 +619,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       }
       return (
         <Suspense fallback="Loading...">
-          <AsyncText ms={2000} text="Async" />
+          <AsyncText text="Async" />
         </Suspense>
       );
     }
@@ -715,9 +715,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       <Fragment>
         <Text text="Sync" />
         <Suspense fallback={<Text text="Loading outer..." />}>
-          <AsyncText text="Outer content" ms={300} />
+          <AsyncText text="Outer content" />
           <Suspense fallback={<Text text="Loading inner..." />}>
-            <AsyncText text="Inner content" ms={1000} />
+            <AsyncText text="Inner content" />
           </Suspense>
         </Suspense>
       </Fragment>,
@@ -2821,7 +2821,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
             <Offscreen />
           </LegacyHiddenDiv>
           <Suspense fallback={<Text text="Loading..." />}>
-            {showContent ? <AsyncText text="A" ms={2000} /> : null}
+            {showContent ? <AsyncText text="A" /> : null}
           </Suspense>
         </>
       );

--- a/packages/react-reconciler/src/__tests__/ReactTransition-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransition-test.js
@@ -719,7 +719,7 @@ describe('ReactTransition', () => {
           <>
             <Text text={`A${step}`} />
             <Suspense fallback={<Text text="Loading..." />}>
-              {shouldSuspend ? <AsyncText text="Async" ms={2000} /> : null}
+              {shouldSuspend ? <AsyncText text="Async" /> : null}
             </Suspense>
             <Text text={`B${step}`} />
             <Text text={`C${step}`} />


### PR DESCRIPTION
These tests now use the built-in cache and the `ms` prop was ignored for a while now so I removed them to avoid confusion when reading tests.

