### PR TITLE
Change to content hash for RN canary VERSION strings

### DIFF
--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -173,25 +173,17 @@ function processStable(buildDir) {
     );
   }
 
-  const reactNativeBuildDir = buildDir + '/react-native/implementations/';
-  if (fs.existsSync(reactNativeBuildDir)) {
-    const hash = crypto.createHash('sha1');
-    for (const fileName of fs.readdirSync(reactNativeBuildDir).sort()) {
-      const filePath = reactNativeBuildDir + fileName;
-      const stats = fs.statSync(filePath);
-      if (!stats.isDirectory()) {
-        hash.update(fs.readFileSync(filePath));
-      }
+  [
+    buildDir + '/react-native/implementations/',
+    buildDir + '/facebook-react-native/',
+  ].forEach(reactNativeBuildDir => {
+    if (fs.existsSync(reactNativeBuildDir)) {
+      updatePlaceholderReactVersionInCompiledArtifacts(
+        reactNativeBuildDir,
+        ReactVersion + '-' + canaryChannelLabel + '-%FILEHASH%'
+      );
     }
-    updatePlaceholderReactVersionInCompiledArtifacts(
-      reactNativeBuildDir,
-      ReactVersion +
-        '-' +
-        canaryChannelLabel +
-        '-' +
-        hash.digest('hex').slice(0, 8)
-    );
-  }
+  });
 
   // Update remaining placeholders with canary channel version
   updatePlaceholderReactVersionInCompiledArtifacts(
@@ -362,9 +354,11 @@ function updatePlaceholderReactVersionInCompiledArtifacts(
 
   for (const artifactFilename of artifactFilenames) {
     const originalText = fs.readFileSync(artifactFilename, 'utf8');
+    const fileHash = crypto.createHash('sha1');
+    fileHash.update(originalText);
     const replacedText = originalText.replaceAll(
       PLACEHOLDER_REACT_VERSION,
-      newVersion
+      newVersion.replace(/%FILEHASH%/g, fileHash.digest('hex').slice(0, 8))
     );
     fs.writeFileSync(artifactFilename, replacedText);
   }


### PR DESCRIPTION
With this change, the different files in RN will have *different* hashes. This replaces the git hash and means that the file content (including version) is only updated when the rest of the file content actually changes. This should remove "noop" changes that need to be synced that only update the version string.

A difference to the www implementation here is (and I'd be looking at updating www as well if this lands well) that each file has an individual hash instead of a combined content hash. This further reduces the number of updated files and I couldn't find a reason we need to have these in sync. The best I can gather is that this hash is used so folks don't directly compare version string and make future updates harder.