### PR TITLE
Also apply content hash for experimental files

### DIFF
--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -239,6 +239,18 @@ function processExperimental(buildDir, version) {
     );
   }
 
+  [
+    buildDir + '/react-native/implementations/',
+    buildDir + '/facebook-react-native/',
+  ].forEach(reactNativeBuildDir => {
+    if (fs.existsSync(reactNativeBuildDir)) {
+      updatePlaceholderReactVersionInCompiledArtifacts(
+        reactNativeBuildDir,
+        ReactVersion + '-' + canaryChannelLabel + '-%FILEHASH%'
+      );
+    }
+  });
+
   // Update remaining placeholders with canary channel version
   updatePlaceholderReactVersionInCompiledArtifacts(
     buildDir,


### PR DESCRIPTION
Also apply content hash for experimental files

In #28582 I missed that experimental files have a copy of this build function setting the version strings.
