### PR TITLE
Update gate pragma to detect global error events

### DIFF
--- a/scripts/babel/__tests__/transform-test-gate-pragma-test.js
+++ b/scripts/babel/__tests__/transform-test-gate-pragma-test.js
@@ -203,6 +203,15 @@ describe('transform test-gate-pragma: actual runtime', () => {
     console.error('Stop that!');
     throw Error('I told you to stop!');
   });
+
+  // @gate false
+  test('a global error event is treated as a test failure', () => {
+    dispatchEvent(
+      new ErrorEvent('error', {
+        error: new Error('Oops!'),
+      })
+    );
+  });
 });
 
 describe('dynamic gate method', () => {


### PR DESCRIPTION
If a global error event is dispatched during a test, Jest reports that test as a failure.

Our `@gate` pragma feature should account for this — if the gate condition is false, and the global error event is dispatched, then the test should be reported as a success.

The solution is to install an error event handler right before invoking the test function. Because we install our own handler, Jest will not report the test as a failure if a global error event is dispatched; it's conceptually as if we wrapped the whole test event in a try-catch.