### PR TITLE
Guard against legacy context not being supported in DevTools fixture

### DIFF
--- a/packages/react-devtools-shell/src/app/InspectableElements/Contexts.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/Contexts.js
@@ -273,15 +273,46 @@ class ModernClassContextConsumerWithUpdates extends Component<any> {
   }
 }
 
+type LegacyContextState = {
+  supportsLegacyContext: boolean,
+};
+class LegacyContext extends React.Component {
+  state: LegacyContextState = {supportsLegacyContext: true};
+
+  static getDerivedStateFromError(error: any): LegacyContextState {
+    return {supportsLegacyContext: false};
+  }
+
+  componentDidCatch(error: any, info: any) {
+    console.info(
+      'Assuming legacy context is not supported in this React version due to: ',
+      error,
+      info,
+    );
+  }
+
+  render(): React.Node {
+    if (!this.state.supportsLegacyContext) {
+      return <p>This version of React does not support legacy context.</p>;
+    }
+
+    return (
+      <React.Fragment>
+        <LegacyContextProvider>
+          <LegacyContextConsumer />
+        </LegacyContextProvider>
+        <LegacyContextProviderWithUpdates />
+      </React.Fragment>
+    );
+  }
+}
+
 export default function Contexts(): React.Node {
   return (
     <div>
       <h1>Contexts</h1>
       <ul>
-        <LegacyContextProvider>
-          <LegacyContextConsumer />
-        </LegacyContextProvider>
-        <LegacyContextProviderWithUpdates />
+        <LegacyContext />
         <ModernContext.Provider value={contextData}>
           <ModernContext.Consumer>
             {(value: $FlowFixMe) =>


### PR DESCRIPTION
Legacy context was removed from experimental builds so the default setup would hide important fixtures.

Now it just assumes that any crash within the tree rendering legacy context is due to legacy context not being supported.

I didn't remove the components entirely since this fixture can be used with older versions of React where we would want to check if legacy context still works.
![Screenshot from 2024-03-20 17-09-07](https://github.com/facebook/react/assets/12292047/bd3701f2-2239-46bf-b79e-7f7bd675ab19)


