### PR TITLE
Deprecate `act` from `react-dom/test-utils` in favor of act from `react`

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -632,4 +632,17 @@ describe('ReactTestUtils', () => {
         'See https://react.dev/warnings/react-dom-test-utils for more info.',
     );
   });
+
+  // @gate __DEV__
+  it('warns when using `act`', () => {
+    expect(() => {
+      ReactTestUtils.act(() => {});
+    }).toErrorDev(
+      [
+        '`ReactDOMTestUtils.act` is deprecated in favor of `React.act`. ' +
+          'Import `act` from `react` instead of `react-dom/test-utils`.',
+      ],
+      {withoutStack: true},
+    );
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -640,7 +640,8 @@ describe('ReactTestUtils', () => {
     }).toErrorDev(
       [
         '`ReactDOMTestUtils.act` is deprecated in favor of `React.act`. ' +
-          'Import `act` from `react` instead of `react-dom/test-utils`.',
+          'Import `act` from `react` instead of `react-dom/test-utils`. ' +
+          'See https://react.dev/warnings/react-dom-test-utils for more info.',
       ],
       {withoutStack: true},
     );

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -9,7 +9,6 @@
 
 let React;
 let ReactDOMClient;
-let ReactTestUtils;
 let Scheduler;
 let act;
 let container;
@@ -27,7 +26,7 @@ function sleep(period) {
   });
 }
 
-describe('ReactTestUtils.act()', () => {
+describe('React.act()', () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
@@ -84,9 +83,8 @@ function runActTests(render, unmount, rerender) {
       jest.resetModules();
       React = require('react');
       ReactDOMClient = require('react-dom/client');
-      ReactTestUtils = require('react-dom/test-utils');
       Scheduler = require('scheduler');
-      act = ReactTestUtils.act;
+      act = React.act;
 
       const InternalTestUtils = require('internal-test-utils');
       assertLog = InternalTestUtils.assertLog;

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -41,7 +41,8 @@ function act(callback) {
     didWarnAboutUsingAct = true;
     console.error(
       '`ReactDOMTestUtils.act` is deprecated in favor of `React.act`. ' +
-        'Import `act` from `react` instead of `react-dom/test-utils`.',
+        'Import `act` from `react` instead of `react-dom/test-utils`. ' +
+        'See https://react.dev/warnings/react-dom-test-utils for more info.',
     );
   }
   return React.act(callback);

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -35,9 +35,17 @@ const getFiberCurrentPropsFromNode = EventInternals[2];
 const enqueueStateRestore = EventInternals[3];
 const restoreStateIfNeeded = EventInternals[4];
 
-// TODO: Add a warning if this API is accessed with advice to switch to
-// importing directly from the React package instead.
-const act = React.act;
+let didWarnAboutUsingAct = false;
+function act(callback) {
+  if (didWarnAboutUsingAct === false) {
+    didWarnAboutUsingAct = true;
+    console.error(
+      '`ReactDOMTestUtils.act` is deprecated in favor of `React.act`. ' +
+        'Import `act` from `react` instead of `react-dom/test-utils`.',
+    );
+  }
+  return React.act(callback);
+}
 
 function Event(suffix) {}
 


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/28541/

## Summary

Use `React.act` instead:
```diff
-import {act} from 'react-dom/test-utils'
+import {act} from 'react'
```

## How did you test this change?

- using `React.act` now instead of `ReactDOMTestUtils` when testing the public `act`
- added test for the new warning
