### PR TITLE
[Fizz][Legacy] use static markup mode for renderToStaticNodeStream

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -609,28 +609,6 @@ describe('ReactDOMServer', () => {
         expect(response.read()).toBeNull();
       });
     });
-  });
-
-  describe('renderToStaticNodeStream', () => {
-    it('should generate simple markup', () => {
-      const SuccessfulElement = React.createElement(() => <img />);
-      const response =
-        ReactDOMServer.renderToStaticNodeStream(SuccessfulElement);
-      expect(response.read().toString()).toMatch(new RegExp('<img' + '/>'));
-    });
-
-    it('should handle errors correctly', () => {
-      const FailingElement = React.createElement(() => {
-        throw new Error('An Error');
-      });
-      const response = ReactDOMServer.renderToStaticNodeStream(FailingElement);
-      return new Promise(resolve => {
-        response.once('error', () => {
-          resolve();
-        });
-        expect(response.read()).toBeNull();
-      });
-    });
 
     it('should refer users to new apis when using suspense', async () => {
       let resolve = null;
@@ -665,6 +643,55 @@ describe('ReactDOMServer', () => {
       expect(response.read().toString()).toEqual(
         '<div><!--$-->resolved<!-- --><!--/$--></div>',
       );
+    });
+  });
+
+  describe('renderToStaticNodeStream', () => {
+    it('should generate simple markup', () => {
+      const SuccessfulElement = React.createElement(() => <img />);
+      const response =
+        ReactDOMServer.renderToStaticNodeStream(SuccessfulElement);
+      expect(response.read().toString()).toMatch(new RegExp('<img' + '/>'));
+    });
+
+    it('should handle errors correctly', () => {
+      const FailingElement = React.createElement(() => {
+        throw new Error('An Error');
+      });
+      const response = ReactDOMServer.renderToStaticNodeStream(FailingElement);
+      return new Promise(resolve => {
+        response.once('error', () => {
+          resolve();
+        });
+        expect(response.read()).toBeNull();
+      });
+    });
+
+    it('should omit text and suspense placeholders', async () => {
+      let resolve = null;
+      const promise = new Promise(res => {
+        resolve = () => {
+          resolved = true;
+          res();
+        };
+      });
+      let resolved = false;
+      function Suspender() {
+        if (resolved) {
+          return 'resolved';
+        }
+        throw promise;
+      }
+
+      const response = ReactDOMServer.renderToStaticNodeStream(
+        <div>
+          <React.Suspense fallback={'fallback'}>
+            <Suspender />
+          </React.Suspense>
+        </div>,
+      );
+      await resolve();
+      expect(response.read().toString()).toEqual('<div>resolved</div>');
     });
   });
 

--- a/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
@@ -78,7 +78,7 @@ function renderToNodeStreamImpl(
   const request = createRequest(
     children,
     resumableState,
-    createRenderState(resumableState, false),
+    createRenderState(resumableState, generateStaticMarkup),
     createRootFormatContext(),
     Infinity,
     onError,


### PR DESCRIPTION
Since it was first implemented renderToStaticNodeStream never correctly set the renderer state to mark the output as static markup which means it was functionally the same as renderToNodeStream. This change fixes this oversight. While we are removing renderToNodeStream in a future version we never did deprecate the static version of this API because it has no immediate analog in the modern APIs.
