### PR TITLE
[RFC][ReactIs]: extract client/server reference types

### DIFF
--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -23,7 +23,8 @@ import {
   REACT_STRICT_MODE_TYPE,
   REACT_SUSPENSE_TYPE,
   REACT_SUSPENSE_LIST_TYPE,
-} from 'shared/ReactSymbols';
+  REACT_CLIENT_REFERENCE_TYPE,
+} from 'shared/ReactSymbols
 import isValidElementType from 'shared/isValidElementType';
 import {enableRenderableContext} from 'shared/ReactFeatureFlags';
 
@@ -88,6 +89,7 @@ export const Profiler = REACT_PROFILER_TYPE;
 export const StrictMode = REACT_STRICT_MODE_TYPE;
 export const Suspense = REACT_SUSPENSE_TYPE;
 export const SuspenseList = REACT_SUSPENSE_LIST_TYPE;
+export const ClientReference = REACT_CLIENT_REFERENCE_TYPE;
 
 export {isValidElementType};
 
@@ -138,4 +140,7 @@ export function isSuspense(object: any): boolean {
 }
 export function isSuspenseList(object: any): boolean {
   return typeOf(object) === REACT_SUSPENSE_LIST_TYPE;
+}
+export function isClientReference(object: any): boolean {
+  return typeOf(object) === REACT_CLIENT_REFERENCE_TYPE;
 }

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -13,6 +13,7 @@ import {
   getIteratorFn,
   REACT_ELEMENT_TYPE,
   REACT_FRAGMENT_TYPE,
+  REACT_CLIENT_REFERENCE_TYPE
 } from 'shared/ReactSymbols';
 import {checkKeyStringCoercion} from 'shared/CheckStringCoercion';
 import isValidElementType from 'shared/isValidElementType';
@@ -22,8 +23,6 @@ import {enableRefAsProp, disableStringRefs} from 'shared/ReactFeatureFlags';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 const ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
-
-const REACT_CLIENT_REFERENCE = Symbol.for('react.client.reference');
 
 let specialPropKeyWarningShown;
 let specialPropRefWarningShown;
@@ -942,7 +941,7 @@ function validateChildKeys(node, parentType) {
     if (typeof node !== 'object' || !node) {
       return;
     }
-    if (node.$$typeof === REACT_CLIENT_REFERENCE) {
+    if (node.$$typeof === REACT_CLIENT_REFERENCE_TYPE) {
       // This is a reference to a client component so it's unknown.
     } else if (isArray(node)) {
       for (let i = 0; i < node.length; i++) {

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -45,6 +45,7 @@ export const REACT_MEMO_CACHE_SENTINEL: symbol = Symbol.for(
 );
 
 export const REACT_POSTPONE_TYPE: symbol = Symbol.for('react.postpone');
+export const REACT_CLIENT_REFERENCE_TYPE: symbol = Symbol.for('react.client.reference');
 
 const MAYBE_ITERATOR_SYMBOL = Symbol.iterator;
 const FAUX_ITERATOR_SYMBOL = '@@iterator';

--- a/packages/shared/getComponentNameFromType.js
+++ b/packages/shared/getComponentNameFromType.js
@@ -25,6 +25,7 @@ import {
   REACT_LAZY_TYPE,
   REACT_CACHE_TYPE,
   REACT_TRACING_MARKER_TYPE,
+  REACT_CLIENT_REFERENCE_TYPE,
 } from 'shared/ReactSymbols';
 
 import {
@@ -52,8 +53,6 @@ function getContextName(type: ReactContext<any>) {
   return type.displayName || 'Context';
 }
 
-const REACT_CLIENT_REFERENCE = Symbol.for('react.client.reference');
-
 // Note that the reconciler package should generally prefer to use getComponentNameFromFiber() instead.
 export default function getComponentNameFromType(type: mixed): string | null {
   if (type == null) {
@@ -61,7 +60,7 @@ export default function getComponentNameFromType(type: mixed): string | null {
     return null;
   }
   if (typeof type === 'function') {
-    if ((type: any).$$typeof === REACT_CLIENT_REFERENCE) {
+    if ((type: any).$$typeof === REACT_CLIENT_REFERENCE_TYPE) {
       // TODO: Create a convention for naming client references with debug info.
       return null;
     }

--- a/packages/shared/isValidElementType.js
+++ b/packages/shared/isValidElementType.js
@@ -25,6 +25,7 @@ import {
   REACT_OFFSCREEN_TYPE,
   REACT_CACHE_TYPE,
   REACT_TRACING_MARKER_TYPE,
+  REACT_CLIENT_REFERENCE_TYPE,
 } from 'shared/ReactSymbols';
 import {
   enableScopeAPI,
@@ -34,8 +35,6 @@ import {
   enableLegacyHidden,
   enableRenderableContext,
 } from './ReactFeatureFlags';
-
-const REACT_CLIENT_REFERENCE: symbol = Symbol.for('react.client.reference');
 
 export default function isValidElementType(type: mixed): boolean {
   if (typeof type === 'string' || typeof type === 'function') {
@@ -71,7 +70,7 @@ export default function isValidElementType(type: mixed): boolean {
       // types supported by any Flight configuration anywhere since
       // we don't know which Flight build this will end up being used
       // with.
-      type.$$typeof === REACT_CLIENT_REFERENCE ||
+      type.$$typeof === REACT_CLIENT_REFERENCE_TYPE ||
       type.getModuleId !== undefined
     ) {
       return true;


### PR DESCRIPTION
## Summary

Hello 👋.

I'm working on an experimental universal react components which are supposed to operate in server-only, server-client (RSC + `use client`) or client-only environments. Obviously not everything could be "universal" so there are a couple of caveats which require conditional passing of props from one component to another based on their environments (e.g. server comp passing something to a client component).

Currently, this was done on my side by checking if the target component is either of type `object` or `function` since nextjs's implementation wraps references in a `Proxy` wrapper. However other frameworks like [`waku`](https://waku.gg/) have different mechanisms to handle server/client references, thus I opted into searching a more "stable" solution through `react-is`.

Symbols for `react.client.reference` and `react.server.reference` already exists in the codebase but are not exposed. Given the scenario above I believe it would be more convenient for library author to utilize the `react-is` package for such cases.

If there is an initial feedback if this is might be even be considered as an option, I will proceed with exposing the `server` symbol. Also I suspect this exact symbols should be tested through ReactFlight but I'm still getting familiar with the codebase. 
