### PR TITLE
[Flight] Use lazy ID if referenced model chunk was not emitted yet

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -864,6 +864,7 @@ describe('ReactFlightDOM', () => {
     }
 
     const [Posts, resolvePostsData] = makeDelayedText();
+    const [Photos, resolvePhotosData] = makeDelayedText();
     const suspendedChunk = createSuspendedChunk(<p>loading</p>);
     const {writable, readable} = getTestStream();
     const {pipe} = ReactServerDOMServer.renderToPipeableStream(
@@ -893,8 +894,9 @@ describe('ReactFlightDOM', () => {
     const donePromise = createResolvablePromise();
 
     const value = (
-      <Suspense fallback={<p>loading posts</p>}>
+      <Suspense fallback={<p>loading posts and photos</p>}>
         <Posts />
+        <Photos />
       </Suspense>
     );
 
@@ -903,13 +905,14 @@ describe('ReactFlightDOM', () => {
       donePromise.resolve({value, done: true});
     });
 
-    expect(container.innerHTML).toBe('<p>loading posts</p>');
+    expect(container.innerHTML).toBe('<p>loading posts and photos</p>');
 
     await act(async () => {
       await resolvePostsData('posts');
+      await resolvePhotosData('photos');
     });
 
-    expect(container.innerHTML).toBe('<div>posts</div>');
+    expect(container.innerHTML).toBe('<div>posts</div><div>photos</div>');
     expect(reportedErrors).toEqual([]);
   });
 

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -891,14 +891,19 @@ describe('ReactFlightDOM', () => {
     expect(container.innerHTML).toBe('<p>loading</p>');
 
     const donePromise = createResolvablePromise();
-    const value = <Posts />;
+
+    const value = (
+      <Suspense fallback={<p>loading posts</p>}>
+        <Posts />
+      </Suspense>
+    );
 
     await act(async () => {
       suspendedChunk.resolve({value, done: false, next: donePromise.promise});
       donePromise.resolve({value, done: true});
     });
 
-    expect(container.innerHTML).toBe('<p>loading</p>');
+    expect(container.innerHTML).toBe('<p>loading posts</p>');
 
     await act(async () => {
       await resolvePostsData('posts');

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -812,6 +812,102 @@ describe('ReactFlightDOM', () => {
     expect(reportedErrors).toEqual([]);
   });
 
+  it('should handle streaming async server components', async () => {
+    const reportedErrors = [];
+
+    const Row = async ({current, next}) => {
+      const chunk = await next;
+
+      if (chunk.done) {
+        return chunk.value;
+      }
+
+      return (
+        <Suspense fallback={chunk.value}>
+          <Row current={chunk.value} next={chunk.next} />
+        </Suspense>
+      );
+    };
+
+    function createResolvablePromise() {
+      let _resolve, _reject;
+
+      const promise = new Promise((resolve, reject) => {
+        _resolve = resolve;
+        _reject = reject;
+      });
+
+      return {promise, resolve: _resolve, reject: _reject};
+    }
+
+    function createSuspendedChunk(initialValue) {
+      const {promise, resolve, reject} = createResolvablePromise();
+
+      return {
+        row: (
+          <Suspense fallback={initialValue}>
+            <Row current={initialValue} next={promise} />
+          </Suspense>
+        ),
+        resolve,
+        reject,
+      };
+    }
+
+    function makeDelayedText() {
+      const {promise, resolve, reject} = createResolvablePromise();
+      async function DelayedText() {
+        const data = await promise;
+        return <div>{data}</div>;
+      }
+      return [DelayedText, resolve, reject];
+    }
+
+    const [Posts, resolvePostsData] = makeDelayedText();
+    const suspendedChunk = createSuspendedChunk(<p>loading</p>);
+    const {writable, readable} = getTestStream();
+    const {pipe} = ReactServerDOMServer.renderToPipeableStream(
+      suspendedChunk.row,
+      webpackMap,
+      {
+        onError(error) {
+          reportedErrors.push(error);
+        },
+      },
+    );
+    pipe(writable);
+    const response = ReactServerDOMClient.createFromReadableStream(readable);
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+
+    function ClientRoot() {
+      return use(response);
+    }
+
+    await act(() => {
+      root.render(<ClientRoot />);
+    });
+
+    expect(container.innerHTML).toBe('<p>loading</p>');
+
+    const donePromise = createResolvablePromise();
+    const value = <Posts />;
+
+    await act(async () => {
+      suspendedChunk.resolve({value, done: false, next: donePromise.promise});
+      donePromise.resolve({value, done: true});
+    });
+
+    expect(container.innerHTML).toBe('<p>loading</p>');
+
+    await act(async () => {
+      await resolvePostsData('posts');
+    });
+
+    expect(container.innerHTML).toBe('<div>posts</div>');
+    expect(reportedErrors).toEqual([]);
+  });
+
   it('should preserve state of client components on refetch', async () => {
     // Client
 


### PR DESCRIPTION
## Summary

With this change, we keep track of emitted model chunk IDs. This allows us to properly decide whether to use a value ID or a lazy ID for a referenced model.

fixes #28595

## How did you test this change?

- `yarn test -r=stable packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js`
- `yarn test -r=stable --env=production packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js`
- locally with https://github.com/unstubbable/ai-rsc-test/tree/colocate-data-fetching