### PR TITLE
Fix gating for alwaysThrottleDisappearingFallbacks

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -1846,7 +1846,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await resolveText('B');
       await waitForPaint(['B']);
 
-      if (gate(flags => flags.alwaysThrottleRetries)) {
+      if (
+        // This behavior only applies if both flags are enabled.
+        gate(
+          flags =>
+            flags.alwaysThrottleDisappearingFallbacks &&
+            flags.alwaysThrottleRetries,
+        )
+      ) {
         // B should not commit yet. Even though it's been a long time since its
         // fallback was shown, it hasn't been long since A appeared. So B's
         // appearance is throttled to reduce jank.


### PR DESCRIPTION
If you turn off these flags independently:
- alwaysThrottleDisappearingFallbacks
- alwaysThrottleRetries

You'll see that this behavior only works if both flags are enabled. I updated the flags with the correct gating. 

Alternatively, we could fix the behavior: https://github.com/facebook/react/pull/28630