### PR TITLE
Fix alwaysThrottleDisappearingFallbacks

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -38,6 +38,7 @@ import {
   useModernStrictMode,
   disableLegacyContext,
   alwaysThrottleRetries,
+  alwaysThrottleDisappearingFallbacks,
   enableInfiniteRenderLoopDetection,
 } from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -1128,7 +1129,9 @@ function finishConcurrentRender(
   } else {
     if (
       includesOnlyRetries(lanes) &&
-      (alwaysThrottleRetries || exitStatus === RootSuspended)
+      (alwaysThrottleRetries ||
+        (alwaysThrottleDisappearingFallbacks && exitStatus === RootCompleted) ||
+        exitStatus === RootSuspended)
     ) {
       // This render only included retries, no updates. Throttle committing
       // retries so that we don't show too many loading states too quickly.

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -1846,7 +1846,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await resolveText('B');
       await waitForPaint(['B']);
 
-      if (gate(flags => flags.alwaysThrottleRetries)) {
+      if (
+        // This behavior only applies if both flags are enabled.
+        gate(
+          flags =>
+            flags.alwaysThrottleDisappearingFallbacks &&
+            flags.alwaysThrottleRetries,
+        )
+      ) {
         // B should not commit yet. Even though it's been a long time since its
         // fallback was shown, it hasn't been long since A appeared. So B's
         // appearance is throttled to reduce jank.

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -1757,7 +1757,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       // Restart and render the complete content.
       await waitForAll(['A', 'B']);
 
-      if (gate(flags => flags.alwaysThrottleRetries)) {
+      if (
+        gate(
+          flags =>
+            flags.alwaysThrottleDisappearingFallbacks ||
+            flags.alwaysThrottleRetries,
+        )
+      ) {
         // Correct behavior:
         //
         // The tree will finish but we won't commit the result yet because the fallback appeared recently.
@@ -1848,11 +1854,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       if (
         // This behavior only applies if both flags are enabled.
-        gate(
-          flags =>
-            flags.alwaysThrottleDisappearingFallbacks &&
-            flags.alwaysThrottleRetries,
-        )
+        gate(flags => flags.alwaysThrottleDisappearingFallbacks)
       ) {
         // B should not commit yet. Even though it's been a long time since its
         // fallback was shown, it hasn't been long since A appeared. So B's


### PR DESCRIPTION
For `alwaysThrottleDisappearingFallbacks`, we need to update the workloop to throttle when the root completes. This fixes the bug found in https://github.com/facebook/react/pull/28629.