### PR TITLE
Support suppressHydrationWarning for element-ish text

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -93,6 +93,7 @@ import {
   enableScopeAPI,
   enableTrustedTypesIntegration,
   enableAsyncActions,
+  disableElementishSuppressionCheck,
 } from 'shared/ReactFeatureFlags';
 import {
   HostComponent,
@@ -1528,13 +1529,32 @@ export function didNotMatchHydratedTextInstance(
   isConcurrentMode: boolean,
   shouldWarnDev: boolean,
 ) {
-  if (parentProps[SUPPRESS_HYDRATION_WARNING] !== true) {
-    checkForUnmatchedText(
-      textInstance.nodeValue,
-      text,
-      isConcurrentMode,
-      shouldWarnDev,
-    );
+  if (disableElementishSuppressionCheck) {
+    if (parentProps[SUPPRESS_HYDRATION_WARNING] !== true) {
+      checkForUnmatchedText(
+        textInstance.nodeValue,
+        text,
+        isConcurrentMode,
+        shouldWarnDev,
+      );
+    }
+  } else {
+    if (
+      parentProps[SUPPRESS_HYDRATION_WARNING] !== true &&
+      // TODO: remove this hack.
+      // For elementish text nodes, we need to check their prop through the parent.
+      parentProps.children &&
+      parentProps.children.length === 1 &&
+      parentProps.children.props &&
+      parentProps.children.props[SUPPRESS_HYDRATION_WARNING] !== true
+    ) {
+      checkForUnmatchedText(
+        textInstance.nodeValue,
+        text,
+        isConcurrentMode,
+        shouldWarnDev,
+      );
+    }
   }
 }
 

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -40,6 +40,8 @@ export const disableSchedulerTimeoutInWorkLoop = false;
 // those can be fixed.
 export const enableDeferRootSchedulingToMicrotask = true;
 
+export const disableElementishSuppressionCheck = true;
+
 // -----------------------------------------------------------------------------
 // Slated for removal in the future (significant effort)
 //

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -14,6 +14,7 @@ import typeof * as DynamicExportsType from './ReactFeatureFlags.native-fb-dynami
 // Re-export dynamic flags from the internal module.
 // Intentionally using * because this import is compiled to a `require` call.
 import * as dynamicFlagsUntyped from 'ReactNativeInternalFeatureFlags';
+import {disableElementishSuppressionCheck} from 'shared/ReactFeatureFlags';
 const dynamicFlags: DynamicExportsType = (dynamicFlagsUntyped: any);
 
 // We destructure each value before re-exporting to avoid a dynamic look-up on
@@ -93,7 +94,7 @@ export const disableClientCache = true;
 
 export const enableServerComponentKeys = true;
 export const enableServerComponentLogs = true;
-
+export const disableElementishSuppressionCheck = true;
 // TODO: Roll out with GK. Don't keep as dynamic flag for too long, though,
 // because JSX is an extremely hot path.
 export const enableRefAsProp = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -105,6 +105,7 @@ export const enableNewBooleanProps = true;
 export const enableTransitionTracing = false;
 export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
 export const passChildrenWhenCloningPersistedNodes = false;
+export const disableElementishSuppressionCheck = true;
 
 // Profiling Only
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -80,6 +80,7 @@ export const disableClientCache = true;
 export const enableServerComponentKeys = true;
 export const enableServerComponentLogs = true;
 export const enableInfiniteRenderLoopDetection = false;
+export const disableElementishSuppressionCheck = true;
 
 // TODO: This must be in sync with the main ReactFeatureFlags file because
 // the Test Renderer's value must be the same as the one used by the

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -90,6 +90,7 @@ export const enableReactTestRendererWarning = false;
 export const disableLegacyMode = false;
 
 export const enableBigIntSupport = false;
+export const disableElementishSuppressionCheck = true;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -92,6 +92,7 @@ export const enableReactTestRendererWarning = false;
 export const disableLegacyMode = false;
 
 export const enableBigIntSupport = true;
+export const disableElementishSuppressionCheck = true;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -33,6 +33,7 @@ export const enableRefAsProp = __VARIANT__;
 export const enableClientRenderFallbackOnTextMismatch = __VARIANT__;
 export const enableNewBooleanProps = __VARIANT__;
 export const enableRetryLaneExpiration = __VARIANT__;
+export const disableElementishSuppressionCheck = !__VARIANT__;
 export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -40,6 +40,7 @@ export const {
   enableRefAsProp,
   enableNewBooleanProps,
   enableClientRenderFallbackOnTextMismatch,
+  disableElementishSuppressionCheck,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.


### PR DESCRIPTION
This would allow setting `suppressHydrationWarning` on element-ish text nodes:

```js
const obj = {
  $$typeof: Symbol.for('react.element'),
  type: props => props.content,
  ref: null,
  key: null,
  props: {
    suppressHydrationWarning: true,
    content: isClient ? 'Client Text' : 'Server Text',
  },
  toString() {
    return this.props.content;
  },
};
```