### PR TITLE
Remove orphaned disableJavaScriptURLs reference

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -52,7 +52,6 @@ export const enableCacheElement = __NEXT_RN_MAJOR__;
 export const enableTaint = __NEXT_RN_MAJOR__;
 export const enableUnifiedSyncLane = __NEXT_RN_MAJOR__;
 export const enableFizzExternalRuntime = __NEXT_RN_MAJOR__; // DOM-only
-export const disableJavaScriptURLs = __NEXT_RN_MAJOR__; // DOM-only
 export const enableBinaryFlight = __NEXT_RN_MAJOR__; // DOM-only
 export const enableCustomElementPropertySupport = __NEXT_RN_MAJOR__; // DOM-only
 export const enableServerComponentKeys = __NEXT_RN_MAJOR__;


### PR DESCRIPTION
Was removed in https://github.com/facebook/react/pull/28615 but didn't land cleanly.

Fixes `yarn flow dom-node` on `main`:https://app.circleci.com/jobs/github/facebook/react/813807

