### PR TITLE
Remove errorHydratingContainer

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -2406,19 +2406,12 @@ describe('ReactDOMFizzServer', () => {
       },
     });
 
-    await expect(async () => {
-      // The first paint switches to client rendering due to mismatch
-      await waitForPaint([
-        'client',
-        "Log recoverable error: Hydration failed because the server rendered HTML didn't match the client.",
-        'Log recoverable error: There was an error while hydrating.',
-      ]);
-    }).toErrorDev(
-      [
-        'Warning: An error occurred during hydration. The server HTML was replaced with client content.',
-      ],
-      {withoutStack: 1},
-    );
+    // The first paint switches to client rendering due to mismatch
+    await waitForPaint([
+      'client',
+      "Log recoverable error: Hydration failed because the server rendered HTML didn't match the client.",
+      'Log recoverable error: There was an error while hydrating.',
+    ]);
     expect(getVisibleChildren(container)).toEqual(<div>client</div>);
   });
 
@@ -2486,19 +2479,12 @@ describe('ReactDOMFizzServer', () => {
     });
 
     // The first paint uses the client due to mismatch forcing client render
-    await expect(async () => {
-      // The first paint switches to client rendering due to mismatch
-      await waitForPaint([
-        'client',
-        "Log recoverable error: Hydration failed because the server rendered HTML didn't match the client.",
-        'Log recoverable error: There was an error while hydrating.',
-      ]);
-    }).toErrorDev(
-      [
-        'Warning: An error occurred during hydration. The server HTML was replaced with client content',
-      ],
-      {withoutStack: 1},
-    );
+    // The first paint switches to client rendering due to mismatch
+    await waitForPaint([
+      'client',
+      "Log recoverable error: Hydration failed because the server rendered HTML didn't match the client.",
+      'Log recoverable error: There was an error while hydrating.',
+    ]);
     expect(getVisibleChildren(container)).toEqual(<div>client</div>);
   });
 
@@ -2564,16 +2550,11 @@ describe('ReactDOMFizzServer', () => {
 
       // An error logged but instead of surfacing it to the UI, we switched
       // to client rendering.
-      await expect(async () => {
-        await waitForAll([
-          'Yay!',
-          'Hydration error',
-          'There was an error while hydrating.',
-        ]);
-      }).toErrorDev(
-        'An error occurred during hydration. The server HTML was replaced',
-        {withoutStack: true},
-      );
+      await waitForAll([
+        'Yay!',
+        'Hydration error',
+        'There was an error while hydrating.',
+      ]);
       expect(getVisibleChildren(container)).toEqual(<span>Yay!</span>);
 
       // The node that's inside the boundary that errored during hydration was
@@ -6339,9 +6320,7 @@ describe('ReactDOMFizzServer', () => {
           errors.push(error);
         },
       });
-      await expect(async () => {
-        await waitForAll([]);
-      }).toErrorDev(['An error occurred during hydration'], {withoutStack: 1});
+      await waitForAll([]);
       expect(errors.length).toEqual(2);
       expect(getVisibleChildren(container)).toEqual(<span />);
     });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzSuppressHydrationWarning-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzSuppressHydrationWarning-test.js
@@ -249,17 +249,10 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.log(normalizeError(error.message));
       },
     });
-    await expect(async () => {
-      await waitForAll([
-        "Hydration failed because the server rendered HTML didn't match the client.",
-        'There was an error while hydrating.',
-      ]);
-    }).toErrorDev(
-      [
-        'An error occurred during hydration. The server HTML was replaced with client content.',
-      ],
-      {withoutStack: 1},
-    );
+    await waitForAll([
+      "Hydration failed because the server rendered HTML didn't match the client.",
+      'There was an error while hydrating.',
+    ]);
     expect(getVisibleChildren(container)).toEqual(
       <div>
         <span>
@@ -337,17 +330,10 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.log(normalizeError(error.message));
       },
     });
-    await expect(async () => {
-      await waitForAll([
-        "Hydration failed because the server rendered HTML didn't match the client.",
-        'There was an error while hydrating.',
-      ]);
-    }).toErrorDev(
-      [
-        'An error occurred during hydration. The server HTML was replaced with client content.',
-      ],
-      {withoutStack: 1},
-    );
+    await waitForAll([
+      "Hydration failed because the server rendered HTML didn't match the client.",
+      'There was an error while hydrating.',
+    ]);
     expect(getVisibleChildren(container)).toEqual(
       <div>
         <span />
@@ -384,17 +370,10 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.log(normalizeError(error.message));
       },
     });
-    await expect(async () => {
-      await waitForAll([
-        "Hydration failed because the server rendered HTML didn't match the client.",
-        'There was an error while hydrating.',
-      ]);
-    }).toErrorDev(
-      [
-        'An error occurred during hydration. The server HTML was replaced with client content.',
-      ],
-      {withoutStack: 1},
-    );
+    await waitForAll([
+      "Hydration failed because the server rendered HTML didn't match the client.",
+      'There was an error while hydrating.',
+    ]);
     expect(getVisibleChildren(container)).toEqual(
       <div>
         <span>
@@ -434,17 +413,10 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.log(normalizeError(error.message));
       },
     });
-    await expect(async () => {
-      await waitForAll([
-        "Hydration failed because the server rendered HTML didn't match the client.",
-        'There was an error while hydrating.',
-      ]);
-    }).toErrorDev(
-      [
-        'An error occurred during hydration. The server HTML was replaced with client content.',
-      ],
-      {withoutStack: 1},
-    );
+    await waitForAll([
+      "Hydration failed because the server rendered HTML didn't match the client.",
+      'There was an error while hydrating.',
+    ]);
     expect(getVisibleChildren(container)).toEqual(
       <div>
         <span>
@@ -482,17 +454,10 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.log(normalizeError(error.message));
       },
     });
-    await expect(async () => {
-      await waitForAll([
-        "Hydration failed because the server rendered HTML didn't match the client.",
-        'There was an error while hydrating.',
-      ]);
-    }).toErrorDev(
-      [
-        'An error occurred during hydration. The server HTML was replaced with client content.',
-      ],
-      {withoutStack: 1},
-    );
+    await waitForAll([
+      "Hydration failed because the server rendered HTML didn't match the client.",
+      'There was an error while hydrating.',
+    ]);
     expect(getVisibleChildren(container)).toEqual(
       <div>
         <span>
@@ -604,17 +569,10 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.log(normalizeError(error.message));
       },
     });
-    await expect(async () => {
-      await waitForAll([
-        "Hydration failed because the server rendered HTML didn't match the client.",
-        'There was an error while hydrating.',
-      ]);
-    }).toErrorDev(
-      [
-        'An error occurred during hydration. The server HTML was replaced with client content.',
-      ],
-      {withoutStack: 1},
-    );
+    await waitForAll([
+      "Hydration failed because the server rendered HTML didn't match the client.",
+      'There was an error while hydrating.',
+    ]);
     expect(getVisibleChildren(container)).toEqual(
       <div>
         <p>Client and server</p>
@@ -649,17 +607,10 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.log(normalizeError(error.message));
       },
     });
-    await expect(async () => {
-      await waitForAll([
-        "Hydration failed because the server rendered HTML didn't match the client.",
-        'There was an error while hydrating.',
-      ]);
-    }).toErrorDev(
-      [
-        'An error occurred during hydration. The server HTML was replaced with client content.',
-      ],
-      {withoutStack: 1},
-    );
+    await waitForAll([
+      "Hydration failed because the server rendered HTML didn't match the client.",
+      'There was an error while hydrating.',
+    ]);
     expect(getVisibleChildren(container)).toEqual(
       <div>
         <p>Client and server</p>

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -6477,14 +6477,7 @@ body {
           },
         },
       );
-      await expect(async () => {
-        await waitForAll([]);
-      }).toErrorDev(
-        [
-          'Warning: An error occurred during hydration. The server HTML was replaced with client content.',
-        ],
-        {withoutStack: 1},
-      );
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -8267,14 +8260,7 @@ background-color: green;
         },
       );
 
-      await expect(async () => {
-        await waitForAll([]);
-      }).toErrorDev(
-        [
-          'Warning: An error occurred during hydration. The server HTML was replaced with client content.',
-        ],
-        {withoutStack: 1},
-      );
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>

--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -89,7 +89,6 @@ describe('ReactDOMServerHydration', () => {
       if (gate(flags => flags.favorSafetyOverHydrationPerf)) {
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
                   [
-                    "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
                     "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
                   - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -154,7 +153,6 @@ describe('ReactDOMServerHydration', () => {
       if (gate(flags => flags.favorSafetyOverHydrationPerf)) {
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -463,7 +461,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -498,7 +495,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -535,7 +531,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -573,7 +568,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -606,28 +600,27 @@ describe('ReactDOMServerHydration', () => {
         }
         if (gate(flags => flags.favorSafetyOverHydrationPerf)) {
           expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
-                      [
-                        "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
-                        "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
+            [
+              "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
-                      - A server/client branch \`if (typeof window !== 'undefined')\`.
-                      - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
-                      - Date formatting in a user's locale which doesn't match the server.
-                      - External changing data without sending a snapshot of it along with the HTML.
-                      - Invalid HTML tag nesting.
+            - A server/client branch \`if (typeof window !== 'undefined')\`.
+            - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
+            - Date formatting in a user's locale which doesn't match the server.
+            - External changing data without sending a snapshot of it along with the HTML.
+            - Invalid HTML tag nesting.
 
-                      It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.
+            It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.
 
-                      https://react.dev/link/hydration-mismatch
+            https://react.dev/link/hydration-mismatch
 
-                        <Mismatch isClient={true}>
-                          <div className="parent">
-                      +     only
-                      -     
-                      ]",
-                        "Caught [There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.]",
-                      ]
-                  `);
+              <Mismatch isClient={true}>
+                <div className="parent">
+            +     only
+            -     
+            ]",
+              "Caught [There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.]",
+            ]
+          `);
         } else {
           expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
             [
@@ -666,7 +659,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -704,7 +696,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -741,7 +732,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -780,7 +770,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -815,7 +804,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -852,7 +840,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -889,7 +876,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -920,7 +906,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -955,7 +940,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -992,7 +976,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -1029,7 +1012,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -1074,7 +1056,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -1111,7 +1092,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -1150,7 +1130,6 @@ describe('ReactDOMServerHydration', () => {
         // TODO: This message doesn't seem to have any useful details.
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -1193,7 +1172,6 @@ describe('ReactDOMServerHydration', () => {
         // rendered suspense boundaries this test will likely change again
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -1365,7 +1343,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -1405,7 +1382,6 @@ describe('ReactDOMServerHydration', () => {
         }
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
             "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -1468,7 +1444,6 @@ describe('ReactDOMServerHydration', () => {
 
       expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
         [
-          "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
           "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
         - A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -1531,7 +1506,6 @@ describe('ReactDOMServerHydration', () => {
 
       expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
         [
-          "Warning: An error occurred during hydration. The server HTML was replaced with client content.",
           "Caught [Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
 
         - A server/client branch \`if (typeof window !== 'undefined')\`.

--- a/packages/react-dom/src/__tests__/ReactDOMOption-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMOption-test.js
@@ -237,7 +237,7 @@ describe('ReactDOMOption', () => {
     expect(node.selectedIndex).toEqual(2);
   });
 
-  it('generates a warning and hydration error when an invalid nested tag is used as a child', async () => {
+  it('generates a hydration error when an invalid nested tag is used as a child', async () => {
     const ref = React.createRef();
     const children = (
       <select readOnly={true} value="bar">
@@ -266,13 +266,7 @@ describe('ReactDOMOption', () => {
           onRecoverableError: () => {},
         });
       });
-    }).toErrorDev(
-      [
-        'Warning: An error occurred during hydration. The server HTML was replaced with client content.',
-        'Warning: In HTML, <div> cannot be a child of <option>',
-      ],
-      {withoutStack: 1},
-    );
+    }).toErrorDev(['Warning: In HTML, <div> cannot be a child of <option>']);
     option = container.firstChild.firstChild;
 
     expect(option.textContent).toBe('BarFooBaz');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContextDisabled-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContextDisabled-test.internal.js
@@ -105,7 +105,7 @@ describe('ReactDOMServerIntegrationLegacyContextDisabled', () => {
           <RegularFn />
         </span>
       </LegacyProvider>,
-      render === clientRenderOnBadMarkup ? 5 : 3,
+      render === clientRenderOnBadMarkup ? 4 : 3,
     );
     expect(e.textContent).toBe('{}undefinedundefined');
     expect(lifecycleContextLog).toEqual([]);

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationSelect-test.js
@@ -254,7 +254,6 @@ describe('ReactDOMServerIntegrationSelect', () => {
           <option value="first">First</option>
           <option value="true">True</option>
         </select>,
-        1,
       );
       expect(e.firstChild.selected).toBe(false);
       expect(e.lastChild.selected).toBe(true);
@@ -269,7 +268,6 @@ describe('ReactDOMServerIntegrationSelect', () => {
           <option value="first">First</option>
           <option value="undefined">Undefined</option>
         </select>,
-        1,
       );
       expect(e.firstChild.selected).toBe(true);
       expect(e.lastChild.selected).toBe(false);

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -3782,23 +3782,15 @@ describe('ReactDOMServerPartialHydration', () => {
     document.body.appendChild(container);
     container.innerHTML = finalHTML;
 
-    await expect(async () => {
-      await act(() => {
-        ReactDOMClient.hydrateRoot(container, <App isClient={true} />, {
-          onRecoverableError(error) {
-            Scheduler.log(
-              'Log recoverable error: ' + normalizeError(error.message),
-            );
-          },
-        });
+    await act(() => {
+      ReactDOMClient.hydrateRoot(container, <App isClient={true} />, {
+        onRecoverableError(error) {
+          Scheduler.log(
+            'Log recoverable error: ' + normalizeError(error.message),
+          );
+        },
       });
-    }).toErrorDev(
-      [
-        'Warning: An error occurred during hydration. ' +
-          'The server HTML was replaced with client content.',
-      ],
-      {withoutStack: 1},
-    );
+    });
     assertLog([
       "Log recoverable error: Hydration failed because the server rendered HTML didn't match the client.",
       'Log recoverable error: There was an error while hydrating.',
@@ -3828,21 +3820,13 @@ describe('ReactDOMServerPartialHydration', () => {
     container.innerHTML = ReactDOMServer.renderToString(
       <DirectTextChild text="good" />,
     );
-    await expect(async () => {
-      await act(() => {
-        ReactDOMClient.hydrateRoot(container, <DirectTextChild text="bad" />, {
-          onRecoverableError(error) {
-            Scheduler.log(normalizeError(error.message));
-          },
-        });
+    await act(() => {
+      ReactDOMClient.hydrateRoot(container, <DirectTextChild text="bad" />, {
+        onRecoverableError(error) {
+          Scheduler.log(normalizeError(error.message));
+        },
       });
-    }).toErrorDev(
-      [
-        'An error occurred during hydration. The server HTML was replaced with ' +
-          'client content.',
-      ],
-      {withoutStack: 1},
-    );
+    });
     assertLog([
       "Hydration failed because the server rendered HTML didn't match the client.",
       'There was an error while hydrating.',
@@ -3867,25 +3851,17 @@ describe('ReactDOMServerPartialHydration', () => {
     container2.innerHTML = ReactDOMServer.renderToString(
       <TextChildWithSibling text="good" />,
     );
-    await expect(async () => {
-      await act(() => {
-        ReactDOMClient.hydrateRoot(
-          container2,
-          <TextChildWithSibling text="bad" />,
-          {
-            onRecoverableError(error) {
-              Scheduler.log(normalizeError(error.message));
-            },
+    await act(() => {
+      ReactDOMClient.hydrateRoot(
+        container2,
+        <TextChildWithSibling text="bad" />,
+        {
+          onRecoverableError(error) {
+            Scheduler.log(normalizeError(error.message));
           },
-        );
-      });
-    }).toErrorDev(
-      [
-        'An error occurred during hydration. The server HTML was replaced with ' +
-          'client content.',
-      ],
-      {withoutStack: 1},
-    );
+        },
+      );
+    });
     assertLog([
       "Hydration failed because the server rendered HTML didn't match the client.",
       'There was an error while hydrating.',

--- a/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
@@ -471,14 +471,7 @@ describe('ReactDOM HostSingleton', () => {
         },
       },
     );
-    await expect(async () => {
-      await waitForAll([]);
-    }).toErrorDev(
-      [
-        `Warning: An error occurred during hydration. The server HTML was replaced with client content.`,
-      ],
-      {withoutStack: 1},
-    );
+    await waitForAll([]);
     expect(hydrationErrors).toEqual([
       [
         "Hydration failed because the server rendered HTML didn't match the client.",

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -196,22 +196,15 @@ describe('rendering React components at document', () => {
       const container = document.createElement('div');
       container.textContent = 'potato';
 
-      expect(() => {
-        ReactDOM.flushSync(() => {
-          ReactDOMClient.hydrateRoot(container, <div>parsnip</div>, {
-            onRecoverableError: error => {
-              Scheduler.log(
-                'Log recoverable error: ' + normalizeError(error.message),
-              );
-            },
-          });
+      ReactDOM.flushSync(() => {
+        ReactDOMClient.hydrateRoot(container, <div>parsnip</div>, {
+          onRecoverableError: error => {
+            Scheduler.log(
+              'Log recoverable error: ' + normalizeError(error.message),
+            );
+          },
         });
-      }).toErrorDev(
-        [
-          'Warning: An error occurred during hydration. The server HTML was replaced with client content.',
-        ],
-        {withoutStack: 1},
-      );
+      });
 
       assertLog([
         "Log recoverable error: Hydration failed because the server rendered HTML didn't match the client.",
@@ -227,28 +220,21 @@ describe('rendering React components at document', () => {
       const wrapper = document.createElement('div');
       wrapper.textContent = 'potato';
       container.appendChild(wrapper);
-      expect(() => {
-        ReactDOM.flushSync(() => {
-          ReactDOMClient.hydrateRoot(
-            container,
-            <div>
-              <div>parsnip</div>
-            </div>,
-            {
-              onRecoverableError: error => {
-                Scheduler.log(
-                  'Log recoverable error: ' + normalizeError(error.message),
-                );
-              },
+      ReactDOM.flushSync(() => {
+        ReactDOMClient.hydrateRoot(
+          container,
+          <div>
+            <div>parsnip</div>
+          </div>,
+          {
+            onRecoverableError: error => {
+              Scheduler.log(
+                'Log recoverable error: ' + normalizeError(error.message),
+              );
             },
-          );
-        });
-      }).toErrorDev(
-        [
-          'Warning: An error occurred during hydration. The server HTML was replaced with client content.',
-        ],
-        {withoutStack: 1},
-      );
+          },
+        );
+      });
 
       assertLog([
         "Log recoverable error: Hydration failed because the server rendered HTML didn't match the client.",
@@ -295,15 +281,11 @@ describe('rendering React components at document', () => {
         });
       }).toErrorDev(
         favorSafetyOverHydrationPerf
-          ? [
-              'Warning: An error occurred during hydration. The server HTML was replaced with client content.',
-            ]
+          ? []
           : [
               "Warning: A tree hydrated but some attributes of the server rendered HTML didn't match the client properties.",
             ],
-        {
-          withoutStack: 1,
-        },
+        {withoutStack: true},
       );
 
       assertLog(
@@ -336,26 +318,19 @@ describe('rendering React components at document', () => {
       }
 
       // with float the title no longer is a hydration mismatch so we get an error on the body mismatch
-      expect(() => {
-        ReactDOM.flushSync(() => {
-          ReactDOMClient.hydrateRoot(
-            testDocument,
-            <Component text="Hello world" />,
-            {
-              onRecoverableError: error => {
-                Scheduler.log(
-                  'Log recoverable error: ' + normalizeError(error.message),
-                );
-              },
+      ReactDOM.flushSync(() => {
+        ReactDOMClient.hydrateRoot(
+          testDocument,
+          <Component text="Hello world" />,
+          {
+            onRecoverableError: error => {
+              Scheduler.log(
+                'Log recoverable error: ' + normalizeError(error.message),
+              );
             },
-          );
-        });
-      }).toErrorDev(
-        [
-          'Warning: An error occurred during hydration. The server HTML was replaced with client content.',
-        ],
-        {withoutStack: 1},
-      );
+          },
+        );
+      });
       assertLog([
         "Log recoverable error: Hydration failed because the server rendered HTML didn't match the client.",
         'Log recoverable error: There was an error while hydrating.',

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -143,13 +143,11 @@ describe('ReactDOMServerHydration', () => {
         });
       }).toErrorDev(
         favorSafetyOverHydrationPerf
-          ? [
-              'An error occurred during hydration. The server HTML was replaced with client content.',
-            ]
+          ? []
           : [
               " A tree hydrated but some attributes of the server rendered HTML didn't match the client properties.",
             ],
-        {withoutStack: 1},
+        {withoutStack: true},
       );
       expect(mountCount).toEqual(4);
       expect(element.innerHTML.length > 0).toBe(true);
@@ -238,13 +236,11 @@ describe('ReactDOMServerHydration', () => {
       });
     }).toErrorDev(
       favorSafetyOverHydrationPerf
-        ? [
-            'An error occurred during hydration. The server HTML was replaced with client content.',
-          ]
+        ? []
         : [
             "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties.",
           ],
-      {withoutStack: 1},
+      {withoutStack: true},
     );
 
     expect(onFocusBeforeHydration).not.toHaveBeenCalled();
@@ -547,13 +543,11 @@ describe('ReactDOMServerHydration', () => {
       });
     }).toErrorDev(
       favorSafetyOverHydrationPerf
-        ? [
-            'An error occurred during hydration. The server HTML was replaced with client content.',
-          ]
+        ? []
         : [
             " A tree hydrated but some attributes of the server rendered HTML didn't match the client properties.",
           ],
-      {withoutStack: 1},
+      {withoutStack: true},
     );
 
     if (favorSafetyOverHydrationPerf) {
@@ -570,22 +564,15 @@ describe('ReactDOMServerHydration', () => {
     );
     domElement.innerHTML = markup;
 
-    await expect(async () => {
-      await act(() => {
-        ReactDOMClient.hydrateRoot(
-          domElement,
-          <div dangerouslySetInnerHTML={undefined} />,
-          {onRecoverableError: error => {}},
-        );
-      });
+    await act(() => {
+      ReactDOMClient.hydrateRoot(
+        domElement,
+        <div dangerouslySetInnerHTML={undefined} />,
+        {onRecoverableError: error => {}},
+      );
+    });
 
-      expect(domElement.innerHTML).not.toEqual(markup);
-    }).toErrorDev(
-      [
-        'An error occurred during hydration. The server HTML was replaced with client content.',
-      ],
-      {withoutStack: 1},
-    );
+    expect(domElement.innerHTML).not.toEqual(markup);
   });
 
   it('should warn when hydrating read-only properties', async () => {

--- a/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
+++ b/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
@@ -101,11 +101,7 @@ module.exports = function (initModules) {
       for (let i = 0; i < console.error.mock.calls.length; i++) {
         const args = console.error.mock.calls[i];
         const [format, ...rest] = args;
-        if (
-          !shouldIgnoreConsoleError(format, rest, {
-            TODO_ignoreHydrationErrors: true,
-          })
-        ) {
+        if (!shouldIgnoreConsoleError(format, rest)) {
           filteredWarnings.push(args);
         }
       }

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -187,16 +187,6 @@ function reenterHydrationStateFromDehydratedSuspenseInstance(
   return true;
 }
 
-export function errorHydratingContainer(parentContainer: Container): void {
-  if (__DEV__) {
-    // TODO: This gets logged by onRecoverableError, too, so we should be
-    // able to remove it.
-    console.error(
-      'An error occurred during hydration. The server HTML was replaced with client content.',
-    );
-  }
-}
-
 function warnNonHydratedInstance(
   fiber: Fiber,
   rejectedCandidate: null | HydratableInstance,

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -78,10 +78,7 @@ import {
 
 import {createWorkInProgress, resetWorkInProgress} from './ReactFiber';
 import {isRootDehydrated} from './ReactFiberShellHydration';
-import {
-  getIsHydrating,
-  errorHydratingContainer,
-} from './ReactFiberHydrationContext';
+import {getIsHydrating} from './ReactFiberHydrationContext';
 import {
   NoMode,
   ProfileMode,
@@ -1017,9 +1014,6 @@ function recoverFromConcurrentError(
     // Something to consider for a future refactor.
     const rootWorkInProgress = prepareFreshStack(root, errorRetryLanes);
     rootWorkInProgress.flags |= ForceClientRender;
-    if (__DEV__) {
-      errorHydratingContainer(root.containerInfo);
-    }
   }
 
   const exitStatus = renderRootSync(root, errorRetryLanes);

--- a/scripts/jest/shouldIgnoreConsoleError.js
+++ b/scripts/jest/shouldIgnoreConsoleError.js
@@ -32,15 +32,6 @@ module.exports = function shouldIgnoreConsoleError(
         // We haven't finished migrating our tests to use createRoot.
         return true;
       }
-      if (
-        TODO_ignoreHydrationErrors &&
-        format.indexOf(
-          'An error occurred during hydration. The server HTML was replaced with client content'
-        ) !== -1
-      ) {
-        // This also gets logged by onRecoverableError, so we can ignore it.
-        return true;
-      }
     }
   } else {
     if (

--- a/scripts/jest/shouldIgnoreConsoleError.js
+++ b/scripts/jest/shouldIgnoreConsoleError.js
@@ -1,10 +1,6 @@
 'use strict';
 
-module.exports = function shouldIgnoreConsoleError(
-  format,
-  args,
-  {TODO_ignoreHydrationErrors} = {TODO_ignoreHydrationErrors: false}
-) {
+module.exports = function shouldIgnoreConsoleError(format, args) {
   if (__DEV__) {
     if (typeof format === 'string') {
       if (


### PR DESCRIPTION
I originally added this in #21021 but I didn't mention why and I don't quite remember why. Maybe because there were no other message? However at the time the recoverable errors mechanism didn't exist.

Today I believe all cases where this happens will trigger another recoverable error. Namely these two:

https://github.com/facebook/react/blob/9f33f699e4f832971dc0f2047129f832655a3b6d/packages/react-reconciler/src/ReactFiberBeginWork.js#L1442-L1446

https://github.com/facebook/react/blob/9f33f699e4f832971dc0f2047129f832655a3b6d/packages/react-reconciler/src/ReactFiberBeginWork.js#L2962-L2965

Therefore this is just an extra unnecessary log.