### PR TITLE
Revert "Remove zoom from special cases list"

### DIFF
--- a/packages/react-dom-bindings/src/shared/isUnitlessNumber.js
+++ b/packages/react-dom-bindings/src/shared/isUnitlessNumber.js
@@ -46,6 +46,7 @@ const unitlessNumbers = new Set([
   'tabSize',
   'widows',
   'zIndex',
+  'zoom',
   'fillOpacity', // SVG-related properties
   'floodOpacity',
   'stopOpacity',
@@ -60,6 +61,7 @@ const unitlessNumbers = new Set([
   'MozLineClamp',
   'msAnimationIterationCount',
   'msFlex',
+  'msZoom',
   'msFlexGrow',
   'msFlexNegative',
   'msFlexOrder',


### PR DESCRIPTION
Reverts facebook/react#26631

This got specced: https://github.com/w3c/csswg-drafts/pull/9699

I left msZoom because it seems plausible someone will still be using it for backwards compat.