### PR TITLE
Don't let error boundaries catch errors during hydration

### DIFF
--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -574,6 +574,13 @@ function throwException(
         return false;
       }
       case ClassComponent:
+        if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
+          // If we're hydrating and got here, it means that we didn't find a suspense
+          // boundary above so it's a root error. In this case we shouldn't let the
+          // error boundary capture it because it'll just try to hydrate the error state.
+          // Instead we let it bubble to the root and let the recover pass handle it.
+          break;
+        }
         // Capture and retry
         const errorInfo = value;
         const ctor = workInProgress.type;


### PR DESCRIPTION
When an error boundary catches an error during hydration it'll try to render the error state which will then try to hydrate that state, causing hydration warnings.

When an error happens inside a Suspense boundary during hydration, we instead let the boundary catch it and restart a client render from there. However, when it's in the root we instead let it fail the root and do the sync recovery pass. This didn't consider that we might hit an error boundary first so this just skips the error boundary in that case.

We should probably instead let the root do a concurrent client render in this same pass instead to unify with Suspense boundaries.