### PR TITLE
Mock modules in tests using `Module`

### DIFF
--- a/packages/react-server-dom-turbopack/src/__tests__/utils/TurbopackMock.js
+++ b/packages/react-server-dom-turbopack/src/__tests__/utils/TurbopackMock.js
@@ -55,7 +55,7 @@ exports.clientModuleError = function clientModuleError(moduleError) {
     chunks: [],
     name: '*',
   };
-  const mod = {exports: {}};
+  const mod = new Module();
   nodeCompile.call(mod, '"use client"', idx);
   return mod.exports;
 };
@@ -107,7 +107,7 @@ exports.clientExports = function clientExports(moduleExports, chunkUrl) {
       name: 's',
     };
   }
-  const mod = {exports: {}};
+  const mod = new Module();
   nodeCompile.call(mod, '"use client"', idx);
   return mod.exports;
 };
@@ -142,7 +142,8 @@ exports.serverExports = function serverExports(moduleExports) {
       name: 's',
     };
   }
-  const mod = {exports: moduleExports};
+  const mod = new Module();
+  mod.exports = moduleExports;
   nodeCompile.call(mod, '"use server"', idx);
   return mod.exports;
 };

--- a/packages/react-server-dom-webpack/src/__tests__/utils/WebpackMock.js
+++ b/packages/react-server-dom-webpack/src/__tests__/utils/WebpackMock.js
@@ -55,7 +55,7 @@ exports.clientModuleError = function clientModuleError(moduleError) {
     chunks: [],
     name: '*',
   };
-  const mod = {exports: {}};
+  const mod = new Module();
   nodeCompile.call(mod, '"use client"', idx);
   return mod.exports;
 };
@@ -111,7 +111,7 @@ exports.clientExports = function clientExports(
       name: 's',
     };
   }
-  const mod = {exports: {}};
+  const mod = new Module();
   nodeCompile.call(mod, '"use client"', idx);
   return mod.exports;
 };
@@ -146,7 +146,8 @@ exports.serverExports = function serverExports(moduleExports) {
       name: 's',
     };
   }
-  const mod = {exports: moduleExports};
+  const mod = new Module();
+  mod.exports = moduleExports;
   nodeCompile.call(mod, '"use server"', idx);
   return mod.exports;
 };


### PR DESCRIPTION
## Summary

Fixes a type validation error introduced in newer versions of Node.js when calling `Module.prototype._compile` in our unit tests. (I tried but have yet to pinpoint the precise change in Node.js that introduced this vaildation.)

The specific error that currently occurs when running unit tests with Node.js v18.16.1:

```
TypeError: The "mod" argument must be an instance of Module. Received an instance of Object

      80 |
      81 |     if (useServer) {
    > 82 |       originalCompile.apply(this, arguments);
         |                       ^
      83 |
      84 |       const moduleId: string = (url.pathToFileURL(filename).href: any);
      85 |
```

This fixes the type validation error by mocking modules using `new Module()` instead of plain objects.

## How did you test this change?

Ran the unit tests successfully:

```
$ node --version
v18.16.1

$ yarn test
```