### PR TITLE
Suppress console output in unit tests

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -1611,7 +1611,7 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should work error event on <source> element', async () => {
-      spyOnDevAndProd(console, 'log');
+      spyOnDevAndProd(console, 'log').mockImplementation(() => {});
       const container = document.createElement('div');
       const root = ReactDOMClient.createRoot(container);
       await act(() => {
@@ -1921,7 +1921,7 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should work load and error events on <image> element in SVG', async () => {
-      spyOnDevAndProd(console, 'log');
+      spyOnDevAndProd(console, 'log').mockImplementation(() => {});
       const container = document.createElement('div');
       const root = ReactDOMClient.createRoot(container);
       await act(() => {

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationInput-test.js
@@ -48,7 +48,6 @@ desc('ReactDOMServerIntegrationInput', () => {
   });
 
   itRenders('an input with a bigint value and an onChange', async render => {
-    console.log(gate(flags => flags.enableBigIntSupport));
     const e = await render(<input value={5n} onChange={() => {}} />);
     expect(e.value).toBe(
       gate(flags => flags.enableBigIntSupport) ||

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -1150,7 +1150,7 @@ describe('context legacy', () => {
 
     if (ReactFeatureFlags.consoleManagedByDevToolsDuringStrictMode) {
       it('does not disable logs for class double render', async () => {
-        spyOnDevAndProd(console, 'log');
+        spyOnDevAndProd(console, 'log').mockImplementation(() => {});
 
         let count = 0;
         class Foo extends React.Component {
@@ -1179,7 +1179,7 @@ describe('context legacy', () => {
       });
 
       it('does not disable logs for class double ctor', async () => {
-        spyOnDevAndProd(console, 'log');
+        spyOnDevAndProd(console, 'log').mockImplementation(() => {});
 
         let count = 0;
         class Foo extends React.Component {
@@ -1211,7 +1211,7 @@ describe('context legacy', () => {
       });
 
       it('does not disable logs for class double getDerivedStateFromProps', async () => {
-        spyOnDevAndProd(console, 'log');
+        spyOnDevAndProd(console, 'log').mockImplementation(() => {});
 
         let count = 0;
         class Foo extends React.Component {
@@ -1244,7 +1244,7 @@ describe('context legacy', () => {
       });
 
       it('does not disable logs for class double shouldComponentUpdate', async () => {
-        spyOnDevAndProd(console, 'log');
+        spyOnDevAndProd(console, 'log').mockImplementation(() => {});
 
         let count = 0;
         class Foo extends React.Component {
@@ -1285,7 +1285,7 @@ describe('context legacy', () => {
       });
 
       it('does not disable logs for class state updaters', async () => {
-        spyOnDevAndProd(console, 'log');
+        spyOnDevAndProd(console, 'log').mockImplementation(() => {});
 
         let inst;
         let count = 0;
@@ -1323,7 +1323,7 @@ describe('context legacy', () => {
       });
 
       it('does not disable logs for function double render', async () => {
-        spyOnDevAndProd(console, 'log');
+        spyOnDevAndProd(console, 'log').mockImplementation(() => {});
 
         let count = 0;
         function Foo() {
@@ -1350,7 +1350,7 @@ describe('context legacy', () => {
       });
     } else {
       it('disable logs for class double render', async () => {
-        spyOnDevAndProd(console, 'log');
+        spyOnDevAndProd(console, 'log').mockImplementation(() => {});
 
         let count = 0;
         class Foo extends React.Component {
@@ -1379,7 +1379,7 @@ describe('context legacy', () => {
       });
 
       it('disables logs for class double ctor', async () => {
-        spyOnDevAndProd(console, 'log');
+        spyOnDevAndProd(console, 'log').mockImplementation(() => {});
 
         let count = 0;
         class Foo extends React.Component {
@@ -1411,7 +1411,7 @@ describe('context legacy', () => {
       });
 
       it('disable logs for class double getDerivedStateFromProps', async () => {
-        spyOnDevAndProd(console, 'log');
+        spyOnDevAndProd(console, 'log').mockImplementation(() => {});
 
         let count = 0;
         class Foo extends React.Component {
@@ -1444,7 +1444,7 @@ describe('context legacy', () => {
       });
 
       it('disable logs for class double shouldComponentUpdate', async () => {
-        spyOnDevAndProd(console, 'log');
+        spyOnDevAndProd(console, 'log').mockImplementation(() => {});
 
         let count = 0;
         class Foo extends React.Component {
@@ -1484,7 +1484,7 @@ describe('context legacy', () => {
       });
 
       it('disable logs for class state updaters', async () => {
-        spyOnDevAndProd(console, 'log');
+        spyOnDevAndProd(console, 'log').mockImplementation(() => {});
 
         let inst;
         let count = 0;
@@ -1522,7 +1522,7 @@ describe('context legacy', () => {
       });
 
       it('disable logs for function double render', async () => {
-        spyOnDevAndProd(console, 'log');
+        spyOnDevAndProd(console, 'log').mockImplementation(() => {});
 
         let count = 0;
         function Foo() {


### PR DESCRIPTION
## Summary

Changes all unit tests that were spewing console output via `console.log` to no longer do so.

This will help reduce logspew and simplify parsing the reported Jest results.

## How did you test this change?

See no more logspew when running unit tests.

```
$ yarn test
```