### PR TITLE
Finish cleaning up digest from onRecoverableError

### DIFF
--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -45,7 +45,7 @@ export type CreateRootOptions = {
   ) => void,
   onRecoverableError?: (
     error: mixed,
-    errorInfo: {+digest?: ?string, +componentStack?: ?string},
+    errorInfo: {+componentStack?: ?string},
   ) => void,
 };
 
@@ -71,7 +71,7 @@ export type HydrateRootOptions = {
   ) => void,
   onRecoverableError?: (
     error: mixed,
-    errorInfo: {+digest?: ?string, +componentStack?: ?string},
+    errorInfo: {+componentStack?: ?string},
   ) => void,
   formState?: ReactFormState<any, any> | null,
 };

--- a/packages/react-reconciler/src/ReactCapturedValue.js
+++ b/packages/react-reconciler/src/ReactCapturedValue.js
@@ -17,7 +17,6 @@ export type CapturedValue<T> = {
   +value: T,
   source: Fiber | null,
   stack: string | null,
-  digest: string | null,
 };
 
 export function createCapturedValueAtFiber<T>(
@@ -43,14 +42,12 @@ export function createCapturedValueAtFiber<T>(
     value,
     source,
     stack,
-    digest: null,
   };
 }
 
 export function createCapturedValueFromError(
   value: Error,
-  digest: ?string,
-  stack: ?string,
+  stack: null | string,
 ): CapturedValue<Error> {
   if (typeof stack === 'string') {
     CapturedStacks.set(value, stack);
@@ -58,7 +55,6 @@ export function createCapturedValueFromError(
   return {
     value,
     source: null,
-    stack: stack != null ? stack : null,
-    digest: digest != null ? digest : null,
+    stack: stack,
   };
 }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -2735,7 +2735,9 @@ function updateDehydratedSuspenseComponent(
       // get an update and we'll never be able to hydrate the final content. Let's just try the
       // client side render instead.
       let digest: ?string;
-      let message, stack, componentStack;
+      let message;
+      let stack = null;
+      let componentStack = null;
       if (__DEV__) {
         ({digest, message, stack, componentStack} =
           getSuspenseInstanceFallbackErrorDetails(suspenseInstance));
@@ -2762,8 +2764,7 @@ function updateDehydratedSuspenseComponent(
         (error: any).digest = digest;
         capturedValue = createCapturedValueFromError(
           error,
-          digest,
-          componentStack,
+          componentStack === undefined ? null : componentStack,
         );
       }
       return retrySuspenseComponentWithoutHydrating(
@@ -2906,6 +2907,7 @@ function updateDehydratedSuspenseComponent(
           'There was an error while hydrating this Suspense boundary. ' +
             'Switched to client rendering.',
         ),
+        null,
       );
       return retrySuspenseComponentWithoutHydrating(
         current,

--- a/packages/react-reconciler/src/ReactFiberErrorLogger.js
+++ b/packages/react-reconciler/src/ReactFiberErrorLogger.js
@@ -94,7 +94,7 @@ export function defaultOnCaughtError(
 
 export function defaultOnRecoverableError(
   error: mixed,
-  errorInfo: {+digest?: ?string, +componentStack?: ?string},
+  errorInfo: {+componentStack?: ?string},
 ) {
   reportGlobalError(error);
 }

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -267,7 +267,7 @@ export function createContainer(
   ) => void,
   onRecoverableError: (
     error: mixed,
-    errorInfo: {+digest?: ?string, +componentStack?: ?string},
+    errorInfo: {+componentStack?: ?string},
   ) => void,
   transitionCallbacks: null | TransitionTracingCallbacks,
 ): OpaqueRoot {
@@ -313,7 +313,7 @@ export function createHydrationContainer(
   ) => void,
   onRecoverableError: (
     error: mixed,
-    errorInfo: {+digest?: ?string, +componentStack?: ?string},
+    errorInfo: {+componentStack?: ?string},
   ) => void,
   transitionCallbacks: null | TransitionTracingCallbacks,
   formState: ReactFormState<any, any> | null,

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -160,7 +160,7 @@ export function createFiberRoot(
   ) => void,
   onRecoverableError: (
     error: mixed,
-    errorInfo: {+digest?: ?string, +componentStack?: ?string},
+    errorInfo: {+componentStack?: ?string},
   ) => void,
   transitionCallbacks: null | TransitionTracingCallbacks,
   formState: ReactFormState<any, any> | null,

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -3128,37 +3128,21 @@ function commitRootImpl(
 }
 
 function makeErrorInfo(componentStack: ?string) {
+  const errorInfo = {
+    componentStack,
+  };
   if (__DEV__) {
-    const errorInfo = {
-      componentStack,
-    };
-    return new Proxy(errorInfo, {
-      get(target, prop, receiver) {
-        if (prop === 'digest') {
-          console.error(
-            'You are accessing "digest" from the errorInfo object passed to onRecoverableError.' +
-              ' This property is no longer provided as part of errorInfo but can be accessed as a property' +
-              ' of the Error instance itself.',
-          );
-        }
-        return Reflect.get(target, prop, receiver);
-      },
-      has(target, prop) {
-        if (prop === 'digest') {
-          console.error(
-            'You are accessing "digest" from the errorInfo object passed to onRecoverableError.' +
-              ' This property is no longer provided as part of errorInfo but can be accessed as a property' +
-              ' of the Error instance itself.',
-          );
-        }
-        return Reflect.has(target, prop);
+    Object.defineProperty((errorInfo: any), 'digest', {
+      get() {
+        console.error(
+          'You are accessing "digest" from the errorInfo object passed to onRecoverableError.' +
+            ' This property is no longer provided as part of errorInfo but can be accessed as a property' +
+            ' of the Error instance itself.',
+        );
       },
     });
-  } else {
-    return {
-      componentStack,
-    };
   }
+  return errorInfo;
 }
 
 function releaseRootPooledCache(root: FiberRoot, remainingLanes: Lanes) {

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -273,7 +273,7 @@ type BaseFiberRootProperties = {
   ) => void,
   onRecoverableError: (
     error: mixed,
-    errorInfo: {+digest?: ?string, +componentStack?: ?string},
+    errorInfo: {+componentStack?: ?string},
   ) => void,
 
   formState: ReactFormState<any, any> | null,


### PR DESCRIPTION
Don't need to track it separately on the captured value anymore.

Shouldn't be in the types.

I used a getter for the warning instead because Proxies are kind of heavy weight options for this kind of warning. We typically use getters.

