### PR TITLE
Correct types for functions stored in useState

### DIFF
--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -13,6 +13,7 @@ import type {
   StartTransitionOptions,
   Usable,
   Awaited,
+  NotFunction,
 } from 'shared/ReactTypes';
 import {REACT_CONSUMER_TYPE} from 'shared/ReactSymbols';
 
@@ -20,7 +21,7 @@ import ReactCurrentDispatcher from './ReactCurrentDispatcher';
 import ReactCurrentCache from './ReactCurrentCache';
 import {enableAsyncActions} from 'shared/ReactFeatureFlags';
 
-type BasicStateAction<S> = (S => S) | S;
+type BasicStateAction<S> = (S => S) | NotFunction<S>;
 type Dispatch<A> = A => void;
 
 function resolveDispatcher() {
@@ -86,7 +87,7 @@ export function useContext<T>(Context: ReactContext<T>): T {
 }
 
 export function useState<S>(
-  initialState: (() => S) | S,
+  initialState: (() => S) | NotFunction<S>,
 ): [S, Dispatch<BasicStateAction<S>>] {
   const dispatcher = resolveDispatcher();
   return dispatcher.useState(initialState);

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -178,6 +178,8 @@ export type Awaited<T> = T extends null | void
     : T // argument was not an object
   : T; // non-thenable
 
+export type NotFunction<V> = Extract<V, Function> extends never ? V : never;
+
 export type ReactComponentInfo = {
   +name?: string,
   +env?: string,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Using a function initialiser to a `useState` hook which was typed to take a function as state could result in the value not being typed as optional where in reality it is.

Example:
```ts
// No TS error despite this not being correct. Should error with `void is not assignable to ()=>void`
// instead `value` is typed as `()=>void` but actually has the value `undefined`.
const [value, setValue] = useState<()=>void>(() => {}); 
```

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

I used the following to validate that my type `NotFunction` detects all function types (both objects with call signatures and `Function` instances) correctly: [typescript playground link](https://www.typescriptlang.org/play?#code/MYewdgzgLgBAZgRhgXhmApgdxgMQK5jBQCW4AFAOQBO6UeVYFAlANwBQcBRpY8ATGSYwA3gF82oSLDgBmFDEEoAfCPFsoATwAO6GFHTQkqTTpBx4Cddt37ofeSfRn+VnXoNQ5x689ltXugBuAIYANgA8ACoqqACiAB5QVMFEUQA0uFwk4CroiehgACYQaOiB6FQwAPzwYRC6AFx6VHjo7BLg0DDBCAhNIRG2UAgxza3sAPQTMAACUBAAtHk6REtUVCBUHVLdCHz9YeFDI-JwdW3bXcF8fTADRx58o0njbFOz80vxK1BrG1uSK58fZ3Q5DJ6nc7sQGwYIyW73IYyZ4tC7vOaLZboVYVf6XWEyEGIjzIyGhertGEwABGvQOEWgVGIYAA5qMzuS0dMMV8fn9NviaXt6eFGcy2Q5UdDOrBqTcRWJ2VC3tzPlicesBVS5UTDorJa9tfCRYEQMRCkrOZNVZjvtjfritTKaYSTWaLQaLoLgHTQQykuKYAAfTKEbJgFGvdFqu0avFUn26-1M1nB0PcHJkine+V+8JiNP4MM8SNcj62vmOgHO4DAhWiQtZEtZi4J41503mxvFzPGKUq8u8+386s7YCujvu7sZiMtlhAA)

I validated that the erroneous type assignment is fixed by my changes in [this ts playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAkgZgOQPbAGIFcB2BjYBLJTAHgDUA+KAXigFEAPYAJwENdSAaKDHfQiiBhEwATAM5RMEAG4RGUAPxQSUAFwTpsgNwAobaEhQAQs1F5sAZWDNgEAIK4CxcxWoAKV6LXmAlFQo+oAB9YRBRuB0IiZx19aAARPFEwa2wACyJbFyhXZjVbX0oKKSQ8YR1tOCwIzCh0UQhLawgosldtKCg8TDx8ZgAbRps1dwL-X2D4ZDQq3icydm1vNQBtc04EpJT041MLKxt7WZayAF0oAG92jqhGCGB0RhrzgF8oEzfMEB1n3WxCUWAUGWUn6AEYztQ6g19s1XKMoMVSq04X4Ls9vJogA).
<img width="754" alt="Screenshot 2024-03-31 at 0 32 44" src="https://github.com/facebook/react/assets/41711263/14eebdfb-acf6-4f42-96d9-86f05a94cbdd">

