### PR TITLE
Cleanup enableUseRefAccessWarning flag

### DIFF
--- a/packages/react-reconciler/src/__tests__/useRef-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/useRef-test.internal.js
@@ -160,24 +160,6 @@ describe('useRef', () => {
       });
     });
 
-    // @gate enableUseRefAccessWarning
-    it('should warn about reads during render', async () => {
-      function Example() {
-        const ref = useRef(123);
-        let value;
-        expect(() => {
-          value = ref.current;
-        }).toWarnDev([
-          'Example: Unsafe read of a mutable value during render.',
-        ]);
-        return value;
-      }
-
-      await act(() => {
-        ReactNoop.render(<Example />);
-      });
-    });
-
     it('should not warn about lazy init during render', async () => {
       function Example() {
         const ref1 = useRef(null);
@@ -213,113 +195,6 @@ describe('useRef', () => {
           ref2.current = 123;
           setDidMount(true);
         }, []);
-        return null;
-      }
-
-      await act(() => {
-        ReactNoop.render(<Example />);
-      });
-    });
-
-    // @gate enableUseRefAccessWarning
-    it('should warn about unconditional lazy init during render', async () => {
-      function Example() {
-        const ref1 = useRef(null);
-        const ref2 = useRef(undefined);
-
-        if (shouldExpectWarning) {
-          expect(() => {
-            ref1.current = 123;
-          }).toWarnDev([
-            'Example: Unsafe write of a mutable value during render',
-          ]);
-          expect(() => {
-            ref2.current = 123;
-          }).toWarnDev([
-            'Example: Unsafe write of a mutable value during render',
-          ]);
-        } else {
-          ref1.current = 123;
-          ref1.current = 123;
-        }
-
-        // But only warn once
-        ref1.current = 345;
-        ref1.current = 345;
-
-        return null;
-      }
-
-      let shouldExpectWarning = true;
-      await act(() => {
-        ReactNoop.render(<Example />);
-      });
-
-      // Should not warn again on update.
-      shouldExpectWarning = false;
-      await act(() => {
-        ReactNoop.render(<Example />);
-      });
-    });
-
-    // @gate enableUseRefAccessWarning
-    it('should warn about reads to ref after lazy init pattern', async () => {
-      function Example() {
-        const ref1 = useRef(null);
-        const ref2 = useRef(undefined);
-
-        // Read 1: safe because lazy init:
-        if (ref1.current === null) {
-          ref1.current = 123;
-        }
-        if (ref2.current === undefined) {
-          ref2.current = 123;
-        }
-
-        let value;
-        expect(() => {
-          value = ref1.current;
-        }).toWarnDev(['Example: Unsafe read of a mutable value during render']);
-        expect(() => {
-          value = ref2.current;
-        }).toWarnDev(['Example: Unsafe read of a mutable value during render']);
-
-        // But it should only warn once.
-        value = ref1.current;
-        value = ref2.current;
-
-        return value;
-      }
-
-      await act(() => {
-        ReactNoop.render(<Example />);
-      });
-    });
-
-    // @gate enableUseRefAccessWarning
-    it('should warn about writes to ref after lazy init pattern', async () => {
-      function Example() {
-        const ref1 = useRef(null);
-        const ref2 = useRef(undefined);
-        // Read: safe because lazy init:
-        if (ref1.current === null) {
-          ref1.current = 123;
-        }
-        if (ref2.current === undefined) {
-          ref2.current = 123;
-        }
-
-        expect(() => {
-          ref1.current = 456;
-        }).toWarnDev([
-          'Example: Unsafe write of a mutable value during render',
-        ]);
-        expect(() => {
-          ref2.current = 456;
-        }).toWarnDev([
-          'Example: Unsafe write of a mutable value during render',
-        ]);
-
         return null;
       }
 

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -195,8 +195,6 @@ export const enableRenderableContext = true;
 // when we plan to enable them.
 // -----------------------------------------------------------------------------
 
-export const enableUseRefAccessWarning = false;
-
 // Enables time slicing for updates that aren't wrapped in startTransition.
 export const forceConcurrentByDefaultForTesting = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -25,6 +25,5 @@ export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const enableInfiniteRenderLoopDetection = __VARIANT__;
 export const enableRenderableContext = __VARIANT__;
 export const enableUnifiedSyncLane = __VARIANT__;
-export const enableUseRefAccessWarning = __VARIANT__;
 export const passChildrenWhenCloningPersistedNodes = __VARIANT__;
 export const useModernStrictMode = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -27,7 +27,6 @@ export const {
   enableInfiniteRenderLoopDetection,
   enableRenderableContext,
   enableUnifiedSyncLane,
-  enableUseRefAccessWarning,
   passChildrenWhenCloningPersistedNodes,
   useModernStrictMode,
 } = dynamicFlags;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -91,7 +91,6 @@ export const enableRetryLaneExpiration = false;
 export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;
-export const enableUseRefAccessWarning = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
 export const enableLegacyHidden = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -48,8 +48,6 @@ export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;
 
-export const enableUseRefAccessWarning = false;
-
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
 export const enableLegacyHidden = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -43,7 +43,6 @@ export const enableCPUSuspense = true;
 export const enableUseMemoCacheHook = true;
 export const enableUseEffectEventHook = false;
 export const favorSafetyOverHydrationPerf = true;
-export const enableUseRefAccessWarning = false;
 export const enableInfiniteRenderLoopDetection = false;
 export const enableRenderableContext = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -50,8 +50,6 @@ export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;
 
-export const enableUseRefAccessWarning = false;
-
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
 export const enableLegacyHidden = false;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -14,7 +14,6 @@
 // with the __VARIANT__ set to `true`, and once set to `false`.
 
 export const disableIEWorkarounds = __VARIANT__;
-export const enableUseRefAccessWarning = __VARIANT__;
 export const disableSchedulerTimeoutInWorkLoop = __VARIANT__;
 export const enableLazyContextPropagation = __VARIANT__;
 export const forceConcurrentByDefaultForTesting = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -18,7 +18,6 @@ export const {
   disableIEWorkarounds,
   enableTrustedTypesIntegration,
   enableDebugTracing,
-  enableUseRefAccessWarning,
   enableLazyContextPropagation,
   enableUnifiedSyncLane,
   enableRetryLaneExpiration,

--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreNative-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreNative-test.js
@@ -124,7 +124,6 @@ describe('useSyncExternalStore (userspace shim, server rendering)', () => {
     expect(root).toMatchRenderedOutput('client');
   });
 
-  // @gate !(enableUseRefAccessWarning && __DEV__)
   test('Using isEqual to bailout', async () => {
     const store = createExternalStore({a: 0, b: 0});
 

--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
@@ -14,7 +14,6 @@ let useSyncExternalStoreWithSelector;
 let React;
 let ReactDOM;
 let ReactDOMClient;
-let ReactFeatureFlags;
 let Scheduler;
 let act;
 let useState;
@@ -54,7 +53,6 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMClient = require('react-dom/client');
-    ReactFeatureFlags = require('shared/ReactFeatureFlags');
     Scheduler = require('scheduler');
     useState = React.useState;
     useEffect = React.useEffect;
@@ -673,8 +671,6 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
   });
 
   describe('extra features implemented in user-space', () => {
-    // The selector implementation uses the lazy ref initialization pattern
-    // @gate !(enableUseRefAccessWarning && __DEV__)
     it('memoized selectors are only called once per update', async () => {
       const store = createExternalStore({a: 0, b: 0});
 
@@ -716,8 +712,6 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
       expect(container.textContent).toEqual('A1');
     });
 
-    // The selector implementation uses the lazy ref initialization pattern
-    // @gate !(enableUseRefAccessWarning && __DEV__)
     it('Using isEqual to bailout', async () => {
       const store = createExternalStore({a: 0, b: 0});
 
@@ -857,8 +851,6 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
     expect(container.textContent).toEqual('UPDATED');
   });
 
-  // The selector implementation uses the lazy ref initialization pattern
-  // @gate !(enableUseRefAccessWarning && __DEV__)
   it('compares selection to rendered selection even if selector changes', async () => {
     const store = createExternalStore({items: ['A', 'B']});
 
@@ -981,26 +973,14 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
       if (__DEV__ && gate(flags => flags.enableUseSyncExternalStoreShim)) {
         // In 17, the error is re-thrown in DEV.
         await expect(async () => {
-          await expect(async () => {
-            await act(() => {
-              store.set({});
-            });
-          }).rejects.toThrow('Malformed state');
-        }).toWarnDev(
-          ReactFeatureFlags.enableUseRefAccessWarning
-            ? ['Warning: App: Unsafe read of a mutable value during render.']
-            : [],
-        );
-      } else {
-        await expect(async () => {
           await act(() => {
             store.set({});
           });
-        }).toWarnDev(
-          ReactFeatureFlags.enableUseRefAccessWarning
-            ? ['Warning: App: Unsafe read of a mutable value during render.']
-            : [],
-        );
+        }).rejects.toThrow('Malformed state');
+      } else {
+        await act(() => {
+          store.set({});
+        });
       }
 
       expect(container.textContent).toEqual('Malformed state');
@@ -1042,26 +1022,14 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
       if (__DEV__ && gate(flags => flags.enableUseSyncExternalStoreShim)) {
         // In 17, the error is re-thrown in DEV.
         await expect(async () => {
-          await expect(async () => {
-            await act(() => {
-              store.set({});
-            });
-          }).rejects.toThrow('Malformed state');
-        }).toWarnDev(
-          ReactFeatureFlags.enableUseRefAccessWarning
-            ? ['Warning: App: Unsafe read of a mutable value during render.']
-            : [],
-        );
-      } else {
-        await expect(async () => {
           await act(() => {
             store.set({});
           });
-        }).toWarnDev(
-          ReactFeatureFlags.enableUseRefAccessWarning
-            ? ['Warning: App: Unsafe read of a mutable value during render.']
-            : [],
-        );
+        }).rejects.toThrow('Malformed state');
+      } else {
+        await act(() => {
+          store.set({});
+        });
       }
 
       expect(container.textContent).toEqual('Malformed state');


### PR DESCRIPTION
Cleanup enableUseRefAccessWarning flag

I don't think this flag has a path forward in the current implementation. The detection by stack trace is too brittle to detect the lazy initialization pattern reliably (see e.g. some internal tests that expect the warning because they use lazy intialization, but a slightly different pattern then the expected pattern.

I think a new version of this could be to fully ban ref access during render with an alternative API for the exceptional cases that today require ref access during render.
