### PR TITLE
[be] Remove unused, experimental getCacheSignal API

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCache.js
+++ b/packages/react-reconciler/src/ReactFiberCache.js
@@ -14,14 +14,6 @@ import {enableCache} from 'shared/ReactFeatureFlags';
 import {readContext} from './ReactFiberNewContext';
 import {CacheContext} from './ReactFiberCacheComponent';
 
-function getCacheSignal(): AbortSignal {
-  if (!enableCache) {
-    throw new Error('Not implemented.');
-  }
-  const cache: Cache = readContext(CacheContext);
-  return cache.controller.signal;
-}
-
 function getCacheForType<T>(resourceType: () => T): T {
   if (!enableCache) {
     throw new Error('Not implemented.');
@@ -36,6 +28,5 @@ function getCacheForType<T>(resourceType: () => T): T {
 }
 
 export const DefaultCacheDispatcher: CacheDispatcher = {
-  getCacheSignal,
   getCacheForType,
 };

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -434,6 +434,5 @@ export type Dispatcher = {
 };
 
 export type CacheDispatcher = {
-  getCacheSignal: () => AbortSignal,
   getCacheForType: <T>(resourceType: () => T) => T,
 };

--- a/packages/react-server/src/ReactFizzCache.js
+++ b/packages/react-server/src/ReactFizzCache.js
@@ -9,15 +9,10 @@
 
 import type {CacheDispatcher} from 'react-reconciler/src/ReactInternalTypes';
 
-function getCacheSignal(): AbortSignal {
-  throw new Error('Not implemented.');
-}
-
 function getCacheForType<T>(resourceType: () => T): T {
   throw new Error('Not implemented.');
 }
 
 export const DefaultCacheDispatcher: CacheDispatcher = {
-  getCacheSignal,
   getCacheForType,
 };

--- a/packages/react-server/src/flight/ReactFlightServerCache.js
+++ b/packages/react-server/src/flight/ReactFlightServerCache.js
@@ -11,10 +11,6 @@ import type {CacheDispatcher} from 'react-reconciler/src/ReactInternalTypes';
 
 import {resolveRequest, getCache} from '../ReactFlightServer';
 
-function createSignal(): AbortSignal {
-  return new AbortController().signal;
-}
-
 function resolveCache(): Map<Function, mixed> {
   const request = resolveRequest();
   if (request) {
@@ -24,15 +20,6 @@ function resolveCache(): Map<Function, mixed> {
 }
 
 export const DefaultCacheDispatcher: CacheDispatcher = {
-  getCacheSignal(): AbortSignal {
-    const cache = resolveCache();
-    let entry: AbortSignal | void = (cache.get(createSignal): any);
-    if (entry === undefined) {
-      entry = createSignal();
-      cache.set(createSignal, entry);
-    }
-    return entry;
-  },
   getCacheForType<T>(resourceType: () => T): T {
     const cache = resolveCache();
     let entry: T | void = (cache.get(resourceType): any);

--- a/packages/react-suspense-test-utils/src/ReactSuspenseTestUtils.js
+++ b/packages/react-suspense-test-utils/src/ReactSuspenseTestUtils.js
@@ -12,14 +12,9 @@ import ReactSharedInternals from 'shared/ReactSharedInternals';
 
 const ReactCurrentCache = ReactSharedInternals.ReactCurrentCache;
 
-function unsupported() {
-  throw new Error('This feature is not supported by ReactSuspenseTestUtils.');
-}
-
 export function waitForSuspense<T>(fn: () => T): Promise<T> {
   const cache: Map<Function, mixed> = new Map();
   const testDispatcher: CacheDispatcher = {
-    getCacheSignal: unsupported,
     getCacheForType<R>(resourceType: () => R): R {
       let entry: R | void = (cache.get(resourceType): any);
       if (entry === undefined) {

--- a/packages/react/index.classic.fb.js
+++ b/packages/react/index.classic.fb.js
@@ -34,7 +34,6 @@ export {
   unstable_LegacyHidden,
   unstable_Scope,
   unstable_SuspenseList,
-  unstable_getCacheSignal,
   unstable_getCacheForType,
   unstable_useCacheRefresh,
   unstable_useMemoCache,

--- a/packages/react/index.experimental.js
+++ b/packages/react/index.experimental.js
@@ -31,7 +31,6 @@ export {
   unstable_DebugTracingMode,
   unstable_Activity,
   unstable_postpone,
-  unstable_getCacheSignal,
   unstable_getCacheForType,
   unstable_SuspenseList,
   unstable_useCacheRefresh,

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -55,6 +55,7 @@ export {
   unstable_Scope,
   unstable_SuspenseList,
   unstable_TracingMarker,
+  unstable_getCacheForType,
   unstable_useCacheRefresh,
   unstable_useMemoCache,
   useId,

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -55,8 +55,6 @@ export {
   unstable_Scope,
   unstable_SuspenseList,
   unstable_TracingMarker,
-  unstable_getCacheSignal,
-  unstable_getCacheForType,
   unstable_useCacheRefresh,
   unstable_useMemoCache,
   useId,

--- a/packages/react/index.modern.fb.js
+++ b/packages/react/index.modern.fb.js
@@ -33,7 +33,6 @@ export {
   unstable_Activity,
   unstable_Scope,
   unstable_SuspenseList,
-  unstable_getCacheSignal,
   unstable_getCacheForType,
   unstable_useCacheRefresh,
   unstable_useMemoCache,

--- a/packages/react/src/ReactClient.js
+++ b/packages/react/src/ReactClient.js
@@ -36,7 +36,6 @@ import {memo} from './ReactMemo';
 import {cache} from './ReactCacheClient';
 import {postpone} from './ReactPostpone';
 import {
-  getCacheSignal,
   getCacheForType,
   useCallback,
   useContext,
@@ -115,7 +114,6 @@ export {
   REACT_SUSPENSE_LIST_TYPE as unstable_SuspenseList,
   REACT_LEGACY_HIDDEN_TYPE as unstable_LegacyHidden,
   REACT_OFFSCREEN_TYPE as unstable_Activity,
-  getCacheSignal as unstable_getCacheSignal,
   getCacheForType as unstable_getCacheForType,
   useCacheRefresh as unstable_useCacheRefresh,
   use,

--- a/packages/react/src/ReactFetch.js
+++ b/packages/react/src/ReactFetch.js
@@ -51,12 +51,8 @@ if (enableCache && enableFetchInstrumentation) {
         // We're outside a cached scope.
         return originalFetch(resource, options);
       }
-      if (
-        options &&
-        options.signal &&
-        options.signal !== dispatcher.getCacheSignal()
-      ) {
-        // If we're passed a signal that is not ours, then we assume that
+      if (options && options.signal) {
+        // If we're passed a signal, then we assume that
         // someone else controls the lifetime of this object and opts out of
         // caching. It's effectively the opt-out mechanism.
         // Ideally we should be able to check this on the Request but

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -43,26 +43,6 @@ function resolveDispatcher() {
   return ((dispatcher: any): Dispatcher);
 }
 
-export function getCacheSignal(): AbortSignal {
-  const dispatcher = ReactCurrentCache.current;
-  if (!dispatcher) {
-    // If we have no cache to associate with this call, then we don't know
-    // its lifetime. We abort early since that's safer than letting it live
-    // for ever. Unlike just caching which can be a functional noop outside
-    // of React, these should generally always be associated with some React
-    // render but we're not limiting quite as much as making it a Hook.
-    // It's safer than erroring early at runtime.
-    const controller = new AbortController();
-    const reason = new Error(
-      'This CacheSignal was requested outside React which means that it is ' +
-        'immediately aborted.',
-    );
-    controller.abort(reason);
-    return controller.signal;
-  }
-  return dispatcher.getCacheSignal();
-}
-
 export function getCacheForType<T>(resourceType: () => T): T {
   const dispatcher = ReactCurrentCache.current;
   if (!dispatcher) {

--- a/packages/react/src/ReactServer.experimental.js
+++ b/packages/react/src/ReactServer.experimental.js
@@ -35,7 +35,6 @@ import {
   useDebugValue,
   useMemo,
   useActionState,
-  getCacheSignal,
   getCacheForType,
 } from './ReactHooks';
 import {forwardRef} from './ReactForwardRef';
@@ -78,7 +77,6 @@ export {
   startTransition,
   REACT_DEBUG_TRACING_MODE_TYPE as unstable_DebugTracingMode,
   REACT_SUSPENSE_TYPE as unstable_SuspenseList,
-  getCacheSignal as unstable_getCacheSignal,
   getCacheForType as unstable_getCacheForType,
   postpone as unstable_postpone,
   useId,


### PR DESCRIPTION
Similar to #28698, this removes the `unstable_getCacheSignal()` API since we don't intend to ship this to stable.