### PR TITLE
[tests] Disallow unasserted console.log

### DIFF
--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -35,6 +35,9 @@ describe('ReactStrictMode', () => {
   });
 
   it('should appear in the client component stack', async () => {
+    // TODO REMOVE AFTER TESTING THIS FAILS ON PR
+    console.log('hit');
+
     function Foo() {
       return <div ariaTypo="" />;
     }

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -35,9 +35,6 @@ describe('ReactStrictMode', () => {
   });
 
   it('should appear in the client component stack', async () => {
-    // TODO REMOVE AFTER TESTING THIS FAILS ON PR
-    console.log('hit');
-
     function Foo() {
       return <div ariaTypo="" />;
     }

--- a/scripts/jest/matchers/__tests__/toWarnDev-test.js
+++ b/scripts/jest/matchers/__tests__/toWarnDev-test.js
@@ -416,3 +416,20 @@ describe('toWarnDev', () => {
     });
   }
 });
+
+describe('toLogDev', () => {
+  it('does not fail if warnings do not include a stack', () => {
+    expect(() => {
+      if (__DEV__) {
+        console.log('Hello');
+      }
+    }).toLogDev('Hello');
+    expect(() => {
+      if (__DEV__) {
+        console.log('Hello');
+        console.log('Good day');
+        console.log('Bye');
+      }
+    }).toLogDev(['Hello', 'Good day', 'Bye']);
+  });
+});

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -181,53 +181,51 @@ const createMatcherFor = (consoleMethod, matcherName) =>
         if (consoleMethod === 'log') {
           // We don't expect any console.log calls to have a stack.
         } else if (typeof withoutStack === 'number') {
-          if (typeof withoutStack === 'number') {
-            // We're expecting a particular number of warnings without stacks.
-            if (withoutStack !== warningsWithoutComponentStack.length) {
-              return {
-                message: () =>
-                  `Expected ${withoutStack} warnings without a component stack but received ${warningsWithoutComponentStack.length}:\n` +
-                  warningsWithoutComponentStack.map(warning =>
-                    this.utils.printReceived(warning)
-                  ),
-                pass: false,
-              };
-            }
-          } else if (withoutStack === true) {
-            // We're expecting that all warnings won't have the stack.
-            // If some warnings have it, it's an error.
-            if (warningsWithComponentStack.length > 0) {
-              return {
-                message: () =>
-                  `Received warning unexpectedly includes a component stack:\n  ${this.utils.printReceived(
-                    warningsWithComponentStack[0]
-                  )}\nIf this warning intentionally includes the component stack, remove ` +
-                  `{withoutStack: true} from the ${matcherName}() call. If you have a mix of ` +
-                  `warnings with and without stack in one ${matcherName}() call, pass ` +
-                  `{withoutStack: N} where N is the number of warnings without stacks.`,
-                pass: false,
-              };
-            }
-          } else if (withoutStack === false || withoutStack === undefined) {
-            // We're expecting that all warnings *do* have the stack (default).
-            // If some warnings don't have it, it's an error.
-            if (warningsWithoutComponentStack.length > 0) {
-              return {
-                message: () =>
-                  `Received warning unexpectedly does not include a component stack:\n  ${this.utils.printReceived(
-                    warningsWithoutComponentStack[0]
-                  )}\nIf this warning intentionally omits the component stack, add ` +
-                  `{withoutStack: true} to the ${matcherName} call.`,
-                pass: false,
-              };
-            }
-          } else {
-            throw Error(
-              `The second argument for ${matcherName}(), when specified, must be an object. It may have a ` +
-                `property called "withoutStack" whose value may be undefined, boolean, or a number. ` +
-                `Instead received ${typeof withoutStack}.`
-            );
+          // We're expecting a particular number of warnings without stacks.
+          if (withoutStack !== warningsWithoutComponentStack.length) {
+            return {
+              message: () =>
+                `Expected ${withoutStack} warnings without a component stack but received ${warningsWithoutComponentStack.length}:\n` +
+                warningsWithoutComponentStack.map(warning =>
+                  this.utils.printReceived(warning)
+                ),
+              pass: false,
+            };
           }
+        } else if (withoutStack === true) {
+          // We're expecting that all warnings won't have the stack.
+          // If some warnings have it, it's an error.
+          if (warningsWithComponentStack.length > 0) {
+            return {
+              message: () =>
+                `Received warning unexpectedly includes a component stack:\n  ${this.utils.printReceived(
+                  warningsWithComponentStack[0]
+                )}\nIf this warning intentionally includes the component stack, remove ` +
+                `{withoutStack: true} from the ${matcherName}() call. If you have a mix of ` +
+                `warnings with and without stack in one ${matcherName}() call, pass ` +
+                `{withoutStack: N} where N is the number of warnings without stacks.`,
+              pass: false,
+            };
+          }
+        } else if (withoutStack === false || withoutStack === undefined) {
+          // We're expecting that all warnings *do* have the stack (default).
+          // If some warnings don't have it, it's an error.
+          if (warningsWithoutComponentStack.length > 0) {
+            return {
+              message: () =>
+                `Received warning unexpectedly does not include a component stack:\n  ${this.utils.printReceived(
+                  warningsWithoutComponentStack[0]
+                )}\nIf this warning intentionally omits the component stack, add ` +
+                `{withoutStack: true} to the ${matcherName} call.`,
+              pass: false,
+            };
+          }
+        } else {
+          throw Error(
+            `The second argument for ${matcherName}(), when specified, must be an object. It may have a ` +
+              `property called "withoutStack" whose value may be undefined, boolean, or a number. ` +
+              `Instead received ${typeof withoutStack}.`
+          );
         }
 
         if (lastWarningWithMismatchingFormat !== null) {

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -178,52 +178,56 @@ const createMatcherFor = (consoleMethod, matcherName) =>
           };
         }
 
-        if (typeof withoutStack === 'number') {
-          // We're expecting a particular number of warnings without stacks.
-          if (withoutStack !== warningsWithoutComponentStack.length) {
-            return {
-              message: () =>
-                `Expected ${withoutStack} warnings without a component stack but received ${warningsWithoutComponentStack.length}:\n` +
-                warningsWithoutComponentStack.map(warning =>
-                  this.utils.printReceived(warning)
-                ),
-              pass: false,
-            };
+        if (consoleMethod === 'log') {
+          // We don't expect any console.log calls to have a stack.
+        } else if (typeof withoutStack === 'number') {
+          if (typeof withoutStack === 'number') {
+            // We're expecting a particular number of warnings without stacks.
+            if (withoutStack !== warningsWithoutComponentStack.length) {
+              return {
+                message: () =>
+                  `Expected ${withoutStack} warnings without a component stack but received ${warningsWithoutComponentStack.length}:\n` +
+                  warningsWithoutComponentStack.map(warning =>
+                    this.utils.printReceived(warning)
+                  ),
+                pass: false,
+              };
+            }
+          } else if (withoutStack === true) {
+            // We're expecting that all warnings won't have the stack.
+            // If some warnings have it, it's an error.
+            if (warningsWithComponentStack.length > 0) {
+              return {
+                message: () =>
+                  `Received warning unexpectedly includes a component stack:\n  ${this.utils.printReceived(
+                    warningsWithComponentStack[0]
+                  )}\nIf this warning intentionally includes the component stack, remove ` +
+                  `{withoutStack: true} from the ${matcherName}() call. If you have a mix of ` +
+                  `warnings with and without stack in one ${matcherName}() call, pass ` +
+                  `{withoutStack: N} where N is the number of warnings without stacks.`,
+                pass: false,
+              };
+            }
+          } else if (withoutStack === false || withoutStack === undefined) {
+            // We're expecting that all warnings *do* have the stack (default).
+            // If some warnings don't have it, it's an error.
+            if (warningsWithoutComponentStack.length > 0) {
+              return {
+                message: () =>
+                  `Received warning unexpectedly does not include a component stack:\n  ${this.utils.printReceived(
+                    warningsWithoutComponentStack[0]
+                  )}\nIf this warning intentionally omits the component stack, add ` +
+                  `{withoutStack: true} to the ${matcherName} call.`,
+                pass: false,
+              };
+            }
+          } else {
+            throw Error(
+              `The second argument for ${matcherName}(), when specified, must be an object. It may have a ` +
+                `property called "withoutStack" whose value may be undefined, boolean, or a number. ` +
+                `Instead received ${typeof withoutStack}.`
+            );
           }
-        } else if (withoutStack === true) {
-          // We're expecting that all warnings won't have the stack.
-          // If some warnings have it, it's an error.
-          if (warningsWithComponentStack.length > 0) {
-            return {
-              message: () =>
-                `Received warning unexpectedly includes a component stack:\n  ${this.utils.printReceived(
-                  warningsWithComponentStack[0]
-                )}\nIf this warning intentionally includes the component stack, remove ` +
-                `{withoutStack: true} from the ${matcherName}() call. If you have a mix of ` +
-                `warnings with and without stack in one ${matcherName}() call, pass ` +
-                `{withoutStack: N} where N is the number of warnings without stacks.`,
-              pass: false,
-            };
-          }
-        } else if (withoutStack === false || withoutStack === undefined) {
-          // We're expecting that all warnings *do* have the stack (default).
-          // If some warnings don't have it, it's an error.
-          if (warningsWithoutComponentStack.length > 0) {
-            return {
-              message: () =>
-                `Received warning unexpectedly does not include a component stack:\n  ${this.utils.printReceived(
-                  warningsWithoutComponentStack[0]
-                )}\nIf this warning intentionally omits the component stack, add ` +
-                `{withoutStack: true} to the ${matcherName} call.`,
-              pass: false,
-            };
-          }
-        } else {
-          throw Error(
-            `The second argument for ${matcherName}(), when specified, must be an object. It may have a ` +
-              `property called "withoutStack" whose value may be undefined, boolean, or a number. ` +
-              `Instead received ${typeof withoutStack}.`
-          );
         }
 
         if (lastWarningWithMismatchingFormat !== null) {
@@ -309,4 +313,5 @@ const createMatcherFor = (consoleMethod, matcherName) =>
 module.exports = {
   toWarnDev: createMatcherFor('warn', 'toWarnDev'),
   toErrorDev: createMatcherFor('error', 'toErrorDev'),
+  toLogDev: createMatcherFor('log', 'toLogDev'),
 };


### PR DESCRIPTION
Followup from https://github.com/facebook/react/pull/28693 and https://github.com/facebook/react/pull/28680.

In CI, we fail the test for any unasserted console.log. In DEV, we don't fail, but you can still use the matchers and we'll assert on them.