### PR TITLE
Enable stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,8 +16,8 @@ jobs:
           days-before-stale: 90
           # Number of days of inactivity before a stale issue or PR is closed
           days-before-close: 7
-          # Tmp dry run setup to test new config
-          debug-only: 'true'
+          # Number of issues or PRs to process per day
+          operations-per-run: 100
 
           # --- Issues ---
           stale-issue-label: "Resolution: Stale"
@@ -30,7 +30,7 @@ jobs:
           close-issue-message: >
             Closing this issue after a prolonged period of inactivity. If this issue is still present in the latest release, please create a new issue with up-to-date information. Thank you!
           # Issues with these labels will never be considered stale
-          exempt-issue-labels: "Partner,React Core Team,Resolution: Backlog,Type: Bug,Type: Discussion,Type: Needs Investigation,Type: Regression,Type: Feature Request"
+          exempt-issue-labels: "Partner,React Core Team,Resolution: Backlog,Type: Bug,Type: Discussion,Type: Needs Investigation,Type: Regression,Type: Feature Request,Type: Enhancement"
 
           # --- PRs ---
           stale-pr-label: "Resolution: Stale"
@@ -43,4 +43,4 @@ jobs:
           close-pr-message: >
             Closing this pull request after a prolonged period of inactivity. If this issue is still present in the latest release, please ask for this pull request to be reopened. Thank you!
           # PRs with these labels will never be considered stale
-          exempt-pr-labels: "Partner,React Core Team,Resolution: Backlog,Type: Bug,Type: Discussion,Type: Needs Investigation,Type: Regression,Type: Feature Request"
+          exempt-pr-labels: "Partner,React Core Team,Resolution: Backlog,Type: Bug,Type: Discussion,Type: Needs Investigation,Type: Regression,Type: Feature Request,Type: Enhancement"


### PR DESCRIPTION
Follows #28695

Now that the action has run successfully in debug mode ([logs](https://github.com/facebook/react/actions/runs/8532177618/job/23372921455#step:2:35)), let's enable it to persist changes.

Also changes the number of operations per run from the default of 30 to 100 since we have a large backlog of issues and PRs to work through.

Finally adds enhancement label as exempt from stale.
