### PR TITLE
[tests] Assert scheduler log empty in internalAct

### DIFF
--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -332,6 +332,31 @@ declare module 'node:worker_threads' {
   }
 }
 
+declare module 'jest-diff' {
+  declare type CompareKeys = ((a: string, b: string) => number) | void;
+  declare type DiffOptions = {
+    aAnnotation?: string,
+    aColor?: (arg: string) => string,
+    aIndicator?: string,
+    bAnnotation?: string,
+    bColor?: (arg: string) => string,
+    bIndicator?: string,
+    changeColor?: (arg: string) => string,
+    changeLineTrailingSpaceColor?: (arg: string) => string,
+    commonColor?: (arg: string) => string,
+    commonIndicator?: string,
+    commonLineTrailingSpaceColor?: (arg: string) => string,
+    contextLines?: number,
+    emptyFirstOrLastLinePlaceholder?: string,
+    expand?: boolean,
+    includeChangeCounts?: boolean,
+    omitAnnotationLines?: boolean,
+    patchColor?: (arg: string) => string,
+    compareKeys?: CompareKeys,
+  };
+  declare function diff(a: any, b: any, options?: DiffOptions): string;
+}
+
 declare const Bun: {
   hash(
     input: string | $TypedArray | DataView | ArrayBuffer | SharedArrayBuffer,


### PR DESCRIPTION
We should force `assertLog` to be called before each `act` block to ensure the queue is empty.

Requires fixing tests:
- https://github.com/facebook/react/pull/28745
- https://github.com/facebook/react/pull/28758
- https://github.com/facebook/react/pull/28759
- https://github.com/facebook/react/pull/28760
- https://github.com/facebook/react/pull/28761
- https://github.com/facebook/react/pull/28762
- https://github.com/facebook/react/pull/28763
- https://github.com/facebook/react/pull/28812