### PR TITLE
Emit Server Error Prefix in the .stack Property Too

### DIFF
--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -842,7 +842,7 @@ function encodeErrorForBoundary(
       ? 'Switched to client rendering because the server rendering aborted due to:\n\n'
       : 'Switched to client rendering because the server rendering errored:\n\n';
     boundary.errorMessage = prefix + message;
-    boundary.errorStack = stack;
+    boundary.errorStack = stack !== null ? prefix + stack : null;
     boundary.errorComponentStack = thrownInfo.componentStack;
   }
 }


### PR DESCRIPTION
Follow up to #28684.

V8 includes the message in the stack and printed errors include just the stack property which is assumed to contain the message. Without this, the prefix doesn't get printed in the console.

<img width="578" alt="Screenshot 2024-04-03 at 6 32 04 PM" src="https://github.com/facebook/react/assets/63648/d98a2db4-6ebc-4805-b669-59f449dfd21f">

A possible alternative would be to use a nested error with a `cause` like #28736 but that would need some more involved serializing since this prefix is coming from the server. Perhaps as a separate attribute.