### PR TITLE
[Fiber] Move updatePriority tracking to renderers

### DIFF
--- a/packages/react-art/src/ReactFiberConfigART.js
+++ b/packages/react-art/src/ReactFiberConfigART.js
@@ -343,16 +343,16 @@ export function shouldSetTextContent(type, props) {
 
 let currentUpdatePriority: EventPriority = NoEventPriority;
 
-export function setCurrentUpdatePriority(newPriority: EventPriority) {
+export function setCurrentUpdatePriority(newPriority: EventPriority): void {
   currentUpdatePriority = newPriority;
 }
 
-export function getCurrentUpdatePriority() {
+export function getCurrentUpdatePriority(): EventPriority {
   return currentUpdatePriority;
 }
 
-export function getCurrentEventPriority() {
-  return DefaultEventPriority;
+export function resolveUpdatePriority(): EventPriority {
+  return currentUpdatePriority || DefaultEventPriority;
 }
 
 export function shouldAttemptEagerTransition() {

--- a/packages/react-art/src/ReactFiberConfigART.js
+++ b/packages/react-art/src/ReactFiberConfigART.js
@@ -5,12 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {EventPriority} from 'react-reconciler/src/ReactEventPriorities';
+
 import Transform from 'art/core/transform';
 import Mode from 'art/modes/current';
 
 import {TYPES, EVENT_TYPES, childrenAsString} from './ReactARTInternals';
 
-import {DefaultEventPriority} from 'react-reconciler/src/ReactEventPriorities';
+import {
+  DefaultEventPriority,
+  NoEventPriority,
+} from 'react-reconciler/src/ReactEventPriorities';
 
 const pooledTransform = new Transform();
 
@@ -334,6 +339,16 @@ export function shouldSetTextContent(type, props) {
   return (
     typeof props.children === 'string' || typeof props.children === 'number'
   );
+}
+
+let currentUpdatePriority: EventPriority = NoEventPriority;
+
+export function setCurrentUpdatePriority(newPriority: EventPriority) {
+  currentUpdatePriority = newPriority;
+}
+
+export function getCurrentUpdatePriority() {
+  return currentUpdatePriority;
 }
 
 export function getCurrentEventPriority() {

--- a/packages/react-dom-bindings/src/client/ReactDOMUpdatePriority.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMUpdatePriority.js
@@ -16,19 +16,24 @@ import {
 } from 'react-reconciler/src/ReactEventPriorities';
 
 import ReactDOMSharedInternals from 'shared/ReactDOMSharedInternals';
-const ReactDOMCurrentUpdatePriority =
-  ReactDOMSharedInternals.ReactDOMCurrentUpdatePriority;
 
-export function setCurrentUpdatePriority(newPriority: EventPriority): void {
-  ReactDOMCurrentUpdatePriority.current = newPriority;
+export function setCurrentUpdatePriority(
+  newPriority: EventPriority,
+  // Closure will consistently not inline this function when it has arity 1
+  // however when it has arity 2 even if the second arg is omitted at every
+  // callsite it seems to inline it even when the internal length of the function
+  // is much longer. I hope this is consistent enough to rely on across builds
+  IntentionallyUnusedArgument?: empty,
+): void {
+  ReactDOMSharedInternals.up = newPriority;
 }
 
 export function getCurrentUpdatePriority(): EventPriority {
-  return ReactDOMCurrentUpdatePriority.current;
+  return ReactDOMSharedInternals.up;
 }
 
 export function resolveUpdatePriority(): EventPriority {
-  const updatePriority = ReactDOMCurrentUpdatePriority.current;
+  const updatePriority = ReactDOMSharedInternals.up;
   if (updatePriority !== NoEventPriority) {
     return updatePriority;
   }

--- a/packages/react-dom-bindings/src/client/ReactDOMUpdatePriority.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMUpdatePriority.js
@@ -9,6 +9,12 @@
 
 import type {EventPriority} from 'react-reconciler/src/ReactEventPriorities';
 
+import {getEventPriority} from '../events/ReactDOMEventListener';
+import {
+  NoEventPriority,
+  DefaultEventPriority,
+} from 'react-reconciler/src/ReactEventPriorities';
+
 import ReactDOMSharedInternals from 'shared/ReactDOMSharedInternals';
 const ReactDOMCurrentUpdatePriority =
   ReactDOMSharedInternals.ReactDOMCurrentUpdatePriority;
@@ -19,6 +25,18 @@ export function setCurrentUpdatePriority(newPriority: EventPriority): void {
 
 export function getCurrentUpdatePriority(): EventPriority {
   return ReactDOMCurrentUpdatePriority.current;
+}
+
+export function resolveUpdatePriority(): EventPriority {
+  const updatePriority = ReactDOMCurrentUpdatePriority.current;
+  if (updatePriority !== NoEventPriority) {
+    return updatePriority;
+  }
+  const currentEvent = window.event;
+  if (currentEvent === undefined) {
+    return DefaultEventPriority;
+  }
+  return getEventPriority(currentEvent.type);
 }
 
 export function runWithPriority<T>(priority: EventPriority, fn: () => T): T {

--- a/packages/react-dom-bindings/src/client/ReactDOMUpdatePriority.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMUpdatePriority.js
@@ -9,16 +9,16 @@
 
 import type {EventPriority} from 'react-reconciler/src/ReactEventPriorities';
 
-import {NoEventPriority} from 'react-reconciler/src/ReactEventPriorities';
-
-let currentUpdatePriority: EventPriority = NoEventPriority;
+import ReactDOMSharedInternals from 'shared/ReactDOMSharedInternals';
+const ReactDOMCurrentUpdatePriority =
+  ReactDOMSharedInternals.ReactDOMCurrentUpdatePriority;
 
 export function setCurrentUpdatePriority(newPriority: EventPriority): void {
-  currentUpdatePriority = newPriority;
+  ReactDOMCurrentUpdatePriority.current = newPriority;
 }
 
 export function getCurrentUpdatePriority(): EventPriority {
-  return currentUpdatePriority;
+  return ReactDOMCurrentUpdatePriority.current;
 }
 
 export function runWithPriority<T>(priority: EventPriority, fn: () => T): T {

--- a/packages/react-dom-bindings/src/client/ReactDOMUpdatePriority.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMUpdatePriority.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {EventPriority} from 'react-reconciler/src/ReactEventPriorities';
+
+import {NoEventPriority} from 'react-reconciler/src/ReactEventPriorities';
+
+let currentUpdatePriority: EventPriority = NoEventPriority;
+
+export function setCurrentUpdatePriority(newPriority: EventPriority): void {
+  currentUpdatePriority = newPriority;
+}
+
+export function getCurrentUpdatePriority(): EventPriority {
+  return currentUpdatePriority;
+}
+
+export function runWithPriority<T>(priority: EventPriority, fn: () => T): T {
+  const previousPriority = getCurrentUpdatePriority();
+  try {
+    setCurrentUpdatePriority(priority);
+    return fn();
+  } finally {
+    setCurrentUpdatePriority(previousPriority);
+  }
+}

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import type {EventPriority} from 'react-reconciler/src/ReactEventPriorities';
 import type {DOMEventName} from '../events/DOMEventNames';
 import type {Fiber, FiberRoot} from 'react-reconciler/src/ReactInternalTypes';
 import type {
@@ -29,7 +28,6 @@ import type {
 
 import {NotPending} from 'react-dom-bindings/src/shared/ReactDOMFormActions';
 import {getCurrentRootHostContainer} from 'react-reconciler/src/ReactFiberHostContext';
-import {DefaultEventPriority} from 'react-reconciler/src/ReactEventPriorities';
 
 import hasOwnProperty from 'shared/hasOwnProperty';
 import {checkAttributeStringCoercion} from 'shared/CheckStringCoercion';
@@ -37,6 +35,7 @@ import {checkAttributeStringCoercion} from 'shared/CheckStringCoercion';
 export {
   setCurrentUpdatePriority,
   getCurrentUpdatePriority,
+  resolveUpdatePriority,
 } from './ReactDOMUpdatePriority';
 import {
   precacheFiberNode,
@@ -73,7 +72,6 @@ import {
 import {
   isEnabled as ReactBrowserEventEmitterIsEnabled,
   setEnabled as ReactBrowserEventEmitterSetEnabled,
-  getEventPriority,
 } from '../events/ReactDOMEventListener';
 import {SVG_NAMESPACE, MATH_NAMESPACE} from './DOMNamespaces';
 import {
@@ -574,14 +572,6 @@ export function createTextInstance(
   ).createTextNode(text);
   precacheFiberNode(internalInstanceHandle, textNode);
   return textNode;
-}
-
-export function getCurrentEventPriority(): EventPriority {
-  const currentEvent = window.event;
-  if (currentEvent === undefined) {
-    return DefaultEventPriority;
-  }
-  return getEventPriority(currentEvent.type);
 }
 
 let currentPopstateTransitionEvent: Event | null = null;

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -34,6 +34,10 @@ import {DefaultEventPriority} from 'react-reconciler/src/ReactEventPriorities';
 import hasOwnProperty from 'shared/hasOwnProperty';
 import {checkAttributeStringCoercion} from 'shared/CheckStringCoercion';
 
+export {
+  setCurrentUpdatePriority,
+  getCurrentUpdatePriority,
+} from './ReactDOMUpdatePriority';
 import {
   precacheFiberNode,
   updateFiberProps,

--- a/packages/react-dom-bindings/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom-bindings/src/events/ReactDOMEventListener.js
@@ -117,9 +117,9 @@ function dispatchDiscreteEvent(
   container: EventTarget,
   nativeEvent: AnyNativeEvent,
 ) {
-  const previousPriority = getCurrentUpdatePriority();
   const prevTransition = ReactCurrentBatchConfig.transition;
   ReactCurrentBatchConfig.transition = null;
+  const previousPriority = getCurrentUpdatePriority();
   try {
     setCurrentUpdatePriority(DiscreteEventPriority);
     dispatchEvent(domEventName, eventSystemFlags, container, nativeEvent);
@@ -135,9 +135,9 @@ function dispatchContinuousEvent(
   container: EventTarget,
   nativeEvent: AnyNativeEvent,
 ) {
-  const previousPriority = getCurrentUpdatePriority();
   const prevTransition = ReactCurrentBatchConfig.transition;
   ReactCurrentBatchConfig.transition = null;
+  const previousPriority = getCurrentUpdatePriority();
   try {
     setCurrentUpdatePriority(ContinuousEventPriority);
     dispatchEvent(domEventName, eventSystemFlags, container, nativeEvent);

--- a/packages/react-dom-bindings/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom-bindings/src/events/ReactDOMEventListener.js
@@ -34,6 +34,10 @@ import {
 } from '../client/ReactDOMComponentTree';
 
 import {dispatchEventForPluginEventSystem} from './DOMPluginEventSystem';
+import {
+  getCurrentUpdatePriority,
+  setCurrentUpdatePriority,
+} from '../client/ReactDOMUpdatePriority';
 
 import {
   getCurrentPriorityLevel as getCurrentSchedulerPriorityLevel,
@@ -48,8 +52,6 @@ import {
   ContinuousEventPriority,
   DefaultEventPriority,
   IdleEventPriority,
-  getCurrentUpdatePriority,
-  setCurrentUpdatePriority,
 } from 'react-reconciler/src/ReactEventPriorities';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {isRootDehydrated} from 'react-reconciler/src/ReactFiberShellHydration';

--- a/packages/react-dom-bindings/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom-bindings/src/events/ReactDOMEventReplaying.js
@@ -37,15 +37,15 @@ import {HostRoot, SuspenseComponent} from 'react-reconciler/src/ReactWorkTags';
 import {isHigherEventPriority} from 'react-reconciler/src/ReactEventPriorities';
 import {isRootDehydrated} from 'react-reconciler/src/ReactFiberShellHydration';
 import {dispatchReplayedFormAction} from './plugins/FormActionEventPlugin';
+import {
+  getCurrentUpdatePriority,
+  runWithPriority as attemptHydrationAtPriority,
+} from '../client/ReactDOMUpdatePriority';
 
 import {
   attemptContinuousHydration,
   attemptHydrationAtCurrentPriority,
 } from 'react-reconciler/src/ReactFiberReconciler';
-import {
-  runWithPriority as attemptHydrationAtPriority,
-  getCurrentUpdatePriority,
-} from 'react-reconciler/src/ReactEventPriorities';
 
 // TODO: Upgrade this definition once we're on a newer version of Flow that
 // has this definition built-in.

--- a/packages/react-dom/src/ReactDOMSharedInternals.js
+++ b/packages/react-dom/src/ReactDOMSharedInternals.js
@@ -23,9 +23,7 @@ type InternalsType = {
     | ((
         componentOrElement: React$Component<any, any>,
       ) => null | Element | Text),
-  ReactDOMCurrentUpdatePriority: {
-    current: EventPriority,
-  },
+  up /* currentUpdatePriority */: EventPriority,
 };
 
 function noop() {}
@@ -47,9 +45,7 @@ const Internals: InternalsType = {
     current: DefaultDispatcher,
   },
   findDOMNode: null,
-  ReactDOMCurrentUpdatePriority: {
-    current: NoEventPriority,
-  },
+  up /* currentUpdatePriority */: NoEventPriority,
 };
 
 export default Internals;

--- a/packages/react-dom/src/ReactDOMSharedInternals.js
+++ b/packages/react-dom/src/ReactDOMSharedInternals.js
@@ -7,7 +7,10 @@
  * @flow
  */
 
+import type {EventPriority} from 'react-reconciler/src/ReactEventPriorities';
 import type {HostDispatcher} from './shared/ReactDOMTypes';
+
+import {NoEventPriority} from 'react-reconciler/src/ReactEventPriorities';
 
 type InternalsType = {
   usingClientEntryPoint: boolean,
@@ -20,6 +23,9 @@ type InternalsType = {
     | ((
         componentOrElement: React$Component<any, any>,
       ) => null | Element | Text),
+  ReactDOMCurrentUpdatePriority: {
+    current: EventPriority,
+  },
 };
 
 function noop() {}
@@ -34,13 +40,16 @@ const DefaultDispatcher: HostDispatcher = {
   preinitModuleScript: noop,
 };
 
-const Internals: InternalsType = ({
+const Internals: InternalsType = {
   usingClientEntryPoint: false,
-  Events: null,
+  Events: (null: any),
   ReactDOMCurrentDispatcher: {
     current: DefaultDispatcher,
   },
   findDOMNode: null,
-}: any);
+  ReactDOMCurrentUpdatePriority: {
+    current: NoEventPriority,
+  },
+};
 
 export default Internals;

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -20,6 +20,7 @@ import {
   isValidContainer,
 } from './ReactDOMRoot';
 import {createEventHandle} from 'react-dom-bindings/src/client/ReactDOMEventHandle';
+import {runWithPriority} from 'react-dom-bindings/src/client/ReactDOMUpdatePriority';
 
 import {
   flushSync as flushSyncWithoutWarningIfAlreadyRendering,
@@ -27,7 +28,6 @@ import {
   injectIntoDevTools,
   findHostInstance,
 } from 'react-reconciler/src/ReactFiberReconciler';
-import {runWithPriority} from 'react-reconciler/src/ReactEventPriorities';
 import {createPortal as createPortalImpl} from 'react-reconciler/src/ReactPortal';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 import ReactVersion from 'shared/ReactVersion';

--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -313,17 +313,19 @@ export function shouldSetTextContent(type: string, props: Props): boolean {
 }
 
 let currentUpdatePriority: EventPriority = NoEventPriority;
-export function setCurrentUpdatePriority(
-  newEventPriority: EventPriority,
-): void {
-  currentUpdatePriority = newEventPriority;
+export function setCurrentUpdatePriority(newPriority: EventPriority): void {
+  currentUpdatePriority = newPriority;
 }
 
 export function getCurrentUpdatePriority(): EventPriority {
   return currentUpdatePriority;
 }
 
-export function getCurrentEventPriority(): EventPriority {
+export function resolveUpdatePriority(): EventPriority {
+  if (currentUpdatePriority !== NoEventPriority) {
+    return currentUpdatePriority;
+  }
+
   const currentEventPriority = fabricGetCurrentEventPriority
     ? fabricGetCurrentEventPriority()
     : null;

--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -15,6 +15,7 @@ import type {
 import {create, diff} from './ReactNativeAttributePayload';
 import {dispatchEvent} from './ReactFabricEventEmitter';
 import {
+  NoEventPriority,
   DefaultEventPriority,
   DiscreteEventPriority,
   type EventPriority,
@@ -309,6 +310,17 @@ export function shouldSetTextContent(type: string, props: Props): boolean {
   // It's not clear to me which is better so I'm deferring for now.
   // More context @ github.com/facebook/react/pull/8560#discussion_r92111303
   return false;
+}
+
+let currentUpdatePriority: EventPriority = NoEventPriority;
+export function setCurrentUpdatePriority(
+  newEventPriority: EventPriority,
+): void {
+  currentUpdatePriority = newEventPriority;
+}
+
+export function getCurrentUpdatePriority(): EventPriority {
+  return currentUpdatePriority;
 }
 
 export function getCurrentEventPriority(): EventPriority {

--- a/packages/react-native-renderer/src/ReactFiberConfigNative.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigNative.js
@@ -26,6 +26,7 @@ import ReactNativeFiberHostComponent from './ReactNativeFiberHostComponent';
 
 import {
   DefaultEventPriority,
+  NoEventPriority,
   type EventPriority,
 } from 'react-reconciler/src/ReactEventPriorities';
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
@@ -251,6 +252,15 @@ export function shouldSetTextContent(type: string, props: Props): boolean {
   // It's not clear to me which is better so I'm deferring for now.
   // More context @ github.com/facebook/react/pull/8560#discussion_r92111303
   return false;
+}
+
+let currentUpdatePriority: EventPriority = NoEventPriority;
+export function setCurrentUpdatePriority(newPriority: EventPriority): void {
+  currentUpdatePriority = newPriority;
+}
+
+export function getCurrentUpdatePriority(): EventPriority {
+  return currentUpdatePriority;
 }
 
 export function getCurrentEventPriority(): EventPriority {

--- a/packages/react-native-renderer/src/ReactFiberConfigNative.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigNative.js
@@ -263,7 +263,10 @@ export function getCurrentUpdatePriority(): EventPriority {
   return currentUpdatePriority;
 }
 
-export function getCurrentEventPriority(): EventPriority {
+export function resolveUpdatePriority(): EventPriority {
+  if (currentUpdatePriority !== NoEventPriority) {
+    return currentUpdatePriority;
+  }
   return DefaultEventPriority;
 }
 

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -21,12 +21,14 @@ import type {
 import type {UpdateQueue} from 'react-reconciler/src/ReactFiberClassUpdateQueue';
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {RootTag} from 'react-reconciler/src/ReactRootTags';
+import type {EventPriority} from 'react-reconciler/src/ReactEventPriorities';
 
 import * as Scheduler from 'scheduler/unstable_mock';
 import {REACT_FRAGMENT_TYPE, REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 import isArray from 'shared/isArray';
 import {checkPropStringCoercion} from 'shared/CheckStringCoercion';
 import {
+  NoEventPriority,
   DefaultEventPriority,
   IdleEventPriority,
   ConcurrentRoot,
@@ -508,6 +510,9 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
     resetAfterCommit(): void {},
 
+    setCurrentUpdatePriority,
+    getCurrentUpdatePriority,
+
     getCurrentEventPriority() {
       return currentEventPriority;
     },
@@ -781,6 +786,15 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
   const rootContainers = new Map();
   const roots = new Map();
   const DEFAULT_ROOT_ID = '<default>';
+
+  let currentUpdatePriority = NoEventPriority;
+  function setCurrentUpdatePriority(newPriority: EventPriority): void {
+    currentUpdatePriority = newPriority;
+  }
+
+  function getCurrentUpdatePriority(): EventPriority {
+    return currentUpdatePriority;
+  }
 
   let currentEventPriority = DefaultEventPriority;
 
@@ -1211,7 +1225,18 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       return Scheduler.unstable_flushExpired();
     },
 
-    unstable_runWithPriority: NoopRenderer.runWithPriority,
+    unstable_runWithPriority: function runWithPriority<T>(
+      priority: EventPriority,
+      fn: () => T,
+    ): T {
+      const previousPriority = getCurrentUpdatePriority();
+      try {
+        setCurrentUpdatePriority(priority);
+        return fn();
+      } finally {
+        setCurrentUpdatePriority(previousPriority);
+      }
+    },
 
     batchedUpdates: NoopRenderer.batchedUpdates,
 

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -513,7 +513,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     setCurrentUpdatePriority,
     getCurrentUpdatePriority,
 
-    getCurrentEventPriority() {
+    resolveUpdatePriority() {
+      if (currentUpdatePriority !== NoEventPriority) {
+        return currentUpdatePriority;
+      }
       return currentEventPriority;
     },
 

--- a/packages/react-reconciler/src/ReactEventPriorities.js
+++ b/packages/react-reconciler/src/ReactEventPriorities.js
@@ -21,30 +21,11 @@ import {
 
 export opaque type EventPriority = Lane;
 
+export const NoEventPriority: EventPriority = NoLane;
 export const DiscreteEventPriority: EventPriority = SyncLane;
 export const ContinuousEventPriority: EventPriority = InputContinuousLane;
 export const DefaultEventPriority: EventPriority = DefaultLane;
 export const IdleEventPriority: EventPriority = IdleLane;
-
-let currentUpdatePriority: EventPriority = NoLane;
-
-export function getCurrentUpdatePriority(): EventPriority {
-  return currentUpdatePriority;
-}
-
-export function setCurrentUpdatePriority(newPriority: EventPriority) {
-  currentUpdatePriority = newPriority;
-}
-
-export function runWithPriority<T>(priority: EventPriority, fn: () => T): T {
-  const previousPriority = currentUpdatePriority;
-  try {
-    currentUpdatePriority = priority;
-    return fn();
-  } finally {
-    currentUpdatePriority = previousPriority;
-  }
-}
 
 export function higherEventPriority(
   a: EventPriority,

--- a/packages/react-reconciler/src/ReactEventPriorities.js
+++ b/packages/react-reconciler/src/ReactEventPriorities.js
@@ -48,6 +48,10 @@ export function isHigherEventPriority(
   return a !== 0 && a < b;
 }
 
+export function eventPriorityToLane(updatePriority: EventPriority): Lane {
+  return updatePriority;
+}
+
 export function lanesToEventPriority(lanes: Lanes): EventPriority {
   const lane = getHighestPriorityLane(lanes);
   if (!isHigherEventPriority(DiscreteEventPriority, lane)) {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -674,7 +674,7 @@ function updateOffscreenComponent(
         // pending work. We can't read `childLanes` from the current Offscreen
         // fiber because we reset it when it was deferred; however, we can read
         // the pending lanes from the child fibers.
-        let currentChildLanes = NoLanes;
+        let currentChildLanes: Lanes = NoLanes;
         while (currentChild !== null) {
           currentChildLanes = mergeLanes(
             mergeLanes(currentChildLanes, currentChild.lanes),

--- a/packages/react-reconciler/src/ReactFiberClassUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactFiberClassUpdateQueue.js
@@ -556,7 +556,7 @@ export function processUpdateQueue<State>(
     let newState = queue.baseState;
     // TODO: Don't need to accumulate this. Instead, we can remove renderLanes
     // from the original lanes.
-    let newLanes = NoLanes;
+    let newLanes: Lanes = NoLanes;
 
     let newBaseState = null;
     let newFirstBaseUpdate = null;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -742,7 +742,7 @@ function bubbleProperties(completedWork: Fiber) {
     completedWork.alternate !== null &&
     completedWork.alternate.child === completedWork.child;
 
-  let newChildLanes = NoLanes;
+  let newChildLanes: Lanes = NoLanes;
   let subtreeFlags = NoFlags;
 
   if (!didBailout) {

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -27,7 +27,11 @@ import type {HookFlags} from './ReactHookEffectTags';
 import type {Flags} from './ReactFiberFlags';
 import type {TransitionStatus} from './ReactFiberConfig';
 
-import {NotPendingTransition as NoPendingHostTransition} from './ReactFiberConfig';
+import {
+  NotPendingTransition as NoPendingHostTransition,
+  setCurrentUpdatePriority,
+  getCurrentUpdatePriority,
+} from './ReactFiberConfig';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {
   enableDebugTracing,
@@ -74,8 +78,6 @@ import {
 } from './ReactFiberLane';
 import {
   ContinuousEventPriority,
-  getCurrentUpdatePriority,
-  setCurrentUpdatePriority,
   higherEventPriority,
 } from './ReactEventPriorities';
 import {readContext, checkIfContextChanged} from './ReactFiberNewContext';

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -223,7 +223,7 @@ export function getNextLanes(root: FiberRoot, wipLanes: Lanes): Lanes {
     return NoLanes;
   }
 
-  let nextLanes = NoLanes;
+  let nextLanes: Lanes = NoLanes;
 
   const suspendedLanes = root.suspendedLanes;
   const pingedLanes = root.pingedLanes;

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -41,7 +41,7 @@ import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFrom
 import isArray from 'shared/isArray';
 import {enableSchedulingProfiler} from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
-import {getPublicInstance, getCurrentUpdatePriority} from './ReactFiberConfig';
+import {getPublicInstance} from './ReactFiberConfig';
 import {
   findCurrentUnmaskedContext,
   processChildContext,
@@ -520,8 +520,6 @@ export function attemptHydrationAtCurrentPriority(fiber: Fiber): void {
   }
   markRetryLaneIfNotHydrated(fiber, lane);
 }
-
-export {getCurrentUpdatePriority};
 
 export {findHostInstance};
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -41,7 +41,7 @@ import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFrom
 import isArray from 'shared/isArray';
 import {enableSchedulingProfiler} from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
-import {getPublicInstance} from './ReactFiberConfig';
+import {getPublicInstance, getCurrentUpdatePriority} from './ReactFiberConfig';
 import {
   findCurrentUnmaskedContext,
   processChildContext,
@@ -86,10 +86,6 @@ import {
   getHighestPriorityPendingLanes,
   higherPriorityLane,
 } from './ReactFiberLane';
-import {
-  getCurrentUpdatePriority,
-  runWithPriority,
-} from './ReactEventPriorities';
 import {
   scheduleRefresh,
   scheduleRoot,
@@ -525,7 +521,7 @@ export function attemptHydrationAtCurrentPriority(fiber: Fiber): void {
   markRetryLaneIfNotHydrated(fiber, lane);
 }
 
-export {getCurrentUpdatePriority, runWithPriority};
+export {getCurrentUpdatePriority};
 
 export {findHostInstance};
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -75,6 +75,8 @@ import {
   waitForCommitToBeReady,
   preloadInstance,
   supportsHydration,
+  getCurrentUpdatePriority,
+  setCurrentUpdatePriority,
 } from './ReactFiberConfig';
 
 import {createWorkInProgress, resetWorkInProgress} from './ReactFiber';
@@ -157,8 +159,6 @@ import {
 import {
   DiscreteEventPriority,
   DefaultEventPriority,
-  getCurrentUpdatePriority,
-  setCurrentUpdatePriority,
   lowerEventPriority,
   lanesToEventPriority,
 } from './ReactEventPriorities';
@@ -3543,7 +3543,7 @@ function retryTimedOutBoundary(boundaryFiber: Fiber, retryLane: Lane) {
 
 export function retryDehydratedSuspenseBoundary(boundaryFiber: Fiber) {
   const suspenseState: null | SuspenseState = boundaryFiber.memoizedState;
-  let retryLane = NoLane;
+  let retryLane: Lane = NoLane;
   if (suspenseState !== null) {
     retryLane = suspenseState.retryLane;
   }
@@ -3551,7 +3551,7 @@ export function retryDehydratedSuspenseBoundary(boundaryFiber: Fiber) {
 }
 
 export function resolveRetryWakeable(boundaryFiber: Fiber, wakeable: Wakeable) {
-  let retryLane = NoLane; // Default
+  let retryLane: Lane = NoLane; // Default
   let retryCache: WeakSet<Wakeable> | Set<Wakeable> | null;
   switch (boundaryFiber.tag) {
     case SuspenseComponent:

--- a/packages/react-reconciler/src/ReactReconcilerConstants.js
+++ b/packages/react-reconciler/src/ReactReconcilerConstants.js
@@ -11,6 +11,7 @@
 // Only expose the minimal subset necessary to implement a host config.
 
 export {
+  NoEventPriority,
   DiscreteEventPriority,
   ContinuousEventPriority,
   DefaultEventPriority,

--- a/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
@@ -15,6 +15,7 @@ let act;
 let ReactFiberReconciler;
 let ConcurrentRoot;
 let DefaultEventPriority;
+let NoEventPriority;
 
 describe('ReactFiberHostContext', () => {
   beforeEach(() => {
@@ -26,6 +27,8 @@ describe('ReactFiberHostContext', () => {
       require('react-reconciler/src/ReactRootTags').ConcurrentRoot;
     DefaultEventPriority =
       require('react-reconciler/src/ReactEventPriorities').DefaultEventPriority;
+    NoEventPriority =
+      require('react-reconciler/src/ReactEventPriorities').NoEventPriority;
   });
 
   global.IS_REACT_ACT_ENVIRONMENT = true;
@@ -34,6 +37,7 @@ describe('ReactFiberHostContext', () => {
   it('should send the context to prepareForCommit and resetAfterCommit', () => {
     const rootContext = {};
     const childContext = {};
+    let updatePriority: typeof DefaultEventPriority = NoEventPriority;
     const Renderer = ReactFiberReconciler({
       prepareForCommit: function (hostContext) {
         expect(hostContext).toBe(rootContext);
@@ -67,6 +71,12 @@ describe('ReactFiberHostContext', () => {
         return null;
       },
       clearContainer: function () {},
+      setCurrentUpdatePriority: function (newPriority: any) {
+        updatePriority = newPriority;
+      },
+      getCurrentUpdatePriority: function () {
+        return updatePriority;
+      },
       getCurrentEventPriority: function () {
         return DefaultEventPriority;
       },

--- a/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
@@ -77,7 +77,10 @@ describe('ReactFiberHostContext', () => {
       getCurrentUpdatePriority: function () {
         return updatePriority;
       },
-      getCurrentEventPriority: function () {
+      resolveUpdatePriority: function () {
+        if (updatePriority !== NoEventPriority) {
+          return updatePriority;
+        }
         return DefaultEventPriority;
       },
       shouldAttemptEagerTransition() {

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
@@ -67,7 +67,7 @@ export const prepareScopeUpdate = $$$config.prepareScopeUpdate;
 export const getInstanceFromScope = $$$config.getInstanceFromScope;
 export const setCurrentUpdatePriority = $$$config.setCurrentUpdatePriority;
 export const getCurrentUpdatePriority = $$$config.getCurrentUpdatePriority;
-export const getCurrentEventPriority = $$$config.getCurrentEventPriority;
+export const resolveUpdatePriority = $$$config.resolveUpdatePriority;
 export const shouldAttemptEagerTransition =
   $$$config.shouldAttemptEagerTransition;
 export const detachDeletedInstance = $$$config.detachDeletedInstance;

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
@@ -65,6 +65,8 @@ export const afterActiveInstanceBlur = $$$config.afterActiveInstanceBlur;
 export const preparePortalMount = $$$config.preparePortalMount;
 export const prepareScopeUpdate = $$$config.prepareScopeUpdate;
 export const getInstanceFromScope = $$$config.getInstanceFromScope;
+export const setCurrentUpdatePriority = $$$config.setCurrentUpdatePriority;
+export const getCurrentUpdatePriority = $$$config.getCurrentUpdatePriority;
 export const getCurrentEventPriority = $$$config.getCurrentEventPriority;
 export const shouldAttemptEagerTransition =
   $$$config.shouldAttemptEagerTransition;

--- a/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
+++ b/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
@@ -211,7 +211,10 @@ export function getCurrentUpdatePriority(): EventPriority {
   return currentUpdatePriority;
 }
 
-export function getCurrentEventPriority(): EventPriority {
+export function resolveUpdatePriority(): EventPriority {
+  if (currentUpdatePriority !== NoEventPriority) {
+    return currentUpdatePriority;
+  }
   return DefaultEventPriority;
 }
 export function shouldAttemptEagerTransition(): boolean {

--- a/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
+++ b/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
@@ -10,6 +10,7 @@
 import isArray from 'shared/isArray';
 import {
   DefaultEventPriority,
+  NoEventPriority,
   type EventPriority,
 } from 'react-reconciler/src/ReactEventPriorities';
 
@@ -199,6 +200,15 @@ export function createTextInstance(
     isHidden: false,
     tag: 'TEXT',
   };
+}
+
+let currentUpdatePriority: EventPriority = NoEventPriority;
+export function setCurrentUpdatePriority(newPriority: EventPriority): void {
+  currentUpdatePriority = newPriority;
+}
+
+export function getCurrentUpdatePriority(): EventPriority {
+  return currentUpdatePriority;
 }
 
 export function getCurrentEventPriority(): EventPriority {


### PR DESCRIPTION
Currently updatePriority is tracked in the reconciler. `flushSync` is going to be implemented reconciler agnostic soon and we need to move the tracking of this state to the renderer and out of reconciler. This change implements new renderer bin dings for getCurrentUpdatePriority and setCurrentUpdatePriority.

I was originally going to have the getter also do the event priority defaulting using window.event so we eliminate getCur rentEventPriority but this makes all the callsites where we store the true current updatePriority on the stack harder to work with so for now they remain separate.

I also moved runWithPriority to the renderer since it really belongs whereever the state is being managed and it is only currently exposed in the DOM renderer.

Additionally the current update priority is not stored on ReactDOMSharedInternals. While not particularly meaningful in this change it opens the door to implementing `flushSync` outside of the reconciler