### PR TITLE
[Flight] Support FormData from Server to Client

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -746,6 +746,16 @@ function parseModelString(
         }
         return undefined;
       }
+      case 'K': {
+        // FormData
+        const id = parseInt(value.slice(2), 16);
+        const data = getOutlinedModel(response, id);
+        const formData = new FormData();
+        for (let i = 0; i < data.length; i++) {
+          formData.append(data[i][0], data[i][1]);
+        }
+        return formData;
+      }
       case 'I': {
         // $Infinity
         return Infinity;

--- a/packages/react-client/src/ReactFlightReplyClient.js
+++ b/packages/react-client/src/ReactFlightReplyClient.js
@@ -75,7 +75,6 @@ export type ReactServerValue =
   | string
   | boolean
   | number
-  | symbol
   | null
   | void
   | bigint
@@ -83,6 +82,7 @@ export type ReactServerValue =
   | Array<ReactServerValue>
   | Map<ReactServerValue, ReactServerValue>
   | Set<ReactServerValue>
+  | FormData
   | Date
   | ReactServerObject
   | Promise<ReactServerValue>; // Thenable<ReactServerValue>

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -239,6 +239,7 @@ export type ReactClientValue =
   | Array<ReactClientValue>
   | Map<ReactClientValue, ReactClientValue>
   | Set<ReactClientValue>
+  | FormData
   | $ArrayBufferView
   | ArrayBuffer
   | Date
@@ -1186,6 +1187,12 @@ function serializeMap(
   return '$Q' + id.toString(16);
 }
 
+function serializeFormData(request: Request, formData: FormData): string {
+  const entries = Array.from(formData.entries());
+  const id = outlineModel(request, (entries: any));
+  return '$K' + id.toString(16);
+}
+
 function serializeSet(request: Request, set: Set<ReactClientValue>): string {
   const entries = Array.from(set);
   for (let i = 0; i < entries.length; i++) {
@@ -1594,6 +1601,10 @@ function renderModelDestructive(
     }
     if (value instanceof Set) {
       return serializeSet(request, value);
+    }
+    // TODO: FormData is not available in old Node. Remove the typeof later.
+    if (typeof FormData === 'function' && value instanceof FormData) {
+      return serializeFormData(request, value);
     }
 
     if (enableBinaryFlight) {
@@ -2138,6 +2149,10 @@ function renderConsoleValue(
     }
     if (value instanceof Set) {
       return serializeSet(request, value);
+    }
+    // TODO: FormData is not available in old Node. Remove the typeof later.
+    if (typeof FormData === 'function' && value instanceof FormData) {
+      return serializeFormData(request, value);
     }
 
     if (enableBinaryFlight) {


### PR DESCRIPTION
We currently support FormData for Replies mainly for Form Actions. This supports it in the other direction too which lets you return it from an action as the response. Mainly for parity.

We don't really recommend that you just pass the original form data back because the action is supposed to be able to clear fields and such but you could potentially at least use this as the format and could clear some fields.

We could potentially optimize this with a temporary reference if the same object was passed to a reply in case you use it as a round trip to avoid serializing it back again. That way the action has the ability to override it to clear fields but if it doesn't you get back the same as you sent.

#28755 adds support for Blobs when the `enableBinaryFlight` is enabled which allows them to be used inside FormData too.