### PR TITLE
[Fiber] Use real event priority for hydration scheduling

### DIFF
--- a/packages/react-dom-bindings/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom-bindings/src/events/ReactDOMEventReplaying.js
@@ -38,7 +38,7 @@ import {isHigherEventPriority} from 'react-reconciler/src/ReactEventPriorities';
 import {isRootDehydrated} from 'react-reconciler/src/ReactFiberShellHydration';
 import {dispatchReplayedFormAction} from './plugins/FormActionEventPlugin';
 import {
-  getCurrentUpdatePriority,
+  resolveUpdatePriority,
   runWithPriority as attemptHydrationAtPriority,
 } from '../client/ReactDOMUpdatePriority';
 
@@ -333,10 +333,7 @@ function attemptExplicitHydrationTarget(
 }
 
 export function queueExplicitHydrationTarget(target: Node): void {
-  // TODO: This will read the priority if it's dispatched by the React
-  // event system but not native events. Should read window.event.type, like
-  // we do for updates (getCurrentEventPriority).
-  const updatePriority = getCurrentUpdatePriority();
+  const updatePriority = resolveUpdatePriority();
   const queuedTarget: QueuedHydrationTarget = {
     blockedOn: null,
     target: target,


### PR DESCRIPTION
Stacked on #28751 

Historically explicit hydration scheduling used the reconciler's update priority to schedule the hydration. There was a lingering todo to switch to using event priority in the absence of an explicit update priority. This change updates the hydration priority by referring to the event priority if no update priority is set