### PR TITLE
Run stale job hourly

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,8 +2,8 @@
 name: 'Manage stale issues and PRs'
 on:
   schedule:
-    # Run daily at 2AM
-    - cron: '0 2 * * *'
+    # Run hourly
+    - cron: '0 * * * *'
 
 jobs:
   stale:
@@ -16,7 +16,7 @@ jobs:
           days-before-stale: 90
           # Number of days of inactivity before a stale issue or PR is closed
           days-before-close: 7
-          # Number of issues or PRs to process per day
+          # API calls per run
           operations-per-run: 100
 
           # --- Issues ---


### PR DESCRIPTION
Run stale job hourly

The stale job is currently limited to 100 API operations per run to protect against API limits and processing of each stale issue / PR take multiple API calls (commenting, adding or removing tags, closing etc).

It seems like we could bump this up as we have more operations available, but the limit seems to be hourly. Instead, this makes the job run hourly, spreading the work.

After an initial wave of marking and closing stale issues, this should keep the labeling "current" according to the "90 day to stale" configuration.
