### PR TITLE
CI: Run with Node.js 18.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 aliases:
   - &docker
-    - image: cimg/openjdk:18.0-node
+    - image: cimg/node:18.20.1-browsers
 
   - &environment
     TZ: /usr/share/zoneinfo/America/Los_Angeles
@@ -246,8 +246,7 @@ jobs:
           command: ./scripts/circleci/run_devtools_e2e_tests.js
 
   run_fixtures_flight_tests:
-    docker:
-      - image: cimg/openjdk:20.0-node
+    docker: *docker
     environment: *environment
     steps:
       - checkout


### PR DESCRIPTION
## Summary

Run CI with Node.js 18.20.1 instead of 16.16.0. Node.js 16.x has reached end-of-life. Codesandbox and local development already use 18.x due to `.nvmrc` anyway.

cimg/openjdk has no version satisfying Node.js ^18.18 which we need for ESLint v9. However, cimg/node does have Java 11 (which is sufficient for GCC). We can only choose between Node.js 18.13 (too low) and Node.js 20.x when using cimg/openjdk. Using Node.js 20.x would be an alternative but means we no longer test the lowest Node.js LTS release.

cimg/node-browsers is also just 170MB instead of 530MB that cimg/openjdk uses which is nice.


## How did you test this change?

- [x] CI
