### PR TITLE
jsx: Remove unnecessary hasOwnProperty check

### DIFF
--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -364,12 +364,8 @@ export function jsxProd(type, config, maybeKey) {
     // because in V8 it will deopt the object to dictionary mode.
     props = {};
     for (const propName in config) {
-      if (
-        hasOwnProperty.call(config, propName) &&
-        // Skip over reserved prop names
-        propName !== 'key' &&
-        (enableRefAsProp || propName !== 'ref')
-      ) {
+      // Skip over reserved prop names
+      if (propName !== 'key' && (enableRefAsProp || propName !== 'ref')) {
         if (enableRefAsProp && !disableStringRefs && propName === 'ref') {
           props.ref = coerceStringRef(
             config[propName],
@@ -603,12 +599,8 @@ export function jsxDEV(type, config, maybeKey, isStaticChildren, source, self) {
       // because in V8 it will deopt the object to dictionary mode.
       props = {};
       for (const propName in config) {
-        if (
-          hasOwnProperty.call(config, propName) &&
-          // Skip over reserved prop names
-          propName !== 'key' &&
-          (enableRefAsProp || propName !== 'ref')
-        ) {
+        // Skip over reserved prop names
+        if (propName !== 'key' && (enableRefAsProp || propName !== 'ref')) {
           if (enableRefAsProp && !disableStringRefs && propName === 'ref') {
             props.ref = coerceStringRef(
               config[propName],


### PR DESCRIPTION
Follow up to #28768.

The modern JSX runtime (`jsx`) does not need to check if each prop is a direct property with `hasOwnProperty` because the compiler always passes a plain object.

I'll leave the check in the old JSX runtime (`createElement`) since that one can be called manually with any kind of object, and if there were old user code that relied on this for some reason, it would be using that runtime.