### PR TITLE
[DOM] disallow client entrypoints with react-server condition

### DIFF
--- a/packages/react-dom/npm/client.react-server.js
+++ b/packages/react-dom/npm/client.react-server.js
@@ -1,0 +1,5 @@
+'use strict';
+
+throw new Error(
+  'react-dom/client is not supported in React Server Components.'
+);

--- a/packages/react-dom/npm/profiling.react-server.js
+++ b/packages/react-dom/npm/profiling.react-server.js
@@ -1,0 +1,5 @@
+'use strict';
+
+throw new Error(
+  'react-dom/profiling is not supported in React Server Components.'
+);

--- a/packages/react-dom/npm/server.react-server.js
+++ b/packages/react-dom/npm/server.react-server.js
@@ -1,0 +1,5 @@
+'use strict';
+
+throw new Error(
+  'react-dom/server is not supported in React Server Components.'
+);

--- a/packages/react-dom/npm/static.react-server.js
+++ b/packages/react-dom/npm/static.react-server.js
@@ -1,0 +1,5 @@
+'use strict';
+
+throw new Error(
+  'react-dom/static is not supported in React Server Components.'
+);

--- a/packages/react-dom/npm/unstable_testing.react-server.js
+++ b/packages/react-dom/npm/unstable_testing.react-server.js
@@ -1,0 +1,5 @@
+'use strict';
+
+throw new Error(
+  'react-dom/unstable_testing is not supported in React Server Components.'
+);

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -50,8 +50,12 @@
       "react-server": "./react-dom.react-server.js",
       "default": "./index.js"
     },
-    "./client": "./client.js",
+    "./client": {
+      "react-server": "./client.react-server.js",
+      "default": "./client.js"
+    },
     "./server": {
+      "react-server": "./server.react-server.js",
       "workerd": "./server.edge.js",
       "bun": "./server.bun.js",
       "deno": "./server.browser.js",
@@ -61,11 +65,24 @@
       "edge-light": "./server.edge.js",
       "default": "./server.node.js"
     },
-    "./server.browser": "./server.browser.js",
-    "./server.bun": "./server.bun.js",
-    "./server.edge": "./server.edge.js",
-    "./server.node": "./server.node.js",
+    "./server.browser": {
+      "react-server": "./server.react-server.js",
+      "default": "./server.browser.js"
+    },
+    "./server.bun": {
+      "react-server": "./server.react-server.js",
+      "default": "./server.bun.js"
+    },
+    "./server.edge": {
+      "react-server": "./server.react-server.js",
+      "default": "./server.edge.js"
+    },
+    "./server.node": {
+      "react-server": "./server.react-server.js",
+      "default": "./server.node.js"
+    },
     "./static": {
+      "react-server": "./static.react-server.js",
       "workerd": "./static.edge.js",
       "deno": "./static.browser.js",
       "worker": "./static.browser.js",
@@ -74,13 +91,28 @@
       "edge-light": "./static.edge.js",
       "default": "./static.node.js"
     },
-    "./static.browser": "./static.browser.js",
-    "./static.edge": "./static.edge.js",
-    "./static.node": "./static.node.js",
+    "./static.browser": {
+      "react-server": "./static.react-server.js",
+      "default": "./static.browser.js"
+    },
+    "./static.edge": {
+      "react-server": "./static.react-server.js",
+      "default": "./static.edge.js"
+    },
+    "./static.node": {
+      "react-server": "./static.react-server.js",
+      "default": "./static.node.js"
+    },
     "./server-rendering-stub": "./server-rendering-stub.js",
-    "./profiling": "./profiling.js",
+    "./profiling": {
+      "react-server": "./profiling.react-server.js",
+      "default": "./profiling.js"
+    },
     "./test-utils": "./test-utils.js",
-    "./unstable_testing": "./unstable_testing.js",
+    "./unstable_testing": {
+      "react-server": "./unstable_testing.react-server.js",
+      "default": "./unstable_testing.js"
+    },
     "./unstable_server-external-runtime": "./unstable_server-external-runtime.js",
     "./src/*": "./src/*",
     "./package.json": "./package.json"


### PR DESCRIPTION
`react-server` precludes loading code that expects to be run in a client context. This includes react-dom/client react-dom/server react-dom/unstable_testing react-dom/profiling and react-dom/static

This update makes importing any of these client only entrypoints an error
