### PR TITLE
Soften useFormState warning

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -104,7 +104,7 @@ describe('ReactDOMFizzServer', () => {
       console.error = (error, ...args) => {
         if (
           typeof error !== 'string' ||
-          error.indexOf('ReactDOM.useFormState has been deprecated') === -1
+          error.indexOf('ReactDOM.useFormState has been renamed') === -1
         ) {
           originalConsoleError(error, ...args);
         }

--- a/packages/react-dom/src/__tests__/ReactDOMForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMForm-test.js
@@ -66,7 +66,7 @@ describe('ReactDOMForm', () => {
       console.error = (error, ...args) => {
         if (
           typeof error !== 'string' ||
-          error.indexOf('ReactDOM.useFormState has been deprecated') === -1
+          error.indexOf('ReactDOM.useFormState has been renamed') === -1
         ) {
           originalConsoleError(error, ...args);
         }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -395,8 +395,8 @@ function warnOnUseFormStateInDev(): void {
       didWarnAboutUseFormState.add(componentName);
 
       console.error(
-        'ReactDOM.useFormState has been deprecated and replaced by ' +
-          'React.useActionState. Please update %s to use React.useActionState.',
+        'ReactDOM.useFormState has been renamed to React.useActionState. ' +
+          'Please update %s to use React.useActionState.',
         componentName,
       );
     }


### PR DESCRIPTION
It's not deprecated, it's really just renamed. Let's make the warning less scary.