### PR TITLE
[Tests][Fizz] Test script runtime even when external runtime is available

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -153,7 +153,7 @@ describe('ReactDOMFizzServer', () => {
     });
 
     renderOptions = {};
-    if (gate(flags => flags.enableFizzExternalRuntime)) {
+    if (gate(flags => flags.shouldUseFizzExternalRuntime)) {
       renderOptions.unstable_externalRuntimeSrc =
         'react-dom-bindings/src/server/ReactDOMServerExternalRuntime.js';
     }
@@ -610,7 +610,7 @@ describe('ReactDOMFizzServer', () => {
         Array.from(container.getElementsByTagName('script')).filter(
           node => node.getAttribute('nonce') === CSPnonce,
         ).length,
-      ).toEqual(6);
+      ).toEqual(gate(flags => flags.shouldUseFizzExternalRuntime) ? 6 : 5);
 
       await act(() => {
         resolve({default: Text});
@@ -4292,7 +4292,7 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate enableFizzExternalRuntime
+  // @gate shouldUseFizzExternalRuntime
   it('does not send script tags for SSR instructions when using the external runtime', async () => {
     function App() {
       return (

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -97,7 +97,7 @@ describe('ReactDOMFloat', () => {
     });
 
     renderOptions = {};
-    if (gate(flags => flags.enableFizzExternalRuntime)) {
+    if (gate(flags => flags.shouldUseFizzExternalRuntime)) {
       renderOptions.unstable_externalRuntimeSrc =
         'react-dom/unstable_server-external-runtime';
     }

--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -83,6 +83,15 @@ function getTestFlags() {
       enableSuspenseList: releaseChannel === 'experimental' || www,
       enableLegacyHidden: www,
 
+      // This flag is used to determine whether we should run Fizz tests using
+      // the external runtime or the inline script runtime.
+      // For Meta we use variant to gate the feature. For OSS we use experimental
+      shouldUseFizzExternalRuntime: !featureFlags.enableFizzExternalRuntime
+        ? false
+        : www
+        ? __VARIANT__
+        : __EXPERIMENTAL__,
+
       // This is used by useSyncExternalStoresShared-test.js to decide whether
       // to test the shim or the native implementation of useSES.
       // TODO: It's disabled when enableRefAsProp is on because the JSX


### PR DESCRIPTION
Previously if the external runtime was enabled Fizz tests would use it exclusively. However now that this flag is enabled for OSS and Meta builds this means we were no longer testing the inline script runtime. This changes the test flags to produce some runs where we test the inline script runtime and others where we test the external runtime

the external runtime will be tested if the flag is enabled and
* Meta Builds: variant is true
* OSS Builds: experiemental is true

this gives us decent coverage. long term we should probably bring variant to OSS builds since we will eventually want to test both modes even when the external runtime is stable.