### PR TITLE
[DOM] Infer react-server entries bundles if not explicitly configured

### DIFF
--- a/packages/react-dom/src/ReactDOMSharedInternals.js
+++ b/packages/react-dom/src/ReactDOMSharedInternals.js
@@ -47,8 +47,4 @@ const Internals: ReactDOMInternals = {
   usingClientEntryPoint: false,
 };
 
-// if (__DEV__) {
-//   (Internals: any).usingClientEntryPoint = false;
-// }
-
 export default Internals;

--- a/scripts/rollup/packaging.js
+++ b/scripts/rollup/packaging.js
@@ -213,6 +213,18 @@ function filterOutEntrypoints(name) {
       hasBundle =
         entryPointsToHasBundle.get(entry + '.node') ||
         entryPointsToHasBundle.get(entry + '.browser');
+
+      // The .react-server and .rsc suffixes may not have a bundle representation but
+      // should infer their bundle status from the non-suffixed entry point.
+      if (entry.endsWith('.react-server')) {
+        hasBundle = entryPointsToHasBundle.get(
+          entry.slice(0, '.react-server'.length * -1)
+        );
+      } else if (entry.endsWith('.rsc')) {
+        hasBundle = entryPointsToHasBundle.get(
+          entry.slice(0, '.rsc'.length * -1)
+        );
+      }
     }
     if (hasBundle === undefined) {
       // This doesn't exist in the bundles. It's an extra file.


### PR DESCRIPTION
When packaging we want to infer that a bundle exists for a `react-server` file even if it isn't explicitly configured. This is useful in particular for the react-server entrypoints that error on import that were recently added to `react-dom`

This change also cleans up a wayward comment left behind in a prior PR