### PR TITLE
Fix cloneElement using string ref w no owner

### DIFF
--- a/packages/react/src/__tests__/ReactElementClone-test.js
+++ b/packages/react/src/__tests__/ReactElementClone-test.js
@@ -292,38 +292,39 @@ describe('ReactElementClone', () => {
     }
   });
 
-  // @gate !flags.enableRefAsProp && !flags.disableStringRefs
   it('should steal the ref if a new string ref is specified without an owner', async () => {
     // Regression test for this specific feature combination calling cloneElement on an element
     // without an owner
-    await expect(async () => {
-      // create an element without an owner
-      const element = React.createElement('div', {id: 'some-id'});
-      class Parent extends React.Component {
-        render() {
-          return <Child>{element}</Child>;
+    if (gate(flags => !flags.enableRefAsProp && !flags.disableStringRefs)) {
+      await expect(async () => {
+        // create an element without an owner
+        const element = React.createElement('div', {id: 'some-id'});
+        class Parent extends React.Component {
+          render() {
+            return <Child>{element}</Child>;
+          }
         }
-      }
-      let child;
-      class Child extends React.Component {
-        render() {
-          child = this;
-          const clone = React.cloneElement(this.props.children, {
-            ref: 'xyz',
-          });
-          return <div>{clone}</div>;
+        let child;
+        class Child extends React.Component {
+          render() {
+            child = this;
+            const clone = React.cloneElement(this.props.children, {
+              ref: 'xyz',
+            });
+            return <div>{clone}</div>;
+          }
         }
-      }
 
-      const root = ReactDOMClient.createRoot(document.createElement('div'));
-      await act(() => root.render(<Parent />));
-      expect(child.refs.xyz.tagName).toBe('DIV');
-    }).toErrorDev([
-      'Warning: Component "Child" contains the string ref "xyz". Support for ' +
-        'string refs will be removed in a future major release. We recommend ' +
-        'using useRef() or createRef() instead. Learn more about using refs ' +
-        'safely here: https://react.dev/link/strict-mode-string-ref',
-    ]);
+        const root = ReactDOMClient.createRoot(document.createElement('div'));
+        await act(() => root.render(<Parent />));
+        expect(child.refs.xyz.tagName).toBe('DIV');
+      }).toErrorDev([
+        'Warning: Component "Child" contains the string ref "xyz". Support for ' +
+          'string refs will be removed in a future major release. We recommend ' +
+          'using useRef() or createRef() instead. Learn more about using refs ' +
+          'safely here: https://react.dev/link/strict-mode-string-ref',
+      ]);
+    }
   });
 
   it('should overwrite props', async () => {

--- a/packages/react/src/__tests__/ReactElementClone-test.js
+++ b/packages/react/src/__tests__/ReactElementClone-test.js
@@ -292,7 +292,9 @@ describe('ReactElementClone', () => {
     }
   });
 
-  it('should steal the ref if a new string ref is specified', async () => {
+  it('should steal the ref if a new string ref is specified without an owner', async () => {
+    // Regression test for this specific feature combination calling cloneElement on an element
+    // without an owner
     if (gate(flags => !flags.enableRefAsProp && !flags.disableStringRefs)) {
       await expect(async () => {
         // create an element without an owner

--- a/packages/react/src/__tests__/ReactElementClone-test.js
+++ b/packages/react/src/__tests__/ReactElementClone-test.js
@@ -274,8 +274,22 @@ describe('ReactElementClone', () => {
 
     const root = ReactDOMClient.createRoot(document.createElement('div'));
     await act(() => root.render(<Grandparent />));
-    expect(component.childRef).toEqual({current: null});
-    expect(component.parentRef.current.xyzRef.current.tagName).toBe('SPAN');
+    if (gate(flags => flags.enableRefAsProp && flags.disableStringRefs)) {
+      expect(component.childRef).toEqual({current: null});
+      expect(component.parentRef.current.xyzRef.current.tagName).toBe('SPAN');
+    } else if (
+      gate(flags => !flags.enableRefAsProp && !flags.disableStringRefs)
+    ) {
+      expect(component.childRef).toEqual({current: null});
+      expect(component.parentRef.current.xyzRef.current.tagName).toBe('SPAN');
+    } else if (
+      gate(flags => flags.enableRefAsProp && !flags.disableStringRefs)
+    ) {
+      expect(component.childRef).toEqual({current: null});
+      expect(component.parentRef.current.xyzRef.current.tagName).toBe('SPAN');
+    } else {
+      // Not going to bother testing every possible combination.
+    }
   });
 
   it('should overwrite props', async () => {
@@ -368,6 +382,11 @@ describe('ReactElementClone', () => {
       expect(clone.props).toEqual({foo: 'ef', ref: '34'});
     } else if (
       gate(flags => !flags.enableRefAsProp && !flags.disableStringRefs)
+    ) {
+      expect(clone.ref).toBe(element.ref);
+      expect(clone.props).toEqual({foo: 'ef'});
+    } else if (
+      gate(flags => flags.enableRefAsProp && !flags.disableStringRefs)
     ) {
       expect(clone.ref).toBe(element.ref);
       expect(clone.props).toEqual({foo: 'ef'});

--- a/packages/react/src/__tests__/ReactElementClone-test.js
+++ b/packages/react/src/__tests__/ReactElementClone-test.js
@@ -292,39 +292,38 @@ describe('ReactElementClone', () => {
     }
   });
 
+  // @gate !disableStringRefs
   it('should steal the ref if a new string ref is specified without an owner', async () => {
     // Regression test for this specific feature combination calling cloneElement on an element
     // without an owner
-    if (gate(flags => !flags.enableRefAsProp && !flags.disableStringRefs)) {
-      await expect(async () => {
-        // create an element without an owner
-        const element = React.createElement('div', {id: 'some-id'});
-        class Parent extends React.Component {
-          render() {
-            return <Child>{element}</Child>;
-          }
+    await expect(async () => {
+      // create an element without an owner
+      const element = React.createElement('div', {id: 'some-id'});
+      class Parent extends React.Component {
+        render() {
+          return <Child>{element}</Child>;
         }
-        let child;
-        class Child extends React.Component {
-          render() {
-            child = this;
-            const clone = React.cloneElement(this.props.children, {
-              ref: 'xyz',
-            });
-            return <div>{clone}</div>;
-          }
+      }
+      let child;
+      class Child extends React.Component {
+        render() {
+          child = this;
+          const clone = React.cloneElement(this.props.children, {
+            ref: 'xyz',
+          });
+          return <div>{clone}</div>;
         }
+      }
 
-        const root = ReactDOMClient.createRoot(document.createElement('div'));
-        await act(() => root.render(<Parent />));
-        expect(child.refs.xyz.tagName).toBe('DIV');
-      }).toErrorDev([
-        'Warning: Component "Child" contains the string ref "xyz". Support for ' +
-          'string refs will be removed in a future major release. We recommend ' +
-          'using useRef() or createRef() instead. Learn more about using refs ' +
-          'safely here: https://react.dev/link/strict-mode-string-ref',
-      ]);
-    }
+      const root = ReactDOMClient.createRoot(document.createElement('div'));
+      await act(() => root.render(<Parent />));
+      expect(child.refs.xyz.tagName).toBe('DIV');
+    }).toErrorDev([
+      'Warning: Component "Child" contains the string ref "xyz". Support for ' +
+        'string refs will be removed in a future major release. We recommend ' +
+        'using useRef() or createRef() instead. Learn more about using refs ' +
+        'safely here: https://react.dev/link/strict-mode-string-ref',
+    ]);
   });
 
   it('should overwrite props', async () => {

--- a/packages/react/src/__tests__/ReactElementClone-test.js
+++ b/packages/react/src/__tests__/ReactElementClone-test.js
@@ -292,39 +292,38 @@ describe('ReactElementClone', () => {
     }
   });
 
+  // @gate !flags.enableRefAsProp && !flags.disableStringRefs
   it('should steal the ref if a new string ref is specified without an owner', async () => {
     // Regression test for this specific feature combination calling cloneElement on an element
     // without an owner
-    if (gate(flags => !flags.enableRefAsProp && !flags.disableStringRefs)) {
-      await expect(async () => {
-        // create an element without an owner
-        const element = React.createElement('div', {id: 'some-id'});
-        class Parent extends React.Component {
-          render() {
-            return <Child>{element}</Child>;
-          }
+    await expect(async () => {
+      // create an element without an owner
+      const element = React.createElement('div', {id: 'some-id'});
+      class Parent extends React.Component {
+        render() {
+          return <Child>{element}</Child>;
         }
-        let child;
-        class Child extends React.Component {
-          render() {
-            child = this;
-            const clone = React.cloneElement(this.props.children, {
-              ref: 'xyz',
-            });
-            return <div>{clone}</div>;
-          }
+      }
+      let child;
+      class Child extends React.Component {
+        render() {
+          child = this;
+          const clone = React.cloneElement(this.props.children, {
+            ref: 'xyz',
+          });
+          return <div>{clone}</div>;
         }
+      }
 
-        const root = ReactDOMClient.createRoot(document.createElement('div'));
-        await act(() => root.render(<Parent />));
-        expect(child.refs.xyz.tagName).toBe('DIV');
-      }).toErrorDev([
-        'Warning: Component "Child" contains the string ref "xyz". Support for ' +
-          'string refs will be removed in a future major release. We recommend ' +
-          'using useRef() or createRef() instead. Learn more about using refs ' +
-          'safely here: https://react.dev/link/strict-mode-string-ref',
-      ]);
-    }
+      const root = ReactDOMClient.createRoot(document.createElement('div'));
+      await act(() => root.render(<Parent />));
+      expect(child.refs.xyz.tagName).toBe('DIV');
+    }).toErrorDev([
+      'Warning: Component "Child" contains the string ref "xyz". Support for ' +
+        'string refs will be removed in a future major release. We recommend ' +
+        'using useRef() or createRef() instead. Learn more about using refs ' +
+        'safely here: https://react.dev/link/strict-mode-string-ref',
+    ]);
   });
 
   it('should overwrite props', async () => {

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -866,6 +866,7 @@ export function cloneElement(element, config, children) {
 
   if (config != null) {
     if (hasValidRef(config)) {
+      owner = ReactSharedInternals.owner;
       if (!enableRefAsProp) {
         // Silently steal the ref from the parent.
         ref = config.ref;
@@ -873,7 +874,6 @@ export function cloneElement(element, config, children) {
           ref = coerceStringRef(ref, owner, element.type);
         }
       }
-      owner = ReactSharedInternals.owner;
     }
     if (hasValidKey(config)) {
       if (__DEV__) {


### PR DESCRIPTION
Fix for an issue introduced in #28473 where cloneElement() with a string ref fails due to lack of an owner. We should use the current owner in this case.