### PR TITLE
Scaffolding for requestFormReset API

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -102,6 +102,7 @@ import {listenToAllSupportedEvents} from '../events/DOMPluginEventSystem';
 import {validateLinkPropsForStyleResource} from '../shared/ReactDOMResourceValidation';
 import escapeSelectorAttributeValueInsideDoubleQuotes from './escapeSelectorAttributeValueInsideDoubleQuotes';
 import {flushSyncWork as flushSyncWorkOnAllRoots} from 'react-reconciler/src/ReactFiberWorkLoop';
+import {requestFormReset as requestFormResetOnFiber} from 'react-reconciler/src/ReactFiberHooks';
 
 import ReactDOMSharedInternals from 'shared/ReactDOMSharedInternals';
 
@@ -1928,6 +1929,7 @@ ReactDOMSharedInternals.d /* ReactDOMCurrentDispatcher */ = {
   f /* flushSyncWork */: disableLegacyMode
     ? flushSyncWork
     : previousDispatcher.f /* flushSyncWork */,
+  r: requestFormReset,
   D /* prefetchDNS */: prefetchDNS,
   C /* preconnect */: preconnect,
   L /* preload */: preload,
@@ -1948,6 +1950,23 @@ function flushSyncWork() {
     throw new Error(
       'flushSyncWork should not be called from builds that support legacy mode. This is a bug in React.',
     );
+  }
+}
+
+function requestFormReset(form: HTMLFormElement) {
+  const formInst = getInstanceFromNodeDOMTree(form);
+  if (
+    formInst !== null &&
+    formInst.tag === HostComponent &&
+    formInst.type === 'form'
+  ) {
+    requestFormResetOnFiber(formInst);
+  } else {
+    // This form was either not rendered by this React renderer (or it's an
+    // invalid type). Try the next one.
+    //
+    // The last implementation in the sequence will throw an error.
+    previousDispatcher.r(/* requestFormReset */ form);
   }
 }
 

--- a/packages/react-dom-bindings/src/server/ReactDOMFlightServerHostDispatcher.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMFlightServerHostDispatcher.js
@@ -28,6 +28,7 @@ const previousDispatcher =
   ReactDOMSharedInternals.d; /* ReactDOMCurrentDispatcher */
 ReactDOMSharedInternals.d /* ReactDOMCurrentDispatcher */ = {
   f /* flushSyncWork */: previousDispatcher.f /* flushSyncWork */,
+  r /* requestFormReset */: previousDispatcher.r /* requestFormReset */,
   D /* prefetchDNS */: prefetchDNS,
   C /* preconnect */: preconnect,
   L /* preload */: preload,

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -88,6 +88,7 @@ const previousDispatcher =
   ReactDOMSharedInternals.d; /* ReactDOMCurrentDispatcher */
 ReactDOMSharedInternals.d /* ReactDOMCurrentDispatcher */ = {
   f /* flushSyncWork */: previousDispatcher.f /* flushSyncWork */,
+  r /* requestFormReset */: previousDispatcher.r /* requestFormReset */,
   D /* prefetchDNS */: prefetchDNS,
   C /* preconnect */: preconnect,
   L /* preload */: preload,

--- a/packages/react-dom-bindings/src/shared/ReactDOMFormActions.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMFormActions.js
@@ -12,6 +12,7 @@ import type {Awaited} from 'shared/ReactTypes';
 
 import {enableAsyncActions} from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
+import ReactDOMSharedInternals from 'shared/ReactDOMSharedInternals';
 
 type FormStatusNotPending = {|
   pending: false,
@@ -86,4 +87,9 @@ export function useFormState<S, P>(
     // $FlowFixMe[not-a-function] This is unstable, thus optional
     return dispatcher.useFormState(action, initialState, permalink);
   }
+}
+
+export function requestFormReset(form: HTMLFormElement) {
+  ReactDOMSharedInternals.d /* ReactDOMCurrentDispatcher */
+    .r(/* requestFormReset */ form);
 }

--- a/packages/react-dom/index.classic.fb.js
+++ b/packages/react-dom/index.classic.fb.js
@@ -25,6 +25,7 @@ export {
   unstable_runWithPriority, // DO NOT USE: Temporarily exposed to migrate off of Scheduler.runWithPriority.
   useFormStatus,
   useFormState,
+  requestFormReset,
   prefetchDNS,
   preconnect,
   preload,

--- a/packages/react-dom/index.experimental.js
+++ b/packages/react-dom/index.experimental.js
@@ -17,6 +17,7 @@ export {
   unstable_runWithPriority, // DO NOT USE: Temporarily exposed to migrate off of Scheduler.runWithPriority.
   useFormStatus,
   useFormState,
+  requestFormReset,
   prefetchDNS,
   preconnect,
   preload,

--- a/packages/react-dom/index.js
+++ b/packages/react-dom/index.js
@@ -20,6 +20,7 @@ export {
   unstable_runWithPriority, // DO NOT USE: Temporarily exposed to migrate off of Scheduler.runWithPriority.
   useFormStatus,
   useFormState,
+  requestFormReset,
   prefetchDNS,
   preconnect,
   preload,

--- a/packages/react-dom/index.modern.fb.js
+++ b/packages/react-dom/index.modern.fb.js
@@ -16,6 +16,7 @@ export {
   unstable_runWithPriority, // DO NOT USE: Temporarily exposed to migrate off of Scheduler.runWithPriority.
   useFormStatus,
   useFormState,
+  requestFormReset,
   prefetchDNS,
   preconnect,
   preload,

--- a/packages/react-dom/index.stable.js
+++ b/packages/react-dom/index.stable.js
@@ -16,6 +16,7 @@ export {
   unstable_batchedUpdates,
   useFormStatus,
   useFormState,
+  requestFormReset,
   prefetchDNS,
   preconnect,
   preload,

--- a/packages/react-dom/src/ReactDOMSharedInternals.js
+++ b/packages/react-dom/src/ReactDOMSharedInternals.js
@@ -29,8 +29,16 @@ export type ReactDOMInternalsDev = ReactDOMInternals & {
 
 function noop() {}
 
+function requestFormReset(element: HTMLFormElement) {
+  throw new Error(
+    'Invalid form element. requestFormReset must be passed a form that was ' +
+      'rendered by React.',
+  );
+}
+
 const DefaultDispatcher: HostDispatcher = {
   f /* flushSyncWork */: noop,
+  r /* requestFormReset */: requestFormReset,
   D /* prefetchDNS */: noop,
   C /* preconnect */: noop,
   L /* preload */: noop,

--- a/packages/react-dom/src/ReactDOMSharedInternalsFB.js
+++ b/packages/react-dom/src/ReactDOMSharedInternalsFB.js
@@ -27,6 +27,7 @@ function noop() {}
 
 const DefaultDispatcher: HostDispatcher = {
   f /* flushSyncWork */: noop,
+  r /* requestFormReset */: noop,
   D /* prefetchDNS */: noop,
   C /* preconnect */: noop,
   L /* preload */: noop,

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -48,6 +48,7 @@ export {
 export {
   useFormStatus,
   useFormState,
+  requestFormReset,
 } from 'react-dom-bindings/src/shared/ReactDOMFormActions';
 
 if (__DEV__) {

--- a/packages/react-dom/src/client/ReactDOMFB.js
+++ b/packages/react-dom/src/client/ReactDOMFB.js
@@ -48,6 +48,7 @@ export {
 export {
   useFormStatus,
   useFormState,
+  requestFormReset,
 } from 'react-dom-bindings/src/shared/ReactDOMFormActions';
 
 if (__DEV__) {

--- a/packages/react-dom/src/shared/ReactDOMTypes.js
+++ b/packages/react-dom/src/shared/ReactDOMTypes.js
@@ -83,6 +83,7 @@ export type PreinitModuleScriptOptions = {
 
 export type HostDispatcher = {
   f /* flushSyncWork */: () => boolean | void,
+  r /* requestFormReset */: (form: HTMLFormElement) => void,
   D /* prefetchDNS */: (href: string) => void,
   C /* preconnect */: (href: string, crossOrigin?: ?CrossOriginEnum) => void,
   L /* preload */: (

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -3008,13 +3008,18 @@ export function startHostTransition<F>(
     // once more of this function is implemented.
     () => {
       // Automatically reset the form when the action completes.
-      requestFormReset(formFiber);
+      requestFormResetImpl(formFiber);
       return callback(formData);
     },
   );
 }
 
-function requestFormReset(formFiber: Fiber) {
+export function requestFormReset(formFiber: Fiber) {
+  // TODO: Not yet implemented. Need to upgrade the fiber to be stateful
+  // before scheduling the form reset.
+}
+
+function requestFormResetImpl(formFiber: Fiber) {
   const transition = requestCurrentTransition();
 
   if (__DEV__) {

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -506,5 +506,6 @@
   "518": "Saw multiple hydration diff roots in a pass. This is a bug in React.",
   "519": "Hydration Mismatch Exception: This is not a real error, and should not leak into userspace. If you're seeing this, it's likely a bug in React.",
   "520": "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root.",
-  "521": "flushSyncWork should not be called from builds that support legacy mode. This is a bug in React."
+  "521": "flushSyncWork should not be called from builds that support legacy mode. This is a bug in React.",
+  "522": "Invalid form element. requestFormReset must be passed a form that was rendered by React."
 }


### PR DESCRIPTION
Based on:

- #28804 

---

This sets adds a new ReactDOM export called requestFormReset, including setting up the export and creating a method on the internal ReactDOM dispatcher. It does not yet add any implementation.

Doing this in its own commit for review purposes.

The API itself will be explained in the next PR.