### PR TITLE
Remove Scheduler.log from ReactSuspenseFuzz-test

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
@@ -115,24 +115,19 @@ describe('ReactSuspenseFuzz', () => {
               setTimeout(() => {
                 cache.set(fullText, fullText);
                 pendingTasks.delete(task);
-                Scheduler.log(task.label);
                 resolve();
               }, delay);
             },
           };
           cache.set(fullText, thenable);
-          Scheduler.log(`Suspended! [${fullText}]`);
           throw thenable;
         } else if (typeof resolvedText.then === 'function') {
-          const thenable = resolvedText;
-          Scheduler.log(`Suspended! [${fullText}]`);
-          throw thenable;
+          throw resolvedText;
         }
       } else {
         resolvedText = fullText;
       }
 
-      Scheduler.log(resolvedText);
       return resolvedText;
     }
 


### PR DESCRIPTION
These test don't `assertLog` or `waitFor` so we don't need to `Scheduler.log`. Ideally we would, but since they're fuzzers it's a bit difficult to know what the expected log is from the helper.

Since this doesn't regress current test behavior, we can improve them after this to unblock https://github.com/facebook/react/pull/28737