### PR TITLE
Move enableUseDeferredValueInitialArg to canary

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -116,8 +116,6 @@ export const alwaysThrottleRetries = true;
 
 export const passChildrenWhenCloningPersistedNodes = false;
 
-export const enableUseDeferredValueInitialArg = __EXPERIMENTAL__;
-
 export const enableServerComponentLogs = __EXPERIMENTAL__;
 
 /**
@@ -190,6 +188,9 @@ export const disableDOMTestUtils = true;
 
 // Make <Context> equivalent to <Context.Provider> instead of <Context.Consumer>
 export const enableRenderableContext = true;
+
+// Enables the `initialValue` option for `useDeferredValue`
+export const enableUseDeferredValueInitialArg = true;
 
 // -----------------------------------------------------------------------------
 // Chopping Block


### PR DESCRIPTION
Per team discussion, this upgrades the `initialValue` argument for `useDeferredValue` from experimental to canary.

- Original implementation PR: https://github.com/facebook/react/pull/27500
- API documentation PR: https://github.com/reactjs/react.dev/pull/6747

I left it disabled at Meta for now in case there's old code somewhere that is still passing an `options` object as the second argument.