### PR TITLE
Fix nightly release job

### DIFF
--- a/scripts/release/publish-commands/publish-to-npm.js
+++ b/scripts/release/publish-commands/publish-to-npm.js
@@ -2,10 +2,11 @@
 
 'use strict';
 
+const {spawnSync} = require('child_process');
 const {exec} = require('child-process-promise');
 const {readJsonSync} = require('fs-extra');
 const {join} = require('path');
-const {confirm, execRead} = require('../utils');
+const {confirm} = require('../utils');
 const theme = require('../theme');
 
 const run = async ({cwd, dry, tags, ci}, packageName, otp) => {
@@ -16,8 +17,9 @@ const run = async ({cwd, dry, tags, ci}, packageName, otp) => {
   // If so we might be resuming from a previous run.
   // We could infer this by comparing the build-info.json,
   // But for now the easiest way is just to ask if this is expected.
-  const info = await execRead(`npm view ${packageName}@${version}`);
-  if (info) {
+  const {status} = spawnSync('npm', ['view', `${packageName}@${version}`]);
+  const packageExists = status === 0;
+  if (!packageExists) {
     console.log(
       theme`{package ${packageName}} {version ${version}} has already been published.`
     );


### PR DESCRIPTION
## Summary

By upgrading Node.js in https://github.com/facebook/react/pull/28774, NPM was also upgraded. `npm view` of a non-existing version now exits non-zero so we need to adjust our implementation to detect if the package was already published.

Fixes 
> Command failed: npm view eslint-plugin-react-hooks@5.1.0-canary-bf09089f6-20240410

-- https://app.circleci.com/pipelines/github/facebook/react/52188/workflows/71bfe167-2a02-4924-98cf-824b7812614e

## How did you test this change?

```js
// main.js
const {spawnSync} = require('child_process');

function npmPackageExists(packageName, version) {
  const {status} = spawnSync('npm', ['view', `${packageName}@${version}`]);
  return status === 0;
}

function main() {
  console.log(npmPackageExists('react', '17.0.1'));
  console.log(npmPackageExists('react', '19.0.0-canary-bf09089f6-20240410'));
}

main();
```

```bash
$ node --version
v18.20.0
$ npm --version
10.5.0
$ node index.js 
true
false
```