### PR TITLE
[Devtools] Look for a ReactMemoCacheSentinel on state

### DIFF
--- a/packages/react-devtools-shared/src/backend/ReactSymbols.js
+++ b/packages/react-devtools-shared/src/backend/ReactSymbols.js
@@ -67,3 +67,7 @@ export const SUSPENSE_LIST_SYMBOL_STRING = 'Symbol(react.suspense_list)';
 
 export const SERVER_CONTEXT_DEFAULT_VALUE_NOT_LOADED_SYMBOL_STRING =
   'Symbol(react.server_context.defaultValue)';
+
+export const REACT_MEMO_CACHE_SENTINEL: symbol = Symbol.for(
+  'react.memo_cache_sentinel',
+);

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -86,6 +86,7 @@ import {
   STRICT_MODE_SYMBOL_STRING,
   PROFILER_NUMBER,
   PROFILER_SYMBOL_STRING,
+  REACT_MEMO_CACHE_SENTINEL,
   SCOPE_NUMBER,
   SCOPE_SYMBOL_STRING,
   FORWARD_REF_NUMBER,
@@ -474,8 +475,12 @@ export function getInternalReactConstants(version: string): {
     }
 
     let resolvedContext: any = null;
-    // $FlowFixMe[incompatible-type] fiber.updateQueue is mixed
-    if (!shouldSkipForgetCheck && fiber.updateQueue?.memoCache != null) {
+    if (
+      !shouldSkipForgetCheck &&
+      // $FlowFixMe[incompatible-type] fiber.updateQueue is mixed
+      (fiber.updateQueue?.memoCache != null ||
+        fiber.memoizedState?.memoizedState?.[REACT_MEMO_CACHE_SENTINEL])
+    ) {
       const displayNameWithoutForgetWrapper = getDisplayNameForFiber(
         fiber,
         true,


### PR DESCRIPTION
The useMemoCache polyfill doesn't have access to the fiber, and it simply uses state, which makes it not work with the devtools.

With this PR, devtools will look on the very first hook's state for this sentinel and display the Forget badge if present.

The polyfill will add this sentinel to it's state (the cache array).