### PR TITLE
feat[devtools-fusebox]: support theme option

### DIFF
--- a/packages/react-devtools-fusebox/src/frontend.js
+++ b/packages/react-devtools-fusebox/src/frontend.js
@@ -13,7 +13,10 @@ import Bridge from 'react-devtools-shared/src/bridge';
 import Store from 'react-devtools-shared/src/devtools/store';
 import DevTools from 'react-devtools-shared/src/devtools/views/DevTools';
 
-import type {Wall} from 'react-devtools-shared/src/frontend/types';
+import type {
+  BrowserTheme,
+  Wall,
+} from 'react-devtools-shared/src/frontend/types';
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
 
 type Config = {
@@ -42,18 +45,20 @@ export function createStore(bridge: FrontendBridge, config?: Config): Store {
 type InitializationOptions = {
   bridge: FrontendBridge,
   store: Store,
+  theme?: BrowserTheme,
 };
 
 export function initialize(
   contentWindow: Element | Document,
   options: InitializationOptions,
 ): void {
-  const {bridge, store} = options;
+  const {bridge, store, theme = 'light'} = options;
   const root = createRoot(contentWindow);
 
   root.render(
     <DevTools
       bridge={bridge}
+      browserTheme={theme}
       store={store}
       showTabBar={true}
       warnIfLegacyBackendDetected={true}


### PR DESCRIPTION
Support propagating theme from Chrome DevTools frontend, the field is optional.

Next step, which is out of scope of this project and general improvement for React DevTools: teach RDT to listen to theme changes and if the theme preference is set to `auto` in settings, update the theme accordingly with the browser devtools.