### PR TITLE
Revert to use console.error for onRecoverableError on RN

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -22,7 +22,6 @@ import {
   getPublicRootInstance,
   defaultOnUncaughtError,
   defaultOnCaughtError,
-  defaultOnRecoverableError,
 } from 'react-reconciler/src/ReactFiberReconciler';
 
 import {createPortal as createPortalImpl} from 'react-reconciler/src/ReactPortal';
@@ -100,6 +99,10 @@ function nativeOnCaughtError(
 
   defaultOnCaughtError(error, errorInfo);
 }
+function nativeOnRecoverableError(error: mixed): void {
+  // eslint-disable-next-line react-internal/no-production-logging, react-internal/warning-args
+  console.error(error);
+}
 
 function render(
   element: Element<ElementType>,
@@ -125,7 +128,7 @@ function render(
       '',
       nativeOnUncaughtError,
       nativeOnCaughtError,
-      defaultOnRecoverableError,
+      nativeOnRecoverableError,
       null,
     );
     roots.set(containerTag, root);

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -22,7 +22,6 @@ import {
   getPublicRootInstance,
   defaultOnUncaughtError,
   defaultOnCaughtError,
-  defaultOnRecoverableError,
 } from 'react-reconciler/src/ReactFiberReconciler';
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 import {getStackByFiberInDevAndProd} from 'react-reconciler/src/ReactFiberComponentStack';
@@ -105,6 +104,10 @@ function nativeOnCaughtError(
 
   defaultOnCaughtError(error, errorInfo);
 }
+function nativeOnRecoverableError(error: mixed): void {
+  // eslint-disable-next-line react-internal/no-production-logging, react-internal/warning-args
+  console.error(error);
+}
 
 function render(
   element: Element<ElementType>,
@@ -129,7 +132,7 @@ function render(
       '',
       nativeOnUncaughtError,
       nativeOnCaughtError,
-      defaultOnRecoverableError,
+      nativeOnRecoverableError,
       null,
     );
     roots.set(containerTag, root);


### PR DESCRIPTION
We are debugging an issue that some error logs are dropped. One potential cause is that `onRecoverableError` behavior was changed for RN in https://github.com/facebook/react/commit/a0537160771bafae90c6fd3154eeead2f2c903e7
The commit reverts the behavior incase this is the root cause.

