### PR TITLE
Enable flag disableClientCache

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -159,7 +159,7 @@ export const disableIEWorkarounds = true;
 export const enableFilterEmptyStringAttributesDOM = true;
 
 // Disabled caching behavior of `react/cache` in client runtimes.
-export const disableClientCache = false;
+export const disableClientCache = true;
 
 // Changes Server Components Reconciliation when they have keys
 export const enableServerComponentKeys = true;

--- a/scripts/jest/setupTests.www.js
+++ b/scripts/jest/setupTests.www.js
@@ -15,10 +15,11 @@ jest.mock('shared/ReactFeatureFlags', () => {
   // code live.
   actual.disableInputAttributeSyncing = __VARIANT__;
 
-  // This is hardcoded to true for the next release,
+  // These are hardcoded to true for the next release,
   // but still run the tests against both variants until
   // we remove the flag.
   actual.disableIEWorkarounds = __VARIANT__;
+  actual.disableClientCache = __VARIANT__;
 
   return actual;
 });


### PR DESCRIPTION
Enable flag disableClientCache

Forcing a `__VARIANT__` in the mock file so we keep testing this until fully removing it.
