### PR TITLE
Add ReactNativeTypes for root options

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -10,6 +10,7 @@
 import type {ReactPortal, ReactNodeList} from 'shared/ReactTypes';
 import type {ElementRef, Element, ElementType} from 'react';
 import type {FiberRoot} from 'react-reconciler/src/ReactInternalTypes';
+import type {RenderRootOptions} from './ReactNativeTypes';
 
 import './ReactFabricInjection';
 
@@ -101,30 +102,12 @@ function nativeOnCaughtError(
   defaultOnCaughtError(error, errorInfo);
 }
 
-type NativeRenderOptions = {
-  onUncaughtError?: (
-    error: mixed,
-    errorInfo: {+componentStack?: ?string},
-  ) => void,
-  onCaughtError?: (
-    error: mixed,
-    errorInfo: {
-      +componentStack?: ?string,
-      +errorBoundary?: ?React$Component<any, any>,
-    },
-  ) => void,
-  onRecoverableError?: (
-    error: mixed,
-    errorInfo: {+componentStack?: ?string},
-  ) => void,
-};
-
 function render(
   element: Element<ElementType>,
   containerTag: number,
   callback: ?() => void,
   concurrentRoot: ?boolean,
-  options?: NativeRenderOptions,
+  options: ?RenderRootOptions,
 ): ?ElementRef<ElementType> {
   if (disableLegacyMode && !concurrentRoot) {
     throw new Error('render: Unsupported Legacy Mode API.');

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -10,6 +10,7 @@
 import type {ReactPortal, ReactNodeList} from 'shared/ReactTypes';
 import type {ElementRef, Element, ElementType} from 'react';
 import type {FiberRoot} from 'react-reconciler/src/ReactInternalTypes';
+import type {RenderRootOptions} from './ReactNativeTypes';
 
 import './ReactNativeInjection';
 
@@ -106,29 +107,11 @@ function nativeOnCaughtError(
   defaultOnCaughtError(error, errorInfo);
 }
 
-type NativeRenderOptions = {
-  onUncaughtError?: (
-    error: mixed,
-    errorInfo: {+componentStack?: ?string},
-  ) => void,
-  onCaughtError?: (
-    error: mixed,
-    errorInfo: {
-      +componentStack?: ?string,
-      +errorBoundary?: ?React$Component<any, any>,
-    },
-  ) => void,
-  onRecoverableError?: (
-    error: mixed,
-    errorInfo: {+componentStack?: ?string},
-  ) => void,
-};
-
 function render(
   element: Element<ElementType>,
   containerTag: number,
   callback: ?() => void,
-  options?: NativeRenderOptions,
+  options: ?RenderRootOptions,
 ): ?ElementRef<ElementType> {
   if (disableLegacyMode) {
     throw new Error('render: Unsupported Legacy Mode API.');

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -215,6 +215,24 @@ export opaque type InternalInstanceHandle = mixed;
 type PublicInstance = mixed;
 type PublicTextInstance = mixed;
 
+export type RenderRootOptions = {
+  onUncaughtError?: (
+    error: mixed,
+    errorInfo: {+componentStack?: ?string},
+  ) => void,
+  onCaughtError?: (
+    error: mixed,
+    errorInfo: {
+      +componentStack?: ?string,
+      +errorBoundary?: ?React$Component<any, any>,
+    },
+  ) => void,
+  onRecoverableError?: (
+    error: mixed,
+    errorInfo: {+componentStack?: ?string},
+  ) => void,
+};
+
 export type ReactFabricType = {
   findHostInstance_DEPRECATED<TElementType: ElementType>(
     componentOrHandle: ?(ElementRef<TElementType> | number),
@@ -237,6 +255,7 @@ export type ReactFabricType = {
     containerTag: number,
     callback: ?() => void,
     concurrentRoot: ?boolean,
+    options: ?RenderRootOptions,
   ): ?ElementRef<ElementType>,
   unmountComponentAtNode(containerTag: number): void,
   getNodeFromInternalInstanceHandle(


### PR DESCRIPTION
Flow should have failed for this but didn't, we need these options sync'd over in the types too.