### PR TITLE
Promote ASYNC_ITERATOR symbol to React Symbols

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -65,6 +65,7 @@ import {
   REACT_LAZY_TYPE,
   REACT_ELEMENT_TYPE,
   REACT_POSTPONE_TYPE,
+  ASYNC_ITERATOR,
 } from 'shared/ReactSymbols';
 
 export type {CallServerCallback, EncodeFormActionCallback};
@@ -1244,8 +1245,6 @@ function startReadableStream<T>(
   };
   resolveStream(response, id, stream, flightController);
 }
-
-const ASYNC_ITERATOR = Symbol.asyncIterator;
 
 function asyncIterator(this: $AsyncIterator<any, any, void>) {
   // Self referencing iterator.

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -99,6 +99,7 @@ import {
   REACT_LAZY_TYPE,
   REACT_MEMO_TYPE,
   REACT_POSTPONE_TYPE,
+  ASYNC_ITERATOR,
 } from 'shared/ReactSymbols';
 
 import {
@@ -200,8 +201,6 @@ if (
 }
 
 const ObjectPrototype = Object.prototype;
-
-const ASYNC_ITERATOR = Symbol.asyncIterator;
 
 type JSONValue =
   | string

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -60,3 +60,5 @@ export function getIteratorFn(maybeIterable: ?any): ?() => ?Iterator<any> {
   }
   return null;
 }
+
+export const ASYNC_ITERATOR = Symbol.asyncIterator;


### PR DESCRIPTION
So that when we end up referring to it in more places, it's only one.

We don't do this same pattern for regular `Symbol.iterator` because we also support the string `"@@iterator"` for backwards compatibility.