### PR TITLE
console test utils fix: match entire string, not just first letter

### DIFF
--- a/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
+++ b/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
@@ -2135,7 +2135,7 @@ describe('ReactInternalTestUtils console assertions', () => {
         console.error('Message that happens to contain a "T"\n    in div');
 
         assertConsoleErrorDev([
-          'This is a complete different message that happens to start with "T"',
+          'This is a completely different message that happens to start with "T"',
         ]);
       });
       expect(message).toMatchInlineSnapshot(`

--- a/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
+++ b/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
@@ -2129,6 +2129,28 @@ describe('ReactInternalTestUtils console assertions', () => {
       `);
     });
 
+    // @gate __DEV__
+    it('regression: checks entire string, not just the first letter', async () => {
+      const message = expectToThrowFailure(() => {
+        console.error('Message that happens to contain a "T"\n    in div');
+
+        assertConsoleErrorDev([
+          'This is a complete different message that happens to start with "T"',
+        ]);
+      });
+      expect(message).toMatchInlineSnapshot(`
+        "assertConsoleErrorDev(expected)
+
+        Unexpected error(s) recorded.
+
+        - Expected errors
+        + Received errors
+
+        - This is a complete different message that happens to start with "T"
+        + Message that happens to contain a "T" <component stack>"
+      `);
+    });
+
     describe('global withoutStack', () => {
       // @gate __DEV__
       it('passes if errors without stack explicitly opt out', () => {

--- a/packages/internal-test-utils/consoleMock.js
+++ b/packages/internal-test-utils/consoleMock.js
@@ -386,7 +386,7 @@ export function createLogAssertion(
           expectedWithoutStack = expectedMessageOrArray[1].withoutStack;
         } else if (typeof expectedMessageOrArray === 'string') {
           // Should be in the form assert(['log']) or assert(['log'], {withoutStack: true})
-          expectedMessage = replaceComponentStack(expectedMessageOrArray[0]);
+          expectedMessage = replaceComponentStack(expectedMessageOrArray);
           if (consoleMethod === 'log') {
             expectedWithoutStack = true;
           } else {


### PR DESCRIPTION
Fixes issue where if the first letter of the expected string appeared anywhere in actual message, the assertion would pass, leading to false negatives. We should check the entire expected string.