### PR TITLE
Add missing bundle types for ReactCacheOld

### DIFF
--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -879,9 +879,7 @@ const bundles = [
 
   /******* React Cache (experimental, old) *******/
   {
-    // This is only used by our own tests.
-    // We can delete it later.
-    bundleTypes: [NODE_DEV, NODE_PROD],
+    bundleTypes: [NODE_DEV, NODE_PROD, FB_WWW_DEV, FB_WWW_PROD],
     moduleType: ISOMORPHIC,
     entry: 'react-cache',
     global: 'ReactCacheOld',


### PR DESCRIPTION
Add missing bundle types for ReactCacheOld

These are used at FB and we need to update them for the SecretInternals update.
