### PR TITLE
Write Diff Train import branch to this repo

### DIFF
--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -210,7 +210,7 @@ jobs:
           commit_user_email: ${{ github.actor }}@users.noreply.github.com
           create_branch: true
 
-  commit_fbsource_artifacts:
+  commit_fbsource_artifacts_external_repo:
     needs: download_artifacts
     runs-on: ubuntu-latest
     if: ${{ (github.ref == 'refs/heads/main' && needs.download_artifacts.outputs.fbsource_branch_count == '0') || github.ref == 'refs/heads/meta-fbsource' }}
@@ -245,3 +245,39 @@ jobs:
             DiffTrain build for commit https://github.com/facebook/react/commit/${{ github.sha }}.
           commit_user_name: ${{ github.actor }}
           commit_user_email: ${{ github.actor }}@users.noreply.github.com
+
+  commit_fbsource_artifacts:
+    needs: download_artifacts
+    if: ${{ (github.ref == 'refs/heads/main' && needs.download_artifacts.outputs.fbsource_branch_count == '0') || github.ref == 'refs/heads/meta-fbsource' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: builds/facebook-fbsource
+      - name: Ensure clean directory
+        run: rm -rf compiled
+      - uses: actions/download-artifact@v3
+        with:
+          name: compiled-rn
+          path: compiled-rn/
+      - run: git status -u
+      - name: Check if only the REVISION file has changed
+        id: check_should_commit
+        run: |
+          if git status --porcelain | grep -qv '/REVISION$'; then
+            echo "should_commit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_commit=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Commit changes to branch
+        if: steps.check_should_commit.outputs.should_commit == 'true'
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: |
+            ${{ github.event.head_commit.message }}
+
+            DiffTrain build for commit https://github.com/facebook/react/commit/${{ github.sha }}.
+          branch: builds/facebook-fbsource
+          commit_user_name: ${{ github.actor }}
+          commit_user_email: ${{ github.actor }}@users.noreply.github.com
+          create_branch: true


### PR DESCRIPTION
For fbsource we've historically used a separate repo for imports due to internal limitations in Diff Train. Those have been lifted so we can now commit this branch here and then we can import from this repo (and get rid of the other repo)