### PR TITLE
Deprecate `renderToStaticNodeStream`

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -580,16 +580,28 @@ describe('ReactDOMServer', () => {
   describe('renderToStaticNodeStream', () => {
     it('should generate simple markup', () => {
       const SuccessfulElement = React.createElement(() => <img />);
-      const response =
-        ReactDOMServer.renderToStaticNodeStream(SuccessfulElement);
-      expect(response.read().toString()).toMatch(new RegExp('<img' + '/>'));
+      expect(() => {
+        const response =
+          ReactDOMServer.renderToStaticNodeStream(SuccessfulElement);
+        expect(response.read().toString()).toMatch(new RegExp('<img' + '/>'));
+      }).toErrorDev(
+        'ReactDOMServer.renderToStaticNodeStream() is deprecated and will be removed in an upcomingrelease of React',
+        {withoutStack: true},
+      );
     });
 
     it('should handle errors correctly', () => {
       const FailingElement = React.createElement(() => {
         throw new Error('An Error');
       });
-      const response = ReactDOMServer.renderToStaticNodeStream(FailingElement);
+
+      let response;
+      expect(() => {
+        response = ReactDOMServer.renderToStaticNodeStream(FailingElement);
+      }).toErrorDev(
+        'ReactDOMServer.renderToStaticNodeStream() is deprecated and will be removed in an upcomingrelease of React',
+        {withoutStack: true},
+      );
       return new Promise(resolve => {
         response.once('error', () => {
           resolve();
@@ -614,12 +626,18 @@ describe('ReactDOMServer', () => {
         throw promise;
       }
 
-      const response = ReactDOMServer.renderToStaticNodeStream(
-        <div>
-          <React.Suspense fallback={'fallback'}>
-            <Suspender />
-          </React.Suspense>
-        </div>,
+      let response;
+      expect(() => {
+        response = ReactDOMServer.renderToStaticNodeStream(
+          <div>
+            <React.Suspense fallback={'fallback'}>
+              <Suspender />
+            </React.Suspense>
+          </div>,
+        );
+      }).toErrorDev(
+        'ReactDOMServer.renderToStaticNodeStream() is deprecated and will be removed in an upcomingrelease of React',
+        {withoutStack: true},
       );
       await resolve();
       expect(response.read().toString()).toEqual('<div>resolved</div>');

--- a/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
@@ -59,10 +59,23 @@ function onError() {
   // Non-fatal errors are ignored.
 }
 
+let didWarnAboutDeprecatedRenderToStaticNodeStream = false;
+
 function renderToStaticNodeStream(
   children: ReactNodeList,
   options?: ServerOptions,
 ): Readable {
+  if (__DEV__) {
+    if (!didWarnAboutDeprecatedRenderToStaticNodeStream) {
+      didWarnAboutDeprecatedRenderToStaticNodeStream = true;
+      console.error(
+        'ReactDOMServer.renderToStaticNodeStream() is deprecated and will be removed in an upcoming' +
+          'release of React. Use ReactDOMServer.renderToPipeableStream() and wait to `pipe` until the `onAllReady`' +
+          ' callback has been called to produce a document suitable for static use cases.',
+      );
+    }
+  }
+
   function onAllReady() {
     // We wait until everything has loaded before starting to write.
     // That way we only end up with fully resolved HTML even if we suspend.


### PR DESCRIPTION
This commit adds warnings indicating that `renderToStaticNodeStream` will be removed in an upcoming React release. This API has been legacy, is not widely used (renderToStaticMarkup is more common) and has semantically eqiuvalent implementations with renderToReadableStream and renderToPipeableStream.