### PR TITLE
Deprecate `renderToStaticNodeStream` (#28872)

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -620,17 +620,27 @@ describe('ReactDOMServer', () => {
   describe('renderToStaticNodeStream', () => {
     it('should generate simple markup', () => {
       const SuccessfulElement = React.createElement(() => <img />);
-      const response = ReactDOMServer.renderToStaticNodeStream(
-        SuccessfulElement,
-      );
-      expect(response.read().toString()).toMatch(new RegExp('<img' + '/>'));
+      expect(() => {
+        const response = ReactDOMServer.renderToStaticNodeStream(
+          SuccessfulElement,
+        );
+        expect(response.read().toString()).toMatch(new RegExp('<img' + '/>'));
+      }).toErrorDev('ReactDOMServer.renderToStaticNodeStream() is deprecated', {
+        withoutStack: true,
+      });
     });
 
     it('should handle errors correctly', () => {
       const FailingElement = React.createElement(() => {
         throw new Error('An Error');
       });
-      const response = ReactDOMServer.renderToStaticNodeStream(FailingElement);
+
+      let response;
+      expect(() => {
+        response = ReactDOMServer.renderToStaticNodeStream(FailingElement);
+      }).toErrorDev('ReactDOMServer.renderToStaticNodeStream() is deprecated', {
+        withoutStack: true,
+      });
       return new Promise(resolve => {
         response.once('error', () => {
           resolve();

--- a/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
@@ -100,6 +100,13 @@ function renderToStaticNodeStream(
   children: ReactNodeList,
   options?: ServerOptions,
 ): Readable {
+  if (__DEV__) {
+    console.error(
+      'ReactDOMServer.renderToStaticNodeStream() is deprecated.' +
+        ' Use ReactDOMServer.renderToPipeableStream() and wait to `pipe` until the `onAllReady`' +
+        ' callback has been called instead.',
+    );
+  }
   return renderToNodeStreamImpl(children, options, true);
 }
 


### PR DESCRIPTION
This commit adds warnings indicating that `renderToStaticNodeStream` will be removed in an upcoming React release. This API has been legacy, is not widely used (renderToStaticMarkup is more common) and has semantically eqiuvalent implementations with renderToReadableStream and renderToPipeableStream.

landed in main in #28872 
changed the warning to match renderToNodeStream