### PR TITLE
Build react-reconciler for FB builds

### DIFF
--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -817,7 +817,7 @@ const bundles = [
 
   /******* React Reconciler *******/
   {
-    bundleTypes: [NODE_DEV, NODE_PROD, NODE_PROFILING],
+    bundleTypes: [NODE_DEV, NODE_PROD, NODE_PROFILING, FB_WWW_DEV, FB_WWW_PROD],
     moduleType: RECONCILER,
     entry: 'react-reconciler',
     global: 'ReactReconciler',

--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -204,6 +204,47 @@ module.exports.default = module.exports;
 Object.defineProperty(module.exports, "__esModule", { value: true });
 `;
   },
+
+  /***************** FB_WWW_DEV (reconciler only) *****************/
+  [FB_WWW_DEV](source, globalName, filename, moduleType) {
+    return `'use strict';
+
+if (__DEV__) {
+  module.exports = function $$$reconciler($$$config) {
+    var exports = {};
+${source}
+    return exports;
+  };
+  module.exports.default = module.exports;
+  Object.defineProperty(module.exports, "__esModule", { value: true });
+}
+`;
+  },
+
+  /***************** FB_WWW_PROD (reconciler only) *****************/
+  [FB_WWW_PROD](source, globalName, filename, moduleType) {
+    return `module.exports = function $$$reconciler($$$config) {
+
+      var exports = {};
+  ${source}
+      return exports;
+  };
+  module.exports.default = module.exports;
+  Object.defineProperty(module.exports, "__esModule", { value: true });
+  `;
+  },
+
+  /***************** FB_WWW_PROFILING (reconciler only) *****************/
+  [FB_WWW_PROFILING](source, globalName, filename, moduleType) {
+    return `module.exports = function $$$reconciler($$$config) {
+      var exports = {};
+  ${source}
+      return exports;
+  };
+  module.exports.default = module.exports;
+  Object.defineProperty(module.exports, "__esModule", { value: true });
+  `;
+  },
 };
 
 const licenseHeaderWrappers = {


### PR DESCRIPTION
Meta uses various tools built on top of the "react-reconciler" package but that package needs to match the version of the "react" package.

This means that it should be synced at the same time. However, more than that the feature flags between the "react" package and the "react-reconciler" package needs to line up. Since FB has custom feature flags, it can't use the OSS version of react-reconciler.
