### PR TITLE
Remove warning for ref cleanup function

### DIFF
--- a/packages/react-dom/src/__tests__/refs-test.js
+++ b/packages/react-dom/src/__tests__/refs-test.js
@@ -706,45 +706,4 @@ describe('refs return clean up function', () => {
     expect(setup).toHaveBeenCalledTimes(1);
     expect(cleanUp).toHaveBeenCalledTimes(1);
   });
-
-  it('warns if clean up function is returned when called with null', async () => {
-    const container = document.createElement('div');
-    const cleanUp = jest.fn();
-    const setup = jest.fn();
-    let returnCleanUp = false;
-
-    const root = ReactDOMClient.createRoot(container);
-    await act(() => {
-      root.render(
-        <div
-          ref={_ref => {
-            setup(_ref);
-            if (returnCleanUp) {
-              return cleanUp;
-            }
-          }}
-        />,
-      );
-    });
-
-    expect(setup).toHaveBeenCalledTimes(1);
-    expect(cleanUp).toHaveBeenCalledTimes(0);
-
-    returnCleanUp = true;
-
-    await expect(async () => {
-      await act(() => {
-        root.render(
-          <div
-            ref={_ref => {
-              setup(_ref);
-              if (returnCleanUp) {
-                return cleanUp;
-              }
-            }}
-          />,
-        );
-      });
-    }).toErrorDev('Unexpected return value from a callback ref in div');
-  });
 });

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -318,29 +318,19 @@ function safelyDetachRef(current: Fiber, nearestMountedAncestor: Fiber | null) {
         }
       }
     } else if (typeof ref === 'function') {
-      let retVal;
       try {
         if (shouldProfile(current)) {
           try {
             startLayoutEffectTimer();
-            retVal = ref(null);
+            ref(null);
           } finally {
             recordLayoutEffectDuration(current);
           }
         } else {
-          retVal = ref(null);
+          ref(null);
         }
       } catch (error) {
         captureCommitPhaseError(current, nearestMountedAncestor, error);
-      }
-      if (__DEV__) {
-        if (typeof retVal === 'function') {
-          console.error(
-            'Unexpected return value from a callback ref in %s. ' +
-              'A callback ref should not return a function.',
-            getComponentNameFromFiber(current),
-          );
-        }
       }
     } else {
       // $FlowFixMe[incompatible-use] unable to narrow type to RefObject


### PR DESCRIPTION
Resources
- RFC: https://github.com/reactjs/rfcs/pull/205
- Warning implemented in https://github.com/facebook/react/pull/22313
- Warning enabled in https://github.com/facebook/react/pull/23145
- Feature added in https://github.com/facebook/react/pull/25686

We have warned to prevent the old behavior since 18.0.0.

The new feature has been on in canary for a while but still triggering the warning. This PR cleans up the warning for 19
