### PR TITLE
Use undici polyfill for tests in old Node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "through2": "^3.0.1",
     "tmp": "^0.1.0",
     "typescript": "^3.7.5",
+    "undici": "^5.28.4",
     "web-streams-polyfill": "^3.1.1",
     "yargs": "^15.3.1"
   },

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -15,11 +15,10 @@ global.ReadableStream =
   require('web-streams-polyfill/ponyfill/es6').ReadableStream;
 global.TextEncoder = require('util').TextEncoder;
 global.TextDecoder = require('util').TextDecoder;
-if (typeof Blob === 'undefined') {
-  global.Blob = require('buffer').Blob;
-}
-if (typeof File === 'undefined') {
-  global.File = require('buffer').File;
+global.Blob = require('buffer').Blob;
+if (typeof File === 'undefined' || typeof FormData === 'undefined') {
+  global.File = require('buffer').File || require('undici').File;
+  global.FormData = require('undici').FormData;
 }
 
 // Don't wait before processing work on the server.
@@ -379,45 +378,40 @@ describe('ReactFlightDOMEdge', () => {
     expect(await result.arrayBuffer()).toEqual(await blob.arrayBuffer());
   });
 
-  if (typeof FormData !== 'undefined' && typeof File !== 'undefined') {
-    // @gate enableBinaryFlight
-    it('can transport FormData (blobs)', async () => {
-      const bytes = new Uint8Array([
-        123, 4, 10, 5, 100, 255, 244, 45, 56, 67, 43, 124, 67, 89, 100, 20,
-      ]);
-      const blob = new Blob([bytes, bytes], {
-        type: 'application/x-test',
-      });
-
-      const formData = new FormData();
-      formData.append('hi', 'world');
-      formData.append('file', blob, 'filename.test');
-
-      expect(formData.get('file') instanceof File).toBe(true);
-      expect(formData.get('file').name).toBe('filename.test');
-
-      const stream = passThrough(
-        ReactServerDOMServer.renderToReadableStream(formData),
-      );
-      const result = await ReactServerDOMClient.createFromReadableStream(
-        stream,
-        {
-          ssrManifest: {
-            moduleMap: null,
-            moduleLoading: null,
-          },
-        },
-      );
-
-      expect(result instanceof FormData).toBe(true);
-      expect(result.get('hi')).toBe('world');
-      const resultBlob = result.get('file');
-      expect(resultBlob instanceof Blob).toBe(true);
-      expect(resultBlob.name).toBe('blob'); // We should not pass through the file name for security.
-      expect(resultBlob.size).toBe(bytes.length * 2);
-      expect(await resultBlob.arrayBuffer()).toEqual(await blob.arrayBuffer());
+  // @gate enableBinaryFlight
+  it('can transport FormData (blobs)', async () => {
+    const bytes = new Uint8Array([
+      123, 4, 10, 5, 100, 255, 244, 45, 56, 67, 43, 124, 67, 89, 100, 20,
+    ]);
+    const blob = new Blob([bytes, bytes], {
+      type: 'application/x-test',
     });
-  }
+
+    const formData = new FormData();
+    formData.append('hi', 'world');
+    formData.append('file', blob, 'filename.test');
+
+    expect(formData.get('file') instanceof File).toBe(true);
+    expect(formData.get('file').name).toBe('filename.test');
+
+    const stream = passThrough(
+      ReactServerDOMServer.renderToReadableStream(formData),
+    );
+    const result = await ReactServerDOMClient.createFromReadableStream(stream, {
+      ssrManifest: {
+        moduleMap: null,
+        moduleLoading: null,
+      },
+    });
+
+    expect(result instanceof FormData).toBe(true);
+    expect(result.get('hi')).toBe('world');
+    const resultBlob = result.get('file');
+    expect(resultBlob instanceof Blob).toBe(true);
+    expect(resultBlob.name).toBe('blob'); // We should not pass through the file name for security.
+    expect(resultBlob.size).toBe(bytes.length * 2);
+    expect(await resultBlob.arrayBuffer()).toEqual(await blob.arrayBuffer());
+  });
 
   it('can pass an async import that resolves later to an outline object like a Map', async () => {
     let resolve;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2182,6 +2182,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.0.0.tgz#1a9e4b4c96d8c7886e0110ed310a0135144a1691"
   integrity sha512-RThY/MnKrhubF6+s1JflwUjPEsnCEmYCWwqa/aRISKWNXGZ9epUwft4bUMM35SdKF9xvBrLydAM1RDHd1Z//ZQ==
 
+"@fastify/busboy@^2.0.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
+  integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
+
 "@gitbeaker/core@^21.7.0":
   version "21.7.0"
   resolved "https://registry.yarnpkg.com/@gitbeaker/core/-/core-21.7.0.tgz#fcf7a12915d39f416e3f316d0a447a814179b8e5"
@@ -15761,6 +15766,13 @@ unc-path-regex@^0.1.0, unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
+
+undici@^5.28.4:
+  version "5.28.4"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.4.tgz#6b280408edb6a1a604a9b20340f45b422e373068"
+  integrity sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==
+  dependencies:
+    "@fastify/busboy" "^2.0.0"
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
We currently don't test FormData / File dependent features in CI because we use an old Node.js version in CI. We should probably upgrade to 18 since that's really the minimum version that supports all the features out of the box.

JSDOM is not a faithful/compatible implementation of these APIs. The recommended way to use Flight together with FormData/Blob/File in older Node.js versions, is to polyfill using the `undici` library.

However, even in these versions the Blob implementation isn't quite faithful so the Reply client needs a slight tweak for multi-byte typed arrays.