### PR TITLE
Cleanup `replayFailedUnitOfWorkWithInvokeGuardedCallback`and `enableProfilerNestedUpdateScheduledHook`

### DIFF
--- a/packages/react/src/__tests__/ReactProfilerComponent-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerComponent-test.internal.js
@@ -20,7 +20,6 @@ function loadModules({
   enableProfilerCommitHooks = true,
   enableProfilerNestedUpdatePhase = true,
   enableProfilerNestedUpdateScheduledHook = false,
-  replayFailedUnitOfWorkWithInvokeGuardedCallback = false,
 } = {}) {
   ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
@@ -30,8 +29,6 @@ function loadModules({
     enableProfilerNestedUpdatePhase;
   ReactFeatureFlags.enableProfilerNestedUpdateScheduledHook =
     enableProfilerNestedUpdateScheduledHook;
-  ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback =
-    replayFailedUnitOfWorkWithInvokeGuardedCallback;
 
   React = require('react');
   ReactDOMClient = require('react-dom/client');

--- a/packages/react/src/__tests__/ReactProfilerComponent-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerComponent-test.internal.js
@@ -19,7 +19,6 @@ function loadModules({
   enableProfilerTimer = true,
   enableProfilerCommitHooks = true,
   enableProfilerNestedUpdatePhase = true,
-  enableProfilerNestedUpdateScheduledHook = false,
 } = {}) {
   ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
@@ -27,8 +26,6 @@ function loadModules({
   ReactFeatureFlags.enableProfilerCommitHooks = enableProfilerCommitHooks;
   ReactFeatureFlags.enableProfilerNestedUpdatePhase =
     enableProfilerNestedUpdatePhase;
-  ReactFeatureFlags.enableProfilerNestedUpdateScheduledHook =
-    enableProfilerNestedUpdateScheduledHook;
 
   React = require('react');
   ReactDOMClient = require('react-dom/client');


### PR DESCRIPTION
https://github.com/facebook/react/pull/28407 was based on a state before https://github.com/facebook/react/pull/28515/ and https://github.com/facebook/react/pull/28509 so it missed the cleanups in those PRs.