### PR TITLE
[Flight][Fizz] ping work within current task

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactDOMLegacyServerStreamConfig.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMLegacyServerStreamConfig.js
@@ -20,6 +20,10 @@ export function scheduleWork(callback: () => void) {
   callback();
 }
 
+export function scheduleEagerWork(callback: () => void) {
+  callback();
+}
+
 export function flushBuffered(destination: Destination) {}
 
 export function beginWriting(destination: Destination) {}

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -38,7 +38,7 @@ describe('ReactDOMFizzServerNode', () => {
       writable.on('finish', () => {
         resolve();
       });
-      writable.on('error', () => {
+      writable.on('error', pl => {
         resolve();
       });
     });
@@ -589,6 +589,7 @@ describe('ReactDOMFizzServerNode', () => {
       if (!hasLoaded) {
         throw promise;
       }
+      console.log('rendering');
       rendered = true;
       return 'Done';
     }
@@ -617,11 +618,10 @@ describe('ReactDOMFizzServerNode', () => {
     writable.end();
 
     await jest.runAllTimers();
+    await completed;
 
     hasLoaded = true;
     resolve();
-
-    await completed;
 
     expect(errors).toEqual([
       'The destination stream errored while writing data.',

--- a/packages/react-noop-renderer/src/ReactNoopFlightServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightServer.js
@@ -28,6 +28,9 @@ const ReactNoopFlightServer = ReactFlightServer({
   scheduleWork(callback: () => void) {
     callback();
   },
+  scheduleEagerWork(callback: () => void) {
+    callback();
+  },
   beginWriting(destination: Destination): void {},
   writeChunk(destination: Destination, chunk: string): void {
     destination.push(chunk);

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -77,6 +77,9 @@ const ReactNoopServer = ReactFizzServer({
   scheduleWork(callback: () => void) {
     callback();
   },
+  scheduleEagerWork(callback: () => void) {
+    callback();
+  },
   beginWriting(destination: Destination): void {},
   writeChunk(destination: Destination, buffer: Uint8Array): void {
     write(destination, buffer);

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -36,6 +36,7 @@ import {describeObjectForErrorMessage} from 'shared/ReactSerializationErrors';
 
 import {
   scheduleWork,
+  scheduleEagerWork,
   beginWriting,
   writeChunk,
   writeChunkAndReturn,
@@ -595,7 +596,7 @@ function pingTask(request: Request, task: Task): void {
   pingedTasks.push(task);
   if (request.pingedTasks.length === 1) {
     request.flushScheduled = request.destination !== null;
-    scheduleWork(() => performWork(request));
+    scheduleEagerWork(() => performWork(request));
   }
 }
 
@@ -4430,6 +4431,7 @@ export function abort(request: Request, reason: mixed): void {
       flushCompletedQueues(request, request.destination);
     }
   } catch (error) {
+    console.log('caught', error);
     const errorInfo: ThrownInfo = {};
     logRecoverableError(request, error, errorInfo);
     fatalError(request, error);

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -24,6 +24,7 @@ import {enableFlightReadableStream} from 'shared/ReactFeatureFlags';
 
 import {
   scheduleWork,
+  scheduleEagerWork,
   flushBuffered,
   beginWriting,
   writeChunkAndReturn,
@@ -1237,7 +1238,7 @@ function pingTask(request: Request, task: Task): void {
   pingedTasks.push(task);
   if (pingedTasks.length === 1) {
     request.flushScheduled = request.destination !== null;
-    scheduleWork(() => performWork(request));
+    scheduleEagerWork(() => performWork(request));
   }
 }
 

--- a/packages/react-server/src/ReactServerStreamConfigBrowser.js
+++ b/packages/react-server/src/ReactServerStreamConfigBrowser.js
@@ -17,6 +17,10 @@ export function scheduleWork(callback: () => void) {
   callback();
 }
 
+export function scheduleEagerWork(callback: () => void) {
+  callback();
+}
+
 export function flushBuffered(destination: Destination) {
   // WHATWG Streams do not yet have a way to flush the underlying
   // transform streams. https://github.com/whatwg/streams/issues/960

--- a/packages/react-server/src/ReactServerStreamConfigBun.js
+++ b/packages/react-server/src/ReactServerStreamConfigBun.js
@@ -25,6 +25,10 @@ export function scheduleWork(callback: () => void) {
   callback();
 }
 
+export function scheduleEagerWork(callback: () => void) {
+  callback();
+}
+
 export function flushBuffered(destination: Destination) {
   // Bun direct streams provide a flush function.
   // If we don't have any more data to send right now.

--- a/packages/react-server/src/ReactServerStreamConfigEdge.js
+++ b/packages/react-server/src/ReactServerStreamConfigEdge.js
@@ -17,6 +17,11 @@ export function scheduleWork(callback: () => void) {
   setTimeout(callback, 0);
 }
 
+const resolved = Promise.resolve();
+export function scheduleEagerWork(callback: () => void) {
+  resolved.then(callback);
+}
+
 export function flushBuffered(destination: Destination) {
   // WHATWG Streams do not yet have a way to flush the underlying
   // transform streams. https://github.com/whatwg/streams/issues/960

--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -26,6 +26,11 @@ export function scheduleWork(callback: () => void) {
   setImmediate(callback);
 }
 
+const resolved = Promise.resolve();
+export function scheduleEagerWork(callback: () => void) {
+  resolved.then(callback);
+}
+
 export function flushBuffered(destination: Destination) {
   // If we don't have any more data to send right now.
   // Flush whatever is in the buffer to the wire.

--- a/packages/react-server/src/forks/ReactServerStreamConfig.custom.js
+++ b/packages/react-server/src/forks/ReactServerStreamConfig.custom.js
@@ -31,6 +31,7 @@ export opaque type Chunk = mixed; // eslint-disable-line no-undef
 export opaque type BinaryChunk = mixed; // eslint-disable-line no-undef
 
 export const scheduleWork = $$$config.scheduleWork;
+export const scheduleEagerWork = $$$config.scheduleEagerWork;
 export const beginWriting = $$$config.beginWriting;
 export const writeChunk = $$$config.writeChunk;
 export const writeChunkAndReturn = $$$config.writeChunkAndReturn;

--- a/packages/react-server/src/forks/ReactServerStreamConfig.dom-fb-experimental.js
+++ b/packages/react-server/src/forks/ReactServerStreamConfig.dom-fb-experimental.js
@@ -46,6 +46,10 @@ export function scheduleWork(callback: () => void) {
   callback();
 }
 
+export function scheduleEagerWork(callback: () => void) {
+  callback();
+}
+
 export function beginWriting(destination: Destination) {
   destination.beginWriting();
 }

--- a/packages/react-server/src/forks/ReactServerStreamConfig.dom-fb.js
+++ b/packages/react-server/src/forks/ReactServerStreamConfig.dom-fb.js
@@ -12,3 +12,7 @@ export * from '../ReactServerStreamConfigFB';
 export function scheduleWork(callback: () => void) {
   // We don't schedule work in this model, and instead expect performWork to always be called repeatedly.
 }
+
+export function scheduleEagerWork(callback: () => void) {
+  // We don't schedule work in this model, and instead expect performWork to always be called repeatedly.
+}


### PR DESCRIPTION
Fizz and Flight both currently have a work schedule that enqueues tasks for retrying in a new macrotask. however it means that any given render will be split across multiple tasks even if any thenables that suspend are available within a microtask. This PR updates the ping mechanism for both renderers to schedule retry work on the microtask queue.

As we've run into many times in React this is another instance where being able to schedule a microtask to run at the end of the queue would be ideal since we can optimize flushing better.
