### PR TITLE
warn -> error for Test Renderer deprecation

### DIFF
--- a/packages/internal-test-utils/shouldIgnoreConsoleError.js
+++ b/packages/internal-test-utils/shouldIgnoreConsoleError.js
@@ -23,7 +23,8 @@ module.exports = function shouldIgnoreConsoleError(format, args) {
         ) !== -1 ||
         format.indexOf(
           'ReactDOM.hydrate has not been supported since React 18',
-        ) !== -1
+        ) !== -1 ||
+        format.indexOf('react-test-renderer is deprecated.') !== -1
       ) {
         // We haven't finished migrating our tests to use createRoot.
         return true;

--- a/packages/internal-test-utils/shouldIgnoreConsoleWarn.js
+++ b/packages/internal-test-utils/shouldIgnoreConsoleWarn.js
@@ -1,11 +1,5 @@
 'use strict';
 
 module.exports = function shouldIgnoreConsoleWarn(format) {
-  if (typeof format === 'string') {
-    if (format.indexOf('Warning: react-test-renderer is deprecated.') === 0) {
-      return true;
-    }
-  }
-
   return false;
 };

--- a/packages/react-devtools-shared/src/__tests__/treeContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/treeContext-test.js
@@ -2586,14 +2586,14 @@ describe('TreeListContext', () => {
         utils.act(() => TestRenderer.create(<Contexts />));
 
         expect(store).toMatchInlineSnapshot(`
-          ✕ 1, ⚠ 1
+          ✕ 2, ⚠ 0
           [root]
               <ErrorBoundary> ✕
         `);
 
         selectNextErrorOrWarning();
         expect(state).toMatchInlineSnapshot(`
-          ✕ 1, ⚠ 1
+          ✕ 2, ⚠ 0
           [root]
           →    <ErrorBoundary> ✕
         `);
@@ -2648,14 +2648,14 @@ describe('TreeListContext', () => {
         utils.act(() => TestRenderer.create(<Contexts />));
 
         expect(store).toMatchInlineSnapshot(`
-          ✕ 1, ⚠ 1
+          ✕ 2, ⚠ 0
           [root]
               <ErrorBoundary> ✕
         `);
 
         selectNextErrorOrWarning();
         expect(state).toMatchInlineSnapshot(`
-          ✕ 1, ⚠ 1
+          ✕ 2, ⚠ 0
           [root]
           →    <ErrorBoundary> ✕
         `);
@@ -2705,7 +2705,7 @@ describe('TreeListContext', () => {
         utils.act(() => TestRenderer.create(<Contexts />));
 
         expect(store).toMatchInlineSnapshot(`
-          ✕ 2, ⚠ 1
+          ✕ 3, ⚠ 0
           [root]
             ▾ <ErrorBoundary> ✕
                 <Child> ✕
@@ -2713,7 +2713,7 @@ describe('TreeListContext', () => {
 
         selectNextErrorOrWarning();
         expect(state).toMatchInlineSnapshot(`
-          ✕ 2, ⚠ 1
+          ✕ 3, ⚠ 0
           [root]
           →  ▾ <ErrorBoundary> ✕
                  <Child> ✕

--- a/packages/react-devtools-shell/src/app/index.js
+++ b/packages/react-devtools-shell/src/app/index.js
@@ -31,6 +31,7 @@ ignoreErrors([
   'Warning: Unsafe lifecycle methods',
   'Warning: %s is deprecated in StrictMode.', // findDOMNode
   'Warning: ReactDOM.render was removed in React 19',
+  'Warning: react-test-renderer is deprecated',
 ]);
 ignoreWarnings(['Warning: componentWillReceiveProps has been renamed']);
 ignoreLogs([]);

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -19,6 +19,7 @@ let Scheduler;
 let ReactDOMServer;
 let act;
 let assertLog;
+let assertConsoleErrorDev;
 let waitForAll;
 let waitForThrow;
 
@@ -35,6 +36,7 @@ describe('ReactHooks', () => {
 
     const InternalTestUtils = require('internal-test-utils');
     assertLog = InternalTestUtils.assertLog;
+    assertConsoleErrorDev = InternalTestUtils.assertConsoleErrorDev;
     waitForAll = InternalTestUtils.waitForAll;
     waitForThrow = InternalTestUtils.waitForThrow;
   });
@@ -1810,7 +1812,6 @@ describe('ReactHooks', () => {
   // Regression test for #14674
   it('does not swallow original error when updating another component in render phase', async () => {
     const {useState} = React;
-    spyOnDev(console, 'error').mockImplementation(() => {});
 
     let _setState;
     function A() {
@@ -1837,14 +1838,10 @@ describe('ReactHooks', () => {
         );
       });
     }).rejects.toThrow('Hello');
-
-    if (__DEV__) {
-      expect(console.error).toHaveBeenCalledTimes(1);
-      expect(console.error.mock.calls[0][0]).toContain(
-        'Warning: Cannot update a component (`%s`) while rendering ' +
-          'a different component (`%s`).',
-      );
-    }
+    assertConsoleErrorDev([
+      'Warning: Cannot update a component (`A`) while rendering ' +
+        'a different component (`B`).',
+    ]);
   });
 
   // Regression test for https://github.com/facebook/react/issues/15057

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -7,6 +7,7 @@ let waitFor;
 let waitForAll;
 let waitForThrow;
 let assertLog;
+let assertConsoleErrorDev;
 let act;
 
 let fakeModuleCache;
@@ -34,6 +35,7 @@ describe('ReactLazy', () => {
     waitForAll = InternalTestUtils.waitForAll;
     waitForThrow = InternalTestUtils.waitForThrow;
     assertLog = InternalTestUtils.assertLog;
+    assertConsoleErrorDev = InternalTestUtils.assertConsoleErrorDev;
     act = InternalTestUtils.act;
 
     fakeModuleCache = new Map();
@@ -205,8 +207,6 @@ describe('ReactLazy', () => {
   });
 
   it('does not support arbitrary promises, only module objects', async () => {
-    spyOnDev(console, 'error').mockImplementation(() => {});
-
     const LazyText = lazy(async () => Text);
 
     const root = ReactTestRenderer.create(null, {
@@ -228,13 +228,11 @@ describe('ReactLazy', () => {
 
     expect(error.message).toMatch('Element type is invalid');
     assertLog(['Loading...']);
+    assertConsoleErrorDev([
+      'Expected the result of a dynamic import() call',
+      'Expected the result of a dynamic import() call',
+    ]);
     expect(root).not.toMatchRenderedOutput('Hi');
-    if (__DEV__) {
-      expect(console.error).toHaveBeenCalledTimes(2);
-      expect(console.error.mock.calls[0][0]).toContain(
-        'Expected the result of a dynamic import() call',
-      );
-    }
   });
 
   it('throws if promise rejects', async () => {

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -475,7 +475,7 @@ function create(
       enableReactTestRendererWarning === true &&
       global.IS_REACT_NATIVE_TEST_ENVIRONMENT !== true
     ) {
-      console.warn(
+      console.error(
         'react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer',
       );
     }

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -60,26 +60,25 @@ describe('ReactTestRenderer', () => {
     ReactFeatureFlags.enableReactTestRendererWarning = false;
   });
 
+  // @gate __DEV__
   it('should warn if enableReactTestRendererWarning is enabled', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     ReactFeatureFlags.enableReactTestRendererWarning = true;
-    expect(() => {
-      ReactTestRenderer.create(<div />);
-    }).toWarnDev(
+    ReactTestRenderer.create(<div />);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error.mock.calls[0][0]).toContain(
       'Warning: react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer',
-      {withoutStack: true},
     );
+    console.error.mockRestore();
   });
 
-  // @gate __DEV__
   it('should not warn if enableReactTestRendererWarning is enabled but the RN global is set', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     global.IS_REACT_NATIVE_TEST_ENVIRONMENT = true;
     ReactFeatureFlags.enableReactTestRendererWarning = true;
-    expect(() => {
-      ReactTestRenderer.create(<div />);
-    }).not.toWarnDev(
-      'Warning: react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer',
-      {withoutStack: true},
-    );
+    ReactTestRenderer.create(<div />);
+    expect(console.error).toHaveBeenCalledTimes(0);
+    console.error.mockRestore();
   });
 
   describe('root tags', () => {


### PR DESCRIPTION
We use `console.error` for deprecations. `console.warn` is for less critical issues, like performance anti-patterns.