### PR TITLE
Update canary channel label to "beta"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -639,7 +639,7 @@ workflows:
           # because this used to be called the "next" channel and some
           # downstream consumers might still expect that tag. We can remove this
           # after some time has elapsed and the change has been communicated.
-          dist_tag: "canary,next"
+          dist_tag: "canary,next,beta"
       - publish_prerelease:
           name: Publish to Experimental channel
           requires:
@@ -668,7 +668,7 @@ workflows:
           name: Publish to Canary channel
           commit_sha: << pipeline.git.revision >>
           release_channel: stable
-          dist_tag: "canary,next"
+          dist_tag: "canary,next,beta"
       - publish_prerelease:
           name: Publish to Experimental channel
           requires:

--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -26,7 +26,7 @@ const ReactVersion = '19.0.0';
 //
 // It only affects the label used in the version string. To customize the
 // npm dist tags used during publish, refer to .circleci/config.yml.
-const canaryChannelLabel = 'canary';
+const canaryChannelLabel = 'beta';
 
 const stablePackages = {
   'eslint-plugin-react-hooks': '5.1.0',


### PR DESCRIPTION
During the beta period, canaries will be published as `19.0.0-beta-<COMMIT_SHA>-<DATE>`. They will also be tagged as `beta` when published to npm.