### PR TITLE
[Flight][Fizz] tasks that ping in a microtask should render synchronously

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -5986,22 +5986,6 @@ describe('ReactDOMFizzServer', () => {
       pipe(writable);
     });
 
-    // TODO: The `act` implementation in this file doesn't unwrap microtasks
-    // automatically. We can't use the same `act` we use for Fiber tests
-    // because that relies on the mock Scheduler. Doesn't affect any public
-    // API but we might want to fix this for our own internal tests.
-    //
-    // For now, wait for each promise in sequence.
-    await act(async () => {
-      await promiseA;
-    });
-    await act(async () => {
-      await promiseB;
-    });
-    await act(async () => {
-      await promiseC;
-    });
-
     expect(getVisibleChildren(container)).toEqual('ABC');
 
     ReactDOMClient.hydrateRoot(container, <App />);

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -5221,20 +5221,6 @@ body {
     );
 
     await act(() => {
-      resolveText('completed inner');
-    });
-    expect(getMeaningfulChildren(document)).toEqual(
-      <html>
-        <head />
-        <body>
-          loading...
-          <link rel="preload" href="completed inner" as="style" />
-          <link rel="preload" href="in fallback inner" as="style" />
-        </body>
-      </html>,
-    );
-
-    await act(() => {
       resolveText('complete root');
     });
     await act(() => {

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -599,6 +599,14 @@ function pingTask(request: Request, task: Task): void {
   const pingedTasks = request.pingedTasks;
   pingedTasks.push(task);
   if (pingedTasks.length === 1) {
+    if (request.schedule === WORK) {
+      // We're pinging in a microtask or a macrotask interleaving the prior
+      // work task and the scheduled flush task. Either way we render it synchronously.
+      performWork(request);
+      return;
+    }
+    // We're pinging in a new task, we can schedule a new work epoch and let
+    // additional pings queue.
     startPerformingWork(request);
   }
 }
@@ -629,7 +637,6 @@ function createSuspenseBoundary(
   }
   return boundary;
 }
-
 function createRenderTask(
   request: Request,
   thenableState: ThenableState | null,

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -1241,6 +1241,14 @@ function pingTask(request: Request, task: Task): void {
   const pingedTasks = request.pingedTasks;
   pingedTasks.push(task);
   if (pingedTasks.length === 1) {
+    if (request.schedule === WORK) {
+      // We're pinging in a microtask or a macrotask interleaving the prior
+      // work task and the scheduled flush task. Either way we render it synchronously.
+      performWork(request);
+      return;
+    }
+    // We're pinging in a new task, we can schedule a new work epoch and let
+    // additional pings queue.
     startPerformingWork(request);
   }
 }


### PR DESCRIPTION
stacked on #28900 

This change modifies the ping mechanism for FlightServer and FizzServer to perform work synchronously if infer the ping is happening in a microtask. The heuristic is to consider whether we're already in a "work" phase which is only cleared in a second macrotask scheduled alongside the work task. If we are and the task is the only task in the queue we assume we're in a microtask and immediately retry the task.

There is an edge case however that I suspect can crop up where a ping is interleaved between a work task and the flush task. If this happens it will also appear like a microtask and be retried synchronously. While this isn't the intent of the PR this also isn't breaking any semantics so this should be fine.

I also updated the flight tests to use the same environment as FizzServer and stopped mocking setImmediate to run synchronously. This was necessary to actually exercise the timing here but it also better tests the Node implementation of FlightServer because it can't hide task scheduling mistakes behind synchronous execution