### PR TITLE
Export `React.act` from 18.3

### DIFF
--- a/packages/react/index.classic.fb.js
+++ b/packages/react/index.classic.fb.js
@@ -9,6 +9,7 @@
 
 export {
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+  act,
   act as unstable_act,
   Children,
   Component,

--- a/packages/react/index.experimental.js
+++ b/packages/react/index.experimental.js
@@ -9,6 +9,7 @@
 
 export {
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+  act,
   act as unstable_act,
   Children,
   Component,

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -8,9 +8,8 @@
  */
 
 // Keep in sync with https://github.com/facebook/flow/blob/main/lib/react.js
-export type StatelessFunctionalComponent<
-  P,
-> = React$StatelessFunctionalComponent<P>;
+export type StatelessFunctionalComponent<P> =
+  React$StatelessFunctionalComponent<P>;
 export type ComponentType<-P> = React$ComponentType<P>;
 export type AbstractComponent<
   -Config,
@@ -33,6 +32,7 @@ export type ChildrenArray<+T> = $ReadOnlyArray<ChildrenArray<T>> | T;
 // We can't use export * from in Flow for some reason.
 export {
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+  act,
   act as unstable_act,
   Children,
   Component,

--- a/packages/react/index.modern.fb.js
+++ b/packages/react/index.modern.fb.js
@@ -9,6 +9,7 @@
 
 export {
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+  act,
   act as unstable_act,
   Children,
   Component,

--- a/packages/react/index.stable.js
+++ b/packages/react/index.stable.js
@@ -9,6 +9,7 @@
 
 export {
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+  act,
   act as unstable_act,
   Children,
   Component,


### PR DESCRIPTION
**Base branch 18.3**

In 18.3 we warn to use `React.act` but we only export `React.unstable_act`.

Fixes https://github.com/facebook/react/issues/28915