### PR TITLE
[react-dom] Provide a way to silence devtools recommendation

### DIFF
--- a/packages/react-dom/src/client/ReactDOMClient.js
+++ b/packages/react-dom/src/client/ReactDOMClient.js
@@ -57,7 +57,12 @@ const foundDevTools = injectIntoDevTools({
 });
 
 if (__DEV__) {
-  if (!foundDevTools && canUseDOM && window.top === window.self) {
+  if (
+    !foundDevTools &&
+    canUseDOM &&
+    window.top === window.self &&
+    !window.__DONT_RECOMMEND_REACT_DEVTOOLS__
+  ) {
     // If we're in Chrome or Firefox, provide a download link if not installed.
     if (
       (navigator.userAgent.indexOf('Chrome') > -1 &&


### PR DESCRIPTION
If you hit this console message and search for how to turn it off, many people recommend hacky ways to do so that also end up breaking the extension if you actually want to use it later on.

This provides a way to turn off just the message, without trying to trick injectIntoDevTools into thinking something's happened.

[This SO answer](https://stackoverflow.com/a/48324794) is a good example of a "wrong answer" to disabling this logging warning:

```
window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = { isDisabled: true };
```

This [disables the integration entirely](https://github.com/facebook/react/blob/c4083616a232028588a2cbaa9ba8992481d1deb7/packages/react-reconciler/src/ReactFiberDevToolsHook.js#L60) instead of simply removing the warning if it's not installed. A project might want to simply not have the log show up for its own reasons.

I'm sending this up, if it's OK in principle the best thing would be to include 2 lines in some docs so that it can be the first result of a web search for people looking to disable it.

As to why I want to disable this: I run some tests without minified react. In the CI environment I do not need the devtools installed. I would like to avoid having to write some special-cased code to hack-away a removal of this message.

related issues: #12041 