### PR TITLE
fix: add `react-server` condition for `react/jsx-dev-runtime`

### DIFF
--- a/packages/react/jsx-dev-runtime.react-server.js
+++ b/packages/react/jsx-dev-runtime.react-server.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export {Fragment, jsxDEV} from './src/jsx/ReactJSXServer';

--- a/packages/react/npm/jsx-dev-runtime.react-server.js
+++ b/packages/react/npm/jsx-dev-runtime.react-server.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-jsx-runtime.react-server.production.min.js');
+} else {
+  module.exports = require('./cjs/react-jsx-runtime.react-server.development.js');
+}

--- a/packages/react/npm/jsx-dev-runtime.react-server.js
+++ b/packages/react/npm/jsx-dev-runtime.react-server.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./cjs/react-jsx-runtime.react-server.production.min.js');
+  module.exports = require('./cjs/react-jsx-dev-runtime.react-server.production.min.js');
 } else {
-  module.exports = require('./cjs/react-jsx-runtime.react-server.development.js');
+  module.exports = require('./cjs/react-jsx-dev-runtime.react-server.development.js');
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,10 @@
       "react-server": "./jsx-runtime.react-server.js",
       "default": "./jsx-runtime.js"
     },
-    "./jsx-dev-runtime": "./jsx-dev-runtime.js",
+    "./jsx-dev-runtime": {
+      "react-server": "./jsx-dev-runtime.js",
+      "default": "./jsx-dev-runtime.js"
+    },
     "./src/*": "./src/*"
   },
   "repository": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,6 +16,7 @@
     "jsx-runtime.js",
     "jsx-runtime.react-server.js",
     "jsx-dev-runtime.js",
+    "jsx-dev-runtime.react-server.js",
     "react.react-server.js"
   ],
   "main": "index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,7 +30,7 @@
       "default": "./jsx-runtime.js"
     },
     "./jsx-dev-runtime": {
-      "react-server": "./jsx-dev-runtime.js",
+      "react-server": "./jsx-dev-runtime.react-server.js",
       "default": "./jsx-dev-runtime.js"
     },
     "./src/*": "./src/*"

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -149,6 +149,19 @@ const bundles = [
     externals: ['react', 'ReactNativeInternalFeatureFlags'],
   },
 
+  /******* React JSX DEV Runtime React Server *******/
+  {
+    bundleTypes: [NODE_DEV, NODE_PROD],
+    moduleType: ISOMORPHIC,
+    entry: 'react/src/jsx/ReactJSXServer.js',
+    name: 'react-jsx-dev-runtime.react-server',
+    condition: 'react-server',
+    global: 'JSXDEVRuntime',
+    minifyWithProdErrorCodes: false,
+    wrapWithModuleBoundaries: false,
+    externals: ['react', 'ReactNativeInternalFeatureFlags'],
+  },
+
   /******* React DOM *******/
   {
     bundleTypes: [NODE_DEV, NODE_PROD],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Add `react-server` condition for `react/jsx-dev-runtime` to ensure they use the same internal in one node thread.

In Waku RSC, we have a node worker under the `react-server` condition and use vite to parse the react component. in development mode, the jsx-dev was linked to `React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE`, which does not exist on the server side. So react@beta cause a runtime error and blocks waku from upgrading react version(https://github.com/dai-shi/waku/pull/671).

```shell
Cannot process SSR Error: TypeError: Cannot read properties of undefined (reading 'A')
    at file:///home/runner/work/waku/waku/packages/waku/dist/lib/renderers/dev-worker-api.js:132:60
    at Worker.<anonymous> (file:///home/runner/work/waku/waku/packages/waku/dist/lib/renderers/dev-worker-api.js:34:52)
    at Worker.emit (node:events:526:35)
    at MessagePort.<anonymous> (node:internal/worker:263:53)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:807:20)
    at exports.emitMessage (node:internal/per_context/messageport:23:28)
```

Related: https://github.com/facebook/react/pull/28217

/cc @dai-shi 

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Copy and paste into waku repo node_modules; not sure how to test React.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
