### PR TITLE
Configure JSX Feature Flags as Dynamic (React Native @ Meta)

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -19,13 +19,15 @@
 
 export const alwaysThrottleRetries = __VARIANT__;
 export const consoleManagedByDevToolsDuringStrictMode = __VARIANT__;
+export const disableDefaultPropsExceptForClasses = __VARIANT__;
+export const disableStringRefs = __VARIANT__;
 export const enableAsyncActions = __VARIANT__;
 export const enableEarlyReturnForPropDiffing = __VARIANT__;
 export const enableComponentStackLocations = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const enableInfiniteRenderLoopDetection = __VARIANT__;
+export const enableRefAsProp = __VARIANT__;
 export const enableRenderableContext = __VARIANT__;
 export const enableUnifiedSyncLane = __VARIANT__;
 export const passChildrenWhenCloningPersistedNodes = __VARIANT__;
 export const useModernStrictMode = __VARIANT__;
-export const disableDefaultPropsExceptForClasses = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -21,16 +21,21 @@ const dynamicFlags: DynamicExportsType = (dynamicFlagsUntyped: any);
 export const {
   alwaysThrottleRetries,
   consoleManagedByDevToolsDuringStrictMode,
+  disableDefaultPropsExceptForClasses,
   enableAsyncActions,
-  enableEarlyReturnForPropDiffing,
   enableComponentStackLocations,
   enableDeferRootSchedulingToMicrotask,
+  enableEarlyReturnForPropDiffing,
   enableInfiniteRenderLoopDetection,
   enableRenderableContext,
   enableUnifiedSyncLane,
   passChildrenWhenCloningPersistedNodes,
   useModernStrictMode,
-  disableDefaultPropsExceptForClasses,
+
+  // TODO: Roll out with GK. Don't keep as dynamic flag for too long, though,
+  // because JSX is an extremely hot path.
+  disableStringRefs,
+  enableRefAsProp,
 } = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.
@@ -92,11 +97,6 @@ export const disableClientCache = true;
 
 export const enableServerComponentKeys = true;
 export const enableServerComponentLogs = true;
-
-// TODO: Roll out with GK. Don't keep as dynamic flag for too long, though,
-// because JSX is an extremely hot path.
-export const enableRefAsProp = false;
-export const disableStringRefs = false;
 
 export const enableReactTestRendererWarning = false;
 export const disableLegacyMode = false;


### PR DESCRIPTION
## Summary

We are almost ready to experiment with enabling `enableRefAsProp` and `disableStringRefs` in React Native at Meta. My plan is to enable and validate both at the same time, in order to minimize the time that we introduce these dynamic checks in the hot code path of JSX.

## How did you test this change?

```
$ yarn test
$ yarn flow fabric
```