### PR TITLE
move from `importAssertions` to `importAttributes`

### DIFF
--- a/packages/react-server-dom-esm/src/ReactFlightESMNodeLoader.js
+++ b/packages/react-server-dom-esm/src/ReactFlightESMNodeLoader.js
@@ -44,7 +44,7 @@ type TransformSourceFunction = (
 type LoadContext = {
   conditions: Array<string>,
   format: string | null | void,
-  importAssertions: Object,
+  importAttributes: Object,
 };
 
 type LoadFunction = (
@@ -261,7 +261,7 @@ async function parseExportNamesInto(
           const {url} = await resolveClientImport(node.source.value, parentURL);
           const {source} = await loader(
             url,
-            {format: 'module', conditions: [], importAssertions: {}},
+            {format: 'module', conditions: [], importAttributes: {}},
             loader,
           );
           if (typeof source !== 'string') {

--- a/packages/react-server-dom-turbopack/src/ReactFlightTurbopackNodeLoader.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightTurbopackNodeLoader.js
@@ -44,7 +44,7 @@ type TransformSourceFunction = (
 type LoadContext = {
   conditions: Array<string>,
   format: string | null | void,
-  importAssertions: Object,
+  importAttributes: Object,
 };
 
 type LoadFunction = (
@@ -261,7 +261,7 @@ async function parseExportNamesInto(
           const {url} = await resolveClientImport(node.source.value, parentURL);
           const {source} = await loader(
             url,
-            {format: 'module', conditions: [], importAssertions: {}},
+            {format: 'module', conditions: [], importAttributes: {}},
             loader,
           );
           if (typeof source !== 'string') {

--- a/packages/react-server-dom-turbopack/src/ReactFlightTurbopackNodeLoader.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightTurbopackNodeLoader.js
@@ -44,7 +44,7 @@ type TransformSourceFunction = (
 type LoadContext = {
   conditions: Array<string>,
   format: string | null | void,
-  importAttributes: Object,
+  importAssertions: Object,
 };
 
 type LoadFunction = (
@@ -261,7 +261,7 @@ async function parseExportNamesInto(
           const {url} = await resolveClientImport(node.source.value, parentURL);
           const {source} = await loader(
             url,
-            {format: 'module', conditions: [], importAttributes: {}},
+            {format: 'module', conditions: [], importAssertions: {}},
             loader,
           );
           if (typeof source !== 'string') {

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
@@ -44,7 +44,7 @@ type TransformSourceFunction = (
 type LoadContext = {
   conditions: Array<string>,
   format: string | null | void,
-  importAssertions: Object,
+  importAttributes: Object,
 };
 
 type LoadFunction = (
@@ -261,7 +261,7 @@ async function parseExportNamesInto(
           const {url} = await resolveClientImport(node.source.value, parentURL);
           const {source} = await loader(
             url,
-            {format: 'module', conditions: [], importAssertions: {}},
+            {format: 'module', conditions: [], importAttributes: {}},
             loader,
           );
           if (typeof source !== 'string') {


### PR DESCRIPTION
## Summary

This is to account for the change in the proposal: https://github.com/tc39/proposal-import-attributes

Without this, you'll get the following warning on recent versions of node:

```
(node:39166) ExperimentalWarning: Use `importAttributes` instead of `importAssertions`
```

## How did you test this change?

Did a find/replace and ran the tests. I also use the `react-server-dom-esm` node loader in a workshop with Node v20.10.0 and this change removed the warning while preserving the functionality. I did not test the other packages.