### PR TITLE
Introduce `forceSyncUpdate` to class component 

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -299,7 +299,7 @@ const classComponentUpdater = {
   enqueueForceSyncUpdate(inst: any, callback) {
     const fiber = getInstance(inst);
 
-    const update = createUpdate(lane);
+    const update = createUpdate(SyncLane);
     update.tag = ForceUpdate;
 
     if (callback !== undefined && callback !== null) {

--- a/packages/react-server/src/ReactFizzClassComponent.js
+++ b/packages/react-server/src/ReactFizzClassComponent.js
@@ -144,6 +144,19 @@ const classComponentUpdater = {
       }
     }
   },
+  // $FlowFixMe[missing-local-annot]
+  enqueueForceSyncUpdate(inst: any, callback) {
+    const internals: InternalInstance = getInstance(inst);
+    if (internals.queue === null) {
+      warnNoop(inst, 'forceSyncUpdate');
+    } else {
+      if (__DEV__) {
+        if (callback !== undefined && callback !== null) {
+          warnOnInvalidCallback(callback);
+        }
+      }
+    }
+  },
 };
 
 function applyDerivedStateFromProps(

--- a/packages/react/src/ReactBaseClasses.js
+++ b/packages/react/src/ReactBaseClasses.js
@@ -87,6 +87,25 @@ Component.prototype.forceUpdate = function (callback) {
 };
 
 /**
+ * Forces an update in SyncLane. This should only be invoked when it is known
+ * with certainty that we are **not** in a DOM transaction and need the changes
+ * to be scheduled immediately.
+ *
+ * You may want to call this when you know that some deeper aspect of the
+ * component's state has changed but `setState` was not called.
+ *
+ * This will not invoke `shouldComponentUpdate`, but it will invoke
+ * `componentWillUpdate` and `componentDidUpdate`.
+ *
+ * @param {?function} callback Called after update is complete.
+ * @final
+ * @protected
+ */
+Component.prototype.forceSyncUpdate = function (callback) {
+  this.updater.enqueueForceSyncUpdate(this, callback, 'forceSyncUpdate');
+};
+
+/**
  * Deprecated APIs. These APIs used to exist on classic React classes but since
  * we would like to deprecate them, we're not going to move them over to this
  * modern base class. Instead, we define a getter that warns if it's accessed.

--- a/packages/react/src/ReactNoopUpdateQueue.js
+++ b/packages/react/src/ReactNoopUpdateQueue.js
@@ -64,6 +64,26 @@ const ReactNoopUpdateQueue = {
   },
 
   /**
+   * Forces an update in SyncLane. This should only be invoked when it is known
+   * with certainty that we are **not** in a DOM transaction and need the changes
+   * to be scheduled immediately.
+   *
+   * You may want to call this when you know that some deeper aspect of the
+   * component's state has changed but `setState` was not called.
+   *
+   * This will not invoke `shouldComponentUpdate`, but it will invoke
+   * `componentWillUpdate` and `componentDidUpdate`.
+   *
+   * @param {ReactClass} publicInstance The instance that should rerender.
+   * @param {?function} callback Called after component is updated.
+   * @param {?string} callerName name of the calling function in the public API.
+   * @internal
+   */
+  enqueueForceSyncUpdate: function (publicInstance, callback, callerName) {
+    warnNoop(publicInstance, 'forceSyncUpdate');
+  },
+
+  /**
    * Replaces all of the state. Always use this or `setState` to mutate state.
    * You should treat `this.state` as immutable.
    *


### PR DESCRIPTION
## Summary

As described in issue [#28897](https://github.com/facebook/react/issues/28897), there is currently no reliable API for a class component to be updated in SyncLane. This API is desired when a class component is subscribed to an external store, e.g. mobx. 

Function component can achieve this reliably by using `useSyncExternalStore`. However, class component may be updated at an arbitrary time.

## How did you test this change?

No implement at the moment
