### PR TITLE
Float: Stringify `crossorigin="anonymous"`

### DIFF
--- a/packages/react-dom-bindings/src/shared/crossOriginStrings.js
+++ b/packages/react-dom-bindings/src/shared/crossOriginStrings.js
@@ -11,7 +11,7 @@ export opaque type CrossOriginString: string = string;
 
 export function getCrossOriginString(input: ?string): ?CrossOriginString {
   if (typeof input === 'string') {
-    return input === 'use-credentials' ? input : '';
+    return input === 'use-credentials' || input === 'anonymous' ? input : '';
   }
   return undefined;
 }
@@ -24,7 +24,7 @@ export function getCrossOriginStringAs(
     return '';
   }
   if (typeof input === 'string') {
-    return input === 'use-credentials' ? input : '';
+    return input === 'use-credentials' || input === 'anonymous' ? input : '';
   }
   return undefined;
 }

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticFloat-test.js
@@ -160,7 +160,12 @@ describe('ReactDOMFizzStaticFloat', () => {
         crossorigin="use-credentials"
         integrity="module-hash"
       />,
-      <link rel="preload" as="style" href="style anon" crossorigin="" />,
+      <link
+        rel="preload"
+        as="style"
+        href="style anon"
+        crossorigin="anonymous"
+      />,
       <link rel="preload" as="script" href="script anon" crossorigin="" />,
       <link
         rel="modulepreload"
@@ -207,7 +212,7 @@ describe('ReactDOMFizzStaticFloat', () => {
             rel="stylesheet"
             data-precedence="default"
             href="style anon"
-            crossorigin=""
+            crossorigin="anonymous"
           />
         </head>
         <body>
@@ -231,7 +236,12 @@ describe('ReactDOMFizzStaticFloat', () => {
               crossorigin="use-credentials"
               integrity="module-hash"
             />
-            <link rel="preload" as="style" href="style anon" crossorigin="" />
+            <link
+              rel="preload"
+              as="style"
+              href="style anon"
+              crossorigin="anonymous"
+            />
             <link rel="preload" as="script" href="script anon" crossorigin="" />
             <link
               rel="modulepreload"

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -3972,6 +3972,34 @@ body {
     );
   });
 
+  it('does not include crossOrigin when keying image preloads', async () => {
+    function App() {
+      return (
+        <html>
+          <body>
+            <img src="foo.png" crossOrigin="" />
+            <img src="foo.png" crossOrigin="anonymous" />
+          </body>
+        </html>
+      );
+    }
+
+    await act(() => {
+      renderToPipeableStream(<App />).pipe(writable);
+    });
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <link rel="preload" as="image" crossorigin="" href="foo.png" />
+        </head>
+        <body>
+          <img src="foo.png" crossorigin="" />
+          <img src="foo.png" crossorigin="anonymous" />
+        </body>
+      </html>,
+    );
+  });
+
   it('can emit preloads for non-lazy images that are rendered', async () => {
     function App() {
       ReactDOM.preload('script', {as: 'script'});

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -3936,7 +3936,12 @@ body {
     expect(getMeaningfulChildren(document)).toEqual(
       <html>
         <head>
-          <link rel="preload" as="image" crossorigin="" href="foo.png" />
+          <link
+            rel="preload"
+            as="image"
+            crossorigin="anonymous"
+            href="foo.png"
+          />
           <link rel="preload" as="image" crossorigin="" href="bar.png" />
         </head>
         <body>
@@ -3951,7 +3956,12 @@ body {
     expect(getMeaningfulChildren(document)).toEqual(
       <html>
         <head>
-          <link rel="preload" as="image" crossorigin="" href="foo.png" />
+          <link
+            rel="preload"
+            as="image"
+            crossorigin="anonymous"
+            href="foo.png"
+          />
           <link rel="preload" as="image" crossorigin="" href="bar.png" />
         </head>
         <body>
@@ -5351,6 +5361,7 @@ body {
             <link rel="preconnect" href="foo" />
             <link rel="preconnect" href="foo" crossorigin="" />
             <link rel="preconnect" href="foo" crossorigin="use-credentials" />
+            <link rel="preconnect" href="foo" crossorigin="anonymous" />
           </head>
           <body>hello world</body>
         </html>,
@@ -5368,8 +5379,10 @@ body {
             <link rel="preconnect" href="foo" />
             <link rel="preconnect" href="foo" crossorigin="" />
             <link rel="preconnect" href="foo" crossorigin="use-credentials" />
+            <link rel="preconnect" href="foo" crossorigin="anonymous" />
             <link rel="preconnect" href="bar" />
             <link rel="preconnect" href="bar" crossorigin="" />
+            <link rel="preconnect" href="bar" crossorigin="anonymous" />
             <link rel="preconnect" href="bar" crossorigin="use-credentials" />
           </head>
           <body>hello world</body>

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -3978,7 +3978,7 @@ body {
         <html>
           <body>
             <img src="foo.png" crossOrigin="" />
-            <img src="foo.png" crossOrigin="anonymous" />
+            <img src="foo.png" crossOrigin="use-credentials" />
           </body>
         </html>
       );
@@ -3994,7 +3994,7 @@ body {
         </head>
         <body>
           <img src="foo.png" crossorigin="" />
-          <img src="foo.png" crossorigin="anonymous" />
+          <img src="foo.png" crossorigin="use-credentials" />
         </body>
       </html>,
     );

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -3918,6 +3918,50 @@ body {
     );
   });
 
+  it('should handle crossOrigin on image preload', async () => {
+    function App() {
+      return (
+        <html>
+          <body>
+            <img src="foo.png" crossOrigin="anonymous" />
+            <img src="bar.png" crossOrigin="" />
+          </body>
+        </html>
+      );
+    }
+
+    await act(() => {
+      renderToPipeableStream(<App />).pipe(writable);
+    });
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <link rel="preload" as="image" crossorigin="" href="foo.png" />
+          <link rel="preload" as="image" crossorigin="" href="bar.png" />
+        </head>
+        <body>
+          <img src="foo.png" crossorigin="anonymous" />
+          <img src="bar.png" crossorigin="" />
+        </body>
+      </html>,
+    );
+
+    ReactDOMClient.hydrateRoot(document, <App />);
+    await waitForAll([]);
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <link rel="preload" as="image" crossorigin="" href="foo.png" />
+          <link rel="preload" as="image" crossorigin="" href="bar.png" />
+        </head>
+        <body>
+          <img src="foo.png" crossorigin="anonymous" />
+          <img src="bar.png" crossorigin="" />
+        </body>
+      </html>,
+    );
+  });
+
   it('can emit preloads for non-lazy images that are rendered', async () => {
     function App() {
       ReactDOM.preload('script', {as: 'script'});

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -1407,22 +1407,32 @@ describe('ReactFlightDOM', () => {
         <head>
           <link rel="dns-prefetch" href="d before" />
           <link rel="preconnect" href="c before" />
-          <link rel="preconnect" href="c2 before" crossorigin="" />
+          <link rel="preconnect" href="c2 before" crossorigin="anonymous" />
           <link rel="preload" as="style" href="l before" />
           <link rel="modulepreload" href="lm before" />
-          <link rel="modulepreload" href="lm2 before" crossorigin="" />
+          <link rel="modulepreload" href="lm2 before" crossorigin="anonymous" />
           <script async="" src="i before" />
           <script type="module" async="" src="m before" />
-          <script type="module" async="" src="m2 before" crossorigin="" />
+          <script
+            type="module"
+            async=""
+            src="m2 before"
+            crossorigin="anonymous"
+          />
           <link rel="dns-prefetch" href="d after" />
           <link rel="preconnect" href="c after" />
-          <link rel="preconnect" href="c2 after" crossorigin="" />
+          <link rel="preconnect" href="c2 after" crossorigin="anonymous" />
           <link rel="preload" as="style" href="l after" />
           <link rel="modulepreload" href="lm after" />
-          <link rel="modulepreload" href="lm2 after" crossorigin="" />
+          <link rel="modulepreload" href="lm2 after" crossorigin="anonymous" />
           <script async="" src="i after" />
           <script type="module" async="" src="m after" />
-          <script type="module" async="" src="m2 after" crossorigin="" />
+          <script
+            type="module"
+            async=""
+            src="m2 after"
+            crossorigin="anonymous"
+          />
         </head>
         <body />
       </html>,
@@ -1599,22 +1609,32 @@ describe('ReactFlightDOM', () => {
         <head>
           <link rel="dns-prefetch" href="d before" />
           <link rel="preconnect" href="c before" />
-          <link rel="preconnect" href="c2 before" crossorigin="" />
+          <link rel="preconnect" href="c2 before" crossorigin="anonymous" />
           <link rel="dns-prefetch" href="d after" />
           <link rel="preconnect" href="c after" />
-          <link rel="preconnect" href="c2 after" crossorigin="" />
+          <link rel="preconnect" href="c2 after" crossorigin="anonymous" />
           <script async="" src="i before" />
           <script type="module" async="" src="m before" />
-          <script type="module" async="" src="m2 before" crossorigin="" />
+          <script
+            type="module"
+            async=""
+            src="m2 before"
+            crossorigin="anonymous"
+          />
           <script async="" src="i after" />
           <script type="module" async="" src="m after" />
-          <script type="module" async="" src="m2 after" crossorigin="" />
+          <script
+            type="module"
+            async=""
+            src="m2 after"
+            crossorigin="anonymous"
+          />
           <link rel="preload" as="style" href="l before" />
           <link rel="modulepreload" href="lm before" />
-          <link rel="modulepreload" href="lm2 before" crossorigin="" />
+          <link rel="modulepreload" href="lm2 before" crossorigin="anonymous" />
           <link rel="preload" as="style" href="l after" />
           <link rel="modulepreload" href="lm after" />
-          <link rel="modulepreload" href="lm2 after" crossorigin="" />
+          <link rel="modulepreload" href="lm2 after" crossorigin="anonymous" />
         </head>
         <body>
           <p>hello world</p>


### PR DESCRIPTION
## Summary

`<img crossOrigin="anonymous" />` now creates the corresponding `<link rel="preload" />` tag preserving `crossOrigin` since [`anonymous` is a valid value for `crossOrigin`](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes). 

It doesn't change production behavior since it results in the same state. Mainly to just reduce confusion but then `crossOrigin="some-non-existing-value"` would also result in `crossorigin=""` so maybe that's fine?

## How did you test this change?

Added test for `<img crossOrigin="anonymous" />`. Other tests were also updated so I'm curious if ignoring `anonymous` is intended for `preconnect`.

I also added a test showing how `crossOrigin` doesn't factor into keying. Mostly to show the difference between how Float and `next/legacy/image` differs with regard to preloading. `next/legacy/image` currently adds a `<link rel="preload" />` matching `crossOrigin` of the **last** `<img />` with the same key whereas Float uses `crossOrigin` from the **first** image.
