### PR TITLE
Stop committing resources to an external repo

### DIFF
--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -210,42 +210,6 @@ jobs:
           commit_user_email: ${{ github.actor }}@users.noreply.github.com
           create_branch: true
 
-  commit_fbsource_artifacts_external_repo:
-    needs: download_artifacts
-    runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/main' && needs.download_artifacts.outputs.fbsource_branch_count == '0') || github.ref == 'refs/heads/meta-fbsource' }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-          repository: facebook/react-fbsource-import
-          token: ${{secrets.FBSOURCE_SYNC_PUSH_TOKEN}}
-      - name: Ensure clean directory
-        run: rm -rf compiled-rn
-      - uses: actions/download-artifact@v3
-        with:
-          name: compiled-rn
-          path: compiled-rn/
-      - run: git status -u
-      - name: Check if only the REVISION file has changed
-        id: check_should_commit
-        run: |
-          if git status --porcelain | grep -qv '/REVISION$'; then
-            echo "should_commit=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_commit=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Commit changes to branch
-        if: steps.check_should_commit.outputs.should_commit == 'true'
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: |
-            ${{ github.event.head_commit.message }}
-
-            DiffTrain build for commit https://github.com/facebook/react/commit/${{ github.sha }}.
-          commit_user_name: ${{ github.actor }}
-          commit_user_email: ${{ github.actor }}@users.noreply.github.com
-
   commit_fbsource_artifacts:
     needs: download_artifacts
     if: ${{ (github.ref == 'refs/heads/main' && needs.download_artifacts.outputs.fbsource_branch_count == '0') || github.ref == 'refs/heads/meta-fbsource' }}


### PR DESCRIPTION
This has been integrated into this repo (`builds/facebook-fbsource`) so we no longer need the extra repo