### PR TITLE
[Tooling] Update critical artifact list

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -44,7 +44,9 @@ const CRITICAL_ARTIFACT_PATHS = new Set([
   // We always report changes to these bundles, even if the change is
   // insignificant or non-existent.
   'oss-stable/react-dom/cjs/react-dom.production.js',
+  'oss-stable/react-dom/cjs/react-dom-client.production.js',
   'oss-experimental/react-dom/cjs/react-dom.production.js',
+  'oss-experimental/react-dom/cjs/react-dom-client.production.js',
   'facebook-www/ReactDOM-prod.classic.js',
   'facebook-www/ReactDOM-prod.modern.js',
 ]);


### PR DESCRIPTION
When a React PR is opened CI will report large size changes. But for critical packages like react-dom it reports always. In React 19 we moved the build for react-dom the client reconciler from react-dom to react-dom/client

This change adds react-dom-client artifacts for stable and oss channels since that is originally what was being tracked. But since react-dom/client always imports react-dom I left the original react-dom packages as critical as well. They are small but it would be good to keep an eye on them
