### PR TITLE
Introduce a faster version of the addProperties function

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeAttributePayload.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayload.js
@@ -444,12 +444,15 @@ function diffProperties(
   return updatePayload;
 }
 
-function fastAddProperties(updatePayload, nextProps, validAttributes) {
-  var attributeConfig;
-  var nextProp;
+function fastAddProperties(
+  updatePayload: null | Object,
+  nextProps: Object,
+  validAttributes: AttributeConfiguration,
+): null | Object {
+  let attributeConfig;
+  let nextProp;
 
-  for (var propKey in nextProps) {
-
+  for (const propKey in nextProps) {
     nextProp = nextProps[propKey];
 
     if (nextProp === undefined) {
@@ -462,34 +465,42 @@ function fastAddProperties(updatePayload, nextProps, validAttributes) {
       continue;
     }
 
-    if (typeof nextProp === "function") {
-      nextProp = true;
+    if (typeof nextProp === 'function') {
+      nextProp = (true: any);
     }
 
-    if (typeof attributeConfig !== "object") {
+    if (typeof attributeConfig !== 'object') {
       if (!updatePayload) {
-        updatePayload = {};
+        updatePayload = ({}: {[string]: $FlowFixMe});
       }
       updatePayload[propKey] = nextProp;
       continue;
     }
 
-    if (typeof attributeConfig.process === "function") {
+    if (typeof attributeConfig.process === 'function') {
       if (!updatePayload) {
-        updatePayload = {};
+        updatePayload = ({}: {[string]: $FlowFixMe});
       }
       updatePayload[propKey] = attributeConfig.process(nextProp);
       continue;
     }
 
     if (isArray(nextProp)) {
-      for (var i = 0; i < nextProp.length; i++) {
-        updatePayload = fastAddProperties(updatePayload, nextProp[i], attributeConfig);
+      for (let i = 0; i < nextProp.length; i++) {
+        updatePayload = fastAddProperties(
+          updatePayload,
+          nextProp[i],
+          ((attributeConfig: any): AttributeConfiguration),
+        );
       }
       continue;
     }
 
-    updatePayload = fastAddProperties(updatePayload, nextProp, attributeConfig);
+    updatePayload = fastAddProperties(
+      updatePayload,
+      nextProp,
+      ((attributeConfig: any): AttributeConfiguration),
+    );
   }
 
   return updatePayload;
@@ -498,7 +509,11 @@ function fastAddProperties(updatePayload, nextProps, validAttributes) {
 /**
  * addProperties adds all the valid props to the payload after being processed.
  */
-function addProperties(updatePayload, props, validAttributes) {
+function addProperties(
+  updatePayload: null | Object,
+  props: Object,
+  validAttributes: AttributeConfiguration,
+): null | Object {
   return fastAddProperties(updatePayload, props, validAttributes);
 }
 

--- a/packages/react-native-renderer/src/ReactNativeAttributePayload.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayload.js
@@ -15,6 +15,7 @@ import {
 import isArray from 'shared/isArray';
 
 import {enableEarlyReturnForPropDiffing} from 'shared/ReactFeatureFlags';
+import {enableAddPropertiesFastPath} from 'shared/ReactFeatureFlags';
 
 import type {AttributeConfiguration} from './ReactNativeTypes';
 
@@ -514,7 +515,11 @@ function addProperties(
   props: Object,
   validAttributes: AttributeConfiguration,
 ): null | Object {
-  return fastAddProperties(updatePayload, props, validAttributes);
+  if (enableAddPropertiesFastPath) {
+    return fastAddProperties(updatePayload, props, validAttributes);
+  } else {
+    return diffProperties(updatePayload, emptyObject, props, validAttributes);
+  }
 }
 
 /**

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -123,6 +123,8 @@ export const enableServerComponentLogs = __EXPERIMENTAL__;
 
 export const enableEarlyReturnForPropDiffing = false;
 
+export const enableAddPropertiesFastPath = false;
+
 /**
  * Enables an expiration time for retry lanes to avoid starvation.
  */

--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -29,3 +29,4 @@ export const enableUnifiedSyncLane = __VARIANT__;
 export const passChildrenWhenCloningPersistedNodes = __VARIANT__;
 export const useModernStrictMode = __VARIANT__;
 export const disableDefaultPropsExceptForClasses = __VARIANT__;
+export const enableAddPropertiesFastPath = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -31,6 +31,7 @@ export const {
   passChildrenWhenCloningPersistedNodes,
   useModernStrictMode,
   disableDefaultPropsExceptForClasses,
+  enableAddPropertiesFastPath,
 } = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -103,6 +103,7 @@ export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
 export const passChildrenWhenCloningPersistedNodes = false;
 export const enableEarlyReturnForPropDiffing = false;
 export const enableAsyncIterableChildren = false;
+export const enableAddPropertiesFastPath = false;
 
 export const renameElementSymbol = true;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -78,6 +78,7 @@ export const enableServerComponentKeys = true;
 export const enableServerComponentLogs = true;
 export const enableInfiniteRenderLoopDetection = false;
 export const enableEarlyReturnForPropDiffing = false;
+export const enableAddPropertiesFastPath = false;
 
 export const renameElementSymbol = true;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -89,6 +89,7 @@ export const disableDOMTestUtils = false;
 
 export const disableDefaultPropsExceptForClasses = false;
 export const enableEarlyReturnForPropDiffing = false;
+export const enableAddPropertiesFastPath = false;
 
 export const renameElementSymbol = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -89,6 +89,7 @@ export const disableDOMTestUtils = false;
 
 export const disableDefaultPropsExceptForClasses = false;
 export const enableEarlyReturnForPropDiffing = false;
+export const enableAddPropertiesFastPath = false;
 
 export const renameElementSymbol = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -31,6 +31,7 @@ export const enableNoCloningMemoCache = __VARIANT__;
 export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;
+export const enableAddPropertiesFastPath = __VARIANT__;
 
 // Enable this flag to help with concurrent mode debugging.
 // It logs information to the console about React scheduling, rendering, and commit phases.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -35,6 +35,7 @@ export const {
   favorSafetyOverHydrationPerf,
   disableDefaultPropsExceptForClasses,
   enableNoCloningMemoCache,
+  enableAddPropertiesFastPath,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.


### PR DESCRIPTION
## Summary

This PR introduces a faster version of the `addProperties` function. This new function is basically the `diffProperties` with `prevProps` set to `null`, propagated constants, and all the unreachable code paths collapsed.

## How did you test this change?

I've tested this change with [the benchmark app](https://github.com/react-native-community/RNNewArchitectureApp/tree/new-architecture-benchmarks) and got ~4.4% improvement in the view creation time.