### PR TITLE
[DevTools] Enable inspected element context menu in Fusebox

### DIFF
--- a/packages/react-devtools-fusebox/src/frontend.js
+++ b/packages/react-devtools-fusebox/src/frontend.js
@@ -62,6 +62,7 @@ export function initialize(
       store={store}
       showTabBar={true}
       warnIfLegacyBackendDetected={true}
+      enabledInspectedElementContextMenu={true}
     />,
   );
 }


### PR DESCRIPTION
## Summary

Enables the inspected element context menu in React Native DevTools (Fusebox).

## How did you test this change?

TODO: Manually sync to rn-chrome-devtools-frontend and test.