### PR TITLE
Devtools: Streamline getting extension from branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,13 @@ jobs:
           command: ./scripts/circleci/pack_and_store_devtools_artifacts.sh
       - store_artifacts:
           path: ./build/devtools.tgz
+      # Simplifies getting the extension for local testing
+      - store_artifacts:
+          path: ./build/devtools/chrome-extension.zip
+          destination: react-devtools-chrome-extension.zip
+      - store_artifacts:
+          path: ./build/devtools/firefox-extension.zip
+          destination: react-devtools-firefox-extension.zip
 
   run_devtools_e2e_tests:
     docker: *docker


### PR DESCRIPTION
Stack:
1. https://github.com/facebook/react/pull/28975 <--- You're here
1. https://github.com/facebook/react/pull/28976
1. https://github.com/facebook/react/pull/28974

## Summary

For manual e2e testing, I oftentimes just need the extension for the browser I'm using. So I'm adding separate artifacts just for Chrome and Firefox extension instead of a single tarball with both. Avoids one unpack step and is also easier for external people to grab a nightly build of the extension.

## How did you test this change?

- [x] Download `react-devtools-chrome-extension.zip` from [`build_devtools_and_process_artifacts ` artifacts](https://app.circleci.com/pipelines/github/facebook/react/52772/workflows/c57fae57-bee3-4b8d-8f2a-fe31464f8922/jobs/850793/artifacts): 
