### PR TITLE
Devtools: Fix build-for-devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "scripts": {
     "build": "node ./scripts/rollup/build-all-release-channels.js",
-    "build-for-devtools": "cross-env RELEASE_CHANNEL=experimental yarn build react/index,react/jsx,react-dom/index,react-dom/unstable_testing,react-dom/test-utils,react-is,react-debug-tools,scheduler,react-test-renderer,react-refresh,react-art --type=NODE",
+    "build-for-devtools": "cross-env RELEASE_CHANNEL=experimental yarn build react/index,react/jsx,react-dom/index,react-dom/client,react-dom/unstable_testing,react-dom/test-utils,react-is,react-debug-tools,scheduler,react-test-renderer,react-refresh,react-art --type=NODE",
     "build-for-devtools-dev": "yarn build-for-devtools --type=NODE_DEV",
     "build-for-devtools-prod": "yarn build-for-devtools --type=NODE_PROD",
     "linc": "node ./scripts/tasks/linc.js",

--- a/packages/react-devtools-extensions/webpack.backend.js
+++ b/packages/react-devtools-extensions/webpack.backend.js
@@ -75,6 +75,8 @@ module.exports = {
       __DEV__: true,
       __PROFILE__: false,
       __DEV____DEV__: true,
+      // By importing `shared/` we may import ReactFeatureFlags
+      __EXPERIMENTAL__: true,
       'process.env.DEVTOOLS_PACKAGE': `"react-devtools-extensions"`,
       'process.env.DEVTOOLS_VERSION': `"${DEVTOOLS_VERSION}"`,
       'process.env.GITHUB_URL': `"${GITHUB_URL}"`,


### PR DESCRIPTION
Stack:
1. https://github.com/facebook/react/pull/28975
1. https://github.com/facebook/react/pull/28976 <--- You're here
1. https://github.com/facebook/react/pull/28974

## Summary

Some devtools code imports from `shared/` this could result in `shared/FeatureFlags` becoming part of the module graph as it did with https://github.com/facebook/react/issues/28813. Without this fix, we'd have a bare `__EXPERIMENTAL__` identifier that would result in `react_devtools_backend_compact.js:3724 Uncaught ReferenceError: __EXPERIMENTAL__ is not defined` in the final build. 

We already hardcoded `__EXPERIMENTAL__: true` in the frontend Webpack config so I'm doing the same for the backend.

## How did you test this change?

- [x] Use `react-devtools-chrome-extension.zip` from this branch and no longer observe `ReferenceError` when inspecting a React app
