### PR TITLE
Enable Wave 1 of Feature Flags for React Native

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -19,13 +19,9 @@
 
 export const alwaysThrottleRetries = __VARIANT__;
 export const consoleManagedByDevToolsDuringStrictMode = __VARIANT__;
-export const enableAsyncActions = __VARIANT__;
 export const enableEarlyReturnForPropDiffing = __VARIANT__;
-export const enableComponentStackLocations = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const enableInfiniteRenderLoopDetection = __VARIANT__;
-export const enableRenderableContext = __VARIANT__;
 export const enableUnifiedSyncLane = __VARIANT__;
 export const passChildrenWhenCloningPersistedNodes = __VARIANT__;
-export const useModernStrictMode = __VARIANT__;
 export const disableDefaultPropsExceptForClasses = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -21,27 +21,26 @@ const dynamicFlags: DynamicExportsType = (dynamicFlagsUntyped: any);
 export const {
   alwaysThrottleRetries,
   consoleManagedByDevToolsDuringStrictMode,
-  enableAsyncActions,
   enableEarlyReturnForPropDiffing,
-  enableComponentStackLocations,
   enableDeferRootSchedulingToMicrotask,
   enableInfiniteRenderLoopDetection,
-  enableRenderableContext,
   enableUnifiedSyncLane,
   passChildrenWhenCloningPersistedNodes,
-  useModernStrictMode,
   disableDefaultPropsExceptForClasses,
 } = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.
+export const enableAsyncActions = true;
 export const enableDebugTracing = false;
 export const enableAsyncDebugInfo = false;
+export const enableRenderableContext = true;
 export const enableSchedulingProfiler = __PROFILE__;
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = __PROFILE__;
 export const enableProfilerNestedUpdatePhase = __PROFILE__;
 export const enableUpdaterTracking = __PROFILE__;
 export const enableCache = true;
+export const enableComponentStackLocations = true;
 export const enableLegacyCache = false;
 export const enableBinaryFlight = true;
 export const enableFlightReadableStream = true;
@@ -68,6 +67,7 @@ export const favorSafetyOverHydrationPerf = true;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = true;
 export const enableGetInspectorDataForInstanceInProduction = true;
+export const useModernStrictMode = true;
 
 export const renameElementSymbol = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -34,7 +34,7 @@ export const enableSuspenseCallback = false;
 export const disableLegacyContext = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
-export const enableComponentStackLocations = false;
+export const enableComponentStackLocations = true;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = true;
 export const enableGetInspectorDataForInstanceInProduction = false;
@@ -46,7 +46,7 @@ export const enableNoCloningMemoCache = false;
 export const enableUseEffectEventHook = false;
 export const favorSafetyOverHydrationPerf = true;
 export const enableInfiniteRenderLoopDetection = false;
-export const enableRenderableContext = false;
+export const enableRenderableContext = true;
 
 export const enableRetryLaneExpiration = false;
 export const retryLaneExpirationMs = 5000;
@@ -64,7 +64,7 @@ export const consoleManagedByDevToolsDuringStrictMode = false;
 
 export const enableTransitionTracing = false;
 
-export const useModernStrictMode = false;
+export const useModernStrictMode = true;
 export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
 export const enableFizzExternalRuntime = true;
 export const enableDeferRootSchedulingToMicrotask = false;


### PR DESCRIPTION
## Summary

We are ready to enable the following feature flags in React Native:

* `enableAsyncActions`
* `enableComponentStackLocations`
* `enableRenderableContext`
* `useModernStrictMode`

This will only affect Meta for now. The open source feature flags are already set to `__TODO_NEXT_RN_MAJOR__`.

## How did you test this change?

```
$ yarn test
$ yarn flow fabric
```