### PR TITLE
[Flight Reply] Resolve outlined models async in Reply just like in Flight Client

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReplyEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReplyEdge-test.js
@@ -86,6 +86,23 @@ describe('ReactFlightDOMReplyEdge', () => {
   });
 
   // @gate enableBinaryFlight
+  it('should be able to serialize a typed array inside a Map', async () => {
+    const array = new Uint8Array([
+      123, 4, 10, 5, 100, 255, 244, 45, 56, 67, 43, 124, 67, 89, 100, 20,
+    ]);
+    const map = new Map();
+    map.set('array', array);
+
+    const body = await ReactServerDOMClient.encodeReply(map);
+    const result = await ReactServerDOMServer.decodeReply(
+      body,
+      webpackServerMap,
+    );
+
+    expect(result.get('array')).toEqual(array);
+  });
+
+  // @gate enableBinaryFlight
   it('should be able to serialize a blob', async () => {
     const bytes = new Uint8Array([
       123, 4, 10, 5, 100, 255, 244, 45, 56, 67, 43, 124, 67, 89, 100, 20,

--- a/packages/react-server-dom-webpack/src/__tests__/utils/WebpackMock.js
+++ b/packages/react-server-dom-webpack/src/__tests__/utils/WebpackMock.js
@@ -11,11 +11,16 @@ const url = require('url');
 const Module = require('module');
 
 let webpackModuleIdx = 0;
+let webpackChunkIdx = 0;
 const webpackServerModules = {};
 const webpackClientModules = {};
 const webpackErroredModules = {};
 const webpackServerMap = {};
 const webpackClientMap = {};
+const webpackChunkMap = {};
+global.__webpack_chunk_load__ = function (id) {
+  return webpackChunkMap[id];
+};
 global.__webpack_require__ = function (id) {
   if (webpackErroredModules[id]) {
     throw webpackErroredModules[id];
@@ -117,13 +122,20 @@ exports.clientExports = function clientExports(
 };
 
 // This tests server to server references. There's another case of client to server references.
-exports.serverExports = function serverExports(moduleExports) {
+exports.serverExports = function serverExports(moduleExports, blockOnChunk) {
   const idx = '' + webpackModuleIdx++;
   webpackServerModules[idx] = moduleExports;
   const path = url.pathToFileURL(idx).href;
+
+  const chunks = [];
+  if (blockOnChunk) {
+    const chunkId = webpackChunkIdx++;
+    webpackChunkMap[chunkId] = blockOnChunk;
+    chunks.push(chunkId);
+  }
   webpackServerMap[path] = {
     id: idx,
-    chunks: [],
+    chunks: chunks,
     name: '*',
   };
   // We only add this if this test is testing ESM compat.


### PR DESCRIPTION
This is the same change as #28780 but for the Flight Reply receiver.

While it's not possible to create an "async module" reference in this case - resolving a server reference can still be async if loading it requires loading chunks like in a new server instance.

Since extracting a typed array from a Blob is async, that's also a case where a dependency can be async.
