### PR TITLE
Setup Wave 2 of Feature Flags for React Native

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -19,10 +19,10 @@
 
 export const alwaysThrottleRetries = __VARIANT__;
 export const consoleManagedByDevToolsDuringStrictMode = __VARIANT__;
-export const enableEarlyReturnForPropDiffing = __VARIANT__;
+export const disableDefaultPropsExceptForClasses = __VARIANT__;
+export const enableAddPropertiesFastPath = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
+export const enableEarlyReturnForPropDiffing = __VARIANT__;
 export const enableInfiniteRenderLoopDetection = __VARIANT__;
 export const enableUnifiedSyncLane = __VARIANT__;
 export const passChildrenWhenCloningPersistedNodes = __VARIANT__;
-export const disableDefaultPropsExceptForClasses = __VARIANT__;
-export const enableAddPropertiesFastPath = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -20,9 +20,12 @@
 export const alwaysThrottleRetries = __VARIANT__;
 export const consoleManagedByDevToolsDuringStrictMode = __VARIANT__;
 export const disableDefaultPropsExceptForClasses = __VARIANT__;
+export const disableStringRefs = __VARIANT__;
 export const enableAddPropertiesFastPath = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const enableEarlyReturnForPropDiffing = __VARIANT__;
+export const enableFastJSX = __VARIANT__;
 export const enableInfiniteRenderLoopDetection = __VARIANT__;
+export const enableRefAsProp = __VARIANT__;
 export const enableUnifiedSyncLane = __VARIANT__;
 export const passChildrenWhenCloningPersistedNodes = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -21,13 +21,13 @@ const dynamicFlags: DynamicExportsType = (dynamicFlagsUntyped: any);
 export const {
   alwaysThrottleRetries,
   consoleManagedByDevToolsDuringStrictMode,
-  enableEarlyReturnForPropDiffing,
+  disableDefaultPropsExceptForClasses,
+  enableAddPropertiesFastPath,
   enableDeferRootSchedulingToMicrotask,
+  enableEarlyReturnForPropDiffing,
   enableInfiniteRenderLoopDetection,
   enableUnifiedSyncLane,
   passChildrenWhenCloningPersistedNodes,
-  disableDefaultPropsExceptForClasses,
-  enableAddPropertiesFastPath,
 } = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -22,10 +22,13 @@ export const {
   alwaysThrottleRetries,
   consoleManagedByDevToolsDuringStrictMode,
   disableDefaultPropsExceptForClasses,
+  disableStringRefs,
   enableAddPropertiesFastPath,
   enableDeferRootSchedulingToMicrotask,
   enableEarlyReturnForPropDiffing,
+  enableFastJSX,
   enableInfiniteRenderLoopDetection,
+  enableRefAsProp,
   enableUnifiedSyncLane,
   passChildrenWhenCloningPersistedNodes,
 } = dynamicFlags;
@@ -93,12 +96,6 @@ export const disableClientCache = true;
 
 export const enableServerComponentKeys = true;
 export const enableServerComponentLogs = true;
-
-// TODO: Roll out with GK. Don't keep as dynamic flag for too long, though,
-// because JSX is an extremely hot path.
-export const enableRefAsProp = false;
-export const disableStringRefs = false;
-export const enableFastJSX = false;
 
 export const enableReactTestRendererWarning = false;
 export const disableLegacyMode = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -80,9 +80,9 @@ export const disableClientCache = true;
 export const enableServerComponentKeys = true;
 export const enableServerComponentLogs = true;
 
-export const enableRefAsProp = false;
-export const disableStringRefs = false;
-export const enableFastJSX = false;
+export const enableRefAsProp = true;
+export const disableStringRefs = true;
+export const enableFastJSX = true;
 
 export const enableReactTestRendererWarning = false;
 export const disableLegacyMode = false;


### PR DESCRIPTION
## Summary

Sets up dynamic feature flags for `disableStringRefs`, `enableFastJSX`, and `enableRefAsProp` in React Native (at Meta).

## How did you test this change?

```
$ yarn test
$ yarn flow fabric
```