### PR TITLE
[Flight Reply] Dedupe Objects and Support Cyclic References

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js
@@ -537,4 +537,13 @@ describe('ReactFlightDOMReply', () => {
       'Values cannot be passed to next() of AsyncIterables passed to Client Components.',
     );
   });
+
+  it('can transport cyclic objects', async () => {
+    const cyclic = {obj: null};
+    cyclic.obj = cyclic;
+
+    const body = await ReactServerDOMClient.encodeReply({prop: cyclic});
+    const root = await ReactServerDOMServer.decodeReply(body, webpackServerMap);
+    expect(root.prop.obj).toBe(root.prop);
+  });
 });


### PR DESCRIPTION
Uses the same technique as in #28996 to encode references to already emitted objects. This now means that Reply can support cyclic objects too for parity.
