### PR TITLE
Dim `console` calls on additional Effect invocations due to `StrictMode`

### DIFF
--- a/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
+++ b/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
@@ -146,6 +146,12 @@ describe('ReactInternalTestUtils', () => {
   test('assertLog', async () => {
     const Yield = ({id}) => {
       Scheduler.log(id);
+      React.useEffect(() => {
+        Scheduler.log(`create effect ${id}`);
+        return () => {
+          Scheduler.log(`cleanup effect ${id}`);
+        };
+      });
       return id;
     };
 
@@ -167,7 +173,26 @@ describe('ReactInternalTestUtils', () => {
         </React.StrictMode>
       );
     });
-    assertLog(['A', 'B', 'C']);
+    assertLog([
+      'A',
+      'B',
+      'C',
+      'create effect A',
+      'create effect B',
+      'create effect C',
+      'cleanup effect A',
+      'cleanup effect B',
+      'cleanup effect C',
+      'create effect A',
+      'create effect B',
+      'create effect C',
+    ]);
+
+    await act(() => {
+      root.render(null);
+    });
+
+    assertLog(['cleanup effect A', 'cleanup effect B', 'cleanup effect C']);
   });
 });
 

--- a/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
+++ b/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
@@ -180,12 +180,6 @@ describe('ReactInternalTestUtils', () => {
       'create effect A',
       'create effect B',
       'create effect C',
-      'cleanup effect A',
-      'cleanup effect B',
-      'cleanup effect C',
-      'create effect A',
-      'create effect B',
-      'create effect C',
     ]);
 
     await act(() => {

--- a/packages/react-devtools-shared/src/__tests__/console-test.js
+++ b/packages/react-devtools-shared/src/__tests__/console-test.js
@@ -663,33 +663,81 @@ describe('console', () => {
     );
     expect(mockLog.mock.calls).toEqual([
       ['log effect create'],
-      ['log effect cleanup'],
-      ['log effect create'],
+      [
+        '%c%s',
+        `color: ${process.env.DARK_MODE_DIMMED_LOG_COLOR}`,
+        'log effect cleanup',
+      ],
+      [
+        '%c%s',
+        `color: ${process.env.DARK_MODE_DIMMED_LOG_COLOR}`,
+        'log effect create',
+      ],
     ]);
     expect(mockWarn.mock.calls).toEqual([
       ['warn effect create'],
-      ['warn effect cleanup'],
-      ['warn effect create'],
+      [
+        '%c%s',
+        `color: ${process.env.DARK_MODE_DIMMED_WARNING_COLOR}`,
+        'warn effect cleanup',
+      ],
+      [
+        '%c%s',
+        `color: ${process.env.DARK_MODE_DIMMED_WARNING_COLOR}`,
+        'warn effect create',
+      ],
     ]);
     expect(mockError.mock.calls).toEqual([
       ['error effect create'],
-      ['error effect cleanup'],
-      ['error effect create'],
+      [
+        '%c%s',
+        `color: ${process.env.DARK_MODE_DIMMED_ERROR_COLOR}`,
+        'error effect cleanup',
+      ],
+      [
+        '%c%s',
+        `color: ${process.env.DARK_MODE_DIMMED_ERROR_COLOR}`,
+        'error effect create',
+      ],
     ]);
     expect(mockInfo.mock.calls).toEqual([
       ['info effect create'],
-      ['info effect cleanup'],
-      ['info effect create'],
+      [
+        '%c%s',
+        `color: ${process.env.DARK_MODE_DIMMED_LOG_COLOR}`,
+        'info effect cleanup',
+      ],
+      [
+        '%c%s',
+        `color: ${process.env.DARK_MODE_DIMMED_LOG_COLOR}`,
+        'info effect create',
+      ],
     ]);
     expect(mockGroup.mock.calls).toEqual([
       ['group effect create'],
-      ['group effect cleanup'],
-      ['group effect create'],
+      [
+        '%c%s',
+        `color: ${process.env.DARK_MODE_DIMMED_LOG_COLOR}`,
+        'group effect cleanup',
+      ],
+      [
+        '%c%s',
+        `color: ${process.env.DARK_MODE_DIMMED_LOG_COLOR}`,
+        'group effect create',
+      ],
     ]);
     expect(mockGroupCollapsed.mock.calls).toEqual([
       ['groupCollapsed effect create'],
-      ['groupCollapsed effect cleanup'],
-      ['groupCollapsed effect create'],
+      [
+        '%c%s',
+        `color: ${process.env.DARK_MODE_DIMMED_LOG_COLOR}`,
+        'groupCollapsed effect cleanup',
+      ],
+      [
+        '%c%s',
+        `color: ${process.env.DARK_MODE_DIMMED_LOG_COLOR}`,
+        'groupCollapsed effect create',
+      ],
     ]);
   });
 
@@ -729,34 +777,12 @@ describe('console', () => {
         </React.StrictMode>,
       ),
     );
-    expect(mockLog.mock.calls).toEqual([
-      ['log effect create'],
-      ['log effect cleanup'],
-      ['log effect create'],
-    ]);
-    expect(mockWarn.mock.calls).toEqual([
-      ['warn effect create'],
-      ['warn effect cleanup'],
-      ['warn effect create'],
-    ]);
-    expect(mockError.mock.calls).toEqual([
-      ['error effect create'],
-      ['error effect cleanup'],
-      ['error effect create'],
-    ]);
-    expect(mockInfo.mock.calls).toEqual([
-      ['info effect create'],
-      ['info effect cleanup'],
-      ['info effect create'],
-    ]);
-    expect(mockGroup.mock.calls).toEqual([
-      ['group effect create'],
-      ['group effect cleanup'],
-      ['group effect create'],
-    ]);
+    expect(mockLog.mock.calls).toEqual([['log effect create']]);
+    expect(mockWarn.mock.calls).toEqual([['warn effect create']]);
+    expect(mockError.mock.calls).toEqual([['error effect create']]);
+    expect(mockInfo.mock.calls).toEqual([['info effect create']]);
+    expect(mockGroup.mock.calls).toEqual([['group effect create']]);
     expect(mockGroupCollapsed.mock.calls).toEqual([
-      ['groupCollapsed effect create'],
-      ['groupCollapsed effect cleanup'],
       ['groupCollapsed effect create'],
     ]);
   });

--- a/packages/react-devtools-shared/src/__tests__/console-test.js
+++ b/packages/react-devtools-shared/src/__tests__/console-test.js
@@ -625,6 +625,142 @@ describe('console', () => {
     expect(mockGroupCollapsed.mock.calls[0][0]).toBe('groupCollapsed');
   });
 
+  it('should double log from Effects if hideConsoleLogsInStrictMode is disabled in Strict mode', () => {
+    global.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = false;
+    global.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ = false;
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+
+    function App() {
+      React.useEffect(() => {
+        fakeConsole.log('log effect create');
+        fakeConsole.warn('warn effect create');
+        fakeConsole.error('error effect create');
+        fakeConsole.info('info effect create');
+        fakeConsole.group('group effect create');
+        fakeConsole.groupCollapsed('groupCollapsed effect create');
+
+        return () => {
+          fakeConsole.log('log effect cleanup');
+          fakeConsole.warn('warn effect cleanup');
+          fakeConsole.error('error effect cleanup');
+          fakeConsole.info('info effect cleanup');
+          fakeConsole.group('group effect cleanup');
+          fakeConsole.groupCollapsed('groupCollapsed effect cleanup');
+        };
+      });
+
+      return <div />;
+    }
+
+    act(() =>
+      root.render(
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>,
+      ),
+    );
+    expect(mockLog.mock.calls).toEqual([
+      ['log effect create'],
+      ['log effect cleanup'],
+      ['log effect create'],
+    ]);
+    expect(mockWarn.mock.calls).toEqual([
+      ['warn effect create'],
+      ['warn effect cleanup'],
+      ['warn effect create'],
+    ]);
+    expect(mockError.mock.calls).toEqual([
+      ['error effect create'],
+      ['error effect cleanup'],
+      ['error effect create'],
+    ]);
+    expect(mockInfo.mock.calls).toEqual([
+      ['info effect create'],
+      ['info effect cleanup'],
+      ['info effect create'],
+    ]);
+    expect(mockGroup.mock.calls).toEqual([
+      ['group effect create'],
+      ['group effect cleanup'],
+      ['group effect create'],
+    ]);
+    expect(mockGroupCollapsed.mock.calls).toEqual([
+      ['groupCollapsed effect create'],
+      ['groupCollapsed effect cleanup'],
+      ['groupCollapsed effect create'],
+    ]);
+  });
+
+  it('should not double log from Effects if hideConsoleLogsInStrictMode is enabled in Strict mode', () => {
+    global.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = false;
+    global.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ = true;
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+
+    function App() {
+      React.useEffect(() => {
+        fakeConsole.log('log effect create');
+        fakeConsole.warn('warn effect create');
+        fakeConsole.error('error effect create');
+        fakeConsole.info('info effect create');
+        fakeConsole.group('group effect create');
+        fakeConsole.groupCollapsed('groupCollapsed effect create');
+
+        return () => {
+          fakeConsole.log('log effect cleanup');
+          fakeConsole.warn('warn effect cleanup');
+          fakeConsole.error('error effect cleanup');
+          fakeConsole.info('info effect cleanup');
+          fakeConsole.group('group effect cleanup');
+          fakeConsole.groupCollapsed('groupCollapsed effect cleanup');
+        };
+      });
+
+      return <div />;
+    }
+
+    act(() =>
+      root.render(
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>,
+      ),
+    );
+    expect(mockLog.mock.calls).toEqual([
+      ['log effect create'],
+      ['log effect cleanup'],
+      ['log effect create'],
+    ]);
+    expect(mockWarn.mock.calls).toEqual([
+      ['warn effect create'],
+      ['warn effect cleanup'],
+      ['warn effect create'],
+    ]);
+    expect(mockError.mock.calls).toEqual([
+      ['error effect create'],
+      ['error effect cleanup'],
+      ['error effect create'],
+    ]);
+    expect(mockInfo.mock.calls).toEqual([
+      ['info effect create'],
+      ['info effect cleanup'],
+      ['info effect create'],
+    ]);
+    expect(mockGroup.mock.calls).toEqual([
+      ['group effect create'],
+      ['group effect cleanup'],
+      ['group effect create'],
+    ]);
+    expect(mockGroupCollapsed.mock.calls).toEqual([
+      ['groupCollapsed effect create'],
+      ['groupCollapsed effect cleanup'],
+      ['groupCollapsed effect create'],
+    ]);
+  });
+
   it('should double log from useMemo if hideConsoleLogsInStrictMode is disabled in Strict mode', () => {
     global.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = false;
     global.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ = false;

--- a/packages/react-devtools-shared/src/backend/console.js
+++ b/packages/react-devtools-shared/src/backend/console.js
@@ -294,7 +294,7 @@ export function unpatch(): void {
 
 let unpatchForStrictModeFn: null | (() => void) = null;
 
-// NOTE: KEEP IN SYNC with src/hook.js:patchConsoleForInitialRenderInStrictMode
+// NOTE: KEEP IN SYNC with src/hook.js:patchConsoleForInitialCommitInStrictMode
 export function patchForStrictMode() {
   if (consoleManagedByDevToolsDuringStrictMode) {
     const overrideConsoleMethods = [
@@ -359,7 +359,7 @@ export function patchForStrictMode() {
   }
 }
 
-// NOTE: KEEP IN SYNC with src/hook.js:unpatchConsoleForInitialRenderInStrictMode
+// NOTE: KEEP IN SYNC with src/hook.js:unpatchConsoleForInitialCommitInStrictMode
 export function unpatchForStrictMode(): void {
   if (consoleManagedByDevToolsDuringStrictMode) {
     if (unpatchForStrictModeFn !== null) {

--- a/packages/react-devtools-shared/src/devtools/views/Settings/DebuggingSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/DebuggingSettings.js
@@ -75,7 +75,7 @@ export default function DebuggingSettings(_: {}): React.Node {
               setHideConsoleLogsInStrictMode(currentTarget.checked)
             }
           />{' '}
-          Hide logs during second render in Strict Mode
+          Hide logs during additional invocations in Strict Mode
         </label>
       </div>
     </div>

--- a/packages/react-devtools-shared/src/devtools/views/Settings/DebuggingSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/DebuggingSettings.js
@@ -75,7 +75,14 @@ export default function DebuggingSettings(_: {}): React.Node {
               setHideConsoleLogsInStrictMode(currentTarget.checked)
             }
           />{' '}
-          Hide logs during additional invocations in Strict Mode
+          Hide logs during additional invocations in{' '}
+          <a
+            className={styles.StrictModeLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://react.dev/reference/react/StrictMode">
+            Strict Mode
+          </a>
         </label>
       </div>
     </div>

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsShared.css
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsShared.css
@@ -141,7 +141,7 @@
   border-radius: 0.25rem;
 }
 
-.ReleaseNotesLink {
+.ReleaseNotesLink, .StrictModeLink {
   color: var(--color-button-active);
 }
 

--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -225,7 +225,7 @@ export function installHook(target: any): DevToolsHook | null {
   // React and DevTools are connecting and the renderer interface isn't avaiable
   // and we want to be able to have consistent logging behavior for double logs
   // during the initial renderer.
-  function patchConsoleForInitialRenderInStrictMode({
+  function patchConsoleForInitialCommitInStrictMode({
     hideConsoleLogsInStrictMode,
     browserTheme,
   }: {
@@ -311,7 +311,7 @@ export function installHook(target: any): DevToolsHook | null {
   }
 
   // NOTE: KEEP IN SYNC with src/backend/console.js:unpatchForStrictMode
-  function unpatchConsoleForInitialRenderInStrictMode() {
+  function unpatchConsoleForInitialCommitInStrictMode() {
     if (unpatchFn !== null) {
       unpatchFn();
       unpatchFn = null;
@@ -451,19 +451,19 @@ export function installHook(target: any): DevToolsHook | null {
         rendererInterface.unpatchConsoleForStrictMode();
       }
     } else {
-      // This should only happen during initial render in the extension before DevTools
+      // This should only happen during initial commit in the extension before DevTools
       // finishes its handshake with the injected renderer
       if (isStrictMode) {
         const hideConsoleLogsInStrictMode =
           window.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ === true;
         const browserTheme = window.__REACT_DEVTOOLS_BROWSER_THEME__;
 
-        patchConsoleForInitialRenderInStrictMode({
+        patchConsoleForInitialCommitInStrictMode({
           hideConsoleLogsInStrictMode,
           browserTheme,
         });
       } else {
-        unpatchConsoleForInitialRenderInStrictMode();
+        unpatchConsoleForInitialCommitInStrictMode();
       }
     }
   }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -251,6 +251,7 @@ import {
   markRenderStopped,
   onCommitRoot as onCommitRootDevTools,
   onPostCommitRoot as onPostCommitRootDevTools,
+  setIsStrictModeForDevtools,
 } from './ReactFiberDevToolsHook';
 import {onCommitRoot as onCommitRootTestSelector} from './ReactTestSelectors';
 import {releaseCache} from './ReactFiberCacheComponent';
@@ -3675,6 +3676,7 @@ function doubleInvokeEffectsOnFiber(
   fiber: Fiber,
   shouldDoubleInvokePassiveEffects: boolean = true,
 ) {
+  setIsStrictModeForDevtools(true);
   disappearLayoutEffects(fiber);
   if (shouldDoubleInvokePassiveEffects) {
     disconnectPassiveEffect(fiber);
@@ -3683,6 +3685,7 @@ function doubleInvokeEffectsOnFiber(
   if (shouldDoubleInvokePassiveEffects) {
     reconnectPassiveEffects(root, fiber, NoLanes, null, false);
   }
+  setIsStrictModeForDevtools(false);
 }
 
 function doubleInvokeEffectsInDEVIfNecessary(

--- a/packages/react-reconciler/src/__tests__/StrictEffectsModeDefaults-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/StrictEffectsModeDefaults-test.internal.js
@@ -115,11 +115,7 @@ describe('StrictEffectsMode defaults', () => {
           </React.StrictMode>,
         );
 
-        await waitForPaint([
-          'useLayoutEffect mount "one"',
-          'useLayoutEffect unmount "one"',
-          'useLayoutEffect mount "one"',
-        ]);
+        await waitForPaint(['useLayoutEffect mount "one"']);
         expect(log).toEqual([
           'useLayoutEffect mount "one"',
           'useLayoutEffect unmount "one"',
@@ -141,10 +137,6 @@ describe('StrictEffectsMode defaults', () => {
           // Cleanup and re-run "one" (and "two") since there is no dependencies array.
           'useLayoutEffect unmount "one"',
           'useLayoutEffect mount "one"',
-          'useLayoutEffect mount "two"',
-
-          // Since "two" is new, it should be double-invoked.
-          'useLayoutEffect unmount "two"',
           'useLayoutEffect mount "two"',
         ]);
         expect(log).toEqual([
@@ -196,10 +188,6 @@ describe('StrictEffectsMode defaults', () => {
         await waitForAll([
           'useLayoutEffect mount "one"',
           'useEffect mount "one"',
-          'useLayoutEffect unmount "one"',
-          'useEffect unmount "one"',
-          'useLayoutEffect mount "one"',
-          'useEffect mount "one"',
         ]);
         expect(log).toEqual([
           'useLayoutEffect mount "one"',
@@ -236,12 +224,6 @@ describe('StrictEffectsMode defaults', () => {
         await waitForAll([
           'useEffect unmount "one"',
           'useEffect mount "one"',
-          'useEffect mount "two"',
-
-          // Since "two" is new, it should be double-invoked.
-          'useLayoutEffect unmount "two"',
-          'useEffect unmount "two"',
-          'useLayoutEffect mount "two"',
           'useEffect mount "two"',
         ]);
         expect(log).toEqual([

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -1567,7 +1567,7 @@ describe('context legacy', () => {
         expect(console.log).toBeCalledWith('foo 1');
       });
 
-      it('does not disable logs for effect double invoke', async () => {
+      it('disable logs for effect double invoke', async () => {
         let create = 0;
         let cleanup = 0;
         function Foo() {
@@ -1593,14 +1593,11 @@ describe('context legacy', () => {
         });
         expect(create).toBe(__DEV__ ? 2 : 1);
         expect(cleanup).toBe(__DEV__ ? 1 : 0);
-        expect(console.log).toBeCalledTimes(__DEV__ ? 3 : 1);
+        expect(console.log).toBeCalledTimes(1);
         // Note: we should display the first log because otherwise
         // there is a risk of suppressing warnings when they happen,
         // and on the next render they'd get deduplicated and ignored.
         expect(console.log).toBeCalledWith('foo create 1');
-        if (__DEV__) {
-          expect(console.log).toBeCalledWith('foo cleanup 1');
-        }
       });
     }
   });

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -1343,6 +1343,42 @@ describe('context legacy', () => {
         // and on the next render they'd get deduplicated and ignored.
         expect(console.log).toBeCalledWith('foo 1');
       });
+
+      it('does not disable logs for effect double invoke', async () => {
+        let create = 0;
+        let cleanup = 0;
+        function Foo() {
+          React.useEffect(() => {
+            create++;
+            console.log('foo create ' + create);
+            return () => {
+              cleanup++;
+              console.log('foo cleanup ' + cleanup);
+            };
+          });
+          return null;
+        }
+
+        const container = document.createElement('div');
+        const root = ReactDOMClient.createRoot(container);
+        await act(() => {
+          root.render(
+            <React.StrictMode>
+              <Foo />
+            </React.StrictMode>,
+          );
+        });
+        expect(create).toBe(__DEV__ ? 2 : 1);
+        expect(cleanup).toBe(__DEV__ ? 1 : 0);
+        expect(console.log).toBeCalledTimes(__DEV__ ? 3 : 1);
+        // Note: we should display the first log because otherwise
+        // there is a risk of suppressing warnings when they happen,
+        // and on the next render they'd get deduplicated and ignored.
+        expect(console.log).toBeCalledWith('foo create 1');
+        if (__DEV__) {
+          expect(console.log).toBeCalledWith('foo cleanup 1');
+        }
+      });
     } else {
       it('disable logs for class double render', async () => {
         let count = 0;
@@ -1529,6 +1565,42 @@ describe('context legacy', () => {
         // there is a risk of suppressing warnings when they happen,
         // and on the next render they'd get deduplicated and ignored.
         expect(console.log).toBeCalledWith('foo 1');
+      });
+
+      it('does not disable logs for effect double invoke', async () => {
+        let create = 0;
+        let cleanup = 0;
+        function Foo() {
+          React.useEffect(() => {
+            create++;
+            console.log('foo create ' + create);
+            return () => {
+              cleanup++;
+              console.log('foo cleanup ' + cleanup);
+            };
+          });
+          return null;
+        }
+
+        const container = document.createElement('div');
+        const root = ReactDOMClient.createRoot(container);
+        await act(() => {
+          root.render(
+            <React.StrictMode>
+              <Foo />
+            </React.StrictMode>,
+          );
+        });
+        expect(create).toBe(__DEV__ ? 2 : 1);
+        expect(cleanup).toBe(__DEV__ ? 1 : 0);
+        expect(console.log).toBeCalledTimes(__DEV__ ? 3 : 1);
+        // Note: we should display the first log because otherwise
+        // there is a risk of suppressing warnings when they happen,
+        // and on the next render they'd get deduplicated and ignored.
+        expect(console.log).toBeCalledWith('foo create 1');
+        if (__DEV__) {
+          expect(console.log).toBeCalledWith('foo cleanup 1');
+        }
       });
     }
   });


### PR DESCRIPTION
Stack:
1. https://github.com/facebook/react/pull/29006
1. https://github.com/facebook/react/pull/29008
1. https://github.com/facebook/react/pull/29007 <-- You're here


## Summary

Same as https://github.com/facebook/react/pull/22030 but for double invocations of Effects due to `StrictMode`:


Before/After
![Screenshot 2024-05-07 at 00 48 46](https://github.com/facebook/react/assets/12292047/a5b720d1-0c0b-4a38-bb24-3e737e92147a) ![Screenshot 2024-05-07 at 00 48 11](https://github.com/facebook/react/assets/12292047/3c762b03-1051-4c03-b328-3af4d72cb22b)


This means that console calls during the double invocations of Effects due to `StrictMode` can be disabled in React DevTools. 

The option has been renamed from "Hide logs during second render in Strict Mode" to "Hide logs during additional invocations in Strict Mode". Not sure if "additional invocations" is clear enough. "additional function calls" is just slightly longer and may be clearer?

This also means that tests using `Scheduler.log` no longer have to assert on the additional invocations (just like `Scheduler.log` during double invocations of render-time functions due to `StrictMode`).

## How did you test this change?

- additional tests like https://github.com/facebook/react/pull/22030 added but for Effects
- extension+build from this branch and console calls during Effects: https://codesandbox.io/p/sandbox/react-devtools-console-calls-during-second-effect-invocation-due-to-strict-mode-6yfd4g
