### PR TITLE
[Flight Reply] Encode Objects Returned to the Client by Reference

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -915,7 +915,7 @@ function parseModelString(
       }
       case 'T': {
         // Temporary Reference
-        const id = parseInt(value.slice(2), 16);
+        const reference = '$' + value.slice(2);
         const temporaryReferences = response._tempRefs;
         if (temporaryReferences == null) {
           throw new Error(
@@ -923,7 +923,7 @@ function parseModelString(
               'Pass a temporaryReference option with the set that was used with the reply.',
           );
         }
-        return readTemporaryReference(temporaryReferences, id);
+        return readTemporaryReference(temporaryReferences, reference);
       }
       case 'Q': {
         // Map

--- a/packages/react-client/src/ReactFlightTemporaryReferences.js
+++ b/packages/react-client/src/ReactFlightTemporaryReferences.js
@@ -9,33 +9,23 @@
 
 interface Reference {}
 
-export opaque type TemporaryReferenceSet = Array<Reference | symbol>;
+export opaque type TemporaryReferenceSet = Map<string, Reference | symbol>;
 
 export function createTemporaryReferenceSet(): TemporaryReferenceSet {
-  return [];
+  return new Map();
 }
 
 export function writeTemporaryReference(
   set: TemporaryReferenceSet,
+  reference: string,
   object: Reference | symbol,
-): number {
-  // We always create a new entry regardless if we've already written the same
-  // object. This ensures that we always generate a deterministic encoding of
-  // each slot in the reply for cacheability.
-  const newId = set.length;
-  set.push(object);
-  return newId;
+): void {
+  set.set(reference, object);
 }
 
 export function readTemporaryReference<T>(
   set: TemporaryReferenceSet,
-  id: number,
+  reference: string,
 ): T {
-  if (id < 0 || id >= set.length) {
-    throw new Error(
-      "The RSC response contained a reference that doesn't exist in the temporary reference set. " +
-        'Always pass the matching set that was used to create the reply when parsing its response.',
-    );
-  }
-  return (set[id]: any);
+  return (set.get(reference): any);
 }

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMServerNode.js
@@ -22,6 +22,7 @@ import {
   createRequest,
   startWork,
   startFlowing,
+  stopFlowing,
   abort,
 } from 'react-server/src/ReactFlightServer';
 
@@ -36,7 +37,10 @@ import {
   getRoot,
 } from 'react-server/src/ReactFlightReplyServer';
 
-import {decodeAction} from 'react-server/src/ReactFlightActionServer';
+import {
+  decodeAction,
+  decodeFormState,
+} from 'react-server/src/ReactFlightActionServer';
 
 export {
   registerServerReference,
@@ -44,8 +48,22 @@ export {
   createClientModuleProxy,
 } from './ReactFlightTurbopackReferences';
 
+import type {TemporaryReferenceSet} from 'react-server/src/ReactFlightServerTemporaryReferences';
+
+export {createTemporaryReferenceSet} from 'react-server/src/ReactFlightServerTemporaryReferences';
+
+export type {TemporaryReferenceSet};
+
 function createDrainHandler(destination: Destination, request: Request) {
   return () => startFlowing(request, destination);
+}
+
+function createCancelHandler(request: Request, reason: string) {
+  return () => {
+    stopFlowing(request);
+    // eslint-disable-next-line react-internal/prod-error-codes
+    abort(request, new Error(reason));
+  };
 }
 
 type Options = {
@@ -53,6 +71,7 @@ type Options = {
   onError?: (error: mixed) => void,
   onPostpone?: (reason: string) => void,
   identifierPrefix?: string,
+  temporaryReferences?: TemporaryReferenceSet,
 };
 
 type PipeableStream = {
@@ -72,6 +91,7 @@ function renderToPipeableStream(
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
     options ? options.environmentName : undefined,
+    options ? options.temporaryReferences : undefined,
   );
   let hasStartedFlowing = false;
   startWork(request);
@@ -85,6 +105,17 @@ function renderToPipeableStream(
       hasStartedFlowing = true;
       startFlowing(request, destination);
       destination.on('drain', createDrainHandler(destination, request));
+      destination.on(
+        'error',
+        createCancelHandler(
+          request,
+          'The destination stream errored while writing data.',
+        ),
+      );
+      destination.on(
+        'close',
+        createCancelHandler(request, 'The destination stream closed early.'),
+      );
       return destination;
     },
     abort(reason: mixed) {
@@ -151,13 +182,19 @@ function decodeReplyFromBusboy<T>(
 function decodeReply<T>(
   body: string | FormData,
   turbopackMap: ServerManifest,
+  options?: {temporaryReferences?: TemporaryReferenceSet},
 ): Thenable<T> {
   if (typeof body === 'string') {
     const form = new FormData();
     form.append('0', body);
     body = form;
   }
-  const response = createResponse(turbopackMap, '', body);
+  const response = createResponse(
+    turbopackMap,
+    '',
+    options ? options.temporaryReferences : undefined,
+    body,
+  );
   const root = getRoot<T>(response);
   close(response);
   return root;
@@ -168,4 +205,5 @@ export {
   decodeReplyFromBusboy,
   decodeReply,
   decodeAction,
+  decodeFormState,
 };

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -37,10 +37,17 @@ export {
   createClientModuleProxy,
 } from './ReactFlightWebpackReferences';
 
+import type {TemporaryReferenceSet} from 'react-server/src/ReactFlightServerTemporaryReferences';
+
+export {createTemporaryReferenceSet} from 'react-server/src/ReactFlightServerTemporaryReferences';
+
+export type {TemporaryReferenceSet};
+
 type Options = {
   environmentName?: string,
   identifierPrefix?: string,
   signal?: AbortSignal,
+  temporaryReferences?: TemporaryReferenceSet,
   onError?: (error: mixed) => void,
   onPostpone?: (reason: string) => void,
 };
@@ -57,6 +64,7 @@ function renderToReadableStream(
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
     options ? options.environmentName : undefined,
+    options ? options.temporaryReferences : undefined,
   );
   if (options && options.signal) {
     const signal = options.signal;
@@ -93,13 +101,19 @@ function renderToReadableStream(
 function decodeReply<T>(
   body: string | FormData,
   webpackMap: ServerManifest,
+  options?: {temporaryReferences?: TemporaryReferenceSet},
 ): Thenable<T> {
   if (typeof body === 'string') {
     const form = new FormData();
     form.append('0', body);
     body = form;
   }
-  const response = createResponse(webpackMap, '', body);
+  const response = createResponse(
+    webpackMap,
+    '',
+    options ? options.temporaryReferences : undefined,
+    body,
+  );
   const root = getRoot<T>(response);
   close(response);
   return root;

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
@@ -37,10 +37,17 @@ export {
   createClientModuleProxy,
 } from './ReactFlightWebpackReferences';
 
+import type {TemporaryReferenceSet} from 'react-server/src/ReactFlightServerTemporaryReferences';
+
+export {createTemporaryReferenceSet} from 'react-server/src/ReactFlightServerTemporaryReferences';
+
+export type {TemporaryReferenceSet};
+
 type Options = {
   environmentName?: string,
   identifierPrefix?: string,
   signal?: AbortSignal,
+  temporaryReferences?: TemporaryReferenceSet,
   onError?: (error: mixed) => void,
   onPostpone?: (reason: string) => void,
 };
@@ -57,6 +64,7 @@ function renderToReadableStream(
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
     options ? options.environmentName : undefined,
+    options ? options.temporaryReferences : undefined,
   );
   if (options && options.signal) {
     const signal = options.signal;
@@ -93,13 +101,19 @@ function renderToReadableStream(
 function decodeReply<T>(
   body: string | FormData,
   webpackMap: ServerManifest,
+  options?: {temporaryReferences?: TemporaryReferenceSet},
 ): Thenable<T> {
   if (typeof body === 'string') {
     const form = new FormData();
     form.append('0', body);
     body = form;
   }
-  const response = createResponse(webpackMap, '', body);
+  const response = createResponse(
+    webpackMap,
+    '',
+    options ? options.temporaryReferences : undefined,
+    body,
+  );
   const root = getRoot<T>(response);
   close(response);
   return root;

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -48,6 +48,12 @@ export {
   createClientModuleProxy,
 } from './ReactFlightWebpackReferences';
 
+import type {TemporaryReferenceSet} from 'react-server/src/ReactFlightServerTemporaryReferences';
+
+export {createTemporaryReferenceSet} from 'react-server/src/ReactFlightServerTemporaryReferences';
+
+export type {TemporaryReferenceSet};
+
 function createDrainHandler(destination: Destination, request: Request) {
   return () => startFlowing(request, destination);
 }
@@ -65,6 +71,7 @@ type Options = {
   onError?: (error: mixed) => void,
   onPostpone?: (reason: string) => void,
   identifierPrefix?: string,
+  temporaryReferences?: TemporaryReferenceSet,
 };
 
 type PipeableStream = {
@@ -84,6 +91,7 @@ function renderToPipeableStream(
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
     options ? options.environmentName : undefined,
+    options ? options.temporaryReferences : undefined,
   );
   let hasStartedFlowing = false;
   startWork(request);
@@ -174,13 +182,19 @@ function decodeReplyFromBusboy<T>(
 function decodeReply<T>(
   body: string | FormData,
   webpackMap: ServerManifest,
+  options?: {temporaryReferences?: TemporaryReferenceSet},
 ): Thenable<T> {
   if (typeof body === 'string') {
     const form = new FormData();
     form.append('0', body);
     body = form;
   }
-  const response = createResponse(webpackMap, '', body);
+  const response = createResponse(
+    webpackMap,
+    '',
+    options ? options.temporaryReferences : undefined,
+    body,
+  );
   const root = getRoot<T>(response);
   close(response);
   return root;

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js
@@ -361,11 +361,21 @@ describe('ReactFlightDOMReply', () => {
         temporaryReferences,
       },
     );
+
+    const temporaryReferencesServer =
+      ReactServerDOMServer.createTemporaryReferenceSet();
     const serverPayload = await ReactServerDOMServer.decodeReply(
       body,
       webpackServerMap,
+      {temporaryReferences: temporaryReferencesServer},
     );
-    const stream = ReactServerDOMServer.renderToReadableStream(serverPayload);
+    const stream = ReactServerDOMServer.renderToReadableStream(
+      serverPayload,
+      null,
+      {
+        temporaryReferences: temporaryReferencesServer,
+      },
+    );
     const response = await ReactServerDOMClient.createFromReadableStream(
       stream,
       {
@@ -390,14 +400,22 @@ describe('ReactFlightDOMReply', () => {
     const body = await ReactServerDOMClient.encodeReply(root, {
       temporaryReferences,
     });
+
+    const temporaryReferencesServer =
+      ReactServerDOMServer.createTemporaryReferenceSet();
     const serverPayload = await ReactServerDOMServer.decodeReply(
       body,
       webpackServerMap,
+      {temporaryReferences: temporaryReferencesServer},
     );
-    const stream = ReactServerDOMServer.renderToReadableStream({
-      root: serverPayload,
-      obj: serverPayload.obj,
-    });
+    const stream = ReactServerDOMServer.renderToReadableStream(
+      {
+        root: serverPayload,
+        obj: serverPayload.obj,
+      },
+      null,
+      {temporaryReferences: temporaryReferencesServer},
+    );
     const response = await ReactServerDOMClient.createFromReadableStream(
       stream,
       {

--- a/packages/react-server/src/ReactFlightActionServer.js
+++ b/packages/react-server/src/ReactFlightActionServer.js
@@ -59,7 +59,12 @@ function decodeBoundActionMetaData(
   formFieldPrefix: string,
 ): {id: ServerReferenceId, bound: null | Promise<Array<any>>} {
   // The data for this reference is encoded in multiple fields under this prefix.
-  const actionResponse = createResponse(serverManifest, formFieldPrefix, body);
+  const actionResponse = createResponse(
+    serverManifest,
+    formFieldPrefix,
+    undefined,
+    body,
+  );
   close(actionResponse);
   const refPromise = getRoot<{
     id: ServerReferenceId,

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -2010,6 +2010,11 @@ function renderModelDestructive(
       );
     }
 
+    const tempRef = resolveTemporaryReference(value);
+    if (tempRef !== undefined) {
+      return serializeTemporaryReference(request, tempRef);
+    }
+
     if (enableTaint) {
       const tainted = TaintRegistryObjects.get(value);
       if (tainted !== undefined) {
@@ -2636,6 +2641,11 @@ function renderConsoleValue(
         parentPropertyName,
         (value: any),
       );
+    }
+
+    const tempRef = resolveTemporaryReference(value);
+    if (tempRef !== undefined) {
+      return serializeTemporaryReference(request, tempRef);
     }
 
     if (counter.objectCount > 20) {

--- a/packages/react-server/src/ReactFlightServerTemporaryReferences.js
+++ b/packages/react-server/src/ReactFlightServerTemporaryReferences.js
@@ -7,20 +7,29 @@
  * @flow
  */
 
+const TEMPORARY_REFERENCE_TAG = Symbol.for('react.temporary.reference');
+
+export opaque type TemporaryReferenceSet = WeakMap<
+  TemporaryReference<any>,
+  string,
+>;
+
 // eslint-disable-next-line no-unused-vars
 export interface TemporaryReference<T> {}
 
-const knownReferences: WeakMap<TemporaryReference<any>, string> = new WeakMap();
+export function createTemporaryReferenceSet(): TemporaryReferenceSet {
+  return new WeakMap();
+}
 
-export function isTemporaryReference(reference: Object): boolean {
-  return knownReferences.has(reference);
+export function isOpaqueTemporaryReference(reference: Object): boolean {
+  return reference.$$typeof === TEMPORARY_REFERENCE_TAG;
 }
 
 export function resolveTemporaryReference<T>(
+  temporaryReferences: TemporaryReferenceSet,
   temporaryReference: TemporaryReference<T>,
-): string {
-  // $FlowFixMe[incompatible-return]: We'll have already asserted on it.
-  return knownReferences.get(temporaryReference);
+): void | string {
+  return temporaryReferences.get(temporaryReference);
 }
 
 const proxyHandlers = {
@@ -73,23 +82,32 @@ const proxyHandlers = {
   },
 };
 
-export function createTemporaryReference<T>(id: string): TemporaryReference<T> {
-  const reference: TemporaryReference<any> = function () {
-    throw new Error(
-      // eslint-disable-next-line react-internal/safe-string-coercion
-      `Attempted to call a temporary Client Reference from the server but it is on the client. ` +
-        `It's not possible to invoke a client function from the server, it can ` +
-        `only be rendered as a Component or passed to props of a Client Component.`,
-    );
-  };
+export function createTemporaryReference<T>(
+  temporaryReferences: TemporaryReferenceSet,
+  id: string,
+): TemporaryReference<T> {
+  const reference: TemporaryReference<any> = Object.defineProperties(
+    (function () {
+      throw new Error(
+        // eslint-disable-next-line react-internal/safe-string-coercion
+        `Attempted to call a temporary Client Reference from the server but it is on the client. ` +
+          `It's not possible to invoke a client function from the server, it can ` +
+          `only be rendered as a Component or passed to props of a Client Component.`,
+      );
+    }: any),
+    {
+      $$typeof: {value: TEMPORARY_REFERENCE_TAG},
+    },
+  );
   const wrapper = new Proxy(reference, proxyHandlers);
-  registerTemporaryReference(wrapper, id);
+  registerTemporaryReference(temporaryReferences, wrapper, id);
   return wrapper;
 }
 
 export function registerTemporaryReference(
+  temporaryReferences: TemporaryReferenceSet,
   object: TemporaryReference<any>,
   id: string,
 ): void {
-  knownReferences.set(object, id);
+  temporaryReferences.set(object, id);
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -511,5 +511,5 @@
   "523": "The render was aborted due to being postponed.",
   "524": "Values cannot be passed to next() of AsyncIterables passed to Client Components.",
   "525": "A React Element from an older version of React was rendered. This is not supported. It can happen if:\n- Multiple copies of the \"react\" package is used.\n- A library pre-bundled an old copy of \"react\" or \"react/jsx-runtime\".\n- A compiler tries to \"inline\" JSX instead of using the runtime.",
-  "526": "Could not reference the temporary reference. This is likely a bug in React."
+  "526": "Could not reference an opaque temporary reference. This is likely due to misconfiguring the temporaryReferences options on the server."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -510,5 +510,6 @@
   "522": "Invalid form element. requestFormReset must be passed a form that was rendered by React.",
   "523": "The render was aborted due to being postponed.",
   "524": "Values cannot be passed to next() of AsyncIterables passed to Client Components.",
-  "525": "A React Element from an older version of React was rendered. This is not supported. It can happen if:\n- Multiple copies of the \"react\" package is used.\n- A library pre-bundled an old copy of \"react\" or \"react/jsx-runtime\".\n- A compiler tries to \"inline\" JSX instead of using the runtime."
+  "525": "A React Element from an older version of React was rendered. This is not supported. It can happen if:\n- Multiple copies of the \"react\" package is used.\n- A library pre-bundled an old copy of \"react\" or \"react/jsx-runtime\".\n- A compiler tries to \"inline\" JSX instead of using the runtime.",
+  "526": "Could not reference the temporary reference. This is likely a bug in React."
 }


### PR DESCRIPTION
Stacked on #28997.

We can use the technique of referencing an object by its row + property name path for temporary references - like we do for deduping. That way we don't need to generate an ID for temporary references. Instead, they can just be an opaque marker in the slot and it has the implicit ID of the row + path.

Then we can stash all objects, even the ones that are actually available to read on the server, as temporary references. Without adding anything to the payload since the IDs are implicit. If the same object is returned to the client, it can be referenced by reference instead of serializing it back to the client. This also helps preserve object identity.

We assume that the objects are immutable when they pass the boundary.

I'm not sure if this is worth it but with this mechanism, if you return the `FormData` payload from a `useActionState` it doesn't have to be serialized on the way back to the client. This is a common pattern for having access to the last submission as "default value" to the form fields. However you can still control it by replacing it with another object if you want. In MPA mode, the temporary references are not configured and so it needs to be serialized in that case. That's required anyway for hydration purposes.

I'm not sure if people will actually use this in practice though or if FormData will always be destructured into some other object like with a library that turns it into typed data, and back. If so, the object identity is lost.