### PR TITLE
fix[react-devtools/ci]: fix configurations for e2e testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "scripts": {
     "build": "node ./scripts/rollup/build-all-release-channels.js",
-    "build-for-devtools": "cross-env RELEASE_CHANNEL=experimental yarn build react/index,react/jsx,react-dom/index,react-dom/client,react-dom/unstable_testing,react-dom/test-utils,react-is,react-debug-tools,scheduler,react-test-renderer,react-refresh,react-art --type=NODE",
+    "build-for-devtools": "cross-env RELEASE_CHANNEL=experimental yarn build react/index,react/jsx,react/compiler-runtime,react-dom/index,react-dom/client,react-dom/unstable_testing,react-dom/test-utils,react-is,react-debug-tools,scheduler,react-test-renderer,react-refresh,react-art --type=NODE",
     "build-for-devtools-dev": "yarn build-for-devtools --type=NODE_DEV",
     "build-for-devtools-prod": "yarn build-for-devtools --type=NODE_PROD",
     "linc": "node ./scripts/tasks/linc.js",

--- a/packages/react-devtools-shell/webpack-server.js
+++ b/packages/react-devtools-shell/webpack-server.js
@@ -124,8 +124,6 @@ const makeConfig = (entry, alias) => ({
   },
 });
 
-const clientAsSeparateBuild = semver.gte(REACT_VERSION, '19.0.0');
-
 const app = makeConfig(
   {
     'app-index': './src/app/index.js',
@@ -144,14 +142,8 @@ const app = makeConfig(
     react: resolve(builtModulesDir, 'react'),
     'react-debug-tools': resolve(builtModulesDir, 'react-debug-tools'),
     'react-devtools-feature-flags': resolveFeatureFlags('shell'),
-    'react-dom/client': resolve(
-      builtModulesDir,
-      clientAsSeparateBuild ? 'react-dom/unstable_testing' : 'react-dom/client',
-    ),
-    'react-dom': resolve(
-      builtModulesDir,
-      clientAsSeparateBuild ? 'react-dom' : 'react-dom/unstable_testing',
-    ),
+    'react-dom/client': resolve(builtModulesDir, 'react-dom/unstable_testing'),
+    'react-dom': resolve(builtModulesDir, 'react-dom'),
     'react-is': resolve(builtModulesDir, 'react-is'),
     scheduler: resolve(builtModulesDir, 'scheduler'),
   },


### PR DESCRIPTION
This should fix failing DevTools e2e tests on `main`.

With these changes, running tests locally successfully passes all cases.