### PR TITLE
fix[react-devtools/InspectedElementView.css]: dont draw bottom border for empty badge list

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSharedStyles.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSharedStyles.css
@@ -1,6 +1,5 @@
 .InspectedElementTree {
   padding: 0.25rem;
-  border-top: 1px solid var(--color-border);
 }
 .InspectedElementTree:first-of-type {
   border-top: none;

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.css
@@ -25,8 +25,9 @@
   line-height: var(--line-height-data);
 }
 
-.InspectedElementBadgesContainer {
+.InspectedElementBadgesContainer:not(:empty) {
   padding: 0.25rem;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .Owner {


### PR DESCRIPTION
Forward fix to https://github.com/facebook/react/pull/29014, the bug was discovered while testing v5.2.0.