### PR TITLE
Remove 2 no longer existing files from inlinedHostConfig

### DIFF
--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -404,8 +404,6 @@ module.exports = [
       'react-dom/src/server/ReactDOMLegacyServerImpl.js', // not an entrypoint, but only usable in *Browser and *Node files
       'react-dom/src/server/ReactDOMLegacyServerBrowser.js', // react-dom/server.browser
       'react-dom/src/server/ReactDOMLegacyServerNode.js', // react-dom/server.node
-      'react-dom/src/server/ReactDOMLegacyServerNode.classic.fb.js',
-      'react-dom/src/server/ReactDOMLegacyServerNodeStream.js', // file indirection to support partial forking of some methods in *Node
       'shared/ReactDOMSharedInternals',
     ],
     isFlowTyped: true,


### PR DESCRIPTION
Remove 2 no longer existing files from inlinedHostConfig

While looking for `.classic` forks, I noticed these files no longer exist.
