### PR TITLE
Add `enableNativeProcessing()` flag for Fabric ViewConfig attributes

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeAttributePayloadFabric.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayloadFabric.js
@@ -446,7 +446,7 @@ function processProperty(
     return prop;
   }
 
-  const process = {attributeConfig};
+  const {process} = attributeConfig;
   if (typeof process !== 'function') {
     return prop;
   }

--- a/packages/react-native-renderer/src/ReactNativeAttributePayloadFabric.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayloadFabric.js
@@ -17,7 +17,10 @@ import isArray from 'shared/isArray';
 import {enableEarlyReturnForPropDiffing} from 'shared/ReactFeatureFlags';
 import {enableAddPropertiesFastPath} from 'shared/ReactFeatureFlags';
 
-import type {AttributeConfiguration} from './ReactNativeTypes';
+import type {
+  AnyAttributeType,
+  AttributeConfiguration,
+} from './ReactNativeTypes';
 
 const emptyObject = {};
 
@@ -98,10 +101,7 @@ function restoreDeletedValuesInNestedArray(
         typeof attributeConfig.process === 'function'
       ) {
         // case: CustomAttributeConfiguration
-        const nextValue =
-          typeof attributeConfig.process === 'function'
-            ? attributeConfig.process(nextProp)
-            : nextProp;
+        const nextValue = processProperty(nextProp, attributeConfig);
         updatePayload[propKey] = nextValue;
       }
       // $FlowFixMe[incompatible-use] found when upgrading Flow
@@ -327,10 +327,7 @@ function diffProperties(
         typeof attributeConfig.process === 'function'
       ) {
         // case: CustomAttributeConfiguration
-        const nextValue =
-          typeof attributeConfig.process === 'function'
-            ? attributeConfig.process(nextProp)
-            : nextProp;
+        const nextValue = processProperty(nextProp, attributeConfig);
         updatePayload[propKey] = nextValue;
       }
       continue;
@@ -360,11 +357,7 @@ function diffProperties(
           ? attributeConfig.diff(prevProp, nextProp)
           : defaultDiffer(prevProp, nextProp));
       if (shouldUpdate) {
-        const nextValue =
-          typeof attributeConfig.process === 'function'
-            ? // $FlowFixMe[incompatible-use] found when upgrading Flow
-              attributeConfig.process(nextProp)
-            : nextProp;
+        const nextValue = processProperty(nextProp, attributeConfig);
         (updatePayload || (updatePayload = ({}: {[string]: $FlowFixMe})))[
           propKey
         ] = nextValue;
@@ -445,6 +438,29 @@ function diffProperties(
   return updatePayload;
 }
 
+function processProperty(
+  prop: mixed,
+  attributeConfig: AnyAttributeType,
+): mixed {
+  if (typeof attributeConfig !== 'object') {
+    return prop;
+  }
+
+  const process = {attributeConfig};
+  if (typeof process !== 'function') {
+    return prop;
+  }
+
+  if (
+    typeof attributeConfig.useNativeProcessing === 'function' &&
+    attributeConfig.useNativeProcessing()
+  ) {
+    return prop;
+  }
+
+  return process(prop);
+}
+
 function fastAddProperties(
   payload: null | Object,
   props: Object,
@@ -476,7 +492,10 @@ function fastAddProperties(
       newValue = prop;
     } else if (typeof attributeConfig.process === 'function') {
       // An atomic prop with custom processing.
-      newValue = attributeConfig.process(prop);
+      newValue = processProperty(
+        prop,
+        ((attributeConfig: any): AnyAttributeType),
+      );
     } else if (typeof attributeConfig.diff === 'function') {
       // An atomic prop with custom diffing. We don't do diffing here.
       newValue = prop;

--- a/packages/react-native-renderer/src/ReactNativeAttributePayloadFabric.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayloadFabric.js
@@ -452,8 +452,8 @@ function processProperty(
   }
 
   if (
-    typeof attributeConfig.useNativeProcessing === 'function' &&
-    attributeConfig.useNativeProcessing()
+    typeof attributeConfig.enableNativeProcessing === 'function' &&
+    attributeConfig.enableNativeProcessing()
   ) {
     return prop;
   }

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -38,6 +38,7 @@ export type AttributeType<T, V> =
   | $ReadOnly<{
       diff?: (arg1: T, arg2: T) => boolean,
       process?: (arg1: V) => T,
+      useNativeProcessing?: () => boolean,
     }>;
 
 // We either force that `diff` and `process` always use mixed,

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -38,7 +38,7 @@ export type AttributeType<T, V> =
   | $ReadOnly<{
       diff?: (arg1: T, arg2: T) => boolean,
       process?: (arg1: V) => T,
-      useNativeProcessing?: () => boolean,
+      enableNativeProcessing?: () => boolean,
     }>;
 
 // We either force that `diff` and `process` always use mixed,


### PR DESCRIPTION
## Summary

We want to move more of the style parsing boundary into the Fabric renderer, instead of the outputs of the JavaScript preprocessing functions used by Paper.

When using Fabric renderer specifically, we will now check for the presence of a `useNativeProcessing` function, which we can wire with arbitrary granularity inside of RN to allow incrementally removing viewconfig processors when using Fabric.

## How did you test this change?

Just flow, and existing tests, for this part of the change. The intention is to wire this function to feature flags on the RN side of the boundary, for specific views/attributes.