### PR TITLE
Clean up the enableEarlyReturnForPropDiffing experiment

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeAttributePayload.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayload.js
@@ -14,8 +14,6 @@ import {
 } from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
 import isArray from 'shared/isArray';
 
-import {enableEarlyReturnForPropDiffing} from 'shared/ReactFeatureFlags';
-
 import type {AttributeConfiguration} from './ReactNativeTypes';
 
 const emptyObject = {};
@@ -485,11 +483,6 @@ export function diff(
   nextProps: Object,
   validAttributes: AttributeConfiguration,
 ): null | Object {
-  if (enableEarlyReturnForPropDiffing) {
-    if (prevProps === nextProps) {
-      return null; // no change
-    }
-  }
   return diffProperties(
     null, // updatePayload
     prevProps,

--- a/packages/react-native-renderer/src/ReactNativeAttributePayloadFabric.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayloadFabric.js
@@ -14,7 +14,6 @@ import {
 } from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
 import isArray from 'shared/isArray';
 
-import {enableEarlyReturnForPropDiffing} from 'shared/ReactFeatureFlags';
 import {enableAddPropertiesFastPath} from 'shared/ReactFeatureFlags';
 
 import type {AttributeConfiguration} from './ReactNativeTypes';
@@ -551,11 +550,6 @@ export function diff(
   nextProps: Object,
   validAttributes: AttributeConfiguration,
 ): null | Object {
-  if (enableEarlyReturnForPropDiffing) {
-    if (prevProps === nextProps) {
-      return null; // no change
-    }
-  }
   return diffProperties(
     null, // updatePayload
     prevProps,

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -121,8 +121,6 @@ export const passChildrenWhenCloningPersistedNodes = false;
 
 export const enableServerComponentLogs = __EXPERIMENTAL__;
 
-export const enableEarlyReturnForPropDiffing = false;
-
 export const enableAddPropertiesFastPath = false;
 
 export const enableOwnerStacks = __EXPERIMENTAL__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -23,7 +23,6 @@ export const disableDefaultPropsExceptForClasses = __VARIANT__;
 export const disableStringRefs = __VARIANT__;
 export const enableAddPropertiesFastPath = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
-export const enableEarlyReturnForPropDiffing = __VARIANT__;
 export const enableFastJSX = __VARIANT__;
 export const enableInfiniteRenderLoopDetection = __VARIANT__;
 export const enableRefAsProp = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -25,7 +25,6 @@ export const {
   disableStringRefs,
   enableAddPropertiesFastPath,
   enableDeferRootSchedulingToMicrotask,
-  enableEarlyReturnForPropDiffing,
   enableFastJSX,
   enableInfiniteRenderLoopDetection,
   enableRefAsProp,

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -101,7 +101,6 @@ export const allowConcurrentByDefault = false;
 export const enableTransitionTracing = false;
 export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
 export const passChildrenWhenCloningPersistedNodes = false;
-export const enableEarlyReturnForPropDiffing = false;
 export const enableAsyncIterableChildren = false;
 export const enableAddPropertiesFastPath = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -76,7 +76,6 @@ export const disableClientCache = true;
 
 export const enableServerComponentLogs = true;
 export const enableInfiniteRenderLoopDetection = false;
-export const enableEarlyReturnForPropDiffing = false;
 export const enableAddPropertiesFastPath = false;
 
 export const renameElementSymbol = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -88,7 +88,6 @@ export const disableLegacyMode = false;
 export const disableDOMTestUtils = false;
 
 export const disableDefaultPropsExceptForClasses = false;
-export const enableEarlyReturnForPropDiffing = false;
 export const enableAddPropertiesFastPath = false;
 
 export const renameElementSymbol = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -88,7 +88,6 @@ export const disableLegacyMode = false;
 export const disableDOMTestUtils = false;
 
 export const disableDefaultPropsExceptForClasses = false;
-export const enableEarlyReturnForPropDiffing = false;
 export const enableAddPropertiesFastPath = false;
 
 export const renameElementSymbol = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -121,7 +121,6 @@ export const disableStringRefs = false;
 export const disableLegacyMode = __EXPERIMENTAL__;
 
 export const disableDOMTestUtils = false;
-export const enableEarlyReturnForPropDiffing = false;
 
 export const enableOwnerStacks = false;
 


### PR DESCRIPTION
## Summary

The experiment has shown no significant performance changes. This PR removes it.

## How did you test this change?
```
yarn flow native
yarn lint
```