### PR TITLE
[Flight] Error if a legacy React Element is attempted to be rendered

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -99,6 +99,7 @@ import {resolveOwner, setCurrentOwner} from './flight/ReactFlightCurrentOwner';
 import {
   getIteratorFn,
   REACT_ELEMENT_TYPE,
+  REACT_LEGACY_ELEMENT_TYPE,
   REACT_FORWARD_REF_TYPE,
   REACT_FRAGMENT_TYPE,
   REACT_LAZY_TYPE,
@@ -2002,6 +2003,15 @@ function renderModelDestructive(
           emptyRoot,
           '',
           resolvedModel,
+        );
+      }
+      case REACT_LEGACY_ELEMENT_TYPE: {
+        throw new Error(
+          'A React Element from an older version of React was rendered. ' +
+            'This is not supported. It can happen if:\n' +
+            '- Multiple copies of the "react" package is used.\n' +
+            '- A library pre-bundled an old copy of "react" or "react/jsx-runtime".\n' +
+            '- A compiler tries to "inline" JSX instead of using the runtime.',
         );
       }
     }


### PR DESCRIPTION
This errors on the client normally but in the case the `type` is a function - i.e. a Server Component - it wouldn't be transferred to error on the client so you end up with a worse error message. So this just implements the same check as ChildFiber.