### PR TITLE
Enable `enableUnifiedSyncLane` for React Native (Meta)

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -26,5 +26,4 @@ export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const enableFastJSX = __VARIANT__;
 export const enableInfiniteRenderLoopDetection = __VARIANT__;
 export const enableRefAsProp = __VARIANT__;
-export const enableUnifiedSyncLane = __VARIANT__;
 export const passChildrenWhenCloningPersistedNodes = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -28,7 +28,6 @@ export const {
   enableFastJSX,
   enableInfiniteRenderLoopDetection,
   enableRefAsProp,
-  enableUnifiedSyncLane,
   passChildrenWhenCloningPersistedNodes,
 } = dynamicFlags;
 
@@ -42,6 +41,7 @@ export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = __PROFILE__;
 export const enableProfilerNestedUpdatePhase = __PROFILE__;
 export const enableUpdaterTracking = __PROFILE__;
+export const enableUnifiedSyncLane = true;
 export const enableCache = true;
 export const enableComponentStackLocations = true;
 export const enableLegacyCache = false;


### PR DESCRIPTION
## Summary

Enables the `enableUnifiedSyncLane` feature flag for React Native (Meta).

## How did you test this change?

```
$ yarn test
$ yarn flow fabric
```