### PR TITLE
Fix react-compiler entrypoint for react-server

### DIFF
--- a/packages/react/compiler-runtime.react-server.js
+++ b/packages/react/compiler-runtime.react-server.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export * from './src/ReactCompilerRuntimeClient';
+export * from './src/ReactCompilerRuntimeServer';

--- a/packages/react/npm/compiler-runtime.react-server.js
+++ b/packages/react/npm/compiler-runtime.react-server.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-compiler-runtime.react-server.production.js');
+} else {
+  module.exports = require('./cjs/react-compiler-runtime.react-server.development.js');
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,6 +14,7 @@
     "index.js",
     "cjs/",
     "compiler-runtime.js",
+    "compiler-runtime.react-server.js",
     "jsx-runtime.js",
     "jsx-runtime.react-server.js",
     "jsx-dev-runtime.js",
@@ -36,7 +37,7 @@
       "default": "./jsx-dev-runtime.js"
     },
     "./compiler-runtime": {
-      "react-server": "./compiler-runtime.js",
+      "react-server": "./compiler-runtime.react-server.js",
       "default": "./compiler-runtime.js"
     },
     "./src/*": "./src/*"

--- a/packages/react/src/ReactCompilerRuntimeClient.js
+++ b/packages/react/src/ReactCompilerRuntimeClient.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export * from './src/ReactCompilerRuntimeClient';
+export {useMemoCache as c} from './ReactHooks';

--- a/packages/react/src/ReactCompilerRuntimeServer.js
+++ b/packages/react/src/ReactCompilerRuntimeServer.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export * from './src/ReactCompilerRuntimeClient';
+export {useMemoCache as c} from './ReactHooks';

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -126,6 +126,19 @@ const bundles = [
     externals: ['react'],
   },
 
+  /******* Compiler Runtime React Server *******/
+  {
+    bundleTypes: [NODE_DEV, NODE_PROD, NODE_PROFILING],
+    moduleType: ISOMORPHIC,
+    entry: 'react/src/ReactCompilerRuntimeServer.js',
+    name: 'react-compiler-runtime.react-server',
+    condition: 'react-server',
+    global: 'CompilerRuntime',
+    minifyWithProdErrorCodes: true,
+    wrapWithModuleBoundaries: false,
+    externals: ['react'],
+  },
+
   /******* React JSX Runtime React Server *******/
   {
     bundleTypes: [NODE_DEV, NODE_PROD],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Currently, if `react/compiler-runtime` is imported under "react-server" and `c()` (a.k.a`useMemoCache`) is called, it'll crash with `"Cannot read properties of undefined (reading 'H')"`.
Instead, we'd likely want it to 1. work correctly or 2. print a sensible error message.

This happens because the current `react-compiler-runtime.{development,production}.js` ends up trying to read `__CLIENT_INTERNALS`, which obviously doesn't exist in `react.react-server`.

The fix is to add a new `react-compiler-runtime.react-server` bundle, built with the "react-server" condition, which will [make imports of `shared/ReactSharedInternals` resolve to the server internals instead](https://github.com/facebook/react/blob/3f848028c67235441a4149c4885245cc49edcb40/scripts/rollup/forks.js#L68-L70).

## How did you test this change?

Not sure what the best way to test this is, but the following command previously crashed with `"Cannot read properties of undefined (reading 'H')"`. after the change it properly warns about a missing hook call (because i'm calling it outside of render)

```
$ yarn build; rm -rf node_modules/react
$ NODE_PATH="$PWD/build/oss-stable" node --conditions=react-server -p \
  'require("react/compiler-runtime").c()'

Warning: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
```

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
