### PR TITLE
Bump React 19 beta to RC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -646,7 +646,7 @@ workflows:
           # because this used to be called the "next" channel and some
           # downstream consumers might still expect that tag. We can remove this
           # after some time has elapsed and the change has been communicated.
-          dist_tag: "canary,next,beta"
+          dist_tag: "canary,next,rc"
       - publish_prerelease:
           name: Publish to Experimental channel
           requires:
@@ -675,7 +675,7 @@ workflows:
           name: Publish to Canary channel
           commit_sha: << pipeline.git.revision >>
           release_channel: stable
-          dist_tag: "canary,next,beta"
+          dist_tag: "canary,next,rc"
       - publish_prerelease:
           name: Publish to Experimental channel
           requires:

--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -26,7 +26,7 @@ const ReactVersion = '19.0.0';
 //
 // It only affects the label used in the version string. To customize the
 // npm dist tags used during publish, refer to .circleci/config.yml.
-const canaryChannelLabel = 'beta';
+const canaryChannelLabel = 'rc';
 
 const stablePackages = {
   'eslint-plugin-react-hooks': '5.1.0',


### PR DESCRIPTION
This updates the Canary label from "beta" to "rc".

We will publish an actual RC (e.g. 19.0.0-rc.0) too; this only changes the label in the canary releases.