### PR TITLE
Add a `main` field to `eslint-plugin-react-compiler`, fixes #29068.

### DIFF
--- a/compiler/packages/eslint-plugin-react-compiler/package.json
+++ b/compiler/packages/eslint-plugin-react-compiler/package.json
@@ -2,6 +2,7 @@
   "name": "eslint-plugin-react-compiler",
   "version": "0.0.0-experimental-e04a001-20240515",
   "description": "ESLint plugin to display errors found by the React compiler.",
+  "main": "dist/index.js",
   "scripts": {
     "build": "rimraf dist && rollup --config --bundleConfigAsCjs",
     "test": "tsc && jest"


### PR DESCRIPTION
## Summary

The main field is missing, this fixes it.

Fixes #29068.

## How did you test this change?

Manually patched the package and tried it in my codebase.