### PR TITLE
Fix ESLint and Prettier configs for React Compiler

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,6 +13,9 @@ scripts/bench/benchmarks/**/*.js
 # React repository clone
 scripts/bench/remote-repo/
 
+# Compiler uses its own lint setup
+compiler/
+
 packages/react-devtools-core/dist
 packages/react-devtools-extensions/chrome/build
 packages/react-devtools-extensions/firefox/build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 build
 
+compiler
 packages/react-devtools-core/dist
 packages/react-devtools-extensions/chrome/build
 packages/react-devtools-extensions/firefox/build


### PR DESCRIPTION
Fixes the top-level ESLint and Prettier configs to ignore the compiler. For now the compiler has its own prettier and linting setup with different versions/configs.