### PR TITLE
[heathcheck] Check for namespaced StrictMode

### DIFF
--- a/compiler/packages/react-compiler-healthcheck/src/checks/strictMode.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/checks/strictMode.ts
@@ -8,7 +8,7 @@
 import chalk from "chalk";
 
 const JsFileExtensionRE = /(js|ts|jsx|tsx)$/;
-const StrictModeRE = /\<StrictMode\>/;
+const StrictModeRE = /<(React\.StrictMode|StrictMode)>/;
 let StrictModeUsage = false;
 
 export default {


### PR DESCRIPTION
Previously, we only checked for StrictMode by searching for `<StrictMode>` but we should also check for the namespaced version, `<React.StrictMode>`.

Fixes https://github.com/facebook/react/issues/29075