### PR TITLE
compiler: add verbose logging to `react-compiler-healthcheck`

### DIFF
--- a/compiler/packages/react-compiler-healthcheck/src/checks/reactCompiler.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/checks/reactCompiler.ts
@@ -123,7 +123,9 @@ export default {
     );
 
     if (verbose) {
-      for (const compilation of SucessfulCompilation) {
+      for (const compilation of [...SucessfulCompilation, ...ActionableFailures, ...OtherFailures]) {
+        const filename = compilation.fnLoc?.filename;
+
         if (compilation.kind === "CompileSuccess") {
           const name = compilation.fnName;
           const isHook = name?.startsWith('use');
@@ -131,12 +133,22 @@ export default {
           if (name) {
             console.log(
               chalk.green(
-                `Successfully compiled ${isHook ? "hook" : "component" } [${name}](${compilation.fnLoc?.filename})`
+                `Successfully compiled ${isHook ? "hook" : "component" } [${name}](${filename})`
               )
             );
           } else {
-            console.log(chalk.green(`Successfully compiled [${compilation.fnLoc?.filename}]`));
+            console.log(chalk.green(`Successfully compiled ${compilation.fnLoc?.filename}`));
           }
+        }
+
+        if (compilation.kind === "CompileError") {
+          const reason = compilation.detail.description;
+  
+          console.log(
+            chalk.red(
+              `Failed to compile ${filename}${reason? `\n Reason: ${reason}` : ''}`
+            )
+          );
         }
       }
     }

--- a/compiler/packages/react-compiler-healthcheck/src/checks/reactCompiler.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/checks/reactCompiler.ts
@@ -111,7 +111,7 @@ export default {
     }
   },
 
-  report(): void {
+  report(verbose: boolean): void {
     const totalComponents =
       SucessfulCompilation.length +
       OtherFailures.length +
@@ -121,5 +121,24 @@ export default {
         `Successfully compiled ${SucessfulCompilation.length} out of ${totalComponents} components.`
       )
     );
+
+    if (verbose) {
+      for (const compilation of SucessfulCompilation) {
+        if (compilation.kind === "CompileSuccess") {
+          const name = compilation.fnName;
+          const isHook = name?.startsWith('use');
+
+          if (name) {
+            console.log(
+              chalk.green(
+                `Successfully compiled ${isHook ? "hook" : "component" } [${name}](${compilation.fnLoc?.filename})`
+              )
+            );
+          } else {
+            console.log(chalk.green(`Successfully compiled [${compilation.fnLoc?.filename}]`));
+          }
+        }
+      }
+    }
   },
 };

--- a/compiler/packages/react-compiler-healthcheck/src/index.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/index.ts
@@ -22,10 +22,17 @@ async function main() {
       type: "string",
       default: "**/+(*.{js,jsx,ts,tsx}|package.json)",
     })
+    .option('verbose', {
+      alias: 'v',
+      type: 'boolean',
+      default: false,
+      description: 'run with verbose logging',
+    })
     .parseSync();
 
   const spinner = ora("Checking").start();
   let src = argv.src;
+  const verbose = argv.verbose;
 
   const globOptions = {
     onlyFiles: true,
@@ -48,7 +55,7 @@ async function main() {
   }
   spinner.stop();
 
-  reactCompilerCheck.report();
+  reactCompilerCheck.report(verbose);
   strictModeCheck.report();
   libraryCompatCheck.report();
 }


### PR DESCRIPTION
## Summary 

This PR adds a verbose option to `react-compiler-healthcheck` CLI which logs all the compiled components/hooks names and files location.

Fixes: https://github.com/facebook/react/issues/29078

<img width="551" alt="healthchekc" src="https://github.com/facebook/react/assets/23306911/5b4dbc79-454f-44d8-8ee4-5020dd7a17e8">

## Test plan

Run the `react-compiler-healthcheck` CLI with the `—-verbose` flag inside a react app and you should be able to see the compiled components/hooks names or the files path printed in green. 

If there are any files that failed to compile, they will be printed in red.
