### PR TITLE
[compiler] Add readme for babel plugin

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/README.md
+++ b/compiler/packages/babel-plugin-react-compiler/README.md
@@ -1,0 +1,5 @@
+# babel-plugin-react-compiler
+
+React Compiler is a compiler that optimizes React applications, ensuring that only the minimal parts of components and hooks will re-render when state changes. The compiler also validates that components and hooks follow the Rules of React.
+
+This package contains the React Compiler Babel plugin use in projects that make use of Babel. You can find instructions for using this plugin here: https://react.dev/learn/react-compiler


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #29084

Adds a simple readme for the babel plugin with links to the docs.