### PR TITLE
[compiler:publish] Specify https for registry

### DIFF
--- a/compiler/scripts/publish.js
+++ b/compiler/scripts/publish.js
@@ -203,7 +203,7 @@ async function main() {
       try {
         await spawnHelper(
           "npm",
-          [...opts, "--registry=http://registry.npmjs.org"],
+          [...opts, "--registry=https://registry.npmjs.org"],
           {
             cwd: pkgDir,
             stdio: "inherit",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #29087

Uses https for the npm registry so the publishing script isn't rejected.
Fixes:

```
Beginning October 4, 2021, all connections to the npm registry - including for package installation - must use TLS 1.2 or higher. You are currently using plaintext http to connect. Please visit the GitHub blog for more information: https://github.blog/2021-08-23-npm-registry-deprecating-tls-1-0-tls-1-1/
```