### PR TITLE
Move createElement/JSX Warnings into the Renderer

### DIFF
--- a/fixtures/flight/server/region.js
+++ b/fixtures/flight/server/region.js
@@ -81,17 +81,20 @@ async function renderApp(res, returnValue, formState) {
     ).main.css;
   }
   const App = m.default.default || m.default;
-  const root = [
+  const root = React.createElement(
+    React.Fragment,
+    null,
     // Prepend the App's tree with stylesheets required for this entrypoint.
     mainCSSChunks.map(filename =>
       React.createElement('link', {
         rel: 'stylesheet',
         href: filename,
         precedence: 'default',
+        key: filename,
       })
     ),
-    React.createElement(App),
-  ];
+    React.createElement(App)
+  );
   // For client-invoked server actions we refresh the tree and return a return value.
   const payload = {root, returnValue, formState};
   const {pipe} = renderToPipeableStream(payload, moduleMap);

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -624,13 +624,13 @@ function createElement(
     // Unfortunately, _store is enumerable in jest matchers so for equality to
     // work, I need to keep it or make _store non-enumerable in the other file.
     element._store = ({}: {
-      validated?: boolean,
+      validated?: number,
     });
     Object.defineProperty(element._store, 'validated', {
       configurable: false,
       enumerable: false,
       writable: true,
-      value: true, // This element has already been validated on the server.
+      value: 1, // This element has already been validated on the server.
     });
     // debugInfo contains Server Component debug information.
     Object.defineProperty(element, '_debugInfo', {

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -579,6 +579,7 @@ function createElement(
   props: mixed,
   owner: null | ReactComponentInfo, // DEV-only
   stack: null | string, // DEV-only
+  validated: number, // DEV-only
 ): React$Element<any> {
   let element: any;
   if (__DEV__ && enableRefAsProp) {
@@ -630,7 +631,7 @@ function createElement(
       configurable: false,
       enumerable: false,
       writable: true,
-      value: 1, // This element has already been validated on the server.
+      value: enableOwnerStacks ? validated : 1, // Whether the element has already been validated on the server.
     });
     // debugInfo contains Server Component debug information.
     Object.defineProperty(element, '_debugInfo', {
@@ -644,7 +645,7 @@ function createElement(
         configurable: false,
         enumerable: false,
         writable: true,
-        value: {stack: stack},
+        value: stack,
       });
       Object.defineProperty(element, '_debugTask', {
         configurable: false,
@@ -1053,6 +1054,7 @@ function parseModelTuple(
       tuple[3],
       __DEV__ ? (tuple: any)[4] : null,
       __DEV__ && enableOwnerStacks ? (tuple: any)[5] : null,
+      __DEV__ && enableOwnerStacks ? (tuple: any)[6] : 0,
     );
   }
   return value;

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -1389,19 +1389,40 @@ describe('ReactFlight', () => {
     ReactNoopFlightClient.read(transport);
   });
 
-  it('should warn in DEV a child is missing keys', () => {
+  it('should warn in DEV a child is missing keys on server component', () => {
+    function NoKey({children}) {
+      return <div key="this has a key but parent doesn't" />;
+    }
+    expect(() => {
+      const transport = ReactNoopFlightServer.render(
+        <div>{Array(6).fill(<NoKey />)}</div>,
+      );
+      ReactNoopFlightClient.read(transport);
+    }).toErrorDev('Each child in a list should have a unique "key" prop.', {
+      withoutStack: gate(flags => flags.enableOwnerStacks),
+    });
+  });
+
+  it('should warn in DEV a child is missing keys in client component', async () => {
     function ParentClient({children}) {
       return children;
     }
     const Parent = clientReference(ParentClient);
-    expect(() => {
+    await expect(async () => {
       const transport = ReactNoopFlightServer.render(
         <Parent>{Array(6).fill(<div>no key</div>)}</Parent>,
       );
       ReactNoopFlightClient.read(transport);
+      await act(async () => {
+        ReactNoop.render(await ReactNoopFlightClient.read(transport));
+      });
     }).toErrorDev(
-      'Each child in a list should have a unique "key" prop. ' +
-        'See https://react.dev/link/warning-keys for more information.',
+      gate(flags => flags.enableOwnerStacks)
+        ? 'Each child in a list should have a unique "key" prop.' +
+            '\n\nCheck the top-level render call using <ParentClient>. ' +
+            'See https://react.dev/link/warning-keys for more information.'
+        : 'Each child in a list should have a unique "key" prop. ' +
+            'See https://react.dev/link/warning-keys for more information.',
     );
   });
 
@@ -2309,7 +2330,7 @@ describe('ReactFlight', () => {
     }
 
     function ThirdPartyFragmentComponent() {
-      return [<span>Who</span>, ' ', <span>dis?</span>];
+      return [<span key="1">Who</span>, ' ', <span key="2">dis?</span>];
     }
 
     function ServerComponent({transport}) {
@@ -2321,7 +2342,7 @@ describe('ReactFlight', () => {
     const promiseComponent = Promise.resolve(<ThirdPartyComponent />);
 
     const thirdPartyTransport = ReactNoopFlightServer.render(
-      [promiseComponent, lazy, <ThirdPartyFragmentComponent />],
+      [promiseComponent, lazy, <ThirdPartyFragmentComponent key="3" />],
       {
         environmentName: 'third-party',
       },
@@ -2413,8 +2434,8 @@ describe('ReactFlight', () => {
     const iteratorPromise = new Promise(r => (resolve = r));
 
     async function* ThirdPartyAsyncIterableComponent({item, initial}) {
-      yield <span>Who</span>;
-      yield <span>dis?</span>;
+      yield <span key="1">Who</span>;
+      yield <span key="2">dis?</span>;
       resolve();
     }
 

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -1143,6 +1143,9 @@ describe('ReactFlight', () => {
         '\n' +
         'Check the render method of `Component`. See https://react.dev/link/warning-keys for more information.\n' +
         '    in span (at **)\n' +
+        // TODO: Because this validates after the div has been mounted, it is part of
+        // the parent stack but since owner stacks will switch to owners this goes away again.
+        (gate(flags => flags.enableOwnerStacks) ? '    in div (at **)\n' : '') +
         '    in Component (at **)\n' +
         '    in Indirection (at **)\n' +
         '    in App (at **)',

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -2562,13 +2562,7 @@ describe('InspectedElement', () => {
       const data = await getErrorsAndWarningsForElementAtIndex(0);
       expect(data).toMatchInlineSnapshot(`
         {
-          "errors": [
-            [
-              "Warning: Each child in a list should have a unique "key" prop. See https://react.dev/link/warning-keys for more information.
-            at Example",
-              1,
-            ],
-          ],
+          "errors": [],
           "warnings": [],
         }
       `);

--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -1932,9 +1932,8 @@ describe('Store', () => {
       );
 
       expect(store).toMatchInlineSnapshot(`
-        ✕ 1, ⚠ 0
         [root]
-          ▾ <Example> ✕
+          ▾ <Example>
               <Child>
       `);
     });

--- a/packages/react-devtools-shared/src/backend/DevToolsComponentStackFrame.js
+++ b/packages/react-devtools-shared/src/backend/DevToolsComponentStackFrame.js
@@ -12,21 +12,7 @@
 // while still maintaining support for multiple renderer versions
 // (which use different values for ReactTypeOfWork).
 
-import type {LazyComponent} from 'react/src/ReactLazy';
 import type {CurrentDispatcherRef} from './types';
-
-import {
-  FORWARD_REF_NUMBER,
-  FORWARD_REF_SYMBOL_STRING,
-  LAZY_NUMBER,
-  LAZY_SYMBOL_STRING,
-  MEMO_NUMBER,
-  MEMO_SYMBOL_STRING,
-  SUSPENSE_NUMBER,
-  SUSPENSE_SYMBOL_STRING,
-  SUSPENSE_LIST_NUMBER,
-  SUSPENSE_LIST_SYMBOL_STRING,
-} from './ReactSymbols';
 
 // The shared console patching code is DEV-only.
 // We can't use it since DevTools only ships production builds.
@@ -296,70 +282,4 @@ export function describeFunctionComponentFrame(
   currentDispatcherRef: CurrentDispatcherRef,
 ): string {
   return describeNativeComponentFrame(fn, false, currentDispatcherRef);
-}
-
-function shouldConstruct(Component: Function) {
-  const prototype = Component.prototype;
-  return !!(prototype && prototype.isReactComponent);
-}
-
-export function describeUnknownElementTypeFrameInDEV(
-  type: any,
-  currentDispatcherRef: CurrentDispatcherRef,
-): string {
-  if (!__DEV__) {
-    return '';
-  }
-  if (type == null) {
-    return '';
-  }
-  if (typeof type === 'function') {
-    return describeNativeComponentFrame(
-      type,
-      shouldConstruct(type),
-      currentDispatcherRef,
-    );
-  }
-  if (typeof type === 'string') {
-    return describeBuiltInComponentFrame(type);
-  }
-  switch (type) {
-    case SUSPENSE_NUMBER:
-    case SUSPENSE_SYMBOL_STRING:
-      return describeBuiltInComponentFrame('Suspense');
-    case SUSPENSE_LIST_NUMBER:
-    case SUSPENSE_LIST_SYMBOL_STRING:
-      return describeBuiltInComponentFrame('SuspenseList');
-  }
-  if (typeof type === 'object') {
-    switch (type.$$typeof) {
-      case FORWARD_REF_NUMBER:
-      case FORWARD_REF_SYMBOL_STRING:
-        return describeFunctionComponentFrame(
-          type.render,
-          currentDispatcherRef,
-        );
-      case MEMO_NUMBER:
-      case MEMO_SYMBOL_STRING:
-        // Memo may contain any component type so we recursively resolve it.
-        return describeUnknownElementTypeFrameInDEV(
-          type.type,
-          currentDispatcherRef,
-        );
-      case LAZY_NUMBER:
-      case LAZY_SYMBOL_STRING: {
-        const lazyComponent: LazyComponent<any, any> = (type: any);
-        const payload = lazyComponent._payload;
-        const init = lazyComponent._init;
-        try {
-          // Lazy may contain any component type so we recursively resolve it.
-          return describeUnknownElementTypeFrameInDEV(
-            init(payload),
-            currentDispatcherRef,
-          );
-        } catch (x) {}
-      }
-    }
-  }
-  return '';
 }

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1833,10 +1833,18 @@ describe('ReactDOMFizzServer', () => {
         expect(mockError).toHaveBeenCalledWith(
           'Warning: Each child in a list should have a unique "key" prop.%s%s' +
             ' See https://react.dev/link/warning-keys for more information.%s',
-          '\n\nCheck the top-level render call using <div>.',
+          gate(flags => flags.enableOwnerStacks)
+            ? // We currently don't track owners in Fizz which is responsible for this frame.
+              ''
+            : '\n\nCheck the top-level render call using <div>.',
           '',
           '\n' +
             '    in span (at **)\n' +
+            // TODO: Because this validates after the div has been mounted, it is part of
+            // the parent stack but since owner stacks will switch to owners this goes away again.
+            (gate(flags => flags.enableOwnerStacks)
+              ? '    in div (at **)\n'
+              : '') +
             '    in B (at **)\n' +
             '    in Suspense (at **)\n' +
             '    in div (at **)\n' +

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1898,7 +1898,12 @@ describe('ReactDOMFizzServer', () => {
           </b>
         );
         if (this.props.prefix) {
-          return [readText(this.props.prefix), child];
+          return (
+            <>
+              {readText(this.props.prefix)}
+              {child}
+            </>
+          );
         }
         return child;
       }
@@ -1908,7 +1913,13 @@ describe('ReactDOMFizzServer', () => {
       const {pipe} = renderToPipeableStream(
         <TestProvider ctx="A">
           <div>
-            <Suspense fallback={[<Text text="Loading: " />, <TestConsumer />]}>
+            <Suspense
+              fallback={
+                <>
+                  <Text text="Loading: " />
+                  <TestConsumer />
+                </>
+              }>
               <TestProvider ctx="B">
                 <TestConsumer prefix="Hello: " />
               </TestProvider>

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -819,7 +819,7 @@ describe('ReactDOMServer', () => {
     }
 
     function Child() {
-      return [<A key="1" />, <B key="2" />, <span ariaTypo2="no" />];
+      return [<A key="1" />, <B key="2" />, <span ariaTypo2="no" key="3" />];
     }
 
     function App() {

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -114,7 +114,11 @@ if (__DEV__) {
     if (child === null || typeof child !== 'object') {
       return;
     }
-    if (!child._store || child._store.validated || child.key != null) {
+    if (
+      !child._store ||
+      ((child._store.validated || child.key != null) &&
+        child._store.validated !== 2)
+    ) {
       return;
     }
 
@@ -126,7 +130,7 @@ if (__DEV__) {
     }
 
     // $FlowFixMe[cannot-write] unable to narrow type from mixed to writable object
-    child._store.validated = true;
+    child._store.validated = 1;
 
     const componentName = getComponentNameFromFiber(returnFiber);
 
@@ -171,6 +175,9 @@ if (__DEV__) {
     }
 
     // We create a fake Fiber for the child to log the stack trace from.
+    // TODO: Refactor the warnForMissingKey calls to happen after fiber creation
+    // so that we can get access to the fiber that will eventually be created.
+    // That way the log can show up associated with the right instance in DevTools.
     const fiber = createFiberFromElement((child: any), returnFiber.mode, 0);
     fiber.return = returnFiber;
 

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -995,7 +995,13 @@ describe('ReactLazy', () => {
     await expect(async () => {
       await act(() => resolveFakeImport(Foo));
       assertLog(['A', 'B']);
-    }).toErrorDev('    in Text (at **)\n' + '    in Foo (at **)');
+    }).toErrorDev(
+      '    in Text (at **)\n' +
+        // TODO: Because this validates after the div has been mounted, it is part of
+        // the parent stack but since owner stacks will switch to owners this goes away again.
+        (gate(flags => flags.enableOwnerStacks) ? '    in div (at **)\n' : '') +
+        '    in Foo (at **)',
+    );
     expect(root).toMatchRenderedOutput(<div>AB</div>);
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactMemo-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactMemo-test.js
@@ -599,7 +599,9 @@ describe('memo', () => {
       await expect(async () => {
         await waitForAll([]);
       }).toErrorDev(
-        'Each child in a list should have a unique "key" prop. See https://react.dev/link/warning-keys for more information.\n' +
+        'Each child in a list should have a unique "key" prop. ' +
+          'See https://react.dev/link/warning-keys for more information.\n' +
+          '    in span (at **)\n' +
           '    in p (at **)',
       );
     });
@@ -616,7 +618,10 @@ describe('memo', () => {
       await expect(async () => {
         await waitForAll([]);
       }).toErrorDev(
-        'Each child in a list should have a unique "key" prop. See https://react.dev/link/warning-keys for more information.\n' +
+        'Each child in a list should have a unique "key" prop.' +
+          '\n\nCheck the top-level render call using <Inner>. It was passed a child from Inner. ' +
+          'See https://react.dev/link/warning-keys for more information.\n' +
+          '    in span (at **)\n' +
           '    in Inner (at **)\n' +
           '    in p (at **)',
       );
@@ -636,7 +641,10 @@ describe('memo', () => {
       await expect(async () => {
         await waitForAll([]);
       }).toErrorDev(
-        'Each child in a list should have a unique "key" prop. See https://react.dev/link/warning-keys for more information.\n' +
+        'Each child in a list should have a unique "key" prop.' +
+          '\n\nCheck the top-level render call using <Inner>. It was passed a child from Inner. ' +
+          'See https://react.dev/link/warning-keys for more information.\n' +
+          '    in span (at **)\n' +
           '    in Inner (at **)\n' +
           '    in p (at **)',
       );
@@ -655,7 +663,10 @@ describe('memo', () => {
       await expect(async () => {
         await waitForAll([]);
       }).toErrorDev(
-        'Each child in a list should have a unique "key" prop. See https://react.dev/link/warning-keys for more information.\n' +
+        'Each child in a list should have a unique "key" prop.' +
+          '\n\nCheck the top-level render call using <Outer>. It was passed a child from Outer. ' +
+          'See https://react.dev/link/warning-keys for more information.\n' +
+          '    in span (at **)\n' +
           '    in Outer (at **)\n' +
           '    in p (at **)',
       );
@@ -676,7 +687,10 @@ describe('memo', () => {
       await expect(async () => {
         await waitForAll([]);
       }).toErrorDev(
-        'Each child in a list should have a unique "key" prop. See https://react.dev/link/warning-keys for more information.\n' +
+        'Each child in a list should have a unique "key" prop.' +
+          '\n\nCheck the top-level render call using <Inner>. It was passed a child from Inner. ' +
+          'See https://react.dev/link/warning-keys for more information.\n' +
+          '    in span (at **)\n' +
           '    in Inner (at **)\n' +
           '    in p (at **)',
       );

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -746,6 +746,10 @@ describe('ReactFlightDOMBrowser', () => {
     }
     const Parent = clientExports(ParentClient);
     const ParentModule = clientExports({Parent: ParentClient});
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+
     await expect(async () => {
       const stream = ReactServerDOMServer.renderToReadableStream(
         <>
@@ -756,11 +760,12 @@ describe('ReactFlightDOMBrowser', () => {
         </>,
         webpackMap,
       );
-      await ReactServerDOMClient.createFromReadableStream(stream);
-    }).toErrorDev(
-      'Each child in a list should have a unique "key" prop. ' +
-        'See https://react.dev/link/warning-keys for more information.',
-    );
+      const result =
+        await ReactServerDOMClient.createFromReadableStream(stream);
+      await act(() => {
+        root.render(result);
+      });
+    }).toErrorDev('Each child in a list should have a unique "key" prop.');
   });
 
   it('basic use(promise)', async () => {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -256,7 +256,41 @@ describe('ReactFlightDOMEdge', () => {
       return str;
     }
     const element = <ServerComponent />;
-    const children = new Array(30).fill(element);
+    // Hardcoded list to avoid the key warning
+    const children = (
+      <>
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+      </>
+    );
     const resolvedChildren = new Array(30).fill(str);
     const stream = ReactServerDOMServer.renderToReadableStream(children);
     const [stream1, stream2] = passThrough(stream).tee();
@@ -288,7 +322,41 @@ describe('ReactFlightDOMEdge', () => {
       return div;
     }
     const element = <ServerComponent />;
-    const children = new Array(30).fill(element);
+    // Hardcoded list to avoid the key warning
+    const children = (
+      <>
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+        {element}
+      </>
+    );
     const resolvedChildren = new Array(30).fill(
       '<div>this is a long return value</div>',
     );

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -207,17 +207,20 @@ function mapIntoArray(
           // The `if` statement here prevents auto-disabling of the safe
           // coercion ESLint rule, so we must manually disable it below.
           // $FlowFixMe[incompatible-type] Flow incorrectly thinks React.Portal doesn't have a key
-          if (mappedChild.key && (!child || child.key !== mappedChild.key)) {
-            checkKeyStringCoercion(mappedChild.key);
+          if (mappedChild.key != null) {
+            if (!child || child.key !== mappedChild.key) {
+              checkKeyStringCoercion(mappedChild.key);
+            }
           }
         }
-        mappedChild = cloneAndReplaceKey(
+        const newChild = cloneAndReplaceKey(
           mappedChild,
           // Keep both the (mapped) and old keys if they differ, just as
           // traverseAllChildren used to do for objects as children
           escapedPrefix +
             // $FlowFixMe[incompatible-type] Flow incorrectly thinks React.Portal doesn't have a key
-            (mappedChild.key && (!child || child.key !== mappedChild.key)
+            (mappedChild.key != null &&
+            (!child || child.key !== mappedChild.key)
               ? escapeUserProvidedKey(
                   // $FlowFixMe[unsafe-addition]
                   '' + mappedChild.key, // eslint-disable-line react-internal/safe-string-coercion
@@ -225,6 +228,17 @@ function mapIntoArray(
               : '') +
             childKey,
         );
+        if (__DEV__) {
+          if (nameSoFar !== '' && mappedChild.key == null) {
+            // We need to validate that this child should have had a key before assigning it one.
+            if (!newChild._store.validated) {
+              // We mark this child as having failed validation but we let the actual renderer
+              // print the warning later.
+              newChild._store.validated = 2;
+            }
+          }
+        }
+        mappedChild = newChild;
       }
       array.push(mappedChild);
     }

--- a/packages/react/src/ReactSharedInternalsClient.js
+++ b/packages/react/src/ReactSharedInternalsClient.js
@@ -34,9 +34,7 @@ export type SharedStateClient = {
   thrownErrors: Array<mixed>,
 
   // ReactDebugCurrentFrame
-  setExtraStackFrame: (stack: null | string) => void,
   getCurrentStack: null | (() => string),
-  getStackAddendum: () => string,
 };
 
 export type RendererTask = boolean => RendererTask | null;
@@ -53,30 +51,8 @@ if (__DEV__) {
   ReactSharedInternals.didScheduleLegacyUpdate = false;
   ReactSharedInternals.didUsePromise = false;
   ReactSharedInternals.thrownErrors = [];
-
-  let currentExtraStackFrame = (null: null | string);
-  ReactSharedInternals.setExtraStackFrame = function (stack: null | string) {
-    currentExtraStackFrame = stack;
-  };
   // Stack implementation injected by the current renderer.
   ReactSharedInternals.getCurrentStack = (null: null | (() => string));
-
-  ReactSharedInternals.getStackAddendum = function (): string {
-    let stack = '';
-
-    // Add an extra top frame while an element is being validated
-    if (currentExtraStackFrame) {
-      stack += currentExtraStackFrame;
-    }
-
-    // Delegate to the injected renderer-specific implementation
-    const impl = ReactSharedInternals.getCurrentStack;
-    if (impl) {
-      stack += impl() || '';
-    }
-
-    return stack;
-  };
 }
 
 export default ReactSharedInternals;

--- a/packages/react/src/ReactSharedInternalsServer.js
+++ b/packages/react/src/ReactSharedInternalsServer.js
@@ -38,9 +38,7 @@ export type SharedStateServer = {
   // DEV-only
 
   // ReactDebugCurrentFrame
-  setExtraStackFrame: (stack: null | string) => void,
   getCurrentStack: null | (() => string),
-  getStackAddendum: () => string,
 };
 
 export type RendererTask = boolean => RendererTask | null;
@@ -59,29 +57,8 @@ if (enableTaint) {
 }
 
 if (__DEV__) {
-  let currentExtraStackFrame = (null: null | string);
-  ReactSharedInternals.setExtraStackFrame = function (stack: null | string) {
-    currentExtraStackFrame = stack;
-  };
   // Stack implementation injected by the current renderer.
   ReactSharedInternals.getCurrentStack = (null: null | (() => string));
-
-  ReactSharedInternals.getStackAddendum = function (): string {
-    let stack = '';
-
-    // Add an extra top frame while an element is being validated
-    if (currentExtraStackFrame) {
-      stack += currentExtraStackFrame;
-    }
-
-    // Delegate to the injected renderer-specific implementation
-    const impl = ReactSharedInternals.getCurrentStack;
-    if (impl) {
-      stack += impl() || '';
-    }
-
-    return stack;
-  };
 }
 
 export default ReactSharedInternals;

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -301,7 +301,7 @@ describe('ReactChildren', () => {
     ]);
   });
 
-  it('should be called for each child in an iterable without keys', () => {
+  it('should be called for each child in an iterable without keys', async () => {
     const threeDivIterable = {
       '@@iterator': function () {
         let i = 0;
@@ -323,11 +323,6 @@ describe('ReactChildren', () => {
       return kid;
     });
 
-    let instance;
-    expect(() => (instance = <div>{threeDivIterable}</div>)).toErrorDev(
-      'Warning: Each child in a list should have a unique "key" prop.',
-    );
-
     function assertCalls() {
       expect(callback).toHaveBeenCalledTimes(3);
       expect(callback).toHaveBeenCalledWith(<div />, 0);
@@ -336,7 +331,18 @@ describe('ReactChildren', () => {
       callback.mockClear();
     }
 
+    let instance;
+    expect(() => {
+      instance = <div>{threeDivIterable}</div>;
+    }).toErrorDev(
+      // With the flag on this doesn't warn eagerly but only when rendered
+      gate(flag => flag.enableOwnerStacks)
+        ? []
+        : ['Warning: Each child in a list should have a unique "key" prop.'],
+    );
+
     React.Children.forEach(instance.props.children, callback, context);
+
     assertCalls();
 
     const mappedChildren = React.Children.map(
@@ -350,6 +356,16 @@ describe('ReactChildren', () => {
       <div key=".1" />,
       <div key=".2" />,
     ]);
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+    await expect(async () => {
+      await act(() => {
+        root.render(instance);
+      });
+    }).toErrorDev(
+      'Warning: Each child in a list should have a unique "key" prop.',
+    );
   });
 
   it('should be called for each child in an iterable with keys', () => {
@@ -953,7 +969,7 @@ describe('ReactChildren', () => {
   });
 
   it('should render React.lazy after suspending', async () => {
-    const lazyElement = React.lazy(async () => ({default: <div />}));
+    const lazyElement = React.lazy(async () => ({default: <div key="hi" />}));
     function Component() {
       return React.Children.map([lazyElement], c =>
         React.cloneElement(c, {children: 'hi'}),
@@ -969,7 +985,7 @@ describe('ReactChildren', () => {
   });
 
   it('should render cached Promises after suspending', async () => {
-    const promise = Promise.resolve(<div />);
+    const promise = Promise.resolve(<div key="hi" />);
     function Component() {
       return React.Children.map([promise], c =>
         React.cloneElement(c, {children: 'hi'}),

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -1015,7 +1015,9 @@ describe('ReactChildren', () => {
       }).toErrorDev(
         'Warning: ' +
           'Each child in a list should have a unique "key" prop.' +
-          ' See https://react.dev/link/warning-keys for more information.' +
+          '\n\nCheck the top-level render call using <ComponentReturningArray>. It was passed a child from ComponentReturningArray. ' +
+          'See https://react.dev/link/warning-keys for more information.' +
+          '\n    in div (at **)' +
           '\n    in ComponentReturningArray (at **)',
       );
     });
@@ -1044,8 +1046,9 @@ describe('ReactChildren', () => {
       }).toErrorDev(
         'Warning: ' +
           'Each child in a list should have a unique "key" prop.' +
-          ' See https://react.dev/link/warning-keys for more information.',
-        {withoutStack: true}, // There's nothing on the stack
+          '\n\nCheck the top-level render call using <Root>. ' +
+          'See https://react.dev/link/warning-keys for more information.' +
+          '\n    in div (at **)',
       );
     });
   });

--- a/packages/react/src/__tests__/ReactElementClone-test.js
+++ b/packages/react/src/__tests__/ReactElementClone-test.js
@@ -364,18 +364,29 @@ describe('ReactElementClone', () => {
     expect(cloneInstance4.props.prop).toBe('newTestKey');
   });
 
-  it('warns for keys for arrays of elements in rest args', () => {
-    expect(() =>
-      React.cloneElement(<div />, null, [<div />, <div />]),
-    ).toErrorDev('Each child in a list should have a unique "key" prop.');
+  it('warns for keys for arrays of elements in rest args', async () => {
+    const root = ReactDOMClient.createRoot(document.createElement('div'));
+    await expect(async () => {
+      await act(() => {
+        root.render(React.cloneElement(<div />, null, [<div />, <div />]));
+      });
+    }).toErrorDev('Each child in a list should have a unique "key" prop.');
   });
 
-  it('does not warns for arrays of elements with keys', () => {
-    React.cloneElement(<div />, null, [<div key="#1" />, <div key="#2" />]);
+  it('does not warns for arrays of elements with keys', async () => {
+    const root = ReactDOMClient.createRoot(document.createElement('div'));
+    await act(() => {
+      root.render(
+        React.cloneElement(<div />, null, [<div key="#1" />, <div key="#2" />]),
+      );
+    });
   });
 
-  it('does not warn when the element is directly in rest args', () => {
-    React.cloneElement(<div />, null, <div />, <div />);
+  it('does not warn when the element is directly in rest args', async () => {
+    const root = ReactDOMClient.createRoot(document.createElement('div'));
+    await act(() => {
+      root.render(React.cloneElement(<div />, null, <div />, <div />));
+    });
   });
 
   it('does not warn when the array contains a non-element', () => {

--- a/packages/react/src/__tests__/ReactElementValidator-test.internal.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.internal.js
@@ -233,56 +233,141 @@ describe('ReactElementValidator', () => {
     );
   });
 
-  it('gives a helpful error when passing invalid types', () => {
+  it('gives a helpful error when passing invalid types', async () => {
     function Foo() {}
-    expect(() => {
-      React.createElement(undefined);
-      React.createElement(null);
-      React.createElement(true);
-      React.createElement({x: 17});
-      React.createElement({});
-      React.createElement(React.createElement('div'));
-      React.createElement(React.createElement(Foo));
-      React.createElement(React.createElement(React.createContext().Consumer));
-      React.createElement({$$typeof: 'non-react-thing'});
+    const errors = [];
+    await expect(async () => {
+      const root = ReactDOMClient.createRoot(document.createElement('div'), {
+        onUncaughtError(error) {
+          errors.push(error.message);
+        },
+      });
+      const cases = [
+        React.createElement(undefined),
+        React.createElement(null),
+        React.createElement(true),
+        React.createElement({x: 17}),
+        React.createElement({}),
+        React.createElement(React.createElement('div')),
+        React.createElement(React.createElement(Foo)),
+        React.createElement(
+          React.createElement(React.createContext().Consumer),
+        ),
+        React.createElement({$$typeof: 'non-react-thing'}),
+      ];
+      for (let i = 0; i < cases.length; i++) {
+        await act(() => root.render(cases[i]));
+      }
     }).toErrorDev(
-      [
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: undefined. You likely forgot to export your ' +
-          "component from the file it's defined in, or you might have mixed up " +
-          'default and named imports.',
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: null.',
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: boolean.',
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: object.',
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: object. You likely forgot to export your ' +
-          "component from the file it's defined in, or you might have mixed up " +
-          'default and named imports.',
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: <div />. Did you accidentally export a JSX literal ' +
-          'instead of a component?',
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: <Foo />. Did you accidentally export a JSX literal ' +
-          'instead of a component?',
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: <Context.Consumer />. Did you accidentally ' +
-          'export a JSX literal instead of a component?',
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: object.',
-      ],
+      gate(flag => flag.enableOwnerStacks)
+        ? // We don't need these extra warnings because we already have the errors.
+          []
+        : [
+            'Warning: React.createElement: type is invalid -- expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: undefined. You likely forgot to export your ' +
+              "component from the file it's defined in, or you might have mixed up " +
+              'default and named imports.',
+            'Warning: React.createElement: type is invalid -- expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: null.',
+            'Warning: React.createElement: type is invalid -- expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: boolean.',
+            'Warning: React.createElement: type is invalid -- expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: object.',
+            'Warning: React.createElement: type is invalid -- expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: object. You likely forgot to export your ' +
+              "component from the file it's defined in, or you might have mixed up " +
+              'default and named imports.',
+            'Warning: React.createElement: type is invalid -- expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: <div />. Did you accidentally export a JSX literal ' +
+              'instead of a component?',
+            'Warning: React.createElement: type is invalid -- expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: <Foo />. Did you accidentally export a JSX literal ' +
+              'instead of a component?',
+            'Warning: React.createElement: type is invalid -- expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: <Context.Consumer />. Did you accidentally ' +
+              'export a JSX literal instead of a component?',
+            'Warning: React.createElement: type is invalid -- expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: object.',
+          ],
       {withoutStack: true},
+    );
+
+    expect(errors).toEqual(
+      __DEV__
+        ? [
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: undefined. You likely forgot to export your ' +
+              "component from the file it's defined in, or you might have mixed up " +
+              'default and named imports.',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: null.',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: boolean.',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: object.',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: object. You likely forgot to export your ' +
+              "component from the file it's defined in, or you might have mixed up " +
+              'default and named imports.',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: <div />. Did you accidentally export a JSX literal ' +
+              'instead of a component?',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: <Foo />. Did you accidentally export a JSX literal ' +
+              'instead of a component?',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: <Context.Consumer />. Did you accidentally ' +
+              'export a JSX literal instead of a component?',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: object.',
+          ]
+        : [
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: undefined.',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: null.',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: boolean.',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: object.',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: object.',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: object.',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: object.',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: object.',
+            'Element type is invalid: expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: object.',
+          ],
     );
 
     // Should not log any additional warnings
@@ -303,16 +388,21 @@ describe('ReactElementValidator', () => {
           'or a class/function (for composite components) but got: null.' +
           (__DEV__ ? '\n\nCheck the render method of `ParentComp`.' : ''),
       );
-    }).toErrorDev([
-      'Warning: React.createElement: type is invalid -- expected a string ' +
-        '(for built-in components) or a class/function (for composite ' +
-        'components) but got: null.\n' +
-        '    in ParentComp (at **)',
-      'Warning: React.createElement: type is invalid -- expected a string ' +
-        '(for built-in components) or a class/function (for composite ' +
-        'components) but got: null.\n' +
-        '    in ParentComp (at **)',
-    ]);
+    }).toErrorDev(
+      gate(flag => flag.enableOwnerStacks)
+        ? // We don't need these extra warnings because we already have the errors.
+          []
+        : [
+            'Warning: React.createElement: type is invalid -- expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: null.\n' +
+              '    in ParentComp (at **)',
+            'Warning: React.createElement: type is invalid -- expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: null.\n' +
+              '    in ParentComp (at **)',
+          ],
+    );
   });
 
   it('warns for fragments with illegal attributes', async () => {

--- a/packages/react/src/__tests__/ReactJSXRuntime-test.js
+++ b/packages/react/src/__tests__/ReactJSXRuntime-test.js
@@ -300,6 +300,9 @@ describe('ReactJSXRuntime', () => {
       'Warning: Each child in a list should have a unique "key" prop.\n\n' +
         'Check the render method of `Parent`. See https://react.dev/link/warning-keys for more information.\n' +
         '    in Child (at **)\n' +
+        // TODO: Because this validates after the div has been mounted, it is part of
+        // the parent stack but since owner stacks will switch to owners this goes away again.
+        (gate(flags => flags.enableOwnerStacks) ? '    in div (at **)\n' : '') +
         '    in Parent (at **)',
     );
   });

--- a/packages/react/src/__tests__/forwardRef-test.js
+++ b/packages/react/src/__tests__/forwardRef-test.js
@@ -193,7 +193,10 @@ describe('forwardRef', () => {
     await expect(async () => {
       await waitForAll([]);
     }).toErrorDev(
-      'Each child in a list should have a unique "key" prop. See https://react.dev/link/warning-keys for more information.\n' +
+      'Each child in a list should have a unique "key" prop.' +
+        '\n\nCheck the top-level render call using <ForwardRef>. It was passed a child from ForwardRef. ' +
+        'See https://react.dev/link/warning-keys for more information.\n' +
+        '    in span (at **)\n' +
         '    in p (at **)',
     );
   });
@@ -210,7 +213,10 @@ describe('forwardRef', () => {
     await expect(async () => {
       await waitForAll([]);
     }).toErrorDev(
-      'Each child in a list should have a unique "key" prop. See https://react.dev/link/warning-keys for more information.\n' +
+      'Each child in a list should have a unique "key" prop.' +
+        '\n\nCheck the top-level render call using <ForwardRef(Inner)>. It was passed a child from ForwardRef(Inner). ' +
+        'See https://react.dev/link/warning-keys for more information.\n' +
+        '    in span (at **)\n' +
         '    in Inner (at **)\n' +
         '    in p (at **)',
     );
@@ -230,7 +236,10 @@ describe('forwardRef', () => {
     await expect(async () => {
       await waitForAll([]);
     }).toErrorDev(
-      'Each child in a list should have a unique "key" prop. See https://react.dev/link/warning-keys for more information.\n' +
+      'Each child in a list should have a unique "key" prop.' +
+        '\n\nCheck the top-level render call using <ForwardRef(Inner)>. It was passed a child from ForwardRef(Inner). ' +
+        'See https://react.dev/link/warning-keys for more information.\n' +
+        '    in span (at **)\n' +
         '    in Inner (at **)\n' +
         '    in p (at **)',
     );
@@ -249,7 +258,10 @@ describe('forwardRef', () => {
     await expect(async () => {
       await waitForAll([]);
     }).toErrorDev(
-      'Each child in a list should have a unique "key" prop. See https://react.dev/link/warning-keys for more information.\n' +
+      'Each child in a list should have a unique "key" prop.' +
+        '\n\nCheck the top-level render call using <Outer>. It was passed a child from Outer. ' +
+        'See https://react.dev/link/warning-keys for more information.\n' +
+        '    in span (at **)\n' +
         '    in Outer (at **)\n' +
         '    in p (at **)',
     );
@@ -270,7 +282,10 @@ describe('forwardRef', () => {
     await expect(async () => {
       await waitForAll([]);
     }).toErrorDev(
-      'Each child in a list should have a unique "key" prop. See https://react.dev/link/warning-keys for more information.\n' +
+      'Each child in a list should have a unique "key" prop.' +
+        '\n\nCheck the top-level render call using <Outer>. It was passed a child from Outer. ' +
+        'See https://react.dev/link/warning-keys for more information.\n' +
+        '    in span (at **)\n' +
         '    in Inner (at **)\n' +
         '    in p (at **)',
     );

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -1047,19 +1047,6 @@ export function cloneElement(element, config, children) {
   return clonedElement;
 }
 
-function getDeclarationErrorAddendum() {
-  if (__DEV__) {
-    const owner = getOwner();
-    if (owner) {
-      const name = getComponentNameFromType(owner.type);
-      if (name) {
-        return '\n\nCheck the render method of `' + name + '`.';
-      }
-    }
-    return '';
-  }
-}
-
 /**
  * Ensure that every element either is passed in a static location, in an
  * array with an explicit keys property defined, or in an object literal
@@ -1138,6 +1125,10 @@ const ownerHasKeyUseWarning = {};
  * @param {*} parentType element's parent's type.
  */
 function validateExplicitKey(element, parentType) {
+  if (enableOwnerStacks) {
+    // Skip. Will verify in renderer instead.
+    return;
+  }
   if (__DEV__) {
     if (!element._store || element._store.validated || element.key != null) {
       return;
@@ -1191,8 +1182,14 @@ function validateExplicitKey(element, parentType) {
 
 function getCurrentComponentErrorInfo(parentType) {
   if (__DEV__) {
-    let info = getDeclarationErrorAddendum();
-
+    let info = '';
+    const owner = getOwner();
+    if (owner) {
+      const name = getComponentNameFromType(owner.type);
+      if (name) {
+        info = '\n\nCheck the render method of `' + name + '`.';
+      }
+    }
     if (!info) {
       const parentName = getComponentNameFromType(parentType);
       if (parentName) {

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -708,7 +708,7 @@ export function jsxDEV(type, config, maybeKey, isStaticChildren, source, self) {
       }
     }
 
-    const element = ReactElement(
+    return ReactElement(
       type,
       key,
       ref,
@@ -719,12 +719,6 @@ export function jsxDEV(type, config, maybeKey, isStaticChildren, source, self) {
       __DEV__ && enableOwnerStacks ? Error('react-stack-top-frame') : undefined,
       __DEV__ && enableOwnerStacks ? createTask(getTaskName(type)) : undefined,
     );
-
-    if (type === REACT_FRAGMENT_TYPE) {
-      validateFragmentProps(element);
-    }
-
-    return element;
   }
 }
 
@@ -900,7 +894,7 @@ export function createElement(type, config, children) {
     }
   }
 
-  const element = ReactElement(
+  return ReactElement(
     type,
     key,
     ref,
@@ -911,12 +905,6 @@ export function createElement(type, config, children) {
     __DEV__ && enableOwnerStacks ? Error('react-stack-top-frame') : undefined,
     __DEV__ && enableOwnerStacks ? createTask(getTaskName(type)) : undefined,
   );
-
-  if (type === REACT_FRAGMENT_TYPE) {
-    validateFragmentProps(element);
-  }
-
-  return element;
 }
 
 export function cloneAndReplaceKey(oldElement, newKey) {
@@ -1209,36 +1197,6 @@ function getCurrentComponentErrorInfo(parentType) {
       }
     }
     return info;
-  }
-}
-
-/**
- * Given a fragment, validate that it can only be provided with fragment props
- * @param {ReactElement} fragment
- */
-function validateFragmentProps(fragment) {
-  // TODO: Move this to render phase instead of at element creation.
-  if (__DEV__) {
-    const keys = Object.keys(fragment.props);
-    for (let i = 0; i < keys.length; i++) {
-      const key = keys[i];
-      if (key !== 'children' && key !== 'key') {
-        setCurrentlyValidatingElement(fragment);
-        console.error(
-          'Invalid prop `%s` supplied to `React.Fragment`. ' +
-            'React.Fragment can only have `key` and `children` props.',
-          key,
-        );
-        setCurrentlyValidatingElement(null);
-        break;
-      }
-    }
-
-    if (!enableRefAsProp && fragment.ref !== null) {
-      setCurrentlyValidatingElement(fragment);
-      console.error('Invalid attribute `ref` supplied to `React.Fragment`.');
-      setCurrentlyValidatingElement(null);
-    }
   }
 }
 

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -342,7 +342,7 @@ function ReactElement(
       configurable: false,
       enumerable: false,
       writable: true,
-      value: false,
+      value: 0,
     });
     // debugInfo contains Server Component debug information.
     Object.defineProperty(element, '_debugInfo', {
@@ -1073,7 +1073,7 @@ function validateChildKeys(node, parentType) {
     } else if (isValidElement(node)) {
       // This element was passed in a valid location.
       if (node._store) {
-        node._store.validated = true;
+        node._store.validated = 1;
       }
     } else {
       const iteratorFn = getIteratorFn(node);
@@ -1133,7 +1133,7 @@ function validateExplicitKey(element, parentType) {
     if (!element._store || element._store.validated || element.key != null) {
       return;
     }
-    element._store.validated = true;
+    element._store.validated = 1;
 
     const currentComponentErrorInfo = getCurrentComponentErrorInfo(parentType);
     if (ownerHasKeyUseWarning[currentComponentErrorInfo]) {

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -728,7 +728,12 @@ export function jsxDEV(type, config, maybeKey, isStaticChildren, source, self) {
  */
 export function createElement(type, config, children) {
   if (__DEV__) {
-    if (!isValidElementType(type)) {
+    if (!enableOwnerStacks && !isValidElementType(type)) {
+      // This is just an optimistic check that provides a better stack trace before
+      // owner stacks. It's really up to the renderer if it's a valid element type.
+      // When owner stacks are enabled, we instead warn in the renderer and it'll
+      // have the stack trace of the JSX element anyway.
+      //
       // This is an invalid element type.
       //
       // We warn in this case but don't throw. We expect the element creation to

--- a/packages/shared/ReactComponentStackFrame.js
+++ b/packages/shared/ReactComponentStackFrame.js
@@ -315,6 +315,7 @@ function shouldConstruct(Component: Function) {
   return !!(prototype && prototype.isReactComponent);
 }
 
+// TODO: Delete this once the key warning no longer uses it. I.e. when enableOwnerStacks ship.
 export function describeUnknownElementTypeFrameInDEV(type: any): string {
   if (!__DEV__) {
     return '';

--- a/packages/shared/ReactElementType.js
+++ b/packages/shared/ReactElementType.js
@@ -23,7 +23,7 @@ export type ReactElement = {
   _owner: any,
 
   // __DEV__
-  _store: {validated: boolean, ...},
+  _store: {validated: 0 | 1 | 2, ...}, // 0: not validated, 1: validated, 2: force fail
   _debugInfo: null | ReactDebugInfo,
   _debugStack: Error,
   _debugTask: null | ConsoleTask,

--- a/packages/shared/consoleWithStackDev.js
+++ b/packages/shared/consoleWithStackDev.js
@@ -43,10 +43,12 @@ function printWarning(level, format, args) {
     const isErrorLogger =
       format === '%s\n\n%s\n' || format === '%o\n\n%s\n\n%s\n';
 
-    const stack = ReactSharedInternals.getStackAddendum();
-    if (stack !== '') {
-      format += '%s';
-      args = args.concat([stack]);
+    if (ReactSharedInternals.getCurrentStack) {
+      const stack = ReactSharedInternals.getCurrentStack();
+      if (stack !== '') {
+        format += '%s';
+        args = args.concat([stack]);
+      }
     }
 
     if (isErrorLogger) {

--- a/packages/shared/forks/consoleWithStackDev.www.js
+++ b/packages/shared/forks/consoleWithStackDev.www.js
@@ -37,8 +37,8 @@ function printWarning(level, format, args) {
     const ReactSharedInternals =
       React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
     // Defensive in case this is fired before React is initialized.
-    if (ReactSharedInternals != null) {
-      const stack = ReactSharedInternals.getStackAddendum();
+    if (ReactSharedInternals != null && ReactSharedInternals.getCurrentStack) {
+      const stack = ReactSharedInternals.getCurrentStack();
       if (stack !== '') {
         format += '%s';
         args.push(stack);

--- a/packages/shared/isValidElementType.js
+++ b/packages/shared/isValidElementType.js
@@ -35,6 +35,8 @@ import {
 
 const REACT_CLIENT_REFERENCE: symbol = Symbol.for('react.client.reference');
 
+// This function is deprecated. Don't use. Only the renderer knows what a valid type is.
+// TODO: Delete this when enableOwnerStacks ships.
 export default function isValidElementType(type: mixed): boolean {
   if (typeof type === 'string' || typeof type === 'function') {
     return true;


### PR DESCRIPTION
This is necessary to simplify the component stack handling to make way for owner stacks. It also solves some hacks that we used to have but don't quite make sense. It also solves the problem where things like key warnings get silenced in RSC because they get deduped. It also surfaces areas where we were missing key warnings to begin with.

Almost every type of warning is issued from the renderer. React Elements are really not anything special themselves. They're just lazily invoked functions and its really the renderer that determines there semantics.

We have three types of warnings that previously fired in JSX/createElement:

- Fragment props validation.
- Type validation.
- Key warning.

It's nice to be able to do some validation in the JSX/createElement because it has a more specific stack frame at the callsite. However, that's the case for every type of component and validation. That's the whole point of enableOwnerStacks. It's also not sufficient to do it in JSX/createElement so we also have validation in the renderers too. So this validation is really just an eager validation but also happens again later.

The problem with these is that we don't really know what types are valid until we get to the renderer. Additionally, by placing it in the isomorphic code it becomes harder to do deduping of warnings in a way that makes sense for that renderer. It also means we can't reuse logic for managing stacks etc.

Fragment props validation really should just be part of the renderer like any other component type. This also matters once we add Fragment refs and other fragment features. So I moved this into Fiber. However, since some Fragments don't have Fibers, I do the validation in ChildFiber instead of beginWork where it would normally happen.

For `type` validation we already do validation when rendering. By leaving it to the renderer we don't have to hard code an extra list. This list also varies by context. E.g. class components aren't allowed in RSC but client references are but we don't have an isomorphic way to identify client references because they're defined by the host config so the current logic is flawed anyway. I kept the early validation for now without the `enableOwnerStacks` since it does provide a nicer stack frame but with that flag on it'll be handled with nice stacks anyway. I normalized some of the errors to ensure tests pass.

For `key` validation it's the same principle. The mechanism for the heuristic is still the same - if it passes statically through a parent JSX/createElement call then it's considered validated. We already did print the error later from the renderer so this also disables the early log in the `enableOwnerStacks` flag.

I also added logging to Fizz so that key warnings can print in SSR logs.

Flight is a bit more complex. For elements that end up on the client we just pass the `validated` flag along to the client and let the client renderer print the error once rendered. For server components we log the error from Flight with the server component as the owner on the stack which will allow us to print the right stack for context. The factoring of this is a little tricky because we only want to warn if it's in an array parent but we want to log the error later to get the right debug info.

Fiber/Fizz has a similar factoring problem that causes us to create a fake Fiber for the owner which means the logs won't be associated with the right place in DevTools.