### PR TITLE
Update `eslint-plugin-react-compiler` README to used named rule severity in example

### DIFF
--- a/compiler/packages/eslint-plugin-react-compiler/README.md
+++ b/compiler/packages/eslint-plugin-react-compiler/README.md
@@ -34,7 +34,7 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
     "rules": {
-        "react-compiler/rule-name": 2
+        "react-compiler/rule-name": "error"
     }
 }
 ```


### PR DESCRIPTION
## Summary
Same as https://github.com/reactjs/react.dev/pull/6870

Move the eslint-rule specifier to use named `"error"` instead of numeric `2` as it's easier to read :) 

## How did you test this change?

N/A documentation.