### PR TITLE
fix: use `filename` instead of `context.filename` in eslint compiler

### DIFF
--- a/compiler/packages/eslint-plugin-react-compiler/src/rules/ReactCompilerRule.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/src/rules/ReactCompilerRule.ts
@@ -114,10 +114,7 @@ const rule: Rule.RuleModule = {
     }
 
     let babelAST;
-    if (
-      context.filename.endsWith(".tsx") ||
-      context.filename.endsWith(".ts")
-    ) {
+    if (filename.endsWith(".tsx") || filename.endsWith(".ts")) {
       try {
         const { parse: babelParse } = require("@babel/parser");
         babelAST = babelParse(sourceCode, {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Use `filename` instead of `context.filename` in eslint compiler.

The problem is that in `react-native` context may not have `filename`.

## How did you test this change?

- add `eslint` plugin to RN project;
- run eslint
