### PR TITLE
Add babel-plugin-react-compiler deps to other packages

### DIFF
--- a/compiler/packages/eslint-plugin-react-compiler/package.json
+++ b/compiler/packages/eslint-plugin-react-compiler/package.json
@@ -14,6 +14,7 @@
     "@babel/core": "^7.24.4",
     "@babel/parser": "^7.24.4",
     "@babel/plugin-proposal-private-methods": "^7.18.6",
+    "babel-plugin-react-compiler": "*",
     "hermes-parser": "^0.20.1",
     "zod": "^3.22.4",
     "zod-validation-error": "^3.0.3"

--- a/compiler/packages/react-compiler-healthcheck/package.json
+++ b/compiler/packages/react-compiler-healthcheck/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@babel/core": "^7.24.4",
     "@babel/parser": "^7.24.4",
+    "babel-plugin-react-compiler": "*",
     "chalk": "4",
     "fast-glob": "^3.3.2",
     "ora": "5.4.1",


### PR DESCRIPTION
## Summary

`eslint-plugin-react-compiler` ([src](https://github.com/facebook/react/blob/main/compiler/packages/eslint-plugin-react-compiler/src/rules/ReactCompilerRule.ts#L12-L20)) and `react-compiler-healthcheck` ([src](https://github.com/facebook/react/blob/main/compiler/packages/react-compiler-healthcheck/src/checks/reactCompiler.ts#L11-L15)) both depend on `babel-plugin-react-compiler`. This adds the missing dependency declarations to their `package.json` files.

## How did you test this change?

Clerical change, using the same wildcard declaration as the [`snap` package](https://github.com/facebook/react/blob/main/compiler/packages/snap/package.json#L28).