### PR TITLE
Add packageManager fields for Corepack compat

### DIFF
--- a/compiler/package.json
+++ b/compiler/package.json
@@ -49,5 +49,6 @@
   },
   "resolutions": {
     "react-is": "19.0.0-beta-b498834eab-20240506"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/package.json
+++ b/package.json
@@ -139,5 +139,6 @@
   "resolutions": {
     "react-is": "npm:react-is",
     "jsdom": "22.1.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
## Summary

For users with Yarn defaulted to >1 / Berry, setting up the repo will result in the creation of the `.yarn/` directory, `yarn.lock` updates, and `package.json` edits. This change enables [corepack](https://nodejs.org/api/corepack.html) users to automatically detect and use Yarn Classic with no effect on anyone else.

I targeted the latest version of Yarn Classic as a guess, since there were no engines entries to key off of. Happy to change this as desired.

## How did you test this change?

Before this, running `yarn` in a fresh clone in either the root or compiler workspaces resulted in Yarn Berry making the above changes to the repo: 2000+ `.yarn/cache` entries, lockfile regeneration, and `package.json` formatting changes.

After this, `yarn` is handled by Yarn Classic as expected and no changes occur (and repo functions as expected).