### PR TITLE
[compiler:playground] Fix broken builds

### DIFF
--- a/compiler/apps/playground/package.json
+++ b/compiler/apps/playground/package.json
@@ -25,7 +25,6 @@
     "@monaco-editor/react": "^4.4.6",
     "@playwright/test": "^1.42.1",
     "@use-gesture/react": "^10.2.22",
-    "babel-plugin-react-compiler": "*",
     "hermes-eslint": "^0.14.0",
     "invariant": "^2.2.4",
     "lz-string": "^1.5.0",

--- a/compiler/packages/snap/package.json
+++ b/compiler/packages/snap/package.json
@@ -25,7 +25,6 @@
     "@babel/preset-typescript": "^7.18.6",
     "@parcel/watcher": "^2.1.0",
     "@testing-library/react": "^13.4.0",
-    "babel-plugin-react-compiler": "*",
     "babel-plugin-syntax-hermes-parser": "^0.15.1",
     "chalk": "4",
     "fbt": "^1.0.0",

--- a/compiler/yarn.lock
+++ b/compiler/yarn.lock
@@ -3745,11 +3745,6 @@ babel-plugin-polyfill-regenerator@^0.5.0:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.4.0"
 
-babel-plugin-react-compiler@*:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-compiler/-/babel-plugin-react-compiler-0.0.0.tgz#1a1f9867fad83f217f0b3fe6f1b94cca0b77b68b"
-  integrity sha512-Kigl0V36a/6hLVH7+CCe1CCtU3mFBqBd829V//VtuG7I/pyq+B2QZJqOefd63snQmdfCryNhO9XW1FbGPBvYDA==
-
 babel-plugin-syntax-hermes-parser@^0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.15.1.tgz#d115ee9761a808af590a9b2a0b568115e25ea743"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #29122

Now that the compiler is public, the `*` version was grabbing the latest
version of the compiler off of npm and was resolving to my very first
push to npm (an empty package containing only a single package.json).
This was breaking the playground as it would attempt to load the
compiler but then crash the babel pipeline due to the node module not
being found.