### PR TITLE
[Flight] Add failing test to reproduce issue with `Object.freeze`

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/utils/WebpackMock.js
+++ b/packages/react-server-dom-webpack/src/__tests__/utils/WebpackMock.js
@@ -69,10 +69,15 @@ exports.clientExports = function clientExports(
   moduleExports,
   chunkId,
   chunkFilename,
+  blockOnChunk,
 ) {
   const chunks = [];
   if (chunkId) {
     chunks.push(chunkId, chunkFilename);
+
+    if (blockOnChunk) {
+      webpackChunkMap[chunkId] = blockOnChunk;
+    }
   }
   const idx = '' + webpackModuleIdx++;
   webpackClientModules[idx] = moduleExports;


### PR DESCRIPTION
Here's a failing test that demonstrates the issue as reported by @eps1lon in https://github.com/facebook/react/pull/29032#discussion_r1604250460.

https://github.com/facebook/react/blob/3f1436cca1f8dd80a19fd52b97b6ff71a4d9ce82/packages/react-client/src/ReactFlightClient.js#L644

When the props object is frozen, the Flight Client's model resolver can't mutate the parent object (i.e. the props) anymore, after the client component that was referenced in the props has been loaded.

https://github.com/facebook/react/blob/3f1436cca1f8dd80a19fd52b97b6ff71a4d9ce82/packages/react-client/src/ReactFlightClient.js#L701