### PR TITLE
[compiler:playground] Resizable tabs

### DIFF
--- a/compiler/apps/playground/components/Editor/EditorImpl.tsx
+++ b/compiler/apps/playground/components/Editor/EditorImpl.tsx
@@ -320,7 +320,6 @@ export default function Editor() {
     <>
       <div className="relative flex basis top-14">
         <div
-          style={{ minWidth: 650 }}
           className={clsx("relative sm:basis-1/4")}
         >
           <Input

--- a/compiler/apps/playground/components/Editor/Input.tsx
+++ b/compiler/apps/playground/components/Editor/Input.tsx
@@ -10,6 +10,7 @@ import { CompilerErrorDetail } from "babel-plugin-react-compiler/src";
 import invariant from "invariant";
 import type { editor } from "monaco-editor";
 import * as monaco from "monaco-editor";
+import { Resizable } from "re-resizable";
 import { useEffect, useState } from "react";
 import { renderReactCompilerMarkers } from "../../lib/reactCompilerMonacoDiagnostics";
 import { useStore, useStoreDispatch } from "../StoreContext";
@@ -102,9 +103,13 @@ export default function Input({ errors }: Props) {
 
   return (
     <div className="relative flex flex-col flex-none border-r border-gray-200">
-      {/* Restrict MonacoEditor's height, since the config autoLayout:true
-          will grow the editor to fit within parent element */}
-      <div className="w-full" style={{ height: "calc(100vh - 3.5rem)" }}>
+      <Resizable
+        minWidth={650}
+        enable={{ right: true }}
+        // Restrict MonacoEditor's height, since the config autoLayout:true
+        // will grow the editor to fit within parent element
+        className="!h-[calc(100vh_-_3.5rem)]"
+      >
         <MonacoEditor
           path={"index.js"}
           // .js and .jsx files are specified to be TS so that Monaco can actually
@@ -116,7 +121,7 @@ export default function Input({ errors }: Props) {
           onChange={handleChange}
           options={monacoOptions}
         />
-      </div>
+      </Resizable>
     </div>
   );
 }

--- a/compiler/apps/playground/components/Editor/Output.tsx
+++ b/compiler/apps/playground/components/Editor/Output.tsx
@@ -130,7 +130,7 @@ async function tabify(source: string, compilerOutput: CompilerOutput) {
         <>
           <iframe
             src={sourceMapUrl}
-            className="w-full h-96"
+            className="w-full h-monaco_small sm:h-monaco"
             title="Generated Code"
           />
         </>,

--- a/compiler/apps/playground/components/TabbedWindow.tsx
+++ b/compiler/apps/playground/components/TabbedWindow.tsx
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { Resizable } from "re-resizable";
 import React, { useCallback } from "react";
 
 type TabsRecord = Map<string, React.ReactNode>;
@@ -68,7 +69,7 @@ function TabbedWindowItem({
   return (
     <div key={name} className="flex flex-row">
       {isShow ? (
-        <div className="border-r" style={{ minWidth: 550, overflow: "hidden" }}>
+        <Resizable className="border-r" minWidth={550} enable={{ right: true }}>
           <h2
             title="Minimize tab"
             aria-label="Minimize tab"
@@ -78,7 +79,7 @@ function TabbedWindowItem({
             - {name}
           </h2>
           {tabs.get(name) ?? <div>No output for {name}</div>}
-        </div>
+        </Resizable>
       ) : (
         <div className="relative items-center h-full px-1 py-6 align-middle border-r border-grey-200">
           <button

--- a/compiler/apps/playground/package.json
+++ b/compiler/apps/playground/package.json
@@ -33,6 +33,7 @@
     "notistack": "^3.0.0-alpha.7",
     "prettier": "3.0.3",
     "pretty-format": "^29.3.1",
+    "re-resizable": "^6.9.16",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-compiler-runtime": "*"

--- a/compiler/yarn.lock
+++ b/compiler/yarn.lock
@@ -8427,6 +8427,11 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
+re-resizable@^6.9.16:
+  version "6.9.16"
+  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.9.16.tgz#d040a3ba9ccb25a3cc85b7622d4eafdee48cf2c2"
+  integrity sha512-D9+ofwgPQRC6PL6cwavCZO9MUR8TKKxV1nHjbutSdNaFHK9v5k8m6DcESMXrw1+mRJn7fBHJRhZpa7EQ1ZWEEA==
+
 react-dom@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"


### PR DESCRIPTION
## Summary

Every tab wraps the text around but there is no way to resize it. It was also hard to use the source map tab. It doesn't occupy the full height nor is the tab resizable. So I made all the tabs resizable.
> Also,
> * make the source map tab occupy full height
> * make it a teeny tiny bit easier to work with the compiler playground (especially source map)

## How did you test this change?

https://github.com/facebook/react/assets/91976421/cdec30e8-cadb-4958-8786-31c54ea83bd6

