### PR TITLE
compiler: Improve ValidateNoRefAccessInRender to ignore access in effects

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-in-effect-indirect-usecallback.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-in-effect-indirect-usecallback.expect.md
@@ -1,0 +1,106 @@
+
+## Input
+
+```javascript
+import { useCallback, useEffect, useState } from "react";
+
+let someGlobal = {};
+
+function Component() {
+  const [state, setState] = useState(someGlobal);
+
+  const setGlobal = useCallback(() => {
+    someGlobal.value = true;
+  }, []);
+  useEffect(() => {
+    setGlobal();
+  }, []);
+
+  useEffect(() => {
+    setState(someGlobal.value);
+  }, [someGlobal]);
+
+  return <div>{String(state)}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { useCallback, useEffect, useState } from "react";
+
+let someGlobal = {};
+
+function Component() {
+  const $ = _c(7);
+  const [state, setState] = useState(someGlobal);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = () => {
+      someGlobal.value = true;
+    };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const setGlobal = t0;
+  let t1;
+  let t2;
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t1 = () => {
+      setGlobal();
+    };
+    t2 = [];
+    $[1] = t1;
+    $[2] = t2;
+  } else {
+    t1 = $[1];
+    t2 = $[2];
+  }
+  useEffect(t1, t2);
+  let t3;
+  if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
+    t3 = () => {
+      setState(someGlobal.value);
+    };
+    $[3] = t3;
+  } else {
+    t3 = $[3];
+  }
+  let t4;
+  if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
+    t4 = [someGlobal];
+    $[4] = t4;
+  } else {
+    t4 = $[4];
+  }
+  useEffect(t3, t4);
+
+  const t5 = String(state);
+  let t6;
+  if ($[5] !== t5) {
+    t6 = <div>{t5}</div>;
+    $[5] = t5;
+    $[6] = t6;
+  } else {
+    t6 = $[6];
+  }
+  return t6;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>true</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-in-effect-indirect-usecallback.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-in-effect-indirect-usecallback.js
@@ -1,0 +1,25 @@
+import { useCallback, useEffect, useState } from "react";
+
+let someGlobal = {};
+
+function Component() {
+  const [state, setState] = useState(someGlobal);
+
+  const setGlobal = useCallback(() => {
+    someGlobal.value = true;
+  }, []);
+  useEffect(() => {
+    setGlobal();
+  }, []);
+
+  useEffect(() => {
+    setState(someGlobal.value);
+  }, [someGlobal]);
+
+  return <div>{String(state)}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-in-effect-indirect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-in-effect-indirect.expect.md
@@ -1,0 +1,106 @@
+
+## Input
+
+```javascript
+import { useEffect, useState } from "react";
+
+let someGlobal = {};
+
+function Component() {
+  const [state, setState] = useState(someGlobal);
+
+  const setGlobal = () => {
+    someGlobal.value = true;
+  };
+  useEffect(() => {
+    setGlobal();
+  }, []);
+
+  useEffect(() => {
+    setState(someGlobal.value);
+  }, [someGlobal]);
+
+  return <div>{String(state)}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { useEffect, useState } from "react";
+
+let someGlobal = {};
+
+function Component() {
+  const $ = _c(7);
+  const [state, setState] = useState(someGlobal);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = () => {
+      someGlobal.value = true;
+    };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const setGlobal = t0;
+  let t1;
+  let t2;
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t1 = () => {
+      setGlobal();
+    };
+    t2 = [];
+    $[1] = t1;
+    $[2] = t2;
+  } else {
+    t1 = $[1];
+    t2 = $[2];
+  }
+  useEffect(t1, t2);
+  let t3;
+  if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
+    t3 = () => {
+      setState(someGlobal.value);
+    };
+    $[3] = t3;
+  } else {
+    t3 = $[3];
+  }
+  let t4;
+  if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
+    t4 = [someGlobal];
+    $[4] = t4;
+  } else {
+    t4 = $[4];
+  }
+  useEffect(t3, t4);
+
+  const t5 = String(state);
+  let t6;
+  if ($[5] !== t5) {
+    t6 = <div>{t5}</div>;
+    $[5] = t5;
+    $[6] = t6;
+  } else {
+    t6 = $[6];
+  }
+  return t6;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>true</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-in-effect-indirect.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-in-effect-indirect.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+let someGlobal = {};
+
+function Component() {
+  const [state, setState] = useState(someGlobal);
+
+  const setGlobal = () => {
+    someGlobal.value = true;
+  };
+  useEffect(() => {
+    setGlobal();
+  }, []);
+
+  useEffect(() => {
+    setState(someGlobal.value);
+  }, [someGlobal]);
+
+  return <div>{String(state)}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-unused-usecallback.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-unused-usecallback.expect.md
@@ -1,0 +1,48 @@
+
+## Input
+
+```javascript
+import { useCallback, useEffect, useState } from "react";
+
+function Component() {
+  const callback = useCallback(() => {
+    window.foo = true;
+  }, []);
+
+  return <div>Ok</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { useCallback, useEffect, useState } from "react";
+
+function Component() {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = <div>Ok</div>;
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>Ok</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-unused-usecallback.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-unused-usecallback.js
@@ -1,0 +1,14 @@
+import { useCallback, useEffect, useState } from "react";
+
+function Component() {
+  const callback = useCallback(() => {
+    window.foo = true;
+  }, []);
+
+  return <div>Ok</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-effect-indirect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-effect-indirect.expect.md
@@ -1,0 +1,121 @@
+
+## Input
+
+```javascript
+// @validateRefAccessDuringRender
+import { useCallback, useEffect, useRef, useState } from "react";
+
+function Component() {
+  const ref = useRef(null);
+  const [state, setState] = useState(false);
+  const setRef = useCallback(() => {
+    ref.current = "Ok";
+  }, []);
+
+  useEffect(() => {
+    setRef();
+  }, []);
+
+  useEffect(() => {
+    setState(true);
+  }, []);
+
+  // We use state to force a re-render and observe whether the
+  // ref updated. This lets us check that the effect actually ran
+  // and wasn't DCE'd
+  return <Child key={String(state)} ref={ref} />;
+}
+
+function Child({ ref }) {
+  // This violates the rules of React, so we access the ref in a child
+  // component
+  return ref.current;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRender
+import { useCallback, useEffect, useRef, useState } from "react";
+
+function Component() {
+  const $ = _c(9);
+  const ref = useRef(null);
+  const [state, setState] = useState(false);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = () => {
+      ref.current = "Ok";
+    };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const setRef = t0;
+  let t1;
+  if ($[1] !== setRef) {
+    t1 = () => {
+      setRef();
+    };
+    $[1] = setRef;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  let t2;
+  if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = [];
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  useEffect(t1, t2);
+  let t3;
+  let t4;
+  if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
+    t3 = () => {
+      setState(true);
+    };
+    t4 = [];
+    $[4] = t3;
+    $[5] = t4;
+  } else {
+    t3 = $[4];
+    t4 = $[5];
+  }
+  useEffect(t3, t4);
+
+  const t5 = String(state);
+  let t6;
+  if ($[6] !== t5 || $[7] !== ref) {
+    t6 = <Child key={t5} ref={ref} />;
+    $[6] = t5;
+    $[7] = ref;
+    $[8] = t6;
+  } else {
+    t6 = $[8];
+  }
+  return t6;
+}
+
+function Child(t0) {
+  const { ref } = t0;
+  return ref.current;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+      
+### Eval output
+(kind: ok) Ok

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-effect-indirect.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-effect-indirect.js
@@ -1,0 +1,34 @@
+// @validateRefAccessDuringRender
+import { useCallback, useEffect, useRef, useState } from "react";
+
+function Component() {
+  const ref = useRef(null);
+  const [state, setState] = useState(false);
+  const setRef = useCallback(() => {
+    ref.current = "Ok";
+  }, []);
+
+  useEffect(() => {
+    setRef();
+  }, []);
+
+  useEffect(() => {
+    setState(true);
+  }, []);
+
+  // We use state to force a re-render and observe whether the
+  // ref updated. This lets us check that the effect actually ran
+  // and wasn't DCE'd
+  return <Child key={String(state)} ref={ref} />;
+}
+
+function Child({ ref }) {
+  // This violates the rules of React, so we access the ref in a child
+  // component
+  return ref.current;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-effect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-effect.expect.md
@@ -1,0 +1,103 @@
+
+## Input
+
+```javascript
+// @validateRefAccessDuringRender
+import { useEffect, useRef, useState } from "react";
+
+function Component() {
+  const ref = useRef(null);
+  const [state, setState] = useState(false);
+  useEffect(() => {
+    ref.current = "Ok";
+  }, []);
+
+  useEffect(() => {
+    setState(true);
+  }, []);
+
+  // We use state to force a re-render and observe whether the
+  // ref updated. This lets us check that the effect actually ran
+  // and wasn't DCE'd
+  return <Child key={String(state)} ref={ref} />;
+}
+
+function Child({ ref }) {
+  // This violates the rules of React, so we access the ref in a child
+  // component
+  return ref.current;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRender
+import { useEffect, useRef, useState } from "react";
+
+function Component() {
+  const $ = _c(7);
+  const ref = useRef(null);
+  const [state, setState] = useState(false);
+  let t0;
+  let t1;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = () => {
+      ref.current = "Ok";
+    };
+    t1 = [];
+    $[0] = t0;
+    $[1] = t1;
+  } else {
+    t0 = $[0];
+    t1 = $[1];
+  }
+  useEffect(t0, t1);
+  let t2;
+  let t3;
+  if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = () => {
+      setState(true);
+    };
+    t3 = [];
+    $[2] = t2;
+    $[3] = t3;
+  } else {
+    t2 = $[2];
+    t3 = $[3];
+  }
+  useEffect(t2, t3);
+
+  const t4 = String(state);
+  let t5;
+  if ($[4] !== t4 || $[5] !== ref) {
+    t5 = <Child key={t4} ref={ref} />;
+    $[4] = t4;
+    $[5] = ref;
+    $[6] = t5;
+  } else {
+    t5 = $[6];
+  }
+  return t5;
+}
+
+function Child(t0) {
+  const { ref } = t0;
+  return ref.current;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+      
+### Eval output
+(kind: ok) Ok

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-effect.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-effect.js
@@ -1,0 +1,30 @@
+// @validateRefAccessDuringRender
+import { useEffect, useRef, useState } from "react";
+
+function Component() {
+  const ref = useRef(null);
+  const [state, setState] = useState(false);
+  useEffect(() => {
+    ref.current = "Ok";
+  }, []);
+
+  useEffect(() => {
+    setState(true);
+  }, []);
+
+  // We use state to force a re-render and observe whether the
+  // ref updated. This lets us check that the effect actually ran
+  // and wasn't DCE'd
+  return <Child key={String(state)} ref={ref} />;
+}
+
+function Child({ ref }) {
+  // This violates the rules of React, so we access the ref in a child
+  // component
+  return ref.current;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-unused-callback-nested.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-unused-callback-nested.expect.md
@@ -1,0 +1,104 @@
+
+## Input
+
+```javascript
+// @validateRefAccessDuringRender
+import { useEffect, useRef, useState } from "react";
+
+function Component() {
+  const ref = useRef(null);
+  const [state, setState] = useState(false);
+  useEffect(() => {
+    const callback = () => {
+      ref.current = "Ok";
+    };
+  }, []);
+
+  useEffect(() => {
+    setState(true);
+  }, []);
+
+  // We use state to force a re-render and observe whether the
+  // ref updated. This lets us check that the effect actually ran
+  // and wasn't DCE'd
+  return <Child key={String(state)} ref={ref} />;
+}
+
+function Child({ ref }) {
+  // This violates the rules of React, so we access the ref in a child
+  // component
+  return ref.current;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRender
+import { useEffect, useRef, useState } from "react";
+
+function Component() {
+  const $ = _c(7);
+  const ref = useRef(null);
+  const [state, setState] = useState(false);
+  let t0;
+  let t1;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = () => {};
+
+    t1 = [];
+    $[0] = t0;
+    $[1] = t1;
+  } else {
+    t0 = $[0];
+    t1 = $[1];
+  }
+  useEffect(t0, t1);
+  let t2;
+  let t3;
+  if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = () => {
+      setState(true);
+    };
+    t3 = [];
+    $[2] = t2;
+    $[3] = t3;
+  } else {
+    t2 = $[2];
+    t3 = $[3];
+  }
+  useEffect(t2, t3);
+
+  const t4 = String(state);
+  let t5;
+  if ($[4] !== t4 || $[5] !== ref) {
+    t5 = <Child key={t4} ref={ref} />;
+    $[4] = t4;
+    $[5] = ref;
+    $[6] = t5;
+  } else {
+    t5 = $[6];
+  }
+  return t5;
+}
+
+function Child(t0) {
+  const { ref } = t0;
+  return ref.current;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+      
+### Eval output
+(kind: ok) 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-unused-callback-nested.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-unused-callback-nested.js
@@ -1,0 +1,32 @@
+// @validateRefAccessDuringRender
+import { useEffect, useRef, useState } from "react";
+
+function Component() {
+  const ref = useRef(null);
+  const [state, setState] = useState(false);
+  useEffect(() => {
+    const callback = () => {
+      ref.current = "Ok";
+    };
+  }, []);
+
+  useEffect(() => {
+    setState(true);
+  }, []);
+
+  // We use state to force a re-render and observe whether the
+  // ref updated. This lets us check that the effect actually ran
+  // and wasn't DCE'd
+  return <Child key={String(state)} ref={ref} />;
+}
+
+function Child({ ref }) {
+  // This violates the rules of React, so we access the ref in a child
+  // component
+  return ref.current;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #29154
* __->__ #29151

Improves ValidateNoRefAccessInRender (still disabled by default) to properly ignore ref access within effects. This includes allowing ref access within functions that are only transitively called from an effect.

While I was here I also added some extra test fixtures for allowing global mutation in effects.