### PR TITLE
compiler: fix accidental propagation of function effects from StartMemoize/FinishMemoize

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReferenceEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReferenceEffects.ts
@@ -1611,14 +1611,14 @@ function inferBlock(
               val,
               Effect.Freeze,
               ValueReason.Other,
-              functionEffects
+              []
             );
           } else {
             state.referenceAndRecordEffects(
               val,
               Effect.Read,
               ValueReason.Other,
-              functionEffects
+              []
             );
           }
         }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-in-effect-indirect-usecallback.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-in-effect-indirect-usecallback.expect.md
@@ -2,6 +2,7 @@
 ## Input
 
 ```javascript
+// @validatePreserveExistingMemoizationGuarantees
 import { useCallback, useEffect, useState } from "react";
 
 let someGlobal = {};
@@ -33,7 +34,7 @@ export const FIXTURE_ENTRYPOINT = {
 ## Code
 
 ```javascript
-import { c as _c } from "react/compiler-runtime";
+import { c as _c } from "react/compiler-runtime"; // @validatePreserveExistingMemoizationGuarantees
 import { useCallback, useEffect, useState } from "react";
 
 let someGlobal = {};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-in-effect-indirect-usecallback.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-in-effect-indirect-usecallback.js
@@ -1,3 +1,4 @@
+// @validatePreserveExistingMemoizationGuarantees
 import { useCallback, useEffect, useState } from "react";
 
 let someGlobal = {};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #29154
* #29151

By default, React Compiler will skip compilation if it cannot preserve existing memoization. Ie, if the code has an existing `useMemo()` or `useCallback()` and the compiler cannot determine that it is safe to keep that memoization — or do even better — then we'll leave the code alone. The actual compilation doesn't use any hints from existing memo calls, this is purely to check and avoid regressing any specific memoization that developers may have already applied.

However, we were accidentally reporting some false-positive _validation_ errors due to the StartMemoize and FinishMemoize instructions that we emit to track where the memoization was in the source code. This is now fixed.

Fixes #29131
Fixes #29132