### PR TITLE
[compiler:chore] fix SSA pdf reference link

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/SSA/EliminateRedundantPhi.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/SSA/EliminateRedundantPhi.ts
@@ -21,7 +21,7 @@ import {
  * In both these cases, the phi is eliminated and all usages of the phi identifier
  * are replaced with the other operand (ie in both cases above, all usages of `x2` are replaced with `x1` .
  *
- * The algorithm is inspired by that in https://pp.info.uni-karlsruhe.de/uploads/publikationen/braun13cc.pdf
+ * The algorithm is inspired by that in https://c9x.me/compile/bib/braun13cc.pdf
  * but modified to reduce passes over the CFG. We visit the blocks in reverse postorder. Each time a redundant
  * phi is encountered we add a mapping (eg x2 -> x1) to a rewrite table. Subsequent instructions, terminals,
  * and phis rewrite all their identifiers based on this table. The algorithm loops over the CFG repeatedly

--- a/compiler/packages/babel-plugin-react-compiler/src/SSA/EliminateRedundantPhi.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/SSA/EliminateRedundantPhi.ts
@@ -21,7 +21,7 @@ import {
  * In both these cases, the phi is eliminated and all usages of the phi identifier
  * are replaced with the other operand (ie in both cases above, all usages of `x2` are replaced with `x1` .
  *
- * The algorithm is inspired by that in https://c9x.me/compile/bib/braun13cc.pdf
+ * The algorithm is inspired by that in https://pp.ipd.kit.edu/uploads/publikationen/braun13cc.pdf
  * but modified to reduce passes over the CFG. We visit the blocks in reverse postorder. Each time a redundant
  * phi is encountered we add a mapping (eg x2 -> x1) to a rewrite table. Subsequent instructions, terminals,
  * and phis rewrite all their identifiers based on this table. The algorithm loops over the CFG repeatedly


### PR DESCRIPTION
## Summary

This PR fixes the deadlink in the SSA comment. Previously the attached link is down now.

## How did you test this change?

1. I can confirm the PDF in the new link is the same as the old now. Reference: https://www.recompiled.dev/blog/ssa/
2. I can confirm the old link is down, and it is [not just me](https://downforeveryoneorjustme.com/pp.info.uni-karlsruhe.de?proto=https)

<img width="580" alt="image" src="https://github.com/facebook/react/assets/2883231/eeca5eda-6f61-4ac4-a113-1b04370533d9">
