### PR TITLE
Remove pointless use of `unsafe`

### DIFF
--- a/compiler/crates/react_utils/src/pointer_address.rs
+++ b/compiler/crates/react_utils/src/pointer_address.rs
@@ -16,12 +16,7 @@ pub struct PointerAddress(usize);
 
 impl PointerAddress {
     pub fn new<T>(ptr: &T) -> Self {
-        // SAFETY: We convert the pointer into a usize for use as an identifier.
-        // This is _safe_ but may lead to logical bugs if different values can
-        // be stored at the same memory address within the lifetime of the
-        // PointerAddress.
-        let ptr_address: usize = unsafe { std::mem::transmute(ptr) };
-        Self(ptr_address)
+        Self(ptr as *const T as usize)
     }
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Removed a call to `std::mem::transmute` that could be replaced with `as`-casts.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

I found no tests for this part of the codebase. However, this code is clearly semantically identical, barring any weirdness coming from pointer transmutes.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
