### PR TITLE
fix: mobile layout for compiler playground

### DIFF
--- a/compiler/apps/playground/app/layout.tsx
+++ b/compiler/apps/playground/app/layout.tsx
@@ -42,7 +42,7 @@ export default function RootLayout({
           crossOrigin="anonymous"
         />
       </head>
-      <body className="font-sans h-screen overflow-y-hidden">{children}</body>
+      <body className="font-sans h-screen">{children}</body>
     </html>
   );
 }

--- a/compiler/apps/playground/components/Editor/EditorImpl.tsx
+++ b/compiler/apps/playground/components/Editor/EditorImpl.tsx
@@ -318,7 +318,7 @@ export default function Editor() {
 
   return (
     <>
-      <div className="relative flex basis top-14">
+      <div className="relative flex basis top-14 flex-col sm:flex-row overflow-y-hidden sm:!h-[calc(100vh_-_3.5rem)]">
         <div
           className={clsx("relative sm:basis-1/4")}
         >
@@ -328,7 +328,7 @@ export default function Editor() {
             }
           />
         </div>
-        <div className={clsx("flex sm:flex flex-wrap")}>
+        <div className="flex w-full border-t sm:border-t-0">
           <Output store={deferredStore} compilerOutput={compilerOutput} />
         </div>
       </div>

--- a/compiler/apps/playground/components/Editor/Input.tsx
+++ b/compiler/apps/playground/components/Editor/Input.tsx
@@ -104,11 +104,11 @@ export default function Input({ errors }: Props) {
   return (
     <div className="relative flex flex-col flex-none border-r border-gray-200">
       <Resizable
-        minWidth={650}
+        minWidth={'320px'}
         enable={{ right: true }}
         // Restrict MonacoEditor's height, since the config autoLayout:true
         // will grow the editor to fit within parent element
-        className="!h-[calc(100vh_-_3.5rem)]"
+        className="sm:!h-[calc(100vh_-_3.5rem)] !h-[calc(50vh_-_3.5rem)]"
       >
         <MonacoEditor
           path={"index.js"}

--- a/compiler/apps/playground/components/Editor/Output.tsx
+++ b/compiler/apps/playground/components/Editor/Output.tsx
@@ -197,14 +197,14 @@ function Output({ store, compilerOutput }: Props) {
       />
       {compilerOutput.kind === "err" ? (
         <div
-          className="flex flex-wrap absolute bottom-0 bg-white grow border-y border-grey-200 transition-all ease-in"
+          className="flex flex-wrap absolute bottom-0 bg-white grow border-y border-grey-200"
           style={{ width: "calc(100vw - 650px)" }}
         >
           <div className="w-full p-4 basis-full border-b">
             <h2>COMPILER ERRORS</h2>
           </div>
           <pre
-            className="p-4 basis-full text-red-600 overflow-y-scroll whitespace-pre-wrap"
+            className="p-4 basis-full text-red-600 whitespace-pre-wrap"
             style={{ width: "calc(100vw - 650px)", height: "150px" }}
           >
             <code>{compilerOutput.error.toString()}</code>

--- a/compiler/apps/playground/components/Header.tsx
+++ b/compiler/apps/playground/components/Header.tsx
@@ -45,7 +45,7 @@ export default function Header() {
   };
 
   return (
-    <div className="fixed z-10 flex items-center justify-between w-screen px-5 py-3 bg-white border-b border-gray-200 h-14">
+    <div className="fixed z-10 flex items-center justify-between w-full px-5 py-3 bg-white border-b border-gray-200 h-14">
       <div className="flex items-center flex-none h-full gap-2 text-lg">
         <Logo
           className={clsx(

--- a/compiler/apps/playground/components/TabbedWindow.tsx
+++ b/compiler/apps/playground/components/TabbedWindow.tsx
@@ -27,7 +27,7 @@ export default function TabbedWindow(props: {
     );
   }
   return (
-    <div className="flex flex-row">
+    <div className="flex flex-col sm:flex-row w-full">
       {Array.from(props.tabs.keys()).map((name) => {
         return (
           <TabbedWindowItem
@@ -67,9 +67,11 @@ function TabbedWindowItem({
   }, [tabsOpen, name, setTabsOpen]);
 
   return (
-    <div key={name} className="flex flex-row">
+    <div key={name} className="flex w-full">
       {isShow ? (
-        <Resizable className="border-r" minWidth={550} enable={{ right: true }}>
+        <Resizable className="border-r" size={{
+          width: '100%',
+        }} minWidth={'320px'} enable={{ right: true }}>
           <h2
             title="Minimize tab"
             aria-label="Minimize tab"
@@ -81,13 +83,13 @@ function TabbedWindowItem({
           {tabs.get(name) ?? <div>No output for {name}</div>}
         </Resizable>
       ) : (
-        <div className="relative items-center h-full px-1 py-6 align-middle border-r border-grey-200">
+        <div className="items-center w-full sm:h-full p-2 sm:px-1 sm:py-6 border-b sm:border-b-0 sm:border-r border-grey-200">
           <button
             title={`Expand compiler tab: ${name}`}
             aria-label={`Expand compiler tab: ${name}`}
-            style={{ transform: "rotate(90deg) translate(-50%)" }}
+            // style={{ transform: "rotate(90deg) translate(-50%)" }}
             onClick={toggleTabs}
-            className="flex-grow-0 w-5 transition-colors duration-150 ease-in font-medium text-secondary hover:text-link"
+            className=" sm:w-5 transition-colors duration-150 ease-in font-medium text-secondary hover:text-link sm:rotate-90 sm:-translate-1/2 text-sm sm:text-base"
           >
             {name}
           </button>

--- a/compiler/apps/playground/package.json
+++ b/compiler/apps/playground/package.json
@@ -24,6 +24,7 @@
     "@heroicons/react": "^1.0.6",
     "@monaco-editor/react": "^4.4.6",
     "@playwright/test": "^1.42.1",
+    "@types/react": "^18.3.2",
     "@use-gesture/react": "^10.2.22",
     "hermes-eslint": "^0.14.0",
     "invariant": "^2.2.4",
@@ -35,8 +36,8 @@
     "pretty-format": "^29.3.1",
     "re-resizable": "^6.9.16",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-compiler-runtime": "*"
+    "react-compiler-runtime": "*",
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
     "@types/node": "18.11.9",


### PR DESCRIPTION
- Adds different layout for mobile
- removes un necessary scrolls in playground desktop mode
- adds `@types/react` to package.json as it was missing in package.json but was being consumed from inside the app