### PR TITLE
feat(compiler-healthcheck): Support strict mode check for nextjs apps

### DIFF
--- a/compiler/packages/react-compiler-healthcheck/src/checks/strictMode.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/checks/strictMode.ts
@@ -8,16 +8,20 @@
 import chalk from "chalk";
 
 const JsFileExtensionRE = /(js|ts|jsx|tsx)$/;
+const NextConfigFileRE = /^next\.config\.(js|mjs)$/;
 const StrictModeRE = /<(React\.StrictMode|StrictMode)>/;
+const NextStrictModeRE = /reactStrictMode:\s*true/;
 let StrictModeUsage = false;
 
 export default {
   run(source: string, path: string): void {
-    if (JsFileExtensionRE.exec(path) === null) {
+    if (StrictModeUsage) {
       return;
     }
 
-    if (!StrictModeUsage) {
+    if (NextConfigFileRE.exec(path) !== null) {
+      StrictModeUsage = NextStrictModeRE.exec(source) !== null;
+    } else if (JsFileExtensionRE.exec(path) !== null) {
       StrictModeUsage = StrictModeRE.exec(source) !== null;
     }
   },

--- a/compiler/packages/react-compiler-healthcheck/src/index.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/index.ts
@@ -20,7 +20,7 @@ async function main() {
     .option("src", {
       description: "glob expression matching src files to compile",
       type: "string",
-      default: "**/+(*.{js,jsx,ts,tsx}|package.json)",
+      default: "**/+(*.{js,mjs,jsx,ts,tsx}|package.json)",
     })
     .parseSync();
 


### PR DESCRIPTION
## Summary

Closes #29130 

## How did you test this change?

Run the healthcheck in the compiler playground and the nodejs.org repo for the next config with a `.mjs` extension. Sanity with Vite React template.