### PR TITLE
React DOM: Treat toggle and beforetoggle as discrete events

### DIFF
--- a/packages/react-dom-bindings/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom-bindings/src/events/ReactDOMEventListener.js
@@ -290,6 +290,7 @@ export function findInstanceBlockingTarget(
 export function getEventPriority(domEventName: DOMEventName): EventPriority {
   switch (domEventName) {
     // Used by SimpleEventPlugin:
+    case 'beforetoggle':
     case 'cancel':
     case 'click':
     case 'close':
@@ -321,6 +322,7 @@ export function getEventPriority(domEventName: DOMEventName): EventPriority {
     case 'resize':
     case 'seeked':
     case 'submit':
+    case 'toggle':
     case 'touchcancel':
     case 'touchend':
     case 'touchstart':
@@ -345,7 +347,6 @@ export function getEventPriority(domEventName: DOMEventName): EventPriority {
     case 'select':
     case 'selectstart':
       return DiscreteEventPriority;
-    case 'beforetoggle':
     case 'drag':
     case 'dragenter':
     case 'dragexit':
@@ -358,7 +359,6 @@ export function getEventPriority(domEventName: DOMEventName): EventPriority {
     case 'pointerout':
     case 'pointerover':
     case 'scroll':
-    case 'toggle':
     case 'touchmove':
     case 'wheel':
     // Not used by React but could be by user code: (fall through)


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/facebook/react/pull/27981#discussion_r1493808116

`toggle` (and therefore `beforetoggle`) is an intentional event that is discrete (either we toggled something or we didn't). This PR adjusts the event priority accordingly. 

`toggle` was only supported on `<details>` and used to use continuous event priority. `beforetoggle` and the generic `toggle` event were only recently introduced.

## How did you test this change?

I don't think we have tests for event priority?