### PR TITLE
Enable `disableStringRefs` and `enableRefAsProp` for React Native (Meta)

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -20,10 +20,8 @@
 export const alwaysThrottleRetries = __VARIANT__;
 export const consoleManagedByDevToolsDuringStrictMode = __VARIANT__;
 export const disableDefaultPropsExceptForClasses = __VARIANT__;
-export const disableStringRefs = __VARIANT__;
 export const enableAddPropertiesFastPath = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const enableFastJSX = __VARIANT__;
 export const enableInfiniteRenderLoopDetection = __VARIANT__;
-export const enableRefAsProp = __VARIANT__;
 export const passChildrenWhenCloningPersistedNodes = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -22,12 +22,10 @@ export const {
   alwaysThrottleRetries,
   consoleManagedByDevToolsDuringStrictMode,
   disableDefaultPropsExceptForClasses,
-  disableStringRefs,
   enableAddPropertiesFastPath,
   enableDeferRootSchedulingToMicrotask,
   enableFastJSX,
   enableInfiniteRenderLoopDetection,
-  enableRefAsProp,
   passChildrenWhenCloningPersistedNodes,
 } = dynamicFlags;
 
@@ -94,6 +92,9 @@ export const enableUseDeferredValueInitialArg = true;
 export const disableClientCache = true;
 
 export const enableServerComponentLogs = true;
+
+export const enableRefAsProp = true;
+export const disableStringRefs = true;
 
 export const enableReactTestRendererWarning = false;
 export const disableLegacyMode = false;


### PR DESCRIPTION
## Summary

Enables the `disableStringRefs` and `enableRefAsProp` feature flags for React Native (Meta).

## How did you test this change?

```
$ yarn test
$ yarn flow fabric
```