### PR TITLE
[compiler] Make @types/node versions consistent

### DIFF
--- a/compiler/apps/playground/package.json
+++ b/compiler/apps/playground/package.json
@@ -39,7 +39,7 @@
     "react-compiler-runtime": "*"
   },
   "devDependencies": {
-    "@types/node": "18.11.9",
+    "@types/node": "18.7.19",
     "@types/prettier": "^2.7.1",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.9",

--- a/compiler/packages/eslint-plugin-react-compiler/package.json
+++ b/compiler/packages/eslint-plugin-react-compiler/package.json
@@ -23,7 +23,7 @@
     "@babel/preset-typescript": "^7.18.6",
     "@babel/types": "^7.19.0",
     "@types/eslint": "^8.56.6",
-    "@types/node": "^20.2.5",
+    "@types/node": "18.7.19",
     "babel-jest": "^29.0.3",
     "eslint": "8.57.0",
     "hermes-eslint": "^0.17.1",

--- a/compiler/packages/make-read-only-util/package.json
+++ b/compiler/packages/make-read-only-util/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/invariant": "^2.2.35",
     "@types/jest": "^28.1.6",
-    "@types/node": "^20.2.5",
+    "@types/node": "18.7.19",
     "jest": "^28.1.3",
     "prettier": "3.2.5",
     "ts-jest": "^28.0.7"

--- a/compiler/yarn.lock
+++ b/compiler/yarn.lock
@@ -2985,20 +2985,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
-"@types/node@*", "@types/node@^18.7.18":
+"@types/node@*", "@types/node@18.7.19", "@types/node@^18.7.18":
   version "18.7.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.19.tgz#ad83aa9b7af470fab7e0f562be87e97dc8ffe08e"
   integrity sha512-Sq1itGUKUX1ap7GgZlrzdBydjbsJL/NSQt/4wkAxUJ7/OS5c2WkoN6WSpWc2Yc5wtKMZOUA0VCs/j2XJadN3HA==
-
-"@types/node@18.11.9":
-  version "18.11.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
-  integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
-
-"@types/node@^20.2.5":
-  version "20.2.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.5.tgz#26d295f3570323b2837d322180dfbf1ba156fefb"
-  integrity sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==
 
 "@types/prettier@^1.0.0 || ^2.0.0 || ^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #29187
* #29186
* __->__ #29185
* #29184
* #29183
* #29182
* #29181
* #29180

