### PR TITLE
compiler: getGlobalDeclaration() takes a NonLocalBinding

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -25,6 +25,7 @@ import {
   Effect,
   FunctionType,
   IdentifierId,
+  NonLocalBinding,
   PolyType,
   ScopeId,
   Type,
@@ -511,7 +512,8 @@ export class Environment {
     return this.#hoistedIdentifiers.has(node);
   }
 
-  getGlobalDeclaration(name: string): Global | null {
+  getGlobalDeclaration(binding: NonLocalBinding): Global | null {
+    const name = binding.name;
     let resolvedName = name;
 
     if (this.config.hookPattern != null) {
@@ -534,6 +536,7 @@ export class Environment {
         log(() => `Undefined global \`${name}\``);
       }
     }
+
     return resolvedGlobal;
   }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIRBuilder.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIRBuilder.ts
@@ -9,7 +9,6 @@ import { Binding, NodePath } from "@babel/traverse";
 import * as t from "@babel/types";
 import { CompilerError } from "../CompilerError";
 import { Environment } from "./Environment";
-import { Global } from "./Globals";
 import {
   BasicBlock,
   BlockId,
@@ -184,25 +183,6 @@ export default class HIRBuilder {
       scope: null,
       type: makeType(),
     };
-  }
-
-  resolveGlobal(
-    path: NodePath<t.Identifier | t.JSXIdentifier>
-  ): (Global & { name: string }) | null {
-    const name = path.node.name;
-    const resolvedGlobal = this.#env.getGlobalDeclaration(name);
-    if (resolvedGlobal) {
-      return {
-        ...resolvedGlobal,
-        name,
-      };
-    } else {
-      // if env records no global with the given name, load it as an unknown type
-      return {
-        kind: "Poly",
-        name,
-      };
-    }
   }
 
   #resolveBabelBinding(

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/DropManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/DropManualMemoization.ts
@@ -127,7 +127,7 @@ function collectTemporaries(
       break;
     }
     case "LoadGlobal": {
-      const global = env.getGlobalDeclaration(value.binding.name);
+      const global = env.getGlobalDeclaration(value.binding);
       const hookKind = global !== null ? getHookKindForType(env, global) : null;
       const lvalId = instr.lvalue.identifier.id;
       if (hookKind === "useMemo" || hookKind === "useCallback") {

--- a/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
@@ -197,7 +197,7 @@ function* generateInstructionTypes(
     }
 
     case "LoadGlobal": {
-      const globalType = env.getGlobalDeclaration(value.binding.name);
+      const globalType = env.getGlobalDeclaration(value.binding);
       if (globalType) {
         yield equation(left, globalType);
       }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

No-op refactor to make Environment#getGlobalDeclaration() take a NonLocalBinding instead of just a name. The idea is that in subsequent PRs we can use information about the binding to resolve a type more accurately. For example, we can resolve `Array` differently if its an import or local and not the global Array. Similar for resolving local `useState` differently than the one from React.