### PR TITLE
cleanup[react-devtools]: remove unused supportsProfiling flag from store config

### DIFF
--- a/packages/react-devtools-extensions/src/main/getProfilingFlags.js
+++ b/packages/react-devtools-extensions/src/main/getProfilingFlags.js
@@ -9,15 +9,13 @@ function getProfilingFlags() {
   // This avoids flashing a temporary "Profiling not supported" message in the Profiler tab,
   // after a user has clicked the "reload and profile" button.
   let isProfiling = false;
-  let supportsProfiling = false;
 
   if (localStorageGetItem(LOCAL_STORAGE_SUPPORTS_PROFILING_KEY) === 'true') {
-    supportsProfiling = true;
     isProfiling = true;
     localStorageRemoveItem(LOCAL_STORAGE_SUPPORTS_PROFILING_KEY);
   }
 
-  return {isProfiling, supportsProfiling};
+  return {isProfiling};
 }
 
 export default getProfilingFlags;

--- a/packages/react-devtools-extensions/src/main/index.js
+++ b/packages/react-devtools-extensions/src/main/index.js
@@ -89,12 +89,11 @@ function createBridge() {
 function createBridgeAndStore() {
   createBridge();
 
-  const {isProfiling, supportsProfiling} = getProfilingFlags();
+  const {isProfiling} = getProfilingFlags();
 
   store = new Store(bridge, {
     isProfiling,
     supportsReloadAndProfile: __IS_CHROME__ || __IS_EDGE__,
-    supportsProfiling,
     // At this time, the timeline can only parse Chrome performance profiles.
     supportsTimeline: __IS_CHROME__,
     supportsTraceUpdates: true,

--- a/packages/react-devtools-fusebox/src/frontend.js
+++ b/packages/react-devtools-fusebox/src/frontend.js
@@ -23,12 +23,7 @@ import type {
   ViewElementSource,
   CanViewElementSource,
 } from 'react-devtools-shared/src/devtools/views/DevTools';
-
-type Config = {
-  checkBridgeProtocolCompatibility?: boolean,
-  supportsNativeInspection?: boolean,
-  supportsProfiling?: boolean,
-};
+import type {Config} from 'react-devtools-shared/src/devtools/store';
 
 export function createBridge(wall?: Wall): FrontendBridge {
   if (wall != null) {

--- a/packages/react-devtools-inline/src/frontend.js
+++ b/packages/react-devtools-inline/src/frontend.js
@@ -16,12 +16,7 @@ import {
 import type {Wall} from 'react-devtools-shared/src/frontend/types';
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
 import type {Props} from 'react-devtools-shared/src/devtools/views/DevTools';
-
-type Config = {
-  checkBridgeProtocolCompatibility?: boolean,
-  supportsNativeInspection?: boolean,
-  supportsProfiling?: boolean,
-};
+import type {Config} from 'react-devtools-shared/src/devtools/store';
 
 export function createStore(bridge: FrontendBridge, config?: Config): Store {
   return new Store(bridge, {

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -68,11 +68,10 @@ const LOCAL_STORAGE_RECORD_CHANGE_DESCRIPTIONS_KEY =
 
 type ErrorAndWarningTuples = Array<{id: number, index: number}>;
 
-type Config = {
+export type Config = {
   checkBridgeProtocolCompatibility?: boolean,
   isProfiling?: boolean,
   supportsNativeInspection?: boolean,
-  supportsProfiling?: boolean,
   supportsReloadAndProfile?: boolean,
   supportsTimeline?: boolean,
   supportsTraceUpdates?: boolean,
@@ -174,7 +173,6 @@ export default class Store extends EventEmitter<{
 
   // These options may be initially set by a configuration option when constructing the Store.
   _supportsNativeInspection: boolean = true;
-  _supportsProfiling: boolean = false;
   _supportsReloadAndProfile: boolean = false;
   _supportsTimeline: boolean = false;
   _supportsTraceUpdates: boolean = false;
@@ -214,15 +212,11 @@ export default class Store extends EventEmitter<{
 
       const {
         supportsNativeInspection,
-        supportsProfiling,
         supportsReloadAndProfile,
         supportsTimeline,
         supportsTraceUpdates,
       } = config;
       this._supportsNativeInspection = supportsNativeInspection !== false;
-      if (supportsProfiling) {
-        this._supportsProfiling = true;
-      }
       if (supportsReloadAndProfile) {
         this._supportsReloadAndProfile = true;
       }
@@ -447,12 +441,6 @@ export default class Store extends EventEmitter<{
 
   get supportsNativeStyleEditor(): boolean {
     return this._isNativeStyleEditorSupported;
-  }
-
-  // This build of DevTools supports the legacy profiler.
-  // This is a static flag, controlled by the Store config.
-  get supportsProfiling(): boolean {
-    return this._supportsProfiling;
   }
 
   get supportsReloadAndProfile(): boolean {


### PR DESCRIPTION
Looks like this is unused