### PR TITLE
Fix assertConsoleErrorDev on message mismatch with withoutStack: true

### DIFF
--- a/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
+++ b/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
@@ -2413,6 +2413,22 @@ describe('ReactInternalTestUtils console assertions', () => {
           If all errors should include the component stack, you may need to remove {withoutStack: true} from the assertConsoleErrorDev call."
         `);
       });
+
+      // @gate __DEV__
+      it('fails with a helpful error message if the expected error message mismatches', () => {
+        const message = expectToThrowFailure(() => {
+          console.error('Bye\n    in div');
+          assertConsoleErrorDev([
+            [
+              'Hello',
+              {
+                withoutStack: true,
+              },
+            ],
+          ]);
+        });
+        expect(message).toMatchInlineSnapshot(`"message.replace is not a function"`);
+      });
     });
 
     // @gate __DEV__

--- a/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
+++ b/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
@@ -2427,7 +2427,17 @@ describe('ReactInternalTestUtils console assertions', () => {
             ],
           ]);
         });
-        expect(message).toMatchInlineSnapshot(`"message.replace is not a function"`);
+        expect(message).toMatchInlineSnapshot(`
+          "assertConsoleErrorDev(expected)
+
+          Unexpected error(s) recorded.
+
+          - Expected errors
+          + Received errors
+
+          - Hello
+          + Bye <component stack>"
+        `);
       });
     });
 

--- a/packages/internal-test-utils/consoleMock.js
+++ b/packages/internal-test-utils/consoleMock.js
@@ -464,7 +464,12 @@ export function createLogAssertion(
       function printDiff() {
         return `${diff(
           expectedMessages
-            .map(message => message.replace('\n', ' '))
+            .map(messageOrTuple => {
+              const message = Array.isArray(messageOrTuple)
+                ? messageOrTuple[0]
+                : messageOrTuple;
+              return message.replace('\n', ' ');
+            })
             .join('\n'),
           receivedLogs.map(message => message.replace('\n', ' ')).join('\n'),
           {


### PR DESCRIPTION

## Summary

```js
assertConsoleErrorDev([
  ['Hello', {withoutStack: true}]
])
```

now errors with a helpful diff message if the message mismatched. See first commit for previous behavior.

## How did you test this change?

- `yarn test --watch packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js`
