### PR TITLE
[compiler:playground] JS tab is expanded by default

### DIFF
--- a/compiler/apps/playground/__tests__/e2e/page.spec.ts
+++ b/compiler/apps/playground/__tests__/e2e/page.spec.ts
@@ -28,7 +28,6 @@ test("editor should compile successfully", async ({ page }) => {
   });
 
   // User input from hash compiles
-  await page.getByRole("button", { name: /JS/ }).click();
   await page.screenshot({
     fullPage: true,
     path: "test-results/01-show-js-before.png",

--- a/compiler/apps/playground/components/Editor/Output.tsx
+++ b/compiler/apps/playground/components/Editor/Output.tsx
@@ -121,7 +121,7 @@ async function tabify(source: string, compilerOutput: CompilerOutput) {
       <TextTabContent
         output={code}
         diff={null}
-        showInfoPanel={false}
+        showInfoPanel={true}
       ></TextTabContent>,
     );
     if (sourceMapUrl) {

--- a/compiler/apps/playground/components/Editor/Output.tsx
+++ b/compiler/apps/playground/components/Editor/Output.tsx
@@ -121,7 +121,7 @@ async function tabify(source: string, compilerOutput: CompilerOutput) {
       <TextTabContent
         output={code}
         diff={null}
-        showInfoPanel={true}
+        showInfoPanel={false}
       ></TextTabContent>,
     );
     if (sourceMapUrl) {
@@ -177,7 +177,7 @@ function getSourceMapUrl(code: string, map: string): string | null {
 }
 
 function Output({ store, compilerOutput }: Props) {
-  const [tabsOpen, setTabsOpen] = useState<Set<string>>(() => new Set());
+  const [tabsOpen, setTabsOpen] = useState<Set<string>>(() => new Set(['JS']));
   const [tabs, setTabs] = useState<Map<string, React.ReactNode>>(
     () => new Map(),
   );


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #29205
* __->__ #29203

When using the playground you typically want to see what it outputs, so
let's make the JS tab expanded by default.