### PR TITLE
[Flight Reply] retain listeners when resolving models with existing listeners

### DIFF
--- a/packages/react-server/src/ReactFlightReplyServer.js
+++ b/packages/react-server/src/ReactFlightReplyServer.js
@@ -205,8 +205,23 @@ function wakeChunkIfInitialized<T>(
     case PENDING:
     case BLOCKED:
     case CYCLIC:
-      chunk.value = resolveListeners;
-      chunk.reason = rejectListeners;
+      if (chunk.value) {
+        for (let i = 0; i < resolveListeners.length; i++) {
+          chunk.value.push(resolveListeners[i]);
+        }
+      } else {
+        chunk.value = resolveListeners;
+      }
+
+      if (chunk.reason) {
+        if (rejectListeners) {
+          for (let i = 0; i < rejectListeners.length; i++) {
+            chunk.reason.push(rejectListeners[i]);
+          }
+        }
+      } else {
+        chunk.reason = rejectListeners;
+      }
       break;
     case ERRORED:
       if (rejectListeners) {


### PR DESCRIPTION
In #29201 a fix was made to ensure we don't "forget" about some listeners when handling cyclic chunks.
In #29204 another fix was made for a special case when the chunk already has listeners before it first resolves.

This implements the followup fix for Flight Reply which was originally missed in #29204