### PR TITLE
[Fiber] Replace setCurrentDebugFiberInDEV with runWithFiberInDEV

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -62,10 +62,7 @@ import {pushTreeFork} from './ReactFiberTreeContext';
 import {createThenableState, trackUsedThenable} from './ReactFiberThenable';
 import {readContextDuringReconciliation} from './ReactFiberNewContext';
 
-import {
-  getCurrentFiber as getCurrentDebugFiberInDEV,
-  setCurrentFiber as setCurrentDebugFiberInDEV,
-} from './ReactCurrentFiber';
+import {runWithFiberInDEV} from './ReactCurrentFiber';
 
 // This tracks the thenables that are unwrapped during reconcilation.
 let thenableState: ThenableState | null = null;
@@ -181,15 +178,14 @@ if (__DEV__) {
     const fiber = createFiberFromElement((child: any), returnFiber.mode, 0);
     fiber.return = returnFiber;
 
-    const prevDebugFiber = getCurrentDebugFiberInDEV();
-    setCurrentDebugFiberInDEV(fiber);
-    console.error(
-      'Each child in a list should have a unique "key" prop.' +
-        '%s%s See https://react.dev/link/warning-keys for more information.',
-      currentComponentErrorInfo,
-      childOwnerAppendix,
-    );
-    setCurrentDebugFiberInDEV(prevDebugFiber);
+    runWithFiberInDEV(fiber, () => {
+      console.error(
+        'Each child in a list should have a unique "key" prop.' +
+          '%s%s See https://react.dev/link/warning-keys for more information.',
+        currentComponentErrorInfo,
+        childOwnerAppendix,
+      );
+    });
   };
 }
 
@@ -212,14 +208,17 @@ function validateFragmentProps(
           fiber = createFiberFromElement(element, returnFiber.mode, 0);
           fiber.return = returnFiber;
         }
-        const prevDebugFiber = getCurrentDebugFiberInDEV();
-        setCurrentDebugFiberInDEV(fiber);
-        console.error(
-          'Invalid prop `%s` supplied to `React.Fragment`. ' +
-            'React.Fragment can only have `key` and `children` props.',
+        runWithFiberInDEV(
+          fiber,
+          erroredKey => {
+            console.error(
+              'Invalid prop `%s` supplied to `React.Fragment`. ' +
+                'React.Fragment can only have `key` and `children` props.',
+              erroredKey,
+            );
+          },
           key,
         );
-        setCurrentDebugFiberInDEV(prevDebugFiber);
         break;
       }
     }
@@ -231,10 +230,9 @@ function validateFragmentProps(
         fiber = createFiberFromElement(element, returnFiber.mode, 0);
         fiber.return = returnFiber;
       }
-      const prevDebugFiber = getCurrentDebugFiberInDEV();
-      setCurrentDebugFiberInDEV(fiber);
-      console.error('Invalid attribute `ref` supplied to `React.Fragment`.');
-      setCurrentDebugFiberInDEV(prevDebugFiber);
+      runWithFiberInDEV(fiber, () => {
+        console.error('Invalid attribute `ref` supplied to `React.Fragment`.');
+      });
     }
   }
 }

--- a/packages/react-reconciler/src/ReactCurrentFiber.js
+++ b/packages/react-reconciler/src/ReactCurrentFiber.js
@@ -41,16 +41,29 @@ function getCurrentFiberStackInDev(): string {
   return '';
 }
 
-export function resetCurrentDebugFiberInDEV() {
+export function runWithFiberInDEV<A0, A1, A2, A3, A4, T>(
+  fiber: null | Fiber,
+  callback: (A0, A1, A2, A3, A4) => T,
+  arg0: A0,
+  arg1: A1,
+  arg2: A2,
+  arg3: A3,
+  arg4: A4,
+): T {
   if (__DEV__) {
-    resetCurrentFiber();
-  }
-}
-
-export function setCurrentDebugFiberInDEV(fiber: Fiber | null) {
-  if (__DEV__) {
+    const previousFiber = current;
     setCurrentFiber(fiber);
+    try {
+      return callback(arg0, arg1, arg2, arg3, arg4);
+    } finally {
+      current = previousFiber;
+    }
   }
+  // These errors should never make it into a build so we don't need to encode them in codes.json
+  // eslint-disable-next-line react-internal/prod-error-codes
+  throw new Error(
+    'runWithFiberInDEV should never be called in production. This is a bug in React.',
+  );
 }
 
 export function resetCurrentFiber() {
@@ -68,13 +81,6 @@ export function setCurrentFiber(fiber: Fiber | null) {
     isRendering = false;
   }
   current = fiber;
-}
-
-export function getCurrentFiber(): Fiber | null {
-  if (__DEV__) {
-    return current;
-  }
-  return null;
 }
 
 export function setIsRendering(rendering: boolean) {

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -78,8 +78,7 @@ import {
 import {
   isRendering as ReactCurrentFiberIsRendering,
   current as ReactCurrentFiberCurrent,
-  resetCurrentDebugFiberInDEV,
-  setCurrentDebugFiberInDEV,
+  runWithFiberInDEV,
 } from './ReactCurrentFiber';
 import {StrictLegacyMode} from './ReactTypeOfMode';
 import {
@@ -202,10 +201,7 @@ function findHostInstanceWithWarning(
       const componentName = getComponentNameFromFiber(fiber) || 'Component';
       if (!didWarnAboutFindNodeInStrictMode[componentName]) {
         didWarnAboutFindNodeInStrictMode[componentName] = true;
-
-        const previousFiber = ReactCurrentFiberCurrent;
-        try {
-          setCurrentDebugFiberInDEV(hostFiber);
+        runWithFiberInDEV(hostFiber, () => {
           if (fiber.mode & StrictLegacyMode) {
             console.error(
               '%s is deprecated in StrictMode. ' +
@@ -229,15 +225,7 @@ function findHostInstanceWithWarning(
               componentName,
             );
           }
-        } finally {
-          // Ideally this should reset to previous but this shouldn't be called in
-          // render and there's another warning for that anyway.
-          if (previousFiber) {
-            setCurrentDebugFiberInDEV(previousFiber);
-          } else {
-            resetCurrentDebugFiberInDEV();
-          }
-        }
+        });
       }
     }
     return getPublicInstance(hostFiber.stateNode);

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -87,10 +87,7 @@ import {
 import {ConcurrentRoot} from './ReactRootTags';
 import {noopSuspenseyCommitThenable} from './ReactFiberThenable';
 import {REACT_POSTPONE_TYPE} from 'shared/ReactSymbols';
-import {
-  setCurrentDebugFiberInDEV,
-  getCurrentFiber as getCurrentDebugFiberInDEV,
-} from './ReactCurrentFiber';
+import {runWithFiberInDEV} from './ReactCurrentFiber';
 
 function createRootErrorUpdate(
   root: FiberRoot,
@@ -104,10 +101,11 @@ function createRootErrorUpdate(
   // being called "element".
   update.payload = {element: null};
   update.callback = () => {
-    const prevFiber = getCurrentDebugFiberInDEV(); // should just be the root
-    setCurrentDebugFiberInDEV(errorInfo.source);
-    logUncaughtError(root, errorInfo);
-    setCurrentDebugFiberInDEV(prevFiber);
+    if (__DEV__) {
+      runWithFiberInDEV(errorInfo.source, logUncaughtError, root, errorInfo);
+    } else {
+      logUncaughtError(root, errorInfo);
+    }
   };
   return update;
 }
@@ -134,10 +132,17 @@ function initializeClassErrorUpdate(
       if (__DEV__) {
         markFailedErrorBoundaryForHotReloading(fiber);
       }
-      const prevFiber = getCurrentDebugFiberInDEV(); // should be the error boundary
-      setCurrentDebugFiberInDEV(errorInfo.source);
-      logCaughtError(root, fiber, errorInfo);
-      setCurrentDebugFiberInDEV(prevFiber);
+      if (__DEV__) {
+        runWithFiberInDEV(
+          errorInfo.source,
+          logCaughtError,
+          root,
+          fiber,
+          errorInfo,
+        );
+      } else {
+        logCaughtError(root, fiber, errorInfo);
+      }
     };
   }
 
@@ -148,10 +153,17 @@ function initializeClassErrorUpdate(
       if (__DEV__) {
         markFailedErrorBoundaryForHotReloading(fiber);
       }
-      const prevFiber = getCurrentDebugFiberInDEV(); // should be the error boundary
-      setCurrentDebugFiberInDEV(errorInfo.source);
-      logCaughtError(root, fiber, errorInfo);
-      setCurrentDebugFiberInDEV(prevFiber);
+      if (__DEV__) {
+        runWithFiberInDEV(
+          errorInfo.source,
+          logCaughtError,
+          root,
+          fiber,
+          errorInfo,
+        );
+      } else {
+        logCaughtError(root, fiber, errorInfo);
+      }
       if (typeof getDerivedStateFromError !== 'function') {
         // To preserve the preexisting retry behavior of error boundaries,
         // we keep track of which ones already failed during this batch.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -230,10 +230,8 @@ import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFrom
 import ReactStrictModeWarnings from './ReactStrictModeWarnings';
 import {
   isRendering as ReactCurrentDebugFiberIsRenderingInDEV,
-  current as ReactCurrentFiberCurrent,
-  resetCurrentDebugFiberInDEV,
-  setCurrentDebugFiberInDEV,
   resetCurrentFiber,
+  runWithFiberInDEV,
 } from './ReactCurrentFiber';
 import {
   isDevToolsPresent,
@@ -2374,18 +2372,37 @@ function performUnitOfWork(unitOfWork: Fiber): void {
   // nothing should rely on this, but relying on it here means that we don't
   // need an additional field on the work in progress.
   const current = unitOfWork.alternate;
-  setCurrentDebugFiberInDEV(unitOfWork);
 
   let next;
   if (enableProfilerTimer && (unitOfWork.mode & ProfileMode) !== NoMode) {
     startProfilerTimer(unitOfWork);
-    next = beginWork(current, unitOfWork, entangledRenderLanes);
+    if (__DEV__) {
+      next = runWithFiberInDEV(
+        unitOfWork,
+        beginWork,
+        current,
+        unitOfWork,
+        entangledRenderLanes,
+      );
+    } else {
+      next = beginWork(current, unitOfWork, entangledRenderLanes);
+    }
     stopProfilerTimerIfRunningAndRecordDelta(unitOfWork, true);
   } else {
-    next = beginWork(current, unitOfWork, entangledRenderLanes);
+    if (__DEV__) {
+      next = runWithFiberInDEV(
+        unitOfWork,
+        beginWork,
+        current,
+        unitOfWork,
+        entangledRenderLanes,
+      );
+    } else {
+      next = beginWork(current, unitOfWork, entangledRenderLanes);
+    }
   }
 
-  if (__DEV__ || !disableStringRefs) {
+  if (!disableStringRefs) {
     resetCurrentFiber();
   }
   unitOfWork.memoizedProps = unitOfWork.pendingProps;
@@ -2400,9 +2417,32 @@ function performUnitOfWork(unitOfWork: Fiber): void {
 function replaySuspendedUnitOfWork(unitOfWork: Fiber): void {
   // This is a fork of performUnitOfWork specifcally for replaying a fiber that
   // just suspended.
-  //
+  let next;
+  if (__DEV__) {
+    next = runWithFiberInDEV(unitOfWork, replayBeginWork, unitOfWork);
+  } else {
+    next = replayBeginWork(unitOfWork);
+  }
+
+  // The begin phase finished successfully without suspending. Return to the
+  // normal work loop.
+  if (!disableStringRefs) {
+    resetCurrentFiber();
+  }
+  unitOfWork.memoizedProps = unitOfWork.pendingProps;
+  if (next === null) {
+    // If this doesn't spawn new work, complete the current work.
+    completeUnitOfWork(unitOfWork);
+  } else {
+    workInProgress = next;
+  }
+}
+
+function replayBeginWork(unitOfWork: Fiber): null | Fiber {
+  // This is a fork of beginWork specifcally for replaying a fiber that
+  // just suspended.
+
   const current = unitOfWork.alternate;
-  setCurrentDebugFiberInDEV(unitOfWork);
 
   let next;
   const isProfilingMode =
@@ -2494,19 +2534,7 @@ function replaySuspendedUnitOfWork(unitOfWork: Fiber): void {
     stopProfilerTimerIfRunningAndRecordDelta(unitOfWork, true);
   }
 
-  // The begin phase finished successfully without suspending. Return to the
-  // normal work loop.
-
-  if (__DEV__ || !disableStringRefs) {
-    resetCurrentFiber();
-  }
-  unitOfWork.memoizedProps = unitOfWork.pendingProps;
-  if (next === null) {
-    // If this doesn't spawn new work, complete the current work.
-    completeUnitOfWork(unitOfWork);
-  } else {
-    workInProgress = next;
-  }
+  return next;
 }
 
 function throwAndUnwindWorkLoop(
@@ -2605,17 +2633,35 @@ function completeUnitOfWork(unitOfWork: Fiber): void {
     const current = completedWork.alternate;
     const returnFiber = completedWork.return;
 
-    setCurrentDebugFiberInDEV(completedWork);
     let next;
     if (!enableProfilerTimer || (completedWork.mode & ProfileMode) === NoMode) {
-      next = completeWork(current, completedWork, entangledRenderLanes);
+      if (__DEV__) {
+        next = runWithFiberInDEV(
+          completedWork,
+          completeWork,
+          current,
+          completedWork,
+          entangledRenderLanes,
+        );
+      } else {
+        next = completeWork(current, completedWork, entangledRenderLanes);
+      }
     } else {
       startProfilerTimer(completedWork);
-      next = completeWork(current, completedWork, entangledRenderLanes);
+      if (__DEV__) {
+        next = runWithFiberInDEV(
+          completedWork,
+          completeWork,
+          current,
+          completedWork,
+          entangledRenderLanes,
+        );
+      } else {
+        next = completeWork(current, completedWork, entangledRenderLanes);
+      }
       // Update render duration assuming we didn't error.
       stopProfilerTimerIfRunningAndRecordDelta(completedWork, false);
     }
-    resetCurrentDebugFiberInDEV();
 
     if (next !== null) {
       // Completing this fiber spawned new work. Work on that next.
@@ -3038,9 +3084,16 @@ function commitRootImpl(
     for (let i = 0; i < recoverableErrors.length; i++) {
       const recoverableError = recoverableErrors[i];
       const errorInfo = makeErrorInfo(recoverableError.stack);
-      setCurrentDebugFiberInDEV(recoverableError.source);
-      onRecoverableError(recoverableError.value, errorInfo);
-      resetCurrentDebugFiberInDEV();
+      if (__DEV__) {
+        runWithFiberInDEV(
+          recoverableError.source,
+          onRecoverableError,
+          recoverableError.value,
+          errorInfo,
+        );
+      } else {
+        onRecoverableError(recoverableError.value, errorInfo);
+      }
     }
   }
 
@@ -3691,15 +3744,15 @@ function doubleInvokeEffectsInDEVIfNecessary(
   // special rules apply to double invoking effects.
   if (fiber.tag !== OffscreenComponent) {
     if (fiber.flags & PlacementDEV) {
-      setCurrentDebugFiberInDEV(fiber);
       if (isInStrictMode) {
-        doubleInvokeEffectsOnFiber(
+        runWithFiberInDEV(
+          fiber,
+          doubleInvokeEffectsOnFiber,
           root,
           fiber,
           (fiber.mode & NoStrictPassiveEffectsMode) === NoMode,
         );
       }
-      resetCurrentDebugFiberInDEV();
     } else {
       recursivelyTraverseAndDoubleInvokeEffectsInDEV(
         root,
@@ -3715,21 +3768,21 @@ function doubleInvokeEffectsInDEVIfNecessary(
   if (fiber.memoizedState === null) {
     // Only consider Offscreen that is visible.
     // TODO (Offscreen) Handle manual mode.
-    setCurrentDebugFiberInDEV(fiber);
     if (isInStrictMode && fiber.flags & Visibility) {
       // Double invoke effects on Offscreen's subtree only
       // if it is visible and its visibility has changed.
-      doubleInvokeEffectsOnFiber(root, fiber);
+      runWithFiberInDEV(fiber, doubleInvokeEffectsOnFiber, root, fiber);
     } else if (fiber.subtreeFlags & PlacementDEV) {
       // Something in the subtree could have been suspended.
       // We need to continue traversal and find newly inserted fibers.
-      recursivelyTraverseAndDoubleInvokeEffectsInDEV(
+      runWithFiberInDEV(
+        fiber,
+        recursivelyTraverseAndDoubleInvokeEffectsInDEV,
         root,
         fiber,
         isInStrictMode,
       );
     }
-    resetCurrentDebugFiberInDEV();
   }
 }
 
@@ -3753,7 +3806,13 @@ function commitDoubleInvokeEffectsInDEV(
         doubleInvokeEffects,
       );
     } else {
-      legacyCommitDoubleInvokeEffectsInDEV(root.current, hasPassiveEffects);
+      // TODO: Is this runWithFiberInDEV needed since the other effect functions do it too?
+      runWithFiberInDEV(
+        root.current,
+        legacyCommitDoubleInvokeEffectsInDEV,
+        root.current,
+        hasPassiveEffects,
+      );
     }
   }
 }
@@ -3766,7 +3825,6 @@ function legacyCommitDoubleInvokeEffectsInDEV(
   // so we don't traverse unnecessarily? similar to subtreeFlags but just at the root level.
   // Maybe not a big deal since this is DEV only behavior.
 
-  setCurrentDebugFiberInDEV(fiber);
   invokeEffectsInDev(fiber, MountLayoutDev, invokeLayoutEffectUnmountInDEV);
   if (hasPassiveEffects) {
     invokeEffectsInDev(fiber, MountPassiveDev, invokePassiveEffectUnmountInDEV);
@@ -3776,7 +3834,6 @@ function legacyCommitDoubleInvokeEffectsInDEV(
   if (hasPassiveEffects) {
     invokeEffectsInDev(fiber, MountPassiveDev, invokePassiveEffectMountInDEV);
   }
-  resetCurrentDebugFiberInDEV();
 }
 
 function invokeEffectsInDev(
@@ -3846,22 +3903,14 @@ export function warnAboutUpdateOnNotYetMountedFiberInDEV(fiber: Fiber) {
       didWarnStateUpdateForNotYetMountedComponent = new Set([componentName]);
     }
 
-    const previousFiber = ReactCurrentFiberCurrent;
-    try {
-      setCurrentDebugFiberInDEV(fiber);
+    runWithFiberInDEV(fiber, () => {
       console.error(
         "Can't perform a React state update on a component that hasn't mounted yet. " +
           'This indicates that you have a side-effect in your render function that ' +
           'asynchronously later calls tries to update the component. Move this work to ' +
           'useEffect instead.',
       );
-    } finally {
-      if (previousFiber) {
-        setCurrentDebugFiberInDEV(fiber);
-      } else {
-        resetCurrentDebugFiberInDEV();
-      }
-    }
+    });
   }
 }
 
@@ -3983,9 +4032,7 @@ function warnIfUpdatesNotWrappedWithActDEV(fiber: Fiber): void {
     }
 
     if (ReactSharedInternals.actQueue === null) {
-      const previousFiber = ReactCurrentFiberCurrent;
-      try {
-        setCurrentDebugFiberInDEV(fiber);
+      runWithFiberInDEV(fiber, () => {
         console.error(
           'An update to %s inside a test was not wrapped in act(...).\n\n' +
             'When testing, code that causes React state updates should be ' +
@@ -3999,13 +4046,7 @@ function warnIfUpdatesNotWrappedWithActDEV(fiber: Fiber): void {
             ' Learn more at https://react.dev/link/wrap-tests-with-act',
           getComponentNameFromFiber(fiber),
         );
-      } finally {
-        if (previousFiber) {
-          setCurrentDebugFiberInDEV(fiber);
-        } else {
-          resetCurrentDebugFiberInDEV();
-        }
-      }
+      });
     }
   }
 }

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -9,10 +9,7 @@
 
 import type {Fiber} from './ReactInternalTypes';
 
-import {
-  resetCurrentDebugFiberInDEV,
-  setCurrentDebugFiberInDEV,
-} from './ReactCurrentFiber';
+import {runWithFiberInDEV} from './ReactCurrentFiber';
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 import {StrictLegacyMode} from './ReactTypeOfMode';
 
@@ -339,8 +336,7 @@ if (__DEV__) {
 
         const sortedNames = setToSortedString(uniqueNames);
 
-        try {
-          setCurrentDebugFiberInDEV(firstFiber);
+        runWithFiberInDEV(firstFiber, () => {
           console.error(
             'Legacy context API has been detected within a strict-mode tree.' +
               '\n\nThe old API will be supported in all 16.x releases, but applications ' +
@@ -349,9 +345,7 @@ if (__DEV__) {
               '\n\nLearn more about this warning here: https://react.dev/link/legacy-context',
             sortedNames,
           );
-        } finally {
-          resetCurrentDebugFiberInDEV();
-        }
+        });
       },
     );
   };


### PR DESCRIPTION
Stacked on #29044.

To work with `console.createTask(...).run(...)` we need to be able to run a function in the scope of the task.

The main concern with this, other than general performance, is that it might add more stack frames on very deep stacks that hit the stack limit. Such as with the commit phase where we recursively go down the tree. These callbacks aren't really necessary in the recursive part but only in the shallow invocation of the commit phase for each tag. So we could refactor the commit phase so that only the shallow part at each level is covered this way.
