### PR TITLE
[Fiber] clarify entry condition for suspensey commit recursion

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -126,6 +126,7 @@ import {
   MountLayoutDev,
   DidDefer,
   ShouldSuspendCommit,
+  MaySuspendCommit,
 } from './ReactFiberFlags';
 import {
   NoLanes,
@@ -1185,7 +1186,13 @@ function commitRootWhenReady(
 ) {
   // TODO: Combine retry throttling with Suspensey commits. Right now they run
   // one after the other.
-  if (finishedWork.subtreeFlags & ShouldSuspendCommit) {
+  const BothVisibilityAndMaySuspendCommit = Visibility | MaySuspendCommit;
+  const subtreeFlags = finishedWork.subtreeFlags;
+  if (
+    subtreeFlags & ShouldSuspendCommit ||
+    (subtreeFlags & BothVisibilityAndMaySuspendCommit) ===
+      BothVisibilityAndMaySuspendCommit
+  ) {
     // Before committing, ask the renderer whether the host tree is ready.
     // If it's not, we'll wait until it notifies us.
     startSuspendingCommit();


### PR DESCRIPTION
Previously Suspensey recursion would only trigger if the ShouldSuspendCommit flag was true. However there is a dependence on the Visibility flag embedded in this logic because these flags share a bit. To make it clear that the semantics of Suspensey resources require considering both flags I've added it to the condition even though this extra or-ing is a noop when the bit is shared