### PR TITLE
Fix async batching in React.startTransition

### DIFF
--- a/packages/react-dom/src/__tests__/ReactStartTransitionMultipleRenderers-test.js
+++ b/packages/react-dom/src/__tests__/ReactStartTransitionMultipleRenderers-test.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+describe('ReactStartTransitionMultipleRenderers', () => {
+  let act;
+  let container;
+  let React;
+  let ReactDOMClient;
+  let Scheduler;
+  let assertLog;
+  let startTransition;
+  let useOptimistic;
+  let textCache;
+
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactDOMClient = require('react-dom/client');
+    Scheduler = require('scheduler');
+    act = require('internal-test-utils').act;
+    assertLog = require('internal-test-utils').assertLog;
+    startTransition = React.startTransition;
+    useOptimistic = React.useOptimistic;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    textCache = new Map();
+  });
+
+  function resolveText(text) {
+    const record = textCache.get(text);
+    if (record === undefined) {
+      const newRecord = {
+        status: 'resolved',
+        value: text,
+      };
+      textCache.set(text, newRecord);
+    } else if (record.status === 'pending') {
+      const thenable = record.value;
+      record.status = 'resolved';
+      record.value = text;
+      thenable.pings.forEach(t => t(text));
+    }
+  }
+
+  function getText(text) {
+    const record = textCache.get(text);
+    if (record === undefined) {
+      const thenable = {
+        pings: [],
+        then(resolve) {
+          if (newRecord.status === 'pending') {
+            thenable.pings.push(resolve);
+          } else {
+            Promise.resolve().then(() => resolve(newRecord.value));
+          }
+        },
+      };
+      const newRecord = {
+        status: 'pending',
+        value: thenable,
+      };
+      textCache.set(text, newRecord);
+      return thenable;
+    } else {
+      switch (record.status) {
+        case 'pending':
+          return record.value;
+        case 'rejected':
+          return Promise.reject(record.value);
+        case 'resolved':
+          return Promise.resolve(record.value);
+      }
+    }
+  }
+
+  function Text({text}) {
+    Scheduler.log(text);
+    return text;
+  }
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  // This test imports multiple reconcilers. Because of how the renderers are
+  // built, it only works when running tests using the actual build artifacts,
+  // not the source files.
+  // @gate !source
+  test('React.startTransition works across multiple renderers', async () => {
+    const ReactNoop = require('react-noop-renderer');
+
+    const setIsPendings = new Set();
+
+    function App() {
+      const [isPending, setIsPending] = useOptimistic(false);
+      setIsPendings.add(setIsPending);
+      return <Text text={isPending ? 'Pending' : 'Not pending'} />;
+    }
+
+    const noopRoot = ReactNoop.createRoot(null);
+    const domRoot = ReactDOMClient.createRoot(container);
+
+    // Run the same component in two separate renderers.
+    await act(() => {
+      noopRoot.render(<App />);
+      domRoot.render(<App />);
+    });
+    assertLog(['Not pending', 'Not pending']);
+    expect(container.textContent).toEqual('Not pending');
+    expect(noopRoot).toMatchRenderedOutput('Not pending');
+
+    await act(() => {
+      startTransition(async () => {
+        // Wait until after an async gap before setting the optimistic state.
+        await getText('Wait before setting isPending');
+        setIsPendings.forEach(setIsPending => setIsPending(true));
+
+        // The optimistic state should not be reverted until the
+        // action completes.
+        await getText('Wait until end of async action');
+      });
+    });
+
+    await act(() => resolveText('Wait before setting isPending'));
+    assertLog(['Pending', 'Pending']);
+    expect(container.textContent).toEqual('Pending');
+    expect(noopRoot).toMatchRenderedOutput('Pending');
+
+    await act(() => resolveText('Wait until end of async action'));
+    assertLog(['Not pending', 'Not pending']);
+    expect(container.textContent).toEqual('Not pending');
+    expect(noopRoot).toMatchRenderedOutput('Not pending');
+  });
+});

--- a/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.js
+++ b/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.js
@@ -47,7 +47,6 @@ export type BatchConfigTransition = {
   name?: string,
   startTime?: number,
   _updatedFibers?: Set<Fiber>,
-  _callbacks: Set<(BatchConfigTransition, mixed) => mixed>,
 };
 
 // TODO: Is there a way to not include the tag or name here?

--- a/packages/react/src/ReactSharedInternalsClient.js
+++ b/packages/react/src/ReactSharedInternalsClient.js
@@ -15,6 +15,7 @@ export type SharedStateClient = {
   H: null | Dispatcher, // ReactCurrentDispatcher for Hooks
   A: null | AsyncDispatcher, // ReactCurrentCache for Cache
   T: null | BatchConfigTransition, // ReactCurrentBatchConfig for Transitions
+  S: null | ((BatchConfigTransition, mixed) => void), // onStartTransitionFinish
 
   // DEV-only
 
@@ -45,6 +46,7 @@ const ReactSharedInternals: SharedStateClient = ({
   H: null,
   A: null,
   T: null,
+  S: null,
 }: any);
 
 if (__DEV__) {

--- a/packages/react/src/ReactStartTransition.js
+++ b/packages/react/src/ReactStartTransition.js
@@ -23,12 +23,7 @@ export function startTransition(
   options?: StartTransitionOptions,
 ) {
   const prevTransition = ReactSharedInternals.T;
-  // Each renderer registers a callback to receive the return value of
-  // the scope function. This is used to implement async actions.
-  const callbacks = new Set<(BatchConfigTransition, mixed) => mixed>();
-  const transition: BatchConfigTransition = {
-    _callbacks: callbacks,
-  };
+  const transition: BatchConfigTransition = {};
   ReactSharedInternals.T = transition;
   const currentTransition = ReactSharedInternals.T;
 
@@ -48,12 +43,15 @@ export function startTransition(
   if (enableAsyncActions) {
     try {
       const returnValue = scope();
+      const onStartTransitionFinish = ReactSharedInternals.S;
+      if (onStartTransitionFinish !== null) {
+        onStartTransitionFinish(transition, returnValue);
+      }
       if (
         typeof returnValue === 'object' &&
         returnValue !== null &&
         typeof returnValue.then === 'function'
       ) {
-        callbacks.forEach(callback => callback(currentTransition, returnValue));
         returnValue.then(noop, reportGlobalError);
       }
     } catch (error) {


### PR DESCRIPTION
Note: Despite the similar-sounding description, this fix is unrelated to the issue where updates that occur after an `await` in an async action must also be wrapped in their own `startTransition`, due to the absence of an AsyncContext mechanism in browsers today.

---

Discovered a flaw in the current implementation of the isomorphic startTransition implementation (React.startTransition), related to async actions. It only creates an async scope if something calls setState within the synchronous part of the action (i.e. before the first `await`). I had thought this was fine because if there's no update during this part, then there's nothing that needs to be entangled. I didn't think this through, though — if there are multiple async updates interleaved throughout the rest of the action, we need the async scope to have already been created so that _those_ are batched together.

An even easier way to observe this is to schedule an optimistic update after an `await` — the optimistic update should not be reverted until the async action is complete.

To implement, during the reconciler's module initialization, we compose its startTransition implementation with any previous reconciler's startTransition that was already initialized. Then, the isomorphic startTransition is the composition of every
reconciler's startTransition.

```js
function startTransition(fn) {
  return startTransitionDOM(() => {
    return startTransitionART(() => {
      return startTransitionThreeFiber(() => {
        // and so on...
        return fn();
      });
    });
  });
}
```

This is basically how flushSync is implemented, too.