### PR TITLE
[compiler:eslint] avoid loading the user config when running Babel + BabelPluginReactCompiler

### DIFF
--- a/compiler/packages/eslint-plugin-react-compiler/src/rules/ReactCompilerRule.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/src/rules/ReactCompilerRule.ts
@@ -135,6 +135,9 @@ const rule: Rule.RuleModule = {
     if (babelAST != null) {
       try {
         transformFromAstSync(babelAST, sourceCode, {
+          // Avoid having conflicting configs between our config using `[PluginProposalPrivateMethods, { loose: true }]`
+          // and the user config (that can have a different config for @babel/plugin-transform-class-properties, @babel/plugin-transform-private-methods, or @babel/plugin-transform-private-property-in-object)
+          configFile: false,
           filename,
           highlightCode: false,
           retainLines: true,

--- a/compiler/packages/eslint-plugin-react-compiler/src/rules/ReactCompilerRule.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/src/rules/ReactCompilerRule.ts
@@ -137,7 +137,9 @@ const rule: Rule.RuleModule = {
         transformFromAstSync(babelAST, sourceCode, {
           // Avoid having conflicting configs between our config using `[PluginProposalPrivateMethods, { loose: true }]`
           // and the user config (that can have a different config for @babel/plugin-transform-class-properties, @babel/plugin-transform-private-methods, or @babel/plugin-transform-private-property-in-object)
-          configFile: false,
+          configFile: false, // for babel.config.*
+          babelrc: false, // for .babelrc
+
           filename,
           highlightCode: false,
           retainLines: true,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

I was trying to use `eslint-plugin-react-compiler` in one of my repo, but it wasn't reporting any error. After digging a bit more, I added a `console.log` in the `catch` just after `transformFromAstSync(babelAST, sourceCode, {` and I saw this error:

```
Error: /path/to/test.tsx: 'loose' mode configuration must be the same for @babel/plugin-transform-class-properties, @babel/plugin-transform-private-methods and @babel/plugin-transform-private-property-in-object (when they are enabled).

If you already set the same 'loose' mode for these plugins in your config, it's possible that they are enabled multiple times with different options.
You can re-run Babel with the BABEL_SHOW_CONFIG_FOR environment variable to show the loaded configuration:
        npx cross-env BABEL_SHOW_CONFIG_FOR=/path/to/test/test.tsx <your build command>
See https://babeljs.io/docs/configuration#print-effective-configs for more info.
```

And in my top level `babel.config.js`, I indeed have the plugin `@babel/plugin-proposal-class-properties` not setup with `loose: true`:
<img width="486" alt="image" src="https://github.com/facebook/react/assets/22725671/aafb36b6-21d2-471a-ac10-2f29086529f1">

To confirm my suspicions, I created https://github.com/Ayc0/bug-react-eslint-compiler-babel in which I have a minimal reproduction of this bug:

When the `babel.config.js` doesn't have anything, it works:
<img width="1131" alt="image" src="https://github.com/facebook/react/assets/22725671/10834326-9993-4b33-9864-832dbac4e0af">

But if it has `root: true`, it stops reporting errors:
<img width="1100" alt="image" src="https://github.com/facebook/react/assets/22725671/d6ed998f-0bfd-463c-b193-022f719c6887">

Or if it has the plugin not set with `loose: true`:
<img width="1078" alt="image" src="https://github.com/facebook/react/assets/22725671/ee183b43-6fb8-4779-8a24-c127e8184e38">

## How did you test this change?

### babel.config.js

In the same repro, I edited my version of `eslint-plugin-react-compiler` present in my node_modules:

Before | After
-|-
<img width="1484" alt="image" src="https://github.com/facebook/react/assets/22725671/92f39998-610f-4678-b451-af26cc3d5d0b"> | <img width="1475" alt="image" src="https://github.com/facebook/react/assets/22725671/959f4f42-1468-49e3-9b28-631ba1d33d85">

### .babelrc

After testing `babel.config.js`, I looked for `.babelrc`. In babel's config, you have both options https://babeljs.io/docs/options#babelrc. And indeed, if just `configFile` is disabled, but not `.babelrc`, it doesn't report any error when there is a `.babelrc` file (but does as soon as we add `babelrc: false`:

Before | After
-|-
<img width="1510" alt="image" src="https://github.com/facebook/react/assets/22725671/8a00e147-ebe1-4ebb-83fa-dbb0f755586a"> | <img width="1453" alt="image" src="https://github.com/facebook/react/assets/22725671/89d4edaf-7740-4914-85a3-407df18aa89b">

### To note

In one of their example on the babel website, when doing 2 passes of babel, they also disable those 2 options in the 2nd pass, see https://babeljs.io/docs/options#ast:

<img width="677" alt="image" src="https://github.com/facebook/react/assets/22725671/a48503cc-0109-40a0-846a-0e5ea526f9a2">


### CI tests

I'd love to add a test in the repo itself, but as this seems to be related to the top-level `babel.config.js` or `.babelrc`, I didn’t know how to test that properly


