### PR TITLE
feat[DevTools]: Use Chrome DevTools Performance extension API

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
+++ b/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
@@ -85,6 +85,8 @@ describe('Timeline profiler', () => {
             markOptions.startTime++;
           }
         },
+        measure() {},
+        clearMeasures() {},
       };
     }
 
@@ -364,9 +366,10 @@ describe('Timeline profiler', () => {
                     "--render-start-128",
                     "--component-render-start-Foo",
                     "--component-render-stop",
-                    "--render-yield",
+                    "--render-yield-stop",
                   ]
               `);
+        await waitForPaint(['Bar']);
       });
 
       it('should mark concurrent render with suspense that resolves', async () => {

--- a/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
+++ b/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
@@ -24,7 +24,7 @@ describe('Timeline profiler', () => {
   let utils;
   let assertLog;
   let waitFor;
-
+  let waitForPaint;
   describe('User Timing API', () => {
     let currentlyNotClearedMarks;
     let registeredMarks;
@@ -75,6 +75,8 @@ describe('Timeline profiler', () => {
             markOptions.startTime++;
           }
         },
+        measure() {},
+        clearMeasures() {},
       };
     }
 
@@ -101,7 +103,7 @@ describe('Timeline profiler', () => {
       const InternalTestUtils = require('internal-test-utils');
       assertLog = InternalTestUtils.assertLog;
       waitFor = InternalTestUtils.waitFor;
-
+      waitForPaint = InternalTestUtils.waitForPaint;
       setPerformanceMock =
         require('react-devtools-shared/src/backend/profilingHooks').setPerformanceMock_ONLY_FOR_TESTING;
       setPerformanceMock(createUserTimingPolyfill());
@@ -1301,6 +1303,8 @@ describe('Timeline profiler', () => {
             const data = await preprocessData(testMarks);
             const event = data.nativeEvents.find(({type}) => type === 'click');
             expect(event.warning).toBe(null);
+
+            await waitForPaint([]);
           });
 
           // @reactVersion >= 18.0

--- a/packages/react-devtools-shared/src/backend/profilingHooks.js
+++ b/packages/react-devtools-shared/src/backend/profilingHooks.js
@@ -123,6 +123,7 @@ export function createProfilingHooks({
   let currentBatchUID: BatchUID = 0;
   let currentReactComponentMeasure: ReactComponentMeasure | null = null;
   let currentReactMeasuresStack: Array<ReactMeasure> = [];
+  const currentBeginMarksStack: Array<string> = [];
   let currentTimelineData: TimelineData | null = null;
   let currentFiberStacks: Map<SchedulingEvent, Array<Fiber>> = new Map();
   let isProfiling: boolean = false;
@@ -214,6 +215,56 @@ export function createProfilingHooks({
     ((performanceTarget: any): Performance).clearMarks(markName);
   }
 
+  function beginMark(taskName: string, ending: string | number) {
+    // This name format is used in preprocessData.js so it cannot just be changed.
+    const startMarkName = `--${taskName}-start-${ending}`;
+    currentBeginMarksStack.push(startMarkName);
+    // This method won't be called unless these functions are defined, so we can skip the extra typeof check.
+    ((performanceTarget: any): Performance).mark(startMarkName);
+  }
+
+  function endMarkAndClear(taskName: string) {
+    const startMarkName = currentBeginMarksStack.pop();
+    if (!startMarkName) {
+      console.error(
+        'endMarkAndClear was unexpectedly called without a corresponding start mark',
+      );
+      return;
+    }
+    const markEnding = startMarkName.split('-').at(-1) || '';
+    const endMarkName = `--${taskName}-stop`;
+    const measureName = `${taskName} ${markEnding}`;
+
+    // Use different color for rendering tasks.
+    const color = taskName.includes('render') ? 'primary' : 'tertiary';
+    // If the ending is not a number, then it's a component name.
+    const properties = isNaN(parseInt(markEnding, 10))
+      ? [['Component', markEnding]]
+      : [];
+    // This method won't be called unless these functions are defined, so we can skip the extra typeof check.
+    ((performanceTarget: any): Performance).mark(endMarkName);
+    // Based on the format in https://bit.ly/rpp-e11y
+    const measureOptions = {
+      start: startMarkName,
+      end: endMarkName,
+      detail: {
+        devtools: {
+          dataType: 'track-entry',
+          color,
+          track: '⚛️ React',
+          properties,
+        },
+      },
+    };
+    ((performanceTarget: any): Performance).measure(
+      measureName,
+      measureOptions,
+    );
+    ((performanceTarget: any): Performance).clearMarks(startMarkName);
+    ((performanceTarget: any): Performance).clearMarks(endMarkName);
+    ((performanceTarget: any): Performance).clearMeasures(measureName);
+  }
+
   function recordReactMeasureStarted(
     type: ReactMeasureType,
     lanes: Lanes,
@@ -301,7 +352,7 @@ export function createProfilingHooks({
     }
 
     if (supportsUserTimingV3) {
-      markAndClear(`--commit-start-${lanes}`);
+      beginMark('commit', lanes);
 
       // Some metadata only needs to be logged once per session,
       // but if profiling information is being recorded via the Performance tab,
@@ -318,7 +369,7 @@ export function createProfilingHooks({
     }
 
     if (supportsUserTimingV3) {
-      markAndClear('--commit-stop');
+      endMarkAndClear('commit');
     }
   }
 
@@ -340,7 +391,7 @@ export function createProfilingHooks({
       }
 
       if (supportsUserTimingV3) {
-        markAndClear(`--component-render-start-${componentName}`);
+        beginMark('component-render', componentName);
       }
     }
   }
@@ -361,9 +412,8 @@ export function createProfilingHooks({
         currentReactComponentMeasure = null;
       }
     }
-
     if (supportsUserTimingV3) {
-      markAndClear('--component-render-stop');
+      endMarkAndClear('component-render');
     }
   }
 
@@ -385,7 +435,7 @@ export function createProfilingHooks({
       }
 
       if (supportsUserTimingV3) {
-        markAndClear(`--component-layout-effect-mount-start-${componentName}`);
+        beginMark('component-layout-effect-mount', componentName);
       }
     }
   }
@@ -408,7 +458,7 @@ export function createProfilingHooks({
     }
 
     if (supportsUserTimingV3) {
-      markAndClear('--component-layout-effect-mount-stop');
+      endMarkAndClear('component-layout-effect-mount');
     }
   }
 
@@ -430,9 +480,7 @@ export function createProfilingHooks({
       }
 
       if (supportsUserTimingV3) {
-        markAndClear(
-          `--component-layout-effect-unmount-start-${componentName}`,
-        );
+        beginMark('component-layout-effect-unmount', componentName);
       }
     }
   }
@@ -455,7 +503,7 @@ export function createProfilingHooks({
     }
 
     if (supportsUserTimingV3) {
-      markAndClear('--component-layout-effect-unmount-stop');
+      endMarkAndClear('component-layout-effect-unmount');
     }
   }
 
@@ -477,7 +525,7 @@ export function createProfilingHooks({
       }
 
       if (supportsUserTimingV3) {
-        markAndClear(`--component-passive-effect-mount-start-${componentName}`);
+        beginMark('component-passive-effect-mount', componentName);
       }
     }
   }
@@ -500,7 +548,7 @@ export function createProfilingHooks({
     }
 
     if (supportsUserTimingV3) {
-      markAndClear('--component-passive-effect-mount-stop');
+      endMarkAndClear('component-passive-effect-mount');
     }
   }
 
@@ -522,9 +570,7 @@ export function createProfilingHooks({
       }
 
       if (supportsUserTimingV3) {
-        markAndClear(
-          `--component-passive-effect-unmount-start-${componentName}`,
-        );
+        beginMark('component-passive-effect-unmount', componentName);
       }
     }
   }
@@ -547,7 +593,7 @@ export function createProfilingHooks({
     }
 
     if (supportsUserTimingV3) {
-      markAndClear('--component-passive-effect-unmount-stop');
+      endMarkAndClear('component-passive-effect-unmount');
     }
   }
 
@@ -679,7 +725,7 @@ export function createProfilingHooks({
     }
 
     if (supportsUserTimingV3) {
-      markAndClear(`--layout-effects-start-${lanes}`);
+      beginMark('layout-effects', lanes);
     }
   }
 
@@ -689,7 +735,7 @@ export function createProfilingHooks({
     }
 
     if (supportsUserTimingV3) {
-      markAndClear('--layout-effects-stop');
+      endMarkAndClear('layout-effects');
     }
   }
 
@@ -699,7 +745,7 @@ export function createProfilingHooks({
     }
 
     if (supportsUserTimingV3) {
-      markAndClear(`--passive-effects-start-${lanes}`);
+      beginMark('passive-effects', lanes);
     }
   }
 
@@ -709,7 +755,7 @@ export function createProfilingHooks({
     }
 
     if (supportsUserTimingV3) {
-      markAndClear('--passive-effects-stop');
+      endMarkAndClear('passive-effects');
     }
   }
 
@@ -734,7 +780,7 @@ export function createProfilingHooks({
     }
 
     if (supportsUserTimingV3) {
-      markAndClear(`--render-start-${lanes}`);
+      beginMark('render', lanes);
     }
   }
 
@@ -744,7 +790,7 @@ export function createProfilingHooks({
     }
 
     if (supportsUserTimingV3) {
-      markAndClear('--render-yield');
+      endMarkAndClear('render-yield');
     }
   }
 
@@ -754,7 +800,7 @@ export function createProfilingHooks({
     }
 
     if (supportsUserTimingV3) {
-      markAndClear('--render-stop');
+      endMarkAndClear('render');
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Hi there React team! ⚛️ 👋 

This change is a proof of concept of how the new Chrome DevTools Performance extension API (https://bit.ly/rpp-e11y) can be used to surface React runtime data directly in the Chrome DevTools Performance panel.

To do this, the hooks in profilingHooks.js that mark beginning and end of React measurements using [Performance marks](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMeasure) are modified to also use [Performance measure](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMeasure) with the `detail` field format specification of the Performance extension API.

Because these marks are used by React Profiler, they are kept untouched and the calls to performance.measure are added on top to surface them to the Chrome DevTools Performance panel, along with the browser's native runtime data.

Because this is a proof of concept, not all the tasks and marks taken by the React Profiler are added to the Chrome DevTools Performance panel (f.e. update scheduling marks), but this could be done as a follow up of this commit.

Note: to enable the user timings to be collected in the first place, the React DevTools extension needs to be installed (so that the hooks are loaded to the website). In an alternative approach, the calls to the api could be added directly to the framework so that no extension needs to be installed, but this would require a more careful implementation.

## Motivation

We (the Chrome Page Quality team) think allowing developers to extend the Chrome Peformance Panel can significantly offer a better experience for developers looking to improve performance to the current solutions available.

Right now, the React Profiler has its own implementation of a timeline that parses a Chromium's trace data and merges it with its own instrumentation data. This is problematic because

1. It fragments the developer workflow:  Users are required to profile with React DevTools and with the browser profiler (the Performance panel). After the recording is finished the output of the Performance panel (browser trace data) needs to be imported into the React profiler.
2. Insufficient details in specialized tools: Users might still need a more detailed view of the browser runtime which is not available in specialized tools like the react profiler (f.e. dropped frames).  This leads them to frequently jump back and forth between tools to obtain the whole picture.
3. Broken deps: Changes to the upstream trace data format will cause the React profiler to break (f.e. React profiler doesn't support the current format exported by the Chrome Performance panel)
4. Cost of maintenance: Framework tool developers need to implement and maintain code that mimics the functionality of the native browser tools (f.e. JS flamechart, network lane, etc.).
 

With the proposed API this problems could be significantly alleviated and it could potentially yield to an overall better experience for web developers.

For reference, here's at an example of a timeline recorded by React's profiler being surfaced to the Chrome DevTools Performance timeline:

React Profiler:
![image](https://github.com/facebook/react/assets/25348062/2b1e8ae5-4482-454d-aeb5-e66bbba23eb6)

Chrome DevTools Performance panel extended with React runtime data:
![image](https://github.com/facebook/react/assets/25348062/b32385a7-f3f0-4cc5-9cf9-4b626180034c)


We aim to collect feeback about the API and explore further potential use cases where the API (or an expansion of it) would offer value in the web ecosystem. The React team is a key player in this space and we would greatly appreciate it if you collaborated in this regard, so please let us know your thoughts! 🙏 

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

