### PR TITLE
Current behavior of precedence ordering

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -7478,6 +7478,29 @@ body {
         </html>,
       );
     });
+
+    it('stylesheets are ordered according to their precedence', async () => {
+      await act(() => {
+        renderToPipeableStream(
+          <html>
+            <body>
+              <link rel="stylesheet" href="foo" precedence="low" />
+              <link rel="stylesheet" href="bar" precedence="high" />
+            </body>
+          </html>,
+        ).pipe(writable);
+      });
+
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <link rel="stylesheet" href="foo" data-precedence="low" />
+            <link rel="stylesheet" href="bar" data-precedence="high" />
+          </head>
+          <body></body>
+        </html>,
+      );
+    });
   });
 
   describe('Style Resource', () => {
@@ -7951,6 +7974,37 @@ background-color: green;
         });
       }).toErrorDev(
         'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but ecountered spaces instead. using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this ocurred is "foo bar".',
+      );
+    });
+
+    it('styles are ordered according to their precedence', async () => {
+      await act(() => {
+        renderToPipeableStream(
+          <html>
+            <body>
+              <style href="foo" precedence="low">
+                one
+              </style>
+              <style href="bar" precedence="high">
+                two
+              </style>
+            </body>
+          </html>,
+        ).pipe(writable);
+      });
+
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <style data-href="foo" data-precedence="low">
+              one
+            </style>
+            <style data-href="bar" data-precedence="high">
+              two
+            </style>
+          </head>
+          <body></body>
+        </html>,
       );
     });
   });


### PR DESCRIPTION


## Summary

Replays behavior experienced in https://github.com/facebook/react/issues/29225

## How did you test this change?

- `yarn test --watch packages/react-dom/src/__tests__/ReactDOMFloat-test.js -t "are ordered according to their precedence"`
