### PR TITLE
compiler: Add todo for getter/setter syntax

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -1520,6 +1520,15 @@ function lowerExpression(
             place,
           });
         } else if (propertyPath.isObjectMethod()) {
+          if (propertyPath.node.kind !== "method") {
+            builder.errors.push({
+              reason: `(BuildHIR::lowerExpression) Handle ${propertyPath.node.kind} functions in ObjectExpression`,
+              severity: ErrorSeverity.Todo,
+              loc: propertyPath.node.loc ?? null,
+              suggestions: null,
+            });
+            continue;
+          }
           const method = lowerObjectMethod(builder, propertyPath);
           const place = lowerValueToTemporary(builder, method);
           const loweredKey = lowerObjectPropertyKey(builder, propertyPath);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-object-expression-get-syntax.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-object-expression-get-syntax.expect.md
@@ -1,0 +1,39 @@
+
+## Input
+
+```javascript
+function Component({ value }) {
+  const object = {
+    get value() {
+      return value;
+    },
+  };
+  return <div>{object.value}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [{ value: 0 }],
+  sequentialRenders: [{ value: 1 }, { value: 2 }],
+};
+
+```
+
+
+## Error
+
+```
+  1 | function Component({ value }) {
+  2 |   const object = {
+> 3 |     get value() {
+    |     ^^^^^^^^^^^^^
+> 4 |       return value;
+    | ^^^^^^^^^^^^^^^^^^^
+> 5 |     },
+    | ^^^^^^ Todo: (BuildHIR::lowerExpression) Handle get functions in ObjectExpression (3:5)
+  6 |   };
+  7 |   return <div>{object.value}</div>;
+  8 | }
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-object-expression-get-syntax.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-object-expression-get-syntax.js
@@ -1,0 +1,14 @@
+function Component({ value }) {
+  const object = {
+    get value() {
+      return value;
+    },
+  };
+  return <div>{object.value}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [{ value: 0 }],
+  sequentialRenders: [{ value: 1 }, { value: 2 }],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-object-expression-set-syntax.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-object-expression-set-syntax.expect.md
@@ -1,0 +1,41 @@
+
+## Input
+
+```javascript
+function Component(props) {
+  let value;
+  const object = {
+    set value(v) {
+      value = v;
+    },
+  };
+  object.value = props.value;
+  return <div>{value}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [{ value: 0 }],
+  sequentialRenders: [{ value: 1 }, { value: 2 }],
+};
+
+```
+
+
+## Error
+
+```
+  2 |   let value;
+  3 |   const object = {
+> 4 |     set value(v) {
+    |     ^^^^^^^^^^^^^^
+> 5 |       value = v;
+    | ^^^^^^^^^^^^^^^^
+> 6 |     },
+    | ^^^^^^ Todo: (BuildHIR::lowerExpression) Handle set functions in ObjectExpression (4:6)
+  7 |   };
+  8 |   object.value = props.value;
+  9 |   return <div>{value}</div>;
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-object-expression-set-syntax.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-object-expression-set-syntax.js
@@ -1,0 +1,16 @@
+function Component(props) {
+  let value;
+  const object = {
+    set value(v) {
+      value = v;
+    },
+  };
+  object.value = props.value;
+  return <div>{value}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [{ value: 0 }],
+  sequentialRenders: [{ value: 1 }, { value: 2 }],
+};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #29592
* #29591

We were missing a check that ObjectMethods are not getters or setters. In our experience this is pretty rare within React components and hooks themselves, so let's start with a todo.

Closes #29586