### PR TITLE
Export `version` from `react-dom` entry with `react-server` condition

### DIFF
--- a/packages/react-dom/src/ReactDOMReactServer.js
+++ b/packages/react-dom/src/ReactDOMReactServer.js
@@ -8,6 +8,10 @@
  */
 
 // This is the subset of APIs that can be accessed from Server Component modules
+
+import ReactVersion from 'shared/ReactVersion';
+export {ReactVersion as version};
+
 export {default as __DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE} from './ReactDOMSharedInternals';
 export {
   prefetchDNS,


### PR DESCRIPTION
## Summary

By exporting the `version` for this entry we can avoid this workaround in Next.js: https://github.com/vercel/next.js/blob/0f55f2ab1da5ee98b39316b4790734dd92ccc5bc/packages/next/src/server/future/route-modules/app-page/vendored/rsc/entrypoints.ts#L73-L79

## How did you test this change?

I ran `RELEASE_CHANNEL=stable node scripts/rollup/build.js --type=NODE_DEV` and then inspected the contents of `build/node_modules/react-dom/cjs/react-dom.react-server.development.js` to verify that `version` is included in the `exports`.