### PR TITLE
Remove Node.js 16 from package.json engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "yargs": "^15.3.1"
   },
   "devEngines": {
-    "node": "16.x || 18.x || 20.x || 21.x"
+    "node": "18.x || 20.x || 21.x"
   },
   "jest": {
     "testRegex": "/scripts/jest/dont-run-jest-directly\\.js$"


### PR DESCRIPTION
## Summary

Remove Node.js 16 from package.json engines field

**Motivation:**

This PR removes support for Node.js 16 to align with the React project's recent decision to drop Node.js 16 support ([#28774](https://github.com/facebook/react/pull/28774)). 
This change also prevents the following error from occurring when installing project dependencies with Yarn using Node.js 16, avoiding potential confusion for developers:

```
error eslint-v9@9.0.0: The engine "node" is incompatible with this module. Expected version "^18.18.0 || ^20.9.0 || >=21.1.0". Got "16.20.2"
```

**Changes:**

* **package.json update:** Removed the Node.js 16 version from the `engines` field in `package.json`, specifying only the supported Node.js versions (18.x, 20.x, 21.x):

```
"engines": {
  "node": "18.x || 20.x || 21.x"
},
```

## How did you test this change?

* **Dependency re-installation:** Ran `yarn install` with Node.js versions 18.x, 20.x, and 21.x to re-install project dependencies and confirm that the previously mentioned error does not occur with these supported Node.js versions.


