### PR TITLE
Fix:- fixed higherPriorityLane call & added a few test to the fibre lane

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -596,7 +596,11 @@ export function laneToLanes(lane: Lane): Lanes {
 
 export function higherPriorityLane(a: Lane, b: Lane): Lane {
   // This works because the bit ranges decrease in priority as you go left.
-  return a !== NoLane && a < b ? a : b;
+  if (a !== NoLane && b !== NoLane) {
+    return a < b ? a : b;
+  } else {
+    return a !== NoLane ? a : b;
+  }
 }
 
 export function createLaneMap<T>(initial: T): LaneMap<T> {

--- a/packages/react-reconciler/src/__tests__/ReactFiberLane-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberLane-test.internal.js
@@ -18,8 +18,6 @@ describe('ReactFiberLane', () => {
     ReactFiberLane = require('../ReactFiberLane');
   });
 
-  
-
   describe('includesNonIdleWork', () => {
     const nonIdleLaneNames = [
       'DefaultHydrationLane',

--- a/packages/react-reconciler/src/__tests__/ReactFiberLane-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberLane-test.internal.js
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+ */
+'use strict';
+
+let ReactFiberLane;
+
+describe('ReactFiberLane', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    ReactFiberLane = require('../ReactFiberLane');
+  });
+
+  
+
+  describe('includesNonIdleWork', () => {
+    const nonIdleLaneNames = [
+      'DefaultHydrationLane',
+      'SomeRetryLane',
+      'SelectiveHydrationLane',
+    ];
+
+    nonIdleLaneNames.forEach(laneName => {
+      it(`is true for ${laneName}`, () => {
+        const lane = ReactFiberLane[laneName];
+        expect(lane).toBeDefined();
+        expect(ReactFiberLane.includesNonIdleWork(lane)).toEqual(true);
+      });
+    });
+
+    const idleLaneNames = ['NoLane', 'OffscreenLane', 'IdleHydrationLane'];
+
+    idleLaneNames.forEach(laneName => {
+      it(`is false for ${laneName}`, () => {
+        const lane = ReactFiberLane[laneName];
+        expect(lane).toBeDefined();
+        expect(ReactFiberLane.includesNonIdleWork(lane)).toEqual(false);
+      });
+    });
+  });
+
+  describe('includesOnlyRetries', () => {
+    it('is true for a retry lane', () => {
+      expect(
+        ReactFiberLane.includesOnlyRetries(ReactFiberLane.SomeRetryLane),
+      ).toEqual(true);
+    });
+
+    it('is false for the sync lane', () => {
+      expect(
+        ReactFiberLane.includesOnlyRetries(ReactFiberLane.SyncLane),
+      ).toEqual(false);
+    });
+
+    it('is false for a retry lane merged with another lane', () => {
+      const mergedLanes = ReactFiberLane.mergeLanes(
+        ReactFiberLane.SyncLane,
+        ReactFiberLane.SomeRetryLane,
+      );
+      expect(ReactFiberLane.includesOnlyRetries(mergedLanes)).toEqual(false);
+    });
+  });
+
+  describe('includesSomeLane', () => {
+    it('is true given the same lane', () => {
+      const lane = ReactFiberLane.SyncLane;
+      expect(ReactFiberLane.includesSomeLane(lane, lane)).toEqual(true);
+    });
+
+    it('is true given lanes that includes the other', () => {
+      const lane = ReactFiberLane.SyncLane;
+      const mergedLanes = ReactFiberLane.mergeLanes(
+        lane,
+        ReactFiberLane.DefaultHydrationLane,
+      );
+
+      expect(ReactFiberLane.includesSomeLane(mergedLanes, lane)).toEqual(true);
+    });
+
+    it('is false for two seperate lanes', () => {
+      expect(
+        ReactFiberLane.includesSomeLane(
+          ReactFiberLane.SyncLane,
+          ReactFiberLane.DefaultHydrationLane,
+        ),
+      ).toEqual(false);
+    });
+  });
+
+  describe('isSubsetOfLanes', () => {
+    it('is true given the same lane', () => {
+      const lane = ReactFiberLane.SyncLane;
+      expect(ReactFiberLane.isSubsetOfLanes(lane, lane)).toEqual(true);
+    });
+
+    it('is true given lanes that includes the other', () => {
+      const subset = ReactFiberLane.mergeLanes(
+        ReactFiberLane.SyncLane,
+        ReactFiberLane.DefaultHydrationLane,
+      );
+      const mergedLanes = ReactFiberLane.mergeLanes(
+        subset,
+        ReactFiberLane.SyncBatchedLane,
+      );
+
+      expect(ReactFiberLane.includesSomeLane(mergedLanes, subset)).toEqual(
+        true,
+      );
+    });
+
+    it('is false for two seperate lanes', () => {
+      expect(
+        ReactFiberLane.includesSomeLane(
+          ReactFiberLane.SyncLane,
+          ReactFiberLane.DefaultHydrationLane,
+        ),
+      ).toEqual(false);
+    });
+  });
+
+  describe('mergeLanes', () => {
+    it('returns a lane that includes both inputs', () => {
+      const laneA = ReactFiberLane.SyncLane;
+      const laneB = ReactFiberLane.DefaultHydrationLane;
+
+      const mergedLanes = ReactFiberLane.mergeLanes(laneA, laneB);
+
+      expect(ReactFiberLane.includesSomeLane(mergedLanes, laneA)).toEqual(true);
+      expect(ReactFiberLane.includesSomeLane(mergedLanes, laneB)).toEqual(true);
+    });
+
+    it('returns the same lane given two identical lanes', () => {
+      const lane = ReactFiberLane.SyncLane;
+      expect(ReactFiberLane.mergeLanes(lane, lane)).toEqual(lane);
+    });
+  });
+
+  describe('removeLanes', () => {
+    it('returns the lanes without the given lane', () => {
+      const laneA = ReactFiberLane.SyncLane;
+      const laneB = ReactFiberLane.DefaultHydrationLane;
+      const mergedLanes = ReactFiberLane.mergeLanes(laneA, laneB);
+
+      expect(ReactFiberLane.removeLanes(mergedLanes, laneA)).toEqual(laneB);
+      expect(ReactFiberLane.removeLanes(mergedLanes, laneB)).toEqual(laneA);
+    });
+
+    it('returns the same lane when removing a lane not included', () => {
+      const lanes = ReactFiberLane.mergeLanes(
+        ReactFiberLane.SyncLane,
+        ReactFiberLane.DefaultHydrationLane,
+      );
+
+      expect(
+        ReactFiberLane.removeLanes(lanes, ReactFiberLane.SyncBatchedLane),
+      ).toEqual(lanes);
+    });
+  });
+
+  describe('higherPriorityLane', () => {
+    it('returns the other lane if one is NoLane', () => {
+      const lane = ReactFiberLane.SyncLane;
+
+      expect(
+        ReactFiberLane.higherPriorityLane(ReactFiberLane.NoLane, lane),
+      ).toEqual(lane);
+      expect(
+        ReactFiberLane.higherPriorityLane(lane, ReactFiberLane.NoLane),
+      ).toEqual(lane);
+    });
+
+    it('returns the higher priority lane', () => {
+      const higherLane = ReactFiberLane.SyncLane;
+      const otherLane = ReactFiberLane.OffscreenLane;
+      expect(ReactFiberLane.higherPriorityLane(higherLane, otherLane)).toEqual(
+        higherLane,
+      );
+      expect(ReactFiberLane.higherPriorityLane(otherLane, higherLane)).toEqual(
+        higherLane,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Just going through the codebase and going through the fibrelane there were no test, so i tried to write a few initial covering test from my understanding of the file, while writing the test found a small error in the `higherPriorityLane` call, If
the second argument is NoLane, it returns NoLane instead of returning the first given lane.

cc  @sebmarkbage  @acdlite  @eps1lon 



<img width="1233" alt="Screenshot 2024-05-27 at 10 30 20 PM" src="https://github.com/facebook/react/assets/72331432/a43fd39e-5205-44d3-945a-02cf6ab8cdb6">



