### PR TITLE
[Flight] Check if a return value is a client reference before introspecting

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -1828,4 +1828,30 @@ describe('ReactFlightDOM', () => {
       );
     }
   });
+
+  it('should be able to render a client reference as return value', async () => {
+    const ClientModule = clientExports({
+      text: 'Hello World',
+    });
+
+    function ServerComponent() {
+      return ClientModule.text;
+    }
+
+    const {writable, readable} = getTestStream();
+    const {pipe} = ReactServerDOMServer.renderToPipeableStream(
+      <ServerComponent />,
+      webpackMap,
+    );
+    pipe(writable);
+    const response = ReactServerDOMClient.createFromReadableStream(readable);
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(() => {
+      root.render(response);
+    });
+    expect(container.innerHTML).toBe('Hello World');
+  });
 });

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -1021,7 +1021,11 @@ function renderFunctionComponent<Props>(
     const secondArg = undefined;
     result = Component(props, secondArg);
   }
-  if (typeof result === 'object' && result !== null) {
+  if (
+    typeof result === 'object' &&
+    result !== null &&
+    !isClientReference(result)
+  ) {
     if (typeof result.then === 'function') {
       // When the return value is in children position we can resolve it immediately,
       // to its value without a wrapper if it's synchronously available.


### PR DESCRIPTION
This didn't actually fail before but I'm just adding an extra check.

Currently Client References are always "function" proxies so they never fall into this branch. However, we do in theory support objects as client references too depending on environment. We have checks elsewhere. So this just makes that consistent.