### PR TITLE
compiler: fix for calls on builtin jsx/function types

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
@@ -431,6 +431,9 @@ addObject(BUILTIN_SHAPES, BuiltInMixedReadonlyId, [
   ["*", { kind: "Object", shapeId: BuiltInMixedReadonlyId }],
 ]);
 
+addObject(BUILTIN_SHAPES, BuiltInJsxId, []);
+addObject(BUILTIN_SHAPES, BuiltInFunctionId, []);
+
 export const DefaultMutatingHook = addHook(
   BUILTIN_SHAPES,
   {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-to-string.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-to-string.expect.md
@@ -1,0 +1,61 @@
+
+## Input
+
+```javascript
+import fbt from "fbt";
+
+function Component(props) {
+  const element = (
+    <fbt desc={"Dialog to show to user"}>
+      Hello <fbt:param name="user name">{props.name}</fbt:param>
+    </fbt>
+  );
+  return element.toString();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ name: "Jason" }],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import fbt from "fbt";
+
+function Component(props) {
+  const $ = _c(4);
+  let t0;
+  if ($[0] !== props.name) {
+    t0 = fbt._("Hello {user name}", [fbt._param("user name", props.name)], {
+      hk: "2zEDKF",
+    });
+    $[0] = props.name;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  const element = t0;
+  let t1;
+  if ($[2] !== element) {
+    t1 = element.toString();
+    $[2] = element;
+    $[3] = t1;
+  } else {
+    t1 = $[3];
+  }
+  return t1;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ name: "Jason" }],
+};
+
+```
+      
+### Eval output
+(kind: ok) "Hello Jason"

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-to-string.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-to-string.js
@@ -1,0 +1,15 @@
+import fbt from "fbt";
+
+function Component(props) {
+  const element = (
+    <fbt desc={"Dialog to show to user"}>
+      Hello <fbt:param name="user name">{props.name}</fbt:param>
+    </fbt>
+  );
+  return element.toString();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ name: "Jason" }],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-expression-prototype-call-mutating.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-expression-prototype-call-mutating.expect.md
@@ -1,0 +1,92 @@
+
+## Input
+
+```javascript
+import { useMemo } from "react";
+import { ValidateMemoization } from "shared-runtime";
+
+function Component(props) {
+  const a = useMemo(() => {
+    const a = [];
+    const f = function () {
+      a.push(props.name);
+    };
+    f.call();
+    return a;
+  }, [props.name]);
+  return <ValidateMemoization inputs={[props.name]} output={a} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ name: "Jason" }],
+  sequentialRenders: [
+    { name: "Lauren" },
+    { name: "Lauren" },
+    { name: "Jason" },
+  ],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { useMemo } from "react";
+import { ValidateMemoization } from "shared-runtime";
+
+function Component(props) {
+  const $ = _c(7);
+  let t0;
+  let a;
+  if ($[0] !== props.name) {
+    a = [];
+    const f = function () {
+      a.push(props.name);
+    };
+
+    f.call();
+    $[0] = props.name;
+    $[1] = a;
+  } else {
+    a = $[1];
+  }
+  t0 = a;
+  const a_0 = t0;
+  let t1;
+  if ($[2] !== props.name) {
+    t1 = [props.name];
+    $[2] = props.name;
+    $[3] = t1;
+  } else {
+    t1 = $[3];
+  }
+  let t2;
+  if ($[4] !== t1 || $[5] !== a_0) {
+    t2 = <ValidateMemoization inputs={t1} output={a_0} />;
+    $[4] = t1;
+    $[5] = a_0;
+    $[6] = t2;
+  } else {
+    t2 = $[6];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ name: "Jason" }],
+  sequentialRenders: [
+    { name: "Lauren" },
+    { name: "Lauren" },
+    { name: "Jason" },
+  ],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"inputs":["Lauren"],"output":["Lauren"]}</div>
+<div>{"inputs":["Lauren"],"output":["Lauren"]}</div>
+<div>{"inputs":["Jason"],"output":["Jason"]}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-expression-prototype-call-mutating.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-expression-prototype-call-mutating.js
@@ -1,0 +1,24 @@
+import { useMemo } from "react";
+import { ValidateMemoization } from "shared-runtime";
+
+function Component(props) {
+  const a = useMemo(() => {
+    const a = [];
+    const f = function () {
+      a.push(props.name);
+    };
+    f.call();
+    return a;
+  }, [props.name]);
+  return <ValidateMemoization inputs={[props.name]} output={a} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ name: "Jason" }],
+  sequentialRenders: [
+    { name: "Lauren" },
+    { name: "Lauren" },
+    { name: "Jason" },
+  ],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-expression-prototype-call.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-expression-prototype-call.expect.md
@@ -1,0 +1,55 @@
+
+## Input
+
+```javascript
+function Component(props) {
+  const f = function () {
+    return <div>{props.name}</div>;
+  };
+  return f.call();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ name: "Jason" }],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component(props) {
+  const $ = _c(4);
+  let t0;
+  if ($[0] !== props.name) {
+    t0 = function () {
+      return <div>{props.name}</div>;
+    };
+    $[0] = props.name;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  const f = t0;
+  let t1;
+  if ($[2] !== f) {
+    t1 = f.call();
+    $[2] = f;
+    $[3] = t1;
+  } else {
+    t1 = $[3];
+  }
+  return t1;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ name: "Jason" }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>Jason</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-expression-prototype-call.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-expression-prototype-call.js
@@ -1,0 +1,11 @@
+function Component(props) {
+  const f = function () {
+    return <div>{props.name}</div>;
+  };
+  return f.call();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ name: "Jason" }],
+};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #29624

When I added new builtin types for jsx and functions, i forget to add a shape definition. This meant that attempting to accesss a property or method on these types would cause an internal error with an unresolved shape. That wasn't obvious because we rarely call methods on these types.

I confirmed that the new fixtures here fail without the fix.