### PR TITLE
Use both displayName and name in forwardRef/memo

### DIFF
--- a/packages/react/src/ReactForwardRef.js
+++ b/packages/react/src/ReactForwardRef.js
@@ -71,6 +71,7 @@ export function forwardRef<Props, ElementType: React$ElementType>(
           Object.defineProperty(render, 'name', {
             value: name,
           });
+          render.displayName = name;
         }
       },
     });

--- a/packages/react/src/ReactMemo.js
+++ b/packages/react/src/ReactMemo.js
@@ -51,6 +51,7 @@ export function memo<Props>(
           Object.defineProperty(type, 'name', {
             value: name,
           });
+          type.displayName = name;
         }
       },
     });


### PR DESCRIPTION
When defining a displayName on forwardRef/memo we forward that name to the inner function.

We used to use displayName for this but in #29206 I switched this to use `"name"`. That's because V8 doesn't use displayName, it only uses the overridden name in stack traces. This is the only thing covered by our tests for component stacks.

However, I realized that Safari only uses displayName and not the name. So this sets both.