### PR TITLE
Fix "findNodeHandle inside its render()" False Positive Warning

### DIFF
--- a/packages/react-native-renderer/src/ReactNativePublicCompat.js
+++ b/packages/react-native-renderer/src/ReactNativePublicCompat.js
@@ -90,7 +90,7 @@ export function findHostInstance_DEPRECATED<TElementType: ElementType>(
 export function findNodeHandle(componentOrHandle: any): ?number {
   if (__DEV__) {
     const owner = currentOwner;
-    if (owner !== null && owner.stateNode !== null) {
+    if (owner !== null && isRendering && owner.stateNode !== null) {
       if (!owner.stateNode._warnedAboutRefsInRender) {
         console.error(
           '%s is accessing findNodeHandle inside its render(). ' +


### PR DESCRIPTION
This was missed in https://github.com/facebook/react/pull/29038 when unifying the "owner" abstractions, causing `findNodeHandle` to warn even outside of `render()` invocations.