### PR TITLE
[Float][Fiber] properly cleanup instances when switching between instance and Resource modes

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2573,7 +2573,7 @@ export function acquireResource(
   hoistableRoot: HoistableRoot,
   resource: Resource,
   props: any,
-): null | Instance {
+): void {
   resource.count++;
   if (resource.instance === null) {
     switch (resource.type) {
@@ -2587,7 +2587,7 @@ export function acquireResource(
         if (instance) {
           resource.instance = instance;
           markNodeAsHoistable(instance);
-          return instance;
+          return;
         }
 
         const styleProps = styleTagPropsFromRawProps(props);
@@ -2604,7 +2604,7 @@ export function acquireResource(
         insertStylesheet(instance, qualifiedProps.precedence, hoistableRoot);
         resource.instance = instance;
 
-        return instance;
+        return;
       }
       case 'stylesheet': {
         // This typing is enforce by `getResource`. If we change the logic
@@ -2621,7 +2621,7 @@ export function acquireResource(
           resource.state.loading |= Inserted;
           resource.instance = instance;
           markNodeAsHoistable(instance);
-          return instance;
+          return;
         }
 
         const stylesheetProps = stylesheetPropsFromRawProps(props);
@@ -2644,7 +2644,7 @@ export function acquireResource(
         insertStylesheet(instance, qualifiedProps.precedence, hoistableRoot);
         resource.instance = instance;
 
-        return instance;
+        return;
       }
       case 'script': {
         // This typing is enforce by `getResource`. If we change the logic
@@ -2660,7 +2660,7 @@ export function acquireResource(
         if (instance) {
           resource.instance = instance;
           markNodeAsHoistable(instance);
-          return instance;
+          return;
         }
 
         let scriptProps = borrowedScriptProps;
@@ -2678,10 +2678,10 @@ export function acquireResource(
         (ownerDocument.head: any).appendChild(instance);
         resource.instance = instance;
 
-        return instance;
+        return;
       }
       case 'void': {
-        return null;
+        return;
       }
       default: {
         throw new Error(
@@ -2712,7 +2712,7 @@ export function acquireResource(
       insertStylesheet(instance, qualifiedProps.precedence, hoistableRoot);
     }
   }
-  return resource.instance;
+  return;
 }
 
 export function releaseResource(resource: Resource): void {

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -5230,6 +5230,103 @@ body {
     );
   });
 
+  it('can update link tags from Resource to instance and back', async () => {
+    const root = ReactDOMClient.createRoot(container);
+
+    root.render(
+      <div>
+        hello
+        <link rel="inst" href="a" />
+        <link rel="inst" href="b" />
+        <link rel="stylesheet" href="c" precedence="default" />
+      </div>,
+    );
+    await waitForAll([]);
+    loadPreloads();
+    loadStylesheets();
+    await assertLog(['load preload: c', 'load stylesheet: c']);
+
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <link rel="stylesheet" href="c" data-precedence="default" />
+          <link rel="preload" href="c" as="style" />
+          <link rel="inst" href="a" />
+          <link rel="inst" href="b" />
+        </head>
+        <body>
+          <div id="container">
+            <div>hello</div>
+          </div>
+        </body>
+      </html>,
+    );
+
+    root.render(
+      <div>
+        hello
+        <link rel="stylesheet" href="d" precedence="default" />
+        <link rel="inst" href="e" />
+        <link rel="inst" href="f" />
+      </div>,
+    );
+    await waitForAll([]);
+    loadPreloads();
+    loadStylesheets();
+    await assertLog(['load preload: d', 'load stylesheet: d']);
+
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <link rel="stylesheet" href="c" data-precedence="default" />
+          <link rel="stylesheet" href="d" data-precedence="default" />
+          <link rel="preload" href="c" as="style" />
+          <link rel="inst" href="e" />
+          <link rel="preload" href="d" as="style" />
+          <link rel="inst" href="f" />
+        </head>
+        <body>
+          <div id="container">
+            <div>hello</div>
+          </div>
+        </body>
+      </html>,
+    );
+
+    root.render(
+      <div>
+        hello
+        <link rel="inst" href="g" />
+        <link rel="inst" href="h" />
+        <link rel="stylesheet" href="i" precedence="default" />
+      </div>,
+    );
+    await waitForAll([]);
+    loadPreloads();
+    loadStylesheets();
+    await assertLog(['load preload: i', 'load stylesheet: i']);
+
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <link rel="stylesheet" href="c" data-precedence="default" />
+          <link rel="stylesheet" href="d" data-precedence="default" />
+          <link rel="stylesheet" href="i" data-precedence="default" />
+          <link rel="preload" href="c" as="style" />
+          <link rel="inst" href="h" />
+          <link rel="preload" href="d" as="style" />
+          <link rel="preload" href="i" as="style" />
+          <link rel="inst" href="g" />
+        </head>
+        <body>
+          <div id="container">
+            <div>hello</div>
+          </div>
+        </body>
+      </html>,
+    );
+  });
+
   describe('ReactDOM.prefetchDNS(href)', () => {
     it('creates a dns-prefetch resource when called', async () => {
       function App({url}) {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1705,6 +1705,27 @@ function updateHostHoistable(
         workInProgress,
       );
     }
+  } else {
+    // we're updating
+    if (current.memoizedState) {
+      if (resource === null) {
+        // we must be transitioning to the instance mode and need to create
+        // an instance
+        workInProgress.stateNode = createHoistableInstance(
+          workInProgress.type,
+          workInProgress.pendingProps,
+          getRootHostContainer(),
+          workInProgress,
+        );
+      }
+    } else {
+      if (resource) {
+        // we must be transitioning to the instance mode and need to void
+        // the previous stateNode. It will be unmounted during the commit
+        // we just null it on the workInProgress so it doesn't carry over
+        workInProgress.stateNode = null;
+      }
+    }
   }
 
   // Resources never have reconciler managed children. It is possible for

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -1039,9 +1039,6 @@ function completeWork(
           markUpdate(workInProgress);
           if (nextResource !== null) {
             // This is a Hoistable Resource
-
-            // This must come at the very end of the complete phase.
-            bubbleProperties(workInProgress);
             preloadResourceAndSuspendIfNeeded(
               workInProgress,
               nextResource,
@@ -1049,36 +1046,26 @@ function completeWork(
               newProps,
               renderLanes,
             );
-            return null;
           } else {
             // This is a Hoistable Instance
-
-            // This must come at the very end of the complete phase.
-            bubbleProperties(workInProgress);
             preloadInstanceAndSuspendIfNeeded(
               workInProgress,
               type,
               newProps,
               renderLanes,
             );
-            return null;
           }
         } else {
           // We are updating.
-          const currentResource = current.memoizedState;
-          if (nextResource !== currentResource) {
-            // We are transitioning to, from, or between Hoistable Resources
-            // and require an update
-            markUpdate(workInProgress);
-          }
           if (nextResource !== null) {
             // This is a Hoistable Resource
-            // This must come at the very end of the complete phase.
+            const currentResource = current.memoizedState;
 
-            bubbleProperties(workInProgress);
+            // This must come at the very end of the complete phase.
             if (nextResource === currentResource) {
               workInProgress.flags &= ~MaySuspendCommit;
             } else {
+              markUpdate(workInProgress);
               preloadResourceAndSuspendIfNeeded(
                 workInProgress,
                 nextResource,
@@ -1087,9 +1074,9 @@ function completeWork(
                 renderLanes,
               );
             }
-            return null;
           } else {
             // This is a Hoistable Instance
+
             // We may have props to update on the Hoistable instance.
             if (supportsMutation) {
               const oldProps = current.memoizedProps;
@@ -1108,17 +1095,17 @@ function completeWork(
               );
             }
 
-            // This must come at the very end of the complete phase.
-            bubbleProperties(workInProgress);
             preloadInstanceAndSuspendIfNeeded(
               workInProgress,
               type,
               newProps,
               renderLanes,
             );
-            return null;
           }
         }
+        // This must come at the very end of the complete phase.
+        bubbleProperties(workInProgress);
+        return null;
       }
       // Fall through
     }


### PR DESCRIPTION
HostHoistable is unfortunately complicated because any give fiber may be an Instance or a Resource and the lifetime of the fiber does not align with the lifetime of the underyling mode. Conceptually it'd be better if Resources were keyed intrinsically rather than using the key in JSX so we could have reconciliation deal with disposal of unmounted fibers. Maybe this is worth pursuing. However the current implementation models the inner identity during the render and commit phase so it needs to do some bookkeeping of things like the stateNode where other fiber types don't need to

@sokra pointed out some suspiciously broken looking code in commit work where we assign to the stateNode. It looks like an oversight in the original implementation but on further investigation there are other ways in which we don't properly clean up on identity transition during update.

This change adds extra logic to do proper clean. If you go from instance to Resource or vice versa we need to better model the unmount semantics and ensure there is no lingering stateNode
