### PR TITLE
Don't allow blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,4 @@
+blank_issues_enabled: false
 contact_links:
     - name: 📃 Documentation Issue
       url: https://github.com/reactjs/react.dev/issues/new/choose


### PR DESCRIPTION
We're getting a ton of issues filed using the blank template, for example these airline support tickets: https://github.com/facebook/react/issues/29678


I think someone somewhere is linking to our issues with pre-filled content. This fixes it by forcing a template to be used.