### PR TITLE
[CI] Output version strings to file for sync

### DIFF
--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -167,10 +167,14 @@ function processStable(buildDir) {
         fs.renameSync(filePath, filePath.replace('.js', '.classic.js'));
       }
     }
+    const versionString =
+      ReactVersion + '-www-classic-' + sha + '-' + dateString;
     updatePlaceholderReactVersionInCompiledArtifacts(
       buildDir + '/facebook-www',
-      ReactVersion + '-www-classic-' + sha + '-' + dateString
+      versionString
     );
+    // Also save a file with the version number
+    fs.writeFileSync(buildDir + '/facebook-www/VERSION_CLASSIC', versionString);
   }
 
   if (fs.existsSync(buildDir + '/sizes')) {
@@ -213,10 +217,15 @@ function processExperimental(buildDir, version) {
         fs.renameSync(filePath, filePath.replace('.js', '.modern.js'));
       }
     }
+    const versionString =
+      ReactVersion + '-www-modern-' + sha + '-' + dateString;
     updatePlaceholderReactVersionInCompiledArtifacts(
       buildDir + '/facebook-www',
-      ReactVersion + '-www-modern-' + sha + '-' + dateString
+      versionString
     );
+
+    // Also save a file with the version number
+    fs.writeFileSync(buildDir + '/facebook-www/VERSION_MODERN', versionString);
   }
 
   if (fs.existsSync(buildDir + '/sizes')) {

--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -228,6 +228,20 @@ function processExperimental(buildDir, version) {
     fs.writeFileSync(buildDir + '/facebook-www/VERSION_MODERN', versionString);
   }
 
+  if (fs.existsSync(buildDir + '/facebook-react-native')) {
+    const versionString = ReactVersion + '-native-fb-' + sha + '-' + dateString;
+    updatePlaceholderReactVersionInCompiledArtifacts(
+      buildDir + '/facebook-react-native',
+      versionString
+    );
+
+    // Also save a file with the version number
+    fs.writeFileSync(
+      buildDir + '/facebook-react-native/VERSION_NATIVE_FB',
+      versionString
+    );
+  }
+
   if (fs.existsSync(buildDir + '/sizes')) {
     fs.renameSync(buildDir + '/sizes', buildDir + '/sizes-experimental');
   }


### PR DESCRIPTION
Updates the build script to output VERSION files for the fb files. 

With these files, we can update the `commit_artifacts` job to do the following steps:

- Get last versions
  - Checkout `builds/facebook-www`
  - Read the last sync'd www `VERSION`
  - Checkout `builds/facebook-fbsource`
  - Read the last sync'd rn `VERSION`
- Download build
  - Checkout out `main` and sync new build
- Get the current versions
    - Read the current sync'd ww `VERSION`
    - Read the current sync'd rn `VERSION`
- For each sync of www/rn
  - Replace the current version with last version
    - `sed/{new version string}/{old version string}`
  - Check for changes
    - Run `git status`,
  - If there are no changes **skip sync**
  - Otherwise, replace the last version with current
    - `sed/{old version string}/{new version string}`
  - Commit to branch