### PR TITLE
[Flight] Run recreated Errors within a fake native stack

### DIFF
--- a/fixtures/flight/config/webpack.config.js
+++ b/fixtures/flight/config/webpack.config.js
@@ -7,6 +7,7 @@ const ReactFlightWebpackPlugin = require('react-server-dom-webpack/plugin');
 const fs = require('fs');
 const {createHash} = require('crypto');
 const path = require('path');
+const {pathToFileURL} = require('url');
 const webpack = require('webpack');
 const resolve = require('resolve');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
@@ -235,7 +236,7 @@ module.exports = function (webpackEnv) {
               .relative(paths.appSrc, info.absoluteResourcePath)
               .replace(/\\/g, '/')
         : isEnvDevelopment &&
-          (info => path.resolve(info.absoluteResourcePath).replace(/\\/g, '/')),
+          (info => pathToFileURL(path.resolve(info.absoluteResourcePath))),
     },
     cache: {
       type: 'filesystem',

--- a/fixtures/flight/src/index.js
+++ b/fixtures/flight/src/index.js
@@ -40,7 +40,11 @@ async function hydrateApp() {
     {
       callServer,
       findSourceMapURL(fileName) {
-        return '/source-maps?name=' + encodeURIComponent(fileName);
+        return (
+          document.location.origin +
+          '/source-maps?name=' +
+          encodeURIComponent(fileName)
+        );
       },
     }
   );

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -1739,8 +1739,14 @@ function createFakeFunction<T>(
   }
 
   if (sourceMap) {
-    code +=
-      '\n//# sourceURL=rsc://server/' + filename + '?' + fakeFunctionIdx++;
+    // We use the prefix rsc://React/ to separate these from other files listed in
+    // the Chrome DevTools. We need a "host name" and not just a protocol because
+    // otherwise the group name becomes the root folder. Ideally we don't want to
+    // show these at all but there's two reasons to assign a fake URL.
+    // 1) A printed stack trace string needs a unique URL to be able to source map it.
+    // 2) If source maps are disabled or fails, you should at least be able to tell
+    //    which file it was.
+    code += '\n//# sourceURL=rsc://React/' + filename + '?' + fakeFunctionIdx++;
     code += '\n//# sourceMappingURL=' + sourceMap;
   } else if (filename) {
     code += '\n//# sourceURL=' + filename;


### PR DESCRIPTION
Stacked on #29740.

Before:

<img width="719" alt="Screenshot 2024-06-02 at 11 51 20 AM" src="https://github.com/facebook/react/assets/63648/8f79fa82-2474-4583-894e-a2329e9a6304">

After (updated with my patches to Chrome):

<img width="813" alt="Screenshot 2024-06-06 at 5 16 20 PM" src="https://github.com/facebook/react/assets/63648/bcc4f52f-e0ac-4708-ac2b-9629acdff705">

Sources panel after:

<img width="1188" alt="Screenshot 2024-06-06 at 5 14 21 PM" src="https://github.com/facebook/react/assets/63648/2c673fac-d32d-42e4-8fac-bb63704e4b7f">

The fake eval file is now under "React" and the real file is now under `file://`