### PR TITLE
Update build script to automatically generate RCs

### DIFF
--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -28,6 +28,10 @@ const ReactVersion = '19.0.0';
 // npm dist tags used during publish, refer to .circleci/config.yml.
 const canaryChannelLabel = 'rc';
 
+// If the canaryChannelLabel is "rc", the build pipeline will use this to build
+// an RC version of the packages.
+const rcNumber = 0;
+
 const stablePackages = {
   'eslint-plugin-react-hooks': '5.1.0',
   'jest-react': '0.16.0',
@@ -53,6 +57,7 @@ const experimentalPackages = [];
 module.exports = {
   ReactVersion,
   canaryChannelLabel,
+  rcNumber,
   stablePackages,
   experimentalPackages,
 };

--- a/scripts/release/shared-commands/download-build-artifacts.js
+++ b/scripts/release/shared-commands/download-build-artifacts.js
@@ -50,6 +50,8 @@ const run = async ({build, cwd, releaseChannel}) => {
     sourceDir = 'oss-stable';
   } else if (releaseChannel === 'experimental') {
     sourceDir = 'oss-experimental';
+  } else if (releaseChannel === 'rc') {
+    sourceDir = 'oss-stable-rc';
   } else if (releaseChannel === 'latest') {
     sourceDir = 'oss-stable-semver';
   } else {

--- a/scripts/release/shared-commands/parse-params.js
+++ b/scripts/release/shared-commands/parse-params.js
@@ -50,10 +50,11 @@ module.exports = async () => {
   if (
     channel !== 'experimental' &&
     channel !== 'stable' &&
+    channel !== 'rc' &&
     channel !== 'latest'
   ) {
     console.error(
-      theme.error`Invalid release channel (-r) "${channel}". Must be "stable", "experimental", or "latest".`
+      theme.error`Invalid release channel (-r) "${channel}". Must be "stable", "experimental", "rc", or "latest".`
     );
     process.exit(1);
   }


### PR DESCRIPTION
RC releases are a special kind of prerelease build because unlike canaries we shouldn't publish new RCs from any commit on `main`, only when we intentionally bump the RC number. But they are still prerelases — like canary and experimental releases, they should use exact version numbers in their dependencies (no ^).

We only need to generate these builds during the RC phase, i.e. when the canary channel label is set to "rc".

Example of resulting package.json output:

```json
{
  "name": "react-dom",
  "version": "19.0.0-rc.0",
  "dependencies": {
    "scheduler": "0.25.0-rc.0"
  },
  "peerDependencies": {
    "react": "19.0.0-rc.0"
  }
}
```

https://react-builds.vercel.app/prs/29736/files/oss-stable-rc/react-dom/package.json