### PR TITLE
Fix xplat sync to ignore @generated header

### DIFF
--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -329,6 +329,8 @@ jobs:
           git status
           echo "===================="
           echo "Checking for changes"
+          # Check if there are changes in the files other than REVISION or @generated headers
+          # We also filter out the file name lines with "---" and "+++".
           if git diff -- . ':(exclude)*REVISION' | grep -vE "^(@@|diff|index|\-\-\-|\+\+\+|@generated SignedSource)" | grep "^[+-]" > /dev/null; then
             echo "Changes detected"
             echo "should_commit=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -329,7 +329,7 @@ jobs:
           git status
           echo "===================="
           echo "Checking for changes"
-          if git status --porcelain | grep -qv '/REVISION'; then
+          if git diff -- . ':(exclude)*REVISION' | grep -vE "^(@@|diff|index|\-\-\-|\+\+\+|@generated SignedSource)" | grep "^[+-]" > /dev/null; then
             echo "Changes detected"
             echo "should_commit=true" >> "$GITHUB_OUTPUT"
           else

--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -168,6 +168,15 @@ function processStable(buildDir) {
       );
     }
 
+    if (fs.existsSync(buildDir + '/facebook-react-native')) {
+      const versionString =
+        ReactVersion + '-native-fb-' + sha + '-' + dateString;
+      updatePlaceholderReactVersionInCompiledArtifacts(
+        buildDir + '/facebook-react-native',
+        versionString
+      );
+    }
+
     // Now do the semver ones
     const semverVersionsMap = new Map();
     for (const moduleName in stablePackages) {


### PR DESCRIPTION
Use some clever git diffing to ignore lines that only change the `@generated` header. We can't do this for the version string because the version string can be embedded in lines with other changes, but this header is always on one line.