### PR TITLE
Fix crash when parsing models with keyed fragments

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -1220,6 +1220,11 @@ function renderFragment(
       REACT_FRAGMENT_TYPE,
       task.keyPath,
       {children},
+      // TODO: Pass debug stack and info?
+      __DEV__ ? null : undefined,
+      __DEV__ ? null : undefined,
+      // validated
+      __DEV__ ? 1 : undefined,
     ];
     if (!task.implicitSlot) {
       // If this was keyed inside a set. I.e. the outer Server Component was keyed
@@ -1279,6 +1284,11 @@ function renderAsyncFragment(
       REACT_FRAGMENT_TYPE,
       task.keyPath,
       {children},
+      // TODO: Pass debug stack and info?
+      __DEV__ ? null : undefined,
+      __DEV__ ? null : undefined,
+      // validated
+      __DEV__ ? 1 : undefined,
     ];
     if (!task.implicitSlot) {
       // If this was keyed inside a set. I.e. the outer Server Component was keyed


### PR DESCRIPTION

## Summary

We expect that every tuple for elements has 7 items in DEV. However, we had some optimizations for fragments that only added the 4 items you need in prod. If we parse that model in a dev client, in environments with `createTask`, we crash because we only expect a stack to be `string | null` but received `undefined`.

## How did you test this change?

- mocked `createTask` in `ReactFlight-test` causing multiple tests to fail with the same error we're seeing in Next.js: https://github.com/vercel/next.js/actions/runs/9368979535/job/25792391746?pr=66533#step:28:406
