### PR TITLE
fix[react-devtools/store-test]: fork the test to represent current be…

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -1915,8 +1915,12 @@ describe('Store', () => {
       });
     });
 
-    // @reactVersion >= 18.0
-    it('from react get counted', () => {
+    // In React 19, JSX warnings were moved into the renderer - https://github.com/facebook/react/pull/29088
+    // When the error is emitted, the source fiber of this error is not yet mounted
+    // So DevTools can't connect the error and the fiber
+    // TODO(hoxyq): update RDT to keep track of such fibers
+    // @reactVersion >= 19.0
+    it('from react get counted [React >= 19]', () => {
       function Example() {
         return [<Child />];
       }
@@ -1934,6 +1938,31 @@ describe('Store', () => {
       expect(store).toMatchInlineSnapshot(`
         [root]
           ▾ <Example>
+              <Child>
+      `);
+    });
+
+    // @reactVersion >= 18.0
+    // @reactVersion < 19.0
+    it('from react get counted [React 18.x]', () => {
+      function Example() {
+        return [<Child />];
+      }
+      function Child() {
+        return null;
+      }
+
+      withErrorsOrWarningsIgnored(
+        ['Warning: Each child in a list should have a unique "key" prop'],
+        () => {
+          act(() => render(<Example />));
+        },
+      );
+
+      expect(store).toMatchInlineSnapshot(`
+        ✕ 1, ⚠ 0
+        [root]
+          ▾ <Example> ✕
               <Child>
       `);
     });


### PR DESCRIPTION
## Summary

The test started to fail after https://github.com/facebook/react/pull/29088.

Fork the test and the expected store state for:
- React 18.x, to represent the previous behavior
- React >= 19, to represent the current RDT behavior, where error can't be connected to the fiber, because it was not yet mounted and shared with DevTools.

Ideally, DevTools should start keeping track of such fibers, but also distinguish them from some that haven't mounted due to Suspense or error boundaries.

