### PR TITLE
compiler: More precise escape analysis

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-mutate.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-mutate.expect.md
@@ -26,11 +26,19 @@ export const FIXTURE_ENTRYPOINT = {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function component(a, b) {
-  const $ = _c(3);
+  const $ = _c(5);
   let z;
   if ($[0] !== a || $[1] !== b) {
     z = { a };
-    const y = { b };
+    let t0;
+    if ($[3] !== b) {
+      t0 = { b };
+      $[3] = b;
+      $[4] = t0;
+    } else {
+      t0 = $[4];
+    }
+    const y = t0;
     const x = function () {
       z.a = 2;
       console.log(y.b);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/method-call-computed.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/method-call-computed.expect.md
@@ -23,7 +23,7 @@ function foo(a, b, c) {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function foo(a, b, c) {
-  const $ = _c(8);
+  const $ = _c(6);
   let t0;
   if ($[0] !== a) {
     t0 = makeObject(a);
@@ -33,26 +33,18 @@ function foo(a, b, c) {
     t0 = $[1];
   }
   const x = t0;
+  const y = makeObject(a);
   let t1;
-  if ($[2] !== a) {
-    t1 = makeObject(a);
-    $[2] = a;
-    $[3] = t1;
+  if ($[2] !== x || $[3] !== y.method || $[4] !== b) {
+    t1 = x[y.method](b);
+    $[2] = x;
+    $[3] = y.method;
+    $[4] = b;
+    $[5] = t1;
   } else {
-    t1 = $[3];
+    t1 = $[5];
   }
-  const y = t1;
-  let t2;
-  if ($[4] !== x || $[5] !== y.method || $[6] !== b) {
-    t2 = x[y.method](b);
-    $[4] = x;
-    $[5] = y.method;
-    $[6] = b;
-    $[7] = t2;
-  } else {
-    t2 = $[7];
-  }
-  const z = t2;
+  const z = t1;
   return z;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/original-reactive-scopes-fork/mutate-outer-scope-within-value-block.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/original-reactive-scopes-fork/mutate-outer-scope-within-value-block.expect.md
@@ -68,26 +68,20 @@ import { CONST_TRUE, identity, shallowCopy } from "shared-runtime";
  * should be merged.
  */
 function useFoo(t0) {
-  const $ = _c(3);
+  const $ = _c(2);
   const { input } = t0;
   const arr = shallowCopy(input);
+
+  const cond = identity(false);
   let t1;
-  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = identity(false);
-    $[0] = t1;
+  if ($[0] !== arr) {
+    t1 = cond ? { val: CONST_TRUE } : mutate(arr);
+    $[0] = arr;
+    $[1] = t1;
   } else {
-    t1 = $[0];
+    t1 = $[1];
   }
-  const cond = t1;
-  let t2;
-  if ($[1] !== arr) {
-    t2 = cond ? { val: CONST_TRUE } : mutate(arr);
-    $[1] = arr;
-    $[2] = t2;
-  } else {
-    t2 = $[2];
-  }
-  return t2;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #29783
* __->__ #29782
* #29781
* #29780

Our current escape analysis currently works by determing values which are returned, finding the scope those values are produced in, and then walking the dependencies of those scopes. Notably, when we traverse into scopes, we _force_ their values to be memoized — even in cases where we can prove it isn't necessary.

The idea of this PR is to change escape analysis to be purely based on the flow of values. So rather than assume all scope deps need to be force-memoized, we look at how those values are used.

Note: the main motivation for this PR is the follow-up, which allows us to infer dependencies for pruned scopes. Without this change, inferring deps for pruned scopes causes the escape analysis pass to consider values as escaping which shouldn't be.