### PR TITLE
[compiler] Add repro for func properties bug with @gating

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-gating-invalid-function-properties.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-gating-invalid-function-properties.expect.md
@@ -1,0 +1,62 @@
+
+## Input
+
+```javascript
+// @gating
+
+/**
+ * Fail: bug-dropped-function-properties
+ *   Unexpected error in Forget runner
+ *   Component is not defined
+ */
+export default function Component() {
+  return <></>;
+}
+
+Component.displayName = "some display name";
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+  sequentialRenders: [],
+};
+
+```
+
+## Code
+
+```javascript
+import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag";
+import { c as _c } from "react/compiler-runtime"; // @gating
+
+/**
+ * Fail: bug-dropped-function-properties
+ *   Unexpected error in Forget runner
+ *   Component is not defined
+ */
+export default isForgetEnabled_Fixtures()
+  ? function Component() {
+      const $ = _c(1);
+      let t0;
+      if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+        t0 = <></>;
+        $[0] = t0;
+      } else {
+        t0 = $[0];
+      }
+      return t0;
+    }
+  : function Component() {
+      return <></>;
+    };
+
+Component.displayName = "some display name";
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+  sequentialRenders: [],
+};
+
+```
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-gating-invalid-function-properties.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-gating-invalid-function-properties.expect.md
@@ -5,7 +5,7 @@
 // @gating
 
 /**
- * Fail: bug-dropped-function-properties
+ * Fail: bug-gating-invalid-function-properties
  *   Unexpected error in Forget runner
  *   Component is not defined
  */
@@ -13,7 +13,12 @@ export default function Component() {
   return <></>;
 }
 
-Component.displayName = "some display name";
+export function Component2() {
+  return <></>;
+}
+
+Component.displayName = "Component ONE";
+Component2.displayName = "Component TWO";
 
 export const FIXTURE_ENTRYPOINT = {
   fn: Component,
@@ -30,7 +35,7 @@ import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag";
 import { c as _c } from "react/compiler-runtime"; // @gating
 
 /**
- * Fail: bug-dropped-function-properties
+ * Fail: bug-gating-invalid-function-properties
  *   Unexpected error in Forget runner
  *   Component is not defined
  */
@@ -50,7 +55,24 @@ export default isForgetEnabled_Fixtures()
       return <></>;
     };
 
-Component.displayName = "some display name";
+export const Component2 = isForgetEnabled_Fixtures()
+  ? function Component2() {
+      const $ = _c(1);
+      let t0;
+      if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+        t0 = <></>;
+        $[0] = t0;
+      } else {
+        t0 = $[0];
+      }
+      return t0;
+    }
+  : function Component2() {
+      return <></>;
+    };
+
+Component.displayName = "Component ONE";
+Component2.displayName = "Component TWO";
 
 export const FIXTURE_ENTRYPOINT = {
   fn: Component,

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-gating-invalid-function-properties.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-gating-invalid-function-properties.tsx
@@ -9,7 +9,12 @@ export default function Component() {
   return <></>;
 }
 
-Component.displayName = "some display name";
+export function Component2() {
+  return <></>;
+}
+
+Component.displayName = "Component ONE";
+Component2.displayName = "Component TWO";
 
 export const FIXTURE_ENTRYPOINT = {
   fn: Component,

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-gating-invalid-function-properties.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-gating-invalid-function-properties.tsx
@@ -1,0 +1,18 @@
+// @gating
+
+/**
+ * Fail: bug-gating-invalid-function-properties
+ *   Unexpected error in Forget runner
+ *   Component is not defined
+ */
+export default function Component() {
+  return <></>;
+}
+
+Component.displayName = "some display name";
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+  sequentialRenders: [],
+};

--- a/compiler/packages/snap/src/SproutTodoFilter.ts
+++ b/compiler/packages/snap/src/SproutTodoFilter.ts
@@ -490,6 +490,7 @@ const skipFilter = new Set([
   "bug-invalid-hoisting-functionexpr",
   "original-reactive-scopes-fork/bug-nonmutating-capture-in-unsplittable-memo-block",
   "original-reactive-scopes-fork/bug-hoisted-declaration-with-scope",
+  "bug-gating-invalid-function-properties",
 
   // 'react-compiler-runtime' not yet supported
   "flag-enable-emit-hook-guards",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #29806
* __->__ #29802

When gating is enabled, any function declaration properties that were
previously set (typically `Function.displayName`) would cause a crash
after compilation as the original identifier is no longer present.