### PR TITLE
compiler: Scope-based reordering

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
@@ -72,6 +72,7 @@ import {
 import { alignMethodCallScopes } from "../ReactiveScopes/AlignMethodCallScopes";
 import { alignReactiveScopesToBlockScopesHIR } from "../ReactiveScopes/AlignReactiveScopesToBlockScopesHIR";
 import { pruneAlwaysInvalidatingScopes } from "../ReactiveScopes/PruneAlwaysInvalidatingScopes";
+import pruneInitializationDependencies from "../ReactiveScopes/PruneInitializationDependencies";
 import { stabilizeBlockIds } from "../ReactiveScopes/StabilizeBlockIds";
 import { eliminateRedundantPhi, enterSSA, leaveSSA } from "../SSA";
 import { inferTypes } from "../TypeInference";
@@ -92,7 +93,6 @@ import {
   validatePreservedManualMemoization,
   validateUseMemo,
 } from "../Validation";
-import pruneInitializationDependencies from "../ReactiveScopes/PruneInitializationDependencies";
 
 export type CompilerPipelineValue =
   | { kind: "ast"; name: string; value: CodegenFunction }
@@ -203,9 +203,6 @@ function* runWithEnvironment(
   deadCodeElimination(hir);
   yield log({ kind: "hir", name: "DeadCodeElimination", value: hir });
 
-  instructionReordering(hir);
-  yield log({ kind: "hir", name: "InstructionReordering", value: hir });
-
   pruneMaybeThrows(hir);
   yield log({ kind: "hir", name: "PruneMaybeThrows", value: hir });
 
@@ -232,6 +229,9 @@ function* runWithEnvironment(
 
   inferReactiveScopeVariables(hir);
   yield log({ kind: "hir", name: "InferReactiveScopeVariables", value: hir });
+
+  instructionReordering(hir);
+  yield log({ kind: "hir", name: "InstructionReordering", value: hir });
 
   alignMethodCallScopes(hir);
   yield log({

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reorder-interleaved.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reorder-interleaved.expect.md
@@ -1,0 +1,58 @@
+
+## Input
+
+```javascript
+function Component(props) {
+  const a = [];
+  const b = [];
+  a.push(props.a);
+  b.push(props.b);
+  return [a, b];
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component(props) {
+  const $ = _c(7);
+  let t0;
+  if ($[0] !== props.a) {
+    const a = [];
+
+    a.push(props.a);
+
+    t0 = a;
+    $[0] = props.a;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  let t1;
+  if ($[2] !== props.b) {
+    const b = [];
+    b.push(props.b);
+    t1 = b;
+    $[2] = props.b;
+    $[3] = t1;
+  } else {
+    t1 = $[3];
+  }
+  let t2;
+  if ($[4] !== t0 || $[5] !== t1) {
+    t2 = [t0, t1];
+    $[4] = t0;
+    $[5] = t1;
+    $[6] = t2;
+  } else {
+    t2 = $[6];
+  }
+  return t2;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reorder-interleaved.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reorder-interleaved.js
@@ -1,0 +1,7 @@
+function Component(props) {
+  const a = [];
+  const b = [];
+  a.push(props.a);
+  b.push(props.b);
+  return [a, b];
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #29803
* #29668
* #29579

Extends instruction reordering further to allow reordering of instructions in different scopes. The basic idea is that each instructions within a scope maintain their original order with respect to each other, but instructions for different scopes can be reordered relative to other scopes. This allows interleaved or nested scopes to be reordered to avoid the interleaving/nesting.

There are lot of things still very broken about this, but the one new fixture shows an example of this working.

Note that this approach works very well for interleaving. We'll probably need to add a bit more to handle nesting - in general it's better to move nested scopes first before their parent scope, but the current algorithm for reordering doesn't take this into account yet.