### PR TITLE
[compiler] Always emit variable decl in gating mode

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating-preserves-function-properties.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating-preserves-function-properties.expect.md
@@ -4,11 +4,6 @@
 ```javascript
 // @gating
 
-/**
- * Fail: bug-gating-invalid-function-properties
- *   Unexpected error in Forget runner
- *   Component is not defined
- */
 export default function Component() {
   return <></>;
 }
@@ -23,7 +18,7 @@ Component2.displayName = "Component TWO";
 export const FIXTURE_ENTRYPOINT = {
   fn: Component,
   params: [],
-  sequentialRenders: [],
+  sequentialRenders: [{}],
 };
 
 ```
@@ -33,13 +28,7 @@ export const FIXTURE_ENTRYPOINT = {
 ```javascript
 import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag";
 import { c as _c } from "react/compiler-runtime"; // @gating
-
-/**
- * Fail: bug-gating-invalid-function-properties
- *   Unexpected error in Forget runner
- *   Component is not defined
- */
-export default isForgetEnabled_Fixtures()
+const Component = isForgetEnabled_Fixtures()
   ? function Component() {
       const $ = _c(1);
       let t0;
@@ -54,6 +43,7 @@ export default isForgetEnabled_Fixtures()
   : function Component() {
       return <></>;
     };
+export default Component;
 
 export const Component2 = isForgetEnabled_Fixtures()
   ? function Component2() {
@@ -77,8 +67,10 @@ Component2.displayName = "Component TWO";
 export const FIXTURE_ENTRYPOINT = {
   fn: Component,
   params: [],
-  sequentialRenders: [],
+  sequentialRenders: [{}],
 };
 
 ```
       
+### Eval output
+(kind: ok) 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating-preserves-function-properties.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating-preserves-function-properties.tsx
@@ -1,10 +1,5 @@
 // @gating
 
-/**
- * Fail: bug-gating-invalid-function-properties
- *   Unexpected error in Forget runner
- *   Component is not defined
- */
 export default function Component() {
   return <></>;
 }
@@ -19,5 +14,5 @@ Component2.displayName = "Component TWO";
 export const FIXTURE_ENTRYPOINT = {
   fn: Component,
   params: [],
-  sequentialRenders: [],
+  sequentialRenders: [{}],
 };

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating-test-export-default-function.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating-test-export-default-function.expect.md
@@ -24,7 +24,7 @@ function Foo(props) {
 ```javascript
 import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag";
 import { c as _c } from "react/compiler-runtime"; // @gating @compilationMode(annotation)
-export default isForgetEnabled_Fixtures()
+const Bar = isForgetEnabled_Fixtures()
   ? function Bar(props) {
       "use forget";
       const $ = _c(2);
@@ -42,6 +42,7 @@ export default isForgetEnabled_Fixtures()
       "use forget";
       return <div>{props.bar}</div>;
     };
+export default Bar;
 
 function NoForget(props) {
   return <Bar>{props.noForget}</Bar>;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating-test-export-function-and-default.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating-test-export-function-and-default.expect.md
@@ -24,7 +24,7 @@ export function Foo(props) {
 ```javascript
 import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag";
 import { c as _c } from "react/compiler-runtime"; // @gating @compilationMode(annotation)
-export default isForgetEnabled_Fixtures()
+const Bar = isForgetEnabled_Fixtures()
   ? function Bar(props) {
       "use forget";
       const $ = _c(2);
@@ -42,6 +42,7 @@ export default isForgetEnabled_Fixtures()
       "use forget";
       return <div>{props.bar}</div>;
     };
+export default Bar;
 
 function NoForget(props) {
   return <Bar>{props.noForget}</Bar>;

--- a/compiler/packages/snap/src/SproutTodoFilter.ts
+++ b/compiler/packages/snap/src/SproutTodoFilter.ts
@@ -490,7 +490,6 @@ const skipFilter = new Set([
   "bug-invalid-hoisting-functionexpr",
   "original-reactive-scopes-fork/bug-nonmutating-capture-in-unsplittable-memo-block",
   "original-reactive-scopes-fork/bug-hoisted-declaration-with-scope",
-  "bug-gating-invalid-function-properties",
 
   // 'react-compiler-runtime' not yet supported
   "flag-enable-emit-hook-guards",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #29806
* #29802

This PR makes it so we always emit a const VariableDeclaration for
compiled functions in gating mode. If the original declaration's parent
was an ExportDefaultDeclaration we'll also append a new
ExportDefaultDeclaration pointing to the new identifier. This allows
code that adds optional properties to the function declaration to still
work in gating mode