### PR TITLE
sanitize javascript: urls for <object> tags

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -406,6 +406,12 @@ function setProp(
       break;
     }
     // These attributes accept URLs. These must not allow javascript: URLS.
+    case 'data':
+      if (tag !== 'object') {
+        setValueForKnownAttribute(domElement, 'data', value);
+        break;
+      }
+    // fallthrough
     case 'src':
     case 'href': {
       if (enableFilterEmptyStringAttributesDOM) {
@@ -2453,13 +2459,22 @@ function diffHydratedGenericElement(
         warnForPropDifference(propKey, serverValue, value, serverDifferences);
         continue;
       }
+      case 'data':
+        if (tag !== 'object') {
+          extraAttributes.delete(propKey);
+          const serverValue = (domElement: any).getAttribute('data');
+          warnForPropDifference(propKey, serverValue, value, serverDifferences);
+          continue;
+        }
+      // fallthrough
       case 'src':
       case 'href':
         if (enableFilterEmptyStringAttributesDOM) {
           if (
             value === '' &&
             // <a href=""> is fine for "reload" links.
-            !(tag === 'a' && propKey === 'href')
+            !(tag === 'a' && propKey === 'href') &&
+            !(tag === 'object' && propKey === 'data')
           ) {
             if (__DEV__) {
               if (propKey === 'src') {

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationObject-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationObject-test.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment ./scripts/jest/ReactDOMServerIntegrationEnvironment
+ */
+
+'use strict';
+
+const ReactDOMServerIntegrationUtils = require('./utils/ReactDOMServerIntegrationTestUtils');
+
+let React;
+let ReactDOMClient;
+let ReactDOMServer;
+
+function initModules() {
+  // Reset warning cache.
+  jest.resetModules();
+  React = require('react');
+  ReactDOMClient = require('react-dom/client');
+  ReactDOMServer = require('react-dom/server');
+
+  // Make them available to the helpers.
+  return {
+    ReactDOMClient,
+    ReactDOMServer,
+  };
+}
+
+const {resetModules, itRenders} = ReactDOMServerIntegrationUtils(initModules);
+
+describe('ReactDOMServerIntegrationObject', () => {
+  beforeEach(() => {
+    resetModules();
+  });
+
+  itRenders('an object with children', async render => {
+    const e = await render(
+      <object type="video/mp4" data="/example.webm" width={600} height={400}>
+        <div>preview</div>
+      </object>,
+    );
+
+    expect(e.outerHTML).toBe(
+      '<object type="video/mp4" data="/example.webm" width="600" height="400"><div>preview</div></object>',
+    );
+  });
+
+  itRenders('an object with empty data', async render => {
+    const e = await render(<object data="" />, 1);
+    expect(e.outerHTML).toBe('<object></object>');
+  });
+});

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.js
@@ -69,6 +69,25 @@ describe('ReactDOMServerIntegration - Untrusted URLs', () => {
     expect(e.lastChild.href).toBe(EXPECTED_SAFE_URL);
   });
 
+  itRenders('sanitizes on various tags', async render => {
+    const aElement = await render(<a href="javascript:notfine" />);
+    expect(aElement.href).toBe(EXPECTED_SAFE_URL);
+
+    const objectElement = await render(<object data="javascript:notfine" />);
+    expect(objectElement.data).toBe(EXPECTED_SAFE_URL);
+
+    const embedElement = await render(<embed src="javascript:notfine" />);
+    expect(embedElement.src).toBe(EXPECTED_SAFE_URL);
+  });
+
+  itRenders('passes through data on non-object tags', async render => {
+    const div = await render(<div data="test" />);
+    expect(div.getAttribute('data')).toBe('test');
+
+    const a = await render(<a data="javascript:fine" />);
+    expect(a.getAttribute('data')).toBe('javascript:fine');
+  });
+
   itRenders('a javascript protocol with leading spaces', async render => {
     const e = await render(
       <a href={'  \t \u0000\u001F\u0003javascript\n: notfine'}>p0wned</a>,


### PR DESCRIPTION
sanitize javascript: urls for <object> tags

React 19 added sanitization for `javascript:` URLs for `href` properties on various tags. This PR also adds that sanitization for `<object>` tags as well that Firefox otherwise executes.
