### PR TITLE
Minify DEV bundles with closure

### DIFF
--- a/packages/shared/CheckStringCoercion.js
+++ b/packages/shared/CheckStringCoercion.js
@@ -43,6 +43,7 @@ function willCoercionThrow(value: mixed): boolean {
   }
 }
 
+/** @noinline */
 function testStringCoercion(value: mixed) {
   // If you ended up here by following an exception call stack, here's what's
   // happened: you supplied an object or symbol value to React (as a prop, key,

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -361,7 +361,8 @@ function getPlugins(
     const isProduction = isProductionBundleType(bundleType);
     const isProfiling = isProfilingBundleType(bundleType);
 
-    const needsMinifiedByClosure = isProduction && bundleType !== ESM_PROD;
+    const needsMinifiedByClosure =
+      bundleType !== ESM_PROD && bundleType !== ESM_DEV;
 
     return [
       // Keep dynamic imports as externals


### PR DESCRIPTION
The goal is to improve speed of the development by inlining and DCE unused branches.

We have the ability to preserve some variable names and pretty print in the production version so might as well do the same with DEV.

