### PR TITLE
compiler: Log metrics on pruned memo blocks/values

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
@@ -169,6 +169,8 @@ export type LoggerEvent =
       fnName: string | null;
       memoSlots: number;
       memoBlocks: number;
+      prunedMemoBlocks: number;
+      prunedMemoValues: number;
     }
   | {
       kind: "PipelineError";

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
@@ -169,6 +169,7 @@ export type LoggerEvent =
       fnName: string | null;
       memoSlots: number;
       memoBlocks: number;
+      memoValues: number;
       prunedMemoBlocks: number;
       prunedMemoValues: number;
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -329,6 +329,7 @@ export function compileProgram(
         fnName: compiledFn.id?.name ?? null,
         memoSlots: compiledFn.memoSlotsUsed,
         memoBlocks: compiledFn.memoBlocks,
+        memoValues: compiledFn.memoValues,
         prunedMemoBlocks: compiledFn.prunedMemoBlocks,
         prunedMemoValues: compiledFn.prunedMemoValues,
       });

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -329,6 +329,8 @@ export function compileProgram(
         fnName: compiledFn.id?.name ?? null,
         memoSlots: compiledFn.memoSlotsUsed,
         memoBlocks: compiledFn.memoBlocks,
+        prunedMemoBlocks: compiledFn.prunedMemoBlocks,
+        prunedMemoValues: compiledFn.prunedMemoValues,
       });
     } catch (err) {
       hasCriticalError ||= isCriticalError(err);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/log-pruned-memoization.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/log-pruned-memoization.expect.md
@@ -7,23 +7,32 @@ import { useState } from "react";
 import { identity, makeObject_Primitives, useHook } from "shared-runtime";
 
 function Component() {
+  // The scopes for x and x2 are interleaved, so this is one scope with two values
   const x = makeObject_Primitives();
   const x2 = makeObject_Primitives();
   useState(null);
   identity(x);
   identity(x2);
 
+  // We create a scope for all call expressions, but prune those with hook calls
+  // in this case it's _just_ a hook call, so we don't count this as pruned
   const y = useHook();
 
   const z = [];
-
   for (let i = 0; i < 10; i++) {
+    // The scope for obj is pruned bc it's in a loop
     const obj = makeObject_Primitives();
     z.push(obj);
   }
 
+  // Overall we expect two pruned scopes (for x+x2, and obj), with 3 pruned scope values.
   return [x, x2, y, z];
 }
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
 
 ```
 
@@ -36,6 +45,7 @@ import { identity, makeObject_Primitives, useHook } from "shared-runtime";
 
 function Component() {
   const $ = _c(5);
+
   const x = makeObject_Primitives();
   const x2 = makeObject_Primitives();
   useState(null);
@@ -67,13 +77,18 @@ function Component() {
   return t0;
 }
 
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
 ```
 
 ## Logs
 
 ```
-{"kind":"CompileSuccess","fnLoc":{"start":{"line":5,"column":0,"index":121},"end":{"line":22,"column":1,"index":431},"filename":"log-pruned-memoization.ts"},"fnName":"Component","memoSlots":5,"memoBlocks":2,"prunedMemoBlocks":2,"prunedMemoValues":3}
+{"kind":"CompileSuccess","fnLoc":{"start":{"line":5,"column":0,"index":121},"end":{"line":26,"column":1,"index":813},"filename":"log-pruned-memoization.ts"},"fnName":"Component","memoSlots":5,"memoBlocks":2,"prunedMemoBlocks":2,"prunedMemoValues":3}
 ```
       
 ### Eval output
-(kind: exception) Fixture not implemented
+(kind: ok) [{"a":0,"b":"value1","c":true},{"a":0,"b":"value1","c":true},{"a":0,"b":"value1","c":true},[{"a":0,"b":"value1","c":true},{"a":0,"b":"value1","c":true},{"a":0,"b":"value1","c":true},{"a":0,"b":"value1","c":true},{"a":0,"b":"value1","c":true},{"a":0,"b":"value1","c":true},{"a":0,"b":"value1","c":true},{"a":0,"b":"value1","c":true},{"a":0,"b":"value1","c":true},{"a":0,"b":"value1","c":true}]]

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/log-pruned-memoization.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/log-pruned-memoization.expect.md
@@ -87,7 +87,7 @@ export const FIXTURE_ENTRYPOINT = {
 ## Logs
 
 ```
-{"kind":"CompileSuccess","fnLoc":{"start":{"line":5,"column":0,"index":121},"end":{"line":26,"column":1,"index":813},"filename":"log-pruned-memoization.ts"},"fnName":"Component","memoSlots":5,"memoBlocks":2,"prunedMemoBlocks":2,"prunedMemoValues":3}
+{"kind":"CompileSuccess","fnLoc":{"start":{"line":5,"column":0,"index":121},"end":{"line":26,"column":1,"index":813},"filename":"log-pruned-memoization.ts"},"fnName":"Component","memoSlots":5,"memoBlocks":2,"memoValues":2,"prunedMemoBlocks":2,"prunedMemoValues":3}
 ```
       
 ### Eval output

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/log-pruned-memoization.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/log-pruned-memoization.expect.md
@@ -1,0 +1,79 @@
+
+## Input
+
+```javascript
+// @logger
+import { useState } from "react";
+import { identity, makeObject_Primitives, useHook } from "shared-runtime";
+
+function Component() {
+  const x = makeObject_Primitives();
+  const x2 = makeObject_Primitives();
+  useState(null);
+  identity(x);
+  identity(x2);
+
+  const y = useHook();
+
+  const z = [];
+
+  for (let i = 0; i < 10; i++) {
+    const obj = makeObject_Primitives();
+    z.push(obj);
+  }
+
+  return [x, x2, y, z];
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @logger
+import { useState } from "react";
+import { identity, makeObject_Primitives, useHook } from "shared-runtime";
+
+function Component() {
+  const $ = _c(5);
+  const x = makeObject_Primitives();
+  const x2 = makeObject_Primitives();
+  useState(null);
+  identity(x);
+  identity(x2);
+
+  const y = useHook();
+  let z;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    z = [];
+    for (let i = 0; i < 10; i++) {
+      const obj = makeObject_Primitives();
+      z.push(obj);
+    }
+    $[0] = z;
+  } else {
+    z = $[0];
+  }
+  let t0;
+  if ($[1] !== x || $[2] !== x2 || $[3] !== y) {
+    t0 = [x, x2, y, z];
+    $[1] = x;
+    $[2] = x2;
+    $[3] = y;
+    $[4] = t0;
+  } else {
+    t0 = $[4];
+  }
+  return t0;
+}
+
+```
+
+## Logs
+
+```
+{"kind":"CompileSuccess","fnLoc":{"start":{"line":5,"column":0,"index":121},"end":{"line":22,"column":1,"index":431},"filename":"log-pruned-memoization.ts"},"fnName":"Component","memoSlots":5,"memoBlocks":2,"prunedMemoBlocks":2,"prunedMemoValues":3}
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/log-pruned-memoization.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/log-pruned-memoization.js
@@ -1,0 +1,22 @@
+// @logger
+import { useState } from "react";
+import { identity, makeObject_Primitives, useHook } from "shared-runtime";
+
+function Component() {
+  const x = makeObject_Primitives();
+  const x2 = makeObject_Primitives();
+  useState(null);
+  identity(x);
+  identity(x2);
+
+  const y = useHook();
+
+  const z = [];
+
+  for (let i = 0; i < 10; i++) {
+    const obj = makeObject_Primitives();
+    z.push(obj);
+  }
+
+  return [x, x2, y, z];
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/log-pruned-memoization.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/log-pruned-memoization.js
@@ -3,20 +3,29 @@ import { useState } from "react";
 import { identity, makeObject_Primitives, useHook } from "shared-runtime";
 
 function Component() {
+  // The scopes for x and x2 are interleaved, so this is one scope with two values
   const x = makeObject_Primitives();
   const x2 = makeObject_Primitives();
   useState(null);
   identity(x);
   identity(x2);
 
+  // We create a scope for all call expressions, but prune those with hook calls
+  // in this case it's _just_ a hook call, so we don't count this as pruned
   const y = useHook();
 
   const z = [];
-
   for (let i = 0; i < 10; i++) {
+    // The scope for obj is pruned bc it's in a loop
     const obj = makeObject_Primitives();
     z.push(obj);
   }
 
+  // Overall we expect two pruned scopes (for x+x2, and obj), with 3 pruned scope values.
   return [x, x2, y, z];
 }
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};

--- a/compiler/packages/snap/src/reporter.ts
+++ b/compiler/packages/snap/src/reporter.ts
@@ -22,6 +22,7 @@ export function writeOutputToString(
   input: string,
   compilerOutput: string | null,
   evaluatorOutput: string | null,
+  logs: string | null,
   errorMessage: string | null
 ) {
   // leading newline intentional
@@ -39,6 +40,14 @@ ${wrapWithTripleBackticks(compilerOutput, "javascript")}
 `;
   } else {
     result += "\n";
+  }
+
+  if (logs != null) {
+    result += `
+## Logs
+
+${wrapWithTripleBackticks(logs, null)}
+`;
   }
 
   if (errorMessage != null) {

--- a/compiler/packages/snap/src/runner-worker.ts
+++ b/compiler/packages/snap/src/runner-worker.ts
@@ -189,6 +189,7 @@ export async function transformFixture(
     input,
     snapOutput,
     sproutOutput,
+    compileResult?.logs ?? null,
     error
   );
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #29820
* __->__ #29810
* #29790
* #29789
* #29781

Adds additional information to the CompileSuccess LoggerEvent:
* `prunedMemoBlocks` is the number of reactive scopes that were pruned for some reason.
* `prunedMemoValues` is the number of unique _values_ produced by those scopes.

Both numbers exclude blocks that are just a hook call - ie although we create and prune a scope for eg `useState()`, that's just an artifact of the sequencing of our pipeline. So what this metric is counting is cases of _other_ values that go unmemoized. See the new fixture, which takes advantage of improvements in the snap runner to optionally emit the logger events in the .expect.md file if you include the "@logger" pragma in a fixture.