### PR TITLE
fix<compiler>: ensure --src option correctly handles unquoted glob patterns (#29639)

### DIFF
--- a/compiler/packages/react-compiler-healthcheck/src/index.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/index.ts
@@ -38,10 +38,10 @@ async function main() {
     ],
   };
 
-  let paths = [];
+  const paths = new Set();
   for (const pattern of argv.src) {
     const resolvedPaths = await glob(pattern, globOptions);
-    paths.push(...resolvedPaths);
+    paths.add(...resolvedPaths);
   }
 
   for (const path of paths) {

--- a/compiler/packages/react-compiler-healthcheck/src/index.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/index.ts
@@ -20,7 +20,7 @@ async function main() {
     .option("src", {
       description: "glob expression matching src files to compile",
       type: "array",
-      default: "**/+(*.{js,mjs,jsx,ts,tsx}|package.json)",
+      default: ["**/+(*.{js,mjs,jsx,ts,tsx}|package.json)"],
     })
     .parseSync();
 

--- a/compiler/packages/react-compiler-healthcheck/src/index.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/index.ts
@@ -19,13 +19,12 @@ async function main() {
     .usage("$ npx healthcheck <src>")
     .option("src", {
       description: "glob expression matching src files to compile",
-      type: "string",
+      type: "array",
       default: "**/+(*.{js,mjs,jsx,ts,tsx}|package.json)",
     })
     .parseSync();
 
   const spinner = ora("Checking").start();
-  let src = argv.src;
 
   const globOptions = {
     onlyFiles: true,
@@ -39,7 +38,13 @@ async function main() {
     ],
   };
 
-  for (const path of await glob(src, globOptions)) {
+  let paths = [];
+  for (const pattern of argv.src) {
+    const resolvedPaths = await glob(pattern, globOptions);
+    paths.push(...resolvedPaths);
+  }
+
+  for (const path of paths) {
     const source = await fs.readFile(path, "utf-8");
     spinner.text = `Checking ${path}`;
     reactCompilerCheck.run(source, path);


### PR DESCRIPTION
## Summary

This pull request fixes issue [#29639](https://github.com/facebook/react/issues/29639) by enhancing the --src option in the healthcheck command to handle both quoted and unquoted glob patterns seamlessly.

## How did you test this change?

Check out the project [here](https://github.com/guillaumebrunerie/LD55). 
We can run 
`npx react-compiler-healthcheck --src 'src/**/*.{tsx,ts}' `
or 
`npx react-compiler-healthcheck --src src/**/*.{tsx,ts}`. 
Both commands work just fine.

Fixes #29639 