### PR TITLE
Fix typo in README.md

### DIFF
--- a/compiler/crates/react_semantic_analysis/README.md
+++ b/compiler/crates/react_semantic_analysis/README.md
@@ -3,4 +3,4 @@
 Implements semantic analysis of JavaScript name resolution and scope information over the `react_estree` AST. Eventually this
 analysis will be extended to cover Flow and TypeScript in addition to the core JS and JSX language.
 
-NOTE: this analsyis *assumes strict mode* and does not support legacy non-strict semantics.
+NOTE: this analysis *assumes strict mode* and does not support legacy non-strict semantics.


### PR DESCRIPTION

## Summary

This PR fixes a typo in the compiler/crates/react_semantic_analysis/README.md file.

- Corrected "analsyis" to "analysis".

## How did you test this change?
No additional code changes or tests were necessary for this documentation update.
