### PR TITLE
fix[compiler] remove duplicate parsePluginOptions from the compilePro…

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -24,7 +24,7 @@ import { isHookDeclaration } from "../Utils/HookDeclaration";
 import { assertExhaustive } from "../Utils/utils";
 import { insertGatedFunctionDeclaration } from "./Gating";
 import { addImportsToProgram, updateMemoCacheFunctionImport } from "./Imports";
-import { PluginOptions, parsePluginOptions } from "./Options";
+import { PluginOptions } from "./Options";
 import { compileFn } from "./Pipeline";
 import {
   filterSuppressionsThatAffectFunction,
@@ -217,9 +217,7 @@ export function compileProgram(
   program: NodePath<t.Program>,
   pass: CompilerPass
 ): void {
-  const options = parsePluginOptions(pass.opts);
-
-  if (options.sources) {
+  if (pass.opts.sources) {
     if (pass.filename === null) {
       const error = new CompilerError();
       error.pushErrorDetail(
@@ -235,21 +233,22 @@ export function compileProgram(
       return;
     }
 
-    if (!isFilePartOfSources(options.sources, pass.filename)) {
+    if (!isFilePartOfSources(pass.opts.sources, pass.filename)) {
       return;
     }
   }
 
   // Top level "use no forget", skip this file entirely
   if (
-    findDirectiveDisablingMemoization(program.node.directives, options) != null
+    findDirectiveDisablingMemoization(program.node.directives, pass.opts) !=
+    null
   ) {
     return;
   }
 
   const environment = parseEnvironmentConfig(pass.opts.environment ?? {});
   const useMemoCacheIdentifier = program.scope.generateUidIdentifier("c");
-  const moduleName = options.runtimeModule ?? "react/compiler-runtime";
+  const moduleName = pass.opts.runtimeModule ?? "react/compiler-runtime";
   if (hasMemoCacheFunctionImport(program, moduleName)) {
     return;
   }
@@ -261,8 +260,8 @@ export function compileProgram(
    */
   const suppressions = findProgramSuppressions(
     pass.comments,
-    options.eslintSuppressionRules ?? DEFAULT_ESLINT_SUPPRESSIONS,
-    options.flowSuppressions
+    pass.opts.eslintSuppressionRules ?? DEFAULT_ESLINT_SUPPRESSIONS,
+    pass.opts.flowSuppressions
   );
   const lintError = suppressionsToCompilerError(suppressions);
   let hasCriticalError = lintError != null;
@@ -319,11 +318,11 @@ export function compileProgram(
         config,
         fnType,
         useMemoCacheIdentifier.name,
-        options.logger,
+        pass.opts.logger,
         pass.filename,
         pass.code
       );
-      options.logger?.logEvent(pass.filename, {
+      pass.opts.logger?.logEvent(pass.filename, {
         kind: "CompileSuccess",
         fnLoc: fn.node.loc ?? null,
         fnName: compiledFn.id?.name ?? null,
@@ -370,12 +369,12 @@ export function compileProgram(
     },
     {
       ...pass,
-      opts: { ...pass.opts, ...options },
+      opts: { ...pass.opts, ...pass.opts },
       filename: pass.filename ?? null,
     }
   );
 
-  if (options.gating != null) {
+  if (pass.opts.gating != null) {
     const error = checkFunctionReferencedBeforeDeclarationAtTopLevel(
       program,
       compiledFns.map(({ originalFn }) => originalFn)
@@ -390,13 +389,13 @@ export function compileProgram(
   let gating: null | ExternalFunction = null;
   try {
     // TODO: check for duplicate import specifiers
-    if (options.gating != null) {
-      gating = tryParseExternalFunction(options.gating);
+    if (pass.opts.gating != null) {
+      gating = tryParseExternalFunction(pass.opts.gating);
       externalFunctions.push(gating);
     }
 
     const enableEmitInstrumentForget =
-      options.environment?.enableEmitInstrumentForget;
+      pass.opts.environment?.enableEmitInstrumentForget;
     if (enableEmitInstrumentForget != null) {
       externalFunctions.push(
         tryParseExternalFunction(enableEmitInstrumentForget.fn)
@@ -408,23 +407,23 @@ export function compileProgram(
       }
     }
 
-    if (options.environment?.enableEmitFreeze != null) {
+    if (pass.opts.environment?.enableEmitFreeze != null) {
       const enableEmitFreeze = tryParseExternalFunction(
-        options.environment.enableEmitFreeze
+        pass.opts.environment.enableEmitFreeze
       );
       externalFunctions.push(enableEmitFreeze);
     }
 
-    if (options.environment?.enableEmitHookGuards != null) {
+    if (pass.opts.environment?.enableEmitHookGuards != null) {
       const enableEmitHookGuards = tryParseExternalFunction(
-        options.environment.enableEmitHookGuards
+        pass.opts.environment.enableEmitHookGuards
       );
       externalFunctions.push(enableEmitHookGuards);
     }
 
-    if (options.environment?.enableChangeDetectionForDebugging != null) {
+    if (pass.opts.environment?.enableChangeDetectionForDebugging != null) {
       const enableChangeDetectionForDebugging = tryParseExternalFunction(
-        options.environment.enableChangeDetectionForDebugging
+        pass.opts.environment.enableChangeDetectionForDebugging
       );
       externalFunctions.push(enableChangeDetectionForDebugging);
     }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

The parsePluginOptions seemed to be duplicated within [BabelPlugin.ts](https://github.com/facebook/react/blob/f5af92d2c47d1e1f455faf912b1d3221d1038c37/compiler/packages/babel-plugin-react-compiler/src/Babel/BabelPlugin.ts#L32) and [Program.ts](https://github.com/facebook/react/blob/f5af92d2c47d1e1f455faf912b1d3221d1038c37/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts#L220).
Since the options already parsed in BabelPlugin.ts should have been passed to compileProgram, in this PR we deleted parsePluginOptions in compileProgram and used the options passed as arguments as they are. I've done that.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<img width="516" alt="image" src="https://github.com/facebook/react/assets/87469023/2a70c6ea-0330-42a2-adff-48ae3e905790">