### PR TITLE
Remove Warning: prefix and toString on console Arguments

### DIFF
--- a/packages/internal-test-utils/shouldIgnoreConsoleError.js
+++ b/packages/internal-test-utils/shouldIgnoreConsoleError.js
@@ -7,6 +7,9 @@ module.exports = function shouldIgnoreConsoleError(format, args) {
         args[0] != null &&
         ((typeof args[0] === 'object' &&
           typeof args[0].message === 'string' &&
+          // This specific log has the same signature as error logging.
+          // The trick is to get rid of this whole file.
+          !format.includes('Failed to serialize an action') &&
           typeof args[0].stack === 'string') ||
           (typeof args[0] === 'string' &&
             args[0].indexOf('An error occurred in ') === 0))

--- a/packages/react-cache/src/__tests__/ReactCacheOld-test.internal.js
+++ b/packages/react-cache/src/__tests__/ReactCacheOld-test.internal.js
@@ -182,7 +182,7 @@ describe('ReactCache', () => {
         await waitForAll(['App', 'Loading...']);
       }).toErrorDev([
         'Invalid key type. Expected a string, number, symbol, or ' +
-          'boolean, but instead received: Hi,100\n\n' +
+          "boolean, but instead received: [ 'Hi', 100 ]\n\n" +
           'To use non-primitive values as keys, you must pass a hash ' +
           'function as the second argument to createResource().',
       ]);

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -2556,7 +2556,7 @@ describe('InspectedElement', () => {
       };
 
       await withErrorsOrWarningsIgnored(
-        ['Warning: Each child in a list should have a unique "key" prop.'],
+        ['Each child in a list should have a unique "key" prop.'],
         async () => {
           await utils.actAsync(() =>
             render(<Example repeatWarningCount={1} />),

--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -154,23 +154,22 @@ beforeEach(() => {
 
   const originalConsoleError = console.error;
   console.error = (...args) => {
-    const firstArg = args[0];
-    if (
-      firstArg === 'Warning: React instrumentation encountered an error: %s'
-    ) {
+    let firstArg = args[0];
+    if (typeof firstArg === 'string' && firstArg.startsWith('Warning: ')) {
+      // Older React versions might use the Warning: prefix. I'm not sure
+      // if they use this code path.
+      firstArg = firstArg.slice(9);
+    }
+    if (firstArg === 'React instrumentation encountered an error: %s') {
       // Rethrow errors from React.
       throw args[1];
     } else if (
       typeof firstArg === 'string' &&
-      (firstArg.startsWith(
-        "Warning: It looks like you're using the wrong act()",
-      ) ||
+      (firstArg.startsWith("It looks like you're using the wrong act()") ||
         firstArg.startsWith(
-          'Warning: The current testing environment is not configured to support act',
+          'The current testing environment is not configured to support act',
         ) ||
-        firstArg.startsWith(
-          'Warning: You seem to have overlapping act() calls',
-        ))
+        firstArg.startsWith('You seem to have overlapping act() calls'))
     ) {
       // DevTools intentionally wraps updates with acts from both DOM and test-renderer,
       // since test updates are expected to impact both renderers.

--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -1927,7 +1927,7 @@ describe('Store', () => {
       }
 
       withErrorsOrWarningsIgnored(
-        ['Warning: Each child in a list should have a unique "key" prop'],
+        ['Each child in a list should have a unique "key" prop'],
         () => {
           act(() => render(<Example />));
         },
@@ -1952,7 +1952,7 @@ describe('Store', () => {
       }
 
       withErrorsOrWarningsIgnored(
-        ['Warning: Each child in a list should have a unique "key" prop'],
+        ['Each child in a list should have a unique "key" prop'],
         () => {
           act(() => render(<Example />));
         },

--- a/packages/react-devtools-shell/src/app/index.js
+++ b/packages/react-devtools-shell/src/app/index.js
@@ -32,8 +32,18 @@ ignoreErrors([
   'Warning: %s is deprecated in StrictMode.', // findDOMNode
   'Warning: ReactDOM.render was removed in React 19',
   'Warning: react-test-renderer is deprecated',
+  // Ignore prefixed and not prefixed since I don't know which
+  // React versions are being tested by this code.
+  'Legacy context API',
+  'Unsafe lifecycle methods',
+  '%s is deprecated in StrictMode.', // findDOMNode
+  'ReactDOM.render was removed in React 19',
+  'react-test-renderer is deprecated',
 ]);
-ignoreWarnings(['Warning: componentWillReceiveProps has been renamed']);
+ignoreWarnings([
+  'Warning: componentWillReceiveProps has been renamed',
+  'componentWillReceiveProps has been renamed',
+]);
 ignoreLogs([]);
 
 const unmountFunctions: Array<() => void | boolean> = [];

--- a/packages/react-dom-bindings/src/client/validateDOMNesting.js
+++ b/packages/react-dom-bindings/src/client/validateDOMNesting.js
@@ -484,7 +484,7 @@ function validateDOMNesting(
       // TODO: Format this as a linkified "diff view" with props instead of
       // a stack trace since the stack trace format is now for owner stacks.
       console['error'](
-        'Warning: In HTML, %s cannot be a child of <%s>.%s\n' +
+        'In HTML, %s cannot be a child of <%s>.%s\n' +
           'This will cause a hydration error.%s',
         tagDisplayName,
         ancestorTag,
@@ -498,7 +498,7 @@ function validateDOMNesting(
       // TODO: Format this as a linkified "diff view" with props instead of
       // a stack trace since the stack trace format is now for owner stacks.
       console['error'](
-        'Warning: In HTML, %s cannot be a descendant of <%s>.\n' +
+        'In HTML, %s cannot be a descendant of <%s>.\n' +
           'This will cause a hydration error.%s',
         tagDisplayName,
         ancestorTag,
@@ -530,7 +530,7 @@ function validateTextNesting(childText: string, parentTag: string): boolean {
       // TODO: Format this as a linkified "diff view" with props instead of
       // a stack trace since the stack trace format is now for owner stacks.
       console['error'](
-        'Warning: In HTML, text nodes cannot be a child of <%s>.\n' +
+        'In HTML, text nodes cannot be a child of <%s>.\n' +
           'This will cause a hydration error.%s',
         parentTag,
         getCurrentParentStackInDev(),
@@ -542,7 +542,7 @@ function validateTextNesting(childText: string, parentTag: string): boolean {
       // TODO: Format this as a linkified "diff view" with props instead of
       // a stack trace since the stack trace format is now for owner stacks.
       console['error'](
-        'Warning: In HTML, whitespace text nodes cannot be a child of <%s>. ' +
+        'In HTML, whitespace text nodes cannot be a child of <%s>. ' +
           "Make sure you don't have any extra whitespace between tags on " +
           'each line of your source code.\n' +
           'This will cause a hydration error.%s',

--- a/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
@@ -108,7 +108,7 @@ describe('CSSPropertyOperations', () => {
         root.render(<Comp />);
       });
     }).toErrorDev(
-      'Warning: Unsupported style property background-color. Did you mean backgroundColor?' +
+      'Unsupported style property background-color. Did you mean backgroundColor?' +
         '\n    in div (at **)' +
         '\n    in Comp (at **)',
     );
@@ -137,10 +137,10 @@ describe('CSSPropertyOperations', () => {
         root.render(<Comp style={styles} />);
       });
     }).toErrorDev([
-      'Warning: Unsupported style property -ms-transform. Did you mean msTransform?' +
+      'Unsupported style property -ms-transform. Did you mean msTransform?' +
         '\n    in div (at **)' +
         '\n    in Comp (at **)',
-      'Warning: Unsupported style property -webkit-transform. Did you mean WebkitTransform?' +
+      'Unsupported style property -webkit-transform. Did you mean WebkitTransform?' +
         '\n    in div (at **)' +
         '\n    in Comp (at **)',
     ]);
@@ -171,11 +171,11 @@ describe('CSSPropertyOperations', () => {
       });
     }).toErrorDev([
       // msTransform is correct already and shouldn't warn
-      'Warning: Unsupported vendor-prefixed style property oTransform. ' +
+      'Unsupported vendor-prefixed style property oTransform. ' +
         'Did you mean OTransform?' +
         '\n    in div (at **)' +
         '\n    in Comp (at **)',
-      'Warning: Unsupported vendor-prefixed style property webkitTransform. ' +
+      'Unsupported vendor-prefixed style property webkitTransform. ' +
         'Did you mean WebkitTransform?' +
         '\n    in div (at **)' +
         '\n    in Comp (at **)',
@@ -207,11 +207,11 @@ describe('CSSPropertyOperations', () => {
         root.render(<Comp />);
       });
     }).toErrorDev([
-      "Warning: Style property values shouldn't contain a semicolon. " +
+      "Style property values shouldn't contain a semicolon. " +
         'Try "backgroundColor: blue" instead.' +
         '\n    in div (at **)' +
         '\n    in Comp (at **)',
-      "Warning: Style property values shouldn't contain a semicolon. " +
+      "Style property values shouldn't contain a semicolon. " +
         'Try "color: red" instead.' +
         '\n    in div (at **)' +
         '\n    in Comp (at **)',
@@ -234,7 +234,7 @@ describe('CSSPropertyOperations', () => {
         root.render(<Comp />);
       });
     }).toErrorDev(
-      'Warning: `NaN` is an invalid value for the `fontSize` css style property.' +
+      '`NaN` is an invalid value for the `fontSize` css style property.' +
         '\n    in div (at **)' +
         '\n    in Comp (at **)',
     );
@@ -270,7 +270,7 @@ describe('CSSPropertyOperations', () => {
         root.render(<Comp />);
       });
     }).toErrorDev(
-      'Warning: `Infinity` is an invalid value for the `fontSize` css style property.' +
+      '`Infinity` is an invalid value for the `fontSize` css style property.' +
         '\n    in div (at **)' +
         '\n    in Comp (at **)',
     );

--- a/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
@@ -1333,7 +1333,7 @@ describe('DOMPropertyOperations', () => {
       });
 
       assertConsoleErrorDev([
-        'The `popoverTarget` prop expects the ID of an Element as a string. Received [object HTMLDivElement] instead.',
+        'The `popoverTarget` prop expects the ID of an Element as a string. Received HTMLDivElement {} instead.',
       ]);
 
       // Dedupe warning

--- a/packages/react-dom/src/__tests__/ReactComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponent-test.js
@@ -217,7 +217,7 @@ describe('ReactComponent', () => {
         root.render(<Component />);
       });
     }).toErrorDev([
-      'Warning: Component "Component" contains the string ref "inner". ' +
+      'Component "Component" contains the string ref "inner". ' +
         'Support for string refs will be removed in a future major release. ' +
         'We recommend using useRef() or createRef() instead. ' +
         'Learn more about using refs safely here: https://react.dev/link/strict-mode-string-ref\n' +
@@ -711,7 +711,7 @@ describe('ReactComponent', () => {
           root.render(<Foo />);
         });
       }).toErrorDev(
-        'Warning: Functions are not valid as a React child. This may happen if ' +
+        'Functions are not valid as a React child. This may happen if ' +
           'you return Foo instead of <Foo /> from render. ' +
           'Or maybe you meant to call this function rather than return it.\n' +
           '  <Foo>{Foo}</Foo>\n' +
@@ -733,7 +733,7 @@ describe('ReactComponent', () => {
           root.render(<Foo />);
         });
       }).toErrorDev(
-        'Warning: Functions are not valid as a React child. This may happen if ' +
+        'Functions are not valid as a React child. This may happen if ' +
           'you return Foo instead of <Foo /> from render. ' +
           'Or maybe you meant to call this function rather than return it.\n' +
           '  <Foo>{Foo}</Foo>\n' +
@@ -756,7 +756,7 @@ describe('ReactComponent', () => {
           root.render(<Foo />);
         });
       }).toErrorDev(
-        'Warning: Functions are not valid as a React child. This may happen if ' +
+        'Functions are not valid as a React child. This may happen if ' +
           'you return Foo instead of <Foo /> from render. ' +
           'Or maybe you meant to call this function rather than return it.\n' +
           '  <span>{Foo}</span>\n' +
@@ -811,13 +811,13 @@ describe('ReactComponent', () => {
           root.render(<Foo ref={current => (component = current)} />);
         });
       }).toErrorDev([
-        'Warning: Functions are not valid as a React child. This may happen if ' +
+        'Functions are not valid as a React child. This may happen if ' +
           'you return Foo instead of <Foo /> from render. ' +
           'Or maybe you meant to call this function rather than return it.\n' +
           '  <div>{Foo}</div>\n' +
           '    in div (at **)\n' +
           '    in Foo (at **)',
-        'Warning: Functions are not valid as a React child. This may happen if ' +
+        'Functions are not valid as a React child. This may happen if ' +
           'you return Foo instead of <Foo /> from render. ' +
           'Or maybe you meant to call this function rather than return it.\n' +
           '  <span>{Foo}</span>\n' +

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -271,7 +271,7 @@ describe('ReactComponentLifeCycle', () => {
         root.render(<StatefulComponent />);
       });
     }).toErrorDev(
-      "Warning: Can't call setState on a component that is not yet mounted. " +
+      "Can't call setState on a component that is not yet mounted. " +
         'This is a no-op, but it might indicate a bug in your application. ' +
         'Instead, assign to `this.state` directly or define a `state = {};` ' +
         'class property with the desired state in the StatefulComponent component.',
@@ -1504,20 +1504,20 @@ describe('ReactComponentLifeCycle', () => {
     }).toWarnDev(
       [
         /* eslint-disable max-len */
-        `Warning: componentWillMount has been renamed, and is not recommended for use. See https://react.dev/link/unsafe-component-lifecycles for details.
+        `componentWillMount has been renamed, and is not recommended for use. See https://react.dev/link/unsafe-component-lifecycles for details.
 
 * Move code with side effects to componentDidMount, and set initial state in the constructor.
 * Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run \`npx react-codemod rename-unsafe-lifecycles\` in your project source folder.
 
 Please update the following components: MyComponent`,
-        `Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://react.dev/link/unsafe-component-lifecycles for details.
+        `componentWillReceiveProps has been renamed, and is not recommended for use. See https://react.dev/link/unsafe-component-lifecycles for details.
 
 * Move data fetching code or side effects to componentDidUpdate.
 * If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://react.dev/link/derived-state
 * Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run \`npx react-codemod rename-unsafe-lifecycles\` in your project source folder.
 
 Please update the following components: MyComponent`,
-        `Warning: componentWillUpdate has been renamed, and is not recommended for use. See https://react.dev/link/unsafe-component-lifecycles for details.
+        `componentWillUpdate has been renamed, and is not recommended for use. See https://react.dev/link/unsafe-component-lifecycles for details.
 
 * Move data fetching code or side effects to componentDidUpdate.
 * Rename componentWillUpdate to UNSAFE_componentWillUpdate to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run \`npx react-codemod rename-unsafe-lifecycles\` in your project source folder.

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -313,7 +313,7 @@ describe('ReactCompositeComponent', () => {
         root.render(<MyComponent />);
       });
     }).toErrorDev(
-      "Warning: Can't call forceUpdate on a component that is not yet mounted. " +
+      "Can't call forceUpdate on a component that is not yet mounted. " +
         'This is a no-op, but it might indicate a bug in your application. ' +
         'Instead, assign to `this.state` directly or define a `state = {};` ' +
         'class property with the desired state in the MyComponent component.',
@@ -347,7 +347,7 @@ describe('ReactCompositeComponent', () => {
         root.render(<MyComponent />);
       });
     }).toErrorDev(
-      "Warning: Can't call setState on a component that is not yet mounted. " +
+      "Can't call setState on a component that is not yet mounted. " +
         'This is a no-op, but it might indicate a bug in your application. ' +
         'Instead, assign to `this.state` directly or define a `state = {};` ' +
         'class property with the desired state in the MyComponent component.',
@@ -484,7 +484,7 @@ describe('ReactCompositeComponent', () => {
         });
       }).rejects.toThrow(TypeError);
     }).toErrorDev(
-      'Warning: The <ClassWithRenderNotExtended /> component appears to have a render method, ' +
+      'The <ClassWithRenderNotExtended /> component appears to have a render method, ' +
         "but doesn't extend React.Component. This is likely to cause errors. " +
         'Change ClassWithRenderNotExtended to extend React.Component instead.',
     );
@@ -631,7 +631,7 @@ describe('ReactCompositeComponent', () => {
         instance.setState({bogus: true});
       });
     }).toErrorDev(
-      'Warning: ClassComponent.shouldComponentUpdate(): Returned undefined instead of a ' +
+      'ClassComponent.shouldComponentUpdate(): Returned undefined instead of a ' +
         'boolean value. Make sure to return true or false.',
     );
   });
@@ -651,7 +651,7 @@ describe('ReactCompositeComponent', () => {
         root.render(<Component />);
       });
     }).toErrorDev(
-      'Warning: Component has a method called ' +
+      'Component has a method called ' +
         'componentDidUnmount(). But there is no such lifecycle method. ' +
         'Did you mean componentWillUnmount()?',
     );
@@ -673,7 +673,7 @@ describe('ReactCompositeComponent', () => {
         root.render(<Component />);
       });
     }).toErrorDev(
-      'Warning: Component has a method called ' +
+      'Component has a method called ' +
         'componentDidReceiveProps(). But there is no such lifecycle method. ' +
         'If you meant to update the state in response to changing props, ' +
         'use componentWillReceiveProps(). If you meant to fetch data or ' +
@@ -699,7 +699,7 @@ describe('ReactCompositeComponent', () => {
         root.render(<Component />);
       });
     }).toErrorDev(
-      'Warning: Setting defaultProps as an instance property on Component is not supported ' +
+      'Setting defaultProps as an instance property on Component is not supported ' +
         'and will be ignored. Instead, define defaultProps as a static property on Component.',
     );
   });
@@ -1199,9 +1199,9 @@ describe('ReactCompositeComponent', () => {
         });
       }).rejects.toThrow();
     }).toErrorDev([
-      'Warning: No `render` method found on the RenderTextInvalidConstructor instance: ' +
+      'No `render` method found on the RenderTextInvalidConstructor instance: ' +
         'did you accidentally return an object from the constructor?',
-      'Warning: No `render` method found on the RenderTextInvalidConstructor instance: ' +
+      'No `render` method found on the RenderTextInvalidConstructor instance: ' +
         'did you accidentally return an object from the constructor?',
     ]);
   });
@@ -1239,9 +1239,9 @@ describe('ReactCompositeComponent', () => {
         });
       }).rejects.toThrow();
     }).toErrorDev([
-      'Warning: No `render` method found on the RenderTestUndefinedRender instance: ' +
+      'No `render` method found on the RenderTestUndefinedRender instance: ' +
         'you may have forgotten to define `render`.',
-      'Warning: No `render` method found on the RenderTestUndefinedRender instance: ' +
+      'No `render` method found on the RenderTestUndefinedRender instance: ' +
         'you may have forgotten to define `render`.',
     ]);
   });

--- a/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
@@ -474,7 +474,7 @@ describe('ReactCompositeComponent-state', () => {
         root.render(<Test />);
       });
     }).toErrorDev(
-      'Warning: Test.componentWillReceiveProps(): Assigning directly to ' +
+      'Test.componentWillReceiveProps(): Assigning directly to ' +
         "this.state is deprecated (except inside a component's constructor). " +
         'Use setState instead.',
     );
@@ -523,7 +523,7 @@ describe('ReactCompositeComponent-state', () => {
         root.render(<Test />);
       });
     }).toErrorDev(
-      'Warning: Test.componentWillMount(): Assigning directly to ' +
+      'Test.componentWillMount(): Assigning directly to ' +
         "this.state is deprecated (except inside a component's constructor). " +
         'Use setState instead.',
     );
@@ -571,7 +571,7 @@ describe('ReactCompositeComponent-state', () => {
         root.render(<B />);
       });
     }).toErrorDev(
-      "Warning: Can't perform a React state update on a component that hasn't mounted yet",
+      "Can't perform a React state update on a component that hasn't mounted yet",
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -198,8 +198,8 @@ describe('ReactDOM', () => {
       );
     }).toErrorDev(
       [
-        'Warning: Expected the last optional `callback` argument to be a function. Instead received: no.',
-        'Warning: Expected the last optional `callback` argument to be a function. Instead received: no.',
+        'Expected the last optional `callback` argument to be a function. Instead received: no.',
+        'Expected the last optional `callback` argument to be a function. Instead received: no.',
       ],
       {withoutStack: 2},
     );
@@ -215,8 +215,8 @@ describe('ReactDOM', () => {
       );
     }).toErrorDev(
       [
-        'Expected the last optional `callback` argument to be a function. Instead received: [object Object].',
-        'Expected the last optional `callback` argument to be a function. Instead received: [object Object].',
+        "Expected the last optional `callback` argument to be a function. Instead received: { foo: 'bar' }",
+        "Expected the last optional `callback` argument to be a function. Instead received: { foo: 'bar' }.",
       ],
       {withoutStack: 2},
     );
@@ -232,8 +232,8 @@ describe('ReactDOM', () => {
       );
     }).toErrorDev(
       [
-        'Expected the last optional `callback` argument to be a function. Instead received: [object Object].',
-        'Expected the last optional `callback` argument to be a function. Instead received: [object Object].',
+        'Expected the last optional `callback` argument to be a function. Instead received: Foo { a: 1, b: 2 }.',
+        'Expected the last optional `callback` argument to be a function. Instead received: Foo { a: 1, b: 2 }.',
       ],
       {withoutStack: 2},
     );
@@ -285,8 +285,8 @@ describe('ReactDOM', () => {
       );
     }).toErrorDev(
       [
-        'Expected the last optional `callback` argument to be a function. Instead received: [object Object].',
-        'Expected the last optional `callback` argument to be a function. Instead received: [object Object].',
+        "Expected the last optional `callback` argument to be a function. Instead received: { foo: 'bar' }.",
+        "Expected the last optional `callback` argument to be a function. Instead received: { foo: 'bar' }.",
       ],
       {withoutStack: 2},
     );
@@ -303,8 +303,8 @@ describe('ReactDOM', () => {
       );
     }).toErrorDev(
       [
-        'Expected the last optional `callback` argument to be a function. Instead received: [object Object].',
-        'Expected the last optional `callback` argument to be a function. Instead received: [object Object].',
+        'Expected the last optional `callback` argument to be a function. Instead received: Foo { a: 1, b: 2 }.',
+        'Expected the last optional `callback` argument to be a function. Instead received: Foo { a: 1, b: 2 }.',
       ],
       {withoutStack: 2},
     );

--- a/packages/react-dom/src/__tests__/ReactDOMAttribute-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMAttribute-test.js
@@ -110,7 +110,7 @@ describe('ReactDOM unknown attribute', () => {
           root.render(<div inert="" />);
         });
       }).toErrorDev([
-        'Warning: Received an empty string for a boolean attribute `inert`. ' +
+        'Received an empty string for a boolean attribute `inert`. ' +
           'This will treat the attribute as if it were false. ' +
           'Either pass `false` to silence this warning, or ' +
           'pass `true` if you used an empty string in earlier versions of React to indicate this attribute is true.',
@@ -137,7 +137,7 @@ describe('ReactDOM unknown attribute', () => {
 
     it('coerces NaN to strings and warns', async () => {
       await expect(() => testUnknownAttributeAssignment(NaN, 'NaN')).toErrorDev(
-        'Warning: Received NaN for the `unknown` attribute. ' +
+        'Received NaN for the `unknown` attribute. ' +
           'If this is expected, cast the value to a string.\n' +
           '    in div (at **)',
       );
@@ -170,14 +170,14 @@ describe('ReactDOM unknown attribute', () => {
       await expect(() =>
         expect(test).rejects.toThrowError(new TypeError('prod message')),
       ).toErrorDev(
-        'Warning: The provided `unknown` attribute is an unsupported type TemporalLike.' +
+        'The provided `unknown` attribute is an unsupported type TemporalLike.' +
           ' This value must be coerced to a string before using it here.',
       );
     });
 
     it('removes symbols and warns', async () => {
       await expect(() => testUnknownAttributeRemoval(Symbol('foo'))).toErrorDev(
-        'Warning: Invalid value for prop `unknown` on <div> tag. Either remove it ' +
+        'Invalid value for prop `unknown` on <div> tag. Either remove it ' +
           'from the element, or pass a string or number value to keep it ' +
           'in the DOM. For details, see https://react.dev/link/attribute-behavior \n' +
           '    in div (at **)',
@@ -188,7 +188,7 @@ describe('ReactDOM unknown attribute', () => {
       await expect(() =>
         testUnknownAttributeRemoval(function someFunction() {}),
       ).toErrorDev(
-        'Warning: Invalid value for prop `unknown` on <div> tag. Either remove ' +
+        'Invalid value for prop `unknown` on <div> tag. Either remove ' +
           'it from the element, or pass a string or number value to ' +
           'keep it in the DOM. For details, see ' +
           'https://react.dev/link/attribute-behavior \n' +

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -194,7 +194,7 @@ describe('ReactDOMComponent', () => {
           root.render(<div foo={() => {}} />);
         });
       }).toErrorDev(
-        'Warning: Invalid value for prop `foo` on <div> tag. Either remove it ' +
+        'Invalid value for prop `foo` on <div> tag. Either remove it ' +
           'from the element, or pass a string or number value to keep ' +
           'it in the DOM. For details, see https://react.dev/link/attribute-behavior ' +
           '\n    in div (at **)',
@@ -209,7 +209,7 @@ describe('ReactDOMComponent', () => {
           root.render(<div foo={() => {}} baz={() => {}} />);
         });
       }).toErrorDev(
-        'Warning: Invalid values for props `foo`, `baz` on <div> tag. Either remove ' +
+        'Invalid values for props `foo`, `baz` on <div> tag. Either remove ' +
           'them from the element, or pass a string or number value to keep ' +
           'them in the DOM. For details, see https://react.dev/link/attribute-behavior ' +
           '\n    in div (at **)',
@@ -224,7 +224,7 @@ describe('ReactDOMComponent', () => {
           root.render(<div onDblClick={() => {}} />);
         });
       }).toErrorDev(
-        'Warning: Invalid event handler property `onDblClick`. Did you mean `onDoubleClick`?\n    in div (at **)',
+        'Invalid event handler property `onDblClick`. Did you mean `onDoubleClick`?\n    in div (at **)',
       );
     });
 
@@ -236,7 +236,7 @@ describe('ReactDOMComponent', () => {
           root.render(<div onUnknown='alert("hack")' />);
         });
       }).toErrorDev(
-        'Warning: Unknown event handler property `onUnknown`. It will be ignored.\n    in div (at **)',
+        'Unknown event handler property `onUnknown`. It will be ignored.\n    in div (at **)',
       );
       expect(container.firstChild.hasAttribute('onUnknown')).toBe(false);
       expect(container.firstChild.onUnknown).toBe(undefined);
@@ -245,7 +245,7 @@ describe('ReactDOMComponent', () => {
           root.render(<div onunknown='alert("hack")' />);
         });
       }).toErrorDev(
-        'Warning: Unknown event handler property `onunknown`. It will be ignored.\n    in div (at **)',
+        'Unknown event handler property `onunknown`. It will be ignored.\n    in div (at **)',
       );
       expect(container.firstChild.hasAttribute('onunknown')).toBe(false);
       expect(container.firstChild.onunknown).toBe(undefined);
@@ -254,7 +254,7 @@ describe('ReactDOMComponent', () => {
           root.render(<div on-unknown='alert("hack")' />);
         });
       }).toErrorDev(
-        'Warning: Unknown event handler property `on-unknown`. It will be ignored.\n    in div (at **)',
+        'Unknown event handler property `on-unknown`. It will be ignored.\n    in div (at **)',
       );
       expect(container.firstChild.hasAttribute('on-unknown')).toBe(false);
       expect(container.firstChild['on-unknown']).toBe(undefined);
@@ -268,7 +268,7 @@ describe('ReactDOMComponent', () => {
           root.render(<div onUnknown={function () {}} />);
         });
       }).toErrorDev(
-        'Warning: Unknown event handler property `onUnknown`. It will be ignored.\n    in div (at **)',
+        'Unknown event handler property `onUnknown`. It will be ignored.\n    in div (at **)',
       );
       expect(container.firstChild.hasAttribute('onUnknown')).toBe(false);
       expect(container.firstChild.onUnknown).toBe(undefined);
@@ -277,7 +277,7 @@ describe('ReactDOMComponent', () => {
           root.render(<div onunknown={function () {}} />);
         });
       }).toErrorDev(
-        'Warning: Unknown event handler property `onunknown`. It will be ignored.\n    in div (at **)',
+        'Unknown event handler property `onunknown`. It will be ignored.\n    in div (at **)',
       );
       expect(container.firstChild.hasAttribute('onunknown')).toBe(false);
       expect(container.firstChild.onunknown).toBe(undefined);
@@ -286,7 +286,7 @@ describe('ReactDOMComponent', () => {
           root.render(<div on-unknown={function () {}} />);
         });
       }).toErrorDev(
-        'Warning: Unknown event handler property `on-unknown`. It will be ignored.\n    in div (at **)',
+        'Unknown event handler property `on-unknown`. It will be ignored.\n    in div (at **)',
       );
       expect(container.firstChild.hasAttribute('on-unknown')).toBe(false);
       expect(container.firstChild['on-unknown']).toBe(undefined);
@@ -300,7 +300,7 @@ describe('ReactDOMComponent', () => {
           root.render(<div CHILDREN="5" />);
         });
       }).toErrorDev(
-        'Warning: Invalid DOM property `CHILDREN`. Did you mean `children`?\n    in div (at **)',
+        'Invalid DOM property `CHILDREN`. Did you mean `children`?\n    in div (at **)',
       );
       expect(container.firstChild.getAttribute('CHILDREN')).toBe('5');
     });
@@ -328,7 +328,7 @@ describe('ReactDOMComponent', () => {
           root.render(<span style={style} />);
         });
       }).toErrorDev(
-        'Warning: `NaN` is an invalid value for the `fontSize` css style property.' +
+        '`NaN` is an invalid value for the `fontSize` css style property.' +
           '\n    in span (at **)',
       );
       await act(() => {
@@ -355,7 +355,7 @@ describe('ReactDOMComponent', () => {
             root.render(<span style={style} />);
           });
         }).toErrorDev(
-          'Warning: The provided `fontSize` CSS property is an unsupported type TemporalLike.' +
+          'The provided `fontSize` CSS property is an unsupported type TemporalLike.' +
             ' This value must be coerced to a string before using it here.',
         );
       }).rejects.toThrowError(new TypeError('prod message'));
@@ -891,8 +891,8 @@ describe('ReactDOMComponent', () => {
           expect(result2.toLowerCase()).not.toContain('script');
         }
       }).toErrorDev([
-        'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
-        'Warning: Invalid attribute name: `></div><script>alert("hi")</script>`',
+        'Invalid attribute name: `blah" onclick="beevil" noise="hi`',
+        'Invalid attribute name: `></div><script>alert("hi")</script>`',
       ]);
     });
 
@@ -915,8 +915,8 @@ describe('ReactDOMComponent', () => {
           expect(result2.toLowerCase()).not.toContain('script');
         }
       }).toErrorDev([
-        'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
-        'Warning: Invalid attribute name: `></x-foo-component><script>alert("hi")</script>`',
+        'Invalid attribute name: `blah" onclick="beevil" noise="hi`',
+        'Invalid attribute name: `></x-foo-component><script>alert("hi")</script>`',
       ]);
     });
 
@@ -953,8 +953,8 @@ describe('ReactDOMComponent', () => {
           expect(container.firstChild.attributes.length).toBe(0);
         }
       }).toErrorDev([
-        'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
-        'Warning: Invalid attribute name: `></div><script>alert("hi")</script>`',
+        'Invalid attribute name: `blah" onclick="beevil" noise="hi`',
+        'Invalid attribute name: `></div><script>alert("hi")</script>`',
       ]);
     });
 
@@ -992,8 +992,8 @@ describe('ReactDOMComponent', () => {
           expect(container.firstChild.attributes.length).toBe(0);
         }
       }).toErrorDev([
-        'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
-        'Warning: Invalid attribute name: `></x-foo-component><script>alert("hi")</script>`',
+        'Invalid attribute name: `blah" onclick="beevil" noise="hi`',
+        'Invalid attribute name: `></x-foo-component><script>alert("hi")</script>`',
       ]);
     });
 
@@ -1030,8 +1030,8 @@ describe('ReactDOMComponent', () => {
           expect(container.firstChild.attributes.length).toBe(0);
         }
       }).toErrorDev([
-        'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
-        'Warning: Invalid attribute name: `></div><script>alert("hi")</script>`',
+        'Invalid attribute name: `blah" onclick="beevil" noise="hi`',
+        'Invalid attribute name: `></div><script>alert("hi")</script>`',
       ]);
     });
 
@@ -1068,8 +1068,8 @@ describe('ReactDOMComponent', () => {
           expect(container.firstChild.attributes.length).toBe(0);
         }
       }).toErrorDev([
-        'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
-        'Warning: Invalid attribute name: `></x-foo-component><script>alert("hi")</script>`',
+        'Invalid attribute name: `blah" onclick="beevil" noise="hi`',
+        'Invalid attribute name: `></x-foo-component><script>alert("hi")</script>`',
       ]);
     });
 
@@ -1410,7 +1410,7 @@ describe('ReactDOMComponent', () => {
           root.render(<input value="" onChange={onChange} />);
         });
       }).toErrorDev(
-        ' A component is changing an uncontrolled input to be controlled. This is likely caused by ' +
+        'A component is changing an uncontrolled input to be controlled. This is likely caused by ' +
           'the value changing from undefined to a defined value, which should not happen. Decide between ' +
           'using a controlled or uncontrolled input element for the lifetime of the component.',
       );
@@ -1866,7 +1866,7 @@ describe('ReactDOMComponent', () => {
       await expect(async () => {
         await mountComponent({contentEditable: true, children: ''});
       }).toErrorDev(
-        'Warning: A component is `contentEditable` and contains `children` ' +
+        'A component is `contentEditable` and contains `children` ' +
           'managed by React. It is now your responsibility to guarantee that ' +
           'none of those nodes are unexpectedly modified or duplicated. This ' +
           'is probably not intentional.\n    in div (at **)',
@@ -2194,7 +2194,7 @@ describe('ReactDOMComponent', () => {
           );
         });
       }).toErrorDev([
-        'Warning: In HTML, <tr> cannot be a child of ' +
+        'In HTML, <tr> cannot be a child of ' +
           '<div>.\n' +
           'This will cause a hydration error.' +
           '\n    in tr (at **)' +
@@ -2215,7 +2215,7 @@ describe('ReactDOMComponent', () => {
           );
         });
       }).toErrorDev(
-        'Warning: In HTML, <p> cannot be a descendant ' +
+        'In HTML, <p> cannot be a descendant ' +
           'of <p>.\n' +
           'This will cause a hydration error.' +
           // There is no outer `p` here because root container is not part of the stack.
@@ -2249,7 +2249,7 @@ describe('ReactDOMComponent', () => {
           root.render(<Foo />);
         });
       }).toErrorDev([
-        'Warning: In HTML, <tr> cannot be a child of ' +
+        'In HTML, <tr> cannot be a child of ' +
           '<table>. Add a <tbody>, <thead> or <tfoot> to your code to match the DOM tree generated ' +
           'by the browser.\n' +
           'This will cause a hydration error.' +
@@ -2257,14 +2257,14 @@ describe('ReactDOMComponent', () => {
           '\n    in Row (at **)' +
           '\n    in table (at **)' +
           '\n    in Foo (at **)',
-        'Warning: In HTML, text nodes cannot be a ' +
+        'In HTML, text nodes cannot be a ' +
           'child of <tr>.\n' +
           'This will cause a hydration error.' +
           '\n    in tr (at **)' +
           '\n    in Row (at **)' +
           '\n    in table (at **)' +
           '\n    in Foo (at **)',
-        'Warning: In HTML, whitespace text nodes cannot ' +
+        'In HTML, whitespace text nodes cannot ' +
           "be a child of <table>. Make sure you don't have any extra " +
           'whitespace between tags on each line of your source code.\n' +
           'This will cause a hydration error.' +
@@ -2294,7 +2294,7 @@ describe('ReactDOMComponent', () => {
           root.render(<Foo> </Foo>);
         });
       }).toErrorDev([
-        'Warning: In HTML, whitespace text nodes cannot ' +
+        'In HTML, whitespace text nodes cannot ' +
           "be a child of <table>. Make sure you don't have any extra " +
           'whitespace between tags on each line of your source code.\n' +
           'This will cause a hydration error.' +
@@ -2323,7 +2323,7 @@ describe('ReactDOMComponent', () => {
           );
         });
       }).toErrorDev([
-        'Warning: In HTML, text nodes cannot be a ' +
+        'In HTML, text nodes cannot be a ' +
           'child of <tr>.\n' +
           'This will cause a hydration error.' +
           '\n    in tr (at **)' +
@@ -2713,7 +2713,7 @@ describe('ReactDOMComponent', () => {
           root.render(<div class="paladin" />);
         });
       }).toErrorDev(
-        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
+        'Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
       await expect(async () => {
         const container = document.createElement('div');
@@ -2722,7 +2722,7 @@ describe('ReactDOMComponent', () => {
           root.render(<input type="text" onclick="1" />);
         });
       }).toErrorDev(
-        'Warning: Invalid event handler property `onclick`. Did you mean ' +
+        'Invalid event handler property `onclick`. Did you mean ' +
           '`onClick`?\n    in input (at **)',
       );
     });
@@ -2731,12 +2731,12 @@ describe('ReactDOMComponent', () => {
       expect(() =>
         ReactDOMServer.renderToString(<div class="paladin" />),
       ).toErrorDev(
-        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
+        'Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
       expect(() =>
         ReactDOMServer.renderToString(<input type="text" oninput="1" />),
       ).toErrorDev(
-        'Warning: Invalid event handler property `oninput`. ' +
+        'Invalid event handler property `oninput`. ' +
           // Note: we don't know the right event name so we
           // use a generic one (onClick) as a suggestion.
           // This is because we don't bundle the event system
@@ -2760,7 +2760,7 @@ describe('ReactDOMComponent', () => {
           root.render(<div class="paladin" />);
         });
       }).toErrorDev(
-        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
+        'Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
     });
 
@@ -2912,7 +2912,7 @@ describe('ReactDOMComponent', () => {
           root.render(React.createElement('label', {for: 'test'}));
         });
       }).toErrorDev(
-        'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
+        'Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
       );
 
       await expect(async () => {
@@ -2924,7 +2924,7 @@ describe('ReactDOMComponent', () => {
           );
         });
       }).toErrorDev(
-        'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
+        'Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
       );
     });
 
@@ -2934,14 +2934,14 @@ describe('ReactDOMComponent', () => {
           React.createElement('label', {for: 'test'}),
         ),
       ).toErrorDev(
-        'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
+        'Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
       );
       expect(() =>
         ReactDOMServer.renderToString(
           React.createElement('input', {type: 'text', autofocus: true}),
         ),
       ).toErrorDev(
-        'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
+        'Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
       );
     });
   });
@@ -2989,9 +2989,7 @@ describe('ReactDOMComponent', () => {
         await act(() => {
           root.render(<div class="test" ref={current => (el = current)} />);
         });
-      }).toErrorDev(
-        'Warning: Invalid DOM property `class`. Did you mean `className`?',
-      );
+      }).toErrorDev('Invalid DOM property `class`. Did you mean `className`?');
 
       expect(el.className).toBe('test');
     });
@@ -3005,9 +3003,7 @@ describe('ReactDOMComponent', () => {
         await act(() => {
           root.render(<div cLASS="test" ref={current => (el = current)} />);
         });
-      }).toErrorDev(
-        'Warning: Invalid DOM property `cLASS`. Did you mean `className`?',
-      );
+      }).toErrorDev('Invalid DOM property `cLASS`. Did you mean `className`?');
 
       expect(el.className).toBe('test');
     });
@@ -3026,7 +3022,7 @@ describe('ReactDOMComponent', () => {
           );
         });
       }).toErrorDev(
-        'Warning: Invalid DOM property `arabic-form`. Did you mean `arabicForm`?',
+        'Invalid DOM property `arabic-form`. Did you mean `arabicForm`?',
       );
       const text = el.querySelector('text');
 
@@ -3164,7 +3160,7 @@ describe('ReactDOMComponent', () => {
             <div whatever={() => {}} ref={current => (el = current)} />,
           );
         });
-      }).toErrorDev('Warning: Invalid value for prop `whatever` on <div> tag');
+      }).toErrorDev('Invalid value for prop `whatever` on <div> tag');
 
       expect(el.hasAttribute('whatever')).toBe(false);
     });
@@ -3257,7 +3253,7 @@ describe('ReactDOMComponent', () => {
           root.render(<div whatever={NaN} ref={current => (el = current)} />);
         });
       }).toErrorDev(
-        'Warning: Received NaN for the `whatever` attribute. If this is ' +
+        'Received NaN for the `whatever` attribute. If this is ' +
           'expected, cast the value to a string.\n    in div',
       );
 
@@ -3274,7 +3270,7 @@ describe('ReactDOMComponent', () => {
         await act(() => {
           root.render(<div whatever={() => {}} />);
         });
-      }).toErrorDev('Warning: Invalid value for prop `whatever` on <div> tag.');
+      }).toErrorDev('Invalid value for prop `whatever` on <div> tag.');
       const el = container.firstChild;
       expect(el.hasAttribute('whatever')).toBe(false);
     });
@@ -3288,9 +3284,7 @@ describe('ReactDOMComponent', () => {
         await act(() => {
           root.render(<div SiZe="30" ref={current => (el = current)} />);
         });
-      }).toErrorDev(
-        'Warning: Invalid DOM property `SiZe`. Did you mean `size`?',
-      );
+      }).toErrorDev('Invalid DOM property `SiZe`. Did you mean `size`?');
 
       expect(el.getAttribute('size')).toBe('30');
     });
@@ -3502,9 +3496,7 @@ describe('ReactDOMComponent', () => {
             </svg>,
           );
         });
-      }).toErrorDev(
-        'Warning: Invalid DOM property `x-height`. Did you mean `xHeight`',
-      );
+      }).toErrorDev('Invalid DOM property `x-height`. Did you mean `xHeight`');
 
       expect(el.querySelector('font-face').hasAttribute('x-height')).toBe(
         false,

--- a/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
@@ -196,7 +196,7 @@ describe('ReactDOMComponentTree', () => {
           simulateInput(inputRef.current, finishValue);
         }),
     ).toErrorDev(
-      'Warning: A component is changing an uncontrolled input to be controlled. ' +
+      'A component is changing an uncontrolled input to be controlled. ' +
         'This is likely caused by the value changing from undefined to ' +
         'a defined value, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1810,7 +1810,7 @@ describe('ReactDOMFizzServer', () => {
 
       if (__DEV__) {
         expect(mockError).toHaveBeenCalledWith(
-          'Warning: <%s /> is using incorrect casing. Use PascalCase for React components, or lowercase for HTML elements.%s',
+          '<%s /> is using incorrect casing. Use PascalCase for React components, or lowercase for HTML elements.%s',
           'inCorrectTag',
           '\n' +
             '    in inCorrectTag (at **)\n' +
@@ -1831,7 +1831,7 @@ describe('ReactDOMFizzServer', () => {
 
       if (__DEV__) {
         expect(mockError).toHaveBeenCalledWith(
-          'Warning: Each child in a list should have a unique "key" prop.%s%s' +
+          'Each child in a list should have a unique "key" prop.%s%s' +
             ' See https://react.dev/link/warning-keys for more information.%s',
           gate(flags => flags.enableOwnerStacks)
             ? // We currently don't track owners in Fizz which is responsible for this frame.
@@ -6543,17 +6543,17 @@ describe('ReactDOMFizzServer', () => {
       if (__DEV__) {
         expect(mockError.mock.calls.length).toBe(3);
         expect(mockError.mock.calls[0]).toEqual([
-          'Warning: A script element was rendered with %s. If script element has children it must be a single string. Consider using dangerouslySetInnerHTML or passing a plain string as children.%s',
+          'A script element was rendered with %s. If script element has children it must be a single string. Consider using dangerouslySetInnerHTML or passing a plain string as children.%s',
           'a number for children',
           componentStack(['script', 'body', 'html']),
         ]);
         expect(mockError.mock.calls[1]).toEqual([
-          'Warning: A script element was rendered with %s. If script element has children it must be a single string. Consider using dangerouslySetInnerHTML or passing a plain string as children.%s',
+          'A script element was rendered with %s. If script element has children it must be a single string. Consider using dangerouslySetInnerHTML or passing a plain string as children.%s',
           'an array for children',
           componentStack(['script', 'body', 'html']),
         ]);
         expect(mockError.mock.calls[2]).toEqual([
-          'Warning: A script element was rendered with %s. If script element has children it must be a single string. Consider using dangerouslySetInnerHTML or passing a plain string as children.%s',
+          'A script element was rendered with %s. If script element has children it must be a single string. Consider using dangerouslySetInnerHTML or passing a plain string as children.%s',
           'something unexpected for children',
           componentStack(['script', 'body', 'html']),
         ]);

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -524,7 +524,7 @@ describe('ReactDOMFloat', () => {
     }).toErrorDev(
       [
         'Cannot render <noscript> outside the main document. Try moving it into the root <head> tag.',
-        'Warning: In HTML, <noscript> cannot be a child of <#document>.',
+        'In HTML, <noscript> cannot be a child of <#document>.',
       ],
       {withoutStack: 1},
     );
@@ -539,7 +539,7 @@ describe('ReactDOMFloat', () => {
       await waitForAll([]);
     }).toErrorDev([
       'Cannot render <template> outside the main document. Try moving it into the root <head> tag.',
-      'Warning: In HTML, <template> cannot be a child of <html>.',
+      'In HTML, <template> cannot be a child of <html>.',
     ]);
 
     await expect(async () => {
@@ -552,7 +552,7 @@ describe('ReactDOMFloat', () => {
       await waitForAll([]);
     }).toErrorDev([
       'Cannot render a <style> outside the main document without knowing its precedence and a unique href key. React can hoist and deduplicate <style> tags if you provide a `precedence` prop along with an `href` prop that does not conflic with the `href` values used in any other hoisted <style> or <link rel="stylesheet" ...> tags.  Note that hoisting <style> tags is considered an advanced feature that most will not use directly. Consider moving the <style> tag to the <head> or consider adding a `precedence="default"` and `href="some unique resource identifier"`, or move the <style> to the <style> tag.',
-      'Warning: In HTML, <style> cannot be a child of <html>.',
+      'In HTML, <style> cannot be a child of <html>.',
     ]);
 
     await expect(async () => {
@@ -575,7 +575,7 @@ describe('ReactDOMFloat', () => {
     }).toErrorDev(
       [
         'Cannot render a <link rel="stylesheet" /> outside the main document without knowing its precedence. Consider adding precedence="default" or moving it into the root <head> tag.',
-        'Warning: In HTML, <link> cannot be a child of <#document>.',
+        'In HTML, <link> cannot be a child of <#document>.',
       ],
       {withoutStack: 1},
     );
@@ -592,7 +592,7 @@ describe('ReactDOMFloat', () => {
       await waitForAll([]);
     }).toErrorDev([
       'Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag.',
-      'Warning: In HTML, <script> cannot be a child of <html>.',
+      'In HTML, <script> cannot be a child of <html>.',
     ]);
 
     await expect(async () => {

--- a/packages/react-dom/src/__tests__/ReactDOMForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMForm-test.js
@@ -386,7 +386,7 @@ describe('ReactDOMForm', () => {
         );
       });
     }).toErrorDev([
-      'Warning: In HTML, <form> cannot be a descendant of <form>.\n' +
+      'In HTML, <form> cannot be a descendant of <form>.\n' +
         'This will cause a hydration error.' +
         '\n    in form (at **)' +
         '\n    in form (at **)',

--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -121,7 +121,7 @@ describe('ReactDOMServerHydration', () => {
       } else {
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
+            "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
           - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
@@ -183,7 +183,7 @@ describe('ReactDOMServerHydration', () => {
       } else {
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
           [
-            "Warning: A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
+            "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
 
           - A server/client branch \`if (typeof window !== 'undefined')\`.
           - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
@@ -224,7 +224,7 @@ describe('ReactDOMServerHydration', () => {
       }
       expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
         [
-          "Warning: A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
+          "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
 
         - A server/client branch \`if (typeof window !== 'undefined')\`.
         - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
@@ -266,7 +266,7 @@ describe('ReactDOMServerHydration', () => {
       }
       expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
         [
-          "Warning: A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
+          "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
 
         - A server/client branch \`if (typeof window !== 'undefined')\`.
         - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
@@ -306,7 +306,7 @@ describe('ReactDOMServerHydration', () => {
       }
       expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
         [
-          "Warning: A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
+          "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
 
         - A server/client branch \`if (typeof window !== 'undefined')\`.
         - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
@@ -347,7 +347,7 @@ describe('ReactDOMServerHydration', () => {
       }
       expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
         [
-          "Warning: A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
+          "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
 
         - A server/client branch \`if (typeof window !== 'undefined')\`.
         - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
@@ -388,7 +388,7 @@ describe('ReactDOMServerHydration', () => {
       }
       expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
         [
-          "Warning: A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
+          "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
 
         - A server/client branch \`if (typeof window !== 'undefined')\`.
         - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
@@ -430,7 +430,7 @@ describe('ReactDOMServerHydration', () => {
       }
       expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
         [
-          "Warning: A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
+          "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
 
         - A server/client branch \`if (typeof window !== 'undefined')\`.
         - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
@@ -626,7 +626,7 @@ describe('ReactDOMServerHydration', () => {
         } else {
           expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
             [
-              "Warning: A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
+              "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
 
             - A server/client branch \`if (typeof window !== 'undefined')\`.
             - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -114,7 +114,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="text" value={0} />);
       });
     }).toErrorDev(
-      'Warning: You provided a `value` prop to a form ' +
+      'You provided a `value` prop to a form ' +
         'field without an `onChange` handler. This will render a read-only ' +
         'field. If the field should be mutable use `defaultValue`. ' +
         'Otherwise, set either `onChange` or `readOnly`.',
@@ -127,7 +127,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="text" value="" />);
       });
     }).toErrorDev(
-      'Warning: You provided a `value` prop to a form ' +
+      'You provided a `value` prop to a form ' +
         'field without an `onChange` handler. This will render a read-only ' +
         'field. If the field should be mutable use `defaultValue`. ' +
         'Otherwise, set either `onChange` or `readOnly`.',
@@ -140,7 +140,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="text" value="0" />);
       });
     }).toErrorDev(
-      'Warning: You provided a `value` prop to a form ' +
+      'You provided a `value` prop to a form ' +
         'field without an `onChange` handler. This will render a read-only ' +
         'field. If the field should be mutable use `defaultValue`. ' +
         'Otherwise, set either `onChange` or `readOnly`.',
@@ -153,7 +153,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="checkbox" checked={false} />);
       });
     }).toErrorDev(
-      'Warning: You provided a `checked` prop to a form field without an `onChange` handler.',
+      'You provided a `checked` prop to a form field without an `onChange` handler.',
     );
   });
 
@@ -169,7 +169,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="checkbox" checked={false} readOnly={false} />);
       });
     }).toErrorDev(
-      'Warning: You provided a `checked` prop to a form field without an `onChange` handler. ' +
+      'You provided a `checked` prop to a form field without an `onChange` handler. ' +
         'This will render a read-only field. If the field should be mutable use `defaultChecked`. ' +
         'Otherwise, set either `onChange` or `readOnly`.',
     );
@@ -218,7 +218,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="text" value="lion" />);
       });
     }).toErrorDev(
-      'Warning: You provided a `value` prop to a form field without an `onChange` handler.',
+      'You provided a `value` prop to a form field without an `onChange` handler.',
     );
     const node = container.firstChild;
     expect(isValueDirty(node)).toBe(true);
@@ -1911,7 +1911,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="text" value="zoink" readOnly={false} />);
       });
     }).toErrorDev(
-      'Warning: You provided a `value` prop to a form ' +
+      'You provided a `value` prop to a form ' +
         'field without an `onChange` handler. This will render a read-only ' +
         'field. If the field should be mutable use `defaultValue`. ' +
         'Otherwise, set either `onChange` or `readOnly`.\n' +
@@ -2048,7 +2048,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="text" />);
       });
     }).toErrorDev(
-      'Warning: A component is changing a controlled input to be uncontrolled. ' +
+      'A component is changing a controlled input to be uncontrolled. ' +
         'This is likely caused by the value changing from a defined to ' +
         'undefined, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2071,7 +2071,7 @@ describe('ReactDOMInput', () => {
     }).toErrorDev([
       '`value` prop on `input` should not be null. ' +
         'Consider using an empty string to clear the component or `undefined` for uncontrolled components',
-      'Warning: A component is changing a controlled input to be uncontrolled. ' +
+      'A component is changing a controlled input to be uncontrolled. ' +
         'This is likely caused by the value changing from a defined to ' +
         'undefined, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2092,7 +2092,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="text" defaultValue="uncontrolled" />);
       });
     }).toErrorDev(
-      'Warning: A component is changing a controlled input to be uncontrolled. ' +
+      'A component is changing a controlled input to be uncontrolled. ' +
         'This is likely caused by the value changing from a defined to ' +
         'undefined, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2111,7 +2111,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="text" value="controlled" />);
       });
     }).toErrorDev(
-      'Warning: A component is changing an uncontrolled input to be controlled. ' +
+      'A component is changing an uncontrolled input to be controlled. ' +
         'This is likely caused by the value changing from undefined to ' +
         'a defined value, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2135,7 +2135,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="text" value="controlled" />);
       });
     }).toErrorDev(
-      'Warning: A component is changing an uncontrolled input to be controlled. ' +
+      'A component is changing an uncontrolled input to be controlled. ' +
         'This is likely caused by the value changing from undefined to ' +
         'a defined value, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2156,7 +2156,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="checkbox" />);
       });
     }).toErrorDev(
-      'Warning: A component is changing a controlled input to be uncontrolled. ' +
+      'A component is changing a controlled input to be uncontrolled. ' +
         'This is likely caused by the value changing from a defined to ' +
         'undefined, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2177,7 +2177,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="checkbox" checked={null} />);
       });
     }).toErrorDev(
-      'Warning: A component is changing a controlled input to be uncontrolled. ' +
+      'A component is changing a controlled input to be uncontrolled. ' +
         'This is likely caused by the value changing from a defined to ' +
         'undefined, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2198,7 +2198,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="checkbox" defaultChecked={true} />);
       });
     }).toErrorDev(
-      'Warning: A component is changing a controlled input to be uncontrolled. ' +
+      'A component is changing a controlled input to be uncontrolled. ' +
         'This is likely caused by the value changing from a defined to ' +
         'undefined, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2217,7 +2217,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="checkbox" checked={true} />);
       });
     }).toErrorDev(
-      'Warning: A component is changing an uncontrolled input to be controlled. ' +
+      'A component is changing an uncontrolled input to be controlled. ' +
         'This is likely caused by the value changing from undefined to ' +
         'a defined value, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2236,7 +2236,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="checkbox" checked={true} />);
       });
     }).toErrorDev(
-      'Warning: A component is changing an uncontrolled input to be controlled. ' +
+      'A component is changing an uncontrolled input to be controlled. ' +
         'This is likely caused by the value changing from undefined to ' +
         'a defined value, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2255,7 +2255,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="radio" />);
       });
     }).toErrorDev(
-      'Warning: A component is changing a controlled input to be uncontrolled. ' +
+      'A component is changing a controlled input to be uncontrolled. ' +
         'This is likely caused by the value changing from a defined to ' +
         'undefined, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2274,7 +2274,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="radio" checked={null} />);
       });
     }).toErrorDev(
-      'Warning: A component is changing a controlled input to be uncontrolled. ' +
+      'A component is changing a controlled input to be uncontrolled. ' +
         'This is likely caused by the value changing from a defined to ' +
         'undefined, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2293,7 +2293,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="radio" defaultChecked={true} />);
       });
     }).toErrorDev(
-      'Warning: A component is changing a controlled input to be uncontrolled. ' +
+      'A component is changing a controlled input to be uncontrolled. ' +
         'This is likely caused by the value changing from a defined to ' +
         'undefined, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2312,7 +2312,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="radio" checked={true} />);
       });
     }).toErrorDev(
-      'Warning: A component is changing an uncontrolled input to be controlled. ' +
+      'A component is changing an uncontrolled input to be controlled. ' +
         'This is likely caused by the value changing from undefined to ' +
         'a defined value, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2331,7 +2331,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="radio" checked={true} />);
       });
     }).toErrorDev(
-      'Warning: A component is changing an uncontrolled input to be controlled. ' +
+      'A component is changing an uncontrolled input to be controlled. ' +
         'This is likely caused by the value changing from undefined to ' +
         'a defined value, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -2395,7 +2395,7 @@ describe('ReactDOMInput', () => {
         root.render(<input type="radio" value="value" />);
       });
     }).toErrorDev(
-      'Warning: A component is changing a controlled input to be uncontrolled. ' +
+      'A component is changing a controlled input to be uncontrolled. ' +
         'This is likely caused by the value changing from a defined to ' +
         'undefined, which should not happen. ' +
         'Decide between using a controlled or uncontrolled input ' +

--- a/packages/react-dom/src/__tests__/ReactDOMInvalidARIAHook-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInvalidARIAHook-test.js
@@ -36,7 +36,7 @@ describe('ReactDOMInvalidARIAHook', () => {
     });
     it('should warn for one invalid aria-* prop', async () => {
       await expect(() => mountComponent({'aria-badprop': 'maybe'})).toErrorDev(
-        'Warning: Invalid aria prop `aria-badprop` on <div> tag. ' +
+        'Invalid aria prop `aria-badprop` on <div> tag. ' +
           'For details, see https://react.dev/link/invalid-aria-props',
       );
     });
@@ -47,14 +47,14 @@ describe('ReactDOMInvalidARIAHook', () => {
           'aria-malprop': 'Turbulent seas',
         }),
       ).toErrorDev(
-        'Warning: Invalid aria props `aria-badprop`, `aria-malprop` on <div> ' +
+        'Invalid aria props `aria-badprop`, `aria-malprop` on <div> ' +
           'tag. For details, see https://react.dev/link/invalid-aria-props',
       );
     });
     it('should warn for an improperly cased aria-* prop', async () => {
       // The valid attribute name is aria-haspopup.
       await expect(() => mountComponent({'aria-hasPopup': 'true'})).toErrorDev(
-        'Warning: Unknown ARIA attribute `aria-hasPopup`. ' +
+        'Unknown ARIA attribute `aria-hasPopup`. ' +
           'Did you mean `aria-haspopup`?',
       );
     });
@@ -62,7 +62,7 @@ describe('ReactDOMInvalidARIAHook', () => {
     it('should warn for use of recognized camel case aria attributes', async () => {
       // The valid attribute name is aria-haspopup.
       await expect(() => mountComponent({ariaHasPopup: 'true'})).toErrorDev(
-        'Warning: Invalid ARIA attribute `ariaHasPopup`. ' +
+        'Invalid ARIA attribute `ariaHasPopup`. ' +
           'Did you mean `aria-haspopup`?',
       );
     });
@@ -72,7 +72,7 @@ describe('ReactDOMInvalidARIAHook', () => {
       await expect(() =>
         mountComponent({ariaSomethingInvalid: 'true'}),
       ).toErrorDev(
-        'Warning: Invalid ARIA attribute `ariaSomethingInvalid`. ARIA ' +
+        'Invalid ARIA attribute `ariaSomethingInvalid`. ARIA ' +
           'attributes follow the pattern aria-* and must be lowercase.',
       );
     });

--- a/packages/react-dom/src/__tests__/ReactDOMOption-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMOption-test.js
@@ -266,7 +266,7 @@ describe('ReactDOMOption', () => {
           onRecoverableError: () => {},
         });
       });
-    }).toErrorDev(['Warning: In HTML, <div> cannot be a child of <option>']);
+    }).toErrorDev(['In HTML, <div> cannot be a child of <option>']);
     option = container.firstChild.firstChild;
 
     expect(option.textContent).toBe('BarFooBaz');

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -1694,7 +1694,7 @@ describe('ReactDOMSelect', () => {
           );
         });
       }).toErrorDev(
-        'Warning: You provided a `value` prop to a form ' +
+        'You provided a `value` prop to a form ' +
           'field without an `onChange` handler. This will render a read-only ' +
           'field. If the field should be mutable use `defaultValue`. ' +
           'Otherwise, set `onChange`.',
@@ -1715,7 +1715,7 @@ describe('ReactDOMSelect', () => {
           );
         });
       }).toErrorDev(
-        'Warning: You provided a `value` prop to a form ' +
+        'You provided a `value` prop to a form ' +
           'field without an `onChange` handler. This will render a read-only ' +
           'field. If the field should be mutable use `defaultValue`. ' +
           'Otherwise, set `onChange`.',
@@ -1736,7 +1736,7 @@ describe('ReactDOMSelect', () => {
           );
         });
       }).toErrorDev(
-        'Warning: You provided a `value` prop to a form ' +
+        'You provided a `value` prop to a form ' +
           'field without an `onChange` handler. This will render a read-only ' +
           'field. If the field should be mutable use `defaultValue`. ' +
           'Otherwise, set `onChange`.',
@@ -1757,7 +1757,7 @@ describe('ReactDOMSelect', () => {
           );
         });
       }).toErrorDev(
-        'Warning: You provided a `value` prop to a form ' +
+        'You provided a `value` prop to a form ' +
           'field without an `onChange` handler. This will render a read-only ' +
           'field. If the field should be mutable use `defaultValue`. ' +
           'Otherwise, set `onChange`.',

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
@@ -987,7 +987,7 @@ describe('ReactDOMServerIntegration', () => {
           expect(() => {
             EmptyComponent = <EmptyComponent />;
           }).toErrorDev(
-            'Warning: React.jsx: type is invalid -- expected a string ' +
+            'React.jsx: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: object. You likely forgot to export your ' +
               "component from the file it's defined in, or you might have mixed up " +
@@ -1011,7 +1011,7 @@ describe('ReactDOMServerIntegration', () => {
           expect(() => {
             NullComponent = <NullComponent />;
           }).toErrorDev(
-            'Warning: React.jsx: type is invalid -- expected a string ' +
+            'React.jsx: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: null.',
             {withoutStack: true},
@@ -1029,7 +1029,7 @@ describe('ReactDOMServerIntegration', () => {
           expect(() => {
             UndefinedComponent = <UndefinedComponent />;
           }).toErrorDev(
-            'Warning: React.jsx: type is invalid -- expected a string ' +
+            'React.jsx: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: undefined. You likely forgot to export your ' +
               "component from the file it's defined in, or you might have mixed up " +

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContext-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContext-test.js
@@ -314,7 +314,7 @@ describe('ReactDOMServerIntegration', () => {
       expect(() => {
         ReactDOMServer.renderToString(<MyComponent />);
       }).toErrorDev(
-        'Warning: MyComponent.getChildContext(): childContextTypes must be defined in order to use getChildContext().\n' +
+        'MyComponent.getChildContext(): childContextTypes must be defined in order to use getChildContext().\n' +
           '    in MyComponent (at **)',
       );
     });

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationRefs-test.js
@@ -96,7 +96,7 @@ describe('ReactDOMServerIntegration', () => {
           true,
         );
       }).toErrorDev([
-        'Warning: Component "RefsComponent" contains the string ref "myDiv". ' +
+        'Component "RefsComponent" contains the string ref "myDiv". ' +
           'Support for string refs will be removed in a future major release. ' +
           'We recommend using useRef() or createRef() instead. ' +
           'Learn more about using refs safely here: https://react.dev/link/strict-mode-string-ref\n' +

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
@@ -260,7 +260,7 @@ describe('ReactDOMServerLifecycles', () => {
         '<div>1-2</div>',
       );
     }).toErrorDev(
-      'Warning: Can only update a mounting component. This ' +
+      'Can only update a mounting component. This ' +
         'usually means you called setState() outside componentWillMount() on ' +
         'the server. This is a no-op.\n\n' +
         'Please check the code for the Outer component.',

--- a/packages/react-dom/src/__tests__/ReactDOMShorthandCSSPropertyCollision-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMShorthandCSSPropertyCollision-test.js
@@ -34,7 +34,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
         root.render(<div style={{font: 'foo'}} />);
       });
     }).toErrorDev(
-      'Warning: Removing a style property during rerender (fontStyle) ' +
+      'Removing a style property during rerender (fontStyle) ' +
         'when a conflicting property is set (font) can lead to styling ' +
         "bugs. To avoid this, don't mix shorthand and non-shorthand " +
         'properties for the same value; instead, replace the shorthand ' +
@@ -55,7 +55,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
         root.render(<div style={{font: 'qux', fontStyle: 'baz'}} />);
       });
     }).toErrorDev(
-      'Warning: Updating a style property during rerender (font) when ' +
+      'Updating a style property during rerender (font) when ' +
         'a conflicting property is set (fontStyle) can lead to styling ' +
         "bugs. To avoid this, don't mix shorthand and non-shorthand " +
         'properties for the same value; instead, replace the shorthand ' +
@@ -67,7 +67,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
         root.render(<div style={{fontStyle: 'baz'}} />);
       });
     }).toErrorDev(
-      'Warning: Removing a style property during rerender (font) when ' +
+      'Removing a style property during rerender (font) when ' +
         'a conflicting property is set (fontStyle) can lead to styling ' +
         "bugs. To avoid this, don't mix shorthand and non-shorthand " +
         'properties for the same value; instead, replace the shorthand ' +
@@ -87,7 +87,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
         root.render(<div style={{background: 'yellow'}} />);
       });
     }).toErrorDev(
-      'Warning: Removing a style property during rerender ' +
+      'Removing a style property during rerender ' +
         '(backgroundPosition) when a conflicting property is set ' +
         "(background) can lead to styling bugs. To avoid this, don't mix " +
         'shorthand and non-shorthand properties for the same value; ' +
@@ -110,7 +110,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
         root.render(<div style={{backgroundPosition: 'top'}} />);
       });
     }).toErrorDev(
-      'Warning: Removing a style property during rerender (background) ' +
+      'Removing a style property during rerender (background) ' +
         'when a conflicting property is set (backgroundPosition) can lead ' +
         "to styling bugs. To avoid this, don't mix shorthand and " +
         'non-shorthand properties for the same value; instead, replace the ' +
@@ -129,7 +129,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
         root.render(<div style={{borderLeft: '1px solid red'}} />);
       });
     }).toErrorDev(
-      'Warning: Removing a style property during rerender (borderStyle) ' +
+      'Removing a style property during rerender (borderStyle) ' +
         'when a conflicting property is set (borderLeft) can lead to ' +
         "styling bugs. To avoid this, don't mix shorthand and " +
         'non-shorthand properties for the same value; instead, replace the ' +
@@ -143,7 +143,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
         );
       });
     }).toErrorDev(
-      'Warning: Updating a style property during rerender (borderStyle) ' +
+      'Updating a style property during rerender (borderStyle) ' +
         'when a conflicting property is set (borderLeft) can lead to ' +
         "styling bugs. To avoid this, don't mix shorthand and " +
         'non-shorthand properties for the same value; instead, replace the ' +
@@ -161,7 +161,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
         root.render(<div style={{borderStyle: 'dotted'}} />);
       });
     }).toErrorDev(
-      'Warning: Removing a style property during rerender (borderLeft) ' +
+      'Removing a style property during rerender (borderLeft) ' +
         'when a conflicting property is set (borderStyle) can lead to ' +
         "styling bugs. To avoid this, don't mix shorthand and " +
         'non-shorthand properties for the same value; instead, replace the ' +

--- a/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
@@ -165,7 +165,7 @@ describe('ReactDOM HostSingleton', () => {
     await expect(async () => {
       await waitForAll([]);
     }).toErrorDev(
-      'Warning: You are mounting a new head component when a previous one has not first unmounted. It is an error to render more than one head component at a time and attributes and children of these components will likely fail in unpredictable ways. Please only render a single instance of <head> and if you need to mount a new one, ensure any previous ones have unmounted first',
+      'You are mounting a new head component when a previous one has not first unmounted. It is an error to render more than one head component at a time and attributes and children of these components will likely fail in unpredictable ways. Please only render a single instance of <head> and if you need to mount a new one, ensure any previous ones have unmounted first',
     );
     expect(getVisibleChildren(document)).toEqual(
       <html>

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -1059,7 +1059,7 @@ describe('ReactDOMTextarea', () => {
         root.render(<textarea value={false} />);
       });
     }).toErrorDev(
-      'Warning: You provided a `value` prop to a form ' +
+      'You provided a `value` prop to a form ' +
         'field without an `onChange` handler. This will render a read-only ' +
         'field. If the field should be mutable use `defaultValue`. ' +
         'Otherwise, set either `onChange` or `readOnly`.',
@@ -1074,7 +1074,7 @@ describe('ReactDOMTextarea', () => {
         root.render(<textarea value={0} />);
       });
     }).toErrorDev(
-      'Warning: You provided a `value` prop to a form ' +
+      'You provided a `value` prop to a form ' +
         'field without an `onChange` handler. This will render a read-only ' +
         'field. If the field should be mutable use `defaultValue`. ' +
         'Otherwise, set either `onChange` or `readOnly`.',
@@ -1089,7 +1089,7 @@ describe('ReactDOMTextarea', () => {
         root.render(<textarea value="0" />);
       });
     }).toErrorDev(
-      'Warning: You provided a `value` prop to a form ' +
+      'You provided a `value` prop to a form ' +
         'field without an `onChange` handler. This will render a read-only ' +
         'field. If the field should be mutable use `defaultValue`. ' +
         'Otherwise, set either `onChange` or `readOnly`.',
@@ -1104,7 +1104,7 @@ describe('ReactDOMTextarea', () => {
         root.render(<textarea value="" />);
       });
     }).toErrorDev(
-      'Warning: You provided a `value` prop to a form ' +
+      'You provided a `value` prop to a form ' +
         'field without an `onChange` handler. This will render a read-only ' +
         'field. If the field should be mutable use `defaultValue`. ' +
         'Otherwise, set either `onChange` or `readOnly`.',

--- a/packages/react-dom/src/__tests__/ReactDeprecationWarnings-test.js
+++ b/packages/react-dom/src/__tests__/ReactDeprecationWarnings-test.js
@@ -38,7 +38,7 @@ describe('ReactDeprecationWarnings', () => {
 
     ReactNoop.render(<FunctionalComponent />);
     await expect(async () => await waitForAll([])).toErrorDev(
-      'Warning: FunctionalComponent: Support for defaultProps ' +
+      'FunctionalComponent: Support for defaultProps ' +
         'will be removed from function components in a future major ' +
         'release. Use JavaScript default parameters instead.',
     );
@@ -60,7 +60,7 @@ describe('ReactDeprecationWarnings', () => {
       </div>,
     );
     await expect(async () => await waitForAll([])).toErrorDev(
-      'Warning: FunctionalComponent: Support for defaultProps ' +
+      'FunctionalComponent: Support for defaultProps ' +
         'will be removed from memo components in a future major ' +
         'release. Use JavaScript default parameters instead.',
     );
@@ -81,7 +81,7 @@ describe('ReactDeprecationWarnings', () => {
 
     ReactNoop.render(<Component />);
     await expect(async () => await waitForAll([])).toErrorDev(
-      'Warning: Component "Component" contains the string ref "refComponent". ' +
+      'Component "Component" contains the string ref "refComponent". ' +
         'Support for string refs will be removed in a future major release. ' +
         'We recommend using useRef() or createRef() instead. ' +
         'Learn more about using refs safely here: ' +
@@ -138,7 +138,7 @@ describe('ReactDeprecationWarnings', () => {
 
     ReactNoop.render(<Component />);
     await expect(async () => await waitForAll([])).toErrorDev([
-      'Warning: Component "Component" contains the string ref "refComponent". ' +
+      'Component "Component" contains the string ref "refComponent". ' +
         'Support for string refs will be removed in a future major release. ' +
         'This case cannot be automatically converted to an arrow function. ' +
         'We ask you to manually fix this case by using useRef() or createRef() instead. ' +
@@ -170,7 +170,7 @@ describe('ReactDeprecationWarnings', () => {
 
     ReactNoop.render(<Component />);
     await expect(async () => await waitForAll([])).toErrorDev([
-      'Warning: Component "Component" contains the string ref "refComponent". ' +
+      'Component "Component" contains the string ref "refComponent". ' +
         'Support for string refs will be removed in a future major release. ' +
         'This case cannot be automatically converted to an arrow function. ' +
         'We ask you to manually fix this case by using useRef() or createRef() instead. ' +

--- a/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
@@ -214,7 +214,7 @@ describe('ReactFunctionComponent', () => {
         root.render(<ParentUsingStringRef />);
       });
     }).toErrorDev(
-      'Warning: Function components cannot be given refs. ' +
+      'Function components cannot be given refs. ' +
         'Attempts to access this ref will fail. ' +
         'Did you mean to use React.forwardRef()?\n\n' +
         'Check the render method ' +
@@ -257,7 +257,7 @@ describe('ReactFunctionComponent', () => {
         root.render(<ParentUsingFunctionRef />);
       });
     }).toErrorDev(
-      'Warning: Function components cannot be given refs. ' +
+      'Function components cannot be given refs. ' +
         'Attempts to access this ref will fail. ' +
         'Did you mean to use React.forwardRef()?\n\n' +
         'Check the render method ' +
@@ -297,7 +297,7 @@ describe('ReactFunctionComponent', () => {
           <AnonymousParentUsingJSX ref={current => (instance1 = current)} />,
         );
       });
-    }).toErrorDev('Warning: Function components cannot be given refs.');
+    }).toErrorDev('Function components cannot be given refs.');
     // Should be deduped (offending element is on the same line):
     instance1.forceUpdate();
     // Should also be deduped (offending element is on the same line):
@@ -326,7 +326,7 @@ describe('ReactFunctionComponent', () => {
           <AnonymousParentNotUsingJSX ref={current => (instance2 = current)} />,
         );
       });
-    }).toErrorDev('Warning: Function components cannot be given refs.');
+    }).toErrorDev('Function components cannot be given refs.');
     // Should be deduped (same internal instance, no additional warnings)
     instance2.forceUpdate();
     // Could not be differentiated (since owner is anonymous and no source location)
@@ -354,7 +354,7 @@ describe('ReactFunctionComponent', () => {
           <NamedParentNotUsingJSX ref={current => (instance3 = current)} />,
         );
       });
-    }).toErrorDev('Warning: Function components cannot be given refs.');
+    }).toErrorDev('Function components cannot be given refs.');
     // Should be deduped (same owner name, no additional warnings):
     instance3.forceUpdate();
     // Should also be deduped (same owner name, no additional warnings):
@@ -398,7 +398,7 @@ describe('ReactFunctionComponent', () => {
         root.render(<Parent />);
       });
     }).toErrorDev(
-      'Warning: Function components cannot be given refs. ' +
+      'Function components cannot be given refs. ' +
         'Attempts to access this ref will fail. ' +
         'Did you mean to use React.forwardRef()?\n\n' +
         'Check the render method ' +
@@ -441,7 +441,7 @@ describe('ReactFunctionComponent', () => {
       });
       expect(container.textContent).toBe('2');
     }).toErrorDev([
-      'Warning: Child: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.',
+      'Child: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.',
     ]);
   });
 

--- a/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
@@ -2106,7 +2106,7 @@ describe('ReactLegacyErrorBoundaries', () => {
         });
       }).rejects.toThrow('got: null');
     }).toErrorDev(
-      'Warning: React.jsx: type is invalid -- expected a string ' +
+      'React.jsx: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function ' +
         '(for composite components) but got: null.',
       {withoutStack: 1},
@@ -2120,7 +2120,7 @@ describe('ReactLegacyErrorBoundaries', () => {
         });
       }).rejects.toThrow('got: undefined');
     }).toErrorDev(
-      'Warning: React.jsx: type is invalid -- expected a string ' +
+      'React.jsx: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function ' +
         '(for composite components) but got: undefined.',
       {withoutStack: 1},

--- a/packages/react-dom/src/__tests__/ReactLegacyMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyMount-test.js
@@ -169,7 +169,7 @@ describe('ReactMount', () => {
     const rootNode = container.firstChild;
 
     expect(() => ReactDOM.render(<span />, rootNode)).toErrorDev(
-      'Warning: Replacing React-rendered children with a new ' +
+      'Replacing React-rendered children with a new ' +
         'root component. If you intended to update the children of this node, ' +
         'you should instead have the existing children update their state and ' +
         'render the new components instead of calling ReactDOM.render.',
@@ -198,7 +198,7 @@ describe('ReactMount', () => {
     expect(ReactDOM).not.toEqual(ReactDOMOther);
 
     expect(() => ReactDOMOther.unmountComponentAtNode(container)).toErrorDev(
-      "Warning: unmountComponentAtNode(): The node you're attempting to unmount " +
+      "unmountComponentAtNode(): The node you're attempting to unmount " +
         'was rendered by another copy of React.',
       {withoutStack: true},
     );

--- a/packages/react-dom/src/__tests__/ReactLegacyUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyUpdates-test.js
@@ -935,7 +935,7 @@ describe('ReactLegacyUpdates', () => {
       );
     }).toErrorDev(
       'Expected the last optional `callback` argument to be ' +
-        'a function. Instead received: [object Object].',
+        "a function. Instead received: { foo: 'bar' }.",
       {withoutStack: 1},
     );
     // Make sure the warning is deduplicated and doesn't fire again
@@ -996,7 +996,7 @@ describe('ReactLegacyUpdates', () => {
       );
     }).toErrorDev(
       'Expected the last optional `callback` argument to be ' +
-        'a function. Instead received: [object Object].',
+        "a function. Instead received: { foo: 'bar' }.",
       {withoutStack: 1},
     );
     // Make sure the warning is deduplicated and doesn't fire again

--- a/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
+++ b/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
@@ -64,7 +64,7 @@ describe('ReactMount', () => {
     // Test that unmounting at a root node gives a helpful warning
     const rootDiv = mainContainerDiv.firstChild;
     expect(() => ReactDOM.unmountComponentAtNode(rootDiv)).toErrorDev(
-      "Warning: unmountComponentAtNode(): The node you're attempting to " +
+      "unmountComponentAtNode(): The node you're attempting to " +
         'unmount was rendered by React and is not a top-level container. You ' +
         'may have accidentally passed in a React root node instead of its ' +
         'container.',
@@ -89,7 +89,7 @@ describe('ReactMount', () => {
     // Test that unmounting at a non-root node gives a different warning
     const nonRootDiv = mainContainerDiv.firstChild.firstChild;
     expect(() => ReactDOM.unmountComponentAtNode(nonRootDiv)).toErrorDev(
-      "Warning: unmountComponentAtNode(): The node you're attempting to " +
+      "unmountComponentAtNode(): The node you're attempting to " +
         'unmount was rendered by React and is not a top-level container. ' +
         'Instead, have the parent component update its state and rerender in ' +
         'order to remove this component.',

--- a/packages/react-dom/src/__tests__/ReactMultiChildText-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChildText-test.js
@@ -169,8 +169,8 @@ describe('ReactMultiChildText', () => {
         ['', 'foo', <div>{true}{<div />}{1.2}{''}</div>, 'foo'], ['', 'foo', <div />, 'foo'],
       ]);
     }).toErrorDev([
-      'Warning: Each child in a list should have a unique "key" prop.',
-      'Warning: Each child in a list should have a unique "key" prop.',
+      'Each child in a list should have a unique "key" prop.',
+      'Each child in a list should have a unique "key" prop.',
     ]);
   });
 

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -292,7 +292,7 @@ describe('rendering React components at document', () => {
         favorSafetyOverHydrationPerf
           ? []
           : [
-              "Warning: A tree hydrated but some attributes of the server rendered HTML didn't match the client properties.",
+              "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties.",
             ],
         {withoutStack: true},
       );

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -592,7 +592,7 @@ describe('ReactDOMServer', () => {
 
     ReactDOMServer.renderToString(<Foo />);
     expect(() => jest.runOnlyPendingTimers()).toErrorDev(
-      'Warning: Can only update a mounting component.' +
+      'Can only update a mounting component.' +
         ' This usually means you called setState() outside componentWillMount() on the server.' +
         ' This is a no-op.\n\nPlease check the code for the Foo component.',
       {withoutStack: true},
@@ -620,7 +620,7 @@ describe('ReactDOMServer', () => {
 
     ReactDOMServer.renderToString(<Baz />);
     expect(() => jest.runOnlyPendingTimers()).toErrorDev(
-      'Warning: Can only update a mounting component. ' +
+      'Can only update a mounting component. ' +
         'This usually means you called forceUpdate() outside componentWillMount() on the server. ' +
         'This is a no-op.\n\nPlease check the code for the Baz component.',
       {withoutStack: true},
@@ -732,11 +732,11 @@ describe('ReactDOMServer', () => {
         </div>,
       ),
     ).toErrorDev([
-      'Warning: <inPUT /> is using incorrect casing. ' +
+      '<inPUT /> is using incorrect casing. ' +
         'Use PascalCase for React components, ' +
         'or lowercase for HTML elements.',
       // linearGradient doesn't warn
-      'Warning: <iFrame /> is using incorrect casing. ' +
+      '<iFrame /> is using incorrect casing. ' +
         'Use PascalCase for React components, ' +
         'or lowercase for HTML elements.',
     ]);
@@ -746,7 +746,7 @@ describe('ReactDOMServer', () => {
     expect(() =>
       ReactDOMServer.renderToString(<div contentEditable={true} children="" />),
     ).toErrorDev(
-      'Warning: A component is `contentEditable` and contains `children` ' +
+      'A component is `contentEditable` and contains `children` ' +
         'managed by React. It is now your responsibility to guarantee that ' +
         'none of those nodes are unexpectedly modified or duplicated. This ' +
         'is probably not intentional.\n    in div (at **)',
@@ -765,7 +765,7 @@ describe('ReactDOMServer', () => {
         ReactDOMServer.renderToString(<ClassWithRenderNotExtended />),
       ).toThrow(TypeError);
     }).toErrorDev(
-      'Warning: The <ClassWithRenderNotExtended /> component appears to have a render method, ' +
+      'The <ClassWithRenderNotExtended /> component appears to have a render method, ' +
         "but doesn't extend React.Component. This is likely to cause errors. " +
         'Change ClassWithRenderNotExtended to extend React.Component instead.',
     );
@@ -923,7 +923,7 @@ describe('ReactDOMServer', () => {
     expect(() => {
       ReactDOMServer.renderToString(<ComponentA />);
     }).toErrorDev(
-      'Warning: ComponentA defines an invalid contextType. ' +
+      'ComponentA defines an invalid contextType. ' +
         'contextType should point to the Context object returned by React.createContext(). ' +
         'Did you accidentally pass the Context.Consumer instead?',
     );

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -145,7 +145,7 @@ describe('ReactDOMServerHydration', () => {
         favorSafetyOverHydrationPerf
           ? []
           : [
-              " A tree hydrated but some attributes of the server rendered HTML didn't match the client properties.",
+              "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties.",
             ],
         {withoutStack: true},
       );
@@ -545,7 +545,7 @@ describe('ReactDOMServerHydration', () => {
       favorSafetyOverHydrationPerf
         ? []
         : [
-            " A tree hydrated but some attributes of the server rendered HTML didn't match the client properties.",
+            "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties.",
           ],
       {withoutStack: true},
     );
@@ -598,7 +598,7 @@ describe('ReactDOMServerHydration', () => {
           ReactDOMClient.hydrateRoot(element, jsx);
         });
       }).toErrorDev(
-        `Warning: Assignment to read-only property will result in a no-op: \`${readOnlyProperty}\``,
+        `Assignment to read-only property will result in a no-op: \`${readOnlyProperty}\``,
       );
     }
   });

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1804,7 +1804,7 @@ describe('ReactUpdates', () => {
         await act(() => ReactDOM.flushSync(() => root.render(<App />)));
       }).rejects.toThrow('Maximum update depth exceeded');
     }).toErrorDev(
-      'Warning: Cannot update a component (`App`) while rendering a different component (`Child`)',
+      'Cannot update a component (`App`) while rendering a different component (`Child`)',
     );
   });
 
@@ -1839,7 +1839,7 @@ describe('ReactUpdates', () => {
       }
       expect(error.message).toMatch('Maximum update depth exceeded');
     }).toErrorDev(
-      'Warning: Cannot update a component (`App`) while rendering a different component (`Child`)',
+      'Cannot update a component (`App`) while rendering a different component (`Child`)',
     );
   });
 

--- a/packages/react-dom/src/__tests__/findDOMNodeFB-test.js
+++ b/packages/react-dom/src/__tests__/findDOMNodeFB-test.js
@@ -130,7 +130,7 @@ describe('findDOMNode', () => {
 
     let match;
     expect(() => (match = ReactDOM.findDOMNode(parent))).toErrorDev([
-      'Warning: findDOMNode is deprecated in StrictMode. ' +
+      'findDOMNode is deprecated in StrictMode. ' +
         'findDOMNode was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
         'Learn more about using refs safely here: ' +
@@ -163,7 +163,7 @@ describe('findDOMNode', () => {
 
     let match;
     expect(() => (match = ReactDOM.findDOMNode(parent))).toErrorDev([
-      'Warning: findDOMNode is deprecated in StrictMode. ' +
+      'findDOMNode is deprecated in StrictMode. ' +
         'findDOMNode was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
         'Learn more about using refs safely here: ' +

--- a/packages/react-dom/src/__tests__/refs-test.js
+++ b/packages/react-dom/src/__tests__/refs-test.js
@@ -122,7 +122,7 @@ describe('reactiverefs', () => {
         );
       });
     }).toErrorDev([
-      'Warning: Component "TestRefsComponent" contains the string ' +
+      'Component "TestRefsComponent" contains the string ' +
         'ref "resetDiv". Support for string refs will be removed in a ' +
         'future major release. We recommend using useRef() or createRef() ' +
         'instead. Learn more about using refs safely ' +
@@ -130,7 +130,7 @@ describe('reactiverefs', () => {
         '    in div (at **)\n' +
         '    in div (at **)\n' +
         '    in TestRefsComponent (at **)',
-      'Warning: Component "ClickCounter" contains the string ' +
+      'Component "ClickCounter" contains the string ' +
         'ref "clickLog0". Support for string refs will be removed in a ' +
         'future major release. We recommend using useRef() or createRef() ' +
         'instead. Learn more about using refs safely ' +
@@ -336,7 +336,7 @@ describe('ref swapping', () => {
         root.render(<A ref={current => (a = current)} />);
       });
     }).toErrorDev([
-      'Warning: Component "A" contains the string ref "1". ' +
+      'Component "A" contains the string ref "1". ' +
         'Support for string refs will be removed in a future major release. ' +
         'We recommend using useRef() or createRef() instead. ' +
         'Learn more about using refs safely here: https://react.dev/link/strict-mode-string-ref\n' +
@@ -565,7 +565,7 @@ describe('strings refs across renderers', () => {
         );
       });
     }).toErrorDev([
-      'Warning: Component "Parent" contains the string ref "child1". ' +
+      'Component "Parent" contains the string ref "child1". ' +
         'Support for string refs will be removed in a future major release. ' +
         'We recommend using useRef() or createRef() instead. ' +
         'Learn more about using refs safely here: https://react.dev/link/strict-mode-string-ref\n' +

--- a/packages/react-dom/src/__tests__/validateDOMNesting-test.js
+++ b/packages/react-dom/src/__tests__/validateDOMNesting-test.js
@@ -126,7 +126,7 @@ describe('validateDOMNesting', () => {
           'This will cause a hydration error.\n' +
           '    in body (at **)\n' +
           '    in foreignObject (at **)',
-        'Warning: You are mounting a new body component when a previous one has not first unmounted. It is an error to render more than one body component at a time and attributes and children of these components will likely fail in unpredictable ways. Please only render a single instance of <body> and if you need to mount a new one, ensure any previous ones have unmounted first.\n' +
+        'You are mounting a new body component when a previous one has not first unmounted. It is an error to render more than one body component at a time and attributes and children of these components will likely fail in unpredictable ways. Please only render a single instance of <body> and if you need to mount a new one, ensure any previous ones have unmounted first.\n' +
           '    in body (at **)',
       ],
     );

--- a/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
+++ b/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
@@ -245,7 +245,7 @@ describe('when Trusted Types are available in global object', () => {
           root.render(<Component />);
         });
       }).toErrorDev(
-        "Warning: Using 'dangerouslySetInnerHTML' in an svg element with " +
+        "Using 'dangerouslySetInnerHTML' in an svg element with " +
           'Trusted Types enabled in an Internet Explorer will cause ' +
           'the trusted value to be converted to string. Assigning string ' +
           "to 'innerHTML' will throw an error if Trusted Types are enforced. " +
@@ -263,7 +263,7 @@ describe('when Trusted Types are available in global object', () => {
         root.render(<script>alert("I am not executed")</script>);
       });
     }).toErrorDev(
-      'Warning: Encountered a script tag while rendering React component. ' +
+      'Encountered a script tag while rendering React component. ' +
         'Scripts inside React components are never executed when rendering ' +
         'on the client. Consider using template tag instead ' +
         '(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).\n' +

--- a/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
@@ -92,7 +92,7 @@ class ReactNativeFiberHostComponent implements INativeMethods {
     if (relativeNode == null) {
       if (__DEV__) {
         console.error(
-          'Warning: ref.measureLayout must be called with a node handle or a ref to a native component.',
+          'ref.measureLayout must be called with a node handle or a ref to a native component.',
         );
       }
 

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -18,7 +18,7 @@ let StrictMode;
 let act;
 
 const DISPATCH_COMMAND_REQUIRES_HOST_COMPONENT =
-  "Warning: dispatchCommand was called with a ref that isn't a " +
+  "dispatchCommand was called with a ref that isn't a " +
   'native component. Use React.forwardRef to get access to the underlying native component';
 
 const SEND_ACCESSIBILITY_EVENT_REQUIRES_HOST_COMPONENT =
@@ -898,7 +898,7 @@ describe('ReactFabric', () => {
     expect(
       () => (match = ReactFabric.findHostInstance_DEPRECATED(parent)),
     ).toErrorDev([
-      'Warning: findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
+      'findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
         'findHostInstance_DEPRECATED was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
         'Learn more about using refs safely here: ' +
@@ -937,7 +937,7 @@ describe('ReactFabric', () => {
     expect(
       () => (match = ReactFabric.findHostInstance_DEPRECATED(parent)),
     ).toErrorDev([
-      'Warning: findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
+      'findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
         'findHostInstance_DEPRECATED was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
         'Learn more about using refs safely here: ' +
@@ -976,7 +976,7 @@ describe('ReactFabric', () => {
 
     let match;
     expect(() => (match = ReactFabric.findNodeHandle(parent))).toErrorDev([
-      'Warning: findNodeHandle is deprecated in StrictMode. ' +
+      'findNodeHandle is deprecated in StrictMode. ' +
         'findNodeHandle was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
         'Learn more about using refs safely here: ' +
@@ -1015,7 +1015,7 @@ describe('ReactFabric', () => {
 
     let match;
     expect(() => (match = ReactFabric.findNodeHandle(parent))).toErrorDev([
-      'Warning: findNodeHandle is deprecated in StrictMode. ' +
+      'findNodeHandle is deprecated in StrictMode. ' +
         'findNodeHandle was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
         'Learn more about using refs safely here: ' +

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -20,11 +20,11 @@ let ReactNativePrivateInterface;
 let act;
 
 const DISPATCH_COMMAND_REQUIRES_HOST_COMPONENT =
-  "Warning: dispatchCommand was called with a ref that isn't a " +
+  "dispatchCommand was called with a ref that isn't a " +
   'native component. Use React.forwardRef to get access to the underlying native component';
 
 const SEND_ACCESSIBILITY_EVENT_REQUIRES_HOST_COMPONENT =
-  "Warning: sendAccessibilityEvent was called with a ref that isn't a " +
+  "sendAccessibilityEvent was called with a ref that isn't a " +
   'native component. Use React.forwardRef to get access to the underlying native component';
 
 describe('ReactNative', () => {
@@ -618,7 +618,7 @@ describe('ReactNative', () => {
     expect(
       () => (match = ReactNative.findHostInstance_DEPRECATED(parent)),
     ).toErrorDev([
-      'Warning: findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
+      'findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
         'findHostInstance_DEPRECATED was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
         'Learn more about using refs safely here: ' +
@@ -656,7 +656,7 @@ describe('ReactNative', () => {
     expect(
       () => (match = ReactNative.findHostInstance_DEPRECATED(parent)),
     ).toErrorDev([
-      'Warning: findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
+      'findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
         'findHostInstance_DEPRECATED was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
         'Learn more about using refs safely here: ' +
@@ -691,7 +691,7 @@ describe('ReactNative', () => {
 
     let match;
     expect(() => (match = ReactNative.findNodeHandle(parent))).toErrorDev([
-      'Warning: findNodeHandle is deprecated in StrictMode. ' +
+      'findNodeHandle is deprecated in StrictMode. ' +
         'findNodeHandle was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
         'Learn more about using refs safely here: ' +
@@ -727,7 +727,7 @@ describe('ReactNative', () => {
 
     let match;
     expect(() => (match = ReactNative.findNodeHandle(parent))).toErrorDev([
-      'Warning: findNodeHandle is deprecated in StrictMode. ' +
+      'findNodeHandle is deprecated in StrictMode. ' +
         'findNodeHandle was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
         'Learn more about using refs safely here: ' +

--- a/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
@@ -279,7 +279,7 @@ describe('DebugTracing', () => {
         );
       });
     }).toErrorDev(
-      'Warning: Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.',
+      'Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.',
     );
 
     expect(logs).toEqual([

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -594,7 +594,7 @@ describe('ReactHooks', () => {
         root.update(<App dependencies={['A', 'B']} />);
       });
     }).toErrorDev([
-      'Warning: The final argument passed to useLayoutEffect changed size ' +
+      'The final argument passed to useLayoutEffect changed size ' +
         'between renders. The order and size of this array must remain ' +
         'constant.\n\n' +
         'Previous: [A]\n' +
@@ -630,7 +630,7 @@ describe('ReactHooks', () => {
         root.update(<App text="Hello" hasDeps={false} />);
       });
     }).toErrorDev([
-      'Warning: useMemo received a final argument during this render, but ' +
+      'useMemo received a final argument during this render, but ' +
         'not during the previous render. Even though the final argument is ' +
         'optional, its type cannot change between renders.',
     ]);
@@ -654,13 +654,13 @@ describe('ReactHooks', () => {
         });
       });
     }).toErrorDev([
-      'Warning: useEffect received a final argument that is not an array (instead, received `string`). ' +
+      'useEffect received a final argument that is not an array (instead, received `string`). ' +
         'When specified, the final argument must be an array.',
-      'Warning: useLayoutEffect received a final argument that is not an array (instead, received `string`). ' +
+      'useLayoutEffect received a final argument that is not an array (instead, received `string`). ' +
         'When specified, the final argument must be an array.',
-      'Warning: useMemo received a final argument that is not an array (instead, received `string`). ' +
+      'useMemo received a final argument that is not an array (instead, received `string`). ' +
         'When specified, the final argument must be an array.',
-      'Warning: useCallback received a final argument that is not an array (instead, received `string`). ' +
+      'useCallback received a final argument that is not an array (instead, received `string`). ' +
         'When specified, the final argument must be an array.',
     ]);
     await expect(async () => {
@@ -670,13 +670,13 @@ describe('ReactHooks', () => {
         });
       });
     }).toErrorDev([
-      'Warning: useEffect received a final argument that is not an array (instead, received `number`). ' +
+      'useEffect received a final argument that is not an array (instead, received `number`). ' +
         'When specified, the final argument must be an array.',
-      'Warning: useLayoutEffect received a final argument that is not an array (instead, received `number`). ' +
+      'useLayoutEffect received a final argument that is not an array (instead, received `number`). ' +
         'When specified, the final argument must be an array.',
-      'Warning: useMemo received a final argument that is not an array (instead, received `number`). ' +
+      'useMemo received a final argument that is not an array (instead, received `number`). ' +
         'When specified, the final argument must be an array.',
-      'Warning: useCallback received a final argument that is not an array (instead, received `number`). ' +
+      'useCallback received a final argument that is not an array (instead, received `number`). ' +
         'When specified, the final argument must be an array.',
     ]);
     await expect(async () => {
@@ -686,13 +686,13 @@ describe('ReactHooks', () => {
         });
       });
     }).toErrorDev([
-      'Warning: useEffect received a final argument that is not an array (instead, received `object`). ' +
+      'useEffect received a final argument that is not an array (instead, received `object`). ' +
         'When specified, the final argument must be an array.',
-      'Warning: useLayoutEffect received a final argument that is not an array (instead, received `object`). ' +
+      'useLayoutEffect received a final argument that is not an array (instead, received `object`). ' +
         'When specified, the final argument must be an array.',
-      'Warning: useMemo received a final argument that is not an array (instead, received `object`). ' +
+      'useMemo received a final argument that is not an array (instead, received `object`). ' +
         'When specified, the final argument must be an array.',
-      'Warning: useCallback received a final argument that is not an array (instead, received `object`). ' +
+      'useCallback received a final argument that is not an array (instead, received `object`). ' +
         'When specified, the final argument must be an array.',
     ]);
 
@@ -725,7 +725,7 @@ describe('ReactHooks', () => {
         });
       });
     }).toErrorDev([
-      'Warning: useImperativeHandle received a final argument that is not an array (instead, received `string`). ' +
+      'useImperativeHandle received a final argument that is not an array (instead, received `string`). ' +
         'When specified, the final argument must be an array.',
     ]);
     await act(() => {
@@ -1127,7 +1127,7 @@ describe('ReactHooks', () => {
       );
     }).toErrorDev([
       'Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks',
-      'Warning: React has detected a change in the order of Hooks called by App. ' +
+      'React has detected a change in the order of Hooks called by App. ' +
         'This will lead to bugs and errors if not fixed. For more information, ' +
         'read the Rules of Hooks: https://react.dev/link/rules-of-hooks\n\n' +
         '   Previous render            Next render\n' +
@@ -1593,7 +1593,7 @@ describe('ReactHooks', () => {
             // We just want to verify that warnings are always logged.
           }
         }).toErrorDev([
-          'Warning: React has detected a change in the order of Hooks called by App. ' +
+          'React has detected a change in the order of Hooks called by App. ' +
             'This will lead to bugs and errors if not fixed. For more information, ' +
             'read the Rules of Hooks: https://react.dev/link/rules-of-hooks\n\n' +
             '   Previous render            Next render\n' +
@@ -1644,7 +1644,7 @@ describe('ReactHooks', () => {
             // We just want to verify that warnings are always logged.
           }
         }).toErrorDev([
-          'Warning: React has detected a change in the order of Hooks called by App. ' +
+          'React has detected a change in the order of Hooks called by App. ' +
             'This will lead to bugs and errors if not fixed. For more information, ' +
             'read the Rules of Hooks: https://react.dev/link/rules-of-hooks\n\n' +
             '   Previous render            Next render\n' +
@@ -1728,7 +1728,7 @@ describe('ReactHooks', () => {
           // This is okay as far as this test is concerned.
           // We just want to verify that warnings are always logged.
         }).toErrorDev([
-          'Warning: React has detected a change in the order of Hooks called by App. ' +
+          'React has detected a change in the order of Hooks called by App. ' +
             'This will lead to bugs and errors if not fixed. For more information, ' +
             'read the Rules of Hooks: https://react.dev/link/rules-of-hooks\n\n' +
             '   Previous render            Next render\n' +
@@ -1778,7 +1778,7 @@ describe('ReactHooks', () => {
           });
         }).rejects.toThrow('custom error');
       }).toErrorDev([
-        'Warning: React has detected a change in the order of Hooks called by App. ' +
+        'React has detected a change in the order of Hooks called by App. ' +
           'This will lead to bugs and errors if not fixed. For more information, ' +
           'read the Rules of Hooks: https://react.dev/link/rules-of-hooks\n\n' +
           '   Previous render            Next render\n' +
@@ -1819,7 +1819,7 @@ describe('ReactHooks', () => {
       });
     }).rejects.toThrow('Hello');
     assertConsoleErrorDev([
-      'Warning: Cannot update a component (`A`) while rendering ' +
+      'Cannot update a component (`A`) while rendering ' +
         'a different component (`B`).',
     ]);
   });

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -2536,7 +2536,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           root1.render(<App return={17} />);
         });
       }).toErrorDev([
-        'Warning: useEffect must not return anything besides a ' +
+        'useEffect must not return anything besides a ' +
           'function, which is used for clean-up. You returned: 17',
       ]);
 
@@ -2546,7 +2546,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           root2.render(<App return={null} />);
         });
       }).toErrorDev([
-        'Warning: useEffect must not return anything besides a ' +
+        'useEffect must not return anything besides a ' +
           'function, which is used for clean-up. You returned null. If your ' +
           'effect does not require clean up, return undefined (or nothing).',
       ]);
@@ -2557,7 +2557,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           root3.render(<App return={Promise.resolve()} />);
         });
       }).toErrorDev([
-        'Warning: useEffect must not return anything besides a ' +
+        'useEffect must not return anything besides a ' +
           'function, which is used for clean-up.\n\n' +
           'It looks like you wrote useEffect(async () => ...) or returned a Promise.',
       ]);
@@ -2915,7 +2915,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           root1.render(<App return={17} />);
         });
       }).toErrorDev([
-        'Warning: useInsertionEffect must not return anything besides a ' +
+        'useInsertionEffect must not return anything besides a ' +
           'function, which is used for clean-up. You returned: 17',
       ]);
 
@@ -2925,7 +2925,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           root2.render(<App return={null} />);
         });
       }).toErrorDev([
-        'Warning: useInsertionEffect must not return anything besides a ' +
+        'useInsertionEffect must not return anything besides a ' +
           'function, which is used for clean-up. You returned null. If your ' +
           'effect does not require clean up, return undefined (or nothing).',
       ]);
@@ -2936,7 +2936,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           root3.render(<App return={Promise.resolve()} />);
         });
       }).toErrorDev([
-        'Warning: useInsertionEffect must not return anything besides a ' +
+        'useInsertionEffect must not return anything besides a ' +
           'function, which is used for clean-up.\n\n' +
           'It looks like you wrote useInsertionEffect(async () => ...) or returned a Promise.',
       ]);
@@ -2965,7 +2965,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         await act(() => {
           root.render(<App />);
         });
-      }).toErrorDev(['Warning: useInsertionEffect must not schedule updates.']);
+      }).toErrorDev(['useInsertionEffect must not schedule updates.']);
 
       await act(async () => {
         root.render(<App throw={true} />);
@@ -3007,7 +3007,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         await act(() => {
           root.render(<App foo="goodbye" />);
         });
-      }).toErrorDev(['Warning: useInsertionEffect must not schedule updates.']);
+      }).toErrorDev(['useInsertionEffect must not schedule updates.']);
 
       await act(async () => {
         root.render(<App throw={true} />);
@@ -3194,7 +3194,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           root1.render(<App return={17} />);
         });
       }).toErrorDev([
-        'Warning: useLayoutEffect must not return anything besides a ' +
+        'useLayoutEffect must not return anything besides a ' +
           'function, which is used for clean-up. You returned: 17',
       ]);
 
@@ -3204,7 +3204,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           root2.render(<App return={null} />);
         });
       }).toErrorDev([
-        'Warning: useLayoutEffect must not return anything besides a ' +
+        'useLayoutEffect must not return anything besides a ' +
           'function, which is used for clean-up. You returned null. If your ' +
           'effect does not require clean up, return undefined (or nothing).',
       ]);
@@ -3215,7 +3215,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           root3.render(<App return={Promise.resolve()} />);
         });
       }).toErrorDev([
-        'Warning: useLayoutEffect must not return anything besides a ' +
+        'useLayoutEffect must not return anything besides a ' +
           'function, which is used for clean-up.\n\n' +
           'It looks like you wrote useLayoutEffect(async () => ...) or returned a Promise.',
       ]);
@@ -3687,7 +3687,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         );
         assertLog([]);
       }).toErrorDev([
-        'Warning: React has detected a change in the order of Hooks called by App. ' +
+        'React has detected a change in the order of Hooks called by App. ' +
           'This will lead to bugs and errors if not fixed. For more information, ' +
           'read the Rules of Hooks: https://react.dev/link/rules-of-hooks\n\n' +
           '   Previous render            Next render\n' +
@@ -3784,7 +3784,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           );
           assertLog(['Unmount A']);
         }).toErrorDev([
-          'Warning: React has detected a change in the order of Hooks called by App. ' +
+          'React has detected a change in the order of Hooks called by App. ' +
             'This will lead to bugs and errors if not fixed. For more information, ' +
             'read the Rules of Hooks: https://react.dev/link/rules-of-hooks\n\n' +
             '   Previous render            Next render\n' +

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1238,9 +1238,9 @@ describe('ReactIncrementalErrorHandling', () => {
       </ErrorBoundary>,
     );
     await expect(async () => await waitForAll([])).toErrorDev([
-      'Warning: React.jsx: type is invalid -- expected a string',
+      'React.jsx: type is invalid -- expected a string',
       // React retries once on error
-      'Warning: React.jsx: type is invalid -- expected a string',
+      'React.jsx: type is invalid -- expected a string',
     ]);
     expect(ReactNoop).toMatchRenderedOutput(
       <span
@@ -1289,9 +1289,9 @@ describe('ReactIncrementalErrorHandling', () => {
       </ErrorBoundary>,
     );
     await expect(async () => await waitForAll([])).toErrorDev([
-      'Warning: React.jsx: type is invalid -- expected a string',
+      'React.jsx: type is invalid -- expected a string',
       // React retries once on error
-      'Warning: React.jsx: type is invalid -- expected a string',
+      'React.jsx: type is invalid -- expected a string',
     ]);
     expect(ReactNoop).toMatchRenderedOutput(
       <span
@@ -1311,7 +1311,7 @@ describe('ReactIncrementalErrorHandling', () => {
   it('recovers from uncaught reconciler errors', async () => {
     const InvalidType = undefined;
     expect(() => ReactNoop.render(<InvalidType />)).toErrorDev(
-      'Warning: React.jsx: type is invalid -- expected a string',
+      'React.jsx: type is invalid -- expected a string',
       {withoutStack: true},
     );
     await waitForThrow(

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.js
@@ -1303,7 +1303,7 @@ describe('ReactIncrementalSideEffects', () => {
       await waitForAll([]);
     } else {
       await expect(async () => await waitForAll([])).toErrorDev(
-        'Warning: Function components cannot be given refs. ' +
+        'Function components cannot be given refs. ' +
           'Attempts to access this ref will fail. ' +
           'Did you mean to use React.forwardRef()?\n\n' +
           'Check the render method ' +
@@ -1372,7 +1372,7 @@ describe('ReactIncrementalSideEffects', () => {
     await expect(async () => {
       await waitForAll([]);
     }).toErrorDev([
-      'Warning: Component "Foo" contains the string ref "bar". ' +
+      'Component "Foo" contains the string ref "bar". ' +
         'Support for string refs will be removed in a future major release. ' +
         'We recommend using useRef() or createRef() instead. ' +
         'Learn more about using refs safely here: https://react.dev/link/strict-mode-string-ref\n' +

--- a/packages/react-reconciler/src/__tests__/ReactIsomorphicAct-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIsomorphicAct-test.js
@@ -290,7 +290,7 @@ describe('isomorphic act()', () => {
 
     expect(console.error).toHaveBeenCalledTimes(1);
     expect(console.error.mock.calls[0][0]).toContain(
-      'Warning: A component suspended inside an `act` scope, but the `act` ' +
+      'A component suspended inside an `act` scope, but the `act` ' +
         'call was not awaited. When testing React components that ' +
         'depend on asynchronous data, you must await the result:\n\n' +
         'await act(() => ...)',

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -703,7 +703,7 @@ describe('ReactLazy', () => {
       await act(() => resolveFakeImport(T));
       assertLog(['Hi Bye']);
     }).toErrorDev(
-      'Warning: T: Support for defaultProps ' +
+      'T: Support for defaultProps ' +
         'will be removed from function components in a future major ' +
         'release. Use JavaScript default parameters instead.',
     );

--- a/packages/react-reconciler/src/__tests__/ReactMemo-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactMemo-test.js
@@ -58,7 +58,7 @@ describe('memo', () => {
     }
     ReactNoop.render(<Outer />);
     await expect(async () => await waitForAll([])).toErrorDev([
-      'Warning: Function components cannot be given refs. Attempts to access ' +
+      'Function components cannot be given refs. Attempts to access ' +
         'this ref will fail.',
     ]);
   });
@@ -76,7 +76,7 @@ describe('memo', () => {
     }
     ReactNoop.render(<Outer />);
     await expect(async () => await waitForAll([])).toErrorDev([
-      'Warning: Function components cannot be given refs. Attempts to access ' +
+      'Function components cannot be given refs. Attempts to access ' +
         'this ref will fail.',
     ]);
   });

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseCallback-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseCallback-test.js
@@ -58,7 +58,7 @@ describe('ReactSuspense', () => {
 
     ReactNoop.render(elementBadType);
     await expect(async () => await waitForAll([])).toErrorDev([
-      'Warning: Unexpected type for suspenseCallback.',
+      'Unexpected type for suspenseCallback.',
     ]);
 
     const elementMissingCallback = (

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.js
@@ -67,7 +67,7 @@ describe('ReactSuspenseList', () => {
         ReactNoop.render(<Foo />);
       });
     }).toErrorDev([
-      'Warning: "something" is not a supported revealOrder on ' +
+      '"something" is not a supported revealOrder on ' +
         '<SuspenseList />. Did you mean "together", "forwards" or "backwards"?' +
         '\n    in SuspenseList (at **)' +
         '\n    in Foo (at **)',
@@ -89,7 +89,7 @@ describe('ReactSuspenseList', () => {
         ReactNoop.render(<Foo />);
       });
     }).toErrorDev([
-      'Warning: "TOGETHER" is not a valid value for revealOrder on ' +
+      '"TOGETHER" is not a valid value for revealOrder on ' +
         '<SuspenseList />. Use lowercase "together" instead.' +
         '\n    in SuspenseList (at **)' +
         '\n    in Foo (at **)',
@@ -111,7 +111,7 @@ describe('ReactSuspenseList', () => {
         ReactNoop.render(<Foo />);
       });
     }).toErrorDev([
-      'Warning: "forward" is not a valid value for revealOrder on ' +
+      '"forward" is not a valid value for revealOrder on ' +
         '<SuspenseList />. React uses the -s suffix in the spelling. ' +
         'Use "forwards" instead.' +
         '\n    in SuspenseList (at **)' +
@@ -146,7 +146,7 @@ describe('ReactSuspenseList', () => {
         );
       });
     }).toErrorDev([
-      'Warning: A single row was passed to a <SuspenseList revealOrder="forwards" />. ' +
+      'A single row was passed to a <SuspenseList revealOrder="forwards" />. ' +
         'This is not useful since it needs multiple rows. ' +
         'Did you mean to pass multiple children or an array?' +
         '\n    in SuspenseList (at **)' +
@@ -169,7 +169,7 @@ describe('ReactSuspenseList', () => {
         ReactNoop.render(<Foo />);
       });
     }).toErrorDev([
-      'Warning: A single row was passed to a <SuspenseList revealOrder="backwards" />. ' +
+      'A single row was passed to a <SuspenseList revealOrder="backwards" />. ' +
         'This is not useful since it needs multiple rows. ' +
         'Did you mean to pass multiple children or an array?' +
         '\n    in SuspenseList (at **)' +
@@ -197,7 +197,7 @@ describe('ReactSuspenseList', () => {
         ReactNoop.render(<Foo items={['A', 'B']} />);
       });
     }).toErrorDev([
-      'Warning: A nested array was passed to row #0 in <SuspenseList />. ' +
+      'A nested array was passed to row #0 in <SuspenseList />. ' +
         'Wrap it in an additional SuspenseList to configure its revealOrder: ' +
         '<SuspenseList revealOrder=...> ... ' +
         '<SuspenseList revealOrder=...>{array}</SuspenseList> ... ' +
@@ -1484,7 +1484,7 @@ describe('ReactSuspenseList', () => {
         ReactNoop.render(<Foo />);
       });
     }).toErrorDev([
-      'Warning: "collapse" is not a supported value for tail on ' +
+      '"collapse" is not a supported value for tail on ' +
         '<SuspenseList />. Did you mean "collapsed" or "hidden"?' +
         '\n    in SuspenseList (at **)' +
         '\n    in Foo (at **)',
@@ -1506,7 +1506,7 @@ describe('ReactSuspenseList', () => {
         ReactNoop.render(<Foo />);
       });
     }).toErrorDev([
-      'Warning: <SuspenseList tail="collapsed" /> is only valid if ' +
+      '<SuspenseList tail="collapsed" /> is only valid if ' +
         'revealOrder is "forwards" or "backwards". ' +
         'Did you mean to specify revealOrder="forwards"?' +
         '\n    in SuspenseList (at **)' +

--- a/packages/react-reconciler/src/__tests__/ReactUse-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUse-test.js
@@ -551,7 +551,7 @@ describe('ReactUse', () => {
     if (__DEV__) {
       expect(console.error).toHaveBeenCalledTimes(1);
       expect(console.error.mock.calls[0][0]).toContain(
-        'Warning: `use` was called from inside a try/catch block. This is not ' +
+        '`use` was called from inside a try/catch block. This is not ' +
           'allowed and can lead to unexpected behavior. To handle errors ' +
           'triggered by `use`, wrap your component in a error boundary.',
       );

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMForm-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMForm-test.js
@@ -968,7 +968,7 @@ describe('ReactFlightDOMForm', () => {
     }
 
     await expect(submitTheForm).toErrorDev(
-      'Warning: Failed to serialize an action for progressive enhancement:\n' +
+      'Failed to serialize an action for progressive enhancement:\n' +
         'Error: React Element cannot be passed to Server Functions from the Client without a temporary reference set. Pass a TemporaryReferenceSet to the options.\n' +
         '  [<div/>]\n' +
         '   ^^^^^^',
@@ -1045,7 +1045,7 @@ describe('ReactFlightDOMForm', () => {
     }
 
     await expect(submitTheForm).toErrorDev(
-      'Warning: Failed to serialize an action for progressive enhancement:\n' +
+      'Failed to serialize an action for progressive enhancement:\n' +
         'Error: File/Blob fields are not yet supported in progressive forms. Will fallback to client hydration.',
     );
 

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -67,7 +67,7 @@ describe('ReactTestRenderer', () => {
     ReactTestRenderer.create(<div />);
     expect(console.error).toHaveBeenCalledTimes(1);
     expect(console.error.mock.calls[0][0]).toContain(
-      'Warning: react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer',
+      'react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer',
     );
     console.error.mockRestore();
   });
@@ -412,7 +412,7 @@ describe('ReactTestRenderer', () => {
         ReactTestRenderer.create(<Foo />);
       });
     }).toErrorDev(
-      'Warning: Function components cannot be given refs. Attempts ' +
+      'Function components cannot be given refs. Attempts ' +
         'to access this ref will fail. ' +
         'Did you mean to use React.forwardRef()?\n' +
         '    in Bar (at **)\n' +

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -338,7 +338,7 @@ describe('ReactChildren', () => {
       // With the flag on this doesn't warn eagerly but only when rendered
       gate(flag => flag.enableOwnerStacks)
         ? []
-        : ['Warning: Each child in a list should have a unique "key" prop.'],
+        : ['Each child in a list should have a unique "key" prop.'],
     );
 
     React.Children.forEach(instance.props.children, callback, context);
@@ -363,9 +363,7 @@ describe('ReactChildren', () => {
       await act(() => {
         root.render(instance);
       });
-    }).toErrorDev(
-      'Warning: Each child in a list should have a unique "key" prop.',
-    );
+    }).toErrorDev('Each child in a list should have a unique "key" prop.');
   });
 
   it('should be called for each child in an iterable with keys', () => {
@@ -889,9 +887,7 @@ describe('ReactChildren', () => {
           </ComponentRenderingMappedChildren>,
         );
       });
-    }).toErrorDev([
-      'Warning: Each child in a list should have a unique "key" prop.',
-    ]);
+    }).toErrorDev(['Each child in a list should have a unique "key" prop.']);
   });
 
   it('does not warn for mapped static children without keys', async () => {
@@ -938,9 +934,7 @@ describe('ReactChildren', () => {
           </ComponentRenderingClonedChildren>,
         );
       });
-    }).toErrorDev([
-      'Warning: Each child in a list should have a unique "key" prop.',
-    ]);
+    }).toErrorDev(['Each child in a list should have a unique "key" prop.']);
   });
 
   it('does not warn for cloned static children without keys', async () => {
@@ -981,9 +975,7 @@ describe('ReactChildren', () => {
           </ComponentRenderingFlattenedChildren>,
         );
       });
-    }).toErrorDev([
-      'Warning: Each child in a list should have a unique "key" prop.',
-    ]);
+    }).toErrorDev(['Each child in a list should have a unique "key" prop.']);
   });
 
   it('does not warn for flattened static children without keys', async () => {
@@ -1166,7 +1158,7 @@ describe('ReactChildren', () => {
           root.render(<ComponentReturningArray />);
         });
       }).toErrorDev(
-        'Warning: ' +
+        '' +
           'Each child in a list should have a unique "key" prop.' +
           '\n\nCheck the top-level render call using <ComponentReturningArray>. It was passed a child from ComponentReturningArray. ' +
           'See https://react.dev/link/warning-keys for more information.' +
@@ -1197,7 +1189,7 @@ describe('ReactChildren', () => {
           root.render([<div />, <div />]);
         });
       }).toErrorDev(
-        'Warning: ' +
+        '' +
           'Each child in a list should have a unique "key" prop.' +
           '\n\nCheck the top-level render call using <Root>. ' +
           'See https://react.dev/link/warning-keys for more information.' +

--- a/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -468,7 +468,7 @@ describe 'ReactCoffeeScriptClass', ->
     expect(->
       test React.createElement(NamedComponent), 'SPAN', 'foo'
     ).toErrorDev(
-      'Warning: NamedComponent has a method called componentShouldUpdate().
+      'NamedComponent has a method called componentShouldUpdate().
        Did you mean shouldComponentUpdate()? The name is phrased as a
        question because the function is expected to return a value.'
     )
@@ -486,7 +486,7 @@ describe 'ReactCoffeeScriptClass', ->
     expect(->
       test React.createElement(NamedComponent), 'SPAN', 'foo'
     ).toErrorDev(
-      'Warning: NamedComponent has a method called componentWillRecieveProps().
+      'NamedComponent has a method called componentWillRecieveProps().
        Did you mean componentWillReceiveProps()?'
     )
 
@@ -503,7 +503,7 @@ describe 'ReactCoffeeScriptClass', ->
     expect(->
       test React.createElement(NamedComponent), 'SPAN', 'foo'
     ).toErrorDev(
-      'Warning: NamedComponent has a method called UNSAFE_componentWillRecieveProps().
+      'NamedComponent has a method called UNSAFE_componentWillRecieveProps().
        Did you mean UNSAFE_componentWillReceiveProps()?'
     )
 
@@ -554,7 +554,7 @@ describe 'ReactCoffeeScriptClass', ->
       expect(->
         test(React.createElement(Foo, ref: ref), 'DIV', 'foo')
       ).toErrorDev([
-        'Warning: Component "Foo" contains the string ref "inner". ' +
+        'Component "Foo" contains the string ref "inner". ' +
           'Support for string refs will be removed in a future major release. ' +
           'We recommend using useRef() or createRef() instead. ' +
           'Learn more about using refs safely here: https://react.dev/link/strict-mode-string-ref\n' +

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -188,7 +188,7 @@ describe('ReactContextValidator', () => {
         root.render(<ComponentA />);
       });
     }).toErrorDev(
-      'Warning: ComponentA.childContextTypes is specified but there is no ' +
+      'ComponentA.childContextTypes is specified but there is no ' +
         'getChildContext() method on the instance. You can either define ' +
         'getChildContext() on ComponentA or remove childContextTypes from it.',
     );
@@ -207,7 +207,7 @@ describe('ReactContextValidator', () => {
         root.render(<ComponentB />);
       });
     }).toErrorDev(
-      'Warning: ComponentB.childContextTypes is specified but there is no ' +
+      'ComponentB.childContextTypes is specified but there is no ' +
         'getChildContext() method on the instance. You can either define ' +
         'getChildContext() on ComponentB or remove childContextTypes from it.',
     );
@@ -259,7 +259,7 @@ describe('ReactContextValidator', () => {
         root.render(<ParentContextProvider />);
       });
     }).toErrorDev([
-      'Warning: MiddleMissingContext.childContextTypes is specified but there is no ' +
+      'MiddleMissingContext.childContextTypes is specified but there is no ' +
         'getChildContext() method on the instance. You can either define getChildContext() ' +
         'on MiddleMissingContext or remove childContextTypes from it.',
     ]);
@@ -436,7 +436,7 @@ describe('ReactContextValidator', () => {
         );
       });
     }).toErrorDev(
-      'Warning: ComponentA declares both contextTypes and contextType static properties. ' +
+      'ComponentA declares both contextTypes and contextType static properties. ' +
         'The legacy contextTypes property will be ignored.',
     );
 
@@ -462,7 +462,7 @@ describe('ReactContextValidator', () => {
         );
       });
     }).toErrorDev(
-      'Warning: ComponentB declares both contextTypes and contextType static properties. ' +
+      'ComponentB declares both contextTypes and contextType static properties. ' +
         'The legacy contextTypes property will be ignored.',
     );
   });
@@ -484,7 +484,7 @@ describe('ReactContextValidator', () => {
         root.render(<ComponentA />);
       });
     }).toErrorDev(
-      'Warning: ComponentA defines an invalid contextType. ' +
+      'ComponentA defines an invalid contextType. ' +
         'contextType should point to the Context object returned by React.createContext(). ' +
         'Did you accidentally pass the Context.Consumer instead?',
     );
@@ -628,7 +628,7 @@ describe('ReactContextValidator', () => {
         root.render(<ComponentA />);
       });
     }).toErrorDev(
-      'Warning: ComponentA: Function components do not support contextType.',
+      'ComponentA: Function components do not support contextType.',
     );
 
     // Warnings should be deduped by component type
@@ -645,7 +645,7 @@ describe('ReactContextValidator', () => {
         root.render(<ComponentB />);
       });
     }).toErrorDev(
-      'Warning: ComponentB: Function components do not support contextType.',
+      'ComponentB: Function components do not support contextType.',
     );
   });
 });

--- a/packages/react/src/__tests__/ReactES6Class-test.js
+++ b/packages/react/src/__tests__/ReactES6Class-test.js
@@ -71,9 +71,9 @@ describe('ReactES6Class', () => {
         ReactDOM.flushSync(() => root.render(<Foo />));
       }).toErrorDev([
         // A failed component renders twice in DEV in concurrent mode
-        'Warning: No `render` method found on the Foo instance: ' +
+        'No `render` method found on the Foo instance: ' +
           'you may have forgotten to define `render`.',
-        'Warning: No `render` method found on the Foo instance: ' +
+        'No `render` method found on the Foo instance: ' +
           'you may have forgotten to define `render`.',
       ]);
     } finally {
@@ -510,8 +510,7 @@ describe('ReactES6Class', () => {
     }
 
     expect(() => runTest(<NamedComponent />, 'SPAN', 'foo')).toErrorDev(
-      'Warning: ' +
-        'NamedComponent has a method called componentShouldUpdate(). Did you ' +
+      'NamedComponent has a method called componentShouldUpdate(). Did you ' +
         'mean shouldComponentUpdate()? The name is phrased as a question ' +
         'because the function is expected to return a value.',
     );
@@ -528,8 +527,7 @@ describe('ReactES6Class', () => {
     }
 
     expect(() => runTest(<NamedComponent />, 'SPAN', 'foo')).toErrorDev(
-      'Warning: ' +
-        'NamedComponent has a method called componentWillRecieveProps(). Did ' +
+      'NamedComponent has a method called componentWillRecieveProps(). Did ' +
         'you mean componentWillReceiveProps()?',
     );
   });
@@ -545,8 +543,7 @@ describe('ReactES6Class', () => {
     }
 
     expect(() => runTest(<NamedComponent />, 'SPAN', 'foo')).toErrorDev(
-      'Warning: ' +
-        'NamedComponent has a method called UNSAFE_componentWillRecieveProps(). ' +
+      'NamedComponent has a method called UNSAFE_componentWillRecieveProps(). ' +
         'Did you mean UNSAFE_componentWillReceiveProps()?',
     );
   });
@@ -598,7 +595,7 @@ describe('ReactES6Class', () => {
       expect(() => {
         runTest(<Foo ref={ref} />, 'DIV', 'foo');
       }).toErrorDev([
-        'Warning: Component "Foo" contains the string ref "inner". ' +
+        'Component "Foo" contains the string ref "inner". ' +
           'Support for string refs will be removed in a future major release. ' +
           'We recommend using useRef() or createRef() instead. ' +
           'Learn more about using refs safely here: https://react.dev/link/strict-mode-string-ref\n' +

--- a/packages/react/src/__tests__/ReactElementClone-test.js
+++ b/packages/react/src/__tests__/ReactElementClone-test.js
@@ -319,7 +319,7 @@ describe('ReactElementClone', () => {
       await act(() => root.render(<Parent />));
       expect(child.refs.xyz.tagName).toBe('DIV');
     }).toErrorDev([
-      'Warning: Component "Child" contains the string ref "xyz". Support for ' +
+      'Component "Child" contains the string ref "xyz". Support for ' +
         'string refs will be removed in a future major release. We recommend ' +
         'using useRef() or createRef() instead. Learn more about using refs ' +
         'safely here: https://react.dev/link/strict-mode-string-ref',

--- a/packages/react/src/__tests__/ReactElementValidator-test.internal.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.internal.js
@@ -95,12 +95,12 @@ describe('ReactElementValidator', () => {
     }).toErrorDev(
       gate(flags => flags.enableOwnerStacks)
         ? // For owner stacks the parent being validated is the div.
-          'Warning: Each child in a list should have a unique ' +
+          'Each child in a list should have a unique ' +
             '"key" prop.' +
             '\n\nCheck the top-level render call using <div>. ' +
             'See https://react.dev/link/warning-keys for more information.\n' +
             '    in div (at **)'
-        : 'Warning: Each child in a list should have a unique ' +
+        : 'Each child in a list should have a unique ' +
             '"key" prop. See https://react.dev/link/warning-keys for more information.\n' +
             '    in div (at **)',
     );
@@ -114,7 +114,7 @@ describe('ReactElementValidator', () => {
 
       await act(() => root.render(<div>{divs}</div>));
     }).toErrorDev(
-      'Warning: Each child in a list should have a unique ' +
+      'Each child in a list should have a unique ' +
         '"key" prop.\n\nCheck the top-level render call using <div>. See ' +
         'https://react.dev/link/warning-keys for more information.\n' +
         '    in div (at **)',
@@ -138,7 +138,7 @@ describe('ReactElementValidator', () => {
       const root = ReactDOMClient.createRoot(document.createElement('div'));
       await act(() => root.render(<GrandParent />));
     }).toErrorDev(
-      'Warning: Each child in a list should have a unique ' +
+      'Each child in a list should have a unique ' +
         '"key" prop.\n\nCheck the render method of `Component`. See ' +
         'https://react.dev/link/warning-keys for more information.\n' +
         '    in div (at **)\n' +
@@ -297,38 +297,38 @@ describe('ReactElementValidator', () => {
         ? // We don't need these extra warnings because we already have the errors.
           []
         : [
-            'Warning: React.createElement: type is invalid -- expected a string ' +
+            'React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: undefined. You likely forgot to export your ' +
               "component from the file it's defined in, or you might have mixed up " +
               'default and named imports.',
-            'Warning: React.createElement: type is invalid -- expected a string ' +
+            'React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: null.',
-            'Warning: React.createElement: type is invalid -- expected a string ' +
+            'React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: boolean.',
-            'Warning: React.createElement: type is invalid -- expected a string ' +
+            'React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: object.',
-            'Warning: React.createElement: type is invalid -- expected a string ' +
+            'React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: object. You likely forgot to export your ' +
               "component from the file it's defined in, or you might have mixed up " +
               'default and named imports.',
-            'Warning: React.createElement: type is invalid -- expected a string ' +
+            'React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: <div />. Did you accidentally export a JSX literal ' +
               'instead of a component?',
-            'Warning: React.createElement: type is invalid -- expected a string ' +
+            'React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: <Foo />. Did you accidentally export a JSX literal ' +
               'instead of a component?',
-            'Warning: React.createElement: type is invalid -- expected a string ' +
+            'React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: <Context.Consumer />. Did you accidentally ' +
               'export a JSX literal instead of a component?',
-            'Warning: React.createElement: type is invalid -- expected a string ' +
+            'React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: object.',
           ],
@@ -427,11 +427,11 @@ describe('ReactElementValidator', () => {
         ? // We don't need these extra warnings because we already have the errors.
           []
         : [
-            'Warning: React.createElement: type is invalid -- expected a string ' +
+            'React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: null.\n' +
               '    in ParentComp (at **)',
-            'Warning: React.createElement: type is invalid -- expected a string ' +
+            'React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: null.\n' +
               '    in ParentComp (at **)',
@@ -515,7 +515,7 @@ describe('ReactElementValidator', () => {
     expect(() => {
       void (<Foo>{[<div />]}</Foo>);
     }).toErrorDev(
-      'Warning: React.jsx: type is invalid -- expected a string ' +
+      'React.jsx: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: undefined. You likely forgot to export your ' +
         "component from the file it's defined in, or you might have mixed up " +

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -221,7 +221,7 @@ describe('ReactJSXElementValidator', () => {
     const True = true;
     const Div = 'div';
     expect(() => void (<Undefined />)).toErrorDev(
-      'Warning: React.jsx: type is invalid -- expected a string ' +
+      'React.jsx: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: undefined. You likely forgot to export your ' +
         "component from the file it's defined in, or you might have mixed up " +
@@ -229,13 +229,13 @@ describe('ReactJSXElementValidator', () => {
       {withoutStack: true},
     );
     expect(() => void (<Null />)).toErrorDev(
-      'Warning: React.jsx: type is invalid -- expected a string ' +
+      'React.jsx: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: null.',
       {withoutStack: true},
     );
     expect(() => void (<True />)).toErrorDev(
-      'Warning: React.jsx: type is invalid -- expected a string ' +
+      'React.jsx: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: boolean.',
       {withoutStack: true},

--- a/packages/react/src/__tests__/ReactJSXRuntime-test.js
+++ b/packages/react/src/__tests__/ReactJSXRuntime-test.js
@@ -297,7 +297,7 @@ describe('ReactJSXRuntime', () => {
         root.render(JSXRuntime.jsx(Parent, {}));
       });
     }).toErrorDev(
-      'Warning: Each child in a list should have a unique "key" prop.\n\n' +
+      'Each child in a list should have a unique "key" prop.\n\n' +
         'Check the render method of `Parent`. See https://react.dev/link/warning-keys for more information.\n' +
         (gate(flags => flags.enableOwnerStacks)
           ? ''
@@ -326,7 +326,7 @@ describe('ReactJSXRuntime', () => {
         root.render(JSXRuntime.jsx(Parent, {}));
       });
     }).toErrorDev(
-      'Warning: A props object containing a "key" prop is being spread into JSX:\n' +
+      'A props object containing a "key" prop is being spread into JSX:\n' +
         '  let props = {key: someKey, prop: ...};\n' +
         '  <Child {...props} />\n' +
         'React keys must be passed directly to JSX without using spread:\n' +

--- a/packages/react/src/__tests__/ReactPureComponent-test.js
+++ b/packages/react/src/__tests__/ReactPureComponent-test.js
@@ -95,7 +95,7 @@ describe('ReactPureComponent', () => {
         root.render(<Component />);
       });
     }).toErrorDev(
-      'Warning: ' +
+      '' +
         'Component has a method called shouldComponentUpdate(). ' +
         'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
         'Please extend React.Component if shouldComponentUpdate is used.',
@@ -138,7 +138,7 @@ describe('ReactPureComponent', () => {
         root.render(<PureComponent />);
       });
     }).toErrorDev(
-      'Warning: ' +
+      '' +
         'PureComponent has a method called shouldComponentUpdate(). ' +
         'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
         'Please extend React.Component if shouldComponentUpdate is used.',

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -626,18 +626,18 @@ describe('Concurrent Mode', () => {
     ).toErrorDev(
       [
         /* eslint-disable max-len */
-        `Warning: Using UNSAFE_componentWillMount in strict mode is not recommended and may indicate bugs in your code. See https://react.dev/link/unsafe-component-lifecycles for details.
+        `Using UNSAFE_componentWillMount in strict mode is not recommended and may indicate bugs in your code. See https://react.dev/link/unsafe-component-lifecycles for details.
 
 * Move code with side effects to componentDidMount, and set initial state in the constructor.
 
 Please update the following components: App`,
-        `Warning: Using UNSAFE_componentWillReceiveProps in strict mode is not recommended and may indicate bugs in your code. See https://react.dev/link/unsafe-component-lifecycles for details.
+        `Using UNSAFE_componentWillReceiveProps in strict mode is not recommended and may indicate bugs in your code. See https://react.dev/link/unsafe-component-lifecycles for details.
 
 * Move data fetching code or side effects to componentDidUpdate.
 * If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://react.dev/link/derived-state
 
 Please update the following components: Bar, Foo`,
-        `Warning: Using UNSAFE_componentWillUpdate in strict mode is not recommended and may indicate bugs in your code. See https://react.dev/link/unsafe-component-lifecycles for details.
+        `Using UNSAFE_componentWillUpdate in strict mode is not recommended and may indicate bugs in your code. See https://react.dev/link/unsafe-component-lifecycles for details.
 
 * Move data fetching code or side effects to componentDidUpdate.
 
@@ -690,18 +690,18 @@ Please update the following components: App`,
       ).toErrorDev(
         [
           /* eslint-disable max-len */
-          `Warning: Using UNSAFE_componentWillMount in strict mode is not recommended and may indicate bugs in your code. See https://react.dev/link/unsafe-component-lifecycles for details.
+          `Using UNSAFE_componentWillMount in strict mode is not recommended and may indicate bugs in your code. See https://react.dev/link/unsafe-component-lifecycles for details.
 
 * Move code with side effects to componentDidMount, and set initial state in the constructor.
 
 Please update the following components: App`,
-          `Warning: Using UNSAFE_componentWillReceiveProps in strict mode is not recommended and may indicate bugs in your code. See https://react.dev/link/unsafe-component-lifecycles for details.
+          `Using UNSAFE_componentWillReceiveProps in strict mode is not recommended and may indicate bugs in your code. See https://react.dev/link/unsafe-component-lifecycles for details.
 
 * Move data fetching code or side effects to componentDidUpdate.
 * If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://react.dev/link/derived-state
 
 Please update the following components: Child`,
-          `Warning: Using UNSAFE_componentWillUpdate in strict mode is not recommended and may indicate bugs in your code. See https://react.dev/link/unsafe-component-lifecycles for details.
+          `Using UNSAFE_componentWillUpdate in strict mode is not recommended and may indicate bugs in your code. See https://react.dev/link/unsafe-component-lifecycles for details.
 
 * Move data fetching code or side effects to componentDidUpdate.
 
@@ -713,20 +713,20 @@ Please update the following components: App`,
     }).toWarnDev(
       [
         /* eslint-disable max-len */
-        `Warning: componentWillMount has been renamed, and is not recommended for use. See https://react.dev/link/unsafe-component-lifecycles for details.
+        `componentWillMount has been renamed, and is not recommended for use. See https://react.dev/link/unsafe-component-lifecycles for details.
 
 * Move code with side effects to componentDidMount, and set initial state in the constructor.
 * Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run \`npx react-codemod rename-unsafe-lifecycles\` in your project source folder.
 
 Please update the following components: Parent`,
-        `Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://react.dev/link/unsafe-component-lifecycles for details.
+        `componentWillReceiveProps has been renamed, and is not recommended for use. See https://react.dev/link/unsafe-component-lifecycles for details.
 
 * Move data fetching code or side effects to componentDidUpdate.
 * If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://react.dev/link/derived-state
 * Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run \`npx react-codemod rename-unsafe-lifecycles\` in your project source folder.
 
 Please update the following components: Parent`,
-        `Warning: componentWillUpdate has been renamed, and is not recommended for use. See https://react.dev/link/unsafe-component-lifecycles for details.
+        `componentWillUpdate has been renamed, and is not recommended for use. See https://react.dev/link/unsafe-component-lifecycles for details.
 
 * Move data fetching code or side effects to componentDidUpdate.
 * Rename componentWillUpdate to UNSAFE_componentWillUpdate to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run \`npx react-codemod rename-unsafe-lifecycles\` in your project source folder.
@@ -997,7 +997,7 @@ describe('string refs', () => {
         root.render(<OuterComponent />);
       });
     }).toErrorDev(
-      'Warning: Component "OuterComponent" contains the string ref "somestring". ' +
+      'Component "OuterComponent" contains the string ref "somestring". ' +
         'Support for string refs will be removed in a future major release. ' +
         'We recommend using useRef() or createRef() instead. ' +
         'Learn more about using refs safely here: https://react.dev/link/strict-mode-string-ref\n' +
@@ -1083,7 +1083,7 @@ describe('context legacy', () => {
         root.render(<Root />);
       });
     }).toErrorDev(
-      'Warning: Legacy context API has been detected within a strict-mode tree.' +
+      'Legacy context API has been detected within a strict-mode tree.' +
         '\n\nThe old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.' +
         '\n\nPlease update the following components: ' +

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -339,9 +339,9 @@ describe('ReactTypeScriptClass', function() {
         ReactDOM.flushSync(() => root.render(React.createElement(Empty)))
       }).toErrorDev([
         // A failed component renders twice in DEV in concurrent mode
-        'Warning: No `render` method found on the Empty instance: ' +
+        'No `render` method found on the Empty instance: ' +
           'you may have forgotten to define `render`.',
-        'Warning: No `render` method found on the Empty instance: ' +
+        'No `render` method found on the Empty instance: ' +
           'you may have forgotten to define `render`.',
       ]);
     } finally {
@@ -644,7 +644,7 @@ describe('ReactTypeScriptClass', function() {
     expect(() =>
       test(React.createElement(MisspelledComponent1), 'SPAN', 'foo')
     ).toErrorDev(
-      'Warning: ' +
+      '' +
         'MisspelledComponent1 has a method called componentShouldUpdate(). Did ' +
         'you mean shouldComponentUpdate()? The name is phrased as a question ' +
         'because the function is expected to return a value.'
@@ -655,7 +655,7 @@ describe('ReactTypeScriptClass', function() {
     expect(() =>
       test(React.createElement(MisspelledComponent2), 'SPAN', 'foo')
     ).toErrorDev(
-      'Warning: ' +
+      '' +
         'MisspelledComponent2 has a method called componentWillRecieveProps(). ' +
         'Did you mean componentWillReceiveProps()?'
     );
@@ -665,7 +665,7 @@ describe('ReactTypeScriptClass', function() {
     expect(() =>
       test(React.createElement(MisspelledComponent3), 'SPAN', 'foo')
     ).toErrorDev(
-      'Warning: ' +
+      '' +
         'MisspelledComponent3 has a method called UNSAFE_componentWillRecieveProps(). ' +
         'Did you mean UNSAFE_componentWillReceiveProps()?'
     );
@@ -700,7 +700,7 @@ describe('ReactTypeScriptClass', function() {
       expect(() => {
         test(React.createElement(ClassicRefs, {ref: ref}), 'DIV', 'foo');
       }).toErrorDev([
-        'Warning: Component "ClassicRefs" contains the string ref "inner". ' +
+        'Component "ClassicRefs" contains the string ref "inner". ' +
           'Support for string refs will be removed in a future major release. ' +
           'We recommend using useRef() or createRef() instead. ' +
           'Learn more about using refs safely here: https://react.dev/link/strict-mode-string-ref\n' +

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -63,7 +63,7 @@ describe('create-react-class-integration', () => {
         },
       }),
     ).toErrorDev(
-      'Warning: Component: prop type `prop` is invalid; ' +
+      'Component: prop type `prop` is invalid; ' +
         'it must be a function, usually from React.PropTypes.',
       {withoutStack: true},
     );
@@ -81,7 +81,7 @@ describe('create-react-class-integration', () => {
         },
       }),
     ).toErrorDev(
-      'Warning: Component: context type `prop` is invalid; ' +
+      'Component: context type `prop` is invalid; ' +
         'it must be a function, usually from React.PropTypes.',
       {withoutStack: true},
     );
@@ -99,7 +99,7 @@ describe('create-react-class-integration', () => {
         },
       }),
     ).toErrorDev(
-      'Warning: Component: child context type `prop` is invalid; ' +
+      'Component: child context type `prop` is invalid; ' +
         'it must be a function, usually from React.PropTypes.',
       {withoutStack: true},
     );
@@ -116,7 +116,7 @@ describe('create-react-class-integration', () => {
         },
       }),
     ).toErrorDev(
-      'Warning: A component has a method called componentShouldUpdate(). Did you ' +
+      'A component has a method called componentShouldUpdate(). Did you ' +
         'mean shouldComponentUpdate()? The name is phrased as a question ' +
         'because the function is expected to return a value.',
       {withoutStack: true},
@@ -133,7 +133,7 @@ describe('create-react-class-integration', () => {
         },
       }),
     ).toErrorDev(
-      'Warning: NamedComponent has a method called componentShouldUpdate(). Did you ' +
+      'NamedComponent has a method called componentShouldUpdate(). Did you ' +
         'mean shouldComponentUpdate()? The name is phrased as a question ' +
         'because the function is expected to return a value.',
       {withoutStack: true},
@@ -151,7 +151,7 @@ describe('create-react-class-integration', () => {
         },
       }),
     ).toErrorDev(
-      'Warning: A component has a method called componentWillRecieveProps(). Did you ' +
+      'A component has a method called componentWillRecieveProps(). Did you ' +
         'mean componentWillReceiveProps()?',
       {withoutStack: true},
     );
@@ -168,7 +168,7 @@ describe('create-react-class-integration', () => {
         },
       }),
     ).toErrorDev(
-      'Warning: A component has a method called UNSAFE_componentWillRecieveProps(). ' +
+      'A component has a method called UNSAFE_componentWillRecieveProps(). ' +
         'Did you mean UNSAFE_componentWillReceiveProps()?',
       {withoutStack: true},
     );
@@ -388,7 +388,7 @@ describe('create-react-class-integration', () => {
     });
 
     expect(() => expect(() => Component()).toThrow()).toErrorDev(
-      'Warning: Something is calling a React component directly. Use a ' +
+      'Something is calling a React component directly. Use a ' +
         'factory or JSX instead. See: https://fb.me/react-legacyfactory',
       {withoutStack: true},
     );
@@ -796,7 +796,7 @@ describe('create-react-class-integration', () => {
         root.render(<Component />);
       });
     }).toErrorDev(
-      'Warning: MyComponent: isMounted is deprecated. Instead, make sure to ' +
+      'MyComponent: isMounted is deprecated. Instead, make sure to ' +
         'clean up subscriptions and pending requests in componentWillUnmount ' +
         'to prevent memory leaks.',
       {withoutStack: true},

--- a/packages/react/src/__tests__/forwardRef-test.js
+++ b/packages/react/src/__tests__/forwardRef-test.js
@@ -427,7 +427,7 @@ describe('forwardRef', () => {
       );
     }).toErrorDev(
       [
-        'Warning: forwardRef requires a render function but received a `memo` ' +
+        'forwardRef requires a render function but received a `memo` ' +
           'component. Instead of forwardRef(memo(...)), use ' +
           'memo(forwardRef(...)).',
       ],

--- a/packages/shared/consoleWithStackDev.js
+++ b/packages/shared/consoleWithStackDev.js
@@ -44,9 +44,6 @@ function printWarning(level, format, args, currentStack) {
   // When changing this logic, you might want to also
   // update consoleWithStackDev.www.js as well.
   if (__DEV__) {
-    const isErrorLogger =
-      format === '%s\n\n%s\n' || format === '%o\n\n%s\n\n%s\n';
-
     if (!supportsCreateTask && ReactSharedInternals.getCurrentStack) {
       // We only add the current stack to the console when createTask is not supported.
       // Since createTask requires DevTools to be open to work, this means that stacks
@@ -58,18 +55,7 @@ function printWarning(level, format, args, currentStack) {
       }
     }
 
-    if (isErrorLogger) {
-      // Don't prefix our default logging formatting in ReactFiberErrorLoggger.
-      // Don't toString the arguments.
-      args.unshift(format);
-    } else {
-      // TODO: Remove this prefix and stop toStringing in the wrapper and
-      // instead do it at each callsite as needed.
-      // Careful: RN currently depends on this prefix
-      // eslint-disable-next-line react-internal/safe-string-coercion
-      args = args.map(item => String(item));
-      args.unshift('Warning: ' + format);
-    }
+    args.unshift(format);
     // We intentionally don't use spread (or .apply) directly because it
     // breaks IE9: https://github.com/facebook/react/issues/13610
     // eslint-disable-next-line react-internal/no-production-logging


### PR DESCRIPTION
Basically make `console.error` and `console.warn` behave like normal - when a component stack isn't appended. I need this because I need to be able to print rich logs with the component stack option and to be able to disable instrumentation completely in `console.createTask` environments that don't need it.

Currently we can't print logs with richer objects because they're toString:ed first. In practice, pretty much all arguments we log are already toString:ed so it's not necessary anyway. Some might be like a number. So it would only be a problem if some environment can't handle proper consoles but then it's up to that environment to toString it before logging.

The `Warning: ` prefix is historic and is both noisy and confusing. It's mostly unnecessary since the UI surrounding `console.error` and `console.warn` tend to have visual treatment around it anyway. However, it's actively misleading when `console.error` gets prefixed with a Warning that we consider an error level. There's an argument to be made that some of our `console.error` don't make the bar for an error but then the argument is to downgrade each of those to `console.warn` - not to brand all our actual error logging with `Warning: `.

Apparently something needs to change in React Native before landing this because it depends on the prefix somehow which probably doesn't make sense already.

