### PR TITLE
[compiler] Remove playground postinstall script

### DIFF
--- a/compiler/apps/playground/package.json
+++ b/compiler/apps/playground/package.json
@@ -8,7 +8,6 @@
     "vercel-build": "yarn workspaces run build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "yarn playwright install",
     "test": "playwright test"
   },
   "dependencies": {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #29842
* __->__ #29841

The ci step for the playground already installs playwright browsers so
this step was unnecessary. It also doesn't work internally for our sync
scripts