### PR TITLE
Add new error message for awaiting the client export

### DIFF
--- a/packages/react-server-dom-turbopack/src/ReactFlightTurbopackReferences.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightTurbopackReferences.js
@@ -133,6 +133,11 @@ const deepProxyHandlers = {
             `Instead, you can export a Client Component wrapper ` +
             `that itself renders a Client Context Provider.`,
         );
+      case 'then':
+        throw new Error(
+          `Cannot await or return from a thenable. ` +
+            `You cannot await a client module from a server component.`,
+        );
     }
     // eslint-disable-next-line react-internal/safe-string-coercion
     const expression = String(target.name) + '.' + String(name);

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js
@@ -141,6 +141,11 @@ const deepProxyHandlers = {
             `Instead, you can export a Client Component wrapper ` +
             `that itself renders a Client Context Provider.`,
         );
+      case 'then':
+        throw new Error(
+          `Cannot await or return from a thenable. ` +
+            `You cannot await a client module from a server component.`,
+        );
     }
     // eslint-disable-next-line react-internal/safe-string-coercion
     const expression = String(target.name) + '.' + String(name);

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -628,7 +628,7 @@ describe('ReactFlightDOM', () => {
       Component: function () {},
     });
     async function read() {
-      return await ClientModule.then(mod => mod.Component);
+      return await ClientModule.Component;
     }
     expect(read).toThrowError(
       `Cannot await or return from a thenable. ` +

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -625,12 +625,13 @@ describe('ReactFlightDOM', () => {
 
   it('throws when await a client module prop of client exports', () => {
     const ClientModule = clientExports({
-      Component: function () {},
+      Component: {deep: 'thing'},
     });
-    async function read() {
-      return await ClientModule.Component;
+    async function awaitExport() {
+      const mod = await ClientModule
+      return await Promise.resolve(mod.Component)
     }
-    expect(read).toThrowError(
+    expect(awaitExport).toThrowError(
       `Cannot await or return from a thenable. ` +
         `You cannot await a client module from a server component.`,
     );

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -623,15 +623,15 @@ describe('ReactFlightDOM', () => {
     );
   });
 
-  it('throws when await a client module prop of client exports', () => {
+  it('throws when await a client module prop of client exports', async () => {
     const ClientModule = clientExports({
       Component: {deep: 'thing'},
     });
     async function awaitExport() {
-      const mod = await ClientModule
-      return await Promise.resolve(mod.Component)
+      const mod = await ClientModule;
+      return await Promise.resolve(mod.Component);
     }
-    expect(awaitExport).toThrowError(
+    await expect(awaitExport()).rejects.toThrowError(
       `Cannot await or return from a thenable. ` +
         `You cannot await a client module from a server component.`,
     );

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -623,6 +623,19 @@ describe('ReactFlightDOM', () => {
     );
   });
 
+  it('throws when await a client module prop of client exports', () => {
+    const ClientModule = clientExports({
+      Component: function () {},
+    });
+    async function read() {
+      return await ClientModule.then(mod => mod.Component);
+    }
+    expect(read).toThrowError(
+      `Cannot await or return from a thenable. ` +
+        `You cannot await a client module from a server component.`,
+    );
+  });
+
   it('throws when accessing a symbol prop from client exports', () => {
     const symbol = Symbol('test');
     const ClientModule = clientExports({


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

`Cannot access .then on server` is not an ideal message when you try to await or do promise chain to the properties of client reference. The below example will let `.then` get accessed by native code while handling the promise chain but the access is not clearly visible in user code.

```
import('./client-module').then((mod) => mod.Component)
```

This PR chnage the error message of module reference proxy '.then' property to show more kinds of usage, then it can be pretty clearly for helping users to avoid the bad usage

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Unit test

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
