### PR TITLE
[compiler] Remove .vscode

### DIFF
--- a/compiler/.vscode/settings.json
+++ b/compiler/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-  "editor.formatOnSave": true,
-  "[typescript][typescriptreact]": {
-    "editor.codeActionsOnSave": {
-      "source.organizeImports": "explicit"
-    }
-  }
-}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #29861

To keep consistent with the rest of the React repo, let's remove this
because editor settings are personal. Additionally this wasn't in the
root directory so it wasn't being applied anyway.