### PR TITLE
[compiler] Option to only compile component syntax

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
@@ -131,6 +131,8 @@ const CompilationModeSchema = z.enum([
    * This is the default mode
    */
   "infer",
+  // Compile only components using Flow component syntax and hooks using hook syntax.
+  "syntax",
   // Compile only functions which are explicitly annotated with "use forget"
   "annotation",
   // Compile all top-level functions

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -499,23 +499,28 @@ function getReactFunctionType(
       return getComponentOrHookLike(fn, hookPattern) ?? "Other";
     }
   }
+
+  // Component and hook declarations are known components/hooks
+  let explicitSyntax: ReactFunctionType | null = null;
+  if (fn.isFunctionDeclaration()) {
+    if (isComponentDeclaration(fn.node)) {
+      explicitSyntax = "Component";
+    } else if (isHookDeclaration(fn.node)) {
+      explicitSyntax = "Hook";
+    }
+  }
+
   switch (pass.opts.compilationMode) {
     case "annotation": {
       // opt-ins are checked above
       return null;
     }
     case "infer": {
-      // Component and hook declarations are known components/hooks
-      if (fn.isFunctionDeclaration()) {
-        if (isComponentDeclaration(fn.node)) {
-          return "Component";
-        } else if (isHookDeclaration(fn.node)) {
-          return "Hook";
-        }
-      }
-
-      // Otherwise check if this is a component or hook-like function
-      return getComponentOrHookLike(fn, hookPattern);
+      // Check if this is a component or hook-like function
+      return explicitSyntax ?? getComponentOrHookLike(fn, hookPattern);
+    }
+    case "syntax": {
+      return explicitSyntax;
     }
     case "all": {
       // Compile only top level functions

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -501,12 +501,12 @@ function getReactFunctionType(
   }
 
   // Component and hook declarations are known components/hooks
-  let explicitSyntax: ReactFunctionType | null = null;
+  let componentSyntaxType: ReactFunctionType | null = null;
   if (fn.isFunctionDeclaration()) {
     if (isComponentDeclaration(fn.node)) {
-      explicitSyntax = "Component";
+      componentSyntaxType = "Component";
     } else if (isHookDeclaration(fn.node)) {
-      explicitSyntax = "Hook";
+      componentSyntaxType = "Hook";
     }
   }
 
@@ -517,10 +517,10 @@ function getReactFunctionType(
     }
     case "infer": {
       // Check if this is a component or hook-like function
-      return explicitSyntax ?? getComponentOrHookLike(fn, hookPattern);
+      return componentSyntaxType ?? getComponentOrHookLike(fn, hookPattern);
     }
     case "syntax": {
-      return explicitSyntax;
+      return componentSyntaxType;
     }
     case "all": {
       // Compile only top level functions


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #29866
* #29865
* __->__ #29864

Summary: Projects which have heavily adopted Flow component syntax may wish to enable the compiler only for components and hooks that use the syntax, rather than trying to guess which functions are components and hooks. This provides that option.