### PR TITLE
[compiler] Expect components to have hook calls or jsx directly in body

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-no-component-nested-jsx.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-no-component-nested-jsx.expect.md
@@ -1,0 +1,51 @@
+
+## Input
+
+```javascript
+// @compilationMode(infer)
+function Component(props) {
+  const result = f(props);
+  function helper() {
+    return <foo />;
+  }
+  helper();
+  return result;
+}
+
+function f(props) {
+  return props;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+
+## Code
+
+```javascript
+// @compilationMode(infer)
+function Component(props) {
+  const result = f(props);
+  function helper() {
+    return <foo />;
+  }
+  helper();
+  return result;
+}
+
+function f(props) {
+  return props;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+      
+### Eval output
+(kind: ok) {}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-no-component-nested-jsx.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-no-component-nested-jsx.js
@@ -1,0 +1,18 @@
+// @compilationMode(infer)
+function Component(props) {
+  const result = f(props);
+  function helper() {
+    return <foo />;
+  }
+  helper();
+  return result;
+}
+
+function f(props) {
+  return props;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-no-component-obj-return.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-no-component-obj-return.expect.md
@@ -1,0 +1,43 @@
+
+## Input
+
+```javascript
+// @compilationMode(infer)
+function Component(props) {
+  const ignore = <foo />;
+  return { foo: f(props) };
+}
+
+function f(props) {
+  return props;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+
+## Code
+
+```javascript
+// @compilationMode(infer)
+function Component(props) {
+  const ignore = <foo />;
+  return { foo: f(props) };
+}
+
+function f(props) {
+  return props;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+      
+### Eval output
+(kind: ok) {"foo":{}}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-no-component-obj-return.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-no-component-obj-return.js
@@ -1,0 +1,14 @@
+// @compilationMode(infer)
+function Component(props) {
+  const ignore = <foo />;
+  return { foo: f(props) };
+}
+
+function f(props) {
+  return props;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/rules-of-hooks/error.invalid-hook-in-nested-function-expression-object-expression.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/rules-of-hooks/error.invalid-hook-in-nested-function-expression-object-expression.expect.md
@@ -4,6 +4,7 @@
 ```javascript
 // @compilationMode(infer)
 function Component() {
+  "use memo";
   const f = () => {
     const x = {
       outer() {
@@ -27,13 +28,13 @@ function Component() {
 ## Error
 
 ```
-   7 |           const y = {
-   8 |             inner() {
->  9 |               return useFoo();
-     |                      ^^^^^^ InvalidReact: Hooks must be called at the top level in the body of a function component or custom hook, and may not be called within function expressions. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning). Cannot call Custom within a function component (9:9)
-  10 |             },
-  11 |           };
-  12 |           return y;
+   8 |           const y = {
+   9 |             inner() {
+> 10 |               return useFoo();
+     |                      ^^^^^^ InvalidReact: Hooks must be called at the top level in the body of a function component or custom hook, and may not be called within function expressions. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning). Cannot call Custom within a function component (10:10)
+  11 |             },
+  12 |           };
+  13 |           return y;
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/rules-of-hooks/error.invalid-hook-in-nested-function-expression-object-expression.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/rules-of-hooks/error.invalid-hook-in-nested-function-expression-object-expression.js
@@ -1,5 +1,6 @@
 // @compilationMode(infer)
 function Component() {
+  "use memo";
   const f = () => {
     const x = {
       outer() {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/rules-of-hooks/error.invalid-hook-in-nested-object-method.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/rules-of-hooks/error.invalid-hook-in-nested-object-method.expect.md
@@ -4,6 +4,7 @@
 ```javascript
 // @compilationMode(infer)
 function Component() {
+  "use memo";
   const x = {
     outer() {
       const y = {
@@ -23,13 +24,13 @@ function Component() {
 ## Error
 
 ```
-   5 |       const y = {
-   6 |         inner() {
->  7 |           return useFoo();
-     |                  ^^^^^^ InvalidReact: Hooks must be called at the top level in the body of a function component or custom hook, and may not be called within function expressions. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning). Cannot call Custom within a function component (7:7)
-   8 |         },
-   9 |       };
-  10 |       return y;
+   6 |       const y = {
+   7 |         inner() {
+>  8 |           return useFoo();
+     |                  ^^^^^^ InvalidReact: Hooks must be called at the top level in the body of a function component or custom hook, and may not be called within function expressions. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning). Cannot call Custom within a function component (8:8)
+   9 |         },
+  10 |       };
+  11 |       return y;
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/rules-of-hooks/error.invalid-hook-in-nested-object-method.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/rules-of-hooks/error.invalid-hook-in-nested-object-method.js
@@ -1,5 +1,6 @@
 // @compilationMode(infer)
 function Component() {
+  "use memo";
   const x = {
     outer() {
       const y = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #29866
* __->__ #29865
* #29864

Summary: We can tighten our criteria for what is a component by requiring that a component or hook contain JSX or hook calls directly within its body, excluding nested functions . Currently, if we see them within the body anywhere -- including nested functions -- we treat it as a component if the other requirements are met. This change makes this stricter.

We also now expect components (but not necessarily hooks) to have return statements, and those returns must be potential React nodes (we can reject functions that return function or object literals, for example).