### PR TITLE
chore[react-devtools]: improve console arguments formatting before passing it to original console

### DIFF
--- a/packages/react-devtools-shared/src/backend/console.js
+++ b/packages/react-devtools-shared/src/backend/console.js
@@ -15,8 +15,11 @@ import type {
   WorkTagMap,
   ConsolePatchSettings,
 } from './types';
-import {formatWithStyles} from './utils';
 
+import {
+  formatConsoleArguments,
+  formatWithStyles,
+} from 'react-devtools-shared/src/backend/utils';
 import {
   FIREFOX_CONSOLE_DIMMING_COLOR,
   ANSI_STYLE_DIMMING_TEMPLATE,
@@ -335,7 +338,10 @@ export function patchForStrictMode() {
               ...formatWithStyles(args, FIREFOX_CONSOLE_DIMMING_COLOR),
             );
           } else {
-            originalMethod(ANSI_STYLE_DIMMING_TEMPLATE, ...args);
+            originalMethod(
+              ANSI_STYLE_DIMMING_TEMPLATE,
+              ...formatConsoleArguments(...args),
+            );
           }
         }
       };

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -40,6 +40,7 @@ import {
 } from 'react-devtools-shared/src/utils';
 import {sessionStorageGetItem} from 'react-devtools-shared/src/storage';
 import {
+  formatConsoleArgumentsToSingleString,
   gt,
   gte,
   parseSourceFromComponentStack,
@@ -95,7 +96,6 @@ import {
   MEMO_SYMBOL_STRING,
   SERVER_CONTEXT_SYMBOL_STRING,
 } from './ReactSymbols';
-import {format} from './utils';
 import {enableStyleXFeatures} from 'react-devtools-feature-flags';
 import is from 'shared/objectIs';
 import hasOwnProperty from 'shared/hasOwnProperty';
@@ -851,7 +851,14 @@ export function attach(
         return;
       }
     }
-    const message = format(...args);
+
+    // We can't really use this message as a unique key, since we can't distinguish
+    // different objects in this implementation. We have to delegate displaying of the objects
+    // to the environment, the browser console, for example, so this is why this should be kept
+    // as an array of arguments, instead of the plain string.
+    // [Warning: %o, {...}] and [Warning: %o, {...}] will be considered as the same message,
+    // even if objects are different
+    const message = formatConsoleArgumentsToSingleString(...args);
     if (__DEBUG__) {
       debug('onErrorOrWarning', fiber, null, `${type}: "${message}"`);
     }

--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -220,6 +220,61 @@ export function installHook(target: any): DevToolsHook | null {
       return [firstArg, style, ...inputArgs];
     }
   }
+  // NOTE: KEEP IN SYNC with src/backend/utils.js
+  function formatConsoleArguments(
+    maybeMessage: any,
+    ...inputArgs: $ReadOnlyArray<any>
+  ): $ReadOnlyArray<any> {
+    if (inputArgs.length === 0 || typeof maybeMessage !== 'string') {
+      return [maybeMessage, ...inputArgs];
+    }
+
+    const args = inputArgs.slice();
+
+    let template = '';
+    let argumentsPointer = 0;
+    for (let i = 0; i < maybeMessage.length; ++i) {
+      const currentChar = maybeMessage[i];
+      if (currentChar !== '%') {
+        template += currentChar;
+        continue;
+      }
+
+      const nextChar = maybeMessage[i + 1];
+      ++i;
+
+      // Only keep CSS and objects, inline other arguments
+      switch (nextChar) {
+        case 'c':
+        case 'O':
+        case 'o': {
+          ++argumentsPointer;
+          template += `%${nextChar}`;
+
+          break;
+        }
+        case 'd':
+        case 'i': {
+          const [arg] = args.splice(argumentsPointer, 1);
+          template += parseInt(arg, 10).toString();
+
+          break;
+        }
+        case 'f': {
+          const [arg] = args.splice(argumentsPointer, 1);
+          template += parseFloat(arg).toString();
+
+          break;
+        }
+        case 's': {
+          const [arg] = args.splice(argumentsPointer, 1);
+          template += arg.toString();
+        }
+      }
+    }
+
+    return [template, ...args];
+  }
 
   let unpatchFn = null;
 
@@ -274,7 +329,10 @@ export function installHook(target: any): DevToolsHook | null {
                 ...formatWithStyles(args, FIREFOX_CONSOLE_DIMMING_COLOR),
               );
             } else {
-              originalMethod(ANSI_STYLE_DIMMING_TEMPLATE, ...args);
+              originalMethod(
+                ANSI_STYLE_DIMMING_TEMPLATE,
+                ...formatConsoleArguments(...args),
+              );
             }
           }
         };


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/29869.

## Summary

When using ANSI escape sequences, we construct a message in the following way: `console.<method>('\x1b...%s\x1b[0m', userspaceArgument1?, userspaceArgument2?, userspaceArgument3?, ...)`.

This won't dim all arguments, if user had something like `console.log(1, 2, 3)`, we would only apply it to `1`, since this is the first arguments, so we need to:
- inline everything whats possible into a single string, while preserving console substitutions defined by the user
- omit css and object substitutions, since we can't really inline them and will delegate in to the environment

## How did you test this change?

Added some tests, manually inspected that it works well for web and native cases.