### PR TITLE
Enable tests with `use-sync-external-store/shim` and react-dom@17

### DIFF
--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -95,13 +95,8 @@ function getTestFlags() {
 
       // This is used by useSyncExternalStoresShared-test.js to decide whether
       // to test the shim or the native implementation of useSES.
-      // TODO: It's disabled when enableRefAsProp is on because the JSX
-      // runtime used by our tests is not compatible with older versions of
-      // React. If we want to keep testing this shim after enableRefIsProp is
-      // on everywhere, we'll need to find some other workaround. Maybe by
-      // only using createElement instead of JSX in that test module.
-      enableUseSyncExternalStoreShim:
-        !__VARIANT__ && !featureFlags.enableRefAsProp,
+
+      enableUseSyncExternalStoreShim: !__VARIANT__,
 
       // If there's a naming conflict between scheduler and React feature flags, the
       // React ones take precedence.


### PR DESCRIPTION

## Summary

When we switched on `enableRefAsProp`, we stopped testing `use-sync-external-store/shim` with React 17. The test suite already switched to `React.createElement` so the TODO item no longer applies. We can now re-enable the test which [break as expected](https://app.circleci.com/pipelines/github/facebook/react/54779/workflows/a30ac8d0-bb7a-4135-bfbe-1389ae681a7f/jobs/912480?invite=true#step-106-1600_89) until we land https://github.com/facebook/react/pull/29868

## How did you test this change?

- `yarn test packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js --variant false --build --watch`
