### PR TITLE
Execute event handlers in the context of the instance that it's associated with

### DIFF
--- a/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
@@ -52,6 +52,7 @@ import {
   enableLegacyFBSupport,
   enableCreateEventHandleAPI,
   enableScopeAPI,
+  enableOwnerStacks,
 } from 'shared/ReactFeatureFlags';
 import {createEventListenerWrapperWithPriority} from './ReactDOMEventListener';
 import {
@@ -69,6 +70,8 @@ import * as SimpleEventPlugin from './plugins/SimpleEventPlugin';
 import * as FormActionEventPlugin from './plugins/FormActionEventPlugin';
 
 import reportGlobalError from 'shared/reportGlobalError';
+
+import {runWithFiberInDEV} from 'react-reconciler/src/ReactCurrentFiber';
 
 type DispatchListener = {
   instance: null | Fiber,
@@ -255,7 +258,17 @@ function processDispatchQueueItemsInOrder(
       if (instance !== previousInstance && event.isPropagationStopped()) {
         return;
       }
-      executeDispatch(event, listener, currentTarget);
+      if (__DEV__ && enableOwnerStacks && instance !== null) {
+        runWithFiberInDEV(
+          instance,
+          executeDispatch,
+          event,
+          listener,
+          currentTarget,
+        );
+      } else {
+        executeDispatch(event, listener, currentTarget);
+      }
       previousInstance = instance;
     }
   } else {
@@ -264,7 +277,17 @@ function processDispatchQueueItemsInOrder(
       if (instance !== previousInstance && event.isPropagationStopped()) {
         return;
       }
-      executeDispatch(event, listener, currentTarget);
+      if (__DEV__ && enableOwnerStacks && instance !== null) {
+        runWithFiberInDEV(
+          instance,
+          executeDispatch,
+          event,
+          listener,
+          currentTarget,
+        );
+      } else {
+        executeDispatch(event, listener, currentTarget);
+      }
       previousInstance = instance;
     }
   }


### PR DESCRIPTION
That way we get owner stacks (native or otherwise) for `console.error` or `console.warn` inside of them.

Since the `reportError` is also called within this context, we also get them for errors thrown within event listeners. You'll also be able to observe this in in the `error` event. Similar to how `onUncaughtError` is in the scope of the instance that errored - even though `onUncaughtError` doesn't kick in for event listeners.

Chrome (from console.createTask):

<img width="306" alt="Screenshot 2024-06-12 at 2 08 19 PM" src="https://github.com/facebook/react/assets/63648/34cd9d57-0df4-44df-a470-e89a5dd1b07d">

<img width="302" alt="Screenshot 2024-06-12 at 2 03 32 PM" src="https://github.com/facebook/react/assets/63648/678117b1-e03a-47d4-9989-8350212c8135">

Firefox (from React DevTools):

<img width="493" alt="Screenshot 2024-06-12 at 2 05 01 PM" src="https://github.com/facebook/react/assets/63648/94ca224d-354a-4ec8-a886-5740bcb418e5">

(This is the parent stack since React DevTools doesn't just yet print owner stack.)

(Firefox doesn't print the component stack for uncaught since we don't add component stacks for "error" events from React DevTools - just console.error. Perhaps an oversight.)

If we didn't have the synthetic event system this would kind of just work natively in Chrome because we have this task active when we attach the event listeners to the DOM node and async stacks just follow along that way. In fact, if you attach a manual listener in useEffect you get this same effect. It's just because we use event delegation that this doesn't work.

However, if we did get rid of the synthetic event system we'd likely still want to add a wrapper on the DOM node to set our internal current owner so that the non-native part of the system still can observe the active instance. That wouldn't work with manually attached listeners though.