### PR TITLE
Standardize condition order so that edge-lite preferred over browser

### DIFF
--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -63,9 +63,9 @@
       "bun": "./server.bun.js",
       "deno": "./server.browser.js",
       "worker": "./server.browser.js",
-      "browser": "./server.browser.js",
       "node": "./server.node.js",
       "edge-light": "./server.edge.js",
+      "browser": "./server.browser.js",
       "default": "./server.node.js"
     },
     "./server.browser": {
@@ -89,9 +89,9 @@
       "workerd": "./static.edge.js",
       "deno": "./static.browser.js",
       "worker": "./static.browser.js",
-      "browser": "./static.browser.js",
       "node": "./static.node.js",
       "edge-light": "./static.edge.js",
+      "browser": "./static.browser.js",
       "default": "./static.node.js"
     },
     "./static.browser": {


### PR DESCRIPTION
The export maps for react packages have to choose an order of preference. Many runtimes use multiple conditions, for instance when building for edge webpack also uses the browser condition which makes sense given most edge runtimes have a web-standards based set of APIs. However React is building the browser builds primarily for actual browsers and sometimes have builds intended for servers that might be browser compat. This change updates the order of conditions to preference specific named runtimes > node > generic edge runtimes > browser > default

