### PR TITLE
[compiler] Fix merging of queues states in InferReferenceEffects

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReferenceEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReferenceEffects.ts
@@ -34,6 +34,7 @@ import {
 } from "../HIR/HIR";
 import { FunctionSignature } from "../HIR/ObjectShape";
 import {
+  printFunction,
   printIdentifier,
   printMixedHIR,
   printPlace,
@@ -201,7 +202,7 @@ export default function inferReferenceEffects(
     let queuedState = queuedStates.get(blockId);
     if (queuedState != null) {
       // merge the queued states for this block
-      state = queuedState.merge(state) ?? state;
+      state = queuedState.merge(state) ?? queuedState;
       queuedStates.set(blockId, state);
     } else {
       /*
@@ -765,7 +766,7 @@ class InferenceState {
       result.values[id] = { kind, value: printMixedHIR(value) };
     }
     for (const [variable, values] of this.#variables) {
-      result.variables[variable] = [...values].map(identify);
+      result.variables[`$${variable}`] = [...values].map(identify);
     }
     return result;
   }

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReferenceEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReferenceEffects.ts
@@ -34,7 +34,6 @@ import {
 } from "../HIR/HIR";
 import { FunctionSignature } from "../HIR/ObjectShape";
 import {
-  printFunction,
   printIdentifier,
   printMixedHIR,
   printPlace,

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/phi-reference-effects.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/phi-reference-effects.expect.md
@@ -1,0 +1,61 @@
+
+## Input
+
+```javascript
+import { arrayPush } from "shared-runtime";
+
+function Foo(cond) {
+  let x = null;
+  if (cond) {
+    x = [];
+  } else {
+  }
+  // Here, x = phi(x$null, x$[]) does not receive the correct ValueKind
+  arrayPush(x, 2);
+
+  return x;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [{ cond: true }],
+  sequentialRenders: [{ cond: true }, { cond: true }],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { arrayPush } from "shared-runtime";
+
+function Foo(cond) {
+  const $ = _c(2);
+  let x;
+  if ($[0] !== cond) {
+    x = null;
+    if (cond) {
+      x = [];
+    }
+
+    arrayPush(x, 2);
+    $[0] = cond;
+    $[1] = x;
+  } else {
+    x = $[1];
+  }
+  return x;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [{ cond: true }],
+  sequentialRenders: [{ cond: true }, { cond: true }],
+};
+
+```
+      
+### Eval output
+(kind: ok) [2]
+[2]

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/phi-reference-effects.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/phi-reference-effects.expect.md
@@ -10,7 +10,7 @@ function Foo(cond) {
     x = [];
   } else {
   }
-  // Here, x = phi(x$null, x$[]) does not receive the correct ValueKind
+  // Here, x = phi(x$null, x$[]) should receive a ValueKind of Mutable
   arrayPush(x, 2);
 
   return x;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/phi-reference-effects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/phi-reference-effects.ts
@@ -1,0 +1,19 @@
+import { arrayPush } from "shared-runtime";
+
+function Foo(cond) {
+  let x = null;
+  if (cond) {
+    x = [];
+  } else {
+  }
+  // Here, x = phi(x$null, x$[]) does not receive the correct ValueKind
+  arrayPush(x, 2);
+
+  return x;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [{ cond: true }],
+  sequentialRenders: [{ cond: true }, { cond: true }],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/phi-reference-effects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/phi-reference-effects.ts
@@ -6,7 +6,7 @@ function Foo(cond) {
     x = [];
   } else {
   }
-  // Here, x = phi(x$null, x$[]) does not receive the correct ValueKind
+  // Here, x = phi(x$null, x$[]) should receive a ValueKind of Mutable
   arrayPush(x, 2);
 
   return x;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #29879

Fixes a bug found by @mofeiZ in #29878. When we merge queued states, if the new state does not introduce changes relative to the queued state we should use the queued state, not the new state.