### PR TITLE
[compiler] Optimize emission in normal (non-value) blocks

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -269,7 +269,7 @@ const EnvironmentConfigSchema = z.object({
    * Enable instruction reordering. See InstructionReordering.ts for the details
    * of the approach.
    */
-  enableInstructionReordering: z.boolean().default(false),
+  enableInstructionReordering: z.boolean().default(true),
 
   /*
    * Enables instrumentation codegen. This emits a dev-mode only call to an

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/InstructionReordering.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/InstructionReordering.ts
@@ -245,67 +245,131 @@ function reorderBlock(
 
   DEBUG && console.log(`bb${block.id}`);
 
-  // First emit everything that can't be reordered
-  if (previous !== null) {
-    DEBUG && console.log(`(last non-reorderable instruction)`);
-    DEBUG && print(env, locals, shared, seen, previous);
-    emit(env, locals, shared, nextInstructions, previous);
-  }
-  /*
-   * For "value" blocks the final instruction represents its value, so we have to be
-   * careful to not change the ordering. Emit the last instruction explicitly.
-   * Any non-reorderable instructions will get emitted first, and any unused
-   * reorderable instructions can be deferred to the shared node list.
+  /**
+   * The ideal order for emitting instructions may change the final instruction,
+   * but value blocks have special semantics for the final instruction of a block -
+   * that's the expression's value!. So we choose between a less optimal strategy
+   * for value blocks which preserves the final instruction order OR a more optimal
+   * ordering for statement-y blocks.
    */
-  if (isExpressionBlockKind(block.kind) && block.instructions.length !== 0) {
-    DEBUG && console.log(`(block value)`);
-    DEBUG &&
-      print(
+  if (isExpressionBlockKind(block.kind)) {
+    // First emit everything that can't be reordered
+    if (previous !== null) {
+      DEBUG && console.log(`(last non-reorderable instruction)`);
+      DEBUG && print(env, locals, shared, seen, previous);
+      emit(env, locals, shared, nextInstructions, previous);
+    }
+    /*
+     * For "value" blocks the final instruction represents its value, so we have to be
+     * careful to not change the ordering. Emit the last instruction explicitly.
+     * Any non-reorderable instructions will get emitted first, and any unused
+     * reorderable instructions can be deferred to the shared node list.
+     */
+    if (block.instructions.length !== 0) {
+      DEBUG && console.log(`(block value)`);
+      DEBUG &&
+        print(
+          env,
+          locals,
+          shared,
+          seen,
+          block.instructions.at(-1)!.lvalue.identifier.id
+        );
+      emit(
         env,
         locals,
         shared,
-        seen,
+        nextInstructions,
         block.instructions.at(-1)!.lvalue.identifier.id
       );
-    emit(
-      env,
-      locals,
-      shared,
-      nextInstructions,
-      block.instructions.at(-1)!.lvalue.identifier.id
-    );
-  }
-  /*
-   * Then emit the dependencies of the terminal operand. In many cases they will have
-   * already been emitted in the previous step and this is a no-op.
-   * TODO: sort the dependencies based on weight, like we do for other nodes. Not a big
-   * deal though since most terminals have a single operand
-   */
-  for (const operand of eachTerminalOperand(block.terminal)) {
-    DEBUG && console.log(`(terminal operand)`);
-    DEBUG && print(env, locals, shared, seen, operand.identifier.id);
-    emit(env, locals, shared, nextInstructions, operand.identifier.id);
-  }
-  // Anything not emitted yet is globally reorderable
-  for (const [id, node] of locals) {
-    if (node.instruction == null) {
-      continue;
     }
-    CompilerError.invariant(
-      node.instruction != null &&
-        getReoderability(node.instruction, references) ===
-          Reorderability.Reorderable,
-      {
-        reason: `Expected all remaining instructions to be reorderable`,
-        loc: node.instruction?.loc ?? block.terminal.loc,
-        description:
-          node.instruction != null
-            ? `Instruction [${node.instruction.id}] was not emitted yet but is not reorderable`
-            : `Lvalue $${id} was not emitted yet but is not reorderable`,
+    /*
+     * Then emit the dependencies of the terminal operand. In many cases they will have
+     * already been emitted in the previous step and this is a no-op.
+     * TODO: sort the dependencies based on weight, like we do for other nodes. Not a big
+     * deal though since most terminals have a single operand
+     */
+    for (const operand of eachTerminalOperand(block.terminal)) {
+      DEBUG && console.log(`(terminal operand)`);
+      DEBUG && print(env, locals, shared, seen, operand.identifier.id);
+      emit(env, locals, shared, nextInstructions, operand.identifier.id);
+    }
+    // Anything not emitted yet is globally reorderable
+    for (const [id, node] of locals) {
+      if (node.instruction == null) {
+        continue;
       }
-    );
-    DEBUG && console.log(`save shared: $${id}`);
-    shared.set(id, node);
+      CompilerError.invariant(
+        node.instruction != null &&
+          getReoderability(node.instruction, references) ===
+            Reorderability.Reorderable,
+        {
+          reason: `Expected all remaining instructions to be reorderable`,
+          loc: node.instruction?.loc ?? block.terminal.loc,
+          description:
+            node.instruction != null
+              ? `Instruction [${node.instruction.id}] was not emitted yet but is not reorderable`
+              : `Lvalue $${id} was not emitted yet but is not reorderable`,
+        }
+      );
+
+      DEBUG && console.log(`save shared: $${id}`);
+      shared.set(id, node);
+    }
+  } else {
+    /**
+     * If this is not a value block, then the order within the block doesn't matter
+     * and we can optimize more. The observation is that blocks often have instructions
+     * such as:
+     *
+     * ```
+     * t$0 = nonreorderable
+     * t$1 = nonreorderable <-- this gets in the way of merging t$0 and t$2
+     * t$2 = reorderable deps[ t$0 ]
+     * return t$2
+     * ```
+     *
+     * Ie where there is some pair of nonreorderable+reorderable values, with some intervening
+     * also non-reorderable instruction. If we emit all non-reorderable instructions first,
+     * then we'll keep the original order. But reordering instructions don't just mean moving
+     * them later: we can also move then _earlier_. By starting from terminal operands, we
+     * end up emitting:
+     *
+     * ```
+     * t$0 = nonreorderable // dep of t$2
+     * t$2 = reorderable deps[ t$0 ]
+     * t$1 = nonreorderable <-- not in the way of merging anymore!
+     * return t$2
+     * ```
+     *
+     * Ie all nonreorderable transitive deps of the terminal operands will get emitted first,
+     * but we'll be able to intersperse the depending reorderable instructions in between
+     * them in a way that works better with scope merging.
+     */
+    for (const operand of eachTerminalOperand(block.terminal)) {
+      DEBUG && console.log(`(terminal operand)`);
+      DEBUG && print(env, locals, shared, seen, operand.identifier.id);
+      emit(env, locals, shared, nextInstructions, operand.identifier.id);
+    }
+    // Anything not emitted yet is globally reorderable
+    for (const id of Array.from(locals.keys()).reverse()) {
+      const node = locals.get(id);
+      if (node === undefined) {
+        continue;
+      }
+      if (
+        node.instruction !== null &&
+        getReoderability(node.instruction, references) ===
+          Reorderability.Reorderable
+      ) {
+        DEBUG && console.log(`save shared: $${id}`);
+        shared.set(id, node);
+      } else {
+        DEBUG && console.log("leftover");
+        DEBUG && print(env, locals, shared, seen, id);
+        emit(env, locals, shared, nextInstructions, id);
+      }
+    }
   }
 
   block.instructions = nextInstructions;
@@ -434,7 +498,6 @@ function getReoderability(
           range !== undefined &&
           range.end === range.start // this LoadLocal is used exactly once
         ) {
-          console.log(`reorderable: ${name.value}`);
           return Reorderability.Reorderable;
         }
       }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/alias-computed-load.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/alias-computed-load.expect.md
@@ -19,19 +19,20 @@ function component(a) {
 import { c as _c } from "react/compiler-runtime";
 function component(a) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== a) {
-    x = { a };
+    const x = { a };
     const y = {};
 
+    t0 = x;
     y.x = x.a;
     mutate(y);
     $[0] = a;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/alias-nested-member-path-mutate.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/alias-nested-member-path-mutate.expect.md
@@ -20,19 +20,21 @@ function component() {
 import { c as _c } from "react/compiler-runtime";
 function component() {
   const $ = _c(1);
-  let x;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     const z = [];
     const y = {};
     y.z = z;
-    x = {};
+    const x = {};
     x.y = y;
+
+    t0 = x;
     mutate(x.y.z);
-    $[0] = x;
+    $[0] = t0;
   } else {
-    x = $[0];
+    t0 = $[0];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/alias-nested-member-path.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/alias-nested-member-path.expect.md
@@ -25,18 +25,20 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function component() {
   const $ = _c(1);
-  let x;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     const z = [];
     const y = {};
     y.z = z;
-    x = {};
+    const x = {};
+
+    t0 = x;
     x.y = y;
-    $[0] = x;
+    $[0] = t0;
   } else {
-    x = $[0];
+    t0 = $[0];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/align-scopes-within-nested-valueblock-in-array.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/align-scopes-within-nested-valueblock-in-array.expect.md
@@ -52,11 +52,12 @@ import { Stringify, identity, makeArray, mutate } from "shared-runtime";
  * handles this correctly.
  */
 function Foo(t0) {
-  const $ = _c(4);
+  const $ = _c(3);
   const { cond1, cond2 } = t0;
-  const arr = makeArray({ a: 2 }, 2, []);
   let t1;
-  if ($[0] !== cond1 || $[1] !== cond2 || $[2] !== arr) {
+  if ($[0] !== cond1 || $[1] !== cond2) {
+    const arr = makeArray({ a: 2 }, 2, []);
+
     t1 = cond1 ? (
       <>
         <div>{identity("foo")}</div>
@@ -65,10 +66,9 @@ function Foo(t0) {
     ) : null;
     $[0] = cond1;
     $[1] = cond2;
-    $[2] = arr;
-    $[3] = t1;
+    $[2] = t1;
   } else {
-    t1 = $[3];
+    t1 = $[2];
   }
   return t1;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-in-effect-indirect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-mutation-in-effect-indirect.expect.md
@@ -39,57 +39,51 @@ import { useEffect, useState } from "react";
 let someGlobal = {};
 
 function Component() {
-  const $ = _c(7);
+  const $ = _c(6);
   const [state, setState] = useState(someGlobal);
   let t0;
+  let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = () => {
+    const setGlobal = () => {
       someGlobal.value = true;
     };
-    $[0] = t0;
-  } else {
-    t0 = $[0];
-  }
-  const setGlobal = t0;
-  let t1;
-  let t2;
-  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = () => {
+
+    t0 = () => {
       setGlobal();
     };
-    t2 = [];
+    t1 = [];
+    $[0] = t0;
     $[1] = t1;
-    $[2] = t2;
   } else {
+    t0 = $[0];
     t1 = $[1];
-    t2 = $[2];
   }
-  useEffect(t1, t2);
+  useEffect(t0, t1);
+  let t2;
   let t3;
-  let t4;
-  if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
-    t3 = () => {
+  if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = () => {
       setState(someGlobal.value);
     };
-    t4 = [someGlobal];
+    t3 = [someGlobal];
+    $[2] = t2;
     $[3] = t3;
-    $[4] = t4;
   } else {
+    t2 = $[2];
     t3 = $[3];
-    t4 = $[4];
   }
-  useEffect(t3, t4);
+  useEffect(t2, t3);
 
-  const t5 = String(state);
-  let t6;
-  if ($[5] !== t5) {
-    t6 = <div>{t5}</div>;
+  const t4 = String(state);
+  let t5;
+  if ($[4] !== t4) {
+    t5 = <div>{t4}</div>;
+    $[4] = t4;
     $[5] = t5;
-    $[6] = t6;
   } else {
-    t6 = $[6];
+    t5 = $[5];
   }
-  return t6;
+  return t5;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-reassignment-in-effect-indirect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-global-reassignment-in-effect-indirect.expect.md
@@ -39,57 +39,51 @@ import { useEffect, useState } from "react";
 let someGlobal = false;
 
 function Component() {
-  const $ = _c(7);
+  const $ = _c(6);
   const [state, setState] = useState(someGlobal);
   let t0;
+  let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = () => {
+    const setGlobal = () => {
       someGlobal = true;
     };
-    $[0] = t0;
-  } else {
-    t0 = $[0];
-  }
-  const setGlobal = t0;
-  let t1;
-  let t2;
-  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = () => {
+
+    t0 = () => {
       setGlobal();
     };
-    t2 = [];
+    t1 = [];
+    $[0] = t0;
     $[1] = t1;
-    $[2] = t2;
   } else {
+    t0 = $[0];
     t1 = $[1];
-    t2 = $[2];
   }
-  useEffect(t1, t2);
+  useEffect(t0, t1);
+  let t2;
   let t3;
-  let t4;
-  if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
-    t3 = () => {
+  if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = () => {
       setState(someGlobal);
     };
-    t4 = [someGlobal];
+    t3 = [someGlobal];
+    $[2] = t2;
     $[3] = t3;
-    $[4] = t4;
   } else {
+    t2 = $[2];
     t3 = $[3];
-    t4 = $[4];
   }
-  useEffect(t3, t4);
+  useEffect(t2, t3);
 
-  const t5 = String(state);
-  let t6;
-  if ($[5] !== t5) {
-    t6 = <div>{t5}</div>;
+  const t4 = String(state);
+  let t5;
+  if ($[4] !== t4) {
+    t5 = <div>{t4}</div>;
+    $[4] = t4;
     $[5] = t5;
-    $[6] = t6;
   } else {
-    t6 = $[6];
+    t5 = $[5];
   }
-  return t6;
+  return t5;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-in-callback-passed-to-jsx-indirect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-in-callback-passed-to-jsx-indirect.expect.md
@@ -66,31 +66,31 @@ function Component() {
   }
   const onClick = t1;
   let t2;
-  if ($[3] !== ref) {
-    t2 = <input ref={ref} />;
-    $[3] = ref;
+  if ($[3] !== onClick) {
+    t2 = <button onClick={onClick} />;
+    $[3] = onClick;
     $[4] = t2;
   } else {
     t2 = $[4];
   }
   let t3;
-  if ($[5] !== onClick) {
-    t3 = <button onClick={onClick} />;
-    $[5] = onClick;
+  if ($[5] !== ref) {
+    t3 = <input ref={ref} />;
+    $[5] = ref;
     $[6] = t3;
   } else {
     t3 = $[6];
   }
   let t4;
-  if ($[7] !== t2 || $[8] !== t3) {
+  if ($[7] !== t3 || $[8] !== t2) {
     t4 = (
       <>
-        {t2}
         {t3}
+        {t2}
       </>
     );
-    $[7] = t2;
-    $[8] = t3;
+    $[7] = t3;
+    $[8] = t2;
     $[9] = t4;
   } else {
     t4 = $[9];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-in-callback-passed-to-jsx.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-in-callback-passed-to-jsx.expect.md
@@ -51,31 +51,31 @@ function Component() {
   }
   const onClick = t0;
   let t1;
-  if ($[1] !== ref) {
-    t1 = <input ref={ref} />;
-    $[1] = ref;
+  if ($[1] !== onClick) {
+    t1 = <button onClick={onClick} />;
+    $[1] = onClick;
     $[2] = t1;
   } else {
     t1 = $[2];
   }
   let t2;
-  if ($[3] !== onClick) {
-    t2 = <button onClick={onClick} />;
-    $[3] = onClick;
+  if ($[3] !== ref) {
+    t2 = <input ref={ref} />;
+    $[3] = ref;
     $[4] = t2;
   } else {
     t2 = $[4];
   }
   let t3;
-  if ($[5] !== t1 || $[6] !== t2) {
+  if ($[5] !== t2 || $[6] !== t1) {
     t3 = (
       <>
-        {t1}
         {t2}
+        {t1}
       </>
     );
-    $[5] = t1;
-    $[6] = t2;
+    $[5] = t2;
+    $[6] = t1;
     $[7] = t3;
   } else {
     t3 = $[7];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-property-in-callback-passed-to-jsx-indirect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-property-in-callback-passed-to-jsx-indirect.expect.md
@@ -66,31 +66,31 @@ function Component() {
   }
   const onClick = t1;
   let t2;
-  if ($[3] !== ref) {
-    t2 = <input ref={ref} />;
-    $[3] = ref;
+  if ($[3] !== onClick) {
+    t2 = <button onClick={onClick} />;
+    $[3] = onClick;
     $[4] = t2;
   } else {
     t2 = $[4];
   }
   let t3;
-  if ($[5] !== onClick) {
-    t3 = <button onClick={onClick} />;
-    $[5] = onClick;
+  if ($[5] !== ref) {
+    t3 = <input ref={ref} />;
+    $[5] = ref;
     $[6] = t3;
   } else {
     t3 = $[6];
   }
   let t4;
-  if ($[7] !== t2 || $[8] !== t3) {
+  if ($[7] !== t3 || $[8] !== t2) {
     t4 = (
       <>
-        {t2}
         {t3}
+        {t2}
       </>
     );
-    $[7] = t2;
-    $[8] = t3;
+    $[7] = t3;
+    $[8] = t2;
     $[9] = t4;
   } else {
     t4 = $[9];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-property-in-callback-passed-to-jsx.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-property-in-callback-passed-to-jsx.expect.md
@@ -51,31 +51,31 @@ function Component() {
   }
   const onClick = t0;
   let t1;
-  if ($[1] !== ref) {
-    t1 = <input ref={ref} />;
-    $[1] = ref;
+  if ($[1] !== onClick) {
+    t1 = <button onClick={onClick} />;
+    $[1] = onClick;
     $[2] = t1;
   } else {
     t1 = $[2];
   }
   let t2;
-  if ($[3] !== onClick) {
-    t2 = <button onClick={onClick} />;
-    $[3] = onClick;
+  if ($[3] !== ref) {
+    t2 = <input ref={ref} />;
+    $[3] = ref;
     $[4] = t2;
   } else {
     t2 = $[4];
   }
   let t3;
-  if ($[5] !== t1 || $[6] !== t2) {
+  if ($[5] !== t2 || $[6] !== t1) {
     t3 = (
       <>
-        {t1}
         {t2}
+        {t1}
       </>
     );
-    $[5] = t1;
-    $[6] = t2;
+    $[5] = t2;
+    $[6] = t1;
     $[7] = t3;
   } else {
     t3 = $[7];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-at-mutate-after-capture.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-at-mutate-after-capture.expect.md
@@ -22,18 +22,20 @@ import { c as _c } from "react/compiler-runtime"; // x's mutable range should ex
 
 function Component(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props.b) {
-    x = [42, {}];
+    const x = [42, {}];
     const idx = foo(props.b);
+
+    t0 = x;
     const y = x.at(idx);
     mutate(y);
     $[0] = props.b;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-push-effect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-push-effect.expect.md
@@ -42,25 +42,27 @@ function Component(props) {
     t1 = $[3];
   }
   const y = t1;
-  let arr;
+  let t2;
   if ($[4] !== x || $[5] !== y) {
-    arr = [];
-    let t2;
+    const arr = [];
+    let t3;
     if ($[7] === Symbol.for("react.memo_cache_sentinel")) {
-      t2 = {};
-      $[7] = t2;
+      t3 = {};
+      $[7] = t3;
     } else {
-      t2 = $[7];
+      t3 = $[7];
     }
-    arr.push(t2);
+    arr.push(t3);
+
+    t2 = arr;
     arr.push(x, y);
     $[4] = x;
     $[5] = y;
-    $[6] = arr;
+    $[6] = t2;
   } else {
-    arr = $[6];
+    t2 = $[6];
   }
-  return arr;
+  return t2;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/assignment-expression-computed.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/assignment-expression-computed.expect.md
@@ -24,18 +24,20 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props.x) {
-    x = [props.x];
+    const x = [props.x];
 
     x[0] = x[0] * 2;
+
+    t0 = x;
     x["0"] = x["0"] + 3;
     $[0] = props.x;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/assignment-expression-nested-path.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/assignment-expression-nested-path.expect.md
@@ -23,17 +23,19 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function g(props) {
   const $ = _c(2);
-  let a;
+  let t0;
   if ($[0] !== props.c) {
-    a = { b: { c: props.c } };
+    const a = { b: { c: props.c } };
     a.b.c = a.b.c + 1;
+
+    t0 = a;
     a.b.c = a.b.c * 2;
     $[0] = props.c;
-    $[1] = a;
+    $[1] = t0;
   } else {
-    a = $[1];
+    t0 = $[1];
   }
-  return a;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/assignment-variations-complex-lvalue-array.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/assignment-variations-complex-lvalue-array.expect.md
@@ -23,16 +23,18 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function foo() {
   const $ = _c(1);
-  let a;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    a = [[1]];
+    const a = [[1]];
+
+    t0 = a;
     const first = a.at(0);
     first.set(0, 2);
-    $[0] = a;
+    $[0] = t0;
   } else {
-    a = $[0];
+    t0 = $[0];
   }
-  return a;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/assignment-variations-complex-lvalue.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/assignment-variations-complex-lvalue.expect.md
@@ -23,16 +23,18 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function g() {
   const $ = _c(1);
-  let x;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    x = { y: { z: 1 } };
+    const x = { y: { z: 1 } };
     x.y.z = x.y.z + 1;
+
+    t0 = x;
     x.y.z = x.y.z * 2;
-    $[0] = x;
+    $[0] = t0;
   } else {
-    x = $[0];
+    t0 = $[0];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/await-side-effecting-promise.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/await-side-effecting-promise.expect.md
@@ -16,16 +16,18 @@ async function Component(props) {
 import { c as _c } from "react/compiler-runtime";
 async function Component(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props.id) {
-    x = [];
+    const x = [];
+
+    t0 = x;
     await populateData(props.id, x);
     $[0] = props.id;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/call-args-assignment.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/call-args-assignment.expect.md
@@ -16,15 +16,17 @@ function Component(props) {
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
   const $ = _c(1);
-  let x;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    x = makeObject();
+    let x = makeObject();
+
+    t0 = x;
     x.foo((x = makeObject()));
-    $[0] = x;
+    $[0] = t0;
   } else {
-    x = $[0];
+    t0 = $[0];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/call-args-destructuring-assignment.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/call-args-destructuring-assignment.expect.md
@@ -16,15 +16,17 @@ function Component(props) {
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
   const $ = _c(1);
-  let x;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    x = makeObject();
+    let x = makeObject();
+
+    t0 = x;
     x.foo(([x] = makeObject()));
-    $[0] = x;
+    $[0] = t0;
   } else {
-    x = $[0];
+    t0 = $[0];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capture-indirect-mutate-alias.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capture-indirect-mutate-alias.expect.md
@@ -30,25 +30,25 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function component(a) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== a) {
-    x = { a };
+    const x = { a };
+
+    t0 = x;
     const f0 = function () {
       const q = x;
       const f1 = function () {
         q.b = 1;
       };
-
       f1();
     };
-
     f0();
     $[0] = a;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capture_mutate-across-fns.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capture_mutate-across-fns.expect.md
@@ -28,24 +28,24 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function component(a) {
   const $ = _c(2);
-  let z;
+  let t0;
   if ($[0] !== a) {
-    z = { a };
+    const z = { a };
+
+    t0 = z;
     const f0 = function () {
       const f1 = function () {
         z.b = 1;
       };
-
       f1();
     };
-
     f0();
     $[0] = a;
-    $[1] = z;
+    $[1] = t0;
   } else {
-    z = $[1];
+    t0 = $[1];
   }
-  return z;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-fun-alias-captured-mutate-2-iife.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-fun-alias-captured-mutate-2-iife.expect.md
@@ -31,23 +31,24 @@ import { mutate } from "shared-runtime";
 
 function component(foo, bar) {
   const $ = _c(3);
-  let x;
+  let t0;
   if ($[0] !== foo || $[1] !== bar) {
-    x = { foo };
+    const x = { foo };
     const y = { bar };
 
     const a = { y };
     const b = x;
     a.x = b;
 
+    t0 = x;
     mutate(y);
     $[0] = foo;
     $[1] = bar;
-    $[2] = x;
+    $[2] = t0;
   } else {
-    x = $[2];
+    t0 = $[2];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-fun-alias-captured-mutate-2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-fun-alias-captured-mutate-2.expect.md
@@ -23,25 +23,26 @@ function component(foo, bar) {
 import { c as _c } from "react/compiler-runtime";
 function component(foo, bar) {
   const $ = _c(3);
-  let x;
+  let t0;
   if ($[0] !== foo || $[1] !== bar) {
-    x = { foo };
+    const x = { foo };
     const y = { bar };
+
+    t0 = x;
     const f0 = function () {
       const a = { y };
       const b = x;
       a.x = b;
     };
-
     f0();
     mutate(y);
     $[0] = foo;
     $[1] = bar;
-    $[2] = x;
+    $[2] = t0;
   } else {
-    x = $[2];
+    t0 = $[2];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-fun-alias-captured-mutate-arr-2-iife.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-fun-alias-captured-mutate-arr-2-iife.expect.md
@@ -31,23 +31,24 @@ const { mutate } = require("shared-runtime");
 
 function component(foo, bar) {
   const $ = _c(3);
-  let x;
+  let t0;
   if ($[0] !== foo || $[1] !== bar) {
-    x = { foo };
+    const x = { foo };
     const y = { bar };
 
     const a = [y];
     const b = x;
     a.x = b;
 
+    t0 = x;
     mutate(y);
     $[0] = foo;
     $[1] = bar;
-    $[2] = x;
+    $[2] = t0;
   } else {
-    x = $[2];
+    t0 = $[2];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-fun-alias-captured-mutate-arr-2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-fun-alias-captured-mutate-arr-2.expect.md
@@ -23,25 +23,26 @@ function component(foo, bar) {
 import { c as _c } from "react/compiler-runtime";
 function component(foo, bar) {
   const $ = _c(3);
-  let x;
+  let t0;
   if ($[0] !== foo || $[1] !== bar) {
-    x = { foo };
+    const x = { foo };
     const y = { bar };
+
+    t0 = x;
     const f0 = function () {
       const a = [y];
       const b = x;
       a.x = b;
     };
-
     f0();
     mutate(y);
     $[0] = foo;
     $[1] = bar;
-    $[2] = x;
+    $[2] = t0;
   } else {
-    x = $[2];
+    t0 = $[2];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-captured-mutate-arr-iife.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-captured-mutate-arr-iife.expect.md
@@ -31,23 +31,24 @@ const { mutate } = require("shared-runtime");
 
 function component(foo, bar) {
   const $ = _c(3);
-  let y;
+  let t0;
   if ($[0] !== foo || $[1] !== bar) {
     const x = { foo };
-    y = { bar };
+    const y = { bar };
 
     const a = [y];
     const b = x;
     a.x = b;
 
+    t0 = y;
     mutate(y);
     $[0] = foo;
     $[1] = bar;
-    $[2] = y;
+    $[2] = t0;
   } else {
-    y = $[2];
+    t0 = $[2];
   }
-  return y;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-captured-mutate-arr.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-captured-mutate-arr.expect.md
@@ -23,10 +23,10 @@ function component(foo, bar) {
 import { c as _c } from "react/compiler-runtime";
 function component(foo, bar) {
   const $ = _c(3);
-  let y;
+  let t0;
   if ($[0] !== foo || $[1] !== bar) {
     const x = { foo };
-    y = { bar };
+    const y = { bar };
     const f0 = function () {
       const a = [y];
       const b = x;
@@ -34,14 +34,16 @@ function component(foo, bar) {
     };
 
     f0();
+
+    t0 = y;
     mutate(y);
     $[0] = foo;
     $[1] = bar;
-    $[2] = y;
+    $[2] = t0;
   } else {
-    y = $[2];
+    t0 = $[2];
   }
-  return y;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-captured-mutate-iife.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-captured-mutate-iife.expect.md
@@ -31,23 +31,24 @@ const { mutate } = require("shared-runtime");
 
 function component(foo, bar) {
   const $ = _c(3);
-  let y;
+  let t0;
   if ($[0] !== foo || $[1] !== bar) {
     const x = { foo };
-    y = { bar };
+    const y = { bar };
 
     const a = { y };
     const b = x;
     a.x = b;
 
+    t0 = y;
     mutate(y);
     $[0] = foo;
     $[1] = bar;
-    $[2] = y;
+    $[2] = t0;
   } else {
-    y = $[2];
+    t0 = $[2];
   }
-  return y;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-captured-mutate.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-captured-mutate.expect.md
@@ -23,10 +23,10 @@ function component(foo, bar) {
 import { c as _c } from "react/compiler-runtime";
 function component(foo, bar) {
   const $ = _c(3);
-  let y;
+  let t0;
   if ($[0] !== foo || $[1] !== bar) {
     const x = { foo };
-    y = { bar };
+    const y = { bar };
     const f0 = function () {
       const a = { y };
       const b = x;
@@ -34,14 +34,16 @@ function component(foo, bar) {
     };
 
     f0();
+
+    t0 = y;
     mutate(y);
     $[0] = foo;
     $[1] = bar;
-    $[2] = y;
+    $[2] = t0;
   } else {
-    y = $[2];
+    t0 = $[2];
   }
-  return y;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-computed-mutate-iife.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-computed-mutate-iife.expect.md
@@ -29,20 +29,21 @@ const { mutate } = require("shared-runtime");
 
 function component(a) {
   const $ = _c(2);
-  let y;
+  let t0;
   if ($[0] !== a) {
     const x = { a };
-    y = {};
+    const y = {};
 
     y.x = x;
 
+    t0 = y;
     mutate(y);
     $[0] = a;
-    $[1] = y;
+    $[1] = t0;
   } else {
-    y = $[1];
+    t0 = $[1];
   }
-  return y;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-computed-mutate.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-computed-mutate.expect.md
@@ -21,22 +21,24 @@ function component(a) {
 import { c as _c } from "react/compiler-runtime";
 function component(a) {
   const $ = _c(2);
-  let y;
+  let t0;
   if ($[0] !== a) {
     const x = { a };
-    y = {};
+    const y = {};
     const f0 = function () {
       y.x = x;
     };
 
     f0();
+
+    t0 = y;
     mutate(y);
     $[0] = a;
-    $[1] = y;
+    $[1] = t0;
   } else {
-    y = $[1];
+    t0 = $[1];
   }
-  return y;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-mutate-iife.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-mutate-iife.expect.md
@@ -29,20 +29,21 @@ const { mutate } = require("shared-runtime");
 
 function component(a) {
   const $ = _c(2);
-  let y;
+  let t0;
   if ($[0] !== a) {
     const x = { a };
-    y = {};
+    const y = {};
 
     y.x = x;
 
+    t0 = y;
     mutate(y);
     $[0] = a;
-    $[1] = y;
+    $[1] = t0;
   } else {
-    y = $[1];
+    t0 = $[1];
   }
-  return y;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-mutate.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-mutate.expect.md
@@ -21,22 +21,24 @@ function component(a) {
 import { c as _c } from "react/compiler-runtime";
 function component(a) {
   const $ = _c(2);
-  let y;
+  let t0;
   if ($[0] !== a) {
     const x = { a };
-    y = {};
+    const y = {};
     const f0 = function () {
       y.x = x;
     };
 
     f0();
+
+    t0 = y;
     mutate(y);
     $[0] = a;
-    $[1] = y;
+    $[1] = t0;
   } else {
-    y = $[1];
+    t0 = $[1];
   }
-  return y;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-receiver-computed-mutate-iife.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-receiver-computed-mutate-iife.expect.md
@@ -30,21 +30,22 @@ import { mutate } from "shared-runtime";
 
 function component(a) {
   const $ = _c(2);
-  let y;
+  let t0;
   if ($[0] !== a) {
     const x = { a };
-    y = {};
+    const y = {};
 
     const a_0 = y;
     a_0.x = x;
 
+    t0 = y;
     mutate(y);
     $[0] = a;
-    $[1] = y;
+    $[1] = t0;
   } else {
-    y = $[1];
+    t0 = $[1];
   }
-  return y;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-receiver-computed-mutate.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-receiver-computed-mutate.expect.md
@@ -22,23 +22,25 @@ function component(a) {
 import { c as _c } from "react/compiler-runtime";
 function component(a) {
   const $ = _c(2);
-  let y;
+  let t0;
   if ($[0] !== a) {
     const x = { a };
-    y = {};
+    const y = {};
     const f0 = function () {
       const a_0 = y;
       a_0.x = x;
     };
 
     f0();
+
+    t0 = y;
     mutate(y);
     $[0] = a;
-    $[1] = y;
+    $[1] = t0;
   } else {
-    y = $[1];
+    t0 = $[1];
   }
-  return y;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-receiver-mutate-iife.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-receiver-mutate-iife.expect.md
@@ -30,21 +30,22 @@ const { mutate } = require("shared-runtime");
 
 function component(a) {
   const $ = _c(2);
-  let y;
+  let t0;
   if ($[0] !== a) {
     const x = { a };
-    y = {};
+    const y = {};
 
     const a_0 = y;
     a_0.x = x;
 
+    t0 = y;
     mutate(y);
     $[0] = a;
-    $[1] = y;
+    $[1] = t0;
   } else {
-    y = $[1];
+    t0 = $[1];
   }
-  return y;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-receiver-mutate.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-receiver-mutate.expect.md
@@ -22,23 +22,25 @@ function component(a) {
 import { c as _c } from "react/compiler-runtime";
 function component(a) {
   const $ = _c(2);
-  let y;
+  let t0;
   if ($[0] !== a) {
     const x = { a };
-    y = {};
+    const y = {};
     const f0 = function () {
       const a_0 = y;
       a_0.x = x;
     };
 
     f0();
+
+    t0 = y;
     mutate(y);
     $[0] = a;
-    $[1] = y;
+    $[1] = t0;
   } else {
-    y = $[1];
+    t0 = $[1];
   }
-  return y;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-mutate-2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-mutate-2.expect.md
@@ -36,21 +36,22 @@ function component(a, b) {
     t0 = $[1];
   }
   const y = t0;
-  let z;
+  let t1;
   if ($[2] !== a || $[3] !== y.b) {
-    z = { a };
+    const z = { a };
+
+    t1 = z;
     const x = function () {
       z.a = 2;
     };
-
     x();
     $[2] = a;
     $[3] = y.b;
-    $[4] = z;
+    $[4] = t1;
   } else {
-    z = $[4];
+    t1 = $[4];
   }
-  return z;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-mutate-nested.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-mutate-nested.expect.md
@@ -25,20 +25,21 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function component(a) {
   const $ = _c(2);
-  let y;
+  let t0;
   if ($[0] !== a) {
-    y = { b: { a } };
+    const y = { b: { a } };
+
+    t0 = y;
     const x = function () {
       y.b.a = 2;
     };
-
     x();
     $[0] = a;
-    $[1] = y;
+    $[1] = t0;
   } else {
-    y = $[1];
+    t0 = $[1];
   }
-  return y;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-mutate.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-mutate.expect.md
@@ -27,23 +27,24 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function component(a, b) {
   const $ = _c(3);
-  let z;
+  let t0;
   if ($[0] !== a || $[1] !== b) {
-    z = { a };
+    const z = { a };
     const y = { b };
+
+    t0 = z;
     const x = function () {
       z.a = 2;
       console.log(y.b);
     };
-
     x();
     $[0] = a;
     $[1] = b;
-    $[2] = z;
+    $[2] = t0;
   } else {
-    z = $[2];
+    t0 = $[2];
   }
-  return z;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-function-decl.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-function-decl.expect.md
@@ -25,20 +25,21 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function component(a) {
   const $ = _c(2);
-  let t;
+  let t0;
   if ($[0] !== a) {
-    t = { a };
+    const t = { a };
     const x = function x() {
       t.foo();
     };
 
+    t0 = t;
     x(t);
     $[0] = a;
-    $[1] = t;
+    $[1] = t0;
   } else {
-    t = $[1];
+    t0 = $[1];
   }
-  return t;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/chained-assignment-expressions.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/chained-assignment-expressions.expect.md
@@ -25,18 +25,20 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function foo() {
   const $ = _c(1);
-  let z;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     const x = { x: 0 };
     const y = { z: 0 };
-    z = { z: 0 };
+    const z = { z: 0 };
     x.x = x.x + (y.y = y.y * 1);
+
+    t0 = z;
     z.z = z.z + (y.y = y.y * (x.x = x.x & 3));
-    $[0] = z;
+    $[0] = t0;
   } else {
-    z = $[0];
+    t0 = $[0];
   }
-  return z;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/codegen-emit-make-read-only.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/codegen-emit-make-read-only.expect.md
@@ -24,21 +24,23 @@ import { c as _c } from "react/compiler-runtime"; // @enableEmitFreeze true
 
 function MyComponentName(props) {
   const $ = _c(3);
-  let y;
+  let t0;
   if ($[0] !== props.a || $[1] !== props.b) {
     const x = {};
     foo(x, props.a);
     foo(x, props.b);
 
-    y = [];
+    const y = [];
+
+    t0 = y;
     y.push(x);
     $[0] = props.a;
     $[1] = props.b;
-    $[2] = __DEV__ ? makeReadOnly(y, "MyComponentName") : y;
+    $[2] = __DEV__ ? makeReadOnly(t0, "MyComponentName") : t0;
   } else {
-    y = $[2];
+    t0 = $[2];
   }
-  return y;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/computed-call-evaluation-order.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/computed-call-evaluation-order.expect.md
@@ -41,18 +41,19 @@ function Component() {
     t0 = $[0];
   }
   const changeF = t0;
-  let x;
+  let t1;
   if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-    x = { f: () => console.log("original") };
+    const x = { f: () => console.log("original") };
 
+    t1 = x;
     (console.log("A"), x)[(console.log("B"), "f")](
       (changeF(x), console.log("arg"), 1),
     );
-    $[1] = x;
+    $[1] = t1;
   } else {
-    x = $[1];
+    t1 = $[1];
   }
-  return x;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/computed-store-alias.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/computed-store-alias.expect.md
@@ -18,19 +18,21 @@ function component(a, b) {
 import { c as _c } from "react/compiler-runtime";
 function component(a, b) {
   const $ = _c(3);
-  let x;
+  let t0;
   if ($[0] !== a || $[1] !== b) {
     const y = { a };
-    x = { b };
+    const x = { b };
     x.y = y;
+
+    t0 = x;
     mutate(x);
     $[0] = a;
     $[1] = b;
-    $[2] = x;
+    $[2] = t0;
   } else {
-    x = $[2];
+    t0 = $[2];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/conditional-break-labeled.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/conditional-break-labeled.expect.md
@@ -34,9 +34,9 @@ import { c as _c } from "react/compiler-runtime"; /**
  */
 function Component(props) {
   const $ = _c(2);
-  let a;
+  let t0;
   if ($[0] !== props) {
-    a = [];
+    const a = [];
     a.push(props.a);
     bb0: {
       if (props.b) {
@@ -46,13 +46,14 @@ function Component(props) {
       a.push(props.c);
     }
 
+    t0 = a;
     a.push(props.d);
     $[0] = props;
-    $[1] = a;
+    $[1] = t0;
   } else {
-    a = $[1];
+    t0 = $[1];
   }
-  return a;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/conditional-early-return.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/conditional-early-return.expect.md
@@ -71,31 +71,32 @@ import { c as _c } from "react/compiler-runtime"; /**
  */
 function ComponentA(props) {
   const $ = _c(3);
-  let a_DEBUG;
   let t0;
+  let t1;
   if ($[0] !== props) {
-    t0 = Symbol.for("react.early_return_sentinel");
+    t1 = Symbol.for("react.early_return_sentinel");
     bb0: {
-      a_DEBUG = [];
+      const a_DEBUG = [];
       a_DEBUG.push(props.a);
       if (props.b) {
-        t0 = null;
+        t1 = null;
         break bb0;
       }
 
+      t0 = a_DEBUG;
       a_DEBUG.push(props.d);
     }
     $[0] = props;
-    $[1] = a_DEBUG;
-    $[2] = t0;
+    $[1] = t0;
+    $[2] = t1;
   } else {
-    a_DEBUG = $[1];
-    t0 = $[2];
+    t0 = $[1];
+    t1 = $[2];
   }
-  if (t0 !== Symbol.for("react.early_return_sentinel")) {
-    return t0;
+  if (t1 !== Symbol.for("react.early_return_sentinel")) {
+    return t1;
   }
-  return a_DEBUG;
+  return t0;
 }
 
 /**
@@ -103,21 +104,22 @@ function ComponentA(props) {
  */
 function ComponentB(props) {
   const $ = _c(2);
-  let a;
+  let t0;
   if ($[0] !== props) {
-    a = [];
+    const a = [];
     a.push(props.a);
     if (props.b) {
       a.push(props.c);
     }
 
+    t0 = a;
     a.push(props.d);
     $[0] = props;
-    $[1] = a;
+    $[1] = t0;
   } else {
-    a = $[1];
+    t0 = $[1];
   }
-  return a;
+  return t0;
 }
 
 /**
@@ -125,32 +127,33 @@ function ComponentB(props) {
  */
 function ComponentC(props) {
   const $ = _c(3);
-  let a;
   let t0;
+  let t1;
   if ($[0] !== props) {
-    t0 = Symbol.for("react.early_return_sentinel");
+    t1 = Symbol.for("react.early_return_sentinel");
     bb0: {
-      a = [];
+      const a = [];
       a.push(props.a);
       if (props.b) {
         a.push(props.c);
-        t0 = null;
+        t1 = null;
         break bb0;
       }
 
+      t0 = a;
       a.push(props.d);
     }
     $[0] = props;
-    $[1] = a;
-    $[2] = t0;
+    $[1] = t0;
+    $[2] = t1;
   } else {
-    a = $[1];
-    t0 = $[2];
+    t0 = $[1];
+    t1 = $[2];
   }
-  if (t0 !== Symbol.for("react.early_return_sentinel")) {
-    return t0;
+  if (t1 !== Symbol.for("react.early_return_sentinel")) {
+    return t1;
   }
-  return a;
+  return t0;
 }
 
 /**
@@ -158,32 +161,33 @@ function ComponentC(props) {
  */
 function ComponentD(props) {
   const $ = _c(3);
-  let a;
   let t0;
+  let t1;
   if ($[0] !== props) {
-    t0 = Symbol.for("react.early_return_sentinel");
+    t1 = Symbol.for("react.early_return_sentinel");
     bb0: {
-      a = [];
+      const a = [];
       a.push(props.a);
       if (props.b) {
         a.push(props.c);
-        t0 = a;
+        t1 = a;
         break bb0;
       }
 
+      t0 = a;
       a.push(props.d);
     }
     $[0] = props;
-    $[1] = a;
-    $[2] = t0;
+    $[1] = t0;
+    $[2] = t1;
   } else {
-    a = $[1];
-    t0 = $[2];
+    t0 = $[1];
+    t1 = $[2];
   }
-  if (t0 !== Symbol.for("react.early_return_sentinel")) {
-    return t0;
+  if (t1 !== Symbol.for("react.early_return_sentinel")) {
+    return t1;
   }
-  return a;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-computed.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-computed.expect.md
@@ -24,17 +24,19 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props.foo) {
-    x = {};
+    const x = {};
     x.foo = x.foo + x.bar;
+
+    t0 = x;
     x.foo(props.foo);
     $[0] = props.foo;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/debugger-memoized.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/debugger-memoized.expect.md
@@ -23,18 +23,19 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props.value) {
-    x = [];
+    const x = [];
     debugger;
 
+    t0 = x;
     x.push(props.value);
     $[0] = props.value;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/delete-computed-property.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/delete-computed-property.expect.md
@@ -23,17 +23,19 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
   const $ = _c(3);
-  let x;
+  let t0;
   if ($[0] !== props.a || $[1] !== props.b) {
-    x = { a: props.a, b: props.b };
+    const x = { a: props.a, b: props.b };
+
+    t0 = x;
     delete x["b"];
     $[0] = props.a;
     $[1] = props.b;
-    $[2] = x;
+    $[2] = t0;
   } else {
-    x = $[2];
+    t0 = $[2];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/delete-property.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/delete-property.expect.md
@@ -22,17 +22,19 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
   const $ = _c(3);
-  let x;
+  let t0;
   if ($[0] !== props.a || $[1] !== props.b) {
-    x = { a: props.a, b: props.b };
+    const x = { a: props.a, b: props.b };
+
+    t0 = x;
     delete x.b;
     $[0] = props.a;
     $[1] = props.b;
-    $[2] = x;
+    $[2] = t0;
   } else {
-    x = $[2];
+    t0 = $[2];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/do-while-early-unconditional-break.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/do-while-early-unconditional-break.expect.md
@@ -19,16 +19,17 @@ function Component(props) {
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
   const $ = _c(1);
-  let x;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    x = [1, 2, 3];
+    const x = [1, 2, 3];
 
+    t0 = x;
     mutate(x);
-    $[0] = x;
+    $[0] = t0;
   } else {
-    x = $[0];
+    t0 = $[0];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/dont-merge-if-dep-is-inner-declaration-of-previous-scope.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/dont-merge-if-dep-is-inner-declaration-of-previous-scope.expect.md
@@ -99,42 +99,42 @@ function Component(t0) {
     t2 = $[12];
   }
   let t3;
-  if ($[13] !== t2 || $[14] !== x) {
-    t3 = <ValidateMemoization inputs={t2} output={x} />;
-    $[13] = t2;
-    $[14] = x;
+  if ($[13] !== a || $[14] !== b) {
+    t3 = [a, b];
+    $[13] = a;
+    $[14] = b;
     $[15] = t3;
   } else {
     t3 = $[15];
   }
   let t4;
-  if ($[16] !== a || $[17] !== b) {
-    t4 = [a, b];
-    $[16] = a;
-    $[17] = b;
+  if ($[16] !== t3 || $[17] !== z) {
+    t4 = <ValidateMemoization inputs={t3} output={z} />;
+    $[16] = t3;
+    $[17] = z;
     $[18] = t4;
   } else {
     t4 = $[18];
   }
   let t5;
-  if ($[19] !== t4 || $[20] !== z) {
-    t5 = <ValidateMemoization inputs={t4} output={z} />;
-    $[19] = t4;
-    $[20] = z;
+  if ($[19] !== t2 || $[20] !== x) {
+    t5 = <ValidateMemoization inputs={t2} output={x} />;
+    $[19] = t2;
+    $[20] = x;
     $[21] = t5;
   } else {
     t5 = $[21];
   }
   let t6;
-  if ($[22] !== t3 || $[23] !== t5) {
+  if ($[22] !== t5 || $[23] !== t4) {
     t6 = (
       <>
-        {t3}
         {t5}
+        {t4}
       </>
     );
-    $[22] = t3;
-    $[23] = t5;
+    $[22] = t5;
+    $[23] = t4;
     $[24] = t6;
   } else {
     t6 = $[24];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bug-repro-trycatch-nested-overlapping-range.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bug-repro-trycatch-nested-overlapping-range.expect.md
@@ -20,7 +20,7 @@ function Foo() {
 ## Error
 
 ```
-Invariant: Invalid nesting in program blocks or scopes. Items overlap but are not nested: 2:24(18:26)
+Invariant: Invalid nesting in program blocks or scopes. Items overlap but are not nested: 2:23(17:25)
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.repro-bug-ref-mutable-range.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.repro-bug-ref-mutable-range.expect.md
@@ -21,7 +21,7 @@ function Foo(props, ref) {
 ## Error
 
 ```
-Invariant: Invalid nesting in program blocks or scopes. Items overlap but are not nested: 1:21(16:23)
+Invariant: Invalid nesting in program blocks or scopes. Items overlap but are not nested: 2:20(16:23)
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-iife-return-modified-later-logical.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-iife-return-modified-later-logical.expect.md
@@ -23,7 +23,7 @@ export const FIXTURE_ENTRYPOINT = {
 ## Error
 
 ```
-Invariant: Invalid nesting in program blocks or scopes. Items overlap but are not nested: 2:15(3:21)
+Invariant: Invalid nesting in program blocks or scopes. Items overlap but are not nested: 2:15(3:22)
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-reactive-scope-overlaps-label.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-reactive-scope-overlaps-label.expect.md
@@ -34,7 +34,7 @@ export const FIXTURE_ENTRYPOINT = {
 ## Error
 
 ```
-Invariant: Invalid nesting in program blocks or scopes. Items overlap but are not nested: 3:14(4:18)
+Invariant: Invalid nesting in program blocks or scopes. Items overlap but are not nested: 3:14(5:19)
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-reactive-scope-overlaps-try.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-reactive-scope-overlaps-try.expect.md
@@ -30,7 +30,7 @@ export const FIXTURE_ENTRYPOINT = {
 ## Error
 
 ```
-Invariant: Invalid nesting in program blocks or scopes. Items overlap but are not nested: 4:19(5:22)
+Invariant: Invalid nesting in program blocks or scopes. Items overlap but are not nested: 3:17(4:21)
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/escape-analysis-non-escaping-interleaved-allocating-dependency.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/escape-analysis-non-escaping-interleaved-allocating-dependency.expect.md
@@ -41,19 +41,21 @@ function Component(props) {
     t0 = $[1];
   }
   const a = t0;
-  let b;
+  let t1;
   if ($[2] !== a || $[3] !== props.b) {
-    b = [];
+    const b = [];
     const c = {};
     c.a = a;
+
+    t1 = b;
     b.push(props.b);
     $[2] = a;
     $[3] = props.b;
-    $[4] = b;
+    $[4] = t1;
   } else {
-    b = $[4];
+    t1 = $[4];
   }
-  return b;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/escape-analysis-non-escaping-interleaved-allocating-nested-dependency.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/escape-analysis-non-escaping-interleaved-allocating-nested-dependency.expect.md
@@ -59,19 +59,21 @@ function Component(props) {
     t1 = $[3];
   }
   const b = t1;
-  let c;
+  let t2;
   if ($[4] !== b || $[5] !== props.b) {
-    c = [];
+    const c = [];
     const d = {};
     d.b = b;
+
+    t2 = c;
     c.push(props.b);
     $[4] = b;
     $[5] = props.b;
-    $[6] = c;
+    $[6] = t2;
   } else {
-    c = $[6];
+    t2 = $[6];
   }
-  return c;
+  return t2;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/escape-analysis-non-escaping-interleaved-primitive-dependency.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/escape-analysis-non-escaping-interleaved-primitive-dependency.expect.md
@@ -36,19 +36,21 @@ function Component(props) {
   const $ = _c(3);
 
   const a = props.a + props.b;
-  let b;
+  let t0;
   if ($[0] !== a || $[1] !== props.c) {
-    b = [];
+    const b = [];
     const c = {};
     c.a = a;
+
+    t0 = b;
     b.push(props.c);
     $[0] = a;
     $[1] = props.c;
-    $[2] = b;
+    $[2] = t0;
   } else {
-    b = $[2];
+    t0 = $[2];
   }
-  return b;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-no-whitespace-btw-text-and-param.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-no-whitespace-btw-text-and-param.expect.md
@@ -29,15 +29,16 @@ import fbt from "fbt";
 const _ = fbt;
 function Component(t0) {
   const $ = _c(2);
-  const { value } = t0;
   let t1;
-  if ($[0] !== value) {
+  if ($[0] !== t0) {
+    const { value } = t0;
+
     t1 = fbt._(
       "Before text{paramName}After text",
       [fbt._param("paramName", value)],
       { hk: "aKEGX" },
     );
-    $[0] = value;
+    $[0] = t0;
     $[1] = t1;
   } else {
     t1 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-preserve-whitespace.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-preserve-whitespace.expect.md
@@ -30,9 +30,10 @@ import fbt from "fbt";
 const _ = fbt;
 function Component(t0) {
   const $ = _c(2);
-  const { value } = t0;
   let t1;
-  if ($[0] !== value) {
+  if ($[0] !== t0) {
+    const { value } = t0;
+
     t1 = fbt._(
       "Before text {paramName}",
       [
@@ -44,7 +45,7 @@ function Component(t0) {
       ],
       { hk: "3z5SVE" },
     );
-    $[0] = value;
+    $[0] = t0;
     $[1] = t1;
   } else {
     t1 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-single-space-btw-param-and-text.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-single-space-btw-param-and-text.expect.md
@@ -29,15 +29,16 @@ import fbt from "fbt";
 const _ = fbt;
 function Component(t0) {
   const $ = _c(2);
-  const { value } = t0;
   let t1;
-  if ($[0] !== value) {
+  if ($[0] !== t0) {
+    const { value } = t0;
+
     t1 = fbt._(
       "Before text {paramName} after text",
       [fbt._param("paramName", value)],
       { hk: "26pxNm" },
     );
-    $[0] = value;
+    $[0] = t0;
     $[1] = t1;
   } else {
     t1 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-whitespace-around-param-value.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-whitespace-around-param-value.expect.md
@@ -29,15 +29,16 @@ import fbt from "fbt";
 const _ = fbt;
 function Component(t0) {
   const $ = _c(2);
-  const { value } = t0;
   let t1;
-  if ($[0] !== value) {
+  if ($[0] !== t0) {
+    const { value } = t0;
+
     t1 = fbt._(
       "Before text {paramName} after text",
       [fbt._param("paramName", value)],
       { hk: "26pxNm" },
     );
-    $[0] = value;
+    $[0] = t0;
     $[1] = t1;
   } else {
     t1 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-whitespace-within-text.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-whitespace-within-text.expect.md
@@ -31,15 +31,16 @@ import fbt from "fbt";
 const _ = fbt;
 function Component(t0) {
   const $ = _c(2);
-  const { value } = t0;
   let t1;
-  if ($[0] !== value) {
+  if ($[0] !== t0) {
+    const { value } = t0;
+
     t1 = fbt._(
       "Before text {paramName} after text more text and more and more and more and more and more and more and more and more and blah blah blah blah",
       [fbt._param("paramName", value)],
       { hk: "24ZPpO" },
     );
-    $[0] = value;
+    $[0] = t0;
     $[1] = t1;
   } else {
     t1 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbtparam-with-jsx-element-content.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbtparam-with-jsx-element-content.expect.md
@@ -29,10 +29,11 @@ import { c as _c } from "react/compiler-runtime";
 import fbt from "fbt";
 
 function Component(t0) {
-  const $ = _c(4);
-  const { name, data, icon } = t0;
+  const $ = _c(2);
   let t1;
-  if ($[0] !== name || $[1] !== icon || $[2] !== data) {
+  if ($[0] !== t0) {
+    const { name, data, icon } = t0;
+
     t1 = (
       <Text type="body4">
         {fbt._(
@@ -61,12 +62,10 @@ function Component(t0) {
         )}
       </Text>
     );
-    $[0] = name;
-    $[1] = icon;
-    $[2] = data;
-    $[3] = t1;
+    $[0] = t0;
+    $[1] = t1;
   } else {
-    t1 = $[3];
+    t1 = $[1];
   }
   return t1;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/lambda-with-fbt.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/lambda-with-fbt.expect.md
@@ -42,10 +42,10 @@ import { c as _c } from "react/compiler-runtime";
 import { fbt } from "fbt";
 
 function Component() {
-  const $ = _c(2);
+  const $ = _c(1);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = () => {
+    const buttonLabel = () => {
       if (!someCondition) {
         return fbt._("Purchase as a gift", null, { hk: "1gHj4g" });
       } else {
@@ -66,23 +66,17 @@ function Component() {
         }
       }
     };
-    $[0] = t0;
-  } else {
-    t0 = $[0];
-  }
-  const buttonLabel = t0;
-  let t1;
-  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = (
+
+    t0 = (
       <View>
         <Button text={buttonLabel()} />
       </View>
     );
-    $[1] = t1;
+    $[0] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[0];
   }
-  return t1;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/for-of-nonmutating-loop-local-collection.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/for-of-nonmutating-loop-local-collection.expect.md
@@ -82,42 +82,42 @@ function Component(t0) {
     t4 = $[6];
   }
   let t5;
-  if ($[7] !== t4 || $[8] !== x) {
-    t5 = <ValidateMemoization inputs={t4} output={x} />;
-    $[7] = t4;
-    $[8] = x;
+  if ($[7] !== x || $[8] !== b) {
+    t5 = [x, b];
+    $[7] = x;
+    $[8] = b;
     $[9] = t5;
   } else {
     t5 = $[9];
   }
   let t6;
-  if ($[10] !== x || $[11] !== b) {
-    t6 = [x, b];
-    $[10] = x;
-    $[11] = b;
+  if ($[10] !== t5 || $[11] !== y) {
+    t6 = <ValidateMemoization inputs={t5} output={y} />;
+    $[10] = t5;
+    $[11] = y;
     $[12] = t6;
   } else {
     t6 = $[12];
   }
   let t7;
-  if ($[13] !== t6 || $[14] !== y) {
-    t7 = <ValidateMemoization inputs={t6} output={y} />;
-    $[13] = t6;
-    $[14] = y;
+  if ($[13] !== t4 || $[14] !== x) {
+    t7 = <ValidateMemoization inputs={t4} output={x} />;
+    $[13] = t4;
+    $[14] = x;
     $[15] = t7;
   } else {
     t7 = $[15];
   }
   let t8;
-  if ($[16] !== t5 || $[17] !== t7) {
+  if ($[16] !== t7 || $[17] !== t6) {
     t8 = (
       <>
-        {t5}
         {t7}
+        {t6}
       </>
     );
-    $[16] = t5;
-    $[17] = t7;
+    $[16] = t7;
+    $[17] = t6;
     $[18] = t8;
   } else {
     t8 = $[18];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-declaration-simple.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-declaration-simple.expect.md
@@ -25,27 +25,28 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function component(a) {
   const $ = _c(3);
-  let t;
+  let t0;
   if ($[0] !== a) {
-    t = { a };
-    let t0;
+    const t = { a };
+    let t1;
     if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
-      t0 = function x(p) {
+      t1 = function x(p) {
         p.foo();
       };
-      $[2] = t0;
+      $[2] = t1;
     } else {
-      t0 = $[2];
+      t1 = $[2];
     }
-    const x = t0;
+    const x = t1;
 
+    t0 = t;
     x(t);
     $[0] = a;
-    $[1] = t;
+    $[1] = t0;
   } else {
-    t = $[1];
+    t0 = $[1];
   }
-  return t;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-expression-with-store-to-parameter.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-expression-with-store-to-parameter.expect.md
@@ -31,16 +31,18 @@ function Component(props) {
     t0 = $[0];
   }
   const mutate = t0;
-  let x;
+  let t1;
   if ($[1] !== props) {
-    x = makeObject(props);
+    const x = makeObject(props);
+
+    t1 = x;
     mutate(x);
     $[1] = props;
-    $[2] = x;
+    $[2] = t1;
   } else {
-    x = $[2];
+    t1 = $[2];
   }
-  return x;
+  return t1;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/iife-return-modified-later.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/iife-return-modified-later.expect.md
@@ -24,20 +24,21 @@ import { c as _c } from "react/compiler-runtime";
 function Component(props) {
   const $ = _c(3);
   let t0;
-  let items;
+  let t1;
   if ($[0] !== props.a) {
     t0 = [];
-    items = t0;
+    const items = t0;
 
+    t1 = items;
     items.push(props.a);
     $[0] = props.a;
-    $[1] = items;
+    $[1] = t1;
     $[2] = t0;
   } else {
-    items = $[1];
+    t1 = $[1];
     t0 = $[2];
   }
-  return items;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inadvertent-mutability-readonly-lambda.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inadvertent-mutability-readonly-lambda.expect.md
@@ -35,15 +35,17 @@ function Component(props) {
   const onChange = t0;
 
   useOtherHook();
-  let x;
+  let t1;
   if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-    x = {};
+    const x = {};
+
+    t1 = x;
     foo(x, onChange);
-    $[1] = x;
+    $[1] = t1;
   } else {
-    x = $[1];
+    t1 = $[1];
   }
-  return x;
+  return t1;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/independently-memoize-object-property.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/independently-memoize-object-property.expect.md
@@ -24,27 +24,29 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function foo(a, b, c) {
   const $ = _c(7);
-  let x;
+  let t0;
   if ($[0] !== a || $[1] !== b || $[2] !== c) {
-    x = { a };
-    let t0;
+    const x = { a };
+    let t1;
     if ($[4] !== b || $[5] !== c) {
-      t0 = [b, c];
+      t1 = [b, c];
       $[4] = b;
       $[5] = c;
-      $[6] = t0;
+      $[6] = t1;
     } else {
-      t0 = $[6];
+      t1 = $[6];
     }
-    x.y = t0;
+
+    t0 = x;
+    x.y = t1;
     $[0] = a;
     $[1] = b;
     $[2] = c;
-    $[3] = x;
+    $[3] = t0;
   } else {
-    x = $[3];
+    t0 = $[3];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-memo-value-not-promoted-to-outer-scope-dynamic.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-memo-value-not-promoted-to-outer-scope-dynamic.expect.md
@@ -24,69 +24,50 @@ function Component(props) {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
-  const $ = _c(15);
+  const $ = _c(7);
   const item = useFragment(FRAGMENT, props.item);
   useFreeze(item);
   let t0;
-  let T0;
-  let t1;
-  let T1;
   if ($[0] !== item) {
     const count = new MaybeMutable(item);
 
-    T1 = View;
-    T0 = View;
-    if ($[5] === Symbol.for("react.memo_cache_sentinel")) {
-      t1 = <span>Text</span>;
-      $[5] = t1;
-    } else {
-      t1 = $[5];
-    }
     t0 = maybeMutate(count);
     $[0] = item;
     $[1] = t0;
-    $[2] = T0;
-    $[3] = t1;
-    $[4] = T1;
   } else {
     t0 = $[1];
-    T0 = $[2];
+  }
+  let t1;
+  if ($[2] !== t0) {
+    t1 = <span>{t0}</span>;
+    $[2] = t0;
+    $[3] = t1;
+  } else {
     t1 = $[3];
-    T1 = $[4];
   }
   let t2;
-  if ($[6] !== t0) {
-    t2 = <span>{t0}</span>;
-    $[6] = t0;
-    $[7] = t2;
+  if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = <span>Text</span>;
+    $[4] = t2;
   } else {
-    t2 = $[7];
+    t2 = $[4];
   }
   let t3;
-  if ($[8] !== T0 || $[9] !== t1 || $[10] !== t2) {
+  if ($[5] !== t1) {
     t3 = (
-      <T0>
-        {t1}
-        {t2}
-      </T0>
+      <View>
+        <View>
+          {t2}
+          {t1}
+        </View>
+      </View>
     );
-    $[8] = T0;
-    $[9] = t1;
-    $[10] = t2;
-    $[11] = t3;
+    $[5] = t1;
+    $[6] = t3;
   } else {
-    t3 = $[11];
+    t3 = $[6];
   }
-  let t4;
-  if ($[12] !== T1 || $[13] !== t3) {
-    t4 = <T1>{t3}</T1>;
-    $[12] = T1;
-    $[13] = t3;
-    $[14] = t4;
-  } else {
-    t4 = $[14];
-  }
-  return t4;
+  return t3;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/issue933-disjoint-set-infinite-loop.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/issue933-disjoint-set-infinite-loop.expect.md
@@ -42,17 +42,19 @@ function makeObj() {
 // This caused an infinite loop in the compiler
 function MyApp(props) {
   const $ = _c(1);
-  let y;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    y = makeObj();
+    const y = makeObj();
     const tmp = y.a;
     const tmp2 = tmp.b;
+
+    t0 = y;
     y.push(tmp2);
-    $[0] = y;
+    $[0] = t0;
   } else {
-    y = $[0];
+    t0 = $[0];
   }
-  return y;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-freeze.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-freeze.expect.md
@@ -31,17 +31,19 @@ import { shallowCopy } from "shared-runtime";
 
 function Component(props) {
   const $ = _c(2);
-  let element;
+  let t0;
   if ($[0] !== props.width) {
     const childprops = { style: { width: props.width } };
-    element = _jsx("div", { childprops, children: '"hello world"' });
+    const element = _jsx("div", { childprops, children: '"hello world"' });
+
+    t0 = element;
     shallowCopy(childprops);
     $[0] = props.width;
-    $[1] = element;
+    $[1] = t0;
   } else {
-    element = $[1];
+    t0 = $[1];
   }
-  return element;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-preserve-whitespace.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-preserve-whitespace.expect.md
@@ -36,39 +36,29 @@ import { c as _c } from "react/compiler-runtime";
 import { StaticText1 } from "shared-runtime";
 
 function Component() {
-  const $ = _c(3);
+  const $ = _c(1);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = <StaticText1 />;
-    $[0] = t0;
-  } else {
-    t0 = $[0];
-  }
-  let t1;
-  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = <StaticText1 />;
-    $[1] = t1;
-  } else {
-    t1 = $[1];
-  }
-  let t2;
-  if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
-    t2 = (
+    t0 = (
       <div>
-        Before text{t0}Middle text
+        Before text
+        <StaticText1 />
+        Middle text
         <StaticText1>
-          Inner before text{t1}Inner middle text
+          Inner before text
+          <StaticText1 />
+          Inner middle text
           <StaticText1 />
           Inner after text
         </StaticText1>
         After text
       </div>
     );
-    $[2] = t2;
+    $[0] = t0;
   } else {
-    t2 = $[2];
+    t0 = $[0];
   }
-  return t2;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/lambda-capture-returned-alias.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/lambda-capture-returned-alias.expect.md
@@ -43,7 +43,7 @@ function CaptureNotMutate(props) {
     t0 = $[1];
   }
   const idx = t0;
-  let aliasedElement;
+  let t1;
   if ($[2] !== props.el || $[3] !== idx) {
     const element = bar(props.el);
 
@@ -52,15 +52,17 @@ function CaptureNotMutate(props) {
       return arr[idx];
     };
 
-    aliasedElement = fn();
+    const aliasedElement = fn();
+
+    t1 = aliasedElement;
     mutate(aliasedElement);
     $[2] = props.el;
     $[3] = idx;
-    $[4] = aliasedElement;
+    $[4] = t1;
   } else {
-    aliasedElement = $[4];
+    t1 = $[4];
   }
-  return aliasedElement;
+  return t1;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/merge-consecutive-scopes-objects.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/merge-consecutive-scopes-objects.expect.md
@@ -44,7 +44,7 @@ import { Stringify } from "shared-runtime";
 // prevent scome scopes from merging, which concealed a bug with the merging logic.
 // By avoiding JSX we eliminate extraneous instructions and more accurately test the merging.
 function Component(props) {
-  const $ = _c(11);
+  const $ = _c(10);
   const [state, setState] = useState(0);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
@@ -54,47 +54,44 @@ function Component(props) {
     t0 = $[0];
   }
   let t1;
+  let t2;
   if ($[1] !== state) {
     t1 = { component: "span", props: { children: [state] } };
+
+    t2 = () => setState(state + 1);
     $[1] = state;
     $[2] = t1;
+    $[3] = t2;
   } else {
     t1 = $[2];
-  }
-  let t2;
-  if ($[3] !== state) {
-    t2 = () => setState(state + 1);
-    $[3] = state;
-    $[4] = t2;
-  } else {
-    t2 = $[4];
+    t2 = $[3];
   }
   let t3;
-  if ($[5] === Symbol.for("react.memo_cache_sentinel")) {
+  if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
     t3 = ["increment"];
-    $[5] = t3;
+    $[4] = t3;
   } else {
-    t3 = $[5];
+    t3 = $[4];
   }
   let t4;
-  if ($[6] !== t2) {
+  if ($[5] !== t2) {
     t4 = {
       component: "button",
       props: { "data-testid": "button", onClick: t2, children: t3 },
     };
-    $[6] = t2;
-    $[7] = t4;
+    $[5] = t2;
+    $[6] = t4;
   } else {
-    t4 = $[7];
+    t4 = $[6];
   }
   let t5;
-  if ($[8] !== t1 || $[9] !== t4) {
+  if ($[7] !== t1 || $[8] !== t4) {
     t5 = [t0, t1, t4];
-    $[8] = t1;
-    $[9] = t4;
-    $[10] = t5;
+    $[7] = t1;
+    $[8] = t4;
+    $[9] = t5;
   } else {
-    t5 = $[10];
+    t5 = $[9];
   }
   return t5;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/merge-consecutive-scopes-reordering.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/merge-consecutive-scopes-reordering.expect.md
@@ -34,59 +34,47 @@ import { useState } from "react";
 import { Stringify } from "shared-runtime";
 
 function Component() {
-  const $ = _c(10);
+  const $ = _c(7);
   const [state, setState] = useState(0);
   let t0;
-  if ($[0] !== state) {
-    t0 = () => setState(state + 1);
-    $[0] = state;
-    $[1] = t0;
-  } else {
-    t0 = $[1];
-  }
   let t1;
-  if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = <Stringify text="Counter" />;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
-  let t2;
-  if ($[3] !== state) {
-    t2 = <span>{state}</span>;
-    $[3] = state;
-    $[4] = t2;
-  } else {
-    t2 = $[4];
-  }
-  let t3;
-  if ($[5] !== t0) {
-    t3 = (
-      <button data-testid="button" onClick={t0}>
+  if ($[0] !== state) {
+    t0 = (
+      <button data-testid="button" onClick={() => setState(state + 1)}>
         increment
       </button>
     );
+    t1 = <span>{state}</span>;
+    $[0] = state;
+    $[1] = t0;
+    $[2] = t1;
+  } else {
+    t0 = $[1];
+    t1 = $[2];
+  }
+  let t2;
+  if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = <Stringify text="Counter" />;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  let t3;
+  if ($[4] !== t1 || $[5] !== t0) {
+    t3 = (
+      <div>
+        {t2}
+        {t1}
+        {t0}
+      </div>
+    );
+    $[4] = t1;
     $[5] = t0;
     $[6] = t3;
   } else {
     t3 = $[6];
   }
-  let t4;
-  if ($[7] !== t2 || $[8] !== t3) {
-    t4 = (
-      <div>
-        {t1}
-        {t2}
-        {t3}
-      </div>
-    );
-    $[7] = t2;
-    $[8] = t3;
-    $[9] = t4;
-  } else {
-    t4 = $[9];
-  }
-  return t4;
+  return t3;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/merge-consecutive-scopes.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/merge-consecutive-scopes.expect.md
@@ -33,49 +33,45 @@ import { useState } from "react";
 import { Stringify } from "shared-runtime";
 
 function Component() {
-  const $ = _c(8);
+  const $ = _c(7);
   const [state, setState] = useState(0);
   let t0;
-  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = <Stringify text="Counter" />;
-    $[0] = t0;
-  } else {
-    t0 = $[0];
-  }
   let t1;
-  if ($[1] !== state) {
-    t1 = <span>{state}</span>;
-    $[1] = state;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
-  let t2;
-  if ($[3] !== state) {
-    t2 = (
+  if ($[0] !== state) {
+    t0 = (
       <button data-testid="button" onClick={() => setState(state + 1)}>
         increment
       </button>
     );
-    $[3] = state;
-    $[4] = t2;
+    t1 = <span>{state}</span>;
+    $[0] = state;
+    $[1] = t0;
+    $[2] = t1;
   } else {
-    t2 = $[4];
+    t0 = $[1];
+    t1 = $[2];
+  }
+  let t2;
+  if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = <Stringify text="Counter" />;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
   }
   let t3;
-  if ($[5] !== t1 || $[6] !== t2) {
+  if ($[4] !== t1 || $[5] !== t0) {
     t3 = (
       <div>
-        {t0}
-        {t1}
         {t2}
+        {t1}
+        {t0}
       </div>
     );
-    $[5] = t1;
-    $[6] = t2;
-    $[7] = t3;
+    $[4] = t1;
+    $[5] = t0;
+    $[6] = t3;
   } else {
-    t3 = $[7];
+    t3 = $[6];
   }
   return t3;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/merge-nested-scopes-with-same-inputs.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/merge-nested-scopes-with-same-inputs.expect.md
@@ -35,21 +35,23 @@ import { setProperty } from "shared-runtime";
 
 function Component(props) {
   const $ = _c(2);
-  let y;
+  let t0;
   if ($[0] !== props.a) {
-    y = {};
+    const y = {};
 
     const x = {};
     setProperty(x, props.a);
 
     y.a = props.a;
+
+    t0 = y;
     y.x = x;
     $[0] = props.a;
-    $[1] = y;
+    $[1] = t0;
   } else {
-    y = $[1];
+    t0 = $[1];
   }
-  return y;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/merge-scopes-callback.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/merge-scopes-callback.expect.md
@@ -27,7 +27,7 @@ import { c as _c } from "react/compiler-runtime"; // @enableInstructionReorderin
 import { useState } from "react";
 
 function Component() {
-  const $ = _c(6);
+  const $ = _c(4);
   const [state, setState] = useState(0);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
@@ -40,34 +40,26 @@ function Component() {
   }
   const onClick = t0;
   let t1;
-  if ($[1] !== state) {
-    t1 = <span>Count: {state}</span>;
-    $[1] = state;
-    $[2] = t1;
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t1 = <button onClick={onClick}>Increment</button>;
+    $[1] = t1;
   } else {
-    t1 = $[2];
+    t1 = $[1];
   }
   let t2;
-  if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
-    t2 = <button onClick={onClick}>Increment</button>;
+  if ($[2] !== state) {
+    t2 = (
+      <>
+        <span>Count: {state}</span>
+        {t1}
+      </>
+    );
+    $[2] = state;
     $[3] = t2;
   } else {
     t2 = $[3];
   }
-  let t3;
-  if ($[4] !== t1) {
-    t3 = (
-      <>
-        {t1}
-        {t2}
-      </>
-    );
-    $[4] = t1;
-    $[5] = t3;
-  } else {
-    t3 = $[5];
-  }
-  return t3;
+  return t2;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/merged-scopes-are-valid-effect-deps.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/merged-scopes-are-valid-effect-deps.expect.md
@@ -32,7 +32,7 @@ import { c as _c } from "react/compiler-runtime"; // @validateMemoizedEffectDepe
 import { useEffect } from "react";
 
 function Component(props) {
-  const $ = _c(5);
+  const $ = _c(6);
   let t0;
   if ($[0] !== props.value) {
     t0 = [[props.value]];
@@ -43,18 +43,22 @@ function Component(props) {
   }
   const y = t0;
   let t1;
-  let t2;
   if ($[2] !== y) {
     t1 = () => {
       console.log(y);
     };
-    t2 = [y];
     $[2] = y;
     $[3] = t1;
-    $[4] = t2;
   } else {
     t1 = $[3];
-    t2 = $[4];
+  }
+  let t2;
+  if ($[4] !== y) {
+    t2 = [y];
+    $[4] = y;
+    $[5] = t2;
+  } else {
+    t2 = $[5];
   }
   useEffect(t1, t2);
   return y;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/mutable-lifetime-with-aliasing.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/mutable-lifetime-with-aliasing.expect.md
@@ -68,14 +68,14 @@ function mutate(x, y) {
 
 function Component(props) {
   const $ = _c(1);
-  let x;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     const a = {};
     const b = [a];
     const c = {};
     const d = { c };
 
-    x = {};
+    const x = {};
     x.b = b;
     const y = mutate(x, d);
     if (a) {
@@ -89,12 +89,13 @@ function Component(props) {
     if (y) {
     }
 
+    t0 = x;
     mutate(x, null);
-    $[0] = x;
+    $[0] = t0;
   } else {
-    x = $[0];
+    t0 = $[0];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/mutation-during-jsx-construction.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/mutation-during-jsx-construction.expect.md
@@ -29,19 +29,20 @@ import { identity, mutate, mutateAndReturnNewValue } from "shared-runtime";
 
 function Component(props) {
   const $ = _c(2);
-  let element;
+  let t0;
   if ($[0] !== props.value) {
     const key = {};
 
-    element = <div key={mutateAndReturnNewValue(key)}>{props.value}</div>;
+    const element = <div key={mutateAndReturnNewValue(key)}>{props.value}</div>;
 
+    t0 = element;
     mutate(key);
     $[0] = props.value;
-    $[1] = element;
+    $[1] = t0;
   } else {
-    element = $[1];
+    t0 = $[1];
   }
-  return element;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/mutation-within-capture-and-mutablerange.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/mutation-within-capture-and-mutablerange.expect.md
@@ -53,22 +53,23 @@ import { mutate } from "shared-runtime";
 function useFoo(t0) {
   const $ = _c(3);
   const { a, b } = t0;
-  let z;
+  let t1;
   if ($[0] !== a || $[1] !== b) {
     const x = { a };
     const y = [b];
     mutate(x);
 
-    z = [mutate(y)];
+    const z = [mutate(y)];
 
+    t1 = z;
     mutate(y);
     $[0] = a;
     $[1] = b;
-    $[2] = z;
+    $[2] = t1;
   } else {
-    z = $[2];
+    t1 = $[2];
   }
-  return z;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nested-scopes-begin-same-instr-valueblock.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nested-scopes-begin-same-instr-valueblock.expect.md
@@ -33,17 +33,18 @@ import { identity, mutate } from "shared-runtime";
 function Foo(t0) {
   const $ = _c(2);
   const { cond } = t0;
-  let x;
+  let t1;
   if ($[0] !== cond) {
-    x = identity(identity(cond)) ? { a: 2 } : { b: 2 };
+    const x = identity(identity(cond)) ? { a: 2 } : { b: 2 };
 
+    t1 = x;
     mutate(x);
     $[0] = cond;
-    $[1] = x;
+    $[1] = t1;
   } else {
-    x = $[1];
+    t1 = $[1];
   }
-  return x;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/obj-literal-mutated-after-if-else.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/obj-literal-mutated-after-if-else.expect.md
@@ -22,22 +22,24 @@ function foo(a, b, c, d) {
 import { c as _c } from "react/compiler-runtime";
 function foo(a, b, c, d) {
   const $ = _c(3);
-  let x;
+  let t0;
   if ($[0] !== b || $[1] !== c) {
+    let x;
     if (someVal) {
       x = { b };
     } else {
       x = { c };
     }
 
+    t0 = x;
     x.f = 1;
     $[0] = b;
     $[1] = c;
-    $[2] = x;
+    $[2] = t0;
   } else {
-    x = $[2];
+    t0 = $[2];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/obj-mutated-after-if-else-with-alias.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/obj-mutated-after-if-else-with-alias.expect.md
@@ -25,8 +25,9 @@ import { c as _c } from "react/compiler-runtime";
 function foo(a, b, c, d) {
   const $ = _c(2);
   someObj();
-  let x;
+  let t0;
   if ($[0] !== a) {
+    let x;
     if (a) {
       const y = someObj();
       const z = y;
@@ -35,13 +36,14 @@ function foo(a, b, c, d) {
       x = someObj();
     }
 
+    t0 = x;
     x.f = 1;
     $[0] = a;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/obj-mutated-after-if-else.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/obj-mutated-after-if-else.expect.md
@@ -23,21 +23,23 @@ import { c as _c } from "react/compiler-runtime";
 function foo(a, b, c, d) {
   const $ = _c(2);
   someObj();
-  let x;
+  let t0;
   if ($[0] !== a) {
+    let x;
     if (a) {
       x = someObj();
     } else {
       x = someObj();
     }
 
+    t0 = x;
     x.f = 1;
     $[0] = a;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/obj-mutated-after-nested-if-else-with-alias.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/obj-mutated-after-nested-if-else-with-alias.expect.md
@@ -31,8 +31,9 @@ import { c as _c } from "react/compiler-runtime";
 function foo(a, b, c, d) {
   const $ = _c(3);
   someObj();
-  let x;
+  let t0;
   if ($[0] !== a || $[1] !== b) {
+    let x;
     if (a) {
       let z;
       if (b) {
@@ -47,14 +48,15 @@ function foo(a, b, c, d) {
       x = someObj();
     }
 
+    t0 = x;
     x.f = 1;
     $[0] = a;
     $[1] = b;
-    $[2] = x;
+    $[2] = t0;
   } else {
-    x = $[2];
+    t0 = $[2];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-shorthand-aliased-mutate-after.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-shorthand-aliased-mutate-after.expect.md
@@ -29,22 +29,23 @@ import { createHookWrapper, mutate, mutateAndReturn } from "shared-runtime";
 function useHook(t0) {
   const $ = _c(2);
   const { value } = t0;
-  let obj;
+  let t1;
   if ($[0] !== value) {
     const x = mutateAndReturn({ value });
-    obj = {
+    const obj = {
       getValue() {
         return value;
       },
     };
 
+    t1 = obj;
     mutate(x);
     $[0] = value;
-    $[1] = obj;
+    $[1] = t1;
   } else {
-    obj = $[1];
+    t1 = $[1];
   }
-  return obj;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-shorthand-mutated-after.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-shorthand-mutated-after.expect.md
@@ -29,22 +29,23 @@ import { createHookWrapper, mutate, mutateAndReturn } from "shared-runtime";
 function useHook(t0) {
   const $ = _c(2);
   const { value } = t0;
-  let obj;
+  let t1;
   if ($[0] !== value) {
     const x = mutateAndReturn({ value });
-    obj = {
+    const obj = {
       getValue() {
         return x;
       },
     };
 
+    t1 = obj;
     mutate(obj);
     $[0] = value;
-    $[1] = obj;
+    $[1] = t1;
   } else {
-    obj = $[1];
+    t1 = $[1];
   }
-  return obj;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/original-reactive-scopes-fork/invalid-align-scopes-within-nested-valueblock-in-array.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/original-reactive-scopes-fork/invalid-align-scopes-within-nested-valueblock-in-array.expect.md
@@ -52,11 +52,12 @@ import { Stringify, identity, makeArray, mutate } from "shared-runtime";
  * handles this correctly.
  */
 function Foo(t0) {
-  const $ = _c(4);
+  const $ = _c(3);
   const { cond1, cond2 } = t0;
-  const arr = makeArray({ a: 2 }, 2, []);
   let t1;
-  if ($[0] !== cond1 || $[1] !== cond2 || $[2] !== arr) {
+  if ($[0] !== cond1 || $[1] !== cond2) {
+    const arr = makeArray({ a: 2 }, 2, []);
+
     t1 = cond1 ? (
       <>
         <div>{identity("foo")}</div>
@@ -65,10 +66,9 @@ function Foo(t0) {
     ) : null;
     $[0] = cond1;
     $[1] = cond2;
-    $[2] = arr;
-    $[3] = t1;
+    $[2] = t1;
   } else {
-    t1 = $[3];
+    t1 = $[2];
   }
   return t1;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/original-reactive-scopes-fork/mutation-within-capture-and-mutablerange.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/original-reactive-scopes-fork/mutation-within-capture-and-mutablerange.expect.md
@@ -54,31 +54,32 @@ import { mutate } from "shared-runtime";
 function useFoo(t0) {
   const $ = _c(5);
   const { a, b } = t0;
-  let z;
+  let t1;
   if ($[0] !== a || $[1] !== b) {
     const x = { a };
     const y = [b];
     mutate(x);
 
-    const t1 = mutate(y);
-    let t2;
-    if ($[3] !== t1) {
-      t2 = [t1];
-      $[3] = t1;
-      $[4] = t2;
+    const t2 = mutate(y);
+    let t3;
+    if ($[3] !== t2) {
+      t3 = [t2];
+      $[3] = t2;
+      $[4] = t3;
     } else {
-      t2 = $[4];
+      t3 = $[4];
     }
-    z = t2;
+    const z = t3;
 
+    t1 = z;
     mutate(y);
     $[0] = a;
     $[1] = b;
-    $[2] = z;
+    $[2] = t1;
   } else {
-    z = $[2];
+    t1 = $[2];
   }
-  return z;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/phi-reference-effects.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/phi-reference-effects.expect.md
@@ -32,20 +32,21 @@ import { arrayPush } from "shared-runtime";
 
 function Foo(cond) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== cond) {
-    x = null;
+    let x = null;
     if (cond) {
       x = [];
     }
 
+    t0 = x;
     arrayPush(x, 2);
     $[0] = cond;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/property-call-evaluation-order.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/property-call-evaluation-order.expect.md
@@ -41,16 +41,17 @@ function Component() {
     t0 = $[0];
   }
   const changeF = t0;
-  let x;
+  let t1;
   if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-    x = { f: () => console.log("original") };
+    const x = { f: () => console.log("original") };
 
+    t1 = x;
     (console.log("A"), x).f((changeF(x), console.log("arg"), 1));
-    $[1] = x;
+    $[1] = t1;
   } else {
-    x = $[1];
+    t1 = $[1];
   }
-  return x;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reactive-scope-grouping.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reactive-scope-grouping.expect.md
@@ -26,18 +26,20 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function foo() {
   const $ = _c(1);
-  let x;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    x = {};
+    const x = {};
     const y = [];
     const z = {};
     y.push(z);
+
+    t0 = x;
     x.y = y;
-    $[0] = x;
+    $[0] = t0;
   } else {
-    x = $[0];
+    t0 = $[0];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-cond-deps-return-in-scope.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-cond-deps-return-in-scope.expect.md
@@ -31,33 +31,34 @@ import { c as _c } from "react/compiler-runtime";
 function useFoo(t0) {
   const $ = _c(4);
   const { obj, objIsNull } = t0;
-  let x;
   let t1;
+  let t2;
   if ($[0] !== objIsNull || $[1] !== obj) {
-    t1 = Symbol.for("react.early_return_sentinel");
+    t2 = Symbol.for("react.early_return_sentinel");
     bb0: {
-      x = [];
+      const x = [];
       if (objIsNull) {
-        t1 = undefined;
+        t2 = undefined;
         break bb0;
       } else {
         x.push(obj.a);
       }
 
+      t1 = x;
       x.push(obj.b);
     }
     $[0] = objIsNull;
     $[1] = obj;
-    $[2] = x;
-    $[3] = t1;
+    $[2] = t1;
+    $[3] = t2;
   } else {
-    x = $[2];
-    t1 = $[3];
+    t1 = $[2];
+    t2 = $[3];
   }
-  if (t1 !== Symbol.for("react.early_return_sentinel")) {
-    return t1;
+  if (t2 !== Symbol.for("react.early_return_sentinel")) {
+    return t2;
   }
-  return x;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/conditional-member-expr.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/conditional-member-expr.expect.md
@@ -28,16 +28,18 @@ import { c as _c } from "react/compiler-runtime"; // To preserve the nullthrows 
 
 function Component(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props.a) {
-    x = [];
+    const x = [];
+
+    t0 = x;
     x.push(props.a?.b);
     $[0] = props.a;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/jump-poisoned/return-in-scope.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/jump-poisoned/return-in-scope.expect.md
@@ -33,31 +33,32 @@ import { c as _c } from "react/compiler-runtime";
 function useFoo(t0) {
   const $ = _c(4);
   const { obj, objIsNull } = t0;
-  let x;
   let t1;
+  let t2;
   if ($[0] !== objIsNull || $[1] !== obj) {
-    t1 = Symbol.for("react.early_return_sentinel");
+    t2 = Symbol.for("react.early_return_sentinel");
     bb0: {
-      x = [];
+      const x = [];
       if (objIsNull) {
-        t1 = undefined;
+        t2 = undefined;
         break bb0;
       }
 
+      t1 = x;
       x.push(obj.b);
     }
     $[0] = objIsNull;
     $[1] = obj;
-    $[2] = x;
-    $[3] = t1;
+    $[2] = t1;
+    $[3] = t2;
   } else {
-    x = $[2];
-    t1 = $[3];
+    t1 = $[2];
+    t2 = $[3];
   }
-  if (t1 !== Symbol.for("react.early_return_sentinel")) {
-    return t1;
+  if (t2 !== Symbol.for("react.early_return_sentinel")) {
+    return t2;
   }
-  return x;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/jump-poisoned/return-poisons-outer-scope.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/jump-poisoned/return-poisons-outer-scope.expect.md
@@ -39,38 +39,40 @@ import { identity } from "shared-runtime";
 function useFoo(t0) {
   const $ = _c(6);
   const { input, cond } = t0;
-  let x;
   let t1;
+  let t2;
   if ($[0] !== cond || $[1] !== input) {
-    t1 = Symbol.for("react.early_return_sentinel");
+    t2 = Symbol.for("react.early_return_sentinel");
     bb0: {
-      x = [];
+      const x = [];
       if (cond) {
-        t1 = null;
+        t2 = null;
         break bb0;
       }
-      let t2;
+
+      t1 = x;
+      let t3;
       if ($[4] !== input.a.b) {
-        t2 = identity(input.a.b);
+        t3 = identity(input.a.b);
         $[4] = input.a.b;
-        $[5] = t2;
+        $[5] = t3;
       } else {
-        t2 = $[5];
+        t3 = $[5];
       }
-      x.push(t2);
+      x.push(t3);
     }
     $[0] = cond;
     $[1] = input;
-    $[2] = x;
-    $[3] = t1;
+    $[2] = t1;
+    $[3] = t2;
   } else {
-    x = $[2];
-    t1 = $[3];
+    t1 = $[2];
+    t2 = $[3];
   }
-  if (t1 !== Symbol.for("react.early_return_sentinel")) {
-    return t1;
+  if (t2 !== Symbol.for("react.early_return_sentinel")) {
+    return t2;
   }
-  return x;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/jump-unpoisoned/jump-target-within-scope-label.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/jump-unpoisoned/jump-target-within-scope-label.expect.md
@@ -37,21 +37,22 @@ import { c as _c } from "react/compiler-runtime";
 function useFoo(t0) {
   const $ = _c(3);
   const { input, cond } = t0;
-  let x;
+  let t1;
   if ($[0] !== cond || $[1] !== input.a.b) {
-    x = [];
+    const x = [];
     bb0: if (cond) {
       break bb0;
     }
 
+    t1 = x;
     x.push(input.a.b);
     $[0] = cond;
     $[1] = input.a.b;
-    $[2] = x;
+    $[2] = t1;
   } else {
-    x = $[2];
+    t1 = $[2];
   }
-  return x;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/jump-unpoisoned/jump-target-within-scope-loop-break.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/jump-unpoisoned/jump-target-within-scope-loop-break.expect.md
@@ -39,9 +39,9 @@ import { c as _c } from "react/compiler-runtime";
 function useFoo(t0) {
   const $ = _c(3);
   const { input, max } = t0;
-  let x;
+  let t1;
   if ($[0] !== max || $[1] !== input.a.b) {
-    x = [];
+    const x = [];
     let i = 0;
     while (true) {
       i = i + 1;
@@ -51,14 +51,16 @@ function useFoo(t0) {
     }
 
     x.push(i);
+
+    t1 = x;
     x.push(input.a.b);
     $[0] = max;
     $[1] = input.a.b;
-    $[2] = x;
+    $[2] = t1;
   } else {
-    x = $[2];
+    t1 = $[2];
   }
-  return x;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/jump-unpoisoned/return-before-scope-starts.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/jump-unpoisoned/return-before-scope-starts.expect.md
@@ -51,16 +51,18 @@ function useFoo(t0) {
     }
     return t1;
   }
-  let x;
+  let t1;
   if ($[1] !== input.a.b) {
-    x = [];
+    const x = [];
+
+    t1 = x;
     arrayPush(x, input.a.b);
     $[1] = input.a.b;
-    $[2] = x;
+    $[2] = t1;
   } else {
-    x = $[2];
+    t1 = $[2];
   }
-  return x;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/jump-unpoisoned/throw-before-scope-starts.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/jump-unpoisoned/throw-before-scope-starts.expect.md
@@ -44,16 +44,18 @@ function useFoo(t0) {
   if (cond) {
     throw new Error("throw with error!");
   }
-  let x;
+  let t1;
   if ($[0] !== input.a.b) {
-    x = [];
+    const x = [];
+
+    t1 = x;
     arrayPush(x, input.a.b);
     $[0] = input.a.b;
-    $[1] = x;
+    $[1] = t1;
   } else {
-    x = $[1];
+    t1 = $[1];
   }
-  return x;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/memberexpr-join-optional-chain.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/memberexpr-join-optional-chain.expect.md
@@ -43,17 +43,19 @@ import { c as _c } from "react/compiler-runtime"; // To preserve the nullthrows 
 
 function Component(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props.a) {
-    x = [];
+    const x = [];
     x.push(props.a?.b);
+
+    t0 = x;
     x.push(props.a.b.c);
     $[0] = props.a;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/memberexpr-join-optional-chain2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/memberexpr-join-optional-chain2.expect.md
@@ -22,17 +22,19 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props.items) {
-    x = [];
+    const x = [];
     x.push(props.items?.length);
+
+    t0 = x;
     x.push(props.items?.edges?.map?.(render)?.filter?.(Boolean) ?? []);
     $[0] = props.items;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/subpath-order2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/subpath-order2.expect.md
@@ -39,21 +39,22 @@ import { identity } from "shared-runtime";
 // ordering of accesses should not matter
 function useConditionalSubpath2(props, other) {
   const $ = _c(3);
-  let x;
+  let t0;
   if ($[0] !== other || $[1] !== props.a) {
-    x = {};
+    const x = {};
     if (identity(other)) {
       x.a = props.a;
     }
 
+    t0 = x;
     x.b = props.a.b;
     $[0] = other;
     $[1] = props.a;
-    $[2] = x;
+    $[2] = t0;
   } else {
-    x = $[2];
+    t0 = $[2];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/superpath-order2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/superpath-order2.expect.md
@@ -47,21 +47,22 @@ import { identity } from "shared-runtime";
 function useConditionalSuperpath2(t0) {
   const $ = _c(3);
   const { props, cond } = t0;
-  let x;
+  let t1;
   if ($[0] !== cond || $[1] !== props.a) {
-    x = {};
+    const x = {};
     if (identity(cond)) {
       x.b = props.a.b;
     }
 
+    t1 = x;
     x.a = props.a;
     $[0] = cond;
     $[1] = props.a;
-    $[2] = x;
+    $[2] = t1;
   } else {
-    x = $[2];
+    t1 = $[2];
   }
-  return x;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/uncond-nonoverlap-descendant.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/uncond-nonoverlap-descendant.expect.md
@@ -26,20 +26,22 @@ import { c as _c } from "react/compiler-runtime"; // Test that we can track non-
 // (not needed for correctness but for dependency granularity)
 function TestNonOverlappingDescendantTracked(props) {
   const $ = _c(4);
-  let x;
+  let t0;
   if ($[0] !== props.a.x.y || $[1] !== props.a.c.x.y.z || $[2] !== props.b) {
-    x = {};
+    const x = {};
     x.a = props.a.x.y;
     x.b = props.b;
+
+    t0 = x;
     x.c = props.a.c.x.y.z;
     $[0] = props.a.x.y;
     $[1] = props.a.c.x.y.z;
     $[2] = props.b;
-    $[3] = x;
+    $[3] = t0;
   } else {
-    x = $[3];
+    t0 = $[3];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/uncond-nonoverlap-direct.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/uncond-nonoverlap-direct.expect.md
@@ -25,18 +25,20 @@ import { c as _c } from "react/compiler-runtime"; // Test that we can track non-
 // (not needed for correctness but for dependency granularity)
 function TestNonOverlappingTracked(props) {
   const $ = _c(3);
-  let x;
+  let t0;
   if ($[0] !== props.a.b || $[1] !== props.a.c) {
-    x = {};
+    const x = {};
     x.b = props.a.b;
+
+    t0 = x;
     x.c = props.a.c;
     $[0] = props.a.b;
     $[1] = props.a.c;
-    $[2] = x;
+    $[2] = t0;
   } else {
-    x = $[2];
+    t0 = $[2];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/uncond-overlap-descendant.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/uncond-overlap-descendant.expect.md
@@ -26,18 +26,20 @@ import { c as _c } from "react/compiler-runtime"; // Test that we correctly trac
 // a dependency
 function TestOverlappingDescendantTracked(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props.a) {
-    x = {};
+    const x = {};
     x.b = props.a.b.c;
     x.c = props.a.b.c.x.y;
+
+    t0 = x;
     x.a = props.a;
     $[0] = props.a;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/uncond-overlap-direct.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/uncond-overlap-direct.expect.md
@@ -26,18 +26,20 @@ import { c as _c } from "react/compiler-runtime"; // Test that we correctly trac
 // a dependency
 function TestOverlappingTracked(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props.a) {
-    x = {};
+    const x = {};
     x.b = props.a.b;
     x.c = props.a.c;
+
+    t0 = x;
     x.a = props.a;
     $[0] = props.a;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/uncond-subpath-order1.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/uncond-subpath-order1.expect.md
@@ -26,18 +26,20 @@ import { c as _c } from "react/compiler-runtime"; // Determine that we only need
 // Ordering of access should not matter
 function TestDepsSubpathOrder1(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props.a) {
-    x = {};
+    const x = {};
     x.b = props.a.b;
     x.a = props.a;
+
+    t0 = x;
     x.c = props.a.b.c;
     $[0] = props.a;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/uncond-subpath-order2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/uncond-subpath-order2.expect.md
@@ -26,18 +26,20 @@ import { c as _c } from "react/compiler-runtime"; // Determine that we only need
 // Ordering of access should not matter
 function TestDepsSubpathOrder2(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props.a) {
-    x = {};
+    const x = {};
     x.a = props.a;
     x.b = props.a.b;
+
+    t0 = x;
     x.c = props.a.b.c;
     $[0] = props.a;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/uncond-subpath-order3.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/uncond-subpath-order3.expect.md
@@ -26,18 +26,20 @@ import { c as _c } from "react/compiler-runtime"; // Determine that we only need
 // Ordering of access should not matter
 function TestDepsSubpathOrder3(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props.a) {
-    x = {};
+    const x = {};
     x.c = props.a.b.c;
     x.a = props.a;
+
+    t0 = x;
     x.b = props.a.b;
     $[0] = props.a;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-duplicate-instruction-from-merge-consecutive-scopes.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-duplicate-instruction-from-merge-consecutive-scopes.expect.md
@@ -29,30 +29,39 @@ import { c as _c } from "react/compiler-runtime";
 import { Stringify } from "shared-runtime";
 
 function Component(t0) {
-  const $ = _c(3);
+  const $ = _c(5);
   const { id } = t0;
-  let t1;
-  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = <Stringify title={undefined} />;
+
+  const t1 = id ? true : false;
+  let t2;
+  if ($[0] !== t1) {
+    t2 = <Stringify title={t1} />;
     $[0] = t1;
-  } else {
-    t1 = $[0];
-  }
-  const t2 = id ? true : false;
-  let t3;
-  if ($[1] !== t2) {
-    t3 = (
-      <>
-        {t1}
-        <Stringify title={t2} />
-      </>
-    );
     $[1] = t2;
+  } else {
+    t2 = $[1];
+  }
+  let t3;
+  if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
+    t3 = <Stringify title={undefined} />;
     $[2] = t3;
   } else {
     t3 = $[2];
   }
-  return t3;
+  let t4;
+  if ($[3] !== t2) {
+    t4 = (
+      <>
+        {t3}
+        {t2}
+      </>
+    );
+    $[3] = t2;
+    $[4] = t4;
+  } else {
+    t4 = $[4];
+  }
+  return t4;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-instruction-part-of-already-closed-scope.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-instruction-part-of-already-closed-scope.expect.md
@@ -35,10 +35,9 @@ import { c as _c } from "react/compiler-runtime"; // @enableAssumeHooksFollowRul
 import { Stringify, identity, useHook } from "shared-runtime";
 
 function Component(t0) {
-  const $ = _c(17);
+  const $ = _c(15);
   const { index } = t0;
   const data = useHook();
-  let T0;
   let t1;
   let t2;
   let t3;
@@ -47,62 +46,60 @@ function Component(t0) {
     const b = identity(data, index);
     const c = identity(data, index);
 
-    const t4 = identity(b);
-    if ($[6] !== t4) {
-      t2 = <Stringify value={t4} />;
-      $[6] = t4;
-      $[7] = t2;
-    } else {
-      t2 = $[7];
-    }
-    const t5 = identity(a);
-    if ($[8] !== t5) {
-      t3 = <Stringify value={t5} />;
-      $[8] = t5;
-      $[9] = t3;
-    } else {
-      t3 = $[9];
-    }
-    T0 = Stringify;
+    t3 = identity(b);
+    t2 = identity(a);
     t1 = identity(c);
     $[0] = data;
     $[1] = index;
-    $[2] = T0;
-    $[3] = t1;
-    $[4] = t2;
-    $[5] = t3;
+    $[2] = t1;
+    $[3] = t2;
+    $[4] = t3;
   } else {
-    T0 = $[2];
-    t1 = $[3];
-    t2 = $[4];
-    t3 = $[5];
+    t1 = $[2];
+    t2 = $[3];
+    t3 = $[4];
   }
   let t4;
-  if ($[10] !== T0 || $[11] !== t1) {
-    t4 = <T0 value={t1} />;
-    $[10] = T0;
-    $[11] = t1;
-    $[12] = t4;
+  if ($[5] !== t1) {
+    t4 = <Stringify value={t1} />;
+    $[5] = t1;
+    $[6] = t4;
   } else {
-    t4 = $[12];
+    t4 = $[6];
   }
   let t5;
-  if ($[13] !== t2 || $[14] !== t3 || $[15] !== t4) {
-    t5 = (
+  if ($[7] !== t2) {
+    t5 = <Stringify value={t2} />;
+    $[7] = t2;
+    $[8] = t5;
+  } else {
+    t5 = $[8];
+  }
+  let t6;
+  if ($[9] !== t3) {
+    t6 = <Stringify value={t3} />;
+    $[9] = t3;
+    $[10] = t6;
+  } else {
+    t6 = $[10];
+  }
+  let t7;
+  if ($[11] !== t6 || $[12] !== t5 || $[13] !== t4) {
+    t7 = (
       <div>
-        {t2}
-        {t3}
+        {t6}
+        {t5}
         {t4}
       </div>
     );
-    $[13] = t2;
-    $[14] = t3;
-    $[15] = t4;
-    $[16] = t5;
+    $[11] = t6;
+    $[12] = t5;
+    $[13] = t4;
+    $[14] = t7;
   } else {
-    t5 = $[16];
+    t7 = $[14];
   }
-  return t5;
+  return t7;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-no-value-for-temporary.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-no-value-for-temporary.expect.md
@@ -17,34 +17,30 @@ function Component(listItem, thread) {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function Component(listItem, thread) {
-  const $ = _c(7);
+  const $ = _c(6);
   let t0;
   let t1;
-  let t2;
   if ($[0] !== thread.threadType || $[1] !== listItem) {
     const isFoo = isFooThread(thread.threadType);
-    t1 = useBar;
-    t2 = listItem;
+    t1 = listItem;
     t0 = getBadgeText(listItem, isFoo);
     $[0] = thread.threadType;
     $[1] = listItem;
     $[2] = t0;
     $[3] = t1;
-    $[4] = t2;
   } else {
     t0 = $[2];
     t1 = $[3];
-    t2 = $[4];
   }
-  let t3;
-  if ($[5] !== t0) {
-    t3 = [t0];
-    $[5] = t0;
-    $[6] = t3;
+  let t2;
+  if ($[4] !== t0) {
+    t2 = [t0];
+    $[4] = t0;
+    $[5] = t2;
   } else {
-    t3 = $[6];
+    t2 = $[5];
   }
-  const body = t1(t2, t3);
+  const body = useBar(t1, t2);
   return body;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-separate-scopes-for-divs.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-separate-scopes-for-divs.expect.md
@@ -56,33 +56,33 @@ function Component(t0) {
     t2 = $[1];
   }
   let t3;
-  if ($[2] !== t2) {
-    t3 = <div className={t2} />;
-    $[2] = t2;
+  if ($[2] !== cond) {
+    t3 = cond === false && (
+      <div className={identity(styles.c, DISPLAY ? styles.d : {})} />
+    );
+    $[2] = cond;
     $[3] = t3;
   } else {
     t3 = $[3];
   }
   let t4;
-  if ($[4] !== cond) {
-    t4 = cond === false && (
-      <div className={identity(styles.c, DISPLAY ? styles.d : {})} />
-    );
-    $[4] = cond;
+  if ($[4] !== t2) {
+    t4 = <div className={t2} />;
+    $[4] = t2;
     $[5] = t4;
   } else {
     t4 = $[5];
   }
   let t5;
-  if ($[6] !== t3 || $[7] !== t4) {
+  if ($[6] !== t4 || $[7] !== t3) {
     t5 = (
       <>
-        {t3}
         {t4}
+        {t3}
       </>
     );
-    $[6] = t3;
-    $[7] = t4;
+    $[6] = t4;
+    $[7] = t3;
     $[8] = t5;
   } else {
     t5 = $[8];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/simple-alias.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/simple-alias.expect.md
@@ -24,21 +24,23 @@ function mutate() {}
 function foo() {
   const $ = _c(2);
   let a;
-  let c;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     let b = {};
-    c = {};
+    let c = {};
     a = b;
     b = c;
     c = a;
+
+    t0 = c;
     mutate(a, b);
-    $[0] = c;
+    $[0] = t0;
     $[1] = a;
   } else {
-    c = $[0];
+    t0 = $[0];
     a = $[1];
   }
-  return c;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-cascading-eliminated-phis.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-cascading-eliminated-phis.expect.md
@@ -33,9 +33,9 @@ import { c as _c } from "react/compiler-runtime";
 function Component(props) {
   const $ = _c(4);
   let x = 0;
-  let values;
+  let t0;
   if ($[0] !== props || $[1] !== x) {
-    values = [];
+    const values = [];
     const y = props.a || props.b;
     values.push(y);
     if (props.c) {
@@ -47,16 +47,17 @@ function Component(props) {
       x = 2;
     }
 
+    t0 = values;
     values.push(x);
     $[0] = props;
     $[1] = x;
-    $[2] = values;
+    $[2] = t0;
     $[3] = x;
   } else {
-    values = $[2];
+    t0 = $[2];
     x = $[3];
   }
-  return values;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property-alias-alias-mutate-if.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property-alias-alias-mutate-if.expect.md
@@ -24,10 +24,10 @@ function foo(a) {
 import { c as _c } from "react/compiler-runtime";
 function foo(a) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== a) {
     const b = {};
-    x = b;
+    const x = b;
     if (a) {
       const y = {};
       x.y = y;
@@ -36,13 +36,14 @@ function foo(a) {
       x.z = z;
     }
 
+    t0 = x;
     mutate(b);
     $[0] = a;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property-alias-mutate-if.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property-alias-mutate-if.expect.md
@@ -23,9 +23,9 @@ function foo(a) {
 import { c as _c } from "react/compiler-runtime";
 function foo(a) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== a) {
-    x = {};
+    const x = {};
     if (a) {
       const y = {};
       x.y = y;
@@ -34,13 +34,14 @@ function foo(a) {
       x.z = z;
     }
 
+    t0 = x;
     mutate(x);
     $[0] = a;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property-alias-mutate.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property-alias-mutate.expect.md
@@ -21,20 +21,21 @@ function foo() {
 import { c as _c } from "react/compiler-runtime";
 function foo() {
   const $ = _c(1);
-  let y;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     const a = {};
     const x = a;
 
-    y = {};
-    y.x = x;
+    const y = {};
 
+    t0 = y;
+    y.x = x;
     mutate(a);
-    $[0] = y;
+    $[0] = t0;
   } else {
-    y = $[0];
+    t0 = $[0];
   }
-  return y;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property-call.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property-call.expect.md
@@ -23,16 +23,18 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function foo() {
   const $ = _c(1);
-  let y;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     const x = [];
-    y = { x };
+    const y = { x };
+
+    t0 = y;
     y.x.push([]);
-    $[0] = y;
+    $[0] = t0;
   } else {
-    y = $[0];
+    t0 = $[0];
   }
-  return y;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property-mutate-2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property-mutate-2.expect.md
@@ -18,17 +18,19 @@ function foo() {
 import { c as _c } from "react/compiler-runtime";
 function foo() {
   const $ = _c(1);
-  let y;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     const x = [];
-    y = {};
+    const y = {};
+
+    t0 = y;
     y.x = x;
     mutate(x);
-    $[0] = y;
+    $[0] = t0;
   } else {
-    y = $[0];
+    t0 = $[0];
   }
-  return y;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property-mutate-alias.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property-mutate-alias.expect.md
@@ -21,20 +21,20 @@ function foo() {
 import { c as _c } from "react/compiler-runtime";
 function foo() {
   const $ = _c(1);
-  let y;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     const a = {};
-    y = a;
+    const y = a;
     const x = [];
 
+    t0 = y;
     y.x = x;
-
     mutate(a);
-    $[0] = y;
+    $[0] = t0;
   } else {
-    y = $[0];
+    t0 = $[0];
   }
-  return y;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property-mutate.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property-mutate.expect.md
@@ -18,17 +18,19 @@ function foo() {
 import { c as _c } from "react/compiler-runtime";
 function foo() {
   const $ = _c(1);
-  let y;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     const x = [];
-    y = {};
+    const y = {};
     y.x = x;
+
+    t0 = y;
     mutate(y);
-    $[0] = y;
+    $[0] = t0;
   } else {
-    y = $[0];
+    t0 = $[0];
   }
-  return y;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-property.expect.md
@@ -23,16 +23,18 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 function foo() {
   const $ = _c(1);
-  let y;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     const x = [];
-    y = {};
+    const y = {};
+
+    t0 = y;
     y.x = x;
-    $[0] = y;
+    $[0] = t0;
   } else {
-    y = $[0];
+    t0 = $[0];
   }
-  return y;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-renaming-ternary-destruction-with-mutation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-renaming-ternary-destruction-with-mutation.expect.md
@@ -18,18 +18,20 @@ function foo(props) {
 import { c as _c } from "react/compiler-runtime";
 function foo(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props) {
-    x = [];
+    let x = [];
     x.push(props.bar);
     props.cond ? (([x] = [[]]), x.push(props.foo)) : null;
+
+    t0 = x;
     mut(x);
     $[0] = props;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-renaming-ternary-with-mutation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-renaming-ternary-with-mutation.expect.md
@@ -18,18 +18,20 @@ function foo(props) {
 import { c as _c } from "react/compiler-runtime";
 function foo(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props) {
-    x = [];
+    let x = [];
     x.push(props.bar);
     props.cond ? ((x = []), x.push(props.foo)) : null;
+
+    t0 = x;
     mut(x);
     $[0] = props;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-renaming-unconditional-ternary-with-mutation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-renaming-unconditional-ternary-with-mutation.expect.md
@@ -32,18 +32,20 @@ import { c as _c } from "react/compiler-runtime";
 import { arrayPush } from "shared-runtime";
 function foo(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props) {
-    x = [];
+    let x = [];
     x.push(props.bar);
     props.cond ? ((x = []), x.push(props.foo)) : ((x = []), x.push(props.bar));
+
+    t0 = x;
     arrayPush(x, 4);
     $[0] = props;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-renaming-unconditional-with-mutation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-renaming-unconditional-with-mutation.expect.md
@@ -26,9 +26,9 @@ function foo(props) {
 import { c as _c } from "react/compiler-runtime";
 function foo(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props) {
-    x = [];
+    let x = [];
     x.push(props.bar);
     if (props.cond) {
       x = [];
@@ -38,13 +38,14 @@ function foo(props) {
       x.push(props.bar);
     }
 
+    t0 = x;
     mut(x);
     $[0] = props;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-renaming-via-destructuring-with-mutation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-renaming-via-destructuring-with-mutation.expect.md
@@ -22,22 +22,23 @@ function foo(props) {
 import { c as _c } from "react/compiler-runtime";
 function foo(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props) {
-    ({ x } = { x: [] });
+    let { x } = { x: [] };
     x.push(props.bar);
     if (props.cond) {
       ({ x } = { x: [] });
       x.push(props.foo);
     }
 
+    t0 = x;
     mut(x);
     $[0] = props;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-renaming-with-mutation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-renaming-with-mutation.expect.md
@@ -22,22 +22,23 @@ function foo(props) {
 import { c as _c } from "react/compiler-runtime";
 function foo(props) {
   const $ = _c(2);
-  let x;
+  let t0;
   if ($[0] !== props) {
-    x = [];
+    let x = [];
     x.push(props.bar);
     if (props.cond) {
       x = [];
       x.push(props.foo);
     }
 
+    t0 = x;
     mut(x);
     $[0] = props;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/store-via-call.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/store-via-call.expect.md
@@ -17,16 +17,18 @@ function foo() {
 import { c as _c } from "react/compiler-runtime";
 function foo() {
   const $ = _c(1);
-  let x;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    x = {};
+    const x = {};
+
+    t0 = x;
     const y = foo(x);
     y.mutate();
-    $[0] = x;
+    $[0] = t0;
   } else {
-    x = $[0];
+    t0 = $[0];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/store-via-new.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/store-via-new.expect.md
@@ -17,16 +17,18 @@ function Foo() {
 import { c as _c } from "react/compiler-runtime";
 function Foo() {
   const $ = _c(1);
-  let x;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    x = {};
+    const x = {};
+
+    t0 = x;
     const y = new Foo(x);
     y.mutate();
-    $[0] = x;
+    $[0] = t0;
   } else {
-    x = $[0];
+    t0 = $[0];
   }
-  return x;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-alias-try-values.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-alias-try-values.expect.md
@@ -33,24 +33,25 @@ const { throwInput } = require("shared-runtime");
 
 function Component(props) {
   const $ = _c(1);
-  let x;
+  let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     let y;
-    x = [];
+    const x = [];
     try {
       throwInput(x);
-    } catch (t0) {
-      const e = t0;
+    } catch (t1) {
+      const e = t1;
 
       y = e;
     }
 
+    t0 = x;
     y.push(null);
-    $[0] = x;
+    $[0] = t0;
   } else {
-    x = $[0];
+    t0 = $[0];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-in-nested-scope.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-in-nested-scope.expect.md
@@ -42,12 +42,12 @@ import { mutate, setProperty, throwErrorWithMessageIf } from "shared-runtime";
 function useFoo(t0) {
   const $ = _c(6);
   const { value, cond } = t0;
-  let y;
   let t1;
+  let t2;
   if ($[0] !== value || $[1] !== cond) {
-    t1 = Symbol.for("react.early_return_sentinel");
+    t2 = Symbol.for("react.early_return_sentinel");
     bb0: {
-      y = [value];
+      const y = [value];
       let x;
       if ($[4] !== cond) {
         x = { cond };
@@ -56,7 +56,7 @@ function useFoo(t0) {
           throwErrorWithMessageIf(x.cond, "error");
         } catch {
           setProperty(x, "henderson");
-          t1 = x;
+          t2 = x;
           break bb0;
         }
 
@@ -66,20 +66,22 @@ function useFoo(t0) {
       } else {
         x = $[5];
       }
+
+      t1 = y;
       y.push(x);
     }
     $[0] = value;
     $[1] = cond;
-    $[2] = y;
-    $[3] = t1;
+    $[2] = t1;
+    $[3] = t2;
   } else {
-    y = $[2];
-    t1 = $[3];
+    t1 = $[2];
+    t2 = $[3];
   }
-  if (t1 !== Symbol.for("react.early_return_sentinel")) {
-    return t1;
+  if (t2 !== Symbol.for("react.early_return_sentinel")) {
+    return t2;
   }
-  return y;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-within-mutable-range.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-within-mutable-range.expect.md
@@ -30,36 +30,37 @@ const { throwErrorWithMessage, shallowCopy } = require("shared-runtime");
 
 function Component(props) {
   const $ = _c(4);
-  let x;
+  let t0;
   if ($[0] !== props.value) {
-    x = [];
+    const x = [];
     try {
-      let t0;
+      let t1;
       if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
-        t0 = throwErrorWithMessage("oops");
-        $[2] = t0;
+        t1 = throwErrorWithMessage("oops");
+        $[2] = t1;
       } else {
-        t0 = $[2];
+        t1 = $[2];
       }
-      x.push(t0);
+      x.push(t1);
     } catch {
-      let t0;
+      let t1;
       if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
-        t0 = shallowCopy({});
-        $[3] = t0;
+        t1 = shallowCopy({});
+        $[3] = t1;
       } else {
-        t0 = $[3];
+        t1 = $[3];
       }
-      x.push(t0);
+      x.push(t1);
     }
 
+    t0 = x;
     x.push(props.value);
     $[0] = props.value;
-    $[1] = x;
+    $[1] = t0;
   } else {
-    x = $[1];
+    t0 = $[1];
   }
-  return x;
+  return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useEffect-arg-memoized.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useEffect-arg-memoized.expect.md
@@ -27,42 +27,42 @@ function Component(props) {
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
   const $ = _c(6);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = <div />;
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
   const dispatch = useDispatch();
   useFreeze(dispatch);
-  let t0;
-  if ($[0] !== dispatch) {
-    t0 = () => {
+  let t1;
+  if ($[1] !== dispatch) {
+    t1 = () => {
       dispatch({ kind: "update" });
     };
-    $[0] = dispatch;
-    $[1] = t0;
+    $[1] = dispatch;
+    $[2] = t1;
   } else {
-    t0 = $[1];
+    t1 = $[2];
   }
-  const onUpdate = t0;
-  let t1;
+  const onUpdate = t1;
   let t2;
-  if ($[2] !== onUpdate) {
-    t1 = () => {
+  let t3;
+  if ($[3] !== onUpdate) {
+    t2 = () => {
       onUpdate();
     };
-    t2 = [onUpdate];
-    $[2] = onUpdate;
-    $[3] = t1;
+    t3 = [onUpdate];
+    $[3] = onUpdate;
     $[4] = t2;
-  } else {
-    t1 = $[3];
-    t2 = $[4];
-  }
-  useEffect(t1, t2);
-  let t3;
-  if ($[5] === Symbol.for("react.memo_cache_sentinel")) {
-    t3 = <div />;
     $[5] = t3;
   } else {
+    t2 = $[4];
     t3 = $[5];
   }
-  return t3;
+  useEffect(t2, t3);
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useEffect-nested-lambdas.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useEffect-nested-lambdas.expect.md
@@ -36,23 +36,30 @@ import { c as _c } from "react/compiler-runtime"; // @enableTransitivelyFreezeFu
 
 function Component(props) {
   const $ = _c(9);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = <div />;
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
   const item = useMutable(props.itemId);
   const dispatch = useDispatch();
   useFreeze(dispatch);
-  let t0;
-  if ($[0] !== dispatch) {
-    t0 = () => {
+  let t1;
+  if ($[1] !== dispatch) {
+    t1 = () => {
       dispatch(createExitAction());
     };
-    $[0] = dispatch;
-    $[1] = t0;
+    $[1] = dispatch;
+    $[2] = t1;
   } else {
-    t0 = $[1];
+    t1 = $[2];
   }
-  const exit = t0;
-  let t1;
-  if ($[2] !== item.value || $[3] !== exit) {
-    t1 = () => {
+  const exit = t1;
+  let t2;
+  if ($[3] !== item.value || $[4] !== exit) {
+    t2 = () => {
       const cleanup = GlobalEventEmitter.addListener("onInput", () => {
         if (item.value) {
           exit();
@@ -60,32 +67,24 @@ function Component(props) {
       });
       return () => cleanup.remove();
     };
-    $[2] = item.value;
-    $[3] = exit;
-    $[4] = t1;
+    $[3] = item.value;
+    $[4] = exit;
+    $[5] = t2;
   } else {
-    t1 = $[4];
+    t2 = $[5];
   }
-  let t2;
-  if ($[5] !== exit || $[6] !== item) {
-    t2 = [exit, item];
-    $[5] = exit;
-    $[6] = item;
-    $[7] = t2;
-  } else {
-    t2 = $[7];
-  }
-  useEffect(t1, t2);
-
-  maybeMutate(item);
   let t3;
-  if ($[8] === Symbol.for("react.memo_cache_sentinel")) {
-    t3 = <div />;
+  if ($[6] !== exit || $[7] !== item) {
+    t3 = [exit, item];
+    $[6] = exit;
+    $[7] = item;
     $[8] = t3;
   } else {
     t3 = $[8];
   }
-  return t3;
+  useEffect(t2, t3);
+  maybeMutate(item);
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-maybe-modified-later-dont-preserve-memoization-guarantees.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-maybe-modified-later-dont-preserve-memoization-guarantees.expect.md
@@ -29,18 +29,20 @@ import { identity, makeObject_Primitives, mutate } from "shared-runtime";
 function Component(props) {
   const $ = _c(2);
   let t0;
-  let object;
+  let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t0 = makeObject_Primitives();
-    object = t0;
+    const object = t0;
+
+    t1 = object;
     identity(object);
-    $[0] = object;
+    $[0] = t1;
     $[1] = t0;
   } else {
-    object = $[0];
+    t1 = $[0];
     t0 = $[1];
   }
-  return object;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/validate-no-set-state-in-render-uncalled-function-with-mutable-range-is-valid.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/validate-no-set-state-in-render-uncalled-function-with-mutable-range-is-valid.expect.md
@@ -80,7 +80,6 @@ function Component(props) {
       return t2;
     }
     default: {
-      logEvent("Invalid step");
       let t1;
       if ($[6] === Symbol.for("react.memo_cache_sentinel")) {
         t1 = <OtherComponent data={null} />;
@@ -88,6 +87,7 @@ function Component(props) {
       } else {
         t1 = $[6];
       }
+      logEvent("Invalid step");
       return t1;
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #29998
* __->__ #29883
* #29882

In #29863 I tried to find a clean way to share code for emitting instructions between value blocks and regular blocks. The catch is that value blocks have special meaning for their final instruction — that's the value of the block — so reordering can't change the last instruction. However, in finding a clean way to share code for these two categories of code, i also inadvertently reduced the effectiveness of the optimization.

This PR updates to use different strategies for these two kinds of blocks: value blocks use the code from #29863 where we first emit all non-reorderable instructions in their original order, _then_ try to emit reorderable values. The reason this is suboptimal, though, is that we want to move instructions closer to their dependencies so that they can invalidate (merge) together. Emitting the reorderable values last prevents this.

So for normal blocks, we now emit terminal operands first. This will invariably cause _some_ of the non-reorderable instructions to be emitted, but it will intersperse reoderable instructions in between, right after their dependencies. This maximizes our ability to merge scopes.

I think the complexity cost of two strategies is worth the benefit, though i still need to double-check all the output changes.