### PR TITLE
Use a constant HostContext in prod builds for Fabric renderer

### DIFF
--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -132,6 +132,8 @@ export function appendInitialChild(
   appendChildNode(parentInstance.node, child.node);
 }
 
+const PROD_HOST_CONTEXT: HostContext = {isInAParentText: true};
+
 export function createInstance(
   type: string,
   props: Props,
@@ -220,29 +222,35 @@ export function finalizeInitialChildren(
 export function getRootHostContext(
   rootContainerInstance: Container,
 ): HostContext {
-  return {isInAParentText: false};
+  if (__DEV__) {
+    return {isInAParentText: false};
+  }
+
+  return PROD_HOST_CONTEXT;
 }
 
 export function getChildHostContext(
   parentHostContext: HostContext,
   type: string,
 ): HostContext {
-  const prevIsInAParentText = parentHostContext.isInAParentText;
-  const isInAParentText =
-    type === 'AndroidTextInput' || // Android
-    type === 'RCTMultilineTextInputView' || // iOS
-    type === 'RCTSinglelineTextInputView' || // iOS
-    type === 'RCTText' ||
-    type === 'RCTVirtualText';
+  if (__DEV__) {
+    const prevIsInAParentText = parentHostContext.isInAParentText;
+    const isInAParentText =
+      type === 'AndroidTextInput' || // Android
+      type === 'RCTMultilineTextInputView' || // iOS
+      type === 'RCTSinglelineTextInputView' || // iOS
+      type === 'RCTText' ||
+      type === 'RCTVirtualText';
 
-  // TODO: If this is an offscreen host container, we should reuse the
-  // parent context.
+    // TODO: If this is an offscreen host container, we should reuse the
+    // parent context.
 
-  if (prevIsInAParentText !== isInAParentText) {
-    return {isInAParentText};
-  } else {
-    return parentHostContext;
+    if (prevIsInAParentText !== isInAParentText) {
+      return {isInAParentText};
+    }
   }
+
+  return parentHostContext;
 }
 
 export function getPublicInstance(instance: Instance): null | PublicInstance {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

In the Fabric renderer in React Native, we only use the HostContext to issue soft errors in __DEV__ bundles when attempting to add a raw text child to a node that may not support them. Moving the logic to set this context to __DEV__ bundles only unblocks more expensive methods for resolving whether a parent context supports raw text children, like resolving this information from `getViewConfigForType`.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

yarn test (--prod)