### PR TITLE
Prepare Feature Flags for React Native 0.75

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -31,75 +31,66 @@ export const {
 } = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.
+export const allowConcurrentByDefault = false;
+export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
+export const disableClientCache = true;
+export const disableCommentsAsDOMContainers = true;
+export const disableIEWorkarounds = true;
+export const disableInputAttributeSyncing = false;
+export const disableLegacyContext = false;
+export const disableLegacyMode = false;
+export const disableSchedulerTimeoutInWorkLoop = false;
+export const disableStringRefs = true;
+export const disableTextareaChildren = false;
 export const enableAsyncActions = true;
-export const enableDebugTracing = false;
 export const enableAsyncDebugInfo = false;
-export const enableRenderableContext = true;
-export const enableSchedulingProfiler = __PROFILE__;
-export const enableProfilerTimer = __PROFILE__;
-export const enableProfilerCommitHooks = __PROFILE__;
-export const enableProfilerNestedUpdatePhase = __PROFILE__;
-export const enableUpdaterTracking = __PROFILE__;
-export const enableUnifiedSyncLane = true;
+export const enableAsyncIterableChildren = false;
+export const enableBinaryFlight = true;
 export const enableCache = true;
 export const enableComponentStackLocations = true;
-export const enableLegacyCache = false;
-export const enableBinaryFlight = true;
-export const enableFlightReadableStream = true;
-export const enableAsyncIterableChildren = false;
-export const enableTaint = true;
-export const enablePostpone = false;
-export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
-export const disableCommentsAsDOMContainers = true;
-export const disableInputAttributeSyncing = false;
-export const disableIEWorkarounds = true;
-export const enableScopeAPI = false;
+export const enableCPUSuspense = true;
 export const enableCreateEventHandleAPI = false;
-export const enableSuspenseCallback = false;
-export const disableLegacyContext = false;
-export const enableTrustedTypesIntegration = false;
-export const disableTextareaChildren = false;
+export const enableDebugTracing = false;
+export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
+export const enableFilterEmptyStringAttributesDOM = true;
+export const enableFizzExternalRuntime = true;
+export const enableFlightReadableStream = true;
+export const enableGetInspectorDataForInstanceInProduction = true;
+export const enableLazyContextPropagation = false;
+export const enableLegacyCache = false;
+export const enableLegacyFBSupport = false;
+export const enableLegacyHidden = false;
+export const enableNoCloningMemoCache = false;
+export const enableOwnerStacks = false;
+export const enablePostpone = false;
+export const enableProfilerCommitHooks = __PROFILE__;
+export const enableProfilerNestedUpdatePhase = __PROFILE__;
+export const enableProfilerTimer = __PROFILE__;
+export const enableReactTestRendererWarning = false;
+export const enableRefAsProp = true;
+export const enableRenderableContext = true;
+export const enableRetryLaneExpiration = false;
+export const enableSchedulingProfiler = __PROFILE__;
+export const enableScopeAPI = false;
+export const enableServerComponentLogs = true;
 export const enableSuspenseAvoidThisFallback = false;
 export const enableSuspenseAvoidThisFallbackFizz = false;
-export const enableCPUSuspense = true;
-export const enableUseMemoCacheHook = true;
-export const enableNoCloningMemoCache = false;
+export const enableSuspenseCallback = false;
+export const enableTaint = true;
+export const enableTransitionTracing = false;
+export const enableTrustedTypesIntegration = false;
+export const enableUnifiedSyncLane = true;
+export const enableUpdaterTracking = __PROFILE__;
+export const enableUseDeferredValueInitialArg = true;
 export const enableUseEffectEventHook = false;
+export const enableUseMemoCacheHook = true;
 export const favorSafetyOverHydrationPerf = true;
-export const enableLegacyFBSupport = false;
-export const enableFilterEmptyStringAttributesDOM = true;
-export const enableGetInspectorDataForInstanceInProduction = true;
-export const useModernStrictMode = true;
-
+export const forceConcurrentByDefaultForTesting = false;
 export const renameElementSymbol = false;
-
-export const enableRetryLaneExpiration = false;
 export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;
-
-export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableLazyContextPropagation = false;
-export const enableLegacyHidden = false;
-export const forceConcurrentByDefaultForTesting = false;
-export const allowConcurrentByDefault = false;
-
-export const enableTransitionTracing = false;
-
-export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
-export const enableFizzExternalRuntime = true;
-
-export const enableUseDeferredValueInitialArg = true;
-export const disableClientCache = true;
-
-export const enableServerComponentLogs = true;
-
-export const enableRefAsProp = true;
-export const disableStringRefs = true;
-
-export const enableReactTestRendererWarning = false;
-export const disableLegacyMode = false;
-export const enableOwnerStacks = false;
+export const useModernStrictMode = true;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -12,47 +12,6 @@ import typeof * as ExportsType from './ReactFeatureFlags.native-oss';
 
 // TODO: Align these flags with canary and delete this file once RN ships from Canary.
 
-// -----------------------------------------------------------------------------
-// TODO for next React Native major.
-//
-// Alias __TODO_NEXT_RN_MAJOR__ to false for easier skimming.
-// -----------------------------------------------------------------------------
-const __TODO_NEXT_RN_MAJOR__ = false;
-export const consoleManagedByDevToolsDuringStrictMode = __TODO_NEXT_RN_MAJOR__;
-export const disableStringRefs = __TODO_NEXT_RN_MAJOR__;
-export const enableAsyncActions = __TODO_NEXT_RN_MAJOR__;
-export const enableComponentStackLocations = __TODO_NEXT_RN_MAJOR__;
-export const enableDeferRootSchedulingToMicrotask = __TODO_NEXT_RN_MAJOR__;
-export const enableFastJSX = __TODO_NEXT_RN_MAJOR__;
-export const enableInfiniteRenderLoopDetection = __TODO_NEXT_RN_MAJOR__;
-export const enableRefAsProp = __TODO_NEXT_RN_MAJOR__;
-export const enableUseDeferredValueInitialArg = __TODO_NEXT_RN_MAJOR__;
-export const useModernStrictMode = __TODO_NEXT_RN_MAJOR__;
-
-// -----------------------------------------------------------------------------
-// These are ready to flip after the next React npm release (or RN switches to
-// Canary, but can't flip before then because of react/renderer mismatches.
-// -----------------------------------------------------------------------------
-export const disableDefaultPropsExceptForClasses = __TODO_NEXT_RN_MAJOR__;
-export const enableCache = __TODO_NEXT_RN_MAJOR__;
-export const enableRenderableContext = __TODO_NEXT_RN_MAJOR__;
-
-// -----------------------------------------------------------------------------
-// Already enabled for next React Native major.
-// Hardcode these to true after the next RN major.
-//
-// Alias __NEXT_RN_MAJOR__ to true for easier skimming.
-// -----------------------------------------------------------------------------
-const __NEXT_RN_MAJOR__ = true;
-export const disableClientCache = __NEXT_RN_MAJOR__;
-export const disableLegacyContext = __NEXT_RN_MAJOR__;
-export const enableBinaryFlight = true;
-export const enableFizzExternalRuntime = __NEXT_RN_MAJOR__; // DOM-only
-export const enableFlightReadableStream = true;
-export const enableServerComponentLogs = __NEXT_RN_MAJOR__;
-export const enableTaint = __NEXT_RN_MAJOR__;
-export const enableUnifiedSyncLane = __NEXT_RN_MAJOR__;
-
 // DEV-only but enabled in the next RN Major.
 // Not supported by flag script to avoid the special case.
 export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
@@ -62,21 +21,35 @@ export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 // -----------------------------------------------------------------------------
 export const allowConcurrentByDefault = false;
 export const alwaysThrottleRetries = false;
+export const consoleManagedByDevToolsDuringStrictMode = true;
+export const disableClientCache = true;
 export const disableCommentsAsDOMContainers = true;
+export const disableDefaultPropsExceptForClasses = true;
 export const disableIEWorkarounds = true;
 export const disableInputAttributeSyncing = false;
+export const disableLegacyContext = true;
 export const disableLegacyMode = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
+export const disableStringRefs = true;
 export const disableTextareaChildren = false;
 export const enableAddPropertiesFastPath = false;
+export const enableAsyncActions = true;
 export const enableAsyncDebugInfo = false;
 export const enableAsyncIterableChildren = false;
+export const enableBinaryFlight = true;
+export const enableCache = true;
+export const enableComponentStackLocations = true;
 export const enableCPUSuspense = false;
 export const enableCreateEventHandleAPI = false;
 export const enableDebugTracing = false;
+export const enableDeferRootSchedulingToMicrotask = true;
 export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
+export const enableFastJSX = true;
 export const enableFilterEmptyStringAttributesDOM = true;
+export const enableFizzExternalRuntime = true;
+export const enableFlightReadableStream = true;
 export const enableGetInspectorDataForInstanceInProduction = false;
+export const enableInfiniteRenderLoopDetection = true;
 export const enableLazyContextPropagation = false;
 export const enableLegacyCache = false;
 export const enableLegacyFBSupport = false;
@@ -85,15 +58,21 @@ export const enableNoCloningMemoCache = false;
 export const enableOwnerStacks = __EXPERIMENTAL__;
 export const enablePostpone = false;
 export const enableReactTestRendererWarning = false;
+export const enableRefAsProp = true;
+export const enableRenderableContext = true;
 export const enableRetryLaneExpiration = false;
 export const enableSchedulingProfiler = __PROFILE__;
 export const enableScopeAPI = false;
+export const enableServerComponentLogs = true;
 export const enableShallowPropDiffing = false;
 export const enableSuspenseAvoidThisFallback = false;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableSuspenseCallback = false;
+export const enableTaint = true;
 export const enableTransitionTracing = false;
 export const enableTrustedTypesIntegration = false;
+export const enableUnifiedSyncLane = true;
+export const enableUseDeferredValueInitialArg = true;
 export const enableUseEffectEventHook = false;
 export const enableUseMemoCacheHook = true;
 export const favorSafetyOverHydrationPerf = true;
@@ -103,6 +82,7 @@ export const renameElementSymbol = true;
 export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;
+export const useModernStrictMode = true;
 
 // Profiling Only
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -21,15 +21,13 @@ const __TODO_NEXT_RN_MAJOR__ = false;
 export const enableRefAsProp = __TODO_NEXT_RN_MAJOR__;
 export const disableStringRefs = __TODO_NEXT_RN_MAJOR__;
 export const enableFastJSX = __TODO_NEXT_RN_MAJOR__;
-export const disableLegacyMode = __TODO_NEXT_RN_MAJOR__;
 export const useModernStrictMode = __TODO_NEXT_RN_MAJOR__;
-export const enableReactTestRendererWarning = __TODO_NEXT_RN_MAJOR__;
 export const enableAsyncActions = __TODO_NEXT_RN_MAJOR__;
 export const consoleManagedByDevToolsDuringStrictMode = __TODO_NEXT_RN_MAJOR__;
 export const enableDeferRootSchedulingToMicrotask = __TODO_NEXT_RN_MAJOR__;
-export const alwaysThrottleRetries = __TODO_NEXT_RN_MAJOR__;
 export const enableInfiniteRenderLoopDetection = __TODO_NEXT_RN_MAJOR__;
 export const enableComponentStackLocations = __TODO_NEXT_RN_MAJOR__;
+export const enableUseDeferredValueInitialArg = __TODO_NEXT_RN_MAJOR__;
 
 // -----------------------------------------------------------------------------
 // These are ready to flip after the next React npm release (or RN switches to
@@ -59,25 +57,25 @@ export const enableServerComponentLogs = __NEXT_RN_MAJOR__;
 // Not supported by flag script to avoid the special case.
 export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 
-// TODO: decide on React 19
-export const enableUseMemoCacheHook = true;
-export const enableNoCloningMemoCache = false;
-export const enableUseDeferredValueInitialArg = __EXPERIMENTAL__;
-
 // -----------------------------------------------------------------------------
 // All other flags
 // -----------------------------------------------------------------------------
+export const alwaysThrottleRetries = false;
 export const enableCPUSuspense = false;
 export const enableDebugTracing = false;
 export const enableAsyncDebugInfo = false;
 export const enableSchedulingProfiler = __PROFILE__;
 export const enableLegacyCache = false;
+export const enableNoCloningMemoCache = false;
 export const enablePostpone = false;
+export const enableUseMemoCacheHook = true;
 export const disableCommentsAsDOMContainers = true;
 export const disableInputAttributeSyncing = false;
 export const disableIEWorkarounds = true;
+export const disableLegacyMode = false;
 export const enableScopeAPI = false;
 export const enableCreateEventHandleAPI = false;
+export const enableReactTestRendererWarning = false;
 export const enableSuspenseCallback = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -18,24 +18,24 @@ import typeof * as ExportsType from './ReactFeatureFlags.native-oss';
 // Alias __TODO_NEXT_RN_MAJOR__ to false for easier skimming.
 // -----------------------------------------------------------------------------
 const __TODO_NEXT_RN_MAJOR__ = false;
-export const enableRefAsProp = __TODO_NEXT_RN_MAJOR__;
-export const disableStringRefs = __TODO_NEXT_RN_MAJOR__;
-export const enableFastJSX = __TODO_NEXT_RN_MAJOR__;
-export const useModernStrictMode = __TODO_NEXT_RN_MAJOR__;
-export const enableAsyncActions = __TODO_NEXT_RN_MAJOR__;
 export const consoleManagedByDevToolsDuringStrictMode = __TODO_NEXT_RN_MAJOR__;
-export const enableDeferRootSchedulingToMicrotask = __TODO_NEXT_RN_MAJOR__;
-export const enableInfiniteRenderLoopDetection = __TODO_NEXT_RN_MAJOR__;
+export const disableStringRefs = __TODO_NEXT_RN_MAJOR__;
+export const enableAsyncActions = __TODO_NEXT_RN_MAJOR__;
 export const enableComponentStackLocations = __TODO_NEXT_RN_MAJOR__;
+export const enableDeferRootSchedulingToMicrotask = __TODO_NEXT_RN_MAJOR__;
+export const enableFastJSX = __TODO_NEXT_RN_MAJOR__;
+export const enableInfiniteRenderLoopDetection = __TODO_NEXT_RN_MAJOR__;
+export const enableRefAsProp = __TODO_NEXT_RN_MAJOR__;
 export const enableUseDeferredValueInitialArg = __TODO_NEXT_RN_MAJOR__;
+export const useModernStrictMode = __TODO_NEXT_RN_MAJOR__;
 
 // -----------------------------------------------------------------------------
 // These are ready to flip after the next React npm release (or RN switches to
 // Canary, but can't flip before then because of react/renderer mismatches.
 // -----------------------------------------------------------------------------
+export const disableDefaultPropsExceptForClasses = __TODO_NEXT_RN_MAJOR__;
 export const enableCache = __TODO_NEXT_RN_MAJOR__;
 export const enableRenderableContext = __TODO_NEXT_RN_MAJOR__;
-export const disableDefaultPropsExceptForClasses = __TODO_NEXT_RN_MAJOR__;
 
 // -----------------------------------------------------------------------------
 // Already enabled for next React Native major.
@@ -46,12 +46,12 @@ export const disableDefaultPropsExceptForClasses = __TODO_NEXT_RN_MAJOR__;
 const __NEXT_RN_MAJOR__ = true;
 export const disableClientCache = __NEXT_RN_MAJOR__;
 export const disableLegacyContext = __NEXT_RN_MAJOR__;
-export const enableTaint = __NEXT_RN_MAJOR__;
-export const enableUnifiedSyncLane = __NEXT_RN_MAJOR__;
-export const enableFizzExternalRuntime = __NEXT_RN_MAJOR__; // DOM-only
 export const enableBinaryFlight = true;
+export const enableFizzExternalRuntime = __NEXT_RN_MAJOR__; // DOM-only
 export const enableFlightReadableStream = true;
 export const enableServerComponentLogs = __NEXT_RN_MAJOR__;
+export const enableTaint = __NEXT_RN_MAJOR__;
+export const enableUnifiedSyncLane = __NEXT_RN_MAJOR__;
 
 // DEV-only but enabled in the next RN Major.
 // Not supported by flag script to avoid the special case.
@@ -60,50 +60,49 @@ export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 // -----------------------------------------------------------------------------
 // All other flags
 // -----------------------------------------------------------------------------
+export const allowConcurrentByDefault = false;
 export const alwaysThrottleRetries = false;
-export const enableCPUSuspense = false;
-export const enableDebugTracing = false;
-export const enableAsyncDebugInfo = false;
-export const enableSchedulingProfiler = __PROFILE__;
-export const enableLegacyCache = false;
-export const enableNoCloningMemoCache = false;
-export const enablePostpone = false;
-export const enableUseMemoCacheHook = true;
 export const disableCommentsAsDOMContainers = true;
-export const disableInputAttributeSyncing = false;
 export const disableIEWorkarounds = true;
+export const disableInputAttributeSyncing = false;
 export const disableLegacyMode = false;
-export const enableScopeAPI = false;
-export const enableCreateEventHandleAPI = false;
-export const enableReactTestRendererWarning = false;
-export const enableSuspenseCallback = false;
-export const enableTrustedTypesIntegration = false;
+export const disableSchedulerTimeoutInWorkLoop = false;
 export const disableTextareaChildren = false;
-export const enableSuspenseAvoidThisFallback = false;
-export const enableSuspenseAvoidThisFallbackFizz = false;
-export const enableUseEffectEventHook = false;
-export const favorSafetyOverHydrationPerf = true;
-export const enableLegacyFBSupport = false;
+export const enableAddPropertiesFastPath = false;
+export const enableAsyncDebugInfo = false;
+export const enableAsyncIterableChildren = false;
+export const enableCPUSuspense = false;
+export const enableCreateEventHandleAPI = false;
+export const enableDebugTracing = false;
+export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
 export const enableFilterEmptyStringAttributesDOM = true;
 export const enableGetInspectorDataForInstanceInProduction = false;
+export const enableLazyContextPropagation = false;
+export const enableLegacyCache = false;
+export const enableLegacyFBSupport = false;
+export const enableLegacyHidden = false;
+export const enableNoCloningMemoCache = false;
+export const enableOwnerStacks = __EXPERIMENTAL__;
+export const enablePostpone = false;
+export const enableReactTestRendererWarning = false;
 export const enableRetryLaneExpiration = false;
+export const enableSchedulingProfiler = __PROFILE__;
+export const enableScopeAPI = false;
+export const enableShallowPropDiffing = false;
+export const enableSuspenseAvoidThisFallback = false;
+export const enableSuspenseAvoidThisFallbackFizz = false;
+export const enableSuspenseCallback = false;
+export const enableTransitionTracing = false;
+export const enableTrustedTypesIntegration = false;
+export const enableUseEffectEventHook = false;
+export const enableUseMemoCacheHook = true;
+export const favorSafetyOverHydrationPerf = true;
+export const forceConcurrentByDefaultForTesting = false;
+export const passChildrenWhenCloningPersistedNodes = false;
+export const renameElementSymbol = true;
 export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;
-export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableLazyContextPropagation = false;
-export const enableLegacyHidden = false;
-export const forceConcurrentByDefaultForTesting = false;
-export const allowConcurrentByDefault = false;
-export const enableTransitionTracing = false;
-export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
-export const passChildrenWhenCloningPersistedNodes = false;
-export const enableAsyncIterableChildren = false;
-export const enableAddPropertiesFastPath = false;
-export const enableShallowPropDiffing = false;
-export const renameElementSymbol = true;
-
-export const enableOwnerStacks = __EXPERIMENTAL__;
 
 // Profiling Only
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -10,89 +10,75 @@
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as ExportsType from './ReactFeatureFlags.test-renderer';
 
+export const allowConcurrentByDefault = true;
+export const alwaysThrottleRetries = false;
+export const consoleManagedByDevToolsDuringStrictMode = false;
 export const debugRenderPhaseSideEffectsForStrictMode = false;
-export const enableDebugTracing = false;
+export const disableClientCache = true;
+export const disableCommentsAsDOMContainers = true;
+export const disableDefaultPropsExceptForClasses = false;
+export const disableIEWorkarounds = true;
+export const disableInputAttributeSyncing = false;
+export const disableLegacyContext = false;
+export const disableLegacyMode = false;
+export const disableSchedulerTimeoutInWorkLoop = false;
+export const disableStringRefs = true;
+export const disableTextareaChildren = false;
+export const enableAddPropertiesFastPath = false;
+export const enableAsyncActions = true;
 export const enableAsyncDebugInfo = false;
-export const enableSchedulingProfiler = __PROFILE__;
-export const enableProfilerTimer = __PROFILE__;
+export const enableAsyncIterableChildren = false;
+export const enableBinaryFlight = true;
+export const enableCache = true;
+export const enableComponentStackLocations = true;
+export const enableCPUSuspense = true;
+export const enableCreateEventHandleAPI = false;
+export const enableDebugTracing = false;
+export const enableDeferRootSchedulingToMicrotask = false;
+export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
+export const enableFastJSX = true;
+export const enableFilterEmptyStringAttributesDOM = true;
+export const enableFizzExternalRuntime = true;
+export const enableFlightReadableStream = true;
+export const enableGetInspectorDataForInstanceInProduction = false;
+export const enableInfiniteRenderLoopDetection = false;
+export const enableLazyContextPropagation = false;
+export const enableLegacyCache = false;
+export const enableLegacyFBSupport = false;
+export const enableLegacyHidden = false;
+export const enableNoCloningMemoCache = false;
+export const enableOwnerStacks = false;
+export const enablePostpone = false;
 export const enableProfilerCommitHooks = __PROFILE__;
 export const enableProfilerNestedUpdatePhase = __PROFILE__;
-export const enableUpdaterTracking = false;
-export const enableCache = true;
-export const enableLegacyCache = false;
-export const enableBinaryFlight = true;
-export const enableFlightReadableStream = true;
-export const enableAsyncIterableChildren = false;
-export const enableTaint = true;
-export const enablePostpone = false;
-export const disableCommentsAsDOMContainers = true;
-export const disableInputAttributeSyncing = false;
-export const disableIEWorkarounds = true;
+export const enableProfilerTimer = __PROFILE__;
+export const enableReactTestRendererWarning = false;
+export const enableRefAsProp = true;
+export const enableRenderableContext = true;
+export const enableRetryLaneExpiration = false;
+export const enableSchedulingProfiler = __PROFILE__;
 export const enableScopeAPI = false;
-export const enableCreateEventHandleAPI = false;
-export const enableSuspenseCallback = false;
-export const disableLegacyContext = false;
-export const enableTrustedTypesIntegration = false;
-export const disableTextareaChildren = false;
-export const enableComponentStackLocations = true;
-export const enableLegacyFBSupport = false;
-export const enableFilterEmptyStringAttributesDOM = true;
-export const enableGetInspectorDataForInstanceInProduction = false;
+export const enableServerComponentLogs = true;
+export const enableShallowPropDiffing = false;
 export const enableSuspenseAvoidThisFallback = false;
 export const enableSuspenseAvoidThisFallbackFizz = false;
-export const enableCPUSuspense = true;
-export const enableUseMemoCacheHook = true;
-export const enableNoCloningMemoCache = false;
+export const enableSuspenseCallback = false;
+export const enableTaint = true;
+export const enableTransitionTracing = false;
+export const enableTrustedTypesIntegration = false;
+export const enableUnifiedSyncLane = true;
+export const enableUpdaterTracking = false;
+export const enableUseDeferredValueInitialArg = __EXPERIMENTAL__;
 export const enableUseEffectEventHook = false;
+export const enableUseMemoCacheHook = true;
 export const favorSafetyOverHydrationPerf = true;
-export const enableInfiniteRenderLoopDetection = false;
-export const enableRenderableContext = true;
-
-export const enableRetryLaneExpiration = false;
+export const forceConcurrentByDefaultForTesting = false;
+export const passChildrenWhenCloningPersistedNodes = false;
+export const renameElementSymbol = false;
 export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;
-
-export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableLazyContextPropagation = false;
-export const enableLegacyHidden = false;
-export const forceConcurrentByDefaultForTesting = false;
-export const enableUnifiedSyncLane = true;
-export const allowConcurrentByDefault = true;
-
-export const consoleManagedByDevToolsDuringStrictMode = false;
-
-export const enableTransitionTracing = false;
-
 export const useModernStrictMode = true;
-export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
-export const enableFizzExternalRuntime = true;
-export const enableDeferRootSchedulingToMicrotask = false;
-
-export const enableAsyncActions = true;
-
-export const alwaysThrottleRetries = false;
-
-export const passChildrenWhenCloningPersistedNodes = false;
-export const enableUseDeferredValueInitialArg = __EXPERIMENTAL__;
-export const disableClientCache = true;
-
-export const enableServerComponentLogs = true;
-
-export const enableRefAsProp = true;
-export const disableStringRefs = true;
-export const enableFastJSX = true;
-
-export const enableReactTestRendererWarning = false;
-export const disableLegacyMode = false;
-
-export const disableDefaultPropsExceptForClasses = false;
-export const enableAddPropertiesFastPath = false;
-
-export const renameElementSymbol = false;
-
-export const enableOwnerStacks = false;
-export const enableShallowPropDiffing = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);


### PR DESCRIPTION
## Summary

Configures the React Native open source feature flags in preparation for React Native 0.75, which will be upgraded to React 19.

## How did you test this change?

```
$ yarn test
$ yarn flow fabric
```