### PR TITLE
[compiler] Treat ref-like named objects as refs

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -407,6 +407,23 @@ const EnvironmentConfigSchema = z.object({
    * and identifiers have been changed.
    */
   hookPattern: z.string().nullable().default(null),
+
+  /**
+   * If enabled, this will treat objects named as `ref` or if their names end with the substring `Ref`,
+   * and contain a property named `current`, as React refs.
+   *
+   * ```
+   * const ref = useMyRef();
+   * const myRef = useMyRef2();
+   * useEffect(() => {
+   *   ref.current = ...;
+   *   myRef.current = ...;
+   * })
+   * ```
+   *
+   * Here the variables `ref` and `myRef` will be typed as Refs.
+   */
+  enableTreatRefLikeIdentifiersAsRefs: z.boolean().nullable().default(false),
 });
 
 export type EnvironmentConfig = z.infer<typeof EnvironmentConfigSchema>;

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Types.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Types.ts
@@ -57,7 +57,8 @@ export type PhiType = {
 };
 export type PropType = {
   kind: "Property";
-  object: Type;
+  objectType: Type;
+  objectName: string;
   propertyName: string;
 };
 
@@ -124,7 +125,8 @@ export function duplicateType(type: Type): Type {
     case "Property": {
       return {
         kind: "Property",
-        object: duplicateType(type.object),
+        objectType: duplicateType(type.objectType),
+        objectName: type.objectName,
         propertyName: type.propertyName,
       };
     }
@@ -165,11 +167,13 @@ function objectMethodTypeEquals(tA: Type, tB: Type): boolean {
 
 function propTypeEquals(tA: Type, tB: Type): boolean {
   if (tA.kind === "Property" && tB.kind === "Property") {
-    if (!typeEquals(tA.object, tB.object)) {
+    if (!typeEquals(tA.objectType, tB.objectType)) {
       return false;
     }
 
-    return tA.propertyName === tB.propertyName;
+    return (
+      tA.propertyName === tB.propertyName && tA.objectName === tB.objectName
+    );
   }
 
   return false;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-like-name-not-Ref.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-like-name-not-Ref.expect.md
@@ -1,0 +1,47 @@
+
+## Input
+
+```javascript
+// @validatePreserveExistingMemoizationGuarantees
+import { useCallback, useRef } from "react";
+
+function useCustomRef() {
+  return useRef({ click: () => {} });
+}
+
+function Foo() {
+  const Ref = useCustomRef();
+
+  const onClick = useCallback(() => {
+    Ref.current?.click();
+  }, []);
+
+  return <button onClick={onClick} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+  isComponent: true,
+};
+
+```
+
+
+## Error
+
+```
+   9 |   const Ref = useCustomRef();
+  10 |
+> 11 |   const onClick = useCallback(() => {
+     |                               ^^^^^^^
+> 12 |     Ref.current?.click();
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^
+> 13 |   }, []);
+     | ^^^^ CannotPreserveMemoization: React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected (11:13)
+  14 |
+  15 |   return <button onClick={onClick} />;
+  16 | }
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-like-name-not-Ref.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-like-name-not-Ref.js
@@ -1,0 +1,22 @@
+// @validatePreserveExistingMemoizationGuarantees
+import { useCallback, useRef } from "react";
+
+function useCustomRef() {
+  return useRef({ click: () => {} });
+}
+
+function Foo() {
+  const Ref = useCustomRef();
+
+  const onClick = useCallback(() => {
+    Ref.current?.click();
+  }, []);
+
+  return <button onClick={onClick} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+  isComponent: true,
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-like-name-not-a-ref.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-like-name-not-a-ref.expect.md
@@ -1,0 +1,47 @@
+
+## Input
+
+```javascript
+// @validatePreserveExistingMemoizationGuarantees
+import { useCallback, useRef } from "react";
+
+function useCustomRef() {
+  return useRef({ click: () => {} });
+}
+
+function Foo() {
+  const notaref = useCustomRef();
+
+  const onClick = useCallback(() => {
+    notaref.current?.click();
+  }, []);
+
+  return <button onClick={onClick} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+  isComponent: true,
+};
+
+```
+
+
+## Error
+
+```
+   9 |   const notaref = useCustomRef();
+  10 |
+> 11 |   const onClick = useCallback(() => {
+     |                               ^^^^^^^
+> 12 |     notaref.current?.click();
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+> 13 |   }, []);
+     | ^^^^ CannotPreserveMemoization: React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected (11:13)
+  14 |
+  15 |   return <button onClick={onClick} />;
+  16 | }
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-like-name-not-a-ref.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-like-name-not-a-ref.js
@@ -1,0 +1,22 @@
+// @validatePreserveExistingMemoizationGuarantees
+import { useCallback, useRef } from "react";
+
+function useCustomRef() {
+  return useRef({ click: () => {} });
+}
+
+function Foo() {
+  const notaref = useCustomRef();
+
+  const onClick = useCallback(() => {
+    notaref.current?.click();
+  }, []);
+
+  return <button onClick={onClick} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+  isComponent: true,
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-effect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-effect.expect.md
@@ -1,0 +1,84 @@
+
+## Input
+
+```javascript
+// @enableTreatRefLikeIdentifiersAsRefs @validatePreserveExistingMemoizationGuarantees
+import { useRef, useEffect } from "react";
+
+function useCustomRef() {
+  return useRef({ click: () => {} });
+}
+
+function Foo() {
+  const ref = useCustomRef();
+
+  useEffect(() => {
+    ref.current?.click();
+  }, []);
+
+  return <div>foo</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+  isComponent: true,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableTreatRefLikeIdentifiersAsRefs @validatePreserveExistingMemoizationGuarantees
+import { useRef, useEffect } from "react";
+
+function useCustomRef() {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = { click: () => {} };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return useRef(t0);
+}
+
+function Foo() {
+  const $ = _c(3);
+  const ref = useCustomRef();
+  let t0;
+  let t1;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = () => {
+      ref.current?.click();
+    };
+    t1 = [];
+    $[0] = t0;
+    $[1] = t1;
+  } else {
+    t0 = $[0];
+    t1 = $[1];
+  }
+  useEffect(t0, t1);
+  let t2;
+  if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = <div>foo</div>;
+    $[2] = t2;
+  } else {
+    t2 = $[2];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+  isComponent: true,
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>foo</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-effect.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-effect.js
@@ -1,0 +1,22 @@
+// @enableTreatRefLikeIdentifiersAsRefs @validatePreserveExistingMemoizationGuarantees
+import { useRef, useEffect } from "react";
+
+function useCustomRef() {
+  return useRef({ click: () => {} });
+}
+
+function Foo() {
+  const ref = useCustomRef();
+
+  useEffect(() => {
+    ref.current?.click();
+  }, []);
+
+  return <div>foo</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+  isComponent: true,
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-useCallback-2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-useCallback-2.expect.md
@@ -1,0 +1,81 @@
+
+## Input
+
+```javascript
+// @enableTreatRefLikeIdentifiersAsRefs @validatePreserveExistingMemoizationGuarantees
+import { useRef, useCallback } from "react";
+
+function useCustomRef() {
+  return useRef({ click: () => {} });
+}
+
+function Foo() {
+  const ref = useCustomRef();
+
+  const onClick = useCallback(() => {
+    ref.current?.click();
+  }, []);
+
+  return <button onClick={onClick} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+  isComponent: true,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableTreatRefLikeIdentifiersAsRefs @validatePreserveExistingMemoizationGuarantees
+import { useRef, useCallback } from "react";
+
+function useCustomRef() {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = { click: () => {} };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return useRef(t0);
+}
+
+function Foo() {
+  const $ = _c(3);
+  const ref = useCustomRef();
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = () => {
+      ref.current?.click();
+    };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const onClick = t0;
+  let t1;
+  if ($[1] !== onClick) {
+    t1 = <button onClick={onClick} />;
+    $[1] = onClick;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  return t1;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+  isComponent: true,
+};
+
+```
+      
+### Eval output
+(kind: ok) <button></button>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-useCallback-2.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-useCallback-2.js
@@ -1,0 +1,22 @@
+// @enableTreatRefLikeIdentifiersAsRefs @validatePreserveExistingMemoizationGuarantees
+import { useRef, useCallback } from "react";
+
+function useCustomRef() {
+  return useRef({ click: () => {} });
+}
+
+function Foo() {
+  const ref = useCustomRef();
+
+  const onClick = useCallback(() => {
+    ref.current?.click();
+  }, []);
+
+  return <button onClick={onClick} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+  isComponent: true,
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-useCallback.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-useCallback.expect.md
@@ -1,0 +1,81 @@
+
+## Input
+
+```javascript
+// @enableTreatRefLikeIdentifiersAsRefs @validatePreserveExistingMemoizationGuarantees
+import { useRef, useCallback } from "react";
+
+function useCustomRef() {
+  return useRef({ click: () => {} });
+}
+
+function Foo() {
+  const customRef = useCustomRef();
+
+  const onClick = useCallback(() => {
+    customRef.current?.click();
+  }, []);
+
+  return <button onClick={onClick} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+  isComponent: true,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableTreatRefLikeIdentifiersAsRefs @validatePreserveExistingMemoizationGuarantees
+import { useRef, useCallback } from "react";
+
+function useCustomRef() {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = { click: () => {} };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return useRef(t0);
+}
+
+function Foo() {
+  const $ = _c(3);
+  const customRef = useCustomRef();
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = () => {
+      customRef.current?.click();
+    };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const onClick = t0;
+  let t1;
+  if ($[1] !== onClick) {
+    t1 = <button onClick={onClick} />;
+    $[1] = onClick;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  return t1;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+  isComponent: true,
+};
+
+```
+      
+### Eval output
+(kind: ok) <button></button>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-useCallback.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-useCallback.js
@@ -1,0 +1,22 @@
+// @enableTreatRefLikeIdentifiersAsRefs @validatePreserveExistingMemoizationGuarantees
+import { useRef, useCallback } from "react";
+
+function useCustomRef() {
+  return useRef({ click: () => {} });
+}
+
+function Foo() {
+  const customRef = useCustomRef();
+
+  const onClick = useCallback(() => {
+    customRef.current?.click();
+  }, []);
+
+  return <button onClick={onClick} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+  isComponent: true,
+};


### PR DESCRIPTION
If a component uses the `useRef` hook directly then we type it's return value as a ref. But if it's wrapped in a custom hook then we lose out on this type information as the compiler doesn't look at the hook definition. This has resulted in some false positives in our analysis like the ones reported in #29160 and #29196.

This PR will treat objects named as `ref` or if their names end with the substring `Ref`, and contain a property named `current`, as React refs.

```
const ref = useMyRef();
const myRef = useMyRef2();
useEffect(() => {
  ref.current = ...;
  myRef.current = ...;
})
```
In the above example, `ref` and `myRef` will be treated as React refs.
