### PR TITLE
Do not closure compile react-test-renderer

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -364,7 +364,9 @@ function getPlugins(
     const isProfiling = isProfilingBundleType(bundleType);
 
     const needsMinifiedByClosure =
-      bundleType !== ESM_PROD && bundleType !== ESM_DEV;
+      packageName !== 'react-test-renderer' &&
+      bundleType !== ESM_PROD &&
+      bundleType !== ESM_DEV;
 
     return [
       // Keep dynamic imports as externals


### PR DESCRIPTION

Summary:
This seeems to be breaking `jest.resetModules()` by internally memoizing some state.
