### PR TITLE
Solve "ENOTDIR: not a directory `node_modules/.DS_Store/package.json`" error when running `yarn build`

### DIFF
--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -337,6 +337,10 @@ function updatePackageVersions(
       version = defaultVersionIfNotFound;
     }
     const packageJSONPath = path.join(modulesDir, moduleName, 'package.json');
+    if (!fs.existsSync(packageJSONPath)) {
+      console.warn(`Skipping missing package.json: ${packageJSONPath}`);
+      continue;
+    }
     const stats = fs.statSync(packageJSONPath);
     if (stats.isFile()) {
       const packageInfo = JSON.parse(fs.readFileSync(packageJSONPath));


### PR DESCRIPTION
TL;DR -- Solve "ENOTDIR: not a directory `node_modules/.DS_Store/package.json`" error when running `yarn build`

## Summary

Fixed an edge case bug in `scripts/rollup/build-all-release-channels.js` that caused the build to fail when a `.DS_Store` file was present in the `node_modules` directory.

## Motivation

1. Wanted to run the build
2. Got an error when I tried to run the build

```
  const stats = binding.stat(
                        ^

Error: ENOTDIR: not a directory, stat '/var/folders/nk/76thgdjx2yz9dhwzwyx0kd440000gn/T/tmp-43728C5YoTppMWD6f/node_modules/.DS_Store/package.json'
    at Object.statSync (node:fs:1659:25)
    at updatePackageVersions (/Users/tom/Projects/react/scripts/rollup/build-all-release-channels.js:340:22)
```

## How I tested this change

### BEFORE: Verify problem exists

1. Add a `.DS_Store` file to the `node_modules` directory
2. `yarn build`
3. Build fails

## AFTER: Verify problem is fixed

1. Add a `.DS_Store` file to the `node_modules` directory
2. `yarn build`
3. Build succeeds
