### PR TITLE
[compiler] include types for the babel-plugin-react-compiler package.

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/package.json
+++ b/compiler/packages/babel-plugin-react-compiler/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-experimental-179941d-20240614",
   "description": "Babel plugin for React Compiler.",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "license": "MIT",
   "files": [
     "dist"

--- a/compiler/packages/babel-plugin-react-compiler/rollup.config.js
+++ b/compiler/packages/babel-plugin-react-compiler/rollup.config.js
@@ -28,8 +28,10 @@ const DEV_ROLLUP_CONFIG = {
   plugins: [
     typescript({
       tsconfig: "./tsconfig.json",
+      exclude: ["**/__tests__/**"],
       compilerOptions: {
         noEmit: true,
+        declaration: true,
       },
     }),
     json(),


### PR DESCRIPTION
## Summary

We would like `babel-plugin-react-compiler` to publish types to improve the code where we specify the options. Without types or API documentation it has been challenging to keep track of the supported options. There is a similar but more involved PR (https://github.com/facebook/react/pull/29894) so please close this if it is unnecessary. 

This PR just updates the Rollup TypeScript plugin to set the [`declaration` tsc option](https://www.typescriptlang.org/tsconfig/#declaration) in order to emit `.d.ts` files for the project. I chose to update rollup configuration instead of the `tsconfig.json` but I'm not sure what belongs where. `noEmit` is specified in the rollup configuration but the [docs say that the options is ignored](https://www.npmjs.com/package/@rollup/plugin-typescript#ignored-options).

## How did you test this change?

I used `yarn link` and tested manually in a webpack/babel project
