### PR TITLE
Read constructor name more carefully

### DIFF
--- a/packages/react-devtools-shared/src/hydration.js
+++ b/packages/react-devtools-shared/src/hydration.js
@@ -84,10 +84,16 @@ function createDehydrated(
     preview_long: formatDataForPreview(data, true),
     preview_short: formatDataForPreview(data, false),
     name:
-      !data.constructor || data.constructor.name === 'Object'
+      typeof data.constructor !== 'function' || data.constructor.name === 'Object'
         ? ''
         : data.constructor.name,
   };
+
+  try {
+    structuredClone(dehydrated.name);
+  } catch (_) {
+    dehydrated.name = '';
+  }
 
   if (type === 'array' || type === 'typed_array') {
     dehydrated.size = data.length;
@@ -240,10 +246,16 @@ export function dehydrate(
           preview_short: formatDataForPreview(data, false),
           preview_long: formatDataForPreview(data, true),
           name:
-            !data.constructor || data.constructor.name === 'Object'
+            typeof data.constructor !== 'function' || data.constructor.name === 'Object'
               ? ''
               : data.constructor.name,
         };
+
+        try {
+          structuredClone(unserializableValue.name);
+        } catch (_) {
+          unserializableValue.name = '';
+        }
 
         // TRICKY
         // Don't use [...spread] syntax for this purpose.
@@ -332,8 +344,14 @@ export function dehydrate(
         readonly: true,
         preview_short: formatDataForPreview(data, false),
         preview_long: formatDataForPreview(data, true),
-        name: data.constructor.name,
+        name: typeof data.constructor === 'function' ? data.constructor.name : '',
       };
+
+      try {
+        structuredClone(value.name);
+      } catch (_) {
+        value.name = '';
+      }
 
       getAllEnumerableKeys(data).forEach(key => {
         const keyAsString = key.toString();

--- a/packages/react-devtools-shared/src/hydration.js
+++ b/packages/react-devtools-shared/src/hydration.js
@@ -332,7 +332,10 @@ export function dehydrate(
         readonly: true,
         preview_short: formatDataForPreview(data, false),
         preview_long: formatDataForPreview(data, true),
-        name: typeof data.constructor === 'function' && typeof data.constructor.name === 'string' ? data.constructor.name : '',
+        name: 
+          typeof data.constructor !== 'function' || typeof data.constructor.name !== 'string'
+            ? ''
+            : data.constructor.name,
       };
 
       getAllEnumerableKeys(data).forEach(key => {

--- a/packages/react-devtools-shared/src/hydration.js
+++ b/packages/react-devtools-shared/src/hydration.js
@@ -84,7 +84,9 @@ function createDehydrated(
     preview_long: formatDataForPreview(data, true),
     preview_short: formatDataForPreview(data, false),
     name:
-      typeof data.constructor !== 'function' || typeof data.constructor.name !== 'string' || data.constructor.name === 'Object'
+      typeof data.constructor !== 'function' ||
+      typeof data.constructor.name !== 'string' ||
+      data.constructor.name === 'Object'
         ? ''
         : data.constructor.name,
   };
@@ -240,7 +242,9 @@ export function dehydrate(
           preview_short: formatDataForPreview(data, false),
           preview_long: formatDataForPreview(data, true),
           name:
-            typeof data.constructor !== 'function' || typeof data.constructor.name !== 'string' || data.constructor.name === 'Object'
+            typeof data.constructor !== 'function' ||
+            typeof data.constructor.name !== 'string' ||
+            data.constructor.name === 'Object'
               ? ''
               : data.constructor.name,
         };
@@ -332,8 +336,9 @@ export function dehydrate(
         readonly: true,
         preview_short: formatDataForPreview(data, false),
         preview_long: formatDataForPreview(data, true),
-        name: 
-          typeof data.constructor !== 'function' || typeof data.constructor.name !== 'string'
+        name:
+          typeof data.constructor !== 'function' ||
+          typeof data.constructor.name !== 'string'
             ? ''
             : data.constructor.name,
       };

--- a/packages/react-devtools-shared/src/hydration.js
+++ b/packages/react-devtools-shared/src/hydration.js
@@ -84,16 +84,10 @@ function createDehydrated(
     preview_long: formatDataForPreview(data, true),
     preview_short: formatDataForPreview(data, false),
     name:
-      typeof data.constructor !== 'function' || data.constructor.name === 'Object'
+      typeof data.constructor !== 'function' || typeof data.constructor.name !== 'string' || data.constructor.name === 'Object'
         ? ''
         : data.constructor.name,
   };
-
-  try {
-    structuredClone(dehydrated.name);
-  } catch (_) {
-    dehydrated.name = '';
-  }
 
   if (type === 'array' || type === 'typed_array') {
     dehydrated.size = data.length;
@@ -246,16 +240,10 @@ export function dehydrate(
           preview_short: formatDataForPreview(data, false),
           preview_long: formatDataForPreview(data, true),
           name:
-            typeof data.constructor !== 'function' || data.constructor.name === 'Object'
+            typeof data.constructor !== 'function' || typeof data.constructor.name !== 'string' || data.constructor.name === 'Object'
               ? ''
               : data.constructor.name,
         };
-
-        try {
-          structuredClone(unserializableValue.name);
-        } catch (_) {
-          unserializableValue.name = '';
-        }
 
         // TRICKY
         // Don't use [...spread] syntax for this purpose.
@@ -344,14 +332,8 @@ export function dehydrate(
         readonly: true,
         preview_short: formatDataForPreview(data, false),
         preview_long: formatDataForPreview(data, true),
-        name: typeof data.constructor === 'function' ? data.constructor.name : '',
+        name: typeof data.constructor === 'function' && typeof data.constructor.name === 'string' ? data.constructor.name : '',
       };
-
-      try {
-        structuredClone(value.name);
-      } catch (_) {
-        value.name = '';
-      }
 
       getAllEnumerableKeys(data).forEach(key => {
         const keyAsString = key.toString();


### PR DESCRIPTION
## Summary

Sometimes `constructor` happens to be the name of an unrelated property, or we may be dealing with a `Proxy` that intercepts every read. Verify the constructor is a function before using its name, and reset the name anyway if it turns out not to be serializable.

Fixes some cases of the devtools crashing and becoming inoperable upon attempting to inspect components whose props are Hookstate `State`s.

## How did you test this change?

Installed a patched version of the extension and confirmed that it solves the problem.