### PR TITLE
fix[compiler playground]: Set source as the pre-change state in HIR diff

### DIFF
--- a/compiler/apps/playground/components/Editor/Output.tsx
+++ b/compiler/apps/playground/components/Editor/Output.tsx
@@ -195,7 +195,7 @@ function Output({ store, compilerOutput }: Props) {
       if (result.kind === "hir" || result.kind === "reactive") {
         currResult += `function ${result.fnName}\n\n${result.value}`;
       }
-      if (currResult !== lastResult) {
+      if (passName !== "HIR" && currResult !== lastResult) {
         changedPasses.add(passName);
       }
       lastResult = currResult;

--- a/compiler/apps/playground/components/Editor/Output.tsx
+++ b/compiler/apps/playground/components/Editor/Output.tsx
@@ -104,7 +104,7 @@ async function tabify(source: string, compilerOutput: CompilerOutput) {
       passName,
       <TextTabContent
         output={text}
-        diff={lastPassOutput ?? null}
+        diff={passName === "HIR" ? source : lastPassOutput ?? null}
         showInfoPanel={true}
       ></TextTabContent>
     );

--- a/compiler/apps/playground/components/Editor/Output.tsx
+++ b/compiler/apps/playground/components/Editor/Output.tsx
@@ -104,7 +104,7 @@ async function tabify(source: string, compilerOutput: CompilerOutput) {
       passName,
       <TextTabContent
         output={text}
-        diff={passName === "HIR" ? source : lastPassOutput ?? null}
+        diff={passName !== "HIR" ? lastPassOutput : null}
         showInfoPanel={true}
       ></TextTabContent>
     );


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

I have fixed an issue where the display of the HIR diff in the React Compiler Playground was incorrect. The HIR diff is supposed to show the pre-change state as the source, but currently, it is showing EnvironmentConfig as the pre-change state. This PR corrects this by setting the pre-change state to source instead of EnvironmentConfig.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

before:

![image](https://github.com/facebook/react/assets/37236438/c98aee7a-b569-430e-8698-0f7eff6c21e2)

after:

![image](https://github.com/facebook/react/assets/37236438/6113297c-80f9-4e71-a0d1-df8cc87507db)

