### PR TITLE
fix[react-devtools/extensions]: propagate globals from env

### DIFF
--- a/packages/react-devtools-extensions/webpack.backend.js
+++ b/packages/react-devtools-extensions/webpack.backend.js
@@ -74,6 +74,9 @@ module.exports = {
       'process.env.IS_CHROME': IS_CHROME,
       'process.env.IS_FIREFOX': IS_FIREFOX,
       'process.env.IS_EDGE': IS_EDGE,
+      __IS_CHROME__: IS_CHROME,
+      __IS_FIREFOX__: IS_FIREFOX,
+      __IS_EDGE__: IS_EDGE,
     }),
     new Webpack.SourceMapDevToolPlugin({
       filename: '[file].map',


### PR DESCRIPTION
Somehow missed this while working on https://github.com/facebook/react/pull/29869.

With these changes, manual inspection of the `react_devtools_backend_compact.js` doesn't have any occurences of `__IS_FIREFOX__` flag.