### PR TITLE
Plumbing of isomorphic code

### DIFF
--- a/packages/react-dom/src/ReactDOMSharedInternals.js
+++ b/packages/react-dom/src/ReactDOMSharedInternals.js
@@ -10,7 +10,9 @@
 import type {EventPriority} from 'react-reconciler/src/ReactEventPriorities';
 import type {HostDispatcher} from './shared/ReactDOMTypes';
 
-import {NoEventPriority} from 'react-reconciler/src/ReactEventPriorities';
+// This should line up with NoEventPriority from react-reconciler/src/ReactEventPriorities
+// but we can't depend on the react-reconciler from this isomorphic code.
+export const NoEventPriority: EventPriority = (0: any);
 
 type ReactDOMInternals = {
   d /* ReactDOMCurrentDispatcher */: HostDispatcher,

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -118,9 +118,7 @@ import {
   objectName,
 } from 'shared/ReactSerializationErrors';
 
-import type {SharedStateServer} from 'react/src/ReactSharedInternalsServer';
-import ReactSharedInternalsImpl from 'shared/ReactSharedInternals';
-const ReactSharedInternals: SharedStateServer = (ReactSharedInternalsImpl: any);
+import ReactSharedInternals from './ReactSharedInternalsServer';
 import isArray from 'shared/isArray';
 import getPrototypeOf from 'shared/getPrototypeOf';
 import binaryToComparableString from 'shared/binaryToComparableString';

--- a/packages/react-server/src/ReactSharedInternalsServer.js
+++ b/packages/react-server/src/ReactSharedInternalsServer.js
@@ -7,9 +7,11 @@
  * @flow
  */
 
+import type {SharedStateServer} from 'react/src/ReactSharedInternalsServer';
+
 import * as React from 'react';
 
-const ReactSharedInternalsServer =
+const ReactSharedInternalsServer: SharedStateServer =
   // $FlowFixMe: It's defined in the one we resolve to.
   React.__SERVER_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
 


### PR DESCRIPTION
Need to tighten up this a bit.

react-dom isomorphic currently depends on react-reconciler which is mostly DCE but it's pulled in which makes it hard to make other bundling changes.

ReactFlightServer can have a hard dependency on the module that imports its internals since even if other internals are aliased it still always needs the server one.