### PR TITLE
fix(flight): improve `stack` type check to avoid throwing on `undefined`

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -696,7 +696,7 @@ function createElement(
       });
 
       let task: null | ConsoleTask = null;
-      if (supportsCreateTask && stack !== null) {
+      if (supportsCreateTask && typeof stack === 'string') {
         const createTaskFn = (console: any).createTask.bind(
           console,
           getTaskName(type),
@@ -1255,7 +1255,7 @@ function parseModelTuple(
       tuple[2],
       tuple[3],
       __DEV__ ? (tuple: any)[4] : null,
-      __DEV__ && enableOwnerStacks ? (tuple: any)[5] : null,
+      __DEV__ && enableOwnerStacks ? (tuple: any)[5] || null : null,
       __DEV__ && enableOwnerStacks ? (tuple: any)[6] : 0,
     );
   }


### PR DESCRIPTION
## Summary

Recently, [an issue](https://github.com/vercel/next.js/issues/66137) on the Next.js repo arose when importing SVGs in a server component using the `svgr` Webpack loader. I tracked it down to [this release](https://github.com/vercel/next.js/releases/tag/v14.3.0-canary.77) and when I debugged it using the debugger in VS Code I found [this line](https://github.com/facebook/react/blob/83d538e0d04aac2a32d335e6b3963273729a9fe6/packages/react-client/src/ReactFlightClient.js#L699) which was recently added in https://github.com/facebook/react/pull/29632. It explicitly checks for `null` here but apparently it can be `undefined`. I added so we always fallback to `null` in the tuple but also hardened the `stack` check to make sure it's a `string`.

## How did you test this change?

I hardcoded the changes into the `react` version in use by Next.js and tested importing a SVG which works fine.