### PR TITLE
[compiler] Replace `Forget` with `Compiler` in comments (docs)

### DIFF
--- a/compiler/crates/react_hermes_parser/tests/fixtures/allocating-primitive-as-dep-nested-scope.js
+++ b/compiler/crates/react_hermes_parser/tests/fixtures/allocating-primitive-as-dep-nested-scope.js
@@ -1,5 +1,5 @@
 // bar(props.b) is an allocating expression that produces a primitive, which means
-// that Forget should memoize it.
+// that Compiler should memoize it.
 // Correctness:
 //   - y depends on either bar(props.b) or bar(props.b) + 1
 function AllocatingPrimitiveAsDepNested(props) {

--- a/compiler/crates/react_hermes_parser/tests/fixtures/allocating-primitive-as-dep.js
+++ b/compiler/crates/react_hermes_parser/tests/fixtures/allocating-primitive-as-dep.js
@@ -1,5 +1,5 @@
 // bar(props.b) is an allocating expression that produces a primitive, which means
-// that Forget should memoize it.
+// that Compiler should memoize it.
 // Correctness:
 //   - y depends on either bar(props.b) or bar(props.b) + 1
 function AllocatingPrimitiveAsDep(props) {

--- a/compiler/crates/react_hermes_parser/tests/fixtures/cond-deps-conditional-member-expr.js
+++ b/compiler/crates/react_hermes_parser/tests/fixtures/cond-deps-conditional-member-expr.js
@@ -1,5 +1,5 @@
 // To preserve the nullthrows behavior and reactive deps of this code,
-// Forget needs to add `props.a` as a dependency (since `props.a.b` is
+// Compiler needs to add `props.a` as a dependency (since `props.a.b` is
 // a conditional dependency, i.e. gated behind control flow)
 
 function Component(props) {

--- a/compiler/crates/react_hermes_parser/tests/fixtures/primitive-as-dep-nested-scope.js
+++ b/compiler/crates/react_hermes_parser/tests/fixtures/primitive-as-dep-nested-scope.js
@@ -1,4 +1,4 @@
-// props.b + 1 is an non-allocating expression, which means Forget can
+// props.b + 1 is an non-allocating expression, which means Compiler can
 // emit it trivially and repeatedly (e.g. no need to memoize props.b + 1
 // separately from props.b)
 // Correctness:

--- a/compiler/crates/react_hermes_parser/tests/fixtures/primitive-as-dep.js
+++ b/compiler/crates/react_hermes_parser/tests/fixtures/primitive-as-dep.js
@@ -1,4 +1,4 @@
-// props.b + 1 is an non-allocating expression, which means Forget can
+// props.b + 1 is an non-allocating expression, which means Compiler can
 // emit it trivially and repeatedly (e.g. no need to memoize props.b + 1
 // separately from props.b)
 // Correctness:

--- a/compiler/crates/react_hermes_parser/tests/fixtures/reduce-reactive-cond-memberexpr-join.js
+++ b/compiler/crates/react_hermes_parser/tests/fixtures/reduce-reactive-cond-memberexpr-join.js
@@ -1,5 +1,5 @@
 // To preserve the nullthrows behavior and reactive deps of this code,
-// Forget needs to add `props.a.b` or a subpath as a dependency.
+// Compiler needs to add `props.a.b` or a subpath as a dependency.
 //
 // (1) Since the reactive block producing x unconditionally read props.a.<...>,
 //     reading `props.a.b` outside of the block would still preserve nullthrows

--- a/compiler/crates/react_hermes_parser/tests/fixtures/reduce-reactive-deps-join-uncond-scopes-cond-deps.js
+++ b/compiler/crates/react_hermes_parser/tests/fixtures/reduce-reactive-deps-join-uncond-scopes-cond-deps.js
@@ -2,7 +2,7 @@
 // When propagating reactive dependencies of an inner scope up to its parent,
 // we prefer to retain granularity.
 //
-// In this test, we check that Forget propagates the inner scope's conditional
+// In this test, we check that Compiler propagates the inner scope's conditional
 // dependencies (e.g. props.a.b) instead of only its derived minimal
 // unconditional dependencies (e.g. props).
 // ```javascript

--- a/compiler/crates/react_hermes_parser/tests/fixtures/ssa-reassign-in-rval.js
+++ b/compiler/crates/react_hermes_parser/tests/fixtures/ssa-reassign-in-rval.js
@@ -1,4 +1,4 @@
-// Forget should call the original x (x = foo()) to compute result
+// Compiler should call the original x (x = foo()) to compute result
 function Component() {
   let x = foo();
   let result = x((x = bar()), 5);

--- a/compiler/crates/react_hermes_parser/tests/fixtures/unknown-hooks-do-not-assert.js
+++ b/compiler/crates/react_hermes_parser/tests/fixtures/unknown-hooks-do-not-assert.js
@@ -1,4 +1,4 @@
-// Forget currently bails out when it detects a potential mutation (Effect.Mutate)
+// Compiler currently bails out when it detects a potential mutation (Effect.Mutate)
 // to an immutable value. This should not apply to unknown / untyped hooks.
 
 // Default feature flags:

--- a/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@allocating-primitive-as-dep-nested-scope.js.snap
+++ b/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@allocating-primitive-as-dep-nested-scope.js.snap
@@ -5,7 +5,7 @@ input_file: crates/react_hermes_parser/tests/fixtures/allocating-primitive-as-de
 ---
 Input:
 // bar(props.b) is an allocating expression that produces a primitive, which means
-// that Forget should memoize it.
+// that Compiler should memoize it.
 // Correctness:
 //   - y depends on either bar(props.b) or bar(props.b) + 1
 function AllocatingPrimitiveAsDepNested(props) {

--- a/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@allocating-primitive-as-dep.js.snap
+++ b/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@allocating-primitive-as-dep.js.snap
@@ -5,7 +5,7 @@ input_file: crates/react_hermes_parser/tests/fixtures/allocating-primitive-as-de
 ---
 Input:
 // bar(props.b) is an allocating expression that produces a primitive, which means
-// that Forget should memoize it.
+// that Compiler should memoize it.
 // Correctness:
 //   - y depends on either bar(props.b) or bar(props.b) + 1
 function AllocatingPrimitiveAsDep(props) {

--- a/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@cond-deps-conditional-member-expr.js.snap
+++ b/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@cond-deps-conditional-member-expr.js.snap
@@ -5,7 +5,7 @@ input_file: crates/react_hermes_parser/tests/fixtures/cond-deps-conditional-memb
 ---
 Input:
 // To preserve the nullthrows behavior and reactive deps of this code,
-// Forget needs to add `props.a` as a dependency (since `props.a.b` is
+// Compiler needs to add `props.a` as a dependency (since `props.a.b` is
 // a conditional dependency, i.e. gated behind control flow)
 
 function Component(props) {

--- a/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@primitive-as-dep-nested-scope.js.snap
+++ b/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@primitive-as-dep-nested-scope.js.snap
@@ -4,7 +4,7 @@ expression: "format!(\"Input:\\n{input}\\n\\nOutput:\\n{output}\")"
 input_file: crates/react_hermes_parser/tests/fixtures/primitive-as-dep-nested-scope.js
 ---
 Input:
-// props.b + 1 is an non-allocating expression, which means Forget can
+// props.b + 1 is an non-allocating expression, which means Compiler can
 // emit it trivially and repeatedly (e.g. no need to memoize props.b + 1
 // separately from props.b)
 // Correctness:

--- a/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@primitive-as-dep.js.snap
+++ b/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@primitive-as-dep.js.snap
@@ -4,7 +4,7 @@ expression: "format!(\"Input:\\n{input}\\n\\nOutput:\\n{output}\")"
 input_file: crates/react_hermes_parser/tests/fixtures/primitive-as-dep.js
 ---
 Input:
-// props.b + 1 is an non-allocating expression, which means Forget can
+// props.b + 1 is an non-allocating expression, which means Compiler can
 // emit it trivially and repeatedly (e.g. no need to memoize props.b + 1
 // separately from props.b)
 // Correctness:

--- a/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@reduce-reactive-cond-memberexpr-join.js.snap
+++ b/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@reduce-reactive-cond-memberexpr-join.js.snap
@@ -5,7 +5,7 @@ input_file: crates/react_hermes_parser/tests/fixtures/reduce-reactive-cond-membe
 ---
 Input:
 // To preserve the nullthrows behavior and reactive deps of this code,
-// Forget needs to add `props.a.b` or a subpath as a dependency.
+// Compiler needs to add `props.a.b` or a subpath as a dependency.
 //
 // (1) Since the reactive block producing x unconditionally read props.a.<...>,
 //     reading `props.a.b` outside of the block would still preserve nullthrows

--- a/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@reduce-reactive-deps-join-uncond-scopes-cond-deps.js.snap
+++ b/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@reduce-reactive-deps-join-uncond-scopes-cond-deps.js.snap
@@ -8,7 +8,7 @@ Input:
 // When propagating reactive dependencies of an inner scope up to its parent,
 // we prefer to retain granularity.
 //
-// In this test, we check that Forget propagates the inner scope's conditional
+// In this test, we check that Compiler propagates the inner scope's conditional
 // dependencies (e.g. props.a.b) instead of only its derived minimal
 // unconditional dependencies (e.g. props).
 // ```javascript

--- a/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@ssa-reassign-in-rval.js.snap
+++ b/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@ssa-reassign-in-rval.js.snap
@@ -4,7 +4,7 @@ expression: "format!(\"Input:\\n{input}\\n\\nOutput:\\n{output}\")"
 input_file: crates/react_hermes_parser/tests/fixtures/ssa-reassign-in-rval.js
 ---
 Input:
-// Forget should call the original x (x = foo()) to compute result
+// Compiler should call the original x (x = foo()) to compute result
 function Component() {
   let x = foo();
   let result = x((x = bar()), 5);

--- a/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@unknown-hooks-do-not-assert.js.snap
+++ b/compiler/crates/react_hermes_parser/tests/snapshots/parser_test__fixtures@unknown-hooks-do-not-assert.js.snap
@@ -4,7 +4,7 @@ expression: "format!(\"Input:\\n{input}\\n\\nOutput:\\n{output}\")"
 input_file: crates/react_hermes_parser/tests/fixtures/unknown-hooks-do-not-assert.js
 ---
 Input:
-// Forget currently bails out when it detects a potential mutation (Effect.Mutate)
+// Compiler currently bails out when it detects a potential mutation (Effect.Mutate)
 // to an immutable value. This should not apply to unknown / untyped hooks.
 
 // Default feature flags:

--- a/compiler/packages/babel-plugin-react-compiler/src/Babel/BabelPlugin.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Babel/BabelPlugin.ts
@@ -13,7 +13,7 @@ import {
 } from "../Entrypoint/Reanimated";
 
 /*
- * The React Forget Babel Plugin
+ * The React Compiler Babel Plugin
  * @param {*} _babel
  * @returns
  */
@@ -26,7 +26,7 @@ export default function BabelPluginReactCompiler(
       /*
        * Note: Babel does some "smart" merging of visitors across plugins, so even if A is inserted
        * prior to B, if A does not have a Program visitor and B does, B will run first. We always
-       * want Forget to run true to source as possible.
+       * want Compiler to run true to source as possible.
        */
       Program(prog, pass): void {
         let opts = parsePluginOptions(pass.opts);

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Imports.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Imports.ts
@@ -23,7 +23,7 @@ export function addImportsToProgram(
      * validation here
      */
     CompilerError.invariant(identifiers.has(importSpecifierName) === false, {
-      reason: `Encountered conflicting import specifier for ${importSpecifierName} in Forget config.`,
+      reason: `Encountered conflicting import specifier for ${importSpecifierName} in Compiler config.`,
       description: null,
       loc: GeneratedSource,
       suggestions: null,

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Imports.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Imports.ts
@@ -23,7 +23,7 @@ export function addImportsToProgram(
      * validation here
      */
     CompilerError.invariant(identifiers.has(importSpecifierName) === false, {
-      reason: `Encountered conflicting import specifier for ${importSpecifierName} in Compiler config.`,
+      reason: `Encountered conflicting import specifier for ${importSpecifierName} in Forget config.`,
       description: null,
       loc: GeneratedSource,
       suggestions: null,

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
@@ -14,15 +14,15 @@ import { hasOwnProperty } from "../Utils/utils";
 const PanicThresholdOptionsSchema = z.enum([
   /*
    * Any errors will panic the compiler by throwing an exception, which will
-   * bubble up to the nearest exception handler above the Forget transform.
-   * If Forget is invoked through `BabelPluginReactCompiler`, this will at the least
-   * skip Forget compilation for the rest of current file.
+   * bubble up to the nearest exception handler above the Compiler transform.
+   * If Compiler is invoked through `BabelPluginReactCompiler`, this will at the least
+   * skip Compiler compilation for the rest of current file.
    */
   "all_errors",
   /*
    * Panic by throwing an exception only on critical or unrecognized errors.
    * For all other errors, skip the erroring function without inserting
-   * a Forget-compiled version (i.e. same behavior as noEmit).
+   * a Compiler-compiled version (i.e. same behavior as noEmit).
    */
   "critical_errors",
   // Never panic by throwing an exception.
@@ -37,7 +37,7 @@ export type PluginOptions = {
   logger: Logger | null;
 
   /*
-   * Specifying a `gating` config, makes Forget compile and emit a separate
+   * Specifying a `gating` config, makes Compiler compile and emit a separate
    * version of the function gated by importing the `gating.importSpecifierName` from the
    * specified `gating.source`.
    *
@@ -61,7 +61,7 @@ export type PluginOptions = {
   panicThreshold: PanicThresholdOptions;
 
   /*
-   * When enabled, Forget will continue statically analyzing and linting code, but skip over codegen
+   * When enabled, Compiler will continue statically analyzing and linting code, but skip over codegen
    * passes.
    *
    * Defaults to false
@@ -83,7 +83,7 @@ export type PluginOptions = {
   compilationMode: CompilationMode;
 
   /*
-   * If enabled, Forget will import `useMemoCache` from the given module
+   * If enabled, Compiler will import `useMemoCache` from the given module
    * instead of `react/compiler-runtime`.
    *
    * ```
@@ -146,10 +146,10 @@ export type CompilationMode = z.infer<typeof CompilationModeSchema>;
  * recorded when a logger is set (through the config).
  * These are the different types of events:
  * CompileError:
- *   Forget skipped compilation of a function / file due to a known todo,
+ *   Compiler skipped compilation of a function / file due to a known todo,
  *   invalid input, or compiler invariant being broken.
  * CompileSuccess:
- *   Forget successfully compiled a function.
+ *   Compiler successfully compiled a function.
  * PipelineError:
  *   Unexpected errors that occurred during compilation (e.g. failures in
  *   babel or other unhandled exceptions).

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
@@ -476,7 +476,7 @@ function* runWithEnvironment(
 
   /**
    * This flag should be only set for unit / fixture tests to check
-   * that Forget correctly handles unexpected errors (e.g. exceptions
+   * that Compiler correctly handles unexpected errors (e.g. exceptions
    * thrown by babel functions or other unexpected exceptions).
    */
   if (env.config.throwUnknownException__testonly) {

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -254,8 +254,8 @@ export function compileProgram(
   }
 
   /*
-   * Record lint errors and critical errors as depending on Forget's config,
-   * we may still need to run Forget's analysis on every function (even if we
+   * Record lint errors and critical errors as depending on Compiler's config,
+   * we may still need to run Compiler's analysis on every function (even if we
    * have already encountered errors) for reporting.
    */
   const suppressions = findProgramSuppressions(
@@ -343,7 +343,7 @@ export function compileProgram(
     }
   };
 
-  // Main traversal to compile with Forget
+  // Main traversal to compile with Compiler
   program.traverse(
     {
       ClassDeclaration(node: NodePath<t.ClassDeclaration>) {
@@ -449,7 +449,7 @@ export function compileProgram(
     }
   }
 
-  // Forget compiled the component, we need to update existing imports of useMemoCache
+  // Compiler compiled the component, we need to update existing imports of useMemoCache
   if (compiledFns.length > 0) {
     let needsMemoCacheFunctionImport = false;
     for (const fn of compiledFns) {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -95,7 +95,7 @@ const HookSchema = z.object({
    * - objects whose values are also transitiveMixed
    *
    * Many state management and data-fetching APIs return data that meets
-   * this criteria since this is JSON + undefined. Forget can compile
+   * this criteria since this is JSON + undefined. Compiler can compile
    * hooks that return transitively mixed data more optimally because it
    * can make inferences about some method calls (especially array methods
    * like `data.items.map(...)` since these builtin types have few built-in
@@ -140,7 +140,7 @@ const EnvironmentConfigSchema = z.object({
 
   /**
    * Enable using information from existing useMemo/useCallback to understand when a value is done
-   * being mutated. With this mode enabled, Forget will still discard the actual useMemo/useCallback
+   * being mutated. With this mode enabled, Compiler will still discard the actual useMemo/useCallback
    * calls and may memoize slightly differently. However, it will assume that the values produced
    * are not subsequently modified, guaranteeing that the value will be memoized.
    *
@@ -148,7 +148,7 @@ const EnvironmentConfigSchema = z.object({
    * behavior that depends on referential equality in the original program. Notably, this preserves
    * existing effect behavior (how often effects fire) for effects that rely on referential equality.
    *
-   * When disabled, Forget will not only prune useMemo and useCallback calls but also completely ignore
+   * When disabled, Compiler will not only prune useMemo and useCallback calls but also completely ignore
    * them, not using any information from them to guide compilation. Therefore, disabling this flag
    * will produce output that mimics the result from removing all memoization.
    *
@@ -163,17 +163,17 @@ const EnvironmentConfigSchema = z.object({
   enablePreserveExistingMemoizationGuarantees: z.boolean().default(false),
 
   /**
-   * Validates that all useMemo/useCallback values are also memoized by Forget. This mode can be
+   * Validates that all useMemo/useCallback values are also memoized by Compiler. This mode can be
    * used with or without @enablePreserveExistingMemoizationGuarantees.
    *
    * With enablePreserveExistingMemoizationGuarantees, this validation enables automatically and
-   * verifies that Forget was able to preserve manual memoization semantics under that mode's
+   * verifies that Compiler was able to preserve manual memoization semantics under that mode's
    * additional assumptions about the input.
    *
    * With enablePreserveExistingMemoizationGuarantees off, this validation ignores manual memoization
    * when determining program behavior, and only uses information from useMemo/useCallback to check
    * that the memoization was preserved. This can be useful for determining where referential equalities
-   * may change under Forget.
+   * may change under Compiler.
    */
   validatePreserveExistingMemoizationGuarantees: z.boolean().default(true),
 
@@ -189,7 +189,7 @@ const EnvironmentConfigSchema = z.object({
 
   /**
    * Enable use of type annotations in the source to drive type inference. By default
-   * Forget attemps to infer types using only information that is guaranteed correct
+   * Compiler attemps to infer types using only information that is guaranteed correct
    * given the source, and does not trust user-supplied type annotations. This mode
    * enables trusting user type annotations.
    */
@@ -215,7 +215,7 @@ const EnvironmentConfigSchema = z.object({
 
   /**
    * Validates that the dependencies of all effect hooks are memoized. This helps ensure
-   * that Forget does not introduce infinite renders caused by a dependency changing,
+   * that Compiler does not introduce infinite renders caused by a dependency changing,
    * triggering an effect, which triggers re-rendering, which causes a dependency to change,
    * triggering the effect, etc.
    *
@@ -254,7 +254,7 @@ const EnvironmentConfigSchema = z.object({
 
   /*
    * Enables codegen mutability debugging. This emits a dev-mode only to log mutations
-   * to values that Forget assumes are immutable (for Forget compiled code).
+   * to values that Compiler assumes are immutable (for Compiler compiled code).
    * For example:
    *   emitFreeze: {
    *     source: 'ReactForgetRuntime',
@@ -285,7 +285,7 @@ const EnvironmentConfigSchema = z.object({
 
   /*
    * Enables instrumentation codegen. This emits a dev-mode only call to an
-   * instrumentation function, for components and hooks that Forget compiles.
+   * instrumentation function, for components and hooks that Compiler compiles.
    * For example:
    *   instrumentForget: {
    *     import: {
@@ -331,7 +331,7 @@ const EnvironmentConfigSchema = z.object({
   enableChangeVariableCodegen: z.boolean().default(false),
 
   /**
-   * Enable emitting comments that explain Forget's output, and which
+   * Enable emitting comments that explain Compiler's output, and which
    * values are being checked and which values produced by each memo block.
    *
    * Intended for use in demo purposes (incl playground)
@@ -403,7 +403,7 @@ const EnvironmentConfigSchema = z.object({
    * For example, by default `React$useState` would not be treated as a hook. By specifying
    * `hookPattern: 'React$(\w+)'`, the compiler will treat this value equivalently to `useState()`.
    *
-   * This setting is intended for cases where Forget is compiling code that has been prebundled
+   * This setting is intended for cases where Compiler is compiling code that has been prebundled
    * and identifiers have been changed.
    */
   hookPattern: z.string().nullable().default(null),
@@ -681,7 +681,7 @@ export class Environment {
     if (shapeId !== null) {
       /*
        * If an object or function has a shapeId, it must have been assigned
-       * by Forget (and be present in a builtin or user-defined registry)
+       * by Compiler (and be present in a builtin or user-defined registry)
        */
       const shape = this.#shapes.get(shapeId);
       CompilerError.invariant(shape !== undefined, {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Globals.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Globals.ts
@@ -26,8 +26,8 @@ import { BuiltInType, PolyType } from "./Types";
 
 /*
  * This file exports types and defaults for JavaScript global objects.
- * A Forget `Environment` stores the GlobalRegistry and ShapeRegistry
- * used for the current project. These ultimately help Forget refine
+ * A Compiler `Environment` stores the GlobalRegistry and ShapeRegistry
+ * used for the current project. These ultimately help Compiler refine
  * its inference of types (i.e. Object vs Primitive) and effects
  * (i.e. read vs mutate) in source programs.
  */

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -796,13 +796,13 @@ export type FinishMemoize = {
 };
 
 /*
- * Forget currently does not handle MethodCall correctly in
+ * Compiler currently does not handle MethodCall correctly in
  * all cases. Specifically, we do not bind the receiver and method property
  * before calling to args. Until we add a SequenceExpression to inline all
  * instructions generated when lowering args, we have a limited representation
  * with some constraints.
  *
- * Forget currently makes these assumptions (checked in codegen):
+ * Compiler currently makes these assumptions (checked in codegen):
  *   - {@link MethodCall.property} is a temporary produced by a PropertyLoad or ComputedLoad
  *     on {@link MethodCall.receiver}
  *   - {@link MethodCall.property} remains an rval (i.e. never promoted to a

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIRBuilder.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIRBuilder.ts
@@ -202,7 +202,7 @@ export default class HIRBuilder {
    * Maps an Identifier (or JSX identifier) Babel node to an internal `Identifier`
    * which represents the variable being referenced, according to the JS scoping rules.
    *
-   * Because Forget does not preserve _all_ block scopes in the input (only those that
+   * Because Compiler does not preserve _all_ block scopes in the input (only those that
    * happen to occur from control flow), this resolution ensures that different variables
    * with the same name are mapped to a unique name. Concretely, this function maintains
    * the invariant that all references to a given variable will return an `Identifier`

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
@@ -17,7 +17,7 @@ import {
 
 /*
  * This file exports types and defaults for JavaScript object shapes. These are
- * stored and used by a Forget `Environment`. See comments in `Types.ts`,
+ * stored and used by a Compiler `Environment`. See comments in `Types.ts`,
  * `Globals.ts`, and `Environment.ts` for more details.
  */
 

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Types.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Types.ts
@@ -25,7 +25,7 @@ export type PrimitiveType = { kind: "Primitive" };
  * OwnPropertyDescriptors and properties present in the prototype chain.
  *
  * {@link ObjectShape.functionType} is always present on the shape of a {@link FunctionType},
- * and it represents the call signature of the function. Note that Forget thinks of a
+ * and it represents the call signature of the function. Note that Compiler thinks of a
  * {@link FunctionType} as any "callable object" (not to be confused with objects that
  *   extend the global `Function`.)
  *

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReactivePlaces.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReactivePlaces.ts
@@ -90,7 +90,7 @@ import { assertExhaustive } from "../Utils/utils";
  * the control-flow graph. We track whether each IdentifierId is reactive and terminate when
  * there are no changes after a given pass over the CFG.
  *
- * Note that in Forget it's possible to create a "readonly" reference to a value where
+ * Note that in Compiler it's possible to create a "readonly" reference to a value where
  * the reference is created within that value's mutable range:
  *
  * ```javascript

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/DeriveMinimalDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/DeriveMinimalDependencies.ts
@@ -35,7 +35,7 @@ export type ReactiveScopePropertyDependency = ReactiveScopeDependency & {
  *
  * Correctness properties:
  *   - All dependencies to a ReactiveBlock must be tracked.
- *     We can always truncate a dependency's path to a subpath, due to Forget assuming
+ *     We can always truncate a dependency's path to a subpath, due to Compiler assuming
  *     deep immutability. If the value produced by a subpath has not changed, then
  *     dependency must have not changed.
  *     i.e. props.a === $[..] implies props.a.b === $[..]
@@ -225,7 +225,7 @@ export class ReactiveScopeDependencyTree {
  * Access / Dependency:
  *    - Access: this property is read on the path of a dependency. We do not
  *      need to track change variables for accessed properties. Tracking accesses
- *      helps Forget do more granular dependency tracking.
+ *      helps Compiler do more granular dependency tracking.
  *    - Dependency: this property is read as a dependency and we must track changes
  *      to it for correctness.
  *

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/MemoizeFbtAndMacroOperandsInSameScope.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/MemoizeFbtAndMacroOperandsInSameScope.ts
@@ -28,7 +28,7 @@ import { eachReactiveValueOperand } from "./visitors";
  * arguments, notably that variable references may not appear directly — variables
  * must always be wrapped in a `<fbt:param>` or `fbt.param()`.
  *
- * To ensure that Forget doesn't rewrite code to violate this restriction, we force
+ * To ensure that Compiler doesn't rewrite code to violate this restriction, we force
  * operands to fbt tags/calls have the same scope as the tag/call itself.
  *
  * Note that this still allows the props/arguments of `<fbt:param>`/`fbt.param()`

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/MergeOverlappingReactiveScopes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/MergeOverlappingReactiveScopes.ts
@@ -36,7 +36,7 @@ import { ReactiveFunctionVisitor, visitReactiveFunction } from "./visitors";
  * the mutable range of multiple reactive scopes. We prefer to avoid executing instructions twice
  * for performance reasons (side effects are less of a concern bc components are required to be
  * idempotent), so we cannot simply repeat the instruction once for each scope. Instead, the only
- * option is to combine the two scopes into one. This is an area where an eventual Forget IDE
+ * option is to combine the two scopes into one. This is an area where an eventual Compiler IDE
  * could provide real-time feedback to the developer that two computations are accidentally merged.
  *
  * ## Detailed Walkthrough

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/RenameVariables.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/RenameVariables.ts
@@ -31,7 +31,7 @@ import { ReactiveFunctionVisitor, visitReactiveFunction } from "./visitors";
  * Note that the scoping is based on the final inferred blocks, not the
  * block scopes that were present in the original source. Thus variables
  * that shadowed in the original source may end up with unique names in the
- * output, if Forget would merge those two blocks into a single scope.
+ * output, if Compiler would merge those two blocks into a single scope.
  *
  * Variables are renamed using their original name followed by a number,
  * starting with 0 and incrementing until a unique name is found. Eg if the

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateMemoizedEffectDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateMemoizedEffectDependencies.ts
@@ -30,9 +30,9 @@ import {
  *   pruned for some reason, such as spanning a hook.
  * - Disallow effect dependencies whose a mutable range that encompasses the effect call.
  *
- * This latter check corresponds to any values which Forget knows may be mutable and may be mutated
- * after the effect. Note that it's possible Forget may miss not memoize a value for some other reason,
- * but in general this is a bug. The only reason Forget would _choose_ to skip memoization of an
+ * This latter check corresponds to any values which Compiler knows may be mutable and may be mutated
+ * after the effect. Note that it's possible Compiler may miss not memoize a value for some other reason,
+ * but in general this is a bug. The only reason Compiler would _choose_ to skip memoization of an
  * effect dependency is because it's mutated later.
  *
  * Example:

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/e2e/update-button.e2e.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/e2e/update-button.e2e.js
@@ -39,7 +39,7 @@ test("update-button", () => {
 
   // Update the label, but not the theme
   rerender(<Button label="Click again" />);
-  // `computeStyle` should not be called again when Forget is enabled
+  // `computeStyle` should not be called again when Compiler is enabled
   expect(styleComputations).toBe(__FORGET__ ? 1 : 2);
   expect(asFragment()).toMatchInlineSnapshot(`
     <DocumentFragment>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allocating-primitive-as-dep-nested-scope.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allocating-primitive-as-dep-nested-scope.expect.md
@@ -3,7 +3,7 @@
 
 ```javascript
 // bar(props.b) is an allocating expression that produces a primitive, which means
-// that Forget should memoize it.
+// that Compiler should memoize it.
 // Correctness:
 
 import { identity, mutate, setProperty } from "shared-runtime";
@@ -38,7 +38,7 @@ export const FIXTURE_ENTRYPOINT = {
 
 ```javascript
 import { c as _c } from "react/compiler-runtime"; // bar(props.b) is an allocating expression that produces a primitive, which means
-// that Forget should memoize it.
+// that Compiler should memoize it.
 // Correctness:
 
 import { identity, mutate, setProperty } from "shared-runtime";

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allocating-primitive-as-dep-nested-scope.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allocating-primitive-as-dep-nested-scope.js
@@ -1,5 +1,5 @@
 // bar(props.b) is an allocating expression that produces a primitive, which means
-// that Forget should memoize it.
+// that Compiler should memoize it.
 // Correctness:
 
 import { identity, mutate, setProperty } from "shared-runtime";

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allocating-primitive-as-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allocating-primitive-as-dep.expect.md
@@ -3,7 +3,7 @@
 
 ```javascript
 // bar(props.b) is an allocating expression that produces a primitive, which means
-// that Forget should memoize it.
+// that Compiler should memoize it.
 // Correctness:
 //   - y depends on either bar(props.b) or bar(props.b) + 1
 function AllocatingPrimitiveAsDep(props) {
@@ -17,7 +17,7 @@ function AllocatingPrimitiveAsDep(props) {
 
 ```javascript
 import { c as _c } from "react/compiler-runtime"; // bar(props.b) is an allocating expression that produces a primitive, which means
-// that Forget should memoize it.
+// that Compiler should memoize it.
 // Correctness:
 //   - y depends on either bar(props.b) or bar(props.b) + 1
 function AllocatingPrimitiveAsDep(props) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allocating-primitive-as-dep.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allocating-primitive-as-dep.js
@@ -1,5 +1,5 @@
 // bar(props.b) is an allocating expression that produces a primitive, which means
-// that Forget should memoize it.
+// that Compiler should memoize it.
 // Correctness:
 //   - y depends on either bar(props.b) or bar(props.b) + 1
 function AllocatingPrimitiveAsDep(props) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-invalid-hoisting-functionexpr.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-invalid-hoisting-functionexpr.expect.md
@@ -14,7 +14,7 @@ import { Stringify } from "shared-runtime";
  *  Found differences in evaluator results
  *  Non-forget (expected):
  *  (kind: ok) <div>{"shouldInvokeFns":true,"callback":{"kind":"Function","result":null}}</div>
- *  Forget:
+ *  Compiler:
  *  (kind: exception) Cannot read properties of null (reading 'prop')
  */
 function Component({ obj, isObjNull }) {
@@ -51,7 +51,7 @@ import { Stringify } from "shared-runtime";
  *  Found differences in evaluator results
  *  Non-forget (expected):
  *  (kind: ok) <div>{"shouldInvokeFns":true,"callback":{"kind":"Function","result":null}}</div>
- *  Forget:
+ *  Compiler:
  *  (kind: exception) Cannot read properties of null (reading 'prop')
  */
 function Component(t0) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-invalid-hoisting-functionexpr.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-invalid-hoisting-functionexpr.tsx
@@ -10,7 +10,7 @@ import { Stringify } from "shared-runtime";
  *  Found differences in evaluator results
  *  Non-forget (expected):
  *  (kind: ok) <div>{"shouldInvokeFns":true,"callback":{"kind":"Function","result":null}}</div>
- *  Forget:
+ *  Compiler:
  *  (kind: exception) Cannot read properties of null (reading 'prop')
  */
 function Component({ obj, isObjNull }) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/dont-merge-if-dep-is-inner-declaration-of-previous-scope.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/dont-merge-if-dep-is-inner-declaration-of-previous-scope.expect.md
@@ -4,8 +4,8 @@
 ```javascript
 import { ValidateMemoization } from "shared-runtime";
 
-// Achieving Forget's level of memoization precision in this example isn't possible with useMemo
-// without significantly altering the code, so disable the non-Forget evaluation of this fixture.
+// Achieving Compiler's level of memoization precision in this example isn't possible with useMemo
+// without significantly altering the code, so disable the non-Compiler evaluation of this fixture.
 // @disableNonForgetInSprout
 function Component({ a, b, c }) {
   const x = [];
@@ -47,8 +47,8 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 import { ValidateMemoization } from "shared-runtime";
 
-// Achieving Forget's level of memoization precision in this example isn't possible with useMemo
-// without significantly altering the code, so disable the non-Forget evaluation of this fixture.
+// Achieving Compiler's level of memoization precision in this example isn't possible with useMemo
+// without significantly altering the code, so disable the non-Compiler evaluation of this fixture.
 // @disableNonForgetInSprout
 function Component(t0) {
   const $ = _c(25);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/dont-merge-if-dep-is-inner-declaration-of-previous-scope.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/dont-merge-if-dep-is-inner-declaration-of-previous-scope.js
@@ -1,7 +1,7 @@
 import { ValidateMemoization } from "shared-runtime";
 
-// Achieving Forget's level of memoization precision in this example isn't possible with useMemo
-// without significantly altering the code, so disable the non-Forget evaluation of this fixture.
+// Achieving Compiler's level of memoization precision in this example isn't possible with useMemo
+// without significantly altering the code, so disable the non-Compiler evaluation of this fixture.
 // @disableNonForgetInSprout
 function Component({ a, b, c }) {
   const x = [];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.component-syntax-ref-gating.flow.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.component-syntax-ref-gating.flow.expect.md
@@ -14,7 +14,7 @@ component Foo(ref: React.RefSetter<Controls>) {
 ```
   1 | // @flow @gating
 > 2 | component Foo(ref: React.RefSetter<Controls>) {
-    |           ^^^ Invariant: Encountered a function used before its declaration, which breaks Forget's gating codegen due to hoisting. Rewrite the reference to Foo_withRef to not rely on hoisting to fix this issue (2:2)
+    |           ^^^ Invariant: Encountered a function used before its declaration, which breaks Compiler's gating codegen due to hoisting. Rewrite the reference to Foo_withRef to not rely on hoisting to fix this issue (2:2)
   3 |   return <Bar ref={ref}/>;
   4 | }
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.gating-hoisting.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.gating-hoisting.expect.md
@@ -17,7 +17,7 @@ function Foo_withRef(props, ref) {
   1 | // @gating
   2 | const Foo = React.forwardRef(Foo_withRef);
 > 3 | function Foo_withRef(props, ref) {
-    |          ^^^^^^^^^^^ Invariant: Encountered a function used before its declaration, which breaks Forget's gating codegen due to hoisting. Rewrite the reference to Foo_withRef to not rely on hoisting to fix this issue (3:3)
+    |          ^^^^^^^^^^^ Invariant: Encountered a function used before its declaration, which breaks Compiler's gating codegen due to hoisting. Rewrite the reference to Foo_withRef to not rely on hoisting to fix this issue (3:3)
   4 |   return <Bar ref={ref} {...props}></Bar>;
   5 | }
   6 |

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.gating-use-before-decl.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.gating-use-before-decl.expect.md
@@ -17,7 +17,7 @@ function Foo() {}
   3 |
   4 | export default memo(Foo);
 > 5 | function Foo() {}
-    |          ^^^ Invariant: Encountered a function used before its declaration, which breaks Forget's gating codegen due to hoisting. Rewrite the reference to Foo to not rely on hoisting to fix this issue (5:5)
+    |          ^^^ Invariant: Encountered a function used before its declaration, which breaks Compiler's gating codegen due to hoisting. Rewrite the reference to Foo to not rely on hoisting to fix this issue (5:5)
   6 |
 ```
           

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.useMemo-non-literal-depslist.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.useMemo-non-literal-depslist.expect.md
@@ -5,7 +5,7 @@
 import { useMemo } from "react";
 
 // react-hooks-deps would error on this code (complex expression in depslist),
-// so Forget could bailout here
+// so Compiler could bailout here
 function App({ text, hasDeps }) {
   const resolvedText = useMemo(
     () => {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.useMemo-non-literal-depslist.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.useMemo-non-literal-depslist.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 
 // react-hooks-deps would error on this code (complex expression in depslist),
-// so Forget could bailout here
+// so Compiler could bailout here
 function App({ text, hasDeps }) {
   const resolvedText = useMemo(
     () => {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fast-refresh-refresh-on-const-changes-dev.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fast-refresh-refresh-on-const-changes-dev.expect.md
@@ -25,7 +25,7 @@ function Component() {
   // unsafe, but in this case we're simulating a fast refresh between each render
   unsafeUpdateConst();
 
-  // TODO: In fast refresh mode (@enableResetCacheOnSourceFileChanges) Forget should
+  // TODO: In fast refresh mode (@enableResetCacheOnSourceFileChanges) Compiler should
   // reset on changes to globals that impact the component/hook, effectively memoizing
   // as if value was reactive. However, we don't want to actually treat globals as
   // reactive (though that would be trivial) since it could change compilation too much

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fast-refresh-refresh-on-const-changes-dev.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fast-refresh-refresh-on-const-changes-dev.js
@@ -21,7 +21,7 @@ function Component() {
   // unsafe, but in this case we're simulating a fast refresh between each render
   unsafeUpdateConst();
 
-  // TODO: In fast refresh mode (@enableResetCacheOnSourceFileChanges) Forget should
+  // TODO: In fast refresh mode (@enableResetCacheOnSourceFileChanges) Compiler should
   // reset on changes to globals that impact the component/hook, effectively memoizing
   // as if value was reactive. However, we don't want to actually treat globals as
   // reactive (though that would be trivial) since it could change compilation too much

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-compile-hooks-with-multiple-params.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-compile-hooks-with-multiple-params.expect.md
@@ -5,7 +5,7 @@
 // @compilationMode(infer)
 import { useNoAlias } from "shared-runtime";
 
-// This should be compiled by Forget
+// This should be compiled by Compiler
 function useFoo(value1, value2) {
   return {
     value: useNoAlias(value1 + value2),
@@ -25,7 +25,7 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime"; // @compilationMode(infer)
 import { useNoAlias } from "shared-runtime";
 
-// This should be compiled by Forget
+// This should be compiled by Compiler
 function useFoo(value1, value2) {
   const $ = _c(2);
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-compile-hooks-with-multiple-params.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-compile-hooks-with-multiple-params.js
@@ -1,7 +1,7 @@
 // @compilationMode(infer)
 import { useNoAlias } from "shared-runtime";
 
-// This should be compiled by Forget
+// This should be compiled by Compiler
 function useFoo(value1, value2) {
   return {
     value: useNoAlias(value1 + value2),

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-tag-evaluation-order-non-global.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-tag-evaluation-order-non-global.expect.md
@@ -16,7 +16,7 @@ function Component(props) {
   // the jsx element's tag observes `Tag` after reassignment, but should observe
   // it before the reassignment.
 
-  // Currently, Forget preserves jsx whitespace in the source text.
+  // Currently, Compiler preserves jsx whitespace in the source text.
   // prettier-ignore
   return (
     <Tag>{((Tag = props.alternateComponent), maybeMutate(maybeMutable))}<Tag /></Tag>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-tag-evaluation-order-non-global.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-tag-evaluation-order-non-global.js
@@ -12,7 +12,7 @@ function Component(props) {
   // the jsx element's tag observes `Tag` after reassignment, but should observe
   // it before the reassignment.
 
-  // Currently, Forget preserves jsx whitespace in the source text.
+  // Currently, Compiler preserves jsx whitespace in the source text.
   // prettier-ignore
   return (
     <Tag>{((Tag = props.alternateComponent), maybeMutate(maybeMutable))}<Tag /></Tag>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-tag-evaluation-order.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-tag-evaluation-order.expect.md
@@ -7,7 +7,7 @@ import { StaticText1, StaticText2 } from "shared-runtime";
 function Component(props: { value: string }) {
   let Tag = StaticText1;
 
-  // Currently, Forget preserves jsx whitespace in the source text.
+  // Currently, Compiler preserves jsx whitespace in the source text.
   // prettier-ignore
   return (
     <Tag>{((Tag = StaticText2), props.value)}<Tag /></Tag>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-tag-evaluation-order.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-tag-evaluation-order.tsx
@@ -3,7 +3,7 @@ import { StaticText1, StaticText2 } from "shared-runtime";
 function Component(props: { value: string }) {
   let Tag = StaticText1;
 
-  // Currently, Forget preserves jsx whitespace in the source text.
+  // Currently, Compiler preserves jsx whitespace in the source text.
   // prettier-ignore
   return (
     <Tag>{((Tag = StaticText2), props.value)}<Tag /></Tag>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/original-reactive-scopes-fork/bug-hoisted-declaration-with-scope.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/original-reactive-scopes-fork/bug-hoisted-declaration-with-scope.expect.md
@@ -13,7 +13,7 @@ import { StaticText1, Stringify, identity, useHook } from "shared-runtime";
  * Found differences in evaluator results
  * Non-forget (expected):
  * (kind: ok) "[[ function params=1 ]]"
- * Forget:
+ * Compiler:
  * (kind: exception) Cannot access 'dispatcher' before initialization
  */
 function useFoo({ onClose }) {
@@ -57,7 +57,7 @@ import { StaticText1, Stringify, identity, useHook } from "shared-runtime";
  * Found differences in evaluator results
  * Non-forget (expected):
  * (kind: ok) "[[ function params=1 ]]"
- * Forget:
+ * Compiler:
  * (kind: exception) Cannot access 'dispatcher' before initialization
  */
 function useFoo(t0) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/original-reactive-scopes-fork/bug-hoisted-declaration-with-scope.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/original-reactive-scopes-fork/bug-hoisted-declaration-with-scope.tsx
@@ -9,7 +9,7 @@ import { StaticText1, Stringify, identity, useHook } from "shared-runtime";
  * Found differences in evaluator results
  * Non-forget (expected):
  * (kind: ok) "[[ function params=1 ]]"
- * Forget:
+ * Compiler:
  * (kind: exception) Cannot access 'dispatcher' before initialization
  */
 function useFoo({ onClose }) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/original-reactive-scopes-fork/bug-nonmutating-capture-in-unsplittable-memo-block.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/original-reactive-scopes-fork/bug-nonmutating-capture-in-unsplittable-memo-block.expect.md
@@ -28,7 +28,7 @@ import { identity, mutate } from "shared-runtime";
  * Non-forget (expected):
  * (kind: ok) [{"wat0":"joe"},3]
  * [{"wat0":"joe"},3]
- * Forget:
+ * Compiler:
  * (kind: ok) [{"wat0":"joe"},3]
  * [[ (exception in render) Error: oh no! ]]
  *
@@ -86,7 +86,7 @@ import { identity, mutate } from "shared-runtime";
  * Non-forget (expected):
  * (kind: ok) [{"wat0":"joe"},3]
  * [{"wat0":"joe"},3]
- * Forget:
+ * Compiler:
  * (kind: ok) [{"wat0":"joe"},3]
  * [[ (exception in render) Error: oh no! ]]
  *

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.false-positive-useMemo-infer-mutate-deps.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.false-positive-useMemo-infer-mutate-deps.expect.md
@@ -6,7 +6,7 @@
 import { useMemo } from "react";
 import { identity } from "shared-runtime";
 
-// This is a false positive as Forget's inferred memoization
+// This is a false positive as Compiler's inferred memoization
 // invalidates strictly less than source. We currently do not
 // track transitive deps / invalidations of manual memo deps
 // because of implementation complexity

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.false-positive-useMemo-infer-mutate-deps.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.false-positive-useMemo-infer-mutate-deps.ts
@@ -2,7 +2,7 @@
 import { useMemo } from "react";
 import { identity } from "shared-runtime";
 
-// This is a false positive as Forget's inferred memoization
+// This is a false positive as Compiler's inferred memoization
 // invalidates strictly less than source. We currently do not
 // track transitive deps / invalidations of manual memo deps
 // because of implementation complexity

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.useMemo-unrelated-mutation-in-depslist.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.useMemo-unrelated-mutation-in-depslist.expect.md
@@ -6,7 +6,7 @@
 
 import { useMemo } from "react";
 
-// Here, Forget infers that the memo block dependency is input1
+// Here, Compiler infers that the memo block dependency is input1
 // 1. StartMemoize is emitted before the function expression
 //    (and thus before the depslist arg and its rvalues)
 // 2. x and y's overlapping reactive scopes forces y's reactive

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.useMemo-unrelated-mutation-in-depslist.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.useMemo-unrelated-mutation-in-depslist.ts
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 
-// Here, Forget infers that the memo block dependency is input1
+// Here, Compiler infers that the memo block dependency is input1
 // 1. StartMemoize is emitted before the function expression
 //    (and thus before the depslist arg and its rvalues)
 // 2. x and y's overlapping reactive scopes forces y's reactive

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-dropped-infer-always-invalidating.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-dropped-infer-always-invalidating.expect.md
@@ -7,7 +7,7 @@
 import { useMemo } from "react";
 import { useHook } from "shared-runtime";
 
-// useMemo values may not be memoized in Forget output if we
+// useMemo values may not be memoized in Compiler output if we
 // infer that their deps always invalidate.
 // This is still correct as the useMemo in source was effectively
 // a no-op already.
@@ -34,7 +34,7 @@ export const FIXTURE_ENTRYPOINT = {
 import { useMemo } from "react";
 import { useHook } from "shared-runtime";
 
-// useMemo values may not be memoized in Forget output if we
+// useMemo values may not be memoized in Compiler output if we
 // infer that their deps always invalidate.
 // This is still correct as the useMemo in source was effectively
 // a no-op already.

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-dropped-infer-always-invalidating.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-dropped-infer-always-invalidating.ts
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import { useHook } from "shared-runtime";
 
-// useMemo values may not be memoized in Forget output if we
+// useMemo values may not be memoized in Compiler output if we
 // infer that their deps always invalidate.
 // This is still correct as the useMemo in source was effectively
 // a no-op already.

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/primitive-as-dep-nested-scope.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/primitive-as-dep-nested-scope.expect.md
@@ -2,7 +2,7 @@
 ## Input
 
 ```javascript
-// props.b + 1 is an non-allocating expression, which means Forget can
+// props.b + 1 is an non-allocating expression, which means Compiler can
 // emit it trivially and repeatedly (e.g. no need to memoize props.b + 1
 // separately from props.b)
 // Correctness:
@@ -38,7 +38,7 @@ export const FIXTURE_ENTRYPOINT = {
 ## Code
 
 ```javascript
-import { c as _c } from "react/compiler-runtime"; // props.b + 1 is an non-allocating expression, which means Forget can
+import { c as _c } from "react/compiler-runtime"; // props.b + 1 is an non-allocating expression, which means Compiler can
 // emit it trivially and repeatedly (e.g. no need to memoize props.b + 1
 // separately from props.b)
 // Correctness:

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/primitive-as-dep-nested-scope.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/primitive-as-dep-nested-scope.js
@@ -1,4 +1,4 @@
-// props.b + 1 is an non-allocating expression, which means Forget can
+// props.b + 1 is an non-allocating expression, which means Compiler can
 // emit it trivially and repeatedly (e.g. no need to memoize props.b + 1
 // separately from props.b)
 // Correctness:

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/primitive-as-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/primitive-as-dep.expect.md
@@ -2,7 +2,7 @@
 ## Input
 
 ```javascript
-// props.b + 1 is an non-allocating expression, which means Forget can
+// props.b + 1 is an non-allocating expression, which means Compiler can
 // emit it trivially and repeatedly (e.g. no need to memoize props.b + 1
 // separately from props.b)
 // Correctness:
@@ -17,7 +17,7 @@ function PrimitiveAsDep(props) {
 ## Code
 
 ```javascript
-import { c as _c } from "react/compiler-runtime"; // props.b + 1 is an non-allocating expression, which means Forget can
+import { c as _c } from "react/compiler-runtime"; // props.b + 1 is an non-allocating expression, which means Compiler can
 // emit it trivially and repeatedly (e.g. no need to memoize props.b + 1
 // separately from props.b)
 // Correctness:

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/primitive-as-dep.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/primitive-as-dep.js
@@ -1,4 +1,4 @@
-// props.b + 1 is an non-allocating expression, which means Forget can
+// props.b + 1 is an non-allocating expression, which means Compiler can
 // emit it trivially and repeatedly (e.g. no need to memoize props.b + 1
 // separately from props.b)
 // Correctness:

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/conditional-member-expr.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/conditional-member-expr.expect.md
@@ -3,7 +3,7 @@
 
 ```javascript
 // To preserve the nullthrows behavior and reactive deps of this code,
-// Forget needs to add `props.a` as a dependency (since `props.a.b` is
+// Compiler needs to add `props.a` as a dependency (since `props.a.b` is
 // a conditional dependency, i.e. gated behind control flow)
 
 function Component(props) {
@@ -23,7 +23,7 @@ export const FIXTURE_ENTRYPOINT = {
 
 ```javascript
 import { c as _c } from "react/compiler-runtime"; // To preserve the nullthrows behavior and reactive deps of this code,
-// Forget needs to add `props.a` as a dependency (since `props.a.b` is
+// Compiler needs to add `props.a` as a dependency (since `props.a.b` is
 // a conditional dependency, i.e. gated behind control flow)
 
 function Component(props) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/conditional-member-expr.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/conditional-member-expr.js
@@ -1,5 +1,5 @@
 // To preserve the nullthrows behavior and reactive deps of this code,
-// Forget needs to add `props.a` as a dependency (since `props.a.b` is
+// Compiler needs to add `props.a` as a dependency (since `props.a.b` is
 // a conditional dependency, i.e. gated behind control flow)
 
 function Component(props) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/join-uncond-scopes-cond-deps.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/join-uncond-scopes-cond-deps.expect.md
@@ -6,7 +6,7 @@
 // When propagating reactive dependencies of an inner scope up to its parent,
 // we prefer to retain granularity.
 //
-// In this test, we check that Forget propagates the inner scope's conditional
+// In this test, we check that Compiler propagates the inner scope's conditional
 // dependencies (e.g. props.a.b) instead of only its derived minimal
 // unconditional dependencies (e.g. props).
 // ```javascript
@@ -45,7 +45,7 @@ import { c as _c } from "react/compiler-runtime"; // This tests an optimization,
 // When propagating reactive dependencies of an inner scope up to its parent,
 // we prefer to retain granularity.
 //
-// In this test, we check that Forget propagates the inner scope's conditional
+// In this test, we check that Compiler propagates the inner scope's conditional
 // dependencies (e.g. props.a.b) instead of only its derived minimal
 // unconditional dependencies (e.g. props).
 // ```javascript

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/join-uncond-scopes-cond-deps.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/join-uncond-scopes-cond-deps.js
@@ -2,7 +2,7 @@
 // When propagating reactive dependencies of an inner scope up to its parent,
 // we prefer to retain granularity.
 //
-// In this test, we check that Forget propagates the inner scope's conditional
+// In this test, we check that Compiler propagates the inner scope's conditional
 // dependencies (e.g. props.a.b) instead of only its derived minimal
 // unconditional dependencies (e.g. props).
 // ```javascript

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/memberexpr-join-optional-chain.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/memberexpr-join-optional-chain.expect.md
@@ -3,7 +3,7 @@
 
 ```javascript
 // To preserve the nullthrows behavior and reactive deps of this code,
-// Forget needs to add `props.a.b` or a subpath as a dependency.
+// Compiler needs to add `props.a.b` or a subpath as a dependency.
 //
 // (1) Since the reactive block producing x unconditionally read props.a.<...>,
 //     reading `props.a.b` outside of the block would still preserve nullthrows
@@ -31,7 +31,7 @@ export const FIXTURE_ENTRYPOINT = {
 
 ```javascript
 import { c as _c } from "react/compiler-runtime"; // To preserve the nullthrows behavior and reactive deps of this code,
-// Forget needs to add `props.a.b` or a subpath as a dependency.
+// Compiler needs to add `props.a.b` or a subpath as a dependency.
 //
 // (1) Since the reactive block producing x unconditionally read props.a.<...>,
 //     reading `props.a.b` outside of the block would still preserve nullthrows

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/memberexpr-join-optional-chain.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/memberexpr-join-optional-chain.ts
@@ -1,5 +1,5 @@
 // To preserve the nullthrows behavior and reactive deps of this code,
-// Forget needs to add `props.a.b` or a subpath as a dependency.
+// Compiler needs to add `props.a.b` or a subpath as a dependency.
 //
 // (1) Since the reactive block producing x unconditionally read props.a.<...>,
 //     reading `props.a.b` outside of the block would still preserve nullthrows

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-reassign-in-rval.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-reassign-in-rval.expect.md
@@ -2,7 +2,7 @@
 ## Input
 
 ```javascript
-// Forget should call the original x (x = foo()) to compute result
+// Compiler should call the original x (x = foo()) to compute result
 function Component() {
   let x = foo();
   let result = x((x = bar()), 5);
@@ -14,7 +14,7 @@ function Component() {
 ## Code
 
 ```javascript
-import { c as _c } from "react/compiler-runtime"; // Forget should call the original x (x = foo()) to compute result
+import { c as _c } from "react/compiler-runtime"; // Compiler should call the original x (x = foo()) to compute result
 function Component() {
   const $ = _c(1);
   let t0;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-reassign-in-rval.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-reassign-in-rval.js
@@ -1,4 +1,4 @@
-// Forget should call the original x (x = foo()) to compute result
+// Compiler should call the original x (x = foo()) to compute result
 function Component() {
   let x = foo();
   let result = x((x = bar()), 5);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/unknown-hooks-do-not-assert.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/unknown-hooks-do-not-assert.expect.md
@@ -2,7 +2,7 @@
 ## Input
 
 ```javascript
-// Forget currently bails out when it detects a potential mutation (Effect.Mutate)
+// Compiler currently bails out when it detects a potential mutation (Effect.Mutate)
 // to an immutable value. This should not apply to unknown / untyped hooks.
 function Component(props) {
   const x = useUnknownHook1(props);
@@ -15,7 +15,7 @@ function Component(props) {
 ## Code
 
 ```javascript
-// Forget currently bails out when it detects a potential mutation (Effect.Mutate)
+// Compiler currently bails out when it detects a potential mutation (Effect.Mutate)
 // to an immutable value. This should not apply to unknown / untyped hooks.
 function Component(props) {
   const x = useUnknownHook1(props);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/unknown-hooks-do-not-assert.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/unknown-hooks-do-not-assert.js
@@ -1,4 +1,4 @@
-// Forget currently bails out when it detects a potential mutation (Effect.Mutate)
+// Compiler currently bails out when it detects a potential mutation (Effect.Mutate)
 // to an immutable value. This should not apply to unknown / untyped hooks.
 function Component(props) {
   const x = useUnknownHook1(props);

--- a/compiler/packages/react-compiler-runtime/src/index.ts
+++ b/compiler/packages/react-compiler-runtime/src/index.ts
@@ -106,12 +106,12 @@ const guardFrames: Array<unknown> = [];
 /**
  * When `enableEmitHookGuards` is set, this does runtime validation
  * of the no-conditional-hook-calls rule.
- * As Forget needs to statically understand which calls to move out of
- * conditional branches (i.e. Forget cannot memoize the results of hook
+ * As Compiler needs to statically understand which calls to move out of
+ * conditional branches (i.e. Compiler cannot memoize the results of hook
  * calls), its understanding of "the rules of React" are more restrictive.
  * This validation throws on unsound inputs at runtime.
  *
- * Components should only be invoked through React as Forget could memoize
+ * Components should only be invoked through React as Compiler could memoize
  * the call to AnotherComponent, introducing conditional hook calls in its
  * compiled output.
  * ```js

--- a/compiler/packages/snap/src/SproutTodoFilter.ts
+++ b/compiler/packages/snap/src/SproutTodoFilter.ts
@@ -7,7 +7,7 @@
 
 const skipFilter = new Set([
   /**
-   * Observable different in logging between Forget and non-Forget
+   * Observable different in logging between Compiler and non-Compiler
    */
   "early-return-no-declarations-reassignments-dependencies",
 

--- a/compiler/packages/snap/src/runner-worker.ts
+++ b/compiler/packages/snap/src/runner-worker.ts
@@ -22,7 +22,7 @@ const originalConsoleError = console.error;
 
 // Try to avoid clearing the entire require cache, which (as of this PR)
 // contains ~1250 files. This assumes that no dependencies have global caches
-// that may need to be invalidated across Forget reloads.
+// that may need to be invalidated across Compiler reloads.
 const invalidationSubpath = "packages/babel-plugin-react-compiler/dist";
 let version: number | null = null;
 export function clearRequireCache() {

--- a/compiler/packages/snap/src/runner.ts
+++ b/compiler/packages/snap/src/runner.ts
@@ -174,7 +174,7 @@ export async function main(opts: RunnerOptions): Promise<void> {
     makeWatchRunner((state) => onChange(worker, state), opts.filter);
     if (opts.filter) {
       /**
-       * Warm up wormers when in watch mode. Loading the Forget babel plugin
+       * Warm up wormers when in watch mode. Loading the Compiler babel plugin
        * and all of its transitive dependencies takes 1-3s (per worker) on a M1.
        * As jest-worker dispatches tasks using a round-robin strategy, we can
        * avoid an additional 1-3s wait on the first num_workers runs by warming

--- a/packages/react-reconciler/src/ReactFiberClassUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactFiberClassUpdateQueue.js
@@ -478,7 +478,7 @@ export function suspendIfUpdateReadFromEntangledAsyncAction() {
   // need to suspend until the action has finished, so that it's batched
   // together with future updates in the same action.
   // TODO: Once we support hooks inside useMemo (or an equivalent
-  // memoization boundary like Forget), hoist this logic so that it only
+  // memoization boundary like Compiler), hoist this logic so that it only
   // suspends if the memo boundary produces a new value.
   if (didReadFromEntangledAsyncAction) {
     const entangledActionThenable = peekEntangledActionThenable();

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1496,7 +1496,7 @@ function updateReducerImpl<S, A>(
       // need to suspend until the action has finished, so that it's batched
       // together with future updates in the same action.
       // TODO: Once we support hooks inside useMemo (or an equivalent
-      // memoization boundary like Forget), hoist this logic so that it only
+      // memoization boundary like Compiler), hoist this logic so that it only
       // suspends if the memo boundary produces a new value.
       if (didReadFromEntangledAsyncAction) {
         const entangledActionThenable = peekEntangledActionThenable();

--- a/packages/react-reconciler/src/ReactFiberThenable.js
+++ b/packages/react-reconciler/src/ReactFiberThenable.js
@@ -121,7 +121,7 @@ export function trackUsedThenable<T>(
           // since this is dev-only, maybe that'd be OK.
           //
           // However, another benefit of doing it this way is we might
-          // eventually have a thenableState per memo/Forget boundary instead
+          // eventually have a thenableState per memo/Compiler boundary instead
           // of per component, so this would allow us to have more
           // granular warnings.
           thenableStateDev.didWarnAboutUncachedPromise = true;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Updated the terminology in comments from Forget to Compiler. No runtime code was altered, ensuring no impact on functionality.
## How did you test this change?
I did not run tests for this change, as it solely involves comment updates and does not affect the execution of the code.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
