### PR TITLE
Re-enable prettier for compiler/

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,5 @@
 build
 
-compiler
 packages/react-devtools-core/dist
 packages/react-devtools-extensions/chrome/build
 packages/react-devtools-extensions/firefox/build

--- a/scripts/prettier/index.js
+++ b/scripts/prettier/index.js
@@ -55,6 +55,7 @@ const files = glob
     ignore: [
       '**/node_modules/**',
       '**/cjs/**',
+      'compiler/**',
       ...ignoredPathsListedInPrettierIgnoreInGlobFormat,
     ],
   })


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #29997
* __->__ #29993

Now that the compiler directory has its own prettier config, we can
remove the prettierignore entry for compiler/ so it still runs in your
editor if you open the root directory