### PR TITLE
[ci] Add new flow GitHub action

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -1,0 +1,25 @@
+name: Flow
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  flow:
+    name: Run flow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: "yarn"
+          cache-dependency-path: yarn.lock
+      - name: Restore cached node_modules
+        uses: actions/cache@v4
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.arch }}-${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+      - run: node ./scripts/tasks/flow-ci


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30030
* #30029
* #30028
* #30026
* __->__ #30025

Copies the existing circleci workflow for flow into GitHub actions. I
didn't remove the circleci job for now just to check for parity.