### PR TITLE
[ci] Parallelize flow github action

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           script: |
             const inlinedHostConfigs = require('./scripts/shared/inlinedHostConfigs.js');
-            return inlineHostConfigs.map(config => config.shortName);
+            return inlinedHostConfigs.map(config => config.shortName);
 
   Flow:
     name: Flow check ${{ matrix.flow_inline_config_shortname }}

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -22,7 +22,7 @@ jobs:
             const inlinedHostConfigs = require('./scripts/shared/inlinedHostConfigs.js');
             return inlinedHostConfigs.map(config => config.shortName);
 
-  Flow:
+  flow:
     name: Flow check ${{ matrix.flow_inline_config_shortname }}
     needs: discover_flow_inline_configs
     runs-on: ubuntu-latest

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -6,9 +6,28 @@ on:
   pull_request:
 
 jobs:
-  flow:
-    name: Run flow
+  discover_flow_inline_configs:
+    name: Discover flow inline configs
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.result }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        id: set-matrix
+        with:
+          script: |
+            const inlinedHostConfigs = require('../../scripts/shared/inlinedHostConfigs.js');
+            return inlineHostConfigs.map(config => config.shortName);
+
+  Flow:
+    name: Flow check ${{ matrix.flow_inline_config_shortname }}
+    needs: discover_flow_inline_configs
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        flow_inline_config_shortname: ${{ fromJSON(needs.discover_flow_inline_configs.outputs) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -18,8 +37,9 @@ jobs:
           cache-dependency-path: yarn.lock
       - name: Restore cached node_modules
         uses: actions/cache@v4
+        id: node_modules
         with:
           path: "**/node_modules"
           key: ${{ runner.arch }}-${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - run: node ./scripts/tasks/flow-ci
+      - run: node ./scripts/tasks/flow-ci-ghaction ${{ matrix.flow_inline_config_shortname }}

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths-ignore:
+      - 'compiler/**'
 
 jobs:
   discover_flow_inline_configs:

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -17,7 +17,7 @@ jobs:
         id: set-matrix
         with:
           script: |
-            const inlinedHostConfigs = require('../../scripts/shared/inlinedHostConfigs.js');
+            const inlinedHostConfigs = require('./scripts/shared/inlinedHostConfigs.js');
             return inlineHostConfigs.map(config => config.shortName);
 
   Flow:

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -27,7 +27,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        flow_inline_config_shortname: ${{ needs.discover_flow_inline_configs.outputs }}
+        flow_inline_config_shortname: ${{ needs.discover_flow_inline_configs.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -27,7 +27,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        flow_inline_config_shortname: ${{ fromJSON(needs.discover_flow_inline_configs.outputs) }}
+        flow_inline_config_shortname: ${{ needs.discover_flow_inline_configs.outputs }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -27,7 +27,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        flow_inline_config_shortname: ${{ needs.discover_flow_inline_configs.outputs.matrix }}
+        flow_inline_config_shortname: ${{ fromJSON(needs.discover_flow_inline_configs.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/scripts/tasks/flow-ci-ghaction.js
+++ b/scripts/tasks/flow-ci-ghaction.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+process.on('unhandledRejection', err => {
+  throw err;
+});
+
+const runFlow = require('../flow/runFlow');
+const inlinedHostConfigs = require('../shared/inlinedHostConfigs');
+
+async function check(idx) {
+  if (idx == null) {
+    throw new Error('Expected an inlinedHostConfig index');
+  }
+  const rendererInfo = inlinedHostConfigs[+idx];
+  if (rendererInfo.isFlowTyped) {
+    await runFlow(rendererInfo.shortName, ['check']);
+    console.log();
+  }
+}
+
+check(process.argv[2]);

--- a/scripts/tasks/flow-ci-ghaction.js
+++ b/scripts/tasks/flow-ci-ghaction.js
@@ -14,11 +14,13 @@ process.on('unhandledRejection', err => {
 const runFlow = require('../flow/runFlow');
 const inlinedHostConfigs = require('../shared/inlinedHostConfigs');
 
-async function check(idx) {
-  if (idx == null) {
-    throw new Error('Expected an inlinedHostConfig index');
+async function check(shortName) {
+  if (shortName == null) {
+    throw new Error('Expected an inlinedHostConfig shortName');
   }
-  const rendererInfo = inlinedHostConfigs[+idx];
+  const rendererInfo = inlinedHostConfigs.find(
+    config => config.shortName === shortName
+  );
   if (rendererInfo.isFlowTyped) {
     await runFlow(rendererInfo.shortName, ['check']);
     console.log();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30030
* #30029
* #30028
* __->__ #30026
* #30025

The existing flow-ci script makes some assumptions about running inside
of circleci for parallelization. This PR forks the script with very smal
ll tweaks to allow for a short name to be passed in as an argument.
These short names are discovered in a new GH job and then each one is
passed as an argument for parallelization