### PR TITLE
[ci] Remove circleci yarn_flags job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,15 +74,6 @@ parameters:
     default: ''
 
 jobs:
-  yarn_flags:
-    docker: *docker
-    environment: *environment
-
-    steps:
-      - checkout
-      - setup_node_modules
-      - run: yarn flags
-
   scrape_warning_messages:
     docker: *docker
     environment: *environment
@@ -441,11 +432,6 @@ workflows:
   build_and_test:
     unless: << pipeline.parameters.prerelease_commit_sha >>
     jobs:
-      - yarn_flags:
-          filters:
-            branches:
-              ignore:
-                - builds/facebook-www
       - check_generated_fizz_runtime:
           filters:
             branches:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30033
* #30032
* __->__ #30030
* #30029

This was migrated to GitHub actions