### PR TITLE
[ci] Improve parallelism of yarn test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,7 +368,7 @@ jobs:
     steps:
       - checkout
       - setup_node_modules
-      - run: yarn test <<parameters.args>> --ci
+      - run: yarn test <<parameters.args>> --ci=circleci
 
   yarn_test_build:
     docker: *docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,7 @@ jobs:
           at: .
       - setup_node_modules
       - run: ./scripts/circleci/download_devtools_regression_build.js << parameters.version >> --replaceBuild
-      - run: node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion << parameters.version >> --ci
+      - run: node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion << parameters.version >> --ci=circleci
 
   run_devtools_e2e_tests_for_versions:
     docker: *docker
@@ -382,7 +382,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_node_modules
-      - run: yarn test --build <<parameters.args>> --ci
+      - run: yarn test --build <<parameters.args>> --ci=circleci
 
   RELEASE_CHANNEL_stable_yarn_test_dom_fixtures:
     docker: *docker

--- a/.github/workflows/fuzz_tests.yml
+++ b/.github/workflows/fuzz_tests.yml
@@ -28,5 +28,5 @@ jobs:
       shell: bash
     - name: Run fuzz tests
       run: |-
-        FUZZ_TEST_SEED=$RANDOM yarn test fuzz --ci
-        FUZZ_TEST_SEED=$RANDOM yarn test --prod fuzz --ci
+        FUZZ_TEST_SEED=$RANDOM yarn test fuzz --ci=github
+        FUZZ_TEST_SEED=$RANDOM yarn test --prod fuzz --ci=github

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -49,7 +49,8 @@ jobs:
         params: ${{ fromJSON(needs.build_test_params.outputs.params) }}
     continue-on-error: true
     outputs:
-      test_names: ${{ steps.chunk-test-files.outputs }}
+      chunks: ${{ steps.chunks.outputs }}
+      chunk_ids: ${{ steps.chunk_ids.outputs }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -64,17 +65,23 @@ jobs:
           path: "**/node_modules"
           key: ${{ runner.arch }}-${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - id: chunk-test-files
-        run: yarn --silent test ${{ matrix.params }} --listTests --json --silent --ci=github | jq '[_nwise(length / 5 | ceil)]' >> $GITHUB_OUTPUT
+      - id: chunks
+        name: Set chunks
+        run: echo "chunks=$(yarn --silent test ${{ matrix.params }} --listTests --json --ci=github | jq -cM '[_nwise(length / 2 | ceil)]')" >> $GITHUB_OUTPUT
+      - id: chunk_ids
+        name: Set chunk IDs
+        run: echo "$chunk_ids=$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')" >> $GITHUB_OUTPUT
+        env:
+          CHUNKS: ${{ steps.chunks.outputs }}
 
   test:
-    name: yarn test ${{ needs.build_test_params.outputs.params }}
+    name: yarn test ${{ matrix.params }} (${{ matrix.chunk_ids }})
     runs-on: ubuntu-latest
     needs: [build_test_params, chunk_tests]
     strategy:
       matrix:
         params: ${{ fromJSON(needs.build_test_params.outputs.params) }}
-        test_names: ${{ fromJSON(needs.chunk_tests.outputs.test_names) }}
+        chunk_ids: ${{ fromJSON(needs.chunk_tests.outputs.chunk_ids) }}
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
@@ -90,4 +97,6 @@ jobs:
           path: "**/node_modules"
           key: ${{ runner.arch }}-${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - run: echo $CHUNKS | jq '.[${{ matrix.test_names }}] | .[] | @text' | xargs yarn test ${{ matrix.params }} --ci=github
+      - run: echo $CHUNKS | jq '.[${{ matrix.chunk_ids }}] | .[] | @text' | xargs yarn test ${{ matrix.params }} --ci=github
+        env:
+          CHUNKS: ${{ needs.chunk_tests.outputs.chunks }}

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -8,36 +8,48 @@ on:
       - 'compiler/**'
 
 jobs:
-  test:
-    name: yarn test
+  build_test_params:
+    name: Build test params
     runs-on: ubuntu-latest
-    continue-on-error: true
+    outputs:
+      params: ${{ steps.define-params.outputs.result }}
+    steps:
+      - uses: actions/github-script@v7
+        id: define-params
+        with:
+          script: |
+            return [
+              "-r=stable --env=development",
+              "-r=stable --env=production",
+              "-r=experimental --env=development",
+              "-r=experimental --env=production",
+              "-r=www-classic --env=development --variant=false",
+              "-r=www-classic --env=production --variant=false",
+              "-r=www-classic --env=development --variant=true",
+              "-r=www-classic --env=production --variant=true",
+              "-r=www-modern --env=development --variant=false",
+              "-r=www-modern --env=production --variant=false",
+              "-r=www-modern --env=development --variant=true",
+              "-r=www-modern --env=production --variant=true",
+              "-r=xplat --env=development --variant=false",
+              "-r=xplat --env=development --variant=true",
+              "-r=xplat --env=production --variant=false",
+              "-r=xplat --env=production --variant=true",
+              // TODO: Test more persistent configurations?
+              "-r=stable --env=development --persistent",
+              "-r=experimental --env=development --persistent"
+            ];
+
+  chunk_tests:
+    name: Chunk tests
+    runs-on: ubuntu-latest
+    needs: build_test_params
     strategy:
       matrix:
-        # Intentionally passing these as strings instead of creating a
-        # separate parameter per CLI argument, since it's easier to
-        # control/see which combinations we want to run.
-        params: [
-          "-r=stable --env=development",
-          "-r=stable --env=production",
-          "-r=experimental --env=development",
-          "-r=experimental --env=production",
-          "-r=www-classic --env=development --variant=false",
-          "-r=www-classic --env=production --variant=false",
-          "-r=www-classic --env=development --variant=true",
-          "-r=www-classic --env=production --variant=true",
-          "-r=www-modern --env=development --variant=false",
-          "-r=www-modern --env=production --variant=false",
-          "-r=www-modern --env=development --variant=true",
-          "-r=www-modern --env=production --variant=true",
-          "-r=xplat --env=development --variant=false",
-          "-r=xplat --env=development --variant=true",
-          "-r=xplat --env=production --variant=false",
-          "-r=xplat --env=production --variant=true",
-          # TODO: Test more persistent configurations?
-          "-r=stable --env=development --persistent",
-          "-r=experimental --env=development --persistent"
-        ]
+        params: ${{ fromJSON(needs.build_test_params.outputs) }}
+    continue-on-error: true
+    outputs:
+      test_names: ${{ steps.chunk-test-files.outputs }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -52,4 +64,30 @@ jobs:
           path: "**/node_modules"
           key: ${{ runner.arch }}-${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - run: yarn test ${{ matrix.params }} --ci=github
+      - id: chunk-test-files
+        run: yarn --silent test ${{ matrix.params }} --listTests --json --silent | jq '[_nwise(length / 5 | ceil)]' >> $GITHUB_OUTPUT
+
+  test:
+    name: yarn test ${{ needs.build_test_params.outputs.params }}
+    runs-on: ubuntu-latest
+    needs: [build_test_params, chunk_tests]
+    strategy:
+      matrix:
+        params: ${{ fromJSON(needs.build_test_params.outputs) }}
+        test_names: ${{ fromJSON(needs.chunk_tests.outputs ) }}
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: "yarn"
+          cache-dependency-path: yarn.lock
+      - name: Restore cached node_modules
+        uses: actions/cache@v4
+        id: node_modules
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.arch }}-${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn test ${{ matrix.params }} --ci=github ${{ matrix.test_names  }}

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -70,7 +70,7 @@ jobs:
         run: echo "chunks=$(yarn --silent test ${{ matrix.params }} --listTests --json --ci=github | jq -cM '[_nwise(length / 2 | ceil)]')" >> $GITHUB_OUTPUT
       - id: chunk_ids
         name: Set chunk IDs
-        run: echo "$chunk_ids=$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')" >> $GITHUB_OUTPUT
+        run: echo "chunk_ids=$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')" >> $GITHUB_OUTPUT
         env:
           CHUNKS: ${{ steps.chunks.outputs.chunks }}
 

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -65,7 +65,7 @@ jobs:
           key: ${{ runner.arch }}-${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
       - id: chunk-test-files
-        run: yarn --silent test ${{ matrix.params }} --listTests --json --silent | jq '[_nwise(length / 5 | ceil)]' >> $GITHUB_OUTPUT
+        run: yarn --silent test ${{ matrix.params }} --listTests --json --silent --ci=github | jq '[_nwise(length / 5 | ceil)]' >> $GITHUB_OUTPUT
 
   test:
     name: yarn test ${{ needs.build_test_params.outputs.params }}

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       params: ${{ steps.define-params.outputs.result }}
+      # How many chunks to group tests into
+      parallelism: 3
     steps:
       - uses: actions/github-script@v7
         id: define-params
@@ -67,7 +69,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - id: chunks
         name: Set chunks
-        run: echo "chunks=$(yarn --silent test ${{ matrix.params }} --listTests --json --ci=github | jq -cM '[_nwise(length / 2 | ceil)]')" >> $GITHUB_OUTPUT
+        run: echo "chunks=$(yarn --silent test ${{ matrix.params }} --listTests --json --ci=github | jq -cM '[_nwise(length / ${{ needs.build_test_params.outputs.parallelism }} | ceil)]')" >> $GITHUB_OUTPUT
       - id: chunk_ids
         name: Set chunk IDs
         run: echo "chunk_ids=$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')" >> $GITHUB_OUTPUT
@@ -75,7 +77,7 @@ jobs:
           CHUNKS: ${{ steps.chunks.outputs.chunks }}
 
   test:
-    name: yarn test ${{ matrix.params }} (${{ matrix.chunk_ids }})
+    name: yarn test ${{ matrix.params }} (Chunk ${{ matrix.chunk_ids }})
     runs-on: ubuntu-latest
     needs: [build_test_params, chunk_tests]
     strategy:

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -7,6 +7,10 @@ on:
     paths-ignore:
       - 'compiler/**'
 
+env:
+  # Number of workers (one per shard) to spawn
+  SHARD_COUNT: 5
+
 jobs:
   # Define the various test parameters and parallelism for this workflow
   build_test_params:
@@ -14,9 +18,20 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       params: ${{ steps.define-params.outputs.result }}
-      # How many chunks to group tests into
-      parallelism: 5
+      shard_id: ${{ steps.define-chunks.outputs.result }}
     steps:
+      - uses: actions/github-script@v7
+        id: define-chunks
+        with:
+          script: |
+            function range(from, to) {
+              const arr = [];
+              for (let n = from; n < to; n++) {
+                arr.push(n);
+              }
+              return arr;
+            }
+            return range(0, process.env.SHARD_COUNT);
       - uses: actions/github-script@v7
         id: define-params
         with:
@@ -43,51 +58,15 @@ jobs:
               "-r=experimental --env=development --persistent"
             ];
 
-  # Chunk tests into groups for parallelism
-  chunk_tests:
-    name: Chunk tests
+  # Spawn a job for each shard for a given set of test params
+  test:
+    name: yarn test ${{ matrix.params }} (Chunk ${{ matrix.shard_id }})
     runs-on: ubuntu-latest
     needs: build_test_params
     strategy:
       matrix:
         params: ${{ fromJSON(needs.build_test_params.outputs.params) }}
-    continue-on-error: true
-    outputs:
-      chunks: ${{ steps.chunks.outputs.chunks }}
-      chunk_ids: ${{ steps.chunk_ids.outputs.chunk_ids }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18.x
-          cache: "yarn"
-          cache-dependency-path: yarn.lock
-      - name: Restore cached node_modules
-        uses: actions/cache@v4
-        id: node_modules
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.arch }}-${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
-      - run: yarn install --frozen-lockfile
-      - id: chunks
-        name: Set chunks
-        run: echo "chunks=$(yarn --silent test ${{ matrix.params }} --listTests --json --ci=github | jq -cM '[_nwise(length / ${{ needs.build_test_params.outputs.parallelism }} | ceil)]')" >> $GITHUB_OUTPUT
-      - id: chunk_ids
-        name: Set chunk IDs
-        run: echo "chunk_ids=$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')" >> $GITHUB_OUTPUT
-        env:
-          CHUNKS: ${{ steps.chunks.outputs.chunks }}
-
-  # Spawn a job for each set of test param and number of chunks
-  test:
-    name: yarn test ${{ matrix.params }} (Chunk ${{ matrix.chunk_ids }})
-    runs-on: ubuntu-latest
-    needs: [build_test_params, chunk_tests]
-    strategy:
-      matrix:
-        params: ${{ fromJSON(needs.build_test_params.outputs.params) }}
-        chunks: ${{ fromJSON(needs.chunk_tests.outputs.chunks) }}
-        chunk_ids: ${{ fromJSON(needs.chunk_tests.outputs.chunk_ids) }}
+        shard_id: ${{ fromJSON(needs.build_test_params.outputs.shard_id) }}
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
@@ -103,6 +82,4 @@ jobs:
           path: "**/node_modules"
           key: ${{ runner.arch }}-${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - run: echo $CHUNKS | jq '.[${{ matrix.chunk_ids }}] | .[] | @text' | xargs yarn test ${{ matrix.params }} --ci=github
-        env:
-          CHUNKS: ${{ matrix.chunks }}
+      - run: yarn test ${{ matrix.params }} --ci=github --shard=${{ matrix.shard_id }}/${{ env.SHARD_COUNT }}

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -72,7 +72,7 @@ jobs:
         name: Set chunk IDs
         run: echo "$chunk_ids=$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')" >> $GITHUB_OUTPUT
         env:
-          CHUNKS: ${{ steps.chunks.outputs }}
+          CHUNKS: ${{ steps.chunks.outputs.chunks }}
 
   test:
     name: yarn test ${{ matrix.params }} (${{ matrix.chunk_ids }})

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       params: ${{ steps.define-params.outputs.result }}
       # How many chunks to group tests into
-      parallelism: 5
+      parallelism: 10
     steps:
       - uses: actions/github-script@v7
         id: define-params

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       params: ${{ steps.define-params.outputs.result }}
       # How many chunks to group tests into
-      parallelism: 10
+      parallelism: 5
     steps:
       - uses: actions/github-script@v7
         id: define-params

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -46,7 +46,7 @@ jobs:
     needs: build_test_params
     strategy:
       matrix:
-        params: ${{ fromJSON(needs.build_test_params.outputs) }}
+        params: ${{ fromJSON(needs.build_test_params.outputs.params) }}
     continue-on-error: true
     outputs:
       test_names: ${{ steps.chunk-test-files.outputs }}
@@ -73,8 +73,8 @@ jobs:
     needs: [build_test_params, chunk_tests]
     strategy:
       matrix:
-        params: ${{ fromJSON(needs.build_test_params.outputs) }}
-        test_names: ${{ fromJSON(needs.chunk_tests.outputs ) }}
+        params: ${{ fromJSON(needs.build_test_params.outputs.params) }}
+        test_names: ${{ fromJSON(needs.chunk_tests.outputs.test_names) }}
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
@@ -90,4 +90,4 @@ jobs:
           path: "**/node_modules"
           key: ${{ runner.arch }}-${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - run: yarn test ${{ matrix.params }} --ci=github ${{ matrix.test_names  }}
+      - run: echo $CHUNKS | jq '.[${{ matrix.test_names }}] | .[] | @text' | xargs yarn test ${{ matrix.params }} --ci=github

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       params: ${{ steps.define-params.outputs.result }}
       # How many chunks to group tests into
-      parallelism: 4
+      parallelism: 5
     steps:
       - uses: actions/github-script@v7
         id: define-params

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       params: ${{ steps.define-params.outputs.result }}
       # How many chunks to group tests into
-      parallelism: 7
+      parallelism: 5
     steps:
       - uses: actions/github-script@v7
         id: define-params
@@ -34,10 +34,11 @@ jobs:
               "-r=www-modern --env=production --variant=false",
               "-r=www-modern --env=development --variant=true",
               "-r=www-modern --env=production --variant=true",
-              "-r=xplat --env=development --variant=false",
-              "-r=xplat --env=development --variant=true",
-              "-r=xplat --env=production --variant=false",
-              "-r=xplat --env=production --variant=true",
+              // Chunks may include only react-dom tests which xplat doesn't run
+              "-r=xplat --env=development --variant=false --passWithNoTests",
+              "-r=xplat --env=development --variant=true --passWithNoTests",
+              "-r=xplat --env=production --variant=false --passWithNoTests",
+              "-r=xplat --env=production --variant=true --passWithNoTests",
               // TODO: Test more persistent configurations?
               "-r=stable --env=development --persistent",
               "-r=experimental --env=development --persistent"

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -52,4 +52,4 @@ jobs:
           path: "**/node_modules"
           key: ${{ runner.arch }}-${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - run: yarn test ${{ matrix.params }} --ci
+      - run: yarn test ${{ matrix.params }} --ci=github

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -49,8 +49,8 @@ jobs:
         params: ${{ fromJSON(needs.build_test_params.outputs.params) }}
     continue-on-error: true
     outputs:
-      chunks: ${{ steps.chunks.outputs }}
-      chunk_ids: ${{ steps.chunk_ids.outputs }}
+      chunks: ${{ steps.chunks.outputs.chunks }}
+      chunk_ids: ${{ steps.chunk_ids.outputs.chunk_ids }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -8,13 +8,14 @@ on:
       - 'compiler/**'
 
 jobs:
+  # Define the various test parameters and parallelism for this workflow
   build_test_params:
     name: Build test params
     runs-on: ubuntu-latest
     outputs:
       params: ${{ steps.define-params.outputs.result }}
       # How many chunks to group tests into
-      parallelism: 3
+      parallelism: 4
     steps:
       - uses: actions/github-script@v7
         id: define-params
@@ -42,6 +43,7 @@ jobs:
               "-r=experimental --env=development --persistent"
             ];
 
+  # Chunk tests into groups for parallelism
   chunk_tests:
     name: Chunk tests
     runs-on: ubuntu-latest
@@ -76,6 +78,7 @@ jobs:
         env:
           CHUNKS: ${{ steps.chunks.outputs.chunks }}
 
+  # Spawn a job for each set of test param and number of chunks
   test:
     name: yarn test ${{ matrix.params }} (Chunk ${{ matrix.chunk_ids }})
     runs-on: ubuntu-latest

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       params: ${{ steps.define-params.outputs.result }}
       # How many chunks to group tests into
-      parallelism: 5
+      parallelism: 7
     steps:
       - uses: actions/github-script@v7
         id: define-params

--- a/.github/workflows/runtime_test.yml
+++ b/.github/workflows/runtime_test.yml
@@ -18,20 +18,20 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       params: ${{ steps.define-params.outputs.result }}
-      shard_id: ${{ steps.define-chunks.outputs.result }}
+      shard_id: ${{ steps.define-shards.outputs.result }}
     steps:
       - uses: actions/github-script@v7
-        id: define-chunks
+        id: define-shards
         with:
           script: |
             function range(from, to) {
               const arr = [];
-              for (let n = from; n < to; n++) {
+              for (let n = from; n <= to; n++) {
                 arr.push(n);
               }
               return arr;
             }
-            return range(0, process.env.SHARD_COUNT);
+            return range(1, process.env.SHARD_COUNT);
       - uses: actions/github-script@v7
         id: define-params
         with:
@@ -60,7 +60,7 @@ jobs:
 
   # Spawn a job for each shard for a given set of test params
   test:
-    name: yarn test ${{ matrix.params }} (Chunk ${{ matrix.shard_id }})
+    name: yarn test ${{ matrix.params }} (Shard ${{ matrix.shard_id }})
     runs-on: ubuntu-latest
     needs: build_test_params
     strategy:

--- a/packages/react-dom/src/__tests__/ReactMultiChildText-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChildText-test.js
@@ -77,7 +77,7 @@ const expectChildren = function (container, children) {
  * faster to render and update.
  */
 describe('ReactMultiChildText', () => {
-  jest.setTimeout(20000);
+  jest.setTimeout(30000);
 
   it('should correctly handle all possible children for render and update', async () => {
     await expect(async () => {

--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -368,16 +368,18 @@ function main() {
   const envars = getEnvars();
   const env = Object.entries(envars).map(([k, v]) => `${k}=${v}`);
 
-  // Print the full command we're actually running.
-  const command = `$ ${env.join(' ')} node ${args.join(' ')}`;
-  console.log(chalk.dim(command));
+  if (argv.ci !== 'github') {
+    // Print the full command we're actually running.
+    const command = `$ ${env.join(' ')} node ${args.join(' ')}`;
+    console.log(chalk.dim(command));
 
-  // Print the release channel and project we're running for quick confirmation.
-  console.log(
-    chalk.blue(
-      `\nRunning tests for ${argv.project} (${argv.releaseChannel})...`
-    )
-  );
+    // Print the release channel and project we're running for quick confirmation.
+    console.log(
+      chalk.blue(
+        `\nRunning tests for ${argv.project} (${argv.releaseChannel})...`
+      )
+    );
+  }
 
   // Print a message that the debugger is starting just
   // for some extra feedback when running the debugger.

--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -313,6 +313,10 @@ function getCommandArgs() {
     args.push('--maxWorkers=2');
   }
 
+  if (argv.ci === 'github') {
+    args.push('--maxConcurrency=10 --workerThreads=true');
+  }
+
   // Push the remaining args onto the command.
   // This will send args like `--watch` to Jest.
   args.push(...argv._);

--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -93,7 +93,6 @@ const argv = yargs
       requiresArg: false,
       type: 'choices',
       choices: ['circleci', 'github'],
-      default: false,
     },
     compactConsole: {
       alias: 'c',

--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -314,7 +314,7 @@ function getCommandArgs() {
   }
 
   if (argv.ci === 'github') {
-    args.push('--maxConcurrency=10 --workerThreads=true');
+    args.push('--maxConcurrency=10');
   }
 
   // Push the remaining args onto the command.

--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -91,7 +91,8 @@ const argv = yargs
     ci: {
       describe: 'Run tests in CI',
       requiresArg: false,
-      type: 'boolean',
+      type: 'choices',
+      choices: ['circleci', 'github'],
       default: false,
     },
     compactConsole: {
@@ -309,7 +310,7 @@ function getCommandArgs() {
   }
 
   // CI Environments have limited workers.
-  if (argv.ci) {
+  if (argv.ci === 'circleci') {
     args.push('--maxWorkers=2');
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30037
* #30036
* #30035
* #30034
* __->__ #30033
* #30032

This PR adds parallelism similar to our existing circleci setup for
running yarn tests with the various test params. It does this by
sharding tests into `$SHARD_COUNT` number of groups, then spawning a job
for each of them and using jest's built in `--shard` option.

Effectively this means that the job will spawn an additional (where `n`
is the number of test params)

`n * $SHARD_COUNT` number of jobs to run tests in parallel

for a total of `n + (n * $SHARD_COUNT)` jobs. This does mean the
GitHub UI at the bottom of each PR gets longer and unfortunately it's
not sorted in any way as far as I can tell. But if something goes wrong
it should still be easy to find out what the problem is.

The PR also changes the `ci` argument for jest-cli to be an enum instead
so the tests use all available workers in GitHub actions. This will have
to live around for a bit until we can fully migrate off of circleci.