### PR TITLE
Clean up enableUnifiedSyncLane flag

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
@@ -313,21 +313,12 @@ describe('ReactDOMFiberAsync', () => {
         assertLog([]);
       });
       // Only the active updates have flushed
-      if (gate(flags => flags.enableUnifiedSyncLane)) {
-        expect(container.textContent).toEqual('ABC');
-        assertLog(['ABC']);
-      } else {
-        expect(container.textContent).toEqual('BC');
-        assertLog(['BC']);
-      }
+      expect(container.textContent).toEqual('ABC');
+      assertLog(['ABC']);
 
       await act(() => {
         instance.push('D');
-        if (gate(flags => flags.enableUnifiedSyncLane)) {
-          expect(container.textContent).toEqual('ABC');
-        } else {
-          expect(container.textContent).toEqual('BC');
-        }
+        expect(container.textContent).toEqual('ABC');
         assertLog([]);
       });
       assertLog(['ABCD']);

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -23,7 +23,6 @@ import {
   enableRetryLaneExpiration,
   enableSchedulingProfiler,
   enableTransitionTracing,
-  enableUnifiedSyncLane,
   enableUpdaterTracking,
   syncLaneExpirationMs,
   transitionLaneExpirationMs,
@@ -51,9 +50,8 @@ export const InputContinuousLane: Lane = /*             */ 0b0000000000000000000
 export const DefaultHydrationLane: Lane = /*            */ 0b0000000000000000000000000010000;
 export const DefaultLane: Lane = /*                     */ 0b0000000000000000000000000100000;
 
-export const SyncUpdateLanes: Lane = enableUnifiedSyncLane
-  ? SyncLane | InputContinuousLane | DefaultLane
-  : SyncLane;
+export const SyncUpdateLanes: Lane =
+  SyncLane | InputContinuousLane | DefaultLane;
 
 const TransitionHydrationLane: Lane = /*                */ 0b0000000000000000000000001000000;
 const TransitionLanes: Lanes = /*                       */ 0b0000000001111111111111110000000;
@@ -151,11 +149,9 @@ let nextTransitionLane: Lane = TransitionLane1;
 let nextRetryLane: Lane = RetryLane1;
 
 function getHighestPriorityLanes(lanes: Lanes | Lane): Lanes {
-  if (enableUnifiedSyncLane) {
-    const pendingSyncLanes = lanes & SyncUpdateLanes;
-    if (pendingSyncLanes !== 0) {
-      return pendingSyncLanes;
-    }
+  const pendingSyncLanes = lanes & SyncUpdateLanes;
+  if (pendingSyncLanes !== 0) {
+    return pendingSyncLanes;
   }
   switch (getHighestPriorityLane(lanes)) {
     case SyncHydrationLane:
@@ -826,7 +822,7 @@ export function getBumpedLaneForHydration(
   const renderLane = getHighestPriorityLane(renderLanes);
 
   let lane;
-  if (enableUnifiedSyncLane && (renderLane & SyncUpdateLanes) !== NoLane) {
+  if ((renderLane & SyncUpdateLanes) !== NoLane) {
     lane = SyncHydrationLane;
   } else {
     switch (renderLane) {

--- a/packages/react-reconciler/src/__tests__/Activity-test.js
+++ b/packages/react-reconciler/src/__tests__/Activity-test.js
@@ -698,15 +698,10 @@ describe('Activity', () => {
       );
 
       // Before the inner update can finish, we receive another pair of updates.
-      if (gate(flags => flags.enableUnifiedSyncLane)) {
-        React.startTransition(() => {
-          setOuter(2);
-          setInner(2);
-        });
-      } else {
+      React.startTransition(() => {
         setOuter(2);
         setInner(2);
-      }
+      });
 
       // Also, before either of these new updates are processed, the hidden
       // tree is revealed at high priority.

--- a/packages/react-reconciler/src/__tests__/ReactBatching-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactBatching-test.internal.js
@@ -159,17 +159,7 @@ describe('ReactBlockingMode', () => {
     );
 
     // Now flush the first update
-    if (gate(flags => flags.enableUnifiedSyncLane)) {
-      assertLog(['A1', 'B1']);
-      expect(root).toMatchRenderedOutput('A1B1');
-    } else {
-      // Only the second update should have flushed synchronously
-      assertLog(['B1']);
-      expect(root).toMatchRenderedOutput('A0B1');
-
-      // Now flush the first update
-      await waitForAll(['A1']);
-      expect(root).toMatchRenderedOutput('A1B1');
-    }
+    assertLog(['A1', 'B1']);
+    expect(root).toMatchRenderedOutput('A1B1');
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactClassSetStateCallback-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactClassSetStateCallback-test.js
@@ -39,13 +39,9 @@ describe('ReactClassSetStateCallback', () => {
     assertLog([0]);
 
     await act(() => {
-      if (gate(flags => flags.enableUnifiedSyncLane)) {
-        React.startTransition(() => {
-          app.setState({step: 1}, () => Scheduler.log('Callback 1'));
-        });
-      } else {
+      React.startTransition(() => {
         app.setState({step: 1}, () => Scheduler.log('Callback 1'));
-      }
+      });
       ReactNoop.flushSync(() => {
         app.setState({step: 2}, () => Scheduler.log('Callback 2'));
       });

--- a/packages/react-reconciler/src/__tests__/ReactFlushSync-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFlushSync-test.js
@@ -102,20 +102,13 @@ describe('ReactFlushSync', () => {
 
       // The passive effect will schedule a sync update and a normal update.
       // They should commit in two separate batches. First the sync one.
-      await waitForPaint(
-        gate(flags => flags.enableUnifiedSyncLane) ? ['1, 1'] : ['1, 0'],
-      );
+      await waitForPaint(['1, 1']);
 
       // The remaining update is not sync
       ReactDOM.flushSync();
       assertLog([]);
 
-      if (gate(flags => flags.enableUnifiedSyncLane)) {
-        await waitForPaint([]);
-      } else {
-        // Now flush it.
-        await waitForPaint(['1, 1']);
-      }
+      await waitForPaint([]);
     });
     expect(getVisibleChildren(container)).toEqual('1, 1');
 

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -541,13 +541,8 @@ describe('ReactHooks', () => {
       });
     };
 
-    if (gate(flags => flags.enableUnifiedSyncLane)) {
-      // Update at transition priority
-      React.startTransition(() => update(n => n * 100));
-    } else {
-      // Update at normal priority
-      ReactTestRenderer.unstable_batchedUpdates(() => update(n => n * 100));
-    }
+    // Update at transition priority
+    React.startTransition(() => update(n => n * 100));
     // The new state is eagerly computed.
     assertLog(['Compute state (1 -> 100)']);
 

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -899,15 +899,8 @@ describe('ReactHooksWithNoopRenderer', () => {
       ReactNoop.flushSync(() => {
         counter.current.dispatch(INCREMENT);
       });
-      if (gate(flags => flags.enableUnifiedSyncLane)) {
-        assertLog(['Count: 4']);
-        expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 4" />);
-      } else {
-        assertLog(['Count: 1']);
-        expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 1" />);
-        await waitForAll(['Count: 4']);
-        expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 4" />);
-      }
+      assertLog(['Count: 4']);
+      expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 4" />);
     });
   });
 
@@ -1613,11 +1606,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       // As a result we, somewhat surprisingly, commit them in the opposite order.
       // This should be fine because any non-discrete set of work doesn't guarantee order
       // and easily could've happened slightly later too.
-      if (gate(flags => flags.enableUnifiedSyncLane)) {
-        assertLog(['Will set count to 1', 'Count: 1']);
-      } else {
-        assertLog(['Will set count to 1', 'Count: 2', 'Count: 1']);
-      }
+      assertLog(['Will set count to 1', 'Count: 1']);
 
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 1" />);
     });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
@@ -156,13 +156,7 @@ describe('ReactIncrementalUpdates', () => {
     }
 
     // Schedule some async updates
-    if (
-      gate(
-        flags =>
-          !flags.forceConcurrentByDefaultForTesting ||
-          flags.enableUnifiedSyncLane,
-      )
-    ) {
+    if (gate(flags => !flags.forceConcurrentByDefaultForTesting)) {
       React.startTransition(() => {
         instance.setState(createUpdate('a'));
         instance.setState(createUpdate('b'));
@@ -189,13 +183,7 @@ describe('ReactIncrementalUpdates', () => {
     });
 
     // The sync updates should have flushed, but not the async ones.
-    if (
-      gate(
-        flags =>
-          !flags.forceConcurrentByDefaultForTesting &&
-          flags.enableUnifiedSyncLane,
-      )
-    ) {
+    if (gate(flags => !flags.forceConcurrentByDefaultForTesting)) {
       assertLog(['d', 'e', 'f']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="def" />);
     } else {
@@ -207,40 +195,16 @@ describe('ReactIncrementalUpdates', () => {
     // Now flush the remaining work. Even though e and f were already processed,
     // they should be processed again, to ensure that the terminal state
     // is deterministic.
-    if (
-      gate(
-        flags =>
-          !flags.forceConcurrentByDefaultForTesting &&
-          !flags.enableUnifiedSyncLane,
-      )
-    ) {
-      await waitForAll([
-        // Since 'g' is in a transition, we'll process 'd' separately first.
-        // That causes us to process 'd' with 'e' and 'f' rebased.
-        'd',
-        'e',
-        'f',
-        // Then we'll re-process everything for 'g'.
-        'a',
-        'b',
-        'c',
-        'd',
-        'e',
-        'f',
-        'g',
-      ]);
-    } else {
-      await waitForAll([
-        // Then we'll re-process everything for 'g'.
-        'a',
-        'b',
-        'c',
-        'd',
-        'e',
-        'f',
-        'g',
-      ]);
-    }
+    await waitForAll([
+      // Then we'll re-process everything for 'g'.
+      'a',
+      'b',
+      'c',
+      'd',
+      'e',
+      'f',
+      'g',
+    ]);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="abcdefg" />);
   });
 
@@ -267,13 +231,7 @@ describe('ReactIncrementalUpdates', () => {
     }
 
     // Schedule some async updates
-    if (
-      gate(
-        flags =>
-          !flags.forceConcurrentByDefaultForTesting ||
-          flags.enableUnifiedSyncLane,
-      )
-    ) {
+    if (gate(flags => !flags.forceConcurrentByDefaultForTesting)) {
       React.startTransition(() => {
         instance.setState(createUpdate('a'));
         instance.setState(createUpdate('b'));
@@ -303,13 +261,7 @@ describe('ReactIncrementalUpdates', () => {
     });
 
     // The sync updates should have flushed, but not the async ones.
-    if (
-      gate(
-        flags =>
-          !flags.forceConcurrentByDefaultForTesting &&
-          flags.enableUnifiedSyncLane,
-      )
-    ) {
+    if (gate(flags => !flags.forceConcurrentByDefaultForTesting)) {
       assertLog(['d', 'e', 'f']);
     } else {
       // Update d was dropped and replaced by e.
@@ -320,13 +272,7 @@ describe('ReactIncrementalUpdates', () => {
     // Now flush the remaining work. Even though e and f were already processed,
     // they should be processed again, to ensure that the terminal state
     // is deterministic.
-    if (
-      gate(
-        flags =>
-          !flags.forceConcurrentByDefaultForTesting &&
-          !flags.enableUnifiedSyncLane,
-      )
-    ) {
+    if (gate(flags => !flags.forceConcurrentByDefaultForTesting)) {
       await waitForAll([
         // Since 'g' is in a transition, we'll process 'd' separately first.
         // That causes us to process 'd' with 'e' and 'f' rebased.
@@ -684,25 +630,7 @@ describe('ReactIncrementalUpdates', () => {
         pushToLog('B'),
       );
     });
-    if (gate(flags => flags.enableUnifiedSyncLane)) {
-      assertLog(['Committed: B', 'Committed: BCD', 'Committed: ABCD']);
-    } else {
-      assertLog([
-        // A and B are pending. B is higher priority, so we'll render that first.
-        'Committed: B',
-        // Because A comes first in the queue, we're now in rebase mode. B must
-        // be rebased on top of A. Also, in a layout effect, we received two new
-        // updates: C and D. C is user-blocking and D is synchronous.
-        //
-        // First render the synchronous update. What we're testing here is that
-        // B *is not dropped* even though it has lower than sync priority. That's
-        // because we already committed it. However, this render should not
-        // include C, because that update wasn't already committed.
-        'Committed: BD',
-        'Committed: BCD',
-        'Committed: ABCD',
-      ]);
-    }
+    assertLog(['Committed: B', 'Committed: BCD', 'Committed: ABCD']);
     expect(root).toMatchRenderedOutput('ABCD');
   });
 
@@ -744,25 +672,7 @@ describe('ReactIncrementalUpdates', () => {
         pushToLog('B'),
       );
     });
-    if (gate(flags => flags.enableUnifiedSyncLane)) {
-      assertLog(['Committed: B', 'Committed: BCD', 'Committed: ABCD']);
-    } else {
-      assertLog([
-        // A and B are pending. B is higher priority, so we'll render that first.
-        'Committed: B',
-        // Because A comes first in the queue, we're now in rebase mode. B must
-        // be rebased on top of A. Also, in a layout effect, we received two new
-        // updates: C and D. C is user-blocking and D is synchronous.
-        //
-        // First render the synchronous update. What we're testing here is that
-        // B *is not dropped* even though it has lower than sync priority. That's
-        // because we already committed it. However, this render should not
-        // include C, because that update wasn't already committed.
-        'Committed: BD',
-        'Committed: BCD',
-        'Committed: ABCD',
-      ]);
-    }
+    assertLog(['Committed: B', 'Committed: BCD', 'Committed: ABCD']);
     expect(root).toMatchRenderedOutput('ABCD');
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactTransition-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransition-test.js
@@ -925,28 +925,15 @@ describe('ReactTransition', () => {
       updateNormalPri();
     });
 
-    if (gate(flags => flags.enableUnifiedSyncLane)) {
-      assertLog([
-        'Normal pri: 0',
-        'Commit',
+    assertLog([
+      'Normal pri: 0',
+      'Commit',
 
-        // Normal pri update.
-        'Transition pri: 1',
-        'Normal pri: 1',
-        'Commit',
-      ]);
-    } else {
-      assertLog([
-        // Finish transition update.
-        'Normal pri: 0',
-        'Commit',
-
-        // Normal pri update.
-        'Transition pri: 1',
-        'Normal pri: 1',
-        'Commit',
-      ]);
-    }
+      // Normal pri update.
+      'Transition pri: 1',
+      'Normal pri: 1',
+      'Commit',
+    ]);
 
     expect(root).toMatchRenderedOutput('Transition pri: 1, Normal pri: 1');
   });

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -210,8 +210,6 @@ export const enableUseDeferredValueInitialArg = true;
 // Enables time slicing for updates that aren't wrapped in startTransition.
 export const forceConcurrentByDefaultForTesting = false;
 
-export const enableUnifiedSyncLane = true;
-
 // Adds an opt-in to time slicing for updates that aren't wrapped in startTransition.
 export const allowConcurrentByDefault = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -79,7 +79,6 @@ export const enableSuspenseCallback = false;
 export const enableTaint = true;
 export const enableTransitionTracing = false;
 export const enableTrustedTypesIntegration = false;
-export const enableUnifiedSyncLane = true;
 export const enableUpdaterTracking = __PROFILE__;
 export const enableUseDeferredValueInitialArg = true;
 export const enableUseEffectEventHook = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -71,7 +71,6 @@ export const enableSuspenseCallback = false;
 export const enableTaint = true;
 export const enableTransitionTracing = false;
 export const enableTrustedTypesIntegration = false;
-export const enableUnifiedSyncLane = true;
 export const enableUseDeferredValueInitialArg = true;
 export const enableUseEffectEventHook = false;
 export const enableUseMemoCacheHook = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -54,7 +54,6 @@ export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
 export const enableLegacyHidden = false;
 export const forceConcurrentByDefaultForTesting = false;
-export const enableUnifiedSyncLane = __EXPERIMENTAL__;
 export const allowConcurrentByDefault = false;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -66,7 +66,6 @@ export const enableSuspenseCallback = false;
 export const enableTaint = true;
 export const enableTransitionTracing = false;
 export const enableTrustedTypesIntegration = false;
-export const enableUnifiedSyncLane = true;
 export const enableUpdaterTracking = false;
 export const enableUseDeferredValueInitialArg = __EXPERIMENTAL__;
 export const enableUseEffectEventHook = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -56,7 +56,6 @@ export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
 export const enableLegacyHidden = false;
 export const forceConcurrentByDefaultForTesting = false;
-export const enableUnifiedSyncLane = true;
 export const allowConcurrentByDefault = true;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -16,7 +16,6 @@
 export const disableSchedulerTimeoutInWorkLoop = __VARIANT__;
 export const enableLazyContextPropagation = __VARIANT__;
 export const forceConcurrentByDefaultForTesting = __VARIANT__;
-export const enableUnifiedSyncLane = __VARIANT__;
 export const enableTransitionTracing = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const alwaysThrottleRetries = true;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -18,7 +18,6 @@ export const {
   enableTrustedTypesIntegration,
   enableDebugTracing,
   enableLazyContextPropagation,
-  enableUnifiedSyncLane,
   enableRetryLaneExpiration,
   enableTransitionTracing,
   enableDeferRootSchedulingToMicrotask,

--- a/packages/use-subscription/src/__tests__/useSubscription-test.js
+++ b/packages/use-subscription/src/__tests__/useSubscription-test.js
@@ -434,13 +434,9 @@ describe('useSubscription', () => {
       observableA.next('a-2');
 
       // Update again
-      if (gate(flags => flags.enableUnifiedSyncLane)) {
-        React.startTransition(() => {
-          root.render(<Parent observed={observableA} />);
-        });
-      } else {
+      React.startTransition(() => {
         root.render(<Parent observed={observableA} />);
-      }
+      });
 
       // Flush everything and ensure that the correct subscribable is used
       await waitForAll([


### PR DESCRIPTION
`enableUnifiedSyncLane` now passes everywhere. Let's clean it up

Implemented with https://github.com/facebook/react/pull/27646

Flag enabled with https://github.com/facebook/react/pull/27646, https://github.com/facebook/react/pull/28269, https://github.com/facebook/react/pull/29052

