### PR TITLE
[compiler] Enable sourceMaps in tsconfig

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/tsconfig.json
+++ b/compiler/packages/babel-plugin-react-compiler/tsconfig.json
@@ -17,7 +17,8 @@
     // ideally turn off only during dev, or on a per-file basis
     "noUnusedLocals": false,
     "composite": true,
-    "removeComments": true
+    "removeComments": true,
+    "sourceMap": true,
   },
   "exclude": [
     "node_modules",

--- a/compiler/packages/babel-plugin-react-compiler/tsconfig.json
+++ b/compiler/packages/babel-plugin-react-compiler/tsconfig.json
@@ -17,8 +17,7 @@
     // ideally turn off only during dev, or on a per-file basis
     "noUnusedLocals": false,
     "composite": true,
-    "removeComments": true,
-    "sourceMap": true,
+    "removeComments": true
   },
   "exclude": [
     "node_modules",

--- a/compiler/packages/snap/src/runner-watch.ts
+++ b/compiler/packages/snap/src/runner-watch.ts
@@ -27,7 +27,7 @@ export function watchSrc(
   const host = ts.createWatchCompilerHost(
     configPath,
     ts.convertCompilerOptionsFromJson(
-      { module: "commonjs", outDir: "dist" },
+      { module: "commonjs", outDir: "dist", sourceMap: true },
       "."
     ).options,
     ts.sys,


### PR DESCRIPTION
With this, we can set a `debugger` breakpoint and we'll break into the source code when running tests with snap. Without this, we'd break into the transpiled js code.