### PR TITLE
compiler: fix the `hookKind` for `useInsertionEffect`

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Globals.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Globals.ts
@@ -363,7 +363,7 @@ const REACT_APIS: Array<[string, BuiltInType]> = [
         restParam: Effect.Freeze,
         returnType: { kind: "Poly" },
         calleeEffect: Effect.Read,
-        hookKind: "useLayoutEffect",
+        hookKind: "useInsertionEffect",
         returnValueKind: ValueKind.Frozen,
       },
       BuiltInUseInsertionEffectHookId

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
@@ -123,6 +123,7 @@ export type HookKind =
   | "useRef"
   | "useEffect"
   | "useLayoutEffect"
+  | "useInsertionEffect"
   | "useMemo"
   | "useCallback"
   | "Custom";


### PR DESCRIPTION
Currently, the `hookKind` for `useInsertionEffect` is set to `useLayoutEffect`. This pull request fixes it by adding a new `hookKind` for `useInsertionEffect`.