### PR TITLE
[compiler][Babel] Refactor insertion of compiled fn

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -454,13 +454,7 @@ export function compileProgram(
    * error elsewhere in the file, regardless of bailout mode.
    */
   for (const { originalFn, compiledFn } of compiledFns) {
-    const transformedFn = createNewFunctionNode(originalFn, compiledFn);
-
-    if (gating != null) {
-      insertGatedFunctionDeclaration(originalFn, transformedFn, gating);
-    } else {
-      originalFn.replaceWith(transformedFn);
-    }
+    insertCompiledFn(originalFn, compiledFn, gating);
   }
 
   // Forget compiled the component, we need to update existing imports of useMemoCache
@@ -481,6 +475,19 @@ export function compileProgram(
       );
     }
     addImportsToProgram(program, externalFunctions);
+  }
+}
+
+function insertCompiledFn(
+  originalFn: BabelFn,
+  compiledFn: CodegenFunction,
+  gating: ExternalFunction | null
+): void {
+  const transformedFn = createNewFunctionNode(originalFn, compiledFn);
+  if (gating != null) {
+    insertGatedFunctionDeclaration(originalFn, transformedFn, gating);
+  } else {
+    originalFn.replaceWith(transformedFn);
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30089
* #30088
* #30087
* #30086
* __->__ #30085
* #30084

This PR moves the code that creates and inserts the babel fn node of the
compiled function to a helper function.

In the future, this helper can be reused by newly created functions
as part of compilation.

There's no functional change in this PR.