### PR TITLE
[compiler] Introduce OutlinedFunctionExpression HIR

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -1083,6 +1083,18 @@ export type FunctionExpression = {
   loc: SourceLocation;
 };
 
+export type OutlinedFunctionExpression = {
+  kind: "OutlinedFunctionExpression";
+  name: string | null;
+  loweredFunc: LoweredFunction;
+  outlinedFunc: HIRFunction;
+  expr:
+    | t.ArrowFunctionExpression
+    | t.FunctionExpression
+    | t.FunctionDeclaration;
+  loc: SourceLocation;
+};
+
 export type Destructure = {
   kind: "Destructure";
   lvalue: LValuePattern;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30089
* __->__ #30088
* #30087
* #30086
* #30085
* #30084

This is very similar to the existing FunctionExpression HIR node
intentionally, so that we can share all the infra between them.

There's a new `outlinedFunc` field on this that will hold the newly
created function that needs to be compiled outside the function body.

The `loweredFunc` will hold the updated HIR for rendering the
outlinedFunc in the callback.