### PR TITLE
[compiler] Handle OutlinedFunctionExpression in various passes

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -987,6 +987,7 @@ export type InstructionValue =
   | LoadGlobal
   | StoreGlobal
   | FunctionExpression
+  | OutlinedFunctionExpression
   | {
       kind: "TaggedTemplateExpression";
       tag: Place;

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -24,6 +24,7 @@ import type {
   MutableRange,
   ObjectMethod,
   ObjectPropertyKey,
+  OutlinedFunctionExpression,
   Pattern,
   Phi,
   Place,
@@ -519,6 +520,7 @@ export function printInstructionValue(instrValue: ReactiveValue): string {
       break;
     }
     case "ObjectMethod":
+    case "OutlinedFunctionExpression":
     case "FunctionExpression": {
       const kind =
         instrValue.kind === "FunctionExpression" ? "Function" : "ObjectMethod";
@@ -888,11 +890,12 @@ export function printAliases(aliases: DisjointSet<Identifier>): string {
 }
 
 function getFunctionName(
-  instrValue: ObjectMethod | FunctionExpression,
+  instrValue: ObjectMethod | FunctionExpression | OutlinedFunctionExpression,
   defaultValue: string
 ): string {
   switch (instrValue.kind) {
     case "FunctionExpression":
+    case "OutlinedFunctionExpression":
       return instrValue.name ?? defaultValue;
     case "ObjectMethod":
       return defaultValue;

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/visitors.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/visitors.ts
@@ -188,6 +188,7 @@ export function* eachInstructionValueOperand(
       break;
     }
     case "ObjectMethod":
+    case "OutlinedFunctionExpression":
     case "FunctionExpression": {
       yield* instrValue.loweredFunc.dependencies;
       break;
@@ -512,6 +513,7 @@ export function mapInstructionValueOperands(
       break;
     }
     case "ObjectMethod":
+    case "OutlinedFunctionExpression":
     case "FunctionExpression": {
       instrValue.loweredFunc.dependencies =
         instrValue.loweredFunc.dependencies.map((d) => fn(d));

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReferenceEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReferenceEffects.ts
@@ -1971,6 +1971,13 @@ function inferBlock(
         };
         break;
       }
+      case "OutlinedFunctionExpression": {
+        CompilerError.invariant(false, {
+          reason:
+            "OutlinedFunctionExpressions should only be created after InferReferenceEffects",
+          loc: null,
+        });
+      }
       default: {
         assertExhaustive(instrValue, "Unexpected instruction kind");
       }

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/DeadCodeElimination.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/DeadCodeElimination.ts
@@ -356,6 +356,7 @@ function pruneableValue(value: InstructionValue, state: State): boolean {
     case "BinaryExpression":
     case "ComputedLoad":
     case "ObjectMethod":
+    case "OutlinedFunctionExpression":
     case "FunctionExpression":
     case "LoadLocal":
     case "JsxExpression":

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -14,6 +14,7 @@ import {
   ArrayPattern,
   BlockId,
   GeneratedSource,
+  HIRFunction,
   Identifier,
   IdentifierId,
   InstructionKind,
@@ -2113,6 +2114,7 @@ function codegenInstructionValue(
     case "DeclareContext":
     case "Destructure":
     case "ObjectMethod":
+    case "OutlinedFunctionExpression":
     case "StoreContext": {
       CompilerError.invariant(false, {
         reason: `Unexpected ${instrValue.kind} in codegenInstructionValue`,

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/InferReactiveScopeVariables.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/InferReactiveScopeVariables.ts
@@ -236,6 +236,7 @@ function mayAllocate(env: Environment, instruction: Instruction): boolean {
     case "ObjectExpression":
     case "UnsupportedNode":
     case "ObjectMethod":
+    case "OutlinedFunctionExpression":
     case "FunctionExpression":
     case "TaggedTemplateExpression": {
       return true;

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonEscapingScopes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonEscapingScopes.ts
@@ -712,6 +712,7 @@ function computeMemoizationInputs(
     }
     case "RegExpLiteral":
     case "ObjectMethod":
+    case "OutlinedFunctionExpression":
     case "FunctionExpression":
     case "TaggedTemplateExpression":
     case "ArrayExpression":

--- a/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
@@ -380,7 +380,8 @@ function* generateInstructionTypes(
     case "UnsupportedNode":
     case "Debugger":
     case "FinishMemoize":
-    case "StartMemoize": {
+    case "StartMemoize":
+    case "OutlinedFunctionExpression": {
       break;
     }
     default:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30089
* #30088
* #30087
* #30086
* #30085
* #30084

There's nothing interesting happening quite yet.

Note that OutlinedFunctionExpression will be created only after
InferReferenceEffects so some of the passes before will not need to
handle this HIR node.

The codegen currently doesn't handle this HIR node for now.