### PR TITLE
refactor: simplifying the build logic

### DIFF
--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -62,9 +62,55 @@ const moduleTypes = {
 
 const {ISOMORPHIC, RENDERER, RENDERER_UTILS, RECONCILER} = moduleTypes;
 
+function bundlesForTypes(conf) {
+  const arrayOfBundles = conf.bundleTypes.map(bundleType => ({
+    bundleType,
+    ...conf
+  }));
+  arrayOfBundles.forEach(bundle => {
+    bundle.hasNonFBBundleTypes = hasNonFBBundleTypes(bundle.bundleTypes);
+    delete bundle.bundleTypes;
+    bundle.getFilename = getFilename;
+    bundle.isProfilingBundleType = isProfilingBundleType;
+    bundle.getBundleTypeFlags = getBundleTypeFlags;
+    bundle.isProductionBundleType = isProductionBundleType;
+    bundle.getFormat = getFormat;
+    bundle.needsMinifiedByClosure = needsMinifiedByClosure;
+    bundle.languageOut = languageOut;
+    bundle.emitUseStrict = emitUseStrict;
+    bundle.getBundleOutputPath = getBundleOutputPath;
+  });
+  return arrayOfBundles;
+}
+
+function needsMinifiedByClosure() {
+  return this.bundleType !== ESM_PROD && this.bundleType !== ESM_DEV;
+}
+
+function languageOut() {
+  return this.bundleType === NODE_ES2015
+              ? 'ECMASCRIPT_2020'
+              : this.bundleType === BROWSER_SCRIPT
+              ? 'ECMASCRIPT5'
+              : 'ECMASCRIPT5_STRICT'
+}
+
+function emitUseStrict() {
+  return this.bundleType !== BROWSER_SCRIPT &&
+    this.bundleType !== ESM_PROD &&
+    this.bundleType !== ESM_DEV;
+}
+
+function hasNonFBBundleTypes(bndlTypes) {
+  return () => bndlTypes.some(
+    type =>
+      type !== FB_WWW_DEV && type !== FB_WWW_PROD && type !== FB_WWW_PROFILING
+  );
+}
+
 const bundles = [
   /******* Isomorphic *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [
       NODE_DEV,
       NODE_PROD,
@@ -81,10 +127,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: true,
     externals: ['ReactNativeInternalFeatureFlags'],
-  },
+  }),
 
   /******* Isomorphic Shared Subset *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'react/src/ReactServer.js',
@@ -94,10 +140,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: false,
     externals: [],
-  },
+  }),
 
   /******* React JSX Runtime *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [
       NODE_DEV,
       NODE_PROD,
@@ -113,10 +159,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'ReactNativeInternalFeatureFlags'],
-  },
+  }),
 
   /******* Compiler Runtime *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD, NODE_PROFILING],
     moduleType: ISOMORPHIC,
     entry: 'react/compiler-runtime',
@@ -124,10 +170,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: false,
     externals: ['react'],
-  },
+  }),
 
   /******* React JSX Runtime React Server *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'react/src/jsx/ReactJSXServer.js',
@@ -137,10 +183,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'ReactNativeInternalFeatureFlags'],
-  },
+  }),
 
   /******* React JSX DEV Runtime *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [
       NODE_DEV,
       NODE_PROD,
@@ -158,10 +204,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'ReactNativeInternalFeatureFlags'],
-  },
+  }),
 
   /******* React JSX DEV Runtime React Server *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'react/src/jsx/ReactJSXServer.js',
@@ -171,10 +217,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'ReactNativeInternalFeatureFlags'],
-  },
+  }),
 
   /******* React DOM *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-dom',
@@ -182,9 +228,9 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: true,
     externals: ['react'],
-  },
+  }),
   /******* React DOM Client *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-dom/client',
@@ -192,10 +238,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: true,
     externals: ['react', 'react-dom'],
-  },
+  }),
 
   /******* React DOM Profiling (Client) *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROFILING],
     moduleType: RENDERER,
     entry: 'react-dom/profiling',
@@ -203,9 +249,9 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: true,
     externals: ['react', 'react-dom'],
-  },
+  }),
   /******* React DOM FB *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [FB_WWW_DEV, FB_WWW_PROD, FB_WWW_PROFILING],
     moduleType: RENDERER,
     entry: 'react-dom/src/ReactDOMFB.js',
@@ -213,10 +259,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: true,
     externals: ['react'],
-  },
+  }),
 
   /******* React DOM React Server *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-dom/src/ReactDOMReactServer.js',
@@ -226,10 +272,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react'],
-  },
+  }),
 
   /******* Test Utils *******/
-  {
+  ...bundlesForTypes({
     moduleType: RENDERER_UTILS,
     bundleTypes: [NODE_DEV, NODE_PROD],
     entry: 'react-dom/test-utils',
@@ -237,10 +283,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom'],
-  },
+  }),
 
   /******* React DOM - Testing *******/
-  {
+  ...bundlesForTypes({
     moduleType: RENDERER,
     bundleTypes: __EXPERIMENTAL__ ? [NODE_DEV, NODE_PROD] : [],
     entry: 'react-dom/unstable_testing',
@@ -248,10 +294,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom'],
-  },
+  }),
 
   /******* React DOM - www - Testing *******/
-  {
+  ...bundlesForTypes({
     moduleType: RENDERER,
     bundleTypes: [FB_WWW_DEV, FB_WWW_PROD],
     entry: 'react-dom/src/ReactDOMTestingFB.js',
@@ -259,10 +305,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: false,
     externals: ['react'],
-  },
+  }),
 
   /******* React DOM Server *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD, FB_WWW_DEV, FB_WWW_PROD],
     moduleType: RENDERER,
     entry: 'react-dom/src/server/ReactDOMLegacyServerBrowser.js',
@@ -277,8 +323,8 @@ const bundles = [
           [require.resolve('@babel/plugin-transform-classes'), {loose: true}],
         ]),
       }),
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-dom/src/server/ReactDOMLegacyServerNode.js',
@@ -292,10 +338,10 @@ const bundles = [
           [require.resolve('@babel/plugin-transform-classes'), {loose: true}],
         ]),
       }),
-  },
+  }),
 
   /******* React DOM Fizz Server *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-dom/src/server/react-dom-server.browser.js',
@@ -304,8 +350,8 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-dom/src/server/react-dom-server.node.js',
@@ -314,8 +360,8 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'util', 'crypto', 'async_hooks', 'react-dom'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: __EXPERIMENTAL__ ? [FB_WWW_DEV, FB_WWW_PROD] : [],
     moduleType: RENDERER,
     entry: 'react-server-dom-fb/src/ReactDOMServerFB.js',
@@ -323,10 +369,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom'],
-  },
+  }),
 
   /******* React DOM Fizz Server Edge *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-dom/src/server/react-dom-server.edge.js',
@@ -336,10 +382,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom'],
-  },
+  }),
 
   /******* React DOM Fizz Server Bun *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [BUN_DEV, BUN_PROD],
     moduleType: RENDERER,
     entry: 'react-dom/src/server/react-dom-server.bun.js',
@@ -349,10 +395,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom'],
-  },
+  }),
 
   /******* React DOM Fizz Server External Runtime *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: __EXPERIMENTAL__ ? [BROWSER_SCRIPT] : [],
     moduleType: RENDERER,
     entry: 'react-dom/unstable_server-external-runtime',
@@ -361,10 +407,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: [],
-  },
+  }),
 
   /******* React Server DOM Webpack Server *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-webpack/server.browser',
@@ -373,8 +419,8 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-webpack/server.node',
@@ -383,8 +429,8 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'util', 'crypto', 'async_hooks', 'react-dom'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-webpack/server.node.unbundled',
@@ -393,8 +439,8 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'util', 'crypto', 'async_hooks', 'react-dom'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-webpack/server.edge',
@@ -403,10 +449,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'util', 'crypto', 'async_hooks', 'react-dom'],
-  },
+  }),
 
   /******* React Server DOM Webpack Client *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-webpack/client.browser',
@@ -414,8 +460,8 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-webpack/client.node',
@@ -423,8 +469,8 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom', 'util', 'crypto'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-webpack/client.node.unbundled',
@@ -432,8 +478,8 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom', 'util', 'crypto'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-webpack/client.edge',
@@ -441,10 +487,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom'],
-  },
+  }),
 
   /******* React Server DOM Webpack Plugin *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_ES2015],
     moduleType: RENDERER_UTILS,
     entry: 'react-server-dom-webpack/plugin',
@@ -452,10 +498,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['fs', 'path', 'url', 'neo-async'],
-  },
+  }),
 
   /******* React Server DOM Webpack Node.js Loader *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [ESM_PROD],
     moduleType: RENDERER_UTILS,
     entry: 'react-server-dom-webpack/node-loader',
@@ -464,10 +510,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['acorn'],
-  },
+  }),
 
   /******* React Server DOM Webpack Node.js CommonJS Loader *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_ES2015],
     moduleType: RENDERER_UTILS,
     entry: 'react-server-dom-webpack/src/ReactFlightWebpackNodeRegister',
@@ -477,10 +523,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['url', 'module', 'react-server-dom-webpack/server'],
-  },
+  }),
 
   /******* React Server DOM Turbopack Server *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-turbopack/server.browser',
@@ -489,8 +535,8 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-turbopack/server.node',
@@ -499,8 +545,8 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'util', 'async_hooks', 'react-dom'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-turbopack/server.node.unbundled',
@@ -509,8 +555,8 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'util', 'async_hooks', 'react-dom'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-turbopack/server.edge',
@@ -519,10 +565,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'util', 'async_hooks', 'react-dom'],
-  },
+  }),
 
   /******* React Server DOM Turbopack Client *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-turbopack/client.browser',
@@ -530,8 +576,8 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-turbopack/client.node',
@@ -539,8 +585,8 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom', 'util'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-turbopack/client.node.unbundled',
@@ -548,8 +594,8 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom', 'util'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-turbopack/client.edge',
@@ -557,14 +603,14 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom'],
-  },
+  }),
 
   /******* React Server DOM Turbopack Plugin *******/
   // There is no plugin the moment because Turbopack
   // does not expose a plugin interface yet.
 
   /******* React Server DOM Turbopack Node.js Loader *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [ESM_PROD],
     moduleType: RENDERER_UTILS,
     entry: 'react-server-dom-turbopack/node-loader',
@@ -573,10 +619,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['acorn'],
-  },
+  }),
 
   /******* React Server DOM Turbopack Node.js CommonJS Loader *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_ES2015],
     moduleType: RENDERER_UTILS,
     entry: 'react-server-dom-turbopack/src/ReactFlightTurbopackNodeRegister',
@@ -586,10 +632,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['url', 'module', 'react-server-dom-turbopack/server'],
-  },
+  }),
 
   /******* React Server DOM ESM Server *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-esm/server.node',
@@ -597,28 +643,28 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'util', 'crypto', 'async_hooks', 'react-dom'],
-  },
+  }),
 
   /******* React Server DOM ESM Client *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD, ESM_DEV, ESM_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-esm/client.browser',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom'],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-esm/client.node',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'react-dom', 'util', 'crypto'],
-  },
+  }),
 
   /******* React Server DOM ESM Node.js Loader *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [ESM_PROD],
     moduleType: RENDERER_UTILS,
     entry: 'react-server-dom-esm/node-loader',
@@ -627,10 +673,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['acorn'],
-  },
+  }),
 
   /******* React Suspense Test Utils *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_ES2015],
     moduleType: RENDERER_UTILS,
     entry: 'react-suspense-test-utils',
@@ -638,10 +684,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react'],
-  },
+  }),
 
   /******* React ART *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD, FB_WWW_DEV, FB_WWW_PROD],
     moduleType: RENDERER,
     entry: 'react-art',
@@ -660,10 +706,10 @@ const bundles = [
           [require.resolve('@babel/plugin-transform-classes'), {loose: true}],
         ]),
       }),
-  },
+  }),
 
   /******* React Native *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: __EXPERIMENTAL__
       ? []
       : [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
@@ -679,8 +725,8 @@ const bundles = [
           [require.resolve('@babel/plugin-transform-classes'), {loose: true}],
         ]),
       }),
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [RN_OSS_DEV, RN_OSS_PROD, RN_OSS_PROFILING],
     moduleType: RENDERER,
     entry: 'react-native-renderer',
@@ -694,10 +740,10 @@ const bundles = [
           [require.resolve('@babel/plugin-transform-classes'), {loose: true}],
         ]),
       }),
-  },
+  }),
 
   /******* React Native Fabric *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: __EXPERIMENTAL__
       ? []
       : [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
@@ -713,8 +759,8 @@ const bundles = [
           [require.resolve('@babel/plugin-transform-classes'), {loose: true}],
         ]),
       }),
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [RN_OSS_DEV, RN_OSS_PROD, RN_OSS_PROFILING],
     moduleType: RENDERER,
     entry: 'react-native-renderer/fabric',
@@ -728,10 +774,10 @@ const bundles = [
           [require.resolve('@babel/plugin-transform-classes'), {loose: true}],
         ]),
       }),
-  },
+  }),
 
   /******* React Test Renderer *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [
       FB_WWW_DEV,
       NODE_DEV,
@@ -757,10 +803,10 @@ const bundles = [
           [require.resolve('@babel/plugin-transform-classes'), {loose: true}],
         ]),
       }),
-  },
+  }),
 
   /******* React Noop Renderer (used for tests) *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-noop-renderer',
@@ -768,10 +814,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'scheduler', 'scheduler/unstable_mock', 'expect'],
-  },
+  }),
 
   /******* React Noop Persistent Renderer (used for tests) *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-noop-renderer/persistent',
@@ -779,10 +825,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'scheduler', 'expect'],
-  },
+  }),
 
   /******* React Noop Server Renderer (used for tests) *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-noop-renderer/server',
@@ -790,10 +836,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'scheduler', 'expect'],
-  },
+  }),
 
   /******* React Noop Flight Server (used for tests) *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-noop-renderer/flight-server',
@@ -807,10 +853,10 @@ const bundles = [
       'expect',
       'react-noop-renderer/flight-modules',
     ],
-  },
+  }),
 
   /******* React Noop Flight Client (used for tests) *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-noop-renderer/flight-client',
@@ -823,10 +869,10 @@ const bundles = [
       'expect',
       'react-noop-renderer/flight-modules',
     ],
-  },
+  }),
 
   /******* React Reconciler *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD, NODE_PROFILING, FB_WWW_DEV, FB_WWW_PROD],
     moduleType: RECONCILER,
     entry: 'react-reconciler',
@@ -834,10 +880,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: false,
     externals: ['react'],
-  },
+  }),
 
   /******* React Server *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RECONCILER,
     entry: 'react-server',
@@ -845,10 +891,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react'],
-  },
+  }),
 
   /******* React Flight Server *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RECONCILER,
     entry: 'react-server/flight',
@@ -857,10 +903,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react'],
-  },
+  }),
 
   /******* React Flight Client *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RECONCILER,
     entry: 'react-client/flight',
@@ -868,10 +914,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: false,
     externals: ['react'],
-  },
+  }),
 
   /******* Reconciler Reflection *******/
-  {
+  ...bundlesForTypes({
     moduleType: RENDERER_UTILS,
     bundleTypes: [NODE_DEV, NODE_PROD],
     entry: 'react-reconciler/reflection',
@@ -879,10 +925,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: false,
     externals: [],
-  },
+  }),
 
   /******* Reconciler Constants *******/
-  {
+  ...bundlesForTypes({
     moduleType: RENDERER_UTILS,
     bundleTypes: [NODE_DEV, NODE_PROD, FB_WWW_DEV, FB_WWW_PROD],
     entry: 'react-reconciler/constants',
@@ -890,10 +936,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: false,
     externals: [],
-  },
+  }),
 
   /******* React Is *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [
       NODE_DEV,
       NODE_PROD,
@@ -909,10 +955,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: false,
     externals: ['ReactNativeInternalFeatureFlags'],
-  },
+  }),
 
   /******* React Debug Tools *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'react-debug-tools',
@@ -920,10 +966,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: [],
-  },
+  }),
 
   /******* React Cache (experimental, old) *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD, FB_WWW_DEV, FB_WWW_PROD],
     moduleType: ISOMORPHIC,
     entry: 'react-cache',
@@ -931,10 +977,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'scheduler'],
-  },
+  }),
 
   /******* Hook for managing subscriptions safely *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'use-subscription',
@@ -942,10 +988,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: true,
     externals: ['react'],
-  },
+  }),
 
   /******* useSyncExternalStore *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'use-sync-external-store',
@@ -953,10 +999,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: true,
     externals: ['react'],
-  },
+  }),
 
   /******* useSyncExternalStore (shim) *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'use-sync-external-store/shim',
@@ -964,10 +1010,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: true,
     externals: ['react'],
-  },
+  }),
 
   /******* useSyncExternalStore (shim, native) *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'use-sync-external-store/shim/index.native',
@@ -975,10 +1021,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: true,
     externals: ['react'],
-  },
+  }),
 
   /******* useSyncExternalStoreWithSelector *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'use-sync-external-store/with-selector',
@@ -986,10 +1032,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: true,
     externals: ['react'],
-  },
+  }),
 
   /******* useSyncExternalStoreWithSelector (shim) *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'use-sync-external-store/shim/with-selector',
@@ -997,10 +1043,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: true,
     externals: ['react', 'use-sync-external-store/shim'],
-  },
+  }),
 
   /******* React Scheduler (experimental) *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [
       NODE_DEV,
       NODE_PROD,
@@ -1017,10 +1063,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: true,
     externals: ['ReactNativeInternalFeatureFlags'],
-  },
+  }),
 
   /******* React Scheduler Mock (experimental) *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [
       NODE_DEV,
       NODE_PROD,
@@ -1035,10 +1081,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['ReactNativeInternalFeatureFlags'],
-  },
+  }),
 
   /******* React Scheduler Native *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'scheduler/index.native',
@@ -1046,10 +1092,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['ReactNativeInternalFeatureFlags'],
-  },
+  }),
 
   /******* React Scheduler Post Task (experimental) *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [
       NODE_DEV,
       NODE_PROD,
@@ -1063,10 +1109,10 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: false,
     externals: [],
-  },
+  }),
 
   /******* Jest React (experimental) *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'jest-react',
@@ -1074,10 +1120,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: ['react', 'scheduler', 'scheduler/unstable_mock'],
-  },
+  }),
 
   /******* ESLint Plugin for Hooks *******/
-  {
+  ...bundlesForTypes({
     // TODO: it's awkward to create a bundle for this but if we don't, the package
     // won't get copied. We also can't create just DEV bundle because it contains a
     // NODE_ENV check inside. We should probably tweak our build process to allow
@@ -1089,10 +1135,10 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: [],
-  },
+  }),
 
   /******* React Fresh *******/
-  {
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'react-refresh/babel',
@@ -1100,8 +1146,8 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: [],
-  },
-  {
+  }),
+  ...bundlesForTypes({
     bundleTypes: [NODE_DEV, NODE_PROD, FB_WWW_DEV],
     moduleType: ISOMORPHIC,
     entry: 'react-refresh/runtime',
@@ -1109,7 +1155,7 @@ const bundles = [
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
     externals: [],
-  },
+  }),
 ];
 
 // Based on deep-freeze by substack (public domain)
@@ -1132,12 +1178,12 @@ deepFreeze(bundles);
 deepFreeze(bundleTypes);
 deepFreeze(moduleTypes);
 
-function getFilename(bundle, bundleType) {
-  let name = bundle.name || bundle.entry;
-  const globalName = bundle.global;
+function getFilename() {
+  let name = this.name || this.entry;
+  const globalName = this.global;
   // we do this to replace / to -, for react-dom/server
   name = name.replace('/index.', '.').replace('/', '-');
-  switch (bundleType) {
+  switch (this.bundleType) {
     case NODE_ES2015:
       return `${name}.js`;
     case BUN_DEV:
@@ -1171,9 +1217,183 @@ function getFilename(bundle, bundleType) {
   }
 }
 
+function getFormat() {
+  switch (this.bundleType) {
+    case NODE_ES2015:
+    case NODE_DEV:
+    case NODE_PROD:
+    case NODE_PROFILING:
+    case BUN_DEV:
+    case BUN_PROD:
+    case FB_WWW_DEV:
+    case FB_WWW_PROD:
+    case FB_WWW_PROFILING:
+    case RN_OSS_DEV:
+    case RN_OSS_PROD:
+    case RN_OSS_PROFILING:
+    case RN_FB_DEV:
+    case RN_FB_PROD:
+    case RN_FB_PROFILING:
+      return `cjs`;
+    case ESM_DEV:
+    case ESM_PROD:
+      return `es`;
+    case BROWSER_SCRIPT:
+      return `iife`;
+  }
+}
+
+function isProductionBundleType() {
+  switch (this.bundleType) {
+    case NODE_ES2015:
+      return true;
+    case ESM_DEV:
+    case NODE_DEV:
+    case BUN_DEV:
+    case FB_WWW_DEV:
+    case RN_OSS_DEV:
+    case RN_FB_DEV:
+      return false;
+    case ESM_PROD:
+    case NODE_PROD:
+    case BUN_PROD:
+    case NODE_PROFILING:
+    case FB_WWW_PROD:
+    case FB_WWW_PROFILING:
+    case RN_OSS_PROD:
+    case RN_OSS_PROFILING:
+    case RN_FB_PROD:
+    case RN_FB_PROFILING:
+    case BROWSER_SCRIPT:
+      return true;
+    default:
+      throw new Error(`Unknown type: ${this.bundleType}`);
+  }
+}
+
+function isProfilingBundleType() {
+  switch (this.bundleType) {
+    case NODE_ES2015:
+    case FB_WWW_DEV:
+    case FB_WWW_PROD:
+    case NODE_DEV:
+    case NODE_PROD:
+    case BUN_DEV:
+    case BUN_PROD:
+    case RN_FB_DEV:
+    case RN_FB_PROD:
+    case RN_OSS_DEV:
+    case RN_OSS_PROD:
+    case ESM_DEV:
+    case ESM_PROD:
+    case BROWSER_SCRIPT:
+      return false;
+    case FB_WWW_PROFILING:
+    case NODE_PROFILING:
+    case RN_FB_PROFILING:
+    case RN_OSS_PROFILING:
+      return true;
+    default:
+      throw new Error(`Unknown type: ${this.bundleType}`);
+  }
+}
+
+function getBundleTypeFlags(forcePrettyOutput) {
+  const isFBWWWBundle =
+    this.bundleType === FB_WWW_DEV ||
+    this.bundleType === FB_WWW_PROD ||
+    this.bundleType === FB_WWW_PROFILING;
+  const isRNBundle =
+    this.bundleType === RN_OSS_DEV ||
+    this.bundleType === RN_OSS_PROD ||
+    this.bundleType === RN_OSS_PROFILING ||
+    this.bundleType === RN_FB_DEV ||
+    this.bundleType === RN_FB_PROD ||
+    this.bundleType === RN_FB_PROFILING;
+
+  const isFBRNBundle =
+    this.bundleType === RN_FB_DEV ||
+    this.bundleType === RN_FB_PROD ||
+    this.bundleType === RN_FB_PROFILING;
+
+  const shouldStayReadable = isFBWWWBundle || isRNBundle || forcePrettyOutput;
+
+  return {
+    isFBWWWBundle,
+    isRNBundle,
+    isFBRNBundle,
+    shouldStayReadable,
+  };
+}
+
+function getBundleOutputPath(filename, packageName) {
+  switch (this.bundleType) {
+    case NODE_ES2015:
+      return `build/node_modules/${packageName}/cjs/${filename}`;
+    case ESM_DEV:
+    case ESM_PROD:
+      return `build/node_modules/${packageName}/esm/${filename}`;
+    case BUN_DEV:
+    case BUN_PROD:
+      return `build/node_modules/${packageName}/cjs/${filename}`;
+    case NODE_DEV:
+    case NODE_PROD:
+    case NODE_PROFILING:
+      return `build/node_modules/${packageName}/cjs/${filename}`;
+    case FB_WWW_DEV:
+    case FB_WWW_PROD:
+    case FB_WWW_PROFILING:
+      return `build/facebook-www/${filename}`;
+    case RN_OSS_DEV:
+    case RN_OSS_PROD:
+    case RN_OSS_PROFILING:
+      switch (packageName) {
+        case 'react-native-renderer':
+          return `build/react-native/implementations/${filename}`;
+        default:
+          throw new Error('Unknown RN package.');
+      }
+    case RN_FB_DEV:
+    case RN_FB_PROD:
+    case RN_FB_PROFILING:
+      switch (packageName) {
+        case 'scheduler':
+        case 'react':
+        case 'react-is':
+        case 'react-test-renderer':
+          return `build/facebook-react-native/${packageName}/cjs/${filename}`;
+        case 'react-native-renderer':
+          return `build/react-native/implementations/${filename.replace(
+            /\.js$/,
+            '.fb.js'
+          )}`;
+        default:
+          throw new Error('Unknown RN package.');
+      }
+    case BROWSER_SCRIPT: {
+      // Bundles that are served as browser scripts need to be able to be sent
+      // straight to the browser with any additional bundling. We shouldn't use
+      // a module to re-export. Depending on how they are served, they also may
+      // not go through package.json module resolution, so we shouldn't rely on
+      // that either. We should consider the output path as part of the public
+      // contract, and explicitly specify its location within the package's
+      // directory structure.
+      const outputPath = this.outputPath;
+      if (!outputPath) {
+        throw new Error(
+          'Bundles with type BROWSER_SCRIPT must specific an explicit ' +
+            'output path.'
+        );
+      }
+      return `build/node_modules/${packageName}/${outputPath}`;
+    }
+    default:
+      throw new Error('Unknown bundle type.');
+  }
+}
+
 module.exports = {
-  bundleTypes,
   moduleTypes,
   bundles,
-  getFilename,
+  bundleTypes
 };

--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -35,7 +35,7 @@ const knownGlobals = Object.freeze({
 });
 
 // Given ['react'] in bundle externals, returns { 'react': 'React' }.
-function getPeerGlobals(externals, bundleType) {
+function getPeerGlobals(externals) {
   const peerGlobals = {};
   externals.forEach(name => {
     peerGlobals[name] = knownGlobals[name];
@@ -44,7 +44,7 @@ function getPeerGlobals(externals, bundleType) {
 }
 
 // Determines node_modules packages that are safe to assume will exist.
-function getDependencies(bundleType, entry) {
+function getDependencies(entry) {
   // Replaces any part of the entry that follow the package name (like
   // "/server" in "react-dom/server") by the path to the package settings
   const packageJson = require(entry.replace(/(\/.*)?$/, '/package.json'));
@@ -58,12 +58,12 @@ function getDependencies(bundleType, entry) {
 }
 
 // Hijacks some modules for optimization and integration reasons.
-function getForks(bundleType, entry, moduleType, bundle) {
+function getForks(entry, moduleType, bundle) {
   const forksForBundle = {};
   Object.keys(forks).forEach(srcModule => {
-    const dependencies = getDependencies(bundleType, entry);
+    const dependencies = getDependencies(entry);
     const targetModule = forks[srcModule](
-      bundleType,
+      bundle.bundleType,
       entry,
       dependencies,
       moduleType,


### PR DESCRIPTION
refactor: moving the logic of bundleType from build.js to bundles.js to simplify the build

## Summary

The current build.js file contains logic that can be moved to the bundles.js and be simpler to understand also I see that there are extra work for creating bundles (which are filtered later at build.shouldSkipBundle function). I say that something that will be removed anyway, why should we add it at first?

## How did you test this change?

By running the yarn test, lint and also building several times