### PR TITLE
Remove isPrimaryRenderer from Flight Server Config

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFlightServerConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFlightServerConfigDOM.js
@@ -20,10 +20,6 @@ import type {
 // but it does not have any exports
 import './ReactDOMFlightServerHostDispatcher';
 
-// Used to distinguish these contexts from ones used in other renderers.
-// E.g. this can be used to distinguish legacy renderers from this modern one.
-export const isPrimaryRenderer = true;
-
 // We use zero to represent the absence of an explicit precedence because it is
 // small, smaller than how we encode undefined, and is unambiguous. We could use
 // a different tuple structure to encode this instead but this makes the runtime

--- a/packages/react-server/src/forks/ReactFlightServerConfig.custom.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.custom.js
@@ -19,8 +19,6 @@ export type HintCode = any;
 // eslint-disable-next-line no-unused-vars
 export type HintModel<T: any> = any;
 
-export const isPrimaryRenderer = false;
-
 export const supportsRequestStorage = false;
 export const requestStorage: AsyncLocalStorage<Request | void> = (null: any);
 


### PR DESCRIPTION
This was used for Context but since ReactFlightNewContext is gone now this is no longer used.

