### PR TITLE
Add renderToMarkup for Client Components

### DIFF
--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-legacy.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-legacy.js
@@ -7,82 +7,20 @@
  * @flow
  */
 
-import type {Thenable} from 'shared/ReactTypes';
+export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
+export * from 'react-client/src/ReactClientConsoleConfigBrowser';
 
-export * from 'react-html/src/ReactHTMLLegacyClientStreamConfig.js';
-export * from 'react-client/src/ReactClientConsoleConfigPlain';
-
-export type ModuleLoading = null;
-export type SSRModuleMap = null;
-export opaque type ServerManifest = null;
+export type Response = any;
+export opaque type ModuleLoading = mixed;
+export opaque type SSRModuleMap = mixed;
+export opaque type ServerManifest = mixed;
 export opaque type ServerReferenceId = string;
-export opaque type ClientReferenceMetadata = null;
-export opaque type ClientReference<T> = null; // eslint-disable-line no-unused-vars
-
-export function prepareDestinationForModule(
-  moduleLoading: ModuleLoading,
-  nonce: ?string,
-  metadata: ClientReferenceMetadata,
-) {
-  throw new Error(
-    'renderToMarkup should not have emitted Client References. This is a bug in React.',
-  );
-}
-
-export function resolveClientReference<T>(
-  bundlerConfig: SSRModuleMap,
-  metadata: ClientReferenceMetadata,
-): ClientReference<T> {
-  throw new Error(
-    'renderToMarkup should not have emitted Client References. This is a bug in React.',
-  );
-}
-
-export function resolveServerReference<T>(
-  config: ServerManifest,
-  id: ServerReferenceId,
-): ClientReference<T> {
-  throw new Error(
-    'renderToMarkup should not have emitted Server References. This is a bug in React.',
-  );
-}
-
-export function preloadModule<T>(
-  metadata: ClientReference<T>,
-): null | Thenable<T> {
-  return null;
-}
-
-export function requireModule<T>(metadata: ClientReference<T>): T {
-  throw new Error(
-    'renderToMarkup should not have emitted Client References. This is a bug in React.',
-  );
-}
-
+export opaque type ClientReferenceMetadata = mixed;
+export opaque type ClientReference<T> = mixed; // eslint-disable-line no-unused-vars
+export const resolveClientReference: any = null;
+export const resolveServerReference: any = null;
+export const preloadModule: any = null;
+export const requireModule: any = null;
+export const dispatchHint: any = null;
+export const prepareDestinationForModule: any = null;
 export const usedWithSSR = true;
-
-type HintCode = string;
-type HintModel<T: HintCode> = null; // eslint-disable-line no-unused-vars
-
-export function dispatchHint<Code: HintCode>(
-  code: Code,
-  model: HintModel<Code>,
-): void {
-  // Should never happen.
-}
-
-export function preinitModuleForSSR(
-  href: string,
-  nonce: ?string,
-  crossOrigin: ?string,
-) {
-  // Should never happen.
-}
-
-export function preinitScriptForSSR(
-  href: string,
-  nonce: ?string,
-  crossOrigin: ?string,
-) {
-  // Should never happen.
-}

--- a/packages/react-client/src/forks/ReactFlightClientConfig.markup.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.markup.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Thenable} from 'shared/ReactTypes';
+
+export * from 'react-html/src/ReactHTMLLegacyClientStreamConfig.js';
+export * from 'react-client/src/ReactClientConsoleConfigPlain';
+
+export type ModuleLoading = null;
+export type SSRModuleMap = null;
+export opaque type ServerManifest = null;
+export opaque type ServerReferenceId = string;
+export opaque type ClientReferenceMetadata = null;
+export opaque type ClientReference<T> = null; // eslint-disable-line no-unused-vars
+
+export function prepareDestinationForModule(
+  moduleLoading: ModuleLoading,
+  nonce: ?string,
+  metadata: ClientReferenceMetadata,
+) {
+  throw new Error(
+    'renderToMarkup should not have emitted Client References. This is a bug in React.',
+  );
+}
+
+export function resolveClientReference<T>(
+  bundlerConfig: SSRModuleMap,
+  metadata: ClientReferenceMetadata,
+): ClientReference<T> {
+  throw new Error(
+    'renderToMarkup should not have emitted Client References. This is a bug in React.',
+  );
+}
+
+export function resolveServerReference<T>(
+  config: ServerManifest,
+  id: ServerReferenceId,
+): ClientReference<T> {
+  throw new Error(
+    'renderToMarkup should not have emitted Server References. This is a bug in React.',
+  );
+}
+
+export function preloadModule<T>(
+  metadata: ClientReference<T>,
+): null | Thenable<T> {
+  return null;
+}
+
+export function requireModule<T>(metadata: ClientReference<T>): T {
+  throw new Error(
+    'renderToMarkup should not have emitted Client References. This is a bug in React.',
+  );
+}
+
+export const usedWithSSR = true;
+
+type HintCode = string;
+type HintModel<T: HintCode> = null; // eslint-disable-line no-unused-vars
+
+export function dispatchHint<Code: HintCode>(
+  code: Code,
+  model: HintModel<Code>,
+): void {
+  // Should never happen.
+}
+
+export function preinitModuleForSSR(
+  href: string,
+  nonce: ?string,
+  crossOrigin: ?string,
+) {
+  // Should never happen.
+}
+
+export function preinitScriptForSSR(
+  href: string,
+  nonce: ?string,
+  crossOrigin: ?string,
+) {
+  // Should never happen.
+}

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -108,6 +108,8 @@ export type HeadersDescriptor = {
 // E.g. this can be used to distinguish legacy renderers from this modern one.
 export const isPrimaryRenderer = true;
 
+export const supportsClientAPIs = true;
+
 export type StreamingFormat = 0 | 1;
 const ScriptStreamingFormat: StreamingFormat = 0;
 const DataStreamingFormat: StreamingFormat = 1;

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
@@ -166,6 +166,7 @@ export {
   resetResumableState,
   completeResumableState,
   emitEarlyPreloads,
+  supportsClientAPIs,
 } from './ReactFizzConfigDOM';
 
 import escapeTextForBrowser from './escapeTextForBrowser';

--- a/packages/react-html/index.js
+++ b/packages/react-html/index.js
@@ -1,5 +1,10 @@
-'use strict';
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
 
-throw new Error(
-  'react-html is not supported outside a React Server Components environment.',
-);
+export * from './src/ReactHTMLClient';

--- a/packages/react-html/npm/index.js
+++ b/packages/react-html/npm/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
-throw new Error(
-  'react-html is not supported outside a React Server Components environment.'
-);
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-html.production.js');
+} else {
+  module.exports = require('./cjs/react-html.development.js');
+}

--- a/packages/react-html/src/ReactFizzConfigHTML.js
+++ b/packages/react-html/src/ReactFizzConfigHTML.js
@@ -33,6 +33,9 @@ import hasOwnProperty from 'shared/hasOwnProperty';
 // Allow embedding inside another Fizz render.
 export const isPrimaryRenderer = false;
 
+// Disable Client Hooks
+export const supportsClientAPIs = false;
+
 import {
   stringToChunk,
   stringToPrecomputedChunk,

--- a/packages/react-html/src/ReactFizzConfigHTML.js
+++ b/packages/react-html/src/ReactFizzConfigHTML.js
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ReactNodeList} from 'shared/ReactTypes';
+
+import type {
+  RenderState,
+  ResumableState,
+  HoistableState,
+  FormatContext,
+} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
+
+import {pushStartInstance as pushStartInstanceImpl} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
+
+import type {
+  Destination,
+  Chunk,
+  PrecomputedChunk,
+} from 'react-server/src/ReactServerStreamConfig';
+
+import type {FormStatus} from 'react-dom-bindings/src/shared/ReactDOMFormActions';
+
+import {NotPending} from 'react-dom-bindings/src/shared/ReactDOMFormActions';
+
+// Allow embedding inside another Fizz render.
+export const isPrimaryRenderer = false;
+
+import {
+  stringToChunk,
+  stringToPrecomputedChunk,
+} from 'react-server/src/ReactServerStreamConfig';
+
+// this chunk is empty on purpose because we do not want to emit the DOCTYPE
+// when markup is rendering HTML
+export const doctypeChunk: PrecomputedChunk = stringToPrecomputedChunk('');
+
+export type {
+  RenderState,
+  ResumableState,
+  HoistableState,
+  FormatContext,
+} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
+
+export {
+  getChildFormatContext,
+  makeId,
+  pushEndInstance,
+  pushStartCompletedSuspenseBoundary,
+  pushEndCompletedSuspenseBoundary,
+  pushFormStateMarkerIsMatching,
+  pushFormStateMarkerIsNotMatching,
+  writeStartSegment,
+  writeEndSegment,
+  writeCompletedSegmentInstruction,
+  writeCompletedBoundaryInstruction,
+  writeClientRenderBoundaryInstruction,
+  writeStartPendingSuspenseBoundary,
+  writeEndPendingSuspenseBoundary,
+  writeHoistablesForBoundary,
+  writePlaceholder,
+  writeCompletedRoot,
+  createRootFormatContext,
+  createRenderState,
+  createResumableState,
+  createHoistableState,
+  writePreamble,
+  writeHoistables,
+  writePostamble,
+  hoistHoistables,
+  resetResumableState,
+  completeResumableState,
+  emitEarlyPreloads,
+} from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
+
+import escapeTextForBrowser from 'react-dom-bindings/src/server/escapeTextForBrowser';
+
+export function pushStartInstance(
+  target: Array<Chunk | PrecomputedChunk>,
+  type: string,
+  props: Object,
+  resumableState: ResumableState,
+  renderState: RenderState,
+  hoistableState: null | HoistableState,
+  formatContext: FormatContext,
+  textEmbedded: boolean,
+  isFallback: boolean,
+): ReactNodeList {
+  // TODO: Error for invalid props.
+  return pushStartInstanceImpl(
+    target,
+    type,
+    props,
+    resumableState,
+    renderState,
+    hoistableState,
+    formatContext,
+    textEmbedded,
+    isFallback,
+  );
+}
+
+export function pushTextInstance(
+  target: Array<Chunk | PrecomputedChunk>,
+  text: string,
+  renderState: RenderState,
+  textEmbedded: boolean,
+): boolean {
+  // Markup doesn't need any termination.
+  target.push(stringToChunk(escapeTextForBrowser(text)));
+  return false;
+}
+
+export function pushSegmentFinale(
+  target: Array<Chunk | PrecomputedChunk>,
+  renderState: RenderState,
+  lastPushedText: boolean,
+  textEmbedded: boolean,
+): void {
+  // Markup doesn't need any termination.
+  return;
+}
+
+export function writeStartCompletedSuspenseBoundary(
+  destination: Destination,
+  renderState: RenderState,
+): boolean {
+  // Markup doesn't have any instructions.
+  return true;
+}
+export function writeStartClientRenderedSuspenseBoundary(
+  destination: Destination,
+  renderState: RenderState,
+  // flushing these error arguments are not currently supported in this legacy streaming format.
+  errorDigest: ?string,
+  errorMessage: ?string,
+  errorStack: ?string,
+  errorComponentStack: ?string,
+): boolean {
+  // Markup doesn't have any instructions.
+  return true;
+}
+
+export function writeEndCompletedSuspenseBoundary(
+  destination: Destination,
+  renderState: RenderState,
+): boolean {
+  // Markup doesn't have any instructions.
+  return true;
+}
+export function writeEndClientRenderedSuspenseBoundary(
+  destination: Destination,
+  renderState: RenderState,
+): boolean {
+  // Markup doesn't have any instructions.
+  return true;
+}
+
+export type TransitionStatus = FormStatus;
+export const NotPendingTransition: TransitionStatus = NotPending;

--- a/packages/react-html/src/ReactFizzConfigHTML.js
+++ b/packages/react-html/src/ReactFizzConfigHTML.js
@@ -28,6 +28,8 @@ import type {FormStatus} from 'react-dom-bindings/src/shared/ReactDOMFormActions
 
 import {NotPending} from 'react-dom-bindings/src/shared/ReactDOMFormActions';
 
+import hasOwnProperty from 'shared/hasOwnProperty';
+
 // Allow embedding inside another Fizz render.
 export const isPrimaryRenderer = false;
 
@@ -91,7 +93,25 @@ export function pushStartInstance(
   textEmbedded: boolean,
   isFallback: boolean,
 ): ReactNodeList {
-  // TODO: Error for invalid props.
+  for (const propKey in props) {
+    if (hasOwnProperty.call(props, propKey)) {
+      const propValue = props[propKey];
+      if (propKey === 'ref' && propValue != null) {
+        throw new Error(
+          'Cannot pass ref in renderToMarkup because they will never be hydrated.',
+        );
+      }
+      if (typeof propValue === 'function') {
+        throw new Error(
+          'Cannot pass event handlers (' +
+            propKey +
+            ') in renderToMarkup because ' +
+            'the HTML will never be hydrated so they can never get called.',
+        );
+      }
+    }
+  }
+
   return pushStartInstanceImpl(
     target,
     type,

--- a/packages/react-html/src/ReactHTMLClient.js
+++ b/packages/react-html/src/ReactHTMLClient.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ReactNodeList} from 'shared/ReactTypes';
+
+import ReactVersion from 'shared/ReactVersion';
+
+import {
+  createRequest as createFizzRequest,
+  startWork as startFizzWork,
+  startFlowing as startFizzFlowing,
+  abort as abortFizz,
+} from 'react-server/src/ReactFizzServer';
+
+import {
+  createResumableState,
+  createRenderState,
+  createRootFormatContext,
+} from 'react-dom-bindings/src/server/ReactFizzConfigDOMLegacy';
+
+type MarkupOptions = {
+  identifierPrefix?: string,
+  signal?: AbortSignal,
+};
+
+export function renderToMarkup(
+  children: ReactNodeList,
+  options?: MarkupOptions,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+    const fizzDestination = {
+      push(chunk: string | null): boolean {
+        if (chunk !== null) {
+          buffer += chunk;
+        } else {
+          // null indicates that we finished
+          resolve(buffer);
+        }
+        return true;
+      },
+      destroy(error: mixed) {
+        reject(error);
+      },
+    };
+    function onError(error: mixed) {
+      // Any error rejects the promise, regardless of where it happened.
+      // Unlike other React SSR we don't want to put Suspense boundaries into
+      // client rendering mode because there's no client rendering here.
+      reject(error);
+    }
+    const resumableState = createResumableState(
+      options ? options.identifierPrefix : undefined,
+      undefined,
+    );
+    const fizzRequest = createFizzRequest(
+      children,
+      resumableState,
+      createRenderState(resumableState, true),
+      createRootFormatContext(),
+      Infinity,
+      onError,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+    if (options && options.signal) {
+      const signal = options.signal;
+      if (signal.aborted) {
+        abortFizz(fizzRequest, (signal: any).reason);
+      } else {
+        const listener = () => {
+          abortFizz(fizzRequest, (signal: any).reason);
+          signal.removeEventListener('abort', listener);
+        };
+        signal.addEventListener('abort', listener);
+      }
+    }
+    startFizzWork(fizzRequest);
+    startFizzFlowing(fizzRequest, fizzDestination);
+  });
+}
+
+export {ReactVersion as version};

--- a/packages/react-html/src/ReactHTMLClient.js
+++ b/packages/react-html/src/ReactHTMLClient.js
@@ -22,7 +22,7 @@ import {
   createResumableState,
   createRenderState,
   createRootFormatContext,
-} from 'react-dom-bindings/src/server/ReactFizzConfigDOMLegacy';
+} from './ReactFizzConfigHTML';
 
 type MarkupOptions = {
   identifierPrefix?: string,
@@ -62,7 +62,14 @@ export function renderToMarkup(
     const fizzRequest = createFizzRequest(
       children,
       resumableState,
-      createRenderState(resumableState, true),
+      createRenderState(
+        resumableState,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      ),
       createRootFormatContext(),
       Infinity,
       onError,

--- a/packages/react-html/src/ReactHTMLServer.js
+++ b/packages/react-html/src/ReactHTMLServer.js
@@ -37,7 +37,7 @@ import {
   createResumableState,
   createRenderState,
   createRootFormatContext,
-} from 'react-dom-bindings/src/server/ReactFizzConfigDOMLegacy';
+} from './ReactFizzConfigHTML';
 
 type ReactMarkupNodeList =
   // This is the intersection of ReactNodeList and ReactClientValue minus
@@ -143,7 +143,14 @@ export function renderToMarkup(
       // $FlowFixMe: Thenables as children are supported.
       root,
       resumableState,
-      createRenderState(resumableState, true),
+      createRenderState(
+        resumableState,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      ),
       createRootFormatContext(),
       Infinity,
       onError,

--- a/packages/react-html/src/__tests__/ReactHTMLClient-test.js
+++ b/packages/react-html/src/__tests__/ReactHTMLClient-test.js
@@ -9,56 +9,44 @@
 
 'use strict';
 
-global.TextDecoder = require('util').TextDecoder;
-global.TextEncoder = require('util').TextEncoder;
-
 let React;
 let ReactHTML;
 
 describe('ReactHTML', () => {
   beforeEach(() => {
     jest.resetModules();
-    // We run in the react-server condition.
-    jest.mock('react', () => require('react/react.react-server'));
-    jest.mock('react-html', () =>
-      require('react-html/react-html.react-server'),
-    );
-
     React = require('react');
     ReactHTML = require('react-html');
   });
 
   it('should be able to render a simple component', async () => {
     function Component() {
-      // We can't use JSX because that's client-JSX in our tests.
-      return React.createElement('div', null, 'hello world');
+      return <div>hello world</div>;
     }
 
-    const html = await ReactHTML.renderToMarkup(React.createElement(Component));
+    const html = await ReactHTML.renderToMarkup(<Component />);
     expect(html).toBe('<div>hello world</div>');
   });
 
   it('should error on useState', async () => {
     function Component() {
       const [state] = React.useState('hello');
-      // We can't use JSX because that's client-JSX in our tests.
-      return React.createElement('div', null, state);
+      return <div>{state}</div>;
     }
 
     await expect(async () => {
-      await ReactHTML.renderToMarkup(React.createElement(Component));
+      await ReactHTML.renderToMarkup(<Component />);
     }).rejects.toThrow();
   });
 
   it('should error on refs passed to host components', async () => {
     function Component() {
       const ref = React.createRef();
-      // We can't use JSX because that's client-JSX in our tests.
-      return React.createElement('div', {ref});
+      return <div ref={ref} />;
     }
 
     await expect(async () => {
-      await ReactHTML.renderToMarkup(React.createElement(Component));
+      await ReactHTML.renderToMarkup(<Component />);
     }).rejects.toThrow();
   });
 
@@ -67,12 +55,11 @@ describe('ReactHTML', () => {
       function onClick() {
         // This won't be able to be called.
       }
-      // We can't use JSX because that's client-JSX in our tests.
-      return React.createElement('div', {onClick});
+      return <div onClick={onClick} />;
     }
 
     await expect(async () => {
-      await ReactHTML.renderToMarkup(React.createElement(Component));
+      await ReactHTML.renderToMarkup(<Component />);
     }).rejects.toThrow();
   });
 
@@ -80,7 +67,6 @@ describe('ReactHTML', () => {
     function Component() {
       const firstNameId = React.useId();
       const lastNameId = React.useId();
-      // We can't use JSX because that's client-JSX in our tests.
       return React.createElement(
         'div',
         null,
@@ -115,7 +101,7 @@ describe('ReactHTML', () => {
       );
     }
 
-    const html = await ReactHTML.renderToMarkup(React.createElement(Component));
+    const html = await ReactHTML.renderToMarkup(<Component />);
     const container = document.createElement('div');
     container.innerHTML = html;
 
@@ -132,8 +118,7 @@ describe('ReactHTML', () => {
     );
   });
 
-  // @gate enableCache
-  it('supports cache', async () => {
+  it('does NOT support cache yet because it is a client component', async () => {
     let counter = 0;
     const getCount = React.cache(() => {
       return counter++;
@@ -141,10 +126,15 @@ describe('ReactHTML', () => {
     function Component() {
       const a = getCount();
       const b = getCount();
-      return React.createElement('div', null, a, b);
+      return (
+        <div>
+          {a}
+          {b}
+        </div>
+      );
     }
 
-    const html = await ReactHTML.renderToMarkup(React.createElement(Component));
-    expect(html).toBe('<div>00</div>');
+    const html = await ReactHTML.renderToMarkup(<Component />);
+    expect(html).toBe('<div>01</div>');
   });
 });

--- a/packages/react-html/src/__tests__/ReactHTMLClient-test.js
+++ b/packages/react-html/src/__tests__/ReactHTMLClient-test.js
@@ -118,6 +118,7 @@ describe('ReactHTML', () => {
     );
   });
 
+  // @gate disableClientCache
   it('does NOT support cache yet because it is a client component', async () => {
     let counter = 0;
     const getCount = React.cache(() => {

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.markup.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.markup.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Re-exported just because we always type check react-reconciler even in
+// dimensions where it's not used.
+export * from 'react-dom-bindings/src/client/ReactFiberConfigDOM';
+export * from 'react-client/src/ReactClientConsoleConfigBrowser';
+
+// eslint-disable-next-line react-internal/prod-error-codes
+throw new Error('Fiber is not used in react-html');

--- a/packages/react-server/src/forks/ReactFizzConfig.custom.js
+++ b/packages/react-server/src/forks/ReactFizzConfig.custom.js
@@ -37,6 +37,8 @@ export type {TransitionStatus};
 
 export const isPrimaryRenderer = false;
 
+export const supportsClientAPIs = true;
+
 export const supportsRequestStorage = false;
 export const requestStorage: AsyncLocalStorage<Request | void> = (null: any);
 

--- a/packages/react-server/src/forks/ReactFizzConfig.markup.js
+++ b/packages/react-server/src/forks/ReactFizzConfig.markup.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+import type {Request} from 'react-server/src/ReactFizzServer';
+
+export * from 'react-dom-bindings/src/server/ReactFizzConfigDOMLegacy';
+
+export * from 'react-client/src/ReactClientConsoleConfigPlain';
+
+export const supportsRequestStorage = false;
+export const requestStorage: AsyncLocalStorage<Request | void> = (null: any);

--- a/packages/react-server/src/forks/ReactFizzConfig.markup.js
+++ b/packages/react-server/src/forks/ReactFizzConfig.markup.js
@@ -8,7 +8,7 @@
  */
 import type {Request} from 'react-server/src/ReactFizzServer';
 
-export * from 'react-dom-bindings/src/server/ReactFizzConfigDOMLegacy';
+export * from 'react-html/src/ReactFizzConfigHTML.js';
 
 export * from 'react-client/src/ReactClientConsoleConfigPlain';
 

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-legacy.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-legacy.js
@@ -9,15 +9,15 @@
 
 import type {Request} from 'react-server/src/ReactFlightServer';
 import type {ReactComponentInfo} from 'shared/ReactTypes';
-import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
 
-export type HintCode = string;
-export type HintModel<T: HintCode> = null; // eslint-disable-line no-unused-vars
-export type Hints = null;
+export * from '../ReactFlightServerConfigBundlerCustom';
 
-export function createHints(): Hints {
-  return null;
-}
+export * from '../ReactFlightServerConfigDebugNoop';
+
+export type Hints = any;
+export type HintCode = any;
+// eslint-disable-next-line no-unused-vars
+export type HintModel<T: any> = any;
 
 export const supportsRequestStorage = false;
 export const requestStorage: AsyncLocalStorage<Request | void> = (null: any);
@@ -26,65 +26,6 @@ export const supportsComponentStorage = false;
 export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
   (null: any);
 
-export * from '../ReactFlightServerConfigDebugNoop';
-
-export type ClientManifest = null;
-export opaque type ClientReference<T> = null; // eslint-disable-line no-unused-vars
-export opaque type ServerReference<T> = null; // eslint-disable-line no-unused-vars
-export opaque type ClientReferenceMetadata: any = null;
-export opaque type ServerReferenceId: string = string;
-export opaque type ClientReferenceKey: any = string;
-
-const CLIENT_REFERENCE_TAG = Symbol.for('react.client.reference');
-const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference');
-
-export function isClientReference(reference: Object): boolean {
-  return reference.$$typeof === CLIENT_REFERENCE_TAG;
-}
-
-export function isServerReference(reference: Object): boolean {
-  return reference.$$typeof === SERVER_REFERENCE_TAG;
-}
-
-export function getClientReferenceKey(
-  reference: ClientReference<any>,
-): ClientReferenceKey {
-  throw new Error(
-    'Attempted to render a Client Component from renderToMarkup. ' +
-      'This is not supported since it will never hydrate. ' +
-      'Only render Server Components with renderToMarkup.',
-  );
-}
-
-export function resolveClientReferenceMetadata<T>(
-  config: ClientManifest,
-  clientReference: ClientReference<T>,
-): ClientReferenceMetadata {
-  throw new Error(
-    'Attempted to render a Client Component from renderToMarkup. ' +
-      'This is not supported since it will never hydrate. ' +
-      'Only render Server Components with renderToMarkup.',
-  );
-}
-
-export function getServerReferenceId<T>(
-  config: ClientManifest,
-  serverReference: ServerReference<T>,
-): ServerReferenceId {
-  throw new Error(
-    'Attempted to render a Server Action from renderToMarkup. ' +
-      'This is not supported since it varies by version of the app. ' +
-      'Use a fixed URL for any forms instead.',
-  );
-}
-
-export function getServerReferenceBoundArguments<T>(
-  config: ClientManifest,
-  serverReference: ServerReference<T>,
-): null | Array<ReactClientValue> {
-  throw new Error(
-    'Attempted to render a Server Action from renderToMarkup. ' +
-      'This is not supported since it varies by version of the app. ' +
-      'Use a fixed URL for any forms instead.',
-  );
+export function createHints(): any {
+  return null;
 }

--- a/packages/react-server/src/forks/ReactFlightServerConfig.markup.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.markup.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Request} from 'react-server/src/ReactFlightServer';
+import type {ReactComponentInfo} from 'shared/ReactTypes';
+import type {ReactClientValue} from 'react-server/src/ReactFlightServer';
+
+export type HintCode = string;
+export type HintModel<T: HintCode> = null; // eslint-disable-line no-unused-vars
+export type Hints = null;
+
+export function createHints(): Hints {
+  return null;
+}
+
+export const supportsRequestStorage = false;
+export const requestStorage: AsyncLocalStorage<Request | void> = (null: any);
+
+export const supportsComponentStorage = false;
+export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
+  (null: any);
+
+export * from '../ReactFlightServerConfigDebugNoop';
+
+export type ClientManifest = null;
+export opaque type ClientReference<T> = null; // eslint-disable-line no-unused-vars
+export opaque type ServerReference<T> = null; // eslint-disable-line no-unused-vars
+export opaque type ClientReferenceMetadata: any = null;
+export opaque type ServerReferenceId: string = string;
+export opaque type ClientReferenceKey: any = string;
+
+const CLIENT_REFERENCE_TAG = Symbol.for('react.client.reference');
+const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference');
+
+export function isClientReference(reference: Object): boolean {
+  return reference.$$typeof === CLIENT_REFERENCE_TAG;
+}
+
+export function isServerReference(reference: Object): boolean {
+  return reference.$$typeof === SERVER_REFERENCE_TAG;
+}
+
+export function getClientReferenceKey(
+  reference: ClientReference<any>,
+): ClientReferenceKey {
+  throw new Error(
+    'Attempted to render a Client Component from renderToMarkup. ' +
+      'This is not supported since it will never hydrate. ' +
+      'Only render Server Components with renderToMarkup.',
+  );
+}
+
+export function resolveClientReferenceMetadata<T>(
+  config: ClientManifest,
+  clientReference: ClientReference<T>,
+): ClientReferenceMetadata {
+  throw new Error(
+    'Attempted to render a Client Component from renderToMarkup. ' +
+      'This is not supported since it will never hydrate. ' +
+      'Only render Server Components with renderToMarkup.',
+  );
+}
+
+export function getServerReferenceId<T>(
+  config: ClientManifest,
+  serverReference: ServerReference<T>,
+): ServerReferenceId {
+  throw new Error(
+    'Attempted to render a Server Action from renderToMarkup. ' +
+      'This is not supported since it varies by version of the app. ' +
+      'Use a fixed URL for any forms instead.',
+  );
+}
+
+export function getServerReferenceBoundArguments<T>(
+  config: ClientManifest,
+  serverReference: ServerReference<T>,
+): null | Array<ReactClientValue> {
+  throw new Error(
+    'Attempted to render a Server Action from renderToMarkup. ' +
+      'This is not supported since it varies by version of the app. ' +
+      'Use a fixed URL for any forms instead.',
+  );
+}

--- a/packages/react-server/src/forks/ReactServerStreamConfig.markup.js
+++ b/packages/react-server/src/forks/ReactServerStreamConfig.markup.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from 'react-dom-bindings/src/server/ReactDOMLegacyServerStreamConfig';

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -520,5 +520,7 @@
   "532": "Attempted to render a Client Component from renderToMarkup. This is not supported since it will never hydrate. Only render Server Components with renderToMarkup.",
   "533": "Attempted to render a Server Action from renderToMarkup. This is not supported since it varies by version of the app. Use a fixed URL for any forms instead.",
   "534": "renderToMarkup should not have emitted Client References. This is a bug in React.",
-  "535": "renderToMarkup should not have emitted Server References. This is a bug in React."
+  "535": "renderToMarkup should not have emitted Server References. This is a bug in React.",
+  "536": "Cannot pass ref in renderToMarkup because they will never be hydrated.",
+  "537": "Cannot pass event handlers (%s) in renderToMarkup because the HTML will never be hydrated so they can never get called."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -522,5 +522,6 @@
   "534": "renderToMarkup should not have emitted Client References. This is a bug in React.",
   "535": "renderToMarkup should not have emitted Server References. This is a bug in React.",
   "536": "Cannot pass ref in renderToMarkup because they will never be hydrated.",
-  "537": "Cannot pass event handlers (%s) in renderToMarkup because the HTML will never be hydrated so they can never get called."
+  "537": "Cannot pass event handlers (%s) in renderToMarkup because the HTML will never be hydrated so they can never get called.",
+  "538": "Cannot use state or effect Hooks in renderToMarkup because this component will never be hydrated."
 }

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -363,13 +363,25 @@ const bundles = [
     externals: [],
   },
 
-  /******* React HTML *******/
+  /******* React HTML RSC *******/
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-html/src/ReactHTMLServer.js',
     name: 'react-html.react-server',
     condition: 'react-server',
+    global: 'ReactHTML',
+    minifyWithProdErrorCodes: false,
+    wrapWithModuleBoundaries: false,
+    externals: ['react'],
+  },
+
+  /******* React HTML Client *******/
+  {
+    bundleTypes: [NODE_DEV, NODE_PROD],
+    moduleType: RENDERER,
+    entry: 'react-html/src/ReactHTMLClient.js',
+    name: 'react-html',
     global: 'ReactHTML',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -100,6 +100,7 @@ const forks = Object.freeze({
       entry === 'react-dom/src/ReactDOMFB.js' ||
       entry === 'react-dom/src/ReactDOMTestingFB.js' ||
       entry === 'react-dom/src/ReactDOMServer.js' ||
+      entry === 'react-html/src/ReactHTMLClient.js' ||
       entry === 'react-html/src/ReactHTMLServer.js'
     ) {
       if (

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -428,7 +428,8 @@ module.exports = [
     entryPoints: [
       'react-dom/src/server/ReactDOMLegacyServerBrowser.js', // react-dom/server.browser
       'react-dom/src/server/ReactDOMLegacyServerNode.js', // react-dom/server.node
-      'react-html/src/ReactHTMLServer.js',
+      'react-html/src/ReactHTMLClient.js', // react-html
+      'react-html/src/ReactHTMLServer.js', // react-html/react-html.react-server
     ],
     paths: [
       'react-dom',

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -428,6 +428,22 @@ module.exports = [
     entryPoints: [
       'react-dom/src/server/ReactDOMLegacyServerBrowser.js', // react-dom/server.browser
       'react-dom/src/server/ReactDOMLegacyServerNode.js', // react-dom/server.node
+    ],
+    paths: [
+      'react-dom',
+      'react-dom/src/ReactDOMReactServer.js',
+      'react-dom-bindings',
+      'react-dom/src/server/ReactDOMLegacyServerImpl.js', // not an entrypoint, but only usable in *Browser and *Node files
+      'react-dom/src/server/ReactDOMLegacyServerBrowser.js', // react-dom/server.browser
+      'react-dom/src/server/ReactDOMLegacyServerNode.js', // react-dom/server.node
+      'shared/ReactDOMSharedInternals',
+    ],
+    isFlowTyped: true,
+    isServerSupported: true,
+  },
+  {
+    shortName: 'markup',
+    entryPoints: [
       'react-html/src/ReactHTMLClient.js', // react-html
       'react-html/src/ReactHTMLServer.js', // react-html/react-html.react-server
     ],
@@ -435,10 +451,6 @@ module.exports = [
       'react-dom',
       'react-dom/src/ReactDOMReactServer.js',
       'react-dom-bindings',
-      'react-server-dom-webpack',
-      'react-dom/src/server/ReactDOMLegacyServerImpl.js', // not an entrypoint, but only usable in *Browser and *Node files
-      'react-dom/src/server/ReactDOMLegacyServerBrowser.js', // react-dom/server.browser
-      'react-dom/src/server/ReactDOMLegacyServerNode.js', // react-dom/server.node
       'react-html',
       'shared/ReactDOMSharedInternals',
     ],


### PR DESCRIPTION
Follow up to #30105.

This supports `renderToMarkup` in a non-RSC environment (not the `react-server` condition).

This is just a Fizz renderer but it errors at runtime when you use state, effects or event handlers that would require hydration - like the RSC version would. (Except RSC can give early errors too.)

To do this I have to move the `react-html` builds to a new `markup` dimension out of the `dom-legacy` dimension so that we can configure this differently from `renderToString`/`renderToStaticMarkup`. Eventually that dimension can go away though if deprecated. That also helps us avoid dynamic configuration and we can just compile in the right configuration so the split helps anyway.

One consideration is that if a compiler strips out useEffects or inlines initial state from useState, then it would not get called an the error wouldn't happen. Therefore to preserve semantics, a compiler would need to inject some call that can check the current renderer and whether it should throw.

There is an argument that it could be useful to not error for these because it's possible to write components that works with SSR but are just optionally hydrated. However, there's also an argument that doing that silently is too easy to lead to mistakes and it's better to error - especially for the e-mail use case where you can't take it back but you can replay a queue that had failures. There are other ways to conditionally branch components intentionally. Besides if you want it to be silent you can still use renderToString (or better yet renderToReadableStream).

The primary mechanism is the RSC environment and the client-environment is really the secondary one that's only there to support legacy environments. So this also ensures parity with the primary environment.