### PR TITLE
[compiler] Clone computation block in change detection mode

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -673,7 +673,7 @@ function codegenReactiveScope(
         t.expressionStatement(
           t.callExpression(t.identifier(detectionFunction), [
             t.identifier(loadName),
-            name,
+            t.cloneNode(name, true),
             t.stringLiteral(name.name),
             t.stringLiteral(cx.fnName),
             t.stringLiteral("cached"),
@@ -684,8 +684,8 @@ function codegenReactiveScope(
       idempotenceDetectionStatements.push(
         t.expressionStatement(
           t.callExpression(t.identifier(detectionFunction), [
-            slot,
-            name,
+            t.cloneNode(slot, true),
+            t.cloneNode(name, true),
             t.stringLiteral(name.name),
             t.stringLiteral(cx.fnName),
             t.stringLiteral("recomputed"),
@@ -698,6 +698,7 @@ function codegenReactiveScope(
       );
     }
     const condition = cx.synthesizeName("condition");
+    const recomputationBlock = t.cloneNode(computationBlock, true);
     memoStatement = t.blockStatement([
       ...computationBlock.body,
       t.variableDeclaration("let", [
@@ -714,7 +715,7 @@ function codegenReactiveScope(
       t.ifStatement(
         t.identifier(condition),
         t.blockStatement([
-          ...computationBlock.body,
+          ...recomputationBlock.body,
           ...idempotenceDetectionStatements,
         ])
       ),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30148

Summary: In change-detection mode, we previously were spreading the contents of the computation block into the result twice. Other babel passes that cause in-place mutations of the AST would then be causing action at a distance and breaking the overall transform result. This pr creates clones of the nodes instead, so that mutations aren't reflected in both places where the block is used.