### PR TITLE
[Fizz] Enable owner stacks for SSR

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -8229,7 +8229,9 @@ describe('ReactDOMFizzServer', () => {
             onError(error, errorInfo) {
               caughtError = error;
               parentStack = errorInfo.componentStack;
-              ownerStack = React.captureOwnerStack();
+              ownerStack = React.captureOwnerStack
+                ? React.captureOwnerStack()
+                : null;
             },
           },
         );

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1766,9 +1766,9 @@ describe('ReactDOMFizzServer', () => {
       // Intentionally trigger a key warning here.
       return (
         <div>
-          {children.map(t => (
-            <span>{t}</span>
-          ))}
+          {children.map(function mapper(t) {
+            return <span>{t}</span>;
+          })}
         </div>
       );
     }
@@ -1813,11 +1813,15 @@ describe('ReactDOMFizzServer', () => {
           '<%s /> is using incorrect casing. Use PascalCase for React components, or lowercase for HTML elements.%s',
           'inCorrectTag',
           '\n' +
-            '    in inCorrectTag (at **)\n' +
-            '    in C (at **)\n' +
-            '    in Suspense (at **)\n' +
-            '    in div (at **)\n' +
-            '    in A (at **)',
+            (gate(flags => flags.enableOwnerStacks)
+              ? '    in inCorrectTag (at **)\n' +
+                '    in C (at **)\n' +
+                '    in A (at **)'
+              : '    in inCorrectTag (at **)\n' +
+                '    in C (at **)\n' +
+                '    in Suspense (at **)\n' +
+                '    in div (at **)\n' +
+                '    in A (at **)'),
         );
         mockError.mockClear();
       } else {
@@ -1834,21 +1838,20 @@ describe('ReactDOMFizzServer', () => {
           'Each child in a list should have a unique "key" prop.%s%s' +
             ' See https://react.dev/link/warning-keys for more information.%s',
           gate(flags => flags.enableOwnerStacks)
-            ? // We currently don't track owners in Fizz which is responsible for this frame.
-              ''
-            : '\n\nCheck the top-level render call using <div>.',
+            ? ''
+            : '\n\nCheck the render method of `B`.',
           '',
           '\n' +
-            '    in span (at **)\n' +
-            // TODO: Because this validates after the div has been mounted, it is part of
-            // the parent stack but since owner stacks will switch to owners this goes away again.
             (gate(flags => flags.enableOwnerStacks)
-              ? '    in div (at **)\n'
-              : '') +
-            '    in B (at **)\n' +
-            '    in Suspense (at **)\n' +
-            '    in div (at **)\n' +
-            '    in A (at **)',
+              ? '    in span (at **)\n' +
+                '    in mapper (at **)\n' +
+                '    in B (at **)\n' +
+                '    in A (at **)'
+              : '    in span (at **)\n' +
+                '    in B (at **)\n' +
+                '    in Suspense (at **)\n' +
+                '    in div (at **)\n' +
+                '    in A (at **)'),
         );
       } else {
         expect(mockError).not.toHaveBeenCalled();
@@ -6519,24 +6522,25 @@ describe('ReactDOMFizzServer', () => {
       mockError(...args.map(normalizeCodeLocInfo));
     };
 
+    function App() {
+      return (
+        <html>
+          <body>
+            <script>{2}</script>
+            <script>
+              {['try { foo() } catch (e) {} ;', 'try { bar() } catch (e) {} ;']}
+            </script>
+            <script>
+              <MyScript />
+            </script>
+          </body>
+        </html>
+      );
+    }
+
     try {
       await act(async () => {
-        const {pipe} = renderToPipeableStream(
-          <html>
-            <body>
-              <script>{2}</script>
-              <script>
-                {[
-                  'try { foo() } catch (e) {} ;',
-                  'try { bar() } catch (e) {} ;',
-                ]}
-              </script>
-              <script>
-                <MyScript />
-              </script>
-            </body>
-          </html>,
-        );
+        const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
 
@@ -6545,17 +6549,29 @@ describe('ReactDOMFizzServer', () => {
         expect(mockError.mock.calls[0]).toEqual([
           'A script element was rendered with %s. If script element has children it must be a single string. Consider using dangerouslySetInnerHTML or passing a plain string as children.%s',
           'a number for children',
-          componentStack(['script', 'body', 'html']),
+          componentStack(
+            gate(flags => flags.enableOwnerStacks)
+              ? ['script', 'App']
+              : ['script', 'body', 'html', 'App'],
+          ),
         ]);
         expect(mockError.mock.calls[1]).toEqual([
           'A script element was rendered with %s. If script element has children it must be a single string. Consider using dangerouslySetInnerHTML or passing a plain string as children.%s',
           'an array for children',
-          componentStack(['script', 'body', 'html']),
+          componentStack(
+            gate(flags => flags.enableOwnerStacks)
+              ? ['script', 'App']
+              : ['script', 'body', 'html', 'App'],
+          ),
         ]);
         expect(mockError.mock.calls[2]).toEqual([
           'A script element was rendered with %s. If script element has children it must be a single string. Consider using dangerouslySetInnerHTML or passing a plain string as children.%s',
           'something unexpected for children',
-          componentStack(['script', 'body', 'html']),
+          componentStack(
+            gate(flags => flags.enableOwnerStacks)
+              ? ['script', 'App']
+              : ['script', 'body', 'html', 'App'],
+          ),
         ]);
       } else {
         expect(mockError.mock.calls.length).toBe(0);
@@ -8147,5 +8163,90 @@ describe('ReactDOMFizzServer', () => {
     );
 
     expect(document.body.textContent).toBe('HelloWorld');
+  });
+
+  // @gate __DEV__ && enableOwnerStacks
+  it('can get the component owner stacks during rendering in dev', async () => {
+    let stack;
+
+    function Foo() {
+      return <Bar />;
+    }
+    function Bar() {
+      return (
+        <div>
+          <Baz />
+        </div>
+      );
+    }
+    function Baz() {
+      stack = React.captureOwnerStack();
+      return <span>hi</span>;
+    }
+
+    await act(() => {
+      const {pipe} = renderToPipeableStream(
+        <div>
+          <Foo />
+        </div>,
+      );
+      pipe(writable);
+    });
+
+    expect(normalizeCodeLocInfo(stack)).toBe(
+      '\n    in Bar (at **)' + '\n    in Foo (at **)',
+    );
+  });
+
+  // @gate __DEV__ && enableOwnerStacks
+  it('can get the component owner stacks for onError in dev', async () => {
+    const thrownError = new Error('hi');
+    let caughtError;
+    let parentStack;
+    let ownerStack;
+
+    function Foo() {
+      return <Bar />;
+    }
+    function Bar() {
+      return (
+        <div>
+          <Baz />
+        </div>
+      );
+    }
+    function Baz() {
+      throw thrownError;
+    }
+
+    await expect(async () => {
+      await act(() => {
+        const {pipe} = renderToPipeableStream(
+          <div>
+            <Foo />
+          </div>,
+          {
+            onError(error, errorInfo) {
+              caughtError = error;
+              parentStack = errorInfo.componentStack;
+              ownerStack = React.captureOwnerStack();
+            },
+          },
+        );
+        pipe(writable);
+      });
+    }).rejects.toThrow(thrownError);
+
+    expect(caughtError).toBe(thrownError);
+    expect(normalizeCodeLocInfo(parentStack)).toBe(
+      '\n    in Baz (at **)' +
+        '\n    in div (at **)' +
+        '\n    in Bar (at **)' +
+        '\n    in Foo (at **)' +
+        '\n    in div (at **)',
+    );
+    expect(normalizeCodeLocInfo(ownerStack)).toBe(
+      '\n    in Bar (at **)' + '\n    in Foo (at **)',
+    );
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1837,9 +1837,7 @@ describe('ReactDOMFizzServer', () => {
         expect(mockError).toHaveBeenCalledWith(
           'Each child in a list should have a unique "key" prop.%s%s' +
             ' See https://react.dev/link/warning-keys for more information.%s',
-          gate(flags => flags.enableOwnerStacks)
-            ? ''
-            : '\n\nCheck the render method of `B`.',
+          '\n\nCheck the render method of `B`.',
           '',
           '\n' +
             (gate(flags => flags.enableOwnerStacks)

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -835,21 +835,30 @@ describe('ReactDOMServer', () => {
 
     expect(() => ReactDOMServer.renderToString(<App />)).toErrorDev([
       'Invalid ARIA attribute `ariaTypo`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
-        '    in span (at **)\n' +
-        '    in b (at **)\n' +
-        '    in C (at **)\n' +
-        '    in font (at **)\n' +
-        '    in B (at **)\n' +
-        '    in Child (at **)\n' +
-        '    in span (at **)\n' +
-        '    in div (at **)\n' +
-        '    in App (at **)',
+        (gate(flags => flags.enableOwnerStacks)
+          ? '    in span (at **)\n' +
+            '    in B (at **)\n' +
+            '    in Child (at **)\n' +
+            '    in App (at **)'
+          : '    in span (at **)\n' +
+            '    in b (at **)\n' +
+            '    in C (at **)\n' +
+            '    in font (at **)\n' +
+            '    in B (at **)\n' +
+            '    in Child (at **)\n' +
+            '    in span (at **)\n' +
+            '    in div (at **)\n' +
+            '    in App (at **)'),
       'Invalid ARIA attribute `ariaTypo2`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
-        '    in span (at **)\n' +
-        '    in Child (at **)\n' +
-        '    in span (at **)\n' +
-        '    in div (at **)\n' +
-        '    in App (at **)',
+        (gate(flags => flags.enableOwnerStacks)
+          ? '    in span (at **)\n' +
+            '    in Child (at **)\n' +
+            '    in App (at **)'
+          : '    in span (at **)\n' +
+            '    in Child (at **)\n' +
+            '    in span (at **)\n' +
+            '    in div (at **)\n' +
+            '    in App (at **)'),
     ]);
   });
 
@@ -885,9 +894,11 @@ describe('ReactDOMServer', () => {
     expect(() => ReactDOMServer.renderToString(<App />)).toErrorDev([
       // ReactDOMServer(App > div > span)
       'Invalid ARIA attribute `ariaTypo`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
-        '    in span (at **)\n' +
-        '    in div (at **)\n' +
-        '    in App (at **)',
+        (gate(flags => flags.enableOwnerStacks)
+          ? '    in span (at **)\n' + '    in App (at **)'
+          : '    in span (at **)\n' +
+            '    in div (at **)\n' +
+            '    in App (at **)'),
       // ReactDOMServer(App > div > Child) >>> ReactDOMServer(App2) >>> ReactDOMServer(blink)
       'Invalid ARIA attribute `ariaTypo2`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
         '    in blink (at **)',
@@ -898,15 +909,21 @@ describe('ReactDOMServer', () => {
         '    in App2 (at **)',
       // ReactDOMServer(App > div > Child > span)
       'Invalid ARIA attribute `ariaTypo4`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
-        '    in span (at **)\n' +
-        '    in Child (at **)\n' +
-        '    in div (at **)\n' +
-        '    in App (at **)',
+        (gate(flags => flags.enableOwnerStacks)
+          ? '    in span (at **)\n' +
+            '    in Child (at **)\n' +
+            '    in App (at **)'
+          : '    in span (at **)\n' +
+            '    in Child (at **)\n' +
+            '    in div (at **)\n' +
+            '    in App (at **)'),
       // ReactDOMServer(App > div > font)
       'Invalid ARIA attribute `ariaTypo5`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
-        '    in font (at **)\n' +
-        '    in div (at **)\n' +
-        '    in App (at **)',
+        (gate(flags => flags.enableOwnerStacks)
+          ? '    in font (at **)\n' + '    in App (at **)'
+          : '    in font (at **)\n' +
+            '    in div (at **)\n' +
+            '    in App (at **)'),
     ]);
   });
 

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -36,6 +36,7 @@ import type {
   Transition,
 } from './ReactFiberTracingMarkerComponent';
 import type {ConcurrentUpdate} from './ReactFiberConcurrentUpdates';
+import type {ComponentStackNode} from 'react-server/src/ReactFizzComponentStack';
 
 // Unwind Circular: moved from ReactFiberHooks.old
 export type HookType =
@@ -439,5 +440,5 @@ export type Dispatcher = {
 export type AsyncDispatcher = {
   getCacheForType: <T>(resourceType: () => T) => T,
   // DEV-only (or !disableStringRefs)
-  getOwner: () => null | Fiber | ReactComponentInfo,
+  getOwner: () => null | Fiber | ReactComponentInfo | ComponentStackNode,
 };

--- a/packages/react-server/src/ReactFizzAsyncDispatcher.js
+++ b/packages/react-server/src/ReactFizzAsyncDispatcher.js
@@ -8,8 +8,11 @@
  */
 
 import type {AsyncDispatcher} from 'react-reconciler/src/ReactInternalTypes';
+import type {ComponentStackNode} from './ReactFizzComponentStack';
 
 import {disableStringRefs} from 'shared/ReactFeatureFlags';
+
+import {currentTaskInDEV} from './ReactFizzCurrentTask';
 
 function getCacheForType<T>(resourceType: () => T): T {
   throw new Error('Not implemented.');
@@ -19,8 +22,14 @@ export const DefaultAsyncDispatcher: AsyncDispatcher = ({
   getCacheForType,
 }: any);
 
-if (__DEV__ || !disableStringRefs) {
-  // Fizz never tracks owner but the JSX runtime looks for this.
+if (__DEV__) {
+  DefaultAsyncDispatcher.getOwner = (): ComponentStackNode | null => {
+    if (currentTaskInDEV === null) {
+      return null;
+    }
+    return currentTaskInDEV.componentStack;
+  };
+} else if (!disableStringRefs) {
   DefaultAsyncDispatcher.getOwner = (): null => {
     return null;
   };

--- a/packages/react-server/src/ReactFizzCallUserSpace.js
+++ b/packages/react-server/src/ReactFizzCallUserSpace.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {LazyComponent} from 'react/src/ReactLazy';
+
+// These indirections exists so we can exclude its stack frame in DEV (and anything below it).
+// TODO: Consider marking the whole bundle instead of these boundaries.
+
+/** @noinline */
+export function callComponentInDEV<Props, Arg, R>(
+  Component: (p: Props, arg: Arg) => R,
+  props: Props,
+  secondArg: Arg,
+): R {
+  return Component(props, secondArg);
+}
+
+interface ClassInstance<R> {
+  render(): R;
+}
+
+/** @noinline */
+export function callRenderInDEV<R>(instance: ClassInstance<R>): R {
+  return instance.render();
+}
+
+/** @noinline */
+export function callLazyInitInDEV(lazy: LazyComponent<any, any>): any {
+  const payload = lazy._payload;
+  const init = lazy._init;
+  return init(payload);
+}

--- a/packages/react-server/src/ReactFizzComponentStack.js
+++ b/packages/react-server/src/ReactFizzComponentStack.js
@@ -15,27 +15,31 @@ import {
   describeClassComponentFrame,
 } from 'shared/ReactComponentStackFrame';
 
+import {enableOwnerStacks} from 'shared/ReactFeatureFlags';
+
+import {formatOwnerStack} from './ReactFizzOwnerStack';
+
 // DEV-only reverse linked list representing the current component stack
 type BuiltInComponentStackNode = {
   tag: 0,
   parent: null | ComponentStackNode,
   type: string,
   owner?: null | ReactComponentInfo | ComponentStackNode, // DEV only
-  stack?: null | Error, // DEV only
+  stack?: null | string | Error, // DEV only
 };
 type FunctionComponentStackNode = {
   tag: 1,
   parent: null | ComponentStackNode,
   type: Function,
   owner?: null | ReactComponentInfo | ComponentStackNode, // DEV only
-  stack?: null | Error, // DEV only
+  stack?: null | string | Error, // DEV only
 };
 type ClassComponentStackNode = {
   tag: 2,
   parent: null | ComponentStackNode,
   type: Function,
   owner?: null | ReactComponentInfo | ComponentStackNode, // DEV only
-  stack?: null | Error, // DEV only
+  stack?: null | string | Error, // DEV only
 };
 export type ComponentStackNode =
   | BuiltInComponentStackNode
@@ -63,6 +67,85 @@ export function getStackByComponentStackNode(
       // $FlowFixMe[incompatible-type] we bail out when we get a null
       node = node.parent;
     } while (node);
+    return info;
+  } catch (x) {
+    return '\nError generating stack: ' + x.message + '\n' + x.stack;
+  }
+}
+
+function describeFunctionComponentFrameWithoutLineNumber(fn: Function): string {
+  // We use this because we don't actually want to describe the line of the component
+  // but just the component name.
+  const name = fn ? fn.displayName || fn.name : '';
+  return name ? describeBuiltInComponentFrame(name) : '';
+}
+
+export function getOwnerStackByComponentStackNodeInDev(
+  componentStack: ComponentStackNode,
+): string {
+  if (!enableOwnerStacks || !__DEV__) {
+    return '';
+  }
+  try {
+    let info = '';
+
+    // The owner stack of the current component will be where it was created, i.e. inside its owner.
+    // There's no actual name of the currently executing component. Instead, that is available
+    // on the regular stack that's currently executing. However, for built-ins there is no such
+    // named stack frame and it would be ignored as being internal anyway. Therefore we add
+    // add one extra frame just to describe the "current" built-in component by name.
+    // Similarly, if there is no owner at all, then there's no stack frame so we add the name
+    // of the root component to the stack to know which component is currently executing.
+    switch (componentStack.tag) {
+      case 0:
+        info += describeBuiltInComponentFrame(componentStack.type);
+        break;
+      case 1:
+      case 2:
+        if (!componentStack.owner) {
+          // Only if we have no other data about the callsite do we add
+          // the component name as the single stack frame.
+          info += describeFunctionComponentFrameWithoutLineNumber(
+            componentStack.type,
+          );
+        }
+        break;
+    }
+
+    let owner: void | null | ComponentStackNode | ReactComponentInfo =
+      componentStack;
+
+    while (owner) {
+      if (typeof owner.tag === 'number') {
+        const node: ComponentStackNode = (owner: any);
+        owner = node.owner;
+        let debugStack = node.stack;
+        // If we don't actually print the stack if there is no owner of this JSX element.
+        // In a real app it's typically not useful since the root app is always controlled
+        // by the framework. These also tend to have noisy stacks because they're not rooted
+        // in a React render but in some imperative bootstrapping code. It could be useful
+        // if the element was created in module scope. E.g. hoisted. We could add a a single
+        // stack frame for context for example but it doesn't say much if that's a wrapper.
+        if (owner && debugStack) {
+          if (typeof debugStack !== 'string') {
+            // Stash the formatted stack so that we can avoid redoing the filtering.
+            node.stack = debugStack = formatOwnerStack(debugStack);
+          }
+          if (debugStack !== '') {
+            info += '\n' + debugStack;
+          }
+        }
+      } else if (typeof owner.stack === 'string') {
+        // Server Component
+        if (owner.stack !== '') {
+          info += '\n' + owner.stack;
+        }
+        const componentInfo: ReactComponentInfo = (owner: any);
+        owner = componentInfo.owner;
+      } else {
+        break;
+      }
+    }
     return info;
   } catch (x) {
     return '\nError generating stack: ' + x.message + '\n' + x.stack;

--- a/packages/react-server/src/ReactFizzComponentStack.js
+++ b/packages/react-server/src/ReactFizzComponentStack.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type {ReactComponentInfo} from 'shared/ReactTypes';
+
 import {
   describeBuiltInComponentFrame,
   describeFunctionComponentFrame,
@@ -18,16 +20,22 @@ type BuiltInComponentStackNode = {
   tag: 0,
   parent: null | ComponentStackNode,
   type: string,
+  owner?: null | ReactComponentInfo | ComponentStackNode, // DEV only
+  stack?: null | Error, // DEV only
 };
 type FunctionComponentStackNode = {
   tag: 1,
   parent: null | ComponentStackNode,
   type: Function,
+  owner?: null | ReactComponentInfo | ComponentStackNode, // DEV only
+  stack?: null | Error, // DEV only
 };
 type ClassComponentStackNode = {
   tag: 2,
   parent: null | ComponentStackNode,
   type: Function,
+  owner?: null | ReactComponentInfo | ComponentStackNode, // DEV only
+  stack?: null | Error, // DEV only
 };
 export type ComponentStackNode =
   | BuiltInComponentStackNode

--- a/packages/react-server/src/ReactFizzCurrentTask.js
+++ b/packages/react-server/src/ReactFizzCurrentTask.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Task} from './ReactFizzServer';
+
+// DEV-only global reference to the currently executing task
+export let currentTaskInDEV: null | Task = null;
+
+export function setCurrentTaskInDEV(task: null | Task): void {
+  if (__DEV__) {
+    currentTaskInDEV = task;
+  }
+}

--- a/packages/react-server/src/ReactFizzOwnerStack.js
+++ b/packages/react-server/src/ReactFizzOwnerStack.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {REACT_LAZY_TYPE} from 'shared/ReactSymbols';
+
+import {
+  callLazyInitInDEV,
+  callComponentInDEV,
+  callRenderInDEV,
+} from './ReactFizzCallUserSpace';
+
+// TODO: Make this configurable on the root.
+const externalRegExp = /\/node\_modules\/|\(\<anonymous\>\)/;
+
+let callComponentFrame: null | string = null;
+let callIteratorFrame: null | string = null;
+let callLazyInitFrame: null | string = null;
+
+function isNotExternal(stackFrame: string): boolean {
+  return !externalRegExp.test(stackFrame);
+}
+
+function initCallComponentFrame(): string {
+  // Extract the stack frame of the callComponentInDEV function.
+  const error = callComponentInDEV(Error, 'react-stack-top-frame', {});
+  const stack = error.stack;
+  const startIdx = stack.startsWith('Error: react-stack-top-frame\n') ? 29 : 0;
+  const endIdx = stack.indexOf('\n', startIdx);
+  if (endIdx === -1) {
+    return stack.slice(startIdx);
+  }
+  return stack.slice(startIdx, endIdx);
+}
+
+function initCallRenderFrame(): string {
+  // Extract the stack frame of the callRenderInDEV function.
+  try {
+    (callRenderInDEV: any)({render: null});
+    return '';
+  } catch (error) {
+    const stack = error.stack;
+    const startIdx = stack.startsWith('TypeError: ')
+      ? stack.indexOf('\n') + 1
+      : 0;
+    const endIdx = stack.indexOf('\n', startIdx);
+    if (endIdx === -1) {
+      return stack.slice(startIdx);
+    }
+    return stack.slice(startIdx, endIdx);
+  }
+}
+
+function initCallLazyInitFrame(): string {
+  // Extract the stack frame of the callLazyInitInDEV function.
+  const error = callLazyInitInDEV({
+    $$typeof: REACT_LAZY_TYPE,
+    _init: Error,
+    _payload: 'react-stack-top-frame',
+  });
+  const stack = error.stack;
+  const startIdx = stack.startsWith('Error: react-stack-top-frame\n') ? 29 : 0;
+  const endIdx = stack.indexOf('\n', startIdx);
+  if (endIdx === -1) {
+    return stack.slice(startIdx);
+  }
+  return stack.slice(startIdx, endIdx);
+}
+
+function filterDebugStack(error: Error): string {
+  // Since stacks can be quite large and we pass a lot of them, we filter them out eagerly
+  // to save bandwidth even in DEV. We'll also replay these stacks on the client so by
+  // stripping them early we avoid that overhead. Otherwise we'd normally just rely on
+  // the DevTools or framework's ignore lists to filter them out.
+  let stack = error.stack;
+  if (stack.startsWith('Error: react-stack-top-frame\n')) {
+    // V8's default formatting prefixes with the error message which we
+    // don't want/need.
+    stack = stack.slice(29);
+  }
+  const frames = stack.split('\n').slice(1);
+  if (callComponentFrame === null) {
+    callComponentFrame = initCallComponentFrame();
+  }
+  let lastFrameIdx = frames.indexOf(callComponentFrame);
+  if (lastFrameIdx === -1) {
+    if (callLazyInitFrame === null) {
+      callLazyInitFrame = initCallLazyInitFrame();
+    }
+    lastFrameIdx = frames.indexOf(callLazyInitFrame);
+    if (lastFrameIdx === -1) {
+      if (callIteratorFrame === null) {
+        callIteratorFrame = initCallRenderFrame();
+      }
+      lastFrameIdx = frames.indexOf(callIteratorFrame);
+    }
+  }
+  if (lastFrameIdx !== -1) {
+    // Cut off everything after our "callComponent" slot since it'll be Fiber internals.
+    frames.length = lastFrameIdx;
+  } else {
+    // We didn't find any internal callsite out to user space.
+    // This means that this was called outside an owner or the owner is fully internal.
+    // To keep things light we exclude the entire trace in this case.
+    return '';
+  }
+  return frames.filter(isNotExternal).join('\n');
+}
+
+export function formatOwnerStack(ownerStackTrace: Error): string {
+  return filterDebugStack(ownerStackTrace);
+}

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -115,6 +115,7 @@ import {
 import {DefaultAsyncDispatcher} from './ReactFizzAsyncDispatcher';
 import {getStackByComponentStackNode} from './ReactFizzComponentStack';
 import {emptyTreeContext, pushTreeContext} from './ReactFizzTreeContext';
+import {currentTaskInDEV, setCurrentTaskInDEV} from './ReactFizzCurrentTask';
 
 import {
   getIteratorFn,
@@ -790,8 +791,6 @@ function createPendingSegment(
   };
 }
 
-// DEV-only global reference to the currently executing task
-let currentTaskInDEV: null | Task = null;
 function getCurrentStackInDEV(): string {
   if (__DEV__) {
     if (currentTaskInDEV === null || currentTaskInDEV.componentStack === null) {
@@ -3775,7 +3774,7 @@ function retryRenderTask(
   let prevTaskInDEV = null;
   if (__DEV__) {
     prevTaskInDEV = currentTaskInDEV;
-    currentTaskInDEV = task;
+    setCurrentTaskInDEV(task);
   }
 
   const childrenLength = segment.children.length;
@@ -3852,7 +3851,7 @@ function retryRenderTask(
     return;
   } finally {
     if (__DEV__) {
-      currentTaskInDEV = prevTaskInDEV;
+      setCurrentTaskInDEV(prevTaskInDEV);
     }
   }
 }
@@ -3870,7 +3869,7 @@ function retryReplayTask(request: Request, task: ReplayTask): void {
   let prevTaskInDEV = null;
   if (__DEV__) {
     prevTaskInDEV = currentTaskInDEV;
-    currentTaskInDEV = task;
+    setCurrentTaskInDEV(task);
   }
 
   try {
@@ -3939,7 +3938,7 @@ function retryReplayTask(request: Request, task: ReplayTask): void {
     return;
   } finally {
     if (__DEV__) {
-      currentTaskInDEV = prevTaskInDEV;
+      setCurrentTaskInDEV(prevTaskInDEV);
     }
   }
 }


### PR DESCRIPTION
Stacked on #30142.

This tracks owners and their stacks in DEV in Fizz. We use the ComponentStackNode as the data structure to track this information - effectively like ReactComponentInfo (Server) or Fiber (Client). They're the instance.

I then port them same logic from ReactFiberComponentStack, ReactFiberOwnerStack and ReactFiberCallUserSpace to Fizz equivalents.

This gets us both owner stacks from `captureOwnerStack()`, as well as appended to console.errors logged by Fizz, while rendering and in onError.