### PR TITLE
chore[react-devtools/renderer]: dont show strict mode warning for prod renderer builds

### DIFF
--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -1984,12 +1984,17 @@ export function attach(
     }
 
     if (isRoot) {
+      // Set supportsStrictMode to false for production renderer builds
+      const isProductionBuildOfRenderer = renderer.bundleType === 0;
+
       pushOperation(TREE_OPERATION_ADD);
       pushOperation(id);
       pushOperation(ElementTypeRoot);
       pushOperation((fiber.mode & StrictModeBits) !== 0 ? 1 : 0);
       pushOperation(profilingFlags);
-      pushOperation(StrictModeBits !== 0 ? 1 : 0);
+      pushOperation(
+        !isProductionBuildOfRenderer && StrictModeBits !== 0 ? 1 : 0,
+      );
       pushOperation(hasOwnerMetadata ? 1 : 0);
 
       if (isProfiling) {


### PR DESCRIPTION
## Summary

We should not be showing StrictMode warnings when React is running in production, since StrictMode is a dev-only feature.

## How did you test this change?

| Before | After |
| --- | --- |
| ![Screenshot 2024-06-30 at 23 42 41](https://github.com/facebook/react/assets/28902667/0154ab2a-435b-4317-b2e8-09083533acec) | ![Screenshot 2024-06-30 at 23 44 14](https://github.com/facebook/react/assets/28902667/b10ffc6e-dbed-43d8-bf08-11188a151009) |
