### PR TITLE
Independent re-renders from UNSAFE_componentWillReceiveProps cause maximum update depth error

### DIFF
--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1777,6 +1777,34 @@ describe('ReactUpdates', () => {
     expect(subscribers.length).toBe(limit);
   });
 
+  it('does not cause maxiumum update error with UNSAFE_componentWillReceiveProps', async () => {
+    class App extends React.Component {
+      state = {
+        value: 0,
+      };
+
+      UNSAFE_componentWillReceiveProps(newProps) {
+        this.setState({value: newProps.value});
+      }
+
+      render() {
+        return (
+          <>
+            <div>this.state.value: {this.state.value}</div>
+            <div>this.props.value: {this.props.value}</div>
+          </>
+        );
+      }
+    }
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+
+    for (let i = 0; i < 60; i++) {
+      await act(() => root.render(<App value={i} />));
+    }
+  });
+
   it("does not infinite loop if there's a synchronous render phase update on another component", async () => {
     if (gate(flags => !flags.enableInfiniteRenderLoopDetection)) {
       return;


### PR DESCRIPTION

In this added test case, each render causes a second pass render follow up, but it always settles.

Repeating this sufficiently often triggers the "Maximum update depth exceeded." error because the `nestedUpdateCount` in `ReactFiberWorkLoop.js` doesn't reset.
