### PR TITLE
[compiler] useMemo calls directly induce memoization blocks

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -182,7 +182,9 @@ const EnvironmentConfigSchema = z.object({
    * that the memoized values remain memoized, the compiler will simply not prune existing calls to
    * useMemo/useCallback.
    */
-  enablePreserveExistingManualUseMemo: z.boolean().default(false),
+  enablePreserveExistingManualUseMemo: z
+    .nullable(z.enum(["hook", "scope"]))
+    .default(null),
 
   // 🌲
   enableForest: z.boolean().default(false),
@@ -453,6 +455,22 @@ export function parseConfigPragma(pragma: string): EnvironmentConfig {
         source: "react-compiler-runtime",
         importSpecifierName: "$structuralCheck",
       };
+      continue;
+    }
+
+    if (
+      key === "enablePreserveExistingManualUseMemoAsHook" &&
+      (val === undefined || val === "true")
+    ) {
+      maybeConfig["enablePreserveExistingManualUseMemo"] = "hook";
+      continue;
+    }
+
+    if (
+      key === "enablePreserveExistingManualUseMemoAsScope" &&
+      (val === undefined || val === "true")
+    ) {
+      maybeConfig["enablePreserveExistingManualUseMemo"] = "scope";
       continue;
     }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -459,19 +459,28 @@ export function parseConfigPragma(pragma: string): EnvironmentConfig {
     }
 
     if (
-      key === "enablePreserveExistingManualUseMemoAsHook" &&
-      (val === undefined || val === "true")
+      key === "enablePreserveExistingManualUseMemo" &&
+      (val === undefined || val === "true" || val === "scope")
     ) {
-      maybeConfig["enablePreserveExistingManualUseMemo"] = "hook";
+      maybeConfig[key] = "scope";
+      continue;
+    }
+
+    if (key === "enablePreserveExistingManualUseMemo" && val === "hook") {
+      maybeConfig[key] = "hook";
       continue;
     }
 
     if (
-      key === "enablePreserveExistingManualUseMemoAsScope" &&
-      (val === undefined || val === "true")
+      key === "enablePreserveExistingManualUseMemo" &&
+      !(val === "false" || val === "off")
     ) {
-      maybeConfig["enablePreserveExistingManualUseMemo"] = "scope";
-      continue;
+      CompilerError.throwInvalidConfig({
+        reason: `Invalid setting '${val}' for 'enablePreserveExistingManualUseMemo'. Valid settings are 'hook', 'scope', or 'off'.`,
+        description: null,
+        loc: null,
+        suggestions: null,
+      });
     }
 
     if (typeof defaultConfig[key as keyof EnvironmentConfig] !== "boolean") {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -1429,6 +1429,8 @@ export type ReactiveScope = {
   merged: Set<ScopeId>;
 
   loc: SourceLocation;
+
+  source: boolean;
 };
 
 export type ReactiveScopeDependencies = Set<ReactiveScopeDependency>;

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/DropManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/DropManualMemoization.ts
@@ -334,6 +334,7 @@ function extractManualMemoizationArgs(
  */
 export function dropManualMemoization(func: HIRFunction): void {
   const isValidationEnabled =
+    func.env.config.enablePreserveExistingManualUseMemo === "scope" ||
     func.env.config.validatePreserveExistingMemoizationGuarantees ||
     func.env.config.enablePreserveExistingMemoizationGuarantees;
   const sidemap: IdentifierSidemap = {

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/MemoizeExistingUseMemos.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/MemoizeExistingUseMemos.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { CompilerError } from "../CompilerError";
+import {
+  BasicBlock,
+  HIRFunction,
+  Identifier,
+  makeInstructionId,
+  ReactiveScope,
+} from "../HIR";
+import { eachTerminalSuccessor } from "../HIR/visitors";
+import {
+  collectMutableOperands,
+  mergeLocation,
+} from "./InferReactiveScopeVariables";
+
+export function memoizeExistingUseMemos(fn: HIRFunction): void {
+  visitBlock(fn, fn.body.blocks.get(fn.body.entry)!, null, new Map());
+}
+
+let ctr = 0;
+function nextId(): number {
+  return ctr++;
+}
+
+type CurrentScope =
+  | null
+  | { kind: "pending"; id: number }
+  | { kind: "available"; scope: ReactiveScope; id: number };
+
+function visitBlock(
+  fn: HIRFunction,
+  block: BasicBlock,
+  scope: CurrentScope,
+  seen: Map<number, CurrentScope>
+): void {
+  const visited = seen.get(block.id);
+  if (visited === undefined) {
+    seen.set(block.id, scope);
+  } else {
+    CompilerError.invariant(
+      visited === null ? scope === null : visited.id === scope?.id,
+      {
+        reason:
+          "MemoizeExistingUseMemos: visiting the same block with different scopes",
+        loc: null,
+        suggestions: null,
+      }
+    );
+    return;
+  }
+
+  function extend(
+    currentScope: ReactiveScope,
+    operands: Iterable<Identifier>
+  ): void {
+    for (const operand of operands) {
+      currentScope.range.start = makeInstructionId(
+        Math.min(currentScope.range.start, operand.mutableRange.start)
+      );
+      currentScope.range.end = makeInstructionId(
+        Math.max(currentScope.range.end, operand.mutableRange.end)
+      );
+      currentScope.loc = mergeLocation(currentScope.loc, operand.loc);
+      operand.scope = currentScope;
+      operand.mutableRange = currentScope.range;
+    }
+  }
+
+  let currentScope = scope;
+  for (const instruction of block.instructions) {
+    if (instruction.value.kind === "StartMemoize") {
+      currentScope = { kind: "pending", id: nextId() };
+    } else if (instruction.value.kind === "FinishMemoize") {
+      currentScope = null;
+    } else if (currentScope != null) {
+      const operands = collectMutableOperands(fn, instruction, true);
+      if (operands.length > 0) {
+        if (currentScope.kind === "pending") {
+          currentScope = {
+            kind: "available",
+            id: currentScope.id,
+            scope: {
+              id: fn.env.nextScopeId,
+              range: { start: instruction.id, end: instruction.id },
+              dependencies: new Set(),
+              declarations: new Map(),
+              reassignments: new Set(),
+              earlyReturnValue: null,
+              merged: new Set(),
+              loc: instruction.loc,
+              source: true,
+            },
+          };
+        }
+        extend(currentScope.scope, operands);
+      }
+    }
+  }
+  for (const successor of eachTerminalSuccessor(block.terminal)) {
+    visitBlock(fn, fn.body.blocks.get(successor)!, currentScope, seen);
+  }
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/MergeReactiveScopesThatInvalidateTogether.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/MergeReactiveScopesThatInvalidateTogether.ts
@@ -15,7 +15,6 @@ import {
   ReactiveFunction,
   ReactiveScope,
   ReactiveScopeBlock,
-  ReactiveScopeDependencies,
   ReactiveScopeDependency,
   ReactiveStatement,
   Type,
@@ -109,7 +108,7 @@ class FindLastUsageVisitor extends ReactiveFunctionVisitor<void> {
   }
 }
 
-class Transform extends ReactiveFunctionTransform<ReactiveScopeDependencies | null> {
+class Transform extends ReactiveFunctionTransform<ReactiveScope | null> {
   lastUsage: Map<IdentifierId, InstructionId>;
 
   constructor(lastUsage: Map<IdentifierId, InstructionId>) {
@@ -119,12 +118,13 @@ class Transform extends ReactiveFunctionTransform<ReactiveScopeDependencies | nu
 
   override transformScope(
     scopeBlock: ReactiveScopeBlock,
-    state: ReactiveScopeDependencies | null
+    state: ReactiveScope | null
   ): Transformed<ReactiveStatement> {
-    this.visitScope(scopeBlock, scopeBlock.scope.dependencies);
+    this.visitScope(scopeBlock, scopeBlock.scope);
     if (
       state !== null &&
-      areEqualDependencies(state, scopeBlock.scope.dependencies)
+      areEqualDependencies(state.dependencies, scopeBlock.scope.dependencies) &&
+      state.source === scopeBlock.scope.source
     ) {
       return { kind: "replace-many", value: scopeBlock.instructions };
     } else {
@@ -132,10 +132,7 @@ class Transform extends ReactiveFunctionTransform<ReactiveScopeDependencies | nu
     }
   }
 
-  override visitBlock(
-    block: ReactiveBlock,
-    state: ReactiveScopeDependencies | null
-  ): void {
+  override visitBlock(block: ReactiveBlock, state: ReactiveScope | null): void {
     // Pass 1: visit nested blocks to potentially merge their scopes
     this.traverseBlock(block, state);
 
@@ -417,6 +414,9 @@ function canMergeScopes(
   current: ReactiveScopeBlock,
   next: ReactiveScopeBlock
 ): boolean {
+  if (current.scope.source !== next.scope.source) {
+    return false;
+  }
   // Don't merge scopes with reassignments
   if (
     current.scope.reassignments.size !== 0 ||

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonEscapingScopes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonEscapingScopes.ts
@@ -947,7 +947,7 @@ class PruneScopesTransform extends ReactiveFunctionTransform<
       Array.from(scopeBlock.scope.reassignments).some((identifier) =>
         state.has(identifier.id)
       );
-    if (hasMemoizedOutput) {
+    if (hasMemoizedOutput || scopeBlock.scope.source) {
       return { kind: "keep" };
     } else {
       this.prunedScopes.add(scopeBlock.scope.id);

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneUnusedScopes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneUnusedScopes.ts
@@ -43,6 +43,7 @@ class Transform extends ReactiveFunctionTransform<State> {
     this.visitScope(scopeBlock, scopeState);
     if (
       !scopeState.hasReturnStatement &&
+      !scopeBlock.scope.source &&
       scopeBlock.scope.reassignments.size === 0 &&
       (scopeBlock.scope.declarations.size === 0 ||
         /*

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-preserve-non-idempotent.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-preserve-non-idempotent.expect.md
@@ -1,0 +1,77 @@
+
+## Input
+
+```javascript
+// @enablePreserveExistingManualUseMemoAsScope
+import { useMemo } from "react";
+let cur = 99;
+function random(id) {
+  "use no forget";
+  cur = cur + 1;
+  return cur;
+}
+
+export default function C(id) {
+  const r = useMemo(() => random(id.id), [id.id]);
+  const a = r + 1;
+  return <>{a}</>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: C,
+  params: [{ id: 1 }],
+  sequentialRenders: [{ id: 1 }, { id: 1 }, { id: 1 }, { id: 1 }],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingManualUseMemoAsScope
+import { useMemo } from "react";
+let cur = 99;
+function random(id) {
+  "use no forget";
+  cur = cur + 1;
+  return cur;
+}
+
+export default function C(id) {
+  const $ = _c(4);
+  let t0;
+  let t1;
+  if ($[0] !== id.id) {
+    t1 = random(id.id);
+    $[0] = id.id;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  t0 = t1;
+  const r = t0;
+  const a = r + 1;
+  let t2;
+  if ($[2] !== a) {
+    t2 = <>{a}</>;
+    $[2] = a;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: C,
+  params: [{ id: 1 }],
+  sequentialRenders: [{ id: 1 }, { id: 1 }, { id: 1 }, { id: 1 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) 101
+101
+101
+101

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-preserve-non-idempotent.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-preserve-non-idempotent.expect.md
@@ -2,7 +2,7 @@
 ## Input
 
 ```javascript
-// @enablePreserveExistingManualUseMemoAsScope
+// @enablePreserveExistingManualUseMemo
 import { useMemo } from "react";
 let cur = 99;
 function random(id) {
@@ -28,7 +28,7 @@ export const FIXTURE_ENTRYPOINT = {
 ## Code
 
 ```javascript
-import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingManualUseMemoAsScope
+import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingManualUseMemo
 import { useMemo } from "react";
 let cur = 99;
 function random(id) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-preserve-non-idempotent.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-preserve-non-idempotent.js
@@ -1,0 +1,20 @@
+// @enablePreserveExistingManualUseMemoAsScope
+import { useMemo } from "react";
+let cur = 99;
+function random(id) {
+  "use no forget";
+  cur = cur + 1;
+  return cur;
+}
+
+export default function C(id) {
+  const r = useMemo(() => random(id.id), [id.id]);
+  const a = r + 1;
+  return <>{a}</>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: C,
+  params: [{ id: 1 }],
+  sequentialRenders: [{ id: 1 }, { id: 1 }, { id: 1 }, { id: 1 }],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-preserve-non-idempotent.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-preserve-non-idempotent.js
@@ -1,4 +1,4 @@
-// @enablePreserveExistingManualUseMemoAsScope
+// @enablePreserveExistingManualUseMemo
 import { useMemo } from "react";
 let cur = 99;
 function random(id) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-simple-preserved.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-simple-preserved.expect.md
@@ -2,7 +2,7 @@
 ## Input
 
 ```javascript
-// @enablePreserveExistingManualUseMemo
+// @enablePreserveExistingManualUseMemoAsScope
 import { useMemo } from "react";
 
 function Component({ a }) {
@@ -21,35 +21,30 @@ export const FIXTURE_ENTRYPOINT = {
 ## Code
 
 ```javascript
-import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingManualUseMemo
+import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingManualUseMemoAsScope
 import { useMemo } from "react";
 
 function Component(t0) {
-  const $ = _c(5);
+  const $ = _c(4);
   const { a } = t0;
   let t1;
-  if ($[0] !== a) {
-    t1 = () => [a];
-    $[0] = a;
-    $[1] = t1;
-  } else {
-    t1 = $[1];
-  }
   let t2;
-  if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
-    t2 = [];
-    $[2] = t2;
+  if ($[0] !== a) {
+    t2 = [a];
+    $[0] = a;
+    $[1] = t2;
   } else {
-    t2 = $[2];
+    t2 = $[1];
   }
-  const x = useMemo(t1, t2);
+  t1 = t2;
+  const x = t1;
   let t3;
-  if ($[3] !== x) {
+  if ($[2] !== x) {
     t3 = <div>{x}</div>;
-    $[3] = x;
-    $[4] = t3;
+    $[2] = x;
+    $[3] = t3;
   } else {
-    t3 = $[4];
+    t3 = $[3];
   }
   return t3;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-simple-preserved.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-simple-preserved.expect.md
@@ -2,7 +2,7 @@
 ## Input
 
 ```javascript
-// @enablePreserveExistingManualUseMemoAsScope
+// @enablePreserveExistingManualUseMemo
 import { useMemo } from "react";
 
 function Component({ a }) {
@@ -21,7 +21,7 @@ export const FIXTURE_ENTRYPOINT = {
 ## Code
 
 ```javascript
-import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingManualUseMemoAsScope
+import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingManualUseMemo
 import { useMemo } from "react";
 
 function Component(t0) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-simple-preserved.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-simple-preserved.js
@@ -1,4 +1,4 @@
-// @enablePreserveExistingManualUseMemo
+// @enablePreserveExistingManualUseMemoAsScope
 import { useMemo } from "react";
 
 function Component({ a }) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-simple-preserved.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-simple-preserved.js
@@ -1,4 +1,4 @@
-// @enablePreserveExistingManualUseMemoAsScope
+// @enablePreserveExistingManualUseMemo
 import { useMemo } from "react";
 
 function Component({ a }) {

--- a/compiler/packages/snap/src/compiler.ts
+++ b/compiler/packages/snap/src/compiler.ts
@@ -46,6 +46,7 @@ function makePluginOptions(
   // TODO(@mofeiZ) rewrite snap fixtures to @validatePreserveExistingMemo:false
   let validatePreserveExistingMemoizationGuarantees = false;
   let enableChangeDetectionForDebugging = null;
+  let enablePreserveExistingManualUseMemo: "hook" | "scope" | null = null;
   let customMacros = null;
 
   if (firstLine.indexOf("@compilationMode(annotation)") !== -1) {
@@ -130,6 +131,17 @@ function makePluginOptions(
       importSpecifierName: "$structuralCheck",
     };
   }
+  if (firstLine.includes("@enablePreserveExistingManualUseMemoAsHook")) {
+    enablePreserveExistingManualUseMemo = "hook";
+  } else if (
+    firstLine.includes("@enablePreserveExistingManualUseMemoAsScope")
+  ) {
+    enablePreserveExistingManualUseMemo = "scope";
+  } else if (firstLine.includes("@enablePreserveExistingManualUseMemo")) {
+    throw new Error(
+      "Use either @enablePreserveExistingManualUseMemoAsScope or @enablePreserveExistingManualUseMemoAsHook"
+    );
+  }
   const hookPatternMatch = /@hookPattern:"([^"]+)"/.exec(firstLine);
   if (
     hookPatternMatch &&
@@ -207,6 +219,7 @@ function makePluginOptions(
       hookPattern,
       validatePreserveExistingMemoizationGuarantees,
       enableChangeDetectionForDebugging,
+      enablePreserveExistingManualUseMemo,
     },
     compilationMode,
     logger,

--- a/compiler/packages/snap/src/compiler.ts
+++ b/compiler/packages/snap/src/compiler.ts
@@ -131,17 +131,28 @@ function makePluginOptions(
       importSpecifierName: "$structuralCheck",
     };
   }
-  if (firstLine.includes("@enablePreserveExistingManualUseMemoAsHook")) {
-    enablePreserveExistingManualUseMemo = "hook";
-  } else if (
-    firstLine.includes("@enablePreserveExistingManualUseMemoAsScope")
+
+  const useMemoMatch = /@enablePreserveExistingManualUseMemo:"([^"]+)"/.exec(
+    firstLine
+  );
+  if (
+    useMemoMatch &&
+    (useMemoMatch[1] === "hook" || useMemoMatch[1] === "scope")
   ) {
-    enablePreserveExistingManualUseMemo = "scope";
-  } else if (firstLine.includes("@enablePreserveExistingManualUseMemo")) {
+    enablePreserveExistingManualUseMemo = useMemoMatch[1];
+  } else if (
+    useMemoMatch &&
+    (useMemoMatch[1] === "false" || useMemoMatch[1] === "off")
+  ) {
+    enablePreserveExistingManualUseMemo = null;
+  } else if (useMemoMatch) {
     throw new Error(
-      "Use either @enablePreserveExistingManualUseMemoAsScope or @enablePreserveExistingManualUseMemoAsHook"
+      `Invalid setting '${useMemoMatch[1]}' for 'enablePreserveExistingManualUseMemo'. Valid settings are 'hook', 'scope', or 'off'.`
     );
+  } else if (firstLine.includes("@enablePreserveExistingManualUseMemo")) {
+    enablePreserveExistingManualUseMemo = "scope";
   }
+
   const hookPatternMatch = /@hookPattern:"([^"]+)"/.exec(firstLine);
   if (
     hookPatternMatch &&


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30191
* #30181
* #30180
* #30179
* #30178
* __->__ #30177

Summary: To support the always-bailing-out and change-detection modes for the compiler, and to potentially support end-user codebases in some situations, we previously built a mode where user-level useMemos weren't dropped. This, however, results in codegen that is quite vastly different from the compiler's default mode, and which is likely to exercise different bugs.

This diff introduces a new mode that attempts to preserve user-level memoization in a way that is more compatible with the normal output of the compiler, dropping the literal useMemo calls and producing reactive scopes. The result of this is different from the existing @ensurePreserveMemoizationGuarantees in that the reactive scope is marked as originating from a useMemo, and cannot be merged with other memoization blocks, and that some operations are memoized that are not necessarily memoized today: specifically, `obj.x` and `f()`. This is to account for the fact that current useMemo calls may call non-idempotent functions inside useMemo--this is a violation of React's rules and is unsupported, but this mode attempts to support this behavior to make the compiler's behavior as close to user-level behavior as possible.

We build the user-level reactive scopes by simply adding all memoizable instructions between `StartMemo` and `FinishMemo` to their own reactive scope, possibly overwriting an existing scope. We do so before the scopes have been populated with dependencies or outputs so those passes can operate over these new scopes as normal.