### PR TITLE
[compiler] Drop useMemos in memoization disabled mode, don't bail from source-level memo blocks

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
@@ -154,11 +154,7 @@ function* runWithEnvironment(
   validateContextVariableLValues(hir);
   validateUseMemo(hir);
 
-  if (
-    env.config.enablePreserveExistingManualUseMemo !== "hook" &&
-    !env.config.disableMemoizationForDebugging &&
-    !env.config.enableChangeDetectionForDebugging
-  ) {
+  if (env.config.enablePreserveExistingManualUseMemo !== "hook") {
     dropManualMemoization(hir);
     yield log({ kind: "hir", name: "DropManualMemoization", value: hir });
   }
@@ -271,7 +267,10 @@ function* runWithEnvironment(
       value: hir,
     });
 
-    if (env.config.enablePreserveExistingManualUseMemo === "scope") {
+    if (
+      env.config.enablePreserveExistingManualUseMemo === "scope" ||
+      env.config.disableMemoizationForDebugging
+    ) {
       memoizeExistingUseMemos(hir);
       yield log({
         kind: "hir",

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/DropManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/DropManualMemoization.ts
@@ -336,7 +336,9 @@ export function dropManualMemoization(func: HIRFunction): void {
   const isValidationEnabled =
     func.env.config.enablePreserveExistingManualUseMemo === "scope" ||
     func.env.config.validatePreserveExistingMemoizationGuarantees ||
-    func.env.config.enablePreserveExistingMemoizationGuarantees;
+    func.env.config.enablePreserveExistingMemoizationGuarantees ||
+    func.env.config.enableChangeDetectionForDebugging ||
+    func.env.config.disableMemoizationForDebugging;
   const sidemap: IdentifierSidemap = {
     functions: new Map(),
     manualMemos: new Map(),

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -622,7 +622,7 @@ function codegenReactiveScope(
     );
   }
 
-  if (cx.env.config.disableMemoizationForDebugging) {
+  if (cx.env.config.disableMemoizationForDebugging && !scope.source) {
     CompilerError.invariant(
       cx.env.config.enableChangeDetectionForDebugging == null,
       {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-simple-preserved-nomemo.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-simple-preserved-nomemo.expect.md
@@ -25,31 +25,26 @@ import { c as _c } from "react/compiler-runtime"; // @disableMemoizationForDebug
 import { useMemo } from "react";
 
 function Component(t0) {
-  const $ = _c(5);
+  const $ = _c(4);
   const { a } = t0;
   let t1;
-  if ($[0] !== a || true) {
-    t1 = () => [a];
-    $[0] = a;
-    $[1] = t1;
-  } else {
-    t1 = $[1];
-  }
   let t2;
-  if ($[2] === Symbol.for("react.memo_cache_sentinel") || true) {
-    t2 = [];
-    $[2] = t2;
+  if ($[0] !== a) {
+    t2 = [a];
+    $[0] = a;
+    $[1] = t2;
   } else {
-    t2 = $[2];
+    t2 = $[1];
   }
-  const x = useMemo(t1, t2);
+  t1 = t2;
+  const x = t1;
   let t3;
-  if ($[3] !== x || true) {
+  if ($[2] !== x || true) {
     t3 = <div>{x}</div>;
-    $[3] = x;
-    $[4] = t3;
+    $[2] = x;
+    $[3] = t3;
   } else {
-    t3 = $[4];
+    t3 = $[3];
   }
   return t3;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30191
* #30181
* #30180
* #30179
* __->__ #30178
* #30177

Summary: When testing Forget with the always-bail-out mode, we now preserve useMemos as reactive scope rather than hook calls, and we don't short-circuit those scopes.