### PR TITLE
[compiler] Use dependencies from source for useMemo scopes

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -771,7 +771,12 @@ export type ManualMemoDependency = {
         kind: "NamedLocal";
         value: Place;
       }
-    | { kind: "Global"; identifierName: string };
+    | {
+        kind: "InlinedGlobal";
+        value: Place;
+        name: string;
+      }
+    | { kind: "Global"; binding: LoadGlobal };
   path: Array<string>;
 };
 

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -843,7 +843,9 @@ export function printManualMemoDependency(
 ): string {
   let rootStr;
   if (val.root.kind === "Global") {
-    rootStr = val.root.identifierName;
+    rootStr = val.root.binding.binding.name;
+  } else if (val.root.kind === "InlinedGlobal") {
+    rootStr = `G(${val.root.name})`;
   } else {
     CompilerError.invariant(val.root.value.identifier.name?.kind === "named", {
       reason: "DepsValidation: expected named local variable in depslist",

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/visitors.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/visitors.ts
@@ -229,7 +229,10 @@ export function* eachInstructionValueOperand(
     case "StartMemoize": {
       if (instrValue.deps != null) {
         for (const dep of instrValue.deps) {
-          if (dep.root.kind === "NamedLocal") {
+          if (
+            dep.root.kind === "NamedLocal" ||
+            dep.root.kind === "InlinedGlobal"
+          ) {
             yield dep.root.value;
           }
         }
@@ -554,7 +557,10 @@ export function mapInstructionValueOperands(
     case "StartMemoize": {
       if (instrValue.deps != null) {
         for (const dep of instrValue.deps) {
-          if (dep.root.kind === "NamedLocal") {
+          if (
+            dep.root.kind === "NamedLocal" ||
+            dep.root.kind === "InlinedGlobal"
+          ) {
             dep.root.value = fn(dep.root.value);
           }
         }

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PropagateScopeDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PropagateScopeDependencies.ts
@@ -685,7 +685,9 @@ class PropagationVisitor extends ReactiveFunctionVisitor<Context> {
     const scopeDependencies = context.enter(scope.scope, () => {
       this.visitBlock(scope.instructions, context);
     });
-    scope.scope.dependencies = scopeDependencies;
+    if (!scope.scope.source) {
+      scope.scope.dependencies = scopeDependencies;
+    }
   }
 
   override visitPrunedScope(

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneInitializationDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneInitializationDependencies.ts
@@ -183,7 +183,7 @@ class Visitor extends ReactiveFunctionVisitor<CreateUpdate> {
       ident.path.forEach((key) => {
         target &&= this.paths.get(target)?.get(key);
       });
-      if (target && this.map.get(target) === "Create") {
+      if (target && this.map.get(target) === "Create" && !scope.scope.source) {
         scope.scope.dependencies.delete(ident);
       }
     });

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonReactiveDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonReactiveDependencies.ts
@@ -97,7 +97,7 @@ class Visitor extends ReactiveFunctionVisitor<ReactiveIdentifiers> {
     this.traverseScope(scopeBlock, state);
     for (const dep of scopeBlock.scope.dependencies) {
       const isReactive = state.has(dep.identifier.id);
-      if (!isReactive) {
+      if (!isReactive && !scopeBlock.scope.source) {
         scopeBlock.scope.dependencies.delete(dep);
       }
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
@@ -146,9 +146,13 @@ function compareDeps(
   const rootsEqual =
     (inferred.root.kind === "Global" &&
       source.root.kind === "Global" &&
-      inferred.root.identifierName === source.root.identifierName) ||
-    (inferred.root.kind === "NamedLocal" &&
-      source.root.kind === "NamedLocal" &&
+      inferred.root.binding.binding.name ===
+        source.root.binding.binding.name) ||
+    ((inferred.root.kind === "NamedLocal" ||
+      inferred.root.kind === "InlinedGlobal") &&
+      (source.root.kind === "NamedLocal" ||
+        source.root.kind === "InlinedGlobal") &&
+      source.root.kind === inferred.root.kind &&
       inferred.root.value.identifier.id === source.root.value.identifier.id);
   if (!rootsEqual) {
     return CompareDependencyResult.RootDifference;
@@ -378,7 +382,8 @@ class Visitor extends ReactiveFunctionVisitor<VisitorState> {
 
     if (
       state.manualMemoState != null &&
-      state.manualMemoState.depsFromSource != null
+      state.manualMemoState.depsFromSource != null &&
+      !scopeBlock.scope.source
     ) {
       for (const dep of scopeBlock.scope.dependencies) {
         validateInferredDep(

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nomemo-path.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nomemo-path.expect.md
@@ -5,14 +5,16 @@
 // @disableMemoizationForDebugging
 import { useMemo } from "react";
 
-function Component({ a }) {
-  let x = useMemo(() => [a], []);
+const w = 42;
+
+function Component(a) {
+  let x = useMemo(() => a.x, [a, w]);
   return <div>{x}</div>;
 }
 
 export const FIXTURE_ENTRYPOINT = {
   fn: Component,
-  params: [{ a: 42 }],
+  params: [{ x: 42 }],
   isComponent: true,
 };
 
@@ -24,33 +26,37 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime"; // @disableMemoizationForDebugging
 import { useMemo } from "react";
 
-function Component(t0) {
-  const $ = _c(3);
-  const { a } = t0;
+const w = 42;
+
+function Component(a) {
+  const $ = _c(5);
+  const t0 = w;
   let t1;
   let t2;
-  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t2 = [a];
-    $[0] = t2;
+  if ($[0] !== a || $[1] !== t0) {
+    t2 = a.x;
+    $[0] = a;
+    $[1] = t0;
+    $[2] = t2;
   } else {
-    t2 = $[0];
+    t2 = $[2];
   }
   t1 = t2;
   const x = t1;
   let t3;
-  if ($[1] !== x || true) {
+  if ($[3] !== x || true) {
     t3 = <div>{x}</div>;
-    $[1] = x;
-    $[2] = t3;
+    $[3] = x;
+    $[4] = t3;
   } else {
-    t3 = $[2];
+    t3 = $[4];
   }
   return t3;
 }
 
 export const FIXTURE_ENTRYPOINT = {
   fn: Component,
-  params: [{ a: 42 }],
+  params: [{ x: 42 }],
   isComponent: true,
 };
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nomemo-path.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nomemo-path.js
@@ -1,0 +1,15 @@
+// @disableMemoizationForDebugging
+import { useMemo } from "react";
+
+const w = 42;
+
+function Component(a) {
+  let x = useMemo(() => a.x, [a, w]);
+  return <div>{x}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ x: 42 }],
+  isComponent: true,
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-simple-preserved.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-simple-preserved.expect.md
@@ -25,26 +25,25 @@ import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingManu
 import { useMemo } from "react";
 
 function Component(t0) {
-  const $ = _c(4);
+  const $ = _c(3);
   const { a } = t0;
   let t1;
   let t2;
-  if ($[0] !== a) {
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t2 = [a];
-    $[0] = a;
-    $[1] = t2;
+    $[0] = t2;
   } else {
-    t2 = $[1];
+    t2 = $[0];
   }
   t1 = t2;
   const x = t1;
   let t3;
-  if ($[2] !== x) {
+  if ($[1] !== x) {
     t3 = <div>{x}</div>;
-    $[2] = x;
-    $[3] = t3;
+    $[1] = x;
+    $[2] = t3;
   } else {
-    t3 = $[3];
+    t3 = $[2];
   }
   return t3;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30191
* #30181
* #30180
* __->__ #30179
* #30178
* #30177

Summary: This modified the behavior of the compiler when preserving source-level useMemos as reactive scopes to use the depencies from the source as well. This accounts for the possibility that the useMemo in the source is more general than is required by local code, but is necessary due to rules of react violations.

The most complex bit here has to do with explicit dependencies that are globals. As currently written, there's no LoadGlobal that corresponds to a Global dependency of a useMemo, so whenever we convert a useMemo into StartMemoize/FinishMemoize instructions, if we plan to use the useMemo's dependencies we also have to synthesize a LoadGlobal instruction for any globals in the dependencies. 

With this change, ideally the disableMemoization mode will behave exactly like the uncompiled code.