### PR TITLE
[Fizz] Track Current debugTask and run it for onError Callbacks

### DIFF
--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -907,7 +907,7 @@ function pushServerComponentStack(
   if (!__DEV__) {
     // eslint-disable-next-line react-internal/prod-error-codes
     throw new Error(
-      'createServerComponentStack should never be called in production. This is a bug in React.',
+      'pushServerComponentStack should never be called in production. This is a bug in React.',
     );
   }
   // Build a Server Component parent stack from the debugInfo.


### PR DESCRIPTION
Stacked on #30174.

This tracks the current debugTask on the Task so that when an error is thrown we can use it to run the `onError` (and `onShellError` and `onFatalError`) callbacks within the Context of that task. Ideally it would be associated with the error object but neither console.error [nor reportError](https://crbug.com/350426235) reports this as the async stack so we have to manually restore it.

That way when you inspect Fizz using node `--inspect` we show the right async stack.

<img width="616" alt="Screenshot 2024-07-01 at 10 52 29 PM" src="https://github.com/facebook/react/assets/63648/db68133e-124e-4509-8241-c67160db94fc">

This is equivalent to how we track the task that created the parent server component or the Fiber:

https://github.com/facebook/react/blob/6d2a97a7113dfac2ad45067001b7e49a98718324/packages/react-reconciler/src/ReactChildFiber.js#L1985

Then use them when invoking the error callbacks:

https://github.com/facebook/react/blob/6d2a97a7113dfac2ad45067001b7e49a98718324/packages/react-reconciler/src/ReactFiberThrow.js#L104-L108