### PR TITLE
[Flight] Add option to replay console logs or not

### DIFF
--- a/packages/react-html/src/ReactHTMLServer.js
+++ b/packages/react-html/src/ReactHTMLServer.js
@@ -179,6 +179,7 @@ export function renderToMarkup(
       undefined,
       undefined,
       undefined,
+      false,
     );
     const resumableState = createResumableState(
       options ? options.identifierPrefix : undefined,

--- a/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
@@ -50,7 +50,16 @@ const {createResponse, processBinaryChunk, getRoot, close} = ReactFlightClient({
 });
 
 function read<T>(source: Source): Thenable<T> {
-  const response = createResponse(source, null);
+  const response = createResponse(
+    source,
+    null,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    true,
+  );
   for (let i = 0; i < source.length; i++) {
     processBinaryChunk(response, source[i], 0);
   }

--- a/packages/react-server-dom-esm/src/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-esm/src/ReactFlightDOMClientBrowser.js
@@ -42,6 +42,7 @@ export type Options = {
   callServer?: CallServerCallback,
   temporaryReferences?: TemporaryReferenceSet,
   findSourceMapURL?: FindSourceMapURLCallback,
+  replayConsoleLogs?: boolean,
 };
 
 function createResponseFromOptions(options: void | Options) {
@@ -57,6 +58,7 @@ function createResponseFromOptions(options: void | Options) {
     __DEV__ && options && options.findSourceMapURL
       ? options.findSourceMapURL
       : undefined,
+    __DEV__ ? (options ? options.replayConsoleLogs !== false : true) : false, // defaults to true
   );
 }
 

--- a/packages/react-server-dom-esm/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-esm/src/ReactFlightDOMClientNode.js
@@ -50,6 +50,7 @@ export type Options = {
   nonce?: string,
   encodeFormAction?: EncodeFormActionCallback,
   findSourceMapURL?: FindSourceMapURLCallback,
+  replayConsoleLogs?: boolean,
 };
 
 function createFromNodeStream<T>(
@@ -68,6 +69,7 @@ function createFromNodeStream<T>(
     __DEV__ && options && options.findSourceMapURL
       ? options.findSourceMapURL
       : undefined,
+    __DEV__ && options ? options.replayConsoleLogs === true : false, // defaults to false
   );
   stream.on('data', chunk => {
     processBinaryChunk(response, chunk);

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMClientBrowser.js
@@ -41,6 +41,7 @@ export type Options = {
   callServer?: CallServerCallback,
   temporaryReferences?: TemporaryReferenceSet,
   findSourceMapURL?: FindSourceMapURLCallback,
+  replayConsoleLogs?: boolean,
 };
 
 function createResponseFromOptions(options: void | Options) {
@@ -56,6 +57,7 @@ function createResponseFromOptions(options: void | Options) {
     __DEV__ && options && options.findSourceMapURL
       ? options.findSourceMapURL
       : undefined,
+    __DEV__ ? (options ? options.replayConsoleLogs !== false : true) : false, // defaults to true
   );
 }
 

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMClientEdge.js
@@ -71,6 +71,7 @@ export type Options = {
   encodeFormAction?: EncodeFormActionCallback,
   temporaryReferences?: TemporaryReferenceSet,
   findSourceMapURL?: FindSourceMapURLCallback,
+  replayConsoleLogs?: boolean,
 };
 
 function createResponseFromOptions(options: Options) {
@@ -86,6 +87,7 @@ function createResponseFromOptions(options: Options) {
     __DEV__ && options && options.findSourceMapURL
       ? options.findSourceMapURL
       : undefined,
+    __DEV__ && options ? options.replayConsoleLogs === true : false, // defaults to false
   );
 }
 

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMClientNode.js
@@ -60,6 +60,7 @@ export type Options = {
   nonce?: string,
   encodeFormAction?: EncodeFormActionCallback,
   findSourceMapURL?: FindSourceMapURLCallback,
+  replayConsoleLogs?: boolean,
 };
 
 function createFromNodeStream<T>(
@@ -77,6 +78,7 @@ function createFromNodeStream<T>(
     __DEV__ && options && options.findSourceMapURL
       ? options.findSourceMapURL
       : undefined,
+    __DEV__ && options ? options.replayConsoleLogs === true : false, // defaults to false
   );
   stream.on('data', chunk => {
     processBinaryChunk(response, chunk);

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js
@@ -41,6 +41,7 @@ export type Options = {
   callServer?: CallServerCallback,
   temporaryReferences?: TemporaryReferenceSet,
   findSourceMapURL?: FindSourceMapURLCallback,
+  replayConsoleLogs?: boolean,
 };
 
 function createResponseFromOptions(options: void | Options) {
@@ -56,6 +57,7 @@ function createResponseFromOptions(options: void | Options) {
     __DEV__ && options && options.findSourceMapURL
       ? options.findSourceMapURL
       : undefined,
+    __DEV__ ? (options ? options.replayConsoleLogs !== false : true) : false, // defaults to true
   );
 }
 

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
@@ -71,6 +71,7 @@ export type Options = {
   encodeFormAction?: EncodeFormActionCallback,
   temporaryReferences?: TemporaryReferenceSet,
   findSourceMapURL?: FindSourceMapURLCallback,
+  replayConsoleLogs?: boolean,
 };
 
 function createResponseFromOptions(options: Options) {
@@ -86,6 +87,7 @@ function createResponseFromOptions(options: Options) {
     __DEV__ && options && options.findSourceMapURL
       ? options.findSourceMapURL
       : undefined,
+    __DEV__ && options ? options.replayConsoleLogs === true : false, // defaults to false
   );
 }
 

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientNode.js
@@ -61,6 +61,7 @@ export type Options = {
   nonce?: string,
   encodeFormAction?: EncodeFormActionCallback,
   findSourceMapURL?: FindSourceMapURLCallback,
+  replayConsoleLogs?: boolean,
 };
 
 function createFromNodeStream<T>(
@@ -78,6 +79,7 @@ function createFromNodeStream<T>(
     __DEV__ && options && options.findSourceMapURL
       ? options.findSourceMapURL
       : undefined,
+    __DEV__ && options ? options.replayConsoleLogs === true : false, // defaults to false
   );
   stream.on('data', chunk => {
     if (typeof chunk === 'string') {


### PR DESCRIPTION
Defaults to true in browser builds, otherwise defaults to false. The assumption is that the server logs will already contain a log from the original Flight server.

We currently always replay console logs but this leads to duplicates on the server by default when you use SSR, because the Flight Client on the server replays the logs. This can be nice since those logs gets badged. It can also be nice if they're running in separate servers but when they're logging to the same stream it's annoying. Which is really the typical set up so we should just make that the default but leave it configurable.