### PR TITLE
Remove propTypes on instance warning

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -376,13 +376,6 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
         name,
       );
     }
-    if (instance.propTypes) {
-      console.error(
-        'propTypes was defined as an instance property on %s. Use a static ' +
-          'property to define propTypes instead.',
-        name,
-      );
-    }
     if (instance.contextType) {
       console.error(
         'contextType was defined as an instance property on %s. Use a static ' +

--- a/packages/react-server/src/ReactFizzClassComponent.js
+++ b/packages/react-server/src/ReactFizzClassComponent.js
@@ -353,13 +353,6 @@ function checkClassInstance(instance: any, ctor: any, newProps: any) {
         name,
       );
     }
-    if (instance.propTypes) {
-      console.error(
-        'propTypes was defined as an instance property on %s. Use a static ' +
-          'property to define propTypes instead.',
-        name,
-      );
-    }
     if (instance.contextType) {
       console.error(
         'contextType was defined as an instance property on %s. Use a static ' +

--- a/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -411,7 +411,6 @@ describe 'ReactCoffeeScriptClass', ->
         constructor: ->
           @contextTypes = {}
           @contextType = {}
-          @propTypes = {}
 
         getInitialState: ->
           getInitialStateWasCalled = true
@@ -431,7 +430,6 @@ describe 'ReactCoffeeScriptClass', ->
       ).toErrorDev([
         'getInitialState was defined on Foo, a plain JavaScript class.',
         'getDefaultProps was defined on Foo, a plain JavaScript class.',
-        'propTypes was defined as an instance property on Foo.',
         'contextTypes was defined as an instance property on Foo.',
         'contextType was defined as an instance property on Foo.',
       ])

--- a/packages/react/src/__tests__/ReactES6Class-test.js
+++ b/packages/react/src/__tests__/ReactES6Class-test.js
@@ -459,7 +459,6 @@ describe('ReactES6Class', () => {
           super();
           this.contextTypes = {};
           this.contextType = {};
-          this.propTypes = {};
         }
         getInitialState() {
           getInitialStateWasCalled = true;
@@ -477,7 +476,6 @@ describe('ReactES6Class', () => {
       expect(() => runTest(<Foo />, 'SPAN', 'foo')).toErrorDev([
         'getInitialState was defined on Foo, a plain JavaScript class.',
         'getDefaultProps was defined on Foo, a plain JavaScript class.',
-        'propTypes was defined as an instance property on Foo.',
         'contextType was defined as an instance property on Foo.',
         'contextTypes was defined as an instance property on Foo.',
       ]);

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -244,7 +244,6 @@ let getDefaultPropsWasCalled = false;
 class ClassicProperties extends React.Component {
   contextTypes = {};
   contextType = {};
-  propTypes = {};
   getDefaultProps() {
     getDefaultPropsWasCalled = true;
     return {};
@@ -612,7 +611,6 @@ describe('ReactTypeScriptClass', function() {
             'a plain JavaScript class.',
           'getDefaultProps was defined on ClassicProperties, ' +
             'a plain JavaScript class.',
-          'propTypes was defined as an instance property on ClassicProperties.',
           'contextTypes was defined as an instance property on ClassicProperties.',
           'contextType was defined as an instance property on ClassicProperties.',
         ]);


### PR DESCRIPTION

`propTypes` are no longer supported at all in React 19, remove this outdated warning.
