### PR TITLE
Warn about legacy context when legacy context is not disabled

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -13,10 +13,12 @@ let React;
 let ReactDOM;
 let PropTypes;
 let ReactDOMClient;
-let root;
 let Scheduler;
+
 let act;
+let assertConsoleErrorDev;
 let assertLog;
+let root;
 
 describe('ReactDOMFiber', () => {
   let container;
@@ -29,7 +31,7 @@ describe('ReactDOMFiber', () => {
     ReactDOMClient = require('react-dom/client');
     Scheduler = require('scheduler');
     act = require('internal-test-utils').act;
-    assertLog = require('internal-test-utils').assertLog;
+    ({assertConsoleErrorDev, assertLog} = require('internal-test-utils'));
 
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -732,6 +734,10 @@ describe('ReactDOMFiber', () => {
     await act(async () => {
       root.render(<Parent />);
     });
+    assertConsoleErrorDev([
+      'Parent uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Component uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
     expect(container.innerHTML).toBe('');
     expect(portalContainer.innerHTML).toBe('<div>bar</div>');
   });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -27,6 +27,8 @@ let ReactDOMFizzServer;
 let ReactDOMFizzStatic;
 let Suspense;
 let SuspenseList;
+
+let assertConsoleErrorDev;
 let useSyncExternalStore;
 let useSyncExternalStoreWithSelector;
 let use;
@@ -116,12 +118,14 @@ describe('ReactDOMFizzServer', () => {
       useActionState = React.useActionState;
     }
 
-    const InternalTestUtils = require('internal-test-utils');
-    waitForAll = InternalTestUtils.waitForAll;
-    waitFor = InternalTestUtils.waitFor;
-    waitForPaint = InternalTestUtils.waitForPaint;
-    assertLog = InternalTestUtils.assertLog;
-    clientAct = InternalTestUtils.act;
+    ({
+      assertConsoleErrorDev,
+      assertLog,
+      act: clientAct,
+      waitFor,
+      waitForAll,
+      waitForPaint,
+    } = require('internal-test-utils'));
 
     if (gate(flags => flags.source)) {
       // The `with-selector` module composes the main `use-sync-external-store`
@@ -1950,6 +1954,10 @@ describe('ReactDOMFizzServer', () => {
       );
       pipe(writable);
     });
+    assertConsoleErrorDev([
+      'TestProvider uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'TestConsumer uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
     expect(getVisibleChildren(container)).toEqual(
       <div>
         Loading: <b>A</b>

--- a/packages/react-dom/src/__tests__/ReactDOMLegacyFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMLegacyFiber-test.js
@@ -786,7 +786,12 @@ describe('ReactDOMLegacyFiber', () => {
       }
     }
 
-    ReactDOM.render(<Parent />, container);
+    expect(() => {
+      ReactDOM.render(<Parent />, container);
+    }).toErrorDev([
+      'Parent uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Component uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
     expect(container.innerHTML).toBe('');
     expect(portalContainer.innerHTML).toBe('<div>bar</div>');
   });
@@ -829,7 +834,13 @@ describe('ReactDOMLegacyFiber', () => {
       }
     }
 
-    const instance = ReactDOM.render(<Parent />, container);
+    let instance;
+    expect(() => {
+      instance = ReactDOM.render(<Parent />, container);
+    }).toErrorDev([
+      'Parent uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Component uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
     expect(portalContainer.innerHTML).toBe('<div>initial-initial</div>');
     expect(container.innerHTML).toBe('');
     instance.setState({bar: 'changed'});
@@ -871,7 +882,12 @@ describe('ReactDOMLegacyFiber', () => {
       }
     }
 
-    ReactDOM.render(<Parent bar="initial" />, container);
+    expect(() => {
+      ReactDOM.render(<Parent bar="initial" />, container);
+    }).toErrorDev([
+      'Parent uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Component uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
     expect(portalContainer.innerHTML).toBe('<div>initial-initial</div>');
     expect(container.innerHTML).toBe('');
     ReactDOM.render(<Parent bar="changed" />, container);

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContext-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContext-test.js
@@ -80,6 +80,7 @@ describe('ReactDOMServerIntegration', () => {
         <PurpleContext>
           <ClassChildWithContext />
         </PurpleContext>,
+        2,
       );
       expect(e.textContent).toBe('purple');
     });
@@ -94,6 +95,7 @@ describe('ReactDOMServerIntegration', () => {
         <PurpleContext>
           <FunctionChildWithContext />
         </PurpleContext>,
+        2,
       );
       expect(e.textContent).toBe('purple');
     });
@@ -110,6 +112,7 @@ describe('ReactDOMServerIntegration', () => {
         <PurpleContext>
           <ClassChildWithoutContext />
         </PurpleContext>,
+        1,
       );
       expect(e.textContent).toBe('');
     });
@@ -124,6 +127,7 @@ describe('ReactDOMServerIntegration', () => {
         <PurpleContext>
           <FunctionChildWithoutContext />
         </PurpleContext>,
+        1,
       );
       expect(e.textContent).toBe('');
     });
@@ -141,6 +145,7 @@ describe('ReactDOMServerIntegration', () => {
         <PurpleContext>
           <ClassChildWithWrongContext />
         </PurpleContext>,
+        2,
       );
       expect(e.textContent).toBe('');
     });
@@ -158,6 +163,7 @@ describe('ReactDOMServerIntegration', () => {
         <PurpleContext>
           <FunctionChildWithWrongContext />
         </PurpleContext>,
+        2,
       );
       expect(e.textContent).toBe('');
     });
@@ -174,6 +180,7 @@ describe('ReactDOMServerIntegration', () => {
         <PurpleContext>
           <Child />
         </PurpleContext>,
+        2,
       );
       expect(e.textContent).toBe('purple');
     });
@@ -190,6 +197,7 @@ describe('ReactDOMServerIntegration', () => {
             <Grandchild />
           </RedContext>
         </PurpleContext>,
+        2,
       );
       expect(e.textContent).toBe('red');
     });
@@ -228,7 +236,7 @@ describe('ReactDOMServerIntegration', () => {
         text2: PropTypes.string,
       };
 
-      const e = await render(<Parent />);
+      const e = await render(<Parent />, 3);
       expect(e.querySelector('#first').textContent).toBe('purple');
       expect(e.querySelector('#second').textContent).toBe('red');
     });
@@ -254,7 +262,7 @@ describe('ReactDOMServerIntegration', () => {
         };
         Child.contextTypes = {text: PropTypes.string};
 
-        const e = await render(<WillMountContext />);
+        const e = await render(<WillMountContext />, 2);
         expect(e.textContent).toBe('foo');
       },
     );
@@ -278,7 +286,8 @@ describe('ReactDOMServerIntegration', () => {
         }
         const e = await render(
           <ForgetfulParent />,
-          render === clientRenderOnBadMarkup ? 2 : 1,
+          // Some warning is not de-duped and logged again on the client retry render.
+          render === clientRenderOnBadMarkup ? 3 : 2,
         );
         expect(e.textContent).toBe('nope');
       },

--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
@@ -36,6 +36,7 @@ describe('ReactErrorBoundaries', () => {
   let RetryErrorBoundary;
   let Normal;
   let assertLog;
+  let assertConsoleErrorDev;
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -47,8 +48,7 @@ describe('ReactErrorBoundaries', () => {
     act = require('internal-test-utils').act;
     Scheduler = require('scheduler');
 
-    const InternalTestUtils = require('internal-test-utils');
-    assertLog = InternalTestUtils.assertLog;
+    ({assertLog, assertConsoleErrorDev} = require('internal-test-utils'));
 
     BrokenConstructor = class extends React.Component {
       constructor(props) {
@@ -895,6 +895,9 @@ describe('ReactErrorBoundaries', () => {
         </ErrorBoundary>,
       );
     });
+    assertConsoleErrorDev([
+      'BrokenComponentWillMountWithContext uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+    ]);
     expect(container.firstChild.textContent).toBe('Caught an error: Hello.');
   });
 

--- a/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
@@ -13,6 +13,7 @@ let PropTypes;
 let React;
 let ReactDOMClient;
 let act;
+let assertConsoleErrorDev;
 
 function FunctionComponent(props) {
   return <div>{props.name}</div>;
@@ -24,7 +25,7 @@ describe('ReactFunctionComponent', () => {
     PropTypes = require('prop-types');
     React = require('react');
     ReactDOMClient = require('react-dom/client');
-    act = require('internal-test-utils').act;
+    ({act, assertConsoleErrorDev} = require('internal-test-utils'));
   });
 
   it('should render stateless component', async () => {
@@ -108,6 +109,11 @@ describe('ReactFunctionComponent', () => {
     await act(() => {
       root.render(<GrandParent test="test" />);
     });
+
+    assertConsoleErrorDev([
+      'GrandParent uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Child uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
 
     expect(el.textContent).toBe('test');
 
@@ -472,6 +478,10 @@ describe('ReactFunctionComponent', () => {
     await act(() => {
       root.render(<Parent />);
     });
+    assertConsoleErrorDev([
+      'Parent uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Child uses the legacy contextTypes API which will be removed soon. Use React.createContext() with React.useContext() instead.',
+    ]);
     expect(el.textContent).toBe('en');
   });
 

--- a/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
@@ -849,6 +849,9 @@ describe('ReactLegacyErrorBoundaries', () => {
       </ErrorBoundary>,
       container,
     );
+    assertConsoleErrorDev([
+      'BrokenComponentWillMountWithContext uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+    ]);
     expect(container.firstChild.textContent).toBe('Caught an error: Hello.');
   });
 

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -371,11 +371,17 @@ describe('ReactDOMServer', () => {
         text: PropTypes.string,
       };
 
-      const markup = ReactDOMServer.renderToStaticMarkup(
-        <ContextProvider>
-          <Component />
-        </ContextProvider>,
-      );
+      let markup;
+      expect(() => {
+        markup = ReactDOMServer.renderToStaticMarkup(
+          <ContextProvider>
+            <Component />
+          </ContextProvider>,
+        );
+      }).toErrorDev([
+        'ContextProvider uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+        'Component uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+      ]);
       expect(markup).toContain('hello, world');
     });
 

--- a/packages/react-native-renderer/src/__tests__/ReactNativeEvents-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeEvents-test.internal.js
@@ -227,27 +227,31 @@ test('handles events on text nodes', () => {
   }
 
   const log = [];
-  ReactNative.render(
-    <ContextHack>
-      <Text>
-        <Text
-          onTouchEnd={() => log.push('string touchend')}
-          onTouchEndCapture={() => log.push('string touchend capture')}
-          onTouchStart={() => log.push('string touchstart')}
-          onTouchStartCapture={() => log.push('string touchstart capture')}>
-          Text Content
+  expect(() => {
+    ReactNative.render(
+      <ContextHack>
+        <Text>
+          <Text
+            onTouchEnd={() => log.push('string touchend')}
+            onTouchEndCapture={() => log.push('string touchend capture')}
+            onTouchStart={() => log.push('string touchstart')}
+            onTouchStartCapture={() => log.push('string touchstart capture')}>
+            Text Content
+          </Text>
+          <Text
+            onTouchEnd={() => log.push('number touchend')}
+            onTouchEndCapture={() => log.push('number touchend capture')}
+            onTouchStart={() => log.push('number touchstart')}
+            onTouchStartCapture={() => log.push('number touchstart capture')}>
+            {123}
+          </Text>
         </Text>
-        <Text
-          onTouchEnd={() => log.push('number touchend')}
-          onTouchEndCapture={() => log.push('number touchend capture')}
-          onTouchStart={() => log.push('number touchstart')}
-          onTouchStartCapture={() => log.push('number touchstart capture')}>
-          {123}
-        </Text>
-      </Text>
-    </ContextHack>,
-    1,
-  );
+      </ContextHack>,
+      1,
+    );
+  }).toErrorDev([
+    'ContextHack uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+  ]);
 
   expect(UIManager.createView).toHaveBeenCalledTimes(5);
 

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -393,7 +393,7 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
         didWarnAboutChildContextTypes.add(ctor);
         console.error(
           '%s uses the legacy childContextTypes API which was removed in React 19. ' +
-            'Use React.createContext() instead.',
+            'Use React.createContext() instead. (https://react.dev/link/legacy-context)',
           name,
         );
       }
@@ -401,7 +401,8 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
         didWarnAboutContextTypes.add(ctor);
         console.error(
           '%s uses the legacy contextTypes API which was removed in React 19. ' +
-            'Use React.createContext() with static contextType instead.',
+            'Use React.createContext() with static contextType instead. ' +
+            '(https://react.dev/link/legacy-context)',
           name,
         );
       }
@@ -423,6 +424,23 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
         console.error(
           '%s declares both contextTypes and contextType static properties. ' +
             'The legacy contextTypes property will be ignored.',
+          name,
+        );
+      }
+      if (ctor.childContextTypes && !didWarnAboutChildContextTypes.has(ctor)) {
+        didWarnAboutChildContextTypes.add(ctor);
+        console.error(
+          '%s uses the legacy childContextTypes API which will soon be removed. ' +
+            'Use React.createContext() instead. (https://react.dev/link/legacy-context)',
+          name,
+        );
+      }
+      if (ctor.contextTypes && !didWarnAboutContextTypes.has(ctor)) {
+        didWarnAboutContextTypes.add(ctor);
+        console.error(
+          '%s uses the legacy contextTypes API which will soon be removed. ' +
+            'Use React.createContext() with static contextType instead. ' +
+            '(https://react.dev/link/legacy-context)',
           name,
         );
       }

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
@@ -14,6 +14,8 @@ let React;
 let ReactNoop;
 let Scheduler;
 let PropTypes;
+
+let assertConsoleErrorDev;
 let waitForAll;
 let waitFor;
 let waitForThrow;
@@ -27,11 +29,13 @@ describe('ReactIncremental', () => {
     Scheduler = require('scheduler');
     PropTypes = require('prop-types');
 
-    const InternalTestUtils = require('internal-test-utils');
-    waitForAll = InternalTestUtils.waitForAll;
-    waitFor = InternalTestUtils.waitFor;
-    waitForThrow = InternalTestUtils.waitForThrow;
-    assertLog = InternalTestUtils.assertLog;
+    ({
+      assertConsoleErrorDev,
+      waitForAll,
+      waitFor,
+      waitForThrow,
+      assertLog,
+    } = require('internal-test-utils'));
   });
 
   // Note: This is based on a similar component we use in www. We can delete
@@ -1793,6 +1797,11 @@ describe('ReactIncremental', () => {
       'ShowLocale {"locale":"fr"}',
       'ShowBoth {"locale":"fr"}',
     ]);
+    assertConsoleErrorDev([
+      'Intl uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'ShowLocale uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+      'ShowBoth uses the legacy contextTypes API which will be removed soon. Use React.createContext() with React.useContext() instead.',
+    ]);
 
     ReactNoop.render(
       <Intl locale="de">
@@ -1843,6 +1852,10 @@ describe('ReactIncremental', () => {
       'ShowBoth {"locale":"en","route":"/about"}',
       'ShowBoth {"locale":"en"}',
     ]);
+    assertConsoleErrorDev([
+      'Router uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'ShowRoute uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
   });
 
   // @gate !disableLegacyContext
@@ -1875,6 +1888,10 @@ describe('ReactIncremental', () => {
       'Recurse {"n":2}',
       'Recurse {"n":1}',
       'Recurse {"n":0}',
+    ]);
+    assertConsoleErrorDev([
+      'Recurse uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Recurse uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
     ]);
   });
 
@@ -1924,6 +1941,10 @@ describe('ReactIncremental', () => {
       'Intl {}',
       'ShowLocale {"locale":"fr"}',
       'ShowLocale {"locale":"fr"}',
+    ]);
+    assertConsoleErrorDev([
+      'Intl uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'ShowLocale uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
     ]);
 
     await waitForAll([
@@ -2012,6 +2033,11 @@ describe('ReactIncremental', () => {
       'ShowLocaleClass:read {"locale":"fr"}',
       'ShowLocaleFn:read {"locale":"fr"}',
     ]);
+    assertConsoleErrorDev([
+      'Intl uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'ShowLocaleClass uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+      'ShowLocaleFn uses the legacy contextTypes API which will be removed soon. Use React.createContext() with React.useContext() instead.',
+    ]);
 
     statefulInst.setState({x: 1});
     await waitForAll([]);
@@ -2098,6 +2124,12 @@ describe('ReactIncremental', () => {
       'ShowLocaleFn:read {"locale":"fr"}',
     ]);
 
+    assertConsoleErrorDev([
+      'Intl uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'ShowLocaleClass uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+      'ShowLocaleFn uses the legacy contextTypes API which will be removed soon. Use React.createContext() with React.useContext() instead.',
+    ]);
+
     statefulInst.setState({locale: 'gr'});
     await waitForAll([
       // Intl is below setState() so it might have been
@@ -2154,6 +2186,10 @@ describe('ReactIncremental', () => {
     ReactNoop.render(<Root />);
     await waitForAll([]);
 
+    assertConsoleErrorDev([
+      'Child uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+    ]);
+
     // Trigger an update in the middle of the tree
     instance.setState({});
     await waitForAll([]);
@@ -2199,7 +2235,9 @@ describe('ReactIncremental', () => {
 
     // Init
     ReactNoop.render(<Root />);
-    await waitForAll([]);
+    await expect(async () => await waitForAll([])).toErrorDev([
+      'ContextProvider uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+    ]);
 
     // Trigger an update in the middle of the tree
     // This is necessary to reproduce the error as it currently exists.
@@ -2251,6 +2289,10 @@ describe('ReactIncremental', () => {
       'shouldComponentUpdate',
       'render',
       'componentDidUpdate',
+    ]);
+
+    assertConsoleErrorDev([
+      'MyComponent uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
     ]);
   });
 
@@ -2384,6 +2426,10 @@ describe('ReactIncremental', () => {
     );
 
     await waitForAll(['count:0']);
+    assertConsoleErrorDev([
+      'TopContextProvider uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Child uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
     instance.updateCount();
     await waitForAll(['count:1']);
   });
@@ -2440,6 +2486,11 @@ describe('ReactIncremental', () => {
     );
 
     await waitForAll(['count:0']);
+    assertConsoleErrorDev([
+      'TopContextProvider uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'MiddleContextProvider uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Child uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
     instance.updateCount();
     await waitForAll(['count:1']);
   });
@@ -2505,6 +2556,11 @@ describe('ReactIncremental', () => {
     );
 
     await waitForAll(['count:0']);
+    assertConsoleErrorDev([
+      'TopContextProvider uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'MiddleContextProvider uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Child uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
     instance.updateCount();
     await waitForAll([]);
   });
@@ -2580,6 +2636,11 @@ describe('ReactIncremental', () => {
     );
 
     await waitForAll(['count:0, name:brian']);
+    assertConsoleErrorDev([
+      'TopContextProvider uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'MiddleContextProvider uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Child uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
     topInstance.updateCount();
     await waitForAll([]);
     middleInstance.updateName('not brian');
@@ -2685,6 +2746,7 @@ describe('ReactIncremental', () => {
       await expect(async () => {
         await waitForAll([]);
       }).toErrorDev([
+        'Boundary uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
         'Legacy context API has been detected within a strict-mode tree',
       ]);
     }

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1211,7 +1211,14 @@ describe('ReactIncrementalErrorHandling', () => {
         <Connector />
       </Provider>,
     );
-    await waitForAll([]);
+
+    await expect(async () => {
+      await waitForAll([]);
+    }).toErrorDev([
+      'Provider uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Provider uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+      'Connector uses the legacy contextTypes API which will be removed soon. Use React.createContext() with React.useContext() instead.',
+    ]);
 
     // If the context stack does not unwind, span will get 'abcde'
     expect(ReactNoop).toMatchRenderedOutput(<span prop="a" />);

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -17,6 +17,7 @@ let gen;
 let waitForAll;
 let waitFor;
 let waitForThrow;
+let assertConsoleErrorDev;
 
 describe('ReactNewContext', () => {
   beforeEach(() => {
@@ -28,10 +29,12 @@ describe('ReactNewContext', () => {
     Scheduler = require('scheduler');
     gen = require('random-seed');
 
-    const InternalTestUtils = require('internal-test-utils');
-    waitForAll = InternalTestUtils.waitForAll;
-    waitFor = InternalTestUtils.waitFor;
-    waitForThrow = InternalTestUtils.waitForThrow;
+    ({
+      waitForAll,
+      waitFor,
+      waitForThrow,
+      assertConsoleErrorDev,
+    } = require('internal-test-utils'));
   });
 
   afterEach(() => {
@@ -1032,6 +1035,9 @@ describe('ReactNewContext', () => {
         </LegacyProvider>,
       );
       await waitForAll(['LegacyProvider', 'App', 'Child']);
+      assertConsoleErrorDev([
+        'LegacyProvider uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      ]);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Child" />);
 
       // Update App with same value (should bail out)

--- a/packages/react-server/src/ReactFizzClassComponent.js
+++ b/packages/react-server/src/ReactFizzClassComponent.js
@@ -370,7 +370,7 @@ function checkClassInstance(instance: any, ctor: any, newProps: any) {
         didWarnAboutChildContextTypes.add(ctor);
         console.error(
           '%s uses the legacy childContextTypes API which was removed in React 19. ' +
-            'Use React.createContext() instead.',
+            'Use React.createContext() instead. (https://react.dev/link/legacy-context)',
           name,
         );
       }
@@ -378,7 +378,8 @@ function checkClassInstance(instance: any, ctor: any, newProps: any) {
         didWarnAboutContextTypes.add(ctor);
         console.error(
           '%s uses the legacy contextTypes API which was removed in React 19. ' +
-            'Use React.createContext() with static contextType instead.',
+            'Use React.createContext() with static contextType instead. ' +
+            '(https://react.dev/link/legacy-context)',
           name,
         );
       }
@@ -386,7 +387,7 @@ function checkClassInstance(instance: any, ctor: any, newProps: any) {
       if (instance.contextTypes) {
         console.error(
           'contextTypes was defined as an instance property on %s. Use a static ' +
-            'property to define contextTypes instead.',
+            'property to define contextTypes instead. (https://react.dev/link/legacy-context)',
           name,
         );
       }
@@ -400,6 +401,23 @@ function checkClassInstance(instance: any, ctor: any, newProps: any) {
         console.error(
           '%s declares both contextTypes and contextType static properties. ' +
             'The legacy contextTypes property will be ignored.',
+          name,
+        );
+      }
+      if (ctor.childContextTypes && !didWarnAboutChildContextTypes.has(ctor)) {
+        didWarnAboutChildContextTypes.add(ctor);
+        console.error(
+          '%s uses the legacy childContextTypes API which will soon be removed. ' +
+            'Use React.createContext() instead. (https://react.dev/link/legacy-context)',
+          name,
+        );
+      }
+      if (ctor.contextTypes && !didWarnAboutContextTypes.has(ctor)) {
+        didWarnAboutContextTypes.add(ctor);
+        console.error(
+          '%s uses the legacy contextTypes API which will soon be removed. ' +
+            'Use React.createContext() with static contextType instead. ' +
+            '(https://react.dev/link/legacy-context)',
           name,
         );
       }

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -1638,6 +1638,7 @@ function renderClassComponent(
 }
 
 const didWarnAboutBadClass: {[string]: boolean} = {};
+const didWarnAboutContextTypes: {[string]: boolean} = {};
 const didWarnAboutContextTypeOnFunctionComponent: {[string]: boolean} = {};
 const didWarnAboutGetDerivedStateOnFunctionComponent: {[string]: boolean} = {};
 let didWarnAboutReassigningProps = false;
@@ -1688,12 +1689,24 @@ function renderFunctionComponent(
   const actionStateMatchingIndex = getActionStateMatchingIndex();
 
   if (__DEV__) {
-    if (disableLegacyContext && Component.contextTypes) {
-      console.error(
-        '%s uses the legacy contextTypes API which was removed in React 19. ' +
-          'Use React.createContext() with React.useContext() instead.',
-        getComponentNameFromType(Component) || 'Unknown',
-      );
+    if (Component.contextTypes) {
+      const componentName = getComponentNameFromType(Component) || 'Unknown';
+      if (!didWarnAboutContextTypes[componentName]) {
+        didWarnAboutContextTypes[componentName] = true;
+        if (disableLegacyContext) {
+          console.error(
+            '%s uses the legacy contextTypes API which was removed in React 19. ' +
+              'Use React.createContext() with React.useContext() instead.',
+            componentName,
+          );
+        } else {
+          console.error(
+            '%s uses the legacy contextTypes API which will be removed soon. ' +
+              'Use React.createContext() with React.useContext() instead.',
+            componentName,
+          );
+        }
+      }
     }
   }
   if (__DEV__) {
@@ -1771,14 +1784,12 @@ function finishFunctionComponent(
 
 function validateFunctionComponentInDev(Component: any): void {
   if (__DEV__) {
-    if (Component) {
-      if (Component.childContextTypes) {
-        console.error(
-          'childContextTypes cannot be defined on a function component.\n' +
-            '  %s.childContextTypes = ...',
-          Component.displayName || Component.name || 'Component',
-        );
-      }
+    if (Component && Component.childContextTypes) {
+      console.error(
+        'childContextTypes cannot be defined on a function component.\n' +
+          '  %s.childContextTypes = ...',
+        Component.displayName || Component.name || 'Component',
+      );
     }
 
     if (

--- a/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -254,7 +254,12 @@ describe 'ReactCoffeeScriptClass', ->
         render: ->
           React.createElement Foo
 
-      test React.createElement(Outer), 'SPAN', 'foo'
+      expect(->
+        test React.createElement(Outer), 'SPAN', 'foo'
+      ).toErrorDev([
+        'Outer uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+        'Foo uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+      ])
 
   it 'renders only once when setting state in componentWillMount', ->
     renderCount = 0
@@ -537,7 +542,14 @@ describe 'ReactCoffeeScriptClass', ->
         render: ->
           React.createElement Bar
 
-      test React.createElement(Foo), 'DIV', 'bar-through-context'
+      expect(->
+        test React.createElement(Foo), 'DIV', 'bar-through-context'
+      ).toErrorDev(
+        [
+          'Foo uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+          'Bar uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+        ],
+      )
 
   if !featureFlags.disableStringRefs
     it 'supports string refs', ->

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -66,11 +66,16 @@ describe('ReactContextValidator', () => {
     let instance;
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(() => {
-      root.render(
-        <ComponentInFooBarContext ref={current => (instance = current)} />,
-      );
-    });
+    await expect(async () => {
+      await act(() => {
+        root.render(
+          <ComponentInFooBarContext ref={current => (instance = current)} />,
+        );
+      });
+    }).toErrorDev([
+      'ComponentInFooBarContext uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Component uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
     expect(instance.childRef.current.context).toEqual({foo: 'abc'});
   });
 
@@ -139,9 +144,14 @@ describe('ReactContextValidator', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await act(() => {
-      root.render(<Parent foo="abc" />);
-    });
+    await expect(async () => {
+      await act(() => {
+        root.render(<Parent foo="abc" />);
+      });
+    }).toErrorDev([
+      'Parent uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Component uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
 
     expect(constructorContext).toEqual({foo: 'abc'});
     expect(renderContext).toEqual({foo: 'abc'});
@@ -187,11 +197,10 @@ describe('ReactContextValidator', () => {
       await act(() => {
         root.render(<ComponentA />);
       });
-    }).toErrorDev(
-      'ComponentA.childContextTypes is specified but there is no ' +
-        'getChildContext() method on the instance. You can either define ' +
-        'getChildContext() on ComponentA or remove childContextTypes from it.',
-    );
+    }).toErrorDev([
+      'ComponentA uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'ComponentA.childContextTypes is specified but there is no getChildContext() method on the instance. You can either define getChildContext() on ComponentA or remove childContextTypes from it.',
+    ]);
 
     // Warnings should be deduped by component type
     let container = document.createElement('div');
@@ -206,11 +215,10 @@ describe('ReactContextValidator', () => {
       await act(() => {
         root.render(<ComponentB />);
       });
-    }).toErrorDev(
-      'ComponentB.childContextTypes is specified but there is no ' +
-        'getChildContext() method on the instance. You can either define ' +
-        'getChildContext() on ComponentB or remove childContextTypes from it.',
-    );
+    }).toErrorDev([
+      'ComponentB uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'ComponentB.childContextTypes is specified but there is no getChildContext() method on the instance. You can either define getChildContext() on ComponentB or remove childContextTypes from it.',
+    ]);
   });
 
   // TODO (bvaughn) Remove this test and the associated behavior in the future.
@@ -259,9 +267,10 @@ describe('ReactContextValidator', () => {
         root.render(<ParentContextProvider />);
       });
     }).toErrorDev([
-      'MiddleMissingContext.childContextTypes is specified but there is no ' +
-        'getChildContext() method on the instance. You can either define getChildContext() ' +
-        'on MiddleMissingContext or remove childContextTypes from it.',
+      'ParentContextProvider uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'MiddleMissingContext uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'MiddleMissingContext.childContextTypes is specified but there is no getChildContext() method on the instance. You can either define getChildContext() on MiddleMissingContext or remove childContextTypes from it.',
+      'ChildContextConsumer uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
     ]);
     expect(childContext.bar).toBeUndefined();
     expect(childContext.foo).toBe('FOO');
@@ -435,10 +444,11 @@ describe('ReactContextValidator', () => {
           </ParentContextProvider>,
         );
       });
-    }).toErrorDev(
-      'ComponentA declares both contextTypes and contextType static properties. ' +
-        'The legacy contextTypes property will be ignored.',
-    );
+    }).toErrorDev([
+      'ParentContextProvider uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead',
+      'ComponentA uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+      'ComponentA declares both contextTypes and contextType static properties. The legacy contextTypes property will be ignored.',
+    ]);
 
     // Warnings should be deduped by component type
     let container = document.createElement('div');
@@ -461,10 +471,10 @@ describe('ReactContextValidator', () => {
           </ParentContextProvider>,
         );
       });
-    }).toErrorDev(
-      'ComponentB declares both contextTypes and contextType static properties. ' +
-        'The legacy contextTypes property will be ignored.',
-    );
+    }).toErrorDev([
+      'ComponentB declares both contextTypes and contextType static properties. The legacy contextTypes property will be ignored.',
+      'ComponentB uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
   });
 
   // @gate enableRenderableContext || !__DEV__

--- a/packages/react/src/__tests__/ReactES6Class-test.js
+++ b/packages/react/src/__tests__/ReactES6Class-test.js
@@ -13,6 +13,7 @@ let PropTypes;
 let React;
 let ReactDOM;
 let ReactDOMClient;
+let assertConsoleErrorDev;
 
 describe('ReactES6Class', () => {
   let container;
@@ -30,6 +31,7 @@ describe('ReactES6Class', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMClient = require('react-dom/client');
+    ({assertConsoleErrorDev} = require('internal-test-utils'));
     container = document.createElement('div');
     root = ReactDOMClient.createRoot(container);
     attachedListener = null;
@@ -287,6 +289,11 @@ describe('ReactES6Class', () => {
         className: PropTypes.string,
       };
       runTest(<Outer />, 'SPAN', 'foo');
+
+      assertConsoleErrorDev([
+        'Outer uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+        'Foo uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+      ]);
     });
   }
 
@@ -579,6 +586,10 @@ describe('ReactES6Class', () => {
       }
       Foo.childContextTypes = {bar: PropTypes.string};
       runTest(<Foo />, 'DIV', 'bar-through-context');
+      assertConsoleErrorDev([
+        'Foo uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+        'Bar uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+      ]);
     });
   }
 

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -18,6 +18,7 @@ let act;
 let useMemo;
 let useState;
 let useReducer;
+let assertConsoleErrorDev;
 
 const ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
@@ -28,7 +29,7 @@ describe('ReactStrictMode', () => {
     ReactDOM = require('react-dom');
     ReactDOMClient = require('react-dom/client');
     ReactDOMServer = require('react-dom/server');
-    act = require('internal-test-utils').act;
+    ({act, assertConsoleErrorDev} = require('internal-test-utils'));
     useMemo = React.useMemo;
     useState = React.useState;
     useReducer = React.useReducer;
@@ -1072,11 +1073,33 @@ describe('context legacy', () => {
 
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);
-    await expect(async () => {
-      await act(() => {
-        root.render(<Root />);
-      });
-    }).toErrorDev(
+    await act(() => {
+      root.render(<Root />);
+    });
+
+    assertConsoleErrorDev([
+      'LegacyContextProvider uses the legacy childContextTypes API ' +
+        'which will soon be removed. Use React.createContext() instead. ' +
+        '(https://react.dev/link/legacy-context)' +
+        '\n    in LegacyContextProvider (at **)' +
+        '\n    in div (at **)' +
+        '\n    in Root (at **)',
+      'LegacyContextConsumer uses the legacy contextTypes API which ' +
+        'will soon be removed. Use React.createContext() with static ' +
+        'contextType instead. (https://react.dev/link/legacy-context)' +
+        '\n    in LegacyContextConsumer (at **)' +
+        '\n    in div (at **)' +
+        '\n    in LegacyContextProvider (at **)' +
+        '\n    in div (at **)' +
+        '\n    in Root (at **)',
+      'FunctionalLegacyContextConsumer uses the legacy contextTypes ' +
+        'API which will be removed soon. Use React.createContext() ' +
+        'with React.useContext() instead. (https://react.dev/link/legacy-context)' +
+        '\n    in FunctionalLegacyContextConsumer (at **)' +
+        '\n    in div (at **)' +
+        '\n    in LegacyContextProvider (at **)' +
+        '\n    in div (at **)' +
+        '\n    in Root (at **)',
       'Legacy context API has been detected within a strict-mode tree.' +
         '\n\nThe old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.' +
@@ -1087,7 +1110,7 @@ describe('context legacy', () => {
         '\n    in LegacyContextProvider (at **)' +
         '\n    in div (at **)' +
         '\n    in Root (at **)',
-    );
+    ]);
 
     // Dedupe
     await act(() => {

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -518,7 +518,10 @@ describe('ReactTypeScriptClass', function() {
 
   if (!ReactFeatureFlags.disableLegacyContext) {
     it('renders based on context in the constructor', function() {
-      test(React.createElement(ProvideChildContextTypes), 'SPAN', 'foo');
+      expect(() => test(React.createElement(ProvideChildContextTypes), 'SPAN', 'foo')).toErrorDev([
+        'ProvideChildContextTypes uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+        'StateBasedOnContext uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.'
+      ]);
     });
   }
 
@@ -687,8 +690,11 @@ describe('ReactTypeScriptClass', function() {
   });
 
   if (!ReactFeatureFlags.disableLegacyContext) {
-    it('supports this.context passed via getChildContext', function() {
-      test(React.createElement(ProvideContext), 'DIV', 'bar-through-context');
+    it('supports this.context passed via getChildContext', () => {
+      expect(() => test(React.createElement(ProvideContext), 'DIV', 'bar-through-context')).toErrorDev([
+        'ProvideContext uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+        'ReadContext uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+]      );
     });
   }
 

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -10,6 +10,7 @@
 'use strict';
 
 let act;
+let assertConsoleErrorDev;
 
 let PropTypes;
 let React;
@@ -19,7 +20,7 @@ let createReactClass;
 describe('create-react-class-integration', () => {
   beforeEach(() => {
     jest.resetModules();
-    ({act} = require('internal-test-utils'));
+    ({act, assertConsoleErrorDev} = require('internal-test-utils'));
     PropTypes = require('prop-types');
     React = require('react');
     ReactDOMClient = require('react-dom/client');
@@ -336,6 +337,10 @@ describe('create-react-class-integration', () => {
     await act(() => {
       root.render(<Outer />);
     });
+    assertConsoleErrorDev([
+      'Component uses the legacy childContextTypes API which will soon be removed. Use React.createContext() instead.',
+      'Component uses the legacy contextTypes API which will soon be removed. Use React.createContext() with static contextType instead.',
+    ]);
     expect(container.firstChild.className).toBe('foo');
   });
 


### PR DESCRIPTION

For environments that still have legacy contexts available, this adds a warning to make the remaining call sites easier to locate and encourage upgrades.
