### PR TITLE
Add RN fork of consoleWithStackDev so we can improve the mainline one

### DIFF
--- a/packages/shared/forks/consoleWithStackDev.rn.js
+++ b/packages/shared/forks/consoleWithStackDev.rn.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import ReactSharedInternals from 'shared/ReactSharedInternals';
+
+let suppressWarning = false;
+export function setSuppressWarning(newSuppressWarning) {
+  if (__DEV__) {
+    suppressWarning = newSuppressWarning;
+  }
+}
+
+// In DEV, calls to console.warn and console.error get replaced
+// by calls to these methods by a Babel plugin.
+//
+// In PROD (or in packages without access to React internals),
+// they are left as they are instead.
+
+export function warn(format, ...args) {
+  if (__DEV__) {
+    if (!suppressWarning) {
+      printWarning('warn', format, args, new Error('react-stack-top-frame'));
+    }
+  }
+}
+
+export function error(format, ...args) {
+  if (__DEV__) {
+    if (!suppressWarning) {
+      printWarning('error', format, args, new Error('react-stack-top-frame'));
+    }
+  }
+}
+
+export let isWritingAppendedStack = false;
+
+function printWarning(level, format, args, currentStack) {
+  if (__DEV__) {
+    if (ReactSharedInternals.getCurrentStack) {
+      const stack = ReactSharedInternals.getCurrentStack(currentStack);
+      if (stack !== '') {
+        isWritingAppendedStack = true;
+        format += '%s';
+        args = args.concat([stack]);
+      }
+    }
+
+    args.unshift(format);
+    // We intentionally don't use spread (or .apply) directly because it
+    // breaks IE9: https://github.com/facebook/react/issues/13610
+    // eslint-disable-next-line react-internal/no-production-logging
+    Function.prototype.apply.call(console[level], console, args);
+    isWritingAppendedStack = false;
+  }
+}

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -209,6 +209,9 @@ const forks = Object.freeze({
     switch (bundleType) {
       case FB_WWW_DEV:
         return './packages/shared/forks/consoleWithStackDev.www.js';
+      case RN_OSS_DEV:
+      case RN_FB_DEV:
+        return './packages/shared/forks/consoleWithStackDev.rn.js';
       default:
         return null;
     }


### PR DESCRIPTION
We're removing this wrapper from the mainline but RN is still using component stacks to filter out warnings.

This is unfortunate since it'll be hard to keep track of the interplay with these, DevTools and how you're supposed to implement error dialogs in userspace.