### PR TITLE
Add FB RSC Entry for React Package

### DIFF
--- a/packages/react/src/ReactServer.fb.js
+++ b/packages/react/src/ReactServer.fb.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export {default as __SERVER_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE} from './ReactSharedInternalsServer';
+
+import {forEach, map, count, toArray, only} from './ReactChildren';
+import {
+  REACT_FRAGMENT_TYPE,
+  REACT_PROFILER_TYPE,
+  REACT_STRICT_MODE_TYPE,
+  REACT_SUSPENSE_TYPE,
+} from 'shared/ReactSymbols';
+import {
+  cloneElement,
+  createElement,
+  isValidElement,
+} from './jsx/ReactJSXElement';
+import {createRef} from './ReactCreateRef';
+import {use, useId, useCallback, useDebugValue, useMemo} from './ReactHooks';
+import {forwardRef} from './ReactForwardRef';
+import {lazy} from './ReactLazy';
+import {memo} from './ReactMemo';
+import {cache} from './ReactCacheServer';
+import version from 'shared/ReactVersion';
+
+const Children = {
+  map,
+  forEach,
+  count,
+  toArray,
+  only,
+};
+
+export {
+  Children,
+  REACT_FRAGMENT_TYPE as Fragment,
+  REACT_PROFILER_TYPE as Profiler,
+  REACT_STRICT_MODE_TYPE as StrictMode,
+  REACT_SUSPENSE_TYPE as Suspense,
+  cloneElement,
+  createElement,
+  createRef,
+  use,
+  forwardRef,
+  isValidElement,
+  lazy,
+  memo,
+  cache,
+  useId,
+  useCallback,
+  useDebugValue,
+  useMemo,
+  version,
+};


### PR DESCRIPTION
I noticed that the www-modern builds pick up the `.experimental.js` entry points but these flags that are associated with these exports are not enabled in www, so it gets the wrong builds.

This file is just a clone over the stable `ReactServer.js` one. We should probably do the reexport pattern instead.
