### PR TITLE
Delete suppressWarning in OSS

### DIFF
--- a/packages/shared/consoleWithStackDev.js
+++ b/packages/shared/consoleWithStackDev.js
@@ -8,11 +8,8 @@
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {enableOwnerStacks} from 'shared/ReactFeatureFlags';
 
-let suppressWarning = false;
 export function setSuppressWarning(newSuppressWarning) {
-  if (__DEV__) {
-    suppressWarning = newSuppressWarning;
-  }
+  // TODO: Noop. Delete.
 }
 
 // In DEV, calls to console.warn and console.error get replaced
@@ -22,19 +19,11 @@ export function setSuppressWarning(newSuppressWarning) {
 // they are left as they are instead.
 
 export function warn(format, ...args) {
-  if (__DEV__) {
-    if (!suppressWarning) {
-      printWarning('warn', format, args, new Error('react-stack-top-frame'));
-    }
-  }
+  printWarning('warn', format, args, new Error('react-stack-top-frame'));
 }
 
 export function error(format, ...args) {
-  if (__DEV__) {
-    if (!suppressWarning) {
-      printWarning('error', format, args, new Error('react-stack-top-frame'));
-    }
-  }
+  printWarning('error', format, args, new Error('react-stack-top-frame'));
 }
 
 // eslint-disable-next-line react-internal/no-production-logging


### PR DESCRIPTION
I'm pretty sure this is completely unnecessary even in www and RN because it's only useful if you use the mock scheduler which typically only we do in our own tests. But all our tests pass so unless www/RN does something with it, I don't think this is used.

Also remove unnecessary `__DEV__` check. If it gets pulled in prod, we'd want to know about it.