### PR TITLE
feat(compiler): Ignore `TSInterfaceDeclaration`

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -1332,6 +1332,7 @@ function lowerStatement(
       return;
     }
     case "TypeAlias":
+    case "TSInterfaceDeclaration":
     case "TSTypeAliasDeclaration": {
       // We do not preserve type annotations/syntax through transformation
       return;
@@ -1358,7 +1359,6 @@ function lowerStatement(
     case "TSEnumDeclaration":
     case "TSExportAssignment":
     case "TSImportEqualsDeclaration":
-    case "TSInterfaceDeclaration":
     case "TSModuleDeclaration":
     case "TSNamespaceExportDeclaration":
     case "WithStatement": {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ignore-inner-interface-types.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ignore-inner-interface-types.expect.md
@@ -1,0 +1,35 @@
+
+## Input
+
+```javascript
+function Foo() {
+  type X = number;
+  interface Bar {
+    baz: number;
+  }
+  return 0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+};
+
+```
+
+## Code
+
+```javascript
+function Foo() {
+  return 0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+};
+
+```
+      
+### Eval output
+(kind: ok) 0

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ignore-inner-interface-types.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ignore-inner-interface-types.ts
@@ -1,0 +1,12 @@
+function Foo() {
+  type X = number;
+  interface Bar {
+    baz: number;
+  }
+  return 0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+};


### PR DESCRIPTION
## Summary

The following was not supported:
```ts
function A() {
  interface C {
    id: number;
  }
  return 0;
}
```

Message:
> Todo: (BuildHIR::lowerStatement) Handle TSInterfaceDeclaration statements (2:4)

Playground:
https://playground.react.dev/#N4Igzg9grgTgxgUxALhAMygOzgFwJYSYAEAggBQCURwAOsUXpjgjGgIaJEDC1dR-DACbIimKAFsARiwDcfIgF95MBDljEADHMwKQCoA

This PR fixes that.

## How did you test this change?
Added a test.