### PR TITLE
easy: add link to legacy context warning

### DIFF
--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -1696,13 +1696,15 @@ function renderFunctionComponent(
         if (disableLegacyContext) {
           console.error(
             '%s uses the legacy contextTypes API which was removed in React 19. ' +
-              'Use React.createContext() with React.useContext() instead.',
+              'Use React.createContext() with React.useContext() instead. ' +
+              '(https://react.dev/link/legacy-context)',
             componentName,
           );
         } else {
           console.error(
             '%s uses the legacy contextTypes API which will be removed soon. ' +
-              'Use React.createContext() with React.useContext() instead.',
+              'Use React.createContext() with React.useContext() instead. ' +
+              '(https://react.dev/link/legacy-context)',
             componentName,
           );
         }


### PR DESCRIPTION

Missed this when adding the link to other places of the same warning in https://github.com/facebook/react/commit/378b305958eb7259cacfce8ad0e66eec07e07074
