### PR TITLE
Remove setSuppressWarning from Meta

### DIFF
--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.js
@@ -38,7 +38,6 @@ import {
   log,
   unstable_setDisableYieldValue,
 } from './Scheduler';
-import {setSuppressWarning} from 'shared/consoleWithStackDev';
 import {disableLogs, reenableLogs} from 'shared/ConsolePatchingDev';
 
 declare const __REACT_DEVTOOLS_GLOBAL_HOOK__: Object | void;
@@ -206,7 +205,6 @@ export function setIsStrictModeForDevtools(newIsStrictMode: boolean) {
       // in SchedulerMock. To reduce the noise in strict mode tests,
       // suppress warnings and disable scheduler yielding during the double render
       unstable_setDisableYieldValue(newIsStrictMode);
-      setSuppressWarning(newIsStrictMode);
     }
 
     if (injectedHook && typeof injectedHook.setStrictMode === 'function') {

--- a/packages/shared/consoleWithStackDev.js
+++ b/packages/shared/consoleWithStackDev.js
@@ -8,10 +8,6 @@
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {enableOwnerStacks} from 'shared/ReactFeatureFlags';
 
-export function setSuppressWarning(newSuppressWarning) {
-  // TODO: Noop. Delete.
-}
-
 // In DEV, calls to console.warn and console.error get replaced
 // by calls to these methods by a Babel plugin.
 //

--- a/packages/shared/forks/consoleWithStackDev.rn.js
+++ b/packages/shared/forks/consoleWithStackDev.rn.js
@@ -7,13 +7,6 @@
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 
-let suppressWarning = false;
-export function setSuppressWarning(newSuppressWarning) {
-  if (__DEV__) {
-    suppressWarning = newSuppressWarning;
-  }
-}
-
 // In DEV, calls to console.warn and console.error get replaced
 // by calls to these methods by a Babel plugin.
 //
@@ -21,19 +14,11 @@ export function setSuppressWarning(newSuppressWarning) {
 // they are left as they are instead.
 
 export function warn(format, ...args) {
-  if (__DEV__) {
-    if (!suppressWarning) {
-      printWarning('warn', format, args, new Error('react-stack-top-frame'));
-    }
-  }
+  printWarning('warn', format, args, new Error('react-stack-top-frame'));
 }
 
 export function error(format, ...args) {
-  if (__DEV__) {
-    if (!suppressWarning) {
-      printWarning('error', format, args, new Error('react-stack-top-frame'));
-    }
-  }
+  printWarning('error', format, args, new Error('react-stack-top-frame'));
 }
 
 export let isWritingAppendedStack = false;

--- a/packages/shared/forks/consoleWithStackDev.www.js
+++ b/packages/shared/forks/consoleWithStackDev.www.js
@@ -8,27 +8,12 @@
 // This refers to a WWW module.
 const warningWWW = require('warning');
 
-let suppressWarning = false;
-export function setSuppressWarning(newSuppressWarning) {
-  if (__DEV__) {
-    suppressWarning = newSuppressWarning;
-  }
-}
-
 export function warn(format, ...args) {
-  if (__DEV__) {
-    if (!suppressWarning) {
-      printWarning('warn', format, args, new Error('react-stack-top-frame'));
-    }
-  }
+  printWarning('warn', format, args, new Error('react-stack-top-frame'));
 }
 
 export function error(format, ...args) {
-  if (__DEV__) {
-    if (!suppressWarning) {
-      printWarning('error', format, args, new Error('react-stack-top-frame'));
-    }
-  }
+  printWarning('error', format, args, new Error('react-stack-top-frame'));
 }
 
 function printWarning(level, format, args, currentStack) {


### PR DESCRIPTION

Confirmed these aren't referenced internally, we can do the same removal as https://github.com/facebook/react/commit/85acf2d19527df568136ba08be97aa766d427ff2
