### PR TITLE
Gate inlined consoleWithStackDev transpilation

### DIFF
--- a/packages/react-client/src/ReactClientConsoleConfigBrowser.js
+++ b/packages/react-client/src/ReactClientConsoleConfigBrowser.js
@@ -65,9 +65,9 @@ export function printToConsole(
     );
   }
 
-  if (methodName === 'error') {
+  if (methodName === 'error' && __DEV__) {
     error.apply(console, newArgs);
-  } else if (methodName === 'warn') {
+  } else if (methodName === 'warn' && __DEV__) {
     warn.apply(console, newArgs);
   } else {
     // $FlowFixMe[invalid-computed-prop]

--- a/packages/react-client/src/ReactClientConsoleConfigPlain.js
+++ b/packages/react-client/src/ReactClientConsoleConfigPlain.js
@@ -46,9 +46,9 @@ export function printToConsole(
     newArgs.splice(offset, 0, badgeFormat, pad + badgeName + pad);
   }
 
-  if (methodName === 'error') {
+  if (methodName === 'error' && __DEV__) {
     error.apply(console, newArgs);
-  } else if (methodName === 'warn') {
+  } else if (methodName === 'warn' && __DEV__) {
     warn.apply(console, newArgs);
   } else {
     // $FlowFixMe[invalid-computed-prop]

--- a/packages/react-client/src/ReactClientConsoleConfigServer.js
+++ b/packages/react-client/src/ReactClientConsoleConfigServer.js
@@ -66,9 +66,9 @@ export function printToConsole(
     );
   }
 
-  if (methodName === 'error') {
+  if (methodName === 'error' && __DEV__) {
     error.apply(console, newArgs);
-  } else if (methodName === 'warn') {
+  } else if (methodName === 'warn' && __DEV__) {
     warn.apply(console, newArgs);
   } else {
     // $FlowFixMe[invalid-computed-prop]


### PR DESCRIPTION
This code is getting deleted in #30313 anyway but it should've been gated all along.

This code exists to basically manually transpile console.error to  consoleWithStackDev because the transpiler doesn't work on `.apply` or `.bind` or the dynamic look up. We only apply the transform in DEV so we should've only done this in DEV.

Otherwise these logs get silenced in prod.