### PR TITLE
Use explicit git hash length in version string

### DIFF
--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -19,9 +19,7 @@ const {
 // Runs the build script for both stable and experimental release channels,
 // by configuring an environment variable.
 
-const sha = String(
-  spawnSync('git', ['show', '-s', '--no-show-signature', '--format=%h']).stdout
-).trim();
+const sha = String(spawnSync('git', ['rev-parse', 'HEAD']).stdout).slice(0, 8);
 
 let dateString = String(
   spawnSync('git', [


### PR DESCRIPTION

This avoids potential differences between Git versions.

Having a guarantee unique hash isn't neccessary as it's just informational and we have the date in the version string as well.
