### PR TITLE
[compiler][eslint] Use logger callback instead of exceptions to report eslint diagnostics

### DIFF
--- a/compiler/packages/eslint-plugin-react-compiler/__tests__/ReactCompilerRule-test.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/__tests__/ReactCompilerRule-test.ts
@@ -149,6 +149,36 @@ const tests: CompilerTestCases = {
         },
       ],
     },
+    {
+      name: "Multiple diagnostics are surfaced",
+      options: [
+        {
+          reportableLevels: new Set([
+            ErrorSeverity.Todo,
+            ErrorSeverity.InvalidReact,
+          ]),
+        },
+      ],
+      code: normalizeIndent`
+        function Foo(x) {
+          var y = 1;
+          return <div>{y * x}</div>;
+        }
+        function Bar(props) {
+          props.a.b = 2;
+          return <div>{props.c}</div>
+        }`,
+      errors: [
+        {
+          message:
+            "(BuildHIR::lowerStatement) Handle var kinds in VariableDeclaration",
+        },
+        {
+          message:
+            "Mutating component props or hook arguments is not allowed. Consider using a local variable instead",
+        },
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30342
* #30341
* __->__ #30336
* #30335

---
* panicThreshold: `all_errors` -> `none`
* inject an error logger through compiler config (instead of using exceptions)

We currently report at most one lint warning per file, this lets us exhaustively report all available ones (see new
test fixture for example)