### PR TITLE
fix(compiler): Align return types of `ErrImp<E>` and `OkImpl<T>` with `Result<T, E>` for TS 5.5

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Utils/Result.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Utils/Result.ts
@@ -124,11 +124,11 @@ class OkImpl<T> implements Result<T, never> {
     return this;
   }
 
-  isOk(): boolean {
+  isOk(): this is OkImpl<T> {
     return true;
   }
 
-  isErr(): boolean {
+  isErr(): this is ErrImpl<never> {
     return false;
   }
 
@@ -199,11 +199,11 @@ class ErrImpl<E> implements Result<never, E> {
     return fn(this.val);
   }
 
-  isOk(): boolean {
+  isOk(): this is OkImpl<never> {
     return false;
   }
 
-  isErr(): boolean {
+  isErr(): this is ErrImpl<E> {
     return true;
   }
 


### PR DESCRIPTION
## Summary
`Result<T, E>` defines `isOk` and `isErr` as type predicates:
```ts
  // Returns `true` if the result is `Ok`.
  isOk(): this is OkImpl<T>;
  // Returns `true` if the result is `Err`.
  isErr(): this is ErrImpl<E>;
```

The implementations just return `boolean`, which seems to break in TS 5.5:

Running `tsc` in current `main`:
```
tsc
src/Utils/Result.ts:202:3 - error TS2416: Property 'isOk' in type 'ErrImpl<E>' is not assignable to the same property in base type 'Result<never, E>'.
  Type '() => boolean' is not assignable to type '() => this is OkImpl<never>'.
    Signature '(): boolean' must be a type predicate.

202   isOk(): boolean {
      ~~~~

src/Utils/Result.ts:206:3 - error TS2416: Property 'isErr' in type 'ErrImpl<E>' is not assignable to the same property in base type 'Result<never, E>'.
  Type '() => boolean' is not assignable to type '() => this is ErrImpl<E>'.
    Signature '(): boolean' must be a type predicate.

206   isErr(): boolean {


Found 38 errors in 7 files.

Errors  Files
     2  src/HIR/BuildHIR.ts:196
     2  src/HIR/Environment.ts:745
     2  src/ReactiveScopes/CodegenReactiveFunction.ts:290
    14  src/Utils/Result.ts:96
     2  src/Validation/ValidateNoRefAccesInRender.ts:201
     2  src/Validation/ValidateNoSetStateInRender.ts:115
    14  src/__tests__/Result-test.ts:13
```

## How did you test this change?
```sh
tsc
# no errors
tsc --version
Version 5.5.3
```
