### PR TITLE
[ci] Remove dep on build_devtools from run_devtools_e2e_tests

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -308,6 +308,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: build
+          pattern: build_*
           merge-multiple: true
       - name: Display structure of build
         run: ls -R build
@@ -336,6 +337,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: build
+          pattern: build_*
           merge-multiple: true
       - run: ./scripts/circleci/pack_and_store_devtools_artifacts.sh
         env:
@@ -361,7 +363,6 @@ jobs:
 
   run_devtools_e2e_tests:
     name: Run DevTools e2e tests
-    needs: build_devtools_and_process_artifacts
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -377,11 +378,6 @@ jobs:
           path: "**/node_modules"
           key: ${{ runner.arch }}-${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - name: Restore archived build
-        uses: actions/download-artifact@v4
-        with:
-          path: build
-          merge-multiple: true
       - run: |
           npx playwright install
           sudo npx playwright install-deps

--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -363,6 +363,7 @@ jobs:
 
   run_devtools_e2e_tests:
     name: Run DevTools e2e tests
+    needs: build_and_lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30349
* __->__ #30348
* #30347

The run_devtools_e2e_tests job does not appear to actually need anything
from the prior job since it always builds inline. Removing this dep
allows us to run both in parallel.