### PR TITLE
[ci] Try sharding test_build

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -219,6 +219,10 @@ jobs:
 
           # TODO: Test more persistent configurations?
         ]
+        shard:
+          - 1/3
+          - 2/3
+          - 3/3
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
@@ -242,7 +246,7 @@ jobs:
           merge-multiple: true
       - name: Display structure of build
         run: ls -R build
-      - run: yarn test --build ${{ matrix.test_params }} --ci=github
+      - run: yarn test --build ${{ matrix.test_params }} --shard=${{ matrix.shard }} --ci=github
 
   process_artifacts_combined:
     name: Process artifacts combined


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30350
* __->__ #30349
* #30347

The tests for the build currently take about 3.5 minutes and is at the
moment the long pole for the whole workflow. By sharding we can make
this workflow faster and save about a minute or so in overall wall time.