### PR TITLE
[ci] Remove DevTools jobs from circleci build_and_test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -481,12 +481,6 @@ workflows:
       - RELEASE_CHANNEL_stable_yarn_test_dom_fixtures:
           requires:
             - yarn_build
-      - build_devtools_and_process_artifacts:
-          requires:
-            - yarn_build
-      - run_devtools_e2e_tests:
-          requires:
-            - build_devtools_and_process_artifacts
       - run_fixtures_flight_tests:
           requires:
             - yarn_build


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30359
* #30358
* #30357
* #30356
* #30355
* #30354
* #30353
* __->__ #30352

Now that these run in GH, we can remove these jobs from the circleci
build_and_test workflow to speed up the remaining jobs left in circleci
since this was the long pole.

I have left the definition of these jobs in tact however, as they are
used for devtools_regression_tests which has yet to be migrated to GH.