### PR TITLE
[ci] Remove some circleci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,27 +311,6 @@ jobs:
       - store_artifacts:
           path: ./tmp/screenshots
 
-  yarn_lint_build:
-    docker: *docker
-    environment: *environment
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - setup_node_modules
-      - run: yarn lint-build
-
-  yarn_check_release_dependencies:
-    docker: *docker
-    environment: *environment
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - setup_node_modules
-      - run: yarn check-release-dependencies
-
-
   check_error_codes:
     docker: *docker
     environment: *environment
@@ -344,20 +323,6 @@ jobs:
           command: |
             yarn extract-errors
             git diff --quiet || (echo "Found unminified errors. Either update the error codes map or disable error minification for the affected build, if appropriate." && false)
-
-  yarn_test_build:
-    docker: *docker
-    environment: *environment
-    parallelism: *TEST_PARALLELISM
-    parameters:
-      args:
-        type: string
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - setup_node_modules
-      - run: yarn test --build <<parameters.args>> --ci=circleci
 
   RELEASE_CHANNEL_stable_yarn_test_dom_fixtures:
     docker: *docker
@@ -421,40 +386,6 @@ workflows:
           requires:
             - scrape_warning_messages
             - yarn_build
-      - yarn_test_build:
-          requires:
-            - yarn_build
-          matrix:
-            parameters:
-              args:
-                # Intentionally passing these as strings instead of creating a
-                # separate parameter per CLI argument, since it's easier to
-                # control/see which combinations we want to run.
-                - "-r=stable --env=development"
-                - "-r=stable --env=production"
-                - "-r=experimental --env=development"
-                - "-r=experimental --env=production"
-
-                # Dev Tools
-                - "--project=devtools -r=experimental"
-
-                # TODO: Update test config to support www build tests
-                # - "-r=www-classic --env=development --variant=false"
-                # - "-r=www-classic --env=production --variant=false"
-                # - "-r=www-classic --env=development --variant=true"
-                # - "-r=www-classic --env=production --variant=true"
-                # - "-r=www-modern --env=development --variant=false"
-                # - "-r=www-modern --env=production --variant=false"
-                # - "-r=www-modern --env=development --variant=true"
-                # - "-r=www-modern --env=production --variant=true"
-
-                # TODO: Update test config to support xplat build tests
-                # - "-r=xplat --env=development --variant=false"
-                # - "-r=xplat --env=development --variant=true"
-                # - "-r=xplat --env=production --variant=false"
-                # - "-r=xplat --env=production --variant=true"
-
-                # TODO: Test more persistent configurations?
       - download_base_build_for_sizebot:
           filters:
             branches:
@@ -468,12 +399,6 @@ workflows:
                 - main
           requires:
             - download_base_build_for_sizebot
-            - yarn_build
-      - yarn_lint_build:
-          requires:
-            - yarn_build
-      - yarn_check_release_dependencies:
-          requires:
             - yarn_build
       - check_error_codes:
           requires:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30359
* #30358
* #30357
* #30356
* #30355
* #30354
* __->__ #30353
* #30352

These are now in GH. Removes:

- yarn_lint_build
- yarn_test_build
- yarn_check_release_dependencies