### PR TITLE
[ci][ez] Rename artifact from process_artifacts_combined

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -285,7 +285,7 @@ jobs:
       - name: Archive build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: combined_artifacts_${{ github.sha }}
+          name: artifacts_combined
           path: |
             ./build.tgz
             ./build2.tgz


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30364

Build artifacts are uniquely associated to a single workflow run, so
appending the sha was unnecessary. I originally included it to make it
easier to download later but this turns out to be unneeded.

Drops the sha suffix to make downloading the artifact in a separate
script / workflow more straightforward.