### PR TITLE
Fixed property of null error in form submit action

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -3204,9 +3204,12 @@ export function requestFormReset(formFiber: Fiber) {
 
   const stateHook = ensureFormComponentIsStateful(formFiber);
   const newResetState = {};
-  const resetStateHook: Hook = (stateHook.next: any);
-  const resetStateQueue = resetStateHook.queue;
-  dispatchSetState(formFiber, resetStateQueue, newResetState);
+  const resetStateHook: Hook | null = stateHook.next;
+  // just in case next is null
+  if (resetStateHook) {
+    const resetStateQueue = resetStateHook.queue;
+    dispatchSetState(formFiber, resetStateQueue, newResetState);
+  }
 }
 
 function mountTransition(): [


### PR DESCRIPTION
## Summary

It partially fixes facebook/react#30041 
This does not throw the error anymore.
 
## How did you test this change?

I have generated a build and tested the same error scenario.
<img width="1436" alt="image" src="https://github.com/user-attachments/assets/0b3563ec-081f-4d74-b5a5-314eda8983be">

