### PR TITLE
RFC(react-client): add $$typeof to server references in Flight

### DIFF
--- a/packages/react-client/src/ReactFlightReplyClient.js
+++ b/packages/react-client/src/ReactFlightReplyClient.js
@@ -47,6 +47,8 @@ const ObjectPrototype = Object.prototype;
 
 import {usedWithSSR} from './ReactFlightClientConfig';
 
+const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference');
+
 type ReactJSONValue =
   | string
   | boolean
@@ -1051,6 +1053,9 @@ export function registerServerReference(
       bind: {value: bind},
     });
   }
+  Object.defineProperties((proxy: any), {
+    $$typeof: {value: SERVER_REFERENCE_TAG},
+  });
   knownServerReferences.set(proxy, reference);
 }
 


### PR DESCRIPTION
still WIP. opening PR for discussion.

## Summary

Hello, I wanted to reach out and ask if it would be possible to add the `$$typeof` property to server references on the client. The exact use-case I'm trying to tackle is identifying server actions in a client component, in order to run callbacks/actions either inside a `startTransition`, or as a regular callback. 

From a UI Library maintainer point-of-view this makes sense as it allows us to build functionality on top-of which we're providing out-of-the-box `pending` state and UI (e.g. while waiting for the server action to run).

```jsx
if(isServerReference(props.onStateChange)) {
  startTransition(() => {
    props.onStateChange(newState, action);
  });
} else {
  props.onStateChange(newState, action, syntheticEvent);
}
```

Additionally, I think this behavior is more in-line with the react-server-dom counterpart of the `registerServerReference` function:
https://github.com/facebook/react/blob/163365a07872337e04826c4f501565d43dbd2fd4/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js#L87-L101

I still believe there's a need for an official way to identify client/server references, as currently I'm working with hardcoded Symbols &mdash; maybe through `react-is` or some other mechanism?

## How did you test this change?

Basically wrote directly into `react-server-dom-webpack-client.browser.development.js` file of my `nextjs` project 🤷

### Thank you for your time!