### PR TITLE
[ci] Use yargs to parse args to download-experimental-build

### DIFF
--- a/scripts/release/download-experimental-build-ghaction.js
+++ b/scripts/release/download-experimental-build-ghaction.js
@@ -2,28 +2,66 @@
 
 'use strict';
 
-const {join} = require('path');
-const {
-  addDefaultParamValue,
-  getPublicPackages,
-  handleError,
-} = require('./utils');
+const {join, relative} = require('path');
+const {getPublicPackages, handleError} = require('./utils');
+const yargs = require('yargs');
+const clear = require('clear');
+const theme = require('./theme');
 
-const downloadBuildArtifacts = require('./shared-commands/download-build-artifacts');
-const parseParams = require('./shared-commands/parse-params');
-const printSummary = require('./download-experimental-build-commands/print-summary');
+const argv = yargs.wrap(yargs.terminalWidth()).options({
+  releaseChannel: {
+    alias: 'r',
+    describe: 'Download the given release channel.',
+    requiresArg: true,
+    type: 'string',
+    choices: ['experimental', 'stable'],
+    default: 'experimental',
+  },
+  commit: {
+    alias: 'c',
+    describe: 'Commit hash to download.',
+    requiresArg: true,
+    type: 'string',
+  },
+  skipTests: {
+    requiresArg: false,
+    type: 'boolean',
+    default: false,
+  },
+  allowBrokenCI: {
+    requiresArg: false,
+    type: 'boolean',
+    default: false,
+  },
+}).argv;
+
+// Inlined from scripts/release/download-experimental-build-commands/print-summary.js
+function printSummary(commit) {
+  const commandPath = relative(
+    process.env.PWD,
+    join(__dirname, '../download-experimental-build-ghaction.js')
+  );
+
+  clear();
+
+  const message = theme`
+    {caution An experimental build has been downloaded!}
+
+    You can download this build again by running:
+    {path   ${commandPath}} --commit={commit ${commit}}
+  `;
+
+  console.log(message.replace(/\n +/g, '\n').trim());
+}
 
 const run = async () => {
   try {
-    addDefaultParamValue('-r', '--releaseChannel', 'experimental');
+    argv.cwd = join(__dirname, '..', '..');
+    argv.packages = await getPublicPackages(true);
 
-    const params = await parseParams();
-    params.cwd = join(__dirname, '..', '..');
-    params.packages = await getPublicPackages(true);
+    console.log(argv);
 
-    await downloadBuildArtifacts(params);
-
-    printSummary(params);
+    printSummary(argv.commit);
   } catch (error) {
     handleError(error);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30388
* #30387
* #30380
* #30376
* __->__ #30375
* #30374
* #30385

