### PR TITLE
[circleci] Inline scrape_warning_messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,22 +48,6 @@ parameters:
     default: ''
 
 jobs:
-  scrape_warning_messages:
-    docker: *docker
-    environment: *environment
-
-    steps:
-      - checkout
-      - setup_node_modules
-      - run:
-          command: |
-            mkdir -p ./build/__test_utils__
-            node ./scripts/print-warnings/print-warnings.js > build/__test_utils__/ReactAllWarnings.js
-      - persist_to_workspace:
-          root: .
-          paths:
-            - build
-
   yarn_build:
     docker: *docker
     environment: *environment
@@ -106,7 +90,10 @@ jobs:
           at: .
       - setup_node_modules
       - run: echo "<< pipeline.git.revision	>>" >> build/COMMIT_SHA
-        # Compress build directory into a single tarball for easy download
+      - run: |
+        mkdir -p ./build/__test_utils__
+        node ./scripts/print-warnings/print-warnings.js > build/__test_utils__/ReactAllWarnings.js
+      # Compress build directory into a single tarball for easy download
       - run: tar -zcvf ./build.tgz ./build
         # TODO: Migrate scripts to use `build` directory instead of `build2`
       - run: cp ./build.tgz ./build2.tgz
@@ -230,14 +217,8 @@ workflows:
             branches:
               ignore:
                 - builds/facebook-www
-      - scrape_warning_messages:
-          filters:
-            branches:
-              ignore:
-                - builds/facebook-www
       - process_artifacts_combined:
           requires:
-            - scrape_warning_messages
             - yarn_build
 
   devtools_regression_tests:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30388
* #30387
* #30380
* #30376
* #30375
* #30374
* #30385

This job was only being used for process_artifacts_combined in circleci
but as it was a separate job would incur the cost and time of spinning
up a new CI worker. We can simply inline this into
process_artifacts_combined.

Test plan: Download
[build.tgz](https://app.circleci.com/pipelines/github/facebook/react/57183/workflows/3b22a99e-b8a5-4c80-9682-576f24581b00/jobs/956476/artifacts)
from circleci and observe that the __test_utils__ directory is still
present.