### PR TITLE
[ci] Fix sizebot job omitting build_and_lint dependency

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -565,7 +565,7 @@ jobs:
 
   sizebot:
     name: Run sizebot
-    needs: download_base_build_for_sizebot
+    needs: [build_and_lint, download_base_build_for_sizebot]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30393
* #30391
* __->__ #30392
* #30390

