### PR TITLE
[ci] Update sizebot node_modules caching strategy

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -539,8 +539,8 @@ jobs:
         uses: actions/cache@v4
         id: node_modules
         with:
-          path: scripts/release/node_modules
-          key: ${{ runner.arch }}-${{ runner.os }}-scripts-modules-${{ hashFiles('scripts/release/yarn.lock') }}
+          path: "**/node_modules"
+          key: ${{ runner.arch }}-${{ runner.os }}-modules-${{ hashFiles('yarn.lock', 'scripts/release/yarn.lock') }}
       - run: yarn install --frozen-lockfile
       - run: yarn install --frozen-lockfile
         working-directory: scripts/release


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30393
* #30391
* #30392
* #30390

The download job for sizebot requires both modules from the root repo
but also has a nested yarn lockfile in scripts/release. Calculate the
hash for the cache using both lockfiles.