### PR TITLE
fix(react-reconciler): not set props and state of instance in will unmount

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -245,12 +245,6 @@ function shouldProfile(current: Fiber): boolean {
 }
 
 function callComponentWillUnmountWithTimer(current: Fiber, instance: any) {
-  instance.props = resolveClassComponentProps(
-    current.type,
-    current.memoizedProps,
-    current.elementType === current.type,
-  );
-  instance.state = current.memoizedState;
   if (shouldProfile(current)) {
     try {
       startLayoutEffectTimer();

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
@@ -267,7 +267,7 @@ describe('ReactIncrementalErrorLogging', () => {
         // Retry one more time before handling error
         'render: 1',
 
-        'componentWillUnmount: 0',
+        'componentWillUnmount: 1',
       ].filter(Boolean),
     );
 

--- a/packages/react-reconciler/src/__tests__/ReactLazyClassComponentPropResolution-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazyClassComponentPropResolution-test.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactTestRenderer;
+let Scheduler;
+let Suspense;
+let lazy;
+let waitForAll;
+let assertLog;
+let act;
+
+let fakeModuleCache;
+
+describe('ReactLazyClassComponentPropResolution', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    React = require('react');
+    ReactTestRenderer = require('react-test-renderer');
+    Scheduler = require('scheduler');
+    Suspense = React.Suspense;
+    lazy = React.lazy;
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
+    assertLog = InternalTestUtils.assertLog;
+    act = InternalTestUtils.act;
+
+    fakeModuleCache = new Map();
+  });
+
+  it('class component defaultProps should be set with lazy module.', async () => {
+    function Text(props) {
+      Scheduler.log(props.text);
+      return props.text;
+    }
+    async function fakeImport(Component) {
+      const record = fakeModuleCache.get(Component);
+      if (record === undefined) {
+        const newRecord = {
+          status: 'pending',
+          value: {default: Component},
+          pings: [],
+          then(ping) {
+            switch (newRecord.status) {
+              case 'pending': {
+                newRecord.pings.push(ping);
+                return;
+              }
+              case 'resolved': {
+                ping(newRecord.value);
+                return;
+              }
+              case 'rejected': {
+                throw newRecord.value;
+              }
+            }
+          },
+        };
+        fakeModuleCache.set(Component, newRecord);
+        return newRecord;
+      }
+      return record;
+    }
+
+    function resolveFakeImport(moduleName) {
+      const record = fakeModuleCache.get(moduleName);
+      if (record === undefined) {
+        throw new Error('Module not found');
+      }
+      if (record.status !== 'pending') {
+        throw new Error('Module already resolved');
+      }
+      record.status = 'resolved';
+      record.pings.forEach(ping => ping(record.value));
+    }
+
+    class Component extends React.Component {
+      state = {};
+      static defaultProps = {defaultProp: true};
+
+      componentDidMount() {
+        Scheduler.log('componentDidMount: ' + this.props.defaultProp);
+        this.setState({defaultProp: this.props.defaultProp});
+      }
+
+      componentWillUnmount() {
+        Scheduler.log('componentWillUnmount: ' + this.props.defaultProp);
+      }
+
+      render() {
+        Scheduler.log('render: ' + this.state.defaultProp);
+        return this.state.defaultProp ? (
+          <Text text="ok" />
+        ) : (
+          <Text text="not ok" />
+        );
+      }
+    }
+
+    const LazyComponent = lazy(async () => fakeImport(Component));
+
+    const root = ReactTestRenderer.create(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <React.StrictMode>
+          <LazyComponent />
+        </React.StrictMode>
+      </Suspense>,
+    );
+
+    await waitForAll(['Loading...']);
+
+    await act(() => resolveFakeImport(Component));
+
+    assertLog([
+      'render: undefined',
+      'not ok',
+      'componentDidMount: true',
+      'render: true',
+      'ok',
+    ]);
+    expect(root).toMatchRenderedOutput('ok');
+  });
+});


### PR DESCRIPTION
## Summary
will unmount is changing props in instance.

I don't know if this is the right behavior. If it's going to mount again after will unmount, the props is damaged.

So I removed this.

Fix: #28505

## How did you test this change?
I tested it using the repro code in issue.