### PR TITLE
Add unstable context bailout for profiling

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -155,7 +155,7 @@ function getPrimitiveStackCache(): Map<string, Array<any>> {
 
 let currentFiber: null | Fiber = null;
 let currentHook: null | Hook = null;
-let currentContextDependency: null | ContextDependency<mixed> = null;
+let currentContextDependency: null | ContextDependency<mixed, mixed> = null;
 
 function nextHook(): null | Hook {
   const hook = currentHook;

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -37,6 +37,7 @@ import {
   REACT_CONTEXT_TYPE,
 } from 'shared/ReactSymbols';
 import hasOwnProperty from 'shared/hasOwnProperty';
+import type {ContextDependencyWithCompare} from '../../react-reconciler/src/ReactInternalTypes';
 
 type CurrentDispatcherRef = typeof ReactSharedInternals;
 
@@ -155,7 +156,10 @@ function getPrimitiveStackCache(): Map<string, Array<any>> {
 
 let currentFiber: null | Fiber = null;
 let currentHook: null | Hook = null;
-let currentContextDependency: null | ContextDependency<mixed, mixed> = null;
+let currentContextDependency:
+  | null
+  | ContextDependency<mixed>
+  | ContextDependencyWithCompare<mixed, mixed> = null;
 
 function nextHook(): null | Hook {
   const hook = currentHook;

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -37,7 +37,7 @@ import {
   REACT_CONTEXT_TYPE,
 } from 'shared/ReactSymbols';
 import hasOwnProperty from 'shared/hasOwnProperty';
-import type {ContextDependencyWithCompare} from '../../react-reconciler/src/ReactInternalTypes';
+import type {ContextDependencyWithSelect} from '../../react-reconciler/src/ReactInternalTypes';
 
 type CurrentDispatcherRef = typeof ReactSharedInternals;
 
@@ -159,7 +159,7 @@ let currentHook: null | Hook = null;
 let currentContextDependency:
   | null
   | ContextDependency<mixed>
-  | ContextDependencyWithCompare<mixed, mixed> = null;
+  | ContextDependencyWithSelect<mixed> = null;
 
 function nextHook(): null | Hook {
   const hook = currentHook;

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -47,6 +47,7 @@ import {
   enableUseDeferredValueInitialArg,
   disableLegacyMode,
   enableNoCloningMemoCache,
+  enableContextProfiling,
 } from 'shared/ReactFeatureFlags';
 import {
   REACT_CONTEXT_TYPE,
@@ -81,7 +82,11 @@ import {
   ContinuousEventPriority,
   higherEventPriority,
 } from './ReactEventPriorities';
-import {readContext, checkIfContextChanged} from './ReactFiberNewContext';
+import {
+  readContext,
+  readContextAndCompare,
+  checkIfContextChanged,
+} from './ReactFiberNewContext';
 import {HostRoot, CacheComponent, HostComponent} from './ReactWorkTags';
 import {
   LayoutStatic as LayoutStaticEffect,
@@ -1051,6 +1056,13 @@ function updateWorkInProgressHook(): Hook {
     }
   }
   return workInProgressHook;
+}
+
+function unstable_useContextWithBailout<T>(
+  context: ReactContext<T>,
+  compare: void | (T => mixed),
+): T {
+  return readContextAndCompare(context, compare);
 }
 
 // NOTE: defining two versions of this function to avoid size impact when this feature is disabled.
@@ -3689,6 +3701,10 @@ if (enableAsyncActions) {
 if (enableAsyncActions) {
   (ContextOnlyDispatcher: Dispatcher).useOptimistic = throwInvalidHookError;
 }
+if (enableContextProfiling) {
+  (ContextOnlyDispatcher: Dispatcher).unstable_useContextWithBailout =
+    throwInvalidHookError;
+}
 
 const HooksDispatcherOnMount: Dispatcher = {
   readContext,
@@ -3727,6 +3743,10 @@ if (enableAsyncActions) {
 }
 if (enableAsyncActions) {
   (HooksDispatcherOnMount: Dispatcher).useOptimistic = mountOptimistic;
+}
+if (enableContextProfiling) {
+  (HooksDispatcherOnMount: Dispatcher).unstable_useContextWithBailout =
+    unstable_useContextWithBailout;
 }
 
 const HooksDispatcherOnUpdate: Dispatcher = {
@@ -3767,6 +3787,10 @@ if (enableAsyncActions) {
 if (enableAsyncActions) {
   (HooksDispatcherOnUpdate: Dispatcher).useOptimistic = updateOptimistic;
 }
+if (enableContextProfiling) {
+  (HooksDispatcherOnUpdate: Dispatcher).unstable_useContextWithBailout =
+    unstable_useContextWithBailout;
+}
 
 const HooksDispatcherOnRerender: Dispatcher = {
   readContext,
@@ -3805,6 +3829,10 @@ if (enableAsyncActions) {
 }
 if (enableAsyncActions) {
   (HooksDispatcherOnRerender: Dispatcher).useOptimistic = rerenderOptimistic;
+}
+if (enableContextProfiling) {
+  (HooksDispatcherOnRerender: Dispatcher).unstable_useContextWithBailout =
+    unstable_useContextWithBailout;
 }
 
 let HooksDispatcherOnMountInDEV: Dispatcher | null = null;
@@ -4019,6 +4047,14 @@ if (__DEV__) {
         return mountOptimistic(passthrough, reducer);
       };
   }
+  if (enableContextProfiling) {
+    (HooksDispatcherOnMountInDEV: Dispatcher).unstable_useContextWithBailout =
+      function <T>(context: ReactContext<T>, compare: void | (T => mixed)): T {
+        currentHookNameInDev = 'useContext';
+        mountHookTypesDev();
+        return unstable_useContextWithBailout(context, compare);
+      };
+  }
 
   HooksDispatcherOnMountWithHookTypesInDEV = {
     readContext<T>(context: ReactContext<T>): T {
@@ -4198,6 +4234,14 @@ if (__DEV__) {
         currentHookNameInDev = 'useOptimistic';
         updateHookTypesDev();
         return mountOptimistic(passthrough, reducer);
+      };
+  }
+  if (enableContextProfiling) {
+    (HooksDispatcherOnMountWithHookTypesInDEV: Dispatcher).unstable_useContextWithBailout =
+      function <T>(context: ReactContext<T>, compare: void | (T => mixed)): T {
+        currentHookNameInDev = 'useContext';
+        updateHookTypesDev();
+        return unstable_useContextWithBailout(context, compare);
       };
   }
 
@@ -4380,6 +4424,14 @@ if (__DEV__) {
         return updateOptimistic(passthrough, reducer);
       };
   }
+  if (enableContextProfiling) {
+    (HooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
+      function <T>(context: ReactContext<T>, compare: void | (T => mixed)): T {
+        currentHookNameInDev = 'useContext';
+        updateHookTypesDev();
+        return unstable_useContextWithBailout(context, compare);
+      };
+  }
 
   HooksDispatcherOnRerenderInDEV = {
     readContext<T>(context: ReactContext<T>): T {
@@ -4558,6 +4610,14 @@ if (__DEV__) {
         currentHookNameInDev = 'useOptimistic';
         updateHookTypesDev();
         return rerenderOptimistic(passthrough, reducer);
+      };
+  }
+  if (enableContextProfiling) {
+    (HooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
+      function <T>(context: ReactContext<T>, compare: void | (T => mixed)): T {
+        currentHookNameInDev = 'useContext';
+        updateHookTypesDev();
+        return unstable_useContextWithBailout(context, compare);
       };
   }
 
@@ -4766,6 +4826,15 @@ if (__DEV__) {
         return mountOptimistic(passthrough, reducer);
       };
   }
+  if (enableContextProfiling) {
+    (HooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
+      function <T>(context: ReactContext<T>, compare: void | (T => mixed)): T {
+        currentHookNameInDev = 'useContext';
+        warnInvalidHookAccess();
+        mountHookTypesDev();
+        return unstable_useContextWithBailout(context, compare);
+      };
+  }
 
   InvalidNestedHooksDispatcherOnUpdateInDEV = {
     readContext<T>(context: ReactContext<T>): T {
@@ -4972,6 +5041,15 @@ if (__DEV__) {
         return updateOptimistic(passthrough, reducer);
       };
   }
+  if (enableContextProfiling) {
+    (InvalidNestedHooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
+      function <T>(context: ReactContext<T>, compare: void | (T => mixed)): T {
+        currentHookNameInDev = 'useContext';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return unstable_useContextWithBailout(context, compare);
+      };
+  }
 
   InvalidNestedHooksDispatcherOnRerenderInDEV = {
     readContext<T>(context: ReactContext<T>): T {
@@ -5176,6 +5254,15 @@ if (__DEV__) {
         warnInvalidHookAccess();
         updateHookTypesDev();
         return rerenderOptimistic(passthrough, reducer);
+      };
+  }
+  if (enableContextProfiling) {
+    (InvalidNestedHooksDispatcherOnRerenderInDEV: Dispatcher).unstable_useContextWithBailout =
+      function <T>(context: ReactContext<T>, compare: void | (T => mixed)): T {
+        currentHookNameInDev = 'useContext';
+        warnInvalidHookAccess();
+        updateHookTypesDev();
+        return unstable_useContextWithBailout(context, compare);
       };
   }
 }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1060,12 +1060,12 @@ function updateWorkInProgressHook(): Hook {
 
 function unstable_useContextWithBailout<T>(
   context: ReactContext<T>,
-  compare: (T => Array<mixed>) | null,
+  select: (T => Array<mixed>) | null,
 ): T {
-  if (compare === null) {
+  if (select === null) {
     return readContext(context);
   }
-  return readContextAndCompare(context, compare);
+  return readContextAndCompare(context, select);
 }
 
 // NOTE: defining two versions of this function to avoid size impact when this feature is disabled.
@@ -4054,11 +4054,11 @@ if (__DEV__) {
     (HooksDispatcherOnMountInDEV: Dispatcher).unstable_useContextWithBailout =
       function <T>(
         context: ReactContext<T>,
-        compare: (T => Array<mixed>) | null,
+        select: (T => Array<mixed>) | null,
       ): T {
         currentHookNameInDev = 'useContext';
         mountHookTypesDev();
-        return unstable_useContextWithBailout(context, compare);
+        return unstable_useContextWithBailout(context, select);
       };
   }
 
@@ -4246,11 +4246,11 @@ if (__DEV__) {
     (HooksDispatcherOnMountWithHookTypesInDEV: Dispatcher).unstable_useContextWithBailout =
       function <T>(
         context: ReactContext<T>,
-        compare: (T => Array<mixed>) | null,
+        select: (T => Array<mixed>) | null,
       ): T {
         currentHookNameInDev = 'useContext';
         updateHookTypesDev();
-        return unstable_useContextWithBailout(context, compare);
+        return unstable_useContextWithBailout(context, select);
       };
   }
 
@@ -4437,11 +4437,11 @@ if (__DEV__) {
     (HooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
       function <T>(
         context: ReactContext<T>,
-        compare: (T => Array<mixed>) | null,
+        select: (T => Array<mixed>) | null,
       ): T {
         currentHookNameInDev = 'useContext';
         updateHookTypesDev();
-        return unstable_useContextWithBailout(context, compare);
+        return unstable_useContextWithBailout(context, select);
       };
   }
 
@@ -4628,11 +4628,11 @@ if (__DEV__) {
     (HooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
       function <T>(
         context: ReactContext<T>,
-        compare: (T => Array<mixed>) | null,
+        select: (T => Array<mixed>) | null,
       ): T {
         currentHookNameInDev = 'useContext';
         updateHookTypesDev();
-        return unstable_useContextWithBailout(context, compare);
+        return unstable_useContextWithBailout(context, select);
       };
   }
 
@@ -4845,12 +4845,12 @@ if (__DEV__) {
     (HooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
       function <T>(
         context: ReactContext<T>,
-        compare: (T => Array<mixed>) | null,
+        select: (T => Array<mixed>) | null,
       ): T {
         currentHookNameInDev = 'useContext';
         warnInvalidHookAccess();
         mountHookTypesDev();
-        return unstable_useContextWithBailout(context, compare);
+        return unstable_useContextWithBailout(context, select);
       };
   }
 
@@ -5063,12 +5063,12 @@ if (__DEV__) {
     (InvalidNestedHooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
       function <T>(
         context: ReactContext<T>,
-        compare: (T => Array<mixed>) | null,
+        select: (T => Array<mixed>) | null,
       ): T {
         currentHookNameInDev = 'useContext';
         warnInvalidHookAccess();
         updateHookTypesDev();
-        return unstable_useContextWithBailout(context, compare);
+        return unstable_useContextWithBailout(context, select);
       };
   }
 
@@ -5281,12 +5281,12 @@ if (__DEV__) {
     (InvalidNestedHooksDispatcherOnRerenderInDEV: Dispatcher).unstable_useContextWithBailout =
       function <T>(
         context: ReactContext<T>,
-        compare: (T => Array<mixed>) | null,
+        select: (T => Array<mixed>) | null,
       ): T {
         currentHookNameInDev = 'useContext';
         warnInvalidHookAccess();
         updateHookTypesDev();
-        return unstable_useContextWithBailout(context, compare);
+        return unstable_useContextWithBailout(context, select);
       };
   }
 }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1060,7 +1060,7 @@ function updateWorkInProgressHook(): Hook {
 
 function unstable_useContextWithBailout<T>(
   context: ReactContext<T>,
-  compare: void | (T => mixed),
+  compare: (T => mixed) | null,
 ): T {
   return readContextAndCompare(context, compare);
 }
@@ -4049,7 +4049,7 @@ if (__DEV__) {
   }
   if (enableContextProfiling) {
     (HooksDispatcherOnMountInDEV: Dispatcher).unstable_useContextWithBailout =
-      function <T>(context: ReactContext<T>, compare: void | (T => mixed)): T {
+      function <T>(context: ReactContext<T>, compare: (T => mixed) | null): T {
         currentHookNameInDev = 'useContext';
         mountHookTypesDev();
         return unstable_useContextWithBailout(context, compare);
@@ -4238,7 +4238,7 @@ if (__DEV__) {
   }
   if (enableContextProfiling) {
     (HooksDispatcherOnMountWithHookTypesInDEV: Dispatcher).unstable_useContextWithBailout =
-      function <T>(context: ReactContext<T>, compare: void | (T => mixed)): T {
+      function <T>(context: ReactContext<T>, compare: (T => mixed) | null): T {
         currentHookNameInDev = 'useContext';
         updateHookTypesDev();
         return unstable_useContextWithBailout(context, compare);
@@ -4426,7 +4426,7 @@ if (__DEV__) {
   }
   if (enableContextProfiling) {
     (HooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
-      function <T>(context: ReactContext<T>, compare: void | (T => mixed)): T {
+      function <T>(context: ReactContext<T>, compare: (T => mixed) | null): T {
         currentHookNameInDev = 'useContext';
         updateHookTypesDev();
         return unstable_useContextWithBailout(context, compare);
@@ -4614,7 +4614,7 @@ if (__DEV__) {
   }
   if (enableContextProfiling) {
     (HooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
-      function <T>(context: ReactContext<T>, compare: void | (T => mixed)): T {
+      function <T>(context: ReactContext<T>, compare: (T => mixed) | null): T {
         currentHookNameInDev = 'useContext';
         updateHookTypesDev();
         return unstable_useContextWithBailout(context, compare);
@@ -4828,7 +4828,7 @@ if (__DEV__) {
   }
   if (enableContextProfiling) {
     (HooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
-      function <T>(context: ReactContext<T>, compare: void | (T => mixed)): T {
+      function <T>(context: ReactContext<T>, compare: (T => mixed) | null): T {
         currentHookNameInDev = 'useContext';
         warnInvalidHookAccess();
         mountHookTypesDev();
@@ -5043,7 +5043,7 @@ if (__DEV__) {
   }
   if (enableContextProfiling) {
     (InvalidNestedHooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
-      function <T>(context: ReactContext<T>, compare: void | (T => mixed)): T {
+      function <T>(context: ReactContext<T>, compare: (T => mixed) | null): T {
         currentHookNameInDev = 'useContext';
         warnInvalidHookAccess();
         updateHookTypesDev();
@@ -5258,7 +5258,7 @@ if (__DEV__) {
   }
   if (enableContextProfiling) {
     (InvalidNestedHooksDispatcherOnRerenderInDEV: Dispatcher).unstable_useContextWithBailout =
-      function <T>(context: ReactContext<T>, compare: void | (T => mixed)): T {
+      function <T>(context: ReactContext<T>, compare: (T => mixed) | null): T {
         currentHookNameInDev = 'useContext';
         warnInvalidHookAccess();
         updateHookTypesDev();

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1060,8 +1060,11 @@ function updateWorkInProgressHook(): Hook {
 
 function unstable_useContextWithBailout<T>(
   context: ReactContext<T>,
-  compare: (T => mixed) | null,
+  compare: (T => Array<mixed>) | null,
 ): T {
+  if (compare === null) {
+    return readContext(context);
+  }
   return readContextAndCompare(context, compare);
 }
 
@@ -4049,7 +4052,10 @@ if (__DEV__) {
   }
   if (enableContextProfiling) {
     (HooksDispatcherOnMountInDEV: Dispatcher).unstable_useContextWithBailout =
-      function <T>(context: ReactContext<T>, compare: (T => mixed) | null): T {
+      function <T>(
+        context: ReactContext<T>,
+        compare: (T => Array<mixed>) | null,
+      ): T {
         currentHookNameInDev = 'useContext';
         mountHookTypesDev();
         return unstable_useContextWithBailout(context, compare);
@@ -4238,7 +4244,10 @@ if (__DEV__) {
   }
   if (enableContextProfiling) {
     (HooksDispatcherOnMountWithHookTypesInDEV: Dispatcher).unstable_useContextWithBailout =
-      function <T>(context: ReactContext<T>, compare: (T => mixed) | null): T {
+      function <T>(
+        context: ReactContext<T>,
+        compare: (T => Array<mixed>) | null,
+      ): T {
         currentHookNameInDev = 'useContext';
         updateHookTypesDev();
         return unstable_useContextWithBailout(context, compare);
@@ -4426,7 +4435,10 @@ if (__DEV__) {
   }
   if (enableContextProfiling) {
     (HooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
-      function <T>(context: ReactContext<T>, compare: (T => mixed) | null): T {
+      function <T>(
+        context: ReactContext<T>,
+        compare: (T => Array<mixed>) | null,
+      ): T {
         currentHookNameInDev = 'useContext';
         updateHookTypesDev();
         return unstable_useContextWithBailout(context, compare);
@@ -4614,7 +4626,10 @@ if (__DEV__) {
   }
   if (enableContextProfiling) {
     (HooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
-      function <T>(context: ReactContext<T>, compare: (T => mixed) | null): T {
+      function <T>(
+        context: ReactContext<T>,
+        compare: (T => Array<mixed>) | null,
+      ): T {
         currentHookNameInDev = 'useContext';
         updateHookTypesDev();
         return unstable_useContextWithBailout(context, compare);
@@ -4828,7 +4843,10 @@ if (__DEV__) {
   }
   if (enableContextProfiling) {
     (HooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
-      function <T>(context: ReactContext<T>, compare: (T => mixed) | null): T {
+      function <T>(
+        context: ReactContext<T>,
+        compare: (T => Array<mixed>) | null,
+      ): T {
         currentHookNameInDev = 'useContext';
         warnInvalidHookAccess();
         mountHookTypesDev();
@@ -5043,7 +5061,10 @@ if (__DEV__) {
   }
   if (enableContextProfiling) {
     (InvalidNestedHooksDispatcherOnUpdateInDEV: Dispatcher).unstable_useContextWithBailout =
-      function <T>(context: ReactContext<T>, compare: (T => mixed) | null): T {
+      function <T>(
+        context: ReactContext<T>,
+        compare: (T => Array<mixed>) | null,
+      ): T {
         currentHookNameInDev = 'useContext';
         warnInvalidHookAccess();
         updateHookTypesDev();
@@ -5258,7 +5279,10 @@ if (__DEV__) {
   }
   if (enableContextProfiling) {
     (InvalidNestedHooksDispatcherOnRerenderInDEV: Dispatcher).unstable_useContextWithBailout =
-      function <T>(context: ReactContext<T>, compare: (T => mixed) | null): T {
+      function <T>(
+        context: ReactContext<T>,
+        compare: (T => Array<mixed>) | null,
+      ): T {
         currentHookNameInDev = 'useContext';
         warnInvalidHookAccess();
         updateHookTypesDev();

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -756,7 +756,7 @@ export function prepareToReadContext(
 
 export function readContextAndCompare<C>(
   context: ReactContext<C>,
-  compare: C => Array<mixed>,
+  select: C => Array<mixed>,
 ): C {
   if (!(enableLazyContextPropagation && enableContextProfiling)) {
     throw new Error('Not implemented.');
@@ -765,7 +765,7 @@ export function readContextAndCompare<C>(
   return readContextForConsumer_withSelect(
     currentlyRenderingFiber,
     context,
-    compare,
+    select,
   );
 }
 

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -668,11 +668,11 @@ function checkIfComparedContextValuesChanged(
   newComparedValue: mixed,
 ): boolean {
   if (isArray(oldComparedValue) && isArray(newComparedValue)) {
-    for (
-      let i = 0;
-      i < oldComparedValue.length && i < newComparedValue.length;
-      i++
-    ) {
+    if (oldComparedValue.length !== newComparedValue.length) {
+      return true;
+    }
+
+    for (let i = 0; i < oldComparedValue.length; i++) {
       if (!is(newComparedValue[i], oldComparedValue[i])) {
         return true;
       }

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -63,29 +63,23 @@ export type HookType =
 
 export type ContextDependency<C> = {
   context: ReactContext<C>,
-  next:
-    | ContextDependency<mixed>
-    | ContextDependencyWithCompare<mixed, mixed>
-    | null,
+  next: ContextDependency<mixed> | ContextDependencyWithSelect<mixed> | null,
   memoizedValue: C,
 };
 
-export type ContextDependencyWithCompare<C, S> = {
+export type ContextDependencyWithSelect<C> = {
   context: ReactContext<C>,
-  next:
-    | ContextDependency<mixed>
-    | ContextDependencyWithCompare<mixed, mixed>
-    | null,
+  next: ContextDependency<mixed> | ContextDependencyWithSelect<mixed> | null,
   memoizedValue: C,
-  compare: C => Array<mixed>,
-  lastComparedValue: ?Array<mixed>,
+  select: C => Array<mixed>,
+  lastSelectedValue: ?Array<mixed>,
 };
 
 export type Dependencies = {
   lanes: Lanes,
   firstContext:
     | ContextDependency<mixed>
-    | ContextDependencyWithCompare<mixed, mixed>
+    | ContextDependencyWithSelect<mixed>
     | null,
   ...
 };
@@ -402,7 +396,7 @@ export type Dispatcher = {
   ): [S, Dispatch<A>],
   unstable_useContextWithBailout?: <T>(
     context: ReactContext<T>,
-    compare: (T => Array<mixed>) | null,
+    select: (T => Array<mixed>) | null,
   ) => T,
   useContext<T>(context: ReactContext<T>): T,
   useRef<T>(initialValue: T): {current: T},

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -77,8 +77,8 @@ export type ContextDependencyWithCompare<C, S> = {
     | ContextDependencyWithCompare<mixed, mixed>
     | null,
   memoizedValue: C,
-  compare: (C => S) | null,
-  lastComparedValue?: S | null,
+  compare: C => Array<mixed>,
+  lastComparedValue: ?Array<mixed>,
 };
 
 export type Dependencies = {
@@ -402,7 +402,7 @@ export type Dispatcher = {
   ): [S, Dispatch<A>],
   unstable_useContextWithBailout?: <T>(
     context: ReactContext<T>,
-    compare: (T => mixed) | null,
+    compare: (T => Array<mixed>) | null,
   ) => T,
   useContext<T>(context: ReactContext<T>): T,
   useRef<T>(initialValue: T): {current: T},

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -61,16 +61,18 @@ export type HookType =
   | 'useFormState'
   | 'useActionState';
 
-export type ContextDependency<T> = {
-  context: ReactContext<T>,
-  next: ContextDependency<mixed> | null,
-  memoizedValue: T,
+export type ContextDependency<C, S> = {
+  context: ReactContext<C>,
+  next: ContextDependency<mixed, mixed> | null,
+  memoizedValue: C,
+  compare: (C => S) | null,
+  lastComparedValue: S | null,
   ...
 };
 
 export type Dependencies = {
   lanes: Lanes,
-  firstContext: ContextDependency<mixed> | null,
+  firstContext: ContextDependency<mixed, mixed> | null,
   ...
 };
 
@@ -384,6 +386,10 @@ export type Dispatcher = {
     initialArg: I,
     init?: (I) => S,
   ): [S, Dispatch<A>],
+  unstable_useContextWithBailout?: <T>(
+    context: ReactContext<T>,
+    compare: void | (T => mixed),
+  ) => T,
   useContext<T>(context: ReactContext<T>): T,
   useRef<T>(initialValue: T): {current: T},
   useEffect(

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -61,18 +61,32 @@ export type HookType =
   | 'useFormState'
   | 'useActionState';
 
-export type ContextDependency<C, S> = {
+export type ContextDependency<C> = {
   context: ReactContext<C>,
-  next: ContextDependency<mixed, mixed> | null,
+  next:
+    | ContextDependency<mixed>
+    | ContextDependencyWithCompare<mixed, mixed>
+    | null,
+  memoizedValue: C,
+};
+
+export type ContextDependencyWithCompare<C, S> = {
+  context: ReactContext<C>,
+  next:
+    | ContextDependency<mixed>
+    | ContextDependencyWithCompare<mixed, mixed>
+    | null,
   memoizedValue: C,
   compare: (C => S) | null,
-  lastComparedValue: S | null,
-  ...
+  lastComparedValue?: S | null,
 };
 
 export type Dependencies = {
   lanes: Lanes,
-  firstContext: ContextDependency<mixed, mixed> | null,
+  firstContext:
+    | ContextDependency<mixed>
+    | ContextDependencyWithCompare<mixed, mixed>
+    | null,
   ...
 };
 
@@ -388,7 +402,7 @@ export type Dispatcher = {
   ): [S, Dispatch<A>],
   unstable_useContextWithBailout?: <T>(
     context: ReactContext<T>,
-    compare: void | (T => mixed),
+    compare: (T => mixed) | null,
   ) => T,
   useContext<T>(context: ReactContext<T>): T,
   useRef<T>(initialValue: T): {current: T},

--- a/packages/react-reconciler/src/__tests__/ReactContextWithBailout-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactContextWithBailout-test.js
@@ -1,0 +1,210 @@
+let React;
+let ReactNoop;
+let Scheduler;
+let act;
+let assertLog;
+let useState;
+let useContext;
+let unstable_useContextWithBailout;
+
+describe('ReactContextWithBailout', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    React = require('react');
+    ReactNoop = require('react-noop-renderer');
+    Scheduler = require('scheduler');
+    const testUtils = require('internal-test-utils');
+    act = testUtils.act;
+    assertLog = testUtils.assertLog;
+    useState = React.useState;
+    useContext = React.useContext;
+    unstable_useContextWithBailout = React.unstable_useContextWithBailout;
+  });
+
+  function Text({text}) {
+    Scheduler.log(text);
+    return text;
+  }
+
+  // @gate enableLazyContextPropagation && enableContextProfiling
+  test('unstable_useContextWithBailout basic usage', async () => {
+    const Context = React.createContext();
+
+    let setContext;
+    function App() {
+      const [context, _setContext] = useState({a: 'A0', b: 'B0', c: 'C0'});
+      setContext = _setContext;
+      return (
+        <Context.Provider value={context}>
+          <Indirection />
+        </Context.Provider>
+      );
+    }
+
+    // Intermediate parent that bails out. Children will only re-render when the
+    // context changes.
+    const Indirection = React.memo(() => {
+      return (
+        <>
+          A: <A />, B: <B />, C: <C />, AB: <AB />
+        </>
+      );
+    });
+
+    function A() {
+      const {a} = unstable_useContextWithBailout(Context, context => context.a);
+      return <Text text={a} />;
+    }
+
+    function B() {
+      const {b} = unstable_useContextWithBailout(Context, context => context.b);
+      return <Text text={b} />;
+    }
+
+    function C() {
+      const {c} = unstable_useContextWithBailout(Context, context => context.c);
+      return <Text text={c} />;
+    }
+
+    function AB() {
+      const {a, b} = unstable_useContextWithBailout(Context, context => [
+        context.a,
+        context.b,
+      ]);
+      return <Text text={a + b} />;
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(async () => {
+      root.render(<App />);
+    });
+    assertLog(['A0', 'B0', 'C0', 'A0B0']);
+    expect(root).toMatchRenderedOutput('A: A0, B: B0, C: C0, AB: A0B0');
+
+    // Update a. Only the A and AB consumer should re-render.
+    await act(async () => {
+      setContext({a: 'A1', c: 'C0', b: 'B0'});
+    });
+    assertLog(['A1', 'A1B0']);
+    expect(root).toMatchRenderedOutput('A: A1, B: B0, C: C0, AB: A1B0');
+
+    // Update b. Only the B and AB consumer should re-render.
+    await act(async () => {
+      setContext({a: 'A1', b: 'B1', c: 'C0'});
+    });
+    assertLog(['B1', 'A1B1']);
+    expect(root).toMatchRenderedOutput('A: A1, B: B1, C: C0, AB: A1B1');
+
+    // Update c. Only the C consumer should re-render.
+    await act(async () => {
+      setContext({a: 'A1', b: 'B1', c: 'C1'});
+    });
+    assertLog(['C1']);
+    expect(root).toMatchRenderedOutput('A: A1, B: B1, C: C1, AB: A1B1');
+  });
+
+  // @gate enableLazyContextPropagation && enableContextProfiling
+  test('unstable_useContextWithBailout and useContext subscribing to same context in same component', async () => {
+    const Context = React.createContext();
+
+    let setContext;
+    function App() {
+      const [context, _setContext] = useState({a: 0, b: 0, unrelated: 0});
+      setContext = _setContext;
+      return (
+        <Context.Provider value={context}>
+          <Indirection />
+        </Context.Provider>
+      );
+    }
+
+    // Intermediate parent that bails out. Children will only re-render when the
+    // context changes.
+    const Indirection = React.memo(() => {
+      return <Child />;
+    });
+
+    function Child() {
+      const {a} = unstable_useContextWithBailout(Context, context => context.a);
+      const context = useContext(Context);
+      return <Text text={`A: ${a}, B: ${context.b}`} />;
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(async () => {
+      root.render(<App />);
+    });
+    assertLog(['A: 0, B: 0']);
+    expect(root).toMatchRenderedOutput('A: 0, B: 0');
+
+    // Update an unrelated field that isn't used by the component. The context
+    // attempts to bail out, but the normal context forces an update.
+    await act(async () => {
+      setContext({a: 0, b: 0, unrelated: 1});
+    });
+    assertLog(['A: 0, B: 0']);
+    expect(root).toMatchRenderedOutput('A: 0, B: 0');
+  });
+
+  // @gate enableLazyContextPropagation && enableContextProfiling
+  test('unstable_useContextWithBailout and useContext subscribing to different contexts in same component', async () => {
+    const ContextA = React.createContext();
+    const ContextB = React.createContext();
+
+    let setContextA;
+    let setContextB;
+    function App() {
+      const [a, _setContextA] = useState({a: 0, unrelated: 0});
+      const [b, _setContextB] = useState(0);
+      setContextA = _setContextA;
+      setContextB = _setContextB;
+      return (
+        <ContextA.Provider value={a}>
+          <ContextB.Provider value={b}>
+            <Indirection />
+          </ContextB.Provider>
+        </ContextA.Provider>
+      );
+    }
+
+    // Intermediate parent that bails out. Children will only re-render when the
+    // context changes.
+    const Indirection = React.memo(() => {
+      return <Child />;
+    });
+
+    function Child() {
+      const {a} = unstable_useContextWithBailout(
+        ContextA,
+        context => context.a,
+      );
+      const b = useContext(ContextB);
+      return <Text text={`A: ${a}, B: ${b}`} />;
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(async () => {
+      root.render(<App />);
+    });
+    assertLog(['A: 0, B: 0']);
+    expect(root).toMatchRenderedOutput('A: 0, B: 0');
+
+    // Update a field in A that isn't part of the compared context. It should
+    // bail out.
+    await act(async () => {
+      setContextA({a: 0, unrelated: 1});
+    });
+    assertLog([]);
+    expect(root).toMatchRenderedOutput('A: 0, B: 0');
+
+    // Now update the same a field again, but this time, also update a different
+    // context in the same batch. The other context prevents a bail out.
+    await act(async () => {
+      setContextA({a: 0, unrelated: 1});
+      setContextB(1);
+    });
+    assertLog(['A: 0, B: 1']);
+    expect(root).toMatchRenderedOutput('A: 0, B: 1');
+  });
+});

--- a/packages/react-reconciler/src/__tests__/ReactContextWithBailout-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactContextWithBailout-test.js
@@ -53,17 +53,23 @@ describe('ReactContextWithBailout', () => {
     });
 
     function A() {
-      const {a} = unstable_useContextWithBailout(Context, context => context.a);
+      const {a} = unstable_useContextWithBailout(Context, context => [
+        context.a,
+      ]);
       return <Text text={a} />;
     }
 
     function B() {
-      const {b} = unstable_useContextWithBailout(Context, context => context.b);
+      const {b} = unstable_useContextWithBailout(Context, context => [
+        context.b,
+      ]);
       return <Text text={b} />;
     }
 
     function C() {
-      const {c} = unstable_useContextWithBailout(Context, context => context.c);
+      const {c} = unstable_useContextWithBailout(Context, context => [
+        context.c,
+      ]);
       return <Text text={c} />;
     }
 
@@ -126,7 +132,9 @@ describe('ReactContextWithBailout', () => {
     });
 
     function Child() {
-      const {a} = unstable_useContextWithBailout(Context, context => context.a);
+      const {a} = unstable_useContextWithBailout(Context, context => [
+        context.a,
+      ]);
       const context = useContext(Context);
       return <Text text={`A: ${a}, B: ${context.b}`} />;
     }
@@ -175,10 +183,9 @@ describe('ReactContextWithBailout', () => {
     });
 
     function Child() {
-      const {a} = unstable_useContextWithBailout(
-        ContextA,
-        context => context.a,
-      );
+      const {a} = unstable_useContextWithBailout(ContextA, context => [
+        context.a,
+      ]);
       const b = useContext(ContextB);
       return <Text text={`A: ${a}, B: ${b}`} />;
     }

--- a/packages/react/index.fb.js
+++ b/packages/react/index.fb.js
@@ -39,6 +39,7 @@ export {
   use,
   useActionState,
   useCallback,
+  unstable_useContextWithBailout,
   useContext,
   useDebugValue,
   useDeferredValue,

--- a/packages/react/src/ReactClient.js
+++ b/packages/react/src/ReactClient.js
@@ -38,6 +38,7 @@ import {postpone} from './ReactPostpone';
 import {
   getCacheForType,
   useCallback,
+  unstable_useContextWithBailout,
   useContext,
   useEffect,
   useEffectEvent,
@@ -83,6 +84,7 @@ export {
   cache,
   postpone as unstable_postpone,
   useCallback,
+  unstable_useContextWithBailout,
   useContext,
   useEffect,
   useEffectEvent as experimental_useEffectEvent,

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -71,7 +71,7 @@ export function useContext<T>(Context: ReactContext<T>): T {
 
 export function unstable_useContextWithBailout<T>(
   context: ReactContext<T>,
-  compare: void | (T => mixed),
+  compare: (T => mixed) | null,
 ): T {
   if (!(enableLazyContextPropagation && enableContextProfiling)) {
     throw new Error('Not implemented.');

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -71,7 +71,7 @@ export function useContext<T>(Context: ReactContext<T>): T {
 
 export function unstable_useContextWithBailout<T>(
   context: ReactContext<T>,
-  compare: (T => Array<mixed>) | null,
+  select: (T => Array<mixed>) | null,
 ): T {
   if (!(enableLazyContextPropagation && enableContextProfiling)) {
     throw new Error('Not implemented.');
@@ -87,7 +87,7 @@ export function unstable_useContextWithBailout<T>(
     }
   }
   // $FlowFixMe[not-a-function] This is unstable, thus optional
-  return dispatcher.unstable_useContextWithBailout(context, compare);
+  return dispatcher.unstable_useContextWithBailout(context, select);
 }
 
 export function useState<S>(

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -71,7 +71,7 @@ export function useContext<T>(Context: ReactContext<T>): T {
 
 export function unstable_useContextWithBailout<T>(
   context: ReactContext<T>,
-  compare: (T => mixed) | null,
+  compare: (T => Array<mixed>) | null,
 ): T {
   if (!(enableLazyContextPropagation && enableContextProfiling)) {
     throw new Error('Not implemented.');

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -19,6 +19,10 @@ import {REACT_CONSUMER_TYPE} from 'shared/ReactSymbols';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 
 import {enableAsyncActions} from 'shared/ReactFeatureFlags';
+import {
+  enableContextProfiling,
+  enableLazyContextPropagation,
+} from '../../shared/ReactFeatureFlags';
 
 type BasicStateAction<S> = (S => S) | S;
 type Dispatch<A> = A => void;
@@ -63,6 +67,27 @@ export function useContext<T>(Context: ReactContext<T>): T {
     }
   }
   return dispatcher.useContext(Context);
+}
+
+export function unstable_useContextWithBailout<T>(
+  context: ReactContext<T>,
+  compare: void | (T => mixed),
+): T {
+  if (!(enableLazyContextPropagation && enableContextProfiling)) {
+    throw new Error('Not implemented.');
+  }
+
+  const dispatcher = resolveDispatcher();
+  if (__DEV__) {
+    if (context.$$typeof === REACT_CONSUMER_TYPE) {
+      console.error(
+        'Calling useContext(Context.Consumer) is not supported and will cause bugs. ' +
+          'Did you mean to call useContext(Context) instead?',
+      );
+    }
+  }
+  // $FlowFixMe[not-a-function] This is unstable, thus optional
+  return dispatcher.unstable_useContextWithBailout(context, compare);
 }
 
 export function useState<S>(

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -97,6 +97,9 @@ export const enableTransitionTracing = false;
 // No known bugs, but needs performance testing
 export const enableLazyContextPropagation = false;
 
+// Expose unstable useContext for performance testing
+export const enableContextProfiling = false;
+
 // FB-only usage. The new API has different semantics.
 export const enableLegacyHidden = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -58,6 +58,7 @@ export const enableFlightReadableStream = true;
 export const enableGetInspectorDataForInstanceInProduction = true;
 export const enableInfiniteRenderLoopDetection = true;
 export const enableLazyContextPropagation = false;
+export const enableContextProfiling = false;
 export const enableLegacyCache = false;
 export const enableLegacyFBSupport = false;
 export const enableLegacyHidden = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -51,6 +51,7 @@ export const enableFlightReadableStream = true;
 export const enableGetInspectorDataForInstanceInProduction = false;
 export const enableInfiniteRenderLoopDetection = true;
 export const enableLazyContextPropagation = false;
+export const enableContextProfiling = false;
 export const enableLegacyCache = false;
 export const enableLegacyFBSupport = false;
 export const enableLegacyHidden = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -52,6 +52,7 @@ export const transitionLaneExpirationMs = 5000;
 
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
+export const enableContextProfiling = false;
 export const enableLegacyHidden = false;
 export const forceConcurrentByDefaultForTesting = false;
 export const allowConcurrentByDefault = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -43,6 +43,7 @@ export const enableFlightReadableStream = true;
 export const enableGetInspectorDataForInstanceInProduction = false;
 export const enableInfiniteRenderLoopDetection = true;
 export const enableLazyContextPropagation = false;
+export const enableContextProfiling = false;
 export const enableLegacyCache = false;
 export const enableLegacyFBSupport = false;
 export const enableLegacyHidden = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -55,6 +55,7 @@ export const transitionLaneExpirationMs = 5000;
 
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
+export const enableContextProfiling = false;
 export const enableLegacyHidden = false;
 export const forceConcurrentByDefaultForTesting = false;
 export const allowConcurrentByDefault = true;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -78,6 +78,8 @@ export const enableTaint = false;
 
 export const enablePostpone = false;
 
+export const enableContextProfiling = true;
+
 // TODO: www currently relies on this feature. It's disabled in open source.
 // Need to remove it.
 export const disableCommentsAsDOMContainers = false;

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -525,5 +525,6 @@
   "537": "Cannot pass event handlers (%s) in renderToMarkup because the HTML will never be hydrated so they can never get called.",
   "538": "Cannot use state or effect Hooks in renderToMarkup because this component will never be hydrated.",
   "539": "Binary RSC chunks cannot be encoded as strings. This is a bug in the wiring of the React streams.",
-  "540": "String chunks need to be passed in their original shape. Not split into smaller string chunks. This is a bug in the wiring of the React streams."
+  "540": "String chunks need to be passed in their original shape. Not split into smaller string chunks. This is a bug in the wiring of the React streams.",
+  "541": "Compared context values must be arrays"
 }


### PR DESCRIPTION
**This API is not intended to ship. This is a temporary unstable hook for internal performance profiling.**

This PR exposes `unstable_useContextWithBailout`, which takes a compare function in addition to Context. The comparison function is run to determine if Context propagation and render should bail out earlier. `unstable_useContextWithBailout` returns the full Context value, same as `useContext`.

We can profile this API against `useContext` to better measure the cost of Context value updates and gather more data around propagation and render performance.

The bailout logic and test cases are based on https://github.com/facebook/react/pull/20646

Additionally, this implementation allows multiple values to be compared in one hook by returning a tuple to avoid requiring additional Context consumer hooks in some cases. 