### PR TITLE
[Flight] Parse Stack on the Server and Transfer Structured Stack

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -12,6 +12,7 @@ import type {
   ReactDebugInfo,
   ReactComponentInfo,
   ReactAsyncInfo,
+  ReactStackTrace,
 } from 'shared/ReactTypes';
 import type {LazyComponent} from 'react/src/ReactLazy';
 
@@ -624,7 +625,7 @@ function createElement(
   key: mixed,
   props: mixed,
   owner: null | ReactComponentInfo, // DEV-only
-  stack: null | string, // DEV-only
+  stack: null | ReactStackTrace, // DEV-only
   validated: number, // DEV-only
 ):
   | React$Element<any>
@@ -1738,6 +1739,27 @@ function stopStream(
   controller.close(row === '' ? '"$undefined"' : row);
 }
 
+function formatV8Stack(
+  errorName: string,
+  errorMessage: string,
+  stack: null | ReactStackTrace,
+): string {
+  let v8StyleStack = errorName + ': ' + errorMessage;
+  if (stack) {
+    for (let i = 0; i < stack.length; i++) {
+      const frame = stack[i];
+      const [name, filename, line, col] = frame;
+      if (!name) {
+        v8StyleStack += '\n    at ' + filename + ':' + line + ':' + col;
+      } else {
+        v8StyleStack +=
+          '\n    at ' + name + ' (' + filename + ':' + line + ':' + col + ')';
+      }
+    }
+  }
+  return v8StyleStack;
+}
+
 type ErrorWithDigest = Error & {digest?: string};
 function resolveErrorProd(
   response: Response,
@@ -1773,7 +1795,7 @@ function resolveErrorDev(
   id: number,
   digest: string,
   message: string,
-  stack: string,
+  stack: ReactStackTrace,
   env: string,
 ): void {
   if (!__DEV__) {
@@ -1793,7 +1815,8 @@ function resolveErrorDev(
       message ||
         'An error occurred in the Server Components render but no message was provided',
     );
-    error.stack = stack;
+    // For backwards compat we use the V8 formatting when the flag is off.
+    error.stack = formatV8Stack(error.name, error.message, stack);
   } else {
     const callStack = buildFakeCallStack(
       response,
@@ -1853,7 +1876,7 @@ function resolvePostponeDev(
   response: Response,
   id: number,
   reason: string,
-  stack: string,
+  stack: ReactStackTrace,
 ): void {
   if (!__DEV__) {
     // These errors should never make it into a build so we don't need to encode them in codes.json
@@ -1862,11 +1885,34 @@ function resolvePostponeDev(
       'resolvePostponeDev should never be called in production mode. Use resolvePostponeProd instead. This is a bug in React.',
     );
   }
-  // eslint-disable-next-line react-internal/prod-error-codes
-  const error = new Error(reason || '');
-  const postponeInstance: Postpone = (error: any);
-  postponeInstance.$$typeof = REACT_POSTPONE_TYPE;
-  postponeInstance.stack = stack;
+  let postponeInstance: Postpone;
+  if (!enableOwnerStacks) {
+    // Executing Error within a native stack isn't really limited to owner stacks
+    // but we gate it behind the same flag for now while iterating.
+    // eslint-disable-next-line react-internal/prod-error-codes
+    postponeInstance = (Error(reason || ''): any);
+    postponeInstance.$$typeof = REACT_POSTPONE_TYPE;
+    // For backwards compat we use the V8 formatting when the flag is off.
+    postponeInstance.stack = formatV8Stack(
+      postponeInstance.name,
+      postponeInstance.message,
+      stack,
+    );
+  } else {
+    const callStack = buildFakeCallStack(
+      response,
+      stack,
+      // $FlowFixMe[incompatible-use]
+      Error.bind(null, reason || ''),
+    );
+    const rootTask = response._debugRootTask;
+    if (rootTask != null) {
+      postponeInstance = rootTask.run(callStack);
+    } else {
+      postponeInstance = callStack();
+    }
+    postponeInstance.$$typeof = REACT_POSTPONE_TYPE;
+  }
   const chunks = response._chunks;
   const chunk = chunks.get(id);
   if (!chunk) {
@@ -1973,40 +2019,25 @@ function createFakeFunction<T>(
   return fn;
 }
 
-// This matches either of these V8 formats.
-//     at name (filename:0:0)
-//     at filename:0:0
-//     at async filename:0:0
-const frameRegExp =
-  /^ {3} at (?:(.+) \(([^\)]+):(\d+):(\d+)\)|(?:async )?([^\)]+):(\d+):(\d+))$/;
-
 function buildFakeCallStack<T>(
   response: Response,
-  stack: string,
+  stack: ReactStackTrace,
   innerCall: () => T,
 ): () => T {
-  const frames = stack.split('\n');
   let callStack = innerCall;
-  for (let i = 0; i < frames.length; i++) {
-    const frame = frames[i];
-    let fn = fakeFunctionCache.get(frame);
+  for (let i = 0; i < stack.length; i++) {
+    const frame = stack[i];
+    const frameKey = frame.join('-');
+    let fn = fakeFunctionCache.get(frameKey);
     if (fn === undefined) {
-      const parsed = frameRegExp.exec(frame);
-      if (!parsed) {
-        // We assume the server returns a V8 compatible stack trace.
-        continue;
-      }
-      const name = parsed[1] || '';
-      const filename = parsed[2] || parsed[5] || '';
-      const line = +(parsed[3] || parsed[6]);
-      const col = +(parsed[4] || parsed[7]);
+      const [name, filename, line, col] = frame;
       const sourceMap = response._debugFindSourceMapURL
         ? response._debugFindSourceMapURL(filename)
         : null;
       fn = createFakeFunction(name, filename, sourceMap, line, col);
       // TODO: This cache should technically live on the response since the _debugFindSourceMapURL
       // function is an input and can vary by response.
-      fakeFunctionCache.set(frame, fn);
+      fakeFunctionCache.set(frameKey, fn);
     }
     callStack = fn.bind(null, callStack);
   }
@@ -2026,7 +2057,7 @@ function initializeFakeTask(
     return cachedEntry;
   }
 
-  if (typeof debugInfo.stack !== 'string') {
+  if (debugInfo.stack == null) {
     // If this is an error, we should've really already initialized the task.
     // If it's null, we can't initialize a task.
     return null;
@@ -2064,7 +2095,7 @@ function initializeFakeTask(
 const createFakeJSXCallStack = {
   'react-stack-bottom-frame': function (
     response: Response,
-    stack: string,
+    stack: ReactStackTrace,
   ): Error {
     const callStackForError = buildFakeCallStack(
       response,
@@ -2077,7 +2108,7 @@ const createFakeJSXCallStack = {
 
 const createFakeJSXCallStackInDEV: (
   response: Response,
-  stack: string,
+  stack: ReactStackTrace,
 ) => Error = __DEV__
   ? // We use this technique to trick minifiers to preserve the function name.
     (createFakeJSXCallStack['react-stack-bottom-frame'].bind(
@@ -2100,7 +2131,7 @@ function initializeFakeStack(
   if (cachedEntry !== undefined) {
     return;
   }
-  if (typeof debugInfo.stack === 'string') {
+  if (debugInfo.stack != null) {
     // $FlowFixMe[cannot-write]
     // $FlowFixMe[prop-missing]
     debugInfo.debugStack = createFakeJSXCallStackInDEV(
@@ -2154,8 +2185,13 @@ function resolveConsoleEntry(
     return;
   }
 
-  const payload: [string, string, null | ReactComponentInfo, string, mixed] =
-    parseModel(response, value);
+  const payload: [
+    string,
+    ReactStackTrace,
+    null | ReactComponentInfo,
+    string,
+    mixed,
+  ] = parseModel(response, value);
   const methodName = payload[0];
   const stackTrace = payload[1];
   const owner = payload[2];

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -27,10 +27,24 @@ function normalizeCodeLocInfo(str) {
   );
 }
 
+function formatV8Stack(stack) {
+  let v8StyleStack = '';
+  if (stack) {
+    for (let i = 0; i < stack.length; i++) {
+      const [name] = stack[i];
+      if (v8StyleStack !== '') {
+        v8StyleStack += '\n';
+      }
+      v8StyleStack += '    in ' + name + ' (at **)';
+    }
+  }
+  return v8StyleStack;
+}
+
 function normalizeComponentInfo(debugInfo) {
-  if (typeof debugInfo.stack === 'string') {
+  if (Array.isArray(debugInfo.stack)) {
     const {debugTask, debugStack, ...copy} = debugInfo;
-    copy.stack = normalizeCodeLocInfo(debugInfo.stack);
+    copy.stack = formatV8Stack(debugInfo.stack);
     if (debugInfo.owner) {
       copy.owner = normalizeComponentInfo(debugInfo.owner);
     }

--- a/packages/react-reconciler/src/ReactFiberOwnerStack.js
+++ b/packages/react-reconciler/src/ReactFiberOwnerStack.js
@@ -8,7 +8,7 @@
  */
 
 // TODO: Make this configurable on the root.
-const externalRegExp = /\/node\_modules\/|\(\<anonymous\>\)/;
+const externalRegExp = /\/node\_modules\/|\(\<anonymous\>/;
 
 function isNotExternal(stackFrame: string): boolean {
   return !externalRegExp.test(stackFrame);

--- a/packages/react-server/src/ReactFizzComponentStack.js
+++ b/packages/react-server/src/ReactFizzComponentStack.js
@@ -165,16 +165,16 @@ export function getOwnerStackByComponentStackNodeInDev(
         // TODO: Should we stash this somewhere for caching purposes?
         ownerStack = formatOwnerStack(owner.debugStack);
         owner = owner.owner;
-      } else if (owner.stack != null) {
+      } else {
         // Client Component
         const node: ComponentStackNode = (owner: any);
-        if (typeof owner.stack !== 'string') {
-          ownerStack = node.stack = formatOwnerStack(owner.stack);
-        } else {
-          ownerStack = owner.stack;
+        if (node.stack != null) {
+          if (typeof node.stack !== 'string') {
+            ownerStack = node.stack = formatOwnerStack(node.stack);
+          } else {
+            ownerStack = node.stack;
+          }
         }
-        owner = owner.owner;
-      } else {
         owner = owner.owner;
       }
       // If we don't actually print the stack if there is no owner of this JSX element.

--- a/packages/react-server/src/ReactFizzOwnerStack.js
+++ b/packages/react-server/src/ReactFizzOwnerStack.js
@@ -8,7 +8,7 @@
  */
 
 // TODO: Make this configurable on the root.
-const externalRegExp = /\/node\_modules\/|\(\<anonymous\>\)/;
+const externalRegExp = /\/node\_modules\/|\(\<anonymous\>/;
 
 function isNotExternal(stackFrame: string): boolean {
   return !externalRegExp.test(stackFrame);

--- a/packages/react-server/src/ReactFlightOwnerStack.js
+++ b/packages/react-server/src/ReactFlightOwnerStack.js
@@ -8,7 +8,7 @@
  */
 
 // TODO: Make this configurable on the Request.
-const externalRegExp = /\/node\_modules\/| \(node\:| node\:|\(\<anonymous\>\)/;
+const externalRegExp = /\/node\_modules\/| \(node\:| node\:|\(\<anonymous\>/;
 
 function isNotExternal(stackFrame: string): boolean {
   return !externalRegExp.test(stackFrame);

--- a/packages/react-server/src/ReactFlightStackConfigV8.js
+++ b/packages/react-server/src/ReactFlightStackConfigV8.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ReactStackTrace} from 'shared/ReactTypes';
+
+function prepareStackTrace(
+  error: Error,
+  structuredStackTrace: CallSite[],
+): string {
+  const name = error.name || 'Error';
+  const message = error.message || '';
+  let stack = name + ': ' + message;
+  for (let i = 0; i < structuredStackTrace.length; i++) {
+    stack += '\n    at ' + structuredStackTrace[i].toString();
+  }
+  return stack;
+}
+
+function getStack(error: Error): string {
+  // We override Error.prepareStackTrace with our own version that normalizes
+  // the stack to V8 formatting even if the server uses other formatting.
+  // It also ensures that source maps are NOT applied to this since that can
+  // be slow we're better off doing that lazily from the client instead of
+  // eagerly on the server. If the stack has already been read, then we might
+  // not get a normalized stack and it might still have been source mapped.
+  const previousPrepare = Error.prepareStackTrace;
+  Error.prepareStackTrace = prepareStackTrace;
+  try {
+    // eslint-disable-next-line react-internal/safe-string-coercion
+    return String(error.stack);
+  } finally {
+    Error.prepareStackTrace = previousPrepare;
+  }
+}
+
+// This matches either of these V8 formats.
+//     at name (filename:0:0)
+//     at filename:0:0
+//     at async filename:0:0
+const frameRegExp =
+  /^ {3} at (?:(.+) \(([^\)]+):(\d+):(\d+)\)|(?:async )?([^\)]+):(\d+):(\d+))$/;
+
+export function parseStackTrace(
+  error: Error,
+  skipFrames: number,
+): ReactStackTrace {
+  let stack = getStack(error);
+  if (stack.startsWith('Error: react-stack-top-frame\n')) {
+    // V8's default formatting prefixes with the error message which we
+    // don't want/need.
+    stack = stack.slice(29);
+  }
+  let idx = stack.indexOf('react-stack-bottom-frame');
+  if (idx !== -1) {
+    idx = stack.lastIndexOf('\n', idx);
+  }
+  if (idx !== -1) {
+    // Cut off everything after the bottom frame since it'll be internals.
+    stack = stack.slice(0, idx);
+  }
+  const frames = stack.split('\n');
+  const parsedFrames: ReactStackTrace = [];
+  // We skip top frames here since they may or may not be parseable but we
+  // want to skip the same number of frames regardless. I.e. we can't do it
+  // in the caller.
+  for (let i = skipFrames; i < frames.length; i++) {
+    const parsed = frameRegExp.exec(frames[i]);
+    if (!parsed) {
+      continue;
+    }
+    let name = parsed[1] || '';
+    if (name === '<anonymous>') {
+      name = '';
+    }
+    let filename = parsed[2] || parsed[5] || '';
+    if (filename === '<anonymous>') {
+      filename = '';
+    }
+    const line = +(parsed[3] || parsed[6]);
+    const col = +(parsed[4] || parsed[7]);
+    parsedFrames.push([name, filename, line, col]);
+  }
+  return parsedFrames;
+}

--- a/packages/react-server/src/forks/ReactFlightServerConfig.custom.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.custom.js
@@ -14,6 +14,8 @@ export * from '../ReactFlightServerConfigBundlerCustom';
 
 export * from '../ReactFlightServerConfigDebugNoop';
 
+export * from '../ReactFlightStackConfigV8';
+
 export type Hints = any;
 export type HintCode = any;
 // eslint-disable-next-line no-unused-vars

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser-esm.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser-esm.js
@@ -21,3 +21,5 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
   (null: any);
 
 export * from '../ReactFlightServerConfigDebugNoop';
+
+export * from '../ReactFlightStackConfigV8';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser-turbopack.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser-turbopack.js
@@ -21,3 +21,5 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
   (null: any);
 
 export * from '../ReactFlightServerConfigDebugNoop';
+
+export * from '../ReactFlightStackConfigV8';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser.js
@@ -21,3 +21,5 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
   (null: any);
 
 export * from '../ReactFlightServerConfigDebugNoop';
+
+export * from '../ReactFlightStackConfigV8';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-bun.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-bun.js
@@ -21,3 +21,5 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
   (null: any);
 
 export * from '../ReactFlightServerConfigDebugNoop';
+
+export * from '../ReactFlightStackConfigV8';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge-turbopack.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge-turbopack.js
@@ -35,4 +35,7 @@ export const createAsyncHook: HookCallbacks => AsyncHook =
       };
 export const executionAsyncId: () => number =
   typeof async_hooks === 'object' ? async_hooks.executionAsyncId : (null: any);
+
 export * from '../ReactFlightServerConfigDebugNode';
+
+export * from '../ReactFlightStackConfigV8';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge.js
@@ -36,4 +36,7 @@ export const createAsyncHook: HookCallbacks => AsyncHook =
       };
 export const executionAsyncId: () => number =
   typeof async_hooks === 'object' ? async_hooks.executionAsyncId : (null: any);
+
 export * from '../ReactFlightServerConfigDebugNode';
+
+export * from '../ReactFlightStackConfigV8';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-legacy.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-legacy.js
@@ -14,6 +14,8 @@ export * from '../ReactFlightServerConfigBundlerCustom';
 
 export * from '../ReactFlightServerConfigDebugNoop';
 
+export * from '../ReactFlightStackConfigV8';
+
 export type Hints = any;
 export type HintCode = any;
 // eslint-disable-next-line no-unused-vars

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-node-esm.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-node-esm.js
@@ -24,4 +24,7 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
   supportsComponentStorage ? new AsyncLocalStorage() : (null: any);
 
 export {createHook as createAsyncHook, executionAsyncId} from 'async_hooks';
+
 export * from '../ReactFlightServerConfigDebugNode';
+
+export * from '../ReactFlightStackConfigV8';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-node-turbopack.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-node-turbopack.js
@@ -24,4 +24,7 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
   supportsComponentStorage ? new AsyncLocalStorage() : (null: any);
 
 export {createHook as createAsyncHook, executionAsyncId} from 'async_hooks';
+
 export * from '../ReactFlightServerConfigDebugNode';
+
+export * from '../ReactFlightStackConfigV8';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-node.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-node.js
@@ -24,4 +24,7 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
   supportsComponentStorage ? new AsyncLocalStorage() : (null: any);
 
 export {createHook as createAsyncHook, executionAsyncId} from 'async_hooks';
+
 export * from '../ReactFlightServerConfigDebugNode';
+
+export * from '../ReactFlightStackConfigV8';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.markup.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.markup.js
@@ -28,6 +28,8 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
 
 export * from '../ReactFlightServerConfigDebugNoop';
 
+export * from '../ReactFlightStackConfigV8';
+
 export type ClientManifest = null;
 export opaque type ClientReference<T> = null; // eslint-disable-line no-unused-vars
 export opaque type ServerReference<T> = null; // eslint-disable-line no-unused-vars

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -178,11 +178,20 @@ export type Awaited<T> = T extends null | void
     : T // argument was not an object
   : T; // non-thenable
 
+export type ReactCallSite = [
+  string, // function name
+  string, // file name TODO: model nested eval locations as nested arrays
+  number, // line number
+  number, // column number
+];
+
+export type ReactStackTrace = Array<ReactCallSite>;
+
 export type ReactComponentInfo = {
   +name?: string,
   +env?: string,
   +owner?: null | ReactComponentInfo,
-  +stack?: null | string,
+  +stack?: null | ReactStackTrace,
   // Stashed Data for the Specific Execution Environment. Not part of the transport protocol
   +debugStack?: null | Error,
   +debugTask?: null | ConsoleTask,
@@ -191,7 +200,7 @@ export type ReactComponentInfo = {
 export type ReactAsyncInfo = {
   +started?: number,
   +completed?: number,
-  +stack?: string,
+  +stack?: null | ReactStackTrace,
 };
 
 export type ReactDebugInfo = Array<ReactComponentInfo | ReactAsyncInfo>;

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -292,13 +292,13 @@ function lazyRequireFunctionExports(moduleName) {
         // If this export is a function, return a wrapper function that lazily
         // requires the implementation from the current module cache.
         if (typeof originalModule[prop] === 'function') {
-          const wrapper = function () {
-            return jest.requireActual(moduleName)[prop].apply(this, arguments);
-          };
-          // We use this to trick the filtering of Flight to exclude this frame.
-          Object.defineProperty(wrapper, 'name', {
-            value: '(<anonymous>)',
-          });
+          // eslint-disable-next-line no-eval
+          const wrapper = eval(`
+            (function () {
+              return jest.requireActual(moduleName)[prop].apply(this, arguments);
+            })
+            // We use this to trick the filtering of Flight to exclude this frame.
+            //# sourceURL=<anonymous>`);
           return wrapper;
         } else {
           return originalModule[prop];


### PR DESCRIPTION
Stacked on #30401.

Previously we were transferring the original V8 stack trace string to the client and then parsing it there. However, really the server is the one that knows what format it is and it should be able to vary by server environment.

We also don't use the raw string anymore (at least not in enableOwnerStacks). We always create the native Error stacks.

The string also made it unclear which environment it is and it was tempting to just use it as is.

Instead I parse it on the server and make it a structured stack in the transfer format. It also makes it clear that it needs to be formatted in the current environment before presented.