### PR TITLE
chore: Replaced links built with Google URL Shortener with full URLs.

### DIFF
--- a/packages/dom-event-testing-library/__tests__/__snapshots__/index-test.internal.js.snap
+++ b/packages/dom-event-testing-library/__tests__/__snapshots__/index-test.internal.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`describeWithPointerEvent: MouseEvent/TouchEvent provides boolean to tests 1`] = `false`;
 

--- a/packages/react-art/src/__tests__/__snapshots__/ReactART-test.js.snap
+++ b/packages/react-art/src/__tests__/__snapshots__/ReactART-test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ReactARTComponents should generate a <Shape> where top radius is 0 if the sum of the top radius is greater than width 1`] = `
 <Shape

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactHooks-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactHooks-test.internal.js.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ReactHooks works with ReactDOMServer calls inside a component 1`] = `"<p>hello</p>0<p>bye</p>"`;

--- a/packages/react-refresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-refresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ReactFreshBabelPlugin can handle implicit arrow returns 1`] = `
 var _s = $RefreshSig$(),

--- a/packages/react/src/__tests__/__snapshots__/ReactProfilerComponent-test.internal.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/ReactProfilerComponent-test.internal.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Profiler works in profiling and non-profiling bundles enableProfilerTimer:disabled should render children 1`] = `"<div><span>outside span</span><span>inside span</span><span>function component</span></div>"`;
 

--- a/scripts/error-codes/__tests__/__snapshots__/transform-error-messages.js.snap
+++ b/scripts/error-codes/__tests__/__snapshots__/transform-error-messages.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`error transform handles deeply nested expressions 1`] = `
 "var val = (a, (b, // eslint-disable-next-line react-internal/prod-error-codes


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Replaced links built with Google URL Shortener with full URLs. (`https://goo.gl/*`)

## Why
Since it was announced that Google URL Shortener will no longer be supported after August 2025

* https://developers.googleblog.com/en/google-url-shortener-links-will-no-longer-be-available/

## Additional
The redirect for https://goo.gl/fbAQLP was to the following link.
*  http://facebook.github.io/jest/docs/snapshot-testing.html.

However, it was further redirected to `jestjs.io` from here, so the URL finally reached is adopted.

## Notes

 I tried to create an Issue, but there was no corresponding topic, so I created a PR directly.

## How did you test this change?

I have run prettier, linter, test and confirmed that everything is fine.
(Just correcting a comment, but just in case)


