### PR TITLE
Update yarn build options

### DIFF
--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -17,6 +17,7 @@ const {
 } = require('../../ReactVersions');
 const yargs = require('yargs');
 const {buildEverything} = require('./build-ghaction');
+const Bundles = require('./bundles');
 
 // Runs the build script for both stable and experimental release channels,
 // by configuring an environment variable.
@@ -78,6 +79,37 @@ const argv = yargs.wrap(yargs.terminalWidth()).options({
     requiresArg: false,
     type: 'choices',
     choices: ['circleci', 'github'],
+  },
+  bundle: {
+    describe: 'Build the given bundle type.',
+    requiresArg: false,
+    type: 'choices',
+    choices: [...Object.values(Bundles.bundleTypes)],
+  },
+  names: {
+    describe: 'Build for matched bundle names. Example: "react-test,index.js".',
+    requiresArg: false,
+    type: 'array',
+  },
+  pretty: {
+    describe: 'Force pretty output.',
+    requiresArg: false,
+    type: 'boolean',
+  },
+  'sync-fbsource': {
+    describe: 'Include to sync build to fbsource.',
+    requiresArg: false,
+    type: 'string',
+  },
+  'sync-www': {
+    describe: 'Include to sync build to www.',
+    requiresArg: false,
+    type: 'string',
+  },
+  'unsafe-partial': {
+    describe: 'Do not clean ./build first.',
+    requiresArg: false,
+    type: 'boolean',
   },
 }).argv;
 

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -84,13 +84,13 @@ function parseRequestedNames(names, toCase) {
   }
   return result;
 }
+const argvType = Array.isArray(argv.bundle) ? argv.bundle : [argv.bundle];
+const requestedBundleTypes = argv.bundle ? argvType : [];
 
-const argvType = Array.isArray(argv.type) ? argv.type : [argv.type];
-const requestedBundleTypes = argv.type
-  ? parseRequestedNames(argvType, 'uppercase')
-  : [];
-
-const requestedBundleNames = parseRequestedNames(argv._, 'lowercase');
+const requestedBundleNames = parseRequestedNames(
+  argv.names ? argv.names : [],
+  'lowercase'
+);
 const forcePrettyOutput = argv.pretty;
 const isWatchMode = argv.watch;
 const syncFBSourcePath = argv['sync-fbsource'];


### PR DESCRIPTION
Improve command documentation and make it easier to build specific bundle types

**Before**
```
% yarn build --help              
yarn run v1.22.19
$ node ./scripts/rollup/build-all-release-channels.js --help
Options:
  --help                Show help                                                                                   [boolean]
  --version             Show version number                                                                         [boolean]
  --releaseChannel, -r  Build the given release channel.                         [string] [choices: "experimental", "stable"]
  --index, -i           Worker id.                                                                                   [number]
  --total, -t           Total number of workers.                                                                     [number]
  --ci                  Run tests in CI                                                       [choices: "circleci", "github"]
✨  Done in 0.69s.
```

**After**
```
% yarn build --help
yarn run v1.22.19
$ node ./scripts/rollup/build-all-release-channels.js --help
Options:
  --help                Show help                                                                                                               [boolean]
  --version             Show version number                                                                                                     [boolean]
  --releaseChannel, -r  Build the given release channel.                                                     [string] [choices: "experimental", "stable"]
  --index, -i           Worker id.                                                                                                               [number]
  --total, -t           Total number of workers.                                                                                                 [number]
  --bundle              Build the given bundle type.
           [choices: "NODE_ES2015", "ESM_DEV", "ESM_PROD", "NODE_DEV", "NODE_PROD", "NODE_PROFILING", "BUN_DEV", "BUN_PROD", "FB_WWW_DEV", "FB_WWW_PROD",
                     "FB_WWW_PROFILING", "RN_OSS_DEV", "RN_OSS_PROD", "RN_OSS_PROFILING", "RN_FB_DEV", "RN_FB_PROD", "RN_FB_PROFILING", "BROWSER_SCRIPT"]
  --ci                  Run tests in CI                                                                                   [choices: "circleci", "github"]
  --names               Build for matched bundle names. Example: "react-test,index.js".                                                           [array]
  --pretty              Force pretty output.                                                                                                    [boolean]
  --sync-fbsource       Include to sync build to fbsource.                                                                                       [string]
  --sync-www            Include to sync build to www.                                                                                            [string]
  --unsafe-partial      Do not clean ./build first.                                                                                             [boolean]
✨  Done in 0.61s.
```

Changes
- Use yargs to document existing options: `pretty`, `sync-fbsource`, `sync-www`, `unsafe-partial`.
- Move `_` arg to `names` option for consistency with other options and discoverability through yargs help
- Add `bundle` option in place of `argv.type` that allows choices of any BundleType to be passed in directly.
