### PR TITLE
[compiler] Add babel-plugin-idx to snap

### DIFF
--- a/compiler/packages/snap/package.json
+++ b/compiler/packages/snap/package.json
@@ -24,6 +24,7 @@
     "@babel/preset-typescript": "^7.18.6",
     "@parcel/watcher": "^2.1.0",
     "@testing-library/react": "^13.4.0",
+    "babel-plugin-idx": "^3.0.3",
     "babel-plugin-syntax-hermes-parser": "^0.15.1",
     "chalk": "4",
     "fbt": "^1.0.0",

--- a/compiler/packages/snap/src/compiler.ts
+++ b/compiler/packages/snap/src/compiler.ts
@@ -250,7 +250,11 @@ function getEvaluatorPresets(
 ): Array<BabelCore.PluginItem> {
   const presets: Array<BabelCore.PluginItem> = [
     {
-      plugins: ['babel-plugin-fbt', 'babel-plugin-fbt-runtime'],
+      plugins: [
+        'babel-plugin-fbt',
+        'babel-plugin-fbt-runtime',
+        'babel-plugin-idx',
+      ],
     },
   ];
   presets.push(
@@ -365,6 +369,7 @@ export async function transformFixtureInput(
       [plugin, options],
       'babel-plugin-fbt',
       'babel-plugin-fbt-runtime',
+      'babel-plugin-idx',
     ],
     sourceType: 'module',
     ast: includeEvaluator,

--- a/compiler/yarn.lock
+++ b/compiler/yarn.lock
@@ -3768,6 +3768,11 @@ babel-plugin-fbt@^1.0.0:
     nullthrows "^1.1.1"
     yargs "^15.3.1"
 
+babel-plugin-idx@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-idx/-/babel-plugin-idx-3.0.3.tgz#326d25772210a40ff7fc63eee7f3ed239e8dc9ed"
+  integrity sha512-05baCoIGsvZJKemq6KQ4KVFlweEpY4aSY56wk3W781JxCNW3u0KfBElBt26/cPZbHkjF1mnwGIOlFY+9I/VOZA==
+
 babel-plugin-istanbul@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30435
* __->__ #30434

To surface any potential conflicts with this plugin, let's install it
into snap so we can surface any runtime errors after compilation