### PR TITLE
Fix resolving of references to deduped props in lazy elements

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -1004,14 +1004,22 @@ function getOutlinedModel<T>(
       for (let i = 1; i < path.length; i++) {
         value = value[path[i]];
         if (value.$$typeof === REACT_LAZY_TYPE) {
-          return waitForReference(
-            value._payload,
-            parentObject,
-            key,
-            response,
-            map,
-            path.slice(i),
-          );
+          const referencedChunk: SomeChunk<any> = value._payload;
+          if (referencedChunk.status === INITIALIZED) {
+            value = referencedChunk.value;
+          } else if (
+            referencedChunk.status === BLOCKED ||
+            referencedChunk.status === PENDING
+          ) {
+            return waitForReference(
+              referencedChunk,
+              parentObject,
+              key,
+              response,
+              map,
+              path.slice(i),
+            );
+          }
         }
       }
       const chunkValue = map(response, value);

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -1003,6 +1003,16 @@ function getOutlinedModel<T>(
       let value = chunk.value;
       for (let i = 1; i < path.length; i++) {
         value = value[path[i]];
+        if (value.$$typeof === REACT_LAZY_TYPE) {
+          return waitForReference(
+            value._payload,
+            parentObject,
+            key,
+            response,
+            map,
+            path.slice(i),
+          );
+        }
       }
       const chunkValue = map(response, value);
       if (__DEV__ && chunk._debugInfo) {

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -827,7 +827,7 @@ function getChunk(response: Response, id: number): SomeChunk<any> {
 }
 
 function waitForReference<T>(
-  referencedChunk: PendingChunk<T> | BlockedChunk<T>,
+  referencedChunk: SomeChunk<T>,
   parentObject: Object,
   key: string,
   response: Response,
@@ -1007,10 +1007,7 @@ function getOutlinedModel<T>(
           const referencedChunk: SomeChunk<any> = value._payload;
           if (referencedChunk.status === INITIALIZED) {
             value = referencedChunk.value;
-          } else if (
-            referencedChunk.status === BLOCKED ||
-            referencedChunk.status === PENDING
-          ) {
+          } else {
             return waitForReference(
               referencedChunk,
               parentObject,


### PR DESCRIPTION
When a model references a deduped object of a blocked element that has subsequently been turned into a lazy element, we need to wait for the lazy element's chunk to resolve before resolving the reference.

Without the fix, the new test failed with the following runtime error:

```
TypeError: Cannot read properties of undefined (reading 'children')
  1003 |       let value = chunk.value;
  1004 |       for (let i = 1; i < path.length; i++) {
> 1005 |         value = value[path[i]];
       |                          ^
  1006 |       }
  1007 |       const chunkValue = map(response, value);
  1008 |       if (__DEV__ && chunk._debugInfo) {

  at getOutlinedModel (packages/react-client/src/ReactFlightClient.js:1005:26)
```

The bug was uncovered after updating React in Next.js in https://github.com/vercel/next.js/pull/66711.