### PR TITLE
Remove allowConcurrentByDefault flag

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -17,7 +17,6 @@ let Scheduler = require('scheduler');
 let act;
 let useEffect;
 let assertLog;
-let waitFor;
 let waitForAll;
 
 describe('ReactDOMRoot', () => {
@@ -36,7 +35,6 @@ describe('ReactDOMRoot', () => {
 
     const InternalTestUtils = require('internal-test-utils');
     assertLog = InternalTestUtils.assertLog;
-    waitFor = InternalTestUtils.waitFor;
     waitForAll = InternalTestUtils.waitForAll;
   });
 
@@ -304,39 +302,6 @@ describe('ReactDOMRoot', () => {
         root.unmount();
       });
     }).rejects.toThrow('The node to be removed is not a child of this node.');
-  });
-
-  it('opts-in to concurrent default updates', async () => {
-    const root = ReactDOMClient.createRoot(container, {
-      unstable_concurrentUpdatesByDefault: true,
-    });
-
-    function Foo({value}) {
-      Scheduler.log(value);
-      return <div>{value}</div>;
-    }
-
-    await act(() => {
-      root.render(<Foo value="a" />);
-    });
-
-    assertLog(['a']);
-    expect(container.textContent).toEqual('a');
-
-    await act(async () => {
-      root.render(<Foo value="b" />);
-
-      assertLog([]);
-      expect(container.textContent).toEqual('a');
-
-      await waitFor(['b']);
-      if (gate(flags => flags.allowConcurrentByDefault)) {
-        expect(container.textContent).toEqual('a');
-      } else {
-        expect(container.textContent).toEqual('b');
-      }
-    });
-    expect(container.textContent).toEqual('b');
   });
 
   it('unmount is synchronous', async () => {

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -16,10 +16,7 @@ import type {
 import {isValidContainer} from 'react-dom-bindings/src/client/ReactDOMContainer';
 import {queueExplicitHydrationTarget} from 'react-dom-bindings/src/events/ReactDOMEventReplaying';
 import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
-import {
-  allowConcurrentByDefault,
-  enableAsyncActions,
-} from 'shared/ReactFeatureFlags';
+import {enableAsyncActions} from 'shared/ReactFeatureFlags';
 
 export type RootType = {
   render(children: ReactNodeList): void,
@@ -29,7 +26,6 @@ export type RootType = {
 
 export type CreateRootOptions = {
   unstable_strictMode?: boolean,
-  unstable_concurrentUpdatesByDefault?: boolean,
   unstable_transitionCallbacks?: TransitionTracingCallbacks,
   identifierPrefix?: string,
   onUncaughtError?: (
@@ -55,7 +51,6 @@ export type HydrateRootOptions = {
   onDeleted?: (suspenseNode: Comment) => void,
   // Options for all roots
   unstable_strictMode?: boolean,
-  unstable_concurrentUpdatesByDefault?: boolean,
   unstable_transitionCallbacks?: TransitionTracingCallbacks,
   identifierPrefix?: string,
   onUncaughtError?: (
@@ -173,8 +168,8 @@ export function createRoot(
 
   warnIfReactDOMContainerInDEV(container);
 
+  const concurrentUpdatesByDefaultOverride = false;
   let isStrictMode = false;
-  let concurrentUpdatesByDefaultOverride = false;
   let identifierPrefix = '';
   let onUncaughtError = defaultOnUncaughtError;
   let onCaughtError = defaultOnCaughtError;
@@ -205,12 +200,6 @@ export function createRoot(
     }
     if (options.unstable_strictMode === true) {
       isStrictMode = true;
-    }
-    if (
-      allowConcurrentByDefault &&
-      options.unstable_concurrentUpdatesByDefault === true
-    ) {
-      concurrentUpdatesByDefaultOverride = true;
     }
     if (options.identifierPrefix !== undefined) {
       identifierPrefix = options.identifierPrefix;
@@ -289,8 +278,8 @@ export function hydrateRoot(
   // the hydration callbacks.
   const hydrationCallbacks = options != null ? options : null;
 
+  const concurrentUpdatesByDefaultOverride = false;
   let isStrictMode = false;
-  let concurrentUpdatesByDefaultOverride = false;
   let identifierPrefix = '';
   let onUncaughtError = defaultOnUncaughtError;
   let onCaughtError = defaultOnCaughtError;
@@ -300,12 +289,6 @@ export function hydrateRoot(
   if (options !== null && options !== undefined) {
     if (options.unstable_strictMode === true) {
       isStrictMode = true;
-    }
-    if (
-      allowConcurrentByDefault &&
-      options.unstable_concurrentUpdatesByDefault === true
-    ) {
-      concurrentUpdatesByDefaultOverride = true;
     }
     if (options.identifierPrefix !== undefined) {
       identifierPrefix = options.identifierPrefix;

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -31,7 +31,6 @@ import {
   enableProfilerTimer,
   enableScopeAPI,
   enableLegacyHidden,
-  allowConcurrentByDefault,
   enableTransitionTracing,
   enableDebugTracing,
   enableDO_NOT_USE_disableStrictPassiveEffect,
@@ -85,7 +84,6 @@ import {
   ProfileMode,
   StrictLegacyMode,
   StrictEffectsMode,
-  ConcurrentUpdatesByDefaultMode,
   NoStrictPassiveEffectsMode,
 } from './ReactTypeOfMode';
 import {
@@ -524,20 +522,12 @@ export function resetWorkInProgress(
 export function createHostRootFiber(
   tag: RootTag,
   isStrictMode: boolean,
-  concurrentUpdatesByDefaultOverride: null | boolean,
 ): Fiber {
   let mode;
   if (disableLegacyMode || tag === ConcurrentRoot) {
     mode = ConcurrentMode;
     if (isStrictMode === true) {
       mode |= StrictLegacyMode | StrictEffectsMode;
-    }
-    if (
-      // Only for internal experiments.
-      allowConcurrentByDefault &&
-      concurrentUpdatesByDefaultOverride
-    ) {
-      mode |= ConcurrentUpdatesByDefaultMode;
     }
   } else {
     mode = NoMode;

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -19,7 +19,6 @@ export type Lane = number;
 export type LaneMap<T> = Array<T>;
 
 import {
-  allowConcurrentByDefault,
   enableRetryLaneExpiration,
   enableSchedulingProfiler,
   enableTransitionTracing,
@@ -29,7 +28,6 @@ import {
   retryLaneExpirationMs,
 } from 'shared/ReactFeatureFlags';
 import {isDevToolsPresent} from './ReactFiberDevToolsHook';
-import {ConcurrentUpdatesByDefaultMode, NoMode} from './ReactTypeOfMode';
 import {clz32} from './clz32';
 
 // Lane values below should be kept in sync with getLabelForLane(), used by react-devtools-timeline.
@@ -287,12 +285,7 @@ export function getNextLanes(root: FiberRoot, wipLanes: Lanes): Lanes {
 export function getEntangledLanes(root: FiberRoot, renderLanes: Lanes): Lanes {
   let entangledLanes = renderLanes;
 
-  if (
-    allowConcurrentByDefault &&
-    (root.current.mode & ConcurrentUpdatesByDefaultMode) !== NoMode
-  ) {
-    // Do nothing, use the lanes as they were assigned.
-  } else if ((entangledLanes & InputContinuousLane) !== NoLanes) {
+  if ((entangledLanes & InputContinuousLane) !== NoLanes) {
     // When updates are sync by default, we entangle continuous priority updates
     // and default updates, so they render in the same batch. The only reason
     // they use separate lanes is because continuous updates should interrupt
@@ -498,13 +491,6 @@ export function includesOnlyTransitions(lanes: Lanes): boolean {
 }
 
 export function includesBlockingLane(root: FiberRoot, lanes: Lanes): boolean {
-  if (
-    allowConcurrentByDefault &&
-    (root.current.mode & ConcurrentUpdatesByDefaultMode) !== NoMode
-  ) {
-    // Concurrent updates by default always use time slicing.
-    return false;
-  }
   const SyncDefaultLanes =
     InputContinuousHydrationLane |
     InputContinuousLane |

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -238,6 +238,7 @@ export function createContainer(
   tag: RootTag,
   hydrationCallbacks: null | SuspenseHydrationCallbacks,
   isStrictMode: boolean,
+  // TODO: Remove `concurrentUpdatesByDefaultOverride`. It is now ignored.
   concurrentUpdatesByDefaultOverride: null | boolean,
   identifierPrefix: string,
   onUncaughtError: (
@@ -266,7 +267,6 @@ export function createContainer(
     initialChildren,
     hydrationCallbacks,
     isStrictMode,
-    concurrentUpdatesByDefaultOverride,
     identifierPrefix,
     onUncaughtError,
     onCaughtError,
@@ -284,6 +284,7 @@ export function createHydrationContainer(
   tag: RootTag,
   hydrationCallbacks: null | SuspenseHydrationCallbacks,
   isStrictMode: boolean,
+  // TODO: Remove `concurrentUpdatesByDefaultOverride`. It is now ignored.
   concurrentUpdatesByDefaultOverride: null | boolean,
   identifierPrefix: string,
   onUncaughtError: (
@@ -312,7 +313,6 @@ export function createHydrationContainer(
     initialChildren,
     hydrationCallbacks,
     isStrictMode,
-    concurrentUpdatesByDefaultOverride,
     identifierPrefix,
     onUncaughtError,
     onCaughtError,

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -147,7 +147,6 @@ export function createFiberRoot(
   initialChildren: ReactNodeList,
   hydrationCallbacks: null | SuspenseHydrationCallbacks,
   isStrictMode: boolean,
-  concurrentUpdatesByDefaultOverride: null | boolean,
   // TODO: We have several of these arguments that are conceptually part of the
   // host config, but because they are passed in at runtime, we have to thread
   // them through the root constructor. Perhaps we should put them all into a
@@ -192,11 +191,7 @@ export function createFiberRoot(
 
   // Cyclic construction. This cheats the type system right now because
   // stateNode is any.
-  const uninitializedFiber = createHostRootFiber(
-    tag,
-    isStrictMode,
-    concurrentUpdatesByDefaultOverride,
-  );
+  const uninitializedFiber = createHostRootFiber(tag, isStrictMode);
   root.current = uninitializedFiber;
   uninitializedFiber.stateNode = root;
 

--- a/packages/react-reconciler/src/ReactTypeOfMode.js
+++ b/packages/react-reconciler/src/ReactTypeOfMode.js
@@ -16,5 +16,4 @@ export const ProfileMode = /*                    */ 0b0000010;
 export const DebugTracingMode = /*               */ 0b0000100;
 export const StrictLegacyMode = /*               */ 0b0001000;
 export const StrictEffectsMode = /*              */ 0b0010000;
-export const ConcurrentUpdatesByDefaultMode = /* */ 0b0100000;
 export const NoStrictPassiveEffectsMode = /*     */ 0b1000000;

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -56,7 +56,6 @@ import {checkPropStringCoercion} from 'shared/CheckStringCoercion';
 import {getPublicInstance} from './ReactFiberConfigTestHost';
 import {ConcurrentRoot, LegacyRoot} from 'react-reconciler/src/ReactRootTags';
 import {
-  allowConcurrentByDefault,
   enableReactTestRendererWarning,
   disableLegacyMode,
 } from 'shared/ReactFeatureFlags';
@@ -70,7 +69,6 @@ type TestRendererOptions = {
   createNodeMock: (element: React$Element<any>) => any,
   unstable_isConcurrent: boolean,
   unstable_strictMode: boolean,
-  unstable_concurrentUpdatesByDefault: boolean,
   ...
 };
 
@@ -486,7 +484,6 @@ function create(
     global.IS_REACT_NATIVE_TEST_ENVIRONMENT !== true;
   let isConcurrent = isConcurrentOnly;
   let isStrictMode = false;
-  let concurrentUpdatesByDefault = null;
   if (typeof options === 'object' && options !== null) {
     if (typeof options.createNodeMock === 'function') {
       // $FlowFixMe[incompatible-type] found when upgrading Flow
@@ -497,12 +494,6 @@ function create(
     }
     if (options.unstable_strictMode === true) {
       isStrictMode = true;
-    }
-    if (allowConcurrentByDefault) {
-      if (options.unstable_concurrentUpdatesByDefault !== undefined) {
-        concurrentUpdatesByDefault =
-          options.unstable_concurrentUpdatesByDefault;
-      }
     }
   }
   let container = {
@@ -515,7 +506,7 @@ function create(
     isConcurrent ? ConcurrentRoot : LegacyRoot,
     null,
     isStrictMode,
-    concurrentUpdatesByDefault,
+    false,
     '',
     defaultOnUncaughtError,
     defaultOnCaughtError,

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -93,7 +93,7 @@ describe('ReactTestRenderer', () => {
         tag,
         null,
         expect.anything(),
-        null,
+        false,
         expect.anything(),
         expect.anything(),
         expect.anything(),

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -217,9 +217,6 @@ export const enableUseDeferredValueInitialArg = true;
 // when we plan to enable them.
 // -----------------------------------------------------------------------------
 
-// Adds an opt-in to time slicing for updates that aren't wrapped in startTransition.
-export const allowConcurrentByDefault = false;
-
 // -----------------------------------------------------------------------------
 // React DOM Chopping Block
 //

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -27,7 +27,6 @@ export const {
 } = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.
-export const allowConcurrentByDefault = false;
 export const consoleManagedByDevToolsDuringStrictMode = true;
 export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 export const disableClientCache = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -19,7 +19,6 @@ export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 // -----------------------------------------------------------------------------
 // All other flags
 // -----------------------------------------------------------------------------
-export const allowConcurrentByDefault = false;
 export const alwaysThrottleRetries = false;
 export const consoleManagedByDevToolsDuringStrictMode = true;
 export const disableClientCache = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -53,7 +53,6 @@ export const transitionLaneExpirationMs = 5000;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
 export const enableLegacyHidden = false;
-export const allowConcurrentByDefault = false;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -10,7 +10,6 @@
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as ExportsType from './ReactFeatureFlags.test-renderer';
 
-export const allowConcurrentByDefault = true;
 export const alwaysThrottleRetries = false;
 export const consoleManagedByDevToolsDuringStrictMode = false;
 export const debugRenderPhaseSideEffectsForStrictMode = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -56,7 +56,6 @@ export const transitionLaneExpirationMs = 5000;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
 export const enableLegacyHidden = false;
-export const allowConcurrentByDefault = true;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -96,8 +96,6 @@ export const enableRefAsProp = true;
 
 export const disableTextareaChildren = __EXPERIMENTAL__;
 
-export const allowConcurrentByDefault = true;
-
 export const consoleManagedByDevToolsDuringStrictMode = true;
 
 export const enableFizzExternalRuntime = true;


### PR DESCRIPTION
Following https://github.com/facebook/react/pull/30436

Concurrent by default strategy has been unshipped. Here we clean up the `allowConcurrentByDefault` path and related logic/tests.

For now, this keeps the `concurrentUpdatesByDefaultOverride` argument in `createContainer` and `createHydrationContainer` and ignores the value to prevent more breaking changes to `react-reconciler` in the RC stage.