### PR TITLE
[compiler] Correctly insert (Arrow)FunctionExpressions

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -230,33 +230,21 @@ function insertNewFunctionNode(
         reason: 'Expected compiled function to have an identifier',
         loc: null,
       });
-      CompilerError.invariant(originalFn.parentPath.isVariableDeclarator(), {
-        reason: 'Expected a variable declarator parent',
-        loc: null,
-      });
+      CompilerError.invariant(
+        originalFn.parentPath.isVariableDeclarator() &&
+          originalFn.parentPath.parentPath.isVariableDeclaration(),
+        {
+          reason: 'Expected a variable declarator parent',
+          loc: null,
+        },
+      );
       const varDecl = originalFn.parentPath.parentPath;
       varDecl.insertAfter(
         t.variableDeclaration('const', [
           t.variableDeclarator(compiledFn.id, funcExpr),
         ]),
       );
-      CompilerError.invariant(typeof varDecl.key === 'number', {
-        reason:
-          'Just Babel things: expected the VariableDeclaration containing the compiled function expression to have a number key',
-        loc: null,
-      });
-      const insertedCompiledFnVarDecl = varDecl.getSibling(varDecl.key + 1);
-      CompilerError.invariant(
-        insertedCompiledFnVarDecl.isVariableDeclaration(),
-        {
-          reason: 'Expected inserted sibling to be a VariableDeclaration',
-          loc: null,
-        },
-      );
-      // safety: we synthesized it above, no need to check again
-      const insertedFuncExpr = insertedCompiledFnVarDecl
-        .get('declarations')[0]!
-        .get('init')!;
+      const insertedFuncExpr = varDecl.get('declarations')[0]!.get('init')!;
       CompilerError.invariant(
         insertedFuncExpr.isArrowFunctionExpression() ||
           insertedFuncExpr.isFunctionExpression(),

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -223,19 +223,19 @@ function insertNewFunctionNode(
         {
           reason: 'Expected an (arrow) function expression to be created',
           description: `Got: ${funcExpr.type}`,
-          loc: null,
+          loc: funcExpr.loc ?? null,
         },
       );
       CompilerError.invariant(compiledFn.id != null, {
         reason: 'Expected compiled function to have an identifier',
-        loc: null,
+        loc: compiledFn.loc,
       });
       CompilerError.invariant(
         originalFn.parentPath.isVariableDeclarator() &&
           originalFn.parentPath.parentPath.isVariableDeclaration(),
         {
           reason: 'Expected a variable declarator parent',
-          loc: null,
+          loc: originalFn.node.loc ?? null,
         },
       );
       const varDecl = originalFn.parentPath.parentPath;
@@ -251,7 +251,7 @@ function insertNewFunctionNode(
         {
           reason: 'Expected inserted (arrow) function expression',
           description: `Got: ${insertedFuncExpr}`,
-          loc: null,
+          loc: insertedFuncExpr.node?.loc ?? null,
         },
       );
       return insertedFuncExpr;

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -239,7 +239,7 @@ function insertNewFunctionNode(
         t.variableDeclaration('const', [
           t.variableDeclarator(compiledFn.id, funcExpr),
         ]),
-      )[0]!;
+      );
       CompilerError.invariant(typeof varDecl.key === 'number', {
         reason:
           'Just Babel things: expected the VariableDeclaration containing the compiled function expression to have a number key',
@@ -253,6 +253,7 @@ function insertNewFunctionNode(
           loc: null,
         },
       );
+      // safety: we synthesized it above, no need to check again
       const insertedFuncExpr = insertedCompiledFnVarDecl
         .get('declarations')[0]!
         .get('init')!;

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -184,10 +184,10 @@ export function createNewFunctionNode(
       break;
     }
     default: {
-      // @ts-ignore
-      console.log(originalFn.node.type);
-      // @ts-ignore
-      throw new Error(originalFn.toString());
+      assertExhaustive(
+        originalFn.node,
+        `Creating unhandled function: ${originalFn.node}`,
+      );
     }
   }
   // Avoid visiting the new transformed version

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bug-outlining-in-func-expr.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bug-outlining-in-func-expr.js
@@ -1,9 +1,0 @@
-const Component2 = props => {
-  return (
-    <ul>
-      {props.items.map(item => (
-        <li key={item.id}>{item.name}</li>
-      ))}
-    </ul>
-  );
-};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outlining-in-func-expr.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outlining-in-func-expr.expect.md
@@ -2,7 +2,6 @@
 ## Input
 
 ```javascript
-// @debug
 const Component2 = props => {
   return (
     <ul>
@@ -18,7 +17,7 @@ const Component2 = props => {
 ## Code
 
 ```javascript
-import { c as _c } from "react/compiler-runtime"; // @debug
+import { c as _c } from "react/compiler-runtime";
 const Component2 = (props) => {
   const $ = _c(4);
   let t0;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outlining-in-func-expr.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outlining-in-func-expr.expect.md
@@ -1,0 +1,49 @@
+
+## Input
+
+```javascript
+// @debug
+const Component2 = props => {
+  return (
+    <ul>
+      {props.items.map(item => (
+        <li key={item.id}>{item.name}</li>
+      ))}
+    </ul>
+  );
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @debug
+const Component2 = (props) => {
+  const $ = _c(4);
+  let t0;
+  if ($[0] !== props.items) {
+    t0 = props.items.map(_temp);
+    $[0] = props.items;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  let t1;
+  if ($[2] !== t0) {
+    t1 = <ul>{t0}</ul>;
+    $[2] = t0;
+    $[3] = t1;
+  } else {
+    t1 = $[3];
+  }
+  return t1;
+};
+const _temp = (item) => {
+  return <li key={item.id}>{item.name}</li>;
+};
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outlining-in-func-expr.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outlining-in-func-expr.expect.md
@@ -12,6 +12,18 @@ const Component2 = props => {
   );
 };
 
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component2,
+  params: [
+    {
+      items: [
+        {id: 2, name: 'foo'},
+        {id: 3, name: 'bar'},
+      ],
+    },
+  ],
+};
+
 ```
 
 ## Code
@@ -42,7 +54,19 @@ const _temp = (item) => {
   return <li key={item.id}>{item.name}</li>;
 };
 
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component2,
+  params: [
+    {
+      items: [
+        { id: 2, name: "foo" },
+        { id: 3, name: "bar" },
+      ],
+    },
+  ],
+};
+
 ```
       
 ### Eval output
-(kind: exception) Fixture not implemented
+(kind: ok) <ul><li>foo</li><li>bar</li></ul>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outlining-in-func-expr.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outlining-in-func-expr.js
@@ -1,7 +1,4 @@
-
-## Input
-
-```javascript
+// @debug
 const Component2 = props => {
   return (
     <ul>
@@ -11,14 +8,3 @@ const Component2 = props => {
     </ul>
   );
 };
-
-```
-
-
-## Error
-
-```
-Invalid value used in weak set
-```
-          
-      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outlining-in-func-expr.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outlining-in-func-expr.js
@@ -1,4 +1,3 @@
-// @debug
 const Component2 = props => {
   return (
     <ul>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outlining-in-func-expr.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outlining-in-func-expr.js
@@ -7,3 +7,15 @@ const Component2 = props => {
     </ul>
   );
 };
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component2,
+  params: [
+    {
+      items: [
+        {id: 2, name: 'foo'},
+        {id: 3, name: 'bar'},
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30446
* #30443

Previously we would insert new (Arrow)FunctionExpressions as a sibling
of the original function. However this would break in the outlining case
as it would cause the original function expression's parent to become a
SequenceExpression, breaking a bunch of assumptions in the babel plugin.

To get around this, we synthesize a new VariableDeclaration to contain
the newly inserted function expression and therefore insert it as a true
sibling to the original function.

Yeah, it's kinda gross