### PR TITLE
[Flight] Add filterStackFrame options to the RSC Server

### DIFF
--- a/packages/react-html/src/ReactHTMLServer.js
+++ b/packages/react-html/src/ReactHTMLServer.js
@@ -168,6 +168,7 @@ export function renderToMarkup(
       handleFlightError,
       options ? options.identifierPrefix : undefined,
       undefined,
+      undefined,
       'Markup',
       undefined,
     );

--- a/packages/react-noop-renderer/src/ReactNoopFlightServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightServer.js
@@ -68,6 +68,7 @@ const ReactNoopFlightServer = ReactFlightServer({
 
 type Options = {
   environmentName?: string | (() => string),
+  filterStackFrame?: (url: string, functionName: string) => boolean,
   identifierPrefix?: string,
   onError?: (error: mixed) => void,
   onPostpone?: (reason: string) => void,
@@ -82,7 +83,9 @@ function render(model: ReactClientValue, options?: Options): Destination {
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
-    options ? options.environmentName : undefined,
+    undefined,
+    __DEV__ && options ? options.environmentName : undefined,
+    __DEV__ && options ? options.filterStackFrame : undefined,
   );
   ReactNoopFlightServer.startWork(request);
   ReactNoopFlightServer.startFlowing(request, destination);

--- a/packages/react-server-dom-esm/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-esm/src/ReactFlightDOMServerNode.js
@@ -66,6 +66,7 @@ function createCancelHandler(request: Request, reason: string) {
 
 type Options = {
   environmentName?: string | (() => string),
+  filterStackFrame?: (url: string, functionName: string) => boolean,
   onError?: (error: mixed) => void,
   onPostpone?: (reason: string) => void,
   identifierPrefix?: string,
@@ -88,8 +89,9 @@ function renderToPipeableStream(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
-    options ? options.environmentName : undefined,
     options ? options.temporaryReferences : undefined,
+    __DEV__ && options ? options.environmentName : undefined,
+    __DEV__ && options ? options.filterStackFrame : undefined,
   );
   let hasStartedFlowing = false;
   startWork(request);

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMServerBrowser.js
@@ -45,6 +45,7 @@ export type {TemporaryReferenceSet};
 
 type Options = {
   environmentName?: string | (() => string),
+  filterStackFrame?: (url: string, functionName: string) => boolean,
   identifierPrefix?: string,
   signal?: AbortSignal,
   temporaryReferences?: TemporaryReferenceSet,
@@ -63,8 +64,9 @@ function renderToReadableStream(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
-    options ? options.environmentName : undefined,
     options ? options.temporaryReferences : undefined,
+    __DEV__ && options ? options.environmentName : undefined,
+    __DEV__ && options ? options.filterStackFrame : undefined,
   );
   if (options && options.signal) {
     const signal = options.signal;

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMServerEdge.js
@@ -45,6 +45,7 @@ export type {TemporaryReferenceSet};
 
 type Options = {
   environmentName?: string | (() => string),
+  filterStackFrame?: (url: string, functionName: string) => boolean,
   identifierPrefix?: string,
   signal?: AbortSignal,
   temporaryReferences?: TemporaryReferenceSet,
@@ -63,8 +64,9 @@ function renderToReadableStream(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
-    options ? options.environmentName : undefined,
     options ? options.temporaryReferences : undefined,
+    __DEV__ && options ? options.environmentName : undefined,
+    __DEV__ && options ? options.filterStackFrame : undefined,
   );
   if (options && options.signal) {
     const signal = options.signal;

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMServerNode.js
@@ -67,6 +67,7 @@ function createCancelHandler(request: Request, reason: string) {
 
 type Options = {
   environmentName?: string | (() => string),
+  filterStackFrame?: (url: string, functionName: string) => boolean,
   onError?: (error: mixed) => void,
   onPostpone?: (reason: string) => void,
   identifierPrefix?: string,
@@ -89,8 +90,9 @@ function renderToPipeableStream(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
-    options ? options.environmentName : undefined,
     options ? options.temporaryReferences : undefined,
+    __DEV__ && options ? options.environmentName : undefined,
+    __DEV__ && options ? options.filterStackFrame : undefined,
   );
   let hasStartedFlowing = false;
   startWork(request);

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -45,6 +45,7 @@ export type {TemporaryReferenceSet};
 
 type Options = {
   environmentName?: string | (() => string),
+  filterStackFrame?: (url: string, functionName: string) => boolean,
   identifierPrefix?: string,
   signal?: AbortSignal,
   temporaryReferences?: TemporaryReferenceSet,
@@ -63,8 +64,9 @@ function renderToReadableStream(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
-    options ? options.environmentName : undefined,
     options ? options.temporaryReferences : undefined,
+    __DEV__ && options ? options.environmentName : undefined,
+    __DEV__ && options ? options.filterStackFrame : undefined,
   );
   if (options && options.signal) {
     const signal = options.signal;

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
@@ -45,6 +45,7 @@ export type {TemporaryReferenceSet};
 
 type Options = {
   environmentName?: string | (() => string),
+  filterStackFrame?: (url: string, functionName: string) => boolean,
   identifierPrefix?: string,
   signal?: AbortSignal,
   temporaryReferences?: TemporaryReferenceSet,
@@ -63,8 +64,9 @@ function renderToReadableStream(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
-    options ? options.environmentName : undefined,
     options ? options.temporaryReferences : undefined,
+    __DEV__ && options ? options.environmentName : undefined,
+    __DEV__ && options ? options.filterStackFrame : undefined,
   );
   if (options && options.signal) {
     const signal = options.signal;

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -67,6 +67,7 @@ function createCancelHandler(request: Request, reason: string) {
 
 type Options = {
   environmentName?: string | (() => string),
+  filterStackFrame?: (url: string, functionName: string) => boolean,
   onError?: (error: mixed) => void,
   onPostpone?: (reason: string) => void,
   identifierPrefix?: string,
@@ -89,8 +90,9 @@ function renderToPipeableStream(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.onPostpone : undefined,
-    options ? options.environmentName : undefined,
     options ? options.temporaryReferences : undefined,
+    __DEV__ && options ? options.environmentName : undefined,
+    __DEV__ && options ? options.filterStackFrame : undefined,
   );
   let hasStartedFlowing = false;
   startWork(request);


### PR DESCRIPTION
This lets you customize the filter, for example allowing node_modules or filter out additional functions that you don't want to include when sending the stack to the client.

Notably this doesn't filter out Server Components out of the parent stack. Those are just like a view of the tree by name. Not virtual stack frames.
