### PR TITLE
Use brackets instead of parenthesis in empty name eval

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -1955,7 +1955,7 @@ function createFakeFunction<T>(
 
   if (!name) {
     // An eval:ed function with no name gets the name "eval". We give it something more descriptive.
-    name = '(anonymous)';
+    name = '<anonymous>';
   }
   const encodedName = JSON.stringify(name);
   // We generate code where the call is at the line and column of the server executed code.

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -1285,8 +1285,8 @@ describe('ReactFlight', () => {
                   'Error: This is an error\n' +
                     '    at eval (eval at testFunction (eval at createFakeFunction (**), <anonymous>:1:35)\n' +
                     '    at ServerComponentError (file://~/(some)(really)(exotic-directory)/ReactFlight-test.js:1166:19)\n' +
-                    '    at (anonymous) (file:///testing.js:42:3)\n' +
-                    '    at (anonymous) (file:///testing.js:42:3)\n',
+                    '    at <anonymous> (file:///testing.js:42:3)\n' +
+                    '    at <anonymous> (file:///testing.js:42:3)\n',
                 )
               : expect.stringContaining(
                   'Error: This is an error\n' +


### PR DESCRIPTION
Otherwise V8 will parse it as a URL and mess it up. The bracket is a magic string meaning empty.