### PR TITLE
Fix existing usage of names/type in build command

### DIFF
--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -80,16 +80,12 @@ const argv = yargs.wrap(yargs.terminalWidth()).options({
     type: 'choices',
     choices: ['circleci', 'github'],
   },
-  bundle: {
-    describe: 'Build the given bundle type.',
+  type: {
+    describe: `Build the given bundle type. (${Object.values(
+      Bundles.bundleTypes
+    )})`,
     requiresArg: false,
-    type: 'choices',
-    choices: [...Object.values(Bundles.bundleTypes)],
-  },
-  names: {
-    describe: 'Build for matched bundle names. Example: "react-test,index.js".',
-    requiresArg: false,
-    type: 'array',
+    type: 'string',
   },
   pretty: {
     describe: 'Force pretty output.',

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -84,11 +84,15 @@ function parseRequestedNames(names, toCase) {
   }
   return result;
 }
-const argvType = Array.isArray(argv.bundle) ? argv.bundle : [argv.bundle];
-const requestedBundleTypes = argv.bundle ? argvType : [];
+const argvType = Array.isArray(argv.type) ? argv.type : [argv.type];
+const requestedBundleTypes = parseRequestedNames(
+  argv.type ? argvType : [],
+  'uppercase'
+);
 
+const names = argv._;
 const requestedBundleNames = parseRequestedNames(
-  argv.names ? argv.names : [],
+  names ? names : [],
   'lowercase'
 );
 const forcePrettyOutput = argv.pretty;


### PR DESCRIPTION
https://github.com/facebook/react/pull/30422 broke existing build shortcuts.

Revert the usage of `names` (`_`) and `type` args.

`yarn build-for-devtools` / `yarn build-for-devtools-dev` / `yarn build-for-devtools-prod` should all work again.

Moved the bundleType documentation into description so they can be fuzzy matched. But a build like `yarn build --type FB_WWW_PROD` still works when matched exactly.

There's probably a better way to document the positional `names` arg in the `--help` command, but didn't see it when browsing the yargs docs so let's just fix the existing builds for now.

Now:

```
% yarn build --help
yarn run v1.22.19
$ node ./scripts/rollup/build-all-release-channels.js --help
Options:
  --help                Show help                                                                                                                                             [boolean]
  --version             Show version number                                                                                                                                   [boolean]
  --releaseChannel, -r  Build the given release channel.                                                                                   [string] [choices: "experimental", "stable"]
  --index, -i           Worker id.                                                                                                                                             [number]
  --total, -t           Total number of workers.                                                                                                                               [number]
  --ci                  Run tests in CI                                                                                                                 [choices: "circleci", "github"]
  --type                Build the given bundle type. (NODE_ES2015,ESM_DEV,ESM_PROD,NODE_DEV,NODE_PROD,NODE_PROFILING,BUN_DEV,BUN_PROD,FB_WWW_DEV,FB_WWW_PROD,FB_WWW_PROFILING,RN_OSS_DE
                        V,RN_OSS_PROD,RN_OSS_PROFILING,RN_FB_DEV,RN_FB_PROD,RN_FB_PROFILING,BROWSER_SCRIPT)                                                                    [string]
  --pretty              Force pretty output.                                                                                                                                  [boolean]
  --sync-fbsource       Include to sync build to fbsource.                                                                                                                     [string]
  --sync-www            Include to sync build to www.                                                                                                                          [string]
  --unsafe-partial      Do not clean ./build first.     
```
