### PR TITLE
Configure the requested environment and annotate tasks at boundary between environments

### DIFF
--- a/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
@@ -65,6 +65,7 @@ function read<T>(source: Source, options: ReadOptions): Thenable<T> {
     undefined,
     options !== undefined ? options.findSourceMapURL : undefined,
     true,
+    undefined,
   );
   for (let i = 0; i < source.length; i++) {
     processBinaryChunk(response, source[i], 0);

--- a/packages/react-server-dom-esm/src/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-esm/src/ReactFlightDOMClientBrowser.js
@@ -43,6 +43,7 @@ export type Options = {
   temporaryReferences?: TemporaryReferenceSet,
   findSourceMapURL?: FindSourceMapURLCallback,
   replayConsoleLogs?: boolean,
+  environmentName?: string,
 };
 
 function createResponseFromOptions(options: void | Options) {
@@ -59,6 +60,9 @@ function createResponseFromOptions(options: void | Options) {
       ? options.findSourceMapURL
       : undefined,
     __DEV__ ? (options ? options.replayConsoleLogs !== false : true) : false, // defaults to true
+    __DEV__ && options && options.environmentName
+      ? options.environmentName
+      : undefined,
   );
 }
 

--- a/packages/react-server-dom-esm/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-esm/src/ReactFlightDOMClientNode.js
@@ -51,6 +51,7 @@ export type Options = {
   encodeFormAction?: EncodeFormActionCallback,
   findSourceMapURL?: FindSourceMapURLCallback,
   replayConsoleLogs?: boolean,
+  environmentName?: string,
 };
 
 function createFromNodeStream<T>(
@@ -70,6 +71,9 @@ function createFromNodeStream<T>(
       ? options.findSourceMapURL
       : undefined,
     __DEV__ && options ? options.replayConsoleLogs === true : false, // defaults to false
+    __DEV__ && options && options.environmentName
+      ? options.environmentName
+      : undefined,
   );
   stream.on('data', chunk => {
     processBinaryChunk(response, chunk);

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMClientBrowser.js
@@ -42,6 +42,7 @@ export type Options = {
   temporaryReferences?: TemporaryReferenceSet,
   findSourceMapURL?: FindSourceMapURLCallback,
   replayConsoleLogs?: boolean,
+  environmentName?: string,
 };
 
 function createResponseFromOptions(options: void | Options) {
@@ -58,6 +59,9 @@ function createResponseFromOptions(options: void | Options) {
       ? options.findSourceMapURL
       : undefined,
     __DEV__ ? (options ? options.replayConsoleLogs !== false : true) : false, // defaults to true
+    __DEV__ && options && options.environmentName
+      ? options.environmentName
+      : undefined,
   );
 }
 

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMClientEdge.js
@@ -72,6 +72,7 @@ export type Options = {
   temporaryReferences?: TemporaryReferenceSet,
   findSourceMapURL?: FindSourceMapURLCallback,
   replayConsoleLogs?: boolean,
+  environmentName?: string,
 };
 
 function createResponseFromOptions(options: Options) {
@@ -88,6 +89,9 @@ function createResponseFromOptions(options: Options) {
       ? options.findSourceMapURL
       : undefined,
     __DEV__ && options ? options.replayConsoleLogs === true : false, // defaults to false
+    __DEV__ && options && options.environmentName
+      ? options.environmentName
+      : undefined,
   );
 }
 

--- a/packages/react-server-dom-turbopack/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightDOMClientNode.js
@@ -61,6 +61,7 @@ export type Options = {
   encodeFormAction?: EncodeFormActionCallback,
   findSourceMapURL?: FindSourceMapURLCallback,
   replayConsoleLogs?: boolean,
+  environmentName?: string,
 };
 
 function createFromNodeStream<T>(
@@ -79,6 +80,9 @@ function createFromNodeStream<T>(
       ? options.findSourceMapURL
       : undefined,
     __DEV__ && options ? options.replayConsoleLogs === true : false, // defaults to false
+    __DEV__ && options && options.environmentName
+      ? options.environmentName
+      : undefined,
   );
   stream.on('data', chunk => {
     processBinaryChunk(response, chunk);

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js
@@ -42,6 +42,7 @@ export type Options = {
   temporaryReferences?: TemporaryReferenceSet,
   findSourceMapURL?: FindSourceMapURLCallback,
   replayConsoleLogs?: boolean,
+  environmentName?: string,
 };
 
 function createResponseFromOptions(options: void | Options) {
@@ -58,6 +59,9 @@ function createResponseFromOptions(options: void | Options) {
       ? options.findSourceMapURL
       : undefined,
     __DEV__ ? (options ? options.replayConsoleLogs !== false : true) : false, // defaults to true
+    __DEV__ && options && options.environmentName
+      ? options.environmentName
+      : undefined,
   );
 }
 

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
@@ -72,6 +72,7 @@ export type Options = {
   temporaryReferences?: TemporaryReferenceSet,
   findSourceMapURL?: FindSourceMapURLCallback,
   replayConsoleLogs?: boolean,
+  environmentName?: string,
 };
 
 function createResponseFromOptions(options: Options) {
@@ -88,6 +89,9 @@ function createResponseFromOptions(options: Options) {
       ? options.findSourceMapURL
       : undefined,
     __DEV__ && options ? options.replayConsoleLogs === true : false, // defaults to false
+    __DEV__ && options && options.environmentName
+      ? options.environmentName
+      : undefined,
   );
 }
 

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClientNode.js
@@ -62,6 +62,7 @@ export type Options = {
   encodeFormAction?: EncodeFormActionCallback,
   findSourceMapURL?: FindSourceMapURLCallback,
   replayConsoleLogs?: boolean,
+  environmentName?: string,
 };
 
 function createFromNodeStream<T>(
@@ -80,6 +81,9 @@ function createFromNodeStream<T>(
       ? options.findSourceMapURL
       : undefined,
     __DEV__ && options ? options.replayConsoleLogs === true : false, // defaults to false
+    __DEV__ && options && options.environmentName
+      ? options.environmentName
+      : undefined,
   );
   stream.on('data', chunk => {
     if (typeof chunk === 'string') {


### PR DESCRIPTION
This enables configuring the name of the requested environment.

When we currently use createTask, we start with a `"use server"` annotation. This option basically configures that string.

I now also deal with the case when switching environments along the owner path. If you go from `"Third Party"` to `"Server"` to `"Client"`, it'll have a task named `"use third party"` at the root, then `"use server"` and then finally `"use client"`.

We don't really have the concept of a Server Component making a request during render to then create another Server Component. Really the inner one should conceptually have the first one as its owner in that case. So currently the inner one will always have a null owner. We could somehow connect them in this server-to-server case.

We don't currently have a way to configure the `"use client"` option but I figured maybe that could be inferred by the server environment that the Flight Client is executed within.

Note: We did talk before about annotating each stack frame with the environment. You can effectively do that manually when parsing `rsc://React/{environment}/` from `captureOwnerStack`. However, we can't do that natively. At least not without deeper integration. Because it's the source map that's responsible for the actual function name of each stack frame - not what we give it at runtime. So for the native stacks, the task showing the change in environment is more practical.