### PR TITLE
[compiler] Add tests for incorrect global mutation detection

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.object-capture-global-mutation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.object-capture-global-mutation.expect.md
@@ -1,0 +1,33 @@
+
+## Input
+
+```javascript
+function Foo() {
+  const x = () => {
+    window.href = "foo";
+  };
+  const y = { x };
+  return <Bar y={y} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+};
+
+```
+
+
+## Error
+
+```
+  1 | function Foo() {
+  2 |   const x = () => {
+> 3 |     window.href = "foo";
+    |     ^^^^^^ InvalidReact: Writing to a variable defined outside a component or hook is not allowed. Consider using an effect (3:3)
+  4 |   };
+  5 |   const y = { x };
+  6 |   return <Bar y={y} />;
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.object-capture-global-mutation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.object-capture-global-mutation.expect.md
@@ -4,9 +4,9 @@
 ```javascript
 function Foo() {
   const x = () => {
-    window.href = "foo";
+    window.href = 'foo';
   };
-  const y = { x };
+  const y = {x};
   return <Bar y={y} />;
 }
 
@@ -23,10 +23,10 @@ export const FIXTURE_ENTRYPOINT = {
 ```
   1 | function Foo() {
   2 |   const x = () => {
-> 3 |     window.href = "foo";
+> 3 |     window.href = 'foo';
     |     ^^^^^^ InvalidReact: Writing to a variable defined outside a component or hook is not allowed. Consider using an effect (3:3)
   4 |   };
-  5 |   const y = { x };
+  5 |   const y = {x};
   6 |   return <Bar y={y} />;
 ```
           

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.object-capture-global-mutation.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.object-capture-global-mutation.js
@@ -1,0 +1,12 @@
+function Foo() {
+  const x = () => {
+    window.href = "foo";
+  };
+  const y = { x };
+  return <Bar y={y} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.object-capture-global-mutation.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.object-capture-global-mutation.js
@@ -1,8 +1,8 @@
 function Foo() {
   const x = () => {
-    window.href = "foo";
+    window.href = 'foo';
   };
-  const y = { x };
+  const y = {x};
   return <Bar y={y} />;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30458
* #30457
* __->__ #30456

If a function expression that mutates a global is passed as a prop,
we don't throw an error as we assume it's not called in render.

But if this function expression is captured in an object and passed down
as prop, we throw an error.