### PR TITLE
[compiler] Always emit FuncDecl for outlined functions

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outlining-in-func-expr.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outlining-in-func-expr.expect.md
@@ -50,9 +50,9 @@ const Component2 = (props) => {
   }
   return t1;
 };
-const _temp = (item) => {
+function _temp(item) {
   return <li key={item.id}>{item.name}</li>;
-};
+}
 
 export const FIXTURE_ENTRYPOINT = {
   fn: Component2,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30466
* #30465
* __->__ #30464

Addresses follow up feedback from #30446. Since the outlined function is
guaranteed to have a module-scoped unique identifier name, we can
simplify the insertion logic for the outlined function to always emit a
function declaration rather than switch based on the original function
type. This is fine because the outlined function is synthetic anyway.