### PR TITLE
[ci] Cleanup run_devtools_e2e_tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,24 +124,6 @@ jobs:
           path: ./build/devtools/firefox-extension.zip
           destination: react-devtools-firefox-extension.zip
 
-  run_devtools_e2e_tests:
-    docker: *docker
-    environment: *environment
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - setup_node_modules
-      - run:
-          name: Playwright install deps
-          command: |
-            npx playwright install
-            sudo npx playwright install-deps
-      - run:
-          environment:
-            RELEASE_CHANNEL: experimental
-          command: ./scripts/circleci/run_devtools_e2e_tests.js
-
   run_devtools_tests_for_versions:
     docker: *docker
     environment: *environment


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30467

This was only used for build_and_test which has since been migrated to
gh actions and is now therefore unused. Looks like I missed this during
the previous cleanup.