### PR TITLE
[circleci] Combine yarn_build and process_artifacts_combined

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,27 +48,13 @@ parameters:
     default: ''
 
 jobs:
-  yarn_build:
-    docker: *docker
-    environment: *environment
-    parallelism: 40
-    steps:
-      - checkout
-      - setup_node_modules
-      - run: yarn build --ci=circleci
-      - persist_to_workspace:
-          root: .
-          paths:
-            - build
-
   process_artifacts_combined:
     docker: *docker
     environment: *environment
     steps:
       - checkout
-      - attach_workspace:
-          at: .
       - setup_node_modules
+      - run: yarn build --ci=circleci
       - run: echo "<< pipeline.git.revision	>>" >> build/COMMIT_SHA
       - run: |
           mkdir -p ./build/__test_utils__
@@ -109,14 +95,11 @@ workflows:
   build_and_test:
     unless: << pipeline.parameters.prerelease_commit_sha >>
     jobs:
-      - yarn_build:
+      - process_artifacts_combined:
           filters:
             branches:
               ignore:
                 - builds/facebook-www
-      - process_artifacts_combined:
-          requires:
-            - yarn_build
 
   # Used to publish a prerelease manually via the command line
   publish_preleases:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30469

Now that process_artifacts_combined is the only job requiring this step,
we can combine them to speed up what's left in circleci by removing the
need for spinning up a new ci worker. There's still a bit more left to
go before we can fully remove circle so let's speed up what we have now.