### PR TITLE
[compiler] Add git info to `package.json` files in compiler packages

### DIFF
--- a/compiler/package.json
+++ b/compiler/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-forget.git"
+    "url": "git+https://github.com/facebook/react.git"
   },
   "scripts": {
     "copyright": "node scripts/copyright.js",

--- a/compiler/packages/babel-plugin-react-compiler/package.json
+++ b/compiler/packages/babel-plugin-react-compiler/package.json
@@ -63,5 +63,10 @@
     "@babel/core": "7.2.0",
     "@babel/generator": "7.2.0",
     "@babel/traverse": "7.7.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebook/react.git",
+    "directory": "compiler/packages/babel-plugin-react-compiler"
   }
 }

--- a/compiler/packages/eslint-plugin-react-compiler/package.json
+++ b/compiler/packages/eslint-plugin-react-compiler/package.json
@@ -35,5 +35,10 @@
   "peerDependencies": {
     "eslint": ">=7"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebook/react.git",
+    "directory": "compiler/packages/eslint-plugin-react-compiler"
+  },
   "license": "MIT"
 }

--- a/compiler/packages/make-read-only-util/package.json
+++ b/compiler/packages/make-read-only-util/package.json
@@ -19,5 +19,10 @@
     "jest": "^28.1.3",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.9.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebook/react.git",
+    "directory": "compiler/packages/make-read-only-util"
   }
 }

--- a/compiler/packages/react-compiler-healthcheck/package.json
+++ b/compiler/packages/react-compiler-healthcheck/package.json
@@ -23,5 +23,10 @@
   "engines": {
     "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebook/react.git",
+    "directory": "compiler/packages/react-compiler-healthcheck"
+  }
 }

--- a/compiler/packages/react-compiler-runtime/package.json
+++ b/compiler/packages/react-compiler-runtime/package.json
@@ -14,5 +14,10 @@
   "scripts": {
     "build": "rimraf dist && rollup --config --bundleConfigAsCjs",
     "test": "echo 'no tests'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebook/react.git",
+    "directory": "compiler/packages/react-compiler-runtime"
   }
 }

--- a/compiler/packages/snap/package.json
+++ b/compiler/packages/snap/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react-forget.git"
+    "url": "git+https://github.com/facebook/react.git",
+    "directory": "compiler/packages/snap"
   },
   "dependencies": {
     "@babel/code-frame": "^7.22.5",


### PR DESCRIPTION
This PR adds the repository field to `compiler/packages/*/package.json`

| eslint-plugin-react-compiler | eslint-plugin-react-hooks |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/3392a496-1ff1-4f36-ab96-cfbe1ed88693) | ![image](https://github.com/user-attachments/assets/b0605dba-eef7-44fe-9484-979b4814d9fb) |
