### PR TITLE
[ci] Remove need for GitHub token

### DIFF
--- a/scripts/release/download-experimental-build-ghaction.js
+++ b/scripts/release/download-experimental-build-ghaction.js
@@ -51,7 +51,6 @@ const REPO = 'react';
 const WORKFLOW_ID = 'runtime_build_and_test.yml';
 const GITHUB_HEADERS = `
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer ${process.env.GH_TOKEN}" \
   -H "X-GitHub-Api-Version: 2022-11-28"`.trim();
 
 function getWorkflowId() {
@@ -170,12 +169,5 @@ const main = async () => {
     handleError(error);
   }
 };
-
-if (process.env.GH_TOKEN == null) {
-  console.log(
-    theme`{error Expected GH_TOKEN to be provided as an env variable}`
-  );
-  process.exit(1);
-}
 
 main();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30481
* #30485
* #30484
* __->__ #30482

React is a public repo so no token is needed.