### PR TITLE
[Fizz] Prerender fallbacks before children

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticNode-test.js
@@ -111,9 +111,7 @@ describe('ReactDOMFizzStaticNode', () => {
 
     const result = await resultPromise;
     const prelude = await readContent(result.prelude);
-    expect(prelude).toMatchInlineSnapshot(
-      `"<div><!--$-->Done<!-- --><!--/$--></div>"`,
-    );
+    expect(prelude).toMatchInlineSnapshot(`"<div><!--$-->Done<!--/$--></div>"`);
   });
 
   // @gate experimental


### PR DESCRIPTION
When prerendering it can be convenient to abort the prerender while rendering. However if any Suspense fallbacks have not yet rendered before the abort happens the fallback itself will error and cause the nearest parent Suspense boundary to render a fallback instead. Prerenders are by definition not time critical so the prioritization of children over fallbacks which makes sense for render isn't similarly motivated for prerender. Given this, this change updates fallback rendering during a prerender to attempt the fallback before attempting children.
