### PR TITLE
[ci] Update prepare-release-from-ci to dl from GH

### DIFF
--- a/scripts/release/prepare-release-from-ci.js
+++ b/scripts/release/prepare-release-from-ci.js
@@ -5,7 +5,9 @@
 const {join} = require('path');
 const {addDefaultParamValue, handleError} = require('./utils');
 
-const downloadBuildArtifacts = require('./shared-commands/download-build-artifacts');
+const {
+  downloadBuildArtifacts,
+} = require('./shared-commands/download-build-artifacts-ghaction');
 const parseParams = require('./shared-commands/parse-params');
 const printPrereleaseSummary = require('./shared-commands/print-prerelease-summary');
 const testPackagingFixture = require('./shared-commands/test-packaging-fixture');
@@ -17,7 +19,10 @@ const run = async () => {
     const params = await parseParams();
     params.cwd = join(__dirname, '..', '..');
 
-    await downloadBuildArtifacts(params);
+    await downloadBuildArtifacts(
+      params.commit,
+      params.releaseChannel ?? process.env.RELEASE_CHANNEL
+    );
 
     if (!params.skipTests) {
       await testPackagingFixture(params);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30481
* __->__ #30485
* #30484

Updates this script to download from GH actions instead, to prepare for
moving the cron jobs over to GH actions.