### PR TITLE
[Fizz] Don't perform work when closing

### DIFF
--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -4215,7 +4215,7 @@ function retryReplayTask(request: Request, task: ReplayTask): void {
 }
 
 export function performWork(request: Request): void {
-  if (request.status === CLOSED) {
+  if (request.status === CLOSED || request.status === CLOSING) {
     return;
   }
   const prevContext = getActiveContext();


### PR DESCRIPTION
When a Fizz render is closing but not yet closed it's possible that pinged tasks can spawn more work. The point of the closing state is to allow time to start piping/reading the underlying stream but semantically the render is finished at that point so work should no longer happen.