### PR TITLE
[ci] Fix prereleases reusable workflow

### DIFF
--- a/.github/workflows/runtime_prereleases.yml
+++ b/.github/workflows/runtime_prereleases.yml
@@ -1,7 +1,7 @@
 name: (Runtime) Publish Prereleases
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       commit_sha:
         required: true
@@ -9,10 +9,7 @@ on:
         type: string
       release_channel:
         required: true
-        type: choice
-        options:
-          - stable
-          - experimental
+        type: string
       dist_tag:
         required: true
         type: string

--- a/.github/workflows/runtime_prereleases_nightly.yml
+++ b/.github/workflows/runtime_prereleases_nightly.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # At 10 minutes past 16:00 on Mon, Tue, Wed, Thu, and Fri
     - cron: 10 16 * * 1,2,3,4,5
-  workflow_dispatch:
-    inputs:
-      prerelease_commit_sha:
-        required: false
 
 env:
   TZ: /usr/share/zoneinfo/America/Los_Angeles


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30498

Turns out I had configured the reusable workflow with the wrong `on`
command.

Also removes the workflow_dispatch config from the nightly workflow as
that was not meant to be triggered manually.