### PR TITLE
[ci] Remove references to CIRCLE_NODE_{TOTAL,INDEX}

### DIFF
--- a/packages/react/src/__tests__/ReactClassEquivalence-test.js
+++ b/packages/react/src/__tests__/ReactClassEquivalence-test.js
@@ -44,10 +44,6 @@ function runJest(testFile) {
       cwd,
       env: Object.assign({}, process.env, {
         REACT_CLASS_EQUIVALENCE_TEST: 'true',
-        // Remove these so that the test file is not filtered out by the mechanism
-        // we use to parallelize tests in CI
-        CIRCLE_NODE_TOTAL: '',
-        CIRCLE_NODE_INDEX: '',
       }),
     },
   );

--- a/scripts/rollup/stats.js
+++ b/scripts/rollup/stats.js
@@ -18,17 +18,7 @@ const currentBuildResults = {
 };
 
 function saveResults() {
-  if (process.env.CIRCLE_NODE_TOTAL) {
-    // In CI, write the bundle sizes to a subdirectory and append the node index
-    // to the filename. A downstream job will consolidate these into a
-    // single file.
-    const nodeIndex = process.env.CIRCLE_NODE_INDEX;
-    mkdirp.sync('build/sizes');
-    fs.writeFileSync(
-      join('build', 'sizes', `bundle-sizes-${nodeIndex}.json`),
-      JSON.stringify(currentBuildResults, null, 2)
-    );
-  } else if (process.env.CI === 'github') {
+  if (process.env.CI === 'github') {
     mkdirp.sync('build/sizes');
     fs.writeFileSync(
       join('build', 'sizes', `bundle-sizes-${process.env.NODE_INDEX}.json`),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30501
* #30500
* #30499

These env variables were used for circlci parallelization and can now be
removed.