### PR TITLE
[ci] Fix passing secrets to runtime_prereleases

### DIFF
--- a/.github/workflows/runtime_prereleases.yml
+++ b/.github/workflows/runtime_prereleases.yml
@@ -13,6 +13,9 @@ on:
       dist_tag:
         required: true
         type: string
+    secrets:
+      NPM_TOKEN:
+        required: true
 
 env:
   TZ: /usr/share/zoneinfo/America/Los_Angeles

--- a/.github/workflows/runtime_prereleases_manual.yml
+++ b/.github/workflows/runtime_prereleases_manual.yml
@@ -28,6 +28,8 @@ jobs:
       # downstream consumers might still expect that tag. We can remove this
       # after some time has elapsed and the change has been communicated.
       dist_tag: canary,next,rc
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish_prerelease_experimental:
     name: Publish to Experimental channel
@@ -41,3 +43,5 @@ jobs:
       commit_sha: ${{ inputs.prerelease_commit_sha }}
       release_channel: experimental
       dist_tag: experimental
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/runtime_prereleases_nightly.yml
+++ b/.github/workflows/runtime_prereleases_nightly.yml
@@ -16,6 +16,8 @@ jobs:
       commit_sha: ${{ github.sha }}
       release_channel: stable
       dist_tag: canary,next,rc
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish_prerelease_experimental:
     name: Publish to Experimental channel
@@ -29,3 +31,5 @@ jobs:
       commit_sha: ${{ github.sha }}
       release_channel: experimental
       dist_tag: experimental
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30504

Second try, seems like you need to explicitly pass secrets to reusable
workflows.