### PR TITLE
[Fiber/DevTools] Stop injecting findHostInstanceByFiber

### DIFF
--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -827,14 +827,6 @@ if (__DEV__) {
   };
 }
 
-function findHostInstanceByFiber(fiber: Fiber): Instance | TextInstance | null {
-  const hostFiber = findCurrentHostFiber(fiber);
-  if (hostFiber === null) {
-    return null;
-  }
-  return hostFiber.stateNode;
-}
-
 function emptyFindFiberByHostInstance(
   instance: Instance | TextInstance,
 ): Fiber | null {
@@ -863,7 +855,6 @@ export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
     setSuspenseHandler,
     scheduleUpdate,
     currentDispatcherRef: ReactSharedInternals,
-    findHostInstanceByFiber,
     findFiberByHostInstance:
       findFiberByHostInstance || emptyFindFiberByHostInstance,
     // React Refresh


### PR DESCRIPTION
This is not used by DevTools since it has its own implementation of it.

This function is getting removed since `findDOMNode` is getting removed so we shouldn't keep around extra bytes unnecessarily.

There is also `findHostInstancesForRefresh` which should really be implemented on the `react-refresh` side. Not using an injection but that's a heavier lift and only affects `__DEV__`.