### PR TITLE
Skip finalizeContainerChildren for suspended transition

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -153,6 +153,7 @@ import {
   getRenderTargetTime,
   getWorkInProgressTransitions,
   shouldRemainOnPreviousScreen,
+  renderDidSuspendWithDelay,
 } from './ReactFiberWorkLoop';
 import {
   OffscreenLane,
@@ -161,6 +162,7 @@ import {
   includesSomeLane,
   mergeLanes,
   claimNextRetryLane,
+  includesOnlyTransitions,
 } from './ReactFiberLane';
 import {resetChildFibers} from './ReactChildFiber';
 import {createScopeInstance} from './ReactFiberScope';
@@ -411,7 +413,12 @@ function updateHostContainer(current: null | Fiber, workInProgress: Fiber) {
       portalOrRoot.pendingChildren = newChildSet;
       // Schedule an update on the container to swap out the container.
       markUpdate(workInProgress);
-      finalizeContainerChildren(container, newChildSet);
+      const isSuspendedTransition =
+        renderDidSuspendWithDelay() &&
+        includesOnlyTransitions(workInProgress.lanes);
+      if (!isSuspendedTransition) {
+        finalizeContainerChildren(container, newChildSet);
+      }
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1939,6 +1939,10 @@ export function renderDidSuspendDelayIfPossible(): void {
   }
 }
 
+export function renderDidSuspendWithDelay(): boolean {
+  return workInProgressRootExitStatus === RootSuspendedWithDelay;
+}
+
 export function renderDidError() {
   if (workInProgressRootExitStatus !== RootSuspendedWithDelay) {
     workInProgressRootExitStatus = RootErrored;


### PR DESCRIPTION
Work-in-progress idea targeting the same situation as https://github.com/facebook/react/pull/30513.

In React Native, we've found a bug with suspense boundaries reverting to the fallback in the following case. The expected behavior (and behavior on web) is as follows:
1. Render a Suspense boundary on initial mount, resolve the promise, show the content.
2. In a transition, update the content of the existing Suspense boundary, suspending again.
3. The UI should continue to show the previous content
4. Resolve the promise, update to the new content.

However on RN, step 3 shows the fallback again. This is unexpected since we're in a transition and the fallback has already revealed.

What's happening is that in step 3 we call completeWork() which in turn calls finalizeContainerChildren(), which updates to use the fallback. However, this isn't committed to the screen since we never call commitRoot() (and therefore don't call replaceContainerChildren()). Instead, we detec that the render exited with status RootSuspendedOnDelay and that the lane was transition-only, so we don't actually commit the fallback.

However, RN currently commits the content it gets in finalizeContainerChildren(), rather than waiting for replaceContainerChildren() from commitRoot(). The original intent was for finalize...() to do layout, and for replace...() to actually commit the updated tree, which would preserve the web behavior.

https://github.com/facebook/react/pull/30513 is a brute force way to address this by simply moving all the native work from finalize -> replace. What i'm experimenting with in this PR is to skip calling finalizeContainerChildren() if the above conditions hold: if this is a suspended render in a transition, don't bother finalizing children.

NOTE: i'm sure that this is failing to account for some cases and likely won't work exactly as-is. I'm curious for feedback about whether this general approach could work — is there some set of conditions for which we can skip finalizeContainerChildren — or whether that is fundamentally flawed and it cannot be skipped.