### PR TITLE
[ci] Make some workflows dispatchable

### DIFF
--- a/.github/workflows/devtools_regression_tests.yml
+++ b/.github/workflows/devtools_regression_tests.yml
@@ -5,8 +5,9 @@ on:
     - cron: 0 0 * * *
   workflow_dispatch:
     inputs:
-      prerelease_commit_sha:
+      commit_sha:
         required: false
+        type: string
 
 env:
   TZ: /usr/share/zoneinfo/America/Los_Angeles
@@ -15,7 +16,6 @@ env:
 
 jobs:
   download_build:
-    if: inputs.prerelease_commit_sha == ''
     name: Download base build
     runs-on: ubuntu-latest
     steps:
@@ -37,7 +37,7 @@ jobs:
       - name: Download react-devtools artifacts for base revision
         run: |
           git fetch origin main
-          GH_TOKEN=${{ github.token }} scripts/release/download-experimental-build.js --commit=$(git rev-parse origin/main)
+          GH_TOKEN=${{ github.token }} scripts/release/download-experimental-build.js --commit=${{ inputs.commit_sha || '$(git rev-parse origin/main)' }}
       - name: Display structure of build
         run: ls -R build
       - name: Archive build

--- a/.github/workflows/runtime_commit_artifacts.yml
+++ b/.github/workflows/runtime_commit_artifacts.yml
@@ -6,6 +6,11 @@ on:
     types: [completed]
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        required: false
+        type: string
 
 env:
   TZ: /usr/share/zoneinfo/America/Los_Angeles
@@ -72,7 +77,7 @@ jobs:
         working-directory: scripts/release
       - name: Download artifacts for base revision
         run: |
-          GH_TOKEN=${{ github.token }} scripts/release/download-experimental-build.js --commit=${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN=${{ github.token }} scripts/release/download-experimental-build.js --commit=${{ inputs.commit_sha || github.event.workflow_run.head_sha }}
       - name: Display structure of build
         run: ls -R build
       - name: Strip @license from eslint plugin and react-refresh

--- a/.github/workflows/runtime_fuzz_tests.yml
+++ b/.github/workflows/runtime_fuzz_tests.yml
@@ -1,24 +1,19 @@
 name: (Runtime) Fuzz tests
+
 on:
   schedule:
-  - cron: 0 * * * *
+    - cron: 0 * * * *
   push:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      prerelease_commit_sha:
-        required: false
 
 env:
   TZ: /usr/share/zoneinfo/America/Los_Angeles
 
 jobs:
   test_fuzz:
-    if: inputs.prerelease_commit_sha == ''
     runs-on: ubuntu-latest
-    env:
-      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: actions/setup-node@v4

--- a/.github/workflows/shared_stale.yml
+++ b/.github/workflows/shared_stale.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Run hourly
     - cron: '0 * * * *'
+  workflow_dispatch:
 
 env:
   TZ: /usr/share/zoneinfo/America/Los_Angeles


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30531
* #30530
* __->__ #30529

The previous checks for prerelease_commit_sha was incorrectly
implemented for devtools regression tests so I fixed it. I also made
some other workflows dispatchable so they can be manually run from
GitHub's UI as needed.

Test plan: https://github.com/facebook/react/actions/runs/10165564989