### PR TITLE
Build all bundles required by flight fixture with `build-for-flight-dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "build-for-devtools": "cross-env RELEASE_CHANNEL=experimental yarn build react/index,react/jsx,react/compiler-runtime,react-dom/index,react-dom/client,react-dom/unstable_testing,react-dom/test-utils,react-is,react-debug-tools,scheduler,react-test-renderer,react-refresh,react-art --type=NODE",
     "build-for-devtools-dev": "yarn build-for-devtools --type=NODE_DEV",
     "build-for-devtools-prod": "yarn build-for-devtools --type=NODE_PROD",
-    "build-for-flight-dev": "cross-env RELEASE_CHANNEL=experimental node ./scripts/rollup/build.js react/index,react/jsx,react-dom/index,react-dom/client,react-dom/server,react-dom-server.node,react-dom-server-legacy.node,scheduler,react-server-dom-webpack/ --type=NODE_DEV && mv ./build/node_modules ./build/oss-experimental",
+    "build-for-flight-dev": "cross-env RELEASE_CHANNEL=experimental node ./scripts/rollup/build.js react/index,react/jsx,react.react-server,react-dom/index,react-dom/client,react-dom/server,react-dom.react-server,react-dom-server.node,react-dom-server-legacy.node,scheduler,react-server-dom-webpack/ --type=NODE_DEV,ESM_PROD,NODE_ES2015 && mv ./build/node_modules ./build/oss-experimental",
     "linc": "node ./scripts/tasks/linc.js",
     "lint": "node ./scripts/tasks/eslint.js",
     "lint-build": "node ./scripts/rollup/validate/index.js",

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -540,10 +540,10 @@ function shouldSkipBundle(bundle, bundleType) {
     return true;
   }
   if (requestedBundleTypes.length > 0) {
-    const isAskingForDifferentType = requestedBundleTypes.some(
-      requestedType => !bundleType.includes(requestedType)
+    const hasRequestedBundleType = requestedBundleTypes.some(requestedType =>
+      bundleType.includes(requestedType)
     );
-    if (isAskingForDifferentType) {
+    if (!hasRequestedBundleType) {
       return true;
     }
   }


### PR DESCRIPTION
The following bundles were missing so that the flight fixture could not be started after running `yarn build-for-flight-dev` on a fresh clone:

- `react-server-dom-webpack-node-loader.production.js` (requires `ESM_PROD`)
- `react-server-dom-webpack-plugin.js` (requires `NODE_ES2015`)
- `react-dom.react-server.development.js`
- `react.react-server.development.js`

Since we now need to specify a list of bundle types, we had to fix the `shouldSkipBundle` function, which apparently was broken in #29906.