### PR TITLE
[compiler] Simplify FunctionExpression node

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -3270,7 +3270,7 @@ function lowerFunctionToValue(
   return {
     kind: 'FunctionExpression',
     name,
-    expr: expr.node,
+    type: expr.node.type,
     loc: exprLoc,
     loweredFunc,
   };

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -1076,10 +1076,10 @@ export type FunctionExpression = {
   kind: 'FunctionExpression';
   name: string | null;
   loweredFunc: LoweredFunction;
-  expr:
-    | t.ArrowFunctionExpression
-    | t.FunctionExpression
-    | t.FunctionDeclaration;
+  type:
+    | 'ArrowFunctionExpression'
+    | 'FunctionExpression'
+    | 'FunctionDeclaration';
   loc: SourceLocation;
 };
 

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -1997,7 +1997,7 @@ function codegenInstructionValue(
         ),
         reactiveFunction,
       ).unwrap();
-      if (instrValue.expr.type === 'ArrowFunctionExpression') {
+      if (instrValue.type === 'ArrowFunctionExpression') {
         let body: t.BlockStatement | t.Expression = fn.body;
         if (body.body.length === 1 && loweredFunc.directives.length == 0) {
           const stmt = body.body[0]!;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30548
* #30547
* #30546
* #30545
* __->__ #30544

Rather than storing the entire babel node, store only the required
information which is the node type.

This will be useful for when we synthesize new functions that don't have
a corresponding babel node.