### PR TITLE
[compiler] Refactor makeTemporary outside HIRBuilder

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -11,7 +11,7 @@ import {CompilerError, CompilerErrorDetailOptions} from '../CompilerError';
 import {assertExhaustive} from '../Utils/utils';
 import {Environment, ReactFunctionType} from './Environment';
 import {HookKind} from './ObjectShape';
-import {Type} from './Types';
+import {Type, makeType} from './Types';
 
 /*
  * *******************************************************************************************
@@ -1204,6 +1204,20 @@ const opaqueValidIdentifierName = Symbol();
 export type ValidIdentifierName = string & {
   [opaqueValidIdentifierName]: 'ValidIdentifierName';
 };
+
+export function makeTemporary(
+  id: IdentifierId,
+  loc: SourceLocation,
+): Identifier {
+  return {
+    id,
+    name: null,
+    mutableRange: {start: makeInstructionId(0), end: makeInstructionId(0)},
+    scope: null,
+    type: makeType(),
+    loc,
+  };
+}
 
 /**
  * Creates a valid identifier name. This should *not* be used for synthesizing

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIRBuilder.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIRBuilder.ts
@@ -27,6 +27,7 @@ import {
   makeBlockId,
   makeIdentifierName,
   makeInstructionId,
+  makeTemporary,
   makeType,
 } from './HIR';
 import {printInstruction} from './PrintHIR';
@@ -182,14 +183,7 @@ export default class HIRBuilder {
 
   makeTemporary(loc: SourceLocation): Identifier {
     const id = this.nextIdentifierId;
-    return {
-      id,
-      name: null,
-      mutableRange: {start: makeInstructionId(0), end: makeInstructionId(0)},
-      scope: null,
-      type: makeType(),
-      loc,
-    };
+    return makeTemporary(id, loc);
   }
 
   #resolveBabelBinding(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30548
* #30547
* #30546
* __->__ #30545
* #30544

This is a useful utility function similar to the existing
`makeInstructionId` and `makeIdentifierId` functions.

This PR moves it outside the HIRBuilder so we can use this in passes
that don't have access to the builder instance.