### PR TITLE
Add failing end-to-end test for an action that returns client components

### DIFF
--- a/fixtures/flight/__tests__/__e2e__/action.test.js
+++ b/fixtures/flight/__tests__/__e2e__/action.test.js
@@ -1,0 +1,35 @@
+// @ts-check
+
+import {test, expect} from '@playwright/test';
+
+test('action returning client component with deduped references', async ({
+  page,
+}) => {
+  const pageErrors = [];
+
+  page.on('pageerror', error => {
+    pageErrors.push(error.stack);
+  });
+
+  await page.goto('/');
+
+  const button = await page.getByRole('button', {
+    name: 'Return element from action',
+  });
+
+  await button.click();
+
+  await expect(
+    page.getByTestId('temporary-references-action-result')
+  ).toHaveText('Hello');
+
+  // Click the button one more time to send the previous result (i.e. the
+  // returned element) back to the server.
+  await button.click();
+
+  await expect(pageErrors).toEqual([]);
+
+  await expect(
+    page.getByTestId('temporary-references-action-result')
+  ).toHaveText('HelloHello');
+});

--- a/fixtures/flight/__tests__/__e2e__/action.test.js
+++ b/fixtures/flight/__tests__/__e2e__/action.test.js
@@ -1,14 +1,18 @@
-// @ts-check
-
 import {test, expect} from '@playwright/test';
 
 test('action returning client component with deduped references', async ({
   page,
 }) => {
-  const pageErrors = [];
+  const errors = [];
+
+  page.on('console', msg => {
+    if (msg.type() === 'error') {
+      errors.push(msg.text());
+    }
+  });
 
   page.on('pageerror', error => {
-    pageErrors.push(error.stack);
+    errors.push(error.stack);
   });
 
   await page.goto('/');
@@ -19,17 +23,13 @@ test('action returning client component with deduped references', async ({
 
   await button.click();
 
-  await expect(
-    page.getByTestId('temporary-references-action-result')
-  ).toHaveText('Hello');
+  await expect(page.getByTestId('form')).toContainText('Hello');
 
   // Click the button one more time to send the previous result (i.e. the
   // returned element) back to the server.
   await button.click();
 
-  await expect(pageErrors).toEqual([]);
+  await expect(errors).toEqual([]);
 
-  await expect(
-    page.getByTestId('temporary-references-action-result')
-  ).toHaveText('HelloHello');
+  await expect(page.getByTestId('form')).toContainText('HelloHello');
 });

--- a/fixtures/flight/src/App.js
+++ b/fixtures/flight/src/App.js
@@ -12,10 +12,11 @@ import Button from './Button.js';
 import Form from './Form.js';
 import {Dynamic} from './Dynamic.js';
 import {Client} from './Client.js';
+import {TemporaryReferences} from './TemporaryReferences.js';
 
 import {Note} from './cjs/Note.js';
 
-import {like, greet, increment} from './actions.js';
+import {like, greet, increment, returnElement} from './actions.js';
 
 import {getServerState} from './ServerState.js';
 
@@ -61,6 +62,7 @@ export default async function App() {
           </div>
           <Client />
           <Note />
+          <TemporaryReferences action={returnElement} />
         </Container>
       </body>
     </html>

--- a/fixtures/flight/src/Deduped.js
+++ b/fixtures/flight/src/Deduped.js
@@ -1,0 +1,8 @@
+'use client';
+
+import * as React from 'react';
+
+export default function Deduped({children, thing}) {
+  console.log({thing});
+  return <div>{children}</div>;
+}

--- a/fixtures/flight/src/TemporaryReferences.js
+++ b/fixtures/flight/src/TemporaryReferences.js
@@ -1,0 +1,14 @@
+'use client';
+
+import * as React from 'react';
+
+export function TemporaryReferences({action}) {
+  const [result, formAction] = React.useActionState(action, null);
+
+  return (
+    <form action={formAction}>
+      <button>Return element from action</button>
+      <div data-testid="temporary-references-action-result">{result}</div>
+    </form>
+  );
+}

--- a/fixtures/flight/src/TemporaryReferences.js
+++ b/fixtures/flight/src/TemporaryReferences.js
@@ -6,9 +6,9 @@ export function TemporaryReferences({action}) {
   const [result, formAction] = React.useActionState(action, null);
 
   return (
-    <form action={formAction}>
+    <form action={formAction} data-testid="form">
       <button>Return element from action</button>
-      <div data-testid="temporary-references-action-result">{result}</div>
+      {result}
     </form>
   );
 }

--- a/fixtures/flight/src/actions.js
+++ b/fixtures/flight/src/actions.js
@@ -1,6 +1,8 @@
 'use server';
 
+import * as React from 'react';
 import {setServerState} from './ServerState.js';
+import Deduped from './Deduped.js';
 
 export async function like() {
   setServerState('Liked!');
@@ -21,4 +23,15 @@ export async function greet(formData) {
 
 export async function increment(n) {
   return n + 1;
+}
+
+export async function returnElement(prevElement) {
+  const text = <div>Hello</div>;
+
+  return (
+    <Deduped thing={text}>
+      {prevElement}
+      {text}
+    </Deduped>
+  );
 }

--- a/fixtures/flight/src/index.js
+++ b/fixtures/flight/src/index.js
@@ -1,12 +1,18 @@
 import * as React from 'react';
 import {use, Suspense, useState, startTransition} from 'react';
 import ReactDOM from 'react-dom/client';
-import {createFromFetch, encodeReply} from 'react-server-dom-webpack/client';
+import {
+  createFromFetch,
+  createTemporaryReferenceSet,
+  encodeReply,
+} from 'react-server-dom-webpack/client';
 
 // TODO: This should be a dependency of the App but we haven't implemented CSS in Node yet.
 import './style.css';
 
 let updateRoot;
+const temporaryReferences = createTemporaryReferenceSet();
+
 async function callServer(id, args) {
   const response = fetch('/', {
     method: 'POST',
@@ -14,9 +20,12 @@ async function callServer(id, args) {
       Accept: 'text/x-component',
       'rsc-action': id,
     },
-    body: await encodeReply(args),
+    body: await encodeReply(args, {temporaryReferences}),
   });
-  const {returnValue, root} = await createFromFetch(response, {callServer});
+  const {returnValue, root} = await createFromFetch(response, {
+    callServer,
+    temporaryReferences,
+  });
   // Refresh the tree with the new RSC payload.
   startTransition(() => {
     updateRoot(root);
@@ -39,6 +48,7 @@ async function hydrateApp() {
     }),
     {
       callServer,
+      temporaryReferences,
       findSourceMapURL(fileName) {
         return (
           document.location.origin +


### PR DESCRIPTION
This playwright test is using the Flight Fixture to demonstrate the Flight Reply equivalent of the scenario that was fixed in #30528 for the Flight Client.

It's basically an advanced case of what was outlined in #28564, returning a client component from a server action that is used in `useActionState`. In addition, the client component uses another element twice, which leads to the element's props being deduped. Resolving those references needs to be handled specifically, both in the Flight Client (done in #30528), as well as in the temporary references of the Flight Reply Client (and possibly Flight Reply Server?).

The test should probably be converted into a unit test, e.g. in `packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js` or `packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js`.