### PR TITLE
Feat:- Added no import expression eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -303,6 +303,7 @@ module.exports = {
     'react-internal/no-to-warn-dev-within-to-throw': ERROR,
     'react-internal/warning-args': ERROR,
     'react-internal/no-production-logging': ERROR,
+    'react-internal/no-dynamic-import-in-literal': ERROR,
   },
 
   overrides: [
@@ -386,6 +387,7 @@ module.exports = {
         'jest/expect-expect': OFF,
         // Lame rule that fires in itRender helpers or in render methods.
         'jest/no-standalone-expect': OFF,
+        'react-internal/no-dynamic-import-in-literal': OFF,
       },
     },
     {

--- a/scripts/eslint-rules/__tests__/no-dynamic-import-in-literal-test.internal.js
+++ b/scripts/eslint-rules/__tests__/no-dynamic-import-in-literal-test.internal.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+const rule = require('../no-dynamic-import-in-literal');
+const {RuleTester} = require('eslint');
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 8,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('eslint-rules/no-dynamic-import-in-literal', rule, {
+  valid: [
+    `console.log(
+      'import react from "react"'
+    )`,
+    `console.log(
+      'should work for non-import expression'
+    )`,
+  ],
+  invalid: [
+    {
+      code: `console.log(
+          'import("react")'
+        )`,
+      errors: [
+        {
+          message: 'Possible dynamic import expression in literal',
+        },
+      ],
+    },
+    {
+      code: `console.log(
+          'const MyComponent = lazy(() => import("./MyComponent"))'
+        )`,
+      errors: [
+        {
+          message: 'Possible dynamic import expression in literal',
+        },
+      ],
+    },
+  ],
+});

--- a/scripts/eslint-rules/index.js
+++ b/scripts/eslint-rules/index.js
@@ -8,5 +8,6 @@ module.exports = {
     'prod-error-codes': require('./prod-error-codes'),
     'no-production-logging': require('./no-production-logging'),
     'safe-string-coercion': require('./safe-string-coercion'),
+    'no-dynamic-import-in-literal': require('./no-dynamic-import-in-literal'),
   },
 };

--- a/scripts/eslint-rules/no-dynamic-import-in-literal.js
+++ b/scripts/eslint-rules/no-dynamic-import-in-literal.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+const IMPORT_PATTERN = /import\(([`'"]([^`'"]+)[`'"])*\)/;
+
+module.exports = {
+  meta: {
+    schema: [],
+  },
+  create(context) {
+    function checkIsImportExpression(node) {
+      const {type: nodeType} = node;
+      const content =
+        (nodeType === 'Literal' && node.value) ||
+        (nodeType === 'TemplateLiteral' && node.quasis[0].value.raw);
+      const isPossibleImportExpression = IMPORT_PATTERN.test(content);
+      if (isPossibleImportExpression) {
+        context.report(node, 'Possible dynamic import expression in literal');
+      }
+    }
+    return {
+      Literal: checkIsImportExpression,
+      TemplateLiteral: checkIsImportExpression,
+    };
+  },
+};


### PR DESCRIPTION
While using Dynamic Imports, having hit by certain type of imports like below
```

// Example 1: String literal
const modulePath = "import('./dynamicModule.js')";

// Example 2: Template literal
const getModule = `import(${'./dynamicModule.js'})`;

// Example 3: String literal in an object
const config = {
  loader: "import('./loader.js')"
};


```

when imports appear inside a literal, a rule shall be implemented to avoid such imports.


I have added test further for the rule

<img width="817" alt="Screenshot 2024-08-01 at 4 33 03 PM" src="https://github.com/user-attachments/assets/1ade927a-b7c0-4183-8d9a-f622a237067f">
