### PR TITLE
refactor[react-devtools]: remove browserTheme from ConsolePatchSettings

### DIFF
--- a/packages/react-devtools-core/src/cachedSettings.js
+++ b/packages/react-devtools-core/src/cachedSettings.js
@@ -9,7 +9,7 @@
 
 import type {ConsolePatchSettings} from 'react-devtools-shared/src/backend/types';
 import {writeConsolePatchSettingsToWindow} from 'react-devtools-shared/src/backend/console';
-import {castBool, castBrowserTheme} from 'react-devtools-shared/src/utils';
+import {castBool} from 'react-devtools-shared/src/utils';
 
 // Note: all keys should be optional in this type, because users can use newer
 // versions of React DevTools with older versions of React Native, and the object
@@ -54,14 +54,13 @@ function parseConsolePatchSettings(
     breakOnConsoleErrors,
     showInlineWarningsAndErrors,
     hideConsoleLogsInStrictMode,
-    browserTheme,
   } = parsedValue;
+
   return {
     appendComponentStack: castBool(appendComponentStack) ?? true,
     breakOnConsoleErrors: castBool(breakOnConsoleErrors) ?? false,
     showInlineWarningsAndErrors: castBool(showInlineWarningsAndErrors) ?? true,
     hideConsoleLogsInStrictMode: castBool(hideConsoleLogsInStrictMode) ?? false,
-    browserTheme: castBrowserTheme(browserTheme) ?? 'dark',
   };
 }
 

--- a/packages/react-devtools-extensions/src/main/syncSavedPreferences.js
+++ b/packages/react-devtools-extensions/src/main/syncSavedPreferences.js
@@ -7,7 +7,6 @@ import {
   getShowInlineWarningsAndErrors,
   getHideConsoleLogsInStrictMode,
 } from 'react-devtools-shared/src/utils';
-import {getBrowserTheme} from 'react-devtools-extensions/src/utils';
 
 // The renderer interface can't read saved component filters directly,
 // because they are stored in localStorage within the context of the extension.
@@ -28,9 +27,6 @@ function syncSavedPreferences() {
     )};
     window.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ = ${JSON.stringify(
       getHideConsoleLogsInStrictMode(),
-    )};
-    window.__REACT_DEVTOOLS_BROWSER_THEME__ = ${JSON.stringify(
-      getBrowserTheme(),
     )};`,
   );
 }

--- a/packages/react-devtools-shared/src/backend/console.js
+++ b/packages/react-devtools-shared/src/backend/console.js
@@ -22,7 +22,7 @@ import {
   ANSI_STYLE_DIMMING_TEMPLATE,
   ANSI_STYLE_DIMMING_TEMPLATE_WITH_COMPONENT_STACK,
 } from 'react-devtools-shared/src/constants';
-import {castBool, castBrowserTheme} from '../utils';
+import {castBool} from '../utils';
 
 const OVERRIDE_CONSOLE_METHODS = ['error', 'trace', 'warn'];
 
@@ -124,7 +124,6 @@ const consoleSettingsRef: ConsolePatchSettings = {
   breakOnConsoleErrors: false,
   showInlineWarningsAndErrors: false,
   hideConsoleLogsInStrictMode: false,
-  browserTheme: 'dark',
 };
 
 // Patches console methods to append component stack for the current fiber.
@@ -134,7 +133,6 @@ export function patch({
   breakOnConsoleErrors,
   showInlineWarningsAndErrors,
   hideConsoleLogsInStrictMode,
-  browserTheme,
 }: $ReadOnly<ConsolePatchSettings>): void {
   // Settings may change after we've patched the console.
   // Using a shared ref allows the patch function to read the latest values.
@@ -142,7 +140,6 @@ export function patch({
   consoleSettingsRef.breakOnConsoleErrors = breakOnConsoleErrors;
   consoleSettingsRef.showInlineWarningsAndErrors = showInlineWarningsAndErrors;
   consoleSettingsRef.hideConsoleLogsInStrictMode = hideConsoleLogsInStrictMode;
-  consoleSettingsRef.browserTheme = browserTheme;
 
   if (
     appendComponentStack ||
@@ -412,15 +409,12 @@ export function patchConsoleUsingWindowValues() {
   const hideConsoleLogsInStrictMode =
     castBool(window.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__) ??
     false;
-  const browserTheme =
-    castBrowserTheme(window.__REACT_DEVTOOLS_BROWSER_THEME__) ?? 'dark';
 
   patch({
     appendComponentStack,
     breakOnConsoleErrors,
     showInlineWarningsAndErrors,
     hideConsoleLogsInStrictMode,
-    browserTheme,
   });
 }
 
@@ -438,7 +432,6 @@ export function writeConsolePatchSettingsToWindow(
     settings.showInlineWarningsAndErrors;
   window.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ =
     settings.hideConsoleLogsInStrictMode;
-  window.__REACT_DEVTOOLS_BROWSER_THEME__ = settings.browserTheme;
 }
 
 export function installConsoleFunctionsToWindow(): void {

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -31,7 +31,6 @@ import type {
 } from 'react-devtools-shared/src/backend/NativeStyleEditor/setupNativeStyleEditor';
 import type {InitBackend} from 'react-devtools-shared/src/backend';
 import type {TimelineDataExport} from 'react-devtools-timeline/src/types';
-import type {BrowserTheme} from 'react-devtools-shared/src/frontend/types';
 import type {BackendBridge} from 'react-devtools-shared/src/bridge';
 import type {Source} from 'react-devtools-shared/src/shared/types';
 import type Agent from './agent';
@@ -531,17 +530,12 @@ export type DevToolsHook = {
   ...
 };
 
-export type ConsolePatchSettings = {
-  appendComponentStack: boolean,
-  breakOnConsoleErrors: boolean,
-  showInlineWarningsAndErrors: boolean,
-  hideConsoleLogsInStrictMode: boolean,
-  browserTheme: BrowserTheme,
-};
-
 export type DevToolsHookSettings = {
   appendComponentStack: boolean,
   breakOnConsoleErrors: boolean,
   showInlineWarningsAndErrors: boolean,
   hideConsoleLogsInStrictMode: boolean,
 };
+
+// Will be removed together with console patching from backend/console.js to hook.js
+export type ConsolePatchSettings = DevToolsHookSettings;

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -202,7 +202,6 @@ function SettingsContextController({
       breakOnConsoleErrors,
       showInlineWarningsAndErrors,
       hideConsoleLogsInStrictMode,
-      browserTheme,
     });
   }, [
     bridge,
@@ -210,7 +209,6 @@ function SettingsContextController({
     breakOnConsoleErrors,
     showInlineWarningsAndErrors,
     hideConsoleLogsInStrictMode,
-    browserTheme,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/30564.

We are no longer using browser theme in our console patching, this was removed in unification of console patching for strict mode, we started using ansi escape symbols and forking based on browser theme is no longer required - https://github.com/facebook/react/pull/29869

The real browser theme initialization for frontend is happening at the other place and is not affected:
https://github.com/facebook/react/blob/40be968257a7a10a267210670103f20dd0429ef3/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js#L117-L120