### PR TITLE
[DevTools] Rename mountFiberRecursively/updateFiberRecursively

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -1094,7 +1094,7 @@ export function attach(
     hook.getFiberRoots(rendererID).forEach(root => {
       currentRootID = getOrGenerateFiberInstance(root.current).id;
       setRootPseudoKey(currentRootID, root.current);
-      mountFiberRecursively(root.current, null, false, false);
+      mountChildrenRecursively(root.current, null, false, false);
       flushPendingEvents(root);
       currentRootID = -1;
     });
@@ -2228,7 +2228,7 @@ export function attach(
     }
   }
 
-  function mountFiberRecursively(
+  function mountChildrenRecursively(
     firstChild: Fiber,
     parentInstance: DevToolsInstance | null,
     traverseSiblings: boolean,
@@ -2243,7 +2243,7 @@ export function attach(
       getOrGenerateFiberInstance(fiber);
 
       if (__DEBUG__) {
-        debug('mountFiberRecursively()', fiber, parentInstance);
+        debug('mountChildrenRecursively()', fiber, parentInstance);
       }
 
       // If we have the tree selection from previous reload, try to match this Fiber.
@@ -2270,8 +2270,7 @@ export function attach(
         // because we don't want to highlight every host node inside of a newly mounted subtree.
       }
 
-      const isSuspense = fiber.tag === ReactTypeOfWork.SuspenseComponent;
-      if (isSuspense) {
+      if (fiber.tag === SuspenseComponent) {
         const isTimedOut = fiber.memoizedState !== null;
         if (isTimedOut) {
           // Special case: if Suspense mounts in a timed-out state,
@@ -2285,7 +2284,7 @@ export function attach(
             ? fallbackChildFragment.child
             : null;
           if (fallbackChild !== null) {
-            mountFiberRecursively(
+            mountChildrenRecursively(
               fallbackChild,
               newParentInstance,
               true,
@@ -2302,7 +2301,7 @@ export function attach(
             primaryChild = fiber.child.child;
           }
           if (primaryChild !== null) {
-            mountFiberRecursively(
+            mountChildrenRecursively(
               primaryChild,
               newParentInstance,
               true,
@@ -2312,7 +2311,7 @@ export function attach(
         }
       } else {
         if (fiber.child !== null) {
-          mountFiberRecursively(
+          mountChildrenRecursively(
             fiber.child,
             newParentInstance,
             true,
@@ -2578,7 +2577,7 @@ export function attach(
         : null;
 
       if (prevFallbackChildSet == null && nextFallbackChildSet != null) {
-        mountFiberRecursively(
+        mountChildrenRecursively(
           nextFallbackChildSet,
           newParentInstance,
           true,
@@ -2607,7 +2606,7 @@ export function attach(
       // 2. Mount primary set
       const nextPrimaryChildSet = nextFiber.child;
       if (nextPrimaryChildSet !== null) {
-        mountFiberRecursively(
+        mountChildrenRecursively(
           nextPrimaryChildSet,
           newParentInstance,
           true,
@@ -2627,7 +2626,7 @@ export function attach(
         ? nextFiberChild.sibling
         : null;
       if (nextFallbackChildSet != null) {
-        mountFiberRecursively(
+        mountChildrenRecursively(
           nextFallbackChildSet,
           newParentInstance,
           true,
@@ -2670,7 +2669,7 @@ export function attach(
               shouldResetChildren = true;
             }
           } else {
-            mountFiberRecursively(
+            mountChildrenRecursively(
               nextChild,
               newParentInstance,
               false,
@@ -2799,7 +2798,7 @@ export function attach(
           };
         }
 
-        mountFiberRecursively(root.current, null, false, false);
+        mountChildrenRecursively(root.current, null, false, false);
         flushPendingEvents(root);
         currentRootID = -1;
       });
@@ -2898,7 +2897,7 @@ export function attach(
       if (!wasMounted && isMounted) {
         // Mount a new root.
         setRootPseudoKey(currentRootID, current);
-        mountFiberRecursively(current, null, false, false);
+        mountChildrenRecursively(current, null, false, false);
       } else if (wasMounted && isMounted) {
         // Update an existing root.
         updateFiberRecursively(current, alternate, null, false);
@@ -2910,7 +2909,7 @@ export function attach(
     } else {
       // Mount a new root.
       setRootPseudoKey(currentRootID, current);
-      mountFiberRecursively(current, null, false, false);
+      mountChildrenRecursively(current, null, false, false);
     }
 
     if (isProfiling && isProfilingSupported) {

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -2337,9 +2337,9 @@ export function attach(
 
   // We use this to simulate unmounting for Suspense trees
   // when we switch from primary to fallback.
-  function unmountFiberChildrenRecursively(fiber: Fiber) {
+  function unmountFiberRecursively(fiber: Fiber) {
     if (__DEBUG__) {
-      debug('unmountFiberChildrenRecursively()', fiber, null);
+      debug('unmountFiberRecursively()', fiber, null);
     }
 
     // We might meet a nested Suspense on our way.
@@ -2358,11 +2358,16 @@ export function attach(
       child = fallbackChildFragment ? fallbackChildFragment.child : null;
     }
 
+    unmountChildrenRecursively(child);
+  }
+
+  function unmountChildrenRecursively(firstChild: null | Fiber) {
+    let child: null | Fiber = firstChild;
     while (child !== null) {
       // Record simulated unmounts children-first.
       // We skip nodes without return because those are real unmounts.
       if (child.return !== null) {
-        unmountFiberChildrenRecursively(child);
+        unmountFiberRecursively(child);
         recordUnmount(child, true);
       }
       child = child.sibling;
@@ -2685,7 +2690,7 @@ export function attach(
       // 1. Hide primary set
       // This is not a real unmount, so it won't get reported by React.
       // We need to manually walk the previous tree and record unmounts.
-      unmountFiberChildrenRecursively(prevFiber);
+      unmountFiberRecursively(prevFiber);
       // 2. Mount fallback set
       const nextFiberChild = nextFiber.child;
       const nextFallbackChildSet = nextFiberChild


### PR DESCRIPTION
This is just for clarity at first.

Before: 
- mountFiberRecursively accepts a set of children and flag that says whether to just do one
- updateFiberRecursively accepts a fiber and loops over its children
- unmountFiberChildrenRecursively accepts a fiber and loops over its children

After:
- mountFiberRecursively accepts a Fiber and calls mountChildrenRecursively
- updateFiberRecursively accepts a Fiber and calls updateChildrenRecursively
- unmountFiberRecursively accepts a Fiber and calls unmountChildrenRecursively
- mountChildrenRecursively accepts a set of children and loops over each one
- updateChildrenRecursively accepts a set of children and loops over each one
- unmountChildrenRecursively accepts a set of children and loops over each one

So now there's one place where things happens for the single item and one place where we do the loop.
