### PR TITLE
chore[react-devtools]: extract getDispatcherRef into a separate module

### DIFF
--- a/packages/react-devtools-core/src/cachedSettings.js
+++ b/packages/react-devtools-core/src/cachedSettings.js
@@ -9,7 +9,7 @@
 
 import type {ConsolePatchSettings} from 'react-devtools-shared/src/backend/types';
 import {writeConsolePatchSettingsToWindow} from 'react-devtools-shared/src/backend/console';
-import {castBool, castBrowserTheme} from 'react-devtools-shared/src/utils';
+import {castBool} from 'react-devtools-shared/src/utils';
 
 // Note: all keys should be optional in this type, because users can use newer
 // versions of React DevTools with older versions of React Native, and the object
@@ -54,14 +54,13 @@ function parseConsolePatchSettings(
     breakOnConsoleErrors,
     showInlineWarningsAndErrors,
     hideConsoleLogsInStrictMode,
-    browserTheme,
   } = parsedValue;
+
   return {
     appendComponentStack: castBool(appendComponentStack) ?? true,
     breakOnConsoleErrors: castBool(breakOnConsoleErrors) ?? false,
     showInlineWarningsAndErrors: castBool(showInlineWarningsAndErrors) ?? true,
     hideConsoleLogsInStrictMode: castBool(hideConsoleLogsInStrictMode) ?? false,
-    browserTheme: castBrowserTheme(browserTheme) ?? 'dark',
   };
 }
 

--- a/packages/react-devtools-extensions/src/main/syncSavedPreferences.js
+++ b/packages/react-devtools-extensions/src/main/syncSavedPreferences.js
@@ -7,7 +7,6 @@ import {
   getShowInlineWarningsAndErrors,
   getHideConsoleLogsInStrictMode,
 } from 'react-devtools-shared/src/utils';
-import {getBrowserTheme} from 'react-devtools-extensions/src/utils';
 
 // The renderer interface can't read saved component filters directly,
 // because they are stored in localStorage within the context of the extension.
@@ -28,9 +27,6 @@ function syncSavedPreferences() {
     )};
     window.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ = ${JSON.stringify(
       getHideConsoleLogsInStrictMode(),
-    )};
-    window.__REACT_DEVTOOLS_BROWSER_THEME__ = ${JSON.stringify(
-      getBrowserTheme(),
     )};`,
   );
 }

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -38,11 +38,9 @@ import type {
   RendererID,
   RendererInterface,
   ConsolePatchSettings,
+  DevToolsHookSettings,
 } from './types';
-import type {
-  ComponentFilter,
-  BrowserTheme,
-} from 'react-devtools-shared/src/frontend/types';
+import type {ComponentFilter} from 'react-devtools-shared/src/frontend/types';
 import {isSynchronousXHRSupported, isReactNativeEnvironment} from './utils';
 
 const debug = (methodName: string, ...args: Array<string>) => {
@@ -153,6 +151,7 @@ export default class Agent extends EventEmitter<{
   traceUpdates: [Set<HostInstance>],
   drawTraceUpdates: [Array<HostInstance>],
   disableTraceUpdates: [],
+  updateHookSettings: [DevToolsHookSettings],
 }> {
   _bridge: BackendBridge;
   _isProfiling: boolean = false;
@@ -762,30 +761,22 @@ export default class Agent extends EventEmitter<{
     }
   };
 
-  updateConsolePatchSettings: ({
-    appendComponentStack: boolean,
-    breakOnConsoleErrors: boolean,
-    browserTheme: BrowserTheme,
-    hideConsoleLogsInStrictMode: boolean,
-    showInlineWarningsAndErrors: boolean,
-  }) => void = ({
-    appendComponentStack,
-    breakOnConsoleErrors,
-    showInlineWarningsAndErrors,
-    hideConsoleLogsInStrictMode,
-    browserTheme,
-  }: ConsolePatchSettings) => {
+  updateConsolePatchSettings: (
+    settings: $ReadOnly<ConsolePatchSettings>,
+  ) => void = settings => {
+    // Propagate the settings, so Backend can subscribe to it and modify hook
+    this.emit('updateHookSettings', {
+      appendComponentStack: settings.appendComponentStack,
+      breakOnConsoleErrors: settings.breakOnConsoleErrors,
+      showInlineWarningsAndErrors: settings.showInlineWarningsAndErrors,
+      hideConsoleLogsInStrictMode: settings.hideConsoleLogsInStrictMode,
+    });
+
     // If the frontend preferences have changed,
     // or in the case of React Native- if the backend is just finding out the preferences-
     // then reinstall the console overrides.
     // It's safe to call `patchConsole` multiple times.
-    patchConsole({
-      appendComponentStack,
-      breakOnConsoleErrors,
-      showInlineWarningsAndErrors,
-      hideConsoleLogsInStrictMode,
-      browserTheme,
-    });
+    patchConsole(settings);
   };
 
   updateComponentFilters: (componentFilters: Array<ComponentFilter>) => void =

--- a/packages/react-devtools-shared/src/backend/console.js
+++ b/packages/react-devtools-shared/src/backend/console.js
@@ -177,7 +177,7 @@ export function patch({
   showInlineWarningsAndErrors,
   hideConsoleLogsInStrictMode,
   browserTheme,
-}: ConsolePatchSettings): void {
+}: $ReadOnly<ConsolePatchSettings>): void {
   // Settings may change after we've patched the console.
   // Using a shared ref allows the patch function to read the latest values.
   consoleSettingsRef.appendComponentStack = appendComponentStack;

--- a/packages/react-devtools-shared/src/backend/console.js
+++ b/packages/react-devtools-shared/src/backend/console.js
@@ -25,7 +25,8 @@ import {
   ANSI_STYLE_DIMMING_TEMPLATE,
   ANSI_STYLE_DIMMING_TEMPLATE_WITH_COMPONENT_STACK,
 } from 'react-devtools-shared/src/constants';
-import {getInternalReactConstants, getDispatcherRef} from './fiber/renderer';
+import getDispatcherRef from 'react-devtools-shared/src/backend/fiber/getDispatcherRef';
+import {getInternalReactConstants} from './fiber/renderer';
 import {
   getStackByFiberInDevAndProd,
   getOwnerStackByFiberInDev,
@@ -227,9 +228,13 @@ export function patch({
           // Search for the first renderer that has a current Fiber.
           // We don't handle the edge case of stacks for more than one (e.g. interleaved renderers?)
           // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-          for (const renderer of injectedRenderers.values()) {
+          for (const [
+            renderer,
+            injectedRendererInterface,
+          ] of injectedRenderers.entries()) {
             const currentDispatcherRef = getDispatcherRef(renderer);
-            const {getCurrentFiber, onErrorOrWarning, workTagMap} = renderer;
+            const {getCurrentFiber, onErrorOrWarning, workTagMap} =
+              injectedRendererInterface;
             const current: ?Fiber = getCurrentFiber();
             if (current != null) {
               try {

--- a/packages/react-devtools-shared/src/backend/console.js
+++ b/packages/react-devtools-shared/src/backend/console.js
@@ -33,7 +33,7 @@ import {
   supportsConsoleTasks,
 } from './fiber/DevToolsFiberComponentStack';
 import {formatOwnerStack} from './shared/DevToolsOwnerStack';
-import {castBool, castBrowserTheme} from '../utils';
+import {castBool} from '../utils';
 
 const OVERRIDE_CONSOLE_METHODS = ['error', 'trace', 'warn'];
 
@@ -166,7 +166,6 @@ const consoleSettingsRef: ConsolePatchSettings = {
   breakOnConsoleErrors: false,
   showInlineWarningsAndErrors: false,
   hideConsoleLogsInStrictMode: false,
-  browserTheme: 'dark',
 };
 
 // Patches console methods to append component stack for the current fiber.
@@ -176,7 +175,6 @@ export function patch({
   breakOnConsoleErrors,
   showInlineWarningsAndErrors,
   hideConsoleLogsInStrictMode,
-  browserTheme,
 }: $ReadOnly<ConsolePatchSettings>): void {
   // Settings may change after we've patched the console.
   // Using a shared ref allows the patch function to read the latest values.
@@ -184,7 +182,6 @@ export function patch({
   consoleSettingsRef.breakOnConsoleErrors = breakOnConsoleErrors;
   consoleSettingsRef.showInlineWarningsAndErrors = showInlineWarningsAndErrors;
   consoleSettingsRef.hideConsoleLogsInStrictMode = hideConsoleLogsInStrictMode;
-  consoleSettingsRef.browserTheme = browserTheme;
 
   if (
     appendComponentStack ||
@@ -459,15 +456,12 @@ export function patchConsoleUsingWindowValues() {
   const hideConsoleLogsInStrictMode =
     castBool(window.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__) ??
     false;
-  const browserTheme =
-    castBrowserTheme(window.__REACT_DEVTOOLS_BROWSER_THEME__) ?? 'dark';
 
   patch({
     appendComponentStack,
     breakOnConsoleErrors,
     showInlineWarningsAndErrors,
     hideConsoleLogsInStrictMode,
-    browserTheme,
   });
 }
 
@@ -485,7 +479,6 @@ export function writeConsolePatchSettingsToWindow(
     settings.showInlineWarningsAndErrors;
   window.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ =
     settings.hideConsoleLogsInStrictMode;
-  window.__REACT_DEVTOOLS_BROWSER_THEME__ = settings.browserTheme;
 }
 
 export function installConsoleFunctionsToWindow(): void {

--- a/packages/react-devtools-shared/src/backend/fiber/getDispatcherRef.js
+++ b/packages/react-devtools-shared/src/backend/fiber/getDispatcherRef.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {
+  CurrentDispatcherRef,
+  ReactRenderer,
+} from 'react-devtools-shared/src/backend/types';
+
+// Do not add / import anything to this file.
+// This function is used from multiple places, including hook.
+
+export default function getDispatcherRef(
+  renderer: ReactRenderer,
+): void | CurrentDispatcherRef {
+  if (renderer.currentDispatcherRef === undefined) {
+    return undefined;
+  }
+  const injectedRef = renderer.currentDispatcherRef;
+  if (
+    typeof injectedRef.H === 'undefined' &&
+    typeof injectedRef.current !== 'undefined'
+  ) {
+    // We got a legacy dispatcher injected, let's create a wrapper proxy to translate.
+    return {
+      get H() {
+        return (injectedRef: any).current;
+      },
+      set H(value) {
+        (injectedRef: any).current = value;
+      },
+    };
+  }
+  return (injectedRef: any);
+}

--- a/packages/react-devtools-shared/src/backend/fiber/getWorkTagMap.js
+++ b/packages/react-devtools-shared/src/backend/fiber/getWorkTagMap.js
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Do not add / import anything to this file.
+// This function is used from multiple places, including hook.
+
+import type {WorkTagMap} from 'react-devtools-shared/src/backend/types';
+
+import {gt, gte} from 'react-devtools-shared/src/backend/utils';
+
+export default function getWorkTagMap(version: string): WorkTagMap {
+  let ReactTypeOfWork: WorkTagMap = ((null: any): WorkTagMap);
+
+  // **********************************************************
+  // The section below is copied from files in React repo, see ReactWorkTags.js.
+  // Keep it in sync, and add version guards if it changes.
+  if (gt(version, '17.0.1')) {
+    ReactTypeOfWork = {
+      CacheComponent: 24, // Experimental
+      ClassComponent: 1,
+      ContextConsumer: 9,
+      ContextProvider: 10,
+      CoroutineComponent: -1, // Removed
+      CoroutineHandlerPhase: -1, // Removed
+      DehydratedSuspenseComponent: 18, // Behind a flag
+      ForwardRef: 11,
+      Fragment: 7,
+      FunctionComponent: 0,
+      HostComponent: 5,
+      HostPortal: 4,
+      HostRoot: 3,
+      HostHoistable: 26, // In reality, 18.2+. But doesn't hurt to include it here
+      HostSingleton: 27, // Same as above
+      HostText: 6,
+      IncompleteClassComponent: 17,
+      IncompleteFunctionComponent: 28,
+      IndeterminateComponent: 2, // removed in 19.0.0
+      LazyComponent: 16,
+      LegacyHiddenComponent: 23,
+      MemoComponent: 14,
+      Mode: 8,
+      OffscreenComponent: 22, // Experimental
+      Profiler: 12,
+      ScopeComponent: 21, // Experimental
+      SimpleMemoComponent: 15,
+      SuspenseComponent: 13,
+      SuspenseListComponent: 19, // Experimental
+      TracingMarkerComponent: 25, // Experimental - This is technically in 18 but we don't
+      // want to fork again so we're adding it here instead
+      YieldComponent: -1, // Removed
+      Throw: 29,
+    };
+  } else if (gte(version, '17.0.0-alpha')) {
+    ReactTypeOfWork = {
+      CacheComponent: -1, // Doesn't exist yet
+      ClassComponent: 1,
+      ContextConsumer: 9,
+      ContextProvider: 10,
+      CoroutineComponent: -1, // Removed
+      CoroutineHandlerPhase: -1, // Removed
+      DehydratedSuspenseComponent: 18, // Behind a flag
+      ForwardRef: 11,
+      Fragment: 7,
+      FunctionComponent: 0,
+      HostComponent: 5,
+      HostPortal: 4,
+      HostRoot: 3,
+      HostHoistable: -1, // Doesn't exist yet
+      HostSingleton: -1, // Doesn't exist yet
+      HostText: 6,
+      IncompleteClassComponent: 17,
+      IncompleteFunctionComponent: -1, // Doesn't exist yet
+      IndeterminateComponent: 2,
+      LazyComponent: 16,
+      LegacyHiddenComponent: 24,
+      MemoComponent: 14,
+      Mode: 8,
+      OffscreenComponent: 23, // Experimental
+      Profiler: 12,
+      ScopeComponent: 21, // Experimental
+      SimpleMemoComponent: 15,
+      SuspenseComponent: 13,
+      SuspenseListComponent: 19, // Experimental
+      TracingMarkerComponent: -1, // Doesn't exist yet
+      YieldComponent: -1, // Removed
+      Throw: -1, // Doesn't exist yet
+    };
+  } else if (gte(version, '16.6.0-beta.0')) {
+    ReactTypeOfWork = {
+      CacheComponent: -1, // Doesn't exist yet
+      ClassComponent: 1,
+      ContextConsumer: 9,
+      ContextProvider: 10,
+      CoroutineComponent: -1, // Removed
+      CoroutineHandlerPhase: -1, // Removed
+      DehydratedSuspenseComponent: 18, // Behind a flag
+      ForwardRef: 11,
+      Fragment: 7,
+      FunctionComponent: 0,
+      HostComponent: 5,
+      HostPortal: 4,
+      HostRoot: 3,
+      HostHoistable: -1, // Doesn't exist yet
+      HostSingleton: -1, // Doesn't exist yet
+      HostText: 6,
+      IncompleteClassComponent: 17,
+      IncompleteFunctionComponent: -1, // Doesn't exist yet
+      IndeterminateComponent: 2,
+      LazyComponent: 16,
+      LegacyHiddenComponent: -1,
+      MemoComponent: 14,
+      Mode: 8,
+      OffscreenComponent: -1, // Experimental
+      Profiler: 12,
+      ScopeComponent: -1, // Experimental
+      SimpleMemoComponent: 15,
+      SuspenseComponent: 13,
+      SuspenseListComponent: 19, // Experimental
+      TracingMarkerComponent: -1, // Doesn't exist yet
+      YieldComponent: -1, // Removed
+      Throw: -1, // Doesn't exist yet
+    };
+  } else if (gte(version, '16.4.3-alpha')) {
+    ReactTypeOfWork = {
+      CacheComponent: -1, // Doesn't exist yet
+      ClassComponent: 2,
+      ContextConsumer: 11,
+      ContextProvider: 12,
+      CoroutineComponent: -1, // Removed
+      CoroutineHandlerPhase: -1, // Removed
+      DehydratedSuspenseComponent: -1, // Doesn't exist yet
+      ForwardRef: 13,
+      Fragment: 9,
+      FunctionComponent: 0,
+      HostComponent: 7,
+      HostPortal: 6,
+      HostRoot: 5,
+      HostHoistable: -1, // Doesn't exist yet
+      HostSingleton: -1, // Doesn't exist yet
+      HostText: 8,
+      IncompleteClassComponent: -1, // Doesn't exist yet
+      IncompleteFunctionComponent: -1, // Doesn't exist yet
+      IndeterminateComponent: 4,
+      LazyComponent: -1, // Doesn't exist yet
+      LegacyHiddenComponent: -1,
+      MemoComponent: -1, // Doesn't exist yet
+      Mode: 10,
+      OffscreenComponent: -1, // Experimental
+      Profiler: 15,
+      ScopeComponent: -1, // Experimental
+      SimpleMemoComponent: -1, // Doesn't exist yet
+      SuspenseComponent: 16,
+      SuspenseListComponent: -1, // Doesn't exist yet
+      TracingMarkerComponent: -1, // Doesn't exist yet
+      YieldComponent: -1, // Removed
+      Throw: -1, // Doesn't exist yet
+    };
+  } else {
+    ReactTypeOfWork = {
+      CacheComponent: -1, // Doesn't exist yet
+      ClassComponent: 2,
+      ContextConsumer: 12,
+      ContextProvider: 13,
+      CoroutineComponent: 7,
+      CoroutineHandlerPhase: 8,
+      DehydratedSuspenseComponent: -1, // Doesn't exist yet
+      ForwardRef: 14,
+      Fragment: 10,
+      FunctionComponent: 1,
+      HostComponent: 5,
+      HostPortal: 4,
+      HostRoot: 3,
+      HostHoistable: -1, // Doesn't exist yet
+      HostSingleton: -1, // Doesn't exist yet
+      HostText: 6,
+      IncompleteClassComponent: -1, // Doesn't exist yet
+      IncompleteFunctionComponent: -1, // Doesn't exist yet
+      IndeterminateComponent: 0,
+      LazyComponent: -1, // Doesn't exist yet
+      LegacyHiddenComponent: -1,
+      MemoComponent: -1, // Doesn't exist yet
+      Mode: 11,
+      OffscreenComponent: -1, // Experimental
+      Profiler: 15,
+      ScopeComponent: -1, // Experimental
+      SimpleMemoComponent: -1, // Doesn't exist yet
+      SuspenseComponent: 16,
+      SuspenseListComponent: -1, // Doesn't exist yet
+      TracingMarkerComponent: -1, // Doesn't exist yet
+      YieldComponent: 9,
+      Throw: -1, // Doesn't exist yet
+    };
+  }
+  // **********************************************************
+  // End of copied code.
+  // **********************************************************
+
+  return ReactTypeOfWork;
+}

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -132,6 +132,7 @@ import type {
 } from 'react-devtools-shared/src/frontend/types';
 import type {Source} from 'react-devtools-shared/src/shared/types';
 import {getStackByFiberInDevAndProd} from './DevToolsFiberComponentStack';
+import getWorkTagMap from 'react-devtools-shared/src/backend/fiber/getWorkTagMap';
 
 // Kinds
 const FIBER_INSTANCE = 0;
@@ -286,195 +287,6 @@ export function getInternalReactConstants(version: string): {
     StrictModeBits = 0b10;
   }
 
-  let ReactTypeOfWork: WorkTagMap = ((null: any): WorkTagMap);
-
-  // **********************************************************
-  // The section below is copied from files in React repo.
-  // Keep it in sync, and add version guards if it changes.
-  //
-  // TODO Update the gt() check below to be gte() whichever the next version number is.
-  // Currently the version in Git is 17.0.2 (but that version has not been/may not end up being released).
-  if (gt(version, '17.0.1')) {
-    ReactTypeOfWork = {
-      CacheComponent: 24, // Experimental
-      ClassComponent: 1,
-      ContextConsumer: 9,
-      ContextProvider: 10,
-      CoroutineComponent: -1, // Removed
-      CoroutineHandlerPhase: -1, // Removed
-      DehydratedSuspenseComponent: 18, // Behind a flag
-      ForwardRef: 11,
-      Fragment: 7,
-      FunctionComponent: 0,
-      HostComponent: 5,
-      HostPortal: 4,
-      HostRoot: 3,
-      HostHoistable: 26, // In reality, 18.2+. But doesn't hurt to include it here
-      HostSingleton: 27, // Same as above
-      HostText: 6,
-      IncompleteClassComponent: 17,
-      IncompleteFunctionComponent: 28,
-      IndeterminateComponent: 2, // removed in 19.0.0
-      LazyComponent: 16,
-      LegacyHiddenComponent: 23,
-      MemoComponent: 14,
-      Mode: 8,
-      OffscreenComponent: 22, // Experimental
-      Profiler: 12,
-      ScopeComponent: 21, // Experimental
-      SimpleMemoComponent: 15,
-      SuspenseComponent: 13,
-      SuspenseListComponent: 19, // Experimental
-      TracingMarkerComponent: 25, // Experimental - This is technically in 18 but we don't
-      // want to fork again so we're adding it here instead
-      YieldComponent: -1, // Removed
-      Throw: 29,
-    };
-  } else if (gte(version, '17.0.0-alpha')) {
-    ReactTypeOfWork = {
-      CacheComponent: -1, // Doesn't exist yet
-      ClassComponent: 1,
-      ContextConsumer: 9,
-      ContextProvider: 10,
-      CoroutineComponent: -1, // Removed
-      CoroutineHandlerPhase: -1, // Removed
-      DehydratedSuspenseComponent: 18, // Behind a flag
-      ForwardRef: 11,
-      Fragment: 7,
-      FunctionComponent: 0,
-      HostComponent: 5,
-      HostPortal: 4,
-      HostRoot: 3,
-      HostHoistable: -1, // Doesn't exist yet
-      HostSingleton: -1, // Doesn't exist yet
-      HostText: 6,
-      IncompleteClassComponent: 17,
-      IncompleteFunctionComponent: -1, // Doesn't exist yet
-      IndeterminateComponent: 2,
-      LazyComponent: 16,
-      LegacyHiddenComponent: 24,
-      MemoComponent: 14,
-      Mode: 8,
-      OffscreenComponent: 23, // Experimental
-      Profiler: 12,
-      ScopeComponent: 21, // Experimental
-      SimpleMemoComponent: 15,
-      SuspenseComponent: 13,
-      SuspenseListComponent: 19, // Experimental
-      TracingMarkerComponent: -1, // Doesn't exist yet
-      YieldComponent: -1, // Removed
-      Throw: -1, // Doesn't exist yet
-    };
-  } else if (gte(version, '16.6.0-beta.0')) {
-    ReactTypeOfWork = {
-      CacheComponent: -1, // Doesn't exist yet
-      ClassComponent: 1,
-      ContextConsumer: 9,
-      ContextProvider: 10,
-      CoroutineComponent: -1, // Removed
-      CoroutineHandlerPhase: -1, // Removed
-      DehydratedSuspenseComponent: 18, // Behind a flag
-      ForwardRef: 11,
-      Fragment: 7,
-      FunctionComponent: 0,
-      HostComponent: 5,
-      HostPortal: 4,
-      HostRoot: 3,
-      HostHoistable: -1, // Doesn't exist yet
-      HostSingleton: -1, // Doesn't exist yet
-      HostText: 6,
-      IncompleteClassComponent: 17,
-      IncompleteFunctionComponent: -1, // Doesn't exist yet
-      IndeterminateComponent: 2,
-      LazyComponent: 16,
-      LegacyHiddenComponent: -1,
-      MemoComponent: 14,
-      Mode: 8,
-      OffscreenComponent: -1, // Experimental
-      Profiler: 12,
-      ScopeComponent: -1, // Experimental
-      SimpleMemoComponent: 15,
-      SuspenseComponent: 13,
-      SuspenseListComponent: 19, // Experimental
-      TracingMarkerComponent: -1, // Doesn't exist yet
-      YieldComponent: -1, // Removed
-      Throw: -1, // Doesn't exist yet
-    };
-  } else if (gte(version, '16.4.3-alpha')) {
-    ReactTypeOfWork = {
-      CacheComponent: -1, // Doesn't exist yet
-      ClassComponent: 2,
-      ContextConsumer: 11,
-      ContextProvider: 12,
-      CoroutineComponent: -1, // Removed
-      CoroutineHandlerPhase: -1, // Removed
-      DehydratedSuspenseComponent: -1, // Doesn't exist yet
-      ForwardRef: 13,
-      Fragment: 9,
-      FunctionComponent: 0,
-      HostComponent: 7,
-      HostPortal: 6,
-      HostRoot: 5,
-      HostHoistable: -1, // Doesn't exist yet
-      HostSingleton: -1, // Doesn't exist yet
-      HostText: 8,
-      IncompleteClassComponent: -1, // Doesn't exist yet
-      IncompleteFunctionComponent: -1, // Doesn't exist yet
-      IndeterminateComponent: 4,
-      LazyComponent: -1, // Doesn't exist yet
-      LegacyHiddenComponent: -1,
-      MemoComponent: -1, // Doesn't exist yet
-      Mode: 10,
-      OffscreenComponent: -1, // Experimental
-      Profiler: 15,
-      ScopeComponent: -1, // Experimental
-      SimpleMemoComponent: -1, // Doesn't exist yet
-      SuspenseComponent: 16,
-      SuspenseListComponent: -1, // Doesn't exist yet
-      TracingMarkerComponent: -1, // Doesn't exist yet
-      YieldComponent: -1, // Removed
-      Throw: -1, // Doesn't exist yet
-    };
-  } else {
-    ReactTypeOfWork = {
-      CacheComponent: -1, // Doesn't exist yet
-      ClassComponent: 2,
-      ContextConsumer: 12,
-      ContextProvider: 13,
-      CoroutineComponent: 7,
-      CoroutineHandlerPhase: 8,
-      DehydratedSuspenseComponent: -1, // Doesn't exist yet
-      ForwardRef: 14,
-      Fragment: 10,
-      FunctionComponent: 1,
-      HostComponent: 5,
-      HostPortal: 4,
-      HostRoot: 3,
-      HostHoistable: -1, // Doesn't exist yet
-      HostSingleton: -1, // Doesn't exist yet
-      HostText: 6,
-      IncompleteClassComponent: -1, // Doesn't exist yet
-      IncompleteFunctionComponent: -1, // Doesn't exist yet
-      IndeterminateComponent: 0,
-      LazyComponent: -1, // Doesn't exist yet
-      LegacyHiddenComponent: -1,
-      MemoComponent: -1, // Doesn't exist yet
-      Mode: 11,
-      OffscreenComponent: -1, // Experimental
-      Profiler: 15,
-      ScopeComponent: -1, // Experimental
-      SimpleMemoComponent: -1, // Doesn't exist yet
-      SuspenseComponent: 16,
-      SuspenseListComponent: -1, // Doesn't exist yet
-      TracingMarkerComponent: -1, // Doesn't exist yet
-      YieldComponent: 9,
-      Throw: -1, // Doesn't exist yet
-    };
-  }
-  // **********************************************************
-  // End of copied code.
-  // **********************************************************
-
   function getTypeSymbol(type: any): symbol | number {
     const symbolOrNumber =
       typeof type === 'object' && type !== null ? type.$$typeof : type;
@@ -485,6 +297,7 @@ export function getInternalReactConstants(version: string): {
       : symbolOrNumber;
   }
 
+  const ReactTypeOfWork = getWorkTagMap(version);
   const {
     CacheComponent,
     ClassComponent,

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -122,8 +122,6 @@ import type {
   RendererInterface,
   SerializedElement,
   WorkTagMap,
-  CurrentDispatcherRef,
-  LegacyDispatcherRef,
 } from '../types';
 import type {
   ComponentFilter,
@@ -133,6 +131,7 @@ import type {
 import type {Source} from 'react-devtools-shared/src/shared/types';
 import {getStackByFiberInDevAndProd} from './DevToolsFiberComponentStack';
 import getWorkTagMap from 'react-devtools-shared/src/backend/fiber/getWorkTagMap';
+import getDispatcherRef from 'react-devtools-shared/src/backend/fiber/getDispatcherRef';
 
 // Kinds
 const FIBER_INSTANCE = 0;
@@ -203,31 +202,6 @@ type ReactPriorityLevelsType = {
   IdlePriority: number,
   NoPriority: number,
 };
-
-export function getDispatcherRef(renderer: {
-  +currentDispatcherRef?: LegacyDispatcherRef | CurrentDispatcherRef,
-  ...
-}): void | CurrentDispatcherRef {
-  if (renderer.currentDispatcherRef === undefined) {
-    return undefined;
-  }
-  const injectedRef = renderer.currentDispatcherRef;
-  if (
-    typeof injectedRef.H === 'undefined' &&
-    typeof injectedRef.current !== 'undefined'
-  ) {
-    // We got a legacy dispatcher injected, let's create a wrapper proxy to translate.
-    return {
-      get H() {
-        return (injectedRef: any).current;
-      },
-      set H(value) {
-        (injectedRef: any).current = value;
-      },
-    };
-  }
-  return (injectedRef: any);
-}
 
 function getFiberFlags(fiber: Fiber): number {
   // The name of this field changed from "effectTag" to "flags"

--- a/packages/react-devtools-shared/src/backend/index.js
+++ b/packages/react-devtools-shared/src/backend/index.js
@@ -130,6 +130,10 @@ export function initBackend(
     agent.removeListener('shutdown', onAgentShutdown);
   });
 
+  agent.addListener('updateHookSettings', settings => {
+    hook.settings = settings;
+  });
+
   return () => {
     subs.forEach(fn => fn());
   };

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -513,6 +513,7 @@ export type DevToolsHook = {
   // Testing
   dangerous_setTargetConsoleForTesting?: (fakeConsole: Object) => void,
 
+  settings: DevToolsHookSettings,
   ...
 };
 
@@ -522,4 +523,11 @@ export type ConsolePatchSettings = {
   showInlineWarningsAndErrors: boolean,
   hideConsoleLogsInStrictMode: boolean,
   browserTheme: BrowserTheme,
+};
+
+export type DevToolsHookSettings = {
+  appendComponentStack: boolean,
+  breakOnConsoleErrors: boolean,
+  showInlineWarningsAndErrors: boolean,
+  hideConsoleLogsInStrictMode: boolean,
 };

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -27,7 +27,6 @@ import type {
 } from 'react-devtools-shared/src/backend/NativeStyleEditor/setupNativeStyleEditor';
 import type {InitBackend} from 'react-devtools-shared/src/backend';
 import type {TimelineDataExport} from 'react-devtools-timeline/src/types';
-import type {BrowserTheme} from 'react-devtools-shared/src/frontend/types';
 import type {BackendBridge} from 'react-devtools-shared/src/bridge';
 import type {Source} from 'react-devtools-shared/src/shared/types';
 import type Agent from './agent';
@@ -517,17 +516,12 @@ export type DevToolsHook = {
   ...
 };
 
-export type ConsolePatchSettings = {
-  appendComponentStack: boolean,
-  breakOnConsoleErrors: boolean,
-  showInlineWarningsAndErrors: boolean,
-  hideConsoleLogsInStrictMode: boolean,
-  browserTheme: BrowserTheme,
-};
-
 export type DevToolsHookSettings = {
   appendComponentStack: boolean,
   breakOnConsoleErrors: boolean,
   showInlineWarningsAndErrors: boolean,
   hideConsoleLogsInStrictMode: boolean,
 };
+
+// Will be removed together with console patching from backend/console.js to hook.js
+export type ConsolePatchSettings = DevToolsHookSettings;

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -202,7 +202,6 @@ function SettingsContextController({
       breakOnConsoleErrors,
       showInlineWarningsAndErrors,
       hideConsoleLogsInStrictMode,
-      browserTheme,
     });
   }, [
     bridge,
@@ -210,7 +209,6 @@ function SettingsContextController({
     breakOnConsoleErrors,
     showInlineWarningsAndErrors,
     hideConsoleLogsInStrictMode,
-    browserTheme,
   ]);
 
   useEffect(() => {

--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -15,6 +15,7 @@ import type {
   RendererID,
   RendererInterface,
   DevToolsBackend,
+  DevToolsHookSettings,
 } from './backend/types';
 
 import {
@@ -24,7 +25,10 @@ import {
 
 declare var window: any;
 
-export function installHook(target: any): DevToolsHook | null {
+export function installHook(
+  target: any,
+  injectedSettings?: DevToolsHookSettings,
+): DevToolsHook | null {
   if (target.hasOwnProperty('__REACT_DEVTOOLS_GLOBAL_HOOK__')) {
     return null;
   }
@@ -543,6 +547,14 @@ export function installHook(target: any): DevToolsHook | null {
   const listeners: {[string]: Array<Handler>} = {};
   const renderers = new Map<RendererID, ReactRenderer>();
   const backends = new Map<string, DevToolsBackend>();
+  const settings = injectedSettings
+    ? injectedSettings
+    : {
+        appendComponentStack: true,
+        breakOnConsoleErrors: false,
+        showInlineWarningsAndErrors: true,
+        hideConsoleLogsInStrictMode: false,
+      };
 
   const hook: DevToolsHook = {
     rendererInterfaces,
@@ -577,6 +589,8 @@ export function installHook(target: any): DevToolsHook | null {
     getInternalModuleRanges,
     registerInternalModuleStart,
     registerInternalModuleStop,
+
+    settings,
   };
 
   if (__TEST__) {


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/30567 and whats under it. See changes [here](https://github.com/facebook/react/pull/30594/commits/4cb7bba185b1e03f72555bdf8c6b1860832830d8).

Similar to https://github.com/facebook/react/pull/30567, but for `getDispatcherRef` function. Will be used in `hook.js` later.