### PR TITLE
Remove flag enableUseDeferredValueInitialArg

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzDeferredValue-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzDeferredValue-test.js
@@ -83,7 +83,6 @@ describe('ReactDOMFizzForm', () => {
     return text;
   }
 
-  // @gate enableUseDeferredValueInitialArg
   it('returns initialValue argument, if provided', async () => {
     function App() {
       return useDeferredValue('Final', 'Initial');
@@ -100,7 +99,6 @@ describe('ReactDOMFizzForm', () => {
     expect(container.textContent).toEqual('Final');
   });
 
-  // @gate enableUseDeferredValueInitialArg
   // @gate enablePostpone
   it(
     'if initial value postpones during hydration, it will switch to the ' +
@@ -136,7 +134,6 @@ describe('ReactDOMFizzForm', () => {
     },
   );
 
-  // @gate enableUseDeferredValueInitialArg
   it(
     'useDeferredValue during hydration has higher priority than remaining ' +
       'incremental hydration',

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -45,7 +45,6 @@ import {
   enableLegacyCache,
   debugRenderPhaseSideEffectsForStrictMode,
   enableAsyncActions,
-  enableUseDeferredValueInitialArg,
   disableLegacyMode,
   enableNoCloningMemoCache,
   enableContextProfiling,
@@ -2879,7 +2878,6 @@ function rerenderDeferredValue<T>(value: T, initialValue?: T): T {
 
 function mountDeferredValueImpl<T>(hook: Hook, value: T, initialValue?: T): T {
   if (
-    enableUseDeferredValueInitialArg &&
     // When `initialValue` is provided, we defer the initial render even if the
     // current render is not synchronous.
     initialValue !== undefined &&

--- a/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
@@ -371,7 +371,6 @@ describe('ReactDeferredValue', () => {
     });
   });
 
-  // @gate enableUseDeferredValueInitialArg
   it('supports initialValue argument', async () => {
     function App() {
       const value = useDeferredValue('Final', 'Initial');
@@ -388,7 +387,6 @@ describe('ReactDeferredValue', () => {
     expect(root).toMatchRenderedOutput('Final');
   });
 
-  // @gate enableUseDeferredValueInitialArg
   it('defers during initial render when initialValue is provided, even if render is not sync', async () => {
     function App() {
       const value = useDeferredValue('Final', 'Initial');
@@ -406,7 +404,6 @@ describe('ReactDeferredValue', () => {
     expect(root).toMatchRenderedOutput('Final');
   });
 
-  // @gate enableUseDeferredValueInitialArg
   it(
     'if a suspended render spawns a deferred task, we can switch to the ' +
       'deferred task without finishing the original one (no Suspense boundary)',
@@ -439,7 +436,6 @@ describe('ReactDeferredValue', () => {
     },
   );
 
-  // @gate enableUseDeferredValueInitialArg
   it(
     'if a suspended render spawns a deferred task, we can switch to the ' +
       'deferred task without finishing the original one (no Suspense boundary, ' +
@@ -479,7 +475,6 @@ describe('ReactDeferredValue', () => {
     },
   );
 
-  // @gate enableUseDeferredValueInitialArg
   it(
     'if a suspended render spawns a deferred task, we can switch to the ' +
       'deferred task without finishing the original one (Suspense boundary)',
@@ -520,7 +515,6 @@ describe('ReactDeferredValue', () => {
     },
   );
 
-  // @gate enableUseDeferredValueInitialArg
   it(
     'if a suspended render spawns a deferred task that also suspends, we can ' +
       'finish the original task if that one loads first',
@@ -556,7 +550,6 @@ describe('ReactDeferredValue', () => {
     },
   );
 
-  // @gate enableUseDeferredValueInitialArg
   it(
     'if there are multiple useDeferredValues in the same tree, only the ' +
       'first level defers; subsequent ones go straight to the final value, to ' +
@@ -604,7 +597,6 @@ describe('ReactDeferredValue', () => {
     },
   );
 
-  // @gate enableUseDeferredValueInitialArg
   it('avoids a useDeferredValue waterfall when separated by a Suspense boundary', async () => {
     // Same as the previous test but with a Suspense boundary separating the
     // two useDeferredValue hooks.
@@ -649,7 +641,6 @@ describe('ReactDeferredValue', () => {
     expect(root).toMatchRenderedOutput('Content');
   });
 
-  // @gate enableUseDeferredValueInitialArg
   // @gate enableActivity
   it('useDeferredValue can spawn a deferred task while prerendering a hidden tree', async () => {
     function App() {
@@ -696,7 +687,6 @@ describe('ReactDeferredValue', () => {
     expect(root).toMatchRenderedOutput(<div>Final</div>);
   });
 
-  // @gate enableUseDeferredValueInitialArg
   // @gate enableActivity
   it('useDeferredValue can prerender the initial value inside a hidden tree', async () => {
     function App({text}) {
@@ -755,7 +745,6 @@ describe('ReactDeferredValue', () => {
     expect(root).toMatchRenderedOutput(<div>B</div>);
   });
 
-  // @gate enableUseDeferredValueInitialArg
   // @gate enableActivity
   it(
     'useDeferredValue skips the preview state when revealing a hidden tree ' +
@@ -796,7 +785,6 @@ describe('ReactDeferredValue', () => {
     },
   );
 
-  // @gate enableUseDeferredValueInitialArg
   // @gate enableActivity
   it(
     'useDeferredValue does not skip the preview state when revealing a ' +

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -43,7 +43,6 @@ import {
   enableUseEffectEventHook,
   enableUseMemoCacheHook,
   enableAsyncActions,
-  enableUseDeferredValueInitialArg,
 } from 'shared/ReactFeatureFlags';
 import is from 'shared/objectIs';
 import {
@@ -570,11 +569,7 @@ function useSyncExternalStore<T>(
 
 function useDeferredValue<T>(value: T, initialValue?: T): T {
   resolveCurrentlyRenderingComponent();
-  if (enableUseDeferredValueInitialArg) {
-    return initialValue !== undefined ? initialValue : value;
-  } else {
-    return value;
-  }
+  return initialValue !== undefined ? initialValue : value;
 }
 
 function unsupportedStartTransition() {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -221,9 +221,6 @@ export const disableLegacyMode = true;
 // Make <Context> equivalent to <Context.Provider> instead of <Context.Consumer>
 export const enableRenderableContext = true;
 
-// Enables the `initialValue` option for `useDeferredValue`
-export const enableUseDeferredValueInitialArg = true;
-
 // -----------------------------------------------------------------------------
 // Chopping Block
 //

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -83,7 +83,6 @@ export const enableTaint = true;
 export const enableTransitionTracing = false;
 export const enableTrustedTypesIntegration = false;
 export const enableUpdaterTracking = __PROFILE__;
-export const enableUseDeferredValueInitialArg = true;
 export const enableUseEffectEventHook = false;
 export const enableUseMemoCacheHook = true;
 export const favorSafetyOverHydrationPerf = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -74,7 +74,6 @@ export const enableSuspenseCallback = false;
 export const enableTaint = true;
 export const enableTransitionTracing = false;
 export const enableTrustedTypesIntegration = false;
-export const enableUseDeferredValueInitialArg = true;
 export const enableUseEffectEventHook = false;
 export const enableUseMemoCacheHook = true;
 export const favorSafetyOverHydrationPerf = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -71,7 +71,6 @@ export const alwaysThrottleRetries = true;
 
 export const passChildrenWhenCloningPersistedNodes = false;
 export const enablePersistedModeClonedFlag = false;
-export const enableUseDeferredValueInitialArg = __EXPERIMENTAL__;
 export const disableClientCache = true;
 
 export const enableServerComponentLogs = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -69,7 +69,6 @@ export const enableTaint = true;
 export const enableTransitionTracing = false;
 export const enableTrustedTypesIntegration = false;
 export const enableUpdaterTracking = false;
-export const enableUseDeferredValueInitialArg = true;
 export const enableUseEffectEventHook = false;
 export const enableUseMemoCacheHook = true;
 export const favorSafetyOverHydrationPerf = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -74,7 +74,6 @@ export const alwaysThrottleRetries = true;
 
 export const passChildrenWhenCloningPersistedNodes = false;
 export const enablePersistedModeClonedFlag = false;
-export const enableUseDeferredValueInitialArg = true;
 export const disableClientCache = true;
 
 export const enableServerComponentLogs = true;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -26,7 +26,6 @@ export const enableObjectFiber = __VARIANT__;
 export const enableRenderableContext = __VARIANT__;
 export const enableRetryLaneExpiration = __VARIANT__;
 export const enableTransitionTracing = __VARIANT__;
-export const enableUseDeferredValueInitialArg = __VARIANT__;
 export const favorSafetyOverHydrationPerf = __VARIANT__;
 export const renameElementSymbol = __VARIANT__;
 export const retryLaneExpirationMs = 5000;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -30,7 +30,6 @@ export const {
   enableRetryLaneExpiration,
   enableTransitionTracing,
   enableTrustedTypesIntegration,
-  enableUseDeferredValueInitialArg,
   favorSafetyOverHydrationPerf,
   renameElementSymbol,
   retryLaneExpirationMs,


### PR DESCRIPTION

This is enabled everywhere for a while and I don't think we'd be backing this out of 19. Seems like it's good to clean up to me.
