### PR TITLE
Replace NodeJS 21 with 22 in devEngines field

### DIFF
--- a/fixtures/flight/package.json
+++ b/fixtures/flight/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "devEngines": {
-    "node": "20.x || 21.x"
+    "node": "20.x || 22.x"
   },
   "dependencies": {
     "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "yargs": "^15.3.1"
   },
   "devEngines": {
-    "node": "16.x || 18.x || 20.x || 21.x"
+    "node": "16.x || 18.x || 20.x || 22.x"
   },
   "jest": {
     "testRegex": "/scripts/jest/dont-run-jest-directly\\.js$"


### PR DESCRIPTION

21 is EOL and 22 is stable now.

Homebrew installs 22 by default as well which is the practical reason for me to update this.
