### PR TITLE
refactor[react-devtools]: propagate settings from global hook object to frontend

### DIFF
--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -162,7 +162,7 @@ export function connectToDevTools(options: ?ConnectOptions) {
     );
 
     if (devToolsSettingsManager != null && bridge != null) {
-      bridge.addListener('updateConsolePatchSettings', consolePatchSettings =>
+      bridge.addListener('updateHookSettings', consolePatchSettings =>
         cacheConsolePatchSettings(
           devToolsSettingsManager,
           consolePatchSettings,
@@ -368,7 +368,7 @@ export function connectWithCustomMessagingProtocol({
   );
 
   if (settingsManager != null) {
-    bridge.addListener('updateConsolePatchSettings', consolePatchSettings =>
+    bridge.addListener('updateHookSettings', consolePatchSettings =>
       cacheConsolePatchSettings(settingsManager, consolePatchSettings),
     );
   }

--- a/packages/react-devtools-core/src/cachedSettings.js
+++ b/packages/react-devtools-core/src/cachedSettings.js
@@ -66,7 +66,7 @@ function parseConsolePatchSettings(
 
 export function cacheConsolePatchSettings(
   devToolsSettingsManager: DevToolsSettingsManager,
-  value: ConsolePatchSettings,
+  value: $ReadOnly<ConsolePatchSettings>,
 ): void {
   if (devToolsSettingsManager.setConsolePatchSettings == null) {
     return;

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -150,6 +150,7 @@ export default class Agent extends EventEmitter<{
   disableTraceUpdates: [],
   getIfHasUnsupportedRendererVersion: [],
   updateHookSettings: [DevToolsHookSettings],
+  getHookSettings: [],
 }> {
   _bridge: BackendBridge;
   _isProfiling: boolean = false;
@@ -213,10 +214,10 @@ export default class Agent extends EventEmitter<{
       this.syncSelectionFromBuiltinElementsPanel,
     );
     bridge.addListener('shutdown', this.shutdown);
-    bridge.addListener(
-      'updateConsolePatchSettings',
-      this.updateConsolePatchSettings,
-    );
+
+    bridge.addListener('updateHookSettings', this.updateHookSettings);
+    bridge.addListener('getHookSettings', this.getHookSettings);
+
     bridge.addListener('updateComponentFilters', this.updateComponentFilters);
     bridge.addListener('getEnvironmentNames', this.getEnvironmentNames);
     bridge.addListener(
@@ -802,17 +803,25 @@ export default class Agent extends EventEmitter<{
     }
   };
 
-  updateConsolePatchSettings: (
-    settings: $ReadOnly<DevToolsHookSettings>,
-  ) => void = settings => {
-    // Propagate the settings, so Backend can subscribe to it and modify hook
-    this.emit('updateHookSettings', {
-      appendComponentStack: settings.appendComponentStack,
-      breakOnConsoleErrors: settings.breakOnConsoleErrors,
-      showInlineWarningsAndErrors: settings.showInlineWarningsAndErrors,
-      hideConsoleLogsInStrictMode: settings.hideConsoleLogsInStrictMode,
-    });
+  updateHookSettings: (settings: $ReadOnly<DevToolsHookSettings>) => void =
+    settings => {
+      // Propagate the settings, so Backend can subscribe to it and modify hook
+      this.emit('updateHookSettings', {
+        appendComponentStack: settings.appendComponentStack,
+        breakOnConsoleErrors: settings.breakOnConsoleErrors,
+        showInlineWarningsAndErrors: settings.showInlineWarningsAndErrors,
+        hideConsoleLogsInStrictMode: settings.hideConsoleLogsInStrictMode,
+      });
+    };
+
+  getHookSettings: () => void = () => {
+    this.emit('getHookSettings');
   };
+
+  onHookSettings: (settings: $ReadOnly<DevToolsHookSettings>) => void =
+    settings => {
+      this._bridge.send('hookSettings', settings);
+    };
 
   updateComponentFilters: (componentFilters: Array<ComponentFilter>) => void =
     componentFilters => {

--- a/packages/react-devtools-shared/src/backend/index.js
+++ b/packages/react-devtools-shared/src/backend/index.js
@@ -54,6 +54,7 @@ export function initBackend(
     hook.sub('fastRefreshScheduled', agent.onFastRefreshScheduled),
     hook.sub('operations', agent.onHookOperations),
     hook.sub('traceUpdates', agent.onTraceUpdates),
+    hook.sub('settingsInitialized', agent.onHookSettings),
 
     // TODO Add additional subscriptions required for profiling mode
   ];
@@ -85,6 +86,12 @@ export function initBackend(
 
   agent.addListener('updateHookSettings', settings => {
     hook.settings = settings;
+  });
+
+  agent.addListener('getHookSettings', () => {
+    if (hook.settings != null) {
+      agent.onHookSettings(hook.settings);
+    }
   });
 
   return () => {

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -207,6 +207,8 @@ export type BackendEvents = {
     {isSupported: boolean, validAttributes: ?$ReadOnlyArray<string>},
   ],
   NativeStyleEditor_styleAndLayout: [StyleAndLayoutPayload],
+
+  hookSettings: [$ReadOnly<DevToolsHookSettings>],
 };
 
 type FrontendEvents = {
@@ -241,7 +243,7 @@ type FrontendEvents = {
   storeAsGlobal: [StoreAsGlobalParams],
   updateComponentFilters: [Array<ComponentFilter>],
   getEnvironmentNames: [],
-  updateConsolePatchSettings: [DevToolsHookSettings],
+  updateHookSettings: [$ReadOnly<DevToolsHookSettings>],
   viewAttributeSource: [ViewAttributeSourceParams],
   viewElementSource: [ElementAndRendererID],
 
@@ -267,6 +269,8 @@ type FrontendEvents = {
 
   resumeElementPolling: [],
   pauseElementPolling: [],
+
+  getHookSettings: [],
 };
 
 class Bridge<

--- a/packages/react-devtools-shared/src/devtools/views/Settings/DebuggingSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/DebuggingSettings.js
@@ -8,22 +8,49 @@
  */
 
 import * as React from 'react';
-import {useContext} from 'react';
-import {SettingsContext} from './SettingsContext';
+import {use, useState, useEffect} from 'react';
+
+import type {DevToolsHookSettings} from 'react-devtools-shared/src/backend/types';
+import type Store from 'react-devtools-shared/src/devtools/store';
 
 import styles from './SettingsShared.css';
 
-export default function DebuggingSettings(_: {}): React.Node {
-  const {
+type Props = {
+  hookSettings: Promise<$ReadOnly<DevToolsHookSettings>>,
+  store: Store,
+};
+
+export default function DebuggingSettings({
+  hookSettings,
+  store,
+}: Props): React.Node {
+  const usedHookSettings = use(hookSettings);
+
+  const [appendComponentStack, setAppendComponentStack] = useState(
+    usedHookSettings.appendComponentStack,
+  );
+  const [breakOnConsoleErrors, setBreakOnConsoleErrors] = useState(
+    usedHookSettings.breakOnConsoleErrors,
+  );
+  const [hideConsoleLogsInStrictMode, setHideConsoleLogsInStrictMode] =
+    useState(usedHookSettings.hideConsoleLogsInStrictMode);
+  const [showInlineWarningsAndErrors, setShowInlineWarningsAndErrors] =
+    useState(usedHookSettings.showInlineWarningsAndErrors);
+
+  useEffect(() => {
+    store.updateHookSettings({
+      appendComponentStack,
+      breakOnConsoleErrors,
+      showInlineWarningsAndErrors,
+      hideConsoleLogsInStrictMode,
+    });
+  }, [
+    store,
     appendComponentStack,
     breakOnConsoleErrors,
-    hideConsoleLogsInStrictMode,
-    setAppendComponentStack,
-    setBreakOnConsoleErrors,
-    setShowInlineWarningsAndErrors,
     showInlineWarningsAndErrors,
-    setHideConsoleLogsInStrictMode,
-  } = useContext(SettingsContext);
+    hideConsoleLogsInStrictMode,
+  ]);
 
   return (
     <div className={styles.Settings}>

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -20,11 +20,7 @@ import {
 import {
   LOCAL_STORAGE_BROWSER_THEME,
   LOCAL_STORAGE_PARSE_HOOK_NAMES_KEY,
-  LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS,
-  LOCAL_STORAGE_SHOULD_APPEND_COMPONENT_STACK_KEY,
   LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY,
-  LOCAL_STORAGE_SHOW_INLINE_WARNINGS_AND_ERRORS_KEY,
-  LOCAL_STORAGE_HIDE_CONSOLE_LOGS_IN_STRICT_MODE,
 } from 'react-devtools-shared/src/constants';
 import {
   COMFORTABLE_LINE_HEIGHT,
@@ -118,30 +114,10 @@ function SettingsContextController({
     LOCAL_STORAGE_BROWSER_THEME,
     'auto',
   );
-  const [appendComponentStack, setAppendComponentStack] =
-    useLocalStorageWithLog<boolean>(
-      LOCAL_STORAGE_SHOULD_APPEND_COMPONENT_STACK_KEY,
-      true,
-    );
-  const [breakOnConsoleErrors, setBreakOnConsoleErrors] =
-    useLocalStorageWithLog<boolean>(
-      LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS,
-      false,
-    );
   const [parseHookNames, setParseHookNames] = useLocalStorageWithLog<boolean>(
     LOCAL_STORAGE_PARSE_HOOK_NAMES_KEY,
     false,
   );
-  const [hideConsoleLogsInStrictMode, setHideConsoleLogsInStrictMode] =
-    useLocalStorageWithLog<boolean>(
-      LOCAL_STORAGE_HIDE_CONSOLE_LOGS_IN_STRICT_MODE,
-      false,
-    );
-  const [showInlineWarningsAndErrors, setShowInlineWarningsAndErrors] =
-    useLocalStorageWithLog<boolean>(
-      LOCAL_STORAGE_SHOW_INLINE_WARNINGS_AND_ERRORS_KEY,
-      true,
-    );
   const [traceUpdatesEnabled, setTraceUpdatesEnabled] =
     useLocalStorageWithLog<boolean>(
       LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY,
@@ -197,63 +173,32 @@ function SettingsContextController({
   }, [browserTheme, theme, documentElements]);
 
   useEffect(() => {
-    bridge.send('updateConsolePatchSettings', {
-      appendComponentStack,
-      breakOnConsoleErrors,
-      showInlineWarningsAndErrors,
-      hideConsoleLogsInStrictMode,
-    });
-  }, [
-    bridge,
-    appendComponentStack,
-    breakOnConsoleErrors,
-    showInlineWarningsAndErrors,
-    hideConsoleLogsInStrictMode,
-  ]);
-
-  useEffect(() => {
     bridge.send('setTraceUpdatesEnabled', traceUpdatesEnabled);
   }, [bridge, traceUpdatesEnabled]);
 
   const value = useMemo(
     () => ({
-      appendComponentStack,
-      breakOnConsoleErrors,
       displayDensity,
       lineHeight:
         displayDensity === 'compact'
           ? COMPACT_LINE_HEIGHT
           : COMFORTABLE_LINE_HEIGHT,
       parseHookNames,
-      setAppendComponentStack,
-      setBreakOnConsoleErrors,
       setDisplayDensity,
       setParseHookNames,
       setTheme,
       setTraceUpdatesEnabled,
-      setShowInlineWarningsAndErrors,
-      showInlineWarningsAndErrors,
-      setHideConsoleLogsInStrictMode,
-      hideConsoleLogsInStrictMode,
       theme,
       browserTheme,
       traceUpdatesEnabled,
     }),
     [
-      appendComponentStack,
-      breakOnConsoleErrors,
       displayDensity,
       parseHookNames,
-      setAppendComponentStack,
-      setBreakOnConsoleErrors,
       setDisplayDensity,
       setParseHookNames,
       setTheme,
       setTraceUpdatesEnabled,
-      setShowInlineWarningsAndErrors,
-      showInlineWarningsAndErrors,
-      setHideConsoleLogsInStrictMode,
-      hideConsoleLogsInStrictMode,
       theme,
       browserTheme,
       traceUpdatesEnabled,

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsModal.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsModal.js
@@ -26,9 +26,11 @@ import ProfilerSettings from './ProfilerSettings';
 
 import styles from './SettingsModal.css';
 
-type TabID = 'general' | 'components' | 'profiler';
+import type Store from 'react-devtools-shared/src/devtools/store';
 
-export default function SettingsModal(_: {}): React.Node {
+type TabID = 'general' | 'debugging' | 'components' | 'profiler';
+
+export default function SettingsModal(): React.Node {
   const {isModalShowing, setIsModalShowing} = useContext(SettingsModalContext);
   const store = useContext(StoreContext);
   const {profilerStore} = store;
@@ -54,11 +56,13 @@ export default function SettingsModal(_: {}): React.Node {
     return null;
   }
 
-  return <SettingsModalImpl />;
+  return <SettingsModalImpl store={store} />;
 }
 
-function SettingsModalImpl(_: {}) {
-  const {setIsModalShowing, environmentNames} =
+type ImplProps = {store: Store};
+
+function SettingsModalImpl({store}: ImplProps) {
+  const {setIsModalShowing, environmentNames, hookSettings} =
     useContext(SettingsModalContext);
   const dismissModal = useCallback(
     () => setIsModalShowing(false),
@@ -84,9 +88,8 @@ function SettingsModalImpl(_: {}) {
     case 'components':
       view = <ComponentsSettings environmentNames={environmentNames} />;
       break;
-    // $FlowFixMe[incompatible-type] is this missing in TabID?
     case 'debugging':
-      view = <DebuggingSettings />;
+      view = <DebuggingSettings hookSettings={hookSettings} store={store} />;
       break;
     case 'general':
       view = <GeneralSettings />;

--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -655,6 +655,8 @@ export function installHook(
     Promise.resolve(maybeSettingsOrSettingsPromise)
       .then(settings => {
         hook.settings = settings;
+        hook.emit('settingsInitialized', settings);
+
         patchConsoleForErrorsAndWarnings();
       })
       .catch(() => {


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/30597 and whats under it. See [this commit](https://github.com/facebook/react/pull/30610/commits/59b4efa72377bf62f5ec8c0e32e56902cf73fbd7).

With this change, the initial values for console patching settings are propagated from hook (which is the source of truth now, because of https://github.com/facebook/react/pull/30596) to the UI. Instead of reading from `localStorage` the frontend is now requesting it from the hook. This happens when settings modal is rendered, and wrapped in a transition. Also, this is happening even if settings modal is not opened yet, so we have enough time to fetch this data without displaying loader or similar UI.

