### PR TITLE
[compiler][be] Remove completed todo comment

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/MergeConsecutiveBlocks.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/MergeConsecutiveBlocks.ts
@@ -25,8 +25,6 @@ import {terminalFallthrough, terminalHasFallthrough} from './visitors';
  * Note that this pass leaves value/loop blocks alone because they cannot
  * be merged without breaking the structure of the high-level terminals
  * that reference them.
- *
- * TODO @josephsavona make value blocks explicit (eg a `kind` on Block).
  */
 export function mergeConsecutiveBlocks(fn: HIRFunction): void {
   const merged = new MergedBlocks();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30633
* #30632

We made block types explicit a long time ago, this comment is super stale