### PR TITLE
[ci] fix path in compiler_typescript.yml

### DIFF
--- a/.github/workflows/compiler_typescript.yml
+++ b/.github/workflows/compiler_typescript.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - compiler/**
-      - .github/workflows/compiler-typescript.yml
+      - .github/workflows/compiler_typescript.yml
 
 env:
   TZ: /usr/share/zoneinfo/America/Los_Angeles


### PR DESCRIPTION

The path was incorrect, so the job didn\t run on changes to it.
