### PR TITLE
Fix react-dom/server used with Deno

### DIFF
--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -61,7 +61,7 @@
       "react-server": "./server.react-server.js",
       "workerd": "./server.edge.js",
       "bun": "./server.bun.js",
-      "deno": "./server.browser.js",
+      "deno": "./server.node.js",
       "worker": "./server.browser.js",
       "node": "./server.node.js",
       "edge-light": "./server.edge.js",


### PR DESCRIPTION
Repro steps [here](https://github.com/denoland/deno/issues/20790#issuecomment-2281237299)

I find that when using react-dom with deno (e.g. with Remix), there is an error when serving a build:

```
Task start remix-serve ./build/server/index.js
error: Uncaught (in promise) SyntaxError: The requested module 'react-dom/server' does not provide an export named 'renderToPipeableStream' at file:///Users/admin/repos/deno-kitchensink/my-remix-app2/build/server/index.js?t=1723290078885:6:10
    at async run (file:///Users/admin/repos/remix-app/node_modules/@remix-run/serve/dist/cli.js:111:15)
```

It's because the react-dom/server try to use the .browser bundle instead of the .node bundle.