### PR TITLE
[DevTools] Remove lodash.throttle

### DIFF
--- a/packages/react-devtools-shared/package.json
+++ b/packages/react-devtools-shared/package.json
@@ -22,8 +22,6 @@
     "jsc-safe-url": "^0.2.4",
     "json5": "^2.1.3",
     "local-storage-fallback": "^4.1.1",
-    "lodash.throttle": "^4.1.1",
-    "memoize-one": "^3.1.1",
     "react-virtualized-auto-sizer": "^1.0.23",
     "react-window": "^1.8.10"
   }

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
@@ -7,8 +7,6 @@
  * @flow
  */
 
-import memoize from 'memoize-one';
-import throttle from 'lodash.throttle';
 import Agent from 'react-devtools-shared/src/backend/agent';
 import {hideOverlay, showOverlay} from './Highlighter';
 
@@ -189,18 +187,12 @@ export default function setupHighlighter(
     event.stopPropagation();
   }
 
-  const selectElementForNode = throttle(
-    memoize((node: HTMLElement) => {
-      const id = agent.getIDForHostInstance(node);
-      if (id !== null) {
-        bridge.send('selectElement', id);
-      }
-    }),
-    200,
-    // Don't change the selection in the very first 200ms
-    // because those are usually unintentional as you lift the cursor.
-    {leading: false},
-  );
+  const selectElementForNode = (node: HTMLElement) => {
+    const id = agent.getIDForHostInstance(node);
+    if (id !== null) {
+      bridge.send('selectElement', id);
+    }
+  };
 
   function getEventTarget(event: MouseEvent): HTMLElement {
     if (event.composed) {

--- a/packages/react-devtools-shared/src/devtools/views/hooks.js
+++ b/packages/react-devtools-shared/src/devtools/views/hooks.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import throttle from 'lodash.throttle';
 import {
   useCallback,
   useEffect,
@@ -125,10 +124,8 @@ export function useIsOverflowing(
 
     const container = ((containerRef.current: any): HTMLDivElement);
 
-    const handleResize = throttle(
-      () => setIsOverflowing(container.clientWidth <= totalChildWidth),
-      100,
-    );
+    const handleResize = () =>
+      setIsOverflowing(container.clientWidth <= totalChildWidth);
 
     handleResize();
 


### PR DESCRIPTION
Same principle as #30555. We shouldn't be throttling the UI to make it feel less snappy. Instead, we should use back-pressure to handle it. Normally the browser handles it automatically with frame aligned events. E.g. if the thread can't keep up with sync updates it doesn't send each event but the next one. E.g. pointermove or resize.

However, it is possible that we end up queuing too many events if the frontend can't keep up but the solution to this is the same as mentioned in #30555. I.e. to track the last message and only send after we get a response.

I still keep the throttle to persist the selection since that affects the disk usage and doesn't have direct UX effects.

The main motivation for this change though is that lodash throttle doesn't rely on timers but Date.now which makes it incompatible with most jest helpers which means I can't write tests against these functions properly.
