### PR TITLE
[compiler] Publish to latest tag

### DIFF
--- a/compiler/scripts/release/publish.js
+++ b/compiler/scripts/release/publish.js
@@ -162,7 +162,9 @@ async function main() {
             'publish',
             ...opts,
             '--registry=https://registry.npmjs.org',
-            '--tag=experimental',
+            // For now, since the compiler is experimental only, to simplify installation we push
+            // to the `latest` tag
+            '--tag=latest',
           ],
           {
             cwd: pkgDir,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30666

> [!NOTE]
> The `latest` tag is published by default if no tag is specified, which
> is what we had done since the first release of the compiler

In my last PR to auto publish compiler releases I had added the
experimental tag to be used in publishing. However because we had
already previously published to the latest tag (which is non-removable)
this means that the `latest` tag is pinned to an old version. That makes
untagged installs of the compiler default to that old version instead of
whatever is the latest.

This changes the behavior back to what it was before. Since we are still
in the experimental release of the compiler anyway it seems fine to use
the latest tag. When we reach stable, we can update this to only push to
latest for stable releases.