### PR TITLE
[DevTools] Ensure the borders collapse collectly when props are not included

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementBadges.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementBadges.css
@@ -6,3 +6,7 @@
 .Root *:not(:first-child) {
   margin-left: 0.25rem;
 }
+
+.InspectedElementBadgesContainer {
+  padding: 0.25rem;
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementBadges.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementBadges.js
@@ -31,13 +31,15 @@ export default function InspectedElementBadges({
   }
 
   return (
-    <div className={styles.Root}>
-      {compiledWithForget && <ForgetBadge indexable={false} />}
+    <div className={styles.InspectedElementBadgesContainer}>
+      <div className={styles.Root}>
+        {compiledWithForget && <ForgetBadge indexable={false} />}
 
-      {hocDisplayNames !== null &&
-        hocDisplayNames.map(hocDisplayName => (
-          <Badge key={hocDisplayName}>{hocDisplayName}</Badge>
-        ))}
+        {hocDisplayNames !== null &&
+          hocDisplayNames.map(hocDisplayName => (
+            <Badge key={hocDisplayName}>{hocDisplayName}</Badge>
+          ))}
+      </div>
     </div>
   );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementPropsTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementPropsTree.js
@@ -54,11 +54,14 @@ export default function InspectedElementPropsTree({
     type === ElementTypeClass || canEditFunctionPropsRenamePaths;
 
   const entries = props != null ? Object.entries(props) : null;
-  if (entries !== null) {
-    entries.sort(alphaSortEntries);
+  if (entries === null) {
+    // Skip the section for null props.
+    return null;
   }
 
-  const isEmpty = entries === null || entries.length === 0;
+  entries.sort(alphaSortEntries);
+
+  const isEmpty = entries.length === 0;
 
   const handleCopy = () => copy(serializeDataForCopy(((props: any): Object)));
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSharedStyles.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSharedStyles.css
@@ -1,5 +1,6 @@
 .InspectedElementTree {
   padding: 0.25rem;
+  border-top: 1px solid var(--color-border);
 }
 .InspectedElementTree:first-of-type {
   border-top: none;

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.css
@@ -25,11 +25,6 @@
   line-height: var(--line-height-data);
 }
 
-.InspectedElementBadgesContainer:not(:empty) {
-  padding: 0.25rem;
-  border-bottom: 1px solid var(--color-border);
-}
-
 .Owner {
   border-radius: 0.25rem;
   padding: 0.125rem 0.25rem;

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
@@ -71,12 +71,10 @@ export default function InspectedElementView({
   return (
     <Fragment>
       <div className={styles.InspectedElement}>
-        <div className={styles.InspectedElementBadgesContainer}>
-          <InspectedElementBadges
-            hocDisplayNames={element.hocDisplayNames}
-            compiledWithForget={element.compiledWithForget}
-          />
-        </div>
+        <InspectedElementBadges
+          hocDisplayNames={element.hocDisplayNames}
+          compiledWithForget={element.compiledWithForget}
+        />
 
         <InspectedElementPropsTree
           bridge={bridge}


### PR DESCRIPTION
I want to omit the `props` section all together on Server Components. At least for now.

The previous fix to collapsing the borders didn't consider the top section being omitted so it ended up with a double border. This is just a little tweak to that.