### PR TITLE
[compiler] Recognize that refs are stable

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -1610,7 +1610,12 @@ export function isDispatcherType(id: Identifier): boolean {
 }
 
 export function isStableType(id: Identifier): boolean {
-  return isSetStateType(id) || isSetActionStateType(id) || isDispatcherType(id);
+  return (
+    isSetStateType(id) ||
+    isSetActionStateType(id) ||
+    isDispatcherType(id) ||
+    isUseRefType(id)
+  );
 }
 
 export function isUseEffectHookType(id: Identifier): boolean {

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
@@ -22,8 +22,6 @@ import {
   ReactiveValue,
   ScopeId,
   SourceLocation,
-  isRefValueType,
-  isUseRefType,
 } from '../HIR';
 import {printManualMemoDependency} from '../HIR/PrintHIR';
 import {eachInstructionValueOperand} from '../HIR/visitors';

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
@@ -262,6 +262,7 @@ function validateInferredDep(
   let errorDiagnostic: CompareDependencyResult | null = null;
   if (
     normalizedDep.root.kind === 'NamedLocal' &&
+    !normalizedDep.root.value.reactive &&
     (isRefValueType(normalizedDep.root.value.identifier) ||
       isUseRefType(normalizedDep.root.value.identifier))
   ) {

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
@@ -22,6 +22,8 @@ import {
   ReactiveValue,
   ScopeId,
   SourceLocation,
+  isRefValueType,
+  isUseRefType,
 } from '../HIR';
 import {printManualMemoDependency} from '../HIR/PrintHIR';
 import {eachInstructionValueOperand} from '../HIR/visitors';
@@ -258,6 +260,13 @@ function validateInferredDep(
     }
   }
   let errorDiagnostic: CompareDependencyResult | null = null;
+  if (
+    normalizedDep.root.kind === 'NamedLocal' &&
+    (isRefValueType(normalizedDep.root.value.identifier) ||
+      isUseRefType(normalizedDep.root.value.identifier))
+  ) {
+    return;
+  }
   for (const originalDep of validDepsInMemoBlock) {
     const compareResult = compareDeps(normalizedDep, originalDep);
     if (compareResult === CompareDependencyResult.Ok) {

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
@@ -260,14 +260,6 @@ function validateInferredDep(
     }
   }
   let errorDiagnostic: CompareDependencyResult | null = null;
-  if (
-    normalizedDep.root.kind === 'NamedLocal' &&
-    !normalizedDep.root.value.reactive &&
-    (isRefValueType(normalizedDep.root.value.identifier) ||
-      isUseRefType(normalizedDep.root.value.identifier))
-  ) {
-    return;
-  }
   for (const originalDep of validDepsInMemoBlock) {
     const compareResult = compareDeps(normalizedDep, originalDep);
     if (compareResult === CompareDependencyResult.Ok) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-in-callback-passed-to-jsx-indirect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-in-callback-passed-to-jsx-indirect.expect.md
@@ -40,62 +40,37 @@ import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRen
 import { useRef } from "react";
 
 function Component() {
-  const $ = _c(10);
+  const $ = _c(2);
   const ref = useRef(null);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = () => {
+    const setRef = () => {
       if (ref.current !== null) {
         ref.current = "";
       }
+    };
+
+    t0 = () => {
+      setRef();
     };
     $[0] = t0;
   } else {
     t0 = $[0];
   }
-  const setRef = t0;
+  const onClick = t0;
   let t1;
-  if ($[1] !== setRef) {
-    t1 = () => {
-      setRef();
-    };
-    $[1] = setRef;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
-  const onClick = t1;
-  let t2;
-  if ($[3] !== ref) {
-    t2 = <input ref={ref} />;
-    $[3] = ref;
-    $[4] = t2;
-  } else {
-    t2 = $[4];
-  }
-  let t3;
-  if ($[5] !== onClick) {
-    t3 = <button onClick={onClick} />;
-    $[5] = onClick;
-    $[6] = t3;
-  } else {
-    t3 = $[6];
-  }
-  let t4;
-  if ($[7] !== t2 || $[8] !== t3) {
-    t4 = (
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t1 = (
       <>
-        {t2}
-        {t3}
+        <input ref={ref} />
+        <button onClick={onClick} />
       </>
     );
-    $[7] = t2;
-    $[8] = t3;
-    $[9] = t4;
+    $[1] = t1;
   } else {
-    t4 = $[9];
+    t1 = $[1];
   }
-  return t4;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-in-callback-passed-to-jsx.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-in-callback-passed-to-jsx.expect.md
@@ -36,7 +36,7 @@ import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRen
 import { useRef } from "react";
 
 function Component() {
-  const $ = _c(8);
+  const $ = _c(2);
   const ref = useRef(null);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
@@ -51,36 +51,18 @@ function Component() {
   }
   const onClick = t0;
   let t1;
-  if ($[1] !== ref) {
-    t1 = <input ref={ref} />;
-    $[1] = ref;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
-  let t2;
-  if ($[3] !== onClick) {
-    t2 = <button onClick={onClick} />;
-    $[3] = onClick;
-    $[4] = t2;
-  } else {
-    t2 = $[4];
-  }
-  let t3;
-  if ($[5] !== t1 || $[6] !== t2) {
-    t3 = (
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t1 = (
       <>
-        {t1}
-        {t2}
+        <input ref={ref} />
+        <button onClick={onClick} />
       </>
     );
-    $[5] = t1;
-    $[6] = t2;
-    $[7] = t3;
+    $[1] = t1;
   } else {
-    t3 = $[7];
+    t1 = $[1];
   }
-  return t3;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-property-in-callback-passed-to-jsx-indirect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-property-in-callback-passed-to-jsx-indirect.expect.md
@@ -40,62 +40,37 @@ import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRen
 import { useRef } from "react";
 
 function Component() {
-  const $ = _c(10);
+  const $ = _c(2);
   const ref = useRef(null);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = () => {
+    const setRef = () => {
       if (ref.current !== null) {
         ref.current.value = "";
       }
+    };
+
+    t0 = () => {
+      setRef();
     };
     $[0] = t0;
   } else {
     t0 = $[0];
   }
-  const setRef = t0;
+  const onClick = t0;
   let t1;
-  if ($[1] !== setRef) {
-    t1 = () => {
-      setRef();
-    };
-    $[1] = setRef;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
-  const onClick = t1;
-  let t2;
-  if ($[3] !== ref) {
-    t2 = <input ref={ref} />;
-    $[3] = ref;
-    $[4] = t2;
-  } else {
-    t2 = $[4];
-  }
-  let t3;
-  if ($[5] !== onClick) {
-    t3 = <button onClick={onClick} />;
-    $[5] = onClick;
-    $[6] = t3;
-  } else {
-    t3 = $[6];
-  }
-  let t4;
-  if ($[7] !== t2 || $[8] !== t3) {
-    t4 = (
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t1 = (
       <>
-        {t2}
-        {t3}
+        <input ref={ref} />
+        <button onClick={onClick} />
       </>
     );
-    $[7] = t2;
-    $[8] = t3;
-    $[9] = t4;
+    $[1] = t1;
   } else {
-    t4 = $[9];
+    t1 = $[1];
   }
-  return t4;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-property-in-callback-passed-to-jsx.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-mutating-ref-property-in-callback-passed-to-jsx.expect.md
@@ -36,7 +36,7 @@ import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRen
 import { useRef } from "react";
 
 function Component() {
-  const $ = _c(8);
+  const $ = _c(2);
   const ref = useRef(null);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
@@ -51,36 +51,18 @@ function Component() {
   }
   const onClick = t0;
   let t1;
-  if ($[1] !== ref) {
-    t1 = <input ref={ref} />;
-    $[1] = ref;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
-  let t2;
-  if ($[3] !== onClick) {
-    t2 = <button onClick={onClick} />;
-    $[3] = onClick;
-    $[4] = t2;
-  } else {
-    t2 = $[4];
-  }
-  let t3;
-  if ($[5] !== t1 || $[6] !== t2) {
-    t3 = (
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t1 = (
       <>
-        {t1}
-        {t2}
+        <input ref={ref} />
+        <button onClick={onClick} />
       </>
     );
-    $[5] = t1;
-    $[6] = t2;
-    $[7] = t3;
+    $[1] = t1;
   } else {
-    t3 = $[7];
+    t1 = $[1];
   }
-  return t3;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-passing-refs-as-props.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-passing-refs-as-props.expect.md
@@ -14,15 +14,14 @@ function Component(props) {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
-  const $ = _c(2);
+  const $ = _c(1);
   const ref = useRef(null);
   let t0;
-  if ($[0] !== ref) {
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t0 = <Foo ref={ref} />;
-    $[0] = ref;
-    $[1] = t0;
+    $[0] = t0;
   } else {
-    t0 = $[1];
+    t0 = $[0];
   }
   return t0;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-effect-indirect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-effect-indirect.expect.md
@@ -46,7 +46,7 @@ import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRen
 import { useCallback, useEffect, useRef, useState } from "react";
 
 function Component() {
-  const $ = _c(9);
+  const $ = _c(7);
   const ref = useRef(null);
   const [state, setState] = useState(false);
   let t0;
@@ -60,47 +60,42 @@ function Component() {
   }
   const setRef = t0;
   let t1;
-  if ($[1] !== setRef) {
+  let t2;
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = () => {
       setRef();
     };
-    $[1] = setRef;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
-  let t2;
-  if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
     t2 = [];
-    $[3] = t2;
+    $[1] = t1;
+    $[2] = t2;
   } else {
-    t2 = $[3];
+    t1 = $[1];
+    t2 = $[2];
   }
   useEffect(t1, t2);
   let t3;
   let t4;
-  if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
+  if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
     t3 = () => {
       setState(true);
     };
     t4 = [];
-    $[4] = t3;
-    $[5] = t4;
+    $[3] = t3;
+    $[4] = t4;
   } else {
-    t3 = $[4];
-    t4 = $[5];
+    t3 = $[3];
+    t4 = $[4];
   }
   useEffect(t3, t4);
 
   const t5 = String(state);
   let t6;
-  if ($[6] !== t5 || $[7] !== ref) {
+  if ($[5] !== t5) {
     t6 = <Child key={t5} ref={ref} />;
-    $[6] = t5;
-    $[7] = ref;
-    $[8] = t6;
+    $[5] = t5;
+    $[6] = t6;
   } else {
-    t6 = $[8];
+    t6 = $[6];
   }
   return t6;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-effect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-effect.expect.md
@@ -42,7 +42,7 @@ import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRen
 import { useEffect, useRef, useState } from "react";
 
 function Component() {
-  const $ = _c(7);
+  const $ = _c(6);
   const ref = useRef(null);
   const [state, setState] = useState(false);
   let t0;
@@ -76,13 +76,12 @@ function Component() {
 
   const t4 = String(state);
   let t5;
-  if ($[4] !== t4 || $[5] !== ref) {
+  if ($[4] !== t4) {
     t5 = <Child key={t4} ref={ref} />;
     $[4] = t4;
-    $[5] = ref;
-    $[6] = t5;
+    $[5] = t5;
   } else {
-    t5 = $[6];
+    t5 = $[5];
   }
   return t5;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-unused-callback-nested.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-access-in-unused-callback-nested.expect.md
@@ -44,7 +44,7 @@ import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRen
 import { useEffect, useRef, useState } from "react";
 
 function Component() {
-  const $ = _c(7);
+  const $ = _c(6);
   const ref = useRef(null);
   const [state, setState] = useState(false);
   let t0;
@@ -77,13 +77,12 @@ function Component() {
 
   const t4 = String(state);
   let t5;
-  if ($[4] !== t4 || $[5] !== ref) {
+  if ($[4] !== t4) {
     t5 = <Child key={t4} ref={ref} />;
     $[4] = t4;
-    $[5] = ref;
-    $[6] = t5;
+    $[5] = t5;
   } else {
-    t5 = $[6];
+    t5 = $[5];
   }
   return t5;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/original-reactive-scopes-fork/capture-ref-for-later-mutation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/original-reactive-scopes-fork/capture-ref-for-later-mutation.expect.md
@@ -37,45 +37,42 @@ import { useRef } from "react";
 import { addOne } from "shared-runtime";
 
 function useKeyCommand() {
-  const $ = _c(7);
+  const $ = _c(6);
   const currentPosition = useRef(0);
   const handleKey = (direction) => () => {
     const position = currentPosition.current;
     const nextPosition = direction === "left" ? addOne(position) : position;
     currentPosition.current = nextPosition;
   };
-
-  const t0 = handleKey("left");
-  let t1;
-  if ($[0] !== t0) {
-    t1 = { handler: t0 };
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = { handler: handleKey("left") };
     $[0] = t0;
-    $[1] = t1;
   } else {
-    t1 = $[1];
+    t0 = $[0];
   }
-  const moveLeft = t1;
+  const moveLeft = t0;
 
-  const t2 = handleKey("right");
-  let t3;
-  if ($[2] !== t2) {
-    t3 = { handler: t2 };
+  const t1 = handleKey("right");
+  let t2;
+  if ($[1] !== t1) {
+    t2 = { handler: t1 };
+    $[1] = t1;
     $[2] = t2;
-    $[3] = t3;
   } else {
-    t3 = $[3];
+    t2 = $[2];
   }
-  const moveRight = t3;
-  let t4;
-  if ($[4] !== moveLeft || $[5] !== moveRight) {
-    t4 = [moveLeft, moveRight];
-    $[4] = moveLeft;
-    $[5] = moveRight;
-    $[6] = t4;
+  const moveRight = t2;
+  let t3;
+  if ($[3] !== moveLeft || $[4] !== moveRight) {
+    t3 = [moveLeft, moveRight];
+    $[3] = moveLeft;
+    $[4] = moveRight;
+    $[5] = t3;
   } else {
-    t4 = $[6];
+    t3 = $[5];
   }
-  return t4;
+  return t3;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.preserve-use-memo-ref-missing-reactive.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.preserve-use-memo-ref-missing-reactive.expect.md
@@ -1,0 +1,48 @@
+
+## Input
+
+```javascript
+// @validatePreserveExistingMemoizationGuarantees
+import {useCallback, useRef} from 'react';
+
+function useFoo({cond}) {
+  const ref1 = useRef<undefined | (() => undefined)>();
+  const ref2 = useRef<undefined | (() => undefined)>();
+  const ref = cond ? ref1 : ref2;
+
+  return useCallback(() => {
+    if (ref != null) {
+      ref.current();
+    }
+  }, []);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: useFoo,
+  params: [],
+};
+
+```
+
+
+## Error
+
+```
+   7 |   const ref = cond ? ref1 : ref2;
+   8 |
+>  9 |   return useCallback(() => {
+     |                      ^^^^^^^
+> 10 |     if (ref != null) {
+     | ^^^^^^^^^^^^^^^^^^^^^^
+> 11 |       ref.current();
+     | ^^^^^^^^^^^^^^^^^^^^^^
+> 12 |     }
+     | ^^^^^^^^^^^^^^^^^^^^^^
+> 13 |   }, []);
+     | ^^^^ CannotPreserveMemoization: React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected (9:13)
+  14 | }
+  15 |
+  16 | export const FIXTURE_ENTRYPOINT = {
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.preserve-use-memo-ref-missing-reactive.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.preserve-use-memo-ref-missing-reactive.ts
@@ -1,0 +1,19 @@
+// @validatePreserveExistingMemoizationGuarantees
+import {useCallback, useRef} from 'react';
+
+function useFoo({cond}) {
+  const ref1 = useRef<undefined | (() => undefined)>();
+  const ref2 = useRef<undefined | (() => undefined)>();
+  const ref = cond ? ref1 : ref2;
+
+  return useCallback(() => {
+    if (ref != null) {
+      ref.current();
+    }
+  }, []);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: useFoo,
+  params: [],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/preserve-use-memo-ref-missing-ok.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/preserve-use-memo-ref-missing-ok.expect.md
@@ -1,0 +1,57 @@
+
+## Input
+
+```javascript
+// @validatePreserveExistingMemoizationGuarantees
+import {useCallback, useRef} from 'react';
+
+function useFoo() {
+  const ref = useRef<undefined | (() => undefined)>();
+
+  return useCallback(() => {
+    if (ref != null) {
+      ref.current();
+    }
+  }, []);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: useFoo,
+  params: [],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validatePreserveExistingMemoizationGuarantees
+import { useCallback, useRef } from "react";
+
+function useFoo() {
+  const $ = _c(2);
+  const ref = useRef();
+  let t0;
+  if ($[0] !== ref) {
+    t0 = () => {
+      if (ref != null) {
+        ref.current();
+      }
+    };
+    $[0] = ref;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: useFoo,
+  params: [],
+};
+
+```
+      
+### Eval output
+(kind: ok) "[[ function params=0 ]]"

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/preserve-use-memo-ref-missing-ok.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/preserve-use-memo-ref-missing-ok.expect.md
@@ -29,19 +29,18 @@ import { c as _c } from "react/compiler-runtime"; // @validatePreserveExistingMe
 import { useCallback, useRef } from "react";
 
 function useFoo() {
-  const $ = _c(2);
+  const $ = _c(1);
   const ref = useRef();
   let t0;
-  if ($[0] !== ref) {
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t0 = () => {
       if (ref != null) {
         ref.current();
       }
     };
-    $[0] = ref;
-    $[1] = t0;
+    $[0] = t0;
   } else {
-    t0 = $[1];
+    t0 = $[0];
   }
   return t0;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/preserve-use-memo-ref-missing-ok.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/preserve-use-memo-ref-missing-ok.ts
@@ -1,0 +1,17 @@
+// @validatePreserveExistingMemoizationGuarantees
+import {useCallback, useRef} from 'react';
+
+function useFoo() {
+  const ref = useRef<undefined | (() => undefined)>();
+
+  return useCallback(() => {
+    if (ref != null) {
+      ref.current();
+    }
+  }, []);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: useFoo,
+  params: [],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/react-namespace.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/react-namespace.expect.md
@@ -29,7 +29,7 @@ import { c as _c } from "react/compiler-runtime";
 const FooContext = React.createContext({ current: null });
 
 function Component(props) {
-  const $ = _c(6);
+  const $ = _c(5);
   React.useContext(FooContext);
   const ref = React.useRef();
   const [x, setX] = React.useState(false);
@@ -53,13 +53,12 @@ function Component(props) {
     t1 = $[2];
   }
   let t2;
-  if ($[3] !== onClick || $[4] !== t1) {
+  if ($[3] !== t1) {
     t2 = <div onClick={onClick}>{t1}</div>;
-    $[3] = onClick;
-    $[4] = t1;
-    $[5] = t2;
+    $[3] = t1;
+    $[4] = t2;
   } else {
-    t2 = $[5];
+    t2 = $[4];
   }
   return t2;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-current-aliased-no-added-to-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-current-aliased-no-added-to-dep.expect.md
@@ -20,28 +20,21 @@ function VideoTab() {
 ```javascript
 import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRender false
 function VideoTab() {
-  const $ = _c(3);
+  const $ = _c(1);
   const ref = useRef();
   const t = ref.current;
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = () => {
+    const x = () => {
       console.log(t);
     };
+
+    t0 = <VideoList videos={x} />;
     $[0] = t0;
   } else {
     t0 = $[0];
   }
-  const x = t0;
-  let t1;
-  if ($[1] !== x) {
-    t1 = <VideoList videos={x} />;
-    $[1] = x;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
-  return t1;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-current-field-not-added-to-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-current-field-not-added-to-dep.expect.md
@@ -19,27 +19,20 @@ function VideoTab() {
 ```javascript
 import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRender false
 function VideoTab() {
-  const $ = _c(3);
+  const $ = _c(1);
   const ref = useRef();
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = () => {
+    const x = () => {
       console.log(ref.current.x);
     };
+
+    t0 = <VideoList videos={x} />;
     $[0] = t0;
   } else {
     t0 = $[0];
   }
-  const x = t0;
-  let t1;
-  if ($[1] !== x) {
-    t1 = <VideoList videos={x} />;
-    $[1] = x;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
-  return t1;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-current-field-write-not-added-to-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-current-field-write-not-added-to-dep.expect.md
@@ -27,7 +27,7 @@ import { c as _c } from "react/compiler-runtime";
 import { useRef } from "react";
 
 function Component() {
-  const $ = _c(4);
+  const $ = _c(2);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t0 = { text: { value: null } };
@@ -38,23 +38,16 @@ function Component() {
   const ref = useRef(t0);
   let t1;
   if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = (e) => {
+    const inputChanged = (e) => {
       ref.current.text.value = e.target.value;
     };
+
+    t1 = <input onChange={inputChanged} />;
     $[1] = t1;
   } else {
     t1 = $[1];
   }
-  const inputChanged = t1;
-  let t2;
-  if ($[2] !== inputChanged) {
-    t2 = <input onChange={inputChanged} />;
-    $[2] = inputChanged;
-    $[3] = t2;
-  } else {
-    t2 = $[3];
-  }
-  return t2;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-current-not-added-to-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-current-not-added-to-dep.expect.md
@@ -18,27 +18,20 @@ function VideoTab() {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function VideoTab() {
-  const $ = _c(3);
+  const $ = _c(1);
   const ref = useRef();
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = () => {
+    const x = () => {
       console.log(ref.current);
     };
+
+    t0 = <VideoList videos={x} />;
     $[0] = t0;
   } else {
     t0 = $[0];
   }
-  const x = t0;
-  let t1;
-  if ($[1] !== x) {
-    t1 = <VideoList videos={x} />;
-    $[1] = x;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
-  return t1;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-current-optional-field-no-added-to-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-current-optional-field-no-added-to-dep.expect.md
@@ -18,27 +18,20 @@ function VideoTab() {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function VideoTab() {
-  const $ = _c(3);
+  const $ = _c(1);
   const ref = useRef();
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = () => {
+    const x = () => {
       ref.current?.x;
     };
+
+    t0 = <VideoList videos={x} />;
     $[0] = t0;
   } else {
     t0 = $[0];
   }
-  const x = t0;
-  let t1;
-  if ($[1] !== x) {
-    t1 = <VideoList videos={x} />;
-    $[1] = x;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
-  return t1;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-current-write-not-added-to-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-current-write-not-added-to-dep.expect.md
@@ -18,27 +18,20 @@ function VideoTab() {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function VideoTab() {
-  const $ = _c(3);
+  const $ = _c(1);
   const ref = useRef();
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = () => {
+    const x = () => {
       ref.current = 1;
     };
+
+    t0 = <VideoList videos={x} />;
     $[0] = t0;
   } else {
     t0 = $[0];
   }
-  const x = t0;
-  let t1;
-  if ($[1] !== x) {
-    t1 = <VideoList videos={x} />;
-    $[1] = x;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
-  return t1;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-in-effect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-in-effect.expect.md
@@ -21,7 +21,7 @@ function Component(props) {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
-  const $ = _c(4);
+  const $ = _c(3);
   const ref = useRef(null);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
@@ -45,12 +45,11 @@ function Component(props) {
   }
   useEffect(t1);
   let t2;
-  if ($[2] !== onChange) {
+  if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
     t2 = <Foo onChange={onChange} />;
-    $[2] = onChange;
-    $[3] = t2;
+    $[2] = t2;
   } else {
-    t2 = $[3];
+    t2 = $[2];
   }
   return t2;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-useCallback-2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-useCallback-2.expect.md
@@ -47,7 +47,7 @@ function useCustomRef() {
 function _temp() {}
 
 function Foo() {
-  const $ = _c(3);
+  const $ = _c(2);
   const ref = useCustomRef();
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
@@ -60,12 +60,11 @@ function Foo() {
   }
   const onClick = t0;
   let t1;
-  if ($[1] !== onClick) {
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = <button onClick={onClick} />;
-    $[1] = onClick;
-    $[2] = t1;
+    $[1] = t1;
   } else {
-    t1 = $[2];
+    t1 = $[1];
   }
   return t1;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-useCallback.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ref-like-name-in-useCallback.expect.md
@@ -47,7 +47,7 @@ function useCustomRef() {
 function _temp() {}
 
 function Foo() {
-  const $ = _c(3);
+  const $ = _c(2);
   const customRef = useCustomRef();
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
@@ -60,12 +60,11 @@ function Foo() {
   }
   const onClick = t0;
   let t1;
-  if ($[1] !== onClick) {
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = <button onClick={onClick} />;
-    $[1] = onClick;
-    $[2] = t1;
+    $[1] = t1;
   } else {
-    t1 = $[2];
+    t1 = $[1];
   }
   return t1;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useCallback-multiple-callbacks-modifying-same-ref-preserve-memoization.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useCallback-multiple-callbacks-modifying-same-ref-preserve-memoization.expect.md
@@ -35,7 +35,7 @@ import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingMemo
 import { useCallback, useRef } from "react";
 
 function Component(props) {
-  const $ = _c(6);
+  const $ = _c(4);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t0 = { inner: null };
@@ -65,13 +65,11 @@ function Component(props) {
   }
   const onReset = t2;
   let t3;
-  if ($[3] !== onChange || $[4] !== onReset) {
+  if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
     t3 = <input onChange={onChange} onReset={onReset} />;
-    $[3] = onChange;
-    $[4] = onReset;
-    $[5] = t3;
+    $[3] = t3;
   } else {
-    t3 = $[5];
+    t3 = $[3];
   }
   return t3;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useCallback-set-ref-nested-property-preserve-memoization.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useCallback-set-ref-nested-property-preserve-memoization.expect.md
@@ -31,7 +31,7 @@ import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingMemo
 import { useCallback, useRef } from "react";
 
 function Component(props) {
-  const $ = _c(4);
+  const $ = _c(3);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t0 = { inner: null };
@@ -51,12 +51,11 @@ function Component(props) {
   }
   const onChange = t1;
   let t2;
-  if ($[2] !== onChange) {
+  if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
     t2 = <input onChange={onChange} />;
-    $[2] = onChange;
-    $[3] = t2;
+    $[2] = t2;
   } else {
-    t2 = $[3];
+    t2 = $[2];
   }
   return t2;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useCallback-set-ref-nested-property.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useCallback-set-ref-nested-property.expect.md
@@ -34,7 +34,7 @@ import { useCallback, useRef } from "react";
 // Identical to useCallback-set-ref-nested-property-preserve-memoization,
 // but with a different set of compiler flags
 function Component(t0) {
-  const $ = _c(4);
+  const $ = _c(3);
   let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = { inner: null };
@@ -54,12 +54,11 @@ function Component(t0) {
   }
   const onChange = t2;
   let t3;
-  if ($[2] !== onChange) {
+  if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
     t3 = <input onChange={onChange} />;
-    $[2] = onChange;
-    $[3] = t3;
+    $[2] = t3;
   } else {
-    t3 = $[3];
+    t3 = $[2];
   }
   return t3;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useCallback-set-ref-value-dont-preserve-memoization.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useCallback-set-ref-value-dont-preserve-memoization.expect.md
@@ -31,7 +31,7 @@ import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingMemo
 import { useCallback, useRef } from "react";
 
 function Component(props) {
-  const $ = _c(3);
+  const $ = _c(2);
   const ref = useRef(null);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
@@ -44,12 +44,11 @@ function Component(props) {
   }
   const onChange = t0;
   let t1;
-  if ($[1] !== onChange) {
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = <input onChange={onChange} />;
-    $[1] = onChange;
-    $[2] = t1;
+    $[1] = t1;
   } else {
-    t1 = $[2];
+    t1 = $[1];
   }
   return t1;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useCallback-set-ref-value-preserve-memoization.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useCallback-set-ref-value-preserve-memoization.expect.md
@@ -31,7 +31,7 @@ import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingMemo
 import { useCallback, useRef } from "react";
 
 function Component(props) {
-  const $ = _c(3);
+  const $ = _c(2);
   const ref = useRef(null);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
@@ -44,12 +44,11 @@ function Component(props) {
   }
   const onChange = t0;
   let t1;
-  if ($[1] !== onChange) {
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = <input onChange={onChange} />;
-    $[1] = onChange;
-    $[2] = t1;
+    $[1] = t1;
   } else {
-    t1 = $[2];
+    t1 = $[1];
   }
   return t1;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30681
* __->__ #30679

Summary:
In theory, as I understand it, the result of a useRef will never change between renders, because we'll always provide the same ref value consistently. We can mark useRef as producing a stable value to get better memoization