### PR TITLE
[compiler] support numeric object keys

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -1439,6 +1439,11 @@ function lowerObjectPropertyKey(
       kind: 'identifier',
       name: key.node.name,
     };
+  } else if (key.isNumericLiteral()) {
+    return {
+      kind: 'identifier',
+      name: String(key.node.value),
+    };
   }
 
   builder.errors.push({

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-numeric-index.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-numeric-index.expect.md
@@ -1,0 +1,47 @@
+
+## Input
+
+```javascript
+function foo(x) {
+  const y = {0x10: x};
+  const {16: z} = y;
+  return z;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [10],
+  isComponent: false,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function foo(x) {
+  const $ = _c(2);
+  let t0;
+  if ($[0] !== x) {
+    t0 = { 16: x };
+    $[0] = x;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  const y = t0;
+  const { 16: z } = y;
+  return z;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [10],
+  isComponent: false,
+};
+
+```
+      
+### Eval output
+(kind: ok) 10

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-numeric-index.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-numeric-index.js
@@ -1,0 +1,11 @@
+function foo(x) {
+  const y = {0x10: x};
+  const {16: z} = y;
+  return z;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [10],
+  isComponent: false,
+};


### PR DESCRIPTION

This feels a *bit* like a hack since I'm just converting the number into a string, but that's just reflecting what happens at runtime. The downside here is that if we converted these identifiers anywhere outside of object keys back to code, we would need to watch out for that.

For example, we might convert an object destructure into a property access which would need to use `obj[2]` instead of obj.bar, but I that should also be the case of property access with string keys that are not valid identifiers
