### PR TITLE
[not for merge] publish react-markup placeholder

### DIFF
--- a/packages/react-markup/LICENSE
+++ b/packages/react-markup/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react-markup/README.md
+++ b/packages/react-markup/README.md
@@ -1,35 +1,6 @@
 # `react-markup`
 
-This package provides the ability to render standalone HTML from Server Components for use in embedded contexts such as e-mails and RSS/Atom feeds. It cannot use Client Components and does not hydrate. It is intended to be paired with the generic React package, which is shipped as `react` to npm.
-
-## Installation
-
-```sh
-npm install react react-markup
-```
-
-## Usage
-
-```js
-import { experimental_renderToHTML as renderToHTML } from 'react-markup';
-import EmailTemplate from './my-email-template-component.js'
-
-async function action(email, name) {
-  "use server";
-  // ... in your server, e.g. a Server Action...
-  const htmlString = await renderToHTML(<EmailTemplate name={name} />);
-  // ... send e-mail using some e-mail provider
-  await sendEmail({ to: email, contentType: 'text/html', body: htmlString });
-}
-```
-
-Note that this is an async function that needs to be awaited - unlike the legacy `renderToString` in `react-dom`.
-
-## API
-
-### `react-markup`
-
-See https://react.dev/reference/react-markup
+Work in progress. Check the `react-markup@experimental` and `react-markup@experimental` instead.
 
 ## Thanks
 

--- a/packages/react-markup/index.js
+++ b/packages/react-markup/index.js
@@ -7,4 +7,6 @@
  * @flow
  */
 
-export * from './src/ReactMarkupClient';
+throw new Error(
+  'This is not a working version of react-markup. Make sure to use a later version.',
+);

--- a/packages/react-markup/package.json
+++ b/packages/react-markup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-markup",
-  "version": "19.0.0",
+  "version": "2.0.0",
   "description": "React package generating embedded markup such as e-mails with support for Server Components.",
   "main": "index.js",
   "repository": {
@@ -16,22 +16,15 @@
     "url": "https://github.com/facebook/react/issues"
   },
   "homepage": "https://react.dev/",
-  "peerDependencies": {
-    "react": "^19.0.0"
-  },
   "files": [
     "LICENSE",
     "README.md",
-    "index.js",
-    "react-markup.react-server.js",
-    "cjs/"
+    "index.js"
   ],
   "exports": {
     ".": {
-      "react-server": "./react-markup.react-server.js",
       "default": "./index.js"
     },
-    "./src/*": "./src/*",
     "./package.json": "./package.json"
   }
 }


### PR DESCRIPTION
Just meant for a manual publish so that the page on npm stops displaying the old content.