### PR TITLE
[DevTools] Hide props section if it is null

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementPropsTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementPropsTree.js
@@ -54,11 +54,14 @@ export default function InspectedElementPropsTree({
     type === ElementTypeClass || canEditFunctionPropsRenamePaths;
 
   const entries = props != null ? Object.entries(props) : null;
-  if (entries !== null) {
-    entries.sort(alphaSortEntries);
+  if (entries === null) {
+    // Skip the section for null props.
+    return null;
   }
 
-  const isEmpty = entries === null || entries.length === 0;
+  entries.sort(alphaSortEntries);
+
+  const isEmpty = entries.length === 0;
 
   const handleCopy = () => copy(serializeDataForCopy(((props: any): Object)));
 


### PR DESCRIPTION
We use null as a marker that we don't know what the props are as opposed to knowing that they're empty.