### PR TITLE
Fix flow configs creation for crlf systems

### DIFF
--- a/scripts/flow/createFlowConfigs.js
+++ b/scripts/flow/createFlowConfigs.js
@@ -108,7 +108,7 @@ function writeConfig(
 
   const config = configTemplate
     .replace(
-      '%CI_MAX_WORKERS%\n',
+      /%CI_MAX_WORKERS%\r?\n/,
       // On CI, we seem to need to limit workers.
       process.env.CI ? 'server.max_workers=4\n' : '',
     )


### PR DESCRIPTION
## Summary

The error appears in CRLF systems because the end of the line is `\r\n` instead of just `\n`. In this case, the line in CRLF is `%CI_MAX_WORKERS%\r\n`, and therefore the condition `%CI_MAX_WORKERS%\n` for this line isn't met.

Rewrote the replace rule with a regular expression that allows an **optional `\r`** (`\r?`) before `\n`.

Fixes #27691