### PR TITLE
[DevTools] Separate RDT Fusebox into single-panel entry points

### DIFF
--- a/packages/react-devtools-fusebox/src/frontend.d.ts
+++ b/packages/react-devtools-fusebox/src/frontend.d.ts
@@ -50,4 +50,5 @@ export type InitializationOptions = {
   canViewElementSourceFunction?: CanViewElementSource,
 };
 
-export function initialize(node: Element | Document, options: InitializationOptions): void;
+export function initializeComponents(node: Element | Document, options: InitializationOptions): void;
+export function initializeProfiler(node: Element | Document, options: InitializationOptions): void;

--- a/packages/react-devtools-fusebox/src/frontend.js
+++ b/packages/react-devtools-fusebox/src/frontend.js
@@ -19,9 +19,10 @@ import type {
 } from 'react-devtools-shared/src/frontend/types';
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
 import type {
+  CanViewElementSource,
+  TabID,
   ViewAttributeSource,
   ViewElementSource,
-  CanViewElementSource,
 } from 'react-devtools-shared/src/devtools/views/DevTools';
 import type {Config} from 'react-devtools-shared/src/devtools/store';
 
@@ -51,10 +52,11 @@ type InitializationOptions = {
   canViewElementSourceFunction?: CanViewElementSource,
 };
 
-export function initialize(
+function initializeTab(
+  tab: TabID,
   contentWindow: Element | Document,
   options: InitializationOptions,
-): void {
+) {
   const {
     bridge,
     store,
@@ -70,7 +72,8 @@ export function initialize(
       bridge={bridge}
       browserTheme={theme}
       store={store}
-      showTabBar={true}
+      showTabBar={false}
+      overrideTab={tab}
       warnIfLegacyBackendDetected={true}
       enabledInspectedElementContextMenu={true}
       viewAttributeSourceFunction={viewAttributeSourceFunction}
@@ -78,4 +81,18 @@ export function initialize(
       canViewElementSourceFunction={canViewElementSourceFunction}
     />,
   );
+}
+
+export function initializeComponents(
+  contentWindow: Element | Document,
+  options: InitializationOptions,
+): void {
+  initializeTab('components', contentWindow, options);
+}
+
+export function initializeProfiler(
+  contentWindow: Element | Document,
+  options: InitializationOptions,
+): void {
+  initializeTab('profiler', contentWindow, options);
 }


### PR DESCRIPTION
## Summary

Separate function entry points for `react-devtools-fusebox` into `initializeComponents` and `initializeProfiler`. The motivation behind this change is to separate these tabs into top-level Chrome DevTools panels (aligned with web) in React Native.

## How did you test this change?

- Build `react-devtools-fusebox` and load into local [rn-chrome-devtools-frontend](https://github.com/facebookexperimental/rn-chrome-devtools-frontend) project with updated call sites.

<img width="1933" alt="image" src="https://github.com/user-attachments/assets/202d32a1-b8da-4936-b0e1-04875a30f256">

<img width="1949" alt="image" src="https://github.com/user-attachments/assets/39dbe154-989c-4f76-b103-aa19f07a3b9c">

✅ Tabs can be separately initialised in individual Chrome DevTools panels