### PR TITLE
Build `react-dom` in `builds/facebook-fbsource`

### DIFF
--- a/.github/workflows/runtime_commit_artifacts.yml
+++ b/.github/workflows/runtime_commit_artifacts.yml
@@ -125,6 +125,7 @@ jobs:
           mv build/react-native/shims/ $BASE_FOLDER/react-native-github/Libraries/Renderer/
           mv build/facebook-react-native/scheduler/cjs/ $BASE_FOLDER/RKJSModules/vendor/react/scheduler/
           mv build/facebook-react-native/react/cjs/ $BASE_FOLDER/RKJSModules/vendor/react/react/
+          mv build/facebook-react-native/react/dom/ $BASE_FOLDER/RKJSModules/vendor/react/react-dom/
           mv build/facebook-react-native/react-is/cjs/ $BASE_FOLDER/RKJSModules/vendor/react/react-is/
           mv build/facebook-react-native/react-test-renderer/cjs/ $BASE_FOLDER/RKJSModules/vendor/react/react-test-renderer/
 

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -175,13 +175,19 @@ const bundles = [
 
   /******* React DOM *******/
   {
-    bundleTypes: [NODE_DEV, NODE_PROD],
+    bundleTypes: [
+      NODE_DEV,
+      NODE_PROD,
+      RN_FB_DEV,
+      RN_FB_PROD,
+      RN_FB_PROFILING,
+    ],
     moduleType: RENDERER,
     entry: 'react-dom',
     global: 'ReactDOM',
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: true,
-    externals: ['react'],
+    externals: ['react', 'ReactNativeInternalFeatureFlags'],
   },
   /******* React DOM Client *******/
   {
@@ -206,20 +212,13 @@ const bundles = [
   },
   /******* React DOM FB *******/
   {
-    bundleTypes: [
-      FB_WWW_DEV,
-      FB_WWW_PROD,
-      FB_WWW_PROFILING,
-      RN_FB_DEV,
-      RN_FB_PROD,
-      RN_FB_PROFILING,
-    ],
+    bundleTypes: [FB_WWW_DEV, FB_WWW_PROD, FB_WWW_PROFILING],
     moduleType: RENDERER,
     entry: 'react-dom/src/ReactDOMFB.js',
     global: 'ReactDOM',
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: true,
-    externals: ['react', 'ReactNativeInternalFeatureFlags'],
+    externals: ['react'],
   },
 
   /******* React DOM React Server *******/

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -206,13 +206,20 @@ const bundles = [
   },
   /******* React DOM FB *******/
   {
-    bundleTypes: [FB_WWW_DEV, FB_WWW_PROD, FB_WWW_PROFILING],
+    bundleTypes: [
+      FB_WWW_DEV,
+      FB_WWW_PROD,
+      FB_WWW_PROFILING,
+      RN_FB_DEV,
+      RN_FB_PROD,
+      RN_FB_PROFILING,
+    ],
     moduleType: RENDERER,
     entry: 'react-dom/src/ReactDOMFB.js',
     global: 'ReactDOM',
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: true,
-    externals: ['react'],
+    externals: ['react', 'ReactNativeInternalFeatureFlags'],
   },
 
   /******* React DOM React Server *******/

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -175,20 +175,15 @@ const bundles = [
 
   /******* React DOM *******/
   {
-    bundleTypes: [
-      NODE_DEV,
-      NODE_PROD,
-      RN_FB_DEV,
-      RN_FB_PROD,
-      RN_FB_PROFILING,
-    ],
+    bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-dom',
     global: 'ReactDOM',
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: true,
-    externals: ['react', 'ReactNativeInternalFeatureFlags'],
+    externals: ['react'],
   },
+
   /******* React DOM Client *******/
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
@@ -210,7 +205,8 @@ const bundles = [
     wrapWithModuleBoundaries: true,
     externals: ['react', 'react-dom'],
   },
-  /******* React DOM FB *******/
+
+  /******* React DOM (www) *******/
   {
     bundleTypes: [FB_WWW_DEV, FB_WWW_PROD, FB_WWW_PROFILING],
     moduleType: RENDERER,
@@ -219,6 +215,50 @@ const bundles = [
     minifyWithProdErrorCodes: true,
     wrapWithModuleBoundaries: true,
     externals: ['react'],
+  },
+
+  /******* React DOM (fbsource) *******/
+  {
+    bundleTypes: [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
+    moduleType: RENDERER,
+    entry: 'react-dom',
+    global: 'ReactDOM',
+    minifyWithProdErrorCodes: true,
+    wrapWithModuleBoundaries: false,
+    externals: ['react', 'ReactNativeInternalFeatureFlags'],
+  },
+
+  /******* React DOM Client (fbsource) *******/
+  {
+    bundleTypes: [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
+    moduleType: RENDERER,
+    entry: 'react-dom/client',
+    global: 'ReactDOMClient',
+    minifyWithProdErrorCodes: true,
+    wrapWithModuleBoundaries: false,
+    externals: ['react', 'react-dom', 'ReactNativeInternalFeatureFlags'],
+  },
+
+  /******* React DOM Profiling (fbsource) *******/
+  {
+    bundleTypes: [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
+    moduleType: RENDERER,
+    entry: 'react-dom/profiling',
+    global: 'ReactDOMProfiling',
+    minifyWithProdErrorCodes: true,
+    wrapWithModuleBoundaries: true,
+    externals: ['react', 'react-dom', 'ReactNativeInternalFeatureFlags'],
+  },
+
+  /******* React DOM Test Utils (fbsource) *******/
+  {
+    moduleType: RENDERER_UTILS,
+    bundleTypes: [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
+    entry: 'react-dom/test-utils',
+    global: 'ReactDOMTestUtils',
+    minifyWithProdErrorCodes: false,
+    wrapWithModuleBoundaries: false,
+    externals: ['react', 'react-dom', 'ReactNativeInternalFeatureFlags'],
   },
 
   /******* React DOM React Server *******/

--- a/scripts/rollup/packaging.js
+++ b/scripts/rollup/packaging.js
@@ -76,6 +76,7 @@ function getBundleOutputPath(bundle, bundleType, filename, packageName) {
       switch (packageName) {
         case 'scheduler':
         case 'react':
+        case 'react-dom':
         case 'react-is':
         case 'react-test-renderer':
           return `build/facebook-react-native/${packageName}/cjs/${filename}`;


### PR DESCRIPTION
## Summary

Builds `react-dom` for React Native so that it also populates the `builds/facebook-fbsource` branch.

**NOTE:** For Meta employees, D61354219 is the internal integration.

## How did you test this change?

```
$ yarn build
…
$ ls build/facebook-react-native/react-dom/cjs
ReactDOM-dev.js       ReactDOM-prod.js      ReactDOM-profiling.js
```