### PR TITLE
[DevTools] Find owners from the parent path that matches the Fiber or ReactComponentInfo

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -2893,26 +2893,29 @@ describe('InspectedElement', () => {
     `);
 
     const inspectedElement = await inspectElementAtIndex(4);
-    expect(inspectedElement.owners).toMatchInlineSnapshot(`
-      [
-        {
-          "compiledWithForget": false,
-          "displayName": "Child",
-          "hocDisplayNames": null,
-          "id": 8,
-          "key": null,
-          "type": 5,
-        },
-        {
-          "compiledWithForget": false,
-          "displayName": "App",
-          "hocDisplayNames": null,
-          "id": 7,
-          "key": null,
-          "type": 5,
-        },
-      ]
-    `);
+    // TODO: Ideally this should match the owners of the Group but those are
+    // part of a different parent tree. Ideally the Group would be parent of
+    // that parent tree though which would fix this issue.
+    //
+    // [
+    //   {
+    //     "compiledWithForget": false,
+    //     "displayName": "Child",
+    //     "hocDisplayNames": null,
+    //     "id": 8,
+    //     "key": null,
+    //     "type": 5,
+    //   },
+    //   {
+    //     "compiledWithForget": false,
+    //     "displayName": "App",
+    //     "hocDisplayNames": null,
+    //     "id": 7,
+    //     "key": null,
+    //     "type": 5,
+    //   },
+    // ]
+    expect(inspectedElement.owners).toMatchInlineSnapshot(`[]`);
   });
 
   describe('error boundary', () => {


### PR DESCRIPTION
This enables finding Server Components on the owner path. Server Components aren't stateful so there's not actually one specific owner that it necessarily matches. So it can't be a global look up. E.g. the same Server Component can be rendered in two places or even nested inside each other.

Therefore we need to find an appropriate instance using a heuristic. We can do that by traversing the parent path since the owner is likely also a parent. Not always but almost always.

To simplify things we can also do the same for Fibers. That brings us one step closer to being able to get rid of the global fiberToFiberInstance map since we can just use the shadow tree to find this information.

This does mean that we can't find owners that aren't parents which is usually ok. However, there is a test case that's interesting where you have a React ART tree inside a DOM tree. In that case the owners actually span multiple renderers and roots so the owner is not on the parent stack. Usually this is fine since you'd just care about the owners within React ART but ideally we'd support this. However, I think that really the fix to this is that the React ART tree itself should actually show up inside the DOM tree in DevTools and in the virtual shadow tree because that's conceptually where it belongs. That would then solve this particular issue. We'd just need some way to associate the root with a DOM parent when it gets mounted.