### PR TITLE
[flow] Eliminate a few React.Element type that will be synced to react-native

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -8,7 +8,7 @@
  */
 
 import type {ReactPortal, ReactNodeList} from 'shared/ReactTypes';
-import type {ElementRef, Element, ElementType} from 'react';
+import type {ElementRef, ElementType, MixedElement} from 'react';
 import type {FiberRoot} from 'react-reconciler/src/ReactInternalTypes';
 import type {RenderRootOptions} from './ReactNativeTypes';
 
@@ -117,7 +117,7 @@ function nativeOnCaughtError(
 }
 
 function render(
-  element: Element<ElementType>,
+  element: MixedElement,
   containerTag: number,
   callback: ?() => void,
   options: ?RenderRootOptions,

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -9,7 +9,7 @@
  * @flow strict
  */
 
-import type {ElementRef, ElementType, Element, AbstractComponent} from 'react';
+import type {ElementRef, ElementType, MixedElement, AbstractComponent} from 'react';
 
 export type MeasureOnSuccessCallback = (
   x: number,
@@ -221,7 +221,7 @@ export type ReactNativeType = {
     eventType: string,
   ): void,
   render(
-    element: Element<ElementType>,
+    element: MixedElement,
     containerTag: number,
     callback: ?() => void,
     options: ?RenderRootOptions,
@@ -256,7 +256,7 @@ export type ReactFabricType = {
     eventType: string,
   ): void,
   render(
-    element: Element<ElementType>,
+    element: MixedElement,
     containerTag: number,
     callback: ?() => void,
     concurrentRoot: ?boolean,

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -9,7 +9,12 @@
  * @flow strict
  */
 
-import type {ElementRef, ElementType, MixedElement, AbstractComponent} from 'react';
+import type {
+  ElementRef,
+  ElementType,
+  MixedElement,
+  AbstractComponent,
+} from 'react';
 
 export type MeasureOnSuccessCallback = (
   x: number,

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -14,7 +14,6 @@ export type AbstractComponent<
   +Instance = mixed,
 > = React$AbstractComponent<Config, Instance>;
 export type ElementType = React$ElementType;
-export type Element<+C> = React$Element<C>;
 export type MixedElement<+C> = React$MixedElement;
 export type Key = React$Key;
 export type Ref<C> = React$Ref<C>;

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -15,6 +15,7 @@ export type AbstractComponent<
 > = React$AbstractComponent<Config, Instance>;
 export type ElementType = React$ElementType;
 export type Element<+C> = React$Element<C>;
+export type MixedElement<+C> = React$MixedElement;
 export type Key = React$Key;
 export type Ref<C> = React$Ref<C>;
 export type Node = React$Node;

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -14,7 +14,7 @@ export type AbstractComponent<
   +Instance = mixed,
 > = React$AbstractComponent<Config, Instance>;
 export type ElementType = React$ElementType;
-export type MixedElement<+C> = React$MixedElement;
+export type MixedElement = React$MixedElement;
 export type Key = React$Key;
 export type Ref<C> = React$Ref<C>;
 export type Node = React$Node;

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -14,7 +14,7 @@ export type AbstractComponent<
   +Instance = mixed,
 > = React$AbstractComponent<Config, Instance>;
 export type ElementType = React$ElementType;
-export type MixedElement = React$MixedElement;
+export type MixedElement = React$Element<ElementType>;
 export type Key = React$Key;
 export type Ref<C> = React$Ref<C>;
 export type Node = React$Node;

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -14,6 +14,7 @@ export type AbstractComponent<
   +Instance = mixed,
 > = React$AbstractComponent<Config, Instance>;
 export type ElementType = React$ElementType;
+export type Element<+C> = React$Element<C>;
 export type MixedElement = React$Element<ElementType>;
 export type Key = React$Key;
 export type Ref<C> = React$Ref<C>;


### PR DESCRIPTION
## Summary

Flow will eventually remove the specific `React.Element` type. For most of the code, it can be replaced with `React.MixedElement` or `React.Node`.

When specific react elements are required, it needs to be replaced with either `React$Element` which will trigger a `internal-type` lint error that can be disabled project-wide, or use `ExactReactElement_DEPRECATED`.

Fortunately in this case, this one can be replaced with just `React.MixedElement`.

## How did you test this change?

`flow`