### PR TITLE
[Fax] Make `react-markup` publishable via scripts

### DIFF
--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -52,7 +52,7 @@ const stablePackages = {
 // These packages do not exist in the @canary or @latest channel, only
 // @experimental. We don't use semver, just the commit sha, so this is just a
 // list of package names instead of a map.
-const experimentalPackages = [];
+const experimentalPackages = ['react-markup'];
 
 module.exports = {
   ReactVersion,


### PR DESCRIPTION


## Summary

Publishable packages are hardcoded which was missed in https://github.com/facebook/react/pull/30690

## How did you test this change?

```bash
$ scripts/release/prepare-release-from-ci.js --skipTests -r experimental --commit=fa6eab58541330349480690ef4e211520cc08d94
$ scripts/release/publish.js --tags experimental
✓ You are about the publish the following packages under the tag experimental:
[...]
react-markup 0.0.0-experimental-fa6eab58-20240815
```