### PR TITLE
[compiler] Validate against JSX in try statements

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
@@ -250,7 +250,9 @@ function* runWithEnvironment(
     validateNoSetStateInPassiveEffects(hir);
   }
 
-  validateNoJSXInTryStatement(hir);
+  if (env.config.validateNoJSXInTryStatements) {
+    validateNoJSXInTryStatement(hir);
+  }
 
   inferReactivePlaces(hir);
   yield log({kind: 'hir', name: 'InferReactivePlaces', value: hir});

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
@@ -105,6 +105,7 @@ import {outlineFunctions} from '../Optimization/OutlineFunctions';
 import {propagatePhiTypes} from '../TypeInference/PropagatePhiTypes';
 import {lowerContextAccess} from '../Optimization/LowerContextAccess';
 import {validateNoSetStateInPassiveEffects} from '../Validation/ValidateNoSetStateInPassiveEffects';
+import {validateNoJSXInTryStatement} from '../Validation/ValidateNoJSXInTryStatement';
 
 export type CompilerPipelineValue =
   | {kind: 'ast'; name: string; value: CodegenFunction}
@@ -248,6 +249,8 @@ function* runWithEnvironment(
   if (env.config.validateNoSetStateInPassiveEffects) {
     validateNoSetStateInPassiveEffects(hir);
   }
+
+  validateNoJSXInTryStatement(hir);
 
   inferReactivePlaces(hir);
   yield log({kind: 'hir', name: 'InferReactivePlaces', value: hir});

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -238,6 +238,12 @@ const EnvironmentConfigSchema = z.object({
   validateNoSetStateInPassiveEffects: z.boolean().default(false),
 
   /**
+   * Validates against creating JSX within a try block and recommends using an error boundary
+   * instead.
+   */
+  validateNoJSXInTryStatements: z.boolean().default(false),
+
+  /**
    * Validates that the dependencies of all effect hooks are memoized. This helps ensure
    * that Forget does not introduce infinite renders caused by a dependency changing,
    * triggering an effect, which triggers re-rendering, which causes a dependency to change,

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoJSXInTryStatement.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoJSXInTryStatement.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {CompilerError, ErrorSeverity} from '..';
+import {BlockId, HIRFunction} from '../HIR';
+import {retainWhere} from '../Utils/utils';
+
+/**
+ * Developers may not be aware of error boundaries and lazy evaluation of JSX, leading them
+ * to use patterns such as `let el; try { el = <Component /> } catch { ... }` to attempt to
+ * catch rendering errors. Such code will fail to catch errors in rendering, but developers
+ * may not realize this right away.
+ *
+ * This validation pass validates against this pattern: specifically, it errors for JSX
+ * created within a try block. JSX is allowed within a catch statement, unless that catch
+ * is itself nested inside an outer try.
+ */
+export function validateNoJSXInTryStatement(fn: HIRFunction): void {
+  const activeTryBlocks: Array<BlockId> = [];
+  const errors = new CompilerError();
+  for (const [, block] of fn.body.blocks) {
+    retainWhere(activeTryBlocks, id => id !== block.id);
+
+    if (activeTryBlocks.length !== 0) {
+      for (const instr of block.instructions) {
+        const {value} = instr;
+        switch (value.kind) {
+          case 'JsxExpression':
+          case 'JsxFragment': {
+            errors.push({
+              severity: ErrorSeverity.InvalidReact,
+              reason: `Unexpected JSX element within a try statement. To catch errors in rendering a given component, wrap that component in an error boundary. (https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary)`,
+              loc: value.loc,
+            });
+            break;
+          }
+        }
+      }
+    }
+
+    if (block.terminal.kind === 'try') {
+      activeTryBlocks.push(block.terminal.handler);
+    }
+  }
+  if (errors.hasErrors()) {
+    throw errors;
+  }
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-catch-in-outer-try-with-catch.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-catch-in-outer-try-with-catch.expect.md
@@ -2,6 +2,7 @@
 ## Input
 
 ```javascript
+// @validateNoJSXInTryStatements
 import {identity} from 'shared-runtime';
 
 function Component(props) {
@@ -25,13 +26,13 @@ function Component(props) {
 ## Error
 
 ```
-   8 |       value = identity(props.foo);
-   9 |     } catch {
-> 10 |       el = <div value={value} />;
-     |            ^^^^^^^^^^^^^^^^^^^^^ InvalidReact: Unexpected JSX element within a try statement. To catch errors in rendering a given component, wrap that component in an error boundary. (https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) (10:10)
-  11 |     }
-  12 |   } catch {
-  13 |     return null;
+   9 |       value = identity(props.foo);
+  10 |     } catch {
+> 11 |       el = <div value={value} />;
+     |            ^^^^^^^^^^^^^^^^^^^^^ InvalidReact: Unexpected JSX element within a try statement. To catch errors in rendering a given component, wrap that component in an error boundary. (https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) (11:11)
+  12 |     }
+  13 |   } catch {
+  14 |     return null;
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-catch-in-outer-try-with-catch.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-catch-in-outer-try-with-catch.expect.md
@@ -1,0 +1,37 @@
+
+## Input
+
+```javascript
+import {identity} from 'shared-runtime';
+
+function Component(props) {
+  let el;
+  try {
+    let value;
+    try {
+      value = identity(props.foo);
+    } catch {
+      el = <div value={value} />;
+    }
+  } catch {
+    return null;
+  }
+  return el;
+}
+
+```
+
+
+## Error
+
+```
+   8 |       value = identity(props.foo);
+   9 |     } catch {
+> 10 |       el = <div value={value} />;
+     |            ^^^^^^^^^^^^^^^^^^^^^ InvalidReact: Unexpected JSX element within a try statement. To catch errors in rendering a given component, wrap that component in an error boundary. (https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) (10:10)
+  11 |     }
+  12 |   } catch {
+  13 |     return null;
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-catch-in-outer-try-with-catch.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-catch-in-outer-try-with-catch.js
@@ -1,0 +1,16 @@
+import {identity} from 'shared-runtime';
+
+function Component(props) {
+  let el;
+  try {
+    let value;
+    try {
+      value = identity(props.foo);
+    } catch {
+      el = <div value={value} />;
+    }
+  } catch {
+    return null;
+  }
+  return el;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-catch-in-outer-try-with-catch.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-catch-in-outer-try-with-catch.js
@@ -1,3 +1,4 @@
+// @validateNoJSXInTryStatements
 import {identity} from 'shared-runtime';
 
 function Component(props) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-try-with-catch.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-try-with-catch.expect.md
@@ -1,0 +1,30 @@
+
+## Input
+
+```javascript
+function Component(props) {
+  let el;
+  try {
+    el = <div />;
+  } catch {
+    return null;
+  }
+  return el;
+}
+
+```
+
+
+## Error
+
+```
+  2 |   let el;
+  3 |   try {
+> 4 |     el = <div />;
+    |          ^^^^^^^ InvalidReact: Unexpected JSX element within a try statement. To catch errors in rendering a given component, wrap that component in an error boundary. (https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) (4:4)
+  5 |   } catch {
+  6 |     return null;
+  7 |   }
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-try-with-catch.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-try-with-catch.expect.md
@@ -2,6 +2,7 @@
 ## Input
 
 ```javascript
+// @validateNoJSXInTryStatements
 function Component(props) {
   let el;
   try {
@@ -18,13 +19,13 @@ function Component(props) {
 ## Error
 
 ```
-  2 |   let el;
-  3 |   try {
-> 4 |     el = <div />;
-    |          ^^^^^^^ InvalidReact: Unexpected JSX element within a try statement. To catch errors in rendering a given component, wrap that component in an error boundary. (https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) (4:4)
-  5 |   } catch {
-  6 |     return null;
-  7 |   }
+  3 |   let el;
+  4 |   try {
+> 5 |     el = <div />;
+    |          ^^^^^^^ InvalidReact: Unexpected JSX element within a try statement. To catch errors in rendering a given component, wrap that component in an error boundary. (https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) (5:5)
+  6 |   } catch {
+  7 |     return null;
+  8 |   }
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-try-with-catch.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-try-with-catch.js
@@ -1,0 +1,9 @@
+function Component(props) {
+  let el;
+  try {
+    el = <div />;
+  } catch {
+    return null;
+  }
+  return el;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-try-with-catch.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-jsx-in-try-with-catch.js
@@ -1,3 +1,4 @@
+// @validateNoJSXInTryStatements
 function Component(props) {
   let el;
   try {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-catch-in-outer-try-with-finally.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-catch-in-outer-try-with-finally.expect.md
@@ -2,6 +2,7 @@
 ## Input
 
 ```javascript
+// @validateNoJSXInTryStatements
 import {identity} from 'shared-runtime';
 
 function Component(props) {
@@ -25,31 +26,31 @@ function Component(props) {
 ## Error
 
 ```
-   3 | function Component(props) {
-   4 |   let el;
->  5 |   try {
+   4 | function Component(props) {
+   5 |   let el;
+>  6 |   try {
      |   ^^^^^
->  6 |     let value;
+>  7 |     let value;
      | ^^^^^^^^^^^^^^
->  7 |     try {
+>  8 |     try {
      | ^^^^^^^^^^^^^^
->  8 |       value = identity(props.foo);
+>  9 |       value = identity(props.foo);
      | ^^^^^^^^^^^^^^
->  9 |     } catch {
+> 10 |     } catch {
      | ^^^^^^^^^^^^^^
-> 10 |       el = <div value={value} />;
+> 11 |       el = <div value={value} />;
      | ^^^^^^^^^^^^^^
-> 11 |     }
+> 12 |     }
      | ^^^^^^^^^^^^^^
-> 12 |   } finally {
+> 13 |   } finally {
      | ^^^^^^^^^^^^^^
-> 13 |     console.log(el);
+> 14 |     console.log(el);
      | ^^^^^^^^^^^^^^
-> 14 |   }
-     | ^^^^ Todo: (BuildHIR::lowerStatement) Handle TryStatement without a catch clause (5:14)
-  15 |   return el;
-  16 | }
-  17 |
+> 15 |   }
+     | ^^^^ Todo: (BuildHIR::lowerStatement) Handle TryStatement without a catch clause (6:15)
+  16 |   return el;
+  17 | }
+  18 |
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-catch-in-outer-try-with-finally.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-catch-in-outer-try-with-finally.expect.md
@@ -1,0 +1,55 @@
+
+## Input
+
+```javascript
+import {identity} from 'shared-runtime';
+
+function Component(props) {
+  let el;
+  try {
+    let value;
+    try {
+      value = identity(props.foo);
+    } catch {
+      el = <div value={value} />;
+    }
+  } finally {
+    console.log(el);
+  }
+  return el;
+}
+
+```
+
+
+## Error
+
+```
+   3 | function Component(props) {
+   4 |   let el;
+>  5 |   try {
+     |   ^^^^^
+>  6 |     let value;
+     | ^^^^^^^^^^^^^^
+>  7 |     try {
+     | ^^^^^^^^^^^^^^
+>  8 |       value = identity(props.foo);
+     | ^^^^^^^^^^^^^^
+>  9 |     } catch {
+     | ^^^^^^^^^^^^^^
+> 10 |       el = <div value={value} />;
+     | ^^^^^^^^^^^^^^
+> 11 |     }
+     | ^^^^^^^^^^^^^^
+> 12 |   } finally {
+     | ^^^^^^^^^^^^^^
+> 13 |     console.log(el);
+     | ^^^^^^^^^^^^^^
+> 14 |   }
+     | ^^^^ Todo: (BuildHIR::lowerStatement) Handle TryStatement without a catch clause (5:14)
+  15 |   return el;
+  16 | }
+  17 |
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-catch-in-outer-try-with-finally.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-catch-in-outer-try-with-finally.js
@@ -1,0 +1,16 @@
+import {identity} from 'shared-runtime';
+
+function Component(props) {
+  let el;
+  try {
+    let value;
+    try {
+      value = identity(props.foo);
+    } catch {
+      el = <div value={value} />;
+    }
+  } finally {
+    console.log(el);
+  }
+  return el;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-catch-in-outer-try-with-finally.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-catch-in-outer-try-with-finally.js
@@ -1,3 +1,4 @@
+// @validateNoJSXInTryStatements
 import {identity} from 'shared-runtime';
 
 function Component(props) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-try-with-finally.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-try-with-finally.expect.md
@@ -2,6 +2,7 @@
 ## Input
 
 ```javascript
+// @validateNoJSXInTryStatements
 function Component(props) {
   let el;
   try {
@@ -18,21 +19,21 @@ function Component(props) {
 ## Error
 
 ```
-   1 | function Component(props) {
-   2 |   let el;
->  3 |   try {
+   2 | function Component(props) {
+   3 |   let el;
+>  4 |   try {
      |   ^^^^^
->  4 |     el = <div />;
+>  5 |     el = <div />;
      | ^^^^^^^^^^^^^^^^^
->  5 |   } finally {
+>  6 |   } finally {
      | ^^^^^^^^^^^^^^^^^
->  6 |     console.log(el);
+>  7 |     console.log(el);
      | ^^^^^^^^^^^^^^^^^
->  7 |   }
-     | ^^^^ Todo: (BuildHIR::lowerStatement) Handle TryStatement without a catch clause (3:7)
-   8 |   return el;
-   9 | }
-  10 |
+>  8 |   }
+     | ^^^^ Todo: (BuildHIR::lowerStatement) Handle TryStatement without a catch clause (4:8)
+   9 |   return el;
+  10 | }
+  11 |
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-try-with-finally.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-try-with-finally.expect.md
@@ -1,0 +1,38 @@
+
+## Input
+
+```javascript
+function Component(props) {
+  let el;
+  try {
+    el = <div />;
+  } finally {
+    console.log(el);
+  }
+  return el;
+}
+
+```
+
+
+## Error
+
+```
+   1 | function Component(props) {
+   2 |   let el;
+>  3 |   try {
+     |   ^^^^^
+>  4 |     el = <div />;
+     | ^^^^^^^^^^^^^^^^^
+>  5 |   } finally {
+     | ^^^^^^^^^^^^^^^^^
+>  6 |     console.log(el);
+     | ^^^^^^^^^^^^^^^^^
+>  7 |   }
+     | ^^^^ Todo: (BuildHIR::lowerStatement) Handle TryStatement without a catch clause (3:7)
+   8 |   return el;
+   9 | }
+  10 |
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-try-with-finally.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-try-with-finally.js
@@ -1,3 +1,4 @@
+// @validateNoJSXInTryStatements
 function Component(props) {
   let el;
   try {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-try-with-finally.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-invalid-jsx-in-try-with-finally.js
@@ -1,0 +1,9 @@
+function Component(props) {
+  let el;
+  try {
+    el = <div />;
+  } finally {
+    console.log(el);
+  }
+  return el;
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30725

Per comments on the new validation pass, this disallows creating JSX (expression/fragment) within a try statement. Developers sometimes use this pattern thinking that they can catch errors during the rendering of the element, without realizing that rendering is lazy. The validation allows us to teach developers about the error boundary pattern.