### PR TITLE
[Flight] Emit Infinite Promise as a Halted Row

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -46,7 +46,6 @@ import {
   enableRefAsProp,
   enableFlightReadableStream,
   enableOwnerStacks,
-  enableHalt,
 } from 'shared/ReactFeatureFlags';
 
 import {
@@ -1194,10 +1193,6 @@ function parseModelString(
       }
       case '@': {
         // Promise
-        if (value.length === 2) {
-          // Infinite promise that never resolves.
-          return new Promise(() => {});
-        }
         const id = parseInt(value.slice(2), 16);
         const chunk = getChunk(response, id);
         return chunk;
@@ -2638,10 +2633,8 @@ function processFullStringRow(
     }
     // Fallthrough
     case 35 /* "#" */: {
-      if (enableHalt) {
-        resolveBlocked(response, id);
-        return;
-      }
+      resolveBlocked(response, id);
+      return;
     }
     // Fallthrough
     default: /* """ "{" "[" "t" "f" "n" "0" - "9" */ {

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -2952,8 +2952,14 @@ describe('ReactFlight', () => {
     function foo() {
       return 'hello';
     }
+
     function ServerComponent() {
-      console.log('hi', {prop: 123, fn: foo, map: new Map([['foo', foo]])});
+      console.log('hi', {
+        prop: 123,
+        fn: foo,
+        map: new Map([['foo', foo]]),
+        promise: new Promise(() => {}),
+      });
       throw new Error('err');
     }
 
@@ -3017,6 +3023,10 @@ describe('ReactFlight', () => {
     expect(typeof loggedFn2).toBe('function');
     expect(loggedFn2).not.toBe(foo);
     expect(loggedFn2.toString()).toBe(foo.toString());
+
+    const promise = mockConsoleLog.mock.calls[0][1].promise;
+    expect(promise).toBeInstanceOf(Promise);
+    expect(promise.status).toBe('blocked');
 
     expect(ownerStacks).toEqual(['\n    in App (at **)']);
   });

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -1817,10 +1817,6 @@ function serializeLazyID(id: number): string {
   return '$L' + id.toString(16);
 }
 
-function serializeInfinitePromise(): string {
-  return '$@';
-}
-
 function serializePromiseID(id: number): string {
   return '$@' + id.toString(16);
 }
@@ -3273,7 +3269,10 @@ function renderConsoleValue(
       }
       // If it hasn't already resolved (and been instrumented) we just encode an infinite
       // promise that will never resolve.
-      return serializeInfinitePromise();
+      request.pendingChunks++;
+      const blockedId = request.nextChunkId++;
+      emitBlockedChunk(request, blockedId);
+      return serializePromiseID(blockedId);
     }
 
     if (existingReference !== undefined) {


### PR DESCRIPTION
Stacked on #30731.

When logging a Promise we emit it as an infinite promise instead of blocking the replay on it.

This models that as a halted row instead. No need for this special case.

I unflag the receiving side since now it's used to replace a feature that's already unflagged so it's used.
