### PR TITLE
[flow] Remove CI_MAX_WORKERS option

### DIFF
--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -33,7 +33,6 @@
 untyped-type-import=error
 
 [options]
-%CI_MAX_WORKERS%
 munge_underscores=false
 
 # Substituted by createFlowConfig.js:

--- a/scripts/flow/createFlowConfigs.js
+++ b/scripts/flow/createFlowConfigs.js
@@ -107,11 +107,6 @@ function writeConfig(
   });
 
   const config = configTemplate
-    .replace(
-      '%CI_MAX_WORKERS%\n',
-      // On CI, we seem to need to limit workers.
-      process.env.CI ? 'server.max_workers=4\n' : '',
-    )
     .replace('%REACT_RENDERER_FLOW_OPTIONS%', moduleMappings.trim())
     .replace('%REACT_RENDERER_FLOW_IGNORES%', ignoredPaths.join('\n'))
     .replace('%FLOW_VERSION%', flowVersion);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30753

Noticed this from #30707. This was vestigial from from circleci and now
that we're on GH actions I think we should be able to remove this option
altogether.