### PR TITLE
Ensure `react-dom/client` is built in Codesandbox preview builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "publish-prereleases": "echo 'This command has been deprecated. Please refer to https://github.com/facebook/react/tree/main/scripts/release#trigger-an-automated-prerelease'",
     "download-build": "node ./scripts/release/download-experimental-build.js",
     "download-build-for-head": "node ./scripts/release/download-experimental-build.js --commit=$(git rev-parse HEAD)",
-    "download-build-in-codesandbox-ci": "yarn build --type=node react/index react-dom/index react-dom/src/server react-dom/test-utils scheduler/index react/jsx-runtime react/jsx-dev-runtime",
+    "download-build-in-codesandbox-ci": "yarn build --type=node react/index react-dom/index react-dom/client react-dom/src/server react-dom/test-utils scheduler/index react/jsx-runtime react/jsx-dev-runtime",
     "check-release-dependencies": "node ./scripts/release/check-release-dependencies",
     "generate-inline-fizz-runtime": "node ./scripts/rollup/generate-inline-fizz-runtime.js",
     "flags": "node ./scripts/flags/flags.js"


### PR DESCRIPTION
## Summary

`react-dom/client` wasn't usable in Codesandbox preview builds because we never built it. This used to work because the client APIs used to be exported from `react-dom/index` but now aren't so we need to explicitly list the entrypoint.

## How did you test this change?

- [x] Codesandbox for this branch works: https://codesandbox.io/p/sandbox/fixed-react-preview-build-in-csb-t2t9gh?file=%2Fpackage.json