### PR TITLE
Test infra: Support gate('enableFeatureFlag')

### DIFF
--- a/scripts/babel/__tests__/transform-test-gate-pragma-test.js
+++ b/scripts/babel/__tests__/transform-test-gate-pragma-test.js
@@ -221,4 +221,8 @@ describe('dynamic gate method', () => {
   it('returns same conditions as pragma', () => {
     expect(gate(ctx => ctx.experimental && ctx.__DEV__)).toBe(true);
   });
+
+  it('converts string conditions to accessor function', () => {
+    expect(gate('experimental')).toBe(gate(flags => flags.experimental));
+  });
 });

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -205,8 +205,17 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
     }
   };
 
+  const coerceGateConditionToFunction = gateFnOrString => {
+    return typeof gateFnOrString === 'string'
+      ? // `gate('foo')` is treated as equivalent to `gate(flags => flags.foo)`
+        flags => flags[gateFnOrString]
+      : // Assume this is already a function
+        gateFnOrString;
+  };
+
   const gatedErrorMessage = 'Gated test was expected to fail, but it passed.';
-  global._test_gate = (gateFn, testName, callback, timeoutMS) => {
+  global._test_gate = (gateFnOrString, testName, callback, timeoutMS) => {
+    const gateFn = coerceGateConditionToFunction(gateFnOrString);
     let shouldPass;
     try {
       const flags = getTestFlags();
@@ -230,7 +239,8 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
         expectTestToFail(callback, error, timeoutMS));
     }
   };
-  global._test_gate_focus = (gateFn, testName, callback, timeoutMS) => {
+  global._test_gate_focus = (gateFnOrString, testName, callback, timeoutMS) => {
+    const gateFn = coerceGateConditionToFunction(gateFnOrString);
     let shouldPass;
     try {
       const flags = getTestFlags();
@@ -259,8 +269,9 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
   };
 
   // Dynamic version of @gate pragma
-  global.gate = fn => {
+  global.gate = gateFnOrString => {
+    const gateFn = coerceGateConditionToFunction(gateFnOrString);
     const flags = getTestFlags();
-    return fn(flags);
+    return gateFn(flags);
   };
 }


### PR DESCRIPTION
Shortcut for the common case where only a single flag is checked. Same as `gate(flags => flags.enableFeatureFlag)`.

Normally I don't care about these types of conveniences but I'm about to add a lot more inline flag checks these all over our tests and it gets noisy. This helps a bit.