### PR TITLE
[compiler] Add returnIdentifier to function expressions

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -211,11 +211,14 @@ export function lower(
     null,
   );
 
+  const returnIdentifier = builder.makeTemporary(func.node.loc ?? GeneratedSource);
+
   return Ok({
     id,
     params,
     fnType: parent == null ? env.fnType : 'Other',
     returnType: null, // TODO: extract the actual return type node if present
+    returnIdentifier,
     body: builder.build(),
     context,
     generator: func.node.generator === true,

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -286,6 +286,7 @@ export type HIRFunction = {
   env: Environment;
   params: Array<Place | SpreadPattern>;
   returnType: t.FlowType | t.TSType | null;
+  returnIdentifier: Identifier;
   context: Array<Place>;
   effects: Array<FunctionEffect> | null;
   body: HIR;

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/LowerContextAccess.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/LowerContextAccess.ts
@@ -238,6 +238,7 @@ function emitSelectorFn(env: Environment, keys: Array<string>): Instruction {
     phis: new Set(),
   };
 
+  const returnIdentifier = createTemporaryPlace(env, GeneratedSource).identifier;
   const fn: HIRFunction = {
     loc: GeneratedSource,
     id: null,
@@ -245,6 +246,7 @@ function emitSelectorFn(env: Environment, keys: Array<string>): Instruction {
     env,
     params: [obj],
     returnType: null,
+    returnIdentifier, 
     context: [],
     effects: null,
     body: {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-repro-named-function-with-shadowed-local-same-name.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-repro-named-function-with-shadowed-local-same-name.expect.md
@@ -22,7 +22,7 @@ function Component(props) {
    7 |     return hasErrors;
    8 |   }
 >  9 |   return hasErrors();
-     |          ^^^^^^^^^ Invariant: [hoisting] Expected value for identifier to be initialized. hasErrors_0$16 (9:9)
+     |          ^^^^^^^^^ Invariant: [hoisting] Expected value for identifier to be initialized. hasErrors_0$17 (9:9)
   10 | }
   11 |
 ```


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30790
* #30789
* #30785
* __->__ #30784
* #30783
* #30771
* #30766
* #30764

This gives us a place to store type information, used in follow-up PRs.