### PR TITLE
[compiler] Rename HIRFunction.returnType

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -219,7 +219,7 @@ export function lower(
     id,
     params,
     fnType: parent == null ? env.fnType : 'Other',
-    returnType: null, // TODO: extract the actual return type node if present
+    returnTypeAnnotation: null, // TODO: extract the actual return type node if present
     returnIdentifier,
     body: builder.build(),
     context,

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -285,7 +285,7 @@ export type HIRFunction = {
   fnType: ReactFunctionType;
   env: Environment;
   params: Array<Place | SpreadPattern>;
-  returnType: t.FlowType | t.TSType | null;
+  returnTypeAnnotation: t.FlowType | t.TSType | null;
   returnIdentifier: Identifier;
   context: Array<Place>;
   effects: Array<FunctionEffect> | null;

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/LowerContextAccess.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/LowerContextAccess.ts
@@ -248,7 +248,7 @@ function emitSelectorFn(env: Environment, keys: Array<string>): Instruction {
     fnType: 'Other',
     env,
     params: [obj],
-    returnType: null,
+    returnTypeAnnotation: null,
     returnIdentifier,
     context: [],
     effects: null,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30790
* __->__ #30789
* #30785
* #30784
* #30783
* #30771
* #30766
* #30764

Rename this field so we can use it for the actual return type.