### PR TITLE
[compiler] Flatten returnIdentifier to just returnType

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -211,16 +211,12 @@ export function lower(
     null,
   );
 
-  const returnIdentifier = builder.makeTemporary(
-    func.node.loc ?? GeneratedSource,
-  );
-
   return Ok({
     id,
     params,
     fnType: parent == null ? env.fnType : 'Other',
     returnTypeAnnotation: null, // TODO: extract the actual return type node if present
-    returnIdentifier,
+    returnType: makeType(),
     body: builder.build(),
     context,
     generator: func.node.generator === true,

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -286,7 +286,7 @@ export type HIRFunction = {
   env: Environment;
   params: Array<Place | SpreadPattern>;
   returnTypeAnnotation: t.FlowType | t.TSType | null;
-  returnIdentifier: Identifier;
+  returnType: Type;
   context: Array<Place>;
   effects: Array<FunctionEffect> | null;
   body: HIR;

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -72,7 +72,7 @@ export function printFunction(fn: HIRFunction): string {
   if (definition.length !== 0) {
     output.push(definition);
   }
-  output.push(printType(fn.returnIdentifier.type));
+  output.push(printType(fn.returnType));
   output.push(printHIR(fn.body));
   output.push(...fn.directives);
   return output.join('\n');
@@ -556,9 +556,7 @@ export function printInstructionValue(instrValue: ReactiveValue): string {
             }
           })
           .join(', ') ?? '';
-      const type = printType(
-        instrValue.loweredFunc.func.returnIdentifier.type,
-      ).trim();
+      const type = printType(instrValue.loweredFunc.func.returnType).trim();
       value = `${kind} ${name} @deps[${deps}] @context[${context}] @effects[${effects}]${type !== '' ? ` return${type}` : ''}:\n${fn}`;
       break;
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/LowerContextAccess.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/LowerContextAccess.ts
@@ -23,6 +23,7 @@ import {
   isUseContextHookType,
   makeBlockId,
   makeInstructionId,
+  makeType,
   markInstructionIds,
   promoteTemporary,
   reversePostorderBlocks,
@@ -238,10 +239,6 @@ function emitSelectorFn(env: Environment, keys: Array<string>): Instruction {
     phis: new Set(),
   };
 
-  const returnIdentifier = createTemporaryPlace(
-    env,
-    GeneratedSource,
-  ).identifier;
   const fn: HIRFunction = {
     loc: GeneratedSource,
     id: null,
@@ -249,7 +246,7 @@ function emitSelectorFn(env: Environment, keys: Array<string>): Instruction {
     env,
     params: [obj],
     returnTypeAnnotation: null,
-    returnIdentifier,
+    returnType: makeType(),
     context: [],
     effects: null,
     body: {

--- a/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
@@ -88,7 +88,7 @@ function apply(func: HIRFunction, unifier: Unifier): void {
       }
     }
   }
-  func.returnIdentifier.type = unifier.get(func.returnIdentifier.type);
+  func.returnType = unifier.get(func.returnType);
 }
 
 type TypeEquation = {
@@ -141,12 +141,12 @@ function* generate(
     }
   }
   if (returnTypes.length > 1) {
-    yield equation(func.returnIdentifier.type, {
+    yield equation(func.returnType, {
       kind: 'Phi',
       operands: returnTypes,
     });
   } else if (returnTypes.length === 1) {
-    yield equation(func.returnIdentifier.type, returnTypes[0]!);
+    yield equation(func.returnType, returnTypes[0]!);
   }
 }
 
@@ -363,7 +363,7 @@ function* generateInstructionTypes(
       yield equation(left, {
         kind: 'Function',
         shapeId: BuiltInFunctionId,
-        return: value.loweredFunc.func.returnIdentifier.type,
+        return: value.loweredFunc.func.returnType,
       });
       break;
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-repro-named-function-with-shadowed-local-same-name.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-repro-named-function-with-shadowed-local-same-name.expect.md
@@ -22,7 +22,7 @@ function Component(props) {
    7 |     return hasErrors;
    8 |   }
 >  9 |   return hasErrors();
-     |          ^^^^^^^^^ Invariant: [hoisting] Expected value for identifier to be initialized. hasErrors_0$17 (9:9)
+     |          ^^^^^^^^^ Invariant: [hoisting] Expected value for identifier to be initialized. hasErrors_0$16 (9:9)
   10 | }
   11 |
 ```


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30790
* #30789
* #30785
* #30784
* #30783
* #30771
* #30766
* #30764

We don't a full Identifier object for the return type, we can just store the type.