### PR TITLE
[compiler] Repro for false positive ref-in-render violation

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-repro-false-positive-ref-in-render-callback-to-frozen-object.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-repro-false-positive-ref-in-render-callback-to-frozen-object.expect.md
@@ -1,0 +1,43 @@
+
+## Input
+
+```javascript
+import {createContext, useCallback, useRef} from 'react';
+
+const Context = createContext(null);
+
+function Component({children}) {
+  const callbackRef = useRef(function () {});
+  const callback = useCallback(() => {
+    callbackRef.current();
+  }, []);
+
+  const setCallback = useCallback(cb => {
+    callbackRef.current = cb;
+  }, []);
+
+  return (
+    <Context.Provider value={{callback, setCallback}}>
+      {children}
+    </Context.Provider>
+  );
+}
+
+```
+
+
+## Error
+
+```
+  14 |
+  15 |   return (
+> 16 |     <Context.Provider value={{callback, setCallback}}>
+     |                               ^^^^^^^^ InvalidReact: Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef) (16:16)
+
+InvalidReact: Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef) (16:16)
+  17 |       {children}
+  18 |     </Context.Provider>
+  19 |   );
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-repro-false-positive-ref-in-render-callback-to-frozen-object.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-repro-false-positive-ref-in-render-callback-to-frozen-object.tsx
@@ -1,0 +1,20 @@
+import {createContext, useCallback, useRef} from 'react';
+
+const Context = createContext(null);
+
+function Component({children}) {
+  const callbackRef = useRef(function () {});
+  const callback = useCallback(() => {
+    callbackRef.current();
+  }, []);
+
+  const setCallback = useCallback(cb => {
+    callbackRef.current = cb;
+  }, []);
+
+  return (
+    <Context.Provider value={{callback, setCallback}}>
+      {children}
+    </Context.Provider>
+  );
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30791

We think that accessing the callback as an operand to the object is an access, but it's just capturing the function not calling it.