### PR TITLE
Revert "[compiler][eslint] remove compilationMode override; report bailouts on first line"

### DIFF
--- a/compiler/packages/eslint-plugin-react-compiler/src/rules/ReactCompilerRule.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/src/rules/ReactCompilerRule.ts
@@ -166,16 +166,9 @@ const rule: Rule.RuleModule = {
               detail.loc != null && typeof detail.loc !== 'symbol'
                 ? ` (@:${detail.loc.start.line}:${detail.loc.start.column})`
                 : '';
-            const firstLineLoc = {
-              start: event.fnLoc.start,
-              end: {
-                line: event.fnLoc.start.line,
-                column: 10e3,
-              },
-            };
             context.report({
               message: `[ReactCompilerBailout] ${detail.reason}${locStr}`,
-              loc: firstLineLoc,
+              loc: event.fnLoc,
               suggest,
             });
           }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30792

This reverts commit b34b750729bcbcfd80f72f82f46da5bc3e72158f.

This hack doesn't play well internally so I'm reverting this for now
(but keeping the compilationMode override). I'll audit the locations we
report later and try to make them more accurate so we won't need this
workaround.