### PR TITLE
[compiler] Fixture to demonstrate issue with returning object containing ref

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.return-ref-callback-structure.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.return-ref-callback-structure.expect.md
@@ -1,0 +1,45 @@
+
+## Input
+
+```javascript
+// @flow @validateRefAccessDuringRender @validatePreserveExistingMemoizationGuarantees
+
+import {useRef} from 'react';
+
+component Foo(cond: boolean, cond2: boolean) {
+  const ref = useRef();
+
+  const s = () => {
+    return ref.current;
+  };
+
+  if (cond) return [s];
+  else if (cond2) return {s};
+  else return {s: [s]};
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [{cond: false, cond2: false}],
+};
+
+```
+
+
+## Error
+
+```
+  10 |   };
+  11 |
+> 12 |   if (cond) return [s];
+     |                     ^ InvalidReact: Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef) (12:12)
+
+InvalidReact: Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef) (13:13)
+
+InvalidReact: Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef) (14:14)
+  13 |   else if (cond2) return {s};
+  14 |   else return {s: [s]};
+  15 | }
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.return-ref-callback-structure.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.return-ref-callback-structure.js
@@ -1,0 +1,20 @@
+// @flow @validateRefAccessDuringRender @validatePreserveExistingMemoizationGuarantees
+
+import {useRef} from 'react';
+
+component Foo(cond: boolean, cond2: boolean) {
+  const ref = useRef();
+
+  const s = () => {
+    return ref.current;
+  };
+
+  if (cond) return [s];
+  else if (cond2) return {s};
+  else return {s: [s]};
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [{cond: false, cond2: false}],
+};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30821
* __->__ #30820

Summary:
We currently can return a ref from a hook but not an object containing a ref.