### PR TITLE
chore[react-devtools/hook]: remove unused native values

### DIFF
--- a/packages/react-devtools-extensions/src/contentScripts/installHook.js
+++ b/packages/react-devtools-extensions/src/contentScripts/installHook.js
@@ -20,10 +20,4 @@ if (!window.hasOwnProperty('__REACT_DEVTOOLS_GLOBAL_HOOK__')) {
       );
     },
   );
-
-  // save native values
-  window.__REACT_DEVTOOLS_GLOBAL_HOOK__.nativeObjectCreate = Object.create;
-  window.__REACT_DEVTOOLS_GLOBAL_HOOK__.nativeMap = Map;
-  window.__REACT_DEVTOOLS_GLOBAL_HOOK__.nativeWeakMap = WeakMap;
-  window.__REACT_DEVTOOLS_GLOBAL_HOOK__.nativeSet = Set;
 }


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/30826. See [this commit](https://github.com/facebook/react/pull/30827/commits/ec0e48ed7a47dbbdafb5e2530ccba1f2e5b17bad).

This is unused.