### PR TITLE
[DevTools] Track all public HostInstances in a Map

### DIFF
--- a/packages/react-devtools-shared/src/backend/console.js
+++ b/packages/react-devtools-shared/src/backend/console.js
@@ -135,17 +135,7 @@ export function registerRenderer(
   renderer: ReactRenderer,
   onErrorOrWarning?: OnErrorOrWarning,
 ): void {
-  const {
-    currentDispatcherRef,
-    getCurrentFiber,
-    findFiberByHostInstance,
-    version,
-  } = renderer;
-
-  // Ignore React v15 and older because they don't expose a component stack anyway.
-  if (typeof findFiberByHostInstance !== 'function') {
-    return;
-  }
+  const {currentDispatcherRef, getCurrentFiber, version} = renderer;
 
   // currentDispatcherRef gets injected for v16.8+ to support hooks inspection.
   // getCurrentFiber gets injected for v16.9+.

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -754,7 +754,9 @@ function getPublicInstance(instance: HostInstance): HostInstance {
     instance !== null &&
     typeof instance.canonical === 'object'
     ? (instance.canonical: any)
-    : instance;
+    : typeof instance._nativeTag === 'number'
+      ? instance._nativeTag
+      : instance;
 }
 
 function aquireHostInstance(

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -3869,23 +3869,12 @@ export function attach(
   }
 
   function getNearestMountedDOMNode(publicInstance: Element): null | Element {
-    // TODO: Remove dependency on findFiberByHostInstance.
-    const mountedFiber = renderer.findFiberByHostInstance(publicInstance);
-    if (mountedFiber != null) {
-      if (mountedFiber.stateNode !== publicInstance) {
-        // If it's not a perfect match the specific one might be a resource.
-        // We don't need to look at any parents because host resources don't have
-        // children so it won't be in any parent if it's not this one.
-        if (publicInstanceToDevToolsInstanceMap.has(publicInstance)) {
-          return publicInstance;
-        }
-      }
-      return mountedFiber.stateNode;
+    let domNode: null | Element = publicInstance;
+    while (domNode && !publicInstanceToDevToolsInstanceMap.has(domNode)) {
+      // $FlowFixMe: In practice this is either null or Element.
+      domNode = domNode.parentNode;
     }
-    if (publicInstanceToDevToolsInstanceMap.has(publicInstance)) {
-      return publicInstance;
-    }
-    return null;
+    return domNode;
   }
 
   function getElementIDForHostInstance(

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -812,11 +812,17 @@ function releaseHostResource(
       if (resourceInstances.size === 0) {
         hostResourceToDevToolsInstanceMap.delete(publicInstance);
         publicInstanceToDevToolsInstanceMap.delete(publicInstance);
-      } else if (publicInstanceToDevToolsInstanceMap.get(publicInstance) === nearestInstance) {
+      } else if (
+        publicInstanceToDevToolsInstanceMap.get(publicInstance) ===
+        nearestInstance
+      ) {
         // This was the first one. Store the next first one in the main map for easy access.
         // eslint-disable-next-line no-for-of-loops/no-for-of-loops
         for (const firstInstance of resourceInstances) {
-          publicInstanceToDevToolsInstanceMap.set(firstInstance, nearestInstance);
+          publicInstanceToDevToolsInstanceMap.set(
+            firstInstance,
+            nearestInstance,
+          );
           break;
         }
       }
@@ -3862,9 +3868,7 @@ export function attach(
     }
   }
 
-  function getNearestMountedHostInstance(
-    publicInstance: HostInstance,
-  ): null | HostInstance {
+  function getNearestMountedDOMNode(publicInstance: Element): null | Element {
     // TODO: Remove dependency on findFiberByHostInstance.
     const mountedFiber = renderer.findFiberByHostInstance(publicInstance);
     if (mountedFiber != null) {
@@ -5822,7 +5826,7 @@ export function attach(
     flushInitialOperations,
     getBestMatchForTrackedPath,
     getDisplayNameForElementID,
-    getNearestMountedHostInstance,
+    getNearestMountedDOMNode,
     getElementIDForHostInstance,
     getInstanceAndStyle,
     getOwnersList,

--- a/packages/react-devtools-shared/src/backend/index.js
+++ b/packages/react-devtools-shared/src/backend/index.js
@@ -73,7 +73,12 @@ export function initBackend(
 
     // Inject any not-yet-injected renderers (if we didn't reload-and-profile)
     if (rendererInterface == null) {
-      if (typeof renderer.findFiberByHostInstance === 'function') {
+      if (
+        // v16-19
+        typeof renderer.findFiberByHostInstance === 'function' ||
+        // v16.8+
+        renderer.currentDispatcherRef != null
+      ) {
         // react-reconciler v16+
         rendererInterface = attach(hook, id, renderer, global);
       } else if (renderer.ComponentTree) {

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -145,15 +145,13 @@ export function attach(
   let getElementIDForHostInstance: GetElementIDForHostInstance =
     ((null: any): GetElementIDForHostInstance);
   let findHostInstanceForInternalID: (id: number) => ?HostInstance;
-  let getNearestMountedHostInstance = (
-    node: HostInstance,
-  ): null | HostInstance => {
+  let getNearestMountedDOMNode = (node: Element): null | Element => {
     // Not implemented.
     return null;
   };
 
   if (renderer.ComponentTree) {
-    getElementIDForHostInstance = (node, findNearestUnfilteredAncestor) => {
+    getElementIDForHostInstance = node => {
       const internalInstance =
         renderer.ComponentTree.getClosestInstanceFromNode(node);
       return internalInstanceToIDMap.get(internalInstance) || null;
@@ -162,9 +160,7 @@ export function attach(
       const internalInstance = idToInternalInstanceMap.get(id);
       return renderer.ComponentTree.getNodeFromInstance(internalInstance);
     };
-    getNearestMountedHostInstance = (
-      node: HostInstance,
-    ): null | HostInstance => {
+    getNearestMountedDOMNode = (node: Element): null | Element => {
       const internalInstance =
         renderer.ComponentTree.getClosestInstanceFromNode(node);
       if (internalInstance != null) {
@@ -173,7 +169,7 @@ export function attach(
       return null;
     };
   } else if (renderer.Mount.getID && renderer.Mount.getNode) {
-    getElementIDForHostInstance = (node, findNearestUnfilteredAncestor) => {
+    getElementIDForHostInstance = node => {
       // Not implemented.
       return null;
     };
@@ -1126,7 +1122,7 @@ export function attach(
     flushInitialOperations,
     getBestMatchForTrackedPath,
     getDisplayNameForElementID,
-    getNearestMountedHostInstance,
+    getNearestMountedDOMNode,
     getElementIDForHostInstance,
     getInstanceAndStyle,
     findHostInstancesForElementID: (id: number) => {

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -90,7 +90,6 @@ export type GetDisplayNameForElementID = (id: number) => string | null;
 
 export type GetElementIDForHostInstance = (
   component: HostInstance,
-  findNearestUnfilteredAncestor?: boolean,
 ) => number | null;
 export type FindHostInstancesForElementID = (
   id: number,
@@ -358,9 +357,7 @@ export type RendererInterface = {
   findHostInstancesForElementID: FindHostInstancesForElementID,
   flushInitialOperations: () => void,
   getBestMatchForTrackedPath: () => PathMatch | null,
-  getNearestMountedHostInstance: (
-    component: HostInstance,
-  ) => HostInstance | null,
+  getNearestMountedDOMNode: (component: Element) => Element | null,
   getElementIDForHostInstance: GetElementIDForHostInstance,
   getDisplayNameForElementID: GetDisplayNameForElementID,
   getInstanceAndStyle(id: number): InstanceAndStyle,

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -105,10 +105,11 @@ export type Lane = number;
 export type Lanes = number;
 
 export type ReactRenderer = {
-  findFiberByHostInstance: (hostInstance: HostInstance) => Fiber | null,
   version: string,
   rendererPackageName: string,
   bundleType: BundleType,
+  // 16.0+ - To be removed in future versions.
+  findFiberByHostInstance?: (hostInstance: HostInstance) => Fiber | null,
   // 16.9+
   overrideHookState?: ?(
     fiber: Object,


### PR DESCRIPTION
This lets us get from a HostInstance to the nearest DevToolsInstance without relying on `findFiberByHostInstance` and `fiberToDevToolsInstanceMap`. We already did the equivalent of this for Resources in HostHoistables.

One issue before was that we'd ideally get away from the `fiberToDevToolsInstanceMap` map in general since we should ideally not treat Fibers as stateful but they could be replaced by something else stateful in principle.

This PR also addresses Virtual Instances. Now you can select a DOM node and have it select a Virtual Instance if that's the nearest parent since the parent doesn't have to be a Fiber anymore.

However, the other reason for this change is that I'd like to get rid of the need for the `findFiberByHostInstance` from being injected. A renderer should not need to store a reference back from its instance to a Fiber. Without the Synthetic Event system this wouldn't be needed by the renderer so we should be able to remove it. We also don't really need it since we have all the information by just walking the commit to collect the nodes if we just maintain our own Map.

There's one subtle nuance that the different renderers do. Typically a HostInstance is the same thing as a PublicInstance in React but technically in Fabric they're not the same. So we need to translate between PublicInstance and HostInstance. I just hardcoded the Fabric implementation of this since it's the only known one that does this but could feature detect other ones too if necessary. On one hand it's more resilient to refactors to not rely on injected helpers and on hand it doesn't follow changes to things like this.

For the conflict resolution I added in #30494 I had to make that specific to DOM so we can move the DOM traversal to the backend instead of the injected helper.