### PR TITLE
[compiler] Silence ref-in-render errors in ESLint

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/CompilerError.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/CompilerError.ts
@@ -19,6 +19,11 @@ export enum ErrorSeverity {
    */
   InvalidReact = 'InvalidReact',
   /**
+   * Code that breaks the rules of React, but which should not be reported in ESLint due to
+   * false positives.
+   */
+  SilentInvalidReact = 'SilentInvalidReact',
+  /**
    * Incorrect configuration of the compiler.
    */
   InvalidConfig = 'InvalidConfig',
@@ -232,6 +237,7 @@ export class CompilerError extends Error {
         case ErrorSeverity.InvalidJS:
         case ErrorSeverity.InvalidReact:
         case ErrorSeverity.InvalidConfig:
+        case ErrorSeverity.SilentInvalidReact:
           return true;
         case ErrorSeverity.CannotPreserveMemoization:
         case ErrorSeverity.Todo:

--- a/compiler/packages/eslint-plugin-react-compiler/__tests__/ReactCompilerRule-test.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/__tests__/ReactCompilerRule-test.ts
@@ -104,6 +104,15 @@ const tests: CompilerTestCases = {
         }
       `,
     },
+    {
+      name: 'Ref access in render (invalid, but suppressed internally)',
+      code: normalizeIndent`
+        function foo(x, y) {
+          const ref = useRef();
+          return ref.current;
+        }
+      `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30843

We need this for compiler correctness but the false positive rate is a bit too high, let's suppress in ESLint for now.