### PR TITLE
[compiler] Errors in earlier functions dont stop subsequent compilation

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -383,29 +383,27 @@ export function compileProgram(
       );
     }
 
-    /**
-     * Note that Babel does not attach comment nodes to nodes; they are dangling off of the
-     * Program node itself. We need to figure out whether an eslint suppression range
-     * applies to this function first.
-     */
-    const suppressionsInFunction = filterSuppressionsThatAffectFunction(
-      suppressions,
-      fn,
-    );
-    if (suppressionsInFunction.length > 0) {
-      const lintError = suppressionsToCompilerError(suppressionsInFunction);
-      if (optOutDirectives.length > 0) {
-        logError(lintError, pass, fn.node.loc ?? null);
-      } else {
-        handleError(lintError, pass, fn.node.loc ?? null);
-      }
-      if (isCriticalError(lintError)) {
-        return null;
-      }
-    }
-
     let compiledFn: CodegenFunction;
     try {
+      /**
+       * Note that Babel does not attach comment nodes to nodes; they are dangling off of the
+       * Program node itself. We need to figure out whether an eslint suppression range
+       * applies to this function first.
+       */
+      const suppressionsInFunction = filterSuppressionsThatAffectFunction(
+        suppressions,
+        fn,
+      );
+      if (suppressionsInFunction.length > 0) {
+        const lintError = suppressionsToCompilerError(suppressionsInFunction);
+        if (optOutDirectives.length > 0) {
+          logError(lintError, pass, fn.node.loc ?? null);
+        } else {
+          handleError(lintError, pass, fn.node.loc ?? null);
+        }
+        return null;
+      }
+
       compiledFn = compileFn(
         fn,
         environment,

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -399,6 +399,8 @@ export function compileProgram(
       } else {
         handleError(lintError, pass, fn.node.loc ?? null);
       }
+      // Skip compiling functions that are covered by a suppression comment
+      return null;
     }
 
     let compiledFn: CodegenFunction;

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -399,8 +399,9 @@ export function compileProgram(
       } else {
         handleError(lintError, pass, fn.node.loc ?? null);
       }
-      // Skip compiling functions that are covered by a suppression comment
-      return null;
+      if (isCriticalError(lintError)) {
+        return null;
+      }
     }
 
     let compiledFn: CodegenFunction;

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Suppression.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Suppression.ts
@@ -14,6 +14,7 @@ import {
   ErrorSeverity,
 } from '../CompilerError';
 import {assertExhaustive} from '../Utils/utils';
+import {GeneratedSource} from '../HIR';
 
 /**
  * Captures the start and end range of a pair of eslint-disable ... eslint-enable comments. In the
@@ -148,10 +149,11 @@ export function findProgramSuppressions(
 
 export function suppressionsToCompilerError(
   suppressionRanges: Array<SuppressionRange>,
-): CompilerError | null {
-  if (suppressionRanges.length === 0) {
-    return null;
-  }
+): CompilerError {
+  CompilerError.invariant(suppressionRanges.length !== 0, {
+    reason: `Expected at least suppression comment source range`,
+    loc: GeneratedSource,
+  });
   const error = new CompilerError();
   for (const suppressionRange of suppressionRanges) {
     if (

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-unclosed-eslint-suppression.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-unclosed-eslint-suppression.expect.md
@@ -39,8 +39,6 @@ function CrimesAgainstReact() {
   1 | // Note: Everything below this is sketchy
 > 2 | /* eslint-disable react-hooks/rules-of-hooks */
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ InvalidReact: React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior. eslint-disable react-hooks/rules-of-hooks (2:2)
-
-InvalidReact: React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior. eslint-disable-next-line react-hooks/rules-of-hooks (25:25)
   3 | function lowercasecomponent() {
   4 |   'use forget';
   5 |   const x = [];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/multiple-components-first-is-invalid.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/multiple-components-first-is-invalid.expect.md
@@ -1,0 +1,50 @@
+
+## Input
+
+```javascript
+// @panicThreshold(none)
+import {useHook} from 'shared-runtime';
+
+function InvalidComponent(props) {
+  if (props.cond) {
+    useHook();
+  }
+  return <div>Hello World!</div>;
+}
+
+function ValidComponent(props) {
+  return <div>{props.greeting}</div>;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @panicThreshold(none)
+import { useHook } from "shared-runtime";
+
+function InvalidComponent(props) {
+  if (props.cond) {
+    useHook();
+  }
+  return <div>Hello World!</div>;
+}
+
+function ValidComponent(props) {
+  const $ = _c(2);
+  let t0;
+  if ($[0] !== props.greeting) {
+    t0 = <div>{props.greeting}</div>;
+    $[0] = props.greeting;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/multiple-components-first-is-invalid.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/multiple-components-first-is-invalid.js
@@ -1,0 +1,13 @@
+// @panicThreshold(none)
+import {useHook} from 'shared-runtime';
+
+function InvalidComponent(props) {
+  if (props.cond) {
+    useHook();
+  }
+  return <div>Hello World!</div>;
+}
+
+function ValidComponent(props) {
+  return <div>{props.greeting}</div>;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/unclosed-eslint-suppression-skips-all-components.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/unclosed-eslint-suppression-skips-all-components.expect.md
@@ -1,0 +1,39 @@
+
+## Input
+
+```javascript
+// @panicThreshold(none)
+
+// unclosed disable rule should affect all components
+/* eslint-disable react-hooks/rules-of-hooks */
+
+function ValidComponent1(props) {
+  return <div>Hello World!</div>;
+}
+
+function ValidComponent2(props) {
+  return <div>{props.greeting}</div>;
+}
+
+```
+
+## Code
+
+```javascript
+// @panicThreshold(none)
+
+// unclosed disable rule should affect all components
+/* eslint-disable react-hooks/rules-of-hooks */
+
+function ValidComponent1(props) {
+  return <div>Hello World!</div>;
+}
+
+function ValidComponent2(props) {
+  return <div>{props.greeting}</div>;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/unclosed-eslint-suppression-skips-all-components.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/unclosed-eslint-suppression-skips-all-components.js
@@ -1,0 +1,12 @@
+// @panicThreshold(none)
+
+// unclosed disable rule should affect all components
+/* eslint-disable react-hooks/rules-of-hooks */
+
+function ValidComponent1(props) {
+  return <div>Hello World!</div>;
+}
+
+function ValidComponent2(props) {
+  return <div>{props.greeting}</div>;
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #30843
* __->__ #30844

Errors in an earlier component/hook shouldn't stop later components from compiling.