### PR TITLE
[DevTools] unstable_getCacheForType -> cache

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/cache.js
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/cache.js
@@ -10,7 +10,7 @@
 import type {Wakeable} from 'shared/ReactTypes';
 import type {GitHubIssue} from './githubAPI';
 
-import {unstable_getCacheForType as getCacheForType} from 'react';
+import {cache} from 'react';
 import {searchGitHubIssues} from './githubAPI';
 
 const API_TIMEOUT = 3000;
@@ -54,9 +54,7 @@ function createMap(): GitHubIssueMap {
   return new Map();
 }
 
-function getRecordMap(): Map<string, Record<GitHubIssue>> {
-  return getCacheForType(createMap);
-}
+const getRecordMap = cache(createMap);
 
 export function findGitHubIssue(errorMessage: string): GitHubIssue | null {
   errorMessage = normalizeErrorMessage(errorMessage);

--- a/packages/react-devtools-shared/src/inspectedElementCache.js
+++ b/packages/react-devtools-shared/src/inspectedElementCache.js
@@ -60,19 +60,6 @@ function createMap(): InspectedElementMap {
 
 const getRecordMap = cache(createMap);
 
-function createCacheSeed(
-  element: Element,
-  inspectedElement: InspectedElementFrontend,
-): [CacheSeedKey, InspectedElementMap] {
-  const newRecord: Record<InspectedElementFrontend> = {
-    status: Resolved,
-    value: inspectedElement,
-  };
-  const map = createMap();
-  map.set(element, newRecord);
-  return [createMap, map];
-}
-
 /**
  * Fetches element props and state from the backend for inspection.
  * This method should be called during render; it will suspend if data has not yet been fetched.
@@ -191,8 +178,8 @@ export function checkForUpdate({
     ]) => {
       if (responseType === 'full-data') {
         startTransition(() => {
-          const [key, value] = createCacheSeed(element, inspectedElement);
-          refresh(key, value);
+          // TODO: We should ideally seed with the new data here but we can't do that anymore.
+          refresh();
         });
       }
     },
@@ -280,7 +267,6 @@ export function startElementUpdatesPolling({
 
 export function clearCacheBecauseOfError(refresh: RefreshFunction): void {
   startTransition(() => {
-    const map = createMap();
-    refresh(createMap, map);
+    refresh();
   });
 }

--- a/packages/react-devtools-shared/src/inspectedElementCache.js
+++ b/packages/react-devtools-shared/src/inspectedElementCache.js
@@ -7,10 +7,7 @@
  * @flow
  */
 
-import {
-  unstable_getCacheForType as getCacheForType,
-  startTransition,
-} from 'react';
+import {cache, startTransition} from 'react';
 import Store from 'react-devtools-shared/src/devtools/store';
 import {inspectElement as inspectElementMutableSource} from 'react-devtools-shared/src/inspectedElementMutableSource';
 import ElementPollingCancellationError from 'react-devtools-shared/src//errors/ElementPollingCancellationError';
@@ -61,9 +58,7 @@ function createMap(): InspectedElementMap {
   return new WeakMap();
 }
 
-function getRecordMap(): WeakMap<Element, Record<InspectedElementFrontend>> {
-  return getCacheForType(createMap);
-}
+const getRecordMap = cache(createMap);
 
 function createCacheSeed(
   element: Element,


### PR DESCRIPTION
Let's use the official API signature here.

We still rely on `unstable_useCacheRefresh` though.