### PR TITLE
Fix:-Fixed Error not thrown on passing invalid Args in hydrateRoot call

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -384,37 +384,6 @@ describe('ReactDOMRoot', () => {
     );
   });
 
-  it('warn if options is passed as second argument to hydrateRoot', async () => {
-    expect(() =>
-      ReactDOMClient.hydrateRoot(container, {
-        onUncaughtError: error => {
-          console.error(error);
-        },
-      }),
-    ).toErrorDev(
-      'Warning: You passed an options object as the second argument to `hydrateRoot(...)`, did you forget to pass a React element?',
-      {withoutStack: true},
-    );
-  });
-
-  it('warn if element is passed as options to hydrateRoot', async () => {
-    expect(() =>
-      ReactDOMClient.hydrateRoot(
-        container,
-        <div>
-          <span />
-        </div>,
-        <div>
-          <span />
-        </div>,
-      ),
-    ).toErrorDev(
-      'You passed a JSX element as an options to hydrateRoot. You probably meant to ' +
-        'call root.render instead. ',
-      {withoutStack: true},
-    );
-  });
-
   it('warn if JSX passed to createRoot', async () => {
     function App() {
       return 'Child';
@@ -426,6 +395,15 @@ describe('ReactDOMRoot', () => {
       {
         withoutStack: true,
       },
+    );
+  });
+
+  it('should warn if options object is passed as the second argument', () => {
+    expect(() =>
+      ReactDOMClient.hydrateRoot(container, {key: 'value'}),
+    ).toErrorDev(
+      'Warning: You passed an options object as the second argument to `hydrateRoot(...)`, did you forget to pass a React element?',
+      {withoutStack: true},
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -384,6 +384,37 @@ describe('ReactDOMRoot', () => {
     );
   });
 
+  it('warn if options is passed as second argument to hydrateRoot', async () => {
+    expect(() =>
+      ReactDOMClient.hydrateRoot(container, {
+        onUncaughtError: error => {
+          console.error(error);
+        },
+      }),
+    ).toErrorDev(
+      'Warning: You passed an options object as the second argument to `hydrateRoot(...)`, did you forget to pass a React element?',
+      {withoutStack: true},
+    );
+  });
+
+  it('warn if element is passed as options to hydrateRoot', async () => {
+    expect(() =>
+      ReactDOMClient.hydrateRoot(
+        container,
+        <div>
+          <span />
+        </div>,
+        <div>
+          <span />
+        </div>,
+      ),
+    ).toErrorDev(
+      'You passed a JSX element as an options to hydrateRoot. You probably meant to ' +
+        'call root.render instead. ',
+      {withoutStack: true},
+    );
+  });
+
   it('warn if JSX passed to createRoot', async () => {
     function App() {
       return 'Child';

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -407,6 +407,36 @@ describe('ReactDOMRoot', () => {
     );
   });
 
+  it('warn if element is passed as options to hydrateRoot', async () => {
+    expect(() =>
+      ReactDOMClient.hydrateRoot(
+        container,
+        <div>
+          <span />
+        </div>,
+        <div>
+          <span />
+        </div>,
+      ),
+    ).toErrorDev(
+      'You passed a JSX element as an options to hydrateRoot. You probably meant to ' +
+        'call root.render instead. ',
+      {withoutStack: true},
+    );
+  });
+
+  it('should not warn if a React element is passed as the second argument', () => {
+    expect(() =>
+      ReactDOMClient.hydrateRoot(container, <div />),
+    ).not.toErrorDev();
+  });
+
+  it('should not warn if a valid options object is passed as the third argument', () => {
+    expect(() =>
+      ReactDOMClient.hydrateRoot(container, <div />, {hydrate: true}),
+    ).not.toErrorDev();
+  });
+
   it('warns when given a function', () => {
     function Component() {
       return <div />;

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -407,6 +407,24 @@ describe('ReactDOMRoot', () => {
     );
   });
 
+  it('should warn if element is passed as options to hydrateRoot', async () => {
+    expect(() =>
+      ReactDOMClient.hydrateRoot(
+        container,
+        <div>
+          <span />
+        </div>,
+        <div>
+          <span />
+        </div>,
+      ),
+    ).toErrorDev(
+      'You passed a JSX element as an options to hydrateRoot. You probably meant to ' +
+        'call root.render instead. ',
+      {withoutStack: true},
+    );
+  });
+
   it('warns when given a function', () => {
     function Component() {
       return <div />;

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -407,36 +407,6 @@ describe('ReactDOMRoot', () => {
     );
   });
 
-  it('warn if element is passed as options to hydrateRoot', async () => {
-    expect(() =>
-      ReactDOMClient.hydrateRoot(
-        container,
-        <div>
-          <span />
-        </div>,
-        <div>
-          <span />
-        </div>,
-      ),
-    ).toErrorDev(
-      'You passed a JSX element as an options to hydrateRoot. You probably meant to ' +
-        'call root.render instead. ',
-      {withoutStack: true},
-    );
-  });
-
-  it('should not warn if a React element is passed as the second argument', () => {
-    expect(() =>
-      ReactDOMClient.hydrateRoot(container, <div />),
-    ).not.toErrorDev();
-  });
-
-  it('should not warn if a valid options object is passed as the third argument', () => {
-    expect(() =>
-      ReactDOMClient.hydrateRoot(container, <div />, {hydrate: true}),
-    ).not.toErrorDev();
-  });
-
   it('warns when given a function', () => {
     function Component() {
       return <div />;

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -276,7 +276,7 @@ export function hydrateRoot(
       typeof initialChildren === 'object' &&
       initialChildren !== null &&
       (!('$$typeof' in initialChildren) ||
-        (initialChildren as any).$$typeof !== REACT_ELEMENT_TYPE)
+        (initialChildren: any).$$typeof !== REACT_ELEMENT_TYPE)
     ) {
       console.error(
         'Warning: You passed an options object as the second argument to `hydrateRoot(...)`, did you forget to pass a React element?',
@@ -286,7 +286,7 @@ export function hydrateRoot(
     if (
       typeof options === 'object' &&
       options !== null &&
-      (options as any).$$typeof === REACT_ELEMENT_TYPE
+      (options: any).$$typeof === REACT_ELEMENT_TYPE
     ) {
       console.error(
         'You passed a JSX element as an options to hydrateRoot. You probably meant to ' +

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -272,6 +272,25 @@ export function hydrateRoot(
           'Example usage: hydrateRoot(domContainer, <App />)',
       );
     }
+    if (
+      typeof initialChildren === 'object' &&
+      initialChildren !== null &&
+      (!('$$typeof' in initialChildren) || (initialChildren as any).$$typeof !== REACT_ELEMENT_TYPE)
+    ) {
+      console.error(
+        'Warning: You passed an options object as the second argument to `hydrateRoot(...)`, did you forget to pass a React element?'
+      );
+    }
+    
+    if (typeof options === 'object' && options !== null && (options as any).$$typeof === REACT_ELEMENT_TYPE) {
+      console.error(
+        'You passed a JSX element as an options to hydrateRoot. You probably meant to ' +
+          'call root.render instead. ' +
+          'Example usage:\n\n' +
+          '  let root = hydrateRoot(domContainer, <App />, {...options});\n' +
+          '  root.render(<App />);'
+      );
+    }
   }
 
   // For now we reuse the whole bag of options since they contain

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -275,20 +275,25 @@ export function hydrateRoot(
     if (
       typeof initialChildren === 'object' &&
       initialChildren !== null &&
-      (!('$$typeof' in initialChildren) || (initialChildren as any).$$typeof !== REACT_ELEMENT_TYPE)
+      (!('$$typeof' in initialChildren) ||
+        (initialChildren as any).$$typeof !== REACT_ELEMENT_TYPE)
     ) {
       console.error(
-        'Warning: You passed an options object as the second argument to `hydrateRoot(...)`, did you forget to pass a React element?'
+        'Warning: You passed an options object as the second argument to `hydrateRoot(...)`, did you forget to pass a React element?',
       );
     }
-    
-    if (typeof options === 'object' && options !== null && (options as any).$$typeof === REACT_ELEMENT_TYPE) {
+
+    if (
+      typeof options === 'object' &&
+      options !== null &&
+      (options as any).$$typeof === REACT_ELEMENT_TYPE
+    ) {
       console.error(
         'You passed a JSX element as an options to hydrateRoot. You probably meant to ' +
           'call root.render instead. ' +
           'Example usage:\n\n' +
           '  let root = hydrateRoot(domContainer, <App />, {...options});\n' +
-          '  root.render(<App />);'
+          '  root.render(<App />);',
       );
     }
   }


### PR DESCRIPTION
fixes #30876 

ThIS PR fixes the invalid argument validation error, where it does not throw the valid error it should throw for the options argument, tests have been added as required


cc @hoxyq  @sebmarkbage 