### PR TITLE
[Fiber] Move runWithFiberInDEV from CommitWork to CommitEffects

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitEffects.js
@@ -184,9 +184,16 @@ export function commitHookEffectListMount(
               } else {
                 addendum = ' You returned: ' + destroy;
               }
-              console.error(
-                '%s must not return anything besides a function, ' +
-                  'which is used for clean-up.%s',
+              runWithFiberInDEV(
+                finishedWork,
+                (n, a) => {
+                  console.error(
+                    '%s must not return anything besides a function, ' +
+                      'which is used for clean-up.%s',
+                    n,
+                    a,
+                  );
+                },
                 hookName,
                 addendum,
               );
@@ -642,11 +649,13 @@ export function commitClassSnapshot(finishedWork: Fiber, current: Fiber) {
         ((didWarnAboutUndefinedSnapshotBeforeUpdate: any): Set<mixed>);
       if (snapshot === undefined && !didWarnSet.has(finishedWork.type)) {
         didWarnSet.add(finishedWork.type);
-        console.error(
-          '%s.getSnapshotBeforeUpdate(): A snapshot value (or null) ' +
-            'must be returned. You have returned undefined.',
-          getComponentNameFromFiber(finishedWork),
-        );
+        runWithFiberInDEV(finishedWork, () => {
+          console.error(
+            '%s.getSnapshotBeforeUpdate(): A snapshot value (or null) ' +
+              'must be returned. You have returned undefined.',
+            getComponentNameFromFiber(finishedWork),
+          );
+        });
       }
     } else {
       snapshot = callGetSnapshotBeforeUpdates(

--- a/packages/react-reconciler/src/ReactFiberCommitEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitEffects.js
@@ -75,6 +75,8 @@ import {
   callDestroyInDEV,
 } from './ReactFiberCallUserSpace';
 
+import {runWithFiberInDEV} from './ReactCurrentFiber';
+
 function shouldProfile(current: Fiber): boolean {
   return (
     enableProfilerTimer &&
@@ -128,7 +130,7 @@ export function commitHookEffectListMount(
             if ((flags & HookInsertion) !== NoHookEffect) {
               setIsRunningInsertionEffect(true);
             }
-            destroy = callCreateInDEV(effect);
+            destroy = runWithFiberInDEV(finishedWork, callCreateInDEV, effect);
             if ((flags & HookInsertion) !== NoHookEffect) {
               setIsRunningInsertionEffect(false);
             }
@@ -330,7 +332,12 @@ export function commitClassLayoutLifecycles(
     if (shouldProfile(finishedWork)) {
       startLayoutEffectTimer();
       if (__DEV__) {
-        callComponentDidMountInDEV(finishedWork, instance);
+        runWithFiberInDEV(
+          finishedWork,
+          callComponentDidMountInDEV,
+          finishedWork,
+          instance,
+        );
       } else {
         try {
           instance.componentDidMount();
@@ -341,7 +348,12 @@ export function commitClassLayoutLifecycles(
       recordLayoutEffectDuration(finishedWork);
     } else {
       if (__DEV__) {
-        callComponentDidMountInDEV(finishedWork, instance);
+        runWithFiberInDEV(
+          finishedWork,
+          callComponentDidMountInDEV,
+          finishedWork,
+          instance,
+        );
       } else {
         try {
           instance.componentDidMount();
@@ -391,7 +403,9 @@ export function commitClassLayoutLifecycles(
     if (shouldProfile(finishedWork)) {
       startLayoutEffectTimer();
       if (__DEV__) {
-        callComponentDidUpdateInDEV(
+        runWithFiberInDEV(
+          finishedWork,
+          callComponentDidUpdateInDEV,
           finishedWork,
           instance,
           prevProps,
@@ -412,7 +426,9 @@ export function commitClassLayoutLifecycles(
       recordLayoutEffectDuration(finishedWork);
     } else {
       if (__DEV__) {
-        callComponentDidUpdateInDEV(
+        runWithFiberInDEV(
+          finishedWork,
+          callComponentDidUpdateInDEV,
           finishedWork,
           instance,
           prevProps,
@@ -439,7 +455,12 @@ export function commitClassDidMount(finishedWork: Fiber) {
   const instance = finishedWork.stateNode;
   if (typeof instance.componentDidMount === 'function') {
     if (__DEV__) {
-      callComponentDidMountInDEV(finishedWork, instance);
+      runWithFiberInDEV(
+        finishedWork,
+        callComponentDidMountInDEV,
+        finishedWork,
+        instance,
+      );
     } else {
       try {
         instance.componentDidMount();
@@ -619,7 +640,13 @@ export function safelyCallComponentWillUnmount(
   if (shouldProfile(current)) {
     startLayoutEffectTimer();
     if (__DEV__) {
-      callComponentWillUnmountInDEV(current, nearestMountedAncestor, instance);
+      runWithFiberInDEV(
+        current,
+        callComponentWillUnmountInDEV,
+        current,
+        nearestMountedAncestor,
+        instance,
+      );
     } else {
       try {
         instance.componentWillUnmount();
@@ -630,7 +657,13 @@ export function safelyCallComponentWillUnmount(
     recordLayoutEffectDuration(current);
   } else {
     if (__DEV__) {
-      callComponentWillUnmountInDEV(current, nearestMountedAncestor, instance);
+      runWithFiberInDEV(
+        current,
+        callComponentWillUnmountInDEV,
+        current,
+        nearestMountedAncestor,
+        instance,
+      );
     } else {
       try {
         instance.componentWillUnmount();
@@ -761,7 +794,13 @@ export function safelyCallDestroy(
   destroy: () => void,
 ) {
   if (__DEV__) {
-    callDestroyInDEV(current, nearestMountedAncestor, destroy);
+    runWithFiberInDEV(
+      current,
+      callDestroyInDEV,
+      current,
+      nearestMountedAncestor,
+      destroy,
+    );
   } else {
     try {
       destroy();

--- a/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
@@ -52,12 +52,25 @@ import {
 } from './ReactFiberConfig';
 import {captureCommitPhaseError} from './ReactFiberWorkLoop';
 
+import {runWithFiberInDEV} from './ReactCurrentFiber';
+
 export function commitHostMount(finishedWork: Fiber) {
   const type = finishedWork.type;
   const props = finishedWork.memoizedProps;
   const instance: Instance = finishedWork.stateNode;
   try {
-    commitMount(instance, type, props, finishedWork);
+    if (__DEV__) {
+      runWithFiberInDEV(
+        finishedWork,
+        commitMount,
+        instance,
+        type,
+        props,
+        finishedWork,
+      );
+    } else {
+      commitMount(instance, type, props, finishedWork);
+    }
   } catch (error) {
     captureCommitPhaseError(finishedWork, finishedWork.return, error);
   }
@@ -69,13 +82,25 @@ export function commitHostUpdate(
   oldProps: any,
 ) {
   try {
-    commitUpdate(
-      finishedWork.stateNode,
-      finishedWork.type,
-      oldProps,
-      newProps,
-      finishedWork,
-    );
+    if (__DEV__) {
+      runWithFiberInDEV(
+        finishedWork,
+        commitUpdate,
+        finishedWork.stateNode,
+        finishedWork.type,
+        oldProps,
+        newProps,
+        finishedWork,
+      );
+    } else {
+      commitUpdate(
+        finishedWork.stateNode,
+        finishedWork.type,
+        oldProps,
+        newProps,
+        finishedWork,
+      );
+    }
   } catch (error) {
     captureCommitPhaseError(finishedWork, finishedWork.return, error);
   }
@@ -88,7 +113,17 @@ export function commitHostTextUpdate(
 ) {
   const textInstance: TextInstance = finishedWork.stateNode;
   try {
-    commitTextUpdate(textInstance, oldText, newText);
+    if (__DEV__) {
+      runWithFiberInDEV(
+        finishedWork,
+        commitTextUpdate,
+        textInstance,
+        oldText,
+        newText,
+      );
+    } else {
+      commitTextUpdate(textInstance, oldText, newText);
+    }
   } catch (error) {
     captureCommitPhaseError(finishedWork, finishedWork.return, error);
   }
@@ -97,7 +132,11 @@ export function commitHostTextUpdate(
 export function commitHostResetTextContent(finishedWork: Fiber) {
   const instance: Instance = finishedWork.stateNode;
   try {
-    resetTextContent(instance);
+    if (__DEV__) {
+      runWithFiberInDEV(finishedWork, resetTextContent, instance);
+    } else {
+      resetTextContent(instance);
+    }
   } catch (error) {
     captureCommitPhaseError(finishedWork, finishedWork.return, error);
   }
@@ -107,9 +146,22 @@ export function commitShowHideHostInstance(node: Fiber, isHidden: boolean) {
   try {
     const instance = node.stateNode;
     if (isHidden) {
-      hideInstance(instance);
+      if (__DEV__) {
+        runWithFiberInDEV(node, hideInstance, instance);
+      } else {
+        hideInstance(instance);
+      }
     } else {
-      unhideInstance(node.stateNode, node.memoizedProps);
+      if (__DEV__) {
+        runWithFiberInDEV(
+          node,
+          unhideInstance,
+          node.stateNode,
+          node.memoizedProps,
+        );
+      } else {
+        unhideInstance(node.stateNode, node.memoizedProps);
+      }
     }
   } catch (error) {
     captureCommitPhaseError(node, node.return, error);
@@ -120,9 +172,22 @@ export function commitShowHideHostTextInstance(node: Fiber, isHidden: boolean) {
   try {
     const instance = node.stateNode;
     if (isHidden) {
-      hideTextInstance(instance);
+      if (__DEV__) {
+        runWithFiberInDEV(node, hideTextInstance, instance);
+      } else {
+        hideTextInstance(instance);
+      }
     } else {
-      unhideTextInstance(instance, node.memoizedProps);
+      if (__DEV__) {
+        runWithFiberInDEV(
+          node,
+          unhideTextInstance,
+          instance,
+          node.memoizedProps,
+        );
+      } else {
+        unhideTextInstance(instance, node.memoizedProps);
+      }
     }
   } catch (error) {
     captureCommitPhaseError(node, node.return, error);
@@ -332,7 +397,11 @@ function commitPlacement(finishedWork: Fiber): void {
 
 export function commitHostPlacement(finishedWork: Fiber) {
   try {
-    commitPlacement(finishedWork);
+    if (__DEV__) {
+      runWithFiberInDEV(finishedWork, commitPlacement, finishedWork);
+    } else {
+      commitPlacement(finishedWork);
+    }
   } catch (error) {
     captureCommitPhaseError(finishedWork, finishedWork.return, error);
   }
@@ -345,7 +414,16 @@ export function commitHostRemoveChildFromContainer(
   hostInstance: Instance | TextInstance,
 ) {
   try {
-    removeChildFromContainer(parentContainer, hostInstance);
+    if (__DEV__) {
+      runWithFiberInDEV(
+        deletedFiber,
+        removeChildFromContainer,
+        parentContainer,
+        hostInstance,
+      );
+    } else {
+      removeChildFromContainer(parentContainer, hostInstance);
+    }
   } catch (error) {
     captureCommitPhaseError(deletedFiber, nearestMountedAncestor, error);
   }
@@ -358,7 +436,16 @@ export function commitHostRemoveChild(
   hostInstance: Instance | TextInstance,
 ) {
   try {
-    removeChild(parentInstance, hostInstance);
+    if (__DEV__) {
+      runWithFiberInDEV(
+        deletedFiber,
+        removeChild,
+        parentInstance,
+        hostInstance,
+      );
+    } else {
+      removeChild(parentInstance, hostInstance);
+    }
   } catch (error) {
     captureCommitPhaseError(deletedFiber, nearestMountedAncestor, error);
   }
@@ -371,7 +458,16 @@ export function commitHostRootContainerChildren(
   const containerInfo = root.containerInfo;
   const pendingChildren = root.pendingChildren;
   try {
-    replaceContainerChildren(containerInfo, pendingChildren);
+    if (__DEV__) {
+      runWithFiberInDEV(
+        finishedWork,
+        replaceContainerChildren,
+        containerInfo,
+        pendingChildren,
+      );
+    } else {
+      replaceContainerChildren(containerInfo, pendingChildren);
+    }
   } catch (error) {
     captureCommitPhaseError(finishedWork, finishedWork.return, error);
   }
@@ -388,7 +484,16 @@ export function commitHostPortalContainerChildren(
 ) {
   const containerInfo = portal.containerInfo;
   try {
-    replaceContainerChildren(containerInfo, pendingChildren);
+    if (__DEV__) {
+      runWithFiberInDEV(
+        finishedWork,
+        replaceContainerChildren,
+        containerInfo,
+        pendingChildren,
+      );
+    } else {
+      replaceContainerChildren(containerInfo, pendingChildren);
+    }
   } catch (error) {
     captureCommitPhaseError(finishedWork, finishedWork.return, error);
   }
@@ -399,7 +504,15 @@ export function commitHostHydratedContainer(
   finishedWork: Fiber,
 ) {
   try {
-    commitHydratedContainer(root.containerInfo);
+    if (__DEV__) {
+      runWithFiberInDEV(
+        finishedWork,
+        commitHydratedContainer,
+        root.containerInfo,
+      );
+    } else {
+      commitHydratedContainer(root.containerInfo);
+    }
   } catch (error) {
     captureCommitPhaseError(finishedWork, finishedWork.return, error);
   }
@@ -410,7 +523,15 @@ export function commitHostHydratedSuspense(
   finishedWork: Fiber,
 ) {
   try {
-    commitHydratedSuspenseInstance(suspenseInstance);
+    if (__DEV__) {
+      runWithFiberInDEV(
+        finishedWork,
+        commitHydratedSuspenseInstance,
+        suspenseInstance,
+      );
+    } else {
+      commitHydratedSuspenseInstance(suspenseInstance);
+    }
   } catch (error) {
     captureCommitPhaseError(finishedWork, finishedWork.return, error);
   }
@@ -423,7 +544,23 @@ export function commitHostSingleton(finishedWork: Fiber) {
   try {
     // This was a new mount, we need to clear and set initial properties
     clearSingleton(singleton);
-    acquireSingletonInstance(finishedWork.type, props, singleton, finishedWork);
+    if (__DEV__) {
+      runWithFiberInDEV(
+        finishedWork,
+        acquireSingletonInstance,
+        finishedWork.type,
+        props,
+        singleton,
+        finishedWork,
+      );
+    } else {
+      acquireSingletonInstance(
+        finishedWork.type,
+        props,
+        singleton,
+        finishedWork,
+      );
+    }
   } catch (error) {
     captureCommitPhaseError(finishedWork, finishedWork.return, error);
   }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -98,7 +98,6 @@ import {
   FormReset,
   Cloned,
 } from './ReactFiberFlags';
-import {runWithFiberInDEV} from './ReactCurrentFiber';
 import {
   isCurrentUpdateNested,
   getCommitTime,
@@ -289,11 +288,7 @@ function commitBeforeMutationEffects_begin() {
 function commitBeforeMutationEffects_complete() {
   while (nextEffect !== null) {
     const fiber = nextEffect;
-    if (__DEV__) {
-      runWithFiberInDEV(fiber, commitBeforeMutationEffectsOnFiber, fiber);
-    } else {
-      commitBeforeMutationEffectsOnFiber(fiber);
-    }
+    commitBeforeMutationEffectsOnFiber(fiber);
 
     const sibling = fiber.sibling;
     if (sibling !== null) {
@@ -1645,17 +1640,7 @@ export function commitMutationEffects(
   inProgressLanes = committedLanes;
   inProgressRoot = root;
 
-  if (__DEV__) {
-    runWithFiberInDEV(
-      finishedWork,
-      commitMutationEffectsOnFiber,
-      finishedWork,
-      root,
-      committedLanes,
-    );
-  } else {
-    commitMutationEffectsOnFiber(finishedWork, root, committedLanes);
-  }
+  commitMutationEffectsOnFiber(finishedWork, root, committedLanes);
 
   inProgressLanes = null;
   inProgressRoot = null;
@@ -1682,17 +1667,7 @@ function recursivelyTraverseMutationEffects(
   ) {
     let child = parentFiber.child;
     while (child !== null) {
-      if (__DEV__) {
-        runWithFiberInDEV(
-          child,
-          commitMutationEffectsOnFiber,
-          child,
-          root,
-          lanes,
-        );
-      } else {
-        commitMutationEffectsOnFiber(child, root, lanes);
-      }
+      commitMutationEffectsOnFiber(child, root, lanes);
       child = child.sibling;
     }
   }
@@ -2235,18 +2210,7 @@ export function commitLayoutEffects(
   inProgressRoot = root;
 
   const current = finishedWork.alternate;
-  if (__DEV__) {
-    runWithFiberInDEV(
-      finishedWork,
-      commitLayoutEffectOnFiber,
-      root,
-      current,
-      finishedWork,
-      committedLanes,
-    );
-  } else {
-    commitLayoutEffectOnFiber(root, current, finishedWork, committedLanes);
-  }
+  commitLayoutEffectOnFiber(root, current, finishedWork, committedLanes);
 
   inProgressLanes = null;
   inProgressRoot = null;
@@ -2261,18 +2225,7 @@ function recursivelyTraverseLayoutEffects(
     let child = parentFiber.child;
     while (child !== null) {
       const current = child.alternate;
-      if (__DEV__) {
-        runWithFiberInDEV(
-          child,
-          commitLayoutEffectOnFiber,
-          root,
-          current,
-          child,
-          lanes,
-        );
-      } else {
-        commitLayoutEffectOnFiber(root, current, child, lanes);
-      }
+      commitLayoutEffectOnFiber(root, current, child, lanes);
       child = child.sibling;
     }
   }
@@ -2529,23 +2482,12 @@ function recursivelyTraverseReappearLayoutEffects(
   let child = parentFiber.child;
   while (child !== null) {
     const current = child.alternate;
-    if (__DEV__) {
-      runWithFiberInDEV(
-        child,
-        reappearLayoutEffects,
-        finishedRoot,
-        current,
-        child,
-        childShouldIncludeWorkInProgressEffects,
-      );
-    } else {
-      reappearLayoutEffects(
-        finishedRoot,
-        current,
-        child,
-        childShouldIncludeWorkInProgressEffects,
-      );
-    }
+    reappearLayoutEffects(
+      finishedRoot,
+      current,
+      child,
+      childShouldIncludeWorkInProgressEffects,
+    );
     child = child.sibling;
   }
 }
@@ -2696,23 +2638,12 @@ export function commitPassiveMountEffects(
   committedLanes: Lanes,
   committedTransitions: Array<Transition> | null,
 ): void {
-  if (__DEV__) {
-    runWithFiberInDEV(
-      finishedWork,
-      commitPassiveMountOnFiber,
-      root,
-      finishedWork,
-      committedLanes,
-      committedTransitions,
-    );
-  } else {
-    commitPassiveMountOnFiber(
-      root,
-      finishedWork,
-      committedLanes,
-      committedTransitions,
-    );
-  }
+  commitPassiveMountOnFiber(
+    root,
+    finishedWork,
+    committedLanes,
+    committedTransitions,
+  );
 }
 
 function recursivelyTraversePassiveMountEffects(
@@ -2724,23 +2655,12 @@ function recursivelyTraversePassiveMountEffects(
   if (parentFiber.subtreeFlags & PassiveMask) {
     let child = parentFiber.child;
     while (child !== null) {
-      if (__DEV__) {
-        runWithFiberInDEV(
-          child,
-          commitPassiveMountOnFiber,
-          root,
-          child,
-          committedLanes,
-          committedTransitions,
-        );
-      } else {
-        commitPassiveMountOnFiber(
-          root,
-          child,
-          committedLanes,
-          committedTransitions,
-        );
-      }
+      commitPassiveMountOnFiber(
+        root,
+        child,
+        committedLanes,
+        committedTransitions,
+      );
       child = child.sibling;
     }
   }
@@ -2982,25 +2902,13 @@ function recursivelyTraverseReconnectPassiveEffects(
   // TODO (Offscreen) Check: flags & (RefStatic | LayoutStatic)
   let child = parentFiber.child;
   while (child !== null) {
-    if (__DEV__) {
-      runWithFiberInDEV(
-        child,
-        reconnectPassiveEffects,
-        finishedRoot,
-        child,
-        committedLanes,
-        committedTransitions,
-        childShouldIncludeWorkInProgressEffects,
-      );
-    } else {
-      reconnectPassiveEffects(
-        finishedRoot,
-        child,
-        committedLanes,
-        committedTransitions,
-        childShouldIncludeWorkInProgressEffects,
-      );
-    }
+    reconnectPassiveEffects(
+      finishedRoot,
+      child,
+      committedLanes,
+      committedTransitions,
+      childShouldIncludeWorkInProgressEffects,
+    );
     child = child.sibling;
   }
 }
@@ -3182,23 +3090,12 @@ function recursivelyTraverseAtomicPassiveEffects(
   if (parentFiber.subtreeFlags & PassiveMask) {
     let child = parentFiber.child;
     while (child !== null) {
-      if (__DEV__) {
-        runWithFiberInDEV(
-          child,
-          commitAtomicPassiveEffects,
-          finishedRoot,
-          child,
-          committedLanes,
-          committedTransitions,
-        );
-      } else {
-        commitAtomicPassiveEffects(
-          finishedRoot,
-          child,
-          committedLanes,
-          committedTransitions,
-        );
-      }
+      commitAtomicPassiveEffects(
+        finishedRoot,
+        child,
+        committedLanes,
+        committedTransitions,
+      );
       child = child.sibling;
     }
   }
@@ -3257,11 +3154,7 @@ function commitAtomicPassiveEffects(
 }
 
 export function commitPassiveUnmountEffects(finishedWork: Fiber): void {
-  if (__DEV__) {
-    runWithFiberInDEV(finishedWork, commitPassiveUnmountOnFiber, finishedWork);
-  } else {
-    commitPassiveUnmountOnFiber(finishedWork);
-  }
+  commitPassiveUnmountOnFiber(finishedWork);
 }
 
 // If we're inside a brand new tree, or a tree that was already visible, then we
@@ -3412,11 +3305,7 @@ function recursivelyTraversePassiveUnmountEffects(parentFiber: Fiber): void {
   if (parentFiber.subtreeFlags & PassiveMask) {
     let child = parentFiber.child;
     while (child !== null) {
-      if (__DEV__) {
-        runWithFiberInDEV(child, commitPassiveUnmountOnFiber, child);
-      } else {
-        commitPassiveUnmountOnFiber(child);
-      }
+      commitPassiveUnmountOnFiber(child);
       child = child.sibling;
     }
   }
@@ -3493,11 +3382,7 @@ function recursivelyTraverseDisconnectPassiveEffects(parentFiber: Fiber): void {
   // TODO: Check PassiveStatic flag
   let child = parentFiber.child;
   while (child !== null) {
-    if (__DEV__) {
-      runWithFiberInDEV(child, disconnectPassiveEffect, child);
-    } else {
-      disconnectPassiveEffect(child);
-    }
+    disconnectPassiveEffect(child);
     child = child.sibling;
   }
 }
@@ -3544,19 +3429,7 @@ function commitPassiveUnmountEffectsInsideOfDeletedTree_begin(
 
     // Deletion effects fire in parent -> child order
     // TODO: Check if fiber has a PassiveStatic flag
-    if (__DEV__) {
-      runWithFiberInDEV(
-        fiber,
-        commitPassiveUnmountInsideDeletedTreeOnFiber,
-        fiber,
-        nearestMountedAncestor,
-      );
-    } else {
-      commitPassiveUnmountInsideDeletedTreeOnFiber(
-        fiber,
-        nearestMountedAncestor,
-      );
-    }
+    commitPassiveUnmountInsideDeletedTreeOnFiber(fiber, nearestMountedAncestor);
 
     const child = fiber.child;
     // TODO: Only traverse subtree if it has a PassiveStatic flag.

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseCallback-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseCallback-test.js
@@ -57,9 +57,10 @@ describe('ReactSuspense', () => {
     );
 
     ReactNoop.render(elementBadType);
-    await expect(async () => await waitForAll([])).toErrorDev([
-      'Unexpected type for suspenseCallback.',
-    ]);
+    await expect(async () => await waitForAll([])).toErrorDev(
+      ['Unexpected type for suspenseCallback.'],
+      {withoutStack: true},
+    );
 
     const elementMissingCallback = (
       <React.Suspense fallback={'Waiting'}>


### PR DESCRIPTION
Stacked on #30881.

Move `runWithFiberInDEV` from the recursive part of the commit phase and instead wrap each call into user space. These should really map 1:1 with where we're using `try/catch` since that's where we're calling into user space.

The goal of this is to avoid the extra stack frames added by `enableOwnerStacks` in the recursive parts to avoid stack overflow. This way we only have a couple of extra at the end of the stack instead of a couple of extra at every depth of the tree.