### PR TITLE
[DevTools] Handle reordered contexts in Profiler

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -1764,6 +1764,14 @@ export function attach(
               // For older versions, there's no good way to read the current context value after render has completed.
               // This is because React maintains a stack of context values during render,
               // but by the time DevTools is called, render has finished and the stack is empty.
+              if (prevContext.context !== nextContext.context) {
+                // If the order of context has changed, then the later context values might have
+                // changed too but the main reason it rerendered was earlier. Either an earlier
+                // context changed value but then we would have exited already. If we end up here
+                // it's because a state or props change caused the order of contexts used to change.
+                // So the main cause is not the contexts themselves.
+                return false;
+              }
               if (!is(prevContext.memoizedValue, nextContext.memoizedValue)) {
                 return true;
               }


### PR DESCRIPTION
While looking at the Context tracking implementation for other reasons I noticed this bug.

Originally it wasn't allowed to have conditional `useContext(context)` (although we did because it's technically possible). With `use(context)` it is officially allowed to be conditional as long as it is within a Hook/Component and not within a try/catch.

This means that this loop comparing previous and next contexts need to consider that the Context objects might not line up and so it's possibly comparing apples to oranges. We already bailed if one was longer than the other.

If the order of contexts changes later in the component that means something else must have already changed earlier so the reason for the rerender isn't the context so we can just return false in that case.