### PR TITLE
[compiler] Validate type configs for hooks/non-hooks

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -788,8 +788,6 @@ export class Environment {
             (isHookName(binding.imported) ? this.#getCustomHookType() : null)
           );
         } else {
-          const expectHook =
-            isHookName(binding.imported) || isHookName(binding.name);
           const moduleType = this.#resolveModuleType(binding.module, loc);
           if (moduleType !== null) {
             const importedType = this.getPropertyType(
@@ -797,11 +795,16 @@ export class Environment {
               binding.imported,
             );
             if (importedType != null) {
+              // Check that hook-like export names are hook types, and non-hook names are non-hook types.
+              // The user-assigned alias isn't decidable by the type provider, so we ignore that for the check.
+              // Thus we allow `import {fooNonHook as useFoo} from ...` because the name and type both say
+              // that it's not a hook.
+              const expectHook = isHookName(binding.imported);
               const isHook = getHookKindForType(this, importedType) != null;
               if (expectHook !== isHook) {
                 CompilerError.throwInvalidConfig({
                   reason: `Invalid type configuration for module`,
-                  description: `Expected type for '${binding.module}.${binding.imported}' to ${expectHook ? 'be a hook' : 'not be a hook'} based on its name`,
+                  description: `Expected type for \`import {${binding.imported}} from '${binding.module}'\` ${expectHook ? 'to be a hook' : 'not to be a hook'} based on the exported name`,
                   loc,
                 });
               }
@@ -817,7 +820,9 @@ export class Environment {
            * `import {useHook as foo} ...`
            * `import {foo as useHook} ...`
            */
-          return expectHook ? this.#getCustomHookType() : null;
+          return isHookName(binding.imported) || isHookName(binding.name)
+            ? this.#getCustomHookType()
+            : null;
         }
       }
       case 'ImportDefault':
@@ -829,7 +834,6 @@ export class Environment {
             (isHookName(binding.name) ? this.#getCustomHookType() : null)
           );
         } else {
-          const expectHook = isHookName(binding.name);
           const moduleType = this.#resolveModuleType(binding.module, loc);
           if (moduleType !== null) {
             let importedType: Type | null = null;
@@ -842,18 +846,21 @@ export class Environment {
               importedType = moduleType;
             }
             if (importedType !== null) {
+              // Check that the hook-like modules are defined as types, and non hook-like modules are not typed as hooks.
+              // So `import Foo from 'useFoo'` is expected to be a hook based on the module name
+              const expectHook = isHookName(binding.module);
               const isHook = getHookKindForType(this, importedType) != null;
               if (expectHook !== isHook) {
                 CompilerError.throwInvalidConfig({
                   reason: `Invalid type configuration for module`,
-                  description: `Expected type for '${binding.module}' (as '${binding.name}') to ${expectHook ? 'be a hook' : 'not be a hook'} based on its name`,
+                  description: `Expected type for \`import ... from '${binding.module}'\` ${expectHook ? 'to be a hook' : 'not to be a hook'} based on the module name`,
                   loc,
                 });
               }
               return importedType;
             }
           }
-          return expectHook ? this.#getCustomHookType() : null;
+          return isHookName(binding.name) ? this.#getCustomHookType() : null;
         }
       }
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -734,9 +734,11 @@ export class Environment {
         }
         const moduleConfig = parsedModuleConfig.data;
         moduleType = installTypeConfig(
+          moduleName,
           this.#globals,
           this.#shapes,
           moduleConfig,
+          moduleName,
         );
       } else {
         moduleType = null;

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -738,6 +738,8 @@ export class Environment {
           this.#globals,
           this.#shapes,
           moduleConfig,
+          moduleName,
+          loc,
         );
       } else {
         moduleType = null;

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -795,10 +795,12 @@ export class Environment {
               binding.imported,
             );
             if (importedType != null) {
-              // Check that hook-like export names are hook types, and non-hook names are non-hook types.
-              // The user-assigned alias isn't decidable by the type provider, so we ignore that for the check.
-              // Thus we allow `import {fooNonHook as useFoo} from ...` because the name and type both say
-              // that it's not a hook.
+              /*
+               * Check that hook-like export names are hook types, and non-hook names are non-hook types.
+               * The user-assigned alias isn't decidable by the type provider, so we ignore that for the check.
+               * Thus we allow `import {fooNonHook as useFoo} from ...` because the name and type both say
+               * that it's not a hook.
+               */
               const expectHook = isHookName(binding.imported);
               const isHook = getHookKindForType(this, importedType) != null;
               if (expectHook !== isHook) {
@@ -846,8 +848,10 @@ export class Environment {
               importedType = moduleType;
             }
             if (importedType !== null) {
-              // Check that the hook-like modules are defined as types, and non hook-like modules are not typed as hooks.
-              // So `import Foo from 'useFoo'` is expected to be a hook based on the module name
+              /*
+               * Check that the hook-like modules are defined as types, and non hook-like modules are not typed as hooks.
+               * So `import Foo from 'useFoo'` is expected to be a hook based on the module name
+               */
               const expectHook = isHookName(binding.module);
               const isHook = getHookKindForType(this, importedType) != null;
               if (expectHook !== isHook) {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Globals.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Globals.ts
@@ -5,11 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {Effect, GeneratedSource, ValueKind, ValueReason} from './HIR';
+import {Effect, ValueKind, ValueReason} from './HIR';
 import {
   BUILTIN_SHAPES,
   BuiltInArrayId,
-  BuiltInJsxId,
   BuiltInMixedReadonlyId,
   BuiltInUseActionStateId,
   BuiltInUseContextHookId,
@@ -29,8 +28,6 @@ import {
 import {BuiltInType, PolyType} from './Types';
 import {TypeConfig} from './TypeSchema';
 import {assertExhaustive} from '../Utils/utils';
-import {isHookName} from './Environment';
-import {CompilerError} from '..';
 
 /*
  * This file exports types and defaults for JavaScript global objects.
@@ -535,50 +532,6 @@ DEFAULT_GLOBALS.set(
 );
 
 export function installTypeConfig(
-  moduleName: string,
-  globals: GlobalRegistry,
-  shapes: ShapeRegistry,
-  typeConfig: TypeConfig,
-  moduleOrPropertyName: string | null,
-): Global {
-  const type = convertTypeConfig(moduleName, globals, shapes, typeConfig);
-  if (moduleOrPropertyName !== null) {
-    if (isHookName(moduleOrPropertyName)) {
-      // Named like a hook => must be typed as a hook
-      if (type.kind !== 'Function' || type.shapeId == null) {
-        CompilerError.throwInvalidConfig({
-          reason: `Invalid moduleTypeProvider result for module '${moduleName}', expected type for '${moduleOrPropertyName}' to be a hook based on its name, but the type was not a hook`,
-          loc: GeneratedSource,
-        });
-      }
-      const functionType = shapes.get(type.shapeId);
-      if (functionType == null || functionType.functionType?.hookKind == null) {
-        CompilerError.throwInvalidConfig({
-          reason: `Invalid moduleTypeProvider result for module '${moduleName}', expected type for '${moduleOrPropertyName}' to be a hook based on its name, but the type was not a hook`,
-          loc: GeneratedSource,
-        });
-      }
-    } else {
-      // Not named like a hook => must not be a hook
-      if (type.kind === 'Function' && type.shapeId != null) {
-        const functionType = shapes.get(type.shapeId);
-        if (
-          functionType != null &&
-          functionType.functionType?.hookKind != null
-        ) {
-          CompilerError.throwInvalidConfig({
-            reason: `Invalid moduleTypeProvider result for module '${moduleName}', expected type for '${moduleOrPropertyName}' not to be a hook, but it was typed as a hook`,
-            loc: GeneratedSource,
-          });
-        }
-      }
-    }
-  }
-  return type;
-}
-
-function convertTypeConfig(
-  moduleName: string,
   globals: GlobalRegistry,
   shapes: ShapeRegistry,
   typeConfig: TypeConfig,
@@ -601,9 +554,6 @@ function convertTypeConfig(
         case 'Any': {
           return {kind: 'Poly'};
         }
-        case 'JSX': {
-          return {kind: 'Object', shapeId: BuiltInJsxId};
-        }
         default: {
           assertExhaustive(
             typeConfig.name,
@@ -617,12 +567,7 @@ function convertTypeConfig(
         positionalParams: typeConfig.positionalParams,
         restParam: typeConfig.restParam,
         calleeEffect: typeConfig.calleeEffect,
-        returnType: convertTypeConfig(
-          moduleName,
-          globals,
-          shapes,
-          typeConfig.returnType,
-        ),
+        returnType: installTypeConfig(globals, shapes, typeConfig.returnType),
         returnValueKind: typeConfig.returnValueKind,
         noAlias: typeConfig.noAlias === true,
         mutableOnlyIfOperandsAreMutable:
@@ -635,12 +580,7 @@ function convertTypeConfig(
         positionalParams: typeConfig.positionalParams ?? [],
         restParam: typeConfig.restParam ?? Effect.Freeze,
         calleeEffect: Effect.Read,
-        returnType: convertTypeConfig(
-          moduleName,
-          globals,
-          shapes,
-          typeConfig.returnType,
-        ),
+        returnType: installTypeConfig(globals, shapes, typeConfig.returnType),
         returnValueKind: typeConfig.returnValueKind ?? ValueKind.Frozen,
         noAlias: typeConfig.noAlias === true,
       });
@@ -651,7 +591,7 @@ function convertTypeConfig(
         null,
         Object.entries(typeConfig.properties ?? {}).map(([key, value]) => [
           key,
-          installTypeConfig(moduleName, globals, shapes, value, key),
+          installTypeConfig(globals, shapes, value),
         ]),
       );
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/TypeSchema.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/TypeSchema.ts
@@ -74,15 +74,13 @@ export type BuiltInTypeConfig =
   | 'Ref'
   | 'Array'
   | 'Primitive'
-  | 'MixedReadonly'
-  | 'JSX';
+  | 'MixedReadonly';
 export const BuiltInTypeSchema: z.ZodType<BuiltInTypeConfig> = z.union([
   z.literal('Any'),
   z.literal('Ref'),
   z.literal('Array'),
   z.literal('Primitive'),
   z.literal('MixedReadonly'),
-  z.literal('JSX'),
 ]);
 
 export type TypeReferenceConfig = {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/TypeSchema.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/TypeSchema.ts
@@ -74,13 +74,15 @@ export type BuiltInTypeConfig =
   | 'Ref'
   | 'Array'
   | 'Primitive'
-  | 'MixedReadonly';
+  | 'MixedReadonly'
+  | 'JSX';
 export const BuiltInTypeSchema: z.ZodType<BuiltInTypeConfig> = z.union([
   z.literal('Any'),
   z.literal('Ref'),
   z.literal('Array'),
   z.literal('Primitive'),
   z.literal('MixedReadonly'),
+  z.literal('JSX'),
 ]);
 
 export type TypeReferenceConfig = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-hook-name-not-typed-as-hook-namespace.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-hook-name-not-typed-as-hook-namespace.expect.md
@@ -1,0 +1,25 @@
+
+## Input
+
+```javascript
+import ReactCompilerTest from 'ReactCompilerTest';
+
+function Component() {
+  return ReactCompilerTest.useHookNotTypedAsHook();
+}
+
+```
+
+
+## Error
+
+```
+  2 |
+  3 | function Component() {
+> 4 |   return ReactCompilerTest.useHookNotTypedAsHook();
+    |          ^^^^^^^^^^^^^^^^^ InvalidConfig: Invalid type configuration for module. Expected type for object property 'useHookNotTypedAsHook' from module 'ReactCompilerTest' to be a hook based on the property name (4:4)
+  5 | }
+  6 |
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-hook-name-not-typed-as-hook-namespace.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-hook-name-not-typed-as-hook-namespace.js
@@ -1,0 +1,5 @@
+import ReactCompilerTest from 'ReactCompilerTest';
+
+function Component() {
+  return ReactCompilerTest.useHookNotTypedAsHook();
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-hook-name-not-typed-as-hook.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-hook-name-not-typed-as-hook.expect.md
@@ -17,7 +17,7 @@ function Component() {
   2 |
   3 | function Component() {
 > 4 |   return useHookNotTypedAsHook();
-    |          ^^^^^^^^^^^^^^^^^^^^^ InvalidConfig: Invalid type configuration for module. Expected type for `import {useHookNotTypedAsHook} from 'ReactCompilerTest'` to be a hook based on the exported name (4:4)
+    |          ^^^^^^^^^^^^^^^^^^^^^ InvalidConfig: Invalid type configuration for module. Expected type for object property 'useHookNotTypedAsHook' from module 'ReactCompilerTest' to be a hook based on the property name (4:4)
   5 | }
   6 |
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-hook-name-not-typed-as-hook.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-hook-name-not-typed-as-hook.expect.md
@@ -1,0 +1,25 @@
+
+## Input
+
+```javascript
+import {useHookNotTypedAsHook} from 'ReactCompilerTest';
+
+function Component() {
+  return useHookNotTypedAsHook();
+}
+
+```
+
+
+## Error
+
+```
+  2 |
+  3 | function Component() {
+> 4 |   return useHookNotTypedAsHook();
+    |          ^^^^^^^^^^^^^^^^^^^^^ InvalidConfig: Invalid type configuration for module. Expected type for `import {useHookNotTypedAsHook} from 'ReactCompilerTest'` to be a hook based on the exported name (4:4)
+  5 | }
+  6 |
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-hook-name-not-typed-as-hook.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-hook-name-not-typed-as-hook.js
@@ -1,0 +1,5 @@
+import {useHookNotTypedAsHook} from 'ReactCompilerTest';
+
+function Component() {
+  return useHookNotTypedAsHook();
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-hooklike-module-default-not-hook.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-hooklike-module-default-not-hook.expect.md
@@ -1,0 +1,25 @@
+
+## Input
+
+```javascript
+import foo from 'useDefaultExportNotTypedAsHook';
+
+function Component() {
+  return <div>{foo()}</div>;
+}
+
+```
+
+
+## Error
+
+```
+  2 |
+  3 | function Component() {
+> 4 |   return <div>{foo()}</div>;
+    |                ^^^ InvalidConfig: Invalid type configuration for module. Expected type for `import ... from 'useDefaultExportNotTypedAsHook'` to be a hook based on the module name (4:4)
+  5 | }
+  6 |
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-hooklike-module-default-not-hook.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-hooklike-module-default-not-hook.js
@@ -1,0 +1,5 @@
+import foo from 'useDefaultExportNotTypedAsHook';
+
+function Component() {
+  return <div>{foo()}</div>;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-nonhook-name-typed-as-hook.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-nonhook-name-typed-as-hook.expect.md
@@ -1,0 +1,25 @@
+
+## Input
+
+```javascript
+import {notAhookTypedAsHook} from 'ReactCompilerTest';
+
+function Component() {
+  return <div>{notAhookTypedAsHook()}</div>;
+}
+
+```
+
+
+## Error
+
+```
+  2 |
+  3 | function Component() {
+> 4 |   return <div>{notAhookTypedAsHook()}</div>;
+    |                ^^^^^^^^^^^^^^^^^^^ InvalidConfig: Invalid type configuration for module. Expected type for `import {notAhookTypedAsHook} from 'ReactCompilerTest'` not to be a hook based on the exported name (4:4)
+  5 | }
+  6 |
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-nonhook-name-typed-as-hook.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-nonhook-name-typed-as-hook.expect.md
@@ -17,7 +17,7 @@ function Component() {
   2 |
   3 | function Component() {
 > 4 |   return <div>{notAhookTypedAsHook()}</div>;
-    |                ^^^^^^^^^^^^^^^^^^^ InvalidConfig: Invalid type configuration for module. Expected type for `import {notAhookTypedAsHook} from 'ReactCompilerTest'` not to be a hook based on the exported name (4:4)
+    |                ^^^^^^^^^^^^^^^^^^^ InvalidConfig: Invalid type configuration for module. Expected type for object property 'useHookNotTypedAsHook' from module 'ReactCompilerTest' to be a hook based on the property name (4:4)
   5 | }
   6 |
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-nonhook-name-typed-as-hook.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-type-provider-nonhook-name-typed-as-hook.js
@@ -1,0 +1,5 @@
+import {notAhookTypedAsHook} from 'ReactCompilerTest';
+
+function Component() {
+  return <div>{notAhookTypedAsHook()}</div>;
+}

--- a/compiler/packages/snap/src/sprout/shared-runtime-type-provider.ts
+++ b/compiler/packages/snap/src/sprout/shared-runtime-type-provider.ts
@@ -18,60 +18,84 @@ export function makeSharedRuntimeTypeProvider({
   return function sharedRuntimeTypeProvider(
     moduleName: string,
   ): TypeConfig | null {
-    if (moduleName !== 'shared-runtime') {
-      return null;
+    if (moduleName === 'shared-runtime') {
+      return {
+        kind: 'object',
+        properties: {
+          default: {
+            kind: 'function',
+            calleeEffect: EffectEnum.Read,
+            positionalParams: [],
+            restParam: EffectEnum.Read,
+            returnType: {kind: 'type', name: 'Primitive'},
+            returnValueKind: ValueKindEnum.Primitive,
+          },
+          graphql: {
+            kind: 'function',
+            calleeEffect: EffectEnum.Read,
+            positionalParams: [],
+            restParam: EffectEnum.Read,
+            returnType: {kind: 'type', name: 'Primitive'},
+            returnValueKind: ValueKindEnum.Primitive,
+          },
+          typedArrayPush: {
+            kind: 'function',
+            calleeEffect: EffectEnum.Read,
+            positionalParams: [EffectEnum.Store, EffectEnum.Capture],
+            restParam: EffectEnum.Capture,
+            returnType: {kind: 'type', name: 'Primitive'},
+            returnValueKind: ValueKindEnum.Primitive,
+          },
+          typedLog: {
+            kind: 'function',
+            calleeEffect: EffectEnum.Read,
+            positionalParams: [],
+            restParam: EffectEnum.Read,
+            returnType: {kind: 'type', name: 'Primitive'},
+            returnValueKind: ValueKindEnum.Primitive,
+          },
+          useFreeze: {
+            kind: 'hook',
+            returnType: {kind: 'type', name: 'Any'},
+          },
+          useFragment: {
+            kind: 'hook',
+            returnType: {kind: 'type', name: 'MixedReadonly'},
+            noAlias: true,
+          },
+          useNoAlias: {
+            kind: 'hook',
+            returnType: {kind: 'type', name: 'Any'},
+            returnValueKind: ValueKindEnum.Mutable,
+            noAlias: true,
+          },
+        },
+      };
+    } else if (moduleName === 'ReactCompilerTest') {
+      return {
+        kind: 'object',
+        properties: {
+          useHookNotTypedAsHook: {
+            kind: 'type',
+            name: 'Any',
+          },
+          notAhookTypedAsHook: {
+            kind: 'hook',
+            returnType: {kind: 'type', name: 'Any'},
+          },
+        },
+      };
+    } else if (moduleName === 'useDefaultExportNotTypedAsHook') {
+      return {
+        kind: 'object',
+        properties: {
+          default: {
+            kind: 'type',
+            name: 'Any',
+          },
+        },
+      };
     }
-    return {
-      kind: 'object',
-      properties: {
-        default: {
-          kind: 'function',
-          calleeEffect: EffectEnum.Read,
-          positionalParams: [],
-          restParam: EffectEnum.Read,
-          returnType: {kind: 'type', name: 'Primitive'},
-          returnValueKind: ValueKindEnum.Primitive,
-        },
-        graphql: {
-          kind: 'function',
-          calleeEffect: EffectEnum.Read,
-          positionalParams: [],
-          restParam: EffectEnum.Read,
-          returnType: {kind: 'type', name: 'Primitive'},
-          returnValueKind: ValueKindEnum.Primitive,
-        },
-        typedArrayPush: {
-          kind: 'function',
-          calleeEffect: EffectEnum.Read,
-          positionalParams: [EffectEnum.Store, EffectEnum.Capture],
-          restParam: EffectEnum.Capture,
-          returnType: {kind: 'type', name: 'Primitive'},
-          returnValueKind: ValueKindEnum.Primitive,
-        },
-        typedLog: {
-          kind: 'function',
-          calleeEffect: EffectEnum.Read,
-          positionalParams: [],
-          restParam: EffectEnum.Read,
-          returnType: {kind: 'type', name: 'Primitive'},
-          returnValueKind: ValueKindEnum.Primitive,
-        },
-        useFreeze: {
-          kind: 'hook',
-          returnType: {kind: 'type', name: 'Any'},
-        },
-        useFragment: {
-          kind: 'hook',
-          returnType: {kind: 'type', name: 'MixedReadonly'},
-          noAlias: true,
-        },
-        useNoAlias: {
-          kind: 'hook',
-          returnType: {kind: 'type', name: 'Any'},
-          returnValueKind: ValueKindEnum.Mutable,
-          noAlias: true,
-        },
-      },
-    };
+    return null;
   };
 }

--- a/compiler/packages/snap/src/sprout/shared-runtime-type-provider.ts
+++ b/compiler/packages/snap/src/sprout/shared-runtime-type-provider.ts
@@ -72,6 +72,10 @@ export function makeSharedRuntimeTypeProvider({
         },
       };
     } else if (moduleName === 'ReactCompilerTest') {
+      /**
+       * Fake module used for testing validation that type providers return hook
+       * types for hook names and non-hook types for non-hook names
+       */
       return {
         kind: 'object',
         properties: {
@@ -86,6 +90,10 @@ export function makeSharedRuntimeTypeProvider({
         },
       };
     } else if (moduleName === 'useDefaultExportNotTypedAsHook') {
+      /**
+       * Fake module used for testing validation that type providers return hook
+       * types for hook names and non-hook types for non-hook names
+       */
       return {
         kind: 'object',
         properties: {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30888

Alternative to #30868. The goal is to ensure that the types coming out of moduleTypeProvider are valid wrt to hook typing. If something is named like a hook, then it must be typed as a hook (or don't type it).