### PR TITLE
Fix useMemoCache with setState in render

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1103,9 +1103,9 @@ if (enableUseMemoCacheHook) {
   };
 }
 
-const resetFunctionComponentUpdateQueue = (
+function resetFunctionComponentUpdateQueue(
   updateQueue: FunctionComponentUpdateQueue,
-) => {
+): void {
   updateQueue.lastEffect = null;
   updateQueue.events = null;
   updateQueue.stores = null;
@@ -1117,7 +1117,7 @@ const resetFunctionComponentUpdateQueue = (
       updateQueue.memoCache.index = 0;
     }
   }
-};
+}
 
 function useThenable<T>(thenable: Thenable<T>): T {
   // Track the position of the thenable within this fiber.

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -770,6 +770,11 @@ export function replaySuspendedComponentWithHooks<Props, SecondArg>(
     ignorePreviousDependencies =
       current !== null && current.type !== workInProgress.type;
   }
+  // renderWithHooks only resets the updateQueue but does not clear it, since
+  // it needs to work for both this case (suspense replay) as well as for double
+  // renders in dev and setState-in-render. However, for the suspense replay case
+  // we need to reset the updateQueue to correctly handle unmount effects, so we
+  // clear the queue here
   workInProgress.updateQueue = null;
   const children = renderWithHooksAgain(
     workInProgress,

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1103,7 +1103,7 @@ if (enableUseMemoCacheHook) {
   };
 }
 
-// NOTE: this function intentionally does not reset memoCache. We reuse updateQueue for the memo
+// NOTE: this function intentionally does not reset memoCache data. We reuse updateQueue for the memo
 // cache to avoid increasing the size of fibers that don't need a cache, but we don't want to reset
 // the cache when other properties are reset.
 const clearFunctionComponentUpdateQueue = (
@@ -1112,8 +1112,10 @@ const clearFunctionComponentUpdateQueue = (
   updateQueue.lastEffect = null;
   updateQueue.events = null;
   updateQueue.stores = null;
-  if (updateQueue.memoCache != null) {
-    updateQueue.memoCache.index = 0;
+  if (enableUseMemoCacheHook) {
+    if (updateQueue.memoCache != null) {
+      updateQueue.memoCache.index = 0;
+    }
   }
 };
 

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -828,7 +828,9 @@ function renderWithHooksAgain<Props, SecondArg>(
     currentHook = null;
     workInProgressHook = null;
 
-    workInProgress.updateQueue = null;
+    if (workInProgress.updateQueue != null) {
+      clearFunctionComponentUpdateQueue(workInProgress.updateQueue);
+    }
 
     if (__DEV__) {
       // Also validate hook order for cascading updates.
@@ -1100,6 +1102,20 @@ if (enableUseMemoCacheHook) {
     };
   };
 }
+
+// NOTE: this function intentionally does not reset memoCache. We reuse updateQueue for the memo
+// cache to avoid increasing the size of fibers that don't need a cache, but we don't want to reset
+// the cache when other properties are reset.
+const clearFunctionComponentUpdateQueue = (
+  updateQueue: FunctionComponentUpdateQueue,
+) => {
+  updateQueue.lastEffect = null;
+  updateQueue.events = null;
+  updateQueue.stores = null;
+  if (updateQueue.memoCache != null) {
+    updateQueue.memoCache.index = 0;
+  }
+};
 
 function useThenable<T>(thenable: Thenable<T>): T {
   // Track the position of the thenable within this fiber.

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -522,9 +522,7 @@ export function renderWithHooks<Props, SecondArg>(
   }
 
   workInProgress.memoizedState = null;
-  if (workInProgress.updateQueue != null) {
-    resetFunctionComponentUpdateQueue(workInProgress.updateQueue);
-  }
+  workInProgress.updateQueue = null;
   workInProgress.lanes = NoLanes;
 
   // The following should have already been reset
@@ -772,6 +770,7 @@ export function replaySuspendedComponentWithHooks<Props, SecondArg>(
     ignorePreviousDependencies =
       current !== null && current.type !== workInProgress.type;
   }
+  workInProgress.updateQueue = null;
   const children = renderWithHooksAgain(
     workInProgress,
     Component,
@@ -2516,17 +2515,15 @@ function pushEffect(
   if (componentUpdateQueue === null) {
     componentUpdateQueue = createFunctionComponentUpdateQueue();
     currentlyRenderingFiber.updateQueue = (componentUpdateQueue: any);
+  }
+  const lastEffect = componentUpdateQueue.lastEffect;
+  if (lastEffect === null) {
     componentUpdateQueue.lastEffect = effect.next = effect;
   } else {
-    const lastEffect = componentUpdateQueue.lastEffect;
-    if (lastEffect === null) {
-      componentUpdateQueue.lastEffect = effect.next = effect;
-    } else {
-      const firstEffect = lastEffect.next;
-      lastEffect.next = effect;
-      effect.next = firstEffect;
-      componentUpdateQueue.lastEffect = effect;
-    }
+    const firstEffect = lastEffect.next;
+    lastEffect.next = effect;
+    effect.next = firstEffect;
+    componentUpdateQueue.lastEffect = effect;
   }
   return effect;
 }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -829,7 +829,7 @@ function renderWithHooksAgain<Props, SecondArg>(
     workInProgressHook = null;
 
     if (workInProgress.updateQueue != null) {
-      clearFunctionComponentUpdateQueue(workInProgress.updateQueue);
+      resetFunctionComponentUpdateQueue(workInProgress.updateQueue);
     }
 
     if (__DEV__) {
@@ -1103,10 +1103,7 @@ if (enableUseMemoCacheHook) {
   };
 }
 
-// NOTE: this function intentionally does not reset memoCache data. We reuse updateQueue for the memo
-// cache to avoid increasing the size of fibers that don't need a cache, but we don't want to reset
-// the cache when other properties are reset.
-const clearFunctionComponentUpdateQueue = (
+const resetFunctionComponentUpdateQueue = (
   updateQueue: FunctionComponentUpdateQueue,
 ) => {
   updateQueue.lastEffect = null;
@@ -1114,6 +1111,9 @@ const clearFunctionComponentUpdateQueue = (
   updateQueue.stores = null;
   if (enableUseMemoCacheHook) {
     if (updateQueue.memoCache != null) {
+      // NOTE: this function intentionally does not reset memoCache data. We reuse updateQueue for the memo
+      // cache to avoid increasing the size of fibers that don't need a cache, but we don't want to reset
+      // the cache when other properties are reset.
       updateQueue.memoCache.index = 0;
     }
   }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -835,7 +835,7 @@ function renderWithHooksAgain<Props, SecondArg>(
     workInProgressHook = null;
 
     if (workInProgress.updateQueue != null) {
-      resetFunctionComponentUpdateQueue(workInProgress.updateQueue);
+      resetFunctionComponentUpdateQueue((workInProgress.updateQueue: any));
     }
 
     if (__DEV__) {

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -522,7 +522,9 @@ export function renderWithHooks<Props, SecondArg>(
   }
 
   workInProgress.memoizedState = null;
-  workInProgress.updateQueue = null;
+  if (workInProgress.updateQueue != null) {
+    resetFunctionComponentUpdateQueue(workInProgress.updateQueue);
+  }
   workInProgress.lanes = NoLanes;
 
   // The following should have already been reset

--- a/packages/react-reconciler/src/__tests__/useMemoCache-test.js
+++ b/packages/react-reconciler/src/__tests__/useMemoCache-test.js
@@ -575,11 +575,7 @@ describe('useMemoCache()', () => {
       'Some expensive processing... [A2]',
       'Suspend! [chunkB]',
 
-      ...(gate('enableSiblingPrerendering')
-        ? gate('enableNoCloningMemoCache')
-          ? ['Suspend! [chunkB]']
-          : ['Some expensive processing... [A2]', 'Suspend! [chunkB]']
-        : []),
+      ...(gate('enableSiblingPrerendering') ? ['Suspend! [chunkB]'] : []),
     ]);
 
     // The second chunk hasn't loaded yet, so we're still showing the
@@ -598,26 +594,13 @@ describe('useMemoCache()', () => {
     await act(() => setInput('hi!'));
 
     // Once the input has updated, we go back to rendering the transition.
-    if (gate(flags => flags.enableNoCloningMemoCache)) {
-      // We did not have process the first chunk again. We reused the
-      // computation from the earlier attempt.
-      assertLog([
-        'Suspend! [chunkB]',
+    // We did not have process the first chunk again. We reused the
+    // computation from the earlier attempt.
+    assertLog([
+      'Suspend! [chunkB]',
 
-        ...(gate('enableSiblingPrerendering') ? ['Suspend! [chunkB]'] : []),
-      ]);
-    } else {
-      // Because we clone/reset the memo cache after every aborted attempt, we
-      // must process the first chunk again.
-      assertLog([
-        'Some expensive processing... [A2]',
-        'Suspend! [chunkB]',
-
-        ...(gate('enableSiblingPrerendering')
-          ? ['Some expensive processing... [A2]', 'Suspend! [chunkB]']
-          : []),
-      ]);
-    }
+      ...(gate('enableSiblingPrerendering') ? ['Suspend! [chunkB]'] : []),
+    ]);
 
     expect(root).toMatchRenderedOutput(
       <>

--- a/packages/react-reconciler/src/__tests__/useMemoCache-test.js
+++ b/packages/react-reconciler/src/__tests__/useMemoCache-test.js
@@ -667,7 +667,7 @@ describe('useMemoCache()', () => {
     }
 
     // Baseline / source code
-    function useUserMemo(value) {
+    function useManualMemo(value) {
       return useMemo(() => [value], [value]);
     }
 
@@ -683,24 +683,22 @@ describe('useMemoCache()', () => {
     }
 
     /**
-     * Test case: note that the initial render never completes
+     * Test with useMemoCache
      */
     let root = ReactNoop.createRoot();
-    const IncorrectInfiniteComponent = makeComponent(useCompilerMemo);
-    root.render(<IncorrectInfiniteComponent value={2} />);
-    await waitForThrow(
-      'Too many re-renders. React limits the number of renders to prevent ' +
-        'an infinite loop.',
-    );
+    const CompilerMemoComponent = makeComponent(useCompilerMemo);
+    await act(() => {
+      root.render(<CompilerMemoComponent value={2} />);
+    });
+    expect(root).toMatchRenderedOutput(<div>2</div>);
 
     /**
-     * Baseline test: initial render is expected to complete after a retry
-     * (triggered by the setState)
+     * Test with useMemo
      */
     root = ReactNoop.createRoot();
-    const CorrectComponent = makeComponent(useUserMemo);
+    const HookMemoComponent = makeComponent(useManualMemo);
     await act(() => {
-      root.render(<CorrectComponent value={2} />);
+      root.render(<HookMemoComponent value={2} />);
     });
     expect(root).toMatchRenderedOutput(<div>2</div>);
   });

--- a/packages/react-reconciler/src/__tests__/useMemoCache-test.js
+++ b/packages/react-reconciler/src/__tests__/useMemoCache-test.js
@@ -628,18 +628,9 @@ describe('useMemoCache()', () => {
 
     // Finish loading the data.
     await act(() => updatedChunkB.resolve('B2'));
-    if (gate(flags => flags.enableNoCloningMemoCache)) {
-      // We did not have process the first chunk again. We reused the
-      // computation from the earlier attempt.
-      assertLog([]);
-    } else {
-      // Because we clone/reset the memo cache after every aborted attempt, we
-      // must process the first chunk again.
-      //
-      // That's three total times we've processed the first chunk, compared to
-      // just once when enableNoCloningMemoCache is on.
-      assertLog(['Some expensive processing... [A2]']);
-    }
+    // We did not have process the first chunk again. We reused the
+    // computation from the earlier attempt.
+    assertLog([]);
     expect(root).toMatchRenderedOutput(
       <>
         <div>Input: hi!</div>

--- a/packages/react-reconciler/src/__tests__/useMemoCache-test.js
+++ b/packages/react-reconciler/src/__tests__/useMemoCache-test.js
@@ -16,7 +16,6 @@ let assertLog;
 let useMemo;
 let useState;
 let useMemoCache;
-let waitForThrow;
 let MemoCacheSentinel;
 let ErrorBoundary;
 
@@ -32,7 +31,6 @@ describe('useMemoCache()', () => {
     useMemo = React.useMemo;
     useMemoCache = require('react/compiler-runtime').c;
     useState = React.useState;
-    waitForThrow = require('internal-test-utils').waitForThrow;
     MemoCacheSentinel = Symbol.for('react.memo_cache_sentinel');
 
     class _ErrorBoundary extends React.Component {

--- a/packages/react-reconciler/src/__tests__/useMemoCache-test.js
+++ b/packages/react-reconciler/src/__tests__/useMemoCache-test.js
@@ -598,8 +598,6 @@ describe('useMemoCache()', () => {
     await act(() => setInput('hi!'));
 
     // Once the input has updated, we go back to rendering the transition.
-    // We did not have process the first chunk again. We reused the
-    // computation from the earlier attempt.
     if (gate(flags => flags.enableNoCloningMemoCache)) {
       // We did not have process the first chunk again. We reused the
       // computation from the earlier attempt.
@@ -630,8 +628,6 @@ describe('useMemoCache()', () => {
 
     // Finish loading the data.
     await act(() => updatedChunkB.resolve('B2'));
-    // We did not have process the first chunk again. We reused the
-    // computation from the earlier attempt.
     if (gate(flags => flags.enableNoCloningMemoCache)) {
       // We did not have process the first chunk again. We reused the
       // computation from the earlier attempt.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30889

Fixes the bug that @alexmckenley and @mofeiZ found where setState-in-render can reset useMemoCache and cause an infinite loop. The bug was that renderWithHooksAgain() was not resetting hook state when rerendering (so useMemo values were preserved) but was resetting the updateQueue. This meant that the entire memo cache was cleared on a setState-in-render.

The fix here is to call a new helper function to clear the update queue. It nulls out other properties, but for memoCache it just sets the index back to zero.