### PR TITLE
[compiler][playground] Fix displayed naming of outlined functions

### DIFF
--- a/compiler/apps/playground/components/Editor/EditorImpl.tsx
+++ b/compiler/apps/playground/components/Editor/EditorImpl.tsx
@@ -235,7 +235,7 @@ function compile(source: string): [CompilerOutput, 'flow' | 'typescript'] {
               name: result.name,
               value: {
                 type: 'FunctionDeclaration',
-                id,
+                id: withIdentifier(result.value.id),
                 async: result.value.async,
                 generator: result.value.generator,
                 body: result.value.body,


### PR DESCRIPTION
At present the playground's output JS tab incorrectly displays the name of all outlined functions as the name of the function from which they were outlined -- see the name of the outlined function in [this](https://playground.react.dev/#N4Igzg9grgTgxgUxALhAMygOzgFwJYSYAEAwhALYAOhCmOAFAJRHAA6xRchYOR0OAGzyYEAEyIBeIk0kA+FkQC+7IkRgIcsYvyEjRAbnaKQioA) example. This PR fixes.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #30907

