### PR TITLE
Fix:- fixed error message of event handler message

### DIFF
--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -960,7 +960,7 @@ describe('ReactFlight', () => {
       startTransition(() => {
         ReactNoop.render(
           <>
-            <ErrorBoundary expectedMessage="Event handlers cannot be passed to Client Component props.">
+            <ErrorBoundary expectedMessage="Event handlers cannot be passed to Server Component props.">
               <Render promise={ReactNoopFlightClient.read(event)} />
             </ErrorBoundary>
             <ErrorBoundary
@@ -977,7 +977,7 @@ describe('ReactFlight', () => {
             <ErrorBoundary expectedMessage="Refs cannot be used in Server Components, nor passed to Client Components.">
               <Render promise={ReactNoopFlightClient.read(refs)} />
             </ErrorBoundary>
-            <ErrorBoundary expectedMessage="Event handlers cannot be passed to Client Component props.">
+            <ErrorBoundary expectedMessage="Event handlers cannot be passed to Server Component props.">
               <Render promise={ReactNoopFlightClient.read(eventClient)} />
             </ErrorBoundary>
             <ErrorBoundary
@@ -1169,7 +1169,7 @@ describe('ReactFlight', () => {
     function App() {
       return (
         <ClientErrorBoundary
-          expectedMessage="Event handlers cannot be passed to Client Component props."
+          expectedMessage="Event handlers cannot be passed to Server Component props."
           expectedStack={expectedStack}>
           <div onClick={function () {}} />
         </ClientErrorBoundary>

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -960,7 +960,7 @@ describe('ReactFlight', () => {
       startTransition(() => {
         ReactNoop.render(
           <>
-            <ErrorBoundary expectedMessage="Event handlers cannot be passed to Client Components props from Server component.">
+            <ErrorBoundary expectedMessage="Event handlers cannot be passed to Client Component props from Server Component.">
               <Render promise={ReactNoopFlightClient.read(event)} />
             </ErrorBoundary>
             <ErrorBoundary

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -960,7 +960,7 @@ describe('ReactFlight', () => {
       startTransition(() => {
         ReactNoop.render(
           <>
-            <ErrorBoundary expectedMessage="Event handlers cannot be passed to Server Component props.">
+            <ErrorBoundary expectedMessage="Event handlers cannot be passed to Client Components props from Server component.">
               <Render promise={ReactNoopFlightClient.read(event)} />
             </ErrorBoundary>
             <ErrorBoundary
@@ -977,7 +977,7 @@ describe('ReactFlight', () => {
             <ErrorBoundary expectedMessage="Refs cannot be used in Server Components, nor passed to Client Components.">
               <Render promise={ReactNoopFlightClient.read(refs)} />
             </ErrorBoundary>
-            <ErrorBoundary expectedMessage="Event handlers cannot be passed to Server Component props.">
+            <ErrorBoundary expectedMessage="Event handlers cannot be passed to Client Component props from Server Component.">
               <Render promise={ReactNoopFlightClient.read(eventClient)} />
             </ErrorBoundary>
             <ErrorBoundary
@@ -1169,7 +1169,7 @@ describe('ReactFlight', () => {
     function App() {
       return (
         <ClientErrorBoundary
-          expectedMessage="Event handlers cannot be passed to Server Component props."
+          expectedMessage="Event handlers cannot be passed to Client Component props from Server Component."
           expectedStack={expectedStack}>
           <div onClick={function () {}} />
         </ClientErrorBoundary>

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -2724,7 +2724,7 @@ function renderModelDestructive(
       );
     } else if (/^on[A-Z]/.test(parentPropertyName)) {
       throw new Error(
-        'Event handlers cannot be passed to Client Component props.' +
+        'Event handlers cannot be passed to Server Component props.' +
           describeObjectForErrorMessage(parent, parentPropertyName) +
           '\nIf you need interactivity, consider converting part of this to a Client Component.',
       );

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -2724,7 +2724,7 @@ function renderModelDestructive(
       );
     } else if (/^on[A-Z]/.test(parentPropertyName)) {
       throw new Error(
-        'Event handlers cannot be passed to Server Component props.' +
+        'Event handlers cannot be passed to Client Component props from Server Component.' +
           describeObjectForErrorMessage(parent, parentPropertyName) +
           '\nIf you need interactivity, consider converting part of this to a Client Component.',
       );

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -360,7 +360,7 @@
   "371": "Text string must be rendered within a <Text> component.\n\nText: %s",
   "372": "Cannot call unstable_createEventHandle with \"%s\", as it is not an event known to React.",
   "373": "This Hook is not supported in Server Components.",
-  "374": "Event handlers cannot be passed to Client Component props.%s\nIf you need interactivity, consider converting part of this to a Client Component.",
+  "374": "Event handlers cannot be passed to Server Component props.%s\nIf you need interactivity, consider converting part of this to a Client Component.",
   "375": "Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with \"use server\". Or maybe you meant to call this function rather than return it.%s",
   "376": "Only global symbols received from Symbol.for(...) can be passed to Client Components. The symbol Symbol.for(%s) cannot be found among global symbols.%s",
   "377": "BigInt (%s) is not yet supported in Client Component props.%s",

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -360,7 +360,7 @@
   "371": "Text string must be rendered within a <Text> component.\n\nText: %s",
   "372": "Cannot call unstable_createEventHandle with \"%s\", as it is not an event known to React.",
   "373": "This Hook is not supported in Server Components.",
-  "374": "`Event handlers cannot be passed to Client Component props from Server Component..%s\nIf you need interactivity, consider converting part of this to a Client Component.",
+  "374": "Event handlers cannot be passed to Client Component props from Server Component.%s\nIf you need interactivity, consider converting part of this to a Client Component.",
   "375": "Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with \"use server\". Or maybe you meant to call this function rather than return it.%s",
   "376": "Only global symbols received from Symbol.for(...) can be passed to Client Components. The symbol Symbol.for(%s) cannot be found among global symbols.%s",
   "377": "BigInt (%s) is not yet supported in Client Component props.%s",

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -360,7 +360,7 @@
   "371": "Text string must be rendered within a <Text> component.\n\nText: %s",
   "372": "Cannot call unstable_createEventHandle with \"%s\", as it is not an event known to React.",
   "373": "This Hook is not supported in Server Components.",
-  "374": "Event handlers cannot be passed to Server Component props.%s\nIf you need interactivity, consider converting part of this to a Client Component.",
+  "374": "`Event handlers cannot be passed to Client Component props from Server Component..%s\nIf you need interactivity, consider converting part of this to a Client Component.",
   "375": "Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with \"use server\". Or maybe you meant to call this function rather than return it.%s",
   "376": "Only global symbols received from Symbol.for(...) can be passed to Client Components. The symbol Symbol.for(%s) cannot be found among global symbols.%s",
   "377": "BigInt (%s) is not yet supported in Client Component props.%s",


### PR DESCRIPTION
The error message of `Event handlers cannot be passed to Client Component props.` seems a bit confusing as we are talking in the context of passing the same from Server components, so we should brief this error message by adding 
`Event handlers cannot be passed to Client Component props from Server Component`
