### PR TITLE
Enable lazy context propagation

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -101,8 +101,7 @@ export const enableObjectFiber = false;
 
 export const enableTransitionTracing = false;
 
-// Shipped on FB, waiting for next stable release to roll out to OSS
-export const enableLazyContextPropagation = __EXPERIMENTAL__;
+export const enableLazyContextPropagation = true;
 
 // Expose unstable useContext for performance testing
 export const enableContextProfiling = false;


### PR DESCRIPTION
Last I heard this was great so not sure there are any more blockers to just include it in 19?