### PR TITLE
[Flight] Unwrap lazy before reading the value

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -1057,8 +1057,7 @@ function getOutlinedModel<T>(
     case INITIALIZED:
       let value = chunk.value;
       for (let i = 1; i < path.length; i++) {
-        value = value[path[i]];
-        if (value.$$typeof === REACT_LAZY_TYPE) {
+        while (value.$$typeof === REACT_LAZY_TYPE) {
           const referencedChunk: SomeChunk<any> = value._payload;
           if (referencedChunk.status === INITIALIZED) {
             value = referencedChunk.value;
@@ -1069,10 +1068,11 @@ function getOutlinedModel<T>(
               key,
               response,
               map,
-              path.slice(i),
+              path.slice(i - 1),
             );
           }
         }
+        value = value[path[i]];
       }
       const chunkValue = map(response, value);
       if (__DEV__ && chunk._debugInfo) {


### PR DESCRIPTION
This is important if the lazy is at the root of the chunk. I don't have a unit test for it but @gnoff has a repro.

It also shouldn't unwrap the last value since that's the one we're referencing.

This was already done correctly by @unstubbable in waitForReference so this just aligns with that.