### PR TITLE
disable `enableSiblingPrerendering` in experimental channel

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
+++ b/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
@@ -21,10 +21,10 @@ import semver from 'semver';
 // TODO: This is how other DevTools tests access the version but we should find
 // a better solution for this
 const ReactVersionTestingAgainst = process.env.REACT_VERSION || ReactVersion;
-const enableSiblingPrerendering = semver.gte(
-  ReactVersionTestingAgainst,
-  '19.0.0',
-);
+// Disabling this while the flag is off in experimental. Leaving the logic so we can
+// restore the behavior when we turn the flag back on.
+const enableSiblingPrerendering =
+  false && semver.gte(ReactVersionTestingAgainst, '19.0.0');
 
 describe('Timeline profiler', () => {
   let React;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -148,7 +148,7 @@ export const enableOwnerStacks = __EXPERIMENTAL__;
 
 export const enableShallowPropDiffing = false;
 
-export const enableSiblingPrerendering = __EXPERIMENTAL__;
+export const enableSiblingPrerendering = false;
 
 /**
  * Enables an expiration time for retry lanes to avoid starvation.

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -80,7 +80,7 @@ export const enableAddPropertiesFastPath = false;
 
 export const renameElementSymbol = true;
 export const enableShallowPropDiffing = false;
-export const enableSiblingPrerendering = __EXPERIMENTAL__;
+export const enableSiblingPrerendering = false;
 
 // TODO: This must be in sync with the main ReactFeatureFlags file because
 // the Test Renderer's value must be the same as the one used by the


### PR DESCRIPTION
Disables `enableSiblingPrerendering` in the experimental builds until the feature is tested at Meta first.