### PR TITLE
[Flight] properly track pendingChunks when changing environment names

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -3813,6 +3813,7 @@ function retryTask(request: Request, task: Task): void {
       if (__DEV__) {
         const currentEnv = (0, request.environmentName)();
         if (currentEnv !== task.environmentName) {
+          request.pendingChunks++;
           // The environment changed since we last emitted any debug information for this
           // task. We emit an entry that just includes the environment name change.
           emitDebugChunk(request, task.id, {env: currentEnv});
@@ -3831,6 +3832,7 @@ function retryTask(request: Request, task: Task): void {
       if (__DEV__) {
         const currentEnv = (0, request.environmentName)();
         if (currentEnv !== task.environmentName) {
+          request.pendingChunks++;
           // The environment changed since we last emitted any debug information for this
           // task. We emit an entry that just includes the environment name change.
           emitDebugChunk(request, task.id, {env: currentEnv});


### PR DESCRIPTION
When the environment name changes for a chunk we issue a new debug chunk which updates the environment name. This chunk was not beign included in the pendingChunks count so the count was off when flushing
