### PR TITLE
Added comments to clarify key handling in jsx and createElement

### DIFF
--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -416,15 +416,9 @@ export function jsxProd(type, config, maybeKey) {
       (enableRefAsProp && !('ref' in config))) &&
     !('key' in config)
   ) {
-    // If key was not spread in, we can reuse the original props object. This
-    // only works for `jsx`, not `createElement`, because `jsx` is a compiler
-    // target and the compiler always passes a new object. For `createElement`,
-    // we can't assume a new object is passed every time because it can be
-    // called manually.
-    //
-    // Spreading key is a warning in dev. In a future release, we will not
-    // remove a spread key from the props object. (But we'll still warn.) We'll
-    // always pass the object straight through.
+    // When the key is not spread into props, we can reuse the original props object. This is applicable to `jsx` since it always passes a new object, unlike `createElement`,
+    // which can be manually invoked with the same object. Spreading keys currently causes a warning in development. In future releases, we'll retain the spread key but will continue to issue a warning.
+
     props = config;
   } else {
     // We need to remove reserved props (key, prop, ref). Create a fresh props


### PR DESCRIPTION
### **Summary**
**Added comments to clarify the handling of key in jsx and createElement.**

- Explained why key can be reused in jsx since it always passes a new object.
- Noted that createElement might reuse the same props object, so assumptions about key reuse cannot be made.
- Updated comments to explain the current behavior of spreading keys causing warnings and noted future plans to retain spread keys while maintaining warnings.

### **How did you test this change?**

- Code Review: Verified that the comments correctly describe the behavior by reviewing the relevant code sections.
- Testing: Ensured no functional changes were made by running the existing test suite and confirmed all tests passed.
- Alignment: Checked that the comments are consistent with the current and planned behavior for handling key.