### PR TITLE
fix[rdt/fiber/renderer.js]: getCurrentFiber can be injected as null

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -1078,7 +1078,7 @@ export function attach(
   function getComponentStack(
     topFrame: Error,
   ): null | {enableOwnerStacks: boolean, componentStack: string} {
-    if (getCurrentFiber === undefined) {
+    if (getCurrentFiber == null) {
       // Expected this to be part of the renderer. Ignore.
       return null;
     }
@@ -1130,7 +1130,7 @@ export function attach(
     type: 'error' | 'warn',
     args: $ReadOnlyArray<any>,
   ): void {
-    if (getCurrentFiber === undefined) {
+    if (getCurrentFiber == null) {
       // Expected this to be part of the renderer. Ignore.
       return;
     }

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -158,7 +158,7 @@ export type ReactRenderer = {
   currentDispatcherRef?: LegacyDispatcherRef | CurrentDispatcherRef,
   // Only injected by React v16.9+ in DEV mode.
   // Enables DevTools to append owners-only component stack to error messages.
-  getCurrentFiber?: () => Fiber | null,
+  getCurrentFiber?: (() => Fiber | null) | null,
   // Only injected by React Flight Clients in DEV mode.
   // Enables DevTools to append owners-only component stack to error messages from Server Components.
   getCurrentComponentInfo?: () => ReactComponentInfo | null,


### PR DESCRIPTION
In production artifacts for `18.x.x` `getCurrentFiber` can actually be injected as `null`. Updated `getComponentStack` and `onErrorOrWarning` implementations to support this.

![Screenshot 2024-09-16 at 10 52 00](https://github.com/user-attachments/assets/a0c773aa-ebbf-4fd5-95c4-cac3cc0c203f)
