### PR TITLE
Remove execution context check from shouldProfile

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitEffects.js
@@ -46,8 +46,6 @@ import {getPublicInstance} from './ReactFiberConfig';
 import {
   captureCommitPhaseError,
   setIsRunningInsertionEffect,
-  getExecutionContext,
-  CommitContext,
 } from './ReactFiberWorkLoop';
 import {
   NoFlags as NoHookEffect,
@@ -917,7 +915,7 @@ export function commitProfilerUpdate(
   commitTime: number,
   effectDuration: number,
 ) {
-  if (enableProfilerTimer && getExecutionContext() & CommitContext) {
+  if (enableProfilerTimer) {
     try {
       if (__DEV__) {
         runWithFiberInDEV(

--- a/packages/react-reconciler/src/ReactFiberCommitEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitEffects.js
@@ -48,7 +48,6 @@ import {
   setIsRunningInsertionEffect,
   getExecutionContext,
   CommitContext,
-  NoContext,
 } from './ReactFiberWorkLoop';
 import {
   NoFlags as NoHookEffect,
@@ -81,8 +80,7 @@ function shouldProfile(current: Fiber): boolean {
   return (
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
-    (current.mode & ProfileMode) !== NoMode &&
-    (getExecutionContext() & CommitContext) !== NoContext
+    (current.mode & ProfileMode) !== NoMode
   );
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -144,7 +144,6 @@ import {
   addMarkerCompleteCallbackToPendingTransition,
   getExecutionContext,
   CommitContext,
-  NoContext,
   setIsRunningInsertionEffect,
 } from './ReactFiberWorkLoop';
 import {
@@ -230,8 +229,7 @@ function shouldProfile(current: Fiber): boolean {
   return (
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
-    (current.mode & ProfileMode) !== NoMode &&
-    (getExecutionContext() & CommitContext) !== NoContext
+    (current.mode & ProfileMode) !== NoMode
   );
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -142,8 +142,6 @@ import {
   addMarkerProgressCallbackToPendingTransition,
   addMarkerIncompleteCallbackToPendingTransition,
   addMarkerCompleteCallbackToPendingTransition,
-  getExecutionContext,
-  CommitContext,
   setIsRunningInsertionEffect,
 } from './ReactFiberWorkLoop';
 import {
@@ -2764,11 +2762,7 @@ function commitPassiveMountOnFiber(
 
       // Only Profilers with work in their subtree will have a Passive effect scheduled.
       if (flags & Passive) {
-        if (
-          enableProfilerTimer &&
-          enableProfilerCommitHooks &&
-          getExecutionContext() & CommitContext
-        ) {
+        if (enableProfilerTimer && enableProfilerCommitHooks) {
           const {passiveEffectDuration} = finishedWork.stateNode;
 
           commitProfilerPostCommit(


### PR DESCRIPTION
I don't know why this is here since all these callsites are within the CommitWork/CommitEffects helpers.

This should help with inlining.
