### PR TITLE
[Fiber] Optimize enableProfilerCommitHooks by Collecting Elapsed Effect Duration in Module Scope

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1033,8 +1033,8 @@ function updateProfiler(
       // Reset effect durations for the next eventual effect phase.
       // These are reset during render to allow the DevTools commit hook a chance to read them,
       const stateNode = workInProgress.stateNode;
-      stateNode.effectDuration = 0;
-      stateNode.passiveEffectDuration = 0;
+      stateNode.effectDuration = -0;
+      stateNode.passiveEffectDuration = -0;
     }
   }
   const nextProps = workInProgress.pendingProps;
@@ -3711,8 +3711,8 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
           // Reset effect durations for the next eventual effect phase.
           // These are reset during render to allow the DevTools commit hook a chance to read them,
           const stateNode = workInProgress.stateNode;
-          stateNode.effectDuration = 0;
-          stateNode.passiveEffectDuration = 0;
+          stateNode.effectDuration = -0;
+          stateNode.passiveEffectDuration = -0;
         }
       }
       break;

--- a/packages/react-reconciler/src/ReactFiberCommitEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitEffects.js
@@ -99,6 +99,33 @@ export function commitHookLayoutEffects(
   }
 }
 
+export function commitHookLayoutUnmountEffects(
+  finishedWork: Fiber,
+  nearestMountedAncestor: null | Fiber,
+  hookFlags: HookFlags,
+) {
+  // Layout effects are destroyed during the mutation phase so that all
+  // destroy functions for all fibers are called before any create functions.
+  // This prevents sibling component effects from interfering with each other,
+  // e.g. a destroy function in one component should never override a ref set
+  // by a create function in another component during the same commit.
+  if (shouldProfile(finishedWork)) {
+    startLayoutEffectTimer();
+    commitHookEffectListUnmount(
+      hookFlags,
+      finishedWork,
+      nearestMountedAncestor,
+    );
+    recordLayoutEffectDuration(finishedWork);
+  } else {
+    commitHookEffectListUnmount(
+      hookFlags,
+      finishedWork,
+      nearestMountedAncestor,
+    );
+  }
+}
+
 export function commitHookEffectListMount(
   flags: HookFlags,
   finishedWork: Fiber,

--- a/packages/react-reconciler/src/ReactFiberCommitEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitEffects.js
@@ -876,7 +876,7 @@ export function safelyDetachRef(
   }
 }
 
-export function safelyCallDestroy(
+function safelyCallDestroy(
   current: Fiber,
   nearestMountedAncestor: Fiber | null,
   destroy: () => void,

--- a/packages/react-reconciler/src/ReactFiberCommitEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitEffects.js
@@ -31,10 +31,8 @@ import {NoFlags} from './ReactFiberFlags';
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 import {resolveClassComponentProps} from './ReactFiberClassComponent';
 import {
-  recordLayoutEffectDuration,
-  startLayoutEffectTimer,
-  recordPassiveEffectDuration,
-  startPassiveEffectTimer,
+  recordEffectDuration,
+  startEffectTimer,
   isCurrentUpdateNested,
 } from './ReactProfilerTimer';
 import {NoMode, ProfileMode} from './ReactTypeOfMode';
@@ -91,9 +89,9 @@ export function commitHookLayoutEffects(
   // e.g. a destroy function in one component should never override a ref set
   // by a create function in another component during the same commit.
   if (shouldProfile(finishedWork)) {
-    startLayoutEffectTimer();
+    startEffectTimer();
     commitHookEffectListMount(hookFlags, finishedWork);
-    recordLayoutEffectDuration(finishedWork);
+    recordEffectDuration(finishedWork);
   } else {
     commitHookEffectListMount(hookFlags, finishedWork);
   }
@@ -110,13 +108,13 @@ export function commitHookLayoutUnmountEffects(
   // e.g. a destroy function in one component should never override a ref set
   // by a create function in another component during the same commit.
   if (shouldProfile(finishedWork)) {
-    startLayoutEffectTimer();
+    startEffectTimer();
     commitHookEffectListUnmount(
       hookFlags,
       finishedWork,
       nearestMountedAncestor,
     );
-    recordLayoutEffectDuration(finishedWork);
+    recordEffectDuration(finishedWork);
   } else {
     commitHookEffectListUnmount(
       hookFlags,
@@ -292,9 +290,9 @@ export function commitHookPassiveMountEffects(
   hookFlags: HookFlags,
 ) {
   if (shouldProfile(finishedWork)) {
-    startPassiveEffectTimer();
+    startEffectTimer();
     commitHookEffectListMount(hookFlags, finishedWork);
-    recordPassiveEffectDuration(finishedWork);
+    recordEffectDuration(finishedWork);
   } else {
     commitHookEffectListMount(hookFlags, finishedWork);
   }
@@ -306,13 +304,13 @@ export function commitHookPassiveUnmountEffects(
   hookFlags: HookFlags,
 ) {
   if (shouldProfile(finishedWork)) {
-    startPassiveEffectTimer();
+    startEffectTimer();
     commitHookEffectListUnmount(
       hookFlags,
       finishedWork,
       nearestMountedAncestor,
     );
-    recordPassiveEffectDuration(finishedWork);
+    recordEffectDuration(finishedWork);
   } else {
     commitHookEffectListUnmount(
       hookFlags,
@@ -360,7 +358,7 @@ export function commitClassLayoutLifecycles(
       }
     }
     if (shouldProfile(finishedWork)) {
-      startLayoutEffectTimer();
+      startEffectTimer();
       if (__DEV__) {
         runWithFiberInDEV(
           finishedWork,
@@ -375,7 +373,7 @@ export function commitClassLayoutLifecycles(
           captureCommitPhaseError(finishedWork, finishedWork.return, error);
         }
       }
-      recordLayoutEffectDuration(finishedWork);
+      recordEffectDuration(finishedWork);
     } else {
       if (__DEV__) {
         runWithFiberInDEV(
@@ -431,7 +429,7 @@ export function commitClassLayoutLifecycles(
       }
     }
     if (shouldProfile(finishedWork)) {
-      startLayoutEffectTimer();
+      startEffectTimer();
       if (__DEV__) {
         runWithFiberInDEV(
           finishedWork,
@@ -453,7 +451,7 @@ export function commitClassLayoutLifecycles(
           captureCommitPhaseError(finishedWork, finishedWork.return, error);
         }
       }
-      recordLayoutEffectDuration(finishedWork);
+      recordEffectDuration(finishedWork);
     } else {
       if (__DEV__) {
         runWithFiberInDEV(
@@ -706,7 +704,7 @@ export function safelyCallComponentWillUnmount(
   );
   instance.state = current.memoizedState;
   if (shouldProfile(current)) {
-    startLayoutEffectTimer();
+    startEffectTimer();
     if (__DEV__) {
       runWithFiberInDEV(
         current,
@@ -722,7 +720,7 @@ export function safelyCallComponentWillUnmount(
         captureCommitPhaseError(current, nearestMountedAncestor, error);
       }
     }
-    recordLayoutEffectDuration(current);
+    recordEffectDuration(current);
   } else {
     if (__DEV__) {
       runWithFiberInDEV(
@@ -763,10 +761,10 @@ function commitAttachRef(finishedWork: Fiber) {
     if (typeof ref === 'function') {
       if (shouldProfile(finishedWork)) {
         try {
-          startLayoutEffectTimer();
+          startEffectTimer();
           finishedWork.refCleanup = ref(instanceToUse);
         } finally {
-          recordLayoutEffectDuration(finishedWork);
+          recordEffectDuration(finishedWork);
         }
       } else {
         finishedWork.refCleanup = ref(instanceToUse);
@@ -820,14 +818,14 @@ export function safelyDetachRef(
       try {
         if (shouldProfile(current)) {
           try {
-            startLayoutEffectTimer();
+            startEffectTimer();
             if (__DEV__) {
               runWithFiberInDEV(current, refCleanup);
             } else {
               refCleanup();
             }
           } finally {
-            recordLayoutEffectDuration(current);
+            recordEffectDuration(current);
           }
         } else {
           if (__DEV__) {
@@ -850,14 +848,14 @@ export function safelyDetachRef(
       try {
         if (shouldProfile(current)) {
           try {
-            startLayoutEffectTimer();
+            startEffectTimer();
             if (__DEV__) {
               (runWithFiberInDEV(current, ref, null): void);
             } else {
               ref(null);
             }
           } finally {
-            recordLayoutEffectDuration(current);
+            recordEffectDuration(current);
           }
         } else {
           if (__DEV__) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -44,7 +44,6 @@ import {
   enablePersistedModeClonedFlag,
   enableProfilerTimer,
   enableProfilerCommitHooks,
-  enableSchedulingProfiler,
   enableSuspenseCallback,
   enableScopeAPI,
   enableUpdaterTracking,
@@ -99,12 +98,7 @@ import {
   FormReset,
   Cloned,
 } from './ReactFiberFlags';
-import {
-  getCommitTime,
-  recordLayoutEffectDuration,
-  startLayoutEffectTimer,
-  getCompleteTime,
-} from './ReactProfilerTimer';
+import {getCommitTime, getCompleteTime} from './ReactProfilerTimer';
 import {logComponentRender} from './ReactFiberPerformanceTrack';
 import {ConcurrentMode, NoMode, ProfileMode} from './ReactTypeOfMode';
 import {deferHiddenCallbacks} from './ReactFiberClassUpdateQueue';
@@ -153,12 +147,7 @@ import {
   Passive as HookPassive,
 } from './ReactHookEffectTags';
 import {doesFiberContain} from './ReactFiberTreeReflection';
-import {
-  isDevToolsPresent,
-  markComponentLayoutEffectUnmountStarted,
-  markComponentLayoutEffectUnmountStopped,
-  onCommitUnmount,
-} from './ReactFiberDevToolsHook';
+import {isDevToolsPresent, onCommitUnmount} from './ReactFiberDevToolsHook';
 import {releaseCache, retainCache} from './ReactFiberCacheComponent';
 import {clearTransitionsForLanes} from './ReactFiberLane';
 import {
@@ -223,14 +212,6 @@ let nextEffect: Fiber | null = null;
 // Used for Profiling builds to track updaters.
 let inProgressLanes: Lanes | null = null;
 let inProgressRoot: FiberRoot | null = null;
-
-function shouldProfile(current: Fiber): boolean {
-  return (
-    enableProfilerTimer &&
-    enableProfilerCommitHooks &&
-    (current.mode & ProfileMode) !== NoMode
-  );
-}
 
 let focusedInstanceHandle: null | Fiber = null;
 let shouldFireAfterActiveInstanceBlur: boolean = false;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1264,6 +1264,7 @@ function commitDeletionEffectsOnFiber(
         enableHiddenSubtreeInsertionEffectCleanup ||
         !offscreenSubtreeWasHidden
       ) {
+        // TODO: Use a commitHookInsertionUnmountEffects wrapper to record timings.
         commitHookEffectListUnmount(
           HookInsertion,
           deletedFiber,
@@ -1271,10 +1272,10 @@ function commitDeletionEffectsOnFiber(
         );
       }
       if (!offscreenSubtreeWasHidden) {
-        commitHookEffectListUnmount(
-          HookLayout,
+        commitHookLayoutUnmountEffects(
           deletedFiber,
           nearestMountedAncestor,
+          HookLayout,
         );
       }
       recursivelyTraverseDeletionEffects(
@@ -1598,6 +1599,7 @@ function commitMutationEffectsOnFiber(
           finishedWork,
           finishedWork.return,
         );
+        // TODO: Use a commitHookInsertionUnmountEffects wrapper to record timings.
         commitHookEffectListMount(HookInsertion | HookHasEffect, finishedWork);
         commitHookLayoutUnmountEffects(
           finishedWork,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -145,10 +145,8 @@ import {
   addMarkerProgressCallbackToPendingTransition,
   addMarkerIncompleteCallbackToPendingTransition,
   addMarkerCompleteCallbackToPendingTransition,
-  setIsRunningInsertionEffect,
 } from './ReactFiberWorkLoop';
 import {
-  NoFlags as NoHookEffect,
   HasEffect as HookHasEffect,
   Layout as HookLayout,
   Insertion as HookInsertion,
@@ -189,7 +187,6 @@ import {
   safelyCallComponentWillUnmount,
   safelyAttachRef,
   safelyDetachRef,
-  safelyCallDestroy,
   commitProfilerUpdate,
   commitProfilerPostCommit,
   commitRootCallbacks,
@@ -1263,132 +1260,23 @@ function commitDeletionEffectsOnFiber(
     case ForwardRef:
     case MemoComponent:
     case SimpleMemoComponent: {
-      if (enableHiddenSubtreeInsertionEffectCleanup) {
-        // When deleting a fiber, we may need to destroy insertion or layout effects.
-        // Insertion effects are not destroyed on hidden, only when destroyed, so now
-        // we need to destroy them. Layout effects are destroyed when hidden, so
-        // we only need to destroy them if the tree is visible.
-        const updateQueue: FunctionComponentUpdateQueue | null =
-          (deletedFiber.updateQueue: any);
-        if (updateQueue !== null) {
-          const lastEffect = updateQueue.lastEffect;
-          if (lastEffect !== null) {
-            const firstEffect = lastEffect.next;
-
-            let effect = firstEffect;
-            do {
-              const tag = effect.tag;
-              const inst = effect.inst;
-              const destroy = inst.destroy;
-              if (destroy !== undefined) {
-                if ((tag & HookInsertion) !== NoHookEffect) {
-                  // TODO: add insertion effect marks and profiling.
-                  if (__DEV__) {
-                    setIsRunningInsertionEffect(true);
-                  }
-
-                  inst.destroy = undefined;
-                  safelyCallDestroy(
-                    deletedFiber,
-                    nearestMountedAncestor,
-                    destroy,
-                  );
-
-                  if (__DEV__) {
-                    setIsRunningInsertionEffect(false);
-                  }
-                } else if (
-                  !offscreenSubtreeWasHidden &&
-                  (tag & HookLayout) !== NoHookEffect
-                ) {
-                  // Offscreen fibers already unmounted their layout effects.
-                  // We only need to destroy layout effects for visible trees.
-                  if (enableSchedulingProfiler) {
-                    markComponentLayoutEffectUnmountStarted(deletedFiber);
-                  }
-
-                  if (shouldProfile(deletedFiber)) {
-                    startLayoutEffectTimer();
-                    inst.destroy = undefined;
-                    safelyCallDestroy(
-                      deletedFiber,
-                      nearestMountedAncestor,
-                      destroy,
-                    );
-                    recordLayoutEffectDuration(deletedFiber);
-                  } else {
-                    inst.destroy = undefined;
-                    safelyCallDestroy(
-                      deletedFiber,
-                      nearestMountedAncestor,
-                      destroy,
-                    );
-                  }
-
-                  if (enableSchedulingProfiler) {
-                    markComponentLayoutEffectUnmountStopped();
-                  }
-                }
-              }
-              effect = effect.next;
-            } while (effect !== firstEffect);
-          }
-        }
-      } else if (!offscreenSubtreeWasHidden) {
-        const updateQueue: FunctionComponentUpdateQueue | null =
-          (deletedFiber.updateQueue: any);
-        if (updateQueue !== null) {
-          const lastEffect = updateQueue.lastEffect;
-          if (lastEffect !== null) {
-            const firstEffect = lastEffect.next;
-
-            let effect = firstEffect;
-            do {
-              const tag = effect.tag;
-              const inst = effect.inst;
-              const destroy = inst.destroy;
-              if (destroy !== undefined) {
-                if ((tag & HookInsertion) !== NoHookEffect) {
-                  inst.destroy = undefined;
-                  safelyCallDestroy(
-                    deletedFiber,
-                    nearestMountedAncestor,
-                    destroy,
-                  );
-                } else if ((tag & HookLayout) !== NoHookEffect) {
-                  if (enableSchedulingProfiler) {
-                    markComponentLayoutEffectUnmountStarted(deletedFiber);
-                  }
-
-                  if (shouldProfile(deletedFiber)) {
-                    startLayoutEffectTimer();
-                    inst.destroy = undefined;
-                    safelyCallDestroy(
-                      deletedFiber,
-                      nearestMountedAncestor,
-                      destroy,
-                    );
-                    recordLayoutEffectDuration(deletedFiber);
-                  } else {
-                    inst.destroy = undefined;
-                    safelyCallDestroy(
-                      deletedFiber,
-                      nearestMountedAncestor,
-                      destroy,
-                    );
-                  }
-
-                  if (enableSchedulingProfiler) {
-                    markComponentLayoutEffectUnmountStopped();
-                  }
-                }
-              }
-              effect = effect.next;
-            } while (effect !== firstEffect);
-          }
-        }
+      if (
+        enableHiddenSubtreeInsertionEffectCleanup ||
+        !offscreenSubtreeWasHidden
+      ) {
+        commitHookEffectListUnmount(
+          HookInsertion,
+          deletedFiber,
+          nearestMountedAncestor,
+        );
       }
-
+      if (!offscreenSubtreeWasHidden) {
+        commitHookEffectListUnmount(
+          HookLayout,
+          deletedFiber,
+          nearestMountedAncestor,
+        );
+      }
       recursivelyTraverseDeletionEffects(
         finishedRoot,
         nearestMountedAncestor,

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -112,8 +112,8 @@ function FiberRootNode(
   }
 
   if (enableProfilerTimer && enableProfilerCommitHooks) {
-    this.effectDuration = 0;
-    this.passiveEffectDuration = 0;
+    this.effectDuration = -0;
+    this.passiveEffectDuration = -0;
   }
 
   if (enableUpdaterTracking) {

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -373,6 +373,11 @@ type TransitionTracingOnlyFiberRootProperties = {
   incompleteTransitions: Map<Transition, TracingMarkerInstance>,
 };
 
+type ProfilerCommitHooksOnlyFiberRootProperties = {
+  effectDuration: number,
+  passiveEffectDuration: number,
+};
+
 // Exported FiberRoot type includes all properties,
 // To avoid requiring potentially error-prone :any casts throughout the project.
 // The types are defined separately within this file to ensure they stay in sync.
@@ -381,7 +386,7 @@ export type FiberRoot = {
   ...SuspenseCallbackOnlyFiberRootProperties,
   ...UpdaterTrackingOnlyFiberRootProperties,
   ...TransitionTracingOnlyFiberRootProperties,
-  ...
+  ...ProfilerCommitHooksOnlyFiberRootProperties,
 };
 
 type BasicStateAction<S> = (S => S) | S;

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -37,8 +37,6 @@ export type ProfilerTimer = {
 let completeTime: number = -0;
 let commitTime: number = -0;
 let profilerStartTime: number = -1.1;
-let layoutEffectStartTime: number = -1.1;
-let passiveEffectStartTime: number = -1.1;
 let profilerEffectDuration: number = -0;
 
 function pushNestedEffectDurations(): number {
@@ -181,15 +179,15 @@ function stopProfilerTimerIfRunningAndRecordIncompleteDuration(
   }
 }
 
-function recordLayoutEffectDuration(fiber: Fiber): void {
+function recordEffectDuration(fiber: Fiber): void {
   if (!enableProfilerTimer || !enableProfilerCommitHooks) {
     return;
   }
 
-  if (layoutEffectStartTime >= 0) {
-    const elapsedTime = now() - layoutEffectStartTime;
+  if (profilerStartTime >= 0) {
+    const elapsedTime = now() - profilerStartTime;
 
-    layoutEffectStartTime = -1;
+    profilerStartTime = -1;
 
     // Store duration on the next nearest Profiler ancestor
     // Or the root (for the DevTools Profiler to read)
@@ -197,34 +195,11 @@ function recordLayoutEffectDuration(fiber: Fiber): void {
   }
 }
 
-function recordPassiveEffectDuration(fiber: Fiber): void {
+function startEffectTimer(): void {
   if (!enableProfilerTimer || !enableProfilerCommitHooks) {
     return;
   }
-
-  if (passiveEffectStartTime >= 0) {
-    const elapsedTime = now() - passiveEffectStartTime;
-
-    passiveEffectStartTime = -1;
-
-    // Store duration on the next nearest Profiler ancestor
-    // Or the root (for the DevTools Profiler to read)
-    profilerEffectDuration += elapsedTime;
-  }
-}
-
-function startLayoutEffectTimer(): void {
-  if (!enableProfilerTimer || !enableProfilerCommitHooks) {
-    return;
-  }
-  layoutEffectStartTime = now();
-}
-
-function startPassiveEffectTimer(): void {
-  if (!enableProfilerTimer || !enableProfilerCommitHooks) {
-    return;
-  }
-  passiveEffectStartTime = now();
+  profilerStartTime = now();
 }
 
 function transferActualDuration(fiber: Fiber): void {
@@ -246,11 +221,9 @@ export {
   recordCommitTime,
   isCurrentUpdateNested,
   markNestedUpdateScheduled,
-  recordLayoutEffectDuration,
-  recordPassiveEffectDuration,
+  recordEffectDuration,
   resetNestedUpdateFlag,
-  startLayoutEffectTimer,
-  startPassiveEffectTimer,
+  startEffectTimer,
   startProfilerTimer,
   stopProfilerTimerIfRunning,
   stopProfilerTimerIfRunningAndRecordDuration,

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -1643,7 +1643,7 @@ describe(`onCommit`, () => {
     expect(call).toHaveLength(4);
     expect(call[0]).toBe('root-update');
     expect(call[1]).toBe('update');
-    expect(call[2]).toBe(1100); // durations
+    expect(call[2]).toBe(11100); // durations
     expect(call[3]).toBe(1124); // commit start time (before mutations or effects)
   });
 
@@ -1952,11 +1952,7 @@ describe(`onPostCommit`, () => {
     expect(call).toHaveLength(4);
     expect(call[0]).toBe('unmount-test');
     expect(call[1]).toBe('update');
-    // TODO (bvaughn) The duration reported below should be 10100, but is 0
-    // by the time the passive effect is flushed its parent Fiber pointer is gone.
-    // If we refactor to preserve the unmounted Fiber tree we could fix this.
-    // The current implementation would require too much extra overhead to track this.
-    expect(call[2]).toBe(0); // durations
+    expect(call[2]).toBe(10100); // durations
     expect(call[3]).toBe(12030); // commit start time (before mutations or effects)
   });
 
@@ -2085,7 +2081,7 @@ describe(`onPostCommit`, () => {
     expect(call).toHaveLength(4);
     expect(call[0]).toBe('root-update');
     expect(call[1]).toBe('update');
-    expect(call[2]).toBe(1100); // durations
+    expect(call[2]).toBe(11100); // durations
     expect(call[3]).toBe(1124); // commit start time (before mutations or effects)
   });
 
@@ -2300,7 +2296,7 @@ describe(`onPostCommit`, () => {
     expect(call).toHaveLength(4);
     expect(call[0]).toBe('root');
     expect(call[1]).toBe('update');
-    expect(call[2]).toBe(100000000); // durations
+    expect(call[2]).toBe(100001000); // durations
     // The commit time varies because the above duration time varies
     expect(call[3]).toBe(11221221); // commit start time (before mutations or effects)
   });


### PR DESCRIPTION
Stacked on #30979.

The problem with the previous approach is that it recursively walked the tree up to propagate the resulting time from recording a layout effect.

Instead, we keep a running count of the effect duration on the module scope. Then we reset it when entering a nested Profiler and then we add its elapsed count when we exit the Profiler.

This also fixes a bug where we weren't previously including unmount times for some detached trees since they couldn't bubble up to find the profiler.