### PR TITLE
[ez] Rewrite optional chaining and nullish coalescing syntax

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactInputSelection.js
+++ b/packages/react-dom-bindings/src/client/ReactInputSelection.js
@@ -57,7 +57,12 @@ function isSameOriginFrame(iframe) {
 }
 
 function getActiveElementDeep(containerInfo) {
-  let win = containerInfo?.ownerDocument?.defaultView ?? window;
+  let win =
+    containerInfo != null &&
+    containerInfo.ownerDocument != null &&
+    containerInfo.ownerDocument.defaultView != null
+      ? containerInfo.ownerDocument.defaultView
+      : window;
   let element = getActiveElement(win.document);
   while (element instanceof win.HTMLIFrameElement) {
     if (isSameOriginFrame(element)) {


### PR DESCRIPTION
Rewrite `containerInfo?.ownerDocument?.defaultView ?? window` to instead use a ternary.

This changes the compilation output (see [bundle changes from #30951]).
```js
// compilation of containerInfo?.ownerDocument?.defaultView ?? window
var $jscomp$optchain$tmpm1756096108$1, $jscomp$nullish$tmp0;
containerInfo =
  null !=
  ($jscomp$nullish$tmp0 =
    null == containerInfo
      ? void 0
      : null ==
          ($jscomp$optchain$tmpm1756096108$1 = containerInfo.ownerDocument)
        ? void 0
        : $jscomp$optchain$tmpm1756096108$1.defaultView)
    ? $jscomp$nullish$tmp0
    : window;

// compilation of ternary expression
containerInfo =
  null != containerInfo &&
  null != containerInfo.ownerDocument &&
  null != containerInfo.ownerDocument.defaultView
    ? containerInfo.ownerDocument.defaultView
    : window;
```

This also reduces the number of no-op bundle syncs for Meta. Note that Closure compiler's `jscomp$optchain$tmp<HASH>` identifiers change when we rebuild (likely due to version number changes). See [workflow](https://github.com/facebook/react/actions/runs/10891164281/job/30221518374) for a PR that was synced despite making no changes to the runtime.