### PR TITLE
[Fiber] Log Component Effects to Performance Track

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -99,8 +99,8 @@ import {
   Cloned,
 } from './ReactFiberFlags';
 import {
-  getCommitTime,
-  getCompleteTime,
+  commitTime,
+  completeTime,
   pushNestedEffectDurations,
   popNestedEffectDurations,
   bubbleNestedEffectDurations,
@@ -504,7 +504,7 @@ function commitLayoutEffectOnFiber(
         commitProfilerUpdate(
           finishedWork,
           current,
-          getCommitTime(),
+          commitTime,
           profilerInstance.effectDuration,
         );
       } else {
@@ -2342,7 +2342,7 @@ export function reappearLayoutEffects(
         commitProfilerUpdate(
           finishedWork,
           current,
-          getCommitTime(),
+          commitTime,
           profilerInstance.effectDuration,
         );
       } else {
@@ -2573,9 +2573,7 @@ export function commitPassiveMountEffects(
     finishedWork,
     committedLanes,
     committedTransitions,
-    enableProfilerTimer && enableComponentPerformanceTrack
-      ? getCompleteTime()
-      : 0,
+    enableProfilerTimer && enableComponentPerformanceTrack ? completeTime : 0,
   );
 }
 
@@ -2762,7 +2760,7 @@ function commitPassiveMountOnFiber(
           finishedWork.alternate,
           // This value will still reflect the previous commit phase.
           // It does not get reset until the start of the next commit phase.
-          getCommitTime(),
+          commitTime,
           profilerInstance.passiveEffectDuration,
         );
       } else {

--- a/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
+++ b/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
@@ -38,9 +38,24 @@ const reusableComponentOptions = {
   },
 };
 
+const reusableComponentEffectDevToolDetails = {
+  dataType: 'track-entry',
+  color: 'secondary',
+  track: 'Blocking', // Lane
+  trackGroup: TRACK_GROUP,
+};
+const reusableComponentEffectOptions = {
+  start: -0,
+  end: -0,
+  detail: {
+    devtools: reusableComponentEffectDevToolDetails,
+  },
+};
+
 export function setCurrentTrackFromLanes(lanes: number): void {
-  reusableComponentDevToolDetails.track =
-    getGroupNameOfHighestPriorityLane(lanes);
+  reusableComponentEffectDevToolDetails.track =
+    reusableComponentDevToolDetails.track =
+      getGroupNameOfHighestPriorityLane(lanes);
 }
 
 export function logComponentRender(
@@ -57,5 +72,22 @@ export function logComponentRender(
     reusableComponentOptions.start = startTime;
     reusableComponentOptions.end = endTime;
     performance.measure(name, reusableComponentOptions);
+  }
+}
+
+export function logComponentEffect(
+  fiber: Fiber,
+  startTime: number,
+  endTime: number,
+): void {
+  const name = getComponentNameFromFiber(fiber);
+  if (name === null) {
+    // Skip
+    return;
+  }
+  if (supportsUserTiming) {
+    reusableComponentEffectOptions.start = startTime;
+    reusableComponentEffectOptions.end = endTime;
+    performance.measure(name, reusableComponentEffectOptions);
   }
 }

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -90,8 +90,13 @@ function popComponentEffectStart(prevEffectStart: number): void {
   if (!enableProfilerTimer || !enableProfilerCommitHooks) {
     return;
   }
-  // If the parent component didn't have a start time, we let this current time persist.
-  if (prevEffectStart >= 0) {
+  if (prevEffectStart < 0) {
+    // If the parent component didn't have a start time, we use the start
+    // of the child as the parent's start time. We subtrack a minimal amount of
+    // time to ensure that the parent's start time is before the child to ensure
+    // that the performance tracks line up in the right order.
+    componentEffectStartTime -= 0.001;
+  } else {
     // Otherwise, we restore the previous parent's start time.
     componentEffectStartTime = prevEffectStart;
   }

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -21,27 +21,14 @@ import * as Scheduler from 'scheduler';
 
 const {unstable_now: now} = Scheduler;
 
-export type ProfilerTimer = {
-  getCommitTime(): number,
-  isCurrentUpdateNested(): boolean,
-  markNestedUpdateScheduled(): void,
-  recordCommitTime(): void,
-  startProfilerTimer(fiber: Fiber): void,
-  stopProfilerTimerIfRunning(fiber: Fiber): void,
-  stopProfilerTimerIfRunningAndRecordDuration(fiber: Fiber): void,
-  stopProfilerTimerIfRunningAndRecordIncompleteDuration(fiber: Fiber): void,
-  syncNestedUpdateFlag(): void,
-  ...
-};
+export let completeTime: number = -0;
+export let commitTime: number = -0;
+export let profilerStartTime: number = -1.1;
+export let profilerEffectDuration: number = -0;
+export let componentEffectStartTime: number = -1.1;
+export let componentEffectEndTime: number = -1.1;
 
-let completeTime: number = -0;
-let commitTime: number = -0;
-let profilerStartTime: number = -1.1;
-let profilerEffectDuration: number = -0;
-let componentEffectStartTime: number = -1.1;
-let componentEffectEndTime: number = -1.1;
-
-function pushNestedEffectDurations(): number {
+export function pushNestedEffectDurations(): number {
   if (!enableProfilerTimer || !enableProfilerCommitHooks) {
     return 0;
   }
@@ -50,7 +37,7 @@ function pushNestedEffectDurations(): number {
   return prevEffectDuration;
 }
 
-function popNestedEffectDurations(prevEffectDuration: number): number {
+export function popNestedEffectDurations(prevEffectDuration: number): number {
   if (!enableProfilerTimer || !enableProfilerCommitHooks) {
     return 0;
   }
@@ -60,7 +47,9 @@ function popNestedEffectDurations(prevEffectDuration: number): number {
 }
 
 // Like pop but it also adds the current elapsed time to the parent scope.
-function bubbleNestedEffectDurations(prevEffectDuration: number): number {
+export function bubbleNestedEffectDurations(
+  prevEffectDuration: number,
+): number {
   if (!enableProfilerTimer || !enableProfilerCommitHooks) {
     return 0;
   }
@@ -69,7 +58,7 @@ function bubbleNestedEffectDurations(prevEffectDuration: number): number {
   return elapsedTime;
 }
 
-function resetComponentEffectTimers(): void {
+export function resetComponentEffectTimers(): void {
   if (!enableProfilerTimer || !enableProfilerCommitHooks) {
     return;
   }
@@ -77,7 +66,7 @@ function resetComponentEffectTimers(): void {
   componentEffectEndTime = -1.1;
 }
 
-function pushComponentEffectStart(): number {
+export function pushComponentEffectStart(): number {
   if (!enableProfilerTimer || !enableProfilerCommitHooks) {
     return 0;
   }
@@ -86,7 +75,7 @@ function pushComponentEffectStart(): number {
   return prevEffectStart;
 }
 
-function popComponentEffectStart(prevEffectStart: number): void {
+export function popComponentEffectStart(prevEffectStart: number): void {
   if (!enableProfilerTimer || !enableProfilerCommitHooks) {
     return;
   }
@@ -121,53 +110,45 @@ function popComponentEffectStart(prevEffectStart: number): void {
 let currentUpdateIsNested: boolean = false;
 let nestedUpdateScheduled: boolean = false;
 
-function isCurrentUpdateNested(): boolean {
+export function isCurrentUpdateNested(): boolean {
   return currentUpdateIsNested;
 }
 
-function markNestedUpdateScheduled(): void {
+export function markNestedUpdateScheduled(): void {
   if (enableProfilerNestedUpdatePhase) {
     nestedUpdateScheduled = true;
   }
 }
 
-function resetNestedUpdateFlag(): void {
+export function resetNestedUpdateFlag(): void {
   if (enableProfilerNestedUpdatePhase) {
     currentUpdateIsNested = false;
     nestedUpdateScheduled = false;
   }
 }
 
-function syncNestedUpdateFlag(): void {
+export function syncNestedUpdateFlag(): void {
   if (enableProfilerNestedUpdatePhase) {
     currentUpdateIsNested = nestedUpdateScheduled;
     nestedUpdateScheduled = false;
   }
 }
 
-function getCompleteTime(): number {
-  return completeTime;
-}
-
-function recordCompleteTime(): void {
+export function recordCompleteTime(): void {
   if (!enableProfilerTimer) {
     return;
   }
   completeTime = now();
 }
 
-function getCommitTime(): number {
-  return commitTime;
-}
-
-function recordCommitTime(): void {
+export function recordCommitTime(): void {
   if (!enableProfilerTimer) {
     return;
   }
   commitTime = now();
 }
 
-function startProfilerTimer(fiber: Fiber): void {
+export function startProfilerTimer(fiber: Fiber): void {
   if (!enableProfilerTimer) {
     return;
   }
@@ -179,14 +160,16 @@ function startProfilerTimer(fiber: Fiber): void {
   }
 }
 
-function stopProfilerTimerIfRunning(fiber: Fiber): void {
+export function stopProfilerTimerIfRunning(fiber: Fiber): void {
   if (!enableProfilerTimer) {
     return;
   }
   profilerStartTime = -1;
 }
 
-function stopProfilerTimerIfRunningAndRecordDuration(fiber: Fiber): void {
+export function stopProfilerTimerIfRunningAndRecordDuration(
+  fiber: Fiber,
+): void {
   if (!enableProfilerTimer) {
     return;
   }
@@ -199,7 +182,7 @@ function stopProfilerTimerIfRunningAndRecordDuration(fiber: Fiber): void {
   }
 }
 
-function stopProfilerTimerIfRunningAndRecordIncompleteDuration(
+export function stopProfilerTimerIfRunningAndRecordIncompleteDuration(
   fiber: Fiber,
 ): void {
   if (!enableProfilerTimer) {
@@ -214,7 +197,7 @@ function stopProfilerTimerIfRunningAndRecordIncompleteDuration(
   }
 }
 
-function recordEffectDuration(fiber: Fiber): void {
+export function recordEffectDuration(fiber: Fiber): void {
   if (!enableProfilerTimer || !enableProfilerCommitHooks) {
     return;
   }
@@ -234,7 +217,7 @@ function recordEffectDuration(fiber: Fiber): void {
   }
 }
 
-function startEffectTimer(): void {
+export function startEffectTimer(): void {
   if (!enableProfilerTimer || !enableProfilerCommitHooks) {
     return;
   }
@@ -245,7 +228,7 @@ function startEffectTimer(): void {
   }
 }
 
-function transferActualDuration(fiber: Fiber): void {
+export function transferActualDuration(fiber: Fiber): void {
   // Transfer time spent rendering these children so we don't lose it
   // after we rerender. This is used as a helper in special cases
   // where we should count the work of multiple passes.
@@ -256,29 +239,3 @@ function transferActualDuration(fiber: Fiber): void {
     child = child.sibling;
   }
 }
-
-export {
-  getCompleteTime,
-  recordCompleteTime,
-  getCommitTime,
-  recordCommitTime,
-  isCurrentUpdateNested,
-  markNestedUpdateScheduled,
-  recordEffectDuration,
-  resetNestedUpdateFlag,
-  startEffectTimer,
-  startProfilerTimer,
-  stopProfilerTimerIfRunning,
-  stopProfilerTimerIfRunningAndRecordDuration,
-  stopProfilerTimerIfRunningAndRecordIncompleteDuration,
-  syncNestedUpdateFlag,
-  transferActualDuration,
-  pushNestedEffectDurations,
-  popNestedEffectDurations,
-  bubbleNestedEffectDurations,
-  resetComponentEffectTimers,
-  pushComponentEffectStart,
-  popComponentEffectStart,
-  componentEffectStartTime,
-  componentEffectEndTime,
-};


### PR DESCRIPTION
Stacked on #30981. Same as #30967 but for effects.

This logs a tree of components using `performance.measure()`.

In addition to the previous render phase this logs one tree for each commit phase:

- Mutation Phase
- Layout Effect
- Passive Unmounts
- Passive Mounts

I currently skip the Before Mutation phase since the snapshots are so unusual it's not worth creating trees for those.

The mechanism is that I reuse the timings we track for `enableProfilerCommitHooks`. I track first and last effect timestamp within each component subtree. Then on the way up do we log the entry. This means that we don't include overhead to find our way down to a component and that we don't need to add any additional overhead by reading timestamps.

To ensure that the entries get ordered correctly we need to ensure that the start time of each parent is slightly before the inner one.
