### PR TITLE
[eslint-plugin-react-hooks] fix: optional chaining safety

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1629,6 +1629,38 @@ const tests = {
     },
     {
       code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            if(props.foo?.bar) {
+              console.log(props.foo.bar);
+            }
+          }, [])
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'props.foo?.bar'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [props.foo?.bar]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  useEffect(() => {
+                    if(props.foo?.bar) {
+                      console.log(props.foo.bar);
+                    }
+                  }, [props.foo?.bar])
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
         function MyComponent() {
           const local = someFunc();
           useEffect(() => {
@@ -3938,7 +3970,7 @@ const tests = {
       errors: [
         {
           message:
-            "React Hook useEffect has unnecessary dependencies: 'ref1.current' and 'ref2.current'. " +
+            "React Hook useEffect has unnecessary dependencies: 'ref1?.current' and 'ref2?.current'. " +
             'Either exclude them or remove the dependency array. ' +
             "Mutable values like 'ref1.current' aren't valid dependencies " +
             "because mutating them doesn't re-render the component.",
@@ -4998,7 +5030,7 @@ const tests = {
         {
           message:
             'React Hook useCallback has unnecessary dependencies: ' +
-            "'MutableStore.hello.world', 'global.stuff', 'props.foo', 'x', 'y', and 'z'. " +
+            "'MutableStore?.hello?.world', 'global?.stuff', 'props.foo', 'x', 'y', and 'z'. " +
             'Either exclude them or remove the dependency array. ' +
             "Outer scope values like 'MutableStore.hello.world' aren't valid dependencies " +
             "because mutating them doesn't re-render the component.",
@@ -7955,11 +7987,11 @@ const testsTypescript = {
       errors: [
         {
           message:
-            "React Hook useEffect has a missing dependency: 'pizza.crust'. " +
+            "React Hook useEffect has a missing dependency: 'pizza?.crust'. " +
             'Either include it or remove the dependency array.',
           suggestions: [
             {
-              desc: 'Update the dependencies array to be: [pizza.crust]',
+              desc: 'Update the dependencies array to be: [pizza?.crust]',
               output: normalizeIndent`
                 function MyComponent() {
                   const pizza = {};
@@ -7967,7 +7999,7 @@ const testsTypescript = {
                   useEffect(() => ({
                     crust: pizza?.crust,
                     density: pizza.crust.density,
-                  }), [pizza.crust]);
+                  }), [pizza?.crust]);
                 }
               `,
             },
@@ -7989,11 +8021,11 @@ const testsTypescript = {
       errors: [
         {
           message:
-            "React Hook useEffect has a missing dependency: 'pizza.crust'. " +
+            "React Hook useEffect has a missing dependency: 'pizza?.crust'. " +
             'Either include it or remove the dependency array.',
           suggestions: [
             {
-              desc: 'Update the dependencies array to be: [pizza.crust]',
+              desc: 'Update the dependencies array to be: [pizza?.crust]',
               output: normalizeIndent`
                 function MyComponent() {
                   const pizza = {};
@@ -8001,7 +8033,7 @@ const testsTypescript = {
                   useEffect(() => ({
                     crust: pizza.crust,
                     density: pizza?.crust.density,
-                  }), [pizza.crust]);
+                  }), [pizza?.crust]);
                 }
               `,
             },

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1661,6 +1661,38 @@ const tests = {
     },
     {
       code: normalizeIndent`
+        function ParentImpliedOptional(props) {
+          useEffect(() => {
+            if(props.foo?.bar) {
+              console.log(props.foo.baz);
+            }
+          }, [])
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has missing dependencies: 'props.foo?.bar' and 'props.foo?.baz'. " +
+            'Either include them or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [props.foo?.bar, props.foo?.baz]',
+              output: normalizeIndent`
+                function ParentImpliedOptional(props) {
+                  useEffect(() => {
+                    if(props.foo?.bar) {
+                      console.log(props.foo.baz);
+                    }
+                  }, [props.foo?.bar, props.foo?.baz])
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
         function MyComponent() {
           const local = someFunc();
           useEffect(() => {
@@ -7953,11 +7985,11 @@ const testsTypescript = {
       errors: [
         {
           message:
-            "React Hook useEffect has missing dependencies: 'pizza.crust' and 'pizza?.toppings'. " +
+            "React Hook useEffect has missing dependencies: 'pizza?.crust' and 'pizza?.toppings'. " +
             'Either include them or remove the dependency array.',
           suggestions: [
             {
-              desc: 'Update the dependencies array to be: [pizza.crust, pizza?.toppings]',
+              desc: 'Update the dependencies array to be: [pizza?.crust, pizza?.toppings]',
               output: normalizeIndent`
                 function MyComponent() {
                   const pizza = {};
@@ -7965,7 +7997,7 @@ const testsTypescript = {
                   useEffect(() => ({
                     crust: pizza.crust,
                     toppings: pizza?.toppings,
-                  }), [pizza.crust, pizza?.toppings]);
+                  }), [pizza?.crust, pizza?.toppings]);
                 }
               `,
             },

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -712,7 +712,7 @@ export default {
           try {
             declaredDependency = analyzePropertyChain(
               declaredDependencyNode,
-              null,
+              optionalChains,
             );
           } catch (error) {
             if (/Unsupported node type/.test(error.message)) {
@@ -1712,13 +1712,10 @@ function getDependency(node) {
 function markNode(node, optionalChains, result) {
   if (optionalChains) {
     if (node.optional) {
-      // We only want to consider it optional if *all* usages were optional.
-      if (!optionalChains.has(result)) {
-        // Mark as (maybe) optional. If there's a required usage, this will be overridden.
-        optionalChains.set(result, true);
-      }
-    } else {
-      // Mark as required.
+      optionalChains.set(result, true);
+    } else if (!optionalChains.has(result)) {
+      // Mark as (maybe) required. We only want to consider it required if *no* usages were optional. If
+      // there's an optional usage, this will be overriden.
       optionalChains.set(result, false);
     }
   }

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -414,6 +414,10 @@ export default {
       // Get dependencies from all our resolved references in pure scopes.
       // Key is dependency string, value is whether it's stable.
       const dependencies = new Map();
+      // Keeps track of paths that have optional chaining
+      // Keys is a path string, value is whether or not there are optional
+      // direct descendants
+      // Example: foo.bar?.baz -> { "foo": false, "foo.bar": true }
       const optionalChains = new Map();
       gatherDependenciesRecursively(scope);
 
@@ -909,9 +913,9 @@ export default {
         let finalPath = '';
         for (let i = 0; i < members.length; i++) {
           if (i !== 0) {
-            const pathSoFar = members.slice(0, i + 1).join('.');
-            const isOptional = optionalChains.get(pathSoFar) === true;
-            finalPath += isOptional ? '?.' : '.';
+            const parentPath = members.slice(0, i).join('.');
+            const isParentOptional = optionalChains.get(parentPath) === true;
+            finalPath += isParentOptional ? '?.' : '.';
           }
           finalPath += members[i];
         }
@@ -1709,16 +1713,18 @@ function getDependency(node) {
  * It just means there is an optional member somewhere inside.
  * This particular node might still represent a required member, so check .optional field.
  */
-function markNode(node, optionalChains, result) {
+function markNode(node, optionalChains, object, property) {
+  const result = `${object}.${property}`;
   if (optionalChains) {
     if (node.optional) {
-      optionalChains.set(result, true);
-    } else if (!optionalChains.has(result)) {
+      optionalChains.set(object, true);
+    } else if (!optionalChains.has(object)) {
       // Mark as (maybe) required. We only want to consider it required if *no* usages were optional. If
       // there's an optional usage, this will be overriden.
-      optionalChains.set(result, false);
+      optionalChains.set(object, false);
     }
   }
+  return result;
 }
 
 /**
@@ -1731,23 +1737,15 @@ function markNode(node, optionalChains, result) {
 function analyzePropertyChain(node, optionalChains) {
   if (node.type === 'Identifier' || node.type === 'JSXIdentifier') {
     const result = node.name;
-    if (optionalChains) {
-      // Mark as required.
-      optionalChains.set(result, false);
-    }
     return result;
   } else if (node.type === 'MemberExpression' && !node.computed) {
     const object = analyzePropertyChain(node.object, optionalChains);
     const property = analyzePropertyChain(node.property, null);
-    const result = `${object}.${property}`;
-    markNode(node, optionalChains, result);
-    return result;
+    return markNode(node, optionalChains, object, property);
   } else if (node.type === 'OptionalMemberExpression' && !node.computed) {
     const object = analyzePropertyChain(node.object, optionalChains);
     const property = analyzePropertyChain(node.property, null);
-    const result = `${object}.${property}`;
-    markNode(node, optionalChains, result);
-    return result;
+    return markNode(node, optionalChains, object, property);
   } else if (node.type === 'ChainExpression' && !node.computed) {
     const expression = node.expression;
 
@@ -1757,9 +1755,7 @@ function analyzePropertyChain(node, optionalChains) {
 
     const object = analyzePropertyChain(expression.object, optionalChains);
     const property = analyzePropertyChain(expression.property, null);
-    const result = `${object}.${property}`;
-    markNode(expression, optionalChains, result);
-    return result;
+    return markNode(expression, optionalChains, object, property);
   } else {
     throw new Error(`Unsupported node type: ${node.type}`);
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

This partially fixes https://github.com/facebook/react/issues/23248

There are are few circumstances where eslint-plugin-react-hooks will generate dependency arrays that unsafely access properties, even if those properties are safely accessed within the hook.

### Problem 1: Preferring required over optional property access

Example 1:
```
useEffect(() => {
  if(props.foo?.bar) {
    console.log(props.foo.bar);
  }
}, [])
```

`props.foo.bar` is being accessed safely in the hook because of the if statement, but eslint-plugin-react-hooks will suggest a dependency array of `[props.foo.bar]` which will unsafely access the property resulting in an error like `Uncaught TypeError: Cannot read properties of undefined (reading 'bar')` when foo is undefined

Right now we always prefer treating a property as required if it appears both with and without optional chaining. In other words, in the example above `props.foo.bar` always wins over `props.foo?.bar`

The fix for this problem is mostly contained in the `markNode` function where optional access now takes precedence over required access. 

### Problem 2: Tracking the property as optional, not the parent object

Example 2:
```
useEffect(() => {
  if(props.foo?.bar) {
    console.log(props.foo.baz);
  }
}, [])
```

This hook safely accesses `props.foo.baz` (albeit in a strange way). In the current implementation we would generate a dependencies array of `[props.foo?.bar, props.foo.baz]`, which doesn't safely access `baz` and could again lead to type errors coming from the dependencies array. The issue here is that we are tracking that `props.foo.bar` is optional when we should instead be tracking that the object, `props.foo`, should have all access done optionally.

The fix here is adjusting the `optionalChains` map to be a map of objects that have optional property access off of them, rather than a map of properties that are accessed optionally. This resulted in changes to `markNode` as well as `formatDependency`

For example 2, the optionalChains map before this change would look like:
```
{
  'props': false,
  'props.foo': false,
  'props.foo.bar': true,
  'props.foo.baz': false
}
```

and after this change it should look like:
```
{
  'props': false
  'props.foo': true
}
```
 
So before we would explicitly say that only `props.foo.bar` needed to be accessed optionally, but now we are saying that any property off of `props.foo` needs to be accessed optionally. 

### Problem 3: Not tracking optionalChains in declaredDependencies

In existing test cases [like this](https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js#L3926-L3964) we have a deps array like `[ref1?.current, ref2?.current, props.someOtherRefs, props.color]` and expect an error message  containing `React Hook useEffect has unnecessary dependencies: 'ref1.current' and 'ref2.current'.` Notably the optional chaining is missing in the error message.

The fix here was to pass `optionalChains` in when calling `analyzePropertyChain` for a declared dependency node

### Why I'm considering this a partial fix

We don't use optional chaining to determine if a dependency is missing or invalid, so this change will not force updates of existing dependency arrays or even alert you that there is potentially unsafe lack of optional chaining in an existing otherwise valid dependency array. I think this is the right tradeoff though, because it would be a pretty major and disruptive change to invalidate existing dependency arrays.

## How did you test this change?
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

```
yarn test --prod
...
Test Suites: 322 passed, 322 total
Tests:       24 skipped, 9689 passed, 9713 total
Snapshots:   182 passed, 182 total
Time:        81.448 s, estimated 91 s
Ran all test suites.
✨  Done in 82.27s.
```

I added two new tests, matching example 1 and example 2 described above in this pull request. I also updated some existing tests to account for these changes. Specifically the pizza related tests are the most meaningfully changed

[For example
](https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js#L7911-L7943)
```
useEffect(() => ({
  crust: pizza.crust,
  toppings: pizza?.toppings,
}), []);
```

before we would want a dependency array of `[pizza.crust, pizza?.toppings]`, but now we are saying that properties on `pizza` must be accessed with optional chaining, so we would want `[pizza?.crust, pizza?.toppings]`