### PR TITLE
Always reset baseQueue

### DIFF
--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -96,30 +96,31 @@ describe('ReactUpdates', () => {
       Scheduler.log(`Render: ${state.prop} ${state.count}`);
 
       if (state.prop !== prop) {
-        Scheduler.log(
-          `setState in render ${state.prop} ${state.count} -> ${prop} ${state.count + 1}`,
-        );
+        Scheduler.log(`setState in render: ${state.prop} ${state.count}`);
         setState(currentState => {
-          Scheduler.log(
-            `Render reducer: ${currentState.prop} ${currentState.count} -> ${prop} ${currentState.count + 1}`,
-          );
-          return {
+          const nextState = {
             prop,
             count: currentState.count + 1,
           };
+
+          Scheduler.log(
+            `Render reducer: ${currentState.prop} ${currentState.count} -> ${nextState.prop} ${nextState.count}`,
+          );
+          return nextState;
         });
       }
 
       _setTransitionState = () => {
         React.startTransition(() => {
           setState(currentState => {
-            Scheduler.log(
-              `Transition reducer: ${currentState.count} ${currentState.prop} -> ${currentState.prop} ${currentState.count + 1}`,
-            );
-            return {
-              prop: currentState.prop,
+            const nextState = {
+              prop,
               count: currentState.count + 10,
             };
+            Scheduler.log(
+              `Transition reducer: ${currentState.count} ${currentState.prop} -> ${nextState.prop} ${nextState.count}`,
+            );
+            return nextState;
           });
         });
       };
@@ -160,11 +161,11 @@ describe('ReactUpdates', () => {
       // Transition setState
       // For isomorphic startTransition,
       // This runs first, not during transition render.
-      'Transition reducer: 0 0 -> 0 1',
+      'Transition reducer: 0 0 -> 0 10',
 
       // Prop change from 0 -> 1
       'Render: 0 0',
-      'setState in render 0 0 -> 1 1',
+      'setState in render: 0 0',
       'Render reducer: 0 0 -> 1 1',
       'Render: 1 1',
 
@@ -174,14 +175,14 @@ describe('ReactUpdates', () => {
         ? []
         : [
             'Render: 0 0',
-            'setState in render 0 0 -> 1 1',
+            'setState in render: 0 0',
             'Render reducer: 0 0 -> 1 1',
           ]),
       'Render: 1 1',
 
       // Transition
       'Render: 0 10',
-      'setState in render 0 10 -> 1 11',
+      'setState in render: 0 10',
       'Render reducer: 0 10 -> 1 11',
       'Render: 1 11',
     ]);
@@ -199,29 +200,29 @@ describe('ReactUpdates', () => {
       Scheduler.log(`Render: ${state.prop} ${state.count}`);
 
       if (state.prop !== prop) {
-        Scheduler.log(
-          `setState in render ${state.prop} ${state.count} -> ${prop} ${state.count + 1}`,
-        );
+        Scheduler.log(`setState in render: ${state.prop} ${state.count}`);
         setState(currentState => {
-          Scheduler.log(
-            `Render reducer: ${currentState.prop} ${currentState.count} -> ${prop} ${currentState.count + 1}`,
-          );
-          return {
+          const nextState = {
             prop,
             count: currentState.count + 1,
           };
+          Scheduler.log(
+            `Render reducer: ${currentState.prop} ${currentState.count} -> ${nextState.prop} ${nextState.count}`,
+          );
+          return nextState;
         });
       }
       _setTransitionState = () => {
         startTransition(() => {
           setState(currentState => {
-            Scheduler.log(
-              `Transition reducer: ${currentState.prop} ${currentState.count} -> ${prop} ${currentState.count + 10}`,
-            );
-            return {
+            const nextState = {
               prop,
               count: currentState.count + 10,
             };
+            Scheduler.log(
+              `Transition reducer: ${currentState.prop} ${currentState.count} -> ${nextState.prop} ${nextState.count}`,
+            );
+            return nextState;
           });
         });
       };
@@ -262,7 +263,7 @@ describe('ReactUpdates', () => {
       assertLog([
         // Prop change from 0 -> 1
         'Render: 0 0',
-        'setState in render 0 0 -> 1 1',
+        'setState in render: 0 0',
         'Render reducer: 0 0 -> 1 1',
         'Render: 1 1',
 
@@ -275,7 +276,7 @@ describe('ReactUpdates', () => {
         // currentProp currentState -> prop currentState + 10.
         'Transition reducer: 1 1 -> 0 11',
         'Render: 0 11',
-        'setState in render 0 11 -> 1 12',
+        'setState in render: 0 11',
         'Render reducer: 0 11 -> 1 12',
         'Render: 1 12',
       ]);
@@ -285,7 +286,7 @@ describe('ReactUpdates', () => {
       assertLog([
         // Prop change from 0 -> 1
         'Render: 0 0',
-        'setState in render 0 0 -> 1 1',
+        'setState in render: 0 0',
         'Render reducer: 0 0 -> 1 1',
         'Render: 1 1',
 
@@ -293,14 +294,14 @@ describe('ReactUpdates', () => {
         'Layout effect setState',
         // Extra render
         'Render: 0 0',
-        'setState in render 0 0 -> 1 1',
+        'setState in render: 0 0',
         'Render reducer: 0 0 -> 1 1',
         'Render: 1 1',
 
         // Transition
         'Transition reducer: 0 0 -> 0 10',
         'Render: 0 10',
-        'setState in render 0 10 -> 1 11',
+        'setState in render: 0 10',
         'Render reducer: 0 10 -> 1 11',
         'Render: 1 11',
       ]);

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -87,9 +87,9 @@ describe('ReactUpdates', () => {
     expect(container.firstChild.textContent).toBe('2');
   });
 
-  it('should keep state from render during layout effect update', async () => {
+  it('should keep state from render during layout effect update with useTransition', async () => {
     let _setState = null;
-
+    let _setTransitionState = null;
     function Component({prop}) {
       const [, setLayoutState] = React.useState({});
       const [state, setState] = React.useState({prop, count: 0});
@@ -111,6 +111,20 @@ describe('ReactUpdates', () => {
           };
         });
       }
+
+      _setTransitionState = () => {
+        React.startTransition(() => {
+          _setState(currentState => {
+            Scheduler.log(
+              `Transition reducer: ${currentState.count} ${currentState.prop} -> ${currentState.prop} ${currentState.count + 1}`,
+            );
+            return {
+              prop: currentState.prop,
+              count: currentState.count + 10,
+            };
+          });
+        });
+      };
 
       React.useLayoutEffect(() => {
         if (prop === 1) {
@@ -137,17 +151,7 @@ describe('ReactUpdates', () => {
 
     await act(() => {
       // Schedule a transition to update the state, this means baseQueue is non-empty.
-      React.startTransition(() => {
-        _setState(currentState => {
-          Scheduler.log(
-            `Transition reducer: ${currentState.count} ${currentState.prop} -> ${currentState.prop} ${currentState.count + 1}`,
-          );
-          return {
-            prop: currentState.prop,
-            count: currentState.count + 10,
-          };
-        });
-      });
+      _setTransitionState();
 
       // Now schedule a blocking update.
       root.render(<Component prop={1} />);
@@ -155,6 +159,7 @@ describe('ReactUpdates', () => {
 
     assertLog([
       // Transition setState
+      // For isomorphic startTransition, this runs first, not during transition render.
       'Transition reducer: 0 0 -> 0 1',
 
       // Prop change from 0 -> 1
@@ -165,9 +170,13 @@ describe('ReactUpdates', () => {
 
       // Layout effect runs with prop 1
       'Layout effect setState',
-      // 'Render: 0 0',
-      // 'setState in render 0 0 -> 1 1',
-      // 'Render reducer: 0 0 -> 1 1',
+      ...(gate('alwaysResetBaseQueue')
+        ? []
+        : [
+            'Render: 0 0',
+            'setState in render 0 0 -> 1 1',
+            'Render reducer: 0 0 -> 1 1',
+          ]),
       'Render: 1 1',
 
       // Transition
@@ -177,6 +186,127 @@ describe('ReactUpdates', () => {
       'Render: 1 11',
     ]);
     expect(container.firstChild.textContent).toBe('1 11');
+  });
+
+  it('should keep state from render during layout effect update with isomorphic transition', async () => {
+    let _setState = null;
+    let _setTransitionState = null;
+
+    function Component({prop}) {
+      const [_, startTransition] = React.useTransition();
+      const [, setLayoutState] = React.useState({});
+      const [state, setState] = React.useState({prop, count: 0});
+      _setState = setState;
+
+      Scheduler.log(`Render: ${state.prop} ${state.count}`);
+
+      if (state.prop !== prop) {
+        Scheduler.log(
+          `setState in render ${state.prop} ${state.count} -> ${prop} ${state.count + 1}`,
+        );
+        setState(currentState => {
+          Scheduler.log(
+            `Render reducer: ${currentState.prop} ${currentState.count} -> ${prop} ${currentState.count + 1}`,
+          );
+          return {
+            prop,
+            count: currentState.count + 1,
+          };
+        });
+      }
+      _setTransitionState = () => {
+        startTransition(() => {
+          setState(currentState => {
+            Scheduler.log(
+              `Transition reducer: ${currentState.prop} ${currentState.count} -> ${prop} ${currentState.count + 10}`,
+            );
+            return {
+              prop,
+              count: currentState.count + 10,
+            };
+          });
+        });
+      };
+
+      React.useLayoutEffect(() => {
+        if (prop === 1) {
+          Scheduler.log(`Layout effect setState`);
+          setLayoutState({});
+        }
+      }, [prop]);
+
+      return (
+        <div>
+          {state.prop} {state.count}
+        </div>
+      );
+    }
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => {
+      root.render(<Component prop={0} />);
+    });
+
+    assertLog(['Render: 0 0']);
+    expect(container.firstChild.textContent).toBe('0 0');
+
+    await act(() => {
+      // Schedule a transition to update the state, this means baseQueue is non-empty.
+      _setTransitionState();
+
+      // Now schedule a blocking update.
+      root.render(<Component prop={1} />);
+    });
+
+    if (gate('alwaysResetBaseQueue')) {
+      assertLog([
+        // Prop change from 0 -> 1
+        'Render: 0 0',
+        'setState in render 0 0 -> 1 1',
+        'Render reducer: 0 0 -> 1 1',
+        'Render: 1 1',
+
+        // Layout effect runs with prop 1
+        'Layout effect setState',
+        // If the base queue is reset, no extra render.
+        'Render: 1 1',
+
+        // Transition
+        // currentProp currentState -> prop currentState + 10.
+        'Transition reducer: 1 1 -> 0 11',
+        'Render: 0 11',
+        'setState in render 0 11 -> 1 12',
+        'Render reducer: 0 11 -> 1 12',
+        'Render: 1 12',
+      ]);
+
+      expect(container.firstChild.textContent).toBe('1 12');
+    } else {
+      assertLog([
+        // Prop change from 0 -> 1
+        'Render: 0 0',
+        'setState in render 0 0 -> 1 1',
+        'Render reducer: 0 0 -> 1 1',
+        'Render: 1 1',
+
+        // Layout effect runs with prop 1
+        'Layout effect setState',
+        // Extra render
+        'Render: 0 0',
+        'setState in render 0 0 -> 1 1',
+        'Render reducer: 0 0 -> 1 1',
+        'Render: 1 1',
+
+        // Transition
+        'Transition reducer: 0 0 -> 0 10',
+        'Render: 0 10',
+        'setState in render 0 10 -> 1 11',
+        'Render reducer: 0 10 -> 1 11',
+        'Render: 1 11',
+      ]);
+      expect(container.firstChild.textContent).toBe('1 11');
+    }
   });
 
   it('should batch state when updating two different states', async () => {

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -87,7 +87,7 @@ describe('ReactUpdates', () => {
     expect(container.firstChild.textContent).toBe('2');
   });
 
-  it('should keep state from render during layout effect update with useTransition', async () => {
+  it('should keep state from render during layout effect update with isomorphic transition', async () => {
     let _setTransitionState = null;
     function Component({prop}) {
       const [, setLayoutState] = React.useState({});
@@ -188,7 +188,7 @@ describe('ReactUpdates', () => {
     expect(container.firstChild.textContent).toBe('1 11');
   });
 
-  it('should keep state from render during layout effect update with isomorphic transition', async () => {
+  it('should keep state from render during layout effect update with useTransition', async () => {
     let _setTransitionState = null;
 
     function Component({prop}) {

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -87,7 +87,7 @@ describe('ReactUpdates', () => {
     expect(container.firstChild.textContent).toBe('2');
   });
 
-  it('should keep state from render during layout effect update', async () => {
+  it.only('should keep state from render during layout effect update', async () => {
     let _setState = null;
 
     function Component({prop}) {
@@ -144,7 +144,7 @@ describe('ReactUpdates', () => {
           );
           return {
             prop: currentState.prop,
-            count: currentState.count + 1,
+            count: currentState.count + 10,
           };
         });
       });
@@ -171,13 +171,12 @@ describe('ReactUpdates', () => {
       'Render: 1 1',
 
       // Transition
-      // !!! BUG?
-      'Render: 0 1',
-      'setState in render 0 1 -> 1 2',
-      'Render reducer: 0 1 -> 1 2',
-      'Render: 1 2',
+      'Render: 0 10',
+      'setState in render 0 10 -> 1 11',
+      'Render reducer: 0 10 -> 1 11',
+      'Render: 1 11',
     ]);
-    expect(container.firstChild.textContent).toBe('1 2');
+    expect(container.firstChild.textContent).toBe('1 11');
   });
 
   it('should batch state when updating two different states', async () => {

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -150,7 +150,8 @@ describe('ReactUpdates', () => {
     expect(container.firstChild.textContent).toBe('0 0');
 
     await act(() => {
-      // Schedule a transition to update the state, this means baseQueue is non-empty.
+      // Schedule a transition to update the state.
+      // This means baseQueue is non-empty.
       _setTransitionState();
 
       // Now schedule a blocking update.
@@ -159,7 +160,8 @@ describe('ReactUpdates', () => {
 
     assertLog([
       // Transition setState
-      // For isomorphic startTransition, this runs first, not during transition render.
+      // For isomorphic startTransition,
+      // This runs first, not during transition render.
       'Transition reducer: 0 0 -> 0 1',
 
       // Prop change from 0 -> 1
@@ -252,7 +254,8 @@ describe('ReactUpdates', () => {
     expect(container.firstChild.textContent).toBe('0 0');
 
     await act(() => {
-      // Schedule a transition to update the state, this means baseQueue is non-empty.
+      // Schedule a transition to update the state.
+      // This means baseQueue is non-empty.
       _setTransitionState();
 
       // Now schedule a blocking update.

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -122,7 +122,7 @@ describe('ReactUpdates', () => {
     expect(container.firstChild.textContent).toBe('0');
 
     await act(() => {
-      // Schedue a transtion to update the state, this means baseQueue is non-empty.
+      // Schedule a transition to update the state, this means baseQueue is non-empty.
       React.startTransition(() => {
         _setState(c => c + 1);
       });
@@ -141,12 +141,9 @@ describe('ReactUpdates', () => {
       'Layout effect setState',
 
       // Render layout effect update
-      // BUG!! Renders with base state 0 instead of 1
-      // 'Render: 0',
-      // 'setState in render 0 -> 1',
-
       'Render: 1',
-      // Transition completes
+
+      // Render transition completes
       'Render: 1',
     ]);
     expect(container.firstChild.textContent).toBe('1');

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -87,7 +87,7 @@ describe('ReactUpdates', () => {
     expect(container.firstChild.textContent).toBe('2');
   });
 
-  it.only('should keep state from render during layout effect update', async () => {
+  it('should keep state from render during layout effect update', async () => {
     let _setState = null;
 
     function Component({prop}) {

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -88,12 +88,10 @@ describe('ReactUpdates', () => {
   });
 
   it('should keep state from render during layout effect update with useTransition', async () => {
-    let _setState = null;
     let _setTransitionState = null;
     function Component({prop}) {
       const [, setLayoutState] = React.useState({});
       const [state, setState] = React.useState({prop, count: 0});
-      _setState = setState;
 
       Scheduler.log(`Render: ${state.prop} ${state.count}`);
 
@@ -114,7 +112,7 @@ describe('ReactUpdates', () => {
 
       _setTransitionState = () => {
         React.startTransition(() => {
-          _setState(currentState => {
+          setState(currentState => {
             Scheduler.log(
               `Transition reducer: ${currentState.count} ${currentState.prop} -> ${currentState.prop} ${currentState.count + 1}`,
             );
@@ -191,14 +189,12 @@ describe('ReactUpdates', () => {
   });
 
   it('should keep state from render during layout effect update with isomorphic transition', async () => {
-    let _setState = null;
     let _setTransitionState = null;
 
     function Component({prop}) {
-      const [_, startTransition] = React.useTransition();
+      const [, startTransition] = React.useTransition();
       const [, setLayoutState] = React.useState({});
       const [state, setState] = React.useState({prop, count: 0});
-      _setState = setState;
 
       Scheduler.log(`Render: ${state.prop} ${state.count}`);
 

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1620,7 +1620,16 @@ function rerenderReducer<S, I, A>(
     }
 
     hook.memoizedState = newState;
+    // Don't persist the state accumulated from the render phase updates to
+    // the base state unless the queue is empty.
+    // TODO: Not sure if this is the desired semantics, but it's what we
+    // do for gDSFP. I can't remember why.
+
+    // TODO: Removing this condition fixes the tests
+    // if (hook.baseQueue === null) {
     hook.baseState = newState;
+    // }
+
     queue.lastRenderedState = newState;
   }
   return [newState, dispatch];

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1620,16 +1620,7 @@ function rerenderReducer<S, I, A>(
     }
 
     hook.memoizedState = newState;
-    // Don't persist the state accumulated from the render phase updates to
-    // the base state unless the queue is empty.
-    // TODO: Not sure if this is the desired semantics, but it's what we
-    // do for gDSFP. I can't remember why.
-
-    // TODO: Removing this condition fixes the tests
-    if (hook.baseQueue === null) {
-      hook.baseState = newState;
-    }
-
+    hook.baseState = newState;
     queue.lastRenderedState = newState;
   }
   return [newState, dispatch];

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1624,6 +1624,8 @@ function rerenderReducer<S, I, A>(
     // the base state unless the queue is empty.
     // TODO: Not sure if this is the desired semantics, but it's what we
     // do for gDSFP. I can't remember why.
+
+    // TODO: Removing this condition fixes the tests
     if (hook.baseQueue === null) {
       hook.baseState = newState;
     }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1625,7 +1625,6 @@ function rerenderReducer<S, I, A>(
     // TODO: Not sure if this is the desired semantics, but it's what we
     // do for gDSFP. I can't remember why.
 
-    // TODO: Removing this condition fixes the tests
     // if (hook.baseQueue === null) {
     hook.baseState = newState;
     // }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -48,6 +48,7 @@ import {
   disableLegacyMode,
   enableNoCloningMemoCache,
   enableContextProfiling,
+  alwaysResetBaseQueue,
 } from 'shared/ReactFeatureFlags';
 import {
   REACT_CONTEXT_TYPE,
@@ -1625,9 +1626,9 @@ function rerenderReducer<S, I, A>(
     // TODO: Not sure if this is the desired semantics, but it's what we
     // do for gDSFP. I can't remember why.
 
-    // if (hook.baseQueue === null) {
-    hook.baseState = newState;
-    // }
+    if (alwaysResetBaseQueue || hook.baseQueue === null) {
+      hook.baseState = newState;
+    }
 
     queue.lastRenderedState = newState;
   }

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -300,3 +300,5 @@ export const enableGetInspectorDataForInstanceInProduction = false;
 export const consoleManagedByDevToolsDuringStrictMode = true;
 
 export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
+
+export const alwaysResetBaseQueue = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -95,6 +95,7 @@ export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;
 export const useModernStrictMode = true;
+export const alwaysResetBaseQueue = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -87,6 +87,7 @@ export const syncLaneExpirationMs = 250;
 export const transitionLaneExpirationMs = 5000;
 export const useModernStrictMode = true;
 export const enableSiblingPrerendering = false;
+export const alwaysResetBaseQueue = false;
 
 // Profiling Only
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -102,6 +102,7 @@ export const disableDefaultPropsExceptForClasses = true;
 
 export const enableObjectFiber = false;
 export const enableOwnerStacks = false;
+export const alwaysResetBaseQueue = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -83,6 +83,7 @@ export const transitionLaneExpirationMs = 5000;
 export const useModernStrictMode = true;
 export const enableFabricCompleteRootInCommitPhase = false;
 export const enableSiblingPrerendering = false;
+export const alwaysResetBaseQueue = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -97,6 +97,7 @@ export const enableObjectFiber = false;
 export const enableOwnerStacks = false;
 export const enableShallowPropDiffing = false;
 export const enableSiblingPrerendering = false;
+export const alwaysResetBaseQueue = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -43,6 +43,7 @@ export const enableSchedulingProfiler = __VARIANT__;
 
 export const enableInfiniteRenderLoopDetection = __VARIANT__;
 export const enableSiblingPrerendering = __VARIANT__;
+export const alwaysResetBaseQueue = __VARIANT__;
 
 // TODO: These flags are hard-coded to the default values used in open source.
 // Update the tests so that they pass in either mode, then set these

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -37,6 +37,7 @@ export const {
   syncLaneExpirationMs,
   transitionLaneExpirationMs,
   enableSiblingPrerendering,
+  alwaysResetBaseQueue,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.


### PR DESCRIPTION
Found a bug where if the `baseQueue` is not empty, and we do a render-phase update, we won't update the base state within the same sync render (like for a layout effect update, but probably also for passive effects for discrete events).