### PR TITLE
[lint] Add no-optional-chaining

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     'babel',
     'ft-flow',
     'jest',
+    'es',
     'no-for-of-loops',
     'no-function-declare-after-return',
     'react',
@@ -47,7 +48,7 @@ module.exports = {
     'ft-flow/no-unused-expressions': ERROR,
     // 'ft-flow/no-weak-types': WARNING,
     // 'ft-flow/require-valid-file-annotation': ERROR,
-
+    'es/no-optional-chaining': ERROR,
     'no-cond-assign': OFF,
     'no-constant-condition': OFF,
     'no-control-regex': OFF,
@@ -435,6 +436,7 @@ module.exports = {
         'packages/react-dom/src/test-utils/*.js',
       ],
       rules: {
+        'es/no-optional-chaining': OFF,
         'react-internal/no-production-logging': OFF,
         'react-internal/warning-args': OFF,
         'react-internal/safe-string-coercion': [

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-babel": "^5.3.0",
+    "eslint-plugin-es": "^4.1.0",
     "eslint-plugin-eslint-plugin": "^3.5.3",
     "eslint-plugin-ft-flow": "^2.0.3",
     "eslint-plugin-jest": "28.4.0",

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -567,8 +567,8 @@ function useMemoCache(size: number): Array<any> {
     return [];
   }
 
-  // $FlowFixMe[incompatible-use]: updateQueue is mixed
   const memoCache =
+    // $FlowFixMe[incompatible-use]: updateQueue is mixed
     fiber.updateQueue != null ? fiber.updateQueue.memoCache : null;
   if (memoCache == null) {
     return [];

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -568,7 +568,8 @@ function useMemoCache(size: number): Array<any> {
   }
 
   // $FlowFixMe[incompatible-use]: updateQueue is mixed
-  const memoCache = fiber.updateQueue?.memoCache;
+  const memoCache =
+    fiber.updateQueue != null ? fiber.updateQueue.memoCache : null;
   if (memoCache == null) {
     return [];
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7262,6 +7262,14 @@ eslint-plugin-babel@^5.3.0:
   dependencies:
     eslint-rule-composer "^0.3.0"
 
+eslint-plugin-es@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz#f0822f0c18a535a97c3e714e89f88586a7641ec9"
+  integrity sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==
+  dependencies:
+    eslint-utils "^2.0.0"
+    regexpp "^3.0.0"
+
 eslint-plugin-eslint-plugin@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-3.5.3.tgz#6cac958e944b820962a4cf9e65cc32a2e0415eaf"
@@ -13971,7 +13979,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpp@^3.1.0:
+regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==


### PR DESCRIPTION
## Overview

Adds a lint rule to prevent optional chaining to catch issues like https://github.com/facebook/react/pull/30982 until we support optional chaining without a bundle impact.