### PR TITLE
s/server action/server function

### DIFF
--- a/packages/react-client/src/ReactFlightReplyClient.js
+++ b/packages/react-client/src/ReactFlightReplyClient.js
@@ -693,7 +693,7 @@ export function processReply(
       ) {
         if (temporaryReferences === undefined) {
           throw new Error(
-            'Only plain objects, and a few built-ins, can be passed to Server Actions. ' +
+            'Only plain objects, and a few built-ins, can be passed to Server Functions. ' +
               'Classes or null prototypes are not supported.' +
               (__DEV__ ? describeObjectForErrorMessage(parent, key) : ''),
           );

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -484,7 +484,7 @@
   "496": "Only objects or functions can be passed to taintObjectReference. Try taintUniqueValue instead.",
   "497": "Only objects or functions can be passed to taintObjectReference.",
   "498": "Only plain objects, and a few built-ins, can be passed to Client Components from Server Components. Classes or null prototypes are not supported.%s",
-  "499": "Only plain objects, and a few built-ins, can be passed to Server Actions. Classes or null prototypes are not supported.%s",
+  "499": "Only plain objects, and a few built-ins, can be passed to Server Functions. Classes or null prototypes are not supported.%s",
   "500": "React expected a headers state to exist when emitEarlyPreloads was called but did not find it. This suggests emitEarlyPreloads was called more than once per request. This is a bug in React.",
   "501": "The render was aborted with postpone when the shell is incomplete. Reason: %s",
   "502": "Cannot read a Client Context from a Server Component.",


### PR DESCRIPTION
## Overview

Changes the error message to say "Server Functions" instead of "Server Actions" since this error can fire in cases like:

```
<button onClick={serverFunction} />
```

Which is calling a server function, not a server action. 