### PR TITLE
Update react-native/react-dom build directory

### DIFF
--- a/.github/workflows/runtime_commit_artifacts.yml
+++ b/.github/workflows/runtime_commit_artifacts.yml
@@ -125,7 +125,7 @@ jobs:
           mv build/react-native/shims/ $BASE_FOLDER/react-native-github/Libraries/Renderer/
           mv build/facebook-react-native/scheduler/cjs/ $BASE_FOLDER/RKJSModules/vendor/react/scheduler/
           mv build/facebook-react-native/react/cjs/ $BASE_FOLDER/RKJSModules/vendor/react/react/
-          mv build/facebook-react-native/react/dom/ $BASE_FOLDER/RKJSModules/vendor/react/react-dom/
+          mv build/facebook-react-native/react-dom/cjs $BASE_FOLDER/RKJSModules/vendor/react/react-dom/
           mv build/facebook-react-native/react-is/cjs/ $BASE_FOLDER/RKJSModules/vendor/react/react-is/
           mv build/facebook-react-native/react-test-renderer/cjs/ $BASE_FOLDER/RKJSModules/vendor/react/react-test-renderer/
 


### PR DESCRIPTION
Commit artifact actions are breaking after https://github.com/facebook/react/pull/30711

See: https://github.com/facebook/react/actions/runs/10930658977/job/30344033974

> mv: cannot stat 'build/facebook-react-native/react/dom/': No such file or directory

After build, the new artifacts are in `/react-dom/cjs`, not `/react/dom/`
```
$> yarn build
$> ls build/facebook-react-native/react/
# ... no dom
$> ls build/facebook-react-native/react-dom/cjs
```