### PR TITLE
[Fiber] Track Event Time, startTransition Time and setState Time

### DIFF
--- a/packages/react-art/src/ReactFiberConfigART.js
+++ b/packages/react-art/src/ReactFiberConfigART.js
@@ -363,6 +363,14 @@ export function resolveUpdatePriority(): EventPriority {
   return currentUpdatePriority || DefaultEventPriority;
 }
 
+export function resolveEventType(): null | string {
+  return null;
+}
+
+export function resolveEventTimeStamp(): number {
+  return -1.1;
+}
+
 export function shouldAttemptEagerTransition() {
   return false;
 }

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -606,6 +606,16 @@ export function shouldAttemptEagerTransition(): boolean {
   return false;
 }
 
+export function resolveEventType(): null | string {
+  const event = window.event;
+  return event ? event.type : null;
+}
+
+export function resolveEventTimeStamp(): number {
+  const event = window.event;
+  return event ? event.timeStamp : -1.1;
+}
+
 export const isPrimaryRenderer = true;
 export const warnsIfNotActing = true;
 // This initialization code may run even on server environments

--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -372,6 +372,14 @@ export function resolveUpdatePriority(): EventPriority {
   return DefaultEventPriority;
 }
 
+export function resolveEventType(): null | string {
+  return null;
+}
+
+export function resolveEventTimeStamp(): number {
+  return -1.1;
+}
+
 export function shouldAttemptEagerTransition(): boolean {
   return false;
 }

--- a/packages/react-native-renderer/src/ReactFiberConfigNative.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigNative.js
@@ -288,6 +288,14 @@ export function resolveUpdatePriority(): EventPriority {
   return DefaultEventPriority;
 }
 
+export function resolveEventType(): null | string {
+  return null;
+}
+
+export function resolveEventTimeStamp(): number {
+  return -1.1;
+}
+
 export function shouldAttemptEagerTransition(): boolean {
   return false;
 }

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -533,6 +533,14 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       return currentEventPriority;
     },
 
+    resolveEventType(): null | string {
+      return null;
+    },
+
+    resolveEventTimeStamp(): number {
+      return -1.1;
+    },
+
     shouldAttemptEagerTransition(): boolean {
       return false;
     },

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -72,6 +72,7 @@ import {
   markStateUpdateScheduled,
   setIsStrictModeForDevtools,
 } from './ReactFiberDevToolsHook';
+import {startUpdateTimerByLane} from './ReactProfilerTimer';
 
 const fakeInternalInstance = {};
 
@@ -194,6 +195,7 @@ const classComponentUpdater = {
 
     const root = enqueueUpdate(fiber, update, lane);
     if (root !== null) {
+      startUpdateTimerByLane(lane);
       scheduleUpdateOnFiber(root, fiber, lane);
       entangleTransitions(root, fiber, lane);
     }
@@ -228,6 +230,7 @@ const classComponentUpdater = {
 
     const root = enqueueUpdate(fiber, update, lane);
     if (root !== null) {
+      startUpdateTimerByLane(lane);
       scheduleUpdateOnFiber(root, fiber, lane);
       entangleTransitions(root, fiber, lane);
     }
@@ -262,6 +265,7 @@ const classComponentUpdater = {
 
     const root = enqueueUpdate(fiber, update, lane);
     if (root !== null) {
+      startUpdateTimerByLane(lane);
       scheduleUpdateOnFiber(root, fiber, lane);
       entangleTransitions(root, fiber, lane);
     }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -131,6 +131,7 @@ import {
   markStateUpdateScheduled,
   setIsStrictModeForDevtools,
 } from './ReactFiberDevToolsHook';
+import {startUpdateTimerByLane} from './ReactProfilerTimer';
 import {createCache} from './ReactFiberCacheComponent';
 import {
   createUpdate as createLegacyQueueUpdate,
@@ -3385,6 +3386,7 @@ function refreshCache<T>(fiber: Fiber, seedKey: ?() => T, seedValue: T): void {
         const refreshUpdate = createLegacyQueueUpdate(lane);
         const root = enqueueLegacyQueueUpdate(provider, refreshUpdate, lane);
         if (root !== null) {
+          startUpdateTimerByLane(lane);
           scheduleUpdateOnFiber(root, provider, lane);
           entangleLegacyQueueTransitions(root, provider, lane);
         }
@@ -3450,6 +3452,7 @@ function dispatchReducerAction<S, A>(
   } else {
     const root = enqueueConcurrentHookUpdate(fiber, queue, update, lane);
     if (root !== null) {
+      startUpdateTimerByLane(lane);
       scheduleUpdateOnFiber(root, fiber, lane);
       entangleTransitionUpdate(root, queue, lane);
     }
@@ -3532,6 +3535,7 @@ function dispatchSetState<S, A>(
 
     const root = enqueueConcurrentHookUpdate(fiber, queue, update, lane);
     if (root !== null) {
+      startUpdateTimerByLane(lane);
       scheduleUpdateOnFiber(root, fiber, lane);
       entangleTransitionUpdate(root, queue, lane);
     }
@@ -3619,6 +3623,7 @@ function dispatchOptimisticSetState<S, A>(
       // will never be attempted before the optimistic update. This currently
       // holds because the optimistic update is always synchronous. If we ever
       // change that, we'll need to account for this.
+      startUpdateTimerByLane(SyncLane);
       scheduleUpdateOnFiber(root, fiber, SyncLane);
       // Optimistic updates are always synchronous, so we don't need to call
       // entangleTransitionUpdate here.

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -592,6 +592,10 @@ export function includesSyncLane(lanes: Lanes): boolean {
   return (lanes & (SyncLane | SyncHydrationLane)) !== NoLanes;
 }
 
+export function isSyncLane(lanes: Lanes): boolean {
+  return (lanes & (SyncLane | SyncHydrationLane)) !== NoLanes;
+}
+
 export function includesNonIdleWork(lanes: Lanes): boolean {
   return (lanes & NonIdleLanes) !== NoLanes;
 }

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -623,6 +623,15 @@ export function includesExpiredLane(root: FiberRoot, lanes: Lanes): boolean {
   return (lanes & root.expiredLanes) !== NoLanes;
 }
 
+export function isBlockingLane(lane: Lane): boolean {
+  const SyncDefaultLanes =
+    InputContinuousHydrationLane |
+    InputContinuousLane |
+    DefaultHydrationLane |
+    DefaultLane;
+  return (lane & SyncDefaultLanes) !== NoLanes;
+}
+
 export function isTransitionLane(lane: Lane): boolean {
   return (lane & TransitionLanes) !== NoLanes;
 }

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -608,6 +608,10 @@ export function includesOnlyTransitions(lanes: Lanes): boolean {
   return (lanes & TransitionLanes) === lanes;
 }
 
+export function includesTransitionLane(lanes: Lanes): boolean {
+  return (lanes & TransitionLanes) !== NoLanes;
+}
+
 export function includesBlockingLane(lanes: Lanes): boolean {
   const SyncDefaultLanes =
     InputContinuousHydrationLane |

--- a/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
+++ b/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
@@ -99,3 +99,68 @@ export function logComponentEffect(
     performance.measure(name, reusableComponentOptions);
   }
 }
+
+export function logBlockingStart(
+  updateTime: number,
+  eventTime: number,
+  eventType: null | string,
+  renderStartTime: number,
+): void {
+  if (supportsUserTiming) {
+    reusableComponentDevToolDetails.track = 'Blocking';
+    if (eventTime > 0 && eventType !== null) {
+      // Log the time from the event timeStamp until we called setState.
+      reusableComponentDevToolDetails.color = 'secondary-dark';
+      reusableComponentOptions.start = eventTime;
+      reusableComponentOptions.end =
+        updateTime > 0 ? updateTime : renderStartTime;
+      performance.measure(eventType, reusableComponentOptions);
+    }
+    if (updateTime > 0) {
+      // Log the time from when we called setState until we started rendering.
+      reusableComponentDevToolDetails.color = 'primary-light';
+      reusableComponentOptions.start = updateTime;
+      reusableComponentOptions.end = renderStartTime;
+      performance.measure('Blocked', reusableComponentOptions);
+    }
+  }
+}
+
+export function logTransitionStart(
+  startTime: number,
+  updateTime: number,
+  eventTime: number,
+  eventType: null | string,
+  renderStartTime: number,
+): void {
+  if (supportsUserTiming) {
+    reusableComponentDevToolDetails.track = 'Transition';
+    if (eventTime > 0 && eventType !== null) {
+      // Log the time from the event timeStamp until we started a transition.
+      reusableComponentDevToolDetails.color = 'secondary-dark';
+      reusableComponentOptions.start = eventTime;
+      reusableComponentOptions.end =
+        startTime > 0
+          ? startTime
+          : updateTime > 0
+            ? updateTime
+            : renderStartTime;
+      performance.measure(eventType, reusableComponentOptions);
+    }
+    if (startTime > 0) {
+      // Log the time from when we started an async transition until we called setState or started rendering.
+      reusableComponentDevToolDetails.color = 'primary-dark';
+      reusableComponentOptions.start = startTime;
+      reusableComponentOptions.end =
+        updateTime > 0 ? updateTime : renderStartTime;
+      performance.measure('Action', reusableComponentOptions);
+    }
+    if (updateTime > 0) {
+      // Log the time from when we called setState until we started rendering.
+      reusableComponentDevToolDetails.color = 'primary-light';
+      reusableComponentOptions.start = updateTime;
+      reusableComponentOptions.end = renderStartTime;
+      performance.measure('Blocked', reusableComponentOptions);
+    }
+  }
+}

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -61,6 +61,7 @@ import {
   onScheduleRoot,
   injectProfilingHooks,
 } from './ReactFiberDevToolsHook';
+import {startUpdateTimerByLane} from './ReactProfilerTimer';
 import {
   requestUpdateLane,
   scheduleUpdateOnFiber,
@@ -433,6 +434,7 @@ function updateContainerImpl(
 
   const root = enqueueUpdate(rootFiber, update, lane);
   if (root !== null) {
+    startUpdateTimerByLane(lane);
     scheduleUpdateOnFiber(root, rootFiber, lane);
     entangleTransitions(root, rootFiber, lane);
   }

--- a/packages/react-reconciler/src/ReactFiberTransition.js
+++ b/packages/react-reconciler/src/ReactFiberTransition.js
@@ -35,6 +35,7 @@ import {
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {entangleAsyncAction} from './ReactFiberAsyncAction';
+import {startAsyncTransitionTimer} from './ReactProfilerTimer';
 
 export const NoTransition = null;
 
@@ -69,6 +70,13 @@ ReactSharedInternals.S = function onStartTransitionFinishForReconciler(
     returnValue !== null &&
     typeof returnValue.then === 'function'
   ) {
+    // If we're going to wait on some async work before scheduling an update.
+    // We mark the time so we can later log how long we were blocked on the Action.
+    // Ideally, we'd include the sync part of the action too but since that starts
+    // in isomorphic code it currently leads to tricky layering. We'd have to pass
+    // in performance.now() to this callback but we sometimes use a polyfill.
+    startAsyncTransitionTimer();
+
     // This is an async action
     const thenable: Thenable<mixed> = (returnValue: any);
     entangleAsyncAction(transition, thenable);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1718,7 +1718,7 @@ function resetWorkInProgressStack() {
 
 function finalizeRender(lanes: Lanes, finalizationTime: number): void {
   if (enableProfilerTimer && enableComponentPerformanceTrack) {
-    if (includesBlockingLane(lanes)) {
+    if (includesSyncLane(lanes) || includesBlockingLane(lanes)) {
       clampBlockingTimers(finalizationTime);
     }
     if (includesTransitionLane(lanes)) {
@@ -1737,7 +1737,7 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes): Fiber {
     // restart so we need to clamp that.
     finalizeRender(workInProgressRootRenderLanes, renderStartTime);
 
-    if (includesBlockingLane(lanes)) {
+    if (includesSyncLane(lanes) || includesBlockingLane(lanes)) {
       logBlockingStart(
         blockingUpdateTime,
         blockingEventTime,

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -12,6 +12,8 @@ import type {Fiber} from './ReactInternalTypes';
 import type {Lane} from './ReactFiberLane';
 import {isTransitionLane, isBlockingLane} from './ReactFiberLane';
 
+import {resolveEventType, resolveEventTimeStamp} from './ReactFiberConfig';
+
 import {
   enableProfilerCommitHooks,
   enableProfilerNestedUpdatePhase,
@@ -34,9 +36,13 @@ export let componentEffectStartTime: number = -1.1;
 export let componentEffectEndTime: number = -1.1;
 
 export let blockingUpdateTime: number = -1.1; // First sync setState scheduled.
+export let blockingEventTime: number = -1.1; // Event timeStamp of the first setState.
+export let blockingEventType: null | string = null; // Event type of the first setState.
 // TODO: This should really be one per Transition lane.
 export let transitionStartTime: number = -1.1; // First startTransition call before setState.
 export let transitionUpdateTime: number = -1.1; // First transition setState scheduled.
+export let transitionEventTime: number = -1.1; // Event timeStamp of the first transition.
+export let transitionEventType: null | string = null; // Event type of the first transition.
 
 export function startUpdateTimerByLane(lane: Lane): void {
   if (!enableProfilerTimer || !enableComponentPerformanceTrack) {
@@ -45,10 +51,16 @@ export function startUpdateTimerByLane(lane: Lane): void {
   if (isBlockingLane(lane)) {
     if (blockingUpdateTime < 0) {
       blockingUpdateTime = now();
+      blockingEventTime = resolveEventTimeStamp();
+      blockingEventType = resolveEventType();
     }
   } else if (isTransitionLane(lane)) {
     if (transitionUpdateTime < 0) {
       transitionUpdateTime = now();
+      if (transitionStartTime < 0) {
+        transitionEventTime = resolveEventTimeStamp();
+        transitionEventType = resolveEventType();
+      }
     }
   }
 }
@@ -63,6 +75,8 @@ export function startAsyncTransitionTimer(): void {
   }
   if (transitionStartTime < 0 && transitionUpdateTime < 0) {
     transitionStartTime = now();
+    transitionEventTime = resolveEventTimeStamp();
+    transitionEventType = resolveEventType();
   }
 }
 

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -27,6 +27,7 @@ import * as Scheduler from 'scheduler';
 
 const {unstable_now: now} = Scheduler;
 
+export let renderStartTime: number = -0;
 export let completeTime: number = -0;
 export let commitTime: number = -0;
 export let profilerStartTime: number = -1.1;
@@ -212,6 +213,13 @@ export function syncNestedUpdateFlag(): void {
     currentUpdateIsNested = nestedUpdateScheduled;
     nestedUpdateScheduled = false;
   }
+}
+
+export function recordRenderTime(): void {
+  if (!enableProfilerTimer || !enableComponentPerformanceTrack) {
+    return;
+  }
+  renderStartTime = now();
 }
 
 export function recordCompleteTime(): void {

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -108,6 +108,39 @@ export function clearTransitionTimers(): void {
   transitionUpdateTime = -1.1;
 }
 
+export function clampBlockingTimers(finalTime: number): void {
+  if (!enableProfilerTimer || !enableComponentPerformanceTrack) {
+    return;
+  }
+  // If we had new updates come in while we were still rendering or committing, we don't want
+  // those update times to create overlapping tracks in the performance timeline so we clamp
+  // them to the end of the commit phase.
+  if (blockingUpdateTime >= 0 && blockingUpdateTime < finalTime) {
+    blockingUpdateTime = finalTime;
+  }
+  if (blockingEventTime >= 0 && blockingEventTime < finalTime) {
+    blockingEventTime = finalTime;
+  }
+}
+
+export function clampTransitionTimers(finalTime: number): void {
+  if (!enableProfilerTimer || !enableComponentPerformanceTrack) {
+    return;
+  }
+  // If we had new updates come in while we were still rendering or committing, we don't want
+  // those update times to create overlapping tracks in the performance timeline so we clamp
+  // them to the end of the commit phase.
+  if (transitionStartTime >= 0 && transitionStartTime < finalTime) {
+    transitionStartTime = finalTime;
+  }
+  if (transitionUpdateTime >= 0 && transitionUpdateTime < finalTime) {
+    transitionUpdateTime = finalTime;
+  }
+  if (transitionEventTime >= 0 && transitionEventTime < finalTime) {
+    transitionEventTime = finalTime;
+  }
+}
+
 export function pushNestedEffectDurations(): number {
   if (!enableProfilerTimer || !enableProfilerCommitHooks) {
     return 0;

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -10,7 +10,7 @@
 import type {Fiber} from './ReactInternalTypes';
 
 import type {Lane} from './ReactFiberLane';
-import {isTransitionLane, isBlockingLane} from './ReactFiberLane';
+import {isTransitionLane, isBlockingLane, isSyncLane} from './ReactFiberLane';
 
 import {resolveEventType, resolveEventTimeStamp} from './ReactFiberConfig';
 
@@ -49,7 +49,7 @@ export function startUpdateTimerByLane(lane: Lane): void {
   if (!enableProfilerTimer || !enableComponentPerformanceTrack) {
     return;
   }
-  if (isBlockingLane(lane)) {
+  if (isSyncLane(lane) || isBlockingLane(lane)) {
     if (blockingUpdateTime < 0) {
       blockingUpdateTime = now();
       blockingEventTime = resolveEventTimeStamp();

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -9,6 +9,9 @@
 
 import type {Fiber} from './ReactInternalTypes';
 
+import type {Lane} from './ReactFiberLane';
+import {isTransitionLane, isBlockingLane} from './ReactFiberLane';
+
 import {
   enableProfilerCommitHooks,
   enableProfilerNestedUpdatePhase,
@@ -35,26 +38,23 @@ export let blockingUpdateTime: number = -1.1; // First sync setState scheduled.
 export let transitionStartTime: number = -1.1; // First startTransition call before setState.
 export let transitionUpdateTime: number = -1.1; // First transition setState scheduled.
 
-export function startBlockingUpdateTimer(): void {
+export function startUpdateTimerByLane(lane: Lane): void {
   if (!enableProfilerTimer || !enableComponentPerformanceTrack) {
     return;
   }
-  if (blockingUpdateTime < 0) {
-    blockingUpdateTime = now();
+  if (isBlockingLane(lane)) {
+    if (blockingUpdateTime < 0) {
+      blockingUpdateTime = now();
+    }
+  } else if (isTransitionLane(lane)) {
+    if (transitionUpdateTime < 0) {
+      transitionUpdateTime = now();
+    }
   }
 }
 
 export function clearBlockingTimers(): void {
   blockingUpdateTime = -1.1;
-}
-
-export function startTransitionUpdateTimer(): void {
-  if (!enableProfilerTimer || !enableComponentPerformanceTrack) {
-    return;
-  }
-  if (transitionUpdateTime < 0) {
-    transitionUpdateTime = now();
-  }
 }
 
 export function startAsyncTransitionTimer(): void {

--- a/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
@@ -83,6 +83,12 @@ describe('ReactFiberHostContext', () => {
         }
         return DefaultEventPriority;
       },
+      resolveEventType: function () {
+        return null;
+      },
+      resolveEventTimeStamp: function () {
+        return -1.1;
+      },
       shouldAttemptEagerTransition() {
         return false;
       },

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
@@ -73,6 +73,8 @@ export const getInstanceFromScope = $$$config.getInstanceFromScope;
 export const setCurrentUpdatePriority = $$$config.setCurrentUpdatePriority;
 export const getCurrentUpdatePriority = $$$config.getCurrentUpdatePriority;
 export const resolveUpdatePriority = $$$config.resolveUpdatePriority;
+export const resolveEventType = $$$config.resolveEventType;
+export const resolveEventTimeStamp = $$$config.resolveEventTimeStamp;
 export const shouldAttemptEagerTransition =
   $$$config.shouldAttemptEagerTransition;
 export const detachDeletedInstance = $$$config.detachDeletedInstance;

--- a/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
+++ b/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
@@ -224,6 +224,13 @@ export function resolveUpdatePriority(): EventPriority {
   }
   return DefaultEventPriority;
 }
+export function resolveEventType(): null | string {
+  return null;
+}
+
+export function resolveEventTimeStamp(): number {
+  return -1.1;
+}
 export function shouldAttemptEagerTransition(): boolean {
   return false;
 }

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -178,6 +178,9 @@ describe(`onRender`, () => {
           'read current time',
           'read current time',
           'read current time',
+          'read current time',
+          'read current time',
+          'read current time',
         ]);
       } else {
         assertLog([
@@ -197,6 +200,9 @@ describe(`onRender`, () => {
     } else {
       if (gate(flags => flags.enableComponentPerformanceTrack)) {
         assertLog([
+          'read current time',
+          'read current time',
+          'read current time',
           'read current time',
           'read current time',
           'read current time',


### PR DESCRIPTION
This tracks the current window.event.timeStamp the first time we setState or call startTransition. For either the blocking track or transition track. We can use this to show how long we were blocked by other events or overhead from when the user interacted until we got called into React.

Then we track the time we start awaiting a Promise returned from startTransition. We can use this track how long we waited on an Action to complete before setState was called.

Then finally we track when setState was called so we can track how long we were blocked by other word before we could actually start rendering. For a Transition this might be blocked by Blocking React render work.

We only log these once a subsequent render actually happened. If no render was actually scheduled, then we don't log these. E.g. if an isomorphic Action doesn't call startTransition there's no render so we don't log it.

We only log the first event/update/transition even if multiple are batched into it later. If multiple Actions are entangled they're all treated as one until an update happens. If no update happens and all entangled actions finish, we clear the transition so that the next time a new sequence starts we can log it.

We also clamp these (start the track later) if they were scheduled within a render/commit. Since we share a single track we don't want to create overlapping tracks.

The purpose of this is not to show every event/action that happens but to show a prelude to how long we were blocked before a render started. So you can follow the first event to commit.

<img width="674" alt="Screenshot 2024-09-20 at 1 59 58 AM" src="https://github.com/user-attachments/assets/151ba9e8-6b3c-4fa1-9f8d-e3602745eeb7">

I still need to add the rendering/suspended phases to the timeline which why this screenshot has a gap.

<img width="993" alt="Screenshot 2024-09-20 at 12 50 27 AM" src="https://github.com/user-attachments/assets/155b6675-b78a-4a22-a32b-212c15051074">

In this case it's a Form Action which started a render into the form which then suspended on the action. The action then caused a refresh, which interrupts with its own update that's blocked before rendering. Suspended roots like this is interesting because we could in theory start working on a different root in the meantime which makes this timeline less linear.