### PR TITLE
fix: consider alternate as a key for componentLogsEntry when inspecting raw fiber instance

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -1029,6 +1029,10 @@ export function attach(
       if (devtoolsInstance.kind === FIBER_INSTANCE) {
         const fiber = devtoolsInstance.data;
         componentLogsEntry = fiberToComponentLogsMap.get(fiber);
+
+        if (componentLogsEntry === undefined && fiber.alternate !== null) {
+          componentLogsEntry = fiberToComponentLogsMap.get(fiber.alternate);
+        }
       } else {
         const componentInfo = devtoolsInstance.data;
         componentLogsEntry = componentInfoToComponentLogsMap.get(componentInfo);
@@ -4248,7 +4252,10 @@ export function attach(
       source = getSourceForFiberInstance(fiberInstance);
     }
 
-    const componentLogsEntry = fiberToComponentLogsMap.get(fiber);
+    let componentLogsEntry = fiberToComponentLogsMap.get(fiber);
+    if (componentLogsEntry === undefined && fiber.alternate !== null) {
+      componentLogsEntry = fiberToComponentLogsMap.get(fiber.alternate);
+    }
 
     return {
       id: fiberInstance.id,


### PR DESCRIPTION
Related - https://github.com/facebook/react/pull/30899.

Looks like this was missed. We actually do this when we record errors and warnings before sending them via Bridge:
https://github.com/facebook/react/blob/e4953922a99b5477c3bcf98cdaa2b13ac0a81f0d/packages/react-devtools-shared/src/backend/fiber/renderer.js#L2169-L2173

So, what is happening in the end, errors or warnings are displayed in the Tree, but when user clicks on the component, nothing is shown, because `fiberToComponentLogsMap` has only `alternate` as a key. 