### PR TITLE
[test] transition updates starve retry lanes

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -4209,11 +4209,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
   // @gate enableLegacyCache
   it('recurring updates in siblings should not block expensive content in suspense boundary from committing', async () => {
-    const {useState} = React;
-
     let setText;
     function UpdatingText() {
-      const [text, _setText] = useState('1');
+      const [text, _setText] = React.useState('1');
       setText = _setText;
       return <Text text={text} />;
     }
@@ -4314,11 +4312,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
   // @gate enableLegacyCache
   it('recurring transition updates in siblings should not block expensive content in suspense boundary from committing', async () => {
-    const {useState, startTransition} = React;
-
     let setText;
     function UpdatingText() {
-      const [text, _setText] = useState('1');
+      const [text, _setText] = React.useState('1');
       setText = _setText;
       return <Text text={text} />;
     }

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -4395,10 +4395,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       );
     } else {
       // Since there's an interruption, the expired content is pushed out.
-      assertLog([
-        'Async',
-        ...(gate('enableRetryLaneExpiration') ? ['A', 'B', 'C'] : []),
-      ]);
+      assertLog(['Async', 'A', 'B', 'C']);
 
       expect(root).toMatchRenderedOutput(
         <>

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -4208,7 +4208,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   );
 
   // @gate enableLegacyCache
-  it.only('recurring updates in siblings should not block expensive content in suspense boundary from committing', async () => {
+  it('recurring updates in siblings should not block expensive content in suspense boundary from committing', async () => {
     const {useState} = React;
 
     let setText;
@@ -4313,7 +4313,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   });
 
   // @gate enableLegacyCache
-  it.only('recurring transition updates in siblings should not block expensive content in suspense boundary from committing', async () => {
+  it('recurring transition updates in siblings should not block expensive content in suspense boundary from committing', async () => {
     const {useState, startTransition} = React;
 
     let setText;


### PR DESCRIPTION
This will fail, but pass if we gate by `enableRetryLaneExpiration`