### PR TITLE
[Fiber] Log the Render/Commit phases and the gaps in between

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitEffects.js
@@ -899,7 +899,7 @@ function safelyCallDestroy(
 function commitProfiler(
   finishedWork: Fiber,
   current: Fiber | null,
-  commitTime: number,
+  commitStartTime: number,
   effectDuration: number,
 ) {
   const {id, onCommit, onRender} = finishedWork.memoizedProps;
@@ -918,7 +918,7 @@ function commitProfiler(
       finishedWork.actualDuration,
       finishedWork.treeBaseDuration,
       finishedWork.actualStartTime,
-      commitTime,
+      commitStartTime,
     );
   }
 
@@ -928,7 +928,7 @@ function commitProfiler(
         finishedWork.memoizedProps.id,
         phase,
         effectDuration,
-        commitTime,
+        commitStartTime,
       );
     }
   }
@@ -937,7 +937,7 @@ function commitProfiler(
 export function commitProfilerUpdate(
   finishedWork: Fiber,
   current: Fiber | null,
-  commitTime: number,
+  commitStartTime: number,
   effectDuration: number,
 ) {
   if (enableProfilerTimer) {
@@ -948,11 +948,11 @@ export function commitProfilerUpdate(
           commitProfiler,
           finishedWork,
           current,
-          commitTime,
+          commitStartTime,
           effectDuration,
         );
       } else {
-        commitProfiler(finishedWork, current, commitTime, effectDuration);
+        commitProfiler(finishedWork, current, commitStartTime, effectDuration);
       }
     } catch (error) {
       captureCommitPhaseError(finishedWork, finishedWork.return, error);
@@ -963,7 +963,7 @@ export function commitProfilerUpdate(
 function commitProfilerPostCommitImpl(
   finishedWork: Fiber,
   current: Fiber | null,
-  commitTime: number,
+  commitStartTime: number,
   passiveEffectDuration: number,
 ): void {
   const {id, onPostCommit} = finishedWork.memoizedProps;
@@ -976,14 +976,14 @@ function commitProfilerPostCommitImpl(
   }
 
   if (typeof onPostCommit === 'function') {
-    onPostCommit(id, phase, passiveEffectDuration, commitTime);
+    onPostCommit(id, phase, passiveEffectDuration, commitStartTime);
   }
 }
 
 export function commitProfilerPostCommit(
   finishedWork: Fiber,
   current: Fiber | null,
-  commitTime: number,
+  commitStartTime: number,
   passiveEffectDuration: number,
 ) {
   try {
@@ -993,14 +993,14 @@ export function commitProfilerPostCommit(
         commitProfilerPostCommitImpl,
         finishedWork,
         current,
-        commitTime,
+        commitStartTime,
         passiveEffectDuration,
       );
     } else {
       commitProfilerPostCommitImpl(
         finishedWork,
         current,
-        commitTime,
+        commitStartTime,
         passiveEffectDuration,
       );
     }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -99,8 +99,8 @@ import {
   Cloned,
 } from './ReactFiberFlags';
 import {
-  commitTime,
-  completeTime,
+  commitStartTime,
+  renderEndTime,
   pushNestedEffectDurations,
   popNestedEffectDurations,
   bubbleNestedEffectDurations,
@@ -505,7 +505,7 @@ function commitLayoutEffectOnFiber(
         commitProfilerUpdate(
           finishedWork,
           current,
-          commitTime,
+          commitStartTime,
           profilerInstance.effectDuration,
         );
       } else {
@@ -2345,7 +2345,7 @@ export function reappearLayoutEffects(
         commitProfilerUpdate(
           finishedWork,
           current,
-          commitTime,
+          commitStartTime,
           profilerInstance.effectDuration,
         );
       } else {
@@ -2576,7 +2576,7 @@ export function commitPassiveMountEffects(
     finishedWork,
     committedLanes,
     committedTransitions,
-    enableProfilerTimer && enableComponentPerformanceTrack ? completeTime : 0,
+    enableProfilerTimer && enableComponentPerformanceTrack ? renderEndTime : 0,
   );
 }
 
@@ -2763,7 +2763,7 @@ function commitPassiveMountOnFiber(
           finishedWork.alternate,
           // This value will still reflect the previous commit phase.
           // It does not get reset until the start of the next commit phase.
-          commitTime,
+          commitStartTime,
           profilerInstance.passiveEffectDuration,
         );
       } else {

--- a/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
+++ b/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
@@ -164,3 +164,12 @@ export function logTransitionStart(
     }
   }
 }
+
+export function logRenderPhase(startTime: number, endTime: number): void {
+  if (supportsUserTiming) {
+    reusableComponentDevToolDetails.color = 'primary-light';
+    reusableComponentOptions.start = startTime;
+    reusableComponentOptions.end = endTime;
+    performance.measure('Render', reusableComponentOptions);
+  }
+}

--- a/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
+++ b/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
@@ -167,9 +167,65 @@ export function logTransitionStart(
 
 export function logRenderPhase(startTime: number, endTime: number): void {
   if (supportsUserTiming) {
-    reusableComponentDevToolDetails.color = 'primary-light';
+    reusableComponentDevToolDetails.color = 'primary-dark';
     reusableComponentOptions.start = startTime;
     reusableComponentOptions.end = endTime;
     performance.measure('Render', reusableComponentOptions);
+  }
+}
+
+export function logSuspenseThrottlePhase(
+  startTime: number,
+  endTime: number,
+): void {
+  // This was inside a throttled Suspense boundary commit.
+  if (supportsUserTiming) {
+    reusableComponentDevToolDetails.color = 'secondary-light';
+    reusableComponentOptions.start = startTime;
+    reusableComponentOptions.end = endTime;
+    performance.measure('Throttled', reusableComponentOptions);
+  }
+}
+
+export function logSuspendedCommitPhase(
+  startTime: number,
+  endTime: number,
+): void {
+  // This means the commit was suspended on CSS or images.
+  if (supportsUserTiming) {
+    reusableComponentDevToolDetails.color = 'secondary-light';
+    reusableComponentOptions.start = startTime;
+    reusableComponentOptions.end = endTime;
+    performance.measure('Suspended', reusableComponentOptions);
+  }
+}
+
+export function logCommitPhase(startTime: number, endTime: number): void {
+  if (supportsUserTiming) {
+    reusableComponentDevToolDetails.color = 'secondary-dark';
+    reusableComponentOptions.start = startTime;
+    reusableComponentOptions.end = endTime;
+    performance.measure('Commit', reusableComponentOptions);
+  }
+}
+
+export function logPaintYieldPhase(startTime: number, endTime: number): void {
+  if (supportsUserTiming) {
+    reusableComponentDevToolDetails.color = 'secondary-light';
+    reusableComponentOptions.start = startTime;
+    reusableComponentOptions.end = endTime;
+    performance.measure('Waiting for Paint', reusableComponentOptions);
+  }
+}
+
+export function logPassiveCommitPhase(
+  startTime: number,
+  endTime: number,
+): void {
+  if (supportsUserTiming) {
+    reusableComponentDevToolDetails.color = 'secondary-dark';
+    reusableComponentOptions.start = startTime;
+    reusableComponentOptions.end = endTime;
+    performance.measure('Remaining Effects', reusableComponentOptions);
   }
 }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -242,6 +242,7 @@ import {
   recordRenderTime,
   recordCompleteTime,
   recordCommitTime,
+  recordCommitEndTime,
   resetNestedUpdateFlag,
   startProfilerTimer,
   stopProfilerTimerIfRunningAndRecordDuration,
@@ -3270,6 +3271,10 @@ function commitRootImpl(
       markLayoutEffectsStopped();
     }
 
+    if (enableProfilerTimer && enableComponentPerformanceTrack) {
+      recordCommitEndTime();
+    }
+
     // Tell Scheduler to yield at the end of the frame, so the browser has an
     // opportunity to paint.
     requestPaint();
@@ -3287,6 +3292,9 @@ function commitRootImpl(
     // TODO: Maybe there's a better way to report this.
     if (enableProfilerTimer) {
       recordCommitTime();
+      if (enableComponentPerformanceTrack) {
+        recordCommitEndTime();
+      }
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -3218,6 +3218,12 @@ function commitRootImpl(
     // of the effect list for each phase: all mutation effects come before all
     // layout effects, and so on.
 
+    if (enableProfilerTimer) {
+      // Mark the current commit time to be shared by all Profilers in this
+      // batch. This enables them to be grouped later.
+      recordCommitTime();
+    }
+
     // The first phase a "before mutation" phase. We use this phase to read the
     // state of the host tree right before we mutate it. This is where
     // getSnapshotBeforeUpdate is called.
@@ -3225,12 +3231,6 @@ function commitRootImpl(
       root,
       finishedWork,
     );
-
-    if (enableProfilerTimer) {
-      // Mark the current commit time to be shared by all Profilers in this
-      // batch. This enables them to be grouped later.
-      recordCommitTime();
-    }
 
     // The next phase is the mutation phase, where we mutate the host tree.
     commitMutationEffects(root, finishedWork, lanes);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -71,6 +71,7 @@ import {
 import {
   logBlockingStart,
   logTransitionStart,
+  logRenderPhase,
 } from './ReactFiberPerformanceTrack';
 
 import {
@@ -239,6 +240,7 @@ import {
   clampTransitionTimers,
   markNestedUpdateScheduled,
   renderStartTime,
+  renderEndTime,
   recordRenderTime,
   recordCompleteTime,
   recordCommitTime,
@@ -1124,6 +1126,8 @@ function finishConcurrentRender(
     // Track when we finished the last unit of work, before we actually commit it.
     // The commit can be suspended/blocked until we commit it.
     recordCompleteTime();
+    setCurrentTrackFromLanes(lanes);
+    logRenderPhase(renderStartTime, renderEndTime);
   }
 
   // TODO: The fact that most of these branches are identical suggests that some
@@ -1509,6 +1513,8 @@ export function performSyncWorkOnRoot(root: FiberRoot, lanes: Lanes): null {
 
   if (enableProfilerTimer && enableComponentPerformanceTrack) {
     recordCompleteTime();
+    setCurrentTrackFromLanes(lanes);
+    logRenderPhase(renderStartTime, renderEndTime);
   }
 
   // We now have a consistent tree. Because this is a sync render, we

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -30,6 +30,7 @@ const {unstable_now: now} = Scheduler;
 export let renderStartTime: number = -0;
 export let renderEndTime: number = -0;
 export let commitStartTime: number = -0;
+export let commitEndTime: number = -0;
 export let profilerStartTime: number = -1.1;
 export let profilerEffectDuration: number = -0;
 export let componentEffectDuration: number = -0;
@@ -267,6 +268,13 @@ export function recordCommitTime(): void {
     return;
   }
   commitStartTime = now();
+}
+
+export function recordCommitEndTime(): void {
+  if (!enableProfilerTimer) {
+    return;
+  }
+  commitEndTime = now();
 }
 
 export function startProfilerTimer(fiber: Fiber): void {

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -28,8 +28,8 @@ import * as Scheduler from 'scheduler';
 const {unstable_now: now} = Scheduler;
 
 export let renderStartTime: number = -0;
-export let completeTime: number = -0;
-export let commitTime: number = -0;
+export let renderEndTime: number = -0;
+export let commitStartTime: number = -0;
 export let profilerStartTime: number = -1.1;
 export let profilerEffectDuration: number = -0;
 export let componentEffectDuration: number = -0;
@@ -259,14 +259,14 @@ export function recordCompleteTime(): void {
   if (!enableProfilerTimer) {
     return;
   }
-  completeTime = now();
+  renderEndTime = now();
 }
 
 export function recordCommitTime(): void {
   if (!enableProfilerTimer) {
     return;
   }
-  commitTime = now();
+  commitStartTime = now();
 }
 
 export function startProfilerTimer(fiber: Fiber): void {


### PR DESCRIPTION
A slight behavior change here too is that I now mark the start of the commit phase before the BeforeMutationEffect phase. This affects `<Profiler>` too.

The named sequences are as follows:

Render -> Suspended or Throttled -> Commit -> Waiting for Paint -> Remaining Effects

The Suspended phase is only logged if we delay the Commit due to CSS / images.

The Throttled phase is only logged if we delay the commit due to the Suspense throttling timer.

<img width="1246" alt="Screenshot 2024-09-20 at 9 14 23 PM" src="https://github.com/user-attachments/assets/8d01f444-bb85-472b-9b42-6157d92c81b4">

I don't yet log render phases that don't complete. I think I also need to special case renders that or don't commit after being suspended.