### PR TITLE
fix: spread props property without constructor

### DIFF
--- a/packages/shared/CheckStringCoercion.js
+++ b/packages/shared/CheckStringCoercion.js
@@ -24,7 +24,7 @@ function typeName(value: mixed): string {
     const hasToStringTag = typeof Symbol === 'function' && Symbol.toStringTag;
     const type =
       (hasToStringTag && (value: any)[Symbol.toStringTag]) ||
-      (value: any).constructor.name ||
+      (value: any).constructor?.name ||
       'Object';
     // $FlowFixMe[incompatible-return]
     return type;


### PR DESCRIPTION
[codesanbox](https://codesandbox.io/p/devbox/764ykq)

snippet
```tsx
const foo = Object.create(null);
foo.age = 18;

const Foo = (props: any) => {
  return <div {...props}>test</div>;
};

function App() {
  return <Foo name1="name1" name2="name2" name3={foo}></Foo>;
}

export default App;
```

![image](https://github.com/user-attachments/assets/64a701f0-7032-48e3-9e15-f0848ada0674)
