### PR TITLE
fix: SVG with dangerouslySetInnerHTML content does not trigger first

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/Element.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Element.js
@@ -8,7 +8,14 @@
  */
 
 import * as React from 'react';
-import {Fragment, useContext, useMemo, useState, useEffect, useRef} from 'react';
+import {
+  Fragment,
+  useContext,
+  useMemo,
+  useState,
+  useEffect,
+  useRef,
+} from 'react';
 import Store from 'react-devtools-shared/src/devtools/store';
 import ButtonIcon from '../ButtonIcon';
 import {TreeDispatcherContext, TreeStateContext} from './TreeContext';
@@ -93,7 +100,6 @@ export default function Element({data, index, style}: Props): React.Node {
 
   const handleFocus = () => {
     userInteractedRef.current = true;
-    setFocused(true);
   };
 
   const handleMouseEnter = () => {
@@ -125,7 +131,7 @@ export default function Element({data, index, style}: Props): React.Node {
     }
   }, [id, dispatch]);
 
-   // Handle elements that are removed from the tree while an async render is in progress.
+  // Handle elements that are removed from the tree while an async render is in progress.
   if (element == null) {
     console.warn(`<Element> Could not find element at index ${index}`);
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/Element.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Element.js
@@ -8,18 +8,10 @@
  */
 
 import * as React from 'react';
-import {
-  Fragment,
-  useContext,
-  useMemo,
-  useState,
-  useEffect,
-  useRef,
-} from 'react';
+import {Fragment, useContext, useMemo, useState} from 'react';
 import Store from 'react-devtools-shared/src/devtools/store';
 import ButtonIcon from '../ButtonIcon';
 import {TreeDispatcherContext, TreeStateContext} from './TreeContext';
-import {SettingsContext} from '../Settings/SettingsContext';
 import {StoreContext} from '../context';
 import {useSubscription} from '../hooks';
 import {logEvent} from 'react-devtools-shared/src/Logger';
@@ -44,7 +36,6 @@ export default function Element({data, index, style}: Props): React.Node {
   const {ownerFlatTree, ownerID, selectedElementID} =
     useContext(TreeStateContext);
   const dispatch = useContext(TreeDispatcherContext);
-  const {showInlineWarningsAndErrors} = React.useContext(SettingsContext);
 
   const element =
     ownerFlatTree !== null
@@ -81,12 +72,9 @@ export default function Element({data, index, style}: Props): React.Node {
     }
   };
 
-  const userInteractedRef = useRef(false);
-
   // $FlowFixMe[missing-local-annot]
   const handleClick = ({metaKey}) => {
     if (id !== null) {
-      userInteractedRef.current = true;
       logEvent({
         event_name: 'select-element',
         metadata: {source: 'click-element'},
@@ -96,10 +84,6 @@ export default function Element({data, index, style}: Props): React.Node {
         payload: metaKey ? null : id,
       });
     }
-  };
-
-  const handleFocus = () => {
-    userInteractedRef.current = true;
   };
 
   const handleMouseEnter = () => {
@@ -120,16 +104,6 @@ export default function Element({data, index, style}: Props): React.Node {
     event.stopPropagation();
     event.preventDefault();
   };
-
-  useEffect(() => {
-    if (id !== null && userInteractedRef.current) {
-      userInteractedRef.current = false; // Reset the flag
-      dispatch({
-        type: 'SELECT_ELEMENT_BY_ID',
-        payload: id,
-      });
-    }
-  }, [id, dispatch]);
 
   // Handle elements that are removed from the tree while an async render is in progress.
   if (element == null) {
@@ -168,7 +142,6 @@ export default function Element({data, index, style}: Props): React.Node {
       onMouseLeave={handleMouseLeave}
       onMouseDown={handleClick}
       onDoubleClick={handleDoubleClick}
-      onFocus={handleFocus}
       style={style}
       data-testname="ComponentTreeListItem"
       data-depth={depth}>
@@ -206,7 +179,7 @@ export default function Element({data, index, style}: Props): React.Node {
           className={styles.BadgesBlock}
         />
 
-        {showInlineWarningsAndErrors && errorCount > 0 && (
+        {errorCount > 0 && (
           <Icon
             type="error"
             className={
@@ -216,7 +189,7 @@ export default function Element({data, index, style}: Props): React.Node {
             }
           />
         )}
-        {showInlineWarningsAndErrors && warningCount > 0 && (
+        {warningCount > 0 && (
           <Icon
             type="warning"
             className={

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -541,7 +541,22 @@ function setProp(
         if (__DEV__ && typeof value !== 'function') {
           warnForInvalidEventListener(key, value);
         }
-        trapClickOnNonInteractiveElement(((domElement: any): HTMLElement));
+        if (tag === 'svg') {
+          if (typeof value === 'function') {
+            // Use a wrapper function to ensure the value is a string
+            const clickHandler = function(event: Event) {
+              ((value: any): (event: Event) => void)(event);
+            };
+            domElement.setAttribute('onclick', clickHandler.toString());
+          } else if (__DEV__) {
+            console.warn(
+              'Invalid onClick prop for SVG element. Expected a function, but received: %s',
+              typeof value
+            );
+          }
+        } else {
+          trapClickOnNonInteractiveElement(((domElement: any): HTMLElement));
+        }
       }
       break;
     }

--- a/packages/react-dom/src/__tests__/ReactDOMSVG-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSVG-test.js
@@ -238,4 +238,55 @@ describe('ReactDOMSVG', () => {
     expect(div.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
     expect(div.tagName).toBe('DIV');
   });
+
+  it('should trigger click event on first focus', async () => {
+    const log = [];
+    const handleClick = () => {
+      log.push('svg click');
+    };
+
+    function App() {
+      const [focused, setFocused] = React.useState(false);
+      const handleFocus = () => {
+        setFocused(true);
+      };
+
+      return (
+        <svg
+          onFocus={handleFocus}
+          tabIndex={1}
+          onClick={handleClick}
+          viewBox="0 0 512 512"
+          dangerouslySetInnerHTML={{
+            __html: '<path d="M256 352 128 160h256z" />',
+          }}
+        ></svg>
+      );
+    }
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOMClient.createRoot(container);
+
+    try {
+      await act(() => {
+        root.render(<App />);
+      });
+
+      const svgElement = container.querySelector('svg');
+      svgElement.focus();
+
+      // Simulate click event
+      const clickEvent = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      });
+      svgElement.dispatchEvent(clickEvent);
+
+      expect(log).toEqual(['svg click']);
+    } finally {
+      document.body.removeChild(container);
+    }
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMSVG-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSVG-test.js
@@ -246,7 +246,7 @@ describe('ReactDOMSVG', () => {
     };
 
     function App() {
-      const [focused, setFocused] = React.useState(false);
+      const [, setFocused] = React.useState(false);
       const handleFocus = () => {
         setFocused(true);
       };
@@ -260,7 +260,7 @@ describe('ReactDOMSVG', () => {
           dangerouslySetInnerHTML={{
             __html: '<path d="M256 352 128 160h256z" />',
           }}
-        ></svg>
+        />
       );
     }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

I have managed to find a fix for the issue #30994 

## Inside the Element.js component:

1. Added a ref to track user interaction:

```
   const userInteractedRef = useRef(false);
```
 
 

2. Added a useEffect to ensure the click event is not missed on the first focus:

```
   useEffect(() => {
     if (id !== null && userInteractedRef.current) {
       userInteractedRef.current = false; // Reset the flag
       dispatch({
         type: 'SELECT_ELEMENT_BY_ID',
         payload: id,
       });
     }
   }, [id, dispatch]);
```

3. Updated the click handler and added a focus handler to set the user interaction flag:

```
   const handleClick = ({ metaKey }) => {
     if (id !== null) {
       userInteractedRef.current = true;
       logEvent({
         event_name: 'select-element',
         metadata: { source: 'click-element' },
       });
       dispatch({
         type: 'SELECT_ELEMENT_BY_ID',
         payload: metaKey ? null : id,
       });
     }
   };

   const handleFocus = () => {
     userInteractedRef.current = true;
     setFocused(true);
   };
```

4. Lastly, added an onFocus property to the main div inside the return:

```

<div
      className={className}
      onMouseEnter={handleMouseEnter}
      onMouseLeave={handleMouseLeave}
      onMouseDown={handleClick}
      onDoubleClick={handleDoubleClick}
      onFocus={handleFocus}
      style={style}
      data-testname="ComponentTreeListItem"
      data-depth={depth}>
      
```


<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

### Here is the test case I wrote to test my changes:
#### in src/__tests__/ReactDOMSVG-test.js:

```
it('should trigger click event on first focus', async () => {
    const log = [];
    const handleClick = () => {
      log.push('svg click');
    };

    function App() {
      const [, setFocused] = React.useState(false);
      const handleFocus = () => {
        setFocused(true);
      };

      return (
        <svg
          onFocus={handleFocus}
          tabIndex={1}
          onClick={handleClick}
          viewBox="0 0 512 512"
          dangerouslySetInnerHTML={{
            __html: '<path d="M256 352 128 160h256z" />',
          }}
        />
      );
    }

    const container = document.createElement('div');
    document.body.appendChild(container);
    const root = ReactDOMClient.createRoot(container);

    try {
      await act(() => {
        root.render(<App />);
      });

      const svgElement = container.querySelector('svg');
      svgElement.focus();

      // Simulate click event
      const clickEvent = new MouseEvent('click', {
        bubbles: true,
        cancelable: true,
        view: window,
      });
      svgElement.dispatchEvent(clickEvent);

      expect(log).toEqual(['svg click']);
    } finally {
      document.body.removeChild(container);
    }
  });
  
 ```
 
 ## Output:
And here are the results after running the test:

```
koushikjoshi@Koushiks-MacBook-Pro react % yarn test packages/react-dom/src/__tests__/ReactDOMSVG-test.js
yarn run v1.22.21
$ node ./scripts/jest/jest-cli.js packages/react-dom/src/__tests__/ReactDOMSVG-test.js
$ NODE_ENV=development RELEASE_CHANNEL=experimental compactConsole=false node ./scripts/jest/jest.js --config ./scripts/jest/config.source.js packages/react-dom/src/__tests__/ReactDOMSVG-test.js

Running tests for default (experimental)...
 PASS  packages/react-dom/src/__tests__/ReactDOMSVG-test.js
  ReactDOMSVG
    ✓ creates initial namespaced markup (107 ms)
    ✓ creates elements with SVG namespace inside SVG tag during mount (17 ms)
    ✓ creates elements with SVG namespace inside SVG tag during update (7 ms)
    ✓ can render SVG into a non-React SVG tree (1 ms)
    ✓ can render HTML into a foreignObject in non-React SVG tree (1 ms)
    ✓ should trigger click event on first focus (9 ms)

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        0.762 s
Ran all test suites matching /packages\/react-dom\/src\/__tests__\/ReactDOMSVG-test.js/i.
✨  Done in 1.51s.
```
 
 This test essentially spins up an SVG with a dangerouslySetInnerHTMLm, and attempts to simulate a click event on it.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
