### PR TITLE
fix: Null check added when resolving event's priority

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMUpdatePriority.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMUpdatePriority.js
@@ -38,7 +38,7 @@ export function resolveUpdatePriority(): EventPriority {
     return updatePriority;
   }
   const currentEvent = window.event;
-  if (currentEvent === undefined) {
+  if (currentEvent === undefined || currentEvent === null) {
     return DefaultEventPriority;
   }
   return getEventPriority(currentEvent.type);

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -431,4 +431,14 @@ describe('ReactDOMRoot', () => {
       {withoutStack: true},
     );
   });
+
+  it("should not throw an error when window.event is null", () => {
+    expect(() =>    {
+      window.event = null
+      const root = ReactDOMClient.createRoot(container);
+      root.render(<div></div>)
+    }).not.toThrow(
+        "Cannot read properties of null (reading 'type')",
+      )
+    })
 });


### PR DESCRIPTION
## Summary

I wanted to migrate from React 17 to React 18 and experienced issues with rendering when using new root API.

When `window.event` is `null`, ` Uncaught TypeError: Cannot read properties of null (reading 'type')`error can be thrown when calling render function.

✅  Example with React 17 where nothing breaks and component is rendered correctly:
https://jsfiddle.net/9zg3t4mc/1/

❌ Example with React 18 where error is thrown and component is not rendered:
https://jsfiddle.net/92wtjb0g/

## How did you test this change?

I run `yarn build` and then use `React-prod.js` inside fiddle that is throwing an error and with this change render is working now.
![image](https://github.com/user-attachments/assets/ed273cbf-e0cc-4ee2-abc1-359ff508fbb9)


