### PR TITLE
chore[react-devtools]: add legacy mode error message to the ignore list for tests

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -150,7 +150,10 @@ function patchConsoleForTestingBeforeHookInstallation() {
         firstArg.startsWith(
           'The current testing environment is not configured to support act',
         ) ||
-        firstArg.startsWith('You seem to have overlapping act() calls'))
+        firstArg.startsWith('You seem to have overlapping act() calls') ||
+        firstArg.startsWith(
+          'ReactDOM.render is no longer supported in React 18.',
+        ))
     ) {
       // DevTools intentionally wraps updates with acts from both DOM and test-renderer,
       // since test updates are expected to impact both renderers.


### PR DESCRIPTION
Without this, the console gets spammy whenever we run React DevTools tests against React 18.x, where this deprecation message was added.