### PR TITLE
Increase nested update limit to 100

### DIFF
--- a/packages/react-dom/src/__tests__/ReactLegacyUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyUpdates-test.js
@@ -1427,7 +1427,7 @@ describe('ReactLegacyUpdates', () => {
       }
     }
 
-    let limit = 55;
+    let limit = 105;
     await expect(async () => {
       await act(() => {
         ReactDOM.render(<EventuallyTerminating ref={ref} />, container);

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1542,7 +1542,7 @@ describe('ReactUpdates', () => {
       }
     }
 
-    let limit = 55;
+    let limit = 105;
     const root = ReactDOMClient.createRoot(container);
     await expect(async () => {
       await act(() => {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -613,7 +613,7 @@ let pendingPassiveEffectsRenderEndTime: number = -0; // Profiling-only
 let pendingPassiveTransitions: Array<Transition> | null = null;
 
 // Use these to prevent an infinite loop of nested updates
-const NESTED_UPDATE_LIMIT = 50;
+const NESTED_UPDATE_LIMIT = 100;
 let nestedUpdateCount: number = 0;
 let rootWithNestedUpdates: FiberRoot | null = null;
 let isFlushingPassiveEffects = false;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -619,7 +619,7 @@ let rootWithNestedUpdates: FiberRoot | null = null;
 let isFlushingPassiveEffects = false;
 let didScheduleUpdateDuringPassiveEffects = false;
 
-const NESTED_PASSIVE_UPDATE_LIMIT = 50;
+const NESTED_PASSIVE_UPDATE_LIMIT = 100;
 let nestedPassiveUpdateCount: number = 0;
 let rootWithPassiveNestedUpdates: FiberRoot | null = null;
 


### PR DESCRIPTION
We're seeing the limit hit in some tests after enabling sibling prerendering. Let's bump the limit so we can run more tests and gather more signal on the changes. When we understand the scope of the problem we can determine whether we need to change how the updates are counted in prerenders and/or fix specific areas of product code.
