### PR TITLE
[Fiber] Fix missing render times when we cancel a pending commit

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3401,7 +3401,7 @@ export function suspendResource(
   }
 }
 
-export function waitForCommitToBeReady(): null | (Function => Function) {
+export function waitForCommitToBeReady(): null | ((() => any) => Function) {
   if (suspendedState === null) {
     throw new Error(
       'Internal React Error: suspendedState null when it was expected to exists. Please report this as a React bug.',

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3401,7 +3401,7 @@ export function suspendResource(
   }
 }
 
-export function waitForCommitToBeReady(): null | ((() => any) => Function) {
+export function waitForCommitToBeReady(): null | ((() => void) => () => void) {
   if (suspendedState === null) {
     throw new Error(
       'Internal React Error: suspendedState null when it was expected to exists. Please report this as a React bug.',

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -3089,8 +3089,6 @@ function commitRoot(
     ReactSharedInternals.T = prevTransition;
     setCurrentUpdatePriority(previousUpdateLanePriority);
   }
-
-  return null;
 }
 
 function commitRootImpl(

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1322,6 +1322,8 @@ function commitRootWhenReady(
           updatedLanes,
           suspendedRetryLanes,
           SUSPENDED_COMMIT,
+          completedRenderStartTime,
+          completedRenderEndTime,
         ),
       );
       markRootSuspended(root, lanes, spawnedLane, didSkipSuspendedSiblings);


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/facebook/react/pull/31016

Fixes `Failed to execute 'measure' on 'Performance': If a non-empty PerformanceMeasureOptions object was passed, at least one of its 'start' or 'end' properties must be present.`

Not clear why we didn't catch this in our test suite. Probably because the `performance` polyfill does not throw if `start` and `end` are undefined when a non-empty PerformanceMeasureOptions is passed to `performance.measure`?

## How did you test this change?

- Discovered when syncing latest React (https://github.com/vercel/next.js/pull/70407) where we encountered above bug. Patching the file locally made the test pass: [vercel/next.js@`744c429` (#70407)](https://github.com/vercel/next.js/pull/70407/commits/744c429cdbea5a982cdeb8167f49e1d0b4722475)
- Also enhanced type to make it clear that you `fn` in `waitForCommitToBeReady()(fn)` does not receive any further arguments. With that change, the bug would've not get passed Flow. The error message isn't as clear as possible but it gives at least a hint that arguments are missing:
    ```bash
    $ yarn flow dom-node
    yarn run v1.22.22
    $ node ./scripts/tasks/flow.js dom-node
    Running Flow on the dom-node renderer...
    Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ packages/react-reconciler/src/ReactFiberWorkLoop.js:1315:9

    Cannot call schedulePendingCommit with commitRoot.bind(...) bound to the first
    parameter because function [1] requires another argument from function type [2].
    [incompatible-call]

        packages/react-reconciler/src/ReactFiberWorkLoop.js
        1312│       // us that it's ready. This will be canceled if we start work on the
        1313│       // root again.
        1314│       root.cancelPendingCommit = schedulePendingCommit(
        1315│         commitRoot.bind(
        1316│           null,
        1317│           root,
        1318│           recoverableErrors,
            :
    [1] 3054│ function commitRoot(
        3055│   root: FiberRoot,
        3056│   recoverableErrors: null | Array<CapturedValue<mixed>>,
        3057│   transitions: Array<Transition> | null,
        3058│   didIncludeRenderPhaseUpdate: boolean,
        3059│   spawnedLane: Lane,
        3060│   updatedLanes: Lanes,
        3061│   suspendedRetryLanes: Lanes,
        3062│   suspendedCommitReason: SuspendedCommitReason, // Profiling-only
        3063│   completedRenderStartTime: number, // Profiling-only
        3064│   completedRenderEndTime: number, // Profiling-only
        3065│ ) {

        packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
    [2] 3404│ export function waitForCommitToBeReady(): null | ((() => any) => Function) {
    ```