### PR TITLE
fix: update release scripts for react devtools

### DIFF
--- a/scripts/devtools/publish-release.js
+++ b/scripts/devtools/publish-release.js
@@ -29,16 +29,16 @@ async function main() {
     console.log(chalk.bold.green('  ' + pathToPrint));
   });
 
-  const {archivePath, buildID} = readSavedBuildMetadata();
+  const {archivePath, currentCommitHash} = readSavedBuildMetadata();
 
   await checkNPMPermissions();
 
   await publishToNPM();
 
-  await printFinalInstructions(buildID, archivePath);
+  await printFinalInstructions(currentCommitHash, archivePath);
 }
 
-async function printFinalInstructions(buildID, archivePath) {
+async function printFinalInstructions(currentCommitHash, archivePath) {
   console.log('');
   console.log(
     'You are now ready to publish the extension to Chrome, Edge, and Firefox:'
@@ -50,7 +50,7 @@ async function printFinalInstructions(buildID, archivePath) {
   );
   console.log('');
   console.log('When publishing to Firefox, remember the following:');
-  console.log(`  Build id: ${chalk.bold(buildID)}`);
+  console.log(`  Commit Hash: ${chalk.bold(currentCommitHash)}`);
   console.log(`  Git archive: ${chalk.bold(archivePath)}`);
   console.log('');
   console.log('Also consider syncing this release to Facebook:');

--- a/scripts/devtools/utils.js
+++ b/scripts/devtools/utils.js
@@ -101,19 +101,19 @@ function readSavedBuildMetadata() {
     process.exit(1);
   }
 
-  const {archivePath, buildID} = readJsonSync(path);
+  const {archivePath, currentCommitHash} = readJsonSync(path);
 
-  return {archivePath, buildID};
+  return {archivePath, currentCommitHash};
 }
 
-function saveBuildMetadata({archivePath, buildID}) {
+function saveBuildMetadata({archivePath, currentCommitHash}) {
   const path = join(BUILD_METADATA_TEMP_DIRECTORY, 'metadata');
 
   if (!existsSync(BUILD_METADATA_TEMP_DIRECTORY)) {
     mkdirSync(BUILD_METADATA_TEMP_DIRECTORY);
   }
 
-  writeJsonSync(path, {archivePath, buildID}, {spaces: 2});
+  writeJsonSync(path, {archivePath, currentCommitHash}, {spaces: 2});
 }
 
 module.exports = {


### PR DESCRIPTION
This has been broken since the migration to GitHub actions.

Previously, we've been using `buildId` as an identifier from CircleCI. I've decided to use a commit hash as an identifier, because I don't know if there is a better option, and `scripts/release/download_build_artifacts.js` allows us to download them for a specific commit.