### PR TITLE
[compiler] Repro for useMemo with no deps not validating

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bug-manual-memo-no-deps.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bug-manual-memo-no-deps.expect.md
@@ -1,0 +1,30 @@
+
+## Input
+
+```javascript
+// @validatePreserveExistingMemoizationGuarantees
+function Wat() {
+  const numbers = useMemo(() => getNumbers(), []);
+  return numbers.map(num => <div key={num} />);
+}
+
+function getNumbers() {
+  return [1, 2, 3];
+}
+
+```
+
+
+## Error
+
+```
+  1 | // @validatePreserveExistingMemoizationGuarantees
+  2 | function Wat() {
+> 3 |   const numbers = useMemo(() => getNumbers(), []);
+    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ CannotPreserveMemoization: React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. This value was memoized in source but not in compilation output. (3:3)
+  4 |   return numbers.map(num => <div key={num} />);
+  5 | }
+  6 |
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bug-manual-memo-no-deps.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bug-manual-memo-no-deps.js
@@ -1,0 +1,9 @@
+// @validatePreserveExistingMemoizationGuarantees
+function Wat() {
+  const numbers = useMemo(() => getNumbers(), []);
+  return numbers.map(num => <div key={num} />);
+}
+
+function getNumbers() {
+  return [1, 2, 3];
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #31075

@mariusschulz found this issue where validatePreservedManualMemoization
would incorrectly bail on manual memoization with (correctly) no deps.