### PR TITLE
[playground] Only deploy changes to compiler directory

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,3 @@
+# Ignore everything (folders and files) on root only
+/*
+!compiler


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #31084

Following this guide:
https://vercel.com/docs/deployments/vercel-ignore#allowlist, allowlist
only the compiler directory for deployments of the playground.