### PR TITLE
fix[scripts/devtools/publish-release]: parse version list instead of handling 404

### DIFF
--- a/scripts/devtools/publish-release.js
+++ b/scripts/devtools/publish-release.js
@@ -82,18 +82,13 @@ async function publishToNPM() {
     // If so we might be resuming from a previous run.
     // We could infer this by comparing the build-info.json,
     // But for now the easiest way is just to ask if this is expected.
-    const info = await execRead(`npm view ${npmPackage}@${version}`)
-      // Early versions of npm view gives empty response, but newer versions give 404 error.
-      // Catch the error to keep it consistent.
-      .catch(childProcessError => {
-        if (childProcessError.stderr.startsWith('npm ERR! code E404')) {
-          return null;
-        }
+    const versionListJSON = await execRead(
+      `npm view ${npmPackage} versions --json`
+    );
+    const versionList = JSON.parse(versionListJSON);
+    const versionIsAlreadyPublished = versionList.includes(version);
 
-        throw childProcessError;
-      });
-
-    if (info) {
+    if (versionIsAlreadyPublished) {
       console.log('');
       console.log(
         `${npmPackage} version ${chalk.bold(


### PR DESCRIPTION
Discovered yesterday while was publishing a new release.

NPM `10.x.x` changed the text for 404 errors, so this check was failing. Instead of handling 404 as a signal, I think its better to just parse the whole list of versions and check if the new one is already there.