### PR TITLE
Consider Text node in the root hydration

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -1047,7 +1047,10 @@ export function canHydrateInstance(
   props: Props,
   inRootOrSingleton: boolean,
 ): null | Instance {
-  while (instance.nodeType === ELEMENT_NODE) {
+  while (
+    instance.nodeType === ELEMENT_NODE ||
+    (inRootOrSingleton && instance.nodeType === TEXT_NODE)
+  ) {
     const element: Element = (instance: any);
     const anyProps = (props: any);
     if (element.nodeName.toLowerCase() !== type.toLowerCase()) {
@@ -1177,11 +1180,9 @@ export function canHydrateInstance(
     }
     instance = nextInstance;
   }
-  // This is a suspense boundary or Text node or we got the end.
+  // This is a suspense boundary or we got the end.
   // Suspense Boundaries are never expected to be injected by 3rd parties. If we see one it should be matched
   // and this is a hydration error.
-  // Text Nodes are also not expected to be injected by 3rd parties. This is less of a guarantee for <body>
-  // but it seems reasonable and conservative to reject this as a hydration error as well
   return null;
 }
 

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -788,4 +788,20 @@ describe('ReactDOMServerHydration', () => {
 
     expect(ref.current).toBe(button);
   });
+
+  it('ignores text nodes on root when hydrating', async () => {
+    const root = document.createElement('div');
+
+    root.innerHTML = '<button>Click</button>';
+    const button = root.firstChild;
+
+    const emptyText = document.createTextNode('');
+    root.insertBefore(emptyText, button);
+
+    const ref = React.createRef();
+    await act(() => {
+      ReactDOMClient.hydrateRoot(root, <button ref={ref}>Click</button>);
+    });
+    expect(ref.current).toBe(button);
+  });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
When a 3rd party script adds a text node in the `body`, the hydration fails instead of trying to get the next sibling to compare. With this PR the `canHydrateInstance()` keeps looking for the nextSibling  considering also text nodes.

The issue can be viewed in this [repo](https://github.com/HenriqueLimas/react-hydrate-text-issue).

It is related to the current opening issue regarding hydration issues #24430

Frameworks usually uses text nodes as a fragment since [DocumentFragment loses](https://github.com/whatwg/dom/issues/736) the reference of their children as they are appended to the DOM.

## How did you test this change?

- Added a test case with issue
- Changed with the same code implemented locally in the browser to fix the issue as shown bellow

https://github.com/user-attachments/assets/fda7c7d6-acc4-4078-b19d-1728c30f55c0

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
