### PR TITLE
fix[react-devtools]: request hook initialization inside http server response

### DIFF
--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -17,7 +17,6 @@ import {registerDevToolsEventLogger} from 'react-devtools-shared/src/registerDev
 import {Server} from 'ws';
 import {join} from 'path';
 import {readFileSync} from 'fs';
-import {installHook} from 'react-devtools-shared/src/hook';
 import DevTools from 'react-devtools-shared/src/devtools/views/DevTools';
 import {doesFilePathExist, launchEditor} from './editor';
 import {
@@ -28,8 +27,6 @@ import {localStorageSetItem} from 'react-devtools-shared/src/storage';
 
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
 import type {Source} from 'react-devtools-shared/src/shared/types';
-
-installHook(window);
 
 export type StatusTypes = 'server-connected' | 'devtools-connected' | 'error';
 export type StatusListener = (message: string, status: StatusTypes) => void;
@@ -371,9 +368,12 @@ function startServer(
         '\n;' +
         backendFile.toString() +
         '\n;' +
+        'ReactDevToolsBackend.initialize();' +
+        '\n' +
         `ReactDevToolsBackend.connectToDevTools({port: ${port}, host: '${host}', useHttps: ${
           useHttps ? 'true' : 'false'
-        }});`,
+        }});
+        `,
     );
   });
 


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/31100.

There are 2 things:
1. In https://github.com/facebook/react/pull/30987, we've introduced a breaking change: importing `react-devtools-core` is no longer enough for installing React DevTools global Hook. You need to call `initialize`, in which you may provide initial settings. I am not adding settings here, because it is not implemented, and there are no plans for supporting this.
2. Calling `installHook` is not necessary inside `standalone.js`, because this script is running inside Electron wrapper (which is just a UI, not the app that we are debugging). We will loose the ability to use React DevTools on this React application, but I guess thats fine.