### PR TITLE
[compiler] Allow known React modules to be extended

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -517,6 +517,12 @@ const EnvironmentConfigSchema = z.object({
    * ```
    */
   lowerContextAccess: ExternalFunctionSchema.nullish(),
+
+  /*
+   * Allows additional modules to be considered as known ones.
+   * Useful for packages that are wrappers around the default ones.
+   */
+  knownReactModules: z.array().nullable().default( [ 'react', 'react-dom' ] ),
 });
 
 export type EnvironmentConfig = z.infer<typeof EnvironmentConfigSchema>;
@@ -889,10 +895,7 @@ export class Environment {
   }
 
   #isKnownReactModule(moduleName: string): boolean {
-    return (
-      moduleName.toLowerCase() === 'react' ||
-      moduleName.toLowerCase() === 'react-dom'
-    );
+    return this.config.knownReactModules.includes(moduleName.toLowerCase());
   }
 
   getPropertyType(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

This PR suggests allowing the known React modules list to be extended.

Currently, in [Gutenberg](https://github.com/WordPress/gutenberg) (The Block Editor project for WordPress) we expose (through re-exporting) React and React DOM APIs through the [`@wordpress/element` package](https://github.com/WordPress/gutenberg/tree/trunk/packages/element). In order for the React Compiler to treat the imports correctly, we need to be able to add `@wordpress/element` to the list of known packages.

The purpose is to expose this through a `knownReactModules` environment config property. 

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

I would still like to add some tests to verify this works as expected.