### PR TITLE
[snap] Add react-compiler-runtime as a dependency

### DIFF
--- a/compiler/package.json
+++ b/compiler/package.json
@@ -19,7 +19,6 @@
     "test": "yarn workspaces run test",
     "snap": "yarn workspace babel-plugin-react-compiler run snap",
     "snap:build": "yarn workspace snap run build",
-    "postinstall": "perl -p -i -e 's/react\\.element/react.transitional.element/' node_modules/fbt/lib/FbtReactUtil.js && perl -p -i -e 's/didWarnAboutUsingAct = false;/didWarnAboutUsingAct = true;/' node_modules/react-dom/cjs/react-dom-test-utils.development.js",
     "npm:publish": "node scripts/release/publish"
   },
   "dependencies": {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/infer-component-props-non-null.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/infer-component-props-non-null.expect.md
@@ -12,7 +12,7 @@ function Foo(props) {
    * as it is arg[0] of a component function
    */
   const arr = [];
-  if (cond) {
+  if (props.cond) {
     arr.push(identity(props.value));
   }
   return <Stringify arr={arr} />;
@@ -20,7 +20,7 @@ function Foo(props) {
 
 export const FIXTURE_ENTRYPOINT = {
   fn: Foo,
-  params: [{value: 2}],
+  params: [{value: 2, cond: true}],
 };
 
 ```
@@ -32,29 +32,38 @@ import { c as _c } from "react/compiler-runtime"; // @enablePropagateDepsInHIR
 import { identity, Stringify } from "shared-runtime";
 
 function Foo(props) {
-  const $ = _c(2);
+  const $ = _c(5);
   let t0;
-  if ($[0] !== props.value) {
+  if ($[0] !== props.cond || $[1] !== props.value) {
     const arr = [];
-    if (cond) {
-      arr.push(identity(props.value));
+    if (props.cond) {
+      let t1;
+      if ($[3] !== props.value) {
+        t1 = identity(props.value);
+        $[3] = props.value;
+        $[4] = t1;
+      } else {
+        t1 = $[4];
+      }
+      arr.push(t1);
     }
 
     t0 = <Stringify arr={arr} />;
-    $[0] = props.value;
-    $[1] = t0;
+    $[0] = props.cond;
+    $[1] = props.value;
+    $[2] = t0;
   } else {
-    t0 = $[1];
+    t0 = $[2];
   }
   return t0;
 }
 
 export const FIXTURE_ENTRYPOINT = {
   fn: Foo,
-  params: [{ value: 2 }],
+  params: [{ value: 2, cond: true }],
 };
 
 ```
       
 ### Eval output
-(kind: exception) cond is not defined
+(kind: ok) <div>{"arr":[2]}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/infer-component-props-non-null.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/infer-component-props-non-null.tsx
@@ -8,7 +8,7 @@ function Foo(props) {
    * as it is arg[0] of a component function
    */
   const arr = [];
-  if (cond) {
+  if (props.cond) {
     arr.push(identity(props.value));
   }
   return <Stringify arr={arr} />;
@@ -16,5 +16,5 @@ function Foo(props) {
 
 export const FIXTURE_ENTRYPOINT = {
   fn: Foo,
-  params: [{value: 2}],
+  params: [{value: 2, cond: true}],
 };

--- a/compiler/packages/snap/package.json
+++ b/compiler/packages/snap/package.json
@@ -9,7 +9,8 @@
     "src"
   ],
   "scripts": {
-    "build": "rimraf dist && tsc --build",
+    "postinstall": "./scripts/link-react-compiler-runtime.sh && perl -p -i -e 's/react\\.element/react.transitional.element/' ../../node_modules/fbt/lib/FbtReactUtil.js && perl -p -i -e 's/didWarnAboutUsingAct = false;/didWarnAboutUsingAct = true;/' ../../node_modules/react-dom/cjs/react-dom-test-utils.development.js",
+    "build": "rimraf dist && concurrently -n snap,runtime \"tsc --build\" \"yarn --silent workspace react-compiler-runtime build --silent\"",
     "test": "echo 'no tests'",
     "prettier": "prettier --write 'src/**/*.ts'"
   },

--- a/compiler/packages/snap/scripts/link-react-compiler-runtime.sh
+++ b/compiler/packages/snap/scripts/link-react-compiler-runtime.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eo pipefail
+
+yarn --silent workspace react-compiler-runtime link
+yarn --silent workspace snap link react-compiler-runtime

--- a/compiler/packages/snap/src/sprout/evaluator.ts
+++ b/compiler/packages/snap/src/sprout/evaluator.ts
@@ -282,7 +282,7 @@ export function doEval(source: string): EvaluatorResult {
         } else {
           return {
             kind: "exception",
-            value: e.message,
+            value: e.stack,
           };
         }
       }

--- a/compiler/packages/snap/src/sprout/evaluator.ts
+++ b/compiler/packages/snap/src/sprout/evaluator.ts
@@ -282,7 +282,7 @@ export function doEval(source: string): EvaluatorResult {
         } else {
           return {
             kind: "exception",
-            value: e.stack,
+            value: e.message,
           };
         }
       }


### PR DESCRIPTION
We need `react-compiler-runtime` to use the same version of React as
snap