### PR TITLE
[rcr] Publish react-compiler-runtime to npm

### DIFF
--- a/compiler/packages/react-compiler-runtime/README.md
+++ b/compiler/packages/react-compiler-runtime/README.md
@@ -1,0 +1,5 @@
+# react-compiler-runtime
+
+Backwards compatible shim for runtime APIs used by React Compiler. Primarily meant for React versions prior to 19, but it will also work on > 19.
+
+See also https://github.com/reactwg/react-compiler/discussions/6.

--- a/compiler/scripts/release/shared/packages.js
+++ b/compiler/scripts/release/shared/packages.js
@@ -2,6 +2,7 @@ const PUBLISHABLE_PACKAGES = [
   'babel-plugin-react-compiler',
   'eslint-plugin-react-compiler',
   'react-compiler-healthcheck',
+  'react-compiler-runtime',
 ];
 
 module.exports = {


### PR DESCRIPTION

Updates our publishing scripts to also publish react-compiler-runtime.
