### PR TITLE
fix[react-devtools]: wrap key string in preformatted text html element

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/Element.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Element.js
@@ -166,7 +166,7 @@ export default function Element({data, index, style}: Props): React.Node {
               className={styles.KeyValue}
               title={key}
               onDoubleClick={handleKeyDoubleClick}>
-              {key}
+              <pre>{key}</pre>
             </span>
             "
           </Fragment>


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/28984.