### PR TITLE
Fix prepare-prerelease script

### DIFF
--- a/scripts/release/prepare-release-from-npm-commands/confirm-stable-version-numbers.js
+++ b/scripts/release/prepare-release-from-npm-commands/confirm-stable-version-numbers.js
@@ -30,9 +30,7 @@ const run = async ({skipPackages}, versionsMap) => {
 
     let version = bestGuessVersion;
     if (
-      skipPackages.some(skipPackageName =>
-        packageNames.includes(skipPackageName)
-      )
+      skipPackages.some(skipPackageName => packages.includes(skipPackageName))
     ) {
       await confirm(
         theme`{spinnerSuccess ✓} Version for ${packageNames} will remain {version ${bestGuessVersion}}`

--- a/scripts/release/prepare-release-from-npm.js
+++ b/scripts/release/prepare-release-from-npm.js
@@ -27,6 +27,9 @@ const run = async () => {
     }
 
     params.packages = await getPublicPackages(isExperimental);
+    params.packages = params.packages.filter(packageName => {
+      return !params.skipPackages.includes(packageName);
+    });
 
     // Map of package name to upcoming stable version.
     // This Map is initially populated with guesses based on local versions.


### PR DESCRIPTION
## Summary

Batch of fixes to allow publishing `eslint-plugin-react-hooks`. Each commit fixes a different bug. 

## How did you test this change?

```bash
$ scripts/release/prepare-release-from-npm.js --version=5.1.0-rc-ed966dac-20241007 --skipTests --skipPackages react react-dom react-server-dom-webpack react-server-dom-turbopack react-is react-reconciler react-refresh react-test-renderer use-subscription use-sync-external-store scheduler jest-react react-art

✓ Checking out "next" from NPM 5.1.0-rc-ed966dac-20241007 582 ms
✓ Guessing stable version numbers 381 ms
✓ Version for eslint-plugin-react-hooks (default 4.6.3): 5.0.0

A stable release candidate has been prepared!

You can review the contents of this release in build/node_modules/

Before publishing, consider testing this release locally with create-react-app!

You can publish this release by running:
  scripts/release/publish.js
```