### PR TITLE
[compiler][ez] Include phi identifier in AssertValidMutableRanges

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/AssertValidMutableRanges.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/AssertValidMutableRanges.ts
@@ -20,6 +20,7 @@ import {
 export function assertValidMutableRanges(fn: HIRFunction): void {
   for (const [, block] of fn.body.blocks) {
     for (const phi of block.phis) {
+      visitIdentifier(phi.id);
       for (const [, operand] of phi.operands) {
         visitIdentifier(operand);
       }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #31170

Summary:
Looks like we accidentally skipped validating this identifier.