### PR TITLE
Schedule prerender after something suspends (#30800)

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
@@ -744,7 +744,7 @@ describe('ReactDOMFiberAsync', () => {
       // Because it suspended, it remains on the current path
       expect(div.textContent).toBe('/path/a');
     });
-    assertLog([]);
+    assertLog(gate('enableSiblingPrerendering') ? ['Suspend! [/path/b]'] : []);
 
     await act(async () => {
       resolvePromise();

--- a/packages/react-dom/src/__tests__/ReactDOMForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMForm-test.js
@@ -699,7 +699,15 @@ describe('ReactDOMForm', () => {
     // This should suspend because form actions are implicitly wrapped
     // in startTransition.
     await submit(formRef.current);
-    assertLog(['Pending...', 'Suspend! [Updated]', 'Loading...']);
+    assertLog([
+      'Pending...',
+      'Suspend! [Updated]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [Updated]', 'Loading...']
+        : []),
+    ]);
     expect(container.textContent).toBe('Pending...Initial');
 
     await act(() => resolveText('Updated'));
@@ -736,7 +744,15 @@ describe('ReactDOMForm', () => {
 
     // Update
     await submit(formRef.current);
-    assertLog(['Pending...', 'Suspend! [Count: 1]', 'Loading...']);
+    assertLog([
+      'Pending...',
+      'Suspend! [Count: 1]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [Count: 1]', 'Loading...']
+        : []),
+    ]);
     expect(container.textContent).toBe('Pending...Count: 0');
 
     await act(() => resolveText('Count: 1'));
@@ -745,7 +761,15 @@ describe('ReactDOMForm', () => {
 
     // Update again
     await submit(formRef.current);
-    assertLog(['Pending...', 'Suspend! [Count: 2]', 'Loading...']);
+    assertLog([
+      'Pending...',
+      'Suspend! [Count: 2]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [Count: 2]', 'Loading...']
+        : []),
+    ]);
     expect(container.textContent).toBe('Pending...Count: 1');
 
     await act(() => resolveText('Count: 2'));
@@ -789,7 +813,14 @@ describe('ReactDOMForm', () => {
     assertLog(['Async action started', 'Pending...']);
 
     await act(() => resolveText('Wait'));
-    assertLog(['Suspend! [Updated]', 'Loading...']);
+    assertLog([
+      'Suspend! [Updated]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [Updated]', 'Loading...']
+        : []),
+    ]);
     expect(container.textContent).toBe('Pending...Initial');
 
     await act(() => resolveText('Updated'));
@@ -1475,7 +1506,15 @@ describe('ReactDOMForm', () => {
     // Now dispatch inside of a transition. This one does not trigger a
     // loading state.
     await act(() => startTransition(() => dispatch()));
-    assertLog(['Count: 1', 'Suspend! [Count: 2]', 'Loading...']);
+    assertLog([
+      'Count: 1',
+      'Suspend! [Count: 2]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [Count: 2]', 'Loading...']
+        : []),
+    ]);
     expect(container.textContent).toBe('Count: 1');
 
     await act(() => resolveText('Count: 2'));
@@ -1495,7 +1534,11 @@ describe('ReactDOMForm', () => {
 
     const root = ReactDOMClient.createRoot(container);
     await act(() => root.render(<App />));
-    assertLog(['Suspend! [Count: 0]']);
+    assertLog([
+      'Suspend! [Count: 0]',
+
+      ...(gate('enableSiblingPrerendering') ? ['Suspend! [Count: 0]'] : []),
+    ]);
     await act(() => resolveText('Count: 0'));
     assertLog(['Count: 0']);
 
@@ -1508,7 +1551,11 @@ describe('ReactDOMForm', () => {
         {withoutStack: true},
       ],
     ]);
-    assertLog(['Suspend! [Count: 1]']);
+    assertLog([
+      'Suspend! [Count: 1]',
+
+      ...(gate('enableSiblingPrerendering') ? ['Suspend! [Count: 1]'] : []),
+    ]);
     expect(container.textContent).toBe('Count: 0');
   });
 

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -75,6 +75,7 @@ function FiberRootNode(
   this.pendingLanes = NoLanes;
   this.suspendedLanes = NoLanes;
   this.pingedLanes = NoLanes;
+  this.warmLanes = NoLanes;
   this.expiredLanes = NoLanes;
   this.finishedLanes = NoLanes;
   this.errorRecoveryDisabledLanes = NoLanes;

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -256,6 +256,7 @@ type BaseFiberRootProperties = {
   pendingLanes: Lanes,
   suspendedLanes: Lanes,
   pingedLanes: Lanes,
+  warmLanes: Lanes,
   expiredLanes: Lanes,
   errorRecoveryDisabledLanes: Lanes,
   shellSuspendCounter: number,

--- a/packages/react-reconciler/src/__tests__/ActivitySuspense-test.js
+++ b/packages/react-reconciler/src/__tests__/ActivitySuspense-test.js
@@ -215,7 +215,15 @@ describe('Activity Suspense', () => {
         );
       });
     });
-    assertLog(['Open', 'Suspend! [Async]', 'Loading...']);
+    assertLog([
+      'Open',
+      'Suspend! [Async]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Open', 'Suspend! [Async]', 'Loading...']
+        : []),
+    ]);
     // It should suspend with delay to prevent the already-visible Suspense
     // boundary from switching to a fallback
     expect(root).toMatchRenderedOutput(<span>Closed</span>);
@@ -276,7 +284,15 @@ describe('Activity Suspense', () => {
         );
       });
     });
-    assertLog(['Open', 'Suspend! [Async]', 'Loading...']);
+    assertLog([
+      'Open',
+      'Suspend! [Async]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Open', 'Suspend! [Async]', 'Loading...']
+        : []),
+    ]);
     // It should suspend with delay to prevent the already-visible Suspense
     // boundary from switching to a fallback
     expect(root).toMatchRenderedOutput(

--- a/packages/react-reconciler/src/__tests__/ReactActWarnings-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactActWarnings-test.js
@@ -349,7 +349,14 @@ describe('act warnings', () => {
           root.render(<App showMore={true} />);
         });
       });
-      assertLog(['Suspend! [Async]', 'Loading...']);
+      assertLog([
+        'Suspend! [Async]',
+        'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [Async]', 'Loading...']
+          : []),
+      ]);
       expect(root).toMatchRenderedOutput('(empty)');
 
       // This is a ping, not a retry, because no fallback is showing.

--- a/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
@@ -297,7 +297,15 @@ describe('ReactAsyncActions', () => {
     // This will schedule an update on C, and also the async action scope
     // will end. This will allow React to attempt to render the updates.
     await act(() => resolveText('Wait before updating C'));
-    assertLog(['Async action ended', 'Pending: false', 'Suspend! [A1]']);
+    assertLog([
+      'Async action ended',
+      'Pending: false',
+      'Suspend! [A1]',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Pending: false', 'Suspend! [A1]', 'Suspend! [B1]', 'Suspend! [C1]']
+        : []),
+    ]);
     expect(root).toMatchRenderedOutput(
       <>
         <span>Pending: true</span>
@@ -309,7 +317,15 @@ describe('ReactAsyncActions', () => {
     // together, only when the all of A, B, and C updates are unblocked is the
     // render allowed to proceed.
     await act(() => resolveText('A1'));
-    assertLog(['Pending: false', 'A1', 'Suspend! [B1]']);
+    assertLog([
+      'Pending: false',
+      'A1',
+      'Suspend! [B1]',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Pending: false', 'A1', 'Suspend! [B1]', 'Suspend! [C1]']
+        : []),
+    ]);
     expect(root).toMatchRenderedOutput(
       <>
         <span>Pending: true</span>
@@ -317,7 +333,16 @@ describe('ReactAsyncActions', () => {
       </>,
     );
     await act(() => resolveText('B1'));
-    assertLog(['Pending: false', 'A1', 'B1', 'Suspend! [C1]']);
+    assertLog([
+      'Pending: false',
+      'A1',
+      'B1',
+      'Suspend! [C1]',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Pending: false', 'A1', 'B1', 'Suspend! [C1]']
+        : []),
+    ]);
     expect(root).toMatchRenderedOutput(
       <>
         <span>Pending: true</span>
@@ -690,6 +715,10 @@ describe('ReactAsyncActions', () => {
       // automatically reverted.
       'Pending: false',
       'Suspend! [B]',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Pending: false', 'Suspend! [B]']
+        : []),
     ]);
 
     // Resolve the transition

--- a/packages/react-reconciler/src/__tests__/ReactCPUSuspense-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactCPUSuspense-test.js
@@ -231,7 +231,11 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       );
     });
     // Inner contents suspended, so we continue showing a fallback.
-    assertLog(['Suspend! [Inner]']);
+    assertLog([
+      'Suspend! [Inner]',
+
+      ...(gate('enableSiblingPrerendering') ? ['Suspend! [Inner]'] : []),
+    ]);
     expect(root).toMatchRenderedOutput(
       <>
         Outer

--- a/packages/react-reconciler/src/__tests__/ReactConcurrentErrorRecovery-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactConcurrentErrorRecovery-test.js
@@ -209,7 +209,16 @@ describe('ReactConcurrentErrorRecovery', () => {
         root.render(<App step={2} />);
       });
     });
-    assertLog(['Suspend! [A2]', 'Loading...', 'Suspend! [B2]', 'Loading...']);
+    assertLog([
+      'Suspend! [A2]',
+      'Loading...',
+      'Suspend! [B2]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [A2]', 'Loading...', 'Suspend! [B2]', 'Loading...']
+        : []),
+    ]);
     // Because this is a refresh, we don't switch to a fallback
     expect(root).toMatchRenderedOutput('A1B1');
 
@@ -220,7 +229,16 @@ describe('ReactConcurrentErrorRecovery', () => {
 
     // Because we're still suspended on A, we can't show an error boundary. We
     // should wait for A to resolve.
-    assertLog(['Suspend! [A2]', 'Loading...', 'Error! [B2]', 'Oops!']);
+    assertLog([
+      'Suspend! [A2]',
+      'Loading...',
+      'Error! [B2]',
+      'Oops!',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [A2]', 'Loading...', 'Error! [B2]', 'Oops!']
+        : []),
+    ]);
     // Remain on previous screen.
     expect(root).toMatchRenderedOutput('A1B1');
 
@@ -281,7 +299,16 @@ describe('ReactConcurrentErrorRecovery', () => {
         root.render(<App step={2} />);
       });
     });
-    assertLog(['Suspend! [A2]', 'Loading...', 'Suspend! [B2]', 'Loading...']);
+    assertLog([
+      'Suspend! [A2]',
+      'Loading...',
+      'Suspend! [B2]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [A2]', 'Loading...', 'Suspend! [B2]', 'Loading...']
+        : []),
+    ]);
     // Because this is a refresh, we don't switch to a fallback
     expect(root).toMatchRenderedOutput('A1B1');
 
@@ -292,7 +319,16 @@ describe('ReactConcurrentErrorRecovery', () => {
 
     // Because we're still suspended on B, we can't show an error boundary. We
     // should wait for B to resolve.
-    assertLog(['Error! [A2]', 'Oops!', 'Suspend! [B2]', 'Loading...']);
+    assertLog([
+      'Error! [A2]',
+      'Oops!',
+      'Suspend! [B2]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Error! [A2]', 'Oops!', 'Suspend! [B2]', 'Loading...']
+        : []),
+    ]);
     // Remain on previous screen.
     expect(root).toMatchRenderedOutput('A1B1');
 
@@ -328,7 +364,11 @@ describe('ReactConcurrentErrorRecovery', () => {
         root.render(<AsyncText text="Async" />);
       });
     });
-    assertLog(['Suspend! [Async]']);
+    assertLog([
+      'Suspend! [Async]',
+
+      ...(gate('enableSiblingPrerendering') ? ['Suspend! [Async]'] : []),
+    ]);
     expect(root).toMatchRenderedOutput(null);
 
     // This also works if the suspended component is wrapped with an error
@@ -344,7 +384,11 @@ describe('ReactConcurrentErrorRecovery', () => {
         );
       });
     });
-    assertLog(['Suspend! [Async]']);
+    assertLog([
+      'Suspend! [Async]',
+
+      ...(gate('enableSiblingPrerendering') ? ['Suspend! [Async]'] : []),
+    ]);
     expect(root).toMatchRenderedOutput(null);
 
     // Continues rendering once data resolves
@@ -397,8 +441,14 @@ describe('ReactConcurrentErrorRecovery', () => {
           );
         });
       });
-      assertLog(['Suspend! [Async]']);
-      // The render suspended without committing or surfacing the error.
+      assertLog([
+        'Suspend! [Async]',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [Async]', 'Caught an error: Oops!']
+          : []),
+      ]);
+      // The render suspended without committing the error.
       expect(root).toMatchRenderedOutput(null);
 
       // Try the reverse order, too: throw then suspend
@@ -414,7 +464,13 @@ describe('ReactConcurrentErrorRecovery', () => {
           );
         });
       });
-      assertLog(['Suspend! [Async]']);
+      assertLog([
+        'Suspend! [Async]',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [Async]', 'Caught an error: Oops!']
+          : []),
+      ]);
       expect(root).toMatchRenderedOutput(null);
 
       await act(async () => {

--- a/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
@@ -420,6 +420,8 @@ describe('ReactDeferredValue', () => {
         // The initial value suspended, so we attempt the final value, which
         // also suspends.
         'Suspend! [Final]',
+
+        ...(gate('enableSiblingPrerendering') ? ['Suspend! [Final]'] : []),
       ]);
       expect(root).toMatchRenderedOutput(null);
 
@@ -459,6 +461,8 @@ describe('ReactDeferredValue', () => {
         // The initial value suspended, so we attempt the final value, which
         // also suspends.
         'Suspend! [Final]',
+
+        ...(gate('enableSiblingPrerendering') ? ['Suspend! [Final]'] : []),
       ]);
       expect(root).toMatchRenderedOutput(null);
 
@@ -531,6 +535,8 @@ describe('ReactDeferredValue', () => {
         // The initial value suspended, so we attempt the final value, which
         // also suspends.
         'Suspend! [Final]',
+
+        ...(gate('enableSiblingPrerendering') ? ['Suspend! [Final]'] : []),
       ]);
       expect(root).toMatchRenderedOutput(null);
 
@@ -540,6 +546,8 @@ describe('ReactDeferredValue', () => {
         'Loading...',
         // Still waiting for the final value.
         'Suspend! [Final]',
+
+        ...(gate('enableSiblingPrerendering') ? ['Suspend! [Final]'] : []),
       ]);
       expect(root).toMatchRenderedOutput('Loading...');
 
@@ -584,6 +592,8 @@ describe('ReactDeferredValue', () => {
         // boundaries work, where we always prefer to show the innermost
         // loading state.)
         'Suspend! [Content]',
+
+        ...(gate('enableSiblingPrerendering') ? ['Suspend! [Content]'] : []),
       ]);
       // Still showing the App preview state because the inner
       // content suspended.

--- a/packages/react-reconciler/src/__tests__/ReactExpiration-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactExpiration-test.js
@@ -652,7 +652,14 @@ describe('ReactExpiration', () => {
       React.startTransition(() => {
         root.render(<App step={1} />);
       });
-      await waitForAll(['Suspend! [A1]', 'Loading...']);
+      await waitForAll([
+        'Suspend! [A1]',
+        'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [A1]', 'B', 'C', 'Loading...']
+          : []),
+      ]);
 
       // Lots of time elapses before the promise resolves
       Scheduler.unstable_advanceTime(10000);

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -198,7 +198,11 @@ describe('ReactLazy', () => {
 
     await resolveFakeImport(Foo);
 
-    await waitForAll(['Foo']);
+    await waitForAll([
+      'Foo',
+
+      ...(gate('enableSiblingPrerendering') ? ['Foo'] : []),
+    ]);
     expect(root).not.toMatchRenderedOutput('FooBar');
 
     await act(() => resolveFakeImport(Bar));
@@ -235,6 +239,13 @@ describe('ReactLazy', () => {
     assertConsoleErrorDev([
       'Expected the result of a dynamic import() call',
       'Expected the result of a dynamic import() call',
+
+      ...(gate('enableSiblingPrerendering')
+        ? [
+            'Expected the result of a dynamic import() call',
+            'Expected the result of a dynamic import() call',
+          ]
+        : []),
     ]);
     expect(root).not.toMatchRenderedOutput('Hi');
   });
@@ -1072,7 +1083,7 @@ describe('ReactLazy', () => {
     expect(ref.current).toBe(null);
 
     await act(() => resolveFakeImport(Foo));
-    assertLog(['Foo']);
+    assertLog(['Foo', ...(gate('enableSiblingPrerendering') ? ['Foo'] : [])]);
 
     await act(() => resolveFakeImport(ForwardRefBar));
     assertLog(['Foo', 'forwardRef', 'Bar']);
@@ -1388,7 +1399,12 @@ describe('ReactLazy', () => {
     expect(root).not.toMatchRenderedOutput('AB');
 
     await act(() => resolveFakeImport(ChildA));
-    assertLog(['A', 'Init B']);
+    assertLog([
+      'A',
+      'Init B',
+
+      ...(gate('enableSiblingPrerendering') ? ['A'] : []),
+    ]);
 
     await act(() => resolveFakeImport(ChildB));
     assertLog(['A', 'B', 'Did mount: A', 'Did mount: B']);
@@ -1472,10 +1488,20 @@ describe('ReactLazy', () => {
     React.startTransition(() => {
       root.update(<Parent swap={true} />);
     });
-    await waitForAll(['Init B2', 'Loading...']);
+    await waitForAll([
+      'Init B2',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering') ? ['Loading...'] : []),
+    ]);
     await act(() => resolveFakeImport(ChildB2));
     // We need to flush to trigger the second one to load.
-    assertLog(['Init A2', 'Loading...']);
+    assertLog([
+      'Init A2',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering') ? ['Loading...'] : []),
+    ]);
     await act(() => resolveFakeImport(ChildA2));
     assertLog(['b', 'a', 'Did update: b', 'Did update: a']);
     expect(root).toMatchRenderedOutput('ba');

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -136,6 +136,10 @@ describe('ReactSuspense', () => {
       // A suspends
       'Suspend! [A]',
       'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Foo', 'Bar', 'Suspend! [A]', 'B', 'Loading...']
+        : []),
     ]);
     expect(container.textContent).toEqual('');
 
@@ -275,7 +279,15 @@ describe('ReactSuspense', () => {
     expect(container.textContent).toEqual('Loading...');
 
     await resolveText('A');
-    await waitForAll(['A', 'Suspend! [B]', 'Loading more...']);
+    await waitForAll([
+      'A',
+      'Suspend! [B]',
+      'Loading more...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['A', 'Suspend! [B]', 'Loading more...']
+        : []),
+    ]);
 
     // By this point, we have enough info to show "A" and "Loading more..."
     // However, we've just shown the outer fallback. So we'll delay
@@ -327,7 +339,14 @@ describe('ReactSuspense', () => {
     // B starts loading. Parent boundary is in throttle.
     // Still shows parent loading under throttle
     jest.advanceTimersByTime(10);
-    await waitForAll(['Suspend! [B]', 'Loading more...']);
+    await waitForAll([
+      'Suspend! [B]',
+      'Loading more...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['A', 'Suspend! [B]', 'Loading more...']
+        : []),
+    ]);
     expect(container.textContent).toEqual('Loading...');
 
     // !! B could have finished before the throttle, but we show a fallback.
@@ -361,7 +380,15 @@ describe('ReactSuspense', () => {
     expect(container.textContent).toEqual('Loading...');
 
     await resolveText('A');
-    await waitForAll(['A', 'Suspend! [B]', 'Loading more...']);
+    await waitForAll([
+      'A',
+      'Suspend! [B]',
+      'Loading more...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['A', 'Suspend! [B]', 'Loading more...']
+        : []),
+    ]);
 
     // By this point, we have enough info to show "A" and "Loading more..."
     // However, we've just shown the outer fallback. So we'll delay
@@ -655,7 +682,14 @@ describe('ReactSuspense', () => {
 
     assertLog(['Suspend! [Child 1]', 'Loading...']);
     await resolveText('Child 1');
-    await waitForAll(['Child 1', 'Suspend! [Child 2]']);
+    await waitForAll([
+      'Child 1',
+      'Suspend! [Child 2]',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Child 1', 'Suspend! [Child 2]']
+        : []),
+    ]);
 
     jest.advanceTimersByTime(6000);
 

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemantics-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemantics-test.js
@@ -1150,7 +1150,19 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(async () => {
         await resolveText('InnerAsync_1');
       });
-      assertLog(['Text:Outer render', 'Suspend:OuterAsync_1']);
+      assertLog([
+        'Text:Outer render',
+        'Suspend:OuterAsync_1',
+
+        ...(gate('enableSiblingPrerendering')
+          ? [
+              'Text:Outer render',
+              'Suspend:OuterAsync_1',
+              'Text:Inner render',
+              'AsyncText:InnerAsync_1 render',
+            ]
+          : []),
+      ]);
       expect(ReactNoop).toMatchRenderedOutput(
         <>
           <span prop="Outer" hidden={true} />
@@ -1194,6 +1206,17 @@ describe('ReactSuspenseEffectsSemantics', () => {
         'Text:Inner render',
         'Suspend:InnerAsync_2',
         'Text:InnerFallback render',
+
+        ...(gate('enableSiblingPrerendering')
+          ? [
+              'Text:Outer render',
+              'AsyncText:OuterAsync_1 render',
+              'Text:Inner render',
+              'Suspend:InnerAsync_2',
+              'Text:InnerFallback render',
+            ]
+          : []),
+
         'Text:OuterFallback destroy layout',
         'Text:Outer create layout',
         'AsyncText:OuterAsync_1 create layout',
@@ -2305,6 +2328,15 @@ describe('ReactSuspenseEffectsSemantics', () => {
         'Text:Function render',
         'AsyncText:Async_1 render',
         'Suspend:Async_2',
+
+        ...(gate('enableSiblingPrerendering')
+          ? [
+              'Text:Function render',
+              'AsyncText:Async_1 render',
+              'Suspend:Async_2',
+              'ClassText:Class render',
+            ]
+          : []),
       ]);
       expect(ReactNoop).toMatchRenderedOutput(
         <>
@@ -2443,7 +2475,20 @@ describe('ReactSuspenseEffectsSemantics', () => {
       await act(async () => {
         await resolveText('A');
       });
-      assertLog(['Text:Function render', 'Suspender "B" render', 'Suspend:B']);
+      assertLog([
+        'Text:Function render',
+        'Suspender "B" render',
+        'Suspend:B',
+
+        ...(gate('enableSiblingPrerendering')
+          ? [
+              'Text:Function render',
+              'Suspender "B" render',
+              'Suspend:B',
+              'ClassText:Class render',
+            ]
+          : []),
+      ]);
       expect(ReactNoop).toMatchRenderedOutput(
         <>
           <span prop="Function" hidden={true} />

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.js
@@ -383,7 +383,13 @@ describe('ReactSuspenseList', () => {
     );
 
     await act(() => B.resolve());
-    assertLog(['A', 'B', 'Suspend! [C]']);
+    assertLog([
+      'A',
+      'B',
+      'Suspend! [C]',
+
+      ...(gate('enableSiblingPrerendering') ? ['A', 'B', 'Suspend! [C]'] : []),
+    ]);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -459,7 +465,13 @@ describe('ReactSuspenseList', () => {
     );
 
     await act(() => B.resolve());
-    assertLog(['A', 'B', 'Suspend! [C]']);
+    assertLog([
+      'A',
+      'B',
+      'Suspend! [C]',
+
+      ...(gate('enableSiblingPrerendering') ? ['A', 'B', 'Suspend! [C]'] : []),
+    ]);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -767,7 +779,12 @@ describe('ReactSuspenseList', () => {
     );
 
     await act(() => B.resolve());
-    assertLog(['B', 'Suspend! [C]']);
+    assertLog([
+      'B',
+      'Suspend! [C]',
+
+      ...(gate('enableSiblingPrerendering') ? ['B', 'Suspend! [C]'] : []),
+    ]);
 
     // Even though we could now show B, we're still waiting on C.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -854,7 +871,12 @@ describe('ReactSuspenseList', () => {
     expect(ReactNoop).toMatchRenderedOutput(<span>A</span>);
 
     await act(() => B.resolve());
-    assertLog(['B', 'Suspend! [C]']);
+    assertLog([
+      'B',
+      'Suspend! [C]',
+
+      ...(gate('enableSiblingPrerendering') ? ['B', 'Suspend! [C]'] : []),
+    ]);
 
     // Even though we could now show B, we're still waiting on C.
     expect(ReactNoop).toMatchRenderedOutput(<span>A</span>);
@@ -908,7 +930,12 @@ describe('ReactSuspenseList', () => {
     );
 
     await act(() => A.resolve());
-    assertLog(['A', 'Suspend! [B]']);
+    assertLog([
+      'A',
+      'Suspend! [B]',
+
+      ...(gate('enableSiblingPrerendering') ? ['A', 'Suspend! [B]'] : []),
+    ]);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -967,7 +994,12 @@ describe('ReactSuspenseList', () => {
     );
 
     await act(() => C.resolve());
-    assertLog(['C', 'Suspend! [B]']);
+    assertLog([
+      'C',
+      'Suspend! [B]',
+
+      ...(gate('enableSiblingPrerendering') ? ['C', 'Suspend! [B]'] : []),
+    ]);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -1072,7 +1104,12 @@ describe('ReactSuspenseList', () => {
     );
 
     await act(() => A.resolve());
-    assertLog(['A', 'Suspend! [C]']);
+    assertLog([
+      'A',
+      'Suspend! [C]',
+
+      ...(gate('enableSiblingPrerendering') ? ['A', 'Suspend! [C]'] : []),
+    ]);
 
     // Even though we could show A, it is still in a fallback state because
     // C is not yet resolved. We need to resolve everything in the head first.
@@ -1088,7 +1125,13 @@ describe('ReactSuspenseList', () => {
     );
 
     await act(() => C.resolve());
-    assertLog(['A', 'C', 'Suspend! [E]']);
+    assertLog([
+      'A',
+      'C',
+      'Suspend! [E]',
+
+      ...(gate('enableSiblingPrerendering') ? ['A', 'C', 'Suspend! [E]'] : []),
+    ]);
 
     // We can now resolve the full head.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -1103,7 +1146,12 @@ describe('ReactSuspenseList', () => {
     );
 
     await act(() => E.resolve());
-    assertLog(['E', 'Suspend! [F]']);
+    assertLog([
+      'E',
+      'Suspend! [F]',
+
+      ...(gate('enableSiblingPrerendering') ? ['E', 'Suspend! [F]'] : []),
+    ]);
 
     // In the tail we can resolve one-by-one.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -1267,7 +1315,12 @@ describe('ReactSuspenseList', () => {
 
     await F.resolve();
 
-    await waitForAll(['Suspend! [D]', 'F']);
+    await waitForAll([
+      'Suspend! [D]',
+      'F',
+
+      ...(gate('enableSiblingPrerendering') ? ['Suspend! [D]', 'F'] : []),
+    ]);
 
     // Even though we could show F, it is still in a fallback state because
     // E is not yet resolved. We need to resolve everything in the head first.
@@ -1287,7 +1340,13 @@ describe('ReactSuspenseList', () => {
     );
 
     await act(() => D.resolve());
-    assertLog(['D', 'F', 'Suspend! [B]']);
+    assertLog([
+      'D',
+      'F',
+      'Suspend! [B]',
+
+      ...(gate('enableSiblingPrerendering') ? ['D', 'F', 'Suspend! [B]'] : []),
+    ]);
 
     // We can now resolve the full head.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -1304,7 +1363,12 @@ describe('ReactSuspenseList', () => {
     );
 
     await act(() => B.resolve());
-    assertLog(['B', 'Suspend! [A]']);
+    assertLog([
+      'B',
+      'Suspend! [A]',
+
+      ...(gate('enableSiblingPrerendering') ? ['B', 'Suspend! [A]'] : []),
+    ]);
 
     // In the tail we can resolve one-by-one.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -1429,7 +1493,15 @@ describe('ReactSuspenseList', () => {
 
     await A.resolve();
 
-    await waitForAll(['A', 'Suspend! [B]', 'Loading B']);
+    await waitForAll([
+      'A',
+      'Suspend! [B]',
+      'Loading B',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['A', 'Suspend! [B]', 'Loading B']
+        : []),
+    ]);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
@@ -1443,7 +1515,15 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    await waitForAll(['B', 'Suspend! [C]', 'Loading C']);
+    await waitForAll([
+      'B',
+      'Suspend! [C]',
+      'Loading C',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['B', 'Suspend! [C]', 'Loading C']
+        : []),
+    ]);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
@@ -1667,7 +1747,12 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    await waitForAll(['B', 'Suspend! [C]']);
+    await waitForAll([
+      'B',
+      'Suspend! [C]',
+
+      ...(gate('enableSiblingPrerendering') ? ['B', 'Suspend! [C]'] : []),
+    ]);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
@@ -1687,7 +1772,17 @@ describe('ReactSuspenseList', () => {
     await C.resolve();
     await E.resolve();
 
-    await waitForAll(['B', 'C', 'E', 'Suspend! [F]', 'Loading F']);
+    await waitForAll([
+      'B',
+      'C',
+      'E',
+      'Suspend! [F]',
+      'Loading F',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['B', 'C', 'E', 'Suspend! [F]', 'Loading F']
+        : []),
+    ]);
 
     jest.advanceTimersByTime(500);
 
@@ -1804,7 +1899,12 @@ describe('ReactSuspenseList', () => {
 
     await D.resolve();
 
-    await waitForAll(['D', 'Suspend! [E]']);
+    await waitForAll([
+      'D',
+      'Suspend! [E]',
+
+      ...(gate('enableSiblingPrerendering') ? ['D', 'Suspend! [E]'] : []),
+    ]);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
@@ -1829,7 +1929,17 @@ describe('ReactSuspenseList', () => {
     await D.resolve();
     await E.resolve();
 
-    await waitForAll(['D', 'E', 'B', 'Suspend! [A]', 'Loading A']);
+    await waitForAll([
+      'D',
+      'E',
+      'B',
+      'Suspend! [A]',
+      'Loading A',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['D', 'E', 'B', 'Suspend! [A]', 'Loading A']
+        : []),
+    ]);
 
     jest.advanceTimersByTime(500);
 
@@ -1958,7 +2068,12 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    await waitForAll(['B', 'Suspend! [C]']);
+    await waitForAll([
+      'B',
+      'Suspend! [C]',
+
+      ...(gate('enableSiblingPrerendering') ? ['B', 'Suspend! [C]'] : []),
+    ]);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
@@ -1981,7 +2096,17 @@ describe('ReactSuspenseList', () => {
     await D.resolve();
     await E.resolve();
 
-    await waitForAll(['C', 'D', 'E', 'Suspend! [F]', 'Loading F']);
+    await waitForAll([
+      'C',
+      'D',
+      'E',
+      'Suspend! [F]',
+      'Loading F',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['C', 'D', 'E', 'Suspend! [F]', 'Loading F']
+        : []),
+    ]);
 
     jest.advanceTimersByTime(500);
 
@@ -2044,7 +2169,15 @@ describe('ReactSuspenseList', () => {
 
     await A.resolve();
 
-    await waitForAll(['A', 'Suspend! [B]', 'Loading B']);
+    await waitForAll([
+      'A',
+      'Suspend! [B]',
+      'Loading B',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['A', 'Suspend! [B]', 'Loading B']
+        : []),
+    ]);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
@@ -2052,7 +2185,15 @@ describe('ReactSuspenseList', () => {
     expect(ReactNoop).toMatchRenderedOutput(<span>A</span>);
 
     await act(() => B.resolve());
-    assertLog(['B', 'Suspend! [C]', 'Loading C']);
+    assertLog([
+      'B',
+      'Suspend! [C]',
+      'Loading C',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['B', 'Suspend! [C]', 'Loading C']
+        : []),
+    ]);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
@@ -2787,7 +2928,12 @@ describe('ReactSuspenseList', () => {
     expect(onRender.mock.calls[2][3]).toBe(1 + 4 + 3 + 3);
 
     await act(() => C.resolve());
-    assertLog(['C', 'Suspend! [D]']);
+    assertLog([
+      'C',
+      'Suspend! [D]',
+
+      ...(gate('enableSiblingPrerendering') ? ['C', 'Suspend! [D]'] : []),
+    ]);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span>A</span>
@@ -2873,7 +3019,12 @@ describe('ReactSuspenseList', () => {
     );
 
     await act(() => A.resolve());
-    assertLog(['A', 'Suspend! [B]']);
+    assertLog([
+      'A',
+      'Suspend! [B]',
+
+      ...(gate('enableSiblingPrerendering') ? ['A', 'Suspend! [B]'] : []),
+    ]);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span>A</span>

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -298,6 +298,19 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       // We immediately unwind and switch to a fallback without
       // rendering siblings.
       'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? [
+            'Foo',
+            'Bar',
+            // A suspends
+            'Suspend! [A]',
+            'B',
+            // We immediately unwind and switch to a fallback without
+            // rendering siblings.
+            'Loading...',
+          ]
+        : []),
     ]);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
@@ -379,7 +392,15 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     });
 
     // B suspends. Render a fallback
-    await waitForAll(['A', 'Suspend! [B]', 'Loading...']);
+    await waitForAll([
+      'A',
+      'Suspend! [B]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['A', 'Suspend! [B]', 'C', 'D', 'Loading...']
+        : []),
+    ]);
     // Did not commit yet.
     expect(ReactNoop).toMatchRenderedOutput(null);
 
@@ -436,7 +457,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     React.startTransition(() => {
       ReactNoop.render(<App renderContent={true} />);
     });
-    await waitForAll(['Suspend! [Result]', 'Loading...']);
+    await waitForAll([
+      'Suspend! [Result]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [Result]', 'Loading...']
+        : []),
+    ]);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     await rejectText('Result', new Error('Failed to load: Result'));
@@ -496,6 +524,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       // React retries one more time
       'Error! [Result]',
 
+      ...(gate('enableSiblingPrerendering')
+        ? ['Error! [Result]', 'Error! [Result]']
+        : []),
+
       // Errored again on retry. Now handle it.
       'Caught error: Failed to load: Result',
     ]);
@@ -547,7 +579,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Update the low-pri text
     await act(() => startTransition(() => setLowPri('2')));
     // Suspends
-    assertLog(['Suspend! [2]', 'Loading...']);
+    assertLog([
+      'Suspend! [2]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [2]', 'Loading...']
+        : []),
+    ]);
 
     // While we're still waiting for the low-pri update to complete, update the
     // high-pri text at high priority.
@@ -592,13 +631,27 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     React.startTransition(() => {
       ReactNoop.render(<App showA={true} showB={false} />);
     });
-    await waitForAll(['Suspend! [A]', 'Loading...']);
+    await waitForAll([
+      'Suspend! [A]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [A]', 'Loading...']
+        : []),
+    ]);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     React.startTransition(() => {
       ReactNoop.render(<App showA={true} showB={true} />);
     });
-    await waitForAll(['Suspend! [A]', 'Loading...']);
+    await waitForAll([
+      'Suspend! [A]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [A]', 'B', 'Loading...']
+        : []),
+    ]);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     await resolveText('A');
@@ -743,6 +796,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       'Outer content',
       'Suspend! [Inner content]',
       'Loading inner...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Outer content', 'Suspend! [Inner content]', 'Loading inner...']
+        : []),
     ]);
     // Don't commit the inner placeholder yet.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -932,7 +989,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </Suspense>,
       );
     });
-    await waitForAll(['Suspend! [Async]', 'Loading...']);
+    await waitForAll([
+      'Suspend! [Async]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [Async]', 'Loading...']
+        : []),
+    ]);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     // Resolve the promise
@@ -964,7 +1028,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Schedule an update, and suspend for up to 5 seconds.
     React.startTransition(() => ReactNoop.render(<App text="A" />));
     // The update should suspend.
-    await waitForAll(['Suspend! [A]', 'Loading...']);
+    await waitForAll([
+      'Suspend! [A]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [A]', 'Loading...']
+        : []),
+    ]);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="S" />);
 
     // Advance time until right before it expires.
@@ -976,7 +1047,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Schedule another low priority update.
     React.startTransition(() => ReactNoop.render(<App text="B" />));
     // This update should also suspend.
-    await waitForAll(['Suspend! [B]', 'Loading...']);
+    await waitForAll([
+      'Suspend! [B]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [B]', 'Loading...']
+        : []),
+    ]);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="S" />);
 
     // Schedule a regular update. Its expiration time will fall between
@@ -1747,6 +1825,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         // B suspends
         'Suspend! [B]',
         'Loading more...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['A', 'Suspend! [B]', 'Loading more...']
+          : []),
       ]);
       // Because we've already been waiting for so long we can
       // wait a bit longer. Still nothing...
@@ -2238,7 +2320,16 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       ReactNoop.render(<Foo showB={true} />);
     });
 
-    await waitForAll(['Foo', 'A', 'Suspend! [B]', 'Loading B...']);
+    await waitForAll([
+      'Foo',
+      'A',
+      'Suspend! [B]',
+      'Loading B...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Foo', 'A', 'Suspend! [B]', 'Loading B...']
+        : []),
+    ]);
 
     // Transitions never fall back.
     expect(ReactNoop).toMatchRenderedOutput(<span prop="A" />);
@@ -2314,7 +2405,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       // Start transition.
       React.startTransition(() => ReactNoop.render(<App page="B" />));
 
-      await waitForAll(['Suspend! [B]', 'Loading...']);
+      await waitForAll([
+        'Suspend! [B]',
+        'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [B]', 'Loading...']
+          : []),
+      ]);
       Scheduler.unstable_advanceTime(100000);
       await advanceTimers(100000);
       // Even after lots of time has passed, we have still not yet flushed the
@@ -2365,7 +2463,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         React.startTransition(() => transitionToPage('B'));
 
-        await waitForAll(['Suspend! [B]', 'Loading...']);
+        await waitForAll([
+          'Suspend! [B]',
+          'Loading...',
+
+          ...(gate('enableSiblingPrerendering')
+            ? ['Suspend! [B]', 'Loading...']
+            : []),
+        ]);
         Scheduler.unstable_advanceTime(100000);
         await advanceTimers(100000);
         // Even after lots of time has passed, we have still not yet flushed the
@@ -2420,7 +2525,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         React.startTransition(() => transitionToPage('B'));
 
-        await waitForAll(['Suspend! [B]', 'Loading...']);
+        await waitForAll([
+          'Suspend! [B]',
+          'Loading...',
+
+          ...(gate('enableSiblingPrerendering')
+            ? ['Suspend! [B]', 'Loading...']
+            : []),
+        ]);
         Scheduler.unstable_advanceTime(100000);
         await advanceTimers(100000);
         // Even after lots of time has passed, we have still not yet flushed the
@@ -2462,7 +2574,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       // Start transition.
       React.startTransition(() => ReactNoop.render(<App page="B" />));
 
-      await waitForAll(['Suspend! [B]', 'Loading...']);
+      await waitForAll([
+        'Suspend! [B]',
+        'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [B]', 'Loading...']
+          : []),
+      ]);
       Scheduler.unstable_advanceTime(2999);
       await advanceTimers(2999);
       // Since the timeout is infinite (or effectively infinite),
@@ -2476,7 +2595,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Start a long (infinite) transition.
       React.startTransition(() => ReactNoop.render(<App page="C" />));
-      await waitForAll(['Suspend! [C]', 'Loading...']);
+      await waitForAll([
+        'Suspend! [C]',
+        'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [C]', 'Loading...']
+          : []),
+      ]);
 
       // Even after lots of time has passed, we have still not yet flushed the
       // loading state.
@@ -2524,7 +2650,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         React.startTransition(() => transitionToPage('B'));
 
-        await waitForAll(['Suspend! [B]', 'Loading...']);
+        await waitForAll([
+          'Suspend! [B]',
+          'Loading...',
+
+          ...(gate('enableSiblingPrerendering')
+            ? ['Suspend! [B]', 'Loading...']
+            : []),
+        ]);
 
         Scheduler.unstable_advanceTime(2999);
         await advanceTimers(2999);
@@ -2542,7 +2675,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         React.startTransition(() => transitionToPage('C'));
 
-        await waitForAll(['Suspend! [C]', 'Loading...']);
+        await waitForAll([
+          'Suspend! [C]',
+          'Loading...',
+
+          ...(gate('enableSiblingPrerendering')
+            ? ['Suspend! [C]', 'Loading...']
+            : []),
+        ]);
 
         // Even after lots of time has passed, we have still not yet flushed the
         // loading state.
@@ -2594,7 +2734,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         React.startTransition(() => transitionToPage('B'));
 
-        await waitForAll(['Suspend! [B]', 'Loading...']);
+        await waitForAll([
+          'Suspend! [B]',
+          'Loading...',
+
+          ...(gate('enableSiblingPrerendering')
+            ? ['Suspend! [B]', 'Loading...']
+            : []),
+        ]);
         Scheduler.unstable_advanceTime(2999);
         await advanceTimers(2999);
         // Since the timeout is infinite (or effectively infinite),
@@ -2611,7 +2758,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         React.startTransition(() => transitionToPage('C'));
 
-        await waitForAll(['Suspend! [C]', 'Loading...']);
+        await waitForAll([
+          'Suspend! [C]',
+          'Loading...',
+
+          ...(gate('enableSiblingPrerendering')
+            ? ['Suspend! [C]', 'Loading...']
+            : []),
+        ]);
 
         // Even after lots of time has passed, we have still not yet flushed the
         // loading state.
@@ -2652,7 +2806,15 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Start transition.
     React.startTransition(() => ReactNoop.render(<App page="B" />));
 
-    await waitForAll(['Hi!', 'Suspend! [B]', 'Loading B...']);
+    await waitForAll([
+      'Hi!',
+      'Suspend! [B]',
+      'Loading B...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Hi!', 'Suspend! [B]', 'Loading B...']
+        : []),
+    ]);
 
     // Suspended
     expect(ReactNoop).toMatchRenderedOutput(
@@ -2713,7 +2875,15 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Start transition.
     React.startTransition(() => ReactNoop.render(<App page="B" />));
 
-    await waitForAll(['Hi!', 'Suspend! [B]', 'Loading B...']);
+    await waitForAll([
+      'Hi!',
+      'Suspend! [B]',
+      'Loading B...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Hi!', 'Suspend! [B]', 'Loading B...']
+        : []),
+    ]);
 
     // Suspended
     expect(ReactNoop).toMatchRenderedOutput(
@@ -2827,7 +2997,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       ReactNoop.render(<App showContent={true} />);
     });
 
-    await waitForAll(['Suspend! [A]', 'Loading...']);
+    await waitForAll([
+      'Suspend! [A]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [A]', 'Loading...']
+        : []),
+    ]);
     await resolveText('A');
     await waitFor(['A', 'Commit']);
     expect(ReactNoop).toMatchRenderedOutput(
@@ -2879,7 +3056,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       ReactNoop.render(<App showContent={true} />);
     });
 
-    await waitForAll(['Suspend! [A]', 'Loading...']);
+    await waitForAll([
+      'Suspend! [A]',
+      'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [A]', 'Loading...']
+        : []),
+    ]);
     await resolveText('A');
     await waitFor(['A', 'Commit']);
     expect(ReactNoop).toMatchRenderedOutput(
@@ -3492,6 +3676,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     );
   });
 
+  // This regression test relies on subtle implementation details that happen to
+  // rely on sibling prerendering being disabled. Not going to bother to rewrite
+  // it for now; maybe once we land the experiment.
+  // @gate !enableSiblingPrerendering
   // @gate enableLegacyCache
   it('regression: ping at high priority causes update to be dropped', async () => {
     const {useState, useTransition} = React;
@@ -3654,7 +3842,16 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Update to "a". That will suspend.
     await act(async () => {
       setTextWithShortTransition('a');
-      await waitForAll(['Pending...', '', 'Suspend! [a]', 'Loading...']);
+      await waitForAll([
+        'Pending...',
+        '',
+        'Suspend! [a]',
+        'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [a]', 'Loading...']
+          : []),
+      ]);
     });
     assertLog([]);
     expect(root).toMatchRenderedOutput(
@@ -3673,6 +3870,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         '',
         'Suspend! [b]',
         'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [b]', 'Loading...']
+          : []),
       ]);
     });
     assertLog([]);
@@ -3687,7 +3888,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       await resolveText('a');
 
-      await waitForAll(['Suspend! [b]', 'Loading...']);
+      await waitForAll([
+        'Suspend! [b]',
+        'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [b]', 'Loading...']
+          : []),
+      ]);
       expect(root).toMatchRenderedOutput(
         <>
           <span prop="Pending..." />

--- a/packages/react-reconciler/src/__tests__/ReactTransition-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransition-test.js
@@ -199,6 +199,10 @@ describe('ReactTransition', () => {
         '(empty)',
         'Suspend! [Async]',
         'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [Async]', 'Loading...']
+          : []),
       ]);
 
       expect(root).toMatchRenderedOutput('Pending...(empty)');
@@ -269,6 +273,10 @@ describe('ReactTransition', () => {
         'B label',
         'Suspend! [B content]',
         'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['B label', 'Suspend! [B content]', 'Loading...']
+          : []),
       ]);
       // This is a refresh transition so it shouldn't show a fallback
       expect(root).toMatchRenderedOutput(
@@ -290,6 +298,10 @@ describe('ReactTransition', () => {
         'C label',
         'Suspend! [C content]',
         'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['C label', 'Suspend! [C content]', 'Loading...']
+          : []),
       ]);
       expect(root).toMatchRenderedOutput(
         <>
@@ -307,6 +319,10 @@ describe('ReactTransition', () => {
         'C label',
         'Suspend! [C content]',
         'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['C label', 'Suspend! [C content]', 'Loading...']
+          : []),
       ]);
       expect(root).toMatchRenderedOutput(
         <>
@@ -394,6 +410,10 @@ describe('ReactTransition', () => {
         'B label',
         'Suspend! [B content]',
         'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['B label', 'Suspend! [B content]', 'Loading...']
+          : []),
       ]);
       // This is a refresh transition so it shouldn't show a fallback
       expect(root).toMatchRenderedOutput(
@@ -415,6 +435,10 @@ describe('ReactTransition', () => {
         'C label',
         'Suspend! [C content]',
         'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['C label', 'Suspend! [C content]', 'Loading...']
+          : []),
       ]);
       expect(root).toMatchRenderedOutput(
         <>
@@ -432,6 +456,10 @@ describe('ReactTransition', () => {
         'C label',
         'Suspend! [C content]',
         'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['C label', 'Suspend! [C content]', 'Loading...']
+          : []),
       ]);
       expect(root).toMatchRenderedOutput(
         <>
@@ -500,7 +528,14 @@ describe('ReactTransition', () => {
           setShowA(true);
         });
       });
-      assertLog(['Suspend! [A]', 'Loading...']);
+      assertLog([
+        'Suspend! [A]',
+        'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [A]', 'Loading...']
+          : []),
+      ]);
       expect(root).toMatchRenderedOutput(null);
 
       // Before A loads, switch to B. This should entangle A with B.
@@ -510,7 +545,14 @@ describe('ReactTransition', () => {
           setShowB(true);
         });
       });
-      assertLog(['Suspend! [B]', 'Loading...']);
+      assertLog([
+        'Suspend! [B]',
+        'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [B]', 'Loading...']
+          : []),
+      ]);
       expect(root).toMatchRenderedOutput(null);
 
       // Before A or B loads, switch to C. This should entangle C with B, and
@@ -521,7 +563,14 @@ describe('ReactTransition', () => {
           setShowC(true);
         });
       });
-      assertLog(['Suspend! [C]', 'Loading...']);
+      assertLog([
+        'Suspend! [C]',
+        'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [C]', 'Loading...']
+          : []),
+      ]);
       expect(root).toMatchRenderedOutput(null);
 
       // Now the data starts resolving out of order.
@@ -533,7 +582,14 @@ describe('ReactTransition', () => {
           resolveText('B');
         });
       });
-      assertLog(['Suspend! [C]', 'Loading...']);
+      assertLog([
+        'Suspend! [C]',
+        'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [C]', 'Loading...']
+          : []),
+      ]);
       expect(root).toMatchRenderedOutput(null);
 
       // Now resolve A. Again, this will attempt to render C, since everything
@@ -543,7 +599,14 @@ describe('ReactTransition', () => {
           resolveText('A');
         });
       });
-      assertLog(['Suspend! [C]', 'Loading...']);
+      assertLog([
+        'Suspend! [C]',
+        'Loading...',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend! [C]', 'Loading...']
+          : []),
+      ]);
       expect(root).toMatchRenderedOutput(null);
 
       // Finally, resolve C. This time we can finish.
@@ -861,6 +924,10 @@ describe('ReactTransition', () => {
       // Suspend.
       'Suspend! [Async]',
       'Loading...',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['Suspend! [Async]', 'Normal pri: 0', 'Loading...']
+        : []),
     ]);
     expect(root).toMatchRenderedOutput('(empty), Normal pri: 0');
 

--- a/packages/react-reconciler/src/__tests__/ReactUse-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUse-test.js
@@ -1066,13 +1066,25 @@ describe('ReactUse', () => {
     await act(() => {
       resolveTextRequests('A');
     });
-    assertLog(['A', '(Loading B...)']);
+    assertLog([
+      'A',
+      '(Loading B...)',
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['A', '(Loading C...)', '(Loading B...)']
+        : []),
+    ]);
     expect(root).toMatchRenderedOutput('A(Loading B...)');
 
     await act(() => {
       resolveTextRequests('B');
     });
-    assertLog(['B', '(Loading C...)']);
+    assertLog([
+      'B',
+      '(Loading C...)',
+
+      ...(gate('enableSiblingPrerendering') ? ['B', '(Loading C...)'] : []),
+    ]);
     expect(root).toMatchRenderedOutput('AB(Loading C...)');
 
     await act(() => {
@@ -1868,16 +1880,26 @@ describe('ReactUse', () => {
 
     await expect(async () => {
       await act(() => resolveTextRequests('Hi'));
-    }).toErrorDev(
+    }).toErrorDev([
       // We get this warning because the generator's promise themselves are not cached.
       'A component was suspended by an uncached promise. Creating ' +
         'promises inside a Client Component or hook is not yet ' +
         'supported, except via a Suspense-compatible library or framework.',
-    );
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['A component was suspended by an uncached promise.']
+        : []),
+    ]);
 
     assertLog(['Async text requested [World]']);
 
-    await act(() => resolveTextRequests('World'));
+    if (gate('enableSiblingPrerendering')) {
+      await expect(async () => {
+        await act(() => resolveTextRequests('World'));
+      }).toErrorDev(['A component was suspended by an uncached promise.']);
+    } else {
+      await act(() => resolveTextRequests('World'));
+    }
 
     assertLog(['Hi', 'World']);
     expect(root).toMatchRenderedOutput('Hi World');
@@ -1913,16 +1935,26 @@ describe('ReactUse', () => {
 
     await expect(async () => {
       await act(() => resolveTextRequests('Hi'));
-    }).toErrorDev(
+    }).toErrorDev([
       // We get this warning because the generator's promise themselves are not cached.
       'A component was suspended by an uncached promise. Creating ' +
         'promises inside a Client Component or hook is not yet ' +
         'supported, except via a Suspense-compatible library or framework.',
-    );
+
+      ...(gate('enableSiblingPrerendering')
+        ? ['A component was suspended by an uncached promise.']
+        : []),
+    ]);
 
     assertLog(['Async text requested [World]']);
 
-    await act(() => resolveTextRequests('World'));
+    if (gate('enableSiblingPrerendering')) {
+      await expect(async () => {
+        await act(() => resolveTextRequests('World'));
+      }).toErrorDev(['A component was suspended by an uncached promise.']);
+    } else {
+      await act(() => resolveTextRequests('World'));
+    }
 
     assertLog(['Hi', 'World']);
     expect(root).toMatchRenderedOutput(<div>Hi World</div>);

--- a/packages/react-reconciler/src/__tests__/useMemoCache-test.js
+++ b/packages/react-reconciler/src/__tests__/useMemoCache-test.js
@@ -559,13 +559,26 @@ describe('useMemoCache()', () => {
         root.render(<App chunkA={updatedChunkA} chunkB={updatedChunkB} />);
       });
     });
-    assertLog(['Suspend! [chunkA]']);
+    assertLog([
+      'Suspend! [chunkA]',
+
+      ...(gate('enableSiblingPrerendering') ? ['Suspend! [chunkA]'] : []),
+    ]);
 
     // The data starts to stream in. Loading the data in the first chunk
     // triggers an expensive computation in the UI. Later, we'll test whether
     // this computation is reused.
     await act(() => updatedChunkA.resolve('A2'));
-    assertLog(['Some expensive processing... [A2]', 'Suspend! [chunkB]']);
+    assertLog([
+      'Some expensive processing... [A2]',
+      'Suspend! [chunkB]',
+
+      ...(gate('enableSiblingPrerendering')
+        ? gate('enableNoCloningMemoCache')
+          ? ['Suspend! [chunkB]']
+          : ['Some expensive processing... [A2]', 'Suspend! [chunkB]']
+        : []),
+    ]);
 
     // The second chunk hasn't loaded yet, so we're still showing the
     // initial UI.
@@ -586,11 +599,22 @@ describe('useMemoCache()', () => {
     if (gate(flags => flags.enableNoCloningMemoCache)) {
       // We did not have process the first chunk again. We reused the
       // computation from the earlier attempt.
-      assertLog(['Suspend! [chunkB]']);
+      assertLog([
+        'Suspend! [chunkB]',
+
+        ...(gate('enableSiblingPrerendering') ? ['Suspend! [chunkB]'] : []),
+      ]);
     } else {
       // Because we clone/reset the memo cache after every aborted attempt, we
       // must process the first chunk again.
-      assertLog(['Some expensive processing... [A2]', 'Suspend! [chunkB]']);
+      assertLog([
+        'Some expensive processing... [A2]',
+        'Suspend! [chunkB]',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Some expensive processing... [A2]', 'Suspend! [chunkB]']
+          : []),
+      ]);
     }
 
     expect(root).toMatchRenderedOutput(

--- a/packages/react-reconciler/src/__tests__/useSyncExternalStore-test.js
+++ b/packages/react-reconciler/src/__tests__/useSyncExternalStore-test.js
@@ -274,6 +274,10 @@ describe('useSyncExternalStore', () => {
         // This should a synchronous re-render of A using the updated value. In
         // this test, this causes A to suspend.
         'Suspend A',
+
+        ...(gate('enableSiblingPrerendering')
+          ? ['Suspend A', 'B: Updated']
+          : []),
       ]);
       // Nothing has committed, because A suspended and no fallback
       // was provided.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Adds the concept of a "prerender". These special renders are spawned
whenever something suspends (and we're not already prerendering).

The purpose is to move speculative rendering work into a separate phase
that does not block the UI from updating. For example, during a
transition, if something suspends, we should not speculatively prerender
siblings that will be replaced by a fallback in the UI until *after* the
fallback has been shown to the user.