### PR TITLE
[DevTools] Fix React Compiler badging

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -599,6 +599,8 @@ export function getInternalReactConstants(version: string): {
       !shouldSkipForgetCheck &&
       // $FlowFixMe[incompatible-type] fiber.updateQueue is mixed
       (fiber.updateQueue?.memoCache != null ||
+        (Array.isArray(fiber.memoizedState) &&
+          fiber.memoizedState[0]?.[REACT_MEMO_CACHE_SENTINEL]) ||
         fiber.memoizedState?.memoizedState?.[REACT_MEMO_CACHE_SENTINEL])
     ) {
       const displayNameWithoutForgetWrapper = getDisplayNameForFiber(

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -599,8 +599,8 @@ export function getInternalReactConstants(version: string): {
       !shouldSkipForgetCheck &&
       // $FlowFixMe[incompatible-type] fiber.updateQueue is mixed
       (fiber.updateQueue?.memoCache != null ||
-        (Array.isArray(fiber.memoizedState) &&
-          fiber.memoizedState[0]?.[REACT_MEMO_CACHE_SENTINEL]) ||
+        (Array.isArray(fiber.memoizedState?.memoizedState) &&
+          fiber.memoizedState.memoizedState[0]?.[REACT_MEMO_CACHE_SENTINEL]) ||
         fiber.memoizedState?.memoizedState?.[REACT_MEMO_CACHE_SENTINEL])
     ) {
       const displayNameWithoutForgetWrapper = getDisplayNameForFiber(


### PR DESCRIPTION

In #31140 we switched over the uMC polyfill to use memo instead of state since memo would FastRefresh properly. However this busted devtools' badging of compiled components; this PR fixes it.

TODO: tests
Co-authored-by: Ruslan Lesiutin <rdlesyutin@gmail.com>
