### PR TITLE
[ESLint] Add test for rejected `useId` in async Components

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -550,6 +550,21 @@ const tests = {
       // TODO: this should error but doesn't.
       // errors: [genericError('useState')],
     },
+    {
+      code: normalizeIndent`
+        async function Page() {
+          useId();
+          React.useId();
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        async function useAsyncHook() {
+          useId();
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -1128,6 +1143,14 @@ const tests = {
         }
       `,
       errors: [asyncComponentHookError('useState')],
+    },
+    {
+      code: normalizeIndent`
+        async function notAHook() {
+          useId();
+        }
+      `,
+      errors: [functionError('useId', 'notAHook')],
     },
     {
       code: normalizeIndent`

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -550,21 +550,6 @@ const tests = {
       // TODO: this should error but doesn't.
       // errors: [genericError('useState')],
     },
-    {
-      code: normalizeIndent`
-        async function Page() {
-          useId();
-          React.useId();
-        }
-      `,
-    },
-    {
-      code: normalizeIndent`
-        async function useAsyncHook() {
-          useId();
-        }
-      `,
-    },
   ],
   invalid: [
     {
@@ -1143,6 +1128,26 @@ const tests = {
         }
       `,
       errors: [asyncComponentHookError('useState')],
+    },
+    {
+      code: normalizeIndent`
+        async function Page() {
+          useId();
+          React.useId();
+        }
+      `,
+      errors: [
+        asyncComponentHookError('useId'),
+        asyncComponentHookError('React.useId'),
+      ],
+    },
+    {
+      code: normalizeIndent`
+        async function useAsyncHook() {
+          useId();
+        }
+      `,
+      errors: [asyncComponentHookError('useId')],
     },
     {
       code: normalizeIndent`

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -40,6 +40,21 @@ function isHook(node) {
   }
 }
 
+const serverComponentHooks = new Set(['useId']);
+function isServerComponentHook(node) {
+  if (node.type === 'Identifier') {
+    return serverComponentHooks.has(node.name);
+  } else if (
+    node.type === 'MemberExpression' &&
+    !node.computed &&
+    node.property.type === 'Identifier'
+  ) {
+    return serverComponentHooks.has(node.property.name);
+  } else {
+    return false;
+  }
+}
+
 /**
  * Checks if the node is a React component name. React component names must
  * always start with an uppercase letter.
@@ -504,7 +519,7 @@ export default {
             if (isDirectlyInsideComponentOrHook) {
               // Report an error if the hook is called inside an async function.
               const isAsyncFunction = codePathNode.async;
-              if (isAsyncFunction) {
+              if (isAsyncFunction && !isServerComponentHook(hook)) {
                 context.report({
                   node: hook,
                   message:

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -40,21 +40,6 @@ function isHook(node) {
   }
 }
 
-const serverComponentHooks = new Set(['useId']);
-function isServerComponentHook(node) {
-  if (node.type === 'Identifier') {
-    return serverComponentHooks.has(node.name);
-  } else if (
-    node.type === 'MemberExpression' &&
-    !node.computed &&
-    node.property.type === 'Identifier'
-  ) {
-    return serverComponentHooks.has(node.property.name);
-  } else {
-    return false;
-  }
-}
-
 /**
  * Checks if the node is a React component name. React component names must
  * always start with an uppercase letter.
@@ -519,7 +504,7 @@ export default {
             if (isDirectlyInsideComponentOrHook) {
               // Report an error if the hook is called inside an async function.
               const isAsyncFunction = codePathNode.async;
-              if (isAsyncFunction && !isServerComponentHook(hook)) {
+              if (isAsyncFunction) {
                 context.report({
                   node: hook,
                   message:


### PR DESCRIPTION
## Summary

Just added tests to make it clear `useId` being disallowed in async Components is intentional.

`useId` is allowed in Server Components. However, it doesn't work after `await` so we shouldn't allow it in `async` functions. We'd also disallow it if it's wrapped in a custom hook because we can't know whether the hook is stateful.

`useId` does work in shared components. Shared components cannot be async.
