### PR TITLE
fix[react-devtools]: fixed timeline profiler tests

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
+++ b/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
@@ -1280,12 +1280,12 @@ describe('Timeline profiler', () => {
     });
 
     describe('when profiling', () => {
-      beforeEach(() => {
-        utils.act(() => store.profilerStore.startProfiling());
-      });
-
       describe('with legacy render', () => {
         const {render: legacyRender} = getLegacyRenderImplementation();
+
+        beforeEach(() => {
+          utils.act(() => store.profilerStore.startProfiling());
+        });
 
         // @reactVersion <= 18.2
         // @reactVersion >= 18.0
@@ -1536,6 +1536,10 @@ describe('Timeline profiler', () => {
         });
 
         const {render: modernRender} = getModernRenderImplementation();
+
+        beforeEach(() => {
+          utils.act(() => store.profilerStore.startProfiling());
+        });
 
         it('should mark concurrent render without suspends or state updates', () => {
           utils.act(() => modernRender(<div />));

--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -256,7 +256,9 @@ beforeEach(() => {
     },
   });
 
-  const store = new Store(((bridge: any): FrontendBridge));
+  const store = new Store(((bridge: any): FrontendBridge), {
+    supportsTimeline: true,
+  });
 
   const agent = new Agent(((bridge: any): BackendBridge));
   const hook = global.__REACT_DEVTOOLS_GLOBAL_HOOK__;


### PR DESCRIPTION
Fixes tests against React 18 after https://github.com/facebook/react/pull/31154:
- Set `supportsTimeline` to true for `Store`.
- Execute `store.profilerStore.startProfiling` after `legacyRender` import, because this is where `react-dom` is imported and renderer is registered. We don't yet propagate `isProfiling` flag to newly registered renderers, when profiling already started see:
https://github.com/facebook/react/blob/d5bba18b5d81f234657586865248c5b6849599cd/packages/react-devtools-shared/src/hook.js#L203-L204