### PR TITLE
[compiler] Fix package version to go up in order

### DIFF
--- a/compiler/scripts/release/publish.js
+++ b/compiler/scripts/release/publish.js
@@ -125,7 +125,7 @@ async function main() {
       files: {exclude: ['.DS_Store']},
     });
     const truncatedHash = hash.slice(0, 7);
-    const newVersion = `0.0.0-experimental-${truncatedHash}-${dateString}`;
+    const newVersion = `0.0.1-experimental-${dateString}-${truncatedHash}`;
 
     for (const pkgName of pkgNames) {
       const pkgDir = path.resolve(__dirname, `../../packages/${pkgName}`);


### PR DESCRIPTION
## Summary

Fixes #31173

I'm a bit tired of closing auto update pr's from react compiler because renovate tries to downgrade all the time to a version in july where the hash begins "e" and so is a higher version than the current one.

## How did you test this change?

Untested.. not sure how. Happy to take any feedback to get this landed.