### PR TITLE
Fix propagation of legacy context when used with memo

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "yargs": "^15.3.1"
   },
   "devEngines": {
-    "node": "^12.17.0 || 13.x || 14.x || 15.x || 16.x || 17.x"
+    "node": "^12.17.0 || 13.x || 14.x || 15.x || 16.x || 17.x || 18.x"
   },
   "jest": {
     "testRegex": "/scripts/jest/dont-run-jest-directly\\.js$"

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
@@ -2260,10 +2260,6 @@ describe('ReactIncremental', () => {
       // its child context.
       'Intl:read {}',
       'Intl:provide {"locale":"gr"}',
-      // TODO: it's unfortunate that we can't reuse work on
-      // these components even though they don't depend on context.
-      'IndirectionFn {}',
-      'IndirectionClass {}',
       // These components depend on context:
       'ShowLocaleClass:read {"locale":"gr"}',
       'ShowLocaleFn:read {"locale":"gr"}',

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -905,7 +905,7 @@ describe('ReactNewContext', () => {
       expect(ReactNoop.getChildren()).toEqual([span('Child')]);
     });
 
-    it('provider does not bail out if legacy context changed above', () => {
+    it('provider is skipped if only legacy context changed above', () => {
       const Context = React.createContext(0);
 
       function Child() {
@@ -962,7 +962,7 @@ describe('ReactNewContext', () => {
 
       // Update LegacyProvider (should not bail out)
       legacyProviderRef.current.setState({value: 1});
-      expect(Scheduler).toFlushAndYield(['LegacyProvider', 'App', 'Child']);
+      expect(Scheduler).toFlushAndYield(['LegacyProvider']);
       expect(ReactNoop.getChildren()).toEqual([span('Child')]);
 
       // Update App with same value (should bail out)


### PR DESCRIPTION
At work our 18.2.0 app has a few remaining uses of legacy context, and @marshallofsound and I noticed a couple bugs:
* [too many rerenders] memo does not always prevent its descendant function components from rerendering if legacy context has changed above
* [too few rerenders] memo can incorrectly prevent its descendant legacy context consumers from receiving legacy context updates

The added test demonstrates both issues. Prior to my changes to ReactFiberBeginWork, `'Second'` is never received by the consumer, and `Intermediate` _sometimes_ rerenders unnecessarily (iff SimpleMemoComponent is not active).

Previously, if hasLegacyContextChanged() then we would always consider didUpdateWork = true, even if oldProps === newProps. This was necessary in order to make sure that we don't go down the bailoutOnAlreadyFinishedWork path which would prevent descendants from receiving updates.

I changed it so that bailoutOnAlreadyFinishedWork doesn't reuse the child fibers if hasLegacyContextChanged(), much like if there are updates scheduled lower in the subtree or modern context changes, and I changed beginWork so that we bailout unless the particular component we're on is one that can consume legacy context (or provide it, since that's necessary for merging).

Ideally we wouldn't even run legacy context consumers that are subscribed to different context keys than the ones that changed but I don't care that much.

Tests all pass except two in ReactIncremental-test that are trying to make sure that sCU returning false can block descendants from receiving a legacy context update. That seems ridiculous to me so IMO it's more correct that these fail now. I don't actually expect we'll land or release this but wanted to put it up for posterity (and a check of my work, if anyone is feeling generous).
