### PR TITLE
Delete `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` from React Native Renderer

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -26,7 +26,6 @@ import {
   defaultOnRecoverableError,
 } from 'react-reconciler/src/ReactFiberReconciler';
 // TODO: direct imports like some-package/src/* are bad. Fix me.
-import {getStackByFiberInDevAndProd} from 'react-reconciler/src/ReactFiberComponentStack';
 import {createPortal as createPortalImpl} from 'react-reconciler/src/ReactPortal';
 import {
   setBatchingImplementation,
@@ -35,7 +34,6 @@ import {
 // Modules provided by RN:
 import {UIManager} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
 
-import {getClosestInstanceFromNode} from './ReactNativeComponentTree';
 import {getInspectorDataForInstance} from './ReactNativeFiberInspector';
 import {LegacyRoot} from 'react-reconciler/src/ReactRootTags';
 import {
@@ -194,19 +192,7 @@ function createPortal(
 
 setBatchingImplementation(batchedUpdatesImpl, discreteUpdates);
 
-function computeComponentStackForErrorReporting(reactTag: number): string {
-  const fiber = getClosestInstanceFromNode(reactTag);
-  if (!fiber) {
-    return '';
-  }
-  return getStackByFiberInDevAndProd(fiber);
-}
-
 const roots = new Map<number, FiberRoot>();
-
-const Internals = {
-  computeComponentStackForErrorReporting,
-};
 
 export {
   // This is needed for implementation details of TouchableNativeFeedback
@@ -220,7 +206,6 @@ export {
   unmountComponentAtNodeAndRemoveContainer,
   createPortal,
   batchedUpdates as unstable_batchedUpdates,
-  Internals as __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
   // This export is typically undefined in production builds.
   // See the "enableGetInspectorDataForInstanceInProduction" flag.
   getInspectorDataForInstance,

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -139,13 +139,6 @@ declare const ensureNativeMethodsAreSynced: NativeMethods;
 export type HostInstance = NativeMethods;
 export type HostComponent<Config> = AbstractComponent<Config, HostInstance>;
 
-type SecretInternalsType = {
-  computeComponentStackForErrorReporting(tag: number): string,
-  // TODO (bvaughn) Decide which additional types to expose here?
-  // And how much information to fill in for the above types.
-  ...
-};
-
 type InspectorDataProps = $ReadOnly<{
   [propName: string]: string,
   ...
@@ -233,7 +226,6 @@ export type ReactNativeType = {
   unmountComponentAtNode(containerTag: number): void,
   unmountComponentAtNodeAndRemoveContainer(containerTag: number): void,
   +unstable_batchedUpdates: <T>(fn: (T) => void, bookkeeping: T) => void,
-  +__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: SecretInternalsType,
   ...
 };
 

--- a/packages/react-native-renderer/src/__tests__/ReactNativeError-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeError-test.internal.js
@@ -10,32 +10,15 @@
 
 'use strict';
 
-let React;
-let ReactNative;
 let createReactNativeComponentClass;
-let computeComponentStackForErrorReporting;
-
-function normalizeCodeLocInfo(str) {
-  return (
-    str &&
-    str.replace(/\n +(?:at|in) ([\S]+)[^\n]*/g, function (m, name) {
-      return '\n    in ' + name + ' (at **)';
-    })
-  );
-}
 
 describe('ReactNativeError', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    React = require('react');
-    ReactNative = require('react-native-renderer');
     createReactNativeComponentClass =
       require('react-native/Libraries/ReactPrivate/ReactNativePrivateInterface')
         .ReactNativeViewConfigRegistry.register;
-    computeComponentStackForErrorReporting =
-      ReactNative.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
-        .computeComponentStackForErrorReporting;
   });
 
   it('should throw error if null component registration getter is used', () => {
@@ -47,45 +30,6 @@ describe('ReactNativeError', () => {
       }
     }).toThrow(
       'View config getter callback for component `View` must be a function (received `null`)',
-    );
-  });
-
-  // @gate !disableLegacyMode
-  it('should be able to extract a component stack from a native view', () => {
-    const View = createReactNativeComponentClass('View', () => ({
-      validAttributes: {foo: true},
-      uiViewClassName: 'View',
-    }));
-
-    const ref = React.createRef();
-
-    function FunctionComponent(props) {
-      return props.children;
-    }
-
-    class ClassComponent extends React.Component {
-      render() {
-        return (
-          <FunctionComponent>
-            <View foo="test" ref={ref} />
-          </FunctionComponent>
-        );
-      }
-    }
-
-    ReactNative.render(<ClassComponent />, 1);
-
-    const reactTag = ReactNative.findNodeHandle(ref.current);
-
-    const componentStack = normalizeCodeLocInfo(
-      computeComponentStackForErrorReporting(reactTag),
-    );
-
-    expect(componentStack).toBe(
-      '\n' +
-        '    in View (at **)\n' +
-        '    in FunctionComponent (at **)\n' +
-        '    in ClassComponent (at **)',
     );
   });
 });


### PR DESCRIPTION
## Summary

The React Native Renderer exports a `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` property with a single method that has no remaining call sites: `computeComponentStackForErrorReporting`

This PR cleans up this unused export.

## How did you test this change?

```
$ yarn
$ yarn flow fabric
$ yarn test
```