### PR TITLE
[ez] Update references to 'forget' in react-compiler-runtime

### DIFF
--- a/compiler/packages/react-compiler-runtime/src/index.ts
+++ b/compiler/packages/react-compiler-runtime/src/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use no forget';
+'use no memo';
 
 import * as React from 'react';
 
@@ -67,7 +67,7 @@ const LazyGuardDispatcher: {[key: string]: (...args: Array<any>) => any} = {};
 ].forEach(name => {
   LazyGuardDispatcher[name] = () => {
     throw new Error(
-      `[React] Unexpected React hook call (${name}) from a React Forget compiled function. ` +
+      `[React] Unexpected React hook call (${name}) from a React compiled function. ` +
         "Check that all hooks are called directly and named according to convention ('use[A-Z]') ",
     );
   };
@@ -79,7 +79,7 @@ let originalDispatcher: unknown = null;
 LazyGuardDispatcher['useMemoCache'] = (count: number) => {
   if (originalDispatcher == null) {
     throw new Error(
-      'React Forget internal invariant violation: unexpected null dispatcher',
+      'React Compiler internal invariant violation: unexpected null dispatcher',
     );
   } else {
     return (originalDispatcher as any).useMemoCache(count);
@@ -103,12 +103,12 @@ const guardFrames: Array<unknown> = [];
 /**
  * When `enableEmitHookGuards` is set, this does runtime validation
  * of the no-conditional-hook-calls rule.
- * As Forget needs to statically understand which calls to move out of
- * conditional branches (i.e. Forget cannot memoize the results of hook
+ * As React Compiler needs to statically understand which calls to move out of
+ * conditional branches (i.e. React Compiler cannot memoize the results of hook
  * calls), its understanding of "the rules of React" are more restrictive.
  * This validation throws on unsound inputs at runtime.
  *
- * Components should only be invoked through React as Forget could memoize
+ * Components should only be invoked through React as React Compiler could memoize
  * the call to AnotherComponent, introducing conditional hook calls in its
  * compiled output.
  * ```js
@@ -148,7 +148,7 @@ export function $dispatcherGuard(kind: GuardKind) {
 
     if (curr === LazyGuardDispatcher) {
       throw new Error(
-        `[React] Unexpected call to custom hook or component from a React Forget compiled function. ` +
+        `[React] Unexpected call to custom hook or component from a React compiled function. ` +
           "Check that (1) all hooks are called directly and named according to convention ('use[A-Z]') " +
           'and (2) components are returned as JSX instead of being directly invoked.',
       );
@@ -160,7 +160,7 @@ export function $dispatcherGuard(kind: GuardKind) {
 
     if (lastFrame == null) {
       throw new Error(
-        'React Forget internal error: unexpected null in guard stack',
+        'React Compiler internal error: unexpected null in guard stack',
       );
     }
     if (guardFrames.length === 0) {
@@ -176,12 +176,12 @@ export function $dispatcherGuard(kind: GuardKind) {
     const lastFrame = guardFrames.pop();
     if (lastFrame == null) {
       throw new Error(
-        'React Forget internal error: unexpected null in guard stack',
+        'React Compiler internal error: unexpected null in guard stack',
       );
     }
     setCurrent(lastFrame);
   } else {
-    throw new Error('Forget internal error: unreachable block' + kind);
+    throw new Error('React Compiler internal error: unreachable block' + kind);
   }
 }
 


### PR DESCRIPTION


Updates the runtime to reference React Compiler instead of Forget.
