### PR TITLE
[ci] Don't auto push to latest tag

### DIFF
--- a/compiler/scripts/release/publish.js
+++ b/compiler/scripts/release/publish.js
@@ -166,14 +166,7 @@ async function main() {
       try {
         await spawnHelper(
           'npm',
-          [
-            'publish',
-            ...opts,
-            '--registry=https://registry.npmjs.org',
-            // For now, since the compiler is experimental only, to simplify installation we push
-            // to the `latest` tag
-            '--tag=latest',
-          ],
+          ['publish', ...opts, '--registry=https://registry.npmjs.org'],
           {
             cwd: pkgDir,
             stdio: 'inherit',


### PR DESCRIPTION

By default let's stop pushing to the latest tag now that we have a non-experimental release.
