### PR TITLE
[ci:compiler] Only add latest tag to non-experimental

### DIFF
--- a/compiler/scripts/release/publish.js
+++ b/compiler/scripts/release/publish.js
@@ -163,6 +163,21 @@ async function main() {
       if (otp != null) {
         opts.push(`--otp=${otp}`);
       }
+      /**
+       * Typically, the `latest` tag is reserved for stable package versions. Since the the compiler
+       * is still pre-release, until we have a stable release let's only add the
+       * `latest` tag to non-experimental releases.
+       *
+       * `latest` is added by default, so we only override it for experimental releases so that
+       * those don't get the `latest` tag.
+       *
+       * TODO: Update this when we have a stable release.
+       */
+      if (argv.tag === 'experimental') {
+        opts.push('--tag=experimental');
+      } else {
+        opts.push('--tag=latest');
+      }
       try {
         await spawnHelper(
           'npm',


### PR DESCRIPTION


It turns out npm sets the latest tag by default so simply removing it didn't change the previous behavior.

The `latest` tag is typically used for stable release versions, and other tags for unstable versions such as prereleases. Since the compiler is still in prerelease, let's set the latest tag only for non-experimental releases to help signal which version is the safest to try out.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/31288).
* #31289
* __->__ #31288