### PR TITLE
[ci] Don't use branch name for concurrency

### DIFF
--- a/.github/workflows/compiler_playground.yml
+++ b/.github/workflows/compiler_playground.yml
@@ -9,7 +9,7 @@ on:
       - .github/workflows/compiler-playground.yml
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/compiler_rust.yml
+++ b/.github/workflows/compiler_rust.yml
@@ -16,7 +16,7 @@ on:
       - compiler/*.toml
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/compiler_typescript.yml
+++ b/.github/workflows/compiler_typescript.yml
@@ -9,7 +9,7 @@ on:
       - .github/workflows/compiler_typescript.yml
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -8,7 +8,7 @@ on:
       - compiler/**
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/shared_lint.yml
+++ b/.github/workflows/shared_lint.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION

I happened to notice some jobs on main get canceled if another PR landed before the prior commit on main had finished running CI. This is not great for difftrain because the commit artifacts job relies on the CI jobs on main finishing before it triggers. This would lead to commits being skipped on DiffTrain which is not great for provenance since we want it to be a 1:1 sync.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/31296).
* #31297
* __->__ #31296