### PR TITLE
[Flight] Add serverModuleMap option for mapping ServerReferences

### DIFF
--- a/packages/react-markup/src/ReactMarkupServer.js
+++ b/packages/react-markup/src/ReactMarkupServer.js
@@ -175,6 +175,7 @@ export function experimental_renderToHTML(
     const flightResponse = createFlightResponse(
       null,
       null,
+      null,
       noServerCallOrFormAction,
       noServerCallOrFormAction,
       undefined,

--- a/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
@@ -62,6 +62,7 @@ function read<T>(source: Source, options: ReadOptions): Thenable<T> {
   const response = createResponse(
     source,
     null,
+    null,
     undefined,
     undefined,
     undefined,

--- a/packages/react-server-dom-esm/src/client/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-esm/src/client/ReactFlightDOMClientBrowser.js
@@ -51,6 +51,7 @@ function createResponseFromOptions(options: void | Options) {
   return createResponse(
     options && options.moduleBaseURL ? options.moduleBaseURL : '',
     null,
+    null,
     options && options.callServer ? options.callServer : undefined,
     undefined, // encodeFormAction
     undefined, // nonce

--- a/packages/react-server-dom-esm/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-esm/src/client/ReactFlightDOMClientNode.js
@@ -62,6 +62,7 @@ function createFromNodeStream<T>(
 ): Thenable<T> {
   const response: Response = createResponse(
     moduleRootPath,
+    null,
     moduleBaseURL,
     noServerCall,
     options ? options.encodeFormAction : undefined,

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientBrowser.js
@@ -50,6 +50,7 @@ function createResponseFromOptions(options: void | Options) {
   return createResponse(
     null,
     null,
+    null,
     options && options.callServer ? options.callServer : undefined,
     undefined, // encodeFormAction
     undefined, // nonce

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientEdge.js
@@ -19,11 +19,13 @@ import type {ReactServerValue} from 'react-client/src/ReactFlightReplyClient';
 import type {
   ServerConsumerModuleMap,
   ModuleLoading,
+  ServerManifest,
 } from 'react-client/src/ReactFlightClientConfig';
 
 type ServerConsumerManifest = {
   moduleMap: ServerConsumerModuleMap,
   moduleLoading: ModuleLoading,
+  serverModuleMap: null | ServerManifest,
 };
 
 import {
@@ -78,6 +80,7 @@ export type Options = {
 function createResponseFromOptions(options: Options) {
   return createResponse(
     options.serverManifest.moduleMap,
+    options.serverManifest.serverModuleMap,
     options.serverManifest.moduleLoading,
     noServerCall,
     options.encodeFormAction,

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
@@ -17,11 +17,13 @@ import type {
 import type {
   ServerConsumerModuleMap,
   ModuleLoading,
+  ServerManifest,
 } from 'react-client/src/ReactFlightClientConfig';
 
 type ServerConsumerManifest = {
   moduleMap: ServerConsumerModuleMap,
   moduleLoading: ModuleLoading,
+  serverModuleMap: null | ServerManifest,
 };
 
 import type {Readable} from 'stream';
@@ -71,6 +73,7 @@ function createFromNodeStream<T>(
 ): Thenable<T> {
   const response: Response = createResponse(
     serverConsumerManifest.moduleMap,
+    serverConsumerManifest.serverModuleMap,
     serverConsumerManifest.moduleLoading,
     noServerCall,
     options ? options.encodeFormAction : undefined,

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientBrowser.js
@@ -50,6 +50,7 @@ function createResponseFromOptions(options: void | Options) {
   return createResponse(
     null,
     null,
+    null,
     options && options.callServer ? options.callServer : undefined,
     undefined, // encodeFormAction
     undefined, // nonce

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientEdge.js
@@ -19,11 +19,13 @@ import type {ReactServerValue} from 'react-client/src/ReactFlightReplyClient';
 import type {
   ServerConsumerModuleMap,
   ModuleLoading,
+  ServerManifest,
 } from 'react-client/src/ReactFlightClientConfig';
 
 type ServerConsumerManifest = {
   moduleMap: ServerConsumerModuleMap,
   moduleLoading: ModuleLoading,
+  serverModuleMap: null | ServerManifest,
 };
 
 import {
@@ -78,6 +80,7 @@ export type Options = {
 function createResponseFromOptions(options: Options) {
   return createResponse(
     options.serverConsumerManifest.moduleMap,
+    options.serverConsumerManifest.serverModuleMap,
     options.serverConsumerManifest.moduleLoading,
     noServerCall,
     options.encodeFormAction,

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
@@ -17,11 +17,13 @@ import type {
 import type {
   ServerConsumerModuleMap,
   ModuleLoading,
+  ServerManifest,
 } from 'react-client/src/ReactFlightClientConfig';
 
 type ServerConsumerManifest = {
   moduleMap: ServerConsumerModuleMap,
   moduleLoading: ModuleLoading,
+  serverModuleMap: null | ServerManifest,
 };
 
 import type {Readable} from 'stream';
@@ -72,6 +74,7 @@ function createFromNodeStream<T>(
 ): Thenable<T> {
   const response: Response = createResponse(
     serverConsumerManifest.moduleMap,
+    serverConsumerManifest.serverModuleMap,
     serverConsumerManifest.moduleLoading,
     noServerCall,
     options ? options.encodeFormAction : undefined,


### PR DESCRIPTION
Stacked on #31299.

We already have an option for resolving Client References to other Client References when consuming an RSC payload on the server. 

This lets you resolve Server References on the consuming side when the environment where you're consuming the RSC payload also has access to those Server References. Basically they becomes like Client References for this consumer but for another consumer they wouldn't be.


