### PR TITLE
refactor: support verbose compiler healthcheck logs

### DIFF
--- a/compiler/packages/react-compiler-healthcheck/src/checks/reactCompiler.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/checks/reactCompiler.ts
@@ -139,11 +139,21 @@ export default {
     }
   },
 
-  report(): void {
+  report(verbose = false): void {
     const totalComponents =
       SucessfulCompilation.length +
       countUniqueLocInEvents(OtherFailures) +
       countUniqueLocInEvents(ActionableFailures);
+    if (verbose) {
+      console.log(
+        chalk.red(
+          `Actionable Failures: ${JSON.stringify(ActionableFailures, null, 2)}`,
+        ),
+      );
+      console.log(
+        chalk.red(`Other Failures: ${JSON.stringify(OtherFailures, null, 2)}`),
+      );
+    }
     console.log(
       chalk.green(
         `Successfully compiled ${SucessfulCompilation.length} out of ${totalComponents} components.`,

--- a/compiler/packages/react-compiler-healthcheck/src/index.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/index.ts
@@ -22,10 +22,16 @@ async function main() {
       type: 'string',
       default: '**/+(*.{js,mjs,jsx,ts,tsx}|package.json)',
     })
+    .option('verbose', {
+      description: 'Show all healthcheck errors and violations',
+      type: 'boolean',
+      default: false,
+    })
     .parseSync();
 
   const spinner = ora('Checking').start();
   let src = argv.src;
+  let verbose = argv.verbose
 
   const globOptions = {
     onlyFiles: true,
@@ -48,7 +54,7 @@ async function main() {
   }
   spinner.stop();
 
-  reactCompilerCheck.report();
+  reactCompilerCheck.report(verbose);
   strictModeCheck.report();
   libraryCompatCheck.report();
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
This adds the `--verbose` flag to the `react-compiler-healthcheck` cli to make it a lot easier to fix errors and violation when migrating to react 19.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Running the react-compiler-healthcheck cli with the `--verbose` flag shows all the errors in my code emitted from the compiler.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
