### PR TITLE
chore: remove unsued deps from React Compiler Babel plugin

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/package.json
+++ b/compiler/packages/babel-plugin-react-compiler/package.json
@@ -18,16 +18,11 @@
     "lint": "yarn eslint src"
   },
   "dependencies": {
-    "@babel/generator": "7.2.0",
-    "@babel/types": "^7.19.0",
-    "chalk": "4",
-    "invariant": "^2.2.4",
-    "pretty-format": "^24",
-    "zod": "^3.22.4",
-    "zod-validation-error": "^2.1.0"
+    "@babel/types": "^7.19.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",
+    "@babel/generator": "7.2.0",
     "@babel/parser": "^7.2.0",
     "@babel/plugin-syntax-typescript": "^7.18.6",
     "@babel/plugin-transform-block-scoping": "^7.18.9",
@@ -46,15 +41,20 @@
     "babel-jest": "^29.0.3",
     "babel-plugin-fbt": "^1.0.0",
     "babel-plugin-fbt-runtime": "^1.0.0",
+    "chalk": "4",
     "eslint": "^8.57.1",
     "glob": "^7.1.6",
+    "invariant": "^2.2.4",
     "jest": "^29.0.3",
     "jest-environment-jsdom": "^29.0.3",
+    "pretty-format": "^24",
     "react": "19.0.0-beta-b498834eab-20240506",
     "react-dom": "19.0.0-beta-b498834eab-20240506",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.1.1",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "zod": "^3.22.4",
+    "zod-validation-error": "^2.1.0"
   },
   "resolutions": {
     "./**/@babel/parser": "7.7.4",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Since the Babel plugin is bundled into a single file (except for `@babel/types` https://github.com/facebook/react/blob/45804af18d589fd2c181f3b020f07661c46b73ea/compiler/packages/babel-plugin-react-compiler/rollup.config.js#L18) we can move these deps to `devDependencies`.

Main motivation is e.g. not installing ancient version of `pretty-format` (asked in https://github.com/facebook/react/issues/29062 without getting a reason, but if consumers can just skip the deps entirely that's even better).

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

I tested by installing the plugin into an empty project, deleting everything in `node_modules` _except_ for `babel-plugin-react-compiler` and doing `require('babel-plugin-react-compiler')`. It still worked fine, so it should work in other cases as well 😀 

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
