### PR TITLE
remove terser from react-compiler-runtime build

### DIFF
--- a/compiler/packages/react-compiler-runtime/rollup.config.js
+++ b/compiler/packages/react-compiler-runtime/rollup.config.js
@@ -11,7 +11,6 @@ import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import path from 'path';
 import process from 'process';
-import terser from '@rollup/plugin-terser';
 import banner2 from 'rollup-plugin-banner2';
 
 const NO_INLINE = new Set(['react']);
@@ -37,11 +36,6 @@ const PROD_ROLLUP_CONFIG = {
       rootDir: path.join(process.cwd(), '..'),
     }),
     commonjs(),
-    terser({
-      format: {
-        comments: false,
-      },
-    }),
     banner2(
       () => `/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.


### PR DESCRIPTION
## Summary

This fixes a minor nit I have about the `react-compiler-runtime` package in that the published code is minified. I assume most consumers will minify their own bundles so there's no real advantage to minifying it as part of the build. 

For my purposes it makes it more difficult to read the code, use `patch-package` (if needed), or diff two versions without referencing the source code on github or mapping it back to original source using the source maps. 

## How did you test this change?

I ran the build locally and looked at the result but did not run the code. It's a lot more readable except for the commonjs compatibility-related stuff that Rollup inserts. 
