### PR TITLE
Fix error handling in `resolveClientReference`

### DIFF
--- a/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerNode.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerNode.js
@@ -62,19 +62,19 @@ export function resolveClientReference<T>(
   metadata: ClientReferenceMetadata,
 ): ClientReference<T> {
   const moduleExports = bundlerConfig[metadata[ID]];
-  let resolvedModuleData = moduleExports[metadata[NAME]];
+  let resolvedModuleData = moduleExports && moduleExports[metadata[NAME]];
   let name;
   if (resolvedModuleData) {
     // The potentially aliased name.
     name = resolvedModuleData.name;
   } else {
     // If we don't have this specific name, we might have the full module.
-    resolvedModuleData = moduleExports['*'];
+    resolvedModuleData = moduleExports && moduleExports['*'];
     if (!resolvedModuleData) {
       throw new Error(
         'Could not find the module "' +
           metadata[ID] +
-          '" in the React SSR Manifest. ' +
+          '" in the React Server Consumer Manifest. ' +
           'This is probably a bug in the React Server Components bundler.',
       );
     }

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopack.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopack.js
@@ -68,19 +68,19 @@ export function resolveClientReference<T>(
 ): ClientReference<T> {
   if (bundlerConfig) {
     const moduleExports = bundlerConfig[metadata[ID]];
-    let resolvedModuleData = moduleExports[metadata[NAME]];
+    let resolvedModuleData = moduleExports && moduleExports[metadata[NAME]];
     let name;
     if (resolvedModuleData) {
       // The potentially aliased name.
       name = resolvedModuleData.name;
     } else {
       // If we don't have this specific name, we might have the full module.
-      resolvedModuleData = moduleExports['*'];
+      resolvedModuleData = moduleExports && moduleExports['*'];
       if (!resolvedModuleData) {
         throw new Error(
           'Could not find the module "' +
             metadata[ID] +
-            '" in the React SSR Manifest. ' +
+            '" in the React Server Consumer Manifest. ' +
             'This is probably a bug in the React Server Components bundler.',
         );
       }

--- a/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerNode.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerNode.js
@@ -62,19 +62,19 @@ export function resolveClientReference<T>(
   metadata: ClientReferenceMetadata,
 ): ClientReference<T> {
   const moduleExports = bundlerConfig[metadata[ID]];
-  let resolvedModuleData = moduleExports[metadata[NAME]];
+  let resolvedModuleData = moduleExports && moduleExports[metadata[NAME]];
   let name;
   if (resolvedModuleData) {
     // The potentially aliased name.
     name = resolvedModuleData.name;
   } else {
     // If we don't have this specific name, we might have the full module.
-    resolvedModuleData = moduleExports['*'];
+    resolvedModuleData = moduleExports && moduleExports['*'];
     if (!resolvedModuleData) {
       throw new Error(
         'Could not find the module "' +
           metadata[ID] +
-          '" in the React SSR Manifest. ' +
+          '" in the React Server Consumer Manifest. ' +
           'This is probably a bug in the React Server Components bundler.',
       );
     }

--- a/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpack.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpack.js
@@ -68,19 +68,19 @@ export function resolveClientReference<T>(
 ): ClientReference<T> {
   if (bundlerConfig) {
     const moduleExports = bundlerConfig[metadata[ID]];
-    let resolvedModuleData = moduleExports[metadata[NAME]];
+    let resolvedModuleData = moduleExports && moduleExports[metadata[NAME]];
     let name;
     if (resolvedModuleData) {
       // The potentially aliased name.
       name = resolvedModuleData.name;
     } else {
       // If we don't have this specific name, we might have the full module.
-      resolvedModuleData = moduleExports['*'];
+      resolvedModuleData = moduleExports && moduleExports['*'];
       if (!resolvedModuleData) {
         throw new Error(
           'Could not find the module "' +
             metadata[ID] +
-            '" in the React SSR Manifest. ' +
+            '" in the React Server Consumer Manifest. ' +
             'This is probably a bug in the React Server Components bundler.',
         );
       }


### PR DESCRIPTION
When a React Server Consumer Manifest does not include an entry for a client reference ID, we must not try to look up the export name (or `'*'`) for the client reference. Otherwise this will fail with `TypeError: Cannot read properties of undefined (reading '...')` instead of the custom error we intended to throw.