### PR TITLE
[Flight] encodeURI filenames parsed from stack traces

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -2275,12 +2275,12 @@ function createFakeFunction<T>(
       '\n//# sourceURL=rsc://React/' +
       encodeURIComponent(environmentName) +
       '/' +
-      filename +
+      encodeURI(filename) +
       '?' +
       fakeFunctionIdx++;
     code += '\n//# sourceMappingURL=' + sourceMap;
   } else if (filename) {
-    code += '\n//# sourceURL=' + filename;
+    code += '\n//# sourceURL=' + encodeURI(filename);
   } else {
     code += '\n//# sourceURL=<anonymous>';
   }

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -1363,7 +1363,7 @@ describe('ReactFlight', () => {
             )
               ? expect.stringContaining(
                   'Error: This is an error\n' +
-                    '    at eval (eval at testFunction (eval at createFakeFunction (**), <anonymous>:1:35)\n' +
+                    '    at eval (eval at testFunction (inspected-page.html:29:11),%20%3Canonymous%3E:1:35)\n' +
                     '    at ServerComponentError (file://~/(some)(really)(exotic-directory)/ReactFlight-test.js:1166:19)\n' +
                     '    at <anonymous> (file:///testing.js:42:3)\n' +
                     '    at <anonymous> (file:///testing.js:42:3)\n' +
@@ -1371,7 +1371,7 @@ describe('ReactFlight', () => {
                 )
               : expect.stringContaining(
                   'Error: This is an error\n' +
-                    '    at eval (eval at testFunction (inspected-page.html:29:11), <anonymous>:1:10)\n' +
+                    '    at eval (eval at testFunction (inspected-page.html:29:11),%20%3Canonymous%3E:1:10)\n' +
                     '    at ServerComponentError (file://~/(some)(really)(exotic-directory)/ReactFlight-test.js:1166:19)\n' +
                     '    at file:///testing.js:42:3\n' +
                     '    at file:///testing.js:42:3\n' +


### PR DESCRIPTION
When parsing stacks from third parties they may include invalid url characters. So we need to encode them. Since these are expected to be urls though we use just encodeURI instead of encodeURIComponent.
