### PR TITLE
fix[Tree]: use selectedElementIndex as key to force re-render

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
@@ -421,7 +421,7 @@ export default function Tree(props: Props): React.Node {
             onMouseLeave={handleMouseLeave}
             ref={focusTargetRef}
             tabIndex={0}>
-            <AutoSizer>
+            <AutoSizer key={selectedElementIndex?.toString()}>
               {({height, width}) => (
                 <FixedSizeList
                   className={styles.List}


### PR DESCRIPTION
There is a feature that syncs the element selection between Elements panel and RDT Components panel.

Before this change, after the `scrollToItem` is called, user is going to see the empty list, because nothing is rendered. This is because `AutoSizer` doesn't know anything about `FixedSizeList` and that it was just scrolled.

With this change, we are using `selectedItemIndex` to force re-render for `AutoSizer`, which will consequently call children function.

See https://fburl.com/workplace/gnu43nok.