### PR TITLE
[compiler][ez] tsconfig: treat all snap fixtures as modules

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/tsconfig.json
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/tsconfig.json
@@ -19,7 +19,9 @@
     },
     "verbatimModuleSyntax": true,
     "module": "ESNext",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "moduleDetection": "force"
+
   },
   "include": [
     "./compiler/**/*.js",


### PR DESCRIPTION

Qol improvement. Currently, typescript lints treat test fixtures without an export as a 'global script' (see [docs](https://www.typescriptlang.org/docs/handbook/2/modules.html#how-javascript-modules-are-defined)). This gives confusing lints for duplicate declarations (in the global scope)
