### PR TITLE
[cleanup] remove legacy path condition in jest preprocessor

### DIFF
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -66,57 +66,54 @@ module.exports = {
     if (filePath.match(/\.json$/)) {
       return {code: src};
     }
-    if (!filePath.match(/\/third_party\//)) {
-      // for test files, we also apply the async-await transform, but we want to
-      // make sure we don't accidentally apply that transform to product code.
-      const isTestFile = !!filePath.match(/\/__tests__\//);
-      const isInDevToolsPackages = !!filePath.match(
-        /\/packages\/react-devtools.*\//
-      );
-      const plugins = [].concat(babelOptions.plugins);
-      if (isTestFile && isInDevToolsPackages) {
-        plugins.push(pathToTransformReactVersionPragma);
-      }
-
-      // This is only for React DevTools tests with React 16.x
-      // `react/jsx-dev-runtime` and `react/jsx-runtime` are included in the package starting from v17
-      if (semver.gte(ReactVersionTestingAgainst, '17.0.0')) {
-        plugins.push([
-          process.env.NODE_ENV === 'development'
-            ? require.resolve('@babel/plugin-transform-react-jsx-development')
-            : require.resolve('@babel/plugin-transform-react-jsx'),
-          // The "automatic" runtime corresponds to react/jsx-runtime. "classic"
-          // would be React.createElement.
-          {runtime: 'automatic'},
-        ]);
-      } else {
-        plugins.push(
-          require.resolve('@babel/plugin-transform-react-jsx'),
-          require.resolve('@babel/plugin-transform-react-jsx-source')
-        );
-      }
-
-      plugins.push(pathToTransformLazyJSXImport);
-
-      let sourceAst = hermesParser.parse(src, {babel: true});
-      return {
-        code: babel.transformFromAstSync(
-          sourceAst,
-          src,
-          Object.assign(
-            {filename: path.relative(process.cwd(), filePath)},
-            babelOptions,
-            {
-              plugins,
-              sourceMaps: process.env.JEST_ENABLE_SOURCE_MAPS
-                ? process.env.JEST_ENABLE_SOURCE_MAPS
-                : false,
-            }
-          )
-        ).code,
-      };
+    // for test files, we also apply the async-await transform, but we want to
+    // make sure we don't accidentally apply that transform to product code.
+    const isTestFile = !!filePath.match(/\/__tests__\//);
+    const isInDevToolsPackages = !!filePath.match(
+      /\/packages\/react-devtools.*\//
+    );
+    const plugins = [].concat(babelOptions.plugins);
+    if (isTestFile && isInDevToolsPackages) {
+      plugins.push(pathToTransformReactVersionPragma);
     }
-    return {code: src};
+
+    // This is only for React DevTools tests with React 16.x
+    // `react/jsx-dev-runtime` and `react/jsx-runtime` are included in the package starting from v17
+    if (semver.gte(ReactVersionTestingAgainst, '17.0.0')) {
+      plugins.push([
+        process.env.NODE_ENV === 'development'
+          ? require.resolve('@babel/plugin-transform-react-jsx-development')
+          : require.resolve('@babel/plugin-transform-react-jsx'),
+        // The "automatic" runtime corresponds to react/jsx-runtime. "classic"
+        // would be React.createElement.
+        {runtime: 'automatic'},
+      ]);
+    } else {
+      plugins.push(
+        require.resolve('@babel/plugin-transform-react-jsx'),
+        require.resolve('@babel/plugin-transform-react-jsx-source')
+      );
+    }
+
+    plugins.push(pathToTransformLazyJSXImport);
+
+    let sourceAst = hermesParser.parse(src, {babel: true});
+    return {
+      code: babel.transformFromAstSync(
+        sourceAst,
+        src,
+        Object.assign(
+          {filename: path.relative(process.cwd(), filePath)},
+          babelOptions,
+          {
+            plugins,
+            sourceMaps: process.env.JEST_ENABLE_SOURCE_MAPS
+              ? process.env.JEST_ENABLE_SOURCE_MAPS
+              : false,
+          }
+        )
+      ).code,
+    };
   },
 
   getCacheKey: createCacheKeyFunction(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
This PR removes a condition that looks legacy inside Jest preprocessor script. 

How I happened upon this:

Running `yarn test` on a fresh clone of the repository, I ran into Jest errors suggesting files were not transformed properly by babel.

I tracked it down to a condition in `scripts/jest/preprocessor.js`:

    if (!filePath.match(/\/third_party\//)) {
        ...
    }

I had cloned the repo on my machine inside a `third_party/react` directory, causing this condition to always be false :smiling_face_with_tear: .

## How did you test this change?

Research done:

- I only found one `third_party` directory, and it was inside `node_modules` (hence already ignored by babel transforms).  
- I looked at the git history with `git log --diff-filter=ACDR -- '*third_party*'`.  
- This confirmed the `third_party` folder existed at some point in the codebase and was removed in commit 8b4ec79d4f4fea7fcea06ed58ec5329fbc64bafe.

Running `yarn test` before/after the change produces the same output in the general case.  
If running `yarn test` with a path like `third_party/react`, the command fails before this change and passes after.

This seemed like a tiny fix so I did not open an issue.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
