### PR TITLE
Capture the source and not just the stack on first seen error

### DIFF
--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -81,6 +81,8 @@ type TextInstance = {
 type HostContext = Object;
 type CreateRootOptions = {
   unstable_transitionCallbacks?: TransitionTracingCallbacks,
+  onUncaughtError?: (error: mixed, errorInfo: {componentStack: string}) => void,
+  onCaughtError?: (error: mixed, errorInfo: {componentStack: string}) => void,
   ...
 };
 
@@ -1069,8 +1071,12 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         null,
         false,
         '',
-        NoopRenderer.defaultOnUncaughtError,
-        NoopRenderer.defaultOnCaughtError,
+        options && options.onUncaughtError
+          ? options.onUncaughtError
+          : NoopRenderer.defaultOnUncaughtError,
+        options && options.onCaughtError
+          ? options.onCaughtError
+          : NoopRenderer.defaultOnCaughtError,
         onRecoverableError,
         options && options.unstable_transitionCallbacks
           ? options.unstable_transitionCallbacks

--- a/packages/react-reconciler/src/ReactCapturedValue.js
+++ b/packages/react-reconciler/src/ReactCapturedValue.js
@@ -11,7 +11,7 @@ import type {Fiber} from './ReactInternalTypes';
 
 import {getStackByFiberInDevAndProd} from './ReactFiberComponentStack';
 
-const CapturedStacks: WeakMap<any, string> = new WeakMap();
+const CapturedStacks: WeakMap<any, CapturedValue<any>> = new WeakMap();
 
 export type CapturedValue<+T> = {
   +value: T,
@@ -25,36 +25,38 @@ export function createCapturedValueAtFiber<T>(
 ): CapturedValue<T> {
   // If the value is an error, call this function immediately after it is thrown
   // so the stack is accurate.
-  let stack;
   if (typeof value === 'object' && value !== null) {
-    const capturedStack = CapturedStacks.get(value);
-    if (typeof capturedStack === 'string') {
-      stack = capturedStack;
-    } else {
-      stack = getStackByFiberInDevAndProd(source);
-      CapturedStacks.set(value, stack);
+    const existing = CapturedStacks.get(value);
+    if (existing !== undefined) {
+      return existing;
     }
+    const captured = {
+      value,
+      source,
+      stack: getStackByFiberInDevAndProd(source),
+    };
+    CapturedStacks.set(value, captured);
+    return captured;
   } else {
-    stack = getStackByFiberInDevAndProd(source);
+    return {
+      value,
+      source,
+      stack: getStackByFiberInDevAndProd(source),
+    };
   }
-
-  return {
-    value,
-    source,
-    stack,
-  };
 }
 
 export function createCapturedValueFromError(
   value: Error,
   stack: null | string,
 ): CapturedValue<Error> {
-  if (typeof stack === 'string') {
-    CapturedStacks.set(value, stack);
-  }
-  return {
+  const captured = {
     value,
     source: null,
     stack: stack,
   };
+  if (typeof stack === 'string') {
+    CapturedStacks.set(value, captured);
+  }
+  return captured;
 }


### PR DESCRIPTION
Otherwise we can't capture the owner stack at the right location when there's a rethrow.