### PR TITLE
Fix Ref Lifecycles in Hidden Subtrees

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2078,12 +2078,10 @@ function commitMutationEffectsOnFiber(
         // TODO: This is a temporary solution that allowed us to transition away
         // from React Flare on www.
         if (flags & Ref) {
-          if (!offscreenSubtreeWasHidden && current !== null) {
+          if (current !== null) {
             safelyDetachRef(finishedWork, finishedWork.return);
           }
-          if (!offscreenSubtreeIsHidden) {
-            safelyAttachRef(finishedWork, finishedWork.return);
-          }
+          safelyAttachRef(finishedWork, finishedWork.return);
         }
         if (flags & Update) {
           const scopeInstance = finishedWork.stateNode;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2081,7 +2081,9 @@ function commitMutationEffectsOnFiber(
           if (!offscreenSubtreeWasHidden && current !== null) {
             safelyDetachRef(finishedWork, finishedWork.return);
           }
-          safelyAttachRef(finishedWork, finishedWork.return);
+          if (!offscreenSubtreeIsHidden) {
+            safelyAttachRef(finishedWork, finishedWork.return);
+          }
         }
         if (flags & Update) {
           const scopeInstance = finishedWork.stateNode;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1640,8 +1640,8 @@ function commitMutationEffectsOnFiber(
       recursivelyTraverseMutationEffects(root, finishedWork, lanes);
       commitReconciliationEffects(finishedWork);
 
-      if (flags & Ref && !offscreenSubtreeWasHidden) {
-        if (current !== null) {
+      if (flags & Ref) {
+        if (!offscreenSubtreeWasHidden && current !== null) {
           safelyDetachRef(current, current.return);
         }
       }
@@ -1663,8 +1663,8 @@ function commitMutationEffectsOnFiber(
         recursivelyTraverseMutationEffects(root, finishedWork, lanes);
         commitReconciliationEffects(finishedWork);
 
-        if (flags & Ref && !offscreenSubtreeWasHidden) {
-          if (current !== null) {
+        if (flags & Ref) {
+          if (!offscreenSubtreeWasHidden && current !== null) {
             safelyDetachRef(current, current.return);
           }
         }
@@ -1748,8 +1748,8 @@ function commitMutationEffectsOnFiber(
       recursivelyTraverseMutationEffects(root, finishedWork, lanes);
       commitReconciliationEffects(finishedWork);
 
-      if (flags & Ref && !offscreenSubtreeWasHidden) {
-        if (current !== null) {
+      if (flags & Ref) {
+        if (!offscreenSubtreeWasHidden && current !== null) {
           safelyDetachRef(current, current.return);
         }
       }
@@ -1964,8 +1964,8 @@ function commitMutationEffectsOnFiber(
       break;
     }
     case OffscreenComponent: {
-      if (flags & Ref && !offscreenSubtreeWasHidden) {
-        if (current !== null) {
+      if (flags & Ref) {
+        if (!offscreenSubtreeWasHidden && current !== null) {
           safelyDetachRef(current, current.return);
         }
       }
@@ -2077,8 +2077,8 @@ function commitMutationEffectsOnFiber(
 
         // TODO: This is a temporary solution that allowed us to transition away
         // from React Flare on www.
-        if (flags & Ref && !offscreenSubtreeWasHidden) {
-          if (current !== null) {
+        if (flags & Ref) {
+          if (!offscreenSubtreeWasHidden && current !== null) {
             safelyDetachRef(finishedWork, finishedWork.return);
           }
           safelyAttachRef(finishedWork, finishedWork.return);

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2078,10 +2078,12 @@ function commitMutationEffectsOnFiber(
         // TODO: This is a temporary solution that allowed us to transition away
         // from React Flare on www.
         if (flags & Ref) {
-          if (current !== null) {
+          if (!offscreenSubtreeWasHidden && current !== null) {
             safelyDetachRef(finishedWork, finishedWork.return);
           }
-          safelyAttachRef(finishedWork, finishedWork.return);
+          if (!offscreenSubtreeIsHidden) {
+            safelyAttachRef(finishedWork, finishedWork.return);
+          }
         }
         if (flags & Update) {
           const scopeInstance = finishedWork.stateNode;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1325,7 +1325,9 @@ function commitDeletionEffectsOnFiber(
     }
     case ScopeComponent: {
       if (enableScopeAPI) {
-        safelyDetachRef(deletedFiber, nearestMountedAncestor);
+        if (!offscreenSubtreeWasHidden) {
+          safelyDetachRef(deletedFiber, nearestMountedAncestor);
+        }
       }
       recursivelyTraverseDeletionEffects(
         finishedRoot,
@@ -1335,7 +1337,9 @@ function commitDeletionEffectsOnFiber(
       return;
     }
     case OffscreenComponent: {
-      safelyDetachRef(deletedFiber, nearestMountedAncestor);
+      if (!offscreenSubtreeWasHidden) {
+        safelyDetachRef(deletedFiber, nearestMountedAncestor);
+      }
       if (disableLegacyMode || deletedFiber.mode & ConcurrentMode) {
         // If this offscreen component is hidden, we already unmounted it. Before
         // deleting the children, track that it's already unmounted so that we
@@ -1572,7 +1576,7 @@ function recursivelyTraverseMutationEffects(
   lanes: Lanes,
 ) {
   // Deletions effects can be scheduled on any fiber type. They need to happen
-  // before the children effects hae fired.
+  // before the children effects have fired.
   const deletions = parentFiber.deletions;
   if (deletions !== null) {
     for (let i = 0; i < deletions.length; i++) {
@@ -1636,7 +1640,7 @@ function commitMutationEffectsOnFiber(
       recursivelyTraverseMutationEffects(root, finishedWork, lanes);
       commitReconciliationEffects(finishedWork);
 
-      if (flags & Ref) {
+      if (flags & Ref && !offscreenSubtreeWasHidden) {
         if (current !== null) {
           safelyDetachRef(current, current.return);
         }
@@ -1659,7 +1663,7 @@ function commitMutationEffectsOnFiber(
         recursivelyTraverseMutationEffects(root, finishedWork, lanes);
         commitReconciliationEffects(finishedWork);
 
-        if (flags & Ref) {
+        if (flags & Ref && !offscreenSubtreeWasHidden) {
           if (current !== null) {
             safelyDetachRef(current, current.return);
           }
@@ -1744,7 +1748,7 @@ function commitMutationEffectsOnFiber(
       recursivelyTraverseMutationEffects(root, finishedWork, lanes);
       commitReconciliationEffects(finishedWork);
 
-      if (flags & Ref) {
+      if (flags & Ref && !offscreenSubtreeWasHidden) {
         if (current !== null) {
           safelyDetachRef(current, current.return);
         }
@@ -1960,7 +1964,7 @@ function commitMutationEffectsOnFiber(
       break;
     }
     case OffscreenComponent: {
-      if (flags & Ref) {
+      if (flags & Ref && !offscreenSubtreeWasHidden) {
         if (current !== null) {
           safelyDetachRef(current, current.return);
         }
@@ -2073,7 +2077,7 @@ function commitMutationEffectsOnFiber(
 
         // TODO: This is a temporary solution that allowed us to transition away
         // from React Flare on www.
-        if (flags & Ref) {
+        if (flags & Ref && !offscreenSubtreeWasHidden) {
           if (current !== null) {
             safelyDetachRef(finishedWork, finishedWork.return);
           }

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -305,6 +305,52 @@ describe('ReactFreshIntegration', () => {
       }
     });
 
+    // @gate enableActivity
+    it('does not re-create refs for Activity hidden', async () => {
+      if (__DEV__) {
+        await render(`
+          import {unstable_Activity as Activity} from 'react';
+
+          export default function App() {
+            return (
+              <Activity mode="hidden">
+                <div ref={(node) => {
+                  if (node === null) {
+                    throw new Error('callback ref should never be null')
+                  }
+                  return () => {
+                    // ignore
+                  }
+                }}>A</div>
+              </Activity>
+            );
+          };
+        `);
+        const el = container.firstChild;
+        expect(el.textContent).toBe('A');
+        await patch(`
+          import {unstable_Activity as Activity} from 'react';
+
+          export default function App() {
+            return (
+              <Activity mode="hidden">
+                <div ref={(node) => {
+                  if (node === null) {
+                    throw new Error('callback ref should never be null.')
+                  }
+                  return () => {
+                    // ignore
+                  }
+                }}>A</div>
+              </Activity>
+            );
+          };
+        `);
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('A');
+      }
+    });
+
     it('reloads HOCs if they return functions', async () => {
       if (__DEV__) {
         await render(`

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -305,50 +305,48 @@ describe('ReactFreshIntegration', () => {
       }
     });
 
-    // @gate enableActivity
+    // @gate __DEV__ && enableActivity
     it('does not re-create refs for Activity hidden', async () => {
-      if (__DEV__) {
-        await render(`
-          import {unstable_Activity as Activity} from 'react';
+      await render(`
+        import {unstable_Activity as Activity} from 'react';
 
-          export default function App() {
-            return (
-              <Activity mode="hidden">
-                <div ref={(node) => {
-                  if (node === null) {
-                    throw new Error('callback ref should never be null')
-                  }
-                  return () => {
-                    // ignore
-                  }
-                }}>A</div>
-              </Activity>
-            );
-          };
-        `);
-        const el = container.firstChild;
-        expect(el.textContent).toBe('A');
-        await patch(`
-          import {unstable_Activity as Activity} from 'react';
+        export default function App() {
+          return (
+            <Activity mode="hidden">
+              <div ref={(node) => {
+                if (node === null) {
+                  throw new Error('callback ref should never be null')
+                }
+                return () => {
+                  // ignore
+                }
+              }}>A</div>
+            </Activity>
+          );
+        };
+      `);
+      const el = container.firstChild;
+      expect(el.textContent).toBe('A');
+      await patch(`
+        import {unstable_Activity as Activity} from 'react';
 
-          export default function App() {
-            return (
-              <Activity mode="hidden">
-                <div ref={(node) => {
-                  if (node === null) {
-                    throw new Error('callback ref should never be null.')
-                  }
-                  return () => {
-                    // ignore
-                  }
-                }}>A</div>
-              </Activity>
-            );
-          };
-        `);
-        expect(container.firstChild).toBe(el);
-        expect(el.textContent).toBe('A');
-      }
+        export default function App() {
+          return (
+            <Activity mode="hidden">
+              <div ref={(node) => {
+                if (node === null) {
+                  throw new Error('callback ref should never be null.')
+                }
+                return () => {
+                  // ignore
+                }
+              }}>A</div>
+            </Activity>
+          );
+        };
+      `);
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('A');
     });
 
     it('reloads HOCs if they return functions', async () => {

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -306,6 +306,58 @@ describe('ReactFreshIntegration', () => {
     });
 
     // @gate __DEV__ && enableActivity
+    it('ignores ref for class component in hidden subtree', async () => {
+      const code = `
+        import {unstable_Activity as Activity} from 'react';
+
+        // Avoid creating a new class on Fast Refresh.
+        global.A = global.A ?? class A extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+        const A = global.A;
+
+        function hiddenRef() {
+          throw new Error('Unexpected hiddenRef() invocation.');
+        }
+
+        export default function App() {
+          return (
+            <Activity mode="hidden">
+              <A ref={hiddenRef} />
+            </Activity>
+          );
+        };
+      `;
+
+      await render(code);
+      await patch(code);
+    });
+
+    // @gate __DEV__ && enableActivity
+    it('ignores ref for hoistable resource in hidden subtree', async () => {
+      const code = `
+        import {unstable_Activity as Activity} from 'react';
+
+        function hiddenRef() {
+          throw new Error('Unexpected hiddenRef() invocation.');
+        }
+
+        export default function App() {
+          return (
+            <Activity mode="hidden">
+              <link rel="preload" href="foo" ref={hiddenRef} />
+            </Activity>
+          );
+        };
+      `;
+
+      await render(code);
+      await patch(code);
+    });
+
+    // @gate __DEV__ && enableActivity
     it('ignores ref for host component in hidden subtree', async () => {
       const code = `
         import {unstable_Activity as Activity} from 'react';
@@ -318,6 +370,54 @@ describe('ReactFreshIntegration', () => {
           return (
             <Activity mode="hidden">
               <div ref={hiddenRef} />
+            </Activity>
+          );
+        };
+      `;
+
+      await render(code);
+      await patch(code);
+    });
+
+    // @gate __DEV__ && enableActivity
+    it('ignores ref for Activity in hidden subtree', async () => {
+      const code = `
+        import {unstable_Activity as Activity} from 'react';
+
+        function hiddenRef(value) {
+          throw new Error('Unexpected hiddenRef() invocation: ' + value);
+        }
+
+        export default function App() {
+          return (
+            <Activity mode="hidden">
+              <Activity mode="visible" ref={hiddenRef}>
+                <div />
+              </Activity>
+            </Activity>
+          );
+        };
+      `;
+
+      await render(code);
+      await patch(code);
+    });
+
+    // @gate __DEV__ && enableActivity && enableScopeAPI
+    it('ignores ref for Scope in hidden subtree', async () => {
+      const code = `
+        import {unstable_Scope as Scope} from 'react';
+
+        function hiddenRef(value) {
+          throw new Error('Unexpected hiddenRef() invocation: ' + value);
+        }
+
+        export default function App() {
+          return (
+            <Activity mode="hidden">
+              <Scope ref={hiddenRef}>
+                <div />
+              </Scope>
             </Activity>
           );
         };

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -306,47 +306,25 @@ describe('ReactFreshIntegration', () => {
     });
 
     // @gate __DEV__ && enableActivity
-    it('does not re-create refs for Activity hidden', async () => {
-      await render(`
+    it('ignores ref for host component in hidden subtree', async () => {
+      const code = `
         import {unstable_Activity as Activity} from 'react';
+
+        function hiddenRef() {
+          throw new Error('Unexpected hiddenRef() invocation.');
+        }
 
         export default function App() {
           return (
             <Activity mode="hidden">
-              <div ref={(node) => {
-                if (node === null) {
-                  throw new Error('callback ref should never be null')
-                }
-                return () => {
-                  // ignore
-                }
-              }}>A</div>
+              <div ref={hiddenRef} />
             </Activity>
           );
         };
-      `);
-      const el = container.firstChild;
-      expect(el.textContent).toBe('A');
-      await patch(`
-        import {unstable_Activity as Activity} from 'react';
+      `;
 
-        export default function App() {
-          return (
-            <Activity mode="hidden">
-              <div ref={(node) => {
-                if (node === null) {
-                  throw new Error('callback ref should never be null.')
-                }
-                return () => {
-                  // ignore
-                }
-              }}>A</div>
-            </Activity>
-          );
-        };
-      `);
-      expect(container.firstChild).toBe(el);
-      expect(el.textContent).toBe('A');
+      await render(code);
+      await patch(code);
     });
 
     it('reloads HOCs if they return functions', async () => {

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -385,7 +385,7 @@ describe('ReactFreshIntegration', () => {
         import {unstable_Activity as Activity} from 'react';
 
         function hiddenRef(value) {
-          throw new Error('Unexpected hiddenRef() invocation: ' + value);
+          throw new Error('Unexpected hiddenRef() invocation.');
         }
 
         export default function App() {
@@ -412,7 +412,7 @@ describe('ReactFreshIntegration', () => {
         } from 'react';
 
         function hiddenRef(value) {
-          throw new Error('Unexpected hiddenRef() invocation: ' + value);
+          throw new Error('Unexpected hiddenRef() invocation.');
         }
 
         export default function App() {

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -406,7 +406,10 @@ describe('ReactFreshIntegration', () => {
     // @gate __DEV__ && enableActivity && enableScopeAPI
     it('ignores ref for Scope in hidden subtree', async () => {
       const code = `
-        import {unstable_Scope as Scope} from 'react';
+        import {
+          unstable_Activity as Activity,
+          unstable_Scope as Scope,
+        } from 'react';
 
         function hiddenRef(value) {
           throw new Error('Unexpected hiddenRef() invocation: ' + value);


### PR DESCRIPTION
## Summary

We're seeing certain situations in React Native development where ref callbacks in `<Activity mode="hidden">` are sometimes invoked exactly once with `null` without ever being called with a "current" value.

This violates the contract for refs because refs are expected to always attach before detach (and to always eventually detach after attach). This is *particularly* bad for refs that return cleanup functions, because refs that return cleanup functions expect to never be invoked with `null`. This bug causes such refs to be invoked with `null` (because since `safelyAttachRef` was never called, `safelyDetachRef` thinks the ref does not return a cleanup function and invokes it with `null`).

This fix makes use of `offscreenSubtreeWasHidden` in `commitDeletionEffectsOnFiber`, similar to how https://github.com/facebook/react/commit/ec52a5698e2dfea7050a0b015f0b79abfb2d81b7 did this for `commitDeletionEffectsOnFiber`.

## How did you test this change?

We were able to isolate the repro steps to isolate the React Native experimental changes. However, the repro steps depend on Fast Refresh.

```
function callbackRef(current) {
  // Called once with `current` as null, upon triggering Fast Refresh.
}

<Activity mode="hidden">
  <View ref={callbackRef} />;
</Activity>
```

Ideally, we would have a unit test that verifies this behavior without Fast Refresh. (We have evidence that this bug occurs without Fast Refresh in real product implementations. However, we have not successfully deduced the root cause, yet.)

This PR currently includes a unit test that reproduces the Fast Refresh scenario, which is also demonstrated in this CodeSandbox: https://codesandbox.io/p/sandbox/hungry-darkness-33wxy7

Verified unit tests pass:

```
$ yarn
$ yarn test
# Run with `-r=www-classic` for `enableScopeAPI` tests.
$ yarn test -r=www-classic
```

Verified on the internal React Native development branch that the bug no longer repros.