### PR TITLE
[compiler] change `component` to `function` in some fixtures

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-initialization.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-initialization.expect.md
@@ -5,7 +5,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   if (r.current == null) {
     r.current = 1;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-initialization.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-initialization.js
@@ -1,7 +1,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   if (r.current == null) {
     r.current = 1;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-arbitrary.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-arbitrary.expect.md
@@ -7,7 +7,7 @@ import {useRef} from 'react';
 
 const DEFAULT_VALUE = 1;
 
-component C() {
+function C() {
   const r = useRef(DEFAULT_VALUE);
   if (r.current == DEFAULT_VALUE) {
     r.current = 1;
@@ -25,7 +25,7 @@ export const FIXTURE_ENTRYPOINT = {
 ## Error
 
 ```
-   6 | component C() {
+   6 | function C() {
    7 |   const r = useRef(DEFAULT_VALUE);
 >  8 |   if (r.current == DEFAULT_VALUE) {
      |       ^^^^^^^^^ InvalidReact: Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef) (8:8)

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-arbitrary.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-arbitrary.js
@@ -3,7 +3,7 @@ import {useRef} from 'react';
 
 const DEFAULT_VALUE = 1;
 
-component C() {
+function C() {
   const r = useRef(DEFAULT_VALUE);
   if (r.current == DEFAULT_VALUE) {
     r.current = 1;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-call-2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-call-2.expect.md
@@ -5,7 +5,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   if (r.current == null) {
     f(r);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-call-2.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-call-2.js
@@ -1,7 +1,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   if (r.current == null) {
     f(r);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-call.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-call.expect.md
@@ -5,7 +5,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   if (r.current == null) {
     f(r.current);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-call.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-call.js
@@ -1,7 +1,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   if (r.current == null) {
     f(r.current);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-linear.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-linear.expect.md
@@ -5,7 +5,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   if (r.current == null) {
     r.current = 42;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-linear.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-linear.js
@@ -1,7 +1,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   if (r.current == null) {
     r.current = 42;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-nonif.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-nonif.expect.md
@@ -5,7 +5,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   const guard = r.current == null;
   if (guard) {
@@ -24,7 +24,7 @@ export const FIXTURE_ENTRYPOINT = {
 ## Error
 
 ```
-  4 | component C() {
+  4 | function C() {
   5 |   const r = useRef(null);
 > 6 |   const guard = r.current == null;
     |                 ^^^^^^^^^^^^^^^^^ InvalidReact: Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef) (6:6)

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-nonif.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-nonif.js
@@ -1,7 +1,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   const guard = r.current == null;
   if (guard) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-other.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-other.expect.md
@@ -5,7 +5,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   const r2 = useRef(null);
   if (r.current == null) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-other.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-other.js
@@ -1,7 +1,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   const r2 = useRef(null);
   if (r.current == null) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-post-access-2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-post-access-2.expect.md
@@ -5,7 +5,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   if (r.current == null) {
     r.current = 1;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-post-access-2.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-post-access-2.js
@@ -1,7 +1,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   if (r.current == null) {
     r.current = 1;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-post-access.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-post-access.expect.md
@@ -5,7 +5,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   if (r.current == null) {
     r.current = 1;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-post-access.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-initialization-post-access.js
@@ -1,7 +1,7 @@
 //@flow
 import {useRef} from 'react';
 
-component C() {
+function C() {
   const r = useRef(null);
   if (r.current == null) {
     r.current = 1;


### PR DESCRIPTION
![Captura de pantalla 2024-10-30 a las 1 27 32 p  m](https://github.com/user-attachments/assets/6d2d9ca7-ee6f-4f6a-a934-ececf26332a1)

This PR replaces the `component` with `function` keyword to fix the above error