### PR TITLE
[compiler] change `Object` type to `object` for WeakMap's keys

### DIFF
--- a/compiler/packages/make-read-only-util/src/makeReadOnly.ts
+++ b/compiler/packages/make-read-only-util/src/makeReadOnly.ts
@@ -29,7 +29,7 @@ type SavedEntry = {
   getter: () => unknown;
 };
 type SavedROObject = Map<string, SavedEntry>;
-type SavedROObjects = WeakMap<Object, SavedROObject>;
+type SavedROObjects = WeakMap<object, SavedROObject>;
 
 // Utility functions
 function isWriteable(desc: PropertyDescriptor) {


### PR DESCRIPTION
JavaScript's `WeakMap` accepts object, non-primitive keys ( [definition](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap) )

Current implementation of `WeakMap`'s key type is `Object`(uppercased). `Object` type includes all primitive types except for undefined, null. This PR changes it to lowercased `object`, which excludes primitive types such as string, boolean, number, etc. 

Also, by tracing back to its original type we have it lowercased:

<img width="151" alt="Captura de pantalla 2024-11-01 a las 4 58 09 p  m" src="https://github.com/user-attachments/assets/7668451c-aecf-4396-8780-9ee278740a94">
