### PR TITLE
temporarily disable lazy context propagation

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -101,7 +101,7 @@ export const enableObjectFiber = false;
 
 export const enableTransitionTracing = false;
 
-export const enableLazyContextPropagation = true;
+export const enableLazyContextPropagation = false;
 
 // Expose unstable useContext for performance testing
 export const enableContextProfiling = false;


### PR DESCRIPTION
disables lazy context propagation in oss to help determine if it is causing bugs in startTransition. Will reenable after cutting a canary release with this flag disabled