### PR TITLE
Reenable lazy context propagation

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -101,7 +101,7 @@ export const enableObjectFiber = false;
 
 export const enableTransitionTracing = false;
 
-export const enableLazyContextPropagation = false;
+export const enableLazyContextPropagation = true;
 
 // Expose unstable useContext for performance testing
 export const enableContextProfiling = false;


### PR DESCRIPTION
Reverts facebook/react#31403 to reenable lazy context propagation

The disabling was to produce a build that could help track down whether this flag is causing a possibly related bug in transitions but we don't intend to disable it just fix forward once we figure out what the problem is