### PR TITLE
Add test for SuspenseList useID bug

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMUseId-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMUseId-test.js
@@ -648,16 +648,17 @@ https://react.dev/link/hydration-mismatch
       </div>
     `);
 
-    await expect(async () => {
-      await clientAct(async () => {
-        ReactDOMClient.hydrateRoot(container, <Foo />);
-      });
+    if (__DEV__) {
       // TODO: this is a bug with useID and SuspenseList revealOrder "backwards"
-    }).rejects.toThrowError(
-      `Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client.`,
-    );
+      await expect(async () => {
+        await clientAct(async () => {
+          ReactDOMClient.hydrateRoot(container, <Foo />);
+        });
+      }).rejects.toThrowError(
+        `Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client.`,
+      );
 
-    expect(container).toMatchInlineSnapshot(`
+      expect(container).toMatchInlineSnapshot(`
       <div
         id="container"
       >
@@ -673,6 +674,28 @@ https://react.dev/link/hydration-mismatch
         </span>
       </div>
     `);
+    } else {
+      await clientAct(async () => {
+        ReactDOMClient.hydrateRoot(container, <Foo />);
+      });
+
+      expect(container).toMatchInlineSnapshot(`
+      <div
+        id="container"
+      >
+        <span
+          id=":R1:"
+        >
+          A
+        </span>
+        <span
+          id=":R2:"
+        >
+          B
+        </span>
+      </div>
+    `);
+    }
   });
 
   it('basic incremental hydration', async () => {

--- a/packages/react-dom/src/__tests__/ReactDOMUseId-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMUseId-test.js
@@ -382,6 +382,7 @@ describe('useId', () => {
     `);
   });
 
+  // @gate enableSuspenseList
   it('Supports SuspenseList (reveal order default)', async () => {
     function Baz({id, children}) {
       return <span id={id}>{children}</span>;
@@ -444,6 +445,7 @@ describe('useId', () => {
     `);
   });
 
+  // @gate enableSuspenseList
   it('Supports SuspenseList (reveal order "together")', async () => {
     function Baz({id, children}) {
       return <span id={id}>{children}</span>;
@@ -506,6 +508,7 @@ describe('useId', () => {
     `);
   });
 
+  // @gate enableSuspenseList
   it('Supports SuspenseList (reveal order "forwards")', async () => {
     function Baz({id, children}) {
       return <span id={id}>{children}</span>;
@@ -604,6 +607,7 @@ https://react.dev/link/hydration-mismatch
     `);
   });
 
+  // @gate enableSuspenseList
   it('Supports SuspenseList (reveal order "backwards")', async () => {
     function Baz({id, children}) {
       return <span id={id}>{children}</span>;

--- a/packages/react-dom/src/__tests__/ReactDOMUseId-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMUseId-test.js
@@ -7,8 +7,6 @@
  * @emails react-core
  * @jest-environment ./scripts/jest/ReactDOMServerIntegrationEnvironment
  */
-import {favorSafetyOverHydrationPerf} from 'shared/forks/ReactFeatureFlags.www-dynamic';
-
 let JSDOM;
 let React;
 let ReactDOMClient;

--- a/packages/react-dom/src/__tests__/ReactDOMUseId-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMUseId-test.js
@@ -24,6 +24,8 @@ let buffer = '';
 let hasErrored = false;
 let fatalError = undefined;
 let waitForPaint;
+let SuspenseList;
+let assertConsoleErrorDev;
 
 describe('useId', () => {
   beforeEach(() => {
@@ -32,11 +34,16 @@ describe('useId', () => {
     React = require('react');
     ReactDOMClient = require('react-dom/client');
     clientAct = require('internal-test-utils').act;
+    assertConsoleErrorDev =
+      require('internal-test-utils').assertConsoleErrorDev;
     ReactDOMFizzServer = require('react-dom/server');
     Stream = require('stream');
     Suspense = React.Suspense;
     useId = React.useId;
     useState = React.useState;
+    if (gate(flags => flags.enableSuspenseList)) {
+      SuspenseList = React.unstable_SuspenseList;
+    }
 
     const InternalTestUtils = require('internal-test-utils');
     waitForPaint = InternalTestUtils.waitForPaint;
@@ -375,6 +382,295 @@ describe('useId', () => {
     `);
   });
 
+  it('Supports SuspenseList (reveal order default)', async () => {
+    function Baz({id, children}) {
+      return <span id={id}>{children}</span>;
+    }
+
+    function Bar({children}) {
+      const id = useId();
+      return <Baz id={id}>{children}</Baz>;
+    }
+
+    function Foo() {
+      return (
+        <SuspenseList>
+          <Bar>A</Bar>
+          <Bar>B</Bar>
+        </SuspenseList>
+      );
+    }
+
+    await serverAct(async () => {
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(<Foo />);
+      pipe(writable);
+    });
+    expect(container).toMatchInlineSnapshot(`
+      <div
+        id="container"
+      >
+        <span
+          id=":R1:"
+        >
+          A
+        </span>
+        <span
+          id=":R2:"
+        >
+          B
+        </span>
+      </div>
+    `);
+
+    await clientAct(async () => {
+      ReactDOMClient.hydrateRoot(container, <Foo />);
+    });
+
+    expect(container).toMatchInlineSnapshot(`
+      <div
+        id="container"
+      >
+        <span
+          id=":R1:"
+        >
+          A
+        </span>
+        <span
+          id=":R2:"
+        >
+          B
+        </span>
+      </div>
+    `);
+  });
+
+  it('Supports SuspenseList (reveal order "together")', async () => {
+    function Baz({id, children}) {
+      return <span id={id}>{children}</span>;
+    }
+
+    function Bar({children}) {
+      const id = useId();
+      return <Baz id={id}>{children}</Baz>;
+    }
+
+    function Foo() {
+      return (
+        <SuspenseList revealOrder="together">
+          <Bar>A</Bar>
+          <Bar>B</Bar>
+        </SuspenseList>
+      );
+    }
+
+    await serverAct(async () => {
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(<Foo />);
+      pipe(writable);
+    });
+    expect(container).toMatchInlineSnapshot(`
+      <div
+        id="container"
+      >
+        <span
+          id=":R1:"
+        >
+          A
+        </span>
+        <span
+          id=":R2:"
+        >
+          B
+        </span>
+      </div>
+    `);
+
+    await clientAct(async () => {
+      ReactDOMClient.hydrateRoot(container, <Foo />);
+    });
+
+    expect(container).toMatchInlineSnapshot(`
+      <div
+        id="container"
+      >
+        <span
+          id=":R1:"
+        >
+          A
+        </span>
+        <span
+          id=":R2:"
+        >
+          B
+        </span>
+      </div>
+    `);
+  });
+
+  it('Supports SuspenseList (reveal order "forwards")', async () => {
+    function Baz({id, children}) {
+      return <span id={id}>{children}</span>;
+    }
+
+    function Bar({children}) {
+      const id = useId();
+      return <Baz id={id}>{children}</Baz>;
+    }
+
+    function Foo() {
+      return (
+        <SuspenseList revealOrder="forwards">
+          <Bar>A</Bar>
+          <Bar>B</Bar>
+        </SuspenseList>
+      );
+    }
+
+    await serverAct(async () => {
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(<Foo />);
+      pipe(writable);
+    });
+    expect(container).toMatchInlineSnapshot(`
+      <div
+        id="container"
+      >
+        <span
+          id=":R1:"
+        >
+          A
+        </span>
+        <span
+          id=":R2:"
+        >
+          B
+        </span>
+      </div>
+    `);
+
+    await clientAct(async () => {
+      ReactDOMClient.hydrateRoot(container, <Foo />);
+    });
+
+    // TODO: this is a bug with useID and SuspenseList revealOrder "forwards"
+    assertConsoleErrorDev(
+      [
+        `A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
+
+- A server/client branch \`if (typeof window !== 'undefined')\`.
+- Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
+- Date formatting in a user's locale which doesn't match the server.
+- External changing data without sending a snapshot of it along with the HTML.
+- Invalid HTML tag nesting.
+
+It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.
+
+https://react.dev/link/hydration-mismatch
+
+  <Foo>
+    <SuspenseList revealOrder="forwards">
+      <Bar>
+        <Baz id=":R0:">
+          <span
++           id=":R0:"
+-           id=":R1:"
+          >
++           A
+      <Bar>
+        <Baz id=":R1:">
+          <span
++           id=":R1:"
+-           id=":R2:"
+          >
++           B
+`,
+      ],
+      {withoutStack: true},
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div
+        id="container"
+      >
+        <span
+          id=":R1:"
+        >
+          A
+        </span>
+        <span
+          id=":R2:"
+        >
+          B
+        </span>
+      </div>
+    `);
+  });
+
+  it('Supports SuspenseList (reveal order "backwards")', async () => {
+    function Baz({id, children}) {
+      return <span id={id}>{children}</span>;
+    }
+
+    function Bar({children}) {
+      const id = useId();
+      return <Baz id={id}>{children}</Baz>;
+    }
+
+    function Foo() {
+      return (
+        <SuspenseList revealOrder="backwards">
+          <Bar>A</Bar>
+          <Bar>B</Bar>
+        </SuspenseList>
+      );
+    }
+
+    await serverAct(async () => {
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(<Foo />);
+      pipe(writable);
+    });
+    expect(container).toMatchInlineSnapshot(`
+      <div
+        id="container"
+      >
+        <span
+          id=":R1:"
+        >
+          A
+        </span>
+        <span
+          id=":R2:"
+        >
+          B
+        </span>
+      </div>
+    `);
+
+    await expect(async () => {
+      await clientAct(async () => {
+        ReactDOMClient.hydrateRoot(container, <Foo />);
+      });
+      // TODO: this is a bug with useID and SuspenseList revealOrder "backwards"
+    }).rejects.toThrowError(
+      `Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client.`,
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div
+        id="container"
+      >
+        <span
+          id=":r1:"
+        >
+          A
+        </span>
+        <span
+          id=":r0:"
+        >
+          B
+        </span>
+      </div>
+    `);
+  });
+
   it('basic incremental hydration', async () => {
     function App() {
       return (
@@ -674,7 +970,7 @@ describe('useId', () => {
         <div>
           :R0:
           <!-- -->
-           
+
           <div>
             :R7:
           </div>
@@ -692,7 +988,7 @@ describe('useId', () => {
         <div>
           :R0:
           <!-- -->
-           
+
           <div>
             :R7:
           </div>

--- a/packages/react-dom/src/__tests__/ReactDOMUseId-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMUseId-test.js
@@ -970,7 +970,7 @@ https://react.dev/link/hydration-mismatch
         <div>
           :R0:
           <!-- -->
-
+           
           <div>
             :R7:
           </div>
@@ -988,7 +988,7 @@ https://react.dev/link/hydration-mismatch
         <div>
           :R0:
           <!-- -->
-
+           
           <div>
             :R7:
           </div>


### PR DESCRIPTION
SuspenseList with revealOrder "forwards" will trigger hydration mismatch error for useID, and "backwards" will throw.