### PR TITLE
Remove trim_trailing_whitespace from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,11 +8,9 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 max_line_length = 80
-trim_trailing_whitespace = true
 
 [*.md]
 max_line_length = 0
-trim_trailing_whitespace = false
 
 [COMMIT_EDITMSG]
 max_line_length = 0


### PR DESCRIPTION
This setting breaks `toMatchInlineSnapshot` by removing whitespace in snapshots.