### PR TITLE
[string-refs] remove enableLogStringRefsProd flag

### DIFF
--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -23,7 +23,6 @@ import {
   disableStringRefs,
   disableDefaultPropsExceptForClasses,
   enableOwnerStacks,
-  enableLogStringRefsProd,
 } from 'shared/ReactFeatureFlags';
 import {checkPropStringCoercion} from 'shared/CheckStringCoercion';
 import {ClassComponent} from 'react-reconciler/src/ReactWorkTags';
@@ -75,7 +74,7 @@ let didWarnAboutStringRefs;
 let didWarnAboutElementRef;
 let didWarnAboutOldJSXRuntime;
 
-if (__DEV__ || enableLogStringRefsProd) {
+if (__DEV__) {
   didWarnAboutStringRefs = {};
   didWarnAboutElementRef = {};
 }
@@ -1228,16 +1227,13 @@ function stringRefAsCallbackRef(stringRef, type, owner, value) {
     );
   }
 
-  if (__DEV__ || enableLogStringRefsProd) {
+  if (__DEV__) {
     if (
       // Will already warn with "Function components cannot be given refs"
       !(typeof type === 'function' && !isReactClass(type))
     ) {
       const componentName = getComponentNameFromFiber(owner) || 'Component';
       if (!didWarnAboutStringRefs[componentName]) {
-        if (enableLogStringRefsProd) {
-          enableLogStringRefsProd(componentName, stringRef);
-        }
         if (__DEV__) {
           console.error(
             'Component "%s" contains the string ref "%s". Support for string refs ' +

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -210,14 +210,6 @@ export const disableClientCache = true;
 
 export const disableStringRefs = true;
 
-/**
- * If set to a function, the function will be called with the component name
- * and ref string.
- *
- * NOTE: This happens also in the production build.
- */
-export const enableLogStringRefsProd: null | ((string, string) => void) = null;
-
 // Warn on any usage of ReactTestRenderer
 export const enableReactTestRendererWarning = true;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -65,7 +65,6 @@ export const enableLazyContextPropagation = true;
 export const enableLegacyCache = false;
 export const enableLegacyFBSupport = false;
 export const enableLegacyHidden = false;
-export const enableLogStringRefsProd: null | ((string, string) => void) = null;
 export const enableNoCloningMemoCache = false;
 export const enableOwnerStacks = false;
 export const enablePostpone = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -56,7 +56,6 @@ export const enableContextProfiling = false;
 export const enableLegacyCache = false;
 export const enableLegacyFBSupport = false;
 export const enableLegacyHidden = false;
-export const enableLogStringRefsProd: null | ((string, string) => void) = null;
 export const enableNoCloningMemoCache = false;
 export const enableObjectFiber = false;
 export const enableOwnerStacks = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -44,7 +44,6 @@ export const enableUseEffectEventHook = false;
 export const favorSafetyOverHydrationPerf = true;
 export const enableComponentStackLocations = true;
 export const enableLegacyFBSupport = false;
-export const enableLogStringRefsProd: null | ((string, string) => void) = null;
 export const enableFilterEmptyStringAttributesDOM = true;
 export const enableGetInspectorDataForInstanceInProduction = false;
 export const enableFabricCompleteRootInCommitPhase = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -46,7 +46,6 @@ export const enableUseEffectEventHook = false;
 export const favorSafetyOverHydrationPerf = true;
 export const enableComponentStackLocations = true;
 export const enableLegacyFBSupport = false;
-export const enableLogStringRefsProd: null | ((string, string) => void) = null;
 export const enableFilterEmptyStringAttributesDOM = true;
 export const enableGetInspectorDataForInstanceInProduction = false;
 export const enableRenderableContext = false;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -22,7 +22,6 @@ export const disableStringRefs = __VARIANT__;
 export const enableDeferRootSchedulingToMicrotask = __VARIANT__;
 export const enableDO_NOT_USE_disableStrictPassiveEffect = __VARIANT__;
 export const enableHiddenSubtreeInsertionEffectCleanup = __VARIANT__;
-export const enableLogStringRefsProd: null | ((string, string) => void) = null;
 export const enableNoCloningMemoCache = __VARIANT__;
 export const enableObjectFiber = __VARIANT__;
 export const enableRenderableContext = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -25,7 +25,6 @@ export const {
   enableDO_NOT_USE_disableStrictPassiveEffect,
   enableHiddenSubtreeInsertionEffectCleanup,
   enableInfiniteRenderLoopDetection,
-  enableLogStringRefsProd,
   enableNoCloningMemoCache,
   enableObjectFiber,
   enableRenderableContext,


### PR DESCRIPTION

We no longer need this production logging.
