### PR TITLE
refactor: `isReactClass` shared util function

### DIFF
--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -18,6 +18,7 @@ import type {
 import type {ReactNodeList} from 'shared/ReactTypes';
 
 import {REACT_MEMO_TYPE, REACT_FORWARD_REF_TYPE} from 'shared/ReactSymbols';
+import isReactClass from 'shared/isReactClass'
 
 type Signature = {
   ownKey: string,
@@ -136,10 +137,6 @@ function haveEqualSignatures(prevType: any, nextType: any) {
   }
 
   return true;
-}
-
-function isReactClass(type: any) {
-  return type.prototype && type.prototype.isReactComponent;
 }
 
 function canPreserveStateBetween(prevType: any, nextType: any) {

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -18,6 +18,7 @@ import {
 import {checkKeyStringCoercion} from 'shared/CheckStringCoercion';
 import isValidElementType from 'shared/isValidElementType';
 import isArray from 'shared/isArray';
+import isReactClass from 'shared/isReactClass'
 import {describeUnknownElementTypeFrameInDEV} from 'shared/ReactComponentStackFrame';
 import {
   disableStringRefs,
@@ -1268,8 +1269,4 @@ function stringRefAsCallbackRef(stringRef, type, owner, value) {
   } else {
     refs[stringRef] = value;
   }
-}
-
-function isReactClass(type) {
-  return type.prototype && type.prototype.isReactComponent;
 }

--- a/packages/shared/isReactClass.js
+++ b/packages/shared/isReactClass.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+function isReactClass(type: any): boolean | undefined {
+  try {
+    return !!(type.prototype && type.prototype.isReactComponent);
+  } catch (error) {
+    console.error("Error in isReactClass:", error);
+  }
+}
+
+export default isReactClass


### PR DESCRIPTION
## Summary

This is a refactoring PR, which takes the existing `isReactClass` util functions from several places into the `shared/` directory. Also, I added double exclamation mark (`!!`) to make sure it returns boolean. Finally, added error handling (try-catch).  

## How did you test this change?

yarn test --watch ReactJSXRuntime-test.js ,  yarn test --watch ReactFresh-test.js  