### PR TITLE
Update React Native shims to use export syntax

### DIFF
--- a/scripts/rollup/shims/react-native/ReactFabric.js
+++ b/scripts/rollup/shims/react-native/ReactFabric.js
@@ -15,7 +15,7 @@ import {BatchedBridge} from 'react-native/Libraries/ReactPrivate/ReactNativePriv
 
 import type {ReactFabricType} from './ReactNativeTypes';
 
-let ReactFabric;
+let ReactFabric: ReactFabricType;
 
 if (__DEV__) {
   ReactFabric = require('../implementations/ReactFabric-dev');
@@ -29,4 +29,4 @@ if (global.RN$Bridgeless !== true) {
   BatchedBridge.registerCallableModule('ReactFabric', ReactFabric);
 }
 
-module.exports = (ReactFabric: ReactFabricType);
+export default ReactFabric;

--- a/scripts/rollup/shims/react-native/ReactFeatureFlags.js
+++ b/scripts/rollup/shims/react-native/ReactFeatureFlags.js
@@ -15,4 +15,4 @@ const ReactFeatureFlags = {
   debugRenderPhaseSideEffects: false,
 };
 
-module.exports = ReactFeatureFlags;
+export default ReactFeatureFlags;

--- a/scripts/rollup/shims/react-native/ReactNative.js
+++ b/scripts/rollup/shims/react-native/ReactNative.js
@@ -12,7 +12,7 @@
 
 import type {ReactNativeType} from './ReactNativeTypes';
 
-let ReactNative;
+let ReactNative: ReactNativeType;
 
 if (__DEV__) {
   ReactNative = require('../implementations/ReactNativeRenderer-dev');
@@ -20,4 +20,4 @@ if (__DEV__) {
   ReactNative = require('../implementations/ReactNativeRenderer-prod');
 }
 
-module.exports = (ReactNative: ReactNativeType);
+export default ReactNative;

--- a/scripts/rollup/shims/react-native/createReactNativeComponentClass.js
+++ b/scripts/rollup/shims/react-native/createReactNativeComponentClass.js
@@ -31,4 +31,4 @@ const createReactNativeComponentClass = function (
   return register(name, callback);
 };
 
-module.exports = createReactNativeComponentClass;
+export default createReactNativeComponentClass;


### PR DESCRIPTION
## Summary

I'm working to get the main `react-native` package parsable by modern Flow tooling (both `flow-bundler`, `flow-api-translator`), and one blocker is legacy `module.exports` syntax. This diff updates files which are [synced to `react-native`](https://github.com/facebook/react-native/tree/main/packages/react-native/Libraries/Renderer/shims) from this repo.

## How did you test this change?

Files were pasted into `react-native-github` under fbsource, where Flow validates ✅.