### PR TITLE
Back out "[bundles] stop building legacy Paper renderer (#31429)"

### DIFF
--- a/.github/workflows/runtime_commit_artifacts.yml
+++ b/.github/workflows/runtime_commit_artifacts.yml
@@ -137,6 +137,7 @@ jobs:
           # Delete OSS renderer. OSS renderer is synced through internal script.
           RENDERER_FOLDER=$BASE_FOLDER/react-native-github/Libraries/Renderer/implementations/
           rm $RENDERER_FOLDER/ReactFabric-{dev,prod,profiling}.js
+          rm $RENDERER_FOLDER/ReactNativeRenderer-{dev,prod,profiling}.js
 
           # Move React Native version file
           mv build/facebook-react-native/VERSION_NATIVE_FB ./compiled-rn/VERSION_NATIVE_FB

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -696,6 +696,40 @@ const bundles = [
       }),
   },
 
+  /******* React Native *******/
+  {
+    bundleTypes: __EXPERIMENTAL__
+      ? []
+      : [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
+    moduleType: RENDERER,
+    entry: 'react-native-renderer',
+    global: 'ReactNativeRenderer',
+    externals: ['react-native', 'ReactNativeInternalFeatureFlags'],
+    minifyWithProdErrorCodes: false,
+    wrapWithModuleBoundaries: true,
+    babel: opts =>
+      Object.assign({}, opts, {
+        plugins: opts.plugins.concat([
+          [require.resolve('@babel/plugin-transform-classes'), {loose: true}],
+        ]),
+      }),
+  },
+  {
+    bundleTypes: [RN_OSS_DEV, RN_OSS_PROD, RN_OSS_PROFILING],
+    moduleType: RENDERER,
+    entry: 'react-native-renderer',
+    global: 'ReactNativeRenderer',
+    externals: ['react-native'],
+    minifyWithProdErrorCodes: false,
+    wrapWithModuleBoundaries: true,
+    babel: opts =>
+      Object.assign({}, opts, {
+        plugins: opts.plugins.concat([
+          [require.resolve('@babel/plugin-transform-classes'), {loose: true}],
+        ]),
+      }),
+  },
+
   /******* React Native Fabric *******/
   {
     bundleTypes: __EXPERIMENTAL__


### PR DESCRIPTION

Backs out the 2 related commits:
- https://github.com/facebook/react/commit/f8f6e1a21a1cac64cf6faf666367d641b2d8b171
- https://github.com/facebook/react/commit/6c0f37f94b020279fb5ada70facc008fccb7172e

Since I only realized when syncing that we need the version of `react` and the legacy renderer to match.

While I investigate if there's anything we can do to work around that while preserving the legacy renderer, this unblocks the sync.
