### PR TITLE
[compiler] Outline JSX with non-jsx children

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-outlining-with-non-jsx-children.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-outlining-with-non-jsx-children.expect.md
@@ -11,12 +11,14 @@ function Component({arr}) {
         return (
           <Bar key={id} x={x}>
             <Baz i={i}>Test</Baz>
+            <Foo k={i} />
           </Bar>
         );
       })}
     </>
   );
 }
+
 function Bar({x, children}) {
   return (
     <>
@@ -26,8 +28,17 @@ function Bar({x, children}) {
   );
 }
 
-function Baz({i}) {
-  return i;
+function Baz({i, children}) {
+  return (
+    <>
+      {i}
+      {children}
+    </>
+  );
+}
+
+function Foo({k}) {
+  return k;
 }
 
 function useX() {
@@ -53,11 +64,11 @@ function Component(t0) {
   if ($[0] !== arr || $[1] !== x) {
     let t2;
     if ($[3] !== x) {
-      t2 = (i, id) => (
-        <Bar key={id} x={x}>
-          <Baz i={i}>Test</Baz>
-        </Bar>
-      );
+      t2 = (i, id) => {
+        const t3 = "Test";
+        const T0 = _temp;
+        return <T0 i={i} t={t3} k={i} key={id} x={x} />;
+      };
       $[3] = x;
       $[4] = t2;
     } else {
@@ -79,6 +90,43 @@ function Component(t0) {
     t2 = $[6];
   }
   return t2;
+}
+function _temp(t0) {
+  const $ = _c(9);
+  const { i: i, t: t, k: k, x: x } = t0;
+  let t1;
+  if ($[0] !== i || $[1] !== t) {
+    t1 = <Baz i={i}>{t}</Baz>;
+    $[0] = i;
+    $[1] = t;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  let t2;
+  if ($[3] !== k) {
+    t2 = <Foo k={k} />;
+    $[3] = k;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  let t3;
+  if ($[5] !== t1 || $[6] !== t2 || $[7] !== x) {
+    t3 = (
+      <Bar x={x}>
+        {t1}
+        {t2}
+      </Bar>
+    );
+    $[5] = t1;
+    $[6] = t2;
+    $[7] = x;
+    $[8] = t3;
+  } else {
+    t3 = $[8];
+  }
+  return t3;
 }
 
 function Bar(t0) {
@@ -102,8 +150,28 @@ function Bar(t0) {
 }
 
 function Baz(t0) {
-  const { i } = t0;
-  return i;
+  const $ = _c(3);
+  const { i, children } = t0;
+  let t1;
+  if ($[0] !== children || $[1] !== i) {
+    t1 = (
+      <>
+        {i}
+        {children}
+      </>
+    );
+    $[0] = children;
+    $[1] = i;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  return t1;
+}
+
+function Foo(t0) {
+  const { k } = t0;
+  return k;
 }
 
 function useX() {
@@ -118,4 +186,4 @@ export const FIXTURE_ENTRYPOINT = {
 ```
       
 ### Eval output
-(kind: ok) xfooxbar
+(kind: ok) xfooTestfooxbarTestbar

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-outlining-with-non-jsx-children.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-outlining-with-non-jsx-children.js
@@ -7,12 +7,14 @@ function Component({arr}) {
         return (
           <Bar key={id} x={x}>
             <Baz i={i}>Test</Baz>
+            <Foo k={i} />
           </Bar>
         );
       })}
     </>
   );
 }
+
 function Bar({x, children}) {
   return (
     <>
@@ -22,8 +24,17 @@ function Bar({x, children}) {
   );
 }
 
-function Baz({i}) {
-  return i;
+function Baz({i, children}) {
+  return (
+    <>
+      {i}
+      {children}
+    </>
+  );
+}
+
+function Foo({k}) {
+  return k;
 }
 
 function useX() {


### PR DESCRIPTION
Previously, we bailed out on outlining jsx that had children that were not part of the outlined jsx.

Now, we add support for children by treating as attributes.