### PR TITLE
[compiler] Ensure strict mode for `EnvironmentConfigSchema` in order to throw an error for unallowed config properties

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -146,416 +146,418 @@ export type Hook = z.infer<typeof HookSchema>;
  *   missing some recursive Object / Function shapeIds
  */
 
-const EnvironmentConfigSchema = z.object({
-  customHooks: z.map(z.string(), HookSchema).default(new Map()),
+const EnvironmentConfigSchema = z
+  .object({
+    customHooks: z.map(z.string(), HookSchema).default(new Map()),
 
-  /**
-   * A function that, given the name of a module, can optionally return a description
-   * of that module's type signature.
-   */
-  moduleTypeProvider: z.nullable(z.function().args(z.string())).default(null),
+    /**
+     * A function that, given the name of a module, can optionally return a description
+     * of that module's type signature.
+     */
+    moduleTypeProvider: z.nullable(z.function().args(z.string())).default(null),
 
-  /**
-   * A list of functions which the application compiles as macros, where
-   * the compiler must ensure they are not compiled to rename the macro or separate the
-   * "function" from its argument.
-   *
-   * For example, Meta has some APIs such as `featureflag("name-of-feature-flag")` which
-   * are rewritten by a plugin. Assigning `featureflag` to a temporary would break the
-   * plugin since it looks specifically for the name of the function being invoked, not
-   * following aliases.
-   */
-  customMacros: z.nullable(z.array(MacroSchema)).default(null),
+    /**
+     * A list of functions which the application compiles as macros, where
+     * the compiler must ensure they are not compiled to rename the macro or separate the
+     * "function" from its argument.
+     *
+     * For example, Meta has some APIs such as `featureflag("name-of-feature-flag")` which
+     * are rewritten by a plugin. Assigning `featureflag` to a temporary would break the
+     * plugin since it looks specifically for the name of the function being invoked, not
+     * following aliases.
+     */
+    customMacros: z.nullable(z.array(MacroSchema)).default(null),
 
-  /**
-   * Enable a check that resets the memoization cache when the source code of the file changes.
-   * This is intended to support hot module reloading (HMR), where the same runtime component
-   * instance will be reused across different versions of the component source.
-   */
-  enableResetCacheOnSourceFileChanges: z.boolean().default(false),
+    /**
+     * Enable a check that resets the memoization cache when the source code of the file changes.
+     * This is intended to support hot module reloading (HMR), where the same runtime component
+     * instance will be reused across different versions of the component source.
+     */
+    enableResetCacheOnSourceFileChanges: z.boolean().default(false),
 
-  /**
-   * Enable using information from existing useMemo/useCallback to understand when a value is done
-   * being mutated. With this mode enabled, Forget will still discard the actual useMemo/useCallback
-   * calls and may memoize slightly differently. However, it will assume that the values produced
-   * are not subsequently modified, guaranteeing that the value will be memoized.
-   *
-   * By preserving guarantees about when values are memoized, this option preserves any existing
-   * behavior that depends on referential equality in the original program. Notably, this preserves
-   * existing effect behavior (how often effects fire) for effects that rely on referential equality.
-   *
-   * When disabled, Forget will not only prune useMemo and useCallback calls but also completely ignore
-   * them, not using any information from them to guide compilation. Therefore, disabling this flag
-   * will produce output that mimics the result from removing all memoization.
-   *
-   * Our recommendation is to first try running your application with this flag enabled, then attempt
-   * to disable this flag and see what changes or breaks. This will mostly likely be effects that
-   * depend on referential equality, which can be refactored (TODO guide for this).
-   *
-   * NOTE: this mode treats freeze as a transitive operation for function expressions. This means
-   * that if a useEffect or useCallback references a function value, that function value will be
-   * considered frozen, and in turn all of its referenced variables will be considered frozen as well.
-   */
-  enablePreserveExistingMemoizationGuarantees: z.boolean().default(false),
+    /**
+     * Enable using information from existing useMemo/useCallback to understand when a value is done
+     * being mutated. With this mode enabled, Forget will still discard the actual useMemo/useCallback
+     * calls and may memoize slightly differently. However, it will assume that the values produced
+     * are not subsequently modified, guaranteeing that the value will be memoized.
+     *
+     * By preserving guarantees about when values are memoized, this option preserves any existing
+     * behavior that depends on referential equality in the original program. Notably, this preserves
+     * existing effect behavior (how often effects fire) for effects that rely on referential equality.
+     *
+     * When disabled, Forget will not only prune useMemo and useCallback calls but also completely ignore
+     * them, not using any information from them to guide compilation. Therefore, disabling this flag
+     * will produce output that mimics the result from removing all memoization.
+     *
+     * Our recommendation is to first try running your application with this flag enabled, then attempt
+     * to disable this flag and see what changes or breaks. This will mostly likely be effects that
+     * depend on referential equality, which can be refactored (TODO guide for this).
+     *
+     * NOTE: this mode treats freeze as a transitive operation for function expressions. This means
+     * that if a useEffect or useCallback references a function value, that function value will be
+     * considered frozen, and in turn all of its referenced variables will be considered frozen as well.
+     */
+    enablePreserveExistingMemoizationGuarantees: z.boolean().default(false),
 
-  /**
-   * Validates that all useMemo/useCallback values are also memoized by Forget. This mode can be
-   * used with or without @enablePreserveExistingMemoizationGuarantees.
-   *
-   * With enablePreserveExistingMemoizationGuarantees, this validation enables automatically and
-   * verifies that Forget was able to preserve manual memoization semantics under that mode's
-   * additional assumptions about the input.
-   *
-   * With enablePreserveExistingMemoizationGuarantees off, this validation ignores manual memoization
-   * when determining program behavior, and only uses information from useMemo/useCallback to check
-   * that the memoization was preserved. This can be useful for determining where referential equalities
-   * may change under Forget.
-   */
-  validatePreserveExistingMemoizationGuarantees: z.boolean().default(true),
+    /**
+     * Validates that all useMemo/useCallback values are also memoized by Forget. This mode can be
+     * used with or without @enablePreserveExistingMemoizationGuarantees.
+     *
+     * With enablePreserveExistingMemoizationGuarantees, this validation enables automatically and
+     * verifies that Forget was able to preserve manual memoization semantics under that mode's
+     * additional assumptions about the input.
+     *
+     * With enablePreserveExistingMemoizationGuarantees off, this validation ignores manual memoization
+     * when determining program behavior, and only uses information from useMemo/useCallback to check
+     * that the memoization was preserved. This can be useful for determining where referential equalities
+     * may change under Forget.
+     */
+    validatePreserveExistingMemoizationGuarantees: z.boolean().default(true),
 
-  /**
-   * When this is true, rather than pruning existing manual memoization but ensuring or validating
-   * that the memoized values remain memoized, the compiler will simply not prune existing calls to
-   * useMemo/useCallback.
-   */
-  enablePreserveExistingManualUseMemo: z.boolean().default(false),
+    /**
+     * When this is true, rather than pruning existing manual memoization but ensuring or validating
+     * that the memoized values remain memoized, the compiler will simply not prune existing calls to
+     * useMemo/useCallback.
+     */
+    enablePreserveExistingManualUseMemo: z.boolean().default(false),
 
-  // 🌲
-  enableForest: z.boolean().default(false),
+    // 🌲
+    enableForest: z.boolean().default(false),
 
-  /**
-   * Enable use of type annotations in the source to drive type inference. By default
-   * Forget attemps to infer types using only information that is guaranteed correct
-   * given the source, and does not trust user-supplied type annotations. This mode
-   * enables trusting user type annotations.
-   */
-  enableUseTypeAnnotations: z.boolean().default(false),
+    /**
+     * Enable use of type annotations in the source to drive type inference. By default
+     * Forget attemps to infer types using only information that is guaranteed correct
+     * given the source, and does not trust user-supplied type annotations. This mode
+     * enables trusting user type annotations.
+     */
+    enableUseTypeAnnotations: z.boolean().default(false),
 
-  /**
-   * Enables inlining ReactElement object literals in place of JSX
-   * An alternative to the standard JSX transform which replaces JSX with React's jsxProd() runtime
-   * Currently a prod-only optimization, requiring Fast JSX dependencies
-   *
-   * The symbol configuration is set for backwards compatability with pre-React 19 transforms
-   */
-  inlineJsxTransform: ReactElementSymbolSchema.nullable().default(null),
+    /**
+     * Enables inlining ReactElement object literals in place of JSX
+     * An alternative to the standard JSX transform which replaces JSX with React's jsxProd() runtime
+     * Currently a prod-only optimization, requiring Fast JSX dependencies
+     *
+     * The symbol configuration is set for backwards compatability with pre-React 19 transforms
+     */
+    inlineJsxTransform: ReactElementSymbolSchema.nullable().default(null),
 
-  /*
-   * Enable validation of hooks to partially check that the component honors the rules of hooks.
-   * When disabled, the component is assumed to follow the rules (though the Babel plugin looks
-   * for suppressions of the lint rule).
-   */
-  validateHooksUsage: z.boolean().default(true),
+    /*
+     * Enable validation of hooks to partially check that the component honors the rules of hooks.
+     * When disabled, the component is assumed to follow the rules (though the Babel plugin looks
+     * for suppressions of the lint rule).
+     */
+    validateHooksUsage: z.boolean().default(true),
 
-  // Validate that ref values (`ref.current`) are not accessed during render.
-  validateRefAccessDuringRender: z.boolean().default(true),
+    // Validate that ref values (`ref.current`) are not accessed during render.
+    validateRefAccessDuringRender: z.boolean().default(true),
 
-  /*
-   * Validates that setState is not unconditionally called during render, as it can lead to
-   * infinite loops.
-   */
-  validateNoSetStateInRender: z.boolean().default(true),
+    /*
+     * Validates that setState is not unconditionally called during render, as it can lead to
+     * infinite loops.
+     */
+    validateNoSetStateInRender: z.boolean().default(true),
 
-  /**
-   * Validates that setState is not called directly within a passive effect (useEffect).
-   * Scheduling a setState (with an event listener, subscription, etc) is valid.
-   */
-  validateNoSetStateInPassiveEffects: z.boolean().default(false),
+    /**
+     * Validates that setState is not called directly within a passive effect (useEffect).
+     * Scheduling a setState (with an event listener, subscription, etc) is valid.
+     */
+    validateNoSetStateInPassiveEffects: z.boolean().default(false),
 
-  /**
-   * Validates against creating JSX within a try block and recommends using an error boundary
-   * instead.
-   */
-  validateNoJSXInTryStatements: z.boolean().default(false),
+    /**
+     * Validates against creating JSX within a try block and recommends using an error boundary
+     * instead.
+     */
+    validateNoJSXInTryStatements: z.boolean().default(false),
 
-  /**
-   * Validates that the dependencies of all effect hooks are memoized. This helps ensure
-   * that Forget does not introduce infinite renders caused by a dependency changing,
-   * triggering an effect, which triggers re-rendering, which causes a dependency to change,
-   * triggering the effect, etc.
-   *
-   * Covers useEffect, useLayoutEffect, useInsertionEffect.
-   */
-  validateMemoizedEffectDependencies: z.boolean().default(false),
+    /**
+     * Validates that the dependencies of all effect hooks are memoized. This helps ensure
+     * that Forget does not introduce infinite renders caused by a dependency changing,
+     * triggering an effect, which triggers re-rendering, which causes a dependency to change,
+     * triggering the effect, etc.
+     *
+     * Covers useEffect, useLayoutEffect, useInsertionEffect.
+     */
+    validateMemoizedEffectDependencies: z.boolean().default(false),
 
-  /**
-   * Validates that there are no capitalized calls other than those allowed by the allowlist.
-   * Calls to capitalized functions are often functions that used to be components and may
-   * have lingering hook calls, which makes those calls risky to memoize.
-   *
-   * You can specify a list of capitalized calls to allowlist using this option. React Compiler
-   * always includes its known global functions, including common functions like Boolean and String,
-   * in this allowlist. You can enable this validation with no additional allowlisted calls by setting
-   * this option to the empty array.
-   */
-  validateNoCapitalizedCalls: z.nullable(z.array(z.string())).default(null),
-  validateBlocklistedImports: z.nullable(z.array(z.string())).default(null),
+    /**
+     * Validates that there are no capitalized calls other than those allowed by the allowlist.
+     * Calls to capitalized functions are often functions that used to be components and may
+     * have lingering hook calls, which makes those calls risky to memoize.
+     *
+     * You can specify a list of capitalized calls to allowlist using this option. React Compiler
+     * always includes its known global functions, including common functions like Boolean and String,
+     * in this allowlist. You can enable this validation with no additional allowlisted calls by setting
+     * this option to the empty array.
+     */
+    validateNoCapitalizedCalls: z.nullable(z.array(z.string())).default(null),
+    validateBlocklistedImports: z.nullable(z.array(z.string())).default(null),
 
-  /*
-   * When enabled, the compiler assumes that hooks follow the Rules of React:
-   * - Hooks may memoize computation based on any of their parameters, thus
-   *   any arguments to a hook are assumed frozen after calling the hook.
-   * - Hooks may memoize the result they return, thus the return value is
-   *   assumed frozen.
-   */
-  enableAssumeHooksFollowRulesOfReact: z.boolean().default(true),
+    /*
+     * When enabled, the compiler assumes that hooks follow the Rules of React:
+     * - Hooks may memoize computation based on any of their parameters, thus
+     *   any arguments to a hook are assumed frozen after calling the hook.
+     * - Hooks may memoize the result they return, thus the return value is
+     *   assumed frozen.
+     */
+    enableAssumeHooksFollowRulesOfReact: z.boolean().default(true),
 
-  /**
-   * When enabled, the compiler assumes that any values are not subsequently
-   * modified after they are captured by a function passed to React. For example,
-   * if a value `x` is referenced inside a function expression passed to `useEffect`,
-   * then this flag will assume that `x` is not subusequently modified.
-   */
-  enableTransitivelyFreezeFunctionExpressions: z.boolean().default(true),
+    /**
+     * When enabled, the compiler assumes that any values are not subsequently
+     * modified after they are captured by a function passed to React. For example,
+     * if a value `x` is referenced inside a function expression passed to `useEffect`,
+     * then this flag will assume that `x` is not subusequently modified.
+     */
+    enableTransitivelyFreezeFunctionExpressions: z.boolean().default(true),
 
-  /*
-   * Enables codegen mutability debugging. This emits a dev-mode only to log mutations
-   * to values that Forget assumes are immutable (for Forget compiled code).
-   * For example:
-   *   emitFreeze: {
-   *     source: 'ReactForgetRuntime',
-   *     importSpecifierName: 'makeReadOnly',
-   *   }
-   *
-   * produces:
-   *   import {makeReadOnly} from 'ReactForgetRuntime';
-   *
-   *   function Component(props) {
-   *     if (c_0) {
-   *       // ...
-   *       $[0] = __DEV__ ? makeReadOnly(x) : x;
-   *     } else {
-   *       x = $[0];
-   *     }
-   *   }
-   */
-  enableEmitFreeze: ExternalFunctionSchema.nullable().default(null),
+    /*
+     * Enables codegen mutability debugging. This emits a dev-mode only to log mutations
+     * to values that Forget assumes are immutable (for Forget compiled code).
+     * For example:
+     *   emitFreeze: {
+     *     source: 'ReactForgetRuntime',
+     *     importSpecifierName: 'makeReadOnly',
+     *   }
+     *
+     * produces:
+     *   import {makeReadOnly} from 'ReactForgetRuntime';
+     *
+     *   function Component(props) {
+     *     if (c_0) {
+     *       // ...
+     *       $[0] = __DEV__ ? makeReadOnly(x) : x;
+     *     } else {
+     *       x = $[0];
+     *     }
+     *   }
+     */
+    enableEmitFreeze: ExternalFunctionSchema.nullable().default(null),
 
-  enableEmitHookGuards: ExternalFunctionSchema.nullable().default(null),
+    enableEmitHookGuards: ExternalFunctionSchema.nullable().default(null),
 
-  /**
-   * Enable instruction reordering. See InstructionReordering.ts for the details
-   * of the approach.
-   */
-  enableInstructionReordering: z.boolean().default(false),
+    /**
+     * Enable instruction reordering. See InstructionReordering.ts for the details
+     * of the approach.
+     */
+    enableInstructionReordering: z.boolean().default(false),
 
-  /**
-   * Enables function outlinining, where anonymous functions that do not close over
-   * local variables can be extracted into top-level helper functions.
-   */
-  enableFunctionOutlining: z.boolean().default(true),
+    /**
+     * Enables function outlinining, where anonymous functions that do not close over
+     * local variables can be extracted into top-level helper functions.
+     */
+    enableFunctionOutlining: z.boolean().default(true),
 
-  /**
-   * If enabled, this will outline nested JSX into a separate component.
-   *
-   * This will enable the compiler to memoize the separate component, giving us
-   * the same behavior as compiling _within_ the callback.
-   *
-   * ```
-   * function Component(countries, onDelete) {
-   *   const name = useFoo();
-   *   return countries.map(() => {
-   *     return (
-   *       <Foo>
-   *         <Bar>{name}</Bar>
-   *         <Button onclick={onDelete}>delete</Button>
-   *       </Foo>
-   *     );
-   *   });
-   * }
-   * ```
-   *
-   * will be transpiled to:
-   *
-   * ```
-   * function Component(countries, onDelete) {
-   *   const name = useFoo();
-   *   return countries.map(() => {
-   *     return (
-   *       <Temp name={name} onDelete={onDelete} />
-   *     );
-   *   });
-   * }
-   *
-   * function Temp({name, onDelete}) {
-   *   return (
-   *     <Foo>
-   *       <Bar>{name}</Bar>
-   *       <Button onclick={onDelete}>delete</Button>
-   *     </Foo>
-   *   );
-   * }
-   *
-   * Both, `Component` and `Temp` will then be memoized by the compiler.
-   *
-   * With this change, when `countries` is updated by adding one single value,
-   * only the newly added value is re-rendered and not the entire list.
-   */
-  enableJsxOutlining: z.boolean().default(false),
+    /**
+     * If enabled, this will outline nested JSX into a separate component.
+     *
+     * This will enable the compiler to memoize the separate component, giving us
+     * the same behavior as compiling _within_ the callback.
+     *
+     * ```
+     * function Component(countries, onDelete) {
+     *   const name = useFoo();
+     *   return countries.map(() => {
+     *     return (
+     *       <Foo>
+     *         <Bar>{name}</Bar>
+     *         <Button onclick={onDelete}>delete</Button>
+     *       </Foo>
+     *     );
+     *   });
+     * }
+     * ```
+     *
+     * will be transpiled to:
+     *
+     * ```
+     * function Component(countries, onDelete) {
+     *   const name = useFoo();
+     *   return countries.map(() => {
+     *     return (
+     *       <Temp name={name} onDelete={onDelete} />
+     *     );
+     *   });
+     * }
+     *
+     * function Temp({name, onDelete}) {
+     *   return (
+     *     <Foo>
+     *       <Bar>{name}</Bar>
+     *       <Button onclick={onDelete}>delete</Button>
+     *     </Foo>
+     *   );
+     * }
+     *
+     * Both, `Component` and `Temp` will then be memoized by the compiler.
+     *
+     * With this change, when `countries` is updated by adding one single value,
+     * only the newly added value is re-rendered and not the entire list.
+     */
+    enableJsxOutlining: z.boolean().default(false),
 
-  /*
-   * Enables instrumentation codegen. This emits a dev-mode only call to an
-   * instrumentation function, for components and hooks that Forget compiles.
-   * For example:
-   *   instrumentForget: {
-   *     import: {
-   *       source: 'react-compiler-runtime',
-   *       importSpecifierName: 'useRenderCounter',
-   *      }
-   *   }
-   *
-   * produces:
-   *   import {useRenderCounter} from 'react-compiler-runtime';
-   *
-   *   function Component(props) {
-   *     if (__DEV__) {
-   *        useRenderCounter("Component", "/filepath/filename.js");
-   *     }
-   *     // ...
-   *   }
-   *
-   */
-  enableEmitInstrumentForget: InstrumentationSchema.nullable().default(null),
+    /*
+     * Enables instrumentation codegen. This emits a dev-mode only call to an
+     * instrumentation function, for components and hooks that Forget compiles.
+     * For example:
+     *   instrumentForget: {
+     *     import: {
+     *       source: 'react-compiler-runtime',
+     *       importSpecifierName: 'useRenderCounter',
+     *      }
+     *   }
+     *
+     * produces:
+     *   import {useRenderCounter} from 'react-compiler-runtime';
+     *
+     *   function Component(props) {
+     *     if (__DEV__) {
+     *        useRenderCounter("Component", "/filepath/filename.js");
+     *     }
+     *     // ...
+     *   }
+     *
+     */
+    enableEmitInstrumentForget: InstrumentationSchema.nullable().default(null),
 
-  // Enable validation of mutable ranges
-  assertValidMutableRanges: z.boolean().default(false),
+    // Enable validation of mutable ranges
+    assertValidMutableRanges: z.boolean().default(false),
 
-  /*
-   * Enable emitting "change variables" which store the result of whether a particular
-   * reactive scope dependency has changed since the scope was last executed.
-   *
-   * Ex:
-   * ```
-   * const c_0 = $[0] !== input; // change variable
-   * let output;
-   * if (c_0) ...
-   * ```
-   *
-   * Defaults to false, where the comparison is inlined:
-   *
-   * ```
-   * let output;
-   * if ($[0] !== input) ...
-   * ```
-   */
-  enableChangeVariableCodegen: z.boolean().default(false),
+    /*
+     * Enable emitting "change variables" which store the result of whether a particular
+     * reactive scope dependency has changed since the scope was last executed.
+     *
+     * Ex:
+     * ```
+     * const c_0 = $[0] !== input; // change variable
+     * let output;
+     * if (c_0) ...
+     * ```
+     *
+     * Defaults to false, where the comparison is inlined:
+     *
+     * ```
+     * let output;
+     * if ($[0] !== input) ...
+     * ```
+     */
+    enableChangeVariableCodegen: z.boolean().default(false),
 
-  /**
-   * Enable emitting comments that explain Forget's output, and which
-   * values are being checked and which values produced by each memo block.
-   *
-   * Intended for use in demo purposes (incl playground)
-   */
-  enableMemoizationComments: z.boolean().default(false),
+    /**
+     * Enable emitting comments that explain Forget's output, and which
+     * values are being checked and which values produced by each memo block.
+     *
+     * Intended for use in demo purposes (incl playground)
+     */
+    enableMemoizationComments: z.boolean().default(false),
 
-  /**
-   * [TESTING ONLY] Throw an unknown exception during compilation to
-   * simulate unexpected exceptions e.g. errors from babel functions.
-   */
-  throwUnknownException__testonly: z.boolean().default(false),
+    /**
+     * [TESTING ONLY] Throw an unknown exception during compilation to
+     * simulate unexpected exceptions e.g. errors from babel functions.
+     */
+    throwUnknownException__testonly: z.boolean().default(false),
 
-  /**
-   * Enables deps of a function epxression to be treated as conditional. This
-   * makes sure we don't load a dep when it's a property (to check if it has
-   * changed) and instead check the receiver.
-   *
-   * This makes sure we don't end up throwing when the reciver is null. Consider
-   * this code:
-   *
-   * ```
-   * function getLength() {
-   *   return props.bar.length;
-   * }
-   * ```
-   *
-   * It's only safe to memoize `getLength` against props, not props.bar, as
-   * props.bar could be null when this `getLength` function is created.
-   *
-   * This does cause the memoization to now be coarse grained, which is
-   * non-ideal.
-   */
-  enableTreatFunctionDepsAsConditional: z.boolean().default(false),
+    /**
+     * Enables deps of a function epxression to be treated as conditional. This
+     * makes sure we don't load a dep when it's a property (to check if it has
+     * changed) and instead check the receiver.
+     *
+     * This makes sure we don't end up throwing when the reciver is null. Consider
+     * this code:
+     *
+     * ```
+     * function getLength() {
+     *   return props.bar.length;
+     * }
+     * ```
+     *
+     * It's only safe to memoize `getLength` against props, not props.bar, as
+     * props.bar could be null when this `getLength` function is created.
+     *
+     * This does cause the memoization to now be coarse grained, which is
+     * non-ideal.
+     */
+    enableTreatFunctionDepsAsConditional: z.boolean().default(false),
 
-  /**
-   * When true, always act as though the dependencies of a memoized value
-   * have changed. This makes the compiler not actually perform any optimizations,
-   * but is useful for debugging. Implicitly also sets
-   * @enablePreserveExistingManualUseMemo, because otherwise memoization in the
-   * original source will be disabled as well.
-   */
-  disableMemoizationForDebugging: z.boolean().default(false),
+    /**
+     * When true, always act as though the dependencies of a memoized value
+     * have changed. This makes the compiler not actually perform any optimizations,
+     * but is useful for debugging. Implicitly also sets
+     * @enablePreserveExistingManualUseMemo, because otherwise memoization in the
+     * original source will be disabled as well.
+     */
+    disableMemoizationForDebugging: z.boolean().default(false),
 
-  /**
-   * When true, rather using memoized values, the compiler will always re-compute
-   * values, and then use a heuristic to compare the memoized value to the newly
-   * computed one. This detects cases where rules of react violations may cause the
-   * compiled code to behave differently than the original.
-   */
-  enableChangeDetectionForDebugging:
-    ExternalFunctionSchema.nullable().default(null),
+    /**
+     * When true, rather using memoized values, the compiler will always re-compute
+     * values, and then use a heuristic to compare the memoized value to the newly
+     * computed one. This detects cases where rules of react violations may cause the
+     * compiled code to behave differently than the original.
+     */
+    enableChangeDetectionForDebugging:
+      ExternalFunctionSchema.nullable().default(null),
 
-  /**
-   * The react native re-animated library uses custom Babel transforms that
-   * requires the calls to library API remain unmodified.
-   *
-   * If this flag is turned on, the React compiler will use custom type
-   * definitions for reanimated library to make it's Babel plugin work
-   * with the compiler.
-   */
-  enableCustomTypeDefinitionForReanimated: z.boolean().default(false),
+    /**
+     * The react native re-animated library uses custom Babel transforms that
+     * requires the calls to library API remain unmodified.
+     *
+     * If this flag is turned on, the React compiler will use custom type
+     * definitions for reanimated library to make it's Babel plugin work
+     * with the compiler.
+     */
+    enableCustomTypeDefinitionForReanimated: z.boolean().default(false),
 
-  /**
-   * If specified, this value is used as a pattern for determing which global values should be
-   * treated as hooks. The pattern should have a single capture group, which will be used as
-   * the hook name for the purposes of resolving hook definitions (for builtin hooks)_.
-   *
-   * For example, by default `React$useState` would not be treated as a hook. By specifying
-   * `hookPattern: 'React$(\w+)'`, the compiler will treat this value equivalently to `useState()`.
-   *
-   * This setting is intended for cases where Forget is compiling code that has been prebundled
-   * and identifiers have been changed.
-   */
-  hookPattern: z.string().nullable().default(null),
+    /**
+     * If specified, this value is used as a pattern for determing which global values should be
+     * treated as hooks. The pattern should have a single capture group, which will be used as
+     * the hook name for the purposes of resolving hook definitions (for builtin hooks)_.
+     *
+     * For example, by default `React$useState` would not be treated as a hook. By specifying
+     * `hookPattern: 'React$(\w+)'`, the compiler will treat this value equivalently to `useState()`.
+     *
+     * This setting is intended for cases where Forget is compiling code that has been prebundled
+     * and identifiers have been changed.
+     */
+    hookPattern: z.string().nullable().default(null),
 
-  /**
-   * If enabled, this will treat objects named as `ref` or if their names end with the substring `Ref`,
-   * and contain a property named `current`, as React refs.
-   *
-   * ```
-   * const ref = useMyRef();
-   * const myRef = useMyRef2();
-   * useEffect(() => {
-   *   ref.current = ...;
-   *   myRef.current = ...;
-   * })
-   * ```
-   *
-   * Here the variables `ref` and `myRef` will be typed as Refs.
-   */
-  enableTreatRefLikeIdentifiersAsRefs: z.boolean().default(false),
+    /**
+     * If enabled, this will treat objects named as `ref` or if their names end with the substring `Ref`,
+     * and contain a property named `current`, as React refs.
+     *
+     * ```
+     * const ref = useMyRef();
+     * const myRef = useMyRef2();
+     * useEffect(() => {
+     *   ref.current = ...;
+     *   myRef.current = ...;
+     * })
+     * ```
+     *
+     * Here the variables `ref` and `myRef` will be typed as Refs.
+     */
+    enableTreatRefLikeIdentifiersAsRefs: z.boolean().default(false),
 
-  /*
-   * If specified a value, the compiler lowers any calls to `useContext` to use
-   * this value as the callee.
-   *
-   * A selector function is compiled and passed as an argument along with the
-   * context to this function call.
-   *
-   * The compiler automatically figures out the keys by looking for the immediate
-   * destructuring of the return value from the useContext call. In the future,
-   * this can be extended to different kinds of context access like property
-   * loads and accesses over multiple statements as well.
-   *
-   * ```
-   * // input
-   * const {foo, bar} = useContext(MyContext);
-   *
-   * // output
-   * const {foo, bar} = useCompiledContext(MyContext, (c) => [c.foo, c.bar]);
-   * ```
-   */
-  lowerContextAccess: ExternalFunctionSchema.nullable().default(null),
-});
+    /*
+     * If specified a value, the compiler lowers any calls to `useContext` to use
+     * this value as the callee.
+     *
+     * A selector function is compiled and passed as an argument along with the
+     * context to this function call.
+     *
+     * The compiler automatically figures out the keys by looking for the immediate
+     * destructuring of the return value from the useContext call. In the future,
+     * this can be extended to different kinds of context access like property
+     * loads and accesses over multiple statements as well.
+     *
+     * ```
+     * // input
+     * const {foo, bar} = useContext(MyContext);
+     *
+     * // output
+     * const {foo, bar} = useCompiledContext(MyContext, (c) => [c.foo, c.bar]);
+     * ```
+     */
+    lowerContextAccess: ExternalFunctionSchema.nullable().default(null),
+  })
+  .strict();
 
 export type EnvironmentConfig = z.infer<typeof EnvironmentConfigSchema>;
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/EnvironmentConfigSchema-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/EnvironmentConfigSchema-test.ts
@@ -1,13 +1,20 @@
-import {validateEnvironmentConfig} from '../HIR/Environment';
-import {CompilerError} from '../CompilerError';
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
-describe('EnvironmentConfigSchema', () => {
+import {CompilerError, validateEnvironmentConfig} from '..';
+
+describe('validateEnvironmentConfig()', () => {
   it('should throw a CompilerError for unknown properties', () => {
     const invalidConfig = {
       unknownProperty: true,
     };
 
     expect(() => {
+      // @ts-expect-error - This is to simulate the usage outside of the package when the types are not available or if used with javascript.
       validateEnvironmentConfig(invalidConfig);
     }).toThrow(CompilerError);
   });

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/EnvironmentConfigSchema-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/EnvironmentConfigSchema-test.ts
@@ -1,0 +1,32 @@
+import {validateEnvironmentConfig} from '../HIR/Environment';
+import {CompilerError} from '../CompilerError';
+
+describe('EnvironmentConfigSchema', () => {
+  it('should throw a CompilerError for unknown properties', () => {
+    const invalidConfig = {
+      unknownProperty: true,
+    };
+
+    expect(() => {
+      validateEnvironmentConfig(invalidConfig);
+    }).toThrow(CompilerError);
+  });
+
+  it('should parse valid config without errors', () => {
+    const validConfig = {
+      customHooks: new Map(),
+      moduleTypeProvider: null,
+      customMacros: null,
+      enableResetCacheOnSourceFileChanges: false,
+      enablePreserveExistingMemoizationGuarantees: false,
+      validatePreserveExistingMemoizationGuarantees: true,
+      enablePreserveExistingManualUseMemo: false,
+      enableForest: false,
+      enableUseTypeAnnotations: false,
+    };
+
+    expect(() => {
+      validateEnvironmentConfig(validConfig);
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Enable strict mode for `EnvironmentConfigSchema` to enforce validation and throw errors for unrecognized configuration properties. This change will help identify typos or incorrect property names in the compiler configuration, making it easier to catch and correct mistakes during setup.

## How did you test this change?
I verified this change within my project, confirming that errors are displayed when incorrect properties are passed to the `ReactCompilerConfig` object. Additionally, I created a test file at `compiler/packages/babel-plugin-react-compiler/src/__tests__/EnvironmentConfigSchema-test.ts`. ~~However, I encountered issues running tests within the `compiler/packages/babel-plugin-react-compiler` package, even without my changes, despite setting up my environment correctly. While I have added the test file, I could use guidance on resolving this testing issue.~~
_Edit: the tests are now ok_

## Potential break
This change could disrupt some environments if the configuration contains disallowed properties, as previously these would have simply been ignored. With the new `strict()` rule, the configuration object is now restricted to only contain allowed properties. If any properties are removed in the future, developers will need to ensure they are also removed from the configuration to avoid errors. In my opinion, this approach is beneficial, as it explicitly flags incorrect properties and encourages developers to maintain a correct configuration object.
As the compiler is still in beta, I think it is better to add the `strict()` now than later.