### PR TITLE
eslint-plugin-react-hooks: Fix international component name compatibility

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -561,6 +561,15 @@ const tests = {
         };
       `,
     },
+    {
+      code: normalizeIndent`
+        // Valid because React supports international languages
+        function ÄndraVärdeComponent() {
+          useHook();
+          return <div />;
+        }
+      `
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.ts
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.ts
@@ -42,7 +42,10 @@ function isHook(node: Node): boolean {
  * always start with an uppercase letter.
  */
 function isComponentName(node: Node): boolean {
-  return node.type === 'Identifier' && /^[A-Z]/.test(node.name);
+  return node.type === 'Identifier' &&
+    node.name[0] === node.name[0].toUpperCase() &&
+    node.name[0] !== '_' &&
+    node.name[0] !== '$';
 }
 
 function isReactFunction(node: Node, functionName: string): boolean {


### PR DESCRIPTION
## Summary
This fixes compatiblity with international functional component names such as `ÄndraVärde` in the ESLint rule `RulesOfHooks`.

The problem is a Regex that only allows component names to start with the characters A-Z when in reality characters from other languages should be supported too.

Fixes #31446

## How did you test this change?
I added a unit test and verified that the rule failed just like it does in my own projects, then I did my modification and verified that the tests pass.