### PR TITLE
[compiler] Disable emit of .tsbuildinfo

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/package.json
+++ b/compiler/packages/babel-plugin-react-compiler/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "license": "MIT",
   "files": [
-    "dist"
+    "dist",
+    "!*.tsbuildinfo"
   ],
   "scripts": {
     "build": "rimraf dist && rollup --config --bundleConfigAsCjs",

--- a/compiler/packages/babel-plugin-react-compiler/rollup.config.js
+++ b/compiler/packages/babel-plugin-react-compiler/rollup.config.js
@@ -28,6 +28,7 @@ const DEV_ROLLUP_CONFIG = {
   plugins: [
     typescript({
       tsconfig: './tsconfig.json',
+      outputToFilesystem: true,
       compilerOptions: {
         noEmit: true,
       },


### PR DESCRIPTION
## Summary
`@rollup/plugin-typescript` emits a warning while building, hinting that `outputToFilesystem` defaults to true.

Although "noEmit" is set to `true` for the tsconfig, rollup writes a `dist/.tsbuildinfo`. That file is then also shipped inside the npm module and doesn't offer any benefit for library consumers. Setting this option to false results in the file not being written and thus omitted from the npm module.

## How did you test this change?
`dist/.tsbuildinfo` is not emitted any more.