### PR TITLE
Status variable type

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -203,7 +203,7 @@ type SomeChunk<T> =
 
 // $FlowFixMe[missing-this-annot]
 function ReactPromise(
-  status: any,
+  status: string,
   value: any,
   reason: any,
   response: Response,


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Issue: #31467

I noticed the status variable in the ReactPromise function of the ReactFlightClient file, is of type any. After carefully checking every other mention of this variable to make sure about it's type, I changed it into string to better suite the intented type and avoid risk of bugs.

![screen](https://github.com/user-attachments/assets/44dcfeeb-ae85-4f59-bed2-f6bf07e8796d)

## How did you test this change?

I run the following commands: 
- yarn
- yarn test
