### PR TITLE
fix: remove mountWorkInProgressOffscreenFiber function

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -14,7 +14,6 @@ import type {
 } from 'shared/ReactTypes';
 import type {LazyComponent as LazyComponentType} from 'react/src/ReactLazy';
 import type {Fiber, FiberRoot} from './ReactInternalTypes';
-import type {TypeOfMode} from './ReactTypeOfMode';
 import type {Lanes, Lane} from './ReactFiberLane';
 import type {
   SuspenseState,
@@ -2347,10 +2346,11 @@ function mountSuspensePrimaryChildren(
     mode: 'visible',
     children: primaryChildren,
   };
-  const primaryChildFragment = mountWorkInProgressOffscreenFiber(
+  const primaryChildFragment = createFiberFromOffscreen(
     primaryChildProps,
     mode,
     renderLanes,
+    null,
   );
   primaryChildFragment.return = workInProgress;
   workInProgress.child = primaryChildFragment;
@@ -2402,10 +2402,11 @@ function mountSuspenseFallbackChildren(
       null,
     );
   } else {
-    primaryChildFragment = mountWorkInProgressOffscreenFiber(
+    primaryChildFragment = createFiberFromOffscreen(
       primaryChildProps,
       mode,
       NoLanes,
+      null,
     );
     fallbackChildFragment = createFiberFromFragment(
       fallbackChildren,
@@ -2420,16 +2421,6 @@ function mountSuspenseFallbackChildren(
   primaryChildFragment.sibling = fallbackChildFragment;
   workInProgress.child = primaryChildFragment;
   return fallbackChildFragment;
-}
-
-function mountWorkInProgressOffscreenFiber(
-  offscreenProps: OffscreenProps,
-  mode: TypeOfMode,
-  renderLanes: Lanes,
-) {
-  // The props argument to `createFiberFromOffscreen` is `any` typed, so we use
-  // this wrapper function to constrain it.
-  return createFiberFromOffscreen(offscreenProps, mode, NoLanes, null);
 }
 
 function updateWorkInProgressOffscreenFiber(
@@ -2608,10 +2599,11 @@ function mountSuspenseFallbackAfterRetryWithoutHydrating(
     mode: 'visible',
     children: primaryChildren,
   };
-  const primaryChildFragment = mountWorkInProgressOffscreenFiber(
+  const primaryChildFragment = createFiberFromOffscreen(
     primaryChildProps,
     fiberMode,
     NoLanes,
+    null,
   );
   const fallbackChildFragment = createFiberFromFragment(
     fallbackChildren,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

I deleted mountWorkInProgressOffscreenFiber.

The prop type of createFiberFromOffscreen is now specified as OffscreenProps, not any.

Therefore, I thought mountWorkInProgressOffscreenFiber was an unnecessary function.

<img width="591" alt="image" src="https://github.com/user-attachments/assets/455c9980-3037-4ead-b5f8-c5286d0b5e89">

<img width="539" alt="image" src="https://github.com/user-attachments/assets/135b73a9-997d-4850-a111-2e129c80de88">


## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
