### PR TITLE
[React 19] When submitting a form action multiple times, requestFormReset throws the TypeError 'Cannot read null property (reading 'queue')'.

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -3200,7 +3200,7 @@ export function startHostTransition<F>(
 
 function ensureFormComponentIsStateful(formFiber: Fiber) {
   const existingStateHook: Hook | null = formFiber.memoizedState;
-  if (existingStateHook !== null) {
+  if (existingStateHook !== null && existingStateHook.next !== null) {
     // This fiber was already upgraded to be stateful.
     return existingStateHook;
   }
@@ -3288,6 +3288,9 @@ export function requestFormReset(formFiber: Fiber) {
   }
 
   const stateHook = ensureFormComponentIsStateful(formFiber);
+  const isEmpty = stateHook === null || stateHook.length === 0;
+  if (isEmpty) return;
+
   const newResetState = {};
   const resetStateHook: Hook = (stateHook.next: any);
   const resetStateQueue = resetStateHook.queue;
@@ -3537,6 +3540,8 @@ function dispatchSetStateInternal<S, A>(
   action: A,
   lane: Lane,
 ): boolean {
+  const isEmptyQueue = queue === null || queue.length === 0;
+  if (isEmptyQueue) return;
   const update: Update<S, A> = {
     lane,
     revertLane: NoLane,


### PR DESCRIPTION
## Summary
Related Previous Issues: https://github.com/facebook/react/issues/30041
Related Previous PR: https://github.com/facebook/react/pull/30365

There was already a PR raised, but I wrote a PR to be more specific and prevent type errors.

When passing an asynchronous function to a <form> action, if you pass that action again before receiving the response, the stateHook.next value will be null in the `ensureFormComponentIsStateful` function running inside the requestFormReset function, resulting in a type error. To prevent this problem, I modified the `ensureFormComponentIsStateful` function to maintain the current statefull state if the `stateHook.next` value is null. 

## Test Code
```javascript
function App() {
  const formAction = async () => {
    await new Promise((resolve) => setTimeout(resolve, 3000));
  };
  return (
    <form action={formAction}>
      <input type="text" name="name" />
      <input type="submit" />
    </form>
  );
}
export default App;
```

## Test Step
1. Enter any text in input text.
2. Submit.
3. Submit multiple times within 3 seconds (setTimeout time). 
(usually after 2-3 seconds, just before the response comes)

## How did you test this change?

- codesandbox: https://codesandbox.io/p/sandbox/react-19-form-reset-error-l79dq5
- React Version: 19.0.0-rc-5c56b873-20241107
- local test and `yarn test`.
![react19-form-action-error](https://github.com/user-attachments/assets/dca553b9-9d23-40b0-8a91-10e0d615c138)

If there is anything wrong, please tell me.