### PR TITLE
Revert "Performance tracks are sorted by start time" hack

### DIFF
--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -193,13 +193,8 @@ export function popComponentEffectStart(prevEffectStart: number): void {
   if (!enableProfilerTimer || !enableProfilerCommitHooks) {
     return;
   }
-  if (prevEffectStart < 0) {
-    // If the parent component didn't have a start time, we use the start
-    // of the child as the parent's start time. We subtrack a minimal amount of
-    // time to ensure that the parent's start time is before the child to ensure
-    // that the performance tracks line up in the right order.
-    componentEffectStartTime -= 0.001;
-  } else {
+  // If the parent component didn't have a start time, we let this current time persist.
+  if (prevEffectStart >= 0) {
     // Otherwise, we restore the previous parent's start time.
     componentEffectStartTime = prevEffectStart;
   }


### PR DESCRIPTION
This reverts commit d3bf32a95806b6d583ef041b8d83781cd686cfd8 which was part of #30983

When you have very deep trees this trick can cause the top levels to skew way too much from the real numbers. Creating unbalanced trees.

The bug should have been fixed in Chrome Canary now so that entries added later are sorted to go first which should've addressed this issue.

