### PR TITLE
Log passive commit phase when it wasn't delayed

### DIFF
--- a/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
+++ b/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
@@ -221,12 +221,19 @@ export function logCommitPhase(startTime: number, endTime: number): void {
   }
 }
 
-export function logPaintYieldPhase(startTime: number, endTime: number): void {
+export function logPaintYieldPhase(
+  startTime: number,
+  endTime: number,
+  delayedUntilPaint: boolean,
+): void {
   if (supportsUserTiming) {
     reusableLaneDevToolDetails.color = 'secondary-light';
     reusableLaneOptions.start = startTime;
     reusableLaneOptions.end = endTime;
-    performance.measure('Waiting for Paint', reusableLaneOptions);
+    performance.measure(
+      delayedUntilPaint ? 'Waiting for Paint' : '',
+      reusableLaneOptions,
+    );
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -3550,9 +3550,11 @@ function flushPassiveEffectsImpl(wasDelayedCommit: void | boolean) {
   let passiveEffectStartTime = 0;
   if (enableProfilerTimer && enableComponentPerformanceTrack) {
     passiveEffectStartTime = now();
-    if (wasDelayedCommit) {
-      logPaintYieldPhase(commitEndTime, passiveEffectStartTime);
-    }
+    logPaintYieldPhase(
+      commitEndTime,
+      passiveEffectStartTime,
+      !!wasDelayedCommit,
+    );
   }
 
   if (enableSchedulingProfiler) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -3550,7 +3550,9 @@ function flushPassiveEffectsImpl(wasDelayedCommit: void | boolean) {
   let passiveEffectStartTime = 0;
   if (enableProfilerTimer && enableComponentPerformanceTrack) {
     passiveEffectStartTime = now();
-    logPaintYieldPhase(commitEndTime, passiveEffectStartTime);
+    if (wasDelayedCommit) {
+      logPaintYieldPhase(commitEndTime, passiveEffectStartTime);
+    }
   }
 
   if (enableSchedulingProfiler) {
@@ -3587,9 +3589,7 @@ function flushPassiveEffectsImpl(wasDelayedCommit: void | boolean) {
 
   if (enableProfilerTimer && enableComponentPerformanceTrack) {
     const passiveEffectsEndTime = now();
-    if (wasDelayedCommit) {
-      logPassiveCommitPhase(passiveEffectStartTime, passiveEffectsEndTime);
-    }
+    logPassiveCommitPhase(passiveEffectStartTime, passiveEffectsEndTime);
     finalizeRender(lanes, passiveEffectsEndTime);
   }
 


### PR DESCRIPTION
Fixes a bug.

We're supposed to not log "Waiting for Paint" if the passive effect phase was forced since we weren't really waiting until the paint. Instead we just log an empty string when we force it to still ensure continuity.

We should always log the passive phase. This check was in the wrong place.
