### PR TITLE
Export __COMPILER_RUNTIME in stable

### DIFF
--- a/packages/react/index.stable.js
+++ b/packages/react/index.stable.js
@@ -9,6 +9,7 @@
 
 export {
   __CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,
+  __COMPILER_RUNTIME,
   act,
   Children,
   Component,


### PR DESCRIPTION


In order to make use of the compiler in stable releases (eg React 19 RC, canary), we need to export the compiler runtime in the stable channel as well.
