### PR TITLE
Don't dist-tag canaries with `rc`

### DIFF
--- a/.github/workflows/runtime_prereleases_manual.yml
+++ b/.github/workflows/runtime_prereleases_manual.yml
@@ -27,7 +27,7 @@ jobs:
       # because this used to be called the "next" channel and some
       # downstream consumers might still expect that tag. We can remove this
       # after some time has elapsed and the change has been communicated.
-      dist_tag: canary,next,rc
+      dist_tag: canary,next
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/runtime_prereleases_nightly.yml
+++ b/.github/workflows/runtime_prereleases_nightly.yml
@@ -15,7 +15,7 @@ jobs:
     with:
       commit_sha: ${{ github.sha }}
       release_channel: stable
-      dist_tag: canary,next,rc
+      dist_tag: canary,next
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
We used to tag canaries with `rc` whenever we were in the RC phase of a release cycle. But now that publish "real" versioned canaries like 19.0.0-rc.1, it's confusing that the `rc` dist-tag could point to an even newer version than that.

So this removes the `rc` dist-tag from the canary publish workflow.