### PR TITLE
[playground] Always upload test results in ci

### DIFF
--- a/.github/workflows/compiler_playground.yml
+++ b/.github/workflows/compiler_playground.yml
@@ -46,6 +46,7 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - run: yarn test
       - name: Archive test results
+        if: '!cancelled()'
         uses: actions/upload-artifact@v4
         with:
           name: test-results


### PR DESCRIPTION


Small change to always upload test results from CI even if the test failed.
