### PR TITLE
[DevTools] Show component names while highlighting renders

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/traceUpdates-test.js
+++ b/packages/react-devtools-shared/src/__tests__/traceUpdates-test.js
@@ -1,0 +1,269 @@
+import {groupAndSortNodes} from 'react-devtools-shared/src/backend/views/TraceUpdates/canvas';
+
+describe('Trace updates group and sort nodes', () => {
+  test('should group nodes by position without changing order within group', () => {
+    const nodeToData = new Map([
+      [
+        {id: 1},
+        {
+          rect: {left: 0, top: 0, width: 100, height: 100},
+          color: '#80b393',
+          displayName: 'Node1',
+          count: 3,
+        },
+      ],
+      [
+        {id: 2},
+        {
+          rect: {left: 0, top: 0, width: 100, height: 100},
+          color: '#63b19e',
+          displayName: 'Node2',
+          count: 2,
+        },
+      ],
+    ]);
+
+    const result = groupAndSortNodes(nodeToData);
+
+    expect(result).toEqual([
+      [
+        {
+          rect: {left: 0, top: 0, width: 100, height: 100},
+          color: '#80b393',
+          displayName: 'Node1',
+          count: 3,
+        },
+        {
+          rect: {left: 0, top: 0, width: 100, height: 100},
+          color: '#63b19e',
+          displayName: 'Node2',
+          count: 2,
+        },
+      ],
+    ]);
+  });
+
+  test('should sort groups by lowest count in each group', () => {
+    const nodeToData = new Map([
+      [
+        {id: 1},
+        {
+          rect: {left: 0, top: 0, width: 100, height: 100},
+          color: '#97b488',
+          displayName: 'Group1',
+          count: 4,
+        },
+      ],
+      [
+        {id: 2},
+        {
+          rect: {left: 100, top: 0, width: 100, height: 100},
+          color: '#37afa9',
+          displayName: 'Group2',
+          count: 1,
+        },
+      ],
+      [
+        {id: 3},
+        {
+          rect: {left: 200, top: 0, width: 100, height: 100},
+          color: '#63b19e',
+          displayName: 'Group3',
+          count: 2,
+        },
+      ],
+    ]);
+
+    const result = groupAndSortNodes(nodeToData);
+
+    expect(result).toEqual([
+      [
+        {
+          rect: {left: 100, top: 0, width: 100, height: 100},
+          color: '#37afa9',
+          displayName: 'Group2',
+          count: 1,
+        },
+      ],
+      [
+        {
+          rect: {left: 200, top: 0, width: 100, height: 100},
+          color: '#63b19e',
+          displayName: 'Group3',
+          count: 2,
+        },
+      ],
+      [
+        {
+          rect: {left: 0, top: 0, width: 100, height: 100},
+          color: '#97b488',
+          displayName: 'Group1',
+          count: 4,
+        },
+      ],
+    ]);
+  });
+
+  test('should maintain order within groups while sorting groups by lowest count', () => {
+    const nodeToData = new Map([
+      [
+        {id: 1},
+        {
+          rect: {left: 0, top: 0, width: 50, height: 50},
+          color: '#97b488',
+          displayName: 'Pos1Node1',
+          count: 4,
+        },
+      ],
+      [
+        {id: 2},
+        {
+          rect: {left: 0, top: 0, width: 60, height: 60},
+          color: '#63b19e',
+          displayName: 'Pos1Node2',
+          count: 2,
+        },
+      ],
+      [
+        {id: 3},
+        {
+          rect: {left: 100, top: 0, width: 70, height: 70},
+          color: '#80b393',
+          displayName: 'Pos2Node1',
+          count: 3,
+        },
+      ],
+      [
+        {id: 4},
+        {
+          rect: {left: 100, top: 0, width: 80, height: 80},
+          color: '#37afa9',
+          displayName: 'Pos2Node2',
+          count: 1,
+        },
+      ],
+    ]);
+
+    const result = groupAndSortNodes(nodeToData);
+
+    expect(result).toEqual([
+      [
+        {
+          rect: {left: 100, top: 0, width: 70, height: 70},
+          color: '#80b393',
+          displayName: 'Pos2Node1',
+          count: 3,
+        },
+        {
+          rect: {left: 100, top: 0, width: 80, height: 80},
+          color: '#37afa9',
+          displayName: 'Pos2Node2',
+          count: 1,
+        },
+      ],
+      [
+        {
+          rect: {left: 0, top: 0, width: 50, height: 50},
+          color: '#97b488',
+          displayName: 'Pos1Node1',
+          count: 4,
+        },
+        {
+          rect: {left: 0, top: 0, width: 60, height: 60},
+          color: '#63b19e',
+          displayName: 'Pos1Node2',
+          count: 2,
+        },
+      ],
+    ]);
+  });
+
+  test('should handle multiple groups with same minimum count', () => {
+    const nodeToData = new Map([
+      [
+        {id: 1},
+        {
+          rect: {left: 0, top: 0, width: 100, height: 100},
+          color: '#37afa9',
+          displayName: 'Group1Node1',
+          count: 1,
+        },
+      ],
+      [
+        {id: 2},
+        {
+          rect: {left: 100, top: 0, width: 100, height: 100},
+          color: '#37afa9',
+          displayName: 'Group2Node1',
+          count: 1,
+        },
+      ],
+    ]);
+
+    const result = groupAndSortNodes(nodeToData);
+
+    expect(result).toEqual([
+      [
+        {
+          rect: {left: 0, top: 0, width: 100, height: 100},
+          color: '#37afa9',
+          displayName: 'Group1Node1',
+          count: 1,
+        },
+      ],
+      [
+        {
+          rect: {left: 100, top: 0, width: 100, height: 100},
+          color: '#37afa9',
+          displayName: 'Group2Node1',
+          count: 1,
+        },
+      ],
+    ]);
+  });
+
+  test('should filter out nodes without rect property', () => {
+    const nodeToData = new Map([
+      [
+        {id: 1},
+        {
+          rect: null,
+          color: '#37afa9',
+          displayName: 'NoRectNode',
+          count: 1,
+        },
+      ],
+      [
+        {id: 2},
+        {
+          rect: undefined,
+          color: '#63b19e',
+          displayName: 'UndefinedRectNode',
+          count: 2,
+        },
+      ],
+      [
+        {id: 3},
+        {
+          rect: {left: 0, top: 0, width: 100, height: 100},
+          color: '#80b393',
+          displayName: 'ValidNode',
+          count: 3,
+        },
+      ],
+    ]);
+
+    const result = groupAndSortNodes(nodeToData);
+
+    expect(result).toEqual([
+      [
+        {
+          rect: {left: 0, top: 0, width: 100, height: 100},
+          color: '#80b393',
+          displayName: 'ValidNode',
+          count: 3,
+        },
+      ],
+    ]);
+  });
+});

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -146,6 +146,7 @@ export default class Agent extends EventEmitter<{
   getIfHasUnsupportedRendererVersion: [],
   updateHookSettings: [$ReadOnly<DevToolsHookSettings>],
   getHookSettings: [],
+  showNamesWhenTracing: [boolean],
 }> {
   _bridge: BackendBridge;
   _isProfiling: boolean = false;
@@ -156,6 +157,7 @@ export default class Agent extends EventEmitter<{
   _onReloadAndProfile:
     | ((recordChangeDescriptions: boolean, recordTimeline: boolean) => void)
     | void;
+  _showNamesWhenTracing: boolean = true;
 
   constructor(
     bridge: BackendBridge,
@@ -200,6 +202,7 @@ export default class Agent extends EventEmitter<{
     bridge.addListener('reloadAndProfile', this.reloadAndProfile);
     bridge.addListener('renamePath', this.renamePath);
     bridge.addListener('setTraceUpdatesEnabled', this.setTraceUpdatesEnabled);
+    bridge.addListener('setShowNamesWhenTracing', this.setShowNamesWhenTracing);
     bridge.addListener('startProfiling', this.startProfiling);
     bridge.addListener('stopProfiling', this.stopProfiling);
     bridge.addListener('storeAsGlobal', this.storeAsGlobal);
@@ -722,6 +725,7 @@ export default class Agent extends EventEmitter<{
       this._traceUpdatesEnabled = traceUpdatesEnabled;
 
       setTraceUpdatesEnabled(traceUpdatesEnabled);
+      this.emit('showNamesWhenTracing', this._showNamesWhenTracing);
 
       for (const rendererID in this._rendererInterfaces) {
         const renderer = ((this._rendererInterfaces[
@@ -730,6 +734,14 @@ export default class Agent extends EventEmitter<{
         renderer.setTraceUpdatesEnabled(traceUpdatesEnabled);
       }
     };
+
+  setShowNamesWhenTracing: (show: boolean) => void = show => {
+    if (this._showNamesWhenTracing === show) {
+      return;
+    }
+    this._showNamesWhenTracing = show;
+    this.emit('showNamesWhenTracing', show);
+  };
 
   syncSelectionFromBuiltinElementsPanel: () => void = () => {
     const target = window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0;

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -28,6 +28,7 @@ import type {
   DevToolsHookSettings,
 } from './types';
 import type {ComponentFilter} from 'react-devtools-shared/src/frontend/types';
+import type {GroupItem} from './views/TraceUpdates/canvas';
 import {isReactNativeEnvironment} from './utils';
 import {
   sessionStorageGetItem,
@@ -142,6 +143,7 @@ export default class Agent extends EventEmitter<{
   shutdown: [],
   traceUpdates: [Set<HostInstance>],
   drawTraceUpdates: [Array<HostInstance>],
+  drawGroupedTraceUpdatesWithNames: [Array<Array<GroupItem>>],
   disableTraceUpdates: [],
   getIfHasUnsupportedRendererVersion: [],
   updateHookSettings: [$ReadOnly<DevToolsHookSettings>],

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -78,26 +78,32 @@ function drawWeb(nodeToData: Map<HostInstance, Data>) {
     }
   });
 
-  positionGroups.forEach(group => {
-    const {rect} = group[0];
+  Array.from(positionGroups.entries())
+    .sort(([, groupA], [, groupB]) => {
+      const maxCountA = Math.max(...groupA.map(item => item.count));
+      const maxCountB = Math.max(...groupB.map(item => item.count));
+      return maxCountA - maxCountB;
+    })
+    .forEach(([_, group]) => {
+      const {rect} = group[0];
 
-    group.forEach(({color}) => {
-      drawBorder(context, rect, color);
-    });
+      group.forEach(({color}) => {
+        drawBorder(context, rect, color);
+      });
 
-    const mergedName = group
-      .map(({displayName, count}) => {
-      if (displayName !== null) {
-        return `${displayName}${count > 1 ? ` x${count}` : ''}`;
+      const mergedName = group
+        .map(({displayName, count}) => {
+          if (displayName !== null) {
+            return `${displayName}${count > 1 ? ` x${count}` : ''}`;
+          }
+        })
+        .filter(Boolean)
+        .join(', ');
+
+      if (mergedName) {
+        drawLabel(context, rect, mergedName, group[0].color);
       }
-      })
-      .filter(Boolean)
-      .join(', ');
-
-    if (mergedName) {
-      drawLabel(context, rect, mergedName, group[0].color);
-    }
-  });
+    });
 }
 
 export function draw(nodeToData: Map<HostInstance, Data>, agent: Agent): void {

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -45,11 +45,18 @@ function drawWeb(nodeToData: Map<HostInstance, Data>) {
   }
 
   const canvasFlow: HTMLCanvasElement = ((canvas: any): HTMLCanvasElement);
-  canvasFlow.width = window.innerWidth;
-  canvasFlow.height = window.innerHeight;
+  const dpr = window.devicePixelRatio || 1;
+
+  canvasFlow.width = window.innerWidth * dpr;
+  canvasFlow.height = window.innerHeight * dpr;
+
+  canvasFlow.style.width = `${window.innerWidth}px`;
+  canvasFlow.style.height = `${window.innerHeight}px`;
 
   const context = canvasFlow.getContext('2d');
-  context.clearRect(0, 0, canvasFlow.width, canvasFlow.height);
+  context.scale(dpr, dpr);
+
+  context.clearRect(0, 0, window.innerWidth, window.innerHeight);
   iterateNodes(nodeToData, (rect, color, displayName) => {
     if (rect !== null) {
       drawBorder(context, rect, color);

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -137,7 +137,15 @@ function iterateNodes(
   nodeToData.forEach((data, node) => {
     const colorIndex = Math.min(COLORS.length - 1, data.count - 1);
     const color = COLORS[colorIndex];
-    execute({...data, color, node});
+    execute({
+      color,
+      node,
+      count: data.count,
+      displayName: data.displayName,
+      expirationTime: data.expirationTime,
+      lastMeasuredAt: data.lastMeasuredAt,
+      rect: data.rect,
+    });
   });
 }
 

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -32,7 +32,7 @@ let canvas: HTMLCanvasElement | null = null;
 
 function drawNative(nodeToData: Map<HostInstance, Data>, agent: Agent) {
   const nodesToDraw = [];
-  iterateNodes(nodeToData, (_, color, node) => {
+  iterateNodes(nodeToData, ({ color, node }) => {
     nodesToDraw.push({node, color});
   });
 
@@ -57,7 +57,7 @@ function drawWeb(nodeToData: Map<HostInstance, Data>) {
   context.scale(dpr, dpr);
 
   context.clearRect(0, 0, window.innerWidth, window.innerHeight);
-  iterateNodes(nodeToData, (rect, color, displayName) => {
+  iterateNodes(nodeToData, ({ rect, color, displayName }) => {
     if (rect !== null) {
       drawBorder(context, rect, color);
       if (displayName !== null) {
@@ -73,14 +73,20 @@ export function draw(nodeToData: Map<HostInstance, Data>, agent: Agent): void {
     : drawWeb(nodeToData);
 }
 
+type DataWithColorAndNode = {
+  ...Data,
+  color: string;
+  node: HostInstance;
+};
+
 function iterateNodes(
   nodeToData: Map<HostInstance, Data>,
-  execute: (rect: Rect | null, color: string, displayName: string | null) => void,
+  execute: (data: DataWithColorAndNode) => void,
 ) {
-  nodeToData.forEach(({count, rect, displayName}, node) => {
-    const colorIndex = Math.min(COLORS.length - 1, count - 1);
+  nodeToData.forEach((data, node) => {
+    const colorIndex = Math.min(COLORS.length - 1, data.count - 1);
     const color = COLORS[colorIndex];
-    execute(rect, color, displayName);
+    execute({...data, color, node});
   });
 }
 

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -32,7 +32,7 @@ let canvas: HTMLCanvasElement | null = null;
 
 function drawNative(nodeToData: Map<HostInstance, Data>, agent: Agent) {
   const nodesToDraw = [];
-  iterateNodes(nodeToData, ({ color, node }) => {
+  iterateNodes(nodeToData, ({color, node}) => {
     nodesToDraw.push({node, color});
   });
 
@@ -57,11 +57,11 @@ function drawWeb(nodeToData: Map<HostInstance, Data>) {
   context.scale(dpr, dpr);
 
   context.clearRect(0, 0, window.innerWidth, window.innerHeight);
-  iterateNodes(nodeToData, ({ rect, color, displayName }) => {
+  iterateNodes(nodeToData, ({rect, color, displayName, count}) => {
     if (rect !== null) {
       drawBorder(context, rect, color);
       if (displayName !== null) {
-        drawComponentName(context, rect, displayName, color);
+        drawComponentName(context, rect, displayName, color, count);
       }
     }
   });
@@ -75,8 +75,8 @@ export function draw(nodeToData: Map<HostInstance, Data>, agent: Agent): void {
 
 type DataWithColorAndNode = {
   ...Data,
-  color: string;
-  node: HostInstance;
+  color: string,
+  node: HostInstance,
 };
 
 function iterateNodes(
@@ -108,14 +108,18 @@ function drawComponentName(
   rect: Rect,
   displayName: string,
   color: string,
+  count: number,
 ): void {
   const {left, top} = rect;
+
+  const countText = count > 1 ? ` x${count}` : '';
+  const text = `${displayName}${countText}`;
 
   context.font = '10px monospace';
   context.textBaseline = 'middle';
   context.textAlign = 'center';
 
-  const metrics = context.measureText(displayName);
+  const metrics = context.measureText(text);
   const padding = 2;
   const textHeight = 14;
   const backgroundWidth = metrics.width + padding * 2;
@@ -128,7 +132,11 @@ function drawComponentName(
   context.fillRect(labelX, labelY, backgroundWidth, backgroundHeight);
 
   context.fillStyle = '#000000';
-  context.fillText(displayName, labelX + (backgroundWidth / 2), labelY + (backgroundHeight / 2));
+  context.fillText(
+    text,
+    labelX + backgroundWidth / 2,
+    labelY + backgroundHeight / 2,
+  );
 }
 
 function destroyNative(agent: Agent) {

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -37,6 +37,9 @@ function drawNative(nodeToData: Map<HostInstance, Data>, agent: Agent) {
   });
 
   agent.emit('drawTraceUpdates', nodesToDraw);
+
+  const mergedNodes = groupAndSortNodes(nodeToData);
+  agent.emit('drawGroupedTraceUpdatesWithNames', mergedNodes);
 }
 
 function drawWeb(nodeToData: Map<HostInstance, Data>) {
@@ -70,6 +73,8 @@ type GroupItem = {
   displayName: string | null,
   count: number,
 };
+
+export type {GroupItem};
 
 export function groupAndSortNodes(
   nodeToData: Map<HostInstance, Data>,

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
@@ -96,7 +96,7 @@ function traceUpdates(nodes: Set<HostInstance>): void {
       rect = measureNode(node);
     }
 
-    let displayName = agent.getComponentNameForHostInstance(node);
+    let displayName = this.showNames && agent.getComponentNameForHostInstance(node);
     if (displayName != null && displayName.startsWith('Forget(')) {
       displayName = '✨' + displayName.slice(7, -1);
     }

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
@@ -26,7 +26,7 @@ const REMEASUREMENT_AFTER_DURATION = 250;
 
 // Markers for different types of HOCs
 const HOC_MARKERS = new Map([
-  ['Forget', '✨ń'],
+  ['Forget', '✨'],
   ['Memo', '🧠'],
 ]);
 

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
@@ -36,6 +36,7 @@ export type Data = {
   expirationTime: number,
   lastMeasuredAt: number,
   rect: Rect | null,
+  displayName: string | null,
 };
 
 const nodeToData: Map<HostInstance, Data> = new Map();
@@ -86,6 +87,11 @@ function traceUpdates(nodes: Set<HostInstance>): void {
       rect = measureNode(node);
     }
 
+    let displayName = agent.getComponentNameForHostInstance(node);
+    if (displayName != null && displayName.startsWith('Forget(')) {
+      displayName = '✨' + displayName.slice(7, -1);
+    }
+
     nodeToData.set(node, {
       count: data != null ? data.count + 1 : 1,
       expirationTime:
@@ -97,6 +103,7 @@ function traceUpdates(nodes: Set<HostInstance>): void {
           : now + DISPLAY_DURATION,
       lastMeasuredAt,
       rect,
+      displayName,
     });
   });
 

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
@@ -44,11 +44,20 @@ const nodeToData: Map<HostInstance, Data> = new Map();
 let agent: Agent = ((null: any): Agent);
 let drawAnimationFrameID: AnimationFrameID | null = null;
 let isEnabled: boolean = false;
+let showNames: boolean = false;
 let redrawTimeoutID: TimeoutID | null = null;
 
 export function initialize(injectedAgent: Agent): void {
   agent = injectedAgent;
   agent.addListener('traceUpdates', traceUpdates);
+  agent.addListener('showNamesWhenTracing', (shouldShowNames: boolean) => {
+    showNames = shouldShowNames;
+    if (isEnabled) {
+      if (drawAnimationFrameID === null) {
+        drawAnimationFrameID = requestAnimationFrame(prepareToDraw);
+      }
+    }
+  });
 }
 
 export function toggleEnabled(value: boolean): void {
@@ -103,7 +112,7 @@ function traceUpdates(nodes: Set<HostInstance>): void {
           : now + DISPLAY_DURATION,
       lastMeasuredAt,
       rect,
-      displayName,
+      displayName: showNames ? displayName : null,
     });
   });
 

--- a/packages/react-devtools-shared/src/backend/views/utils.js
+++ b/packages/react-devtools-shared/src/backend/views/utils.js
@@ -139,7 +139,10 @@ export function getElementDimensions(domElement: HTMLElement): {
   };
 }
 
-export function extractHOCNames(displayName: string) {
+export function extractHOCNames(displayName: string):{
+  baseComponentName: string,
+  hocNames: string[],
+} {
   if (!displayName) return {baseComponentName: '', hocNames: []};
 
   const hocRegex = /([A-Z][a-zA-Z0-9]*?)\((.*)\)/g;

--- a/packages/react-devtools-shared/src/backend/views/utils.js
+++ b/packages/react-devtools-shared/src/backend/views/utils.js
@@ -138,3 +138,25 @@ export function getElementDimensions(domElement: HTMLElement): {
     paddingBottom: parseInt(calculatedStyle.paddingBottom, 10),
   };
 }
+
+export function extractHOCNames(displayName: string) {
+  if (!displayName) return {baseComponentName: '', hocNames: []};
+
+  const hocRegex = /([A-Z][a-zA-Z0-9]*?)\((.*)\)/g;
+  const hocNames: string[] = [];
+  let baseComponentName = displayName;
+  let match;
+
+  while ((match = hocRegex.exec(baseComponentName)) != null) {
+    if (Array.isArray(match)) {
+      const [, hocName, inner] = match;
+      hocNames.push(hocName);
+      baseComponentName = inner;
+    }
+  }
+
+  return {
+    baseComponentName,
+    hocNames,
+  };
+}

--- a/packages/react-devtools-shared/src/backend/views/utils.js
+++ b/packages/react-devtools-shared/src/backend/views/utils.js
@@ -139,7 +139,7 @@ export function getElementDimensions(domElement: HTMLElement): {
   };
 }
 
-export function extractHOCNames(displayName: string):{
+export function extractHOCNames(displayName: string): {
   baseComponentName: string,
   hocNames: string[],
 } {

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -234,6 +234,7 @@ type FrontendEvents = {
   renamePath: [RenamePath],
   savedPreferences: [SavedPreferencesParams],
   setTraceUpdatesEnabled: [boolean],
+  setShowNamesWhenTracing: [boolean],
   shutdown: [],
   startInspectingHost: [],
   startProfiling: [StartProfilingParams],

--- a/packages/react-devtools-shared/src/constants.js
+++ b/packages/react-devtools-shared/src/constants.js
@@ -50,6 +50,8 @@ export const LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY =
   'React::DevTools::traceUpdatesEnabled';
 export const LOCAL_STORAGE_SUPPORTS_PROFILING_KEY =
   'React::DevTools::supportsProfiling';
+export const LOCAL_STORAGE_SHOW_NAMES_WHEN_TRACING_KEY =
+  'React::DevTools::showNamesWhenTracing';
 
 export const PROFILER_EXPORT_VERSION = 5;
 

--- a/packages/react-devtools-shared/src/devtools/views/Settings/GeneralSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/GeneralSettings.js
@@ -34,8 +34,10 @@ export default function GeneralSettings(_: {}): React.Node {
     setDisplayDensity,
     setTheme,
     setTraceUpdatesEnabled,
+    setShowNamesWhenTracing,
     theme,
     traceUpdatesEnabled,
+    showNamesWhenTracing,
   } = useContext(SettingsContext);
 
   const {backendVersion, supportsTraceUpdates} = useContext(StoreContext);
@@ -83,6 +85,19 @@ export default function GeneralSettings(_: {}): React.Node {
             />{' '}
             Highlight updates when components render.
           </label>
+          <div className={styles.Setting}>
+            <label>
+              <input
+                type="checkbox"
+                checked={showNamesWhenTracing}
+                disabled={!traceUpdatesEnabled}
+                onChange={({currentTarget}) =>
+                  setShowNamesWhenTracing(currentTarget.checked)
+                }
+              />{' '}
+              Show component names while highlighting.
+            </label>
+          </div>
         </div>
       )}
 

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -21,6 +21,7 @@ import {
   LOCAL_STORAGE_BROWSER_THEME,
   LOCAL_STORAGE_PARSE_HOOK_NAMES_KEY,
   LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY,
+  LOCAL_STORAGE_SHOW_NAMES_WHEN_TRACING_KEY,
 } from 'react-devtools-shared/src/constants';
 import {
   COMFORTABLE_LINE_HEIGHT,
@@ -53,6 +54,9 @@ type Context = {
 
   traceUpdatesEnabled: boolean,
   setTraceUpdatesEnabled: (value: boolean) => void,
+
+  showNamesWhenTracing: boolean,
+  setShowNamesWhenTracing: (showNames: boolean) => void,
 };
 
 const SettingsContext: ReactContext<Context> = createContext<Context>(
@@ -111,6 +115,10 @@ function SettingsContextController({
       LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY,
       false,
     );
+  const [showNamesWhenTracing, setShowNamesWhenTracing] = useLocalStorageWithLog<boolean>(
+    LOCAL_STORAGE_SHOW_NAMES_WHEN_TRACING_KEY,
+    true,
+  );
 
   const documentElements = useMemo<DocumentElements>(() => {
     const array: Array<HTMLElement> = [
@@ -164,6 +172,11 @@ function SettingsContextController({
     bridge.send('setTraceUpdatesEnabled', traceUpdatesEnabled);
   }, [bridge, traceUpdatesEnabled]);
 
+  useEffect(() => {
+    console.log('sent to bridge: setShowNamesWhenTracing', showNamesWhenTracing);
+    bridge.send('setShowNamesWhenTracing', showNamesWhenTracing);
+  }, [bridge, showNamesWhenTracing]);
+
   const value: Context = useMemo(
     () => ({
       displayDensity,
@@ -179,6 +192,8 @@ function SettingsContextController({
       theme,
       browserTheme,
       traceUpdatesEnabled,
+      showNamesWhenTracing,
+      setShowNamesWhenTracing,
     }),
     [
       displayDensity,
@@ -190,6 +205,7 @@ function SettingsContextController({
       theme,
       browserTheme,
       traceUpdatesEnabled,
+      showNamesWhenTracing,
     ],
   );
 

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -174,10 +174,6 @@ function SettingsContextController({
   }, [bridge, traceUpdatesEnabled]);
 
   useEffect(() => {
-    console.log(
-      'sent to bridge: setShowNamesWhenTracing',
-      showNamesWhenTracing,
-    );
     bridge.send('setShowNamesWhenTracing', showNamesWhenTracing);
   }, [bridge, showNamesWhenTracing]);
 

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -115,10 +115,11 @@ function SettingsContextController({
       LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY,
       false,
     );
-  const [showNamesWhenTracing, setShowNamesWhenTracing] = useLocalStorageWithLog<boolean>(
-    LOCAL_STORAGE_SHOW_NAMES_WHEN_TRACING_KEY,
-    true,
-  );
+  const [showNamesWhenTracing, setShowNamesWhenTracing] =
+    useLocalStorageWithLog<boolean>(
+      LOCAL_STORAGE_SHOW_NAMES_WHEN_TRACING_KEY,
+      true,
+    );
 
   const documentElements = useMemo<DocumentElements>(() => {
     const array: Array<HTMLElement> = [
@@ -173,7 +174,10 @@ function SettingsContextController({
   }, [bridge, traceUpdatesEnabled]);
 
   useEffect(() => {
-    console.log('sent to bridge: setShowNamesWhenTracing', showNamesWhenTracing);
+    console.log(
+      'sent to bridge: setShowNamesWhenTracing',
+      showNamesWhenTracing,
+    );
     bridge.send('setShowNamesWhenTracing', showNamesWhenTracing);
   }, [bridge, showNamesWhenTracing]);
 

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsShared.css
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsShared.css
@@ -154,3 +154,14 @@
   padding: 0;
   margin: 0;
 }
+
+.Setting .Setting {
+  margin-left: 1rem;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.Setting label:has(input:disabled) {
+  opacity: 0.5;
+  cursor: default;
+}


### PR DESCRIPTION
## Summary
This PR improves the Trace Updates feature by letting developers see component names directly on the update overlay. Before this change, the overlay only highlighted updated regions, leaving it unclear which components were involved. With this update, you can now match visual updates to their corresponding components, making it much easier to debug rendering performance.

### New Feature: Show component names while highlighting
When the new **"Show component names while highlighting"** setting is enabled, the update overlay display the names of affected components above the rectangles, along with the update count. This gives immediate context about what’s rendering and why. The preference is stored in local storage and synced with the backend, so it’s remembered across sessions.

### Improvements to Drawing Logic
The drawing logic has been updated to make the overlay sharper and easier to read. Overlay now respect device pixel ratios, so they look great on high-DPI screens. Outlines have also been made crisper, which makes it easier to spot exactly where updates are happening.

> [!NOTE]
> **Grouping Logic and Limitations**
> Updates are grouped by their screen position `(left, top coordinates)` to combine overlapping or nearby regions into a single group. Groups are sorted by the highest update count within each group, making the most frequently updated components stand out.
> Overlapping labels may still occur when multiple updates involve components that overlap but are not in the exact same position. This is intentional, as the logic aims to maintain a straightforward mapping between update regions and component names without introducing unnecessary complexity.

### Testing
This PR also adds tests for the new `groupAndSortNodes` utility, which handles the logic for grouping and sorting updates. The tests ensure the behavior is reliable across different scenarios.

## Before & After

https://github.com/user-attachments/assets/6ea0fe3e-9354-44fa-95f3-9a867554f74c

https://github.com/user-attachments/assets/32af4d98-92a5-47dd-a732-f05c2293e41b