### PR TITLE
Improve type safety in startReadingFromStream function

### DIFF
--- a/packages/react-server-dom-esm/src/client/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-esm/src/client/ReactFlightDOMClientBrowser.js
@@ -78,14 +78,14 @@ function startReadingFromStream(
     value,
   }: {
     done: boolean,
-    value: ?any,
+    value: ?Uint8Array,
     ...
   }): void | Promise<void> {
     if (done) {
       close(response);
       return;
     }
-    const buffer: Uint8Array = (value: any);
+    const buffer: Uint8Array = (value: Uint8Array);
     processBinaryChunk(response, buffer);
     return reader.read().then(progress).catch(error);
   }


### PR DESCRIPTION
## Summary

This PR improves type safety in the `startReadingFromStream` function by specifying a more precise type for the `value` parameter in the `progress` function.

## Detailed changes

- Changed the type of `value` from `?any` to `?Uint8Array` in the `progress` function's parameter type definition.
- Updated the type assertion for `buffer` to match the new type of `value`.

## Motivation

The `startReadingFromStream` function is designed to work with binary data, specifically `Uint8Array`. The previous type annotation of `?any` was too broad and didn't accurately represent the expected data type. By changing it to `?Uint8Array`, we achieve the following benefits:

1. Improved type safety: The code now explicitly states that it expects either `Uint8Array` or `undefined`.
2. Better developer experience: IDE autocompletion and type checking will be more accurate.
3. Reduced potential for runtime errors: The stricter type helps prevent accidental use of incompatible data types.