### PR TITLE
[crud] Only export uRC when flag is enabled

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -3276,6 +3276,11 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
     }
 
+    // @gate !enableUseResourceEffectHook
+    it('is null when flag is disabled', async () => {
+      expect(useResourceEffect).toBeUndefined();
+    });
+
     // @gate enableUseResourceEffectHook
     it('validates create return value', async () => {
       function App({id}) {

--- a/packages/react/src/ReactClient.js
+++ b/packages/react/src/ReactClient.js
@@ -65,6 +65,7 @@ import {startTransition} from './ReactStartTransition';
 import {act} from './ReactAct';
 import {captureOwnerStack} from './ReactOwnerStack';
 import ReactCompilerRuntime from './ReactCompilerRuntime';
+import {enableUseResourceEffectHook} from 'shared/ReactFeatureFlags';
 
 const Children = {
   map,
@@ -90,7 +91,6 @@ export {
   useContext,
   useEffect,
   useEffectEvent as experimental_useEffectEvent,
-  useResourceEffect as experimental_useResourceEffect,
   useImperativeHandle,
   useDebugValue,
   useInsertionEffect,
@@ -131,3 +131,6 @@ export {
   act, // DEV-only
   captureOwnerStack, // DEV-only
 };
+
+export const experimental_useResourceEffect: typeof useResourceEffect | void =
+  enableUseResourceEffectHook ? useResourceEffect : undefined;


### PR DESCRIPTION


It's tricky to do feature detection of uRC currently because it's always present on the export. Let's conditionally export it instead.
