### PR TITLE
refactor: change react promise status type

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -152,6 +152,14 @@ const RESOLVED_MODULE = 'resolved_module';
 const INITIALIZED = 'fulfilled';
 const ERRORED = 'rejected';
 
+type ReactPromiseStatus =
+  | typeof PENDING
+  | typeof BLOCKED
+  | typeof RESOLVED_MODEL
+  | typeof RESOLVED_MODULE
+  | typeof INITIALIZED
+  | typeof ERRORED;
+
 type PendingChunk<T> = {
   status: 'pending',
   value: null | Array<(T) => mixed>,
@@ -227,7 +235,7 @@ type SomeChunk<T> =
 
 // $FlowFixMe[missing-this-annot]
 function ReactPromise(
-  status: any,
+  status: ReactPromiseStatus,
   value: any,
   reason: any,
   response: Response,


### PR DESCRIPTION
Issue #31467

## Summary
This PR standardizes the use of predefined types for the ReactPromise function's status field. Currently, it accepts any type for the status field, which reduces code readability and prevents proper autocompletion.

## How did you test this change?
I ran the tests using yarn test and yarn test --prod. Since this is a type change, all relevant usage scenarios were already covered during development and testing.