### PR TITLE
Backport `useId` tracking fix to React 18

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -440,7 +440,6 @@ export function renderWithHooks<Props, SecondArg>(
     let numberOfReRenders: number = 0;
     do {
       didScheduleRenderPhaseUpdateDuringThisPass = false;
-      localIdCounter = 0;
 
       if (numberOfReRenders >= RE_RENDER_LIMIT) {
         throw new Error(

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -439,7 +439,6 @@ export function renderWithHooks<Props, SecondArg>(
     let numberOfReRenders: number = 0;
     do {
       didScheduleRenderPhaseUpdateDuringThisPass = false;
-      localIdCounter = 0;
 
       if (numberOfReRenders >= RE_RENDER_LIMIT) {
         throw new Error(


### PR DESCRIPTION
Fixes #31653.

A hydration error occurs when using `useId` with a parent that has a render phase update. @gnoff and @sebmarkbage fixed this for React 19 in #25713.

React 18 will have users for some time, and we are encountering this issue in production. For these reasons, I think it is a good idea to backport that fix to React 18.

I am definitely not a React contributor nor familiar with its internals, so this may be unwanted or an incorrect solution. I also apologize if I used the wrong base branch for a new release.

Consideration appreciated!