### PR TITLE
Don't serialize chunk ids for Hint and Console rows

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -3227,8 +3227,7 @@ function emitHintChunk<Code: HintCode>(
   model: HintModel<Code>,
 ): void {
   const json: string = stringify(model);
-  const id = request.nextChunkId++;
-  const row = serializeRowHeader('H' + code, id) + json + '\n';
+  const row = ':H' + code + json + '\n';
   const processedChunk = stringToChunk(row);
   request.completedHintChunks.push(processedChunk);
 }

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -213,11 +213,8 @@ function patchConsole(consoleInst: typeof console, methodName: string) {
           1,
         );
         request.pendingChunks++;
-        // We don't currently use this id for anything but we emit it so that we can later
-        // refer to previous logs in debug info to associate them with a component.
-        const id = request.nextChunkId++;
         const owner: null | ReactComponentInfo = resolveOwner();
-        emitConsoleChunk(request, id, methodName, owner, stack, arguments);
+        emitConsoleChunk(request, methodName, owner, stack, arguments);
       }
       // $FlowFixMe[prop-missing]
       return originalMethod.apply(this, arguments);
@@ -3763,7 +3760,6 @@ function outlineConsoleValue(
 
 function emitConsoleChunk(
   request: Request,
-  id: number,
   methodName: string,
   owner: null | ReactComponentInfo,
   stackTrace: ReactStackTrace,
@@ -3827,7 +3823,7 @@ function emitConsoleChunk(
       replacer,
     );
   }
-  const row = serializeRowHeader('W', id) + json + '\n';
+  const row = ':W' + json + '\n';
   const processedChunk = stringToChunk(row);
   request.completedRegularChunks.push(processedChunk);
 }


### PR DESCRIPTION
Hints and Console logs are side-effects and don't belong to any particular value. They're `void`. Therefore they don't need a row ID.

In the current parsing scheme it's ok to omit the id. It just becomes `0` which is the initial value which is then unused for these row types.

So it looks like:

```
:HP[...]
:W[...]
0:{...}
```

We could patch the parsing to encode the tag in the ID so it's more like the ID is the target of the side-effect.

```
H:P[...]
W:[...]
0:{...}
```

Or move the tagging to the beginning like it used to be.

But this seems simple enough for now.