### PR TITLE
docs: use diff codeblock for `useReducer` typings change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,11 +97,15 @@ The most common changes can be codemodded with `npx types-react-codemod@latest p
 * JSX namespace in TypeScript: The global `JSX` namespace is removed to improve interoperability with other libraries using JSX. Instead, the JSX namespace is available from the React package: `import { JSX } from 'react'`  
 * Better `useReducer` typings: Most `useReducer` usage should not require explicit type arguments.  
   For example,  
-  \-useReducer\<React.Reducer\<State, Action\>\>(reducer)  
-  \+useReducer(reducer)  
-  or  
-  \-useReducer\<React.Reducer\<State, Action\>\>(reducer)  
-  \+useReducer\<State, \[Action\]\>(reducer)
+  ```diff
+  -useReducer<React.Reducer<State, Action>>(reducer)
+  +useReducer(reducer)
+  ```
+  or
+  ```diff
+  -useReducer<React.Reducer<State, Action>>(reducer)
+  +useReducer<State, Action>(reducer)
+  ```
 
 
 ## All Changes


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

This PR updates the 19.0.0 changelog to use diff-styled code blocks for illustrating changes to `useReducer` typings. Also removes the incorrect square brackets in the second diff, it should be `Action` instead of `[Action]`.


## How did you test this change?

**Before**

![2024-12-06_10-49](https://github.com/user-attachments/assets/bde94eec-a7cc-4fc8-bcca-37867633d37e)


**After**

![2024-12-06_10-51](https://github.com/user-attachments/assets/693fb7ac-68a3-45fc-aada-0c7594441b2a)

