### PR TITLE
Clean up findFiberByHostInstance from DevTools Hook

### DIFF
--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -42,7 +42,6 @@ import {enableSchedulingProfiler} from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {
   getPublicInstance,
-  getInstanceFromNode,
   rendererVersion,
   rendererPackageName,
   extraDevToolsConfig,
@@ -847,7 +846,6 @@ export function injectIntoDevTools(): boolean {
     version: rendererVersion,
     rendererPackageName: rendererPackageName,
     currentDispatcherRef: ReactSharedInternals,
-    findFiberByHostInstance: getInstanceFromNode,
     // Enables DevTools to detect reconciler version rather than renderer version
     // which may not match for third party renderers.
     reconcilerVersion: ReactVersion,


### PR DESCRIPTION
The need for this was removed in https://github.com/facebook/react/pull/30831

Since the new DevTools version has been released for a while and we expect people to more or less auto-update. Future versions of React don't need this.

Once we remove the remaining uses of `getInstanceFromNode` e.g. in the deprecated internal `findDOMNode`/`findNodeHandle` and the event system, we can completely remove the tagging of DOM nodes.