### PR TITLE
[Flight] Track Timing Information

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -48,6 +48,8 @@ import {
   enableFlightReadableStream,
   enableOwnerStacks,
   enableServerComponentLogs,
+  enableProfilerTimer,
+  enableComponentPerformanceTrack,
 } from 'shared/ReactFeatureFlags';
 
 import {
@@ -286,6 +288,7 @@ export type Response = {
   _rowLength: number, // remaining bytes in the row. 0 indicates that we're looking for a newline.
   _buffer: Array<Uint8Array>, // chunks received so far as part of this row
   _tempRefs: void | TemporaryReferenceSet, // the set temporary references can be resolved from
+  _timeOrigin: number, // Profiling-only
   _debugRootOwner?: null | ReactComponentInfo, // DEV-only
   _debugRootStack?: null | Error, // DEV-only
   _debugRootTask?: null | ConsoleTask, // DEV-only
@@ -1585,6 +1588,9 @@ function ResponseInstance(
   this._rowLength = 0;
   this._buffer = [];
   this._tempRefs = temporaryReferences;
+  if (enableProfilerTimer && enableComponentPerformanceTrack) {
+    this._timeOrigin = 0;
+  }
   if (__DEV__) {
     // TODO: The Flight Client can be used in a Client Environment too and we should really support
     // getting the owner there as well, but currently the owner of ReactComponentInfo is typed as only
@@ -2791,6 +2797,19 @@ function processFullStringRow(
     case 84 /* "T" */: {
       resolveText(response, id, row);
       return;
+    }
+    case 78 /* "N" */: {
+      if (enableProfilerTimer && enableComponentPerformanceTrack) {
+        // Track the time origin for future debug info. We track it relative
+        // to the current environment's time space.
+        const timeOrigin: number = +row;
+        response._timeOrigin =
+          timeOrigin -
+          // $FlowFixMe[prop-missing]
+          performance.timeOrigin;
+        return;
+      }
+      // Fallthrough to share the error with Debug and Console entries.
     }
     case 68 /* "D" */: {
       if (__DEV__) {

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -2518,6 +2518,16 @@ function resolveDebugInfo(
       debugInfo;
     initializeFakeStack(response, componentInfoOrAsyncInfo);
   }
+  if (enableProfilerTimer && enableComponentPerformanceTrack) {
+    if (typeof debugInfo.time === 'number') {
+      // Adjust the time to the current environment's time space.
+      // Since this might be a deduped object, we clone it to avoid
+      // applying the adjustment twice.
+      debugInfo = {
+        time: debugInfo.time + response._timeOrigin,
+      };
+    }
+  }
 
   const chunk = getChunk(response, id);
   const chunkDebugInfo: ReactDebugInfo =

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -2744,12 +2744,13 @@ describe('ReactFlight', () => {
           : undefined,
       );
       const result = await promise;
+
       const thirdPartyChildren = await result.props.children[1];
       // We expect the debug info to be transferred from the inner stream to the outer.
       expect(getDebugInfo(thirdPartyChildren[0])).toEqual(
         __DEV__
           ? [
-              {time: 30},
+              {time: 13},
               {
                 name: 'ThirdPartyComponent',
                 env: 'third-party',
@@ -2760,15 +2761,15 @@ describe('ReactFlight', () => {
                   : undefined,
                 props: {},
               },
-              {time: 31},
-              {time: 21},
+              {time: 14},
+              {time: 21}, // This last one is when the promise resolved into the first party.
             ]
           : undefined,
       );
       expect(getDebugInfo(thirdPartyChildren[1])).toEqual(
         __DEV__
           ? [
-              {time: 32},
+              {time: 15},
               {
                 name: 'ThirdPartyLazyComponent',
                 env: 'third-party',
@@ -2779,14 +2780,14 @@ describe('ReactFlight', () => {
                   : undefined,
                 props: {},
               },
-              {time: 33},
+              {time: 16},
             ]
           : undefined,
       );
       expect(getDebugInfo(thirdPartyChildren[2])).toEqual(
         __DEV__
           ? [
-              {time: 28},
+              {time: 11},
               {
                 name: 'ThirdPartyFragmentComponent',
                 env: 'third-party',
@@ -2797,7 +2798,7 @@ describe('ReactFlight', () => {
                   : undefined,
                 props: {},
               },
-              {time: 29},
+              {time: 12},
             ]
           : undefined,
       );
@@ -2906,7 +2907,7 @@ describe('ReactFlight', () => {
       expect(getDebugInfo(thirdPartyFragment.props.children)).toEqual(
         __DEV__
           ? [
-              {time: 24},
+              {time: 11},
               {
                 name: 'ThirdPartyAsyncIterableComponent',
                 env: 'third-party',
@@ -2917,7 +2918,7 @@ describe('ReactFlight', () => {
                   : undefined,
                 props: {},
               },
-              {time: 25},
+              {time: 12},
             ]
           : undefined,
       );

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -125,6 +125,20 @@ let assertConsoleErrorDev;
 
 describe('ReactFlight', () => {
   beforeEach(() => {
+    // Mock performance.now for timing tests
+    let time = 10;
+    const now = jest.fn().mockImplementation(() => {
+      return time++;
+    });
+    Object.defineProperty(performance, 'timeOrigin', {
+      value: time,
+      configurable: true,
+    });
+    Object.defineProperty(performance, 'now', {
+      value: now,
+      configurable: true,
+    });
+
     jest.resetModules();
     jest.mock('react', () => require('react/react.react-server'));
     ReactServer = require('react');
@@ -274,6 +288,7 @@ describe('ReactFlight', () => {
     });
   });
 
+  // @gate !__DEV__ || enableComponentPerformanceTrack
   it('can render a Client Component using a module reference and render there', async () => {
     function UserClient(props) {
       return (
@@ -300,6 +315,7 @@ describe('ReactFlight', () => {
       expect(getDebugInfo(greeting)).toEqual(
         __DEV__
           ? [
+              {time: 11},
               {
                 name: 'Greeting',
                 env: 'Server',
@@ -313,6 +329,7 @@ describe('ReactFlight', () => {
                   lastName: 'Smith',
                 },
               },
+              {time: 12},
             ]
           : undefined,
       );
@@ -322,6 +339,7 @@ describe('ReactFlight', () => {
     expect(ReactNoop).toMatchRenderedOutput(<span>Hello, Seb Smith</span>);
   });
 
+  // @gate !__DEV__ || enableComponentPerformanceTrack
   it('can render a shared forwardRef Component', async () => {
     const Greeting = React.forwardRef(function Greeting(
       {firstName, lastName},
@@ -343,6 +361,7 @@ describe('ReactFlight', () => {
       expect(getDebugInfo(promise)).toEqual(
         __DEV__
           ? [
+              {time: 11},
               {
                 name: 'Greeting',
                 env: 'Server',
@@ -356,6 +375,7 @@ describe('ReactFlight', () => {
                   lastName: 'Smith',
                 },
               },
+              {time: 12},
             ]
           : undefined,
       );
@@ -2659,6 +2679,7 @@ describe('ReactFlight', () => {
     );
   });
 
+  // @gate !__DEV__ || enableComponentPerformanceTrack
   it('preserves debug info for server-to-server pass through', async () => {
     function ThirdPartyLazyComponent() {
       return <span>!</span>;
@@ -2705,6 +2726,7 @@ describe('ReactFlight', () => {
       expect(getDebugInfo(promise)).toEqual(
         __DEV__
           ? [
+              {time: 18},
               {
                 name: 'ServerComponent',
                 env: 'Server',
@@ -2717,6 +2739,7 @@ describe('ReactFlight', () => {
                   transport: expect.arrayContaining([]),
                 },
               },
+              {time: 19},
             ]
           : undefined,
       );
@@ -2726,6 +2749,7 @@ describe('ReactFlight', () => {
       expect(getDebugInfo(thirdPartyChildren[0])).toEqual(
         __DEV__
           ? [
+              {time: 30},
               {
                 name: 'ThirdPartyComponent',
                 env: 'third-party',
@@ -2736,12 +2760,15 @@ describe('ReactFlight', () => {
                   : undefined,
                 props: {},
               },
+              {time: 31},
+              {time: 21},
             ]
           : undefined,
       );
       expect(getDebugInfo(thirdPartyChildren[1])).toEqual(
         __DEV__
           ? [
+              {time: 32},
               {
                 name: 'ThirdPartyLazyComponent',
                 env: 'third-party',
@@ -2752,12 +2779,14 @@ describe('ReactFlight', () => {
                   : undefined,
                 props: {},
               },
+              {time: 33},
             ]
           : undefined,
       );
       expect(getDebugInfo(thirdPartyChildren[2])).toEqual(
         __DEV__
           ? [
+              {time: 28},
               {
                 name: 'ThirdPartyFragmentComponent',
                 env: 'third-party',
@@ -2768,6 +2797,7 @@ describe('ReactFlight', () => {
                   : undefined,
                 props: {},
               },
+              {time: 29},
             ]
           : undefined,
       );
@@ -2833,6 +2863,7 @@ describe('ReactFlight', () => {
       expect(getDebugInfo(promise)).toEqual(
         __DEV__
           ? [
+              {time: 14},
               {
                 name: 'ServerComponent',
                 env: 'Server',
@@ -2845,6 +2876,7 @@ describe('ReactFlight', () => {
                   transport: expect.arrayContaining([]),
                 },
               },
+              {time: 15},
             ]
           : undefined,
       );
@@ -2853,6 +2885,7 @@ describe('ReactFlight', () => {
       expect(getDebugInfo(thirdPartyFragment)).toEqual(
         __DEV__
           ? [
+              {time: 16},
               {
                 name: 'Keyed',
                 env: 'Server',
@@ -2865,6 +2898,7 @@ describe('ReactFlight', () => {
                   children: {},
                 },
               },
+              {time: 17},
             ]
           : undefined,
       );
@@ -2872,6 +2906,7 @@ describe('ReactFlight', () => {
       expect(getDebugInfo(thirdPartyFragment.props.children)).toEqual(
         __DEV__
           ? [
+              {time: 24},
               {
                 name: 'ThirdPartyAsyncIterableComponent',
                 env: 'third-party',
@@ -2882,6 +2917,7 @@ describe('ReactFlight', () => {
                   : undefined,
                 props: {},
               },
+              {time: 25},
             ]
           : undefined,
       );
@@ -3017,6 +3053,7 @@ describe('ReactFlight', () => {
     }
   });
 
+  // @gate !__DEV__ || enableComponentPerformanceTrack
   it('can change the environment name inside a component', async () => {
     let env = 'A';
     function Component(props) {
@@ -3041,6 +3078,7 @@ describe('ReactFlight', () => {
       expect(getDebugInfo(greeting)).toEqual(
         __DEV__
           ? [
+              {time: 11},
               {
                 name: 'Component',
                 env: 'A',
@@ -3054,6 +3092,7 @@ describe('ReactFlight', () => {
               {
                 env: 'B',
               },
+              {time: 12},
             ]
           : undefined,
       );
@@ -3205,6 +3244,7 @@ describe('ReactFlight', () => {
     );
   });
 
+  // @gate !__DEV__ || enableComponentPerformanceTrack
   it('uses the server component debug info as the element owner in DEV', async () => {
     function Container({children}) {
       return children;
@@ -3244,7 +3284,9 @@ describe('ReactFlight', () => {
           },
         };
         expect(getDebugInfo(greeting)).toEqual([
+          {time: 11},
           greetInfo,
+          {time: 12},
           {
             name: 'Container',
             env: 'Server',
@@ -3262,10 +3304,11 @@ describe('ReactFlight', () => {
               }),
             },
           },
+          {time: 13},
         ]);
         // The owner that created the span was the outer server component.
         // We expect the debug info to be referentially equal to the owner.
-        expect(greeting._owner).toBe(greeting._debugInfo[0]);
+        expect(greeting._owner).toBe(greeting._debugInfo[1]);
       } else {
         expect(greeting._debugInfo).toBe(undefined);
         expect(greeting._owner).toBe(undefined);
@@ -3531,7 +3574,7 @@ describe('ReactFlight', () => {
     expect(caughtError.digest).toBe('digest("my-error")');
   });
 
-  // @gate __DEV__
+  // @gate __DEV__ && enableComponentPerformanceTrack
   it('can render deep but cut off JSX in debug info', async () => {
     function createDeepJSX(n) {
       if (n <= 0) {
@@ -3555,7 +3598,7 @@ describe('ReactFlight', () => {
     await act(async () => {
       const rootModel = await ReactNoopFlightClient.read(transport);
       const root = rootModel.root;
-      const children = root._debugInfo[0].props.children;
+      const children = root._debugInfo[1].props.children;
       expect(children.type).toBe('div');
       expect(children.props.children.type).toBe('div');
       ReactNoop.render(root);
@@ -3564,7 +3607,7 @@ describe('ReactFlight', () => {
     expect(ReactNoop).toMatchRenderedOutput(<div>not using props</div>);
   });
 
-  // @gate __DEV__
+  // @gate __DEV__ && enableComponentPerformanceTrack
   it('can render deep but cut off Map/Set in debug info', async () => {
     function createDeepMap(n) {
       if (n <= 0) {
@@ -3603,8 +3646,8 @@ describe('ReactFlight', () => {
 
     await act(async () => {
       const rootModel = await ReactNoopFlightClient.read(transport);
-      const set = rootModel.set._debugInfo[0].props.set;
-      const map = rootModel.map._debugInfo[0].props.map;
+      const set = rootModel.set._debugInfo[1].props.set;
+      const map = rootModel.map._debugInfo[1].props.map;
       expect(set instanceof Set).toBe(true);
       expect(set.size).toBe(1);
       // eslint-disable-next-line no-for-of-loops/no-for-of-loops


### PR DESCRIPTION
Stacked on #31715.

This adds profiling data for Server Components to the RSC stream (but doesn't yet use it for anything). This is on behind `enableProfilerTimer` which is on for Dev and Profiling builds. However, for now there's no Profiling build of Flight so in practice only in DEV. It's gated on `enableComponentPerformanceTrack` which is experimental only for now.

We first emit a timeOrigin in the beginning of the stream. This provides us a relative time to emit timestamps against for cross environment transfer so that we can log it in terms of absolute times. Using this as a separate field allows the actual relative timestamps to be a bit more compact representation and preserves floating point precision.

We emit a timestamp before emitting a Server Component which represents the start time of the Server Component. The end time is either when the next Server Component starts or when we finish the task.

We omit the end time for simple tasks that are outlined without Server Components.

By encoding this as part of the debugInfo stream, this information can be forwarded between Server to Server RSC.