### PR TITLE
Fix canary version strings

### DIFF
--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -26,11 +26,11 @@ const ReactVersion = '19.0.0';
 //
 // It only affects the label used in the version string. To customize the
 // npm dist tags used during publish, refer to .github/workflows/runtime_prereleases_*.yml.
-const canaryChannelLabel = 'rc';
+const canaryChannelLabel = 'canary';
 
 // If the canaryChannelLabel is "rc", the build pipeline will use this to build
 // an RC version of the packages.
-const rcNumber = 1;
+const rcNumber = 0;
 
 const stablePackages = {
   'eslint-plugin-react-hooks': '5.1.0',


### PR DESCRIPTION
We're still publishing RCs and creating canary version strings using the RC naming convention. Setting the `canaryChannelLabel` back to canary fixes the version names and tags after the 19 stable release.