### PR TITLE
[compiler] Allow sequence expressions in for loops, and prevent DCE of declarations when the variable is reassigned in a value block

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/for-inits.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/for-inits.expect.md
@@ -8,6 +8,8 @@ function Foo() {
   for (bar(); i < 1; i += 1) {}
   for (; i < 1; i += 1) {}
   for (i = 0; i < 1; i += 1) {}
+  let j = 0;
+  for (i = 0, j = 0; i < 1; i += 1) {}
 }
 
 function bar() {}
@@ -28,6 +30,8 @@ function Foo() {
   for (bar(); i < 1; i = i + 1, i) {}
   for (undefined; i < 1; i = i + 1, i) {}
   for (i = 0; i < 1; i = i + 1, i) {}
+  let j;
+  for (((i = 0), (j = 0)), undefined; i < 1; i = i + 1, i) {}
 }
 
 function bar() {}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/for-inits.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/for-inits.js
@@ -4,6 +4,8 @@ function Foo() {
   for (bar(); i < 1; i += 1) {}
   for (; i < 1; i += 1) {}
   for (i = 0; i < 1; i += 1) {}
+  let j = 0;
+  for (i = 0, j = 0; i < 1; i += 1) {}
 }
 
 function bar() {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #31723
* #31712

Summary:
Two somewhat unrelated fixes that combine to allow loops like `for (i =1, j =1; ...)` to be handled. We introduce a new case for building reactive functions when a block prior to a goto doesnt generate a value; this is the case for the fallthrough of sequence blocks in for loop inits, since the value is not read by anything.

We also make it so that we don't DCE declarations of variables that are written to in value blocks. If we did DCE such declarations, we would then later convert the reassignment to a const declaration--but declarations in value blocks are banned.