### PR TITLE
 [Flight] rename `prerender` to `unstable_prerender` and include in stable channel

### DIFF
--- a/fixtures/flight/server/region.js
+++ b/fixtures/flight/server/region.js
@@ -106,7 +106,7 @@ async function renderApp(res, returnValue, formState) {
 }
 
 async function prerenderApp(res, returnValue, formState) {
-  const {prerenderToNodeStream} = await import(
+  const {unstable_prerenderToNodeStream: prerenderToNodeStream} = await import(
     'react-server-dom-webpack/static'
   );
   // const m = require('../src/App.js');

--- a/packages/react-server-dom-esm/npm/static.node.js
+++ b/packages/react-server-dom-esm/npm/static.node.js
@@ -7,6 +7,6 @@ if (process.env.NODE_ENV === 'production') {
   s = require('./cjs/react-server-dom-esm-server.node.development.js');
 }
 
-if (s.prerenderToNodeStream) {
-  exports.prerenderToNodeStream = s.prerenderToNodeStream;
+if (s.unstable_prerenderToNodeStream) {
+  exports.unstable_prerenderToNodeStream = s.unstable_prerenderToNodeStream;
 }

--- a/packages/react-server-dom-esm/src/server/react-flight-dom-server.node.js
+++ b/packages/react-server-dom-esm/src/server/react-flight-dom-server.node.js
@@ -9,7 +9,7 @@
 
 export {
   renderToPipeableStream,
-  prerenderToNodeStream,
+  prerenderToNodeStream as unstable_prerenderToNodeStream,
   decodeReplyFromBusboy,
   decodeReply,
   decodeAction,

--- a/packages/react-server-dom-esm/src/server/react-flight-dom-server.node.stable.js
+++ b/packages/react-server-dom-esm/src/server/react-flight-dom-server.node.stable.js
@@ -9,6 +9,7 @@
 
 export {
   renderToPipeableStream,
+  prerenderToNodeStream as unstable_prerenderToNodeStream,
   decodeReplyFromBusboy,
   decodeReply,
   decodeAction,

--- a/packages/react-server-dom-esm/static.node.js
+++ b/packages/react-server-dom-esm/static.node.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export {prerenderToNodeStream} from './src/server/react-flight-dom-server.node';
+export {unstable_prerenderToNodeStream} from './src/server/react-flight-dom-server.node';

--- a/packages/react-server-dom-turbopack/npm/static.browser.js
+++ b/packages/react-server-dom-turbopack/npm/static.browser.js
@@ -7,6 +7,6 @@ if (process.env.NODE_ENV === 'production') {
   s = require('./cjs/react-server-dom-turbopack-server.browser.development.js');
 }
 
-if (s.prerender) {
-  exports.prerender = s.prerender;
+if (s.unstable_prerender) {
+  exports.unstable_prerender = s.unstable_prerender;
 }

--- a/packages/react-server-dom-turbopack/npm/static.edge.js
+++ b/packages/react-server-dom-turbopack/npm/static.edge.js
@@ -7,6 +7,6 @@ if (process.env.NODE_ENV === 'production') {
   s = require('./cjs/react-server-dom-turbopack-server.edge.development.js');
 }
 
-if (s.prerender) {
-  exports.prerender = s.prerender;
+if (s.unstable_prerender) {
+  exports.unstable_prerender = s.unstable_prerender;
 }

--- a/packages/react-server-dom-turbopack/npm/static.node.js
+++ b/packages/react-server-dom-turbopack/npm/static.node.js
@@ -7,6 +7,6 @@ if (process.env.NODE_ENV === 'production') {
   s = require('./cjs/react-server-dom-turbopack-server.node.development.js');
 }
 
-if (s.prerenderToNodeStream) {
-  exports.prerenderToNodeStream = s.prerenderToNodeStream;
+if (s.unstable_prerenderToNodeStream) {
+  exports.unstable_prerenderToNodeStream = s.unstable_prerenderToNodeStream;
 }

--- a/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.browser.js
+++ b/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.browser.js
@@ -9,7 +9,7 @@
 
 export {
   renderToReadableStream,
-  prerender,
+  prerender as unstable_prerender,
   decodeReply,
   decodeAction,
   decodeFormState,

--- a/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.browser.stable.js
+++ b/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.browser.stable.js
@@ -9,6 +9,7 @@
 
 export {
   renderToReadableStream,
+  prerender as unstable_prerender,
   decodeReply,
   decodeAction,
   decodeFormState,

--- a/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.edge.js
+++ b/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.edge.js
@@ -9,7 +9,7 @@
 
 export {
   renderToReadableStream,
-  prerender,
+  prerender as unstable_prerender,
   decodeReply,
   decodeAction,
   decodeFormState,

--- a/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.edge.stable.js
+++ b/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.edge.stable.js
@@ -9,6 +9,7 @@
 
 export {
   renderToReadableStream,
+  prerender as unstable_prerender,
   decodeReply,
   decodeAction,
   decodeFormState,

--- a/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.node.js
+++ b/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.node.js
@@ -9,7 +9,7 @@
 
 export {
   renderToPipeableStream,
-  prerenderToNodeStream,
+  prerenderToNodeStream as unstable_prerenderToNodeStream,
   decodeReplyFromBusboy,
   decodeReply,
   decodeAction,

--- a/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.node.stable.js
+++ b/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.node.stable.js
@@ -9,6 +9,7 @@
 
 export {
   renderToPipeableStream,
+  prerenderToNodeStream as unstable_prerenderToNodeStream,
   decodeReplyFromBusboy,
   decodeReply,
   decodeAction,

--- a/packages/react-server-dom-turbopack/static.browser.js
+++ b/packages/react-server-dom-turbopack/static.browser.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export {prerender} from './src/server/react-flight-dom-server.browser';
+export {unstable_prerender} from './src/server/react-flight-dom-server.browser';

--- a/packages/react-server-dom-turbopack/static.edge.js
+++ b/packages/react-server-dom-turbopack/static.edge.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export {prerender} from './src/server/react-flight-dom-server.edge';
+export {unstable_prerender} from './src/server/react-flight-dom-server.edge';

--- a/packages/react-server-dom-turbopack/static.node.js
+++ b/packages/react-server-dom-turbopack/static.node.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export {prerenderToNodeStream} from './src/server/react-flight-dom-server.node';
+export {unstable_prerenderToNodeStream} from './src/server/react-flight-dom-server.node';

--- a/packages/react-server-dom-webpack/npm/static.browser.js
+++ b/packages/react-server-dom-webpack/npm/static.browser.js
@@ -7,6 +7,6 @@ if (process.env.NODE_ENV === 'production') {
   s = require('./cjs/react-server-dom-webpack-server.browser.development.js');
 }
 
-if (s.prerender) {
-  exports.prerender = s.prerender;
+if (s.unstable_prerender) {
+  exports.unstable_prerender = s.unstable_prerender;
 }

--- a/packages/react-server-dom-webpack/npm/static.edge.js
+++ b/packages/react-server-dom-webpack/npm/static.edge.js
@@ -7,6 +7,6 @@ if (process.env.NODE_ENV === 'production') {
   s = require('./cjs/react-server-dom-webpack-server.edge.development.js');
 }
 
-if (s.prerender) {
-  exports.prerender = s.prerender;
+if (s.unstable_prerender) {
+  exports.unstable_prerender = s.unstable_prerender;
 }

--- a/packages/react-server-dom-webpack/npm/static.node.js
+++ b/packages/react-server-dom-webpack/npm/static.node.js
@@ -7,6 +7,6 @@ if (process.env.NODE_ENV === 'production') {
   s = require('./cjs/react-server-dom-webpack-server.node.development.js');
 }
 
-if (s.prerenderToNodeStream) {
-  exports.prerenderToNodeStream = s.prerenderToNodeStream;
+if (s.unstable_prerenderToNodeStream) {
+  exports.unstable_prerenderToNodeStream = s.unstable_prerenderToNodeStream;
 }

--- a/packages/react-server-dom-webpack/npm/static.node.unbundled.js
+++ b/packages/react-server-dom-webpack/npm/static.node.unbundled.js
@@ -7,6 +7,6 @@ if (process.env.NODE_ENV === 'production') {
   s = require('./cjs/react-server-dom-webpack-server.node.unbundled.development.js');
 }
 
-if (s.prerenderToNodeStream) {
-  exports.prerenderToNodeStream = s.prerenderToNodeStream;
+if (s.unstable_prerenderToNodeStream) {
+  exports.unstable_prerenderToNodeStream = s.unstable_prerenderToNodeStream;
 }

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -2787,10 +2787,11 @@ describe('ReactFlightDOM', () => {
     const {pendingResult} = await serverAct(async () => {
       // destructure trick to avoid the act scope from awaiting the returned value
       return {
-        pendingResult: ReactServerDOMStaticServer.prerenderToNodeStream(
-          <App />,
-          webpackMap,
-        ),
+        pendingResult:
+          ReactServerDOMStaticServer.unstable_prerenderToNodeStream(
+            <App />,
+            webpackMap,
+          ),
       };
     });
 
@@ -2853,16 +2854,17 @@ describe('ReactFlightDOM', () => {
     const {pendingResult} = await serverAct(async () => {
       // destructure trick to avoid the act scope from awaiting the returned value
       return {
-        pendingResult: ReactServerDOMStaticServer.prerenderToNodeStream(
-          <App />,
-          webpackMap,
-          {
-            signal: controller.signal,
-            onError(err) {
-              errors.push(err);
+        pendingResult:
+          ReactServerDOMStaticServer.unstable_prerenderToNodeStream(
+            <App />,
+            webpackMap,
+            {
+              signal: controller.signal,
+              onError(err) {
+                errors.push(err);
+              },
             },
-          },
-        ),
+          ),
       };
     });
 
@@ -2934,18 +2936,19 @@ describe('ReactFlightDOM', () => {
     const controller = new AbortController();
     const {pendingResult} = await serverAct(() => {
       return {
-        pendingResult: ReactServerDOMStaticServer.prerenderToNodeStream(
-          {
-            multiShotIterable,
-          },
-          {},
-          {
-            onError(x) {
-              errors.push(x);
+        pendingResult:
+          ReactServerDOMStaticServer.unstable_prerenderToNodeStream(
+            {
+              multiShotIterable,
             },
-            signal: controller.signal,
-          },
-        ),
+            {},
+            {
+              onError(x) {
+                errors.push(x);
+              },
+              signal: controller.signal,
+            },
+          ),
       };
     });
 
@@ -3017,16 +3020,17 @@ describe('ReactFlightDOM', () => {
     const errors = [];
     const {pendingResult} = await serverAct(() => {
       return {
-        pendingResult: ReactServerDOMStaticServer.prerenderToNodeStream(
-          <App />,
-          {},
-          {
-            onError(x) {
-              errors.push(x);
+        pendingResult:
+          ReactServerDOMStaticServer.unstable_prerenderToNodeStream(
+            <App />,
+            {},
+            {
+              onError(x) {
+                errors.push(x);
+              },
+              signal: controller.signal,
             },
-            signal: controller.signal,
-          },
-        ),
+          ),
       };
     });
 

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -2490,7 +2490,7 @@ describe('ReactFlightDOMBrowser', () => {
     const {pendingResult} = await serverAct(async () => {
       // destructure trick to avoid the act scope from awaiting the returned value
       return {
-        pendingResult: ReactServerDOMStaticServer.prerender(
+        pendingResult: ReactServerDOMStaticServer.unstable_prerender(
           <App />,
           webpackMap,
         ),
@@ -2543,7 +2543,7 @@ describe('ReactFlightDOMBrowser', () => {
     const {pendingResult} = await serverAct(async () => {
       // destructure trick to avoid the act scope from awaiting the returned value
       return {
-        pendingResult: ReactServerDOMStaticServer.prerender(
+        pendingResult: ReactServerDOMStaticServer.unstable_prerender(
           <App />,
           webpackMap,
           {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1134,7 +1134,7 @@ describe('ReactFlightDOMEdge', () => {
     const {pendingResult} = await serverAct(async () => {
       // destructure trick to avoid the act scope from awaiting the returned value
       return {
-        pendingResult: ReactServerDOMStaticServer.prerender(
+        pendingResult: ReactServerDOMStaticServer.unstable_prerender(
           <App />,
           webpackMap,
         ),
@@ -1192,7 +1192,7 @@ describe('ReactFlightDOMEdge', () => {
     const {pendingResult} = await serverAct(async () => {
       // destructure trick to avoid the act scope from awaiting the returned value
       return {
-        pendingResult: ReactServerDOMStaticServer.prerender(
+        pendingResult: ReactServerDOMStaticServer.unstable_prerender(
           <App />,
           webpackMap,
           {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -411,10 +411,11 @@ describe('ReactFlightDOMNode', () => {
     const {pendingResult} = await serverAct(async () => {
       // destructure trick to avoid the act scope from awaiting the returned value
       return {
-        pendingResult: ReactServerDOMStaticServer.prerenderToNodeStream(
-          <App />,
-          webpackMap,
-        ),
+        pendingResult:
+          ReactServerDOMStaticServer.unstable_prerenderToNodeStream(
+            <App />,
+            webpackMap,
+          ),
       };
     });
 
@@ -469,16 +470,17 @@ describe('ReactFlightDOMNode', () => {
     const {pendingResult} = await serverAct(async () => {
       // destructure trick to avoid the act scope from awaiting the returned value
       return {
-        pendingResult: ReactServerDOMStaticServer.prerenderToNodeStream(
-          <App />,
-          webpackMap,
-          {
-            signal: controller.signal,
-            onError(err) {
-              errors.push(err);
+        pendingResult:
+          ReactServerDOMStaticServer.unstable_prerenderToNodeStream(
+            <App />,
+            webpackMap,
+            {
+              signal: controller.signal,
+              onError(err) {
+                errors.push(err);
+              },
             },
-          },
-        ),
+          ),
       };
     });
 

--- a/packages/react-server-dom-webpack/src/server/react-flight-dom-server.browser.js
+++ b/packages/react-server-dom-webpack/src/server/react-flight-dom-server.browser.js
@@ -9,7 +9,7 @@
 
 export {
   renderToReadableStream,
-  prerender,
+  prerender as unstable_prerender,
   decodeReply,
   decodeAction,
   decodeFormState,

--- a/packages/react-server-dom-webpack/src/server/react-flight-dom-server.browser.stable.js
+++ b/packages/react-server-dom-webpack/src/server/react-flight-dom-server.browser.stable.js
@@ -9,6 +9,7 @@
 
 export {
   renderToReadableStream,
+  prerender as unstable_prerender,
   decodeReply,
   decodeAction,
   decodeFormState,

--- a/packages/react-server-dom-webpack/src/server/react-flight-dom-server.edge.js
+++ b/packages/react-server-dom-webpack/src/server/react-flight-dom-server.edge.js
@@ -9,7 +9,7 @@
 
 export {
   renderToReadableStream,
-  prerender,
+  prerender as unstable_prerender,
   decodeReply,
   decodeAction,
   decodeFormState,

--- a/packages/react-server-dom-webpack/src/server/react-flight-dom-server.edge.stable.js
+++ b/packages/react-server-dom-webpack/src/server/react-flight-dom-server.edge.stable.js
@@ -9,6 +9,7 @@
 
 export {
   renderToReadableStream,
+  prerender as unstable_prerender,
   decodeReply,
   decodeAction,
   decodeFormState,

--- a/packages/react-server-dom-webpack/src/server/react-flight-dom-server.node.js
+++ b/packages/react-server-dom-webpack/src/server/react-flight-dom-server.node.js
@@ -9,7 +9,7 @@
 
 export {
   renderToPipeableStream,
-  prerenderToNodeStream,
+  prerenderToNodeStream as unstable_prerenderToNodeStream,
   decodeReplyFromBusboy,
   decodeReply,
   decodeAction,

--- a/packages/react-server-dom-webpack/src/server/react-flight-dom-server.node.stable.js
+++ b/packages/react-server-dom-webpack/src/server/react-flight-dom-server.node.stable.js
@@ -9,6 +9,7 @@
 
 export {
   renderToPipeableStream,
+  prerenderToNodeStream as unstable_prerenderToNodeStream,
   decodeReplyFromBusboy,
   decodeReply,
   decodeAction,

--- a/packages/react-server-dom-webpack/src/server/react-flight-dom-server.node.unbundled.js
+++ b/packages/react-server-dom-webpack/src/server/react-flight-dom-server.node.unbundled.js
@@ -9,7 +9,7 @@
 
 export {
   renderToPipeableStream,
-  prerenderToNodeStream,
+  prerenderToNodeStream as unstable_prerenderToNodeStream,
   decodeReplyFromBusboy,
   decodeReply,
   decodeAction,

--- a/packages/react-server-dom-webpack/src/server/react-flight-dom-server.node.unbundled.stable.js
+++ b/packages/react-server-dom-webpack/src/server/react-flight-dom-server.node.unbundled.stable.js
@@ -9,6 +9,7 @@
 
 export {
   renderToPipeableStream,
+  prerenderToNodeStream as unstable_prerenderToNodeStream,
   decodeReplyFromBusboy,
   decodeReply,
   decodeAction,

--- a/packages/react-server-dom-webpack/static.browser.js
+++ b/packages/react-server-dom-webpack/static.browser.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export {prerender} from './src/server/react-flight-dom-server.browser';
+export {unstable_prerender} from './src/server/react-flight-dom-server.browser';

--- a/packages/react-server-dom-webpack/static.edge.js
+++ b/packages/react-server-dom-webpack/static.edge.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export {prerender} from './src/server/react-flight-dom-server.edge';
+export {unstable_prerender} from './src/server/react-flight-dom-server.edge';

--- a/packages/react-server-dom-webpack/static.node.js
+++ b/packages/react-server-dom-webpack/static.node.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export {prerenderToNodeStream} from './src/server/react-flight-dom-server.node';
+export {unstable_prerenderToNodeStream} from './src/server/react-flight-dom-server.node';

--- a/packages/react-server-dom-webpack/static.node.unbundled.js
+++ b/packages/react-server-dom-webpack/static.node.unbundled.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export {prerenderToNodeStream} from './src/server/react-flight-dom-server.node.unbundled';
+export {unstable_prerenderToNodeStream} from './src/server/react-flight-dom-server.node.unbundled';


### PR DESCRIPTION
We added an experimental `prerender` API to flight. This change exposes this API in stable channels prefixed as `unstable_prerender`. We have high confidence this API should exist but because we have not yet settled on how to handle resuming/replaying of RSC streams we may need to change the API contract to suit future needs. This release will allow us to get more usage out of the existing implemented functionality without requiring you to use experimental builds which will open up greater adoption and opportunity for feedback.

the `prerender` implementation is documented in the `react-server` package. As with all RSC APIs implemented in bundler specific binding packages these aren't intended to be called by end users but instead be used by frameworks implementing React Server Components.

Previously `prerender` was exposed unprefixed and only in the experimental channel. This PR renames the export across all channels to `unstable_prerender` so users of this previously unprefixed api will need to update to the unstable form. This isn't a breaking change because it was only exposed in the experimental channel which does not follow semver. The reason we don't expose it under both names is that users may feature detect the unprefixed form and then when we finally do ship it as unprefixed we may change the function signature and break this code. Changing the name now is much safer.