### PR TITLE
Fix useResourceEffect in Fizz

### DIFF
--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -43,6 +43,7 @@ import {
   enableUseEffectEventHook,
   enableUseMemoCacheHook,
   enableAsyncActions,
+  enableUseResourceEffectHook,
 } from 'shared/ReactFeatureFlags';
 import is from 'shared/objectIs';
 import {
@@ -869,6 +870,11 @@ if (enableAsyncActions) {
   HooksDispatcher.useOptimistic = useOptimistic;
   HooksDispatcher.useFormState = useActionState;
   HooksDispatcher.useActionState = useActionState;
+}
+if (enableUseResourceEffectHook) {
+  HooksDispatcher.useResourceEffect = supportsClientAPIs
+    ? noop
+    : clientHookNotSupported;
 }
 
 export let currentResumableState: null | ResumableState = (null: any);


### PR DESCRIPTION
We're seeing errors when testing useResourceEffect in SSR and it turns out we're missing the noop dispatcher function on Fizz.

I tested a local build with this change and it resolved the late mutation errors in the e2e tests.