### PR TITLE
[refactor] clean up describeNativeComponentFrame

### DIFF
--- a/packages/react-devtools-shared/src/backend/shared/DevToolsComponentStackFrame.js
+++ b/packages/react-devtools-shared/src/backend/shared/DevToolsComponentStackFrame.js
@@ -51,7 +51,7 @@ if (__DEV__) {
   componentFrameCache = new PossiblyWeakMap<$FlowFixMe, string>();
 }
 
-export function describeNativeComponentFrame(
+export function describeFunctionComponentFrame(
   fn: Function,
   construct: boolean,
   currentDispatcherRef: CurrentDispatcherRef,
@@ -280,12 +280,5 @@ export function describeClassComponentFrame(
   ctor: Function,
   currentDispatcherRef: CurrentDispatcherRef,
 ): string {
-  return describeNativeComponentFrame(ctor, true, currentDispatcherRef);
-}
-
-export function describeFunctionComponentFrame(
-  fn: Function,
-  currentDispatcherRef: CurrentDispatcherRef,
-): string {
-  return describeNativeComponentFrame(fn, false, currentDispatcherRef);
+  return describeFunctionComponentFrame(ctor, true, currentDispatcherRef);
 }

--- a/packages/shared/ReactComponentStackFrame.js
+++ b/packages/shared/ReactComponentStackFrame.js
@@ -70,7 +70,7 @@ if (__DEV__) {
  *   (3) diffing the control and sample error stacks to find the stack frame
  *       which represents our component.
  */
-export function describeNativeComponentFrame(
+export function describeFunctionComponentFrame(
   fn: Function,
   construct: boolean,
 ): string {
@@ -291,11 +291,7 @@ export function describeNativeComponentFrame(
 }
 
 export function describeClassComponentFrame(ctor: Function): string {
-  return describeNativeComponentFrame(ctor, true);
-}
-
-export function describeFunctionComponentFrame(fn: Function): string {
-  return describeNativeComponentFrame(fn, false);
+  return describeFunctionComponentFrame(ctor, true);
 }
 
 function shouldConstruct(Component: Function) {
@@ -312,7 +308,7 @@ export function describeUnknownElementTypeFrameInDEV(type: any): string {
     return '';
   }
   if (typeof type === 'function') {
-    return describeNativeComponentFrame(type, shouldConstruct(type));
+    return describeFunctionComponentFrame(type, shouldConstruct(type));
   }
   if (typeof type === 'string') {
     return describeBuiltInComponentFrame(type);


### PR DESCRIPTION
We only need one of these methods now, I chose to keep `describeFunctionComponentFrame` because that makes sense as saying what the caller is describing instead of how, but I could flip if desired. 