### PR TITLE
Delete requestPaint from Scheduler

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMImageLoad-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMImageLoad-test.internal.js
@@ -78,7 +78,6 @@ function Img({src: maybeSrc, onLoad, useImageLoader, ref}) {
 
 function Yield() {
   Scheduler.log('Yield');
-  Scheduler.unstable_requestPaint();
   return null;
 }
 
@@ -250,7 +249,6 @@ describe('ReactDOMImageLoad', () => {
       'load triggered',
       'last layout',
     ]);
-    Scheduler.unstable_requestPaint();
     const img = last(images);
     loadImage(img);
     assertLog(['actualLoadSpy [default]', 'onLoadSpy [default]']);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -50,7 +50,6 @@ import {
   // Aliased because `act` will override and push to an internal queue
   scheduleCallback as Scheduler_scheduleCallback,
   shouldYield,
-  requestPaint,
   now,
   NormalPriority as NormalSchedulerPriority,
   IdlePriority as IdleSchedulerPriority,
@@ -3427,10 +3426,6 @@ function commitRootImpl(
     if (enableSchedulingProfiler) {
       markLayoutEffectsStopped();
     }
-
-    // Tell Scheduler to yield at the end of the frame, so the browser has an
-    // opportunity to paint.
-    requestPaint();
 
     executionContext = prevExecutionContext;
 

--- a/packages/react-reconciler/src/Scheduler.js
+++ b/packages/react-reconciler/src/Scheduler.js
@@ -16,7 +16,6 @@ import * as Scheduler from 'scheduler';
 export const scheduleCallback = Scheduler.unstable_scheduleCallback;
 export const cancelCallback = Scheduler.unstable_cancelCallback;
 export const shouldYield = Scheduler.unstable_shouldYield;
-export const requestPaint = Scheduler.unstable_requestPaint;
 export const now = Scheduler.unstable_now;
 export const getCurrentPriorityLevel =
   Scheduler.unstable_getCurrentPriorityLevel;

--- a/packages/react-reconciler/src/__tests__/ReactSchedulerIntegration-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSchedulerIntegration-test.js
@@ -258,7 +258,6 @@ describe(
         // This triggers a once-upon-a-time bug in Scheduler that caused
         // `shouldYield` to return true even though the current task expired.
         Scheduler.unstable_advanceTime(10000);
-        Scheduler.unstable_requestPaint();
         return null;
       }
 

--- a/packages/scheduler/src/__tests__/Scheduler-test.js
+++ b/packages/scheduler/src/__tests__/Scheduler-test.js
@@ -15,7 +15,6 @@ let runtime;
 let performance;
 let cancelCallback;
 let scheduleCallback;
-let requestPaint;
 let shouldYield;
 let NormalPriority;
 
@@ -40,7 +39,6 @@ describe('SchedulerBrowser', () => {
     cancelCallback = Scheduler.unstable_cancelCallback;
     scheduleCallback = Scheduler.unstable_scheduleCallback;
     NormalPriority = Scheduler.unstable_NormalPriority;
-    requestPaint = Scheduler.unstable_requestPaint;
     shouldYield = Scheduler.unstable_shouldYield;
   });
 
@@ -183,8 +181,6 @@ describe('SchedulerBrowser', () => {
   it('task with continuation', () => {
     scheduleCallback(NormalPriority, () => {
       runtime.log('Task');
-      // Request paint so that we yield at the end of the frame interval
-      requestPaint();
       while (!Scheduler.unstable_shouldYield()) {
         runtime.advanceTime(1);
       }

--- a/packages/scheduler/src/forks/Scheduler.js
+++ b/packages/scheduler/src/forks/Scheduler.js
@@ -466,8 +466,6 @@ function shouldYieldToHost(): boolean {
   return true;
 }
 
-function requestPaint() {}
-
 function forceFrameRate(fps: number) {
   if (fps < 0 || fps > 125) {
     // Using console['error'] to evade Babel and ESLint
@@ -582,7 +580,6 @@ export {
   unstable_wrapCallback,
   unstable_getCurrentPriorityLevel,
   shouldYieldToHost as unstable_shouldYield,
-  requestPaint as unstable_requestPaint,
   unstable_continueExecution,
   unstable_pauseExecution,
   unstable_getFirstCallbackNode,

--- a/packages/scheduler/src/forks/SchedulerMock.js
+++ b/packages/scheduler/src/forks/SchedulerMock.js
@@ -661,10 +661,6 @@ function unstable_advanceTime(ms: number) {
   }
 }
 
-function requestPaint() {
-  needsPaint = true;
-}
-
 export {
   ImmediatePriority as unstable_ImmediatePriority,
   UserBlockingPriority as unstable_UserBlockingPriority,
@@ -678,7 +674,6 @@ export {
   unstable_wrapCallback,
   unstable_getCurrentPriorityLevel,
   shouldYieldToHost as unstable_shouldYield,
-  requestPaint as unstable_requestPaint,
   unstable_continueExecution,
   unstable_pauseExecution,
   unstable_getFirstCallbackNode,

--- a/packages/scheduler/src/forks/SchedulerNative.js
+++ b/packages/scheduler/src/forks/SchedulerNative.js
@@ -28,7 +28,6 @@ type NativeSchedulerType = {
   unstable_cancelCallback: (task: Task) => void,
   unstable_getCurrentPriorityLevel: () => PriorityLevel,
   unstable_shouldYield: () => boolean,
-  unstable_requestPaint: () => void,
   unstable_now: () => DOMHighResTimeStamp,
 };
 
@@ -81,11 +80,6 @@ export const unstable_shouldYield: () => boolean =
   typeof nativeRuntimeScheduler !== 'undefined'
     ? nativeRuntimeScheduler.unstable_shouldYield
     : Scheduler.unstable_shouldYield;
-
-export const unstable_requestPaint: () => void =
-  typeof nativeRuntimeScheduler !== 'undefined'
-    ? nativeRuntimeScheduler.unstable_requestPaint
-    : Scheduler.unstable_requestPaint;
 
 export const unstable_now: () => number | DOMHighResTimeStamp =
   typeof nativeRuntimeScheduler !== 'undefined'

--- a/packages/scheduler/src/forks/SchedulerPostTask.js
+++ b/packages/scheduler/src/forks/SchedulerPostTask.js
@@ -62,10 +62,6 @@ export function unstable_shouldYield(): boolean {
   return getCurrentTime() >= deadline;
 }
 
-export function unstable_requestPaint() {
-  // Since we yield every frame regardless, `requestPaint` has no effect.
-}
-
 type SchedulerCallback<T> = (didTimeout_DEPRECATED: boolean) =>
   | T
   // May return a continuation


### PR DESCRIPTION
It's a noop so it's misleading. It's only implemented in the SchedulerMock. Which means that a bunch of our tests are actually testing behavior that doesn't work in the real runtime nor in tests when not using the mock. See failing tests.

