### PR TITLE
[compiler] transform fire calls

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
@@ -98,6 +98,7 @@ import {validateNoJSXInTryStatement} from '../Validation/ValidateNoJSXInTryState
 import {propagateScopeDependenciesHIR} from '../HIR/PropagateScopeDependenciesHIR';
 import {outlineJSX} from '../Optimization/OutlineJsx';
 import {optimizePropsMethodCalls} from '../Optimization/OptimizePropsMethodCalls';
+import {transformFire} from '../Transform';
 
 export type CompilerPipelineValue =
   | {kind: 'ast'; name: string; value: CodegenFunction}
@@ -195,6 +196,11 @@ function runWithEnvironment(
 
   if (env.config.validateHooksUsage) {
     validateHooksUsage(hir);
+  }
+
+  if (env.config.enableFire) {
+    transformFire(hir);
+    log({kind: 'hir', name: 'TransformFire', value: hir});
   }
 
   if (env.config.validateNoCapitalizedCalls) {

--- a/compiler/packages/babel-plugin-react-compiler/src/Transform/TransformFire.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Transform/TransformFire.ts
@@ -1,0 +1,613 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {CompilerError, CompilerErrorDetailOptions, ErrorSeverity} from '..';
+import {
+  CallExpression,
+  Effect,
+  Environment,
+  FunctionExpression,
+  GeneratedSource,
+  HIRFunction,
+  Identifier,
+  IdentifierId,
+  Instruction,
+  InstructionId,
+  InstructionKind,
+  InstructionValue,
+  isUseEffectHookType,
+  LoadLocal,
+  makeInstructionId,
+  Place,
+  promoteTemporary,
+} from '../HIR';
+import {createTemporaryPlace, markInstructionIds} from '../HIR/HIRBuilder';
+import {getOrInsertWith} from '../Utils/utils';
+import {BuiltInFireId, DefaultNonmutatingHook} from '../HIR/ObjectShape';
+
+/*
+ * TODO(jmbrown):
+ *   In this stack:
+ *     - Insert useFire import
+ *     - Assert no lingering fire calls
+ *     - Ensure a fired function is not called regularly elsewhere in the same effect
+ *
+ *   Future:
+ *   - rewrite dep arrays
+ *   - traverse object methods
+ *   - method calls
+ *   - React.useEffect calls
+ */
+
+const CANNOT_COMPILE_FIRE = 'Cannot compile `fire`';
+
+export function transformFire(fn: HIRFunction): void {
+  const context = new Context(fn.env);
+  replaceFireFunctions(fn, context);
+  context.throwIfErrorsFound();
+}
+
+function replaceFireFunctions(fn: HIRFunction, context: Context): void {
+  let hasRewrite = false;
+  for (const [, block] of fn.body.blocks) {
+    const rewriteInstrs = new Map<InstructionId, Array<Instruction>>();
+    const deleteInstrs = new Set<InstructionId>();
+    for (const instr of block.instructions) {
+      const {value, lvalue} = instr;
+      if (
+        value.kind === 'CallExpression' &&
+        isUseEffectHookType(value.callee.identifier) &&
+        value.args.length > 0 &&
+        value.args[0].kind === 'Identifier'
+      ) {
+        const lambda = context.getFunctionExpression(
+          value.args[0].identifier.id,
+        );
+        if (lambda != null) {
+          const capturedCallees =
+            visitFunctionExpressionAndPropagateFireDependencies(
+              lambda,
+              context,
+              true,
+            );
+
+          // Add useFire calls for all fire calls in found in the lambda
+          const newInstrs = [];
+          for (const [
+            fireCalleePlace,
+            fireCalleeInfo,
+          ] of capturedCallees.entries()) {
+            if (!context.hasCalleeWithInsertedFire(fireCalleePlace)) {
+              context.addCalleeWithInsertedFire(fireCalleePlace);
+              const loadUseFireInstr = makeLoadUseFireInstruction(fn.env);
+              const loadFireCalleeInstr = makeLoadFireCalleeInstruction(
+                fn.env,
+                fireCalleeInfo.capturedCalleeIdentifier,
+              );
+              const callUseFireInstr = makeCallUseFireInstruction(
+                fn.env,
+                loadUseFireInstr.lvalue,
+                loadFireCalleeInstr.lvalue,
+              );
+              const storeUseFireInstr = makeStoreUseFireInstruction(
+                fn.env,
+                callUseFireInstr.lvalue,
+                fireCalleeInfo.fireFunctionBinding,
+              );
+              newInstrs.push(
+                loadUseFireInstr,
+                loadFireCalleeInstr,
+                callUseFireInstr,
+                storeUseFireInstr,
+              );
+
+              // We insert all of these instructions before the useEffect is loaded
+              const loadUseEffectInstrId = context.getLoadGlobalInstrId(
+                value.callee.identifier.id,
+              );
+              if (loadUseEffectInstrId == null) {
+                context.pushError({
+                  loc: value.loc,
+                  description: null,
+                  severity: ErrorSeverity.Invariant,
+                  reason: '[InsertFire] No LoadGlobal found for useEffect call',
+                  suggestions: null,
+                });
+                continue;
+              }
+              rewriteInstrs.set(loadUseEffectInstrId, newInstrs);
+            }
+          }
+        }
+      } else if (
+        value.kind === 'CallExpression' &&
+        value.callee.identifier.type.kind === 'Function' &&
+        value.callee.identifier.type.shapeId === BuiltInFireId &&
+        context.inUseEffectLambda()
+      ) {
+        /*
+         * We found a fire(callExpr()) call. We remove the `fire()` call and replace the callExpr()
+         * with a freshly generated fire function binding. We'll insert the useFire call before the
+         * useEffect call, which happens in the CallExpression (useEffect) case above.
+         */
+
+        /*
+         * We only allow fire to be called with a CallExpression: `fire(f())`
+         * TODO: add support for method calls: `fire(this.method())`
+         */
+        if (value.args.length === 1 && value.args[0].kind === 'Identifier') {
+          const callExpr = context.getCallExpression(
+            value.args[0].identifier.id,
+          );
+
+          if (callExpr != null) {
+            const calleeId = callExpr.callee.identifier.id;
+            const loadLocal = context.getLoadLocalInstr(calleeId);
+            if (loadLocal == null) {
+              context.pushError({
+                loc: value.loc,
+                description: null,
+                severity: ErrorSeverity.Invariant,
+                reason:
+                  '[InsertFire] No loadLocal found for fire call argument',
+                suggestions: null,
+              });
+              continue;
+            }
+
+            const fireFunctionBinding =
+              context.getOrGenerateFireFunctionBinding(loadLocal.place);
+
+            loadLocal.place = {...fireFunctionBinding};
+
+            // Delete the fire call expression
+            deleteInstrs.add(instr.id);
+          } else {
+            context.pushError({
+              loc: value.loc,
+              description:
+                '`fire()` can only receive a function call such as `fire(fn(a,b)). Method calls and other expressions are not allowed',
+              severity: ErrorSeverity.InvalidReact,
+              reason: CANNOT_COMPILE_FIRE,
+              suggestions: null,
+            });
+          }
+        } else {
+          let description: string =
+            'fire() can only take in a single call expression as an argument';
+          if (value.args.length === 0) {
+            description += ' but received none';
+          } else if (value.args.length > 1) {
+            description += ' but received multiple arguments';
+          } else if (value.args[0].kind === 'Spread') {
+            description += ' but received a spread argument';
+          }
+          context.pushError({
+            loc: value.loc,
+            description,
+            severity: ErrorSeverity.InvalidReact,
+            reason: CANNOT_COMPILE_FIRE,
+            suggestions: null,
+          });
+        }
+      } else if (value.kind === 'CallExpression') {
+        context.addCallExpression(lvalue.identifier.id, value);
+      } else if (
+        value.kind === 'FunctionExpression' &&
+        context.inUseEffectLambda()
+      ) {
+        visitFunctionExpressionAndPropagateFireDependencies(
+          value,
+          context,
+          false,
+        );
+      } else if (value.kind === 'FunctionExpression') {
+        context.addFunctionExpression(lvalue.identifier.id, value);
+      } else if (value.kind === 'LoadLocal') {
+        context.addLoadLocalInstr(lvalue.identifier.id, value);
+      } else if (
+        value.kind === 'LoadGlobal' &&
+        value.binding.kind === 'ImportSpecifier' &&
+        value.binding.module === 'react' &&
+        value.binding.imported === 'fire' &&
+        context.inUseEffectLambda()
+      ) {
+        deleteInstrs.add(instr.id);
+      } else if (value.kind === 'LoadGlobal') {
+        context.addLoadGlobalInstrId(lvalue.identifier.id, instr.id);
+      }
+    }
+    block.instructions = rewriteInstructions(rewriteInstrs, block.instructions);
+    block.instructions = deleteInstructions(deleteInstrs, block.instructions);
+
+    if (rewriteInstrs.size > 0 || deleteInstrs.size > 0) {
+      hasRewrite = true;
+    }
+  }
+
+  if (hasRewrite) {
+    markInstructionIds(fn.body);
+  }
+}
+
+/**
+ * Traverses a function expression to find fire calls fire(foo()) and replaces them with
+ * fireFoo().
+ *
+ * When a function captures a fire call we need to update its context to reflect the newly created
+ * fire function bindings and update the LoadLocals referenced by the function's dependencies.
+ *
+ * @param isUseEffect is necessary so we can keep track of when we should additionally insert
+ * useFire hooks calls.
+ */
+function visitFunctionExpressionAndPropagateFireDependencies(
+  fnExpr: FunctionExpression,
+  context: Context,
+  enteringUseEffect: boolean,
+): FireCalleesToFireFunctionBinding {
+  let withScope = enteringUseEffect
+    ? context.withUseEffectLambdaScope.bind(context)
+    : context.withFunctionScope.bind(context);
+
+  const calleesCapturedByFnExpression = withScope(() =>
+    replaceFireFunctions(fnExpr.loweredFunc.func, context),
+  );
+
+  /*
+   * Make a mapping from each dependency to the corresponding LoadLocal for it so that
+   * we can replace the loaded place with the generated fire function binding
+   */
+  const loadLocalsToDepLoads = new Map<IdentifierId, LoadLocal>();
+  for (const dep of fnExpr.loweredFunc.dependencies) {
+    const loadLocal = context.getLoadLocalInstr(dep.identifier.id);
+    if (loadLocal != null) {
+      loadLocalsToDepLoads.set(loadLocal.place.identifier.id, loadLocal);
+    }
+  }
+
+  const replacedCallees = new Map<IdentifierId, Place>();
+  for (const [
+    calleeIdentifierId,
+    loadedFireFunctionBindingPlace,
+  ] of calleesCapturedByFnExpression.entries()) {
+    /*
+     * Given the ids of captured fire callees, look at the deps for loads of those identifiers
+     * and replace them with the new fire function binding
+     */
+    const loadLocal = loadLocalsToDepLoads.get(calleeIdentifierId);
+    if (loadLocal == null) {
+      context.pushError({
+        loc: fnExpr.loc,
+        description: null,
+        severity: ErrorSeverity.Invariant,
+        reason:
+          '[InsertFire] No loadLocal found for fire call argument for lambda',
+        suggestions: null,
+      });
+      continue;
+    }
+
+    const oldPlaceId = loadLocal.place.identifier.id;
+    loadLocal.place = {
+      ...loadedFireFunctionBindingPlace.fireFunctionBinding,
+    };
+
+    replacedCallees.set(
+      oldPlaceId,
+      loadedFireFunctionBindingPlace.fireFunctionBinding,
+    );
+  }
+
+  // For each replaced callee, update the context of the function expression to track it
+  for (
+    let contextIdx = 0;
+    contextIdx < fnExpr.loweredFunc.func.context.length;
+    contextIdx++
+  ) {
+    const contextItem = fnExpr.loweredFunc.func.context[contextIdx];
+    const replacedCallee = replacedCallees.get(contextItem.identifier.id);
+    if (replacedCallee != null) {
+      fnExpr.loweredFunc.func.context[contextIdx] = replacedCallee;
+    }
+  }
+
+  context.mergeCalleesFromInnerScope(calleesCapturedByFnExpression);
+
+  return calleesCapturedByFnExpression;
+}
+
+function makeLoadUseFireInstruction(env: Environment): Instruction {
+  const useFirePlace = createTemporaryPlace(env, GeneratedSource);
+  useFirePlace.effect = Effect.Read;
+  useFirePlace.identifier.type = DefaultNonmutatingHook;
+  const instrValue: InstructionValue = {
+    kind: 'LoadGlobal',
+    binding: {
+      kind: 'ImportSpecifier',
+      name: 'useFire',
+      module: 'react',
+      imported: 'useFire',
+    },
+    loc: GeneratedSource,
+  };
+  return {
+    id: makeInstructionId(0),
+    value: instrValue,
+    lvalue: {...useFirePlace},
+    loc: GeneratedSource,
+  };
+}
+
+function makeLoadFireCalleeInstruction(
+  env: Environment,
+  fireCalleeIdentifier: Identifier,
+): Instruction {
+  const loadedFireCallee = createTemporaryPlace(env, GeneratedSource);
+  const fireCallee: Place = {
+    kind: 'Identifier',
+    identifier: fireCalleeIdentifier,
+    reactive: false,
+    effect: Effect.Unknown,
+    loc: fireCalleeIdentifier.loc,
+  };
+  return {
+    id: makeInstructionId(0),
+    value: {
+      kind: 'LoadLocal',
+      loc: GeneratedSource,
+      place: {...fireCallee},
+    },
+    lvalue: {...loadedFireCallee},
+    loc: GeneratedSource,
+  };
+}
+
+function makeCallUseFireInstruction(
+  env: Environment,
+  useFirePlace: Place,
+  argPlace: Place,
+): Instruction {
+  const useFireCallResultPlace = createTemporaryPlace(env, GeneratedSource);
+  useFireCallResultPlace.effect = Effect.Read;
+
+  const useFireCall: CallExpression = {
+    kind: 'CallExpression',
+    callee: {...useFirePlace},
+    args: [argPlace],
+    loc: GeneratedSource,
+  };
+
+  return {
+    id: makeInstructionId(0),
+    value: useFireCall,
+    lvalue: {...useFireCallResultPlace},
+    loc: GeneratedSource,
+  };
+}
+
+function makeStoreUseFireInstruction(
+  env: Environment,
+  useFireCallResultPlace: Place,
+  fireFunctionBindingPlace: Place,
+): Instruction {
+  promoteTemporary(fireFunctionBindingPlace.identifier);
+
+  const fireFunctionBindingLValuePlace = createTemporaryPlace(
+    env,
+    GeneratedSource,
+  );
+  return {
+    id: makeInstructionId(0),
+    value: {
+      kind: 'StoreLocal',
+      lvalue: {
+        kind: InstructionKind.Const,
+        place: {...fireFunctionBindingPlace},
+      },
+      value: {...useFireCallResultPlace},
+      type: null,
+      loc: GeneratedSource,
+    },
+    lvalue: fireFunctionBindingLValuePlace,
+    loc: GeneratedSource,
+  };
+}
+
+type FireCalleesToFireFunctionBinding = Map<
+  IdentifierId,
+  {
+    fireFunctionBinding: Place;
+    capturedCalleeIdentifier: Identifier;
+  }
+>;
+
+class Context {
+  #env: Environment;
+
+  #errors: CompilerError = new CompilerError();
+
+  /*
+   * Used to look up the call expression passed to a `fire(callExpr())`. Gives back
+   * the `callExpr()`.
+   */
+  #callExpressions = new Map<IdentifierId, CallExpression>();
+
+  /*
+   * We keep track of function expressions so that we can traverse them when
+   * we encounter a lambda passed to a useEffect call
+   */
+  #functionExpressions = new Map<IdentifierId, FunctionExpression>();
+
+  /*
+   * Mapping from lvalue ids to the LoadLocal for it. Allows us to replace dependency LoadLocals.
+   */
+  #loadLocals = new Map<IdentifierId, LoadLocal>();
+
+  /*
+   * Maps all of the fire callees found in a component/hook to the generated fire function places
+   * we create for them. Allows us to reuse already-inserted useFire results
+   */
+  #fireCalleesToFireFunctions: Map<IdentifierId, Place> = new Map();
+
+  /*
+   * The callees for which we have already created fire bindings. Used to skip inserting a new
+   * useFire call for a fire callee if one has already been created.
+   */
+  #calleesWithInsertedFire = new Set<IdentifierId>();
+
+  /*
+   * A mapping from fire callees to the created fire function bindings that are reachable from this
+   * scope.
+   *
+   * We additionally keep track of the captured callee identifier so that we can properly reference
+   * it in the place where we LoadLocal the callee as an argument to useFire.
+   */
+  #capturedCalleeIdentifierIds: FireCalleesToFireFunctionBinding = new Map();
+
+  /*
+   * We only transform fire calls if we're syntactically within a useEffect lambda (for now)
+   */
+  #inUseEffectLambda = false;
+
+  /*
+   * Mapping from useEffect callee identifier ids to the instruction id of the
+   * load global instruction for the useEffect call. We use this to insert the
+   * useFire calls before the useEffect call
+   */
+  #loadGlobalInstructionIds = new Map<IdentifierId, InstructionId>();
+
+  constructor(env: Environment) {
+    this.#env = env;
+  }
+
+  pushError(error: CompilerErrorDetailOptions): void {
+    this.#errors.push(error);
+  }
+
+  withFunctionScope(fn: () => void): FireCalleesToFireFunctionBinding {
+    fn();
+    return this.#capturedCalleeIdentifierIds;
+  }
+
+  withUseEffectLambdaScope(fn: () => void): FireCalleesToFireFunctionBinding {
+    const capturedCalleeIdentifierIds = this.#capturedCalleeIdentifierIds;
+    const inUseEffectLambda = this.#inUseEffectLambda;
+
+    this.#capturedCalleeIdentifierIds = new Map();
+    this.#inUseEffectLambda = true;
+
+    const resultCapturedCalleeIdentifierIds = this.withFunctionScope(fn);
+
+    this.#capturedCalleeIdentifierIds = capturedCalleeIdentifierIds;
+    this.#inUseEffectLambda = inUseEffectLambda;
+
+    return resultCapturedCalleeIdentifierIds;
+  }
+
+  addCallExpression(id: IdentifierId, callExpr: CallExpression): void {
+    this.#callExpressions.set(id, callExpr);
+  }
+
+  getCallExpression(id: IdentifierId): CallExpression | undefined {
+    return this.#callExpressions.get(id);
+  }
+
+  addLoadLocalInstr(id: IdentifierId, loadLocal: LoadLocal): void {
+    this.#loadLocals.set(id, loadLocal);
+  }
+
+  getLoadLocalInstr(id: IdentifierId): LoadLocal | undefined {
+    return this.#loadLocals.get(id);
+  }
+
+  getOrGenerateFireFunctionBinding(callee: Place): Place {
+    const fireFunctionBinding = getOrInsertWith(
+      this.#fireCalleesToFireFunctions,
+      callee.identifier.id,
+      () => createTemporaryPlace(this.#env, GeneratedSource),
+    );
+
+    this.#capturedCalleeIdentifierIds.set(callee.identifier.id, {
+      fireFunctionBinding,
+      capturedCalleeIdentifier: callee.identifier,
+    });
+
+    return fireFunctionBinding;
+  }
+
+  mergeCalleesFromInnerScope(
+    innerCallees: FireCalleesToFireFunctionBinding,
+  ): void {
+    for (const [id, calleeInfo] of innerCallees.entries()) {
+      this.#capturedCalleeIdentifierIds.set(id, calleeInfo);
+    }
+  }
+
+  addCalleeWithInsertedFire(id: IdentifierId): void {
+    this.#calleesWithInsertedFire.add(id);
+  }
+
+  hasCalleeWithInsertedFire(id: IdentifierId): boolean {
+    return this.#calleesWithInsertedFire.has(id);
+  }
+
+  inUseEffectLambda(): boolean {
+    return this.#inUseEffectLambda;
+  }
+
+  addFunctionExpression(id: IdentifierId, fn: FunctionExpression): void {
+    this.#functionExpressions.set(id, fn);
+  }
+
+  getFunctionExpression(id: IdentifierId): FunctionExpression | undefined {
+    return this.#functionExpressions.get(id);
+  }
+
+  addLoadGlobalInstrId(id: IdentifierId, instrId: InstructionId): void {
+    this.#loadGlobalInstructionIds.set(id, instrId);
+  }
+
+  getLoadGlobalInstrId(id: IdentifierId): InstructionId | undefined {
+    return this.#loadGlobalInstructionIds.get(id);
+  }
+
+  throwIfErrorsFound(): void {
+    if (this.#errors.hasErrors()) throw this.#errors;
+  }
+}
+
+function deleteInstructions(
+  deleteInstrs: Set<InstructionId>,
+  instructions: Array<Instruction>,
+): Array<Instruction> {
+  if (deleteInstrs.size > 0) {
+    const newInstrs = instructions.filter(instr => !deleteInstrs.has(instr.id));
+    return newInstrs;
+  }
+  return instructions;
+}
+
+function rewriteInstructions(
+  rewriteInstrs: Map<InstructionId, Array<Instruction>>,
+  instructions: Array<Instruction>,
+): Array<Instruction> {
+  if (rewriteInstrs.size > 0) {
+    const newInstrs = [];
+    for (const instr of instructions) {
+      const newInstrsAtId = rewriteInstrs.get(instr.id);
+      if (newInstrsAtId != null) {
+        newInstrs.push(...newInstrsAtId, instr);
+      } else {
+        newInstrs.push(instr);
+      }
+    }
+
+    return newInstrs;
+  }
+
+  return instructions;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/Transform/index.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Transform/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+export {transformFire} from './TransformFire';

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/basic.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/basic.expect.md
@@ -1,0 +1,52 @@
+
+## Input
+
+```javascript
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = props => {
+    console.log(props);
+  };
+  useEffect(() => {
+    fire(foo(props));
+  });
+
+  return null;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableFire
+import { fire } from "react";
+
+function Component(props) {
+  const $ = _c(3);
+  const foo = _temp;
+  const t0 = useFire(foo);
+  let t1;
+  if ($[0] !== props || $[1] !== t0) {
+    t1 = () => {
+      t0(props);
+    };
+    $[0] = props;
+    $[1] = t0;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  useEffect(t1);
+  return null;
+}
+function _temp(props_0) {
+  console.log(props_0);
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/basic.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/basic.js
@@ -1,0 +1,13 @@
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = props => {
+    console.log(props);
+  };
+  useEffect(() => {
+    fire(foo(props));
+  });
+
+  return null;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/deep-scope.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/deep-scope.expect.md
@@ -1,0 +1,73 @@
+
+## Input
+
+```javascript
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = props => {
+    console.log(props);
+  };
+  useEffect(() => {
+    function nested() {
+      function nestedAgain() {
+        function nestedThrice() {
+          fire(foo(props));
+        }
+        nestedThrice();
+      }
+      nestedAgain();
+    }
+    nested();
+  });
+
+  return null;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableFire
+import { fire } from "react";
+
+function Component(props) {
+  const $ = _c(3);
+  const foo = _temp;
+  const t0 = useFire(foo);
+  let t1;
+  if ($[0] !== props || $[1] !== t0) {
+    t1 = () => {
+      const nested = function nested() {
+        const nestedAgain = function nestedAgain() {
+          const nestedThrice = function nestedThrice() {
+            t0(props);
+          };
+
+          nestedThrice();
+        };
+
+        nestedAgain();
+      };
+
+      nested();
+    };
+    $[0] = props;
+    $[1] = t0;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  useEffect(t1);
+  return null;
+}
+function _temp(props_0) {
+  console.log(props_0);
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/deep-scope.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/deep-scope.js
@@ -1,0 +1,22 @@
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = props => {
+    console.log(props);
+  };
+  useEffect(() => {
+    function nested() {
+      function nestedAgain() {
+        function nestedThrice() {
+          fire(foo(props));
+        }
+        nestedThrice();
+      }
+      nestedAgain();
+    }
+    nested();
+  });
+
+  return null;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-conditional-use-effect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-conditional-use-effect.expect.md
@@ -1,0 +1,37 @@
+
+## Input
+
+```javascript
+// @enableFire
+import {fire, useEffect} from 'react';
+
+function Component(props) {
+  const foo = props => {
+    console.log(props);
+  };
+
+  if (props.cond) {
+    useEffect(() => {
+      fire(foo(props));
+    });
+  }
+
+  return null;
+}
+
+```
+
+
+## Error
+
+```
+   8 |
+   9 |   if (props.cond) {
+> 10 |     useEffect(() => {
+     |     ^^^^^^^^^ InvalidReact: Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning) (10:10)
+  11 |       fire(foo(props));
+  12 |     });
+  13 |   }
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-conditional-use-effect.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-conditional-use-effect.js
@@ -1,0 +1,16 @@
+// @enableFire
+import {fire, useEffect} from 'react';
+
+function Component(props) {
+  const foo = props => {
+    console.log(props);
+  };
+
+  if (props.cond) {
+    useEffect(() => {
+      fire(foo(props));
+    });
+  }
+
+  return null;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-multiple-args.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-multiple-args.expect.md
@@ -1,0 +1,34 @@
+
+## Input
+
+```javascript
+// @enableFire
+import {fire} from 'react';
+
+function Component({bar, baz}) {
+  const foo = () => {
+    console.log(bar, baz);
+  };
+  useEffect(() => {
+    fire(foo(bar), baz);
+  });
+
+  return null;
+}
+
+```
+
+
+## Error
+
+```
+   7 |   };
+   8 |   useEffect(() => {
+>  9 |     fire(foo(bar), baz);
+     |     ^^^^^^^^^^^^^^^^^^^ InvalidReact: Cannot compile `fire`. fire() can only take in a single call expression as an argument but received multiple arguments (9:9)
+  10 |   });
+  11 |
+  12 |   return null;
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-multiple-args.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-multiple-args.js
@@ -1,0 +1,13 @@
+// @enableFire
+import {fire} from 'react';
+
+function Component({bar, baz}) {
+  const foo = () => {
+    console.log(bar, baz);
+  };
+  useEffect(() => {
+    fire(foo(bar), baz);
+  });
+
+  return null;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-nested-use-effect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-nested-use-effect.expect.md
@@ -1,0 +1,40 @@
+
+## Input
+
+```javascript
+// @enable
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = props => {
+    console.log(props);
+  };
+  useEffect(() => {
+    useEffect(() => {
+      function nested() {
+        fire(foo(props));
+      }
+
+      nested();
+    });
+  });
+
+  return null;
+}
+
+```
+
+
+## Error
+
+```
+   7 |   };
+   8 |   useEffect(() => {
+>  9 |     useEffect(() => {
+     |     ^^^^^^^^^ InvalidReact: Hooks must be called at the top level in the body of a function component or custom hook, and may not be called within function expressions. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning). Cannot call useEffect within a function component (9:9)
+  10 |       function nested() {
+  11 |         fire(foo(props));
+  12 |       }
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-nested-use-effect.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-nested-use-effect.js
@@ -1,0 +1,19 @@
+// @enable
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = props => {
+    console.log(props);
+  };
+  useEffect(() => {
+    useEffect(() => {
+      function nested() {
+        fire(foo(props));
+      }
+
+      nested();
+    });
+  });
+
+  return null;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-not-call.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-not-call.expect.md
@@ -1,0 +1,34 @@
+
+## Input
+
+```javascript
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = () => {
+    console.log(props);
+  };
+  useEffect(() => {
+    fire(props);
+  });
+
+  return null;
+}
+
+```
+
+
+## Error
+
+```
+   7 |   };
+   8 |   useEffect(() => {
+>  9 |     fire(props);
+     |     ^^^^^^^^^^^ InvalidReact: Cannot compile `fire`. `fire()` can only receive a function call such as `fire(fn(a,b)). Method calls and other expressions are not allowed (9:9)
+  10 |   });
+  11 |
+  12 |   return null;
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-not-call.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-not-call.js
@@ -1,0 +1,13 @@
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = () => {
+    console.log(props);
+  };
+  useEffect(() => {
+    fire(props);
+  });
+
+  return null;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-spread.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-spread.expect.md
@@ -1,0 +1,34 @@
+
+## Input
+
+```javascript
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = () => {
+    console.log(props);
+  };
+  useEffect(() => {
+    fire(...foo);
+  });
+
+  return null;
+}
+
+```
+
+
+## Error
+
+```
+   7 |   };
+   8 |   useEffect(() => {
+>  9 |     fire(...foo);
+     |     ^^^^^^^^^^^^ InvalidReact: Cannot compile `fire`. fire() can only take in a single call expression as an argument but received a spread argument (9:9)
+  10 |   });
+  11 |
+  12 |   return null;
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-spread.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-spread.js
@@ -1,0 +1,13 @@
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = () => {
+    console.log(props);
+  };
+  useEffect(() => {
+    fire(...foo);
+  });
+
+  return null;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.todo-method.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.todo-method.expect.md
@@ -1,0 +1,34 @@
+
+## Input
+
+```javascript
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = () => {
+    console.log(props);
+  };
+  useEffect(() => {
+    fire(props.foo());
+  });
+
+  return null;
+}
+
+```
+
+
+## Error
+
+```
+   7 |   };
+   8 |   useEffect(() => {
+>  9 |     fire(props.foo());
+     |     ^^^^^^^^^^^^^^^^^ InvalidReact: Cannot compile `fire`. `fire()` can only receive a function call such as `fire(fn(a,b)). Method calls and other expressions are not allowed (9:9)
+  10 |   });
+  11 |
+  12 |   return null;
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.todo-method.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.todo-method.js
@@ -1,0 +1,13 @@
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = () => {
+    console.log(props);
+  };
+  useEffect(() => {
+    fire(props.foo());
+  });
+
+  return null;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/multiple-scope.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/multiple-scope.expect.md
@@ -1,0 +1,65 @@
+
+## Input
+
+```javascript
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = props => {
+    console.log(props);
+  };
+  useEffect(() => {
+    fire(foo(props));
+    function nested() {
+      fire(foo(props));
+      function innerNested() {
+        fire(foo(props));
+      }
+    }
+
+    nested();
+  });
+
+  return null;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableFire
+import { fire } from "react";
+
+function Component(props) {
+  const $ = _c(3);
+  const foo = _temp;
+  const t0 = useFire(foo);
+  let t1;
+  if ($[0] !== props || $[1] !== t0) {
+    t1 = () => {
+      t0(props);
+      const nested = function nested() {
+        t0(props);
+      };
+
+      nested();
+    };
+    $[0] = props;
+    $[1] = t0;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  useEffect(t1);
+  return null;
+}
+function _temp(props_0) {
+  console.log(props_0);
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/multiple-scope.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/multiple-scope.js
@@ -1,0 +1,21 @@
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = props => {
+    console.log(props);
+  };
+  useEffect(() => {
+    fire(foo(props));
+    function nested() {
+      fire(foo(props));
+      function innerNested() {
+        fire(foo(props));
+      }
+    }
+
+    nested();
+  });
+
+  return null;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/repeated-calls.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/repeated-calls.expect.md
@@ -1,0 +1,61 @@
+
+## Input
+
+```javascript
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = () => {
+    console.log(props);
+  };
+  useEffect(() => {
+    fire(foo(props));
+    fire(foo(props));
+  });
+
+  return null;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableFire
+import { fire } from "react";
+
+function Component(props) {
+  const $ = _c(5);
+  let t0;
+  if ($[0] !== props) {
+    t0 = () => {
+      console.log(props);
+    };
+    $[0] = props;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  const foo = t0;
+  const t1 = useFire(foo);
+  let t2;
+  if ($[2] !== props || $[3] !== t1) {
+    t2 = () => {
+      t1(props);
+      t1(props);
+    };
+    $[2] = props;
+    $[3] = t1;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  useEffect(t2);
+  return null;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/repeated-calls.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/repeated-calls.js
@@ -1,0 +1,14 @@
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  const foo = () => {
+    console.log(props);
+  };
+  useEffect(() => {
+    fire(foo(props));
+    fire(foo(props));
+  });
+
+  return null;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/shared-hook-calls.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/shared-hook-calls.expect.md
@@ -1,0 +1,80 @@
+
+## Input
+
+```javascript
+// @enableFire
+import {fire} from 'react';
+
+function Component({bar, baz}) {
+  const foo = () => {
+    console.log(bar);
+  };
+  useEffect(() => {
+    fire(foo(bar));
+    fire(baz(bar));
+  });
+
+  useEffect(() => {
+    fire(foo(bar));
+  });
+
+  return null;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableFire
+import { fire } from "react";
+
+function Component(t0) {
+  const $ = _c(9);
+  const { bar, baz } = t0;
+  let t1;
+  if ($[0] !== bar) {
+    t1 = () => {
+      console.log(bar);
+    };
+    $[0] = bar;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const foo = t1;
+  const t2 = useFire(foo);
+  const t3 = useFire(baz);
+  let t4;
+  if ($[2] !== bar || $[3] !== t2 || $[4] !== t3) {
+    t4 = () => {
+      t2(bar);
+      t3(bar);
+    };
+    $[2] = bar;
+    $[3] = t2;
+    $[4] = t3;
+    $[5] = t4;
+  } else {
+    t4 = $[5];
+  }
+  useEffect(t4);
+  let t5;
+  if ($[6] !== bar || $[7] !== t2) {
+    t5 = () => {
+      t2(bar);
+    };
+    $[6] = bar;
+    $[7] = t2;
+    $[8] = t5;
+  } else {
+    t5 = $[8];
+  }
+  useEffect(t5);
+  return null;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/shared-hook-calls.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/shared-hook-calls.js
@@ -1,0 +1,18 @@
+// @enableFire
+import {fire} from 'react';
+
+function Component({bar, baz}) {
+  const foo = () => {
+    console.log(bar);
+  };
+  useEffect(() => {
+    fire(foo(bar));
+    fire(baz(bar));
+  });
+
+  useEffect(() => {
+    fire(foo(bar));
+  });
+
+  return null;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/use-effect-no-args-no-op.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/use-effect-no-args-no-op.expect.md
@@ -1,0 +1,30 @@
+
+## Input
+
+```javascript
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  useEffect();
+
+  return null;
+}
+
+```
+
+## Code
+
+```javascript
+// @enableFire
+import { fire } from "react";
+
+function Component(props) {
+  useEffect();
+  return null;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/use-effect-no-args-no-op.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/use-effect-no-args-no-op.js
@@ -1,0 +1,8 @@
+// @enableFire
+import {fire} from 'react';
+
+function Component(props) {
+  useEffect();
+
+  return null;
+}


### PR DESCRIPTION

This is the diff with the meaningful changes. The approach is:
1. Collect fire callees and remove fire() calls, create a new binding for the useFire result
2. Update LoadLocals for captured callees to point to the useFire result
3. Update function context to reference useFire results
4. Insert useFire calls after getting to the component scope

This approach aims to minimize the amount of new bindings we introduce for the function expressions
to minimize bookkeeping for dependency arrays. We keep all of the LoadLocals leading up to function
calls as they are and insert new instructions to load the originally captured function, call useFire,
and store the result in a new promoted temporary. The lvalues that referenced the original callee are
changed to point to the new useFire result.

This is the minimal diff to implement the expected behavior (up to importing the useFire call, next diff)
and further stacked diffs implement error handling. The rules for fire are:
1. If you use fire for a callee in the effect once you must use it for every time you call it in that effect
2. You can only use fire in a useEffect lambda/functions defined inside the useEffect lambda

There is still more work to do here, like updating the effect dependency array and handling object methods

--
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/31796).
* #31811
* #31798
* #31797
* __->__ #31796