### PR TITLE
[Flight Parcel] Implement prepareDestinationForModule

### DIFF
--- a/fixtures/flight-parcel/package.json
+++ b/fixtures/flight-parcel/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "predev": "cp -r ../../build/oss-experimental/* ./node_modules/",
     "prebuild": "cp -r ../../build/oss-experimental/* ./node_modules/",
-    "dev": "concurrently \"npm run dev:watch\" \"npm run dev:start\"",
+    "dev": "concurrently \"npm run dev:watch\" \"sleep 2 && npm run dev:start\"",
     "dev:watch": "NODE_ENV=development parcel watch",
     "dev:start": "NODE_ENV=development node dist/server.js",
     "build": "parcel build",
@@ -28,8 +28,8 @@
     "packageExports": true
   },
   "dependencies": {
-    "@parcel/config-default": "2.0.0-dev.1789",
-    "@parcel/runtime-rsc": "2.13.3-dev.3412",
+    "@parcel/config-default": "2.0.0-dev.1795",
+    "@parcel/runtime-rsc": "2.13.3-dev.3418",
     "@types/parcel-env": "^0.0.6",
     "@types/express": "*",
     "@types/node": "^22.10.1",
@@ -37,7 +37,7 @@
     "@types/react-dom": "^19",
     "concurrently": "^7.3.0",
     "express": "^4.18.2",
-    "parcel": "2.0.0-dev.1787",
+    "parcel": "2.0.0-dev.1793",
     "process": "^0.11.10",
     "react": "experimental",
     "react-dom": "experimental",

--- a/fixtures/flight-parcel/src/server.tsx
+++ b/fixtures/flight-parcel/src/server.tsx
@@ -15,8 +15,8 @@ import {injectRSCPayload} from 'rsc-html-stream/server';
 
 // Client dependencies, used for SSR.
 // These must run in the same environment as client components (e.g. same instance of React).
-import {createFromReadableStream} from 'react-server-dom-parcel/client' with {env: 'react-client'};
-import {renderToReadableStream as renderHTMLToReadableStream} from 'react-dom/server' with {env: 'react-client'};
+import {createFromReadableStream} from 'react-server-dom-parcel/client.edge' with {env: 'react-client'};
+import {renderToReadableStream as renderHTMLToReadableStream} from 'react-dom/server.edge' with {env: 'react-client'};
 import ReactClient, {ReactElement} from 'react' with {env: 'react-client'};
 
 // Page components. These must have "use server-entry" so they are treated as code splitting entry points.
@@ -66,8 +66,9 @@ async function render(
 
     // Use client react to render the RSC payload to HTML.
     let [s1, s2] = stream.tee();
-    let data = createFromReadableStream<ReactElement>(s1);
+    let data: Promise<ReactElement>;
     function Content() {
+      data ??= createFromReadableStream<ReactElement>(s1);
       return ReactClient.use(data);
     }
 

--- a/fixtures/flight-parcel/types.d.ts
+++ b/fixtures/flight-parcel/types.d.ts
@@ -2,11 +2,14 @@
 
 declare module 'react-server-dom-parcel/client' {
   export function createFromFetch<T>(res: Promise<Response>): Promise<T>;
-  export function createFromReadableStream<T>(stream: ReadableStream): Promise<T>;
   export function encodeReply(value: any): Promise<string | URLSearchParams | FormData>;
 
   type CallServerCallback = <T>(id: string, args: any[]) => Promise<T>;
   export function setServerCallback(cb: CallServerCallback): void;
+}
+
+declare module 'react-server-dom-parcel/client.edge' {
+  export function createFromReadableStream<T>(stream: ReadableStream): Promise<T>;
 }
 
 declare module 'react-server-dom-parcel/server.edge' {
@@ -17,5 +20,10 @@ declare module 'react-server-dom-parcel/server.edge' {
 }
 
 declare module '@parcel/runtime-rsc' {
+  import {JSX} from 'react';
   export function Resources(): JSX.Element;
+}
+
+declare module 'react-dom/server.edge' {
+  export * from 'react-dom/server';
 }

--- a/fixtures/flight-parcel/yarn.lock
+++ b/fixtures/flight-parcel/yarn.lock
@@ -104,100 +104,100 @@
   resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz#0aa5502d547b57abfc4ac492de68e2006e417242"
   integrity sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==
 
-"@parcel/bundler-default@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/bundler-default/-/bundler-default-2.0.0-dev.1789.tgz#815e0e6c96046621eead2fb0c71c1ac3337b39ec"
-  integrity sha512-UCXy0G/kbJnB5fLbzU9dRdmRT3dbPAFvyHSWgOXeNZG1qn2ckGXQJFEoIfhtvpoGPUb4b0EM+vM4mOwnkXYziQ==
+"@parcel/bundler-default@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/bundler-default/-/bundler-default-2.0.0-dev.1795.tgz#0fff101f37e3defe676c4b66bce234e563c25825"
+  integrity sha512-nK82Osr6A6ZjYeRfy2KT6197rD+5SzMPQ9LqMLbh8h/WoKye8ywAYSyeckDp7GQZa8aqFZXpVqUtmI0SvdUcIQ==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/graph" "3.3.3-dev.3412+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/rust" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/graph" "3.3.3-dev.3418+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/rust" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     nullthrows "^1.1.1"
 
-"@parcel/cache@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/cache/-/cache-2.0.0-dev.1789.tgz#19e63615bba7b1a0871fef38263ed89759722bd8"
-  integrity sha512-/Vzv6w8JE+vgPA+5zXIntgXRLeg9YA6nOMhA2OGyjHnMouNeyUggPjalTtv+upxkPwRyME4DT4fq8Pzx/EsC6w==
+"@parcel/cache@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/cache/-/cache-2.0.0-dev.1795.tgz#2d7a97fa5c276b6cff60561e38b91cb88a8e834a"
+  integrity sha512-RUkCwGK/2qpGFtZslaNPp+/uPnh2YsFVk2XoLpw3H0JY9K8dDawlkfhFKz0r5nYfUYvhFiO1QPyC+20NWX1ovw==
   dependencies:
-    "@parcel/fs" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/logger" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/fs" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/logger" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     lmdb "2.8.5"
 
-"@parcel/codeframe@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/codeframe/-/codeframe-2.0.0-dev.1789.tgz#60ce9718e8d7d472d472f2d1e8bbd9dc8af7e8ac"
-  integrity sha512-a6loCDmJHg/87bAL7+Nu4fN09ByXqO16vUGpO/YCZk0Ub6CypCqE7UX+t4OQFmpImGy52OkbuMSeAFNPKb+FyQ==
+"@parcel/codeframe@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/codeframe/-/codeframe-2.0.0-dev.1795.tgz#a9957966df6a4ac65b01f7ccf94db06414cf7bb2"
+  integrity sha512-xNk/Xw3mqo+qjmKrNKECqEmOILsrCBU40iUkldE0LgaRip9wR0fODtj2+KacP12ttCHbrgCdrela/AFV3FinKQ==
   dependencies:
     chalk "^4.1.2"
 
-"@parcel/compressor-raw@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/compressor-raw/-/compressor-raw-2.13.3-dev.3412.tgz#b61fa5341a51c28587e82c86f8dbc3e0ae3452ec"
-  integrity sha512-rF+LwyX8X9o48cIfVOZGl1YcR1VZlH/C0TkLab8yEDeue7PwKaVJczdJDR1z+1KHQt7bZRtAu+Thz/PjSeHP4w==
+"@parcel/compressor-raw@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/compressor-raw/-/compressor-raw-2.13.3-dev.3418.tgz#65823d6bf7d99611f2d8f6d75e3a9c5b9b2ffd7e"
+  integrity sha512-pz4SaczIsQhMiaCZUehoEXQHZJoBd/T5kvoOcbg7S1chS1CouIwlT6vY4bseRlXoprDBEmK07HCItPF2W2SX+w==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
 
-"@parcel/config-default@2.0.0-dev.1789", "@parcel/config-default@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/config-default/-/config-default-2.0.0-dev.1789.tgz#5dc90f7733cf5b49a62448dfe5603de47ce9c364"
-  integrity sha512-mfXeHjrCQaT+8N9TjAmNHq2rA7JPTux1hDjVg5A84gkwXTkO2V4j8GTARq6Bdz2MoH7PuKcDNwsU8eQpMzpTEg==
+"@parcel/config-default@2.0.0-dev.1795", "@parcel/config-default@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/config-default/-/config-default-2.0.0-dev.1795.tgz#bae822637ff74e20f19aca3d26348416da9180f3"
+  integrity sha512-iaXwuLUZJ/L31I5TTeFE/mq6FL6gw15Vh27oEb/KS4pc6eYMvZRzyrIDCEJ6vxpi8VO4r0ncc7fOQqroT+vGIA==
   dependencies:
-    "@parcel/bundler-default" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/compressor-raw" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/namer-default" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/optimizer-css" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/optimizer-htmlnano" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/optimizer-image" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/optimizer-svgo" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/optimizer-swc" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/packager-css" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/packager-html" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/packager-js" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/packager-raw" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/packager-svg" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/packager-wasm" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/reporter-dev-server" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/resolver-default" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/runtime-browser-hmr" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/runtime-js" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/runtime-react-refresh" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/runtime-service-worker" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/transformer-babel" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/transformer-css" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/transformer-html" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/transformer-image" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/transformer-js" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/transformer-json" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/transformer-postcss" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/transformer-posthtml" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/transformer-raw" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/transformer-react-refresh-wrap" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/transformer-svg" "2.13.3-dev.3412+0b82b13d6"
+    "@parcel/bundler-default" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/compressor-raw" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/namer-default" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/optimizer-css" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/optimizer-htmlnano" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/optimizer-image" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/optimizer-svgo" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/optimizer-swc" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/packager-css" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/packager-html" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/packager-js" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/packager-raw" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/packager-svg" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/packager-wasm" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/reporter-dev-server" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/resolver-default" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/runtime-browser-hmr" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/runtime-js" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/runtime-react-refresh" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/runtime-service-worker" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/transformer-babel" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/transformer-css" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/transformer-html" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/transformer-image" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/transformer-js" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/transformer-json" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/transformer-postcss" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/transformer-posthtml" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/transformer-raw" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/transformer-react-refresh-wrap" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/transformer-svg" "2.13.3-dev.3418+9f297b15c"
 
-"@parcel/core@2.0.0-dev.1787+0b82b13d6":
-  version "2.0.0-dev.1787"
-  resolved "https://registry.yarnpkg.com/@parcel/core/-/core-2.0.0-dev.1787.tgz#95c757595d4a9e6dbdf7a7efe3337bfc1c6bd616"
-  integrity sha512-yyLhl32e4e5cJLFMOPRIMiOZRxh9K7t/KU3E3wOok+BURevMFtPhDlLy94BbJAvYycCw91uiY1bQdyej+MPcQg==
+"@parcel/core@2.0.0-dev.1793+9f297b15c":
+  version "2.0.0-dev.1793"
+  resolved "https://registry.yarnpkg.com/@parcel/core/-/core-2.0.0-dev.1793.tgz#a911d743f26a3b15476936289b2c1847c21e6e9b"
+  integrity sha512-0O+crHFX4eoogpP/22sIPtjv4stNbzdeBZIoKqWl6Wndk63UdxVIEn6OvGokelgt/9qng9VoulMxAsrjKodemA==
   dependencies:
     "@mischnic/json-sourcemap" "^0.1.0"
-    "@parcel/cache" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/events" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/feature-flags" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/fs" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/graph" "3.3.3-dev.3412+0b82b13d6"
-    "@parcel/logger" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/package-manager" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/profiler" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/rust" "2.13.3-dev.3412+0b82b13d6"
+    "@parcel/cache" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/events" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/feature-flags" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/fs" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/graph" "3.3.3-dev.3418+9f297b15c"
+    "@parcel/logger" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/package-manager" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/profiler" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/rust" "2.13.3-dev.3418+9f297b15c"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/types" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/workers" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/types" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/workers" "2.0.0-dev.1795+9f297b15c"
     base-x "^3.0.8"
     browserslist "^4.6.6"
     clone "^2.1.1"
@@ -208,318 +208,319 @@
     nullthrows "^1.1.1"
     semver "^7.5.2"
 
-"@parcel/diagnostic@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/diagnostic/-/diagnostic-2.0.0-dev.1789.tgz#0be5c2e675c7488f79e26efc3cd8a77500ae3cf5"
-  integrity sha512-TvTGBOCIeRDgWShhKRL1G/p78kCrqEP7m6k2QHuY3tHWO7rsXr25zUDec4G/u0knpuUwxaivuX5f7b5jPPD7Rg==
+"@parcel/diagnostic@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/diagnostic/-/diagnostic-2.0.0-dev.1795.tgz#273e049c8f88a19e824c5edf097e391a5b87b0c2"
+  integrity sha512-uWhJ7ojynh8wL0wr4EcR2wDVCxalsaLunEF/IfIpuWv5F+wEc8cTLsd4eAGjzMOO5jzWP2pK5XSK9TbWl4hTpQ==
   dependencies:
     "@mischnic/json-sourcemap" "^0.1.0"
     nullthrows "^1.1.1"
 
-"@parcel/events@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/events/-/events-2.0.0-dev.1789.tgz#16776859ec582ed05dd24e5edd34a1f7e78170ed"
-  integrity sha512-jHuRvZrNerTjY7KvqVhtdZgyC4vv2QTE599Fh2EZeEXU7d+SQmDIoMeZwqUPy9Q8FW+SOVvgl1YQ6Mhc/NNyNA==
+"@parcel/events@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/events/-/events-2.0.0-dev.1795.tgz#d609260e0a6faa3bf0169936e770002c440e1f24"
+  integrity sha512-YREBS/8Yulm8wlZbwpbeez38BrOknSrjzBzj1nxL9gIoWLeB9c0zopZK0LFxaC+JDSzbtAsKYb94FoEe08Mo4w==
 
-"@parcel/feature-flags@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/feature-flags/-/feature-flags-2.13.3-dev.3412.tgz#e823b957d364158d7c189ba179ad20142b8237ba"
-  integrity sha512-GClA//tlUQHuiBe+Lw/zDP85Ri5F/fZshOZ9Z6q/x3CWrDmdZVwInkQWC9CYsILXPGU7b4ZW6XdEsB6Rbrnt+Q==
+"@parcel/feature-flags@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/feature-flags/-/feature-flags-2.13.3-dev.3418.tgz#2da678e6725449d7b70428073a0ef660d1c7dd3e"
+  integrity sha512-oTxIVXGJFjqTmefaugqV2nRsuXpN2aYTP/aJmm1mk06EyrkXTdAMrKoFsPimEshxvu8lGZ2fvZdF3pyWkR39FQ==
 
-"@parcel/fs@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/fs/-/fs-2.0.0-dev.1789.tgz#49c1b1a9e41ccf70334265adaec696e8f71ce92f"
-  integrity sha512-9dLlvCCUyY1g6A8tGfIx03Q/T1gZlKWjQ0n3Tla5HiWe+4QG5X0vuToOjVxr66Ju1GJImwj3qNzMv0wkmhj7mw==
+"@parcel/fs@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/fs/-/fs-2.0.0-dev.1795.tgz#1dc534e806cc81f79e9aab578fa01bdf63b055aa"
+  integrity sha512-bY417DPxe921P/lYKiZhBv0fwCtgm5x0vUOhd9xPlAGasQrtqSUMoBwLcRStHd8e1xMrxp9UEJDfESL5+N/UuQ==
   dependencies:
-    "@parcel/feature-flags" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/rust" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/types-internal" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/feature-flags" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/rust" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/types-internal" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     "@parcel/watcher" "^2.0.7"
-    "@parcel/workers" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/workers" "2.0.0-dev.1795+9f297b15c"
 
-"@parcel/graph@3.3.3-dev.3412+0b82b13d6":
-  version "3.3.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/graph/-/graph-3.3.3-dev.3412.tgz#3913c41f7052c73c4157ddf80b0d6c134e0d45c9"
-  integrity sha512-ADEMR+Bg+nIjaliyYCGUPK7iyiaNU0x3MNRylg9GMXoB4bfUqCGsWzpR4FYGbSUijVnDOfQfaoHZVI5hwopATg==
+"@parcel/graph@3.3.3-dev.3418+9f297b15c":
+  version "3.3.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/graph/-/graph-3.3.3-dev.3418.tgz#d62963b948b3ec3384ef6da136a23282c974736e"
+  integrity sha512-L7pOceNtP6dYx82MLrzMBe8uiUXPENoOaj/s6qCvPxjr8x6/Jo8qhIaz0f1htU1AtRMiTZjNL7Vw9Datwe8chg==
   dependencies:
-    "@parcel/feature-flags" "2.13.3-dev.3412+0b82b13d6"
+    "@parcel/feature-flags" "2.13.3-dev.3418+9f297b15c"
     nullthrows "^1.1.1"
 
-"@parcel/logger@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/logger/-/logger-2.0.0-dev.1789.tgz#fd1f9786210b10d3e3447e824fc17599b1cd7014"
-  integrity sha512-1StCxPppvriJLiI8bF/gmdHM00qnJTdq8vs83gA8l1OeL/g3LtAyRKznraRwBhMtagN5UB4JKBLIpPaUlTZlng==
+"@parcel/logger@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/logger/-/logger-2.0.0-dev.1795.tgz#23ea704050e7d43c36f74ca9bd553d75f04c369f"
+  integrity sha512-haIJ2HRDef8D44nznCToiMB7OkpV2Er8NwOPQm9aJDyl1g4Lqro7cd5tZgEySHe3TlH6r8UWd6+C2ob+ws/jdA==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/events" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/events" "2.0.0-dev.1795+9f297b15c"
 
-"@parcel/markdown-ansi@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-dev.1789.tgz#089789e3e6b4b272ad6e634f204a3da68dce1892"
-  integrity sha512-C4erPSJiVtHmbTf9LU9Q8fNwzdvZn9RPeZ8fbbl1k6vcCKBh7i/pTnKI/ijz/cFEa6ThBvim+0FR6BaBa9RtMA==
+"@parcel/markdown-ansi@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-dev.1795.tgz#410d31e4e7f178ec5039645e8a0e9fa318cb622e"
+  integrity sha512-HWYo1qJYcmtjKR6VAD4KHVjQ+30kGyxCTHt9oWqxLQeLakXKevWO6tR+htzxyAOH/YFwWeZr3cKstayoFnNkqA==
   dependencies:
     chalk "^4.1.2"
 
-"@parcel/namer-default@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/namer-default/-/namer-default-2.0.0-dev.1789.tgz#1260d41e9721e06d4caedaada52dbebe6c0f6f57"
-  integrity sha512-xKRfmUeGQXpxbAQR/oDRt0ti1bA6OcEmd74MCNQiJnRErNA/qqxiRhqaOYNfIXD80s2cWmIuFy1s1kRB1NiCWA==
+"@parcel/namer-default@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/namer-default/-/namer-default-2.0.0-dev.1795.tgz#a5f2957fed9b49c819d56d2be7b6e4e996b14176"
+  integrity sha512-nmbkhtDxaEEzKvAFbhZEX4A/qz35PtjMwIr79sGFmUir7APuITf0MG8d5L9NTXHMgtNXPq+0t1A1gjaCO6aC5g==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
     nullthrows "^1.1.1"
 
-"@parcel/node-resolver-core@3.4.3-dev.3412+0b82b13d6":
-  version "3.4.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/node-resolver-core/-/node-resolver-core-3.4.3-dev.3412.tgz#dcf90ac15ae9b2e397a57d75aaed625c1b5e0a42"
-  integrity sha512-tE8S192z/uiDxRgTs8TVw6+XylHsgv7IAkFWw1RfKaWQHxl5Pi57yM6MIl42tgChgcUfhChqf5qkZAiBPgaQ0g==
+"@parcel/node-resolver-core@3.4.3-dev.3418+9f297b15c":
+  version "3.4.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/node-resolver-core/-/node-resolver-core-3.4.3-dev.3418.tgz#cd25a6c86deefe2f4bc1007f26297c5518a196bd"
+  integrity sha512-qPpgrPc8KEQWbA9HrfNf9KiqFTHqO4YsMhD3DCtFenc5OJM5emt+a/ducqCW7e7W/az2kozhy/T9LJjYDP1PiQ==
   dependencies:
     "@mischnic/json-sourcemap" "^0.1.0"
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/fs" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/rust" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/fs" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/rust" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     nullthrows "^1.1.1"
     semver "^7.5.2"
 
-"@parcel/optimizer-css@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/optimizer-css/-/optimizer-css-2.13.3-dev.3412.tgz#6f1d7e6963a49d6586c00a57bedc0dfcf00a5810"
-  integrity sha512-cNvDfgS6Kp8Y+uEsWgm+I7wnuo6myntvY3cD5osvhybFitmmobosoqNL6aMmMm1onVxYH4QMgqOW06lT5ggmvg==
+"@parcel/optimizer-css@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/optimizer-css/-/optimizer-css-2.13.3-dev.3418.tgz#d0064debbe5b0fce075182d0c74836fec2b17ecc"
+  integrity sha512-i8Bl1dcl8+y275prrwzeJFnoovrev+GmOO4T0RMk3hZmcUW+lhUf1vtn/MENQ2sgfQKl8oD1KdMW6tvYeJ7g2g==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     browserslist "^4.6.6"
     lightningcss "^1.22.1"
     nullthrows "^1.1.1"
 
-"@parcel/optimizer-htmlnano@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.0.0-dev.1789.tgz#1874dd4677602ca89c76ca1c03712bf3ea4de229"
-  integrity sha512-sRCzArD9pwoliZ0h3KQN0ILKQpy9MyTJBuD8Ptwv/IakvwP0bg4dvisW5o3ELH2jyq9KSP3Gz/oJ2fQUF4xm8A==
+"@parcel/optimizer-htmlnano@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.0.0-dev.1795.tgz#f7d3345dbcec03df9cc5db5f9913404ffd6051be"
+  integrity sha512-+2upe/5VvEe0d0K9ZFMuXwzbvolCCwZlQcu/P4hPAJEM/fs6A6zS3RA3hiVc18LNNz4UEM8sYp9X59dFHzYQnw==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     htmlnano "^2.0.0"
     nullthrows "^1.1.1"
     posthtml "^0.16.5"
 
-"@parcel/optimizer-image@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/optimizer-image/-/optimizer-image-2.13.3-dev.3412.tgz#3918e075c24749d72f29e12e7ef566d8cbc690ba"
-  integrity sha512-w+IN2lmrX3f4Vk+WUg+m4hUKFl5ae+0mzXa+0u7MIIaqe136kfSBE53I2E5reqQVoieWybuUfnQYbVUANKjUXg==
+"@parcel/optimizer-image@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/optimizer-image/-/optimizer-image-2.13.3-dev.3418.tgz#69de333f47da2e32446db9d29a1c66aa63b04137"
+  integrity sha512-mQhZLFCPLwjUUVde+obImTy6mVSOF2z/VIs8n94BVOAVz1L/sksWON4eRF3tCdpi43kK7Jr/hHn53gIaveZu7w==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/rust" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/workers" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/rust" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/workers" "2.0.0-dev.1795+9f297b15c"
 
-"@parcel/optimizer-svgo@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/optimizer-svgo/-/optimizer-svgo-2.13.3-dev.3412.tgz#643b3596957e163e2c143ca8abfd74ed29489ccf"
-  integrity sha512-Qm+5F5iFtymzDpR2szA/SrdZgfMrTBmQxFee92XHxGjjlyIujcfBspCMLxkGb5HwUcqgbc+dIXOmOlf4FROCMg==
+"@parcel/optimizer-svgo@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/optimizer-svgo/-/optimizer-svgo-2.13.3-dev.3418.tgz#1cd24b71a179a2ffd928f385ace5f4c8697bf795"
+  integrity sha512-+oGOLNwMtgYo1Vo4lzSOH9LQLekFkHaVmBq+B5WljedbszI2MklYBdrrEzBagjRzIYqinxB4j9t8DaLRvOeYag==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
 
-"@parcel/optimizer-swc@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/optimizer-swc/-/optimizer-swc-2.13.3-dev.3412.tgz#49821dd7bdaf0f5f4f3f283f2986fa03fb0558af"
-  integrity sha512-hpHkrFOyRNRzAfjPpFgJpICVSOmIgfFc3+toR3O8vpV4vhQu8O6uZaRlIt+LZR/5FFI8kVA0RVPkUmTiYg4Arw==
+"@parcel/optimizer-swc@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/optimizer-swc/-/optimizer-swc-2.13.3-dev.3418.tgz#cef3f416ba4e18edf66d18f5c1cd2b374cd6b502"
+  integrity sha512-mMUZCrY1g1xCgA5VdnucDhUefhQY0pS3rJht3pxs3ifj7AJnmTJzZeY2wj8KdmjrOrRLTqSiQa+ESyNg6q8aqg==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     "@swc/core" "^1.7.26"
     nullthrows "^1.1.1"
 
-"@parcel/package-manager@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/package-manager/-/package-manager-2.0.0-dev.1789.tgz#1b1282ffb5e2a51998c095fdb0ef6b400cef14c2"
-  integrity sha512-6lZLvyS6W1i806rWXCj4GywmFKc2zt1s2Tk0sSI+tmyj1wZvYq3iBwhBYsZ9xFikec5eDS2oXfIITD0bnbDYxA==
+"@parcel/package-manager@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/package-manager/-/package-manager-2.0.0-dev.1795.tgz#b76fc0398561e66f369f47bc960ca706b640e5f2"
+  integrity sha512-SR0LhO3CXNjKb1ufC+zwl1HvpIfWTRLey1MZ0sx8e+wmpJAzLFoFvjJb9ve3/gPEM3Wu12J30JizZ9ZPM5b7Yg==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/fs" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/logger" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/node-resolver-core" "3.4.3-dev.3412+0b82b13d6"
-    "@parcel/types" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/workers" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/fs" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/logger" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/node-resolver-core" "3.4.3-dev.3418+9f297b15c"
+    "@parcel/types" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/workers" "2.0.0-dev.1795+9f297b15c"
     "@swc/core" "^1.7.26"
     semver "^7.5.2"
 
-"@parcel/packager-css@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-css/-/packager-css-2.0.0-dev.1789.tgz#8d076a20f628b021bbc25b8ede1e2f28cd518c2c"
-  integrity sha512-Oqq/9o+q/COi1k8pD5529XZJUR/n3QNLi0Rlvfclb1PFBurk21WL3huFlii1MXqdtxN0KqP8m9GMpbic+km7BQ==
+"@parcel/packager-css@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-css/-/packager-css-2.0.0-dev.1795.tgz#80a17e214d0e4b51c48daa45546e64c2c3a6ac3b"
+  integrity sha512-xDdNaDvriZ91s6EPTRbT9qUOYimXNHhlQ/rHuIDyiWhJSL3nHdGvljvJa2olZqDgafeU34ewqo7sVGqG9Ts5lg==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     lightningcss "^1.22.1"
     nullthrows "^1.1.1"
 
-"@parcel/packager-html@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-html/-/packager-html-2.0.0-dev.1789.tgz#cb9c0e83c2a63283eaa25848e89ab608f6c63f82"
-  integrity sha512-jz14m6z5PoE5W58hzbWhle4A/TH5y4X9JTIume8ts13P+xbcSLpCxzqVT9OglleHIxlZbseiKG1PRBaa/ZDh8Q==
+"@parcel/packager-html@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-html/-/packager-html-2.0.0-dev.1795.tgz#3bc7a3c7ce970b0f5ad0f23a0367b0f16576f5ac"
+  integrity sha512-4Q4UJt3VP47GzcXg3bZwjOGNehkfRJw9YhfnOUzWQMr/+LTk0/syY7DAP3e7gUchchBLpaCt77tY/j6bLIFgtA==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/types" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/types" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     nullthrows "^1.1.1"
     posthtml "^0.16.5"
 
-"@parcel/packager-js@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-js/-/packager-js-2.0.0-dev.1789.tgz#7b8f38f05c4fc83b31770aec0fb2b3b0624f515b"
-  integrity sha512-MSbdZsbD56258/okHC+D8PsSNyz5ziD6I6dEx9bOTq7x8RjFowa9yQS1fcN0ua+kSqqDkKk3B3lX6+jxvFeX8w==
+"@parcel/packager-js@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-js/-/packager-js-2.0.0-dev.1795.tgz#3cbd0720ee774188a8e2ef3d5547efd36d0bda9a"
+  integrity sha512-XEyYQiop3Y5/R2vFFcxpsVXbnmMGb4YYGKJC1XJOgI2MrNZL053s5Tk9AIMCYE94MfX/TARbiEonrO2jbISx+A==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/rust" "2.13.3-dev.3412+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/rust" "2.13.3-dev.3418+9f297b15c"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/types" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/types" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     globals "^13.2.0"
     nullthrows "^1.1.1"
 
-"@parcel/packager-raw@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-raw/-/packager-raw-2.0.0-dev.1789.tgz#017048d8cee41f6971c57f3ea9021f5cb76fc54b"
-  integrity sha512-dwWwzxp8rL9x5JLoF8gOukKp3cWXn4UpfwPEo1lgCElYRO+QEdui4mWPT6Ci8WAK4Nr/kDY6PqX4Vyf/erJpvg==
+"@parcel/packager-raw@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-raw/-/packager-raw-2.0.0-dev.1795.tgz#549c8a54f8fd5b6a693149508a118023afe1f66d"
+  integrity sha512-T9Dp9Qt5JREDD1N21QRfEEKMCuxZ0pa4G34J14sI7QTh2hDPDqeeFWYMkE0Pk+Yn3w2pWfS+Qod1DuRvm6WFZg==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
 
-"@parcel/packager-svg@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-svg/-/packager-svg-2.13.3-dev.3412.tgz#f6a8928c06347c1286bbfd9fb92f019cf9a9fd63"
-  integrity sha512-kUNENa6nhT84a/8L5u+S8MiN6EUVKiRdlD8aYUF0xxbiTYvt/uDboUxvHHPZuoNp9I1TmQqX7sQ1yivEVIccyA==
+"@parcel/packager-svg@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-svg/-/packager-svg-2.13.3-dev.3418.tgz#4c6a6b06d87955c444f2e1d861b80720ba02e816"
+  integrity sha512-RxeL6JRXld+SPTqds0mLswsgKCvkarM8pyBBXJLvP5a8G2jmc7OkgkaYonORz8EXGJCH21JAP6mxbwq4EjsuQQ==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/types" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/types" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     posthtml "^0.16.4"
 
-"@parcel/packager-wasm@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-wasm/-/packager-wasm-2.13.3-dev.3412.tgz#c7eb96fcb65bbf1e550cadd8d05f521fe4651644"
-  integrity sha512-b3mYX+TOYySN0KGLOe8Vz+eas2vNGnF2qLvrd3h8FvrgxUDiOaWRFQZ1Ep13/+8VyIbSrOuTVznau7jz4Ee2Cg==
+"@parcel/packager-wasm@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-wasm/-/packager-wasm-2.13.3-dev.3418.tgz#ecd6dc970e10b805be6768ecee28a795f79130ec"
+  integrity sha512-XNIiDGbf8ZMyqxJYYQq2TrshMbBTDU5DdC9V7ByS4EuPpr9DjNhZWa7NXzU5rfze2b/sNyL5Y9w52wIU2JNMEA==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
 
-"@parcel/plugin@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/plugin/-/plugin-2.0.0-dev.1789.tgz#b4678e9197352e1e6b734913580ee826f10d2f5a"
-  integrity sha512-zxWiQ/aXiD6qYPPs8Q0GQd+sYWJcDuOQPc6wuDFxehiBw1+cEL5EeJyKCdeh7HoYuCZHDEnKjK+f3k511zTzTw==
+"@parcel/plugin@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/plugin/-/plugin-2.0.0-dev.1795.tgz#6ad492e83bc6cef4c3c360fc0dac3f6bc61d3631"
+  integrity sha512-2lj8IU3DHZvoBbKbuRwDr8s+ktPd8EOMIZZZ8bWuQ28mGCE5HaogbU7mHuzJqbSzcd9GnxPqSoKSA7msv1jDew==
   dependencies:
-    "@parcel/types" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/types" "2.0.0-dev.1795+9f297b15c"
 
-"@parcel/profiler@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/profiler/-/profiler-2.13.3-dev.3412.tgz#a271b4402150ae19534ea19f9c25d7f61663eaf5"
-  integrity sha512-a6btgthz0hRDy6ASQgGb/HQSxvrV0B5VfVYkL+QjTSdcybXklMTrP0qHHBoUkOWCpJ/xePvu3JzKhOlc76W2hw==
+"@parcel/profiler@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/profiler/-/profiler-2.13.3-dev.3418.tgz#551a2b7d8181c971ea4912919094bfa5d3fc65e6"
+  integrity sha512-AisnQYasAaJNqepRnihs50SEtO+hBUKoX1BzJ/ha63MAnB5eGRXilHjjjVgGPcvthn89II+NtejNp0eiiXeYBQ==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/events" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/types-internal" "2.13.3-dev.3412+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/events" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/types-internal" "2.13.3-dev.3418+9f297b15c"
     chrome-trace-event "^1.0.2"
 
-"@parcel/reporter-cli@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/reporter-cli/-/reporter-cli-2.0.0-dev.1789.tgz#d5822f505bbdb1fe9d460015acc4c44b0666c37e"
-  integrity sha512-M6J3P/eVfQXCt4+VcQVS05AB5IyH7SmI9iPTKH9E30gORdndciydgQLsdoU/nx1N2c33x41P/8hHfpqUKzGvHg==
+"@parcel/reporter-cli@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/reporter-cli/-/reporter-cli-2.0.0-dev.1795.tgz#f449ac4fb987dd36367cd6a137e2d61ebf23d39a"
+  integrity sha512-KdF4fTodClz/SBCmTgn1s3hF8FRDFLMiOArNF4zzpwYR7LqVb21fD6uCzdKluqR/dC8S6bQvyjKdYDxKbEuoGQ==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/types" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/types" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     chalk "^4.1.2"
     term-size "^2.2.1"
 
-"@parcel/reporter-dev-server@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/reporter-dev-server/-/reporter-dev-server-2.0.0-dev.1789.tgz#86377aeffc57539732624ca56ea74ec7042ce783"
-  integrity sha512-8Xmh8YEd9QN7TgwicOSsL2Vdtk5JWoXu4lIvLLn96ux8pHs8ReVE/r2o29xsIwy43uhRQbwYSX8tG1FDxUnuiw==
+"@parcel/reporter-dev-server@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/reporter-dev-server/-/reporter-dev-server-2.0.0-dev.1795.tgz#b5fc225cdb1f186003bbf862c61842358c002752"
+  integrity sha512-cot7qGAkujf/XMIH/jk2NY+agxgXO+PG8YrbCn3Tul/Gm3bYy5pc2XCuMYqyRHAIWe3wKLuHba2RHMR4WgZitg==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
 
-"@parcel/reporter-tracer@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/reporter-tracer/-/reporter-tracer-2.13.3-dev.3412.tgz#f953447f6132a69895fbc27f65fb3d2ca541071e"
-  integrity sha512-oKoact1zmzW6bcbAg0X3JVZ2zZjovFqpTc/6P2vdF2FiBAwaafq4RdTRPdAh8z1YnqJU3Kh1ONaY+wfTzxCtYQ==
+"@parcel/reporter-tracer@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/reporter-tracer/-/reporter-tracer-2.13.3-dev.3418.tgz#7996aae33b5e3776bd2c1f61bebac26263bc3536"
+  integrity sha512-SpTrCT51wjYMPqlRPqKAx6rXpUGx3rkfYov97ID1K17z1KoWqIkZPvjDrTRD01aEz9lLHF4Ywc5beaguVwecJA==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     chrome-trace-event "^1.0.3"
     nullthrows "^1.1.1"
 
-"@parcel/resolver-default@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/resolver-default/-/resolver-default-2.0.0-dev.1789.tgz#54bfa782a4dc687ce3c9ca9c2d80f37b176a28df"
-  integrity sha512-h6YC6BZJcNFW1Wz7x3PXFyFTjyrPfjybtmObEUWgFQVkqwGfGRiNfpQqdNDNeABeE0Fn46dX/FymQ7u4LzQPVg==
+"@parcel/resolver-default@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/resolver-default/-/resolver-default-2.0.0-dev.1795.tgz#684e45e1d92847882332a3b61fde91bd58b831d4"
+  integrity sha512-0oXyPHEWf6fLrLe1FDN7fwhnKB/QmMw4di1wosxRHtyfTgIa/hs+r8hK0n5Jqy3JzmMlwgBr+p4gwnxOLPK/KQ==
   dependencies:
-    "@parcel/node-resolver-core" "3.4.3-dev.3412+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/node-resolver-core" "3.4.3-dev.3418+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
 
-"@parcel/runtime-browser-hmr@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.0.0-dev.1789.tgz#c5ba22bb7afeb3ad8acc48d47176fd57f1fb33e6"
-  integrity sha512-0Kqd2Wlc+piflkz46YIEz0+FglS6BBzyREW0e8rYbD2BHlnunbifl7E4e899UdfWSjRUFa1brHlUBFjidGwQgQ==
+"@parcel/runtime-browser-hmr@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.0.0-dev.1795.tgz#c2c72a056b53c43e4e642197382e885f0f17425f"
+  integrity sha512-L0VpGl6D92WOsoF98eesLg/09VnGUr/14TlDzh0G7tRG+LHXcg0o/6vsGzVLKjR6yXQHuc/6SepbY2U5NsQNNg==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
 
-"@parcel/runtime-js@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/runtime-js/-/runtime-js-2.0.0-dev.1789.tgz#324661b5976a8ef982fd53dfde20ebc1b84c03f8"
-  integrity sha512-2mxG1sZgTDoMddBcrRa/vaqUaVtMUw5Sn+DonubGn68SJdQ9JWzJt5dmpy2mbleCBlFjRI5X8jjNfvbFciLkAw==
+"@parcel/runtime-js@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/runtime-js/-/runtime-js-2.0.0-dev.1795.tgz#e0843dbeb6d2790bf4221c9128125eb208f46c06"
+  integrity sha512-np7fz79T7zxIuzZOZIgUpeLy297r0pkHQn0TfGvXs16m7Yz3KGOXsYe8gJGLfhsJk2JLOZ0PQsLvgXRfyKDoxA==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     nullthrows "^1.1.1"
 
-"@parcel/runtime-react-refresh@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.0.0-dev.1789.tgz#08d92779681acd628a7e86284c3c13338723e0b4"
-  integrity sha512-3TCh5PHa7e+NQ4ZHCDPTZNrOiV1BDJdl7zFkjMyl8BWOa80cJbt3F0PrF5xx+VVQ3LtMoQH3RtjsvyfoHlhn9Q==
+"@parcel/runtime-react-refresh@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.0.0-dev.1795.tgz#06469b97471044fae8528dcad4e39c51b4945e8f"
+  integrity sha512-UQHDuBOTC0lsoFmyTD7zELmErVvt9wge5yeqLrB59yYvK570MrU/ujkyCECCOIf5IojbNn7GI4rmntO3SEp4Kg==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     react-error-overlay "6.0.9"
     react-refresh ">=0.9 <=0.14"
 
-"@parcel/runtime-rsc@2.13.3-dev.3412":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/runtime-rsc/-/runtime-rsc-2.13.3-dev.3412.tgz#434cc6afeff78027b6703af5ef27fdbbddd3d6df"
-  integrity sha512-kz+kJWJkQhEDIcnJhiG5PbG2zX4hRkwwiS7aIbby/9rMHexaENy54KMA6+PbMLXZdSlq42HvUSPyW3nHOz7+ew==
+"@parcel/runtime-rsc@2.13.3-dev.3418":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/runtime-rsc/-/runtime-rsc-2.13.3-dev.3418.tgz#288351ebfb2b89a8b9fb6ebc880480950a97c8da"
+  integrity sha512-uBs80TXnx3rlauNeolYwfrrvLNjQgkM0ilxXmE2636hEhI6TRUWR86s/DoLKx/WFW+A7oAxSgXa4LUXPhiuQhA==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/rust" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     nullthrows "^1.1.1"
 
-"@parcel/runtime-service-worker@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/runtime-service-worker/-/runtime-service-worker-2.13.3-dev.3412.tgz#c59e6ce37e8e961d2f14b8bc03a5818a9f905cf7"
-  integrity sha512-okUqDtRuFAknQpg7EhmOYvqCn8rTWAW3Ldcv/qD5OzfcQPAI/kmAACDEf1UOWzv7+SCKs1ihRZZ0AfW//j0VJQ==
+"@parcel/runtime-service-worker@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/runtime-service-worker/-/runtime-service-worker-2.13.3-dev.3418.tgz#5a55a63ecbe338f6950899db69b7319957a14490"
+  integrity sha512-ptW3S1klF5XBcMVInmuXYvYzJMFoTTB/0U56knKDq2dvFBbsLtHdTR+oMREzv0sqkT/UeT75uC5gLTYnqogvKw==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     nullthrows "^1.1.1"
 
-"@parcel/rust@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/rust/-/rust-2.13.3-dev.3412.tgz#40016415f749f2d52b46e9bc32522b45e6f176ad"
-  integrity sha512-Bqf7lcrs+FDZ1bUASwPTBC1SYKLO+8fjcP9VzTHHH0xgcv9wAVslzLwn2S3763rP3sZeQHlXLabO4nDUrqfxQw==
+"@parcel/rust@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/rust/-/rust-2.13.3-dev.3418.tgz#8fb1db9f7c361f4d08476380c0b823b84f9107c8"
+  integrity sha512-HcwkHle9XCqg3rXv+sQR5LcoiSJAoGNWrOC5Abz3ANev8frisLnHqL6foFT1nCmEWQ8QUluBYJfNgv1DZ/aVxg==
 
 "@parcel/source-map@^2.1.1":
   version "2.1.1"
@@ -528,41 +529,41 @@
   dependencies:
     detect-libc "^1.0.3"
 
-"@parcel/transformer-babel@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-babel/-/transformer-babel-2.0.0-dev.1789.tgz#559177c6236a0b65ca9a22fbfba108030cef7534"
-  integrity sha512-PLkE6NQGJfydZ+juCESwTbMrinfKwGYwEeYganBKmWCccnYUgSqKF4QWab2sMMXvXNnyazgE/NzPmgyBQEtW4A==
+"@parcel/transformer-babel@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-babel/-/transformer-babel-2.0.0-dev.1795.tgz#f9612f6a224ddd0cb149d45e8ae4f5bf87c73c44"
+  integrity sha512-VpLZDimLWosfUbuqgcJTj6Y/3QETmZdJtb3JRAP1hc0EDvYsWkvUcCDe7CzYeYFsMSA8lAZxWmU3mG5Fp8h9pA==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     browserslist "^4.6.6"
     json5 "^2.2.0"
     nullthrows "^1.1.1"
     semver "^7.5.2"
 
-"@parcel/transformer-css@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-css/-/transformer-css-2.0.0-dev.1789.tgz#b9144e0bcb7bfd0e64c0768bbb36d2a3c6b985ce"
-  integrity sha512-TB0KorHhRHJ5C5AWdbXpbwao0g1rzQj0d/ptieoQUip3IBzEUjJn99YqpOCJI6AeOHZYMMcfUkdCEy7Aghk4Aw==
+"@parcel/transformer-css@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-css/-/transformer-css-2.0.0-dev.1795.tgz#bc7a59f7de7ec4b3cba2ba174c0f5e5c0cfaf35c"
+  integrity sha512-nwiES/2DD/pmzZCj1enfmfloC2ehKoGZ6vr5XKEM7y+ld42Hea5UT0sjinJHoV+Xuk6pkcOa1j1Vb8d4JURgTQ==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     browserslist "^4.6.6"
     lightningcss "^1.22.1"
     nullthrows "^1.1.1"
 
-"@parcel/transformer-html@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-html/-/transformer-html-2.0.0-dev.1789.tgz#ac382abafdfc1c4bb4de8a7bf7c0423084f67e69"
-  integrity sha512-HDeTR0ah8mtHalB65BkbmUR1Xgi2BJmZNTRvUn6x3Rd6qS4YUzuAA5en6k64XruZOwP5nvhnkWR1Lwa/h9XfBQ==
+"@parcel/transformer-html@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-html/-/transformer-html-2.0.0-dev.1795.tgz#cc5fa7398b51e8ddf08838677255b74cdae1118c"
+  integrity sha512-hlnc1KfrLNlKndDa5wXOY6EVKJjbeTQX2/d5w7eifSbDBW7yejDq1k2PByVZpitJ2dgO41NXMeDWSpvZt36G1A==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/rust" "2.13.3-dev.3412+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/rust" "2.13.3-dev.3418+9f297b15c"
     nullthrows "^1.1.1"
     posthtml "^0.16.5"
     posthtml-parser "^0.12.1"
@@ -570,126 +571,126 @@
     semver "^7.5.2"
     srcset "4"
 
-"@parcel/transformer-image@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-image/-/transformer-image-2.13.3-dev.3412.tgz#acd31d217748aa5ac95c7aa1562da47336e2dce1"
-  integrity sha512-A3958b4pQYcSPYwdJn7oHPdGe7LXF7LC9kq/HA5jIcnY5iWqpmeZ0E4QxjuZcOCcMdezUTl9VOKy1Lo++g4YLQ==
+"@parcel/transformer-image@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-image/-/transformer-image-2.13.3-dev.3418.tgz#a8153a7d94c9e6ddc49ff0a0bb41b645a4a5459e"
+  integrity sha512-lXkkCWbhuYd0UWm3zwVAIoC6B8fvyRacDkbhjhDO96gs7kmZPh369P4rlh03HeoOJlgTcpuvIH4LcnoVeccUSw==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/workers" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/workers" "2.0.0-dev.1795+9f297b15c"
     nullthrows "^1.1.1"
 
-"@parcel/transformer-js@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-js/-/transformer-js-2.0.0-dev.1789.tgz#bbd1a08f14d153a422ae2b1d8221e2af44a2a2f4"
-  integrity sha512-FxdroHko0GONty4gM8lJ8gmftwFw+rRX+4m2i4fMOZ+ekARLAoSiQ7uhob2PcIuNeOPvzeHxjV6eg2F9skUasw==
+"@parcel/transformer-js@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-js/-/transformer-js-2.0.0-dev.1795.tgz#741ee51638cbd8787f7a0903aef670382ecad19f"
+  integrity sha512-7ZxmALPqcI/B1Ywg835qwicZlmE5is2bbPYkjx7Pjc3MB5q+GKTwz/iWEjTS5AbZkKw9Db3QXp/+dubFoLSI4g==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/rust" "2.13.3-dev.3412+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/rust" "2.13.3-dev.3418+9f297b15c"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/workers" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/workers" "2.0.0-dev.1795+9f297b15c"
     "@swc/helpers" "^0.5.0"
     browserslist "^4.6.6"
     nullthrows "^1.1.1"
     regenerator-runtime "^0.14.1"
     semver "^7.5.2"
 
-"@parcel/transformer-json@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-json/-/transformer-json-2.0.0-dev.1789.tgz#3f712d8e1343d65e5f92898d4c47723cfc10e877"
-  integrity sha512-1u7UowT1KhzNviHJnhdHV8aULBM0JgOk9vOIAe+7aVXvl5SGQSO/s87oAxUcIodKePqkRIBU27dqf2i3VHBuoQ==
+"@parcel/transformer-json@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-json/-/transformer-json-2.0.0-dev.1795.tgz#a5215f863cab73d58e66d9466e45da145879cddd"
+  integrity sha512-2oKPaX2oFmynkMN8pA/BnrssnNL5xWuh6nKW5qqX/n9R7GoGIPAJ7iZrsFlU5vPLw2nsz1EDdhv4R5ydZK3a+Q==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
     json5 "^2.2.0"
 
-"@parcel/transformer-postcss@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-postcss/-/transformer-postcss-2.0.0-dev.1789.tgz#19ee839823eda37940b1edef6c81c4074894e695"
-  integrity sha512-zzMXmUblf/4VrKPukvqM+24vTFx+W/x0POJwUJ9vcer+e2FV9gAPcYvMMdEHbqNoO6dcs7J4o/DnmqgCDF3IrQ==
+"@parcel/transformer-postcss@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-postcss/-/transformer-postcss-2.0.0-dev.1795.tgz#0413805bb09bf22227b15bfcbb817142d7a9c6ce"
+  integrity sha512-b2+r8gMtGczhEuUFJmYi8Joo0TEN+8VD4mMaQxtUbz3cNdJxDVWjD5fLQNJcbWFzEsAv2aU5eXJ1dGU8vofd5Q==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/rust" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/rust" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     clone "^2.1.1"
     nullthrows "^1.1.1"
     postcss-value-parser "^4.2.0"
     semver "^7.5.2"
 
-"@parcel/transformer-posthtml@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-posthtml/-/transformer-posthtml-2.0.0-dev.1789.tgz#ac9f937485a748bf3cba1fb689488093ecb0e7db"
-  integrity sha512-JNx5LhRh2W0D7pACy1APzr00EH/Lxm54p5BT0B+fAVavuQvyHdYjtLS1L/B3wBKIPQNJNqkgjatebH/OnGrZOQ==
+"@parcel/transformer-posthtml@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-posthtml/-/transformer-posthtml-2.0.0-dev.1795.tgz#787682376cb01bd6d8811246619881af2e7cd0a7"
+  integrity sha512-9lrdDY1pIQtRMkxe8r0EghSd+7hFEyU3xb2nNO68m9Eut9zHjZo3p1As6rKp6eJ5ZqZxOJYj4xhqymwc5Evi4Q==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     nullthrows "^1.1.1"
     posthtml "^0.16.5"
     posthtml-parser "^0.12.1"
     posthtml-render "^3.0.0"
     semver "^7.5.2"
 
-"@parcel/transformer-raw@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-raw/-/transformer-raw-2.0.0-dev.1789.tgz#0e2c5f826dabe7f929e06b54e1e91f1efec4e2c9"
-  integrity sha512-LKq8UFFmERO4be0rjPkLC4yziXDMRbule7l6mSXMCh3t+TIlGu7K/8SWLidNQk8C8yxePt6sl5MYsend7rbYLA==
+"@parcel/transformer-raw@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-raw/-/transformer-raw-2.0.0-dev.1795.tgz#97edd45f72b39286aa1d79601912ea68c127448a"
+  integrity sha512-pg6/3C3kFLbWghdE7v4OdMRDvNIhSLhYy4AGOI+6KbPtVCI/0We1ZCSf1ciAluYbq7/tvYJhUuwGLukrdxTfDg==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
 
-"@parcel/transformer-react-refresh-wrap@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.0.0-dev.1789.tgz#12371b903f77de2d27aed2ddbf4cbdacbd3713e2"
-  integrity sha512-nk9d4/XSv0kTrvEN0Rt8KbZrMpHRlPOlMvqlpRx+gGIZabT/XL67wg6CgzoVT/fLOF50B/9hHIs/ecpQQnDHGg==
+"@parcel/transformer-react-refresh-wrap@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.0.0-dev.1795.tgz#96fc5b5ead89eae1d6a23690bc9b63cfd2f7bb11"
+  integrity sha512-OT41I1Y5anyvy6ocnzsgfvMi71J/DUlgcu0X1d3eRl3ui4ACmXB/NkzZr4+EmCFKgE8cp0UR67y6OpoIYFP79Q==
   dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     react-refresh ">=0.9 <=0.14"
 
-"@parcel/transformer-svg@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-svg/-/transformer-svg-2.13.3-dev.3412.tgz#76679120fb7599f27e2dd86c7b75108c97e58f83"
-  integrity sha512-A9tRc+OjjZ5/UA0Ej6SHj1Rim7ue0379duV3mgk+VduvfEIZ1GQjgKgkrGpMJDZ/pPsoM23GLjLa/ZyYOFbV1A==
+"@parcel/transformer-svg@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-svg/-/transformer-svg-2.13.3-dev.3418.tgz#17556f8fbb5a972dc01fd1c43aa26be1ca539460"
+  integrity sha512-AkrAKTdEU0L2Hoz7CPjTg81ChroffpoX71RZffmBAcFi0vkpBMlFzvITjrbV1dC+OtQ5t/+gnmZnowSpZBgU+A==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/rust" "2.13.3-dev.3412+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/plugin" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/rust" "2.13.3-dev.3418+9f297b15c"
     nullthrows "^1.1.1"
     posthtml "^0.16.5"
     posthtml-parser "^0.12.1"
     posthtml-render "^3.0.0"
     semver "^7.5.2"
 
-"@parcel/types-internal@2.13.3-dev.3412+0b82b13d6":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/types-internal/-/types-internal-2.13.3-dev.3412.tgz#47bbe12a0a9b51d6c11fed394e98af61c05d95af"
-  integrity sha512-EKVDGRxLamtSeH7xAZUciz8eH5zQCExnhqlQNtsRB+9jFoz5hGlsGOX6U7rimSUbe6Hw1DtX9jo5SqtyVRZ+ug==
+"@parcel/types-internal@2.13.3-dev.3418+9f297b15c":
+  version "2.13.3-dev.3418"
+  resolved "https://registry.yarnpkg.com/@parcel/types-internal/-/types-internal-2.13.3-dev.3418.tgz#76644a7b21bd78e654134be6679afd6a727bb4db"
+  integrity sha512-B0L3jAMe6tAxB22p2UZwJQGl1FRte9ikLJw4fcPJbszcv5MRLnszISNcSgJQN99hM5ISu+bRMioMksZ2FrDIYA==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/feature-flags" "2.13.3-dev.3412+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/feature-flags" "2.13.3-dev.3418+9f297b15c"
     "@parcel/source-map" "^2.1.1"
     utility-types "^3.10.0"
 
-"@parcel/types@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/types/-/types-2.0.0-dev.1789.tgz#58f406fb572bd3687025bb34fcbdb77f6cf1b47a"
-  integrity sha512-Jh6mHW1HPfwg/CRcNfQoZM9hr0nXvQhSXG+/AUxczcxYzc/KflReYHzyk4du4Z3dS/m9QT+3arVvbVhnZLsOeA==
+"@parcel/types@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/types/-/types-2.0.0-dev.1795.tgz#1f1503870d97245d1dc82263306cbd25d4313a5b"
+  integrity sha512-VojyhwPI2L54XMJ45sHFnMm8T75zhQKjhB6tlARWA02sDveCfvfBONfJY/r+O1poeel42Gci+bLanri0s3GgTg==
   dependencies:
-    "@parcel/types-internal" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/workers" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/types-internal" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/workers" "2.0.0-dev.1795+9f297b15c"
 
-"@parcel/utils@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/utils/-/utils-2.0.0-dev.1789.tgz#5f9f208359fbf85c84a07102be6a34dc28bbf7af"
-  integrity sha512-SeTQr4rWpvq/yjp5kZrACvewMgz/Q5QuekSlEViICPfsI1L9BNfnNdacAbqOTpsZGW/p/RVobEamQqjIjzhBTQ==
+"@parcel/utils@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/utils/-/utils-2.0.0-dev.1795.tgz#12aca94ddd344170b5b1081c012bb524f37ebfda"
+  integrity sha512-JjleEfv9NJD02AOPEOjwMVr5h0SZdtTocQuQBS4S+SC6Ql9ZdiUArE5jXVbUCYmyQnfjG7FYfajzrFnfnA9Uqg==
   dependencies:
-    "@parcel/codeframe" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/logger" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/markdown-ansi" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/rust" "2.13.3-dev.3412+0b82b13d6"
+    "@parcel/codeframe" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/logger" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/markdown-ansi" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/rust" "2.13.3-dev.3418+9f297b15c"
     "@parcel/source-map" "^2.1.1"
     chalk "^4.1.2"
     nullthrows "^1.1.1"
@@ -783,16 +784,16 @@
     "@parcel/watcher-win32-ia32" "2.5.0"
     "@parcel/watcher-win32-x64" "2.5.0"
 
-"@parcel/workers@2.0.0-dev.1789+0b82b13d6":
-  version "2.0.0-dev.1789"
-  resolved "https://registry.yarnpkg.com/@parcel/workers/-/workers-2.0.0-dev.1789.tgz#d9cbfac188ff6d87858735ff23d304be03060bbe"
-  integrity sha512-qtjpw3tfoK8Mr3jbF4YISwYqwRIpAeKhpnSX/r73Jz3iVbCvi+WuYv26A1CexSkc4jGWGnXJRAEQSI/4h1vYuQ==
+"@parcel/workers@2.0.0-dev.1795+9f297b15c":
+  version "2.0.0-dev.1795"
+  resolved "https://registry.yarnpkg.com/@parcel/workers/-/workers-2.0.0-dev.1795.tgz#5d7840b90cc80a1f01619ed676a744f6e3524af9"
+  integrity sha512-MiW001+79Qox78Xy7bNBGKWB2PdurL5qdrKxLdKnIU41mZ5ki5tg4cxsgf9+H5KTp4Y8MnLqOh0yjD/8ujdB8g==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/logger" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/profiler" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/types-internal" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/logger" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/profiler" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/types-internal" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     nullthrows "^1.1.1"
 
 "@swc/core-darwin-arm64@1.10.1":
@@ -1872,23 +1873,23 @@ ordered-binary@^1.4.1:
   resolved "https://registry.yarnpkg.com/ordered-binary/-/ordered-binary-1.5.3.tgz#8bee2aa7a82c3439caeb1e80c272fd4cf51170fb"
   integrity sha512-oGFr3T+pYdTGJ+YFEILMpS3es+GiIbs9h/XQrclBXUtd44ey7XwfsMzM31f64I1SQOawDoDr/D823kNCADI8TA==
 
-parcel@2.0.0-dev.1787:
-  version "2.0.0-dev.1787"
-  resolved "https://registry.yarnpkg.com/parcel/-/parcel-2.0.0-dev.1787.tgz#036c9155b5daf942e5cabaa6738bc8ea96d2f8fc"
-  integrity sha512-u6uPbkrrhHaTBm7d5RLP9VMgjJkFs23QAMLkqAFcM+M2WQRfb0S6sW0jksRgheEOvpkOlxLgJxXQ6Ein2JZtLw==
+parcel@2.0.0-dev.1793:
+  version "2.0.0-dev.1793"
+  resolved "https://registry.yarnpkg.com/parcel/-/parcel-2.0.0-dev.1793.tgz#f9705f9dc730f9f06b8447eeb697930d52819fce"
+  integrity sha512-+OyZB74SZfkVxZjNb4euYkBPXkx5st6/Ic0mvmGoKcNOLiHyb/1BW3TuoWRcqNsZs9vFMf2i24rpOZKITBeDOA==
   dependencies:
-    "@parcel/config-default" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/core" "2.0.0-dev.1787+0b82b13d6"
-    "@parcel/diagnostic" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/events" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/feature-flags" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/fs" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/logger" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/package-manager" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/reporter-cli" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/reporter-dev-server" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/reporter-tracer" "2.13.3-dev.3412+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
+    "@parcel/config-default" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/core" "2.0.0-dev.1793+9f297b15c"
+    "@parcel/diagnostic" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/events" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/feature-flags" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/fs" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/logger" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/package-manager" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/reporter-cli" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/reporter-dev-server" "2.0.0-dev.1795+9f297b15c"
+    "@parcel/reporter-tracer" "2.13.3-dev.3418+9f297b15c"
+    "@parcel/utils" "2.0.0-dev.1795+9f297b15c"
     chalk "^4.1.2"
     commander "^12.1.0"
     get-port "^4.2.0"

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser-parcel.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser-parcel.js
@@ -13,5 +13,6 @@ export const rendererPackageName = 'react-server-dom-parcel';
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
 export * from 'react-client/src/ReactClientConsoleConfigBrowser';
 export * from 'react-server-dom-parcel/src/client/ReactFlightClientConfigBundlerParcel';
+export * from 'react-server-dom-parcel/src/client/ReactFlightClientConfigTargetParcelBrowser';
 export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';
 export const usedWithSSR = false;

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-parcel.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-parcel.js
@@ -13,5 +13,6 @@ export const rendererPackageName = 'react-server-dom-parcel';
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
 export * from 'react-client/src/ReactClientConsoleConfigServer';
 export * from 'react-server-dom-parcel/src/client/ReactFlightClientConfigBundlerParcel';
+export * from 'react-server-dom-parcel/src/client/ReactFlightClientConfigTargetParcelServer';
 export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';
 export const usedWithSSR = true;

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-parcel.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-parcel.js
@@ -13,5 +13,6 @@ export const rendererPackageName = 'react-server-dom-parcel';
 export * from 'react-client/src/ReactFlightClientStreamConfigNode';
 export * from 'react-client/src/ReactClientConsoleConfigServer';
 export * from 'react-server-dom-parcel/src/client/ReactFlightClientConfigBundlerParcel';
+export * from 'react-server-dom-parcel/src/client/ReactFlightClientConfigTargetParcelServer';
 export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';
 export const usedWithSSR = true;

--- a/packages/react-server-dom-parcel/src/client/ReactFlightClientConfigBundlerParcel.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightClientConfigBundlerParcel.js
@@ -12,6 +12,7 @@ import type {Thenable} from 'shared/ReactTypes';
 import type {ImportMetadata} from '../shared/ReactFlightImportMetadata';
 
 import {ID, NAME, BUNDLES} from '../shared/ReactFlightImportMetadata';
+import {prepareDestinationWithChunks} from 'react-client/src/ReactFlightClientConfig';
 
 export type ServerManifest = {
   [string]: Array<string>,
@@ -31,7 +32,7 @@ export function prepareDestinationForModule(
   nonce: ?string,
   metadata: ClientReferenceMetadata,
 ) {
-  return;
+  prepareDestinationWithChunks(moduleLoading, metadata[BUNDLES], nonce);
 }
 
 export function resolveClientReference<T>(

--- a/packages/react-server-dom-parcel/src/client/ReactFlightClientConfigBundlerParcel.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightClientConfigBundlerParcel.js
@@ -24,14 +24,7 @@ export type ServerReferenceId = string;
 export opaque type ClientReferenceMetadata = ImportMetadata;
 
 // eslint-disable-next-line no-unused-vars
-export opaque type ClientReference<T> = {
-  // Module id.
-  id: string,
-  // Export name.
-  name: string,
-  // List of bundle URLs, relative to the distDir.
-  bundles: Array<string>,
-};
+export opaque type ClientReference<T> = ImportMetadata;
 
 export function prepareDestinationForModule(
   moduleLoading: ModuleLoading,
@@ -46,11 +39,7 @@ export function resolveClientReference<T>(
   metadata: ClientReferenceMetadata,
 ): ClientReference<T> {
   // Reference is already resolved during the build.
-  return {
-    id: metadata[ID],
-    name: metadata[NAME],
-    bundles: metadata[BUNDLES],
-  };
+  return metadata;
 }
 
 export function resolveServerReference<T>(
@@ -64,20 +53,19 @@ export function resolveServerReference<T>(
   if (!bundles) {
     throw new Error('Invalid server action: ' + ref);
   }
-  return {
-    id,
-    name,
-    bundles,
-  };
+  return [id, name, bundles];
 }
 
 export function preloadModule<T>(
   metadata: ClientReference<T>,
 ): null | Thenable<any> {
-  return Promise.all(metadata.bundles.map(url => parcelRequire.load(url)));
+  if (metadata[BUNDLES].length === 0) {
+    return null;
+  }
+  return Promise.all(metadata[BUNDLES].map(url => parcelRequire.load(url)));
 }
 
 export function requireModule<T>(metadata: ClientReference<T>): T {
-  const moduleExports = parcelRequire(metadata.id);
-  return moduleExports[metadata.name];
+  const moduleExports = parcelRequire(metadata[ID]);
+  return moduleExports[metadata[NAME]];
 }

--- a/packages/react-server-dom-parcel/src/client/ReactFlightClientConfigTargetParcelBrowser.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightClientConfigTargetParcelBrowser.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ModuleLoading} from './ReactFlightClientConfigBundlerParcel';
+
+export function prepareDestinationWithChunks(
+  moduleLoading: ModuleLoading,
+  bundles: Array<string>,
+  nonce: ?string,
+) {
+  // In the browser we don't need to prepare our destination since the browser is the Destination
+}

--- a/packages/react-server-dom-parcel/src/client/ReactFlightClientConfigTargetParcelServer.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightClientConfigTargetParcelServer.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ModuleLoading} from './ReactFlightClientConfigBundlerParcel';
+import {preinitModuleForSSR} from 'react-client/src/ReactFlightClientConfig';
+
+export function prepareDestinationWithChunks(
+  moduleLoading: ModuleLoading,
+  bundles: Array<string>,
+  nonce: ?string,
+) {
+  for (let i = 0; i < bundles.length; i++) {
+    preinitModuleForSSR(parcelRequire.meta.publicUrl + bundles[i], nonce);
+  }
+}

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -106,6 +106,9 @@ declare const __turbopack_require__: ((id: string) => any) & {
 declare var parcelRequire: {
   (id: string): any,
   load: (url: string) => Promise<mixed>,
+  meta: {
+    publicUrl: string
+  }
 };
 
 declare module 'fs/promises' {

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -107,8 +107,8 @@ declare var parcelRequire: {
   (id: string): any,
   load: (url: string) => Promise<mixed>,
   meta: {
-    publicUrl: string
-  }
+    publicUrl: string,
+  },
 };
 
 declare module 'fs/promises' {


### PR DESCRIPTION
Followup to #31725

This implements `prepareDestinationForModule` in the Parcel Flight client. On the Parcel side, the `<Resources>` component now only inserts `<link>` elements for stylesheets (along with a bootstrap script when needed), and React is responsible for inserting scripts. This ensures that components that are conditionally dynamic imported during render are also preloaded.

CSS must be added to the RSC tree using `<Resources>` to avoid FOUC. This must be manually rendered in both the top-level page, and in any component that is dynamic imported. It would be nice if there was a way for React to automatically insert CSS as well, but unfortunately `prepareDestinationForModule` only knows about client components and not CSS for server components. Perhaps there could be a way we could annotate components at code splitting boundaries with the resources they need? More thoughts in this thread: https://github.com/facebook/react/pull/31725#discussion_r1884867607