### PR TITLE
[compiler] Cleanup some feature flags

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -41,7 +41,6 @@ import {
 } from './HIR';
 import {
   BuiltInMixedReadonlyId,
-  DefaultMutatingHook,
   DefaultNonmutatingHook,
   FunctionSignature,
   ShapeRegistry,
@@ -336,23 +335,6 @@ const EnvironmentConfigSchema = z.object({
    */
   validateNoCapitalizedCalls: z.nullable(z.array(z.string())).default(null),
   validateBlocklistedImports: z.nullable(z.array(z.string())).default(null),
-
-  /*
-   * When enabled, the compiler assumes that hooks follow the Rules of React:
-   * - Hooks may memoize computation based on any of their parameters, thus
-   *   any arguments to a hook are assumed frozen after calling the hook.
-   * - Hooks may memoize the result they return, thus the return value is
-   *   assumed frozen.
-   */
-  enableAssumeHooksFollowRulesOfReact: z.boolean().default(true),
-
-  /**
-   * When enabled, the compiler assumes that any values are not subsequently
-   * modified after they are captured by a function passed to React. For example,
-   * if a value `x` is referenced inside a function expression passed to `useEffect`,
-   * then this flag will assume that `x` is not subusequently modified.
-   */
-  enableTransitivelyFreezeFunctionExpressions: z.boolean().default(true),
 
   /*
    * Enables codegen mutability debugging. This emits a dev-mode only to log mutations
@@ -919,19 +901,19 @@ export class Environment {
         isHookName(match[1])
       ) {
         const resolvedName = match[1];
-        return this.#globals.get(resolvedName) ?? this.#getCustomHookType();
+        return this.#globals.get(resolvedName) ?? DefaultNonmutatingHook;
       }
     }
 
     switch (binding.kind) {
       case 'ModuleLocal': {
         // don't resolve module locals
-        return isHookName(binding.name) ? this.#getCustomHookType() : null;
+        return isHookName(binding.name) ? DefaultNonmutatingHook : null;
       }
       case 'Global': {
         return (
           this.#globals.get(binding.name) ??
-          (isHookName(binding.name) ? this.#getCustomHookType() : null)
+          (isHookName(binding.name) ? DefaultNonmutatingHook : null)
         );
       }
       case 'ImportSpecifier': {
@@ -946,7 +928,7 @@ export class Environment {
           return (
             this.#globals.get(binding.imported) ??
             (isHookName(binding.imported) || isHookName(binding.name)
-              ? this.#getCustomHookType()
+              ? DefaultNonmutatingHook
               : null)
           );
         } else {
@@ -985,7 +967,7 @@ export class Environment {
            * `import {foo as useHook} ...`
            */
           return isHookName(binding.imported) || isHookName(binding.name)
-            ? this.#getCustomHookType()
+            ? DefaultNonmutatingHook
             : null;
         }
       }
@@ -995,7 +977,7 @@ export class Environment {
           // only resolve imports to modules we know about
           return (
             this.#globals.get(binding.name) ??
-            (isHookName(binding.name) ? this.#getCustomHookType() : null)
+            (isHookName(binding.name) ? DefaultNonmutatingHook : null)
           );
         } else {
           const moduleType = this.#resolveModuleType(binding.module, loc);
@@ -1026,7 +1008,7 @@ export class Environment {
               return importedType;
             }
           }
-          return isHookName(binding.name) ? this.#getCustomHookType() : null;
+          return isHookName(binding.name) ? DefaultNonmutatingHook : null;
         }
       }
     }
@@ -1062,11 +1044,11 @@ export class Environment {
       let value =
         shape.properties.get(property) ?? shape.properties.get('*') ?? null;
       if (value === null && isHookName(property)) {
-        value = this.#getCustomHookType();
+        value = DefaultNonmutatingHook;
       }
       return value;
     } else if (isHookName(property)) {
-      return this.#getCustomHookType();
+      return DefaultNonmutatingHook;
     } else {
       return null;
     }
@@ -1090,14 +1072,6 @@ export class Environment {
   addHoistedIdentifier(node: t.Identifier): void {
     this.#contextIdentifiers.add(node);
     this.#hoistedIdentifiers.add(node);
-  }
-
-  #getCustomHookType(): Global {
-    if (this.config.enableAssumeHooksFollowRulesOfReact) {
-      return DefaultNonmutatingHook;
-    } else {
-      return DefaultMutatingHook;
-    }
   }
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
@@ -664,19 +664,6 @@ addObject(BUILTIN_SHAPES, BuiltInMixedReadonlyId, [
 addObject(BUILTIN_SHAPES, BuiltInJsxId, []);
 addObject(BUILTIN_SHAPES, BuiltInFunctionId, []);
 
-export const DefaultMutatingHook = addHook(
-  BUILTIN_SHAPES,
-  {
-    positionalParams: [],
-    restParam: Effect.ConditionallyMutate,
-    returnType: {kind: 'Poly'},
-    calleeEffect: Effect.Read,
-    hookKind: 'Custom',
-    returnValueKind: ValueKind.Mutable,
-  },
-  'DefaultMutatingHook',
-);
-
 export const DefaultNonmutatingHook = addHook(
   BUILTIN_SHAPES,
   {

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReferenceEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReferenceEffects.ts
@@ -396,10 +396,7 @@ class InferenceState {
         context: new Set(),
       });
       if (value.kind === 'FunctionExpression') {
-        if (
-          this.#env.config.enablePreserveExistingMemoizationGuarantees ||
-          this.#env.config.enableTransitivelyFreezeFunctionExpressions
-        ) {
+        if (this.#env.config.enablePreserveExistingMemoizationGuarantees) {
           if (value.kind === 'FunctionExpression') {
             /*
              * We want to freeze the captured values, not mark the operands

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/meta-isms/repro-cx-assigned-to-temporary.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/meta-isms/repro-cx-assigned-to-temporary.expect.md
@@ -2,7 +2,7 @@
 ## Input
 
 ```javascript
-// @compilationMode(infer) @enableAssumeHooksFollowRulesOfReact:false @customMacros(cx)
+// @compilationMode(infer) @customMacros(cx)
 import {identity} from 'shared-runtime';
 
 const DARK = 'dark';
@@ -47,26 +47,29 @@ export const FIXTURE_ENTRYPOINT = {
 ## Code
 
 ```javascript
-import { c as _c } from "react/compiler-runtime"; // @compilationMode(infer) @enableAssumeHooksFollowRulesOfReact:false @customMacros(cx)
+import { c as _c } from "react/compiler-runtime"; // @compilationMode(infer) @customMacros(cx)
 import { identity } from "shared-runtime";
 
 const DARK = "dark";
 
 function Component() {
-  const $ = _c(2);
+  const $ = _c(4);
   const theme = useTheme();
-
-  const t0 = cx({
-    "styles/light": true,
-    "styles/dark": theme.getTheme() === DARK,
-  });
-  let t1;
-  if ($[0] !== t0) {
-    t1 = <div className={t0} />;
-    $[0] = t0;
-    $[1] = t1;
+  let t0;
+  if ($[0] !== theme) {
+    t0 = cx({ "styles/light": true, "styles/dark": theme.getTheme() === DARK });
+    $[0] = theme;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
+  }
+  let t1;
+  if ($[2] !== t0) {
+    t1 = <div className={t0} />;
+    $[2] = t0;
+    $[3] = t1;
+  } else {
+    t1 = $[3];
   }
   return t1;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/meta-isms/repro-cx-assigned-to-temporary.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/meta-isms/repro-cx-assigned-to-temporary.js
@@ -1,4 +1,4 @@
-// @compilationMode(infer) @enableAssumeHooksFollowRulesOfReact:false @customMacros(cx)
+// @compilationMode(infer) @customMacros(cx)
 import {identity} from 'shared-runtime';
 
 const DARK = 'dark';

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/meta-isms/repro-cx-namespace-assigned-to-temporary.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/meta-isms/repro-cx-namespace-assigned-to-temporary.expect.md
@@ -2,7 +2,7 @@
 ## Input
 
 ```javascript
-// @compilationMode(infer) @enableAssumeHooksFollowRulesOfReact:false @customMacros(cx)
+// @compilationMode(infer) @customMacros(cx)
 import {identity} from 'shared-runtime';
 
 const DARK = 'dark';
@@ -49,26 +49,32 @@ export const FIXTURE_ENTRYPOINT = {
 ## Code
 
 ```javascript
-import { c as _c } from "react/compiler-runtime"; // @compilationMode(infer) @enableAssumeHooksFollowRulesOfReact:false @customMacros(cx)
+import { c as _c } from "react/compiler-runtime"; // @compilationMode(infer) @customMacros(cx)
 import { identity } from "shared-runtime";
 
 const DARK = "dark";
 
 function Component() {
-  const $ = _c(2);
+  const $ = _c(4);
   const theme = useTheme();
-
-  const t0 = cx.foo({
-    "styles/light": true,
-    "styles/dark": identity([theme.getTheme()]),
-  });
-  let t1;
-  if ($[0] !== t0) {
-    t1 = <div className={t0} />;
-    $[0] = t0;
-    $[1] = t1;
+  let t0;
+  if ($[0] !== theme) {
+    t0 = cx.foo({
+      "styles/light": true,
+      "styles/dark": identity([theme.getTheme()]),
+    });
+    $[0] = theme;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
+  }
+  let t1;
+  if ($[2] !== t0) {
+    t1 = <div className={t0} />;
+    $[2] = t0;
+    $[3] = t1;
+  } else {
+    t1 = $[3];
   }
   return t1;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/meta-isms/repro-cx-namespace-assigned-to-temporary.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/meta-isms/repro-cx-namespace-assigned-to-temporary.js
@@ -1,4 +1,4 @@
-// @compilationMode(infer) @enableAssumeHooksFollowRulesOfReact:false @customMacros(cx)
+// @compilationMode(infer) @customMacros(cx)
 import {identity} from 'shared-runtime';
 
 const DARK = 'dark';


### PR DESCRIPTION
Cleans up the flags to assume hooks follow the rules, and to transitively freeze function expressions. These have been the default for a very long time.
