### PR TITLE
fix(compiler): add tanstack table and virtual to known incompat libraries

### DIFF
--- a/compiler/packages/react-compiler-healthcheck/src/config.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/config.ts
@@ -1,3 +1,3 @@
 export const config = {
-  knownIncompatibleLibraries: ['mobx', '@risingstack/react-easy-state'],
+  knownIncompatibleLibraries: ['mobx', '@risingstack/react-easy-state', '@tanstack/react-table', '@tanstack/react-virtual'],
 };


### PR DESCRIPTION
## Summary

In our testing with the compiler the `@tanstack/react-table` and `@tanstack/react-virtual` both need `use no memo` directives to avoid breakage.
It seems to be a known issue: 
- https://github.com/TanStack/virtual/issues/736
- https://github.com/TanStack/table/issues/5567

It can save someone quite some time of debugging if the health check can flag these :) 