### PR TITLE
changing frameYieldMS from 5 to 16.7 issue #31800

### DIFF
--- a/packages/scheduler/src/SchedulerFeatureFlags.js
+++ b/packages/scheduler/src/SchedulerFeatureFlags.js
@@ -9,7 +9,7 @@
 
 export const enableSchedulerDebugging = false;
 export const enableProfiling = false;
-export const frameYieldMs = 5;
+export const frameYieldMs = 16.7;
 
 export const userBlockingPriorityTimeout = 250;
 export const normalPriorityTimeout = 5000;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
changed the frameYieldMS from 5 to 16.7 ms
<!--
 Saw in the issue that the 5ms is not the best for rendering fields and the standard one was 16.7 so used that
-->

## How did you test this change?
  added a test case in package/scheduler/src/__tests__/Scheduler-test.js
but was not able to see if it works because from some reason the Yarn was not installing completely and the test were not working so not sure what was wrong with the installing of yarn 

hopefully you can provide me with some review and guide me also.....

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
