### PR TITLE
[flags] Delete enableSchedulerDebugger

### DIFF
--- a/fixtures/scheduler/index.html
+++ b/fixtures/scheduler/index.html
@@ -91,19 +91,8 @@
       <div> If the counter advanced while you were away from this tab, it's correct.</div>
     </li>
     <li>
-      <p>Can pause execution, dump scheduled callbacks, and continue where it left off</p>
-      <button onClick="runTestEight()">Run Test 8</button>
-      <div><b>Click the button above, press "continue" to finish the test after it pauses:</b></div>
-      <button onClick="continueTestEight()">continue</button>
-      <div><b>Expected:</b></div>
-      <div id="test-8-expected">
-      </div>
-      <div> -------------------------------------------------</div>
-      <div> If the test didn't progress until you hit "continue" and </div>
-      <div> you see the same above and below afterwards it's correct.
-        <div> -------------------------------------------------</div>
-        <div><b>Actual:</b></div>
-        <div id="test-8"></div>
+      <p>Test Eight Removed</p>
+      <p>Test 8 was removed because it was testing a feature that was removed from the scheduler.</p>
     </li>
     <li>
       <p>Can force a specific framerate</p>
@@ -156,9 +145,6 @@ const {
   unstable_scheduleCallback: scheduleCallback,
   unstable_cancelCallback: cancelCallback,
   unstable_now: now,
-  unstable_getFirstCallbackNode: getFirstCallbackNode,
-  unstable_pauseExecution: pauseExecution,
-  unstable_continueExecution: continueExecution,
   unstable_forceFrameRate: forceFrameRate,
   unstable_shouldYield: shouldYield,
   unstable_NormalPriority: NormalPriority,
@@ -585,50 +571,6 @@ function runTestSeven() {
     scheduleCallback(NormalPriority, incrementCounterAndScheduleNextCallback);
   }
   scheduleCallback(NormalPriority, incrementCounterAndScheduleNextCallback);
-}
-
-function runTestEight() {
-  // Test 8
-  // Pauses execution, dumps the queue, and continues execution
-  clearTestResult(8);
-
-  function countNodesInStack(firstCallbackNode) {
-    var node = firstCallbackNode;
-    var count = 0;
-    if (node !== null) {
-      do {
-        count = count + 1;
-        node = node.next;
-      } while (node !== firstCallbackNode);
-    }
-    return count;
-  }
-
-  scheduleCallback(NormalPriority, () => {
-
-    // size should be 0
-    updateTestResult(8, `Queue size: ${countNodesInStack(getFirstCallbackNode())}.`);
-    updateTestResult(8, 'Pausing... press continue to resume.');
-    pauseExecution();
-
-    scheduleCallback(NormalPriority, function () {
-      updateTestResult(8, 'Finishing...');
-      displayTestResult(8);
-    })
-    scheduleCallback(NormalPriority, function () {
-      updateTestResult(8, 'Done!');
-      displayTestResult(8);
-      checkTestResult(8);
-    })
-
-    // new size should be 2 now
-    updateTestResult(8, `Queue size: ${countNodesInStack(getFirstCallbackNode())}.`);
-    displayTestResult(8);
-  });
-}
-
-function continueTestEight() {
-  continueExecution();
 }
 
 function runTestNine() {

--- a/packages/scheduler/src/SchedulerFeatureFlags.js
+++ b/packages/scheduler/src/SchedulerFeatureFlags.js
@@ -7,7 +7,6 @@
  * @flow strict
  */
 
-export const enableSchedulerDebugging = false;
 export const enableProfiling = false;
 export const frameYieldMs = 5;
 

--- a/packages/scheduler/src/forks/Scheduler.js
+++ b/packages/scheduler/src/forks/Scheduler.js
@@ -12,7 +12,6 @@
 import type {PriorityLevel} from '../SchedulerPriorities';
 
 import {
-  enableSchedulerDebugging,
   enableProfiling,
   frameYieldMs,
   userBlockingPriorityTimeout,
@@ -82,9 +81,6 @@ var timerQueue: Array<Task> = [];
 
 // Incrementing id counter. Used to maintain insertion order.
 var taskIdCounter = 1;
-
-// Pausing the scheduler is useful for debugging.
-var isSchedulerPaused = false;
 
 var currentTask = null;
 var currentPriorityLevel = NormalPriority;
@@ -193,10 +189,7 @@ function workLoop(initialTime: number) {
   let currentTime = initialTime;
   advanceTimers(currentTime);
   currentTask = peek(taskQueue);
-  while (
-    currentTask !== null &&
-    !(enableSchedulerDebugging && isSchedulerPaused)
-  ) {
+  while (currentTask !== null) {
     if (!enableAlwaysYieldScheduler) {
       if (currentTask.expirationTime > currentTime && shouldYieldToHost()) {
         // This currentTask hasn't expired, and we've reached the deadline.
@@ -422,22 +415,6 @@ function unstable_scheduleCallback(
   return newTask;
 }
 
-function unstable_pauseExecution() {
-  isSchedulerPaused = true;
-}
-
-function unstable_continueExecution() {
-  isSchedulerPaused = false;
-  if (!isHostCallbackScheduled && !isPerformingWork) {
-    isHostCallbackScheduled = true;
-    requestHostCallback();
-  }
-}
-
-function unstable_getFirstCallbackNode(): Task | null {
-  return peek(taskQueue);
-}
-
 function unstable_cancelCallback(task: Task) {
   if (enableProfiling) {
     if (task.isQueued) {
@@ -606,9 +583,6 @@ export {
   unstable_getCurrentPriorityLevel,
   shouldYieldToHost as unstable_shouldYield,
   requestPaint as unstable_requestPaint,
-  unstable_continueExecution,
-  unstable_pauseExecution,
-  unstable_getFirstCallbackNode,
   getCurrentTime as unstable_now,
   forceFrameRate as unstable_forceFrameRate,
 };

--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
@@ -12,7 +12,6 @@ const dynamicFeatureFlags = require('SchedulerFeatureFlags');
 
 export const {enableRequestPaint} = dynamicFeatureFlags;
 
-export const enableSchedulerDebugging = false;
 export const enableProfiling = __DEV__;
 export const frameYieldMs = 10;
 

--- a/packages/scheduler/src/forks/SchedulerMock.js
+++ b/packages/scheduler/src/forks/SchedulerMock.js
@@ -12,10 +12,7 @@
 
 import type {PriorityLevel} from '../SchedulerPriorities';
 
-import {
-  enableSchedulerDebugging,
-  enableProfiling,
-} from '../SchedulerFeatureFlags';
+import {enableProfiling} from '../SchedulerFeatureFlags';
 import {push, pop, peek} from '../SchedulerMinHeap';
 
 // TODO: Use symbols?
@@ -71,9 +68,6 @@ var timerQueue: Array<Task> = [];
 
 // Incrementing id counter. Used to maintain insertion order.
 var taskIdCounter = 1;
-
-// Pausing the scheduler is useful for debugging.
-var isSchedulerPaused = false;
 
 var currentTask = null;
 var currentPriorityLevel = NormalPriority;
@@ -195,10 +189,7 @@ function workLoop(hasTimeRemaining: boolean, initialTime: number): boolean {
   let currentTime = initialTime;
   advanceTimers(currentTime);
   currentTask = peek(taskQueue);
-  while (
-    currentTask !== null &&
-    !(enableSchedulerDebugging && isSchedulerPaused)
-  ) {
+  while (currentTask !== null) {
     if (
       currentTask.expirationTime > currentTime &&
       (!hasTimeRemaining || shouldYieldToHost())
@@ -420,22 +411,6 @@ function unstable_scheduleCallback(
   }
 
   return newTask;
-}
-
-function unstable_pauseExecution() {
-  isSchedulerPaused = true;
-}
-
-function unstable_continueExecution() {
-  isSchedulerPaused = false;
-  if (!isHostCallbackScheduled && !isPerformingWork) {
-    isHostCallbackScheduled = true;
-    requestHostCallback(flushWork);
-  }
-}
-
-function unstable_getFirstCallbackNode(): Task | null {
-  return peek(taskQueue);
 }
 
 function unstable_cancelCallback(task: Task) {
@@ -679,9 +654,6 @@ export {
   unstable_getCurrentPriorityLevel,
   shouldYieldToHost as unstable_shouldYield,
   requestPaint as unstable_requestPaint,
-  unstable_continueExecution,
-  unstable_pauseExecution,
-  unstable_getFirstCallbackNode,
   getCurrentTime as unstable_now,
   forceFrameRate as unstable_forceFrameRate,
   unstable_flushAllWithoutAsserting,

--- a/packages/scheduler/src/forks/SchedulerNative.js
+++ b/packages/scheduler/src/forks/SchedulerNative.js
@@ -97,9 +97,6 @@ export const unstable_now: () => number | DOMHighResTimeStamp =
 export const unstable_next: any = throwNotImplemented;
 export const unstable_runWithPriority: any = throwNotImplemented;
 export const unstable_wrapCallback: any = throwNotImplemented;
-export const unstable_continueExecution: any = throwNotImplemented;
-export const unstable_pauseExecution: any = throwNotImplemented;
-export const unstable_getFirstCallbackNode: any = throwNotImplemented;
 export const unstable_forceFrameRate: any = throwNotImplemented;
 export const unstable_Profiling: any = null;
 

--- a/packages/scheduler/src/forks/SchedulerPostTask.js
+++ b/packages/scheduler/src/forks/SchedulerPostTask.js
@@ -234,13 +234,5 @@ export function unstable_wrapCallback<T>(callback: () => T): () => T {
 
 export function unstable_forceFrameRate() {}
 
-export function unstable_pauseExecution() {}
-
-export function unstable_continueExecution() {}
-
-export function unstable_getFirstCallbackNode(): null {
-  return null;
-}
-
 // Currently no profiling build
 export const unstable_Profiling = null;

--- a/scripts/jest/setupTests.www.js
+++ b/scripts/jest/setupTests.www.js
@@ -34,9 +34,9 @@ jest.mock('scheduler/src/SchedulerFeatureFlags', () => {
     schedulerSrcPath + '/src/forks/SchedulerFeatureFlags.www'
   );
 
-  // These flags are not a dynamic on www, but we still want to run
-  // tests in both versions.
-  actual.enableSchedulerDebugging = __VARIANT__;
+  // Add flags here that are not a dynamic on www,
+  // but we still want to run tests in both versions.
+  // <this list is empty>
 
   return actual;
 });


### PR DESCRIPTION
The tool for this isn't used so I killed it internally and we can clean up the code to make it easier to reduce the scheduler code.