### PR TITLE
[Flight] Fix double-incremented pending chunks counter

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -3810,11 +3810,11 @@ function forwardDebugInfo(
   debugInfo: ReactDebugInfo,
 ) {
   for (let i = 0; i < debugInfo.length; i++) {
-    request.pendingChunks++;
     if (typeof debugInfo[i].time === 'number') {
       // When forwarding time we need to ensure to convert it to the time space of the payload.
       emitTimingChunk(request, id, debugInfo[i].time);
     } else {
+      request.pendingChunks++;
       if (typeof debugInfo[i].name === 'string') {
         // We outline this model eagerly so that we can refer to by reference as an owner.
         // If we had a smarter way to dedupe we might not have to do this if there ends up


### PR DESCRIPTION
Before calling `emitTimingChunk` inside of `forwardDebugInfo`, we must not increment `request.pendingChunks`, as this is already done inside of the `emitTimingChunk` function.

I don't have a unit test for this, but manually verified that this fixes the hanging responses in https://github.com/vercel/next.js/pull/73804.