### PR TITLE
Allow `<script>` and `<template>` tags in `<select>` tag

### DIFF
--- a/packages/react-dom-bindings/src/client/validateDOMNesting.js
+++ b/packages/react-dom-bindings/src/client/validateDOMNesting.js
@@ -297,6 +297,8 @@ function isTagValidWithParent(tag: string, parentTag: ?string): boolean {
         tag === 'hr' ||
         tag === 'option' ||
         tag === 'optgroup' ||
+        tag === 'script' ||
+        tag === 'template' ||
         tag === '#text'
       );
     case 'optgroup':


### PR DESCRIPTION
## Summary

As per https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inselect, `<script>` and `<template>` tags may be nested in a `<select>` tag.  This PR modifies `isTagValidWithParent` to allow that.

## How did you test this change?

Based on #27632 (a similar PR), I did not add a test.  I noticed that all the tests in [`validateDOMNesting-test.js`](https://github.com/facebook/react/blob/1e9ef39a8742889f8414c7df9c9e6ef463fe3d01/packages/react-dom/src/__tests__/validateDOMNesting-test.js) are negative tests (i.e. expect warnings), not positive tests (i.e. expect no warnings), so I assume this is preferred.  But I can add a test, if desired.
