### PR TITLE
[flags] Remove debugRenderPhaseSideEffectsForStrictMode

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -92,7 +92,6 @@ import {
   DidDefer,
 } from './ReactFiberFlags';
 import {
-  debugRenderPhaseSideEffectsForStrictMode,
   disableLegacyContext,
   disableLegacyContextForFunctionComponents,
   enableProfilerCommitHooks,
@@ -1375,10 +1374,7 @@ function finishClassComponent(
     }
     if (__DEV__) {
       nextChildren = callRenderInDEV(instance);
-      if (
-        debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictLegacyMode
-      ) {
+      if (workInProgress.mode & StrictLegacyMode) {
         setIsStrictModeForDevtools(true);
         try {
           callRenderInDEV(instance);

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -18,7 +18,6 @@ import {
   MountLayoutDev,
 } from './ReactFiberFlags';
 import {
-  debugRenderPhaseSideEffectsForStrictMode,
   disableLegacyContext,
   enableSchedulingProfiler,
   disableDefaultPropsExceptForClasses,
@@ -138,10 +137,7 @@ function applyDerivedStateFromProps(
   const prevState = workInProgress.memoizedState;
   let partialState = getDerivedStateFromProps(nextProps, prevState);
   if (__DEV__) {
-    if (
-      debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictLegacyMode
-    ) {
+    if (workInProgress.mode & StrictLegacyMode) {
       setIsStrictModeForDevtools(true);
       try {
         // Invoke the function an extra time to help detect side-effects.
@@ -266,10 +262,7 @@ function checkShouldComponentUpdate(
       nextContext,
     );
     if (__DEV__) {
-      if (
-        debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictLegacyMode
-      ) {
+      if (workInProgress.mode & StrictLegacyMode) {
         setIsStrictModeForDevtools(true);
         try {
           // Invoke the function an extra time to help detect side-effects.
@@ -598,10 +591,7 @@ function constructClassInstance(
   let instance = new ctor(props, context);
   // Instantiate twice to help detect side-effects.
   if (__DEV__) {
-    if (
-      debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictLegacyMode
-    ) {
+    if (workInProgress.mode & StrictLegacyMode) {
       setIsStrictModeForDevtools(true);
       try {
         instance = new ctor(props, context);

--- a/packages/react-reconciler/src/ReactFiberClassUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactFiberClassUpdateQueue.js
@@ -110,8 +110,6 @@ import {
 } from './ReactFiberFlags';
 import getComponentNameFromFiber from './getComponentNameFromFiber';
 
-import {debugRenderPhaseSideEffectsForStrictMode} from 'shared/ReactFeatureFlags';
-
 import {StrictLegacyMode} from './ReactTypeOfMode';
 import {
   markSkippedUpdateLanes,
@@ -402,10 +400,7 @@ function getStateFromUpdate<State>(
         }
         const nextState = payload.call(instance, prevState, nextProps);
         if (__DEV__) {
-          if (
-            debugRenderPhaseSideEffectsForStrictMode &&
-            workInProgress.mode & StrictLegacyMode
-          ) {
+          if (workInProgress.mode & StrictLegacyMode) {
             setIsStrictModeForDevtools(true);
             try {
               payload.call(instance, prevState, nextProps);
@@ -435,10 +430,7 @@ function getStateFromUpdate<State>(
         }
         partialState = payload.call(instance, prevState, nextProps);
         if (__DEV__) {
-          if (
-            debugRenderPhaseSideEffectsForStrictMode &&
-            workInProgress.mode & StrictLegacyMode
-          ) {
+          if (workInProgress.mode & StrictLegacyMode) {
             setIsStrictModeForDevtools(true);
             try {
               payload.call(instance, prevState, nextProps);

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -40,7 +40,6 @@ import {
   enableUseEffectEventHook,
   enableUseResourceEffectHook,
   enableLegacyCache,
-  debugRenderPhaseSideEffectsForStrictMode,
   disableLegacyMode,
   enableNoCloningMemoCache,
 } from 'shared/ReactFeatureFlags';
@@ -623,9 +622,7 @@ export function renderWithHooks<Props, SecondArg>(
   //
   // There are plenty of tests to ensure this behavior is correct.
   const shouldDoubleRenderDEV =
-    __DEV__ &&
-    debugRenderPhaseSideEffectsForStrictMode &&
-    (workInProgress.mode & StrictLegacyMode) !== NoMode;
+    __DEV__ && (workInProgress.mode & StrictLegacyMode) !== NoMode;
 
   shouldDoubleInvokeUserFnsInHooksDEV = shouldDoubleRenderDEV;
   let children = __DEV__

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1240,8 +1240,6 @@ describe('ReactHooks', () => {
   });
 
   it('double-invokes components with Hooks in Strict Mode', async () => {
-    ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = true;
-
     const {useState, StrictMode} = React;
     let renderCount = 0;
 
@@ -1459,7 +1457,6 @@ describe('ReactHooks', () => {
   });
 
   it('double-invokes useMemo in DEV StrictMode despite []', async () => {
-    ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = true;
     const {useMemo, StrictMode} = React;
 
     let useMemoCount = 0;

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -13,7 +13,6 @@
 'use strict';
 
 let React;
-let ReactFeatureFlags;
 let ReactTestRenderer;
 let Scheduler;
 let ReactDOMServer;
@@ -26,8 +25,6 @@ let waitForThrow;
 describe('ReactHooks', () => {
   beforeEach(() => {
     jest.resetModules();
-    ReactFeatureFlags = require('shared/ReactFeatureFlags');
-
     React = require('react');
     ReactTestRenderer = require('react-test-renderer');
     Scheduler = require('scheduler');

--- a/packages/react-reconciler/src/__tests__/ReactUpdaters-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactUpdaters-test.internal.js
@@ -34,7 +34,6 @@ describe('updaters', () => {
 
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.enableUpdaterTracking = true;
-    ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
 
     mockDevToolsHook = {
       injectInternals: jest.fn(() => {}),

--- a/packages/react-reconciler/src/__tests__/useRef-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/useRef-test.internal.js
@@ -29,7 +29,6 @@ describe('useRef', () => {
     Scheduler = require('scheduler');
 
     const ReactFeatureFlags = require('shared/ReactFeatureFlags');
-    ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
 
     act = require('internal-test-utils').act;
     useCallback = React.useCallback;

--- a/packages/react-reconciler/src/__tests__/useRef-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/useRef-test.internal.js
@@ -28,8 +28,6 @@ describe('useRef', () => {
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');
 
-    const ReactFeatureFlags = require('shared/ReactFeatureFlags');
-
     act = require('internal-test-utils').act;
     useCallback = React.useCallback;
     useEffect = React.useEffect;

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -202,7 +202,6 @@ describe('ReactStrictMode', () => {
     expect(instance.state.count).toBe(2);
   });
 
-  // @gate debugRenderPhaseSideEffectsForStrictMode
   it('double invokes useState and useReducer initializers functions', async () => {
     const log = [];
 
@@ -390,7 +389,6 @@ describe('ReactStrictMode', () => {
     expect(instance.state.count).toBe(2);
   });
 
-  // @gate debugRenderPhaseSideEffectsForStrictMode
   it('double invokes useMemo functions', async () => {
     let log = [];
 
@@ -436,7 +434,6 @@ describe('ReactStrictMode', () => {
     ]);
   });
 
-  // @gate debugRenderPhaseSideEffectsForStrictMode
   it('double invokes useMemo functions with first result', async () => {
     let log = [];
     function Uppercased({text}) {
@@ -499,7 +496,6 @@ describe('ReactStrictMode', () => {
     expect(log[2]).toBe(log[3]);
   });
 
-  // @gate debugRenderPhaseSideEffectsForStrictMode
   it('double invokes setState updater functions', async () => {
     const log = [];
 
@@ -532,7 +528,6 @@ describe('ReactStrictMode', () => {
     expect(log).toEqual(['Compute count: 1', 'Compute count: 1']);
   });
 
-  // @gate debugRenderPhaseSideEffectsForStrictMode
   it('double invokes reducer functions', async () => {
     const log = [];
 

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -202,6 +202,7 @@ describe('ReactStrictMode', () => {
     expect(instance.state.count).toBe(2);
   });
 
+  // @gate __DEV__
   it('double invokes useState and useReducer initializers functions', async () => {
     const log = [];
 
@@ -389,6 +390,7 @@ describe('ReactStrictMode', () => {
     expect(instance.state.count).toBe(2);
   });
 
+  // @gate __DEV__
   it('double invokes useMemo functions', async () => {
     let log = [];
 
@@ -434,6 +436,7 @@ describe('ReactStrictMode', () => {
     ]);
   });
 
+  // @gate __DEV__
   it('double invokes useMemo functions with first result', async () => {
     let log = [];
     function Uppercased({text}) {
@@ -496,6 +499,7 @@ describe('ReactStrictMode', () => {
     expect(log[2]).toBe(log[3]);
   });
 
+  // @gate __DEV__
   it('double invokes setState updater functions', async () => {
     const log = [];
 
@@ -528,6 +532,7 @@ describe('ReactStrictMode', () => {
     expect(log).toEqual(['Compute count: 1', 'Compute count: 1']);
   });
 
+  // @gate __DEV__
   it('double invokes reducer functions', async () => {
     const log = [];
 

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -240,10 +240,6 @@ export const disableTextareaChildren = false;
 // Debugging and DevTools
 // -----------------------------------------------------------------------------
 
-// Helps identify side effects in render-phase lifecycle hooks and setState
-// reducers by double invoking them in StrictLegacyMode.
-export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
-
 // Gather advanced timing metrics for Profiler subtrees.
 export const enableProfilerTimer = __PROFILE__;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -32,7 +32,6 @@ export const {
 } = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.
-export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 export const disableClientCache = true;
 export const disableCommentsAsDOMContainers = true;
 export const disableDefaultPropsExceptForClasses = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -12,12 +12,8 @@ import typeof * as ExportsType from './ReactFeatureFlags.native-oss';
 
 // TODO: Align these flags with canary and delete this file once RN ships from Canary.
 
-// DEV-only but enabled in the next RN Major.
-// Not supported by flag script to avoid the special case.
-export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
-
 // -----------------------------------------------------------------------------
-// All other flags
+// All flags
 // -----------------------------------------------------------------------------
 export const alwaysThrottleRetries = false;
 export const disableClientCache = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -10,7 +10,6 @@
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as ExportsType from './ReactFeatureFlags.test-renderer';
 
-export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 export const enableAsyncDebugInfo = false;
 export const enableSchedulingProfiler = false;
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -11,7 +11,6 @@ import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as ExportsType from './ReactFeatureFlags.test-renderer';
 
 export const alwaysThrottleRetries = false;
-export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 export const disableClientCache = true;
 export const disableCommentsAsDOMContainers = true;
 export const disableDefaultPropsExceptForClasses = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -10,7 +10,6 @@
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as ExportsType from './ReactFeatureFlags.test-renderer.www';
 
-export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 export const enableAsyncDebugInfo = false;
 export const enableSchedulingProfiler = false;
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -42,7 +42,6 @@ export const {
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.
 // It's not used anywhere in production yet.
 
-export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = __PROFILE__;
 export const enableProfilerNestedUpdatePhase = __PROFILE__;


### PR DESCRIPTION
This is enabled everywhere, we can just use the inline `__DEV__` checks.