### PR TITLE
[ci] Allow build artifacts to be downloaded from any branch

### DIFF
--- a/scripts/release/shared-commands/download-build-artifacts.js
+++ b/scripts/release/shared-commands/download-build-artifacts.js
@@ -39,18 +39,16 @@ function getWorkflowId() {
 
 async function getWorkflowRun(commit) {
   const res = await exec(
-    `curl -L ${GITHUB_HEADERS} https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${getWorkflowId()}/runs?head_sha=${commit}&branch=main&exclude_pull_requests=true`
+    `curl -L ${GITHUB_HEADERS} https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${getWorkflowId()}/runs?head_sha=${commit}`
   );
 
   const json = JSON.parse(res.stdout);
-  let workflowRun;
-  if (json.total_count === 1) {
-    workflowRun = json.workflow_runs[0];
-  } else {
-    workflowRun = json.workflow_runs.find(
-      run => run.head_sha === commit && run.head_branch === 'main'
-    );
-  }
+  const workflowRun = json.workflow_runs.find(
+    run =>
+      run.head_sha === commit &&
+      run.status === 'completed' &&
+      run.conclusion === 'success'
+  );
 
   if (workflowRun == null || workflowRun.id == null) {
     console.log(
@@ -68,14 +66,9 @@ async function getArtifact(workflowRunId, artifactName) {
   );
 
   const json = JSON.parse(res.stdout);
-  let artifact;
-  if (json.total_count === 1) {
-    artifact = json.artifacts[0];
-  } else {
-    artifact = json.artifacts.find(
-      _artifact => _artifact.name === artifactName
-    );
-  }
+  const artifact = json.artifacts.find(
+    _artifact => _artifact.name === artifactName
+  );
 
   if (artifact == null) {
     console.log(


### PR DESCRIPTION
This was previously scoped to just commits on `main` but this restriction is unnecessary.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/31846).
* #31848
* #31847
* __->__ #31846