### PR TITLE
[ci] Don't cancel runs if more than one branch triggers CI

### DIFF
--- a/.github/workflows/compiler_playground.yml
+++ b/.github/workflows/compiler_playground.yml
@@ -9,7 +9,7 @@ on:
       - .github/workflows/compiler_playground.yml
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/compiler_rust.yml
+++ b/.github/workflows/compiler_rust.yml
@@ -16,7 +16,7 @@ on:
       - compiler/*.toml
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/compiler_typescript.yml
+++ b/.github/workflows/compiler_typescript.yml
@@ -9,7 +9,7 @@ on:
       - .github/workflows/compiler_typescript.yml
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -8,7 +8,7 @@ on:
       - compiler/**
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/shared_lint.yml
+++ b/.github/workflows/shared_lint.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/scripts/release/shared-commands/download-build-artifacts.js
+++ b/scripts/release/shared-commands/download-build-artifacts.js
@@ -39,18 +39,16 @@ function getWorkflowId() {
 
 async function getWorkflowRun(commit) {
   const res = await exec(
-    `curl -L ${GITHUB_HEADERS} https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${getWorkflowId()}/runs?head_sha=${commit}&branch=main&exclude_pull_requests=true`
+    `curl -L ${GITHUB_HEADERS} https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${getWorkflowId()}/runs?head_sha=${commit}`
   );
 
   const json = JSON.parse(res.stdout);
-  let workflowRun;
-  if (json.total_count === 1) {
-    workflowRun = json.workflow_runs[0];
-  } else {
-    workflowRun = json.workflow_runs.find(
-      run => run.head_sha === commit && run.head_branch === 'main'
-    );
-  }
+  const workflowRun = json.workflow_runs.find(
+    run =>
+      run.head_sha === commit &&
+      run.status === 'completed' &&
+      run.conclusion === 'success'
+  );
 
   if (workflowRun == null || workflowRun.id == null) {
     console.log(
@@ -68,14 +66,9 @@ async function getArtifact(workflowRunId, artifactName) {
   );
 
   const json = JSON.parse(res.stdout);
-  let artifact;
-  if (json.total_count === 1) {
-    artifact = json.artifacts[0];
-  } else {
-    artifact = json.artifacts.find(
-      _artifact => _artifact.name === artifactName
-    );
-  }
+  const artifact = json.artifacts.find(
+    _artifact => _artifact.name === artifactName
+  );
 
   if (artifact == null) {
     console.log(


### PR DESCRIPTION
This might primarily only affect those using Sapling for React development, but pushing the same commit to multiple branches shouldn't cancel the run

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/31848).
* __->__ #31848
* #31847
* #31846