### PR TITLE
[Flight] Support streaming of decodeReply in Edge environments

### DIFF
--- a/packages/react-server-dom-parcel/npm/server.edge.js
+++ b/packages/react-server-dom-parcel/npm/server.edge.js
@@ -9,6 +9,7 @@ if (process.env.NODE_ENV === 'production') {
 
 exports.renderToReadableStream = s.renderToReadableStream;
 exports.decodeReply = s.decodeReply;
+exports.decodeReplyFromAsyncIterable = s.decodeReplyFromAsyncIterable;
 exports.decodeAction = s.decodeAction;
 exports.decodeFormState = s.decodeFormState;
 exports.createClientReference = s.createClientReference;

--- a/packages/react-server-dom-parcel/server.edge.js
+++ b/packages/react-server-dom-parcel/server.edge.js
@@ -10,6 +10,7 @@
 export {
   renderToReadableStream,
   decodeReply,
+  decodeReplyFromAsyncIterable,
   decodeAction,
   decodeFormState,
   createClientReference,

--- a/packages/react-server-dom-parcel/src/server/react-flight-dom-server.edge.js
+++ b/packages/react-server-dom-parcel/src/server/react-flight-dom-server.edge.js
@@ -11,6 +11,7 @@ export {
   renderToReadableStream,
   prerender as unstable_prerender,
   decodeReply,
+  decodeReplyFromAsyncIterable,
   decodeAction,
   decodeFormState,
   createClientReference,

--- a/packages/react-server-dom-turbopack/npm/server.edge.js
+++ b/packages/react-server-dom-turbopack/npm/server.edge.js
@@ -9,6 +9,7 @@ if (process.env.NODE_ENV === 'production') {
 
 exports.renderToReadableStream = s.renderToReadableStream;
 exports.decodeReply = s.decodeReply;
+exports.decodeReplyFromAsyncIterable = s.decodeReplyFromAsyncIterable;
 exports.decodeAction = s.decodeAction;
 exports.decodeFormState = s.decodeFormState;
 exports.registerServerReference = s.registerServerReference;

--- a/packages/react-server-dom-turbopack/server.edge.js
+++ b/packages/react-server-dom-turbopack/server.edge.js
@@ -10,6 +10,7 @@
 export {
   renderToReadableStream,
   decodeReply,
+  decodeReplyFromAsyncIterable,
   decodeAction,
   decodeFormState,
   registerServerReference,

--- a/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.edge.js
+++ b/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.edge.js
@@ -11,6 +11,7 @@ export {
   renderToReadableStream,
   prerender as unstable_prerender,
   decodeReply,
+  decodeReplyFromAsyncIterable,
   decodeAction,
   decodeFormState,
   registerServerReference,

--- a/packages/react-server-dom-webpack/npm/server.edge.js
+++ b/packages/react-server-dom-webpack/npm/server.edge.js
@@ -9,6 +9,7 @@ if (process.env.NODE_ENV === 'production') {
 
 exports.renderToReadableStream = s.renderToReadableStream;
 exports.decodeReply = s.decodeReply;
+exports.decodeReplyFromAsyncIterable = s.decodeReplyFromAsyncIterable;
 exports.decodeAction = s.decodeAction;
 exports.decodeFormState = s.decodeFormState;
 exports.registerServerReference = s.registerServerReference;

--- a/packages/react-server-dom-webpack/server.edge.js
+++ b/packages/react-server-dom-webpack/server.edge.js
@@ -10,6 +10,7 @@
 export {
   renderToReadableStream,
   decodeReply,
+  decodeReplyFromAsyncIterable,
   decodeAction,
   decodeFormState,
   registerServerReference,

--- a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js
@@ -12,6 +12,8 @@ import type {Thenable} from 'shared/ReactTypes';
 import type {ClientManifest} from './ReactFlightServerConfigWebpackBundler';
 import type {ServerManifest} from 'react-client/src/ReactFlightClientConfig';
 
+import {ASYNC_ITERATOR} from 'shared/ReactSymbols';
+
 import {
   createRequest,
   createPrerenderRequest,
@@ -25,6 +27,9 @@ import {
   createResponse,
   close,
   getRoot,
+  reportGlobalError,
+  resolveField,
+  resolveFile,
 } from 'react-server/src/ReactFlightReplyServer';
 
 import {
@@ -183,10 +188,56 @@ function decodeReply<T>(
   return root;
 }
 
+function decodeReplyFromAsyncIterable<T>(
+  iterable: AsyncIterable<[string, string | File]>,
+  webpackMap: ServerManifest,
+  options?: {temporaryReferences?: TemporaryReferenceSet},
+): Thenable<T> {
+  const iterator: AsyncIterator<[string, string | File]> =
+    iterable[ASYNC_ITERATOR]();
+
+  const response = createResponse(
+    webpackMap,
+    '',
+    options ? options.temporaryReferences : undefined,
+  );
+
+  function progress(
+    entry:
+      | {done: false, +value: [string, string | File], ...}
+      | {done: true, +value: void, ...},
+  ) {
+    if (entry.done) {
+      close(response);
+    } else {
+      const [name, value] = entry.value;
+      if (typeof value === 'string') {
+        resolveField(response, name, value);
+      } else {
+        resolveFile(response, name, value);
+      }
+      iterator.next().then(progress, error);
+    }
+  }
+  function error(reason: Error) {
+    reportGlobalError(response, reason);
+    if (typeof (iterator: any).throw === 'function') {
+      // The iterator protocol doesn't necessarily include this but a generator do.
+      // $FlowFixMe should be able to pass mixed
+      iterator.throw(reason).then(error, error);
+    }
+  }
+
+  iterator.next().then(progress, error);
+
+  return getRoot(response);
+}
+
 export {
   renderToReadableStream,
   prerender,
   decodeReply,
+  decodeReplyFromAsyncIterable,
   decodeAction,
   decodeFormState,
 };

--- a/packages/react-server-dom-webpack/src/server/react-flight-dom-server.edge.js
+++ b/packages/react-server-dom-webpack/src/server/react-flight-dom-server.edge.js
@@ -11,6 +11,7 @@ export {
   renderToReadableStream,
   prerender as unstable_prerender,
   decodeReply,
+  decodeReplyFromAsyncIterable,
   decodeAction,
   decodeFormState,
   registerServerReference,


### PR DESCRIPTION
We support streaming `multipart/form-data` in Node.js using Busboy since that's kind of the idiomatic ecosystem way for handling these stream there. There's not really anything idiomatic like that for Edge that's universal yet.

This adds a version that's basically just `AsyncIterable.from(formData)`. It could also be a `ReadableStream` of those entries since those are also `AsyncIterable`.

I imagine that in the future we might add one from a binary `ReadableStream` that does the parsing built-in.