### PR TITLE
Turn off enableYieldingBeforePassive

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -3278,6 +3278,9 @@ function commitRootImpl(
       // We don't schedule a separate task for flushing passive effects.
       // Instead, we just rely on ensureRootIsScheduled below to schedule
       // a callback for us to flush the passive effects.
+      // We do need to clear this callback.
+      // Otherwise, we'll still think the commit is suspended.
+      root.cancelPendingCommit = null;
     } else {
       // So we can clear these now to allow a new callback to be scheduled.
       root.callbackNode = null;

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseyCommitPhase-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseyCommitPhase-test.js
@@ -491,4 +491,46 @@ describe('ReactSuspenseyCommitPhase', () => {
       </>,
     );
   });
+
+  // FIXME: Should pass with `enableYieldingBeforePassive`
+  // @gate !enableYieldingBeforePassive
+  it('runs passive effects after suspended commit resolves', async () => {
+    function Effect() {
+      React.useEffect(() => {
+        Scheduler.log('flush effect');
+      });
+      return <Text text="render effect" />;
+    }
+
+    const root = ReactNoop.createRoot();
+
+    await act(() => {
+      root.render(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <Effect />
+          <SuspenseyImage src="A" />
+        </Suspense>,
+      );
+    });
+
+    assertLog([
+      'render effect',
+      'Image requested [A]',
+      'Loading...',
+      'render effect',
+    ]);
+    expect(root).toMatchRenderedOutput('Loading...');
+
+    await act(() => {
+      resolveSuspenseyThing('A');
+    });
+
+    assertLog(['flush effect']);
+    expect(root).toMatchRenderedOutput(
+      <>
+        {'render effect'}
+        <suspensey-thing src="A" />
+      </>,
+    );
+  });
 });

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseyCommitPhase-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseyCommitPhase-test.js
@@ -492,8 +492,6 @@ describe('ReactSuspenseyCommitPhase', () => {
     );
   });
 
-  // FIXME: Should pass with `enableYieldingBeforePassive`
-  // @gate !enableYieldingBeforePassive
   it('runs passive effects after suspended commit resolves', async () => {
     function Effect() {
       React.useEffect(() => {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -78,7 +78,8 @@ export const enableLegacyFBSupport = false;
 // -----------------------------------------------------------------------------
 
 // Yield to the browser event loop and not just the scheduler event loop before passive effects.
-export const enableYieldingBeforePassive = __EXPERIMENTAL__;
+// Introduced a regression by not flushing passive effects with Suspensey CSS: https://codesandbox.io/p/sandbox/suspensey-css-and-passive-effects-mww52c
+export const enableYieldingBeforePassive = false;
 
 export const enableLegacyCache = __EXPERIMENTAL__;
 

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -78,7 +78,7 @@ export const enableLegacyFBSupport = false;
 // -----------------------------------------------------------------------------
 
 // Yield to the browser event loop and not just the scheduler event loop before passive effects.
-// Introduced a regression by not flushing passive effects with Suspensey CSS: https://codesandbox.io/p/sandbox/suspensey-css-and-passive-effects-mww52c
+// Fix gated tests that fail with this flag enabled before turning it back on.
 export const enableYieldingBeforePassive = false;
 
 export const enableLegacyCache = __EXPERIMENTAL__;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -78,8 +78,7 @@ export const enableLegacyFBSupport = false;
 // -----------------------------------------------------------------------------
 
 // Yield to the browser event loop and not just the scheduler event loop before passive effects.
-// Fix gated tests that fail with this flag enabled before turning it back on.
-export const enableYieldingBeforePassive = false;
+export const enableYieldingBeforePassive = __EXPERIMENTAL__;
 
 export const enableLegacyCache = __EXPERIMENTAL__;
 


### PR DESCRIPTION
## Summary

`ensureRootIsScheduled` will bail out of flushing passive effects if it thinks the commit is suspended. So we need to make sure we clear the `cancelPendingcommit` callback since we use that to check if a commit is suspended.

## How did you test this change?

- [x] new unit test
- [ ] repro works with a build from this branch: 