### PR TITLE
Fork Scheduler feature flags for native-fb

### DIFF
--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.native-fb.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.native-fb.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export const enableProfiling = __DEV__;
+export const frameYieldMs = 5;
+
+export const userBlockingPriorityTimeout = 250;
+export const normalPriorityTimeout = 5000;
+export const lowPriorityTimeout = 10000;
+export const enableRequestPaint = true;
+
+export const enableAlwaysYieldScheduler = false;

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -195,14 +195,18 @@ const forks = Object.freeze({
     entry,
     dependencies
   ) => {
-    if (
-      bundleType === FB_WWW_DEV ||
-      bundleType === FB_WWW_PROD ||
-      bundleType === FB_WWW_PROFILING
-    ) {
-      return './packages/scheduler/src/forks/SchedulerFeatureFlags.www.js';
+    switch (bundleType) {
+      case FB_WWW_DEV:
+      case FB_WWW_PROD:
+      case FB_WWW_PROFILING:
+        return './packages/scheduler/src/forks/SchedulerFeatureFlags.www.js';
+      case RN_FB_DEV:
+      case RN_FB_PROD:
+      case RN_FB_PROFILING:
+        return './packages/scheduler/src/forks/SchedulerFeatureFlags.native-fb.js';
+      default:
+        return './packages/scheduler/src/SchedulerFeatureFlags.js';
     }
-    return './packages/scheduler/src/SchedulerFeatureFlags.js';
   },
 
   './packages/shared/consoleWithStackDev.js': (bundleType, entry) => {


### PR DESCRIPTION
#31787 introduces an experimental scheduler flag: `enableAlwaysYieldScheduler`, which is turned off for www. There wasn't a SchedulerFeatureFlags fork for native-fb, so the experimental change was enabled in the Scheduler-dev build there which causes test failures and is blocking the sync.

#31805 introduces another scheduler flag `enableRequestPaint`, which is set as a `__VARIANT__` on www. I've set this to `true` here to preserve the existing behavior. We can follow up with dynamic flags for native-fb after unblocking the sync.