### PR TITLE
[ci] getWorkflowRun should not throw early if workflow hasn't completed

### DIFF
--- a/scripts/release/shared-commands/download-build-artifacts.js
+++ b/scripts/release/shared-commands/download-build-artifacts.js
@@ -43,12 +43,7 @@ async function getWorkflowRun(commit) {
   );
 
   const json = JSON.parse(res.stdout);
-  const workflowRun = json.workflow_runs.find(
-    run =>
-      run.head_sha === commit &&
-      run.status === 'completed' &&
-      run.conclusion === 'success'
-  );
+  const workflowRun = json.workflow_runs.find(run => run.head_sha === commit);
 
   if (workflowRun == null || workflowRun.id == null) {
     console.log(


### PR DESCRIPTION

We already have handling and retry logic for in-flight workflows in `downloadArtifactsFromGitHub`, so there's no need to exit early if we find a workflow for a given commit but it hasn't finished yet.
