### PR TITLE
[compiler] Allow type cast expressions with refs

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccesInRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccesInRender.ts
@@ -305,6 +305,14 @@ function validateNoRefAccessInRenderImpl(
             );
             break;
           }
+          case 'TypeCastExpression': {
+            env.set(
+              instr.lvalue.identifier.id,
+              env.get(instr.value.value.identifier.id) ??
+                refTypeOfType(instr.lvalue),
+            );
+            break;
+          }
           case 'LoadContext':
           case 'LoadLocal': {
             env.set(

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-type-cast-in-render.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-type-cast-in-render.expect.md
@@ -1,0 +1,60 @@
+
+## Input
+
+```javascript
+import {useRef} from 'react';
+
+function useArrayOfRef() {
+  const ref = useRef(null);
+  const callback = value => {
+    ref.current = value;
+  };
+  return [callback] as const;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: () => {
+    useArrayOfRef();
+    return 'ok';
+  },
+  params: [{}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { useRef } from "react";
+
+function useArrayOfRef() {
+  const $ = _c(1);
+  const ref = useRef(null);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    const callback = (value) => {
+      ref.current = value;
+    };
+
+    t0 = [callback];
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0 as const;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: () => {
+    useArrayOfRef();
+    return "ok";
+  },
+
+  params: [{}],
+};
+
+```
+      
+### Eval output
+(kind: ok) "ok"

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-type-cast-in-render.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-type-cast-in-render.js
@@ -1,0 +1,17 @@
+import {useRef} from 'react';
+
+function useArrayOfRef() {
+  const ref = useRef(null);
+  const callback = value => {
+    ref.current = value;
+  };
+  return [callback] as const;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: () => {
+    useArrayOfRef();
+    return 'ok';
+  },
+  params: [{}],
+};


### PR DESCRIPTION
We report a false positive for the combination of a ref-accessing function placed inside an array which is they type-cast. Here we teach ref validation about type casts. I also tried other variants like `return ref as const` but those already worked.

Closes #31864