### PR TITLE
[Flight] Add Parcel Runtime Plugin

### DIFF
--- a/fixtures/flight-parcel/.parcelrc
+++ b/fixtures/flight-parcel/.parcelrc
@@ -1,4 +1,4 @@
 {
   "extends": "@parcel/config-default",
-  "runtimes": ["...", "@parcel/runtime-rsc"]
+  "runtimes": ["...", "parcel-runtime-rsc/runtime"]
 }

--- a/fixtures/flight-parcel/package.json
+++ b/fixtures/flight-parcel/package.json
@@ -16,7 +16,7 @@
     }
   },
   "scripts": {
-    "predev": "cp -r ../../build/oss-experimental/* ./node_modules/",
+    "predev": "cp -r ../../build/oss-experimental/* ./node_modules/ && cp -r ../../build/oss-experimental/react-server-dom-parcel ./node_modules/parcel-runtime-rsc",
     "prebuild": "cp -r ../../build/oss-experimental/* ./node_modules/",
     "dev": "concurrently \"npm run dev:watch\" \"npm run dev:start\"",
     "dev:watch": "NODE_ENV=development parcel watch",
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@parcel/config-default": "2.0.0-dev.1789",
-    "@parcel/runtime-rsc": "2.13.3-dev.3412",
     "@types/parcel-env": "^0.0.6",
     "@types/express": "*",
     "@types/node": "^22.10.1",

--- a/fixtures/flight-parcel/src/Todos.tsx
+++ b/fixtures/flight-parcel/src/Todos.tsx
@@ -2,7 +2,7 @@
 
 import './client';
 import './Todos.css';
-import {Resources} from '@parcel/runtime-rsc';
+import {Resources} from 'react-server-dom-parcel/runtime';
 import {Dialog} from './Dialog';
 import {TodoDetail} from './TodoDetail';
 import {TodoCreate} from './TodoCreate';

--- a/fixtures/flight-parcel/types.d.ts
+++ b/fixtures/flight-parcel/types.d.ts
@@ -16,6 +16,6 @@ declare module 'react-server-dom-parcel/server.edge' {
   export function decodeAction(body: FormData): Promise<(...args: any[]) => any>;
 }
 
-declare module '@parcel/runtime-rsc' {
+declare module 'react-server-dom-parcel/runtime' {
   export function Resources(): JSX.Element;
 }

--- a/fixtures/flight-parcel/yarn.lock
+++ b/fixtures/flight-parcel/yarn.lock
@@ -498,15 +498,6 @@
     react-error-overlay "6.0.9"
     react-refresh ">=0.9 <=0.14"
 
-"@parcel/runtime-rsc@2.13.3-dev.3412":
-  version "2.13.3-dev.3412"
-  resolved "https://registry.yarnpkg.com/@parcel/runtime-rsc/-/runtime-rsc-2.13.3-dev.3412.tgz#434cc6afeff78027b6703af5ef27fdbbddd3d6df"
-  integrity sha512-kz+kJWJkQhEDIcnJhiG5PbG2zX4hRkwwiS7aIbby/9rMHexaENy54KMA6+PbMLXZdSlq42HvUSPyW3nHOz7+ew==
-  dependencies:
-    "@parcel/plugin" "2.0.0-dev.1789+0b82b13d6"
-    "@parcel/utils" "2.0.0-dev.1789+0b82b13d6"
-    nullthrows "^1.1.1"
-
 "@parcel/runtime-service-worker@2.13.3-dev.3412+0b82b13d6":
   version "2.13.3-dev.3412"
   resolved "https://registry.yarnpkg.com/@parcel/runtime-service-worker/-/runtime-service-worker-2.13.3-dev.3412.tgz#c59e6ce37e8e961d2f14b8bc03a5818a9f905cf7"

--- a/packages/react-server-dom-parcel/npm/resources.js
+++ b/packages/react-server-dom-parcel/npm/resources.js
@@ -1,0 +1,1 @@
+// Empty file that is replaced by the runtime.

--- a/packages/react-server-dom-parcel/npm/runtime.js
+++ b/packages/react-server-dom-parcel/npm/runtime.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./cjs/react-server-dom-parcel-runtime.js');

--- a/packages/react-server-dom-parcel/package.json
+++ b/packages/react-server-dom-parcel/package.json
@@ -24,6 +24,8 @@
     "static.browser.js",
     "static.edge.js",
     "static.node.js",
+    "resources.js",
+    "runtime.js",
     "cjs/"
   ],
   "exports": {
@@ -66,6 +68,10 @@
     "./static.browser": "./static.browser.js",
     "./static.edge": "./static.edge.js",
     "./static.node": "./static.node.js",
+    "./runtime": {
+      "react-server": "./resources.js",
+      "default": "./runtime.js"
+    },
     "./src/*": "./src/*.js",
     "./package.json": "./package.json"
   },
@@ -77,6 +83,11 @@
   },
   "engines": {
     "node": ">=0.10.0"
+  },
+  "dependencies": {
+    "@parcel/plugin": "2.0.0-dev.1781+61f02c2f3",
+    "@parcel/utils": "2.0.0-dev.1781+61f02c2f3",
+    "nullthrows": "^1.1.1"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/packages/react-server-dom-parcel/runtime.js
+++ b/packages/react-server-dom-parcel/runtime.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export {default} from './src/RSCRuntime';

--- a/packages/react-server-dom-parcel/src/RSCRuntime.js
+++ b/packages/react-server-dom-parcel/src/RSCRuntime.js
@@ -1,0 +1,318 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present Devon Govett
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+// @flow strict-local
+/* eslint-disable no-for-of-loops/no-for-of-loops */
+/* eslint-disable es/no-optional-chaining */
+
+import {Runtime} from '@parcel/plugin';
+import nullthrows from 'nullthrows';
+import {urlJoin, normalizeSeparators} from '@parcel/utils';
+import path from 'path';
+import {hashString} from '@parcel/rust';
+
+export default (new Runtime({
+  async loadConfig({config, options}) {
+    // This logic must be synced with the packager...
+    const packageName = await config.getConfigFrom(
+      options.projectRoot + '/index',
+      [],
+      {
+        packageKey: 'name',
+      },
+    );
+
+    const name = packageName?.contents ?? '';
+    return {
+      parcelRequireName: 'parcelRequire' + hashString(name).slice(-4),
+    };
+  },
+  apply({bundle, bundleGraph, config}) {
+    if (
+      bundle.type !== 'js' ||
+      (bundle.env.context !== 'react-server' &&
+        bundle.env.context !== 'react-client')
+    ) {
+      return [];
+    }
+
+    const runtimes: Array<{
+      filePath: string,
+      code: any,
+      dependency?: any,
+      env?: {sourceType: 'module'},
+      isEntry?: boolean,
+      shouldReplaceResolution?: boolean,
+    }> = [];
+    bundle.traverse(node => {
+      if (node.type === 'dependency') {
+        const resolvedAsset = bundleGraph.getResolvedAsset(node.value, bundle);
+        const directives = resolvedAsset?.meta?.directives;
+
+        // Server dependency on a client component.
+        if (
+          node.value.env.isServer() &&
+          resolvedAsset &&
+          Array.isArray(directives) &&
+          directives.includes('use client')
+        ) {
+          let browserBundles;
+          const async = bundleGraph.resolveAsyncDependency(node.value, bundle);
+          if (async?.type === 'bundle_group') {
+            browserBundles = bundleGraph
+              .getBundlesInBundleGroup(async.value)
+              .filter(b => b.type === 'js' && b.env.isBrowser())
+              .map(b => normalizeSeparators(b.name));
+          } else {
+            browserBundles = bundleGraph
+              .getReferencedBundles(bundle)
+              .filter(b => b.type === 'js' && b.env.isBrowser())
+              .map(b => normalizeSeparators(b.name));
+          }
+
+          let code = `import {createClientReference} from "react-server-dom-parcel/server.edge";\n`;
+          for (const symbol of bundleGraph.getExportedSymbols(
+            resolvedAsset,
+            bundle,
+          )) {
+            code += `exports[${JSON.stringify(
+              symbol.exportAs,
+            )}] = createClientReference(${JSON.stringify(
+              bundleGraph.getAssetPublicId(symbol.asset),
+            )}, ${JSON.stringify(symbol.exportSymbol)}, ${JSON.stringify(
+              browserBundles,
+            )});\n`;
+          }
+
+          code += `exports.__esModule = true;\n`;
+
+          if (node.value.priority === 'lazy') {
+            code += 'module.exports = Promise.resolve(exports);\n';
+          }
+
+          runtimes.push({
+            filePath: replaceExtension(resolvedAsset.filePath),
+            code,
+            dependency: node.value,
+            env: {sourceType: 'module'},
+          });
+
+          // Dependency on a server action.
+        } else if (
+          resolvedAsset &&
+          Array.isArray(directives) &&
+          directives.includes('use server')
+        ) {
+          let code;
+          if (node.value.env.isServer()) {
+            // Dependency on a "use server" module from a server environment.
+            // Mark each export as a server reference that can be passed to a client component as a prop.
+            code = `import {registerServerReference} from "react-server-dom-parcel/server.edge";\n`;
+            const publicId = JSON.stringify(
+              bundleGraph.getAssetPublicId(resolvedAsset),
+            );
+            code += `let originalModule = parcelRequire(${publicId});\n`;
+            code += `for (let key in originalModule) {\n`;
+            code += `  Object.defineProperty(exports, key, {\n`;
+            code += `    enumerable: true,\n`;
+            code += `    get: () => {\n`;
+            code += `      let value = originalModule[key];\n`;
+            code += `      if (typeof value === 'function' && !value.$$typeof) {\n`;
+            code += `        registerServerReference(value, ${publicId}, key);\n`;
+            code += `      }\n`;
+            code += `      return value;\n`;
+            code += `    }\n`;
+            code += `  });\n`;
+            code += `}\n`;
+          } else {
+            // Dependency on a "use server" module from a client environment.
+            // Create a client proxy module that will call the server.
+            code = `import {createServerReference} from "react-server-dom-parcel/client";\n`;
+            let usedSymbols = bundleGraph.getUsedSymbols(resolvedAsset);
+            if (usedSymbols?.has('*')) {
+              usedSymbols = null;
+            }
+            for (const symbol of bundleGraph.getExportedSymbols(
+              resolvedAsset,
+              bundle,
+            )) {
+              if (usedSymbols && !usedSymbols.has(symbol.exportAs)) {
+                continue;
+              }
+              code += `exports[${JSON.stringify(
+                symbol.exportAs,
+              )}] = createServerReference(${JSON.stringify(
+                bundleGraph.getAssetPublicId(symbol.asset),
+              )}, ${JSON.stringify(symbol.exportSymbol)});\n`;
+            }
+          }
+
+          code += `exports.__esModule = true;\n`;
+          if (node.value.priority === 'lazy') {
+            code += 'module.exports = Promise.resolve(exports);\n';
+          }
+
+          runtimes.push({
+            filePath: replaceExtension(resolvedAsset.filePath),
+            code,
+            dependency: node.value,
+            env: {sourceType: 'module'},
+            shouldReplaceResolution: true,
+          });
+
+          // Server dependency on a client entry.
+        } else if (
+          node.value.env.isServer() &&
+          resolvedAsset &&
+          Array.isArray(directives) &&
+          directives.includes('use client-entry')
+        ) {
+          // Resolve to an empty module so the client entry does not run on the server.
+          runtimes.push({
+            filePath: replaceExtension(resolvedAsset.filePath),
+            code: '',
+            dependency: node.value,
+            env: {sourceType: 'module'},
+          });
+
+          // Dependency on a Resources component.
+        } else if (node.value.specifier === 'react-server-dom-parcel/runtime') {
+          // Generate a component that renders link tags for stylesheets referenced by the bundle.
+          const bundles = bundleGraph.getReferencedBundles(bundle);
+          let code =
+            'import React from "react";\nexport function Resources() {\n  return <>\n';
+          let entry;
+          let imports = '';
+          for (const b of bundles) {
+            if (!b.env.isBrowser()) {
+              continue;
+            }
+            const url = urlJoin(b.target.publicUrl, b.name);
+            if (b.type === 'css') {
+              code += `<link rel="stylesheet" href=${JSON.stringify(
+                url,
+              )} precedence="default" />\n`;
+            } else if (b.type === 'js') {
+              imports += `import ${JSON.stringify(url)};`;
+            }
+            b.traverseAssets((a, ctx, actions) => {
+              if (
+                Array.isArray(a.meta.directives) &&
+                a.meta.directives.includes('use client-entry')
+              ) {
+                entry = a;
+                actions.stop();
+              }
+            });
+          }
+
+          // React will insert async script tags for client components to preinit them asap.
+          // Add an inline script element to bootstrap the page, by calling parcelRequire for the client-entry module.
+          // We use import statements to wait for the dependent bundles to load.
+          if (entry) {
+            code += `<script type="module">${imports}${
+              nullthrows(config).parcelRequireName
+            }(${JSON.stringify(
+              bundleGraph.getAssetPublicId(entry),
+            )})</script>\n`;
+          }
+
+          code += '</>;\n}\n';
+
+          const filePath = nullthrows(node.value.sourcePath);
+          runtimes.push({
+            filePath: replaceExtension(filePath),
+            code,
+            dependency: node.value,
+            env: {sourceType: 'module'},
+            shouldReplaceResolution: true,
+          });
+        }
+      }
+    });
+
+    // Register server actions in the server entry point.
+    if (
+      bundle.env.isServer() &&
+      bundleGraph.getParentBundles(bundle).length === 0
+    ) {
+      let serverActions = '';
+      bundleGraph.traverse(node => {
+        if (
+          node.type === 'asset' &&
+          Array.isArray(node.value.meta?.directives) &&
+          node.value.meta.directives.includes('use server')
+        ) {
+          const bundlesWithAsset = bundleGraph.getBundlesWithAsset(node.value);
+          const bundles: Set<any> = new Set();
+          const referenced = bundleGraph.getReferencedBundles(
+            bundlesWithAsset[0],
+          );
+          bundles.add(normalizeSeparators(bundlesWithAsset[0].name));
+          for (const r of referenced) {
+            if (r.type === 'js' && r.env.context === bundle.env.context) {
+              bundles.add(normalizeSeparators(r.name));
+            }
+          }
+          serverActions += `  ${JSON.stringify(
+            bundleGraph.getAssetPublicId(node.value),
+          )}: ${JSON.stringify([...bundles])},\n`;
+        }
+      });
+
+      let code = '';
+      if (serverActions.length > 0) {
+        code +=
+          'import {registerServerActions} from "react-server-dom-parcel/server.edge";\n';
+        code += `registerServerActions({\n`;
+        code += serverActions;
+        code += '});\n';
+      }
+
+      // React needs AsyncLocalStorage defined as a global for the edge environment.
+      // Without this, preinit scripts won't be inserted during SSR.
+      code += 'if (typeof AsyncLocalHooks === "undefined") {\n';
+      code += '  try {\n';
+      code +=
+        '    globalThis.AsyncLocalStorage = require("node:async_hooks").AsyncLocalStorage;\n';
+      code += '  } catch {}\n';
+      code += '}\n';
+
+      runtimes.push({
+        filePath: replaceExtension(
+          bundle.getMainEntry()?.filePath ?? __filename,
+        ),
+        code,
+        isEntry: true,
+        env: {sourceType: 'module'},
+      });
+    }
+
+    return runtimes;
+  },
+}): Runtime);
+
+function replaceExtension(filePath: string, extension: string = '.jsx') {
+  const ext = path.extname(filePath);
+  return filePath.slice(0, -ext.length) + extension;
+}

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -372,3 +372,18 @@ declare const Bun: {
     input: string | $TypedArray | DataView | ArrayBuffer | SharedArrayBuffer,
   ): number,
 };
+
+declare module '@parcel/plugin' {
+  declare class Runtime {
+    constructor(config: any): Runtime;
+  }
+}
+
+declare module '@parcel/utils' {
+  declare function urlJoin(publicURL: string, assetPath: string): string;
+  declare function normalizeSeparators(filePath: any): string;
+}
+
+declare module '@parcel/rust' {
+  declare function hashString(str: string): string;
+}

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -685,6 +685,23 @@ const bundles = [
     externals: ['react', 'react-dom'],
   },
 
+  /******* React Server DOM Parcel Runtime Plugin *******/
+  {
+    bundleTypes: [NODE_ES2015],
+    moduleType: RENDERER_UTILS,
+    entry: 'react-server-dom-parcel/runtime',
+    global: 'ReactServerParcelRuntime',
+    minifyWithProdErrorCodes: false,
+    wrapWithModuleBoundaries: false,
+    externals: [
+      '@parcel/plugin',
+      '@parcel/utils',
+      '@parcel/rust',
+      'path',
+      'nullthrows',
+    ],
+  },
+
   /******* React Server DOM ESM Server *******/
   {
     bundleTypes: [NODE_DEV, NODE_PROD],


### PR DESCRIPTION
Ideally the Parcel RSC runtime shouldn't have to be a separate dependency. It should all be built-in so you can just use it out of the box and we can change the implementation details. There could be more specialized plugins that you use instead in particular frameworks/setups but it's important to have at least some basic functionality upstreamed.

A problem is that Parcel requires runtime packages to be named `parcel-runtime-*` which I'm not sure how we should get around.

@devongovett 