### PR TITLE
DevTools: fix initial host instance selection

### DIFF
--- a/packages/react-devtools-extensions/src/main/index.js
+++ b/packages/react-devtools-extensions/src/main/index.js
@@ -345,8 +345,6 @@ function mountReactDevTools() {
 
   createBridgeAndStore();
 
-  setReactSelectionFromBrowser(bridge);
-
   createComponentsPanel();
   createProfilerPanel();
 }


### PR DESCRIPTION
Related: https://github.com/facebook/react/pull/31342

This fixes RDT behaviour when some DOM element was pre-selected in built-in browser's Elements panel, and then Components panel of React DevTools was opened for the first time. With this change, React DevTools will correctly display the initial state of the Components Tree with the corresponding React Element (if possible) pre-selected.

Previously, we would only subscribe listener when `TreeContext` is mounted, but this only happens when user opens one of React DevTools panels for the first time. With this change, we keep state inside `Store`, which is created when Browser DevTools are opened. Later, `TreeContext` will use it for initial state value.

Planned next changes:
1. Merge `inspectedElementID` and `selectedElementID`, I have no idea why we need both.
2. Fix issue with `AutoSizer` rendering a blank container.