### PR TITLE
DevTools: fork FastRefresh test for <18 versions of React

### DIFF
--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -648,6 +648,7 @@ export function installHook(
     checkDCE,
     onCommitFiberUnmount,
     onCommitFiberRoot,
+    // React v18.0+
     onPostCommitFiberRoot,
     setStrictMode,
 


### PR DESCRIPTION
We currently have a failing test for React DevTools against React 17. This started failing in https://github.com/facebook/react/pull/30899, where we changed logic for error tracking and started relying on `onPostCommitFiberRoot` hook.

Looking at https://github.com/facebook/react/pull/21183, `onPostCommitFiberRoot` was shipped in 18, which means that any console errors / warnings emitted in passive effects won't be recorded by React DevTools for React < 18.