### PR TITLE
DevTools: fix Compiler inegration test with 18.2

### DIFF
--- a/scripts/ci/download_devtools_regression_build.js
+++ b/scripts/ci/download_devtools_regression_build.js
@@ -110,7 +110,7 @@ async function downloadRegressionBuild() {
     );
   }
 
-  if (semver.gte(reactVersion, '18.2.0') && semver.lt(reactVersion, '19')) {
+  if (semver.gte(reactVersion, '18.2.0') && semver.lt(reactVersion, '19.0.0')) {
     console.log(chalk.white(`Downloading react-compiler-runtime\n`));
     await exec(
       `npm install --prefix ${REGRESSION_FOLDER} react-compiler-runtime`


### PR DESCRIPTION
Currently failing with `TypeError: Invalid Version: 19`, looks like I've overlooked this one in https://github.com/facebook/react/pull/31241.