### PR TITLE
Fix missing import for `performance` from `perf_hooks` in runner.ts

### DIFF
--- a/compiler/packages/snap/src/runner.ts
+++ b/compiler/packages/snap/src/runner.ts
@@ -22,6 +22,7 @@ import {
   watchSrc,
 } from './runner-watch';
 import * as runnerWorker from './runner-worker';
+import { performance } from 'perf_hooks';
 
 const WORKER_PATH = require.resolve('./runner-worker.js');
 const NUM_WORKERS = cpus().length - 1;


### PR DESCRIPTION
## Summary

I stumbled upon a critical issue in the `runner.ts` file within the React compiler's `snap` package. The `performance` object was being used in the `onChange` function to track how long certain operations take, but it wasn't imported from Node.js's `perf_hooks` module. This small oversight caused a `ReferenceError`, which messed up our performance measurements and led to some unexpected runtime crashes.

## Motivation

Accurate performance tracking is super important for ensuring our compiler runs efficiently and reliably. Without importing `performance` from `perf_hooks`, every call to `performance.now()` throws a `ReferenceError`, making it impossible to measure execution times. This not only hampers our ability to debug and optimize but also affects the overall stability of the test runner.

## Changes Made

- **Added Import Statement:** Introduced `import { performance } from 'perf_hooks';` at the top of `runner.ts` to ensure the `performance` object is correctly referenced.
  
 ```typescript
  import { performance } from 'perf_hooks';
```

By implementing the `import`, `performance.now()` works as intended, accurately measuring execution time.

Feel free to reach out to me for further details.