### PR TITLE
[rcr] Relax react peer dep requirement

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-rewrite-deps-spread.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/transform-fire/error.invalid-rewrite-deps-spread.expect.md
@@ -12,9 +12,12 @@ function Component(props) {
 
   const deps = [foo, props];
 
-  useEffect(() => {
-    fire(foo(props));
-  }, ...deps);
+  useEffect(
+    () => {
+      fire(foo(props));
+    },
+    ...deps
+  );
 
   return null;
 }
@@ -25,13 +28,13 @@ function Component(props) {
 ## Error
 
 ```
-  11 |   useEffect(() => {
-  12 |     fire(foo(props));
-> 13 |   }, ...deps);
-     |         ^^^^ Invariant: Cannot compile `fire`. You must use an array literal for an effect dependency array when that effect uses `fire()` (13:13)
-  14 |
-  15 |   return null;
-  16 | }
+  13 |       fire(foo(props));
+  14 |     },
+> 15 |     ...deps
+     |        ^^^^ Invariant: Cannot compile `fire`. You must use an array literal for an effect dependency array when that effect uses `fire()` (15:15)
+  16 |   );
+  17 |
+  18 |   return null;
 ```
           
       

--- a/compiler/packages/react-compiler-runtime/package.json
+++ b/compiler/packages/react-compiler-runtime/package.json
@@ -9,7 +9,7 @@
     "src"
   ],
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
   },
   "scripts": {
     "build": "rimraf dist && rollup --config --bundleConfigAsCjs",


### PR DESCRIPTION

There's no real reason to restrict the React peer dep to non-experimental, so relax it.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/31915).
* #31919
* #31918
* #31917
* #31916
* __->__ #31915
* #31920