### PR TITLE
[compiler] Add support for canonical reactrc configs

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/package.json
+++ b/compiler/packages/babel-plugin-react-compiler/package.json
@@ -42,6 +42,7 @@
     "babel-jest": "^29.0.3",
     "babel-plugin-fbt": "^1.0.0",
     "babel-plugin-fbt-runtime": "^1.0.0",
+    "cosmiconfig": "^9.0.0",
     "eslint": "^8.57.1",
     "invariant": "^2.2.4",
     "jest": "^29.0.3",

--- a/compiler/packages/babel-plugin-react-compiler/src/Babel/BabelPlugin.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Babel/BabelPlugin.ts
@@ -6,7 +6,12 @@
  */
 
 import type * as BabelCore from '@babel/core';
-import {compileProgram, parsePluginOptions} from '../Entrypoint';
+import {
+  compileProgram,
+  findReactConfig,
+  parsePluginOptions,
+  type PluginOptions,
+} from '../Entrypoint';
 import {
   injectReanimatedFlag,
   pipelineUsesReanimatedPlugin,
@@ -29,7 +34,18 @@ export default function BabelPluginReactCompiler(
        * want Forget to run true to source as possible.
        */
       Program(prog, pass): void {
-        let opts = parsePluginOptions(pass.opts);
+        const reactConfig = findReactConfig();
+        let opts: PluginOptions | null = null;
+        if (reactConfig != null) {
+          opts = parsePluginOptions(reactConfig.config);
+          if (pass.opts != null) {
+            console.warn(
+              `Duplicate React Compiler config found, defaulting to reactrc found in: ${reactConfig.filepath}`,
+            );
+          }
+        } else {
+          opts = parsePluginOptions(pass.opts);
+        }
         const isDev =
           (typeof __DEV__ !== 'undefined' && __DEV__ === true) ||
           process.env['NODE_ENV'] === 'development';

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
@@ -16,6 +16,7 @@ import {
 import {hasOwnProperty} from '../Utils/utils';
 import {fromZodError} from 'zod-validation-error';
 import {CompilerPipelineValue} from './Pipeline';
+import {type CosmiconfigResult, cosmiconfigSync} from 'cosmiconfig';
 
 const PanicThresholdOptionsSchema = z.enum([
   /*
@@ -285,4 +286,12 @@ export function parseTargetConfig(value: unknown): CompilerReactTarget {
 
 function isCompilerFlag(s: string): s is keyof PluginOptions {
   return hasOwnProperty(defaultOptions, s);
+}
+
+export function findReactConfig(): CosmiconfigResult {
+  const explorerSync = cosmiconfigSync('react', {
+    searchStrategy: 'project',
+    cache: true,
+  });
+  return explorerSync.search();
 }

--- a/compiler/packages/react-compiler-runtime/package.json
+++ b/compiler/packages/react-compiler-runtime/package.json
@@ -9,7 +9,7 @@
     "src"
   ],
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
   },
   "scripts": {
     "build": "rimraf dist && rollup --config --bundleConfigAsCjs",

--- a/compiler/yarn.lock
+++ b/compiler/yarn.lock
@@ -3841,6 +3841,16 @@ core-js-compat@^3.30.1, core-js-compat@^3.30.2:
   dependencies:
     browserslist "^4.21.5"
 
+cosmiconfig@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-9.0.0.tgz#34c3fc58287b915f3ae905ab6dc3de258b55ad9d"
+  integrity sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==
+  dependencies:
+    env-paths "^2.2.1"
+    import-fresh "^3.3.0"
+    js-yaml "^4.1.0"
+    parse-json "^5.2.0"
+
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
@@ -4075,6 +4085,11 @@ entities@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
   integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
+
+env-paths@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
+  integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -4758,7 +4773,7 @@ ignore@^5.3.1:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
-import-fresh@^3.2.1:
+import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==


### PR DESCRIPTION

This PR adds experimental support for a canoncial reactrc config file to be provided. This will be used later by other tooling such as a compiler upgrade script, IDE extension and so on, as the canonical configuration source for the compiler.
