### PR TITLE
[Fiber] Gate Update flag on BeforeMutationMask on flags

### DIFF
--- a/packages/react-reconciler/src/ReactFiberFlags.js
+++ b/packages/react-reconciler/src/ReactFiberFlags.js
@@ -7,7 +7,10 @@
  * @flow
  */
 
-import {enableCreateEventHandleAPI} from 'shared/ReactFeatureFlags';
+import {
+  enableCreateEventHandleAPI,
+  enableUseEffectEventHook,
+} from 'shared/ReactFeatureFlags';
 
 export type Flags = number;
 
@@ -77,17 +80,19 @@ export const MountPassiveDev = /*              */ 0b1000000000000000000000000000
 // don't contain effects, by checking subtreeFlags.
 
 export const BeforeMutationMask: number =
-  // TODO: Remove Update flag from before mutation phase by re-landing Visibility
-  // flag logic (see #20043)
-  Update |
   Snapshot |
   (enableCreateEventHandleAPI
     ? // createEventHandle needs to visit deleted and hidden trees to
       // fire beforeblur
       // TODO: Only need to visit Deletions during BeforeMutation phase if an
       // element is focused.
-      ChildDeletion | Visibility
-    : 0);
+      Update | ChildDeletion | Visibility
+    : enableUseEffectEventHook
+      ? // TODO: The useEffectEvent hook uses the snapshot phase for clean up but it
+        // really should use the mutation phase for this or at least schedule an
+        // explicit Snapshot phase flag for this.
+        Update
+      : 0);
 
 export const MutationMask =
   Placement |


### PR DESCRIPTION
We're currently visiting the snapshot phase for every `Update` flag even though we rarely have to do anything in the Snapshot phase.

The only flags that seem to use these wider visits is `enableCreateEventHandleAPI` and `enableUseEffectEventHook` but really neither of those should do that neither. They should schedule explicit Snapshot phases if needed.