### PR TITLE
[Fiber] Avoid return value from commitBeforeMutationEffects

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -232,23 +232,20 @@ let inProgressLanes: Lanes | null = null;
 let inProgressRoot: FiberRoot | null = null;
 
 let focusedInstanceHandle: null | Fiber = null;
-let shouldFireAfterActiveInstanceBlur: boolean = false;
+export let shouldFireAfterActiveInstanceBlur: boolean = false;
 
 export function commitBeforeMutationEffects(
   root: FiberRoot,
   firstChild: Fiber,
-): boolean {
+): void {
   focusedInstanceHandle = prepareForCommit(root.containerInfo);
+  shouldFireAfterActiveInstanceBlur = false;
 
   nextEffect = firstChild;
   commitBeforeMutationEffects_begin();
 
   // We no longer need to track the active instance fiber
-  const shouldFire = shouldFireAfterActiveInstanceBlur;
-  shouldFireAfterActiveInstanceBlur = false;
   focusedInstanceHandle = null;
-
-  return shouldFire;
 }
 
 function commitBeforeMutationEffects_begin() {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -197,6 +197,7 @@ import {
 } from './ReactFiberThrow';
 import {
   commitBeforeMutationEffects,
+  shouldFireAfterActiveInstanceBlur,
   commitLayoutEffects,
   commitMutationEffects,
   commitPassiveMountEffects,
@@ -3361,10 +3362,7 @@ function commitRootImpl(
     // The first phase a "before mutation" phase. We use this phase to read the
     // state of the host tree right before we mutate it. This is where
     // getSnapshotBeforeUpdate is called.
-    const shouldFireAfterActiveInstanceBlur = commitBeforeMutationEffects(
-      root,
-      finishedWork,
-    );
+    commitBeforeMutationEffects(root, finishedWork);
 
     // The next phase is the mutation phase, where we mutate the host tree.
     commitMutationEffects(root, finishedWork, lanes);


### PR DESCRIPTION
This is behind an unusual flag (enableCreateEventHandleAPI) that doesn't serve a special return value. I'll be collecting other flags from this phase too.

We can just use the global flag and reset it before the next mutation phase. Unlike focusedInstanceHandle this doesn't leak any memory in the meantime.