### PR TITLE
remove unnecessary line in updateWorkInProgressHook

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1056,7 +1056,6 @@ function updateWorkInProgressHook(): Hook {
   if (nextWorkInProgressHook !== null) {
     // There's already a work-in-progress. Reuse it.
     workInProgressHook = nextWorkInProgressHook;
-    nextWorkInProgressHook = workInProgressHook.next;
 
     currentHook = nextCurrentHook;
   } else {


### PR DESCRIPTION

## Summary
There are unnecessary lines in `packages/react-reconciler/src/ReactFiberHooks.js`

## How did you test this change?
There is no need for tests ! I simply removed the unused code.