### PR TITLE
DevTools: merge element fields in TreeStateContext

### DIFF
--- a/packages/react-devtools-inline/__tests__/__e2e__/components.test.js
+++ b/packages/react-devtools-inline/__tests__/__e2e__/components.test.js
@@ -119,7 +119,7 @@ test.describe('Components', () => {
     runOnlyForReactRange('>=16.8');
 
     // Select the first list item in DevTools.
-    await devToolsUtils.selectElement(page, 'ListItem', 'List\nApp');
+    await devToolsUtils.selectElement(page, 'ListItem', 'List\nApp', true);
 
     // Then read the inspected values.
     const sourceText = await page.evaluate(() => {
@@ -127,7 +127,7 @@ test.describe('Components', () => {
       const container = document.getElementById('devtools');
 
       const source = findAllNodes(container, [
-        createTestNameSelector('InspectedElementView-Source'),
+        createTestNameSelector('InspectedElementView-FormattedSourceString'),
       ])[0];
 
       return source.innerText;
@@ -237,35 +237,35 @@ test.describe('Components', () => {
     }
 
     await focusComponentSearch();
-    page.keyboard.insertText('List');
+    await page.keyboard.insertText('List');
     let count = await getComponentSearchResultsCount();
     expect(count).toBe('1 | 4');
 
-    page.keyboard.insertText('Item');
+    await page.keyboard.insertText('Item');
     count = await getComponentSearchResultsCount();
     expect(count).toBe('1 | 3');
 
-    page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
     count = await getComponentSearchResultsCount();
     expect(count).toBe('2 | 3');
 
-    page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
     count = await getComponentSearchResultsCount();
     expect(count).toBe('3 | 3');
 
-    page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
     count = await getComponentSearchResultsCount();
     expect(count).toBe('1 | 3');
 
-    page.keyboard.press('Shift+Enter');
+    await page.keyboard.press('Shift+Enter');
     count = await getComponentSearchResultsCount();
     expect(count).toBe('3 | 3');
 
-    page.keyboard.press('Shift+Enter');
+    await page.keyboard.press('Shift+Enter');
     count = await getComponentSearchResultsCount();
     expect(count).toBe('2 | 3');
 
-    page.keyboard.press('Shift+Enter');
+    await page.keyboard.press('Shift+Enter');
     count = await getComponentSearchResultsCount();
     expect(count).toBe('1 | 3');
   });

--- a/packages/react-devtools-inline/__tests__/__e2e__/devtools-utils.js
+++ b/packages/react-devtools-inline/__tests__/__e2e__/devtools-utils.js
@@ -27,7 +27,12 @@ async function getElementCount(page, displayName) {
   }, displayName);
 }
 
-async function selectElement(page, displayName, waitForOwnersText) {
+async function selectElement(
+  page,
+  displayName,
+  waitForOwnersText,
+  waitForSourceLoaded = false
+) {
   await page.evaluate(listItemText => {
     const {createTestNameSelector, createTextSelector, findAllNodes} =
       window.REACT_DOM_DEVTOOLS;
@@ -68,6 +73,20 @@ async function selectElement(page, displayName, waitForOwnersText) {
       },
       {titleText: displayName, ownersListText: waitForOwnersText}
     );
+  }
+
+  if (waitForSourceLoaded) {
+    await page.waitForFunction(() => {
+      const {createTestNameSelector, findAllNodes} = window.REACT_DOM_DEVTOOLS;
+      const container = document.getElementById('devtools');
+
+      const sourceStringBlock = findAllNodes(container, [
+        createTestNameSelector('InspectedElementView-FormattedSourceString'),
+      ])[0];
+
+      // Wait for a new source line to be fetched
+      return sourceStringBlock != null && sourceStringBlock.innerText != null;
+    });
   }
 }
 

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -115,16 +115,15 @@ describe('InspectedElement', () => {
 
   const Contexts = ({
     children,
-    defaultSelectedElementID = null,
-    defaultSelectedElementIndex = null,
+    defaultInspectedElementID = null,
+    defaultInspectedElementIndex = null,
   }) => (
     <BridgeContext.Provider value={bridge}>
       <StoreContext.Provider value={store}>
         <SettingsContextController>
           <TreeContextController
-            defaultSelectedElementID={defaultSelectedElementID}
-            defaultSelectedElementIndex={defaultSelectedElementIndex}
-            defaultInspectedElementID={defaultSelectedElementID}>
+            defaultInspectedElementID={defaultInspectedElementID}
+            defaultInspectedElementIndex={defaultInspectedElementIndex}>
             <InspectedElementContextController>
               {children}
             </InspectedElementContextController>
@@ -167,8 +166,8 @@ describe('InspectedElement', () => {
       testRendererInstance.update(
         <ErrorBoundary>
           <Contexts
-            defaultSelectedElementID={id}
-            defaultSelectedElementIndex={index}>
+            defaultInspectedElementID={id}
+            defaultInspectedElementIndex={index}>
             <React.Suspense fallback={null}>
               <Suspender id={id} index={index} />
             </React.Suspense>
@@ -355,7 +354,7 @@ describe('InspectedElement', () => {
       const {index, shouldHaveLegacyContext} = cases[i];
 
       // HACK: Recreate TestRenderer instance because we rely on default state values
-      // from props like defaultSelectedElementID and it's easier to reset here than
+      // from props like defaultInspectedElementID and it's easier to reset here than
       // to read the TreeDispatcherContext and update the selected ID that way.
       // We're testing the inspected values here, not the context wiring, so that's ok.
       withErrorsOrWarningsIgnored(
@@ -2069,7 +2068,7 @@ describe('InspectedElement', () => {
     }, false);
 
     // HACK: Recreate TestRenderer instance because we rely on default state values
-    // from props like defaultSelectedElementID and it's easier to reset here than
+    // from props like defaultInspectedElementID and it's easier to reset here than
     // to read the TreeDispatcherContext and update the selected ID that way.
     // We're testing the inspected values here, not the context wiring, so that's ok.
     withErrorsOrWarningsIgnored(
@@ -2129,7 +2128,7 @@ describe('InspectedElement', () => {
     }, false);
 
     // HACK: Recreate TestRenderer instance because we rely on default state values
-    // from props like defaultSelectedElementID and it's easier to reset here than
+    // from props like defaultInspectedElementID and it's easier to reset here than
     // to read the TreeDispatcherContext and update the selected ID that way.
     // We're testing the inspected values here, not the context wiring, so that's ok.
     withErrorsOrWarningsIgnored(
@@ -2408,8 +2407,8 @@ describe('InspectedElement', () => {
       await utils.actAsync(() => {
         root = TestRenderer.create(
           <Contexts
-            defaultSelectedElementID={id}
-            defaultSelectedElementIndex={index}>
+            defaultInspectedElementID={id}
+            defaultInspectedElementIndex={index}>
             <React.Suspense fallback={null}>
               <Suspender target={id} />
             </React.Suspense>
@@ -3101,6 +3100,7 @@ describe('InspectedElement', () => {
 
     await utils.actAsync(() => {
       store.componentFilters = [utils.createDisplayNameFilter('Wrapper')];
+      jest.runOnlyPendingTimers();
     }, false);
 
     expect(state).toMatchInlineSnapshot(`
@@ -3120,6 +3120,7 @@ describe('InspectedElement', () => {
 
     await utils.actAsync(() => {
       store.componentFilters = [];
+      jest.runOnlyPendingTimers();
     }, false);
     expect(state).toMatchInlineSnapshot(`
       ✕ 0, ⚠ 2

--- a/packages/react-devtools-shared/src/__tests__/profilerContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilerContext-test.js
@@ -69,14 +69,14 @@ describe('ProfilerContext', () => {
 
   const Contexts = ({
     children = null,
-    defaultSelectedElementID = null,
-    defaultSelectedElementIndex = null,
+    defaultInspectedElementID = null,
+    defaultInspectedElementIndex = null,
   }: any) => (
     <BridgeContext.Provider value={bridge}>
       <StoreContext.Provider value={store}>
         <TreeContextController
-          defaultSelectedElementID={defaultSelectedElementID}
-          defaultSelectedElementIndex={defaultSelectedElementIndex}>
+          defaultInspectedElementID={defaultInspectedElementID}
+          defaultInspectedElementIndex={defaultInspectedElementIndex}>
           <ProfilerContextController>{children}</ProfilerContextController>
         </TreeContextController>
       </StoreContext.Provider>
@@ -225,8 +225,8 @@ describe('ProfilerContext', () => {
     await utils.actAsync(() =>
       TestRenderer.create(
         <Contexts
-          defaultSelectedElementID={store.getElementIDAtIndex(3)}
-          defaultSelectedElementIndex={3}>
+          defaultInspectedElementID={store.getElementIDAtIndex(3)}
+          defaultInspectedElementIndex={3}>
           <ContextReader />
         </Contexts>,
       ),
@@ -276,8 +276,8 @@ describe('ProfilerContext', () => {
     await utils.actAsync(() =>
       TestRenderer.create(
         <Contexts
-          defaultSelectedElementID={store.getElementIDAtIndex(3)}
-          defaultSelectedElementIndex={3}>
+          defaultInspectedElementID={store.getElementIDAtIndex(3)}
+          defaultInspectedElementIndex={3}>
           <ContextReader />
         </Contexts>,
       ),
@@ -323,8 +323,8 @@ describe('ProfilerContext', () => {
     await utils.actAsync(() =>
       TestRenderer.create(
         <Contexts
-          defaultSelectedElementID={store.getElementIDAtIndex(3)}
-          defaultSelectedElementIndex={3}>
+          defaultInspectedElementID={store.getElementIDAtIndex(3)}
+          defaultInspectedElementIndex={3}>
           <ContextReader />
         </Contexts>,
       ),
@@ -374,8 +374,8 @@ describe('ProfilerContext', () => {
     await utils.actAsync(() =>
       TestRenderer.create(
         <Contexts
-          defaultSelectedElementID={store.getElementIDAtIndex(3)}
-          defaultSelectedElementIndex={3}>
+          defaultInspectedElementID={store.getElementIDAtIndex(3)}
+          defaultInspectedElementIndex={3}>
           <ContextReader />
         </Contexts>,
       ),
@@ -415,11 +415,12 @@ describe('ProfilerContext', () => {
 
     let context: Context = ((null: any): Context);
     let dispatch: DispatcherContext = ((null: any): DispatcherContext);
-    let selectedElementID = null;
+    let inspectedElementID = null;
     function ContextReader() {
       context = React.useContext(ProfilerContext);
       dispatch = React.useContext(TreeDispatcherContext);
-      selectedElementID = React.useContext(TreeStateContext).selectedElementID;
+      inspectedElementID =
+        React.useContext(TreeStateContext).inspectedElementID;
       return null;
     }
 
@@ -428,13 +429,15 @@ describe('ProfilerContext', () => {
     // Select an element within the second root.
     await utils.actAsync(() =>
       TestRenderer.create(
-        <Contexts defaultSelectedElementID={id} defaultSelectedElementIndex={3}>
+        <Contexts
+          defaultInspectedElementID={id}
+          defaultInspectedElementIndex={3}>
           <ContextReader />
         </Contexts>,
       ),
     );
 
-    expect(selectedElementID).toBe(id);
+    expect(inspectedElementID).toBe(id);
 
     // Profile and record more updates to both roots
     await utils.actAsync(() => store.profilerStore.startProfiling());
@@ -448,7 +451,7 @@ describe('ProfilerContext', () => {
     utils.act(() => dispatch({type: 'SELECT_ELEMENT_AT_INDEX', payload: 0}));
 
     // Verify that the initial Profiler root selection is maintained.
-    expect(selectedElementID).toBe(otherID);
+    expect(inspectedElementID).toBe(otherID);
     expect(context).not.toBeNull();
     expect(context.rootID).toBe(store.getRootIDForElement(id));
   });
@@ -484,11 +487,12 @@ describe('ProfilerContext', () => {
 
     let context: Context = ((null: any): Context);
     let dispatch: DispatcherContext = ((null: any): DispatcherContext);
-    let selectedElementID = null;
+    let inspectedElementID = null;
     function ContextReader() {
       context = React.useContext(ProfilerContext);
       dispatch = React.useContext(TreeDispatcherContext);
-      selectedElementID = React.useContext(TreeStateContext).selectedElementID;
+      inspectedElementID =
+        React.useContext(TreeStateContext).inspectedElementID;
       return null;
     }
 
@@ -497,13 +501,15 @@ describe('ProfilerContext', () => {
     // Select an element within the second root.
     await utils.actAsync(() =>
       TestRenderer.create(
-        <Contexts defaultSelectedElementID={id} defaultSelectedElementIndex={3}>
+        <Contexts
+          defaultInspectedElementID={id}
+          defaultInspectedElementIndex={3}>
           <ContextReader />
         </Contexts>,
       ),
     );
 
-    expect(selectedElementID).toBe(id);
+    expect(inspectedElementID).toBe(id);
 
     // Profile and record more updates to both roots
     await utils.actAsync(() => store.profilerStore.startProfiling());
@@ -517,7 +523,7 @@ describe('ProfilerContext', () => {
     utils.act(() => dispatch({type: 'SELECT_ELEMENT_AT_INDEX', payload: 0}));
 
     // Verify that the initial Profiler root selection is maintained.
-    expect(selectedElementID).toBe(otherID);
+    expect(inspectedElementID).toBe(otherID);
     expect(context).not.toBeNull();
     expect(context.rootID).toBe(store.getRootIDForElement(id));
   });
@@ -553,10 +559,11 @@ describe('ProfilerContext', () => {
     `);
 
     let context: Context = ((null: any): Context);
-    let selectedElementID = null;
+    let inspectedElementID = null;
     function ContextReader() {
       context = React.useContext(ProfilerContext);
-      selectedElementID = React.useContext(TreeStateContext).selectedElementID;
+      inspectedElementID =
+        React.useContext(TreeStateContext).inspectedElementID;
       return null;
     }
 
@@ -567,14 +574,14 @@ describe('ProfilerContext', () => {
         </Contexts>,
       ),
     );
-    expect(selectedElementID).toBeNull();
+    expect(inspectedElementID).toBeNull();
 
     // Select an element in the Profiler tab and verify that the selection is synced to the Components tab.
     await utils.actAsync(() => context.selectFiber(parentID, 'Parent'));
-    expect(selectedElementID).toBe(parentID);
+    expect(inspectedElementID).toBe(parentID);
 
     // Select an unmounted element and verify no Components tab selection doesn't change.
     await utils.actAsync(() => context.selectFiber(childID, 'Child'));
-    expect(selectedElementID).toBe(parentID);
+    expect(inspectedElementID).toBe(parentID);
   });
 });

--- a/packages/react-devtools-shared/src/devtools/utils.js
+++ b/packages/react-devtools-shared/src/devtools/utils.js
@@ -67,7 +67,7 @@ export function printStore(
     if (state === null) {
       return '';
     }
-    return state.selectedElementIndex === index ? `→` : ' ';
+    return state.inspectedElementIndex === index ? `→` : ' ';
   }
 
   function printErrorsAndWarnings(element: Element): string {

--- a/packages/react-devtools-shared/src/devtools/views/Components/Element.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Element.js
@@ -33,7 +33,7 @@ type Props = {
 
 export default function Element({data, index, style}: Props): React.Node {
   const store = useContext(StoreContext);
-  const {ownerFlatTree, ownerID, selectedElementID} =
+  const {ownerFlatTree, ownerID, inspectedElementID} =
     useContext(TreeStateContext);
   const dispatch = useContext(TreeDispatcherContext);
 
@@ -46,7 +46,7 @@ export default function Element({data, index, style}: Props): React.Node {
 
   const {isNavigatingWithKeyboard, onElementMouseEnter, treeFocused} = data;
   const id = element === null ? null : element.id;
-  const isSelected = selectedElementID === id;
+  const isSelected = inspectedElementID === id;
 
   const errorsAndWarningsSubscription = useMemo(
     () => ({

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSourcePanel.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSourcePanel.js
@@ -28,7 +28,7 @@ function InspectedElementSourcePanel({
   symbolicatedSourcePromise,
 }: Props): React.Node {
   return (
-    <div data-testname="InspectedElementView-Source">
+    <div>
       <div className={styles.SourceHeaderRow}>
         <div className={styles.SourceHeader}>source</div>
 
@@ -84,7 +84,9 @@ function FormattedSourceString({source, symbolicatedSourcePromise}: Props) {
     const {sourceURL, line} = source;
 
     return (
-      <div className={styles.SourceOneLiner}>
+      <div
+        className={styles.SourceOneLiner}
+        data-testname="InspectedElementView-FormattedSourceString">
         {formatSourceForDisplay(sourceURL, line)}
       </div>
     );
@@ -93,7 +95,9 @@ function FormattedSourceString({source, symbolicatedSourcePromise}: Props) {
   const {sourceURL, line} = symbolicatedSource;
 
   return (
-    <div className={styles.SourceOneLiner}>
+    <div
+      className={styles.SourceOneLiner}
+      data-testname="InspectedElementView-FormattedSourceString">
       {formatSourceForDisplay(sourceURL, line)}
     </div>
   );

--- a/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/context.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/context.js
@@ -100,10 +100,10 @@ function NativeStyleContextController({children}: Props): React.Node {
     [store],
   );
 
-  // It's very important that this context consumes selectedElementID and not NativeStyleID.
+  // It's very important that this context consumes inspectedElementID and not NativeStyleID.
   // Otherwise the effect that sends the "inspect" message across the bridge-
   // would itself be blocked by the same render that suspends (waiting for the data).
-  const {selectedElementID} = useContext<StateContext>(TreeStateContext);
+  const {inspectedElementID} = useContext<StateContext>(TreeStateContext);
 
   const [currentStyleAndLayout, setCurrentStyleAndLayout] =
     useState<StyleAndLayoutFrontend | null>(null);
@@ -128,7 +128,7 @@ function NativeStyleContextController({children}: Props): React.Node {
           resource.write(element, styleAndLayout);
 
           // Schedule update with React if the currently-selected element has been invalidated.
-          if (id === selectedElementID) {
+          if (id === inspectedElementID) {
             setCurrentStyleAndLayout(styleAndLayout);
           }
         }
@@ -141,15 +141,15 @@ function NativeStyleContextController({children}: Props): React.Node {
         'NativeStyleEditor_styleAndLayout',
         onStyleAndLayout,
       );
-  }, [bridge, currentStyleAndLayout, selectedElementID, store]);
+  }, [bridge, currentStyleAndLayout, inspectedElementID, store]);
 
   // This effect handler polls for updates on the currently selected element.
   useEffect(() => {
-    if (selectedElementID === null) {
+    if (inspectedElementID === null) {
       return () => {};
     }
 
-    const rendererID = store.getRendererIDForElement(selectedElementID);
+    const rendererID = store.getRendererIDForElement(inspectedElementID);
 
     let timeoutID: TimeoutID | null = null;
 
@@ -158,7 +158,7 @@ function NativeStyleContextController({children}: Props): React.Node {
 
       if (rendererID !== null) {
         bridge.send('NativeStyleEditor_measure', {
-          id: selectedElementID,
+          id: inspectedElementID,
           rendererID,
         });
       }
@@ -170,7 +170,7 @@ function NativeStyleContextController({children}: Props): React.Node {
 
     const onStyleAndLayout = ({id}: StyleAndLayoutBackend) => {
       // If this is the element we requested, wait a little bit and then ask for another update.
-      if (id === selectedElementID) {
+      if (id === inspectedElementID) {
         if (timeoutID !== null) {
           clearTimeout(timeoutID);
         }
@@ -190,7 +190,7 @@ function NativeStyleContextController({children}: Props): React.Node {
         clearTimeout(timeoutID);
       }
     };
-  }, [bridge, selectedElementID, store]);
+  }, [bridge, inspectedElementID, store]);
 
   const value = useMemo(
     () => ({getStyleAndLayout}),

--- a/packages/react-devtools-shared/src/devtools/views/Components/SelectedTreeHighlight.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SelectedTreeHighlight.js
@@ -28,19 +28,19 @@ export default function SelectedTreeHighlight(_: {}): React.Node {
   const {lineHeight} = useContext(SettingsContext);
   const store = useContext(StoreContext);
   const treeFocused = useContext(TreeFocusedContext);
-  const {ownerID, selectedElementID} = useContext(TreeStateContext);
+  const {ownerID, inspectedElementID} = useContext(TreeStateContext);
 
   const subscription = useMemo(
     () => ({
       getCurrentValue: () => {
         if (
-          selectedElementID === null ||
-          store.isInsideCollapsedSubTree(selectedElementID)
+          inspectedElementID === null ||
+          store.isInsideCollapsedSubTree(inspectedElementID)
         ) {
           return null;
         }
 
-        const element = store.getElementByID(selectedElementID);
+        const element = store.getElementByID(inspectedElementID);
         if (
           element === null ||
           element.isCollapsed ||
@@ -83,7 +83,7 @@ export default function SelectedTreeHighlight(_: {}): React.Node {
         };
       },
     }),
-    [selectedElementID, store],
+    [inspectedElementID, store],
   );
   const data = useSubscription<Data | null>(subscription);
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
@@ -54,8 +54,8 @@ export default function Tree(): React.Node {
     ownerID,
     searchIndex,
     searchResults,
-    selectedElementID,
-    selectedElementIndex,
+    inspectedElementID,
+    inspectedElementIndex,
   } = useContext(TreeStateContext);
   const bridge = useContext(BridgeContext);
   const store = useContext(StoreContext);
@@ -84,11 +84,11 @@ export default function Tree(): React.Node {
   // Using a callback ref accounts for this case...
   const listCallbackRef = useCallback(
     (list: $FlowFixMe) => {
-      if (list != null && selectedElementIndex !== null) {
-        list.scrollToItem(selectedElementIndex, 'smart');
+      if (list != null && inspectedElementIndex !== null) {
+        list.scrollToItem(inspectedElementIndex, 'smart');
       }
     },
-    [selectedElementIndex],
+    [inspectedElementIndex],
   );
 
   // Picking an element in the inspector should put focus into the tree.
@@ -133,8 +133,8 @@ export default function Tree(): React.Node {
         case 'ArrowLeft':
           event.preventDefault();
           element =
-            selectedElementID !== null
-              ? store.getElementByID(selectedElementID)
+            inspectedElementID !== null
+              ? store.getElementByID(inspectedElementID)
               : null;
           if (element !== null) {
             if (event.altKey) {
@@ -153,8 +153,8 @@ export default function Tree(): React.Node {
         case 'ArrowRight':
           event.preventDefault();
           element =
-            selectedElementID !== null
-              ? store.getElementByID(selectedElementID)
+            inspectedElementID !== null
+              ? store.getElementByID(inspectedElementID)
               : null;
           if (element !== null) {
             if (event.altKey) {
@@ -202,7 +202,7 @@ export default function Tree(): React.Node {
     return () => {
       container.removeEventListener('keydown', handleKeyDown);
     };
-  }, [dispatch, selectedElementID, store]);
+  }, [dispatch, inspectedElementID, store]);
 
   // Focus management.
   const handleBlur = useCallback(() => setTreeFocused(false), []);
@@ -213,15 +213,15 @@ export default function Tree(): React.Node {
       switch (event.key) {
         case 'Enter':
         case ' ':
-          if (selectedElementID !== null) {
-            dispatch({type: 'SELECT_OWNER', payload: selectedElementID});
+          if (inspectedElementID !== null) {
+            dispatch({type: 'SELECT_OWNER', payload: inspectedElementID});
           }
           break;
         default:
           break;
       }
     },
-    [dispatch, selectedElementID],
+    [dispatch, inspectedElementID],
   );
 
   // If we switch the selected element while using the keyboard,
@@ -238,8 +238,8 @@ export default function Tree(): React.Node {
       didSelectNewSearchResult = true;
     }
     if (isNavigatingWithKeyboard || didSelectNewSearchResult) {
-      if (selectedElementID !== null) {
-        highlightHostInstance(selectedElementID);
+      if (inspectedElementID !== null) {
+        highlightHostInstance(inspectedElementID);
       } else {
         clearHighlightHostInstance();
       }
@@ -250,7 +250,7 @@ export default function Tree(): React.Node {
     highlightHostInstance,
     searchIndex,
     searchResults,
-    selectedElementID,
+    inspectedElementID,
   ]);
 
   // Highlight last hovered element.

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilerContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilerContext.js
@@ -88,7 +88,7 @@ type Props = {
 
 function ProfilerContextController({children}: Props): React.Node {
   const store = useContext(StoreContext);
-  const {selectedElementID} = useContext(TreeStateContext);
+  const {inspectedElementID} = useContext(TreeStateContext);
   const dispatch = useContext(TreeDispatcherContext);
 
   const {profilerStore} = store;
@@ -176,9 +176,9 @@ function ProfilerContextController({children}: Props): React.Node {
 
         if (rootID === null || !dataForRoots.has(rootID)) {
           let selectedElementRootID = null;
-          if (selectedElementID !== null) {
+          if (inspectedElementID !== null) {
             selectedElementRootID =
-              store.getRootIDForElement(selectedElementID);
+              store.getRootIDForElement(inspectedElementID);
           }
           if (
             selectedElementRootID !== null &&


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/31892, see commit on top.

For some reason, there were 2 fields different fields for essentially same thing: `selectedElementID` and `inspectedElementID`. Basically, the change is:
```
selectedElementID -> inspectedElementID
selectedElementIndex -> inspectedElementIndex
```

I have a theory that it was due to previously used async approach around element inspection, and the whole `InspectedElementView` was wrapped in `Suspense`. 
