### PR TITLE
fix: `react-compiler-runtime` should be cjs

### DIFF
--- a/compiler/packages/react-compiler-runtime/scripts/build.js
+++ b/compiler/packages/react-compiler-runtime/scripts/build.js
@@ -29,7 +29,7 @@ const config = {
   outfile: path.join(__dirname, '../dist/index.js'),
   bundle: true,
   external: ['react'],
-  format: argv.p === 'browser' ? 'esm' : 'cjs',
+  format: 'cjs',
   platform: argv.p,
   target: 'es6',
   banner: {


### PR DESCRIPTION
## Summary

The move to `esbuild` in https://github.com/facebook/react/pull/31963 is [causing build errors in many of our systems due to the changed output format](https://npmdiff.dev/react-compiler-runtime/19.0.0-beta-55955c9-20241229/19.0.0-beta-63e3235-20250105/):
```bash
perf-studio:build: /vercel/path1/node_modules/.pnpm/react-compiler-runtime@19.0.0-beta-63e3235-20250105_react@18.3.1/node_modules/react-compiler-runtime/dist/index.js:17
perf-studio:build: import * as React from "react";
perf-studio:build: ^^^^^^
perf-studio:build: SyntaxError: Cannot use import statement outside a module
perf-studio:build:     at extensions..js (~/path1/node_modules/.pnpm/esbuild-register@3.6.0_esbuild@0.21.5/node_modules/esbuild-register/dist/node.js:4833:24)
```
`esbuild-register` and `jest` are repeat offenders.

## How did you test this change?

The new output with this change is cjs, which is what it used to be and matches what `react` itself is currently published as.
