### PR TITLE
[Fiber] Support only View Transitions v2

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -1187,19 +1187,28 @@ export function startViewTransition(
     rootContainer.nodeType === DOCUMENT_NODE
       ? rootContainer
       : rootContainer.ownerDocument;
-  // $FlowFixMe[prop-missing]
-  if (typeof ownerDocument.startViewTransition !== 'function') {
+  try {
+    // $FlowFixMe[prop-missing]
+    const transition = ownerDocument.startViewTransition({
+      update() {
+        mutationCallback();
+        // TODO: Wait for fonts.
+        afterMutationCallback();
+      },
+      types: null, // TODO: Provide types.
+    });
+    transition.ready.then(layoutCallback, layoutCallback);
+    transition.finished.then(passiveCallback);
+    return true;
+  } catch (x) {
+    // We use the error as feature detection.
+    // The only thing that should throw is if startViewTransition is missing
+    // or if it doesn't accept the object form. Other errors are async.
+    // I.e. it's before the View Transitions v2 spec. We only support View
+    // Transitions v2 otherwise we fallback to not animating to ensure that
+    // we're not animating with the wrong animation mapped.
     return false;
   }
-  // $FlowFixMe[incompatible-use]
-  const transition = ownerDocument.startViewTransition(() => {
-    mutationCallback();
-    // TODO: Wait for fonts.
-    afterMutationCallback();
-  });
-  transition.ready.then(layoutCallback, layoutCallback);
-  transition.finished.then(passiveCallback);
-  return true;
 }
 
 export function clearContainer(container: Container): void {


### PR DESCRIPTION
Stacked on #31975.

We're going to recommend that the primary way you style a View Transition is using a View Transition Class (and/or Type). These are only available in the View Transitions v2 spec. When they're not available it's better to fallback to just not animating instead of animating with the wrong styling rules applied.

This is already widely supported in Chrome and Safari 18.2. Safari 18.2 usage is still somewhat low but it's rolling out quickly as we speak.

A way to detect this is by just passing the object form to `startViewTransition` which throws if it's an earlier version. The object form is required for `types` but luckily classes rolled out at the same time. Therefore we're only indirectly detecting class support.

This means that in practice Safari 18.0 and 18.1 won't animate. We could try to only apply the feature detection if you're actually using classes or types, but that would create an unfortunate ecosystem burden to try to support names. It also leads to flaky effects when only some animations work. Better to just disable them all.

Firefox has yet to ship anything. We'll have to look out for how the feature detection happens there and if they roll things out in different order but if you ship late, you deal with web compat as the ball lies.