### PR TITLE
chore[react-devtools-shell]: disable warnings in dev server overlay

### DIFF
--- a/packages/react-devtools-shell/webpack-server.js
+++ b/packages/react-devtools-shell/webpack-server.js
@@ -174,6 +174,9 @@ const appServer = new WebpackDevServer(
     port: 8080,
     client: {
       logging: 'warn',
+      overlay: {
+        warnings: false,
+      },
     },
     static: {
       directory: __dirname,
@@ -189,6 +192,9 @@ const e2eRegressionAppServer = new WebpackDevServer(
     port: 8181,
     client: {
       logging: 'warn',
+      overlay: {
+        warnings: false,
+      },
     },
     static: {
       publicPath: '/dist/',


### PR DESCRIPTION
Disables warnings Webpack DevServer overlay, which is used by React DevTools shell.

We are testing against `react-native-web` in this shell, and it installs older versions of the `react-dom` package, and there are some expected discrepancies between it and `react-dom` from source.

Before:
![Screenshot 2025-01-07 at 12 50 21](https://github.com/user-attachments/assets/ba7d435e-3265-4446-9994-6a77c6d3d4ef)

After:
![Screenshot 2025-01-07 at 12 49 47](https://github.com/user-attachments/assets/cb45d07c-f561-496a-b76f-bdce3154ab88)
