### PR TITLE
[playground] Use default compiler config

### DIFF
--- a/compiler/apps/playground/components/Editor/EditorImpl.tsx
+++ b/compiler/apps/playground/components/Editor/EditorImpl.tsx
@@ -78,8 +78,6 @@ function invokeCompiler(
       logEvent: () => {},
     },
     environment,
-    compilationMode: 'all',
-    panicThreshold: 'all_errors',
   });
   const ast = parseInput(source, language);
   let result = transformFromAstSync(ast, source, {


### PR DESCRIPTION

The playground's compilation mode is currently set to 'all' along with reporting all errors.

This tends to be misleading since people usually expect a 1:1 match between how the playground works with what the compiler does in their codebase, eg https://github.com/reactwg/react-compiler/discussions/51.
