### PR TITLE
[ci] Make gh workflow names consistent

### DIFF
--- a/.github/workflows/shared_discord_notify.yml
+++ b/.github/workflows/shared_discord_notify.yml
@@ -1,8 +1,8 @@
-name: Discord Notify
+name: (Shared) Discord Notify
 
 on:
   pull_request_target:
-    types: [ labeled ]
+    types: [labeled]
 
 jobs:
   notify:


### PR DESCRIPTION

Super minor change to keep our naming scheme consistent for gh workflows
