### PR TITLE
[compiler] Playground qol: shared compilation option directives with tests

### DIFF
--- a/compiler/apps/playground/__tests__/e2e/__snapshots__/page.spec.ts/compilationMode-all-output.txt
+++ b/compiler/apps/playground/__tests__/e2e/__snapshots__/page.spec.ts/compilationMode-all-output.txt
@@ -1,0 +1,13 @@
+import { c as _c } from "react/compiler-runtime"; // 
+        @compilationMode(all)
+function nonReactFn() {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = {};
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0;
+}

--- a/compiler/apps/playground/__tests__/e2e/__snapshots__/page.spec.ts/compilationMode-infer-output.txt
+++ b/compiler/apps/playground/__tests__/e2e/__snapshots__/page.spec.ts/compilationMode-infer-output.txt
@@ -1,0 +1,4 @@
+// @compilationMode(infer)
+function nonReactFn() {
+  return {};
+}

--- a/compiler/apps/playground/__tests__/e2e/page.spec.ts
+++ b/compiler/apps/playground/__tests__/e2e/page.spec.ts
@@ -83,6 +83,24 @@ function useFoo(propVal: {+baz: number}) {
     `,
     noFormat: true,
   },
+  {
+    name: 'compilationMode-infer',
+    input: `// @compilationMode(infer)
+function nonReactFn() {
+  return {};
+}
+    `,
+    noFormat: true,
+  },
+  {
+    name: 'compilationMode-all',
+    input: `// @compilationMode(all)
+function nonReactFn() {
+  return {};
+}
+    `,
+    noFormat: true,
+  },
 ];
 
 test('editor should open successfully', async ({page}) => {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/parseConfigPragma-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/parseConfigPragma-test.ts
@@ -6,6 +6,7 @@
  */
 
 import {parseConfigPragmaForTests, validateEnvironmentConfig} from '..';
+import {defaultOptions} from '../Entrypoint';
 
 describe('parseConfigPragmaForTests()', () => {
   it('parses flags in various forms', () => {
@@ -19,13 +20,18 @@ describe('parseConfigPragmaForTests()', () => {
 
     const config = parseConfigPragmaForTests(
       '@enableUseTypeAnnotations @validateNoSetStateInPassiveEffects:true @validateNoSetStateInRender:false',
+      {compilationMode: defaultOptions.compilationMode},
     );
     expect(config).toEqual({
-      ...defaultConfig,
-      enableUseTypeAnnotations: true,
-      validateNoSetStateInPassiveEffects: true,
-      validateNoSetStateInRender: false,
-      enableResetCacheOnSourceFileChanges: false,
+      ...defaultOptions,
+      panicThreshold: 'all_errors',
+      environment: {
+        ...defaultOptions.environment,
+        enableUseTypeAnnotations: true,
+        validateNoSetStateInPassiveEffects: true,
+        validateNoSetStateInRender: false,
+        enableResetCacheOnSourceFileChanges: false,
+      },
     });
   });
 });

--- a/compiler/packages/snap/src/compiler.ts
+++ b/compiler/packages/snap/src/compiler.ts
@@ -11,12 +11,9 @@ import {transformFromAstSync} from '@babel/core';
 import * as BabelParser from '@babel/parser';
 import {NodePath} from '@babel/traverse';
 import * as t from '@babel/types';
-import assert from 'assert';
 import type {
-  CompilationMode,
   Logger,
   LoggerEvent,
-  PanicThresholdOptions,
   PluginOptions,
   CompilerReactTarget,
   CompilerPipelineValue,
@@ -51,30 +48,12 @@ function makePluginOptions(
   ValueKindEnum: typeof ValueKind,
 ): [PluginOptions, Array<{filename: string | null; event: LoggerEvent}>] {
   let gating = null;
-  let compilationMode: CompilationMode = 'all';
-  let panicThreshold: PanicThresholdOptions = 'all_errors';
   let hookPattern: string | null = null;
   // TODO(@mofeiZ) rewrite snap fixtures to @validatePreserveExistingMemo:false
   let validatePreserveExistingMemoizationGuarantees = false;
   let customMacros: null | Array<Macro> = null;
   let validateBlocklistedImports = null;
-  let enableFire = false;
   let target: CompilerReactTarget = '19';
-
-  if (firstLine.indexOf('@compilationMode(annotation)') !== -1) {
-    assert(
-      compilationMode === 'all',
-      'Cannot set @compilationMode(..) more than once',
-    );
-    compilationMode = 'annotation';
-  }
-  if (firstLine.indexOf('@compilationMode(infer)') !== -1) {
-    assert(
-      compilationMode === 'all',
-      'Cannot set @compilationMode(..) more than once',
-    );
-    compilationMode = 'infer';
-  }
 
   if (firstLine.includes('@gating')) {
     gating = {
@@ -94,10 +73,6 @@ function makePluginOptions(
       // @ts-ignore
       target = targetMatch[1];
     }
-  }
-
-  if (firstLine.includes('@panicThreshold(none)')) {
-    panicThreshold = 'none';
   }
 
   let eslintSuppressionRules: Array<string> | null = null;
@@ -128,10 +103,6 @@ function makePluginOptions(
    */
   if (firstLine.includes('@validatePreserveExistingMemoizationGuarantees')) {
     validatePreserveExistingMemoizationGuarantees = true;
-  }
-
-  if (firstLine.includes('@enableFire')) {
-    enableFire = true;
   }
 
   const hookPatternMatch = /@hookPattern:"([^"]+)"/.exec(firstLine);
@@ -199,10 +170,11 @@ function makePluginOptions(
     debugLogIRs: debugIRLogger,
   };
 
-  const config = parseConfigPragmaFn(firstLine);
+  const config = parseConfigPragmaFn(firstLine, {compilationMode: 'all'});
   const options = {
+    ...config,
     environment: {
-      ...config,
+      ...config.environment,
       moduleTypeProvider: makeSharedRuntimeTypeProvider({
         EffectEnum,
         ValueKindEnum,
@@ -212,12 +184,9 @@ function makePluginOptions(
       hookPattern,
       validatePreserveExistingMemoizationGuarantees,
       validateBlocklistedImports,
-      enableFire,
     },
-    compilationMode,
     logger,
     gating,
-    panicThreshold,
     noEmit: false,
     eslintSuppressionRules,
     flowSuppressions,


### PR DESCRIPTION

- Adds @compilationMode(all|infer|syntax|annotation) and @panicMode(none) directives. This is now shared with our test infra
- Playground still defaults to `infer` mode while tests default to `all` mode
- See added fixture tests
