### PR TITLE
[compiler] ReactiveIR: add Let/Assign/Branch/Join nodes

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reactive-graph-conditional-let.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reactive-graph-conditional-let.expect.md
@@ -1,0 +1,61 @@
+
+## Input
+
+```javascript
+// @enableReactiveGraph
+function Component(props) {
+  let element = props.default;
+  let other = element;
+  if (props.cond) {
+    element = <div></div>;
+  } else {
+    element = <span></span>;
+  }
+  return [element, other];
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableReactiveGraph
+function Component(props) {
+  const $ = _c(5);
+  let element = props.default;
+  const other = element;
+  if (props.cond) {
+    let t0;
+    if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+      t0 = <div />;
+      $[0] = t0;
+    } else {
+      t0 = $[0];
+    }
+    element = t0;
+  } else {
+    let t0;
+    if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+      t0 = <span />;
+      $[1] = t0;
+    } else {
+      t0 = $[1];
+    }
+    element = t0;
+  }
+  let t0;
+  if ($[2] !== element || $[3] !== other) {
+    t0 = [element, other];
+    $[2] = element;
+    $[3] = other;
+    $[4] = t0;
+  } else {
+    t0 = $[4];
+  }
+  return t0;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reactive-graph-conditional-let.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reactive-graph-conditional-let.js
@@ -1,0 +1,11 @@
+// @enableReactiveGraph
+function Component(props) {
+  let element = props.default;
+  let other = element;
+  if (props.cond) {
+    element = <div></div>;
+  } else {
+    element = <span></span>;
+  }
+  return [element, other];
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

The implementation ensures writes are ordered, but is missing the logic to ensure that reads are ordered. The easy thing would be to order reads the same as writes, but we want to be able to order reads relative to each other — the real ordering constraint is that an instruction read the correct write. That will take a bit more work, for a follow-up.