### PR TITLE
fix[DevTools/Tree]: only scroll to item when panel is visible

### DIFF
--- a/packages/react-devtools-extensions/src/main/index.js
+++ b/packages/react-devtools-extensions/src/main/index.js
@@ -206,8 +206,12 @@ function createComponentsPanel() {
         }
       });
 
-      // TODO: we should listen to createdPanel.onHidden to unmount some listeners
-      // and potentially stop highlighting
+      createdPanel.onShown.addListener(() => {
+        bridge.emit('extensionComponentsPanelShown');
+      });
+      createdPanel.onHidden.addListener(() => {
+        bridge.emit('extensionComponentsPanelHidden');
+      });
     },
   );
 }

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -217,6 +217,8 @@ type FrontendEvents = {
   clearWarningsForElementID: [ElementAndRendererID],
   copyElementPath: [CopyElementPathParams],
   deletePath: [DeletePath],
+  extensionComponentsPanelShown: [],
+  extensionComponentsPanelHidden: [],
   getBackendVersion: [],
   getBridgeProtocol: [],
   getIfHasUnsupportedRendererVersion: [],

--- a/packages/react-devtools-shared/src/frontend/hooks/useExtensionComponentsPanelVisibility.js
+++ b/packages/react-devtools-shared/src/frontend/hooks/useExtensionComponentsPanelVisibility.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {useState, useEffect} from 'react';
+import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
+
+// Events that are prefixed with `extension` will only be emitted for the browser extension implementation.
+// For other implementations, this hook will just return constant `true` value.
+export function useExtensionComponentsPanelVisibility(
+  bridge: FrontendBridge,
+): boolean {
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    function onPanelShown() {
+      setIsVisible(true);
+    }
+    function onPanelHidden() {
+      setIsVisible(false);
+    }
+
+    bridge.addListener('extensionComponentsPanelShown', onPanelShown);
+    bridge.addListener('extensionComponentsPanelHidden', onPanelHidden);
+
+    return () => {
+      bridge.removeListener('extensionComponentsPanelShown', onPanelShown);
+      bridge.removeListener('extensionComponentsPanelHidden', onPanelHidden);
+    };
+  }, [bridge]);
+
+  return isVisible;
+}


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/31968. See commit on top.

Fixes an issue with bank tree view, when we are scrolling to an item while syncing user DOM selection. This should only have an effect on browser extension. Added events with `extension` prefix will only be emitted in browser extension implementation, for other implementations `useExtensionComponentsPanelVisibility` will return constant `true` value.

Before:

https://github.com/user-attachments/assets/82667c16-d495-4346-af0a-7ed22ff89cfc


After:

https://github.com/user-attachments/assets/a5d223fd-0328-44f0-af68-5c3863f1efee

