### PR TITLE
Suspensey Fonts for View Transition 

### DIFF
--- a/fixtures/view-transition/src/components/Chrome.js
+++ b/fixtures/view-transition/src/components/Chrome.js
@@ -12,6 +12,16 @@ export default class Chrome extends Component {
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <link rel="shortcut icon" href="favicon.ico" />
           <link rel="stylesheet" href={assets['main.css']} />
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin=""
+          />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Roboto:wght@100&display=swap"
+            rel="stylesheet"
+          />
           <title>{this.props.title}</title>
         </head>
         <body>

--- a/fixtures/view-transition/src/components/Page.css
+++ b/fixtures/view-transition/src/components/Page.css
@@ -1,0 +1,8 @@
+.roboto-font {
+  font-family: "Roboto", serif;
+  font-optical-sizing: auto;
+  font-weight: 100;
+  font-style: normal;
+  font-variation-settings:
+    "wdth" 100;
+}

--- a/fixtures/view-transition/src/components/Page.js
+++ b/fixtures/view-transition/src/components/Page.js
@@ -29,7 +29,7 @@ function Component() {
       className={
         transitions['enter-slide-right'] + ' ' + transitions['exit-slide-left']
       }>
-      <p>Slide In from Left, Slide Out to Right</p>
+      <p className="roboto-font">Slide In from Left, Slide Out to Right</p>
     </ViewTransition>
   );
 }


### PR DESCRIPTION
Fonts flickering in while loading can be disturbing to any transition but especially View Transitions. Even if they don't cause layout thrash - the paint thrash is bad enough. We might add Suspensey fonts to all Transitions in the future but it's especially a no-brainer for View Transitions.

We need to apply mutations to the DOM first to know whether that will trigger new fonts to load. For general Suspensey fonts, we'd have to revert the commit by applying mutations in reverse to return to the previous state. For View Transitions, since a snapshot is already frozen, we can freeze the screen while we're waiting for the font at no extra cost. It does mean that the page isn't responsive during this time but we should only block this for a short period anyway.

The timeout needs to be short enough that it doesn't cause too much of an issue when it's a new load and slow, yet long enough that you have a chance to load it. Otherwise we wait for no reason. The assumption here is that you likely have either cached the font or preloaded it earlier - or you're on an extremely fast connection. This case is for optimizing the high end experience.

Before:

https://github.com/user-attachments/assets/e0acfffe-fa49-40d6-82c3-5b08760175fb

After:

https://github.com/user-attachments/assets/615a03d3-9d6b-4eb1-8bd5-182c4c37a628

Note that since the Navigation is blocked on the font now the browser spinner shows up while the font is loading.