### PR TITLE
Remove enableGetInspectorDataForInstanceInProduction flag

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -29,7 +29,6 @@ import {
 import {createPortal as createPortalImpl} from 'react-reconciler/src/ReactPortal';
 import {setBatchingImplementation} from './legacy-events/ReactGenericBatching';
 
-import {getInspectorDataForInstance} from './ReactNativeFiberInspector';
 import {LegacyRoot, ConcurrentRoot} from 'react-reconciler/src/ReactRootTags';
 import {
   findHostInstance_DEPRECATED,
@@ -188,9 +187,6 @@ export {
   unmountComponentAtNode,
   stopSurface,
   createPortal,
-  // This export is typically undefined in production builds.
-  // See the "enableGetInspectorDataForInstanceInProduction" flag.
-  getInspectorDataForInstance,
   // The public instance has a reference to the internal instance handle.
   // This method allows it to acess the most recent shadow node for
   // the instance (it's only accessible through it).

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -36,7 +36,7 @@ if (__DEV__) {
   const emptyObject = Object.freeze({});
 
   // $FlowFixMe[missing-local-annot]
-  const createHierarchy = function(fiberHierarchy) {
+  const createHierarchy = function (fiberHierarchy) {
     return fiberHierarchy.map(fiber => ({
       name: getComponentNameFromType(fiber.type),
       getInspectorData: () => {
@@ -59,9 +59,9 @@ if (__DEV__) {
         };
       },
     }));
-  }
+  };
 
-  const getHostNode = function(fiber: Fiber | null) {
+  const getHostNode = function (fiber: Fiber | null) {
     let hostNode;
     // look for children first for the hostNode
     // as composite fibers do not have a hostNode
@@ -75,15 +75,15 @@ if (__DEV__) {
       fiber = fiber.child;
     }
     return null;
-  }
+  };
 
-  const getHostProps = function(fiber: Fiber) {
+  const getHostProps = function (fiber: Fiber) {
     const host = findCurrentHostFiber(fiber);
     if (host) {
       return host.memoizedProps || emptyObject;
     }
     return emptyObject;
-  }
+  };
 
   getInspectorDataForInstance = function (
     closestInstance: Fiber | null,
@@ -124,14 +124,14 @@ if (__DEV__) {
     };
   };
 
-  const getOwnerHierarchy = function(instance: Fiber) {
+  const getOwnerHierarchy = function (instance: Fiber) {
     const hierarchy: Array<$FlowFixMe> = [];
     traverseOwnerTreeUp(hierarchy, instance);
     return hierarchy;
-  }
+  };
 
   // $FlowFixMe[missing-local-annot]
-  const lastNonHostInstance = function(hierarchy) {
+  const lastNonHostInstance = function (hierarchy) {
     for (let i = hierarchy.length - 1; i > 1; i--) {
       const instance = hierarchy[i];
 
@@ -140,9 +140,9 @@ if (__DEV__) {
       }
     }
     return hierarchy[0];
-  }
+  };
 
-  const traverseOwnerTreeUp = function(
+  const traverseOwnerTreeUp = function (
     hierarchy: Array<$FlowFixMe>,
     instance: Fiber,
   ): void {
@@ -153,7 +153,7 @@ if (__DEV__) {
     } else {
       // TODO: Traverse Server Components owners.
     }
-  }
+  };
 }
 
 function getInspectorDataForViewTag(viewTag: number): InspectorData {

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -34,7 +34,6 @@ import {
 // Modules provided by RN:
 import {UIManager} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
 
-import {getInspectorDataForInstance} from './ReactNativeFiberInspector';
 import {LegacyRoot} from 'react-reconciler/src/ReactRootTags';
 import {
   findHostInstance_DEPRECATED,
@@ -206,9 +205,6 @@ export {
   unmountComponentAtNodeAndRemoveContainer,
   createPortal,
   batchedUpdates as unstable_batchedUpdates,
-  // This export is typically undefined in production builds.
-  // See the "enableGetInspectorDataForInstanceInProduction" flag.
-  getInspectorDataForInstance,
   // DEV-only:
   isChildPublicInstance,
 };

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -260,6 +260,4 @@ export const enableAsyncDebugInfo = __EXPERIMENTAL__;
 export const enableUpdaterTracking = __PROFILE__;
 
 // Internal only.
-export const enableGetInspectorDataForInstanceInProduction = false;
-
 export const enableDO_NOT_USE_disableStrictPassiveEffect = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -48,7 +48,6 @@ export const enableCreateEventHandleAPI = false;
 export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
 export const enableMoveBefore = true;
 export const enableFizzExternalRuntime = true;
-export const enableGetInspectorDataForInstanceInProduction = true;
 export const enableHalt = false;
 export const enableInfiniteRenderLoopDetection = false;
 export const enableLegacyCache = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -33,7 +33,6 @@ export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
 export const enableFabricCompleteRootInCommitPhase = false;
 export const enableMoveBefore = true;
 export const enableFizzExternalRuntime = true;
-export const enableGetInspectorDataForInstanceInProduction = false;
 export const enableHalt = false;
 export const enableHiddenSubtreeInsertionEffectCleanup = false;
 export const enableInfiniteRenderLoopDetection = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -36,7 +36,6 @@ export const enableUseEffectEventHook = false;
 export const favorSafetyOverHydrationPerf = true;
 export const enableLegacyFBSupport = false;
 export const enableMoveBefore = false;
-export const enableGetInspectorDataForInstanceInProduction = false;
 export const enableFabricCompleteRootInCommitPhase = false;
 export const enableHiddenSubtreeInsertionEffectCleanup = false;
 export const enableHydrationLaneScheduling = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -27,7 +27,6 @@ export const enableCreateEventHandleAPI = false;
 export const enableDO_NOT_USE_disableStrictPassiveEffect = false;
 export const enableMoveBefore = false;
 export const enableFizzExternalRuntime = true;
-export const enableGetInspectorDataForInstanceInProduction = false;
 export const enableHalt = false;
 export const enableInfiniteRenderLoopDetection = false;
 export const enableHiddenSubtreeInsertionEffectCleanup = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -38,7 +38,6 @@ export const enableUseEffectEventHook = false;
 export const favorSafetyOverHydrationPerf = true;
 export const enableLegacyFBSupport = false;
 export const enableMoveBefore = false;
-export const enableGetInspectorDataForInstanceInProduction = false;
 export const enableRenderableContext = false;
 export const enableFabricCompleteRootInCommitPhase = false;
 export const enableHiddenSubtreeInsertionEffectCleanup = true;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -69,7 +69,6 @@ export const enableSchedulingProfiler: boolean =
   __PROFILE__ && dynamicFeatureFlags.enableSchedulingProfiler;
 
 export const disableLegacyContext = __EXPERIMENTAL__;
-export const enableGetInspectorDataForInstanceInProduction = false;
 
 export const enableLegacyCache = true;
 


### PR DESCRIPTION
## Summary

Callers for this method has been removed in https://github.com/facebook/react-native/commit/65bda542320a85f4627d7957e1c6f45c2776298d, so these methods no longer need to be conditionally exported and the feature flag can be removed.

## How did you test this change?

Flow fabric/native