### PR TITLE
[playground] Partially revert #32009

### DIFF
--- a/compiler/apps/playground/components/Editor/EditorImpl.tsx
+++ b/compiler/apps/playground/components/Editor/EditorImpl.tsx
@@ -78,6 +78,7 @@ function invokeCompiler(
       logEvent: () => {},
     },
     environment,
+    panicThreshold: 'all_errors',
   });
   const ast = parseInput(source, language);
   let result = transformFromAstSync(ast, source, {


### PR DESCRIPTION

I had forgotten that our default error reporting threshold was `none` due to the fact that build pipelines should not throw errors. This resets it back to throwing on all errors which mostly is the same as the eslint plugin.

Closes #32014.
