### PR TITLE
fix(eslint-plugin-react-compiler): support v9 context api

### DIFF
--- a/compiler/packages/eslint-plugin-react-compiler/src/rules/ReactCompilerRule.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/src/rules/ReactCompilerRule.ts
@@ -121,7 +121,7 @@ const rule: Rule.RuleModule = {
   },
   create(context: Rule.RuleContext) {
     // Compat with older versions of eslint
-    const sourceCode = context.sourceCode?.text ?? context.getSourceCode().text;
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
     const filename = context.filename ?? context.getFilename();
     const userOpts = context.options[0] ?? {};
     if (
@@ -180,7 +180,7 @@ const rule: Rule.RuleModule = {
               endLoc = {
                 line: event.fnLoc.start.line,
                 // Babel loc line numbers are 1-indexed
-                column: sourceCode.split(
+                column: sourceCode.text.split(
                   /\r?\n|\r|\n/g,
                   event.fnLoc.start.line,
                 )[event.fnLoc.start.line - 1].length,
@@ -234,7 +234,6 @@ const rule: Rule.RuleModule = {
       nodeLoc: BabelSourceLocation,
       suppression: string,
     ): boolean {
-      const sourceCode = context.getSourceCode();
       const comments = sourceCode.getAllComments();
       const flowSuppressionRegex = new RegExp(
         '\\$FlowFixMe\\[' + suppression + '\\]',
@@ -254,7 +253,7 @@ const rule: Rule.RuleModule = {
     if (filename.endsWith('.tsx') || filename.endsWith('.ts')) {
       try {
         const {parse: babelParse} = require('@babel/parser');
-        babelAST = babelParse(sourceCode, {
+        babelAST = babelParse(sourceCode.text, {
           filename,
           sourceType: 'unambiguous',
           plugins: ['typescript', 'jsx'],
@@ -264,7 +263,7 @@ const rule: Rule.RuleModule = {
       }
     } else {
       try {
-        babelAST = HermesParser.parse(sourceCode, {
+        babelAST = HermesParser.parse(sourceCode.text, {
           babel: true,
           enableExperimentalComponentSyntax: true,
           sourceFilename: filename,
@@ -277,7 +276,7 @@ const rule: Rule.RuleModule = {
 
     if (babelAST != null) {
       try {
-        transformFromAstSync(babelAST, sourceCode, {
+        transformFromAstSync(babelAST, sourceCode.text, {
           filename,
           highlightCode: false,
           retainLines: true,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

This change fixes a gap in the plugin's support of eslint v9.  In one place that it's using the `SourceCode` api, it's correctly considering v9's api.  But in the other place where `SourceCode` is used, it's only using the legacy api, which was removed in v9.

