### PR TITLE
Enable owner stacks in Canary builds

### DIFF
--- a/packages/react/index.stable.development.js
+++ b/packages/react/index.stable.development.js
@@ -48,4 +48,5 @@ export {
   useActionState,
   version,
   act, // DEV-only
+  captureOwnerStack, // DEV-only
 } from './src/ReactClient';

--- a/packages/react/src/ReactServer.js
+++ b/packages/react/src/ReactServer.js
@@ -28,6 +28,7 @@ import {lazy} from './ReactLazy';
 import {memo} from './ReactMemo';
 import {cache} from './ReactCacheServer';
 import version from 'shared/ReactVersion';
+import {captureOwnerStack} from './ReactOwnerStack';
 
 const Children = {
   map,
@@ -57,4 +58,5 @@ export {
   useDebugValue,
   useMemo,
   version,
+  captureOwnerStack, // DEV-only
 };

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -127,7 +127,7 @@ export const passChildrenWhenCloningPersistedNodes = false;
  */
 export const enablePersistedModeClonedFlag = false;
 
-export const enableOwnerStacks = __EXPERIMENTAL__;
+export const enableOwnerStacks = true;
 
 export const enableShallowPropDiffing = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -88,7 +88,7 @@ export const enableReactTestRendererWarning = true;
 export const disableDefaultPropsExceptForClasses = true;
 
 export const enableObjectFiber = false;
-export const enableOwnerStacks = false;
+export const enableOwnerStacks = true;
 export const enableRemoveConsolePatches = true;
 
 // Flow magic to verify the exports of this file match the original version.


### PR DESCRIPTION
Pending internal decision to ship in Canary.
Still off for FB builds.

Docs: https://github.com/reactjs/react.dev/pull/7427