### PR TITLE
Use internal `ReactCompilerRuntime` in `react/compiler-runtime` entrypoint

### DIFF
--- a/packages/react/compiler-runtime.js
+++ b/packages/react/compiler-runtime.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export {useMemoCache as c} from './src/ReactHooks';
+export * from './src/ReactCompilerRuntime';

--- a/packages/react/src/ReactClient.js
+++ b/packages/react/src/ReactClient.js
@@ -63,7 +63,7 @@ import ReactSharedInternals from './ReactSharedInternalsClient';
 import {startTransition} from './ReactStartTransition';
 import {act} from './ReactAct';
 import {captureOwnerStack} from './ReactOwnerStack';
-import ReactCompilerRuntime from './ReactCompilerRuntime';
+import * as ReactCompilerRuntime from './ReactCompilerRuntime';
 import {enableUseResourceEffectHook} from 'shared/ReactFeatureFlags';
 
 const Children = {

--- a/packages/react/src/ReactCompilerRuntime.js
+++ b/packages/react/src/ReactCompilerRuntime.js
@@ -7,8 +7,4 @@
  * @flow
  */
 
-import {useMemoCache} from './ReactHooks';
-
-export default {
-  c: useMemoCache,
-};
+export {useMemoCache as c} from './ReactHooks';


### PR DESCRIPTION
## Summary


`react/compiler-runtime` had its own logic while `src/ReactCompilerRuntime` exported the runtime as a default.

Now `src/ReactCompilerRuntime` matches `react/compiler-runtime`. This is the same layout we use in the JSX runtime.

## How did you test this change?

`yarn build react/compiler-runtime` and then diffed folders locally. Only contained version changes

<details>
<summary>`diff -bur build/ build-new/ `</summary>

```diff
diff --color -bur build/facebook-www/VERSION_CLASSIC build-new/facebook-www/VERSION_CLASSIC
--- build/facebook-www/VERSION_CLASSIC  2025-01-13 17:45:07
+++ build-new/facebook-www/VERSION_CLASSIC      2025-01-13 17:44:18
@@ -1 +1 @@
-19.1.0-www-classic-540efebc-20250112
\ No newline at end of file
+19.1.0-www-classic-56b463c9-20250113
\ No newline at end of file
diff --color -bur build/facebook-www/VERSION_MODERN build-new/facebook-www/VERSION_MODERN
--- build/facebook-www/VERSION_MODERN   2025-01-13 17:45:10
+++ build-new/facebook-www/VERSION_MODERN       2025-01-13 17:44:21
@@ -1 +1 @@
-19.1.0-www-modern-540efebc-20250112
\ No newline at end of file
+19.1.0-www-modern-56b463c9-20250113
\ No newline at end of file
diff --color -bur build/oss-experimental/react/package.json build-new/oss-experimental/react/package.json
--- build/oss-experimental/react/package.json   2025-01-13 17:45:10
+++ build-new/oss-experimental/react/package.json       2025-01-13 17:44:21
@@ -4,7 +4,7 @@
   "keywords": [
     "react"
   ],
-  "version": "0.0.0-experimental-540efebc-20250112",
+  "version": "0.0.0-experimental-56b463c9-20250113",
   "homepage": "https://react.dev/",
   "bugs": "https://github.com/facebook/react/issues",
   "license": "MIT",
diff --color -bur build/oss-stable/react/package.json build-new/oss-stable/react/package.json
--- build/oss-stable/react/package.json 2025-01-13 17:45:07
+++ build-new/oss-stable/react/package.json     2025-01-13 17:44:18
@@ -4,7 +4,7 @@
   "keywords": [
     "react"
   ],
-  "version": "19.1.0-canary-540efebc-20250112",
+  "version": "19.1.0-canary-56b463c9-20250113",
   "homepage": "https://react.dev/",
   "bugs": "https://github.com/facebook/react/issues",
   "license": "MIT",
```
</details>