### PR TITLE
[rcr, Flight] Add throwing RSC entrypoint for compiler-runtime

### DIFF
--- a/compiler/packages/react-compiler-runtime/package.json
+++ b/compiler/packages/react-compiler-runtime/package.json
@@ -5,6 +5,13 @@
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "react-server": "./dist/index.react-server.js",
+      "default": "./dist/index.js"
+    }
+  },
   "files": [
     "dist",
     "src"

--- a/compiler/packages/react-compiler-runtime/scripts/build.js
+++ b/compiler/packages/react-compiler-runtime/scripts/build.js
@@ -26,8 +26,11 @@ const argv = yargs(process.argv.slice(2))
   .parse();
 
 const config = {
-  entryPoints: [path.join(__dirname, '../src/index.ts')],
-  outfile: path.join(__dirname, '../dist/index.js'),
+  entryPoints: [
+    path.join(__dirname, '../src/index.ts'),
+    path.join(__dirname, '../src/index.react-server.ts'),
+  ],
+  outdir: path.join(__dirname, '../dist'),
   bundle: true,
   external: ['react'],
   format: 'cjs',

--- a/compiler/packages/react-compiler-runtime/src/index.react-server.ts
+++ b/compiler/packages/react-compiler-runtime/src/index.react-server.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+throw new Error(
+  'The React Compiler is currently not supported in a React Server environment. ' +
+    'Ensure that files importable with a `react-server` condition are not compiled with the React Compiler. ' +
+    "Libraries should provide a dedicated `react-server` entrypoint that wasn't compiled with the React Compiler.",
+);

--- a/compiler/packages/react-compiler-runtime/src/index.react-server.ts
+++ b/compiler/packages/react-compiler-runtime/src/index.react-server.ts
@@ -7,6 +7,6 @@
 
 throw new Error(
   'The React Compiler is currently not supported in a React Server environment. ' +
-    'Ensure that files importable with a `react-server` condition are not compiled with the React Compiler. ' +
+    'Ensure that modules imported with a `react-server` condition are not compiled with the React Compiler. ' +
     "Libraries should provide a dedicated `react-server` entrypoint that wasn't compiled with the React Compiler.",
 );

--- a/packages/react/compiler-runtime.react-server.js
+++ b/packages/react/compiler-runtime.react-server.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from './src/ReactCompilerRuntimeServer';

--- a/packages/react/npm/compiler-runtime.react-server.js
+++ b/packages/react/npm/compiler-runtime.react-server.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-compiler-runtime.react-server.production.js');
+} else {
+  module.exports = require('./cjs/react-compiler-runtime.react-server.development.js');
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,6 +14,7 @@
     "index.js",
     "cjs/",
     "compiler-runtime.js",
+    "compiler-runtime.react-server.js",
     "jsx-runtime.js",
     "jsx-runtime.react-server.js",
     "jsx-dev-runtime.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,7 @@
       "default": "./jsx-dev-runtime.js"
     },
     "./compiler-runtime": {
-      "react-server": "./compiler-runtime.js",
+      "react-server": "./compiler-runtime.react-server.js",
       "default": "./compiler-runtime.js"
     },
     "./src/*": "./src/*"

--- a/packages/react/src/ReactCompilerRuntimeServer.js
+++ b/packages/react/src/ReactCompilerRuntimeServer.js
@@ -9,6 +9,6 @@
 
 throw new Error(
   'The React Compiler is currently not supported in a React Server environment. ' +
-    'Ensure that files importable with a `react-server` condition are not compiled with the React Compiler. ' +
+    'Ensure that modules imported with a `react-server` condition are not compiled with the React Compiler. ' +
     "Libraries should provide a dedicated `react-server` entrypoint that wasn't compiled with the React Compiler.",
 );

--- a/packages/react/src/ReactCompilerRuntimeServer.js
+++ b/packages/react/src/ReactCompilerRuntimeServer.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+throw new Error(
+  'The React Compiler is currently not supported in a React Server environment. ' +
+    'Ensure that files importable with a `react-server` condition are not compiled with the React Compiler. ' +
+    "Libraries should provide a dedicated `react-server` entrypoint that wasn't compiled with the React Compiler.",
+);

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -530,5 +530,5 @@
   "542": "Suspense Exception: This is not a real error! It's an implementation detail of `useActionState` to interrupt the current render. You must either rethrow it immediately, or move the `useActionState` call outside of the `try/catch` block. Capturing without rethrowing will lead to unexpected behavior.\n\nTo handle async errors, wrap your component in an error boundary.",
   "543": "Expected a ResourceEffectUpdate to be pushed together with ResourceEffectIdentity. This is a bug in React.",
   "544": "Found a pair with an auto name. This is a bug in React.",
-  "545": "The React Compiler is currently not supported in a React Server environment. Ensure that files importable with a `react-server` condition are not compiled with the React Compiler. Libraries should provide a dedicated `react-server` entrypoint that wasn't compiled with the React Compiler."
+  "545": "The React Compiler is currently not supported in a React Server environment. Ensure that modules imported with a `react-server` condition are not compiled with the React Compiler. Libraries should provide a dedicated `react-server` entrypoint that wasn't compiled with the React Compiler."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -529,5 +529,6 @@
   "541": "Compared context values must be arrays",
   "542": "Suspense Exception: This is not a real error! It's an implementation detail of `useActionState` to interrupt the current render. You must either rethrow it immediately, or move the `useActionState` call outside of the `try/catch` block. Capturing without rethrowing will lead to unexpected behavior.\n\nTo handle async errors, wrap your component in an error boundary.",
   "543": "Expected a ResourceEffectUpdate to be pushed together with ResourceEffectIdentity. This is a bug in React.",
-  "544": "Found a pair with an auto name. This is a bug in React."
+  "544": "Found a pair with an auto name. This is a bug in React.",
+  "545": "The React Compiler is currently not supported in a React Server environment. Ensure that files importable with a `react-server` condition are not compiled with the React Compiler. Libraries should provide a dedicated `react-server` entrypoint that wasn't compiled with the React Compiler."
 }

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -126,6 +126,19 @@ const bundles = [
     externals: ['react'],
   },
 
+  /******* Compiler Runtime React Server *******/
+  {
+    bundleTypes: [NODE_DEV, NODE_PROD],
+    moduleType: ISOMORPHIC,
+    entry: 'react/src/ReactCompilerRuntimeServer.js',
+    name: 'react-compiler-runtime.react-server',
+    condition: 'react-server',
+    global: 'CompilerRuntime',
+    minifyWithProdErrorCodes: true,
+    wrapWithModuleBoundaries: false,
+    externals: ['react'],
+  },
+
   /******* React JSX Runtime React Server *******/
   {
     bundleTypes: [NODE_DEV, NODE_PROD],


### PR DESCRIPTION
## Summary

Alternate to https://github.com/facebook/react/pull/29057
Closes https://github.com/facebook/react/issues/31702

Adds a throwing stub to `react-compiler-runtime` and `react/compiler-runtime` if the `react-server` import condition is set that throw:
```
The React Compiler is currently not supported in a React Server environment.
Ensure that modules imported with a `react-server` condition are not compiled with the React Compiler.
Libraries should provide a dedicated `react-server` entrypoint that wasn't compiled with the React Compiler.
```

For `react-compiler-runtime` I had to add `exports` so this is technically a breaking change. Though I think we consider this only to be used as a Compiler target so any `react-compiler-runtime/dist/*` or `react-compiler-runtime/src/*` imports are already out of SemVer guarantees I guess?

## How did you test this change?

Tested `react/compiler-runtime` with CSB artifacts merged with a local `yarn build react-compiler-runtime.react-server,react/compiler-runtime`

`react-compiler-runtime` I just manually checked that `dist/` is as expected:
```console
$ ls dist
index.d.ts                index.js.map              index.react-server.js.map
index.js                  index.react-server.js
```