### PR TITLE
Add `enableNativeProcessing` flag for Fabric ViewConfigs

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeAttributePayloadFabric.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayloadFabric.js
@@ -16,7 +16,10 @@ import isArray from 'shared/isArray';
 
 import {enableShallowPropDiffing} from 'shared/ReactFeatureFlags';
 
-import type {AttributeConfiguration} from './ReactNativeTypes';
+import type {
+  AnyAttributeType,
+  AttributeConfiguration,
+} from './ReactNativeTypes';
 
 const emptyObject = {};
 
@@ -97,10 +100,7 @@ function restoreDeletedValuesInNestedArray(
         typeof attributeConfig.process === 'function'
       ) {
         // case: CustomAttributeConfiguration
-        const nextValue =
-          typeof attributeConfig.process === 'function'
-            ? attributeConfig.process(nextProp)
-            : nextProp;
+        const nextValue = processProperty(nextProp, attributeConfig);
         updatePayload[propKey] = nextValue;
       }
       // $FlowFixMe[incompatible-use] found when upgrading Flow
@@ -326,10 +326,7 @@ function diffProperties(
         typeof attributeConfig.process === 'function'
       ) {
         // case: CustomAttributeConfiguration
-        const nextValue =
-          typeof attributeConfig.process === 'function'
-            ? attributeConfig.process(nextProp)
-            : nextProp;
+        const nextValue = processProperty(nextProp, attributeConfig);
         updatePayload[propKey] = nextValue;
       }
       continue;
@@ -360,11 +357,7 @@ function diffProperties(
           ? attributeConfig.diff(prevProp, nextProp)
           : defaultDiffer(prevProp, nextProp));
       if (shouldUpdate) {
-        const nextValue =
-          typeof attributeConfig.process === 'function'
-            ? // $FlowFixMe[incompatible-use] found when upgrading Flow
-              attributeConfig.process(nextProp)
-            : nextProp;
+        const nextValue = processProperty(nextProp, attributeConfig);
         (updatePayload || (updatePayload = ({}: {[string]: $FlowFixMe})))[
           propKey
         ] = nextValue;
@@ -445,6 +438,29 @@ function diffProperties(
   return updatePayload;
 }
 
+function processProperty(
+  prop: mixed,
+  attributeConfig: AnyAttributeType,
+): mixed {
+  if (typeof attributeConfig !== 'object') {
+    return prop;
+  }
+
+  const {process} = attributeConfig;
+  if (typeof process !== 'function') {
+    return prop;
+  }
+
+  if (
+    typeof attributeConfig.enableNativeProcessing === 'function' &&
+    attributeConfig.enableNativeProcessing()
+  ) {
+    return prop;
+  }
+
+  return process(prop);
+}
+
 function fastAddProperties(
   payload: null | Object,
   props: Object,
@@ -486,7 +502,10 @@ function fastAddProperties(
       newValue = prop;
     } else if (typeof attributeConfig.process === 'function') {
       // An atomic prop with custom processing.
-      newValue = attributeConfig.process(prop);
+      newValue = processProperty(
+        prop,
+        ((attributeConfig: any): AnyAttributeType),
+      );
     } else if (typeof attributeConfig.diff === 'function') {
       // An atomic prop with custom diffing. We don't need to do diffing when adding props.
       newValue = prop;

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -39,6 +39,7 @@ export type AttributeType<T, V> =
   | $ReadOnly<{
       diff?: (arg1: T, arg2: T) => boolean,
       process?: (arg1: V) => T,
+      enableNativeProcessing?: () => boolean,
     }>;
 
 // We either force that `diff` and `process` always use mixed,

--- a/packages/react-native-renderer/src/__tests__/ReactNativeAttributePayloadFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeAttributePayloadFabric-test.internal.js
@@ -102,6 +102,28 @@ describe('ReactNativeAttributePayloadFabric.create', () => {
     expect(processA).toBeCalledWith(2);
   });
 
+  it('should not use the process attribute when "enableNativeProcessing" returns true', () => {
+    const processA = jest.fn(a => a + 1);
+    expect(
+      create(
+        {a: 2},
+        {a: {process: processA, enableNativeProcessing: () => true}},
+      ),
+    ).toEqual({a: 2});
+    expect(processA).not.toHaveBeenCalled();
+  });
+
+  it('should use the process attribute when "enableNativeProcessing" returns false', () => {
+    const processA = jest.fn(a => a + 1);
+    expect(
+      create(
+        {a: 2},
+        {a: {process: processA, enableNativeProcessing: () => false}},
+      ),
+    ).toEqual({a: 3});
+    expect(processA).toBeCalledWith(2);
+  });
+
   it('should work with undefined styles', () => {
     expect(create({style: undefined}, {style: {b: true}})).toEqual(null);
     expect(create({style: {a: '#ffffff', b: 1}}, {style: {b: true}})).toEqual({


### PR DESCRIPTION
## Summary

This is effectively a resubmission of #29039 now that the work has resumed (and now we have tests for the area!).

We want to move more of the style parsing boundary into the Fabric renderer, instead of the outputs of the JavaScript preprocessing functions used by Paper.

When using Fabric renderer, we will now check for the presence of a `enableNativeProcessing` function, which we can wire with arbitrary granularity inside of RN to allow incrementally removing viewconfig processors when using Fabric.

## How did you test this change?

Added a couple of unit tests and ran `yarn test`. There were existing tests that validated processing without the attribute as well.
