### PR TITLE
fix(JSXElement): React19 regression: element._store may not be present in mixed dev/prod environment

### DIFF
--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -1039,7 +1039,6 @@ describe('ReactChildren', () => {
     });
   });
 
-  // @gate __DEV__
   it('does not throw on children without `_store`', async () => {
     function ComponentRenderingFlattenedChildren({children}) {
       return <div>{React.Children.toArray(children)}</div>;

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -1047,11 +1047,11 @@ describe('ReactChildren', () => {
 
     const source = <div />;
     const productionElement = {};
-    for (const [key, value] of Object.entries(source)) {
+    Object.entries(source).forEach(([key, value]) => {
       if (key !== '_owner' && key !== '_store') {
         productionElement[key] = value;
       }
-    }
+    });
     Object.freeze(productionElement);
 
     const container = document.createElement('div');

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -1039,6 +1039,32 @@ describe('ReactChildren', () => {
     });
   });
 
+  // @gate __DEV__
+  it('does not throw on children without `_store`', async () => {
+    function ComponentRenderingFlattenedChildren({children}) {
+      return <div>{React.Children.toArray(children)}</div>;
+    }
+
+    const source = <div />;
+    const productionElement = {};
+    for (const [key, value] of Object.entries(source)) {
+      if (key !== '_owner' && key !== '_store') {
+        productionElement[key] = value;
+      }
+    }
+    Object.freeze(productionElement);
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => {
+      root.render(
+        <ComponentRenderingFlattenedChildren>
+          {productionElement}
+        </ComponentRenderingFlattenedChildren>,
+      );
+    });
+  });
+
   it('should escape keys', () => {
     const zero = <div key="1" />;
     const one = <div key="1=::=2" />;

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -813,7 +813,9 @@ export function cloneAndReplaceKey(oldElement, newKey) {
   );
   if (__DEV__) {
     // The cloned element should inherit the original element's key validation.
-    clonedElement._store.validated = oldElement._store.validated;
+    if (oldElement._store) {
+      clonedElement._store.validated = oldElement._store.validated;
+    }
   }
   return clonedElement;
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

@yungsters @javache 

Fix comments in https://github.com/facebook/react/pull/29662#discussion_r1913820616

> Hi @yungsters, we have encountered issue that such keys does not exist.
> 
> Our use case is as follows, we use microfrontend where some part of code is built with production flag and loaded through https://github.com/Paciolan/remote-component and some other part of the code is used in development mode.
> 
> Production code in react does not have private variables like _store and when cloning it certainly has problem.
> 
> Please check for the existences of _store.

## How did you test this change?

React 18 does not have such issue, and upgrading to react 19 should behave the same when doing development.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<img width="1438" alt="Screenshot 2025-01-13 at 3 09 37 PM" src="https://github.com/user-attachments/assets/6a38a93f-4bbf-4a1b-adaf-303f70bbe603" />
