### PR TITLE
[DevTools] Prevent crash when starting consecutive profiling sessions

### DIFF
--- a/packages/react-devtools-shared/src/devtools/ProfilerStore.js
+++ b/packages/react-devtools-shared/src/devtools/ProfilerStore.js
@@ -191,6 +191,8 @@ export default class ProfilerStore extends EventEmitter<{
   }
 
   startProfiling(): void {
+    this.clear();
+
     this._bridge.send('startProfiling', {
       recordChangeDescriptions: this._store.recordChangeDescriptions,
       recordTimeline: this._store.supportsTimeline,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

This pull request resolves an issue where consecutive profiling sessions would cause Dev Tools to freeze due to an infinite loop of state updates. The problem occurs when the startProfiling function triggers a call to [`selectCommitIndex(0)` in SnapshotSelector](https://github.com/facebook/react/blob/b3a95caf61bc716fb618997e6e9f3a0c8c9c8374/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotSelector.js#L77-L85) as previous profiling data is available, which causes a re-render. Then, [ProfilerContextProvider calls `selectCommitIndex(null)`](https://github.com/facebook/react/blob/b3a95caf61bc716fb618997e6e9f3a0c8c9c8374/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilerContext.js#L231-L241) to clear the view while profiling is in progress, leading to another re-render and creating an infinite loop. This behavior was prevented by clearing the existing profiling data before starting a new session.

Closes #31977
Closes #31679

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

I ran the Dev Tools locally following [the contributing guideline](https://github.com/facebook/react/blob/b3a95caf61bc716fb618997e6e9f3a0c8c9c8374/packages/react-devtools/CONTRIBUTING.md). I observed the freeze at the start of the second profiling session. Then, I modified the code to clear the store when starting a new session and ran the Dev Tools again. This time, no freeze was observed.

Before:
https://github.com/user-attachments/assets/9d790f84-f6d0-4951-8202-e599cf8d225b

After:
https://github.com/user-attachments/assets/af097019-0b8f-49dd-8afc-0f6cd72af787


