### PR TITLE
[Fizz] Restore `useMemoCache` in renderers with support for Client APIs

### DIFF
--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -430,7 +430,7 @@ export type Dispatcher = {
   ): T,
   useId(): string,
   useCacheRefresh?: () => <T>(?() => T, ?T) => void,
-  useMemoCache?: (size: number) => Array<any>,
+  useMemoCache: (size: number) => Array<any>,
   useHostTransitionStatus: () => TransitionStatus,
   useOptimistic: <S, A>(
     passthrough: S,

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -834,6 +834,7 @@ export const HooksDispatcher: Dispatcher = supportsClientAPIs
       useActionState,
       useFormState: useActionState,
       useHostTransitionStatus,
+      useMemoCache,
     }
   : {
       readContext,


### PR DESCRIPTION
e.g. in `react-dom/server`: https://codesandbox.io/p/sandbox/usememocache-react-dom-server-nkz4zc?file=%2Fsrc%2Findex.js%3A9%2C1

Broke only recently in https://github.com/facebook/react/pull/31767. No stable release is affected

## Summary

Mainly an oversight since we don't have types based off of feature flags. Now that `enableUseMemoCache` is shipped, `useMemoCache` can be non-nullable.

Discovered during integration testing with Next.js where SSR threw with `TypeError: dispatcher.useMemoCache is not a function` but ultimately recovered due to client-side rendering.

## How did you test this change?

Hardened types.

