### PR TITLE
Reduce risk of leaving shipped Hooks as nullable on Dispatcher

### DIFF
--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -394,7 +394,9 @@ export type Dispatcher = {
     create: () => (() => void) | void,
     deps: Array<mixed> | void | null,
   ): void,
+  // TODO: Non-nullable once `enableUseEffectEventHook` is on everywhere.
   useEffectEvent?: <Args, F: (...Array<Args>) => mixed>(callback: F) => F,
+  // TODO: Non-nullable once `enableUseResourceEffectHook` is on everywhere.
   useResourceEffect?: (
     create: () => mixed,
     createDeps: Array<mixed> | void | null,
@@ -429,7 +431,7 @@ export type Dispatcher = {
     getServerSnapshot?: () => T,
   ): T,
   useId(): string,
-  useCacheRefresh?: () => <T>(?() => T, ?T) => void,
+  useCacheRefresh: () => <T>(?() => T, ?T) => void,
   useMemoCache: (size: number) => Array<any>,
   useHostTransitionStatus: () => TransitionStatus,
   useOptimistic: <S, A>(

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -835,6 +835,7 @@ export const HooksDispatcher: Dispatcher = supportsClientAPIs
       useFormState: useActionState,
       useHostTransitionStatus,
       useMemoCache,
+      useCacheRefresh,
     }
   : {
       readContext,


### PR DESCRIPTION
By grepping for the feature flag you're now directed to the Dispatcher type. Members are only nullable if they're behind a feature flag so we should make them non-nullable when the flag ships. There's still the possibility that types are not updated when the flag is on everywhere but cleanup should flush it out.