### PR TITLE
[internal] fix console patch, add RN

### DIFF
--- a/packages/shared/forks/consoleWithStackDev.rn.js
+++ b/packages/shared/forks/consoleWithStackDev.rn.js
@@ -6,9 +6,15 @@
  */
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
+import * as dynamicFlagsUntyped from 'ReactNativeInternalFeatureFlags';
+const enableRemoveConsolePatches =
+  dynamicFlagsUntyped && dynamicFlagsUntyped.enableRemoveConsolePatches;
 
 let suppressWarning = false;
 export function setSuppressWarning(newSuppressWarning) {
+  if (enableRemoveConsolePatches) {
+    return;
+  }
   if (__DEV__) {
     suppressWarning = newSuppressWarning;
   }
@@ -21,7 +27,11 @@ export function setSuppressWarning(newSuppressWarning) {
 // they are left as they are instead.
 
 export function warn(format, ...args) {
-  if (__DEV__) {
+  if (enableRemoveConsolePatches) {
+    if (__DEV__) {
+      console['warn'](format, ...args);
+    }
+  } else if (__DEV__) {
     if (!suppressWarning) {
       printWarning('warn', format, args);
     }
@@ -29,7 +39,11 @@ export function warn(format, ...args) {
 }
 
 export function error(format, ...args) {
-  if (__DEV__) {
+  if (enableRemoveConsolePatches) {
+    if (__DEV__) {
+      console['error'](format, ...args);
+    }
+  } else if (__DEV__) {
     if (!suppressWarning) {
       printWarning('error', format, args);
     }
@@ -37,6 +51,9 @@ export function error(format, ...args) {
 }
 
 function printWarning(level, format, args) {
+  if (enableRemoveConsolePatches) {
+    return;
+  }
   if (__DEV__) {
     if (ReactSharedInternals.getCurrentStack) {
       const stack = ReactSharedInternals.getCurrentStack();

--- a/packages/shared/forks/consoleWithStackDev.www.js
+++ b/packages/shared/forks/consoleWithStackDev.www.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {enableRemoveConsolePatches} = require('shared/ReactFeatureFlags');
+const {enableRemoveConsolePatches} = require('ReactFeatureFlags');
 
 // This refers to a WWW module.
 const warningWWW = require('warning');

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -783,7 +783,9 @@ const bundles = [
     moduleType: RENDERER,
     entry: 'react-native-renderer',
     global: 'ReactNativeRenderer',
-    externals: ['react-native'],
+    // ReactNativeInternalFeatureFlags temporary until we land enableRemoveConsolePatches.
+    // Needs to be done before the next RN OSS release.
+    externals: ['react-native', 'ReactNativeInternalFeatureFlags'],
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: true,
     babel: opts =>

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -819,7 +819,9 @@ const bundles = [
     moduleType: RENDERER,
     entry: 'react-native-renderer/fabric',
     global: 'ReactFabric',
-    externals: ['react-native'],
+    // ReactNativeInternalFeatureFlags temporary until we land enableRemoveConsolePatches.
+    // Needs to be done before the next RN OSS release.
+    externals: ['react-native', 'ReactNativeInternalFeatureFlags'],
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: true,
     babel: opts =>


### PR DESCRIPTION
The forking for `shared/ReactFeatureFlags` doesn't work in the console patches. Since they're already forked, we can import the internal ReactFeatureFlags files directly. 

Would have caught this in testing a PR sync, but the PR syncs are broken right now.