### PR TITLE
Fix copy functionality in Firefox

### DIFF
--- a/packages/react-devtools-extensions/chrome/manifest.json
+++ b/packages/react-devtools-extensions/chrome/manifest.json
@@ -43,7 +43,8 @@
   "permissions": [
     "scripting",
     "storage",
-    "tabs"
+    "tabs",
+    "clipboardWrite"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/packages/react-devtools-extensions/edge/manifest.json
+++ b/packages/react-devtools-extensions/edge/manifest.json
@@ -43,7 +43,8 @@
   "permissions": [
     "scripting",
     "storage",
-    "tabs"
+    "tabs",
+    "clipboardWrite"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/packages/react-devtools-extensions/firefox/manifest.json
+++ b/packages/react-devtools-extensions/firefox/manifest.json
@@ -50,7 +50,8 @@
   "permissions": [
     "scripting",
     "storage",
-    "tabs"
+    "tabs",
+    "clipboardWrite"
   ],
   "host_permissions": [
     "<all_urls>"


### PR DESCRIPTION
## Summary

This pull request addresses an issue where the copy functionality was not working in Firefox. The root cause was the absence of the 'clipboardWrite' permission in the manifest. To ensure consistency across all supported browsers, the 'clipboardWrite' permission has been added to the manifests for Chrome, Edge, and Firefox extensions.

Closes #31422 

## How did you test this change?

I ran the modified extension in all browsers (MacOS) and verified that the copy functionality works in each.
https://github.com/user-attachments/assets/a41ff14b-3d65-409c-ac7f-1ccd72fa944a

