### PR TITLE
Fix moveBefore feature detection

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -780,7 +780,7 @@ const supportsMoveBefore =
   // $FlowFixMe[prop-missing]: We're doing the feature detection here.
   enableMoveBefore &&
   typeof window !== 'undefined' &&
-  typeof window.Node.prototype.moveBefore === 'function';
+  typeof window.Element.prototype.moveBefore === 'function';
 
 export function appendChild(
   parentInstance: Instance,


### PR DESCRIPTION
`moveBefore` was moved to the `ParentNode` mixin as per https://github.com/whatwg/dom/pull/1307#discussion_r1881981120 _(and was committed in https://github.com/whatwg/dom/commit/3f3e94c5beda922962dacaeb606087f57bd7f7be)_

As a result, its existence can no longer be checked on `Node.prototype` but must be checked in `Element.prototype`