### PR TITLE
React DevTools 6.0.1 -> 6.1.0

### DIFF
--- a/packages/react-devtools-core/package.json
+++ b/packages/react-devtools-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-devtools-core",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Use react-devtools outside of the browser",
   "license": "MIT",
   "main": "./dist/backend.js",

--- a/packages/react-devtools-extensions/chrome/manifest.json
+++ b/packages/react-devtools-extensions/chrome/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "React Developer Tools",
   "description": "Adds React debugging tools to the Chrome Developer Tools.",
-  "version": "6.0.1",
-  "version_name": "6.0.1",
+  "version": "6.1.0",
+  "version_name": "6.1.0",
   "minimum_chrome_version": "102",
   "icons": {
     "16": "icons/16-production.png",

--- a/packages/react-devtools-extensions/edge/manifest.json
+++ b/packages/react-devtools-extensions/edge/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "React Developer Tools",
   "description": "Adds React debugging tools to the Microsoft Edge Developer Tools.",
-  "version": "6.0.1",
-  "version_name": "6.0.1",
+  "version": "6.1.0",
+  "version_name": "6.1.0",
   "minimum_chrome_version": "102",
   "icons": {
     "16": "icons/16-production.png",

--- a/packages/react-devtools-extensions/firefox/manifest.json
+++ b/packages/react-devtools-extensions/firefox/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "React Developer Tools",
   "description": "Adds React debugging tools to the Firefox Developer Tools.",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "browser_specific_settings": {
     "gecko": {
       "id": "@react-devtools",

--- a/packages/react-devtools-inline/package.json
+++ b/packages/react-devtools-inline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-devtools-inline",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Embed react-devtools within a website",
   "license": "MIT",
   "main": "./dist/backend.js",

--- a/packages/react-devtools-timeline/package.json
+++ b/packages/react-devtools-timeline/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "react-devtools-timeline",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "license": "MIT",
   "dependencies": {
     "@elg/speedscope": "1.9.0-a6f84db",

--- a/packages/react-devtools/CHANGELOG.md
+++ b/packages/react-devtools/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ---
 
+### 6.1.0
+January 16, 2025
+
+* fix[DevTools]: fix HostComponent naming in filters for Native ([hoxyq](https://github.com/hoxyq) in [#32086](https://github.com/facebook/react/pull/32086))
+* Fix copy functionality in Firefox ([V3RON](https://github.com/V3RON) in [#32077](https://github.com/facebook/react/pull/32077))
+* Prevent crash when starting consecutive profiling sessions ([V3RON](https://github.com/V3RON) in [#32066](https://github.com/facebook/react/pull/32066))
+* fix[DevTools/Tree]: only scroll to item when panel is visible ([hoxyq](https://github.com/hoxyq) in [#32018](https://github.com/facebook/react/pull/32018))
+* feat[Tree]: set initial scroll offset when inspected element index is set ([hoxyq](https://github.com/hoxyq) in [#31968](https://github.com/facebook/react/pull/31968))
+* DevTools: fix initial host instance selection ([hoxyq](https://github.com/hoxyq) in [#31892](https://github.com/facebook/react/pull/31892))
+* chore[DevTools/Tree]: don't pre-select root element ([hoxyq](https://github.com/hoxyq) in [#32015](https://github.com/facebook/react/pull/32015))
+* Show component names while highlighting renders ([piotrski](https://github.com/piotrski) in [#31577](https://github.com/facebook/react/pull/31577))
+* allow non-coercible objects in formatConsoleArgumentsToSingleString ([henryqdineen](https://github.com/henryqdineen) in [#31444](https://github.com/facebook/react/pull/31444))
+
+---
+
 ### 6.0.1
 October 15, 2024
 

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-devtools",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Use react-devtools outside of the browser",
   "license": "MIT",
   "repository": {
@@ -26,7 +26,7 @@
     "electron": "^23.1.2",
     "internal-ip": "^6.2.0",
     "minimist": "^1.2.3",
-    "react-devtools-core": "6.0.1",
+    "react-devtools-core": "6.1.0",
     "update-notifier": "^2.1.0"
   }
 }


### PR DESCRIPTION
List of changes in this release:

* fix[DevTools]: fix HostComponent naming in filters for Native ([hoxyq](https://github.com/hoxyq) in [#32086](https://github.com/facebook/react/pull/32086))
* Fix copy functionality in Firefox ([V3RON](https://github.com/V3RON) in [#32077](https://github.com/facebook/react/pull/32077))
* chore[DevTools]: don't use batchedUpdate ([hoxyq](https://github.com/hoxyq) in [#32074](https://github.com/facebook/react/pull/32074))
* Prevent crash when starting consecutive profiling sessions ([V3RON](https://github.com/V3RON) in [#32066](https://github.com/facebook/react/pull/32066))
* fix[DevTools/Tree]: only scroll to item when panel is visible ([hoxyq](https://github.com/hoxyq) in [#32018](https://github.com/facebook/react/pull/32018))
* feat[Tree]: set initial scroll offset when inspected element index is set ([hoxyq](https://github.com/hoxyq) in [#31968](https://github.com/facebook/react/pull/31968))
* DevTools: merge element fields in TreeStateContext ([hoxyq](https://github.com/hoxyq) in [#31956](https://github.com/facebook/react/pull/31956))
* DevTools: fix initial host instance selection ([hoxyq](https://github.com/hoxyq) in [#31892](https://github.com/facebook/react/pull/31892))
* chore[DevTools/Tree]: don't pre-select root element and remove unused code ([hoxyq](https://github.com/hoxyq) in [#32015](https://github.com/facebook/react/pull/32015))
* chore[DevTools/TraceUpdates]: display names by default ([hoxyq](https://github.com/hoxyq) in [#32019](https://github.com/facebook/react/pull/32019))
* Add ViewTransitionComponent to Stacks and DevTools ([sebmarkbage](https://github.com/sebmarkbage) in [#32034](https://github.com/facebook/react/pull/32034))
* Add <ViewTransition> Component ([sebmarkbage](https://github.com/sebmarkbage) in [#31975](https://github.com/facebook/react/pull/31975))
* chore[react-devtools-shell]: disable warnings in dev server overlay ([hoxyq](https://github.com/hoxyq) in [#32005](https://github.com/facebook/react/pull/32005))
* DevTools: fork FastRefresh test for <18 versions of React ([hoxyq](https://github.com/hoxyq) in [#31893](https://github.com/facebook/react/pull/31893))
* Show component names while highlighting renders ([piotrski](https://github.com/piotrski) in [#31577](https://github.com/facebook/react/pull/31577))
* allow non-coercible objects in formatConsoleArgumentsToSingleString ([henryqdineen](https://github.com/henryqdineen) in [#31444](https://github.com/facebook/react/pull/31444))
* Remove enableRefAsProp feature flag ([kassens](https://github.com/kassens) in [#30346](https://github.com/facebook/react/pull/30346))
* [flow] Eliminate usage of more than 1-arg `React.AbstractComponent` in React codebase ([SamChou19815](https://github.com/SamChou19815) in [#31314](https://github.com/facebook/react/pull/31314))
* Audit try/finally around console patching ([sebmarkbage](https://github.com/sebmarkbage) in [#31286](https://github.com/facebook/react/pull/31286))
* tests[react-devtools]: added tests for Compiler integration ([hoxyq](https://github.com/hoxyq) in [#31241](https://github.com/facebook/react/pull/31241))
* Add Bridge types for Fusebox ([EdmondChuiHW](https://github.com/EdmondChuiHW) in [#31274](https://github.com/facebook/react/pull/31274))