### PR TITLE
[rcr] Always target node

### DIFF
--- a/compiler/packages/react-compiler-runtime/scripts/build.js
+++ b/compiler/packages/react-compiler-runtime/scripts/build.js
@@ -13,11 +13,6 @@ const path = require('path');
 const {Generator} = require('npm-dts');
 
 const argv = yargs(process.argv.slice(2))
-  .options('p', {
-    alias: 'platform',
-    default: 'browser',
-    choices: ['browser', 'node'],
-  })
   .options('w', {
     alias: 'watch',
     default: false,
@@ -31,7 +26,7 @@ const config = {
   bundle: true,
   external: ['react'],
   format: 'cjs',
-  platform: argv.p,
+  platform: 'node',
   target: 'es6',
   banner: {
     js: `/**

--- a/compiler/packages/snap/package.json
+++ b/compiler/packages/snap/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "postinstall": "./scripts/link-react-compiler-runtime.sh && perl -p -i -e 's/react\\.element/react.transitional.element/' ../../node_modules/fbt/lib/FbtReactUtil.js && perl -p -i -e 's/didWarnAboutUsingAct = false;/didWarnAboutUsingAct = true;/' ../../node_modules/react-dom/cjs/react-dom-test-utils.development.js",
-    "build": "rimraf dist && concurrently -n snap,runtime \"tsc --build\" \"yarn --silent workspace react-compiler-runtime build -p node\"",
+    "build": "rimraf dist && concurrently -n snap,runtime \"tsc --build\" \"yarn --silent workspace react-compiler-runtime build\"",
     "test": "echo 'no tests'",
     "prettier": "prettier --write 'src/**/*.ts'"
   },


### PR DESCRIPTION

Alternative to #32071. As a follow up to #31993, the `platform` target was incorrectly being set to `browser` since it was the default argument for the build script. This corrects it to `node` and `cjs` which I think should resolve node 20 issues.
