### PR TITLE
Fix outdated maintainers list

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,4 @@
 acdlite
-bvaughn
 eps1lon
 gaearon
 gnoff
@@ -13,7 +12,9 @@ kassens
 lunaleaps
 mattcarrollcode
 mofeiZ
+mvitousek
 noahlemen
+pieterv
 poteto
 rickhanlonii
 sebmarkbage


### PR DESCRIPTION

I made a few mistakes while adding the initial list
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32102).
* #32103
* __->__ #32102