### PR TITLE
Fix maintainer check condition

### DIFF
--- a/.github/workflows/shared_label_core_team_prs.yml
+++ b/.github/workflows/shared_label_core_team_prs.yml
@@ -13,7 +13,7 @@ jobs:
     uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
 
   label:
-    if: ${{ needs.check_maintainer.outputs.is_core_team }}
+    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}
     runs-on: ubuntu-latest
     needs: check_maintainer
     steps:


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

I've noticed that the value stored under `is_core_team` gets stringified, so some PRs may be mislabelled as coming from the core team.

I've checked this on my fork and saw stringified `null` returned by the `is_core_team`, and this PR explicitly checks for the correct value. Feel free to close this PR if you want to go with another approach.

## How did you test this change?

Checked this change on my fork with and without listing myself in the maintainers file.