### PR TITLE
[ci] Fix maintainer output condition check

### DIFF
--- a/.github/workflows/compiler_discord_notify.yml
+++ b/.github/workflows/compiler_discord_notify.yml
@@ -12,7 +12,7 @@ jobs:
     uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
 
   notify:
-    if: ${{ needs.check_maintainer.outputs.is_core_team }}
+    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}
     needs: check_maintainer
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/runtime_discord_notify.yml
+++ b/.github/workflows/runtime_discord_notify.yml
@@ -12,7 +12,7 @@ jobs:
     uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
 
   notify:
-    if: ${{ needs.check_maintainer.outputs.is_core_team }}
+    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}
     needs: check_maintainer
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

It appears GH actions treats outputs from workflow_calls to [always be strings](https://github.com/orgs/community/discussions/9343) so we need to do an explicit comparison.
