### PR TITLE
[ci] Use correct actor when checking if maintainer

### DIFF
--- a/.github/workflows/compiler_discord_notify.yml
+++ b/.github/workflows/compiler_discord_notify.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   check_maintainer:
     uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    with:
+      actor: ${{ github.event.pull_request.user.login }}
 
   notify:
     if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}

--- a/.github/workflows/runtime_discord_notify.yml
+++ b/.github/workflows/runtime_discord_notify.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   check_maintainer:
     uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    with:
+      actor: ${{ github.event.pull_request.user.login }}
 
   notify:
     if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}

--- a/.github/workflows/shared_check_maintainer.yml
+++ b/.github/workflows/shared_check_maintainer.yml
@@ -2,6 +2,10 @@ name: (Shared) Check maintainer
 
 on:
   workflow_call:
+    inputs:
+      actor:
+        required: true
+        type: string
     outputs:
       is_core_team:
         value: ${{ jobs.check_maintainer.outputs.is_core_team }}
@@ -24,7 +28,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const actor = '${{ github.actor }}';
+            const actor = '${{ inputs.actor }}';
             const data = await fs.readFileSync('./MAINTAINERS', { encoding: 'utf8' });
             const maintainers = new Set(data.split('\n'));
             if (maintainers.has(actor)) {

--- a/.github/workflows/shared_label_core_team_prs.yml
+++ b/.github/workflows/shared_label_core_team_prs.yml
@@ -11,6 +11,8 @@ env:
 jobs:
   check_maintainer:
     uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    with:
+      actor: ${{ github.event.pull_request.user.login }}
 
   label:
     if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}


### PR DESCRIPTION

The discord notification workflows were checking the label event's actor (ie a bot) instead of the pull request's actor. To fix this, parameterize the shared maintainer check workflow and always use the pull request user as the input.
