### PR TITLE
[eslint-plugin-react-hooks] Inline meta fields

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.js
+++ b/packages/eslint-plugin-react-hooks/src/index.js
@@ -10,8 +10,6 @@
 import RulesOfHooks from './RulesOfHooks';
 import ExhaustiveDeps from './ExhaustiveDeps';
 
-const {name, version} = require('../package.json');
-
 // All rules
 export const rules = {
   'rules-of-hooks': RulesOfHooks,
@@ -32,7 +30,7 @@ const legacyRecommendedConfig = {
 
 // Base plugin object
 const reactHooksPlugin = {
-  meta: {name, version},
+  meta: {name: 'eslint-plugin-react-hooks'},
   rules,
 };
 


### PR DESCRIPTION

rollup doesn't inline cjs requires (although it can with an external plugin), so requiring package.json was causing issues internally at Meta since that file doesn't exist there.

We could teach our build scripts to do so but given that the eslint meta field is optional anyways I opted to just hardcode the name and omit the version.
