### PR TITLE
Permit non-`DEV` Elements in `React.Children` w/ `DEV`

### DIFF
--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -1039,7 +1039,6 @@ describe('ReactChildren', () => {
     });
   });
 
-  // @gate __DEV__
   it('does not throw on children without `_store`', async () => {
     function ComponentRenderingFlattenedChildren({children}) {
       return <div>{React.Children.toArray(children)}</div>;

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -1047,11 +1047,11 @@ describe('ReactChildren', () => {
 
     const source = <div />;
     const productionElement = {};
-    for (const [key, value] of Object.entries(source)) {
+    Object.entries(source).forEach(([key, value]) => {
       if (key !== '_owner' && key !== '_store') {
         productionElement[key] = value;
       }
-    }
+    });
     Object.freeze(productionElement);
 
     const container = document.createElement('div');

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -1039,6 +1039,32 @@ describe('ReactChildren', () => {
     });
   });
 
+  // @gate __DEV__
+  it('does not throw on children without `_store`', async () => {
+    function ComponentRenderingFlattenedChildren({children}) {
+      return <div>{React.Children.toArray(children)}</div>;
+    }
+
+    const source = <div />;
+    const productionElement = {};
+    for (const [key, value] of Object.entries(source)) {
+      if (key !== '_owner' && key !== '_store') {
+        productionElement[key] = value;
+      }
+    }
+    Object.freeze(productionElement);
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => {
+      root.render(
+        <ComponentRenderingFlattenedChildren>
+          {productionElement}
+        </ComponentRenderingFlattenedChildren>,
+      );
+    });
+  });
+
   it('should escape keys', () => {
     const zero = <div key="1" />;
     const one = <div key="1=::=2" />;

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -813,7 +813,9 @@ export function cloneAndReplaceKey(oldElement, newKey) {
   );
   if (__DEV__) {
     // The cloned element should inherit the original element's key validation.
-    clonedElement._store.validated = oldElement._store.validated;
+    if (oldElement._store) {
+      clonedElement._store.validated = oldElement._store.validated;
+    }
   }
   return clonedElement;
 }


### PR DESCRIPTION
## Summary

As mentioned in https://github.com/facebook/react/pull/29662#discussion_r1913820616, the `key` validation when using `React.Children` does not currently support non-`DEV` elements in `DEV`. This minor fix preserves support for these use cases.

## How did you test this change?

```
$ yarn test ReactChildren-test.js
```