### PR TITLE
DevTools: Add support for opening in editor with custom URL protocols

### DIFF
--- a/packages/react-devtools-shared/src/constants.js
+++ b/packages/react-devtools-shared/src/constants.js
@@ -35,6 +35,10 @@ export const SESSION_STORAGE_LAST_SELECTION_KEY =
   'React::DevTools::lastSelection';
 export const LOCAL_STORAGE_OPEN_IN_EDITOR_URL =
   'React::DevTools::openInEditorUrl';
+export const LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE =
+  'React::DevTools::openInEditorUrlProtocolReplace';
+export const LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE_WITH =
+  'React::DevTools::openInEditorUrlProtocolReplaceWith';
 export const LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PRESET =
   'React::DevTools::openInEditorUrlPreset';
 export const LOCAL_STORAGE_PARSE_HOOK_NAMES_KEY =

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElement.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElement.js
@@ -18,8 +18,16 @@ import Toggle from '../Toggle';
 import {ElementTypeSuspense} from 'react-devtools-shared/src/frontend/types';
 import InspectedElementView from './InspectedElementView';
 import {InspectedElementContext} from './InspectedElementContext';
-import {getOpenInEditorURL} from '../../../utils';
-import {LOCAL_STORAGE_OPEN_IN_EDITOR_URL} from '../../../constants';
+import {
+  getOpenInEditorURL,
+  getOpenInEditorURLProtocolReplace,
+  getOpenInEditorURLProtocolReplaceWith,
+} from '../../../utils';
+import {
+  LOCAL_STORAGE_OPEN_IN_EDITOR_URL,
+  LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE,
+  LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE_WITH,
+} from '../../../constants';
 import FetchFileWithCachingContext from './FetchFileWithCachingContext';
 import {symbolicateSourceWithCache} from 'react-devtools-shared/src/symbolicateSource';
 import OpenInEditorButton from './OpenInEditorButton';
@@ -130,6 +138,42 @@ export default function InspectedElementWrapper(_: Props): React.Node {
     },
   );
 
+  const editorURLProtocolReplace = useSyncExternalStore(
+    function subscribe(callback) {
+      window.addEventListener(
+        LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE,
+        callback,
+      );
+      return function unsubscribe() {
+        window.removeEventListener(
+          LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE,
+          callback,
+        );
+      };
+    },
+    function getState() {
+      return getOpenInEditorURLProtocolReplace();
+    },
+  );
+
+  const editorURLProtocolReplaceWith = useSyncExternalStore(
+    function subscribe(callback) {
+      window.addEventListener(
+        LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE_WITH,
+        callback,
+      );
+      return function unsubscribe() {
+        window.removeEventListener(
+          LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE_WITH,
+          callback,
+        );
+      };
+    },
+    function getState() {
+      return getOpenInEditorURLProtocolReplaceWith();
+    },
+  );
+
   const toggleErrored = useCallback(() => {
     if (inspectedElement == null) {
       return;
@@ -224,6 +268,8 @@ export default function InspectedElementWrapper(_: Props): React.Node {
             <React.Suspense fallback={<Skeleton height={16} width={24} />}>
               <OpenInEditorButton
                 editorURL={editorURL}
+                editorURLProtocolReplace={editorURLProtocolReplace}
+                editorURLProtocolReplaceWith={editorURLProtocolReplaceWith}
                 source={inspectedElement.source}
                 symbolicatedSourcePromise={symbolicatedSourcePromise}
               />

--- a/packages/react-devtools-shared/src/devtools/views/Components/OpenInEditorButton.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/OpenInEditorButton.js
@@ -32,12 +32,12 @@ function checkConditions(
 
     let sourceURL = source.sourceURL;
 
-    if (editorURLProtocolReplace) {
+    const replaceRegex = editorURLProtocolReplace
+      ? new RegExp(editorURLProtocolReplace)
+      : undefined;
+    if (replaceRegex?.test(sourceURL)) {
       sourceURL = sourceURL
-        .replace(
-          new RegExp(editorURLProtocolReplace),
-          editorURLProtocolReplaceWith ?? '',
-        )
+        .replace(replaceRegex, editorURLProtocolReplaceWith ?? '')
         .split('?')[0];
     }
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/OpenInEditorButton.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/OpenInEditorButton.js
@@ -15,18 +15,31 @@ import type {Source} from 'react-devtools-shared/src/shared/types';
 
 type Props = {
   editorURL: string,
+  editorURLProtocolReplace?: string,
+  editorURLProtocolReplaceWith?: string,
   source: Source,
   symbolicatedSourcePromise: Promise<Source | null>,
 };
 
 function checkConditions(
   editorURL: string,
+  editorURLProtocolReplace?: string,
+  editorURLProtocolReplaceWith?: string,
   source: Source,
 ): {url: URL | null, shouldDisableButton: boolean} {
   try {
     const url = new URL(editorURL);
 
     let sourceURL = source.sourceURL;
+
+    if (editorURLProtocolReplace) {
+      sourceURL = sourceURL
+        .replace(
+          new RegExp(editorURLProtocolReplace),
+          editorURLProtocolReplaceWith ?? '',
+        )
+        .split('?')[0];
+    }
 
     // Check if sourceURL is a correct URL, which has a protocol specified
     if (sourceURL.includes('://')) {
@@ -67,6 +80,8 @@ function checkConditions(
 
 function OpenInEditorButton({
   editorURL,
+  editorURLProtocolReplace,
+  editorURLProtocolReplaceWith,
   source,
   symbolicatedSourcePromise,
 }: Props): React.Node {
@@ -74,6 +89,8 @@ function OpenInEditorButton({
 
   const {url, shouldDisableButton} = checkConditions(
     editorURL,
+    editorURLProtocolReplace,
+    editorURLProtocolReplaceWith,
     symbolicatedSource ? symbolicatedSource : source,
   );
 

--- a/packages/react-devtools-shared/src/devtools/views/Settings/ComponentsSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/ComponentsSettings.js
@@ -20,6 +20,8 @@ import {
 import {
   LOCAL_STORAGE_OPEN_IN_EDITOR_URL,
   LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PRESET,
+  LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE,
+  LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE_WITH,
 } from '../../../constants';
 import {useLocalStorage, useSubscription} from '../hooks';
 import {StoreContext} from '../context';
@@ -102,6 +104,20 @@ export default function ComponentsSettings({
   const [openInEditorURL, setOpenInEditorURL] = useLocalStorage<string>(
     LOCAL_STORAGE_OPEN_IN_EDITOR_URL,
     getDefaultOpenInEditorURL(),
+  );
+
+  const [openInEditorURLProtocolReplace, setOpenInEditorURLProtocolReplace] =
+    useLocalStorage<string>(
+      LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE,
+      '',
+    );
+
+  const [
+    openInEditorURLProtocolReplaceWith,
+    setOpenInEditorURLProtocolReplaceWith,
+  ] = useLocalStorage<string>(
+    LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE_WITH,
+    '',
   );
 
   const [componentFilters, setComponentFilters] = useState<
@@ -375,15 +391,38 @@ export default function ComponentsSettings({
           <option value="custom">Custom</option>
         </select>
         {openInEditorURLPreset === 'custom' && (
-          <input
-            className={styles.Input}
-            type="text"
-            placeholder={process.env.EDITOR_URL ? process.env.EDITOR_URL : ''}
-            value={openInEditorURL}
-            onChange={event => {
-              setOpenInEditorURL(event.target.value);
-            }}
-          />
+          <>
+            <input
+              className={styles.Input}
+              type="text"
+              placeholder={process.env.EDITOR_URL ? process.env.EDITOR_URL : ''}
+              value={openInEditorURL}
+              onChange={event => {
+                setOpenInEditorURL(event.target.value);
+              }}
+            />
+            <br />
+            Replace:
+            <input
+              className={styles.Input}
+              type="text"
+              placeholder={'Optional eg:webpack://'}
+              value={openInEditorURLProtocolReplace}
+              onChange={event => {
+                setOpenInEditorURLProtocolReplace(event.target.value);
+              }}
+            />{' '}
+            with:
+            <input
+              className={styles.Input}
+              type="text"
+              placeholder={'What to replace with'}
+              value={openInEditorURLProtocolReplaceWith}
+              onChange={event => {
+                setOpenInEditorURLProtocolReplaceWith(event.target.value);
+              }}
+            />
+          </>
         )}
       </label>
 

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -40,6 +40,8 @@ import {
   SESSION_STORAGE_RELOAD_AND_PROFILE_KEY,
   SESSION_STORAGE_RECORD_CHANGE_DESCRIPTIONS_KEY,
   SESSION_STORAGE_RECORD_TIMELINE_KEY,
+  LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE,
+  LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE_WITH,
 } from './constants';
 import {
   ComponentFilterElementType,
@@ -397,6 +399,30 @@ export function getOpenInEditorURL(): string {
     }
   } catch (error) {}
   return getDefaultOpenInEditorURL();
+}
+
+export function getOpenInEditorURLProtocolReplace(): string {
+  try {
+    const raw = localStorageGetItem(
+      LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE,
+    );
+    if (raw != null) {
+      return JSON.parse(raw);
+    }
+  } catch (error) {}
+  return '';
+}
+
+export function getOpenInEditorURLProtocolReplaceWith(): string {
+  try {
+    const raw = localStorageGetItem(
+      LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PROTOCOL_REPLACE_WITH,
+    );
+    if (raw != null) {
+      return JSON.parse(raw);
+    }
+  } catch (error) {}
+  return '';
 }
 
 type ParseElementDisplayNameFromBackendReturn = {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Today it is not possible to open VSCode or other editors if a custom URL protocol is used (such as 'webpack://').

This adds the ability to replace a URL protocol for another string when the "custom" option in "Open in Editor URL" is selected: 

<img width="429" alt="image" src="https://github.com/user-attachments/assets/6c44deaf-98f7-46d6-a869-3057cbaa4626" />

In turn, this allows the "Open in editor" link to appear in these cases:
<img width="215" alt="image" src="https://github.com/user-attachments/assets/78b8047c-9a82-424f-a28f-80e1ebd9af7e" />

The empty state looks like:
<img width="417" alt="image" src="https://github.com/user-attachments/assets/6b0fe2d2-4523-4efb-8304-b85d61e8fc8e" />


Open to alternative approaches on how to make the replace handle more cases, but this seemed simple and easy!

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

Tested locally, see the screenshots above, clicking the link opens the editor to the correct line.
