### PR TITLE
Consolidate event listener

### DIFF
--- a/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
@@ -57,10 +57,7 @@ import {
 import {createEventListenerWrapperWithPriority} from './ReactDOMEventListener';
 import {
   removeEventListener,
-  addEventCaptureListener,
-  addEventBubbleListener,
-  addEventBubbleListenerWithPassiveFlag,
-  addEventCaptureListenerWithPassiveFlag,
+  addEventListener,
 } from './EventListener';
 import * as BeforeInputEventPlugin from './plugins/BeforeInputEventPlugin';
 import * as ChangeEventPlugin from './plugins/ChangeEventPlugin';
@@ -454,7 +451,7 @@ function addTrappedEventListener(
   );
   // If passive option is not supported, then the event will be
   // active and not passive.
-  let isPassiveListener: void | boolean = undefined;
+  let isPassiveListener: boolean = false;
   if (passiveBrowserEventsSupported) {
     // Browsers introduced an intervention, making these events
     // passive by default on document. React doesn't bind them
@@ -476,6 +473,7 @@ function addTrappedEventListener(
       ? (targetContainer: any).ownerDocument
       : targetContainer;
 
+  // eslint-disable-next-line prefer-const
   let unsubscribeListener;
   // When legacyFBSupport is enabled, it's for when we
   // want to add a one time event listener to a container.
@@ -501,38 +499,13 @@ function addTrappedEventListener(
       return originalListener.apply(this, p);
     };
   }
-  // TODO: There are too many combinations here. Consolidate them.
-  if (isCapturePhaseListener) {
-    if (isPassiveListener !== undefined) {
-      unsubscribeListener = addEventCaptureListenerWithPassiveFlag(
-        targetContainer,
-        domEventName,
-        listener,
-        isPassiveListener,
-      );
-    } else {
-      unsubscribeListener = addEventCaptureListener(
-        targetContainer,
-        domEventName,
-        listener,
-      );
-    }
-  } else {
-    if (isPassiveListener !== undefined) {
-      unsubscribeListener = addEventBubbleListenerWithPassiveFlag(
-        targetContainer,
-        domEventName,
-        listener,
-        isPassiveListener,
-      );
-    } else {
-      unsubscribeListener = addEventBubbleListener(
-        targetContainer,
-        domEventName,
-        listener,
-      );
-    }
-  }
+  unsubscribeListener = addEventListener(
+    targetContainer,
+    domEventName,
+    listener,
+    isCapturePhaseListener,
+    isPassiveListener,
+  );
 }
 
 function deferClickToDocumentForLegacyFBSupport(

--- a/packages/react-dom-bindings/src/events/EventListener.js
+++ b/packages/react-dom-bindings/src/events/EventListener.js
@@ -7,45 +7,16 @@
  * @flow
  */
 
-export function addEventBubbleListener(
+export function addEventListener(
   target: EventTarget,
   eventType: string,
   listener: Function,
-): Function {
-  target.addEventListener(eventType, listener, false);
-  return listener;
-}
-
-export function addEventCaptureListener(
-  target: EventTarget,
-  eventType: string,
-  listener: Function,
-): Function {
-  target.addEventListener(eventType, listener, true);
-  return listener;
-}
-
-export function addEventCaptureListenerWithPassiveFlag(
-  target: EventTarget,
-  eventType: string,
-  listener: Function,
-  passive: boolean,
+  isCapture: boolean,
+  isPassive: boolean,
 ): Function {
   target.addEventListener(eventType, listener, {
-    capture: true,
-    passive,
-  });
-  return listener;
-}
-
-export function addEventBubbleListenerWithPassiveFlag(
-  target: EventTarget,
-  eventType: string,
-  listener: Function,
-  passive: boolean,
-): Function {
-  target.addEventListener(eventType, listener, {
-    passive,
+    capture: isCapture,
+    passive: isPassive,
   });
   return listener;
 }

--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -1299,6 +1299,6 @@ describe('ReactDOMEventListener', () => {
       document.addEventListener = originalDocAddEventListener;
     }
 
-    expect(log).toEqual([false]);
+    expect(log.length).toEqual(1);
   });
 });


### PR DESCRIPTION
## Summary
Complete `TODO: There are too many combinations here. Consolidate them.`

We can directly use the third options parameter of `addEventListener`; this way, we can avoid a lot of conditional checks (combinations) directly.