### PR TITLE
docs(eslint-plugin-react-compiler): fix typo

### DIFF
--- a/compiler/packages/eslint-plugin-react-compiler/README.md
+++ b/compiler/packages/eslint-plugin-react-compiler/README.md
@@ -29,7 +29,7 @@ import react from "eslint-plugin-react"
 export default [
     // Your existing config
     { ...pluginReact.configs.flat.recommended, settings: { react: { version: "detect" } } },
-+   reactCompiler.config.recommended    
++   reactCompiler.configs.recommended    
 ]
 ```
 


### PR DESCRIPTION
## Summary

According to:

https://github.com/facebook/react/blob/028c8e6cf5ce2a87147a7e03e503ce94c7a7a0cf/compiler/packages/eslint-plugin-react-compiler/src/index.ts#L10-L15

It should be `configs` instead of `config`.
