### PR TITLE
[Fiber] Support Suspense boundaries anywhere (excluding hydration)

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -798,24 +798,37 @@ export function appendChildToContainer(
   container: Container,
   child: Instance | TextInstance,
 ): void {
-  let parentNode;
-  if (container.nodeType === COMMENT_NODE) {
-    parentNode = (container.parentNode: any);
-    if (supportsMoveBefore) {
-      // $FlowFixMe[prop-missing]: We've checked this with supportsMoveBefore.
-      parentNode.moveBefore(child, container);
-    } else {
-      parentNode.insertBefore(child, container);
+  let parentNode: Document | Element;
+  switch (container.nodeType) {
+    case COMMENT_NODE: {
+      parentNode = (container.parentNode: any);
+      if (supportsMoveBefore) {
+        // $FlowFixMe[prop-missing]: We've checked this with supportsMoveBefore.
+        parentNode.moveBefore(child, container);
+      } else {
+        parentNode.insertBefore(child, container);
+      }
+      return;
     }
-  } else {
-    parentNode = container;
-    if (supportsMoveBefore) {
-      // $FlowFixMe[prop-missing]: We've checked this with supportsMoveBefore.
-      parentNode.moveBefore(child, null);
-    } else {
-      parentNode.appendChild(child);
+    case DOCUMENT_NODE: {
+      parentNode = (container: any).body;
+      break;
+    }
+    default: {
+      if (container.nodeName === 'HTML') {
+        parentNode = (container.ownerDocument.body: any);
+      } else {
+        parentNode = (container: any);
+      }
     }
   }
+  if (supportsMoveBefore) {
+    // $FlowFixMe[prop-missing]: We've checked this with supportsMoveBefore.
+    parentNode.moveBefore(child, null);
+  } else {
+    parentNode.appendChild(child);
+  }
+
   // This container might be used for a portal.
   // If something inside a portal is clicked, that click should bubble
   // through the React tree. However, on Mobile Safari the click would
@@ -852,21 +865,35 @@ export function insertInContainerBefore(
   child: Instance | TextInstance,
   beforeChild: Instance | TextInstance | SuspenseInstance,
 ): void {
-  if (container.nodeType === COMMENT_NODE) {
-    if (supportsMoveBefore) {
-      // $FlowFixMe[prop-missing]: We've checked this with supportsMoveBefore.
-      (container.parentNode: any).moveBefore(child, beforeChild);
-    } else {
-      (container.parentNode: any).insertBefore(child, beforeChild);
+  let parentNode: Document | Element;
+  switch (container.nodeType) {
+    case COMMENT_NODE: {
+      parentNode = (container.parentNode: any);
+      break;
     }
-  } else {
-    if (supportsMoveBefore) {
-      // $FlowFixMe[prop-missing]: We've checked this with supportsMoveBefore.
-      container.moveBefore(child, beforeChild);
-    } else {
-      container.insertBefore(child, beforeChild);
+    case DOCUMENT_NODE: {
+      const ownerDocument: Document = (container: any);
+      parentNode = (ownerDocument.body: any);
+      break;
+    }
+    default: {
+      if (container.nodeName === 'HTML') {
+        parentNode = (container.ownerDocument.body: any);
+      } else {
+        parentNode = (container: any);
+      }
     }
   }
+  if (supportsMoveBefore) {
+    // $FlowFixMe[prop-missing]: We've checked this with supportsMoveBefore.
+    parentNode.moveBefore(child, beforeChild);
+  } else {
+    parentNode.insertBefore(child, beforeChild);
+  }
+}
+
+export function isSingletonScope(type: string): boolean {
+  return type === 'head';
 }
 
 function createEvent(type: DOMEventName, bubbles: boolean): Event {
@@ -912,11 +939,22 @@ export function removeChildFromContainer(
   container: Container,
   child: Instance | TextInstance | SuspenseInstance,
 ): void {
-  if (container.nodeType === COMMENT_NODE) {
-    (container.parentNode: any).removeChild(child);
-  } else {
-    container.removeChild(child);
+  let parentNode: Document | Element;
+  switch (container.nodeType) {
+    case COMMENT_NODE:
+      parentNode = (container.parentNode: any);
+      break;
+    case DOCUMENT_NODE:
+      parentNode = (container: any).body;
+      break;
+    default:
+      if (container.nodeName === 'HTML') {
+        parentNode = (container.ownerDocument.body: any);
+      } else {
+        parentNode = (container: any);
+      }
   }
+  parentNode.removeChild(child);
 }
 
 export function clearSuspenseBoundary(
@@ -964,10 +1002,15 @@ export function clearSuspenseBoundaryFromContainer(
 ): void {
   if (container.nodeType === COMMENT_NODE) {
     clearSuspenseBoundary((container.parentNode: any), suspenseInstance);
-  } else if (container.nodeType === ELEMENT_NODE) {
-    clearSuspenseBoundary((container: any), suspenseInstance);
+  } else if (container.nodeType === DOCUMENT_NODE) {
+    clearSuspenseBoundary((container: any).body, suspenseInstance);
+  } else if (container.nodeName === 'HTML') {
+    clearSuspenseBoundary(
+      (container.ownerDocument.body: any),
+      suspenseInstance,
+    );
   } else {
-    // Document nodes should never contain suspense boundaries.
+    clearSuspenseBoundary((container: any), suspenseInstance);
   }
   // Retry if any event replaying was blocked on this.
   retryIfBlockedOn(container);
@@ -2295,30 +2338,6 @@ export function releaseSingletonInstance(instance: Instance): void {
     instance.removeAttributeNode(attributes[0]);
   }
   detachDeletedInstance(instance);
-}
-
-export function clearSingleton(instance: Instance): void {
-  const element: Element = (instance: any);
-  let node = element.firstChild;
-  while (node) {
-    const nextNode = node.nextSibling;
-    const nodeName = node.nodeName;
-    if (
-      isMarkedHoistable(node) ||
-      nodeName === 'HEAD' ||
-      nodeName === 'BODY' ||
-      nodeName === 'SCRIPT' ||
-      nodeName === 'STYLE' ||
-      (nodeName === 'LINK' &&
-        ((node: any): HTMLLinkElement).rel.toLowerCase() === 'stylesheet')
-    ) {
-      // retain these nodes
-    } else {
-      element.removeChild(node);
-    }
-    node = nextNode;
-  }
-  return;
 }
 
 // -------------------

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -566,4 +566,412 @@ describe('ReactDOM', () => {
         '    in App (at **)',
     ]);
   });
+
+  it('should render root host components into body scope when the container is a Document', async () => {
+    function App({phase}) {
+      return (
+        <>
+          {phase < 1 ? null : <div>..before</div>}
+          {phase < 3 ? <div>before</div> : null}
+          {phase < 2 ? null : <div>before..</div>}
+          <html lang="en">
+            <head data-h="">
+              {phase < 1 ? null : <meta itemProp="" content="..head" />}
+              {phase < 3 ? <meta itemProp="" content="head" /> : null}
+              {phase < 2 ? null : <meta itemProp="" content="head.." />}
+            </head>
+            <body data-b="">
+              {phase < 1 ? null : <div>..inside</div>}
+              {phase < 3 ? <div>inside</div> : null}
+              {phase < 2 ? null : <div>inside..</div>}
+            </body>
+          </html>
+          {phase < 1 ? null : <div>..after</div>}
+          {phase < 3 ? <div>after</div> : null}
+          {phase < 2 ? null : <div>after..</div>}
+        </>
+      );
+    }
+
+    const root = ReactDOMClient.createRoot(document);
+    await act(() => {
+      root.render(<App phase={0} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html lang="en"><head data-h=""><meta itemprop="" content="head"></head><body data-b=""><div>before</div><div>inside</div><div>after</div></body></html>',
+    );
+
+    // @TODO remove this warning check when we loosen the tag nesting restrictions to allow arbitrary tags at the
+    // root of the application
+    assertConsoleErrorDev(['In HTML, <div> cannot be a child of <#document>']);
+
+    await act(() => {
+      root.render(<App phase={1} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html lang="en"><head data-h=""><meta itemprop="" content="..head"><meta itemprop="" content="head"></head><body data-b=""><div>..before</div><div>before</div><div>..inside</div><div>inside</div><div>..after</div><div>after</div></body></html>',
+    );
+
+    await act(() => {
+      root.render(<App phase={2} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html lang="en"><head data-h=""><meta itemprop="" content="..head"><meta itemprop="" content="head"><meta itemprop="" content="head.."></head><body data-b=""><div>..before</div><div>before</div><div>before..</div><div>..inside</div><div>inside</div><div>inside..</div><div>..after</div><div>after</div><div>after..</div></body></html>',
+    );
+
+    await act(() => {
+      root.render(<App phase={3} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html lang="en"><head data-h=""><meta itemprop="" content="..head"><meta itemprop="" content="head.."></head><body data-b=""><div>..before</div><div>before..</div><div>..inside</div><div>inside..</div><div>..after</div><div>after..</div></body></html>',
+    );
+
+    await act(() => {
+      root.unmount();
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head></head><body></body></html>',
+    );
+  });
+
+  it('should render root host components into body scope when the container is a the <html> tag', async () => {
+    function App({phase}) {
+      return (
+        <>
+          {phase < 1 ? null : <div>..before</div>}
+          {phase < 3 ? <div>before</div> : null}
+          {phase < 2 ? null : <div>before..</div>}
+          <head data-h="">
+            {phase < 1 ? null : <meta itemProp="" content="..head" />}
+            {phase < 3 ? <meta itemProp="" content="head" /> : null}
+            {phase < 2 ? null : <meta itemProp="" content="head.." />}
+          </head>
+          <body data-b="">
+            {phase < 1 ? null : <div>..inside</div>}
+            {phase < 3 ? <div>inside</div> : null}
+            {phase < 2 ? null : <div>inside..</div>}
+          </body>
+          {phase < 1 ? null : <div>..after</div>}
+          {phase < 3 ? <div>after</div> : null}
+          {phase < 2 ? null : <div>after..</div>}
+        </>
+      );
+    }
+
+    const root = ReactDOMClient.createRoot(document.documentElement);
+    await act(() => {
+      root.render(<App phase={0} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head data-h=""><meta itemprop="" content="head"></head><body data-b=""><div>before</div><div>inside</div><div>after</div></body></html>',
+    );
+
+    // @TODO remove this warning check when we loosen the tag nesting restrictions to allow arbitrary tags at the
+    // root of the application
+    assertConsoleErrorDev(['In HTML, <div> cannot be a child of <html>']);
+
+    await act(() => {
+      root.render(<App phase={1} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head data-h=""><meta itemprop="" content="..head"><meta itemprop="" content="head"></head><body data-b=""><div>..before</div><div>before</div><div>..inside</div><div>inside</div><div>..after</div><div>after</div></body></html>',
+    );
+
+    await act(() => {
+      root.render(<App phase={2} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head data-h=""><meta itemprop="" content="..head"><meta itemprop="" content="head"><meta itemprop="" content="head.."></head><body data-b=""><div>..before</div><div>before</div><div>before..</div><div>..inside</div><div>inside</div><div>inside..</div><div>..after</div><div>after</div><div>after..</div></body></html>',
+    );
+
+    await act(() => {
+      root.render(<App phase={3} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head data-h=""><meta itemprop="" content="..head"><meta itemprop="" content="head.."></head><body data-b=""><div>..before</div><div>before..</div><div>..inside</div><div>inside..</div><div>..after</div><div>after..</div></body></html>',
+    );
+
+    await act(() => {
+      root.unmount();
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head></head><body></body></html>',
+    );
+  });
+
+  it('should render root host components into body scope when the container is a the <body> tag', async () => {
+    function App({phase}) {
+      return (
+        <>
+          {phase < 1 ? null : <div>..before</div>}
+          {phase < 3 ? <div>before</div> : null}
+          {phase < 2 ? null : <div>before..</div>}
+          <head data-h="">
+            {phase < 1 ? null : <meta itemProp="" content="..head" />}
+            {phase < 3 ? <meta itemProp="" content="head" /> : null}
+            {phase < 2 ? null : <meta itemProp="" content="head.." />}
+          </head>
+          {phase < 1 ? null : <div>..inside</div>}
+          {phase < 3 ? <div>inside</div> : null}
+          {phase < 2 ? null : <div>inside..</div>}
+          {phase < 1 ? null : <div>..after</div>}
+          {phase < 3 ? <div>after</div> : null}
+          {phase < 2 ? null : <div>after..</div>}
+        </>
+      );
+    }
+
+    const root = ReactDOMClient.createRoot(document.body);
+    await act(() => {
+      root.render(<App phase={0} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head data-h=""><meta itemprop="" content="head"></head><body><div>before</div><div>inside</div><div>after</div></body></html>',
+    );
+
+    // @TODO remove this warning check when we loosen the tag nesting restrictions to allow arbitrary tags at the
+    // root of the application
+    assertConsoleErrorDev(['In HTML, <head> cannot be a child of <body>']);
+
+    await act(() => {
+      root.render(<App phase={1} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head data-h=""><meta itemprop="" content="..head"><meta itemprop="" content="head"></head><body><div>..before</div><div>before</div><div>..inside</div><div>inside</div><div>..after</div><div>after</div></body></html>',
+    );
+
+    await act(() => {
+      root.render(<App phase={2} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head data-h=""><meta itemprop="" content="..head"><meta itemprop="" content="head"><meta itemprop="" content="head.."></head><body><div>..before</div><div>before</div><div>before..</div><div>..inside</div><div>inside</div><div>inside..</div><div>..after</div><div>after</div><div>after..</div></body></html>',
+    );
+
+    await act(() => {
+      root.render(<App phase={3} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head data-h=""><meta itemprop="" content="..head"><meta itemprop="" content="head.."></head><body><div>..before</div><div>before..</div><div>..inside</div><div>inside..</div><div>..after</div><div>after..</div></body></html>',
+    );
+
+    await act(() => {
+      root.unmount();
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head></head><body></body></html>',
+    );
+  });
+
+  it('should render children of <head> into the document head even when the container is inside the document body', async () => {
+    function App({phase}) {
+      return (
+        <>
+          <div>before</div>
+          <head data-h="">
+            {phase < 1 ? null : <meta itemProp="" content="..head" />}
+            {phase < 3 ? <meta itemProp="" content="head" /> : null}
+            {phase < 2 ? null : <meta itemProp="" content="head.." />}
+          </head>
+          <div>after</div>
+        </>
+      );
+    }
+
+    const container = document.createElement('main');
+    document.body.append(container);
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => {
+      root.render(<App phase={0} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head data-h=""><meta itemprop="" content="head"></head><body><main><div>before</div><div>after</div></main></body></html>',
+    );
+
+    // @TODO remove this warning check when we loosen the tag nesting restrictions to allow arbitrary tags at the
+    // root of the application
+    assertConsoleErrorDev(['In HTML, <head> cannot be a child of <main>']);
+
+    await act(() => {
+      root.render(<App phase={1} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head data-h=""><meta itemprop="" content="..head"><meta itemprop="" content="head"></head><body><main><div>before</div><div>after</div></main></body></html>',
+    );
+
+    await act(() => {
+      root.render(<App phase={2} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head data-h=""><meta itemprop="" content="..head"><meta itemprop="" content="head"><meta itemprop="" content="head.."></head><body><main><div>before</div><div>after</div></main></body></html>',
+    );
+
+    await act(() => {
+      root.render(<App phase={3} />);
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head data-h=""><meta itemprop="" content="..head"><meta itemprop="" content="head.."></head><body><main><div>before</div><div>after</div></main></body></html>',
+    );
+
+    await act(() => {
+      root.unmount();
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html><head></head><body><main></main></body></html>',
+    );
+  });
+
+  it('can render a Suspense boundary above the <html> tag', async () => {
+    let suspendOnNewPromise;
+    let resolveCurrentPromise;
+    let currentPromise;
+    function createNewPromise() {
+      currentPromise = new Promise(r => {
+        resolveCurrentPromise = r;
+      });
+      return currentPromise;
+    }
+    createNewPromise();
+    function Comp() {
+      const [promise, setPromise] = React.useState(currentPromise);
+      suspendOnNewPromise = () => {
+        setPromise(createNewPromise());
+      };
+      React.use(promise);
+      return null;
+    }
+
+    const fallback = (
+      <html data-fallback="">
+        <body data-fallback="">
+          <div>fallback</div>
+        </body>
+      </html>
+    );
+
+    const main = (
+      <html lang="en">
+        <head>
+          <meta itemProp="" content="primary" />
+        </head>
+        <body>
+          <div>
+            <Message />
+          </div>
+        </body>
+      </html>
+    );
+
+    let suspendOnNewMessage;
+    let currentMessage;
+    let resolveCurrentMessage;
+    function createNewMessage() {
+      currentMessage = new Promise(r => {
+        resolveCurrentMessage = r;
+      });
+      return currentMessage;
+    }
+    createNewMessage();
+    resolveCurrentMessage('hello world');
+    function Message() {
+      const [pendingMessage, setPendingMessage] =
+        React.useState(currentMessage);
+      suspendOnNewMessage = () => {
+        setPendingMessage(createNewMessage());
+      };
+      return React.use(pendingMessage);
+    }
+
+    function App() {
+      return (
+        <React.Suspense fallback={fallback}>
+          <Comp />
+          {main}
+        </React.Suspense>
+      );
+    }
+
+    const root = ReactDOMClient.createRoot(document);
+    await act(() => {
+      root.render(<App />);
+    });
+    // The initial render is blocked by promiseA so we see the fallback Document
+    expect(document.documentElement.outerHTML).toBe(
+      '<html data-fallback=""><head></head><body data-fallback=""><div>fallback</div></body></html>',
+    );
+
+    await act(() => {
+      resolveCurrentPromise();
+    });
+    // When promiseA resolves we see the primary Document
+    expect(document.documentElement.outerHTML).toBe(
+      '<html lang="en"><head><meta itemprop="" content="primary"></head><body><div>hello world</div></body></html>',
+    );
+
+    await act(() => {
+      suspendOnNewPromise();
+    });
+    // When we switch to rendering ComponentB synchronously we have to put the Document back into fallback
+    // The primary content remains hidden until promiseB resolves
+    expect(document.documentElement.outerHTML).toBe(
+      '<html data-fallback=""><head><meta itemprop="" content="primary" style="display: none;"></head><body data-fallback=""><div style="display: none;">hello world</div><div>fallback</div></body></html>',
+    );
+
+    await act(() => {
+      resolveCurrentPromise();
+    });
+    // When promiseB resolves we see the new primary content inside the primary Document
+    // style attributes stick around after being unhidden by the Suspense boundary
+    expect(document.documentElement.outerHTML).toBe(
+      '<html lang="en"><head><meta itemprop="" content="primary" style=""></head><body><div style="">hello world</div></body></html>',
+    );
+
+    await act(() => {
+      React.startTransition(() => {
+        suspendOnNewPromise();
+      });
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html lang="en"><head><meta itemprop="" content="primary" style=""></head><body><div style="">hello world</div></body></html>',
+    );
+
+    await act(() => {
+      resolveCurrentPromise();
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html lang="en"><head><meta itemprop="" content="primary" style=""></head><body><div style="">hello world</div></body></html>',
+    );
+
+    await act(() => {
+      suspendOnNewMessage();
+    });
+    // When we update the message itself we will be causing updates on the primary content of the Suspense boundary.
+    // The reason we also test for this is to make sure we don't double acquire the document singletons while
+    // disappearing and reappearing layout effects
+    expect(document.documentElement.outerHTML).toBe(
+      '<html data-fallback=""><head><meta itemprop="" content="primary" style="display: none;"></head><body data-fallback=""><div style="display: none;">hello world</div><div>fallback</div></body></html>',
+    );
+
+    await act(() => {
+      resolveCurrentMessage('hello you!');
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html lang="en"><head><meta itemprop="" content="primary" style=""></head><body><div style="">hello you!</div></body></html>',
+    );
+
+    await act(() => {
+      React.startTransition(() => {
+        suspendOnNewMessage();
+      });
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html lang="en"><head><meta itemprop="" content="primary" style=""></head><body><div style="">hello you!</div></body></html>',
+    );
+
+    await act(() => {
+      resolveCurrentMessage('goodbye!');
+    });
+    expect(document.documentElement.outerHTML).toBe(
+      '<html lang="en"><head><meta itemprop="" content="primary" style=""></head><body><div style="">goodbye!</div></body></html>',
+    );
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -31,7 +31,6 @@ let hasErrored = false;
 let fatalError = undefined;
 let renderOptions;
 let waitForAll;
-let waitForThrow;
 let assertLog;
 let Scheduler;
 let clientAct;
@@ -76,7 +75,6 @@ describe('ReactDOMFloat', () => {
 
     const InternalTestUtils = require('internal-test-utils');
     waitForAll = InternalTestUtils.waitForAll;
-    waitForThrow = InternalTestUtils.waitForThrow;
     assertLog = InternalTestUtils.assertLog;
     clientAct = InternalTestUtils.act;
     assertConsoleErrorDev = InternalTestUtils.assertConsoleErrorDev;
@@ -507,14 +505,7 @@ describe('ReactDOMFloat', () => {
         </html>
       </>,
     );
-    let aggregateError = await waitForThrow();
-    expect(aggregateError.errors.length).toBe(2);
-    expect(aggregateError.errors[0].message).toContain(
-      'Invalid insertion of NOSCRIPT',
-    );
-    expect(aggregateError.errors[1].message).toContain(
-      'The node to be removed is not a child of this node',
-    );
+    await waitForAll([]);
     assertConsoleErrorDev([
       [
         'Cannot render <noscript> outside the main document. Try moving it into the root <head> tag.',
@@ -579,14 +570,7 @@ describe('ReactDOMFloat', () => {
         <link rel="stylesheet" href="foo" />
       </>,
     );
-    aggregateError = await waitForThrow();
-    expect(aggregateError.errors.length).toBe(2);
-    expect(aggregateError.errors[0].message).toContain(
-      'Invalid insertion of LINK',
-    );
-    expect(aggregateError.errors[1].message).toContain(
-      'The node to be removed is not a child of this node',
-    );
+    await waitForAll([]);
     assertConsoleErrorDev([
       [
         'Cannot render a <link rel="stylesheet" /> outside the main document without knowing its precedence. ' +
@@ -644,14 +628,7 @@ describe('ReactDOMFloat', () => {
         </html>
       </>,
     );
-    aggregateError = await waitForThrow();
-    expect(aggregateError.errors.length).toBe(2);
-    expect(aggregateError.errors[0].message).toContain(
-      'Invalid insertion of LINK',
-    );
-    expect(aggregateError.errors[1].message).toContain(
-      'The node to be removed is not a child of this node',
-    );
+    await waitForAll([]);
     assertConsoleErrorDev(
       [
         'Cannot render a <link> with onLoad or onError listeners outside the main document. ' +
@@ -660,6 +637,7 @@ describe('ReactDOMFloat', () => {
       ],
       {withoutStack: true},
     );
+    return;
   });
 
   it('can acquire a resource after releasing it in the same commit', async () => {
@@ -1256,6 +1234,13 @@ body {
       const {pipe} = renderToPipeableStream(<App />);
       pipe(writable);
     });
+
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head />
+        <body>loading...</body>
+      </html>,
+    );
 
     await act(() => {
       resolveText('unblock');

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -97,6 +97,7 @@ import {
   Passive,
   DidDefer,
   ViewTransitionNamedStatic,
+  LayoutStatic,
 } from './ReactFiberFlags';
 import {
   disableLegacyContext,
@@ -1703,21 +1704,13 @@ function updateHostSingleton(
   }
 
   const nextChildren = workInProgress.pendingProps.children;
-
-  if (current === null && !getIsHydrating()) {
-    // Similar to Portals we append Singleton children in the commit phase. So we
-    // Track insertions even on mount.
-    // TODO: Consider unifying this with how the root works.
-    workInProgress.child = reconcileChildFibers(
-      workInProgress,
-      null,
-      nextChildren,
-      renderLanes,
-    );
-  } else {
-    reconcileChildren(current, workInProgress, nextChildren, renderLanes);
-  }
+  reconcileChildren(current, workInProgress, nextChildren, renderLanes);
   markRef(current, workInProgress);
+  if (current === null) {
+    // We mark Singletons with a static flag to more efficiently manage their
+    // ownership of the singleton host instance when in offscreen trees including Suspense
+    workInProgress.flags |= LayoutStatic;
+  }
   return workInProgress.child;
 }
 

--- a/packages/react-reconciler/src/ReactFiberConfigWithNoSingletons.js
+++ b/packages/react-reconciler/src/ReactFiberConfigWithNoSingletons.js
@@ -21,7 +21,7 @@ function shim(...args: any): any {
 // Resources (when unsupported)
 export const supportsSingletons = false;
 export const resolveSingletonInstance = shim;
-export const clearSingleton = shim;
 export const acquireSingletonInstance = shim;
 export const releaseSingletonInstance = shim;
 export const isHostSingletonType = shim;
+export const isSingletonScope = shim;

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
@@ -232,7 +232,7 @@ export const suspendResource = $$$config.suspendResource;
 // -------------------
 export const supportsSingletons = $$$config.supportsSingletons;
 export const resolveSingletonInstance = $$$config.resolveSingletonInstance;
-export const clearSingleton = $$$config.clearSingleton;
 export const acquireSingletonInstance = $$$config.acquireSingletonInstance;
 export const releaseSingletonInstance = $$$config.releaseSingletonInstance;
 export const isHostSingletonType = $$$config.isHostSingletonType;
+export const isSingletonScope = $$$config.isSingletonScope;


### PR DESCRIPTION
This is a follow up to https://github.com/facebook/react/pull/32069

In the prior change I updated Fizz to allow you to render Suspense boundaries at any level within a react-dom application by treating the document body as the default render scope. This change updates Fiber to provide similar semantics. Note that this update still does not deliver hydration so unifying the Fizz and Fiber implementations in a single App is not possible yet.

The implementation required a rework of the getHostSibling and getHostParent algorithms. Now most HostSingletons are invisible from a host positioning perspective. Head is special in that it is a valid host scope so when you have Placements inside of it, it will act as the parent. But body, and html, will not directly participate in host positioning.

Additionally to support flipping to a fallback html, head, and body tag in a Suspense fallback I updated the offscreen hiding/unhide logic to pierce through singletons when lookin for matching hidable nod boundaries anywhere (excluding hydration)