### PR TITLE
[ci] Make maintainer check workflow usable from other repositories

### DIFF
--- a/.github/workflows/shared_check_maintainer.yml
+++ b/.github/workflows/shared_check_maintainer.yml
@@ -6,6 +6,10 @@ on:
       actor:
         required: true
         type: string
+      is_remote:
+        required: false
+        type: boolean
+        default: false
     outputs:
       is_core_team:
         value: ${{ jobs.check_maintainer.outputs.is_core_team }}
@@ -29,8 +33,30 @@ jobs:
           script: |
             const fs = require('fs');
             const actor = '${{ inputs.actor }}';
-            const data = await fs.readFileSync('./MAINTAINERS', { encoding: 'utf8' });
-            const maintainers = new Set(data.split('\n'));
+            const isRemote = ${{ inputs.is_remote }};
+
+            let content = null;
+            if (isRemote === true) {
+              const res = await github.rest.repos.getContent({
+                owner: 'facebook',
+                repo: 'react',
+                path: 'MAINTAINERS',
+                ref: 'main',
+                headers: { Accept: 'application/vnd.github+json' }
+              });
+              if (res.status !== 200) {
+                console.error(res);
+                throw new Error('Unable to fetch MAINTAINERS file');
+              }
+              content = Buffer.from(res.data.content, 'base64').toString();
+            } else {
+              content = await fs.readFileSync('./MAINTAINERS', { encoding: 'utf8' });
+            }
+            if (content === null) {
+              throw new Error('Unable to retrieve local or http MAINTAINERS file');
+            }
+
+            const maintainers = new Set(content.split('\n'));
             if (maintainers.has(actor)) {
               console.log(`🟢 ${actor} is a maintainer`);
               return true;


### PR DESCRIPTION

For use in reactjs/react.dev
