### PR TITLE
fix(react-compiler-healthcheck): Add shebang to banner

### DIFF
--- a/compiler/packages/react-compiler-healthcheck/scripts/build.js
+++ b/compiler/packages/react-compiler-healthcheck/scripts/build.js
@@ -36,7 +36,9 @@ const config = {
   format: 'cjs',
   platform: 'node',
   banner: {
-    js: `/**
+    js: `#!/usr/bin/env node
+
+/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the


### PR DESCRIPTION
## Summary

PR https://github.com/facebook/react/pull/31963 migrated the bundler from Rollup to esbuild, but the `react-compiler-healthcheck` script lacks a shebang, leading to issues with `npx` not being able to execute it.

https://github.com/facebook/react/blob/dc7578290f1bc55c358bee3a7eeb5e5f4551adfd/compiler/packages/react-compiler-healthcheck/rollup.config.js#L60-L78

https://github.com/facebook/react/blob/9eabb37338e6bea18441dec58a4284fe00ee09ae/compiler/packages/react-compiler-healthcheck/scripts/build.js#L38-L53

## How did you test this change?

**Before**

(fail)

```shell
(main)> npx --version
10.5.0
(main)> npx react-compiler-healthcheck
/home/jeremy/.npm/_npx/67b118a83a29962c/node_modules/.bin/react-compiler-healthcheck: line 1: /bin: Is a directory
/home/jeremy/.npm/_npx/67b118a83a29962c/node_modules/.bin/react-compiler-healthcheck: line 2: syntax error near unexpected token `('
/home/jeremy/.npm/_npx/67b118a83a29962c/node_modules/.bin/react-compiler-healthcheck: line 2: ` * Copyright (c) Meta Platforms, Inc. and affiliates.'
```

**After**

```shell
(main)> npx react-compiler-healthcheck
Successfully compiled 108 out of 146 components.
StrictMode usage not found.
Found no usage of incompatible libraries.
```
