### PR TITLE
[Scheduler]: optimize priority timeout lookup

### DIFF
--- a/packages/scheduler/src/SchedulerFeatureFlags.js
+++ b/packages/scheduler/src/SchedulerFeatureFlags.js
@@ -7,12 +7,35 @@
  * @flow strict
  */
 
+import type {PriorityLevel} from './SchedulerPriorities';
+
 export const enableProfiling = false;
 export const frameYieldMs = 5;
 
+// Max 31 bit integer. The max integer size in V8 for 32-bit systems.
+// Math.pow(2, 30) - 1
+// 0b111111111111111111111111111111
+const maxSigned31BitInt = 1073741823;
+export const immediatePriorityTimeout = -1;
+export const idlePriorityTimeout = maxSigned31BitInt;
 export const userBlockingPriorityTimeout = 250;
 export const normalPriorityTimeout = 5000;
 export const lowPriorityTimeout = 10000;
+
+const timeoutMap = [
+  null, // NoPriority
+  immediatePriorityTimeout, // ImmediatePriority
+  userBlockingPriorityTimeout, // UserBlockingPriority
+  normalPriorityTimeout, // NormalPriority
+  lowPriorityTimeout, // LowPriority
+  idlePriorityTimeout, // IdlePriority
+];
+
+export function getPriorityTimeout(priorityLevel: PriorityLevel): number {
+  const timeout = timeoutMap[priorityLevel];
+  return typeof timeout === 'number' ? timeout : normalPriorityTimeout;
+}
+
 export const enableRequestPaint = true;
 
 export const enableAlwaysYieldScheduler = __EXPERIMENTAL__;

--- a/packages/scheduler/src/SchedulerPriorities.js
+++ b/packages/scheduler/src/SchedulerPriorities.js
@@ -8,8 +8,6 @@
  */
 
 export type PriorityLevel = 0 | 1 | 2 | 3 | 4 | 5;
-
-// TODO: Use symbols?
 export const NoPriority = 0;
 export const ImmediatePriority = 1;
 export const UserBlockingPriority = 2;


### PR DESCRIPTION
## Summary

Complete: `TODO: Use symbols?`.
**Answer is NO.**

Benefits: We can directly use `PriorityLevel` as the index of the array => **More Concise Code**. Slight performance benefits, switch statements are typically compiled into jump tables.

## How did you test this change?

No behavior changes, all existing tests pass.