### PR TITLE
[ci] Try to parallelize devtools builds

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -501,6 +501,9 @@ jobs:
     name: Build DevTools and process artifacts
     needs: build_and_lint
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        browser: [chrome, firefox, edge]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -525,7 +528,7 @@ jobs:
           pattern: _build_*
           path: build
           merge-multiple: true
-      - run: ./scripts/ci/pack_and_store_devtools_artifacts.sh
+      - run: ./scripts/ci/pack_and_store_devtools_artifacts.sh ${{ matrix.browser }}
         env:
           RELEASE_CHANNEL: experimental
       - name: Display structure of build
@@ -533,19 +536,14 @@ jobs:
       - name: Archive devtools build
         uses: actions/upload-artifact@v4
         with:
-          name: react-devtools
+          name: react-devtools-${{ matrix.browser }}
           path: build/devtools.tgz
       # Simplifies getting the extension for local testing
-      - name: Archive chrome extension
+      - name: Archive ${{ matrix.browser }} extension
         uses: actions/upload-artifact@v4
         with:
-          name: react-devtools-chrome-extension
-          path: build/devtools/chrome-extension.zip
-      - name: Archive firefox extension
-        uses: actions/upload-artifact@v4
-        with:
-          name: react-devtools-firefox-extension
-          path: build/devtools/firefox-extension.zip
+          name: react-devtools-${{ matrix.browser }}-extension
+          path: build/devtools/${{ matrix.browser }}-extension.zip
 
   run_devtools_e2e_tests:
     name: Run DevTools e2e tests

--- a/scripts/ci/pack_and_store_devtools_artifacts.sh
+++ b/scripts/ci/pack_and_store_devtools_artifacts.sh
@@ -17,9 +17,15 @@ npm pack
 mv ./react-devtools-inline*.tgz ../../build/devtools/
 
 cd ../react-devtools-extensions
-yarn build
-mv ./chrome/build/ReactDevTools.zip ../../build/devtools/chrome-extension.zip
-mv ./firefox/build/ReactDevTools.zip ../../build/devtools/firefox-extension.zip
+if [[ -n "$1" ]]; then
+  yarn build:$1
+  mv ./$1/build/ReactDevTools.zip ../../build/devtools/$1-extension.zip
+else
+  yarn build
+  for browser in chrome firefox edge; do
+    mv ./$browser/build/ReactDevTools.zip ../../build/devtools/$browser-extension.zip
+  done
+fi
 
 # Compress all DevTools artifacts into a single tarball for easy download
 cd ../../build/devtools


### PR DESCRIPTION

Building DevTools is currently the long pole for the runtime CI job. Let's see if we can get the overall runtime for runtime build and test down by speeding this one step up.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32266).
* #32267
* __->__ #32266