### PR TITLE
Expose new method in Fabric renderer to access root instance from root tag

### DIFF
--- a/compiled-rn/facebook-fbsource/xplat/js/react-native-github/Libraries/Renderer/shims/ReactNativeTypes.js
+++ b/compiled-rn/facebook-fbsource/xplat/js/react-native-github/Libraries/Renderer/shims/ReactNativeTypes.js
@@ -262,6 +262,9 @@ export type ReactFabricType = {
   getPublicInstanceFromInternalInstanceHandle(
     internalInstanceHandle: InternalInstanceHandle,
   ): PublicInstance | PublicTextInstance | null,
+  getPublicInstanceFromRootTag(
+    rootTag: number,
+  ): PublicRootInstance | null,
   ...
 };
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/react-native/pull/49011

Changelog: [internal]

This exposes the new `getPublicInstanceFromRoot` method from the React renderer in our RN façades, preparing for the new change to implement the document interface in RN.

Reviewed By: javache

Differential Revision: D68767143
