### PR TITLE
[ci] Only install chromium for flight fixtures

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -476,9 +476,7 @@ jobs:
           fi
       - name: Playwright install deps
         working-directory: fixtures/flight
-        run: |
-          npx playwright install
-          sudo npx playwright install-deps
+        run: npx playwright install --with-deps chromium
       - name: Run tests
         working-directory: fixtures/flight
         run: yarn test


### PR DESCRIPTION

I noticed we only use chromium in fixtures/flight, so let's specifically only install that browser in ci.
