### PR TITLE
Fix typo in dangerfile.js which results in an unreachable code path…

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -70,7 +70,7 @@ const percentFormatter = new Intl.NumberFormat('en', {
 });
 
 function change(decimal) {
-  if (Number === Infinity) {
+  if (decimal === Infinity) {
     return 'New file';
   }
   if (decimal === -1) {


### PR DESCRIPTION
## Summary

Fix typo in dangerfile.js which results in an unreachable code path which ought to be hit when there is no matching base artifact during DangerCI automated code review.

See: https://github.com/facebook/react/blob/221f3002caa2314cba0a62950da6fb92b453d1d0/dangerfile.js#L73
Compare: https://github.com/facebook/react/blob/221f3002caa2314cba0a62950da6fb92b453d1d0/dangerfile.js#L171
And the case which should hit this code path: https://github.com/facebook/react/blob/221f3002caa2314cba0a62950da6fb92b453d1d0/dangerfile.js#L160

Given the above context, the condition `Number === Infinity` is clearly meant to be `decimal === Infinity`, which it will be if the `catch` statement triggers when there is no matching base artifact. Without this fix, the primitive value `Infinity` is passed to `percentFormatter.format(decimal)`, resulting in the string `'+∞%'`. With this fix, the resulting string will be the intended `'New file'`.

## [Resolves issue 32278](https://github.com/facebook/react/issues/32278)