### PR TITLE
Use stricter equality check

### DIFF
--- a/packages/react-dom-bindings/src/events/ReactDOMControlledComponent.js
+++ b/packages/react-dom-bindings/src/events/ReactDOMControlledComponent.js
@@ -30,7 +30,7 @@ function restoreStateOfTarget(target: Node) {
 
   const stateNode = internalInstance.stateNode;
   // Guard against Fiber being unmounted.
-  if (stateNode) {
+  if (stateNode !== null) {
     const props = getFiberCurrentPropsFromNode(stateNode);
     restoreControlledState(
       internalInstance.stateNode,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2728,7 +2728,7 @@ function commitMutationEffectsOnFiber(
 
         if (flags & Update) {
           const instance: Instance = finishedWork.stateNode;
-          if (instance != null) {
+          if (instance !== null) {
             // Commit the work prepared earlier.
             // For hydration we reuse the update path but we treat the oldProps
             // as the newProps. The updatePayload will contain the real change in

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -246,7 +246,7 @@ function invalidateContextProvider(
   } else {
     const instance = workInProgress.stateNode;
 
-    if (!instance) {
+    if (instance === null) {
       throw new Error(
         'Expected to have an instance by this point. ' +
           'This error is likely caused by a bug in React. Please file an issue.',


### PR DESCRIPTION
In `Fiber` node, the default value of `stateNode` is `null`, so it's better to use `===` directly for comparison(Additionally, it avoids implicit type conversion)

https://github.com/facebook/react/blob/152bfe3769f87e29c8d68cb87fdb608d2483b7f1/packages/react-reconciler/src/ReactFiber.js#L152