### PR TITLE
DevTools: fix host component filter option title

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Settings/ComponentsSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/ComponentsSettings.js
@@ -478,8 +478,8 @@ export default function ComponentsSettings({
                     <option value={ElementTypeForwardRef}>forward ref</option>
                     <option value={ElementTypeHostComponent}>
                       {__IS_NATIVE__
-                        ? 'host components (e.g. &lt;RCTText&gt;)'
-                        : 'dom nodes (e.g. &lt;div&gt;)'}
+                        ? 'host components (e.g. <RCTText>)'
+                        : 'dom nodes (e.g. <div>)'}
                     </option>
                     <option value={ElementTypeMemo}>memo</option>
                     <option value={ElementTypeOtherOrUnknown}>other</option>


### PR DESCRIPTION
Overlook that in https://github.com/facebook/react/pull/32086, because of ternany, it is already string literals, so html entities names no longer needed.