### PR TITLE
[ci] Only notify discord on core team label

### DIFF
--- a/.github/workflows/compiler_discord_notify.yml
+++ b/.github/workflows/compiler_discord_notify.yml
@@ -14,7 +14,7 @@ jobs:
       actor: ${{ github.event.pull_request.user.login }}
 
   notify:
-    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}
+    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' && github.event.label.name == 'React Core Team' }}
     needs: check_maintainer
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/runtime_discord_notify.yml
+++ b/.github/workflows/runtime_discord_notify.yml
@@ -14,7 +14,7 @@ jobs:
       actor: ${{ github.event.pull_request.user.login }}
 
   notify:
-    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}
+    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' && github.event.label.name == 'React Core Team' }}
     needs: check_maintainer
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

Rather than notify on every label event on a PR by a core team member, only do so for the specific core team label event.
