### PR TITLE
Double invoke effects in a subtree wrapped with `StrictMode`

### DIFF
--- a/packages/react-reconciler/src/__tests__/StrictEffectsModeDefaults-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/StrictEffectsModeDefaults-test.internal.js
@@ -240,64 +240,6 @@ describe('StrictEffectsMode defaults', () => {
       });
     });
 
-    it('should double invoke effects in a mounted strict subtree', async () => {
-      const log = [];
-      function ComponentWithEffects({label}) {
-        React.useEffect(() => {
-          log.push(`useEffect mount "${label}"`);
-          Scheduler.log(`useEffect mount "${label}"`);
-          return () => {
-            log.push(`useEffect unmount "${label}"`);
-            Scheduler.log(`useEffect unmount "${label}"`);
-          };
-        });
-
-        React.useLayoutEffect(() => {
-          log.push(`useLayoutEffect mount "${label}"`);
-          Scheduler.log(`useLayoutEffect mount "${label}"`);
-          return () => {
-            log.push(`useLayoutEffect unmount "${label}"`);
-            Scheduler.log(`useLayoutEffect unmount "${label}"`);
-          };
-        });
-
-        return label;
-      }
-
-      // this component intentionally introduces a component layer between the root and the StrictMode
-      function RenderChildren({children}) {
-        return children;
-      }
-
-      await act(async () => {
-        ReactNoop.render(
-          <RenderChildren>
-            <ComponentWithEffects label={'one'} />
-            <React.StrictMode>
-              <ComponentWithEffects label={'two'} />
-            </React.StrictMode>
-          </RenderChildren>,
-        );
-
-        await waitForAll([
-          'useLayoutEffect mount "one"',
-          'useLayoutEffect mount "two"',
-          'useEffect mount "one"',
-          'useEffect mount "two"',
-        ]);
-        expect(log).toEqual([
-          'useLayoutEffect mount "one"',
-          'useLayoutEffect mount "two"',
-          'useEffect mount "one"',
-          'useEffect mount "two"',
-          'useLayoutEffect unmount "two"',
-          'useEffect unmount "two"',
-          'useLayoutEffect mount "two"',
-          'useEffect mount "two"',
-        ]);
-      });
-    });
-
     it('double invoking for effects for modern roots', async () => {
       const log = [];
       function App({text}) {

--- a/packages/react/src/__tests__/ReactStrictMode-test.internal.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.internal.js
@@ -206,11 +206,10 @@ describe('ReactStrictMode', () => {
           'B: useLayoutEffect mount',
           'A: useEffect mount',
           'B: useEffect mount',
-          // TODO: this is currently broken
-          // 'B: useLayoutEffect unmount',
-          // 'B: useEffect unmount',
-          // 'B: useLayoutEffect mount',
-          // 'B: useEffect mount',
+          'B: useLayoutEffect unmount',
+          'B: useEffect unmount',
+          'B: useLayoutEffect mount',
+          'B: useEffect mount',
         ]);
       });
     }


### PR DESCRIPTION
## Summary

Currently, strict effects don't behave as expected when `StrictMode` isn't placed at the root of the app. Wrapping only a part of the app is a valid use case described in the docs: https://react.dev/reference/react/StrictMode#enabling-strict-mode-for-a-part-of-the-app

## How did you test this change?

I added tests in the repo to verify that it works 😉 

---

I expect some subtleties around this so this might not be a fully correct PR (yet). With some guidance I could improve it. I'm especially not sure if the code paths related to Offscree/Visibility are changed correctly. If you could suggest some extra test cases for them, I'd appreciate it
