### PR TITLE
[Flight] Resolve deduped references when chunks are blocked on each other

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -163,6 +163,7 @@ type BlockedChunk<T> = {
   status: 'blocked',
   value: null | Array<(T) => mixed>,
   reason: null | Array<(mixed) => mixed>,
+  intermediaryValue?: mixed,
   _response: Response,
   _children: Array<SomeChunk<any>> | ProfilingResult, // Profiling-only
   _debugInfo?: null | ReactDebugInfo, // DEV-only
@@ -568,6 +569,7 @@ type InitializationHandler = {
 };
 let initializingHandler: null | InitializationHandler = null;
 let initializingChunk: null | BlockedChunk<any> = null;
+let isParsingRootModel = false;
 
 function initializeModelChunk<T>(chunk: ResolvedModelChunk<T>): void {
   const prevHandler = initializingHandler;
@@ -584,9 +586,7 @@ function initializeModelChunk<T>(chunk: ResolvedModelChunk<T>): void {
   cyclicChunk.value = null;
   cyclicChunk.reason = null;
 
-  if (enableProfilerTimer && enableComponentPerformanceTrack) {
-    initializingChunk = cyclicChunk;
-  }
+  initializingChunk = cyclicChunk;
 
   try {
     const value: T = parseModel(chunk._response, resolvedModel);
@@ -620,9 +620,7 @@ function initializeModelChunk<T>(chunk: ResolvedModelChunk<T>): void {
     erroredChunk.reason = error;
   } finally {
     initializingHandler = prevHandler;
-    if (enableProfilerTimer && enableComponentPerformanceTrack) {
-      initializingChunk = prevChunk;
-    }
+    initializingChunk = prevChunk;
   }
 }
 
@@ -876,8 +874,18 @@ function createElement(
       return createLazyChunkWrapper(erroredChunk);
     }
     if (handler.deps > 0) {
-      // We have blocked references inside this Element but we can turn this into
-      // a Lazy node referencing this Element to let everything around it proceed.
+      // We have blocked references inside this element but we can turn this
+      // into a Lazy node referencing this element to let everything around it
+      // proceed. If the element is for the root model, we store it as an
+      // intermediary value on the initializing chunk, so that referencing
+      // models can peek into it to resolve their value.
+      if (
+        isParsingRootModel &&
+        initializingChunk &&
+        !initializingChunk.intermediaryValue
+      ) {
+        initializingChunk.intermediaryValue = element;
+      }
       const blockedChunk: BlockedChunk<React$Element<any>> =
         createBlockedChunk(response);
       handler.value = element;
@@ -967,6 +975,15 @@ function waitForReference<T>(
         } else if (chunk.status === INITIALIZED) {
           value = chunk.value;
           continue;
+        } else if (
+          // For the first iteration of the path we need the root model of the
+          // referenced chunk. If we have an intermediary value for it, we can
+          // peek into it, even if it's not fully resolved yet.
+          i === 1 &&
+          referencedChunk.status === BLOCKED &&
+          referencedChunk.intermediaryValue
+        ) {
+          value = referencedChunk.intermediaryValue;
         } else {
           // If we're not yet initialized we need to skip what we've already drilled
           // through and then wait for the next value to become available.
@@ -1410,13 +1427,11 @@ function parseModelString(
         // Lazy node
         const id = parseInt(value.slice(2), 16);
         const chunk = getChunk(response, id);
-        if (enableProfilerTimer && enableComponentPerformanceTrack) {
-          if (
-            initializingChunk !== null &&
-            isArray(initializingChunk._children)
-          ) {
-            initializingChunk._children.push(chunk);
-          }
+        if (
+          initializingChunk !== null &&
+          isArray(initializingChunk._children)
+        ) {
+          initializingChunk._children.push(chunk);
         }
         // We create a React.lazy wrapper around any lazy values.
         // When passed into React, we'll know how to suspend on this.
@@ -1430,13 +1445,11 @@ function parseModelString(
         }
         const id = parseInt(value.slice(2), 16);
         const chunk = getChunk(response, id);
-        if (enableProfilerTimer && enableComponentPerformanceTrack) {
-          if (
-            initializingChunk !== null &&
-            isArray(initializingChunk._children)
-          ) {
-            initializingChunk._children.push(chunk);
-          }
+        if (
+          initializingChunk !== null &&
+          isArray(initializingChunk._children)
+        ) {
+          initializingChunk._children.push(chunk);
         }
         return chunk;
       }
@@ -3393,6 +3406,7 @@ function parseModel<T>(response: Response, json: UninitializedModel): T {
 function createFromJSONCallback(response: Response) {
   // $FlowFixMe[missing-this-annot]
   return function (key: string, value: JSONValue) {
+    isParsingRootModel = key === '';
     if (typeof value === 'string') {
       // We can't use .bind here because we need the "this" value.
       return parseModelString(response, this, key, value);

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -1427,11 +1427,13 @@ function parseModelString(
         // Lazy node
         const id = parseInt(value.slice(2), 16);
         const chunk = getChunk(response, id);
-        if (
-          initializingChunk !== null &&
-          isArray(initializingChunk._children)
-        ) {
-          initializingChunk._children.push(chunk);
+        if (enableProfilerTimer && enableComponentPerformanceTrack) {
+          if (
+            initializingChunk !== null &&
+            isArray(initializingChunk._children)
+          ) {
+            initializingChunk._children.push(chunk);
+          }
         }
         // We create a React.lazy wrapper around any lazy values.
         // When passed into React, we'll know how to suspend on this.
@@ -1445,11 +1447,13 @@ function parseModelString(
         }
         const id = parseInt(value.slice(2), 16);
         const chunk = getChunk(response, id);
-        if (
-          initializingChunk !== null &&
-          isArray(initializingChunk._children)
-        ) {
-          initializingChunk._children.push(chunk);
+        if (enableProfilerTimer && enableComponentPerformanceTrack) {
+          if (
+            initializingChunk !== null &&
+            isArray(initializingChunk._children)
+          ) {
+            initializingChunk._children.push(chunk);
+          }
         }
         return chunk;
       }

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -534,8 +534,11 @@ describe('ReactFlightDOMBrowser', () => {
   });
 
   it('should resolve deduped references in maps used in client component props', async () => {
-    const ClientComponent = clientExports(function ClientComponent({shared}) {
-      return JSON.stringify(shared);
+    const ClientComponent = clientExports(function ClientComponent({
+      shared,
+      map,
+    }) {
+      return JSON.stringify({shared, map: Array.from(map)});
     });
 
     function Server() {
@@ -561,7 +564,9 @@ describe('ReactFlightDOMBrowser', () => {
       root.render(<ClientRoot response={response} />);
     });
 
-    expect(container.innerHTML).toBe('{"id":42}');
+    expect(container.innerHTML).toBe(
+      '{"shared":{"id":42},"map":[[42,{"id":42}]]}',
+    );
   });
 
   it('should handle deduped props of re-used elements in fragments (same-chunk reference)', async () => {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -538,6 +538,7 @@ describe('ReactFlightDOMBrowser', () => {
       shared,
       map,
     }) {
+      expect(map.get(42)).toBe(shared);
       return JSON.stringify({shared, map: Array.from(map)});
     });
 


### PR DESCRIPTION
This PR includes a reduced test case of https://github.com/vercel/next.js/pull/75726:

```jsx
function Server() {
  const shared = {id: 42};
  const map = new Map([[42, shared]]);

  return <ClientComponent shared={shared} map={map} />;
}
```

This is serialized into the following RSC payload which the Flight Client was not able to resolve, because two chunks are blocked on each other:

```
1:I["0",[],"*"]
2:[[42,"$0:props:shared"]]
0:["$","$L1",null,{"shared":{"id":42},"map":"$Q2"}]
```

We can fix this by storing intermediary values (only elements for now) on the initializing chunk. When the `fulfill` listener in `waitForReference` is called with a lazy element that has a blocked chunk, which is not the current chunk, we can peek into the intermediary value of the referenced chunk to resolve a reference for a different chunk that's still blocked.

fixes https://github.com/vercel/next.js/issues/72104