### PR TITLE
[Fiber] `getHoistableRoot()` should account for Document containers

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2523,10 +2523,13 @@ export type HoistableRoot = Document | ShadowRoot;
 export function getHoistableRoot(container: Container): HoistableRoot {
   // $FlowFixMe[method-unbinding]
   return typeof container.getRootNode === 'function'
-    ? /* $FlowFixMe[incompatible-return] Flow types this as returning a `Node`,
+    ? /* $FlowFixMe[incompatible-cast] Flow types this as returning a `Node`,
        * but it's either a `Document` or `ShadowRoot`. */
-      container.getRootNode()
-    : container.ownerDocument;
+      (container.getRootNode(): Document | ShadowRoot)
+    : container.nodeType === DOCUMENT_NODE
+      ? // $FlowFixMe[incompatible-cast] We've constrained this to be a Document which satisfies the return type
+        (container: Document)
+      : container.ownerDocument;
 }
 
 function getCurrentResourceRoot(): null | HoistableRoot {


### PR DESCRIPTION
While modern DOM implementations all support getRootNode if you are running React in a runtime which does not the fallback logic which uses `.ownerDocument` works everywhere except when the container is a Document itself. This change corrects this by returning the container intsance if it is a Document type.