### PR TITLE
[RN] Return document instance from Fabric `render` method

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -105,7 +105,7 @@ function render(
   callback: ?() => void,
   concurrentRoot: ?boolean,
   options: ?RenderRootOptions,
-): ?ElementRef<ElementType> {
+): PublicRootInstance {
   if (disableLegacyMode && !concurrentRoot) {
     throw new Error('render: Unsupported Legacy Mode API.');
   }
@@ -155,7 +155,8 @@ function render(
   }
   updateContainer(element, root, null, callback);
 
-  return getPublicRootInstance(root);
+  // $FlowExpectedError[incompatible-return] at this point we know publicInstance cannot be null.
+  return root.containerInfo.publicInstance;
 }
 
 // $FlowFixMe[missing-this-annot]

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/createPublicRootInstance.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/createPublicRootInstance.js
@@ -12,5 +12,5 @@ import type {PublicRootInstance} from './ReactNativePrivateInterface';
 export default function createPublicRootInstance(
   rootTag: number,
 ): PublicRootInstance {
-  return null;
+  return {__publicRootInstanceFor: rootTag};
 }

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -533,7 +533,7 @@ describe('ReactFabric', () => {
     expect(nativeFabricUIManager.sendAccessibilityEvent).not.toBeCalled();
   });
 
-  it('calls the callback with the correct instance and returns null', async () => {
+  it('calls the callback with the correct instance and returns the public root instance', async () => {
     const View = createReactNativeComponentClass('RCTView', () => ({
       validAttributes: {foo: true},
       uiViewClassName: 'RCTView',
@@ -555,7 +555,7 @@ describe('ReactFabric', () => {
 
     expect(a).toBeTruthy();
     expect(a).toBe(b);
-    expect(c).toBe(null);
+    expect(c).toEqual({__publicRootInstanceFor: 11});
   });
 
   // @gate !disableLegacyMode


### PR DESCRIPTION
## Summary

This modifies the API of the Fabric renderer interface to return document instances from the `render` method. This will make it easier to access it in use cases like Fantom (the new integration testing solution for RN), where we can return the document easily to do test assertions.

## How did you test this change?

Updated unit tests and tested e2e in RN manually syncing the renderer.