### PR TITLE
[ci] Use 'opened' event for discord notifications

### DIFF
--- a/.github/workflows/compiler_discord_notify.yml
+++ b/.github/workflows/compiler_discord_notify.yml
@@ -2,7 +2,7 @@ name: (Compiler) Discord Notify
 
 on:
   pull_request_target:
-    types: [labeled]
+    types: [opened]
     paths:
       - compiler/**
       - .github/workflows/compiler_**.yml
@@ -14,7 +14,7 @@ jobs:
       actor: ${{ github.event.pull_request.user.login }}
 
   notify:
-    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' && github.event.label.name == 'React Core Team' }}
+    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}
     needs: check_maintainer
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/runtime_discord_notify.yml
+++ b/.github/workflows/runtime_discord_notify.yml
@@ -2,7 +2,7 @@ name: (Runtime) Discord Notify
 
 on:
   pull_request_target:
-    types: [labeled]
+    types: [opened]
     paths-ignore:
       - compiler/**
       - .github/workflows/compiler_**.yml
@@ -14,7 +14,7 @@ jobs:
       actor: ${{ github.event.pull_request.user.login }}
 
   notify:
-    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' && github.event.label.name == 'React Core Team' }}
+    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}
     needs: check_maintainer
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

We don't need to wait for it to be labeled now that we have the shared maintainer check workflow.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32332).
* #32333
* __->__ #32332