### PR TITLE
[ci] Combine sizebot jobs

### DIFF
--- a/.github/workflows/compiler_discord_notify.yml
+++ b/.github/workflows/compiler_discord_notify.yml
@@ -2,7 +2,7 @@ name: (Compiler) Discord Notify
 
 on:
   pull_request_target:
-    types: [labeled]
+    types: [opened]
     paths:
       - compiler/**
       - .github/workflows/compiler_**.yml
@@ -14,7 +14,7 @@ jobs:
       actor: ${{ github.event.pull_request.user.login }}
 
   notify:
-    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' && github.event.label.name == 'React Core Team' }}
+    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}
     needs: check_maintainer
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -585,52 +585,10 @@ jobs:
           RELEASE_CHANNEL: experimental
 
   # ----- SIZEBOT -----
-  download_base_build_for_sizebot:
-    if: ${{ github.event_name == 'pull_request' && github.ref_name != 'main' }}
-    name: Download base build for sizebot
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: yarn
-          cache-dependency-path: yarn.lock
-      - name: Restore cached node_modules
-        uses: actions/cache@v4
-        id: node_modules
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.arch }}-${{ runner.os }}-modules-${{ hashFiles('yarn.lock', 'scripts/release/yarn.lock') }}
-      - name: Ensure clean build directory
-        run: rm -rf build
-      - run: yarn install --frozen-lockfile
-      - run: yarn install --frozen-lockfile
-        working-directory: scripts/release
-      - name: Download artifacts for base revision
-        run: |
-          git fetch origin main
-          GH_TOKEN=${{ github.token }} scripts/release/download-experimental-build.js --commit=$(git rev-parse origin/main)
-          mv ./build ./base-build
-      # TODO: The `download-experimental-build` script copies the npm
-      # packages into the `node_modules` directory. This is a historical
-      # quirk of how the release script works. Let's pretend they
-      # don't exist.
-      - name: Delete extraneous files
-        run: rm -rf ./base-build/node_modules
-      - name: Display structure of base-build
-        run: ls -R base-build
-      - name: Archive base-build
-        uses: actions/upload-artifact@v4
-        with:
-          name: base-build
-          path: base-build
-
   sizebot:
+    if: ${{ github.event_name == 'pull_request' && github.ref_name != 'main' && github.event.pull_request.base.ref == 'main' }}
     name: Run sizebot
-    needs: [build_and_lint, download_base_build_for_sizebot]
+    needs: [build_and_lint]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -650,6 +608,22 @@ jobs:
       - name: Ensure clean build directory
         run: rm -rf build
       - run: yarn install --frozen-lockfile
+        working-directory: scripts/release
+      - name: Download artifacts for base revision
+        run: |
+          GH_TOKEN=${{ github.token }} scripts/release/download-experimental-build.js --commit=$(git rev-parse ${{ github.event.pull_request.base.sha }})
+          mv ./build ./base-build
+      # TODO: The `download-experimental-build` script copies the npm
+      # packages into the `node_modules` directory. This is a historical
+      # quirk of how the release script works. Let's pretend they
+      # don't exist.
+      - name: Delete extraneous files
+        run: rm -rf ./base-build/node_modules
+      - name: Display structure of base-build from origin/main
+        run: ls -R base-build
+      - name: Ensure clean build directory
+        run: rm -rf build
+      - run: yarn install --frozen-lockfile
       - name: Restore archived build for PR
         uses: actions/download-artifact@v4
         with:
@@ -662,13 +636,6 @@ jobs:
           node ./scripts/print-warnings/print-warnings.js > build/__test_utils__/ReactAllWarnings.js
       - name: Display structure of build for PR
         run: ls -R build
-      - name: Restore archived base-build from origin/main
-        uses: actions/download-artifact@v4
-        with:
-          name: base-build
-          path: base-build
-      - name: Display structure of base-build from origin/main
-        run: ls -R base-build
       - run: echo ${{ github.sha }} >> build/COMMIT_SHA
       - run: node ./scripts/tasks/danger
       - name: Archive sizebot results

--- a/.github/workflows/runtime_discord_notify.yml
+++ b/.github/workflows/runtime_discord_notify.yml
@@ -2,7 +2,7 @@ name: (Runtime) Discord Notify
 
 on:
   pull_request_target:
-    types: [labeled]
+    types: [opened]
     paths-ignore:
       - compiler/**
       - .github/workflows/compiler_**.yml
@@ -14,7 +14,7 @@ jobs:
       actor: ${{ github.event.pull_request.user.login }}
 
   notify:
-    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' && github.event.label.name == 'React Core Team' }}
+    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}
     needs: check_maintainer
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

There's no real reason to have 2 jobs for sizebot. It's more of a historical artifact from before the GH migration. Merging them should require one less worker needing to be provisioned and some of the extra overhead
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32333).
* __->__ #32333
* #32332