### PR TITLE
[ci] Disallow PRs against builds branch

### DIFF
--- a/.github/workflows/shared_close_direct_sync_branch_prs.yml
+++ b/.github/workflows/shared_close_direct_sync_branch_prs.yml
@@ -1,0 +1,37 @@
+name: (Shared) Close Direct Sync Branch PRs
+
+on:
+  pull_request:
+    branches:
+      - builds/facebook-*
+
+env:
+  TZ: /usr/share/zoneinfo/America/Los_Angeles
+  # https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cache-segment-restore-timeout
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
+
+jobs:
+  close_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullNumber = ${{ github.event.number }};
+
+            await github.rest.pulls.createReview({
+              owner,
+              repo,
+              pull_number: pullNumber,
+              body: 'Do not land changes to `${{ github.event.pull_request.base.ref }}`. Please re-open your PR targeting `main` instead.',
+              event: 'REQUEST_CHANGES'
+            });
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: pullNumber,
+              state: 'closed'
+            });


### PR DESCRIPTION

Our internal build infra relies on a 1:1 mapping between `main` and the 2 build branches. Directly committing changes to those branches breaks that infra.

Adds a simple workflow to leave a comment and decline the PR.
