### PR TITLE
Remove useActionState Hook export from experimental react-server condition

### DIFF
--- a/packages/react/src/ReactServer.experimental.development.js
+++ b/packages/react/src/ReactServer.experimental.development.js
@@ -30,7 +30,6 @@ import {
   useCallback,
   useDebugValue,
   useMemo,
-  useActionState,
   getCacheForType,
 } from './ReactHooks';
 import {forwardRef} from './ReactForwardRef';
@@ -78,7 +77,6 @@ export {
   useCallback,
   useDebugValue,
   useMemo,
-  useActionState,
   version,
   // Experimental
   REACT_SUSPENSE_LIST_TYPE as unstable_SuspenseList,

--- a/packages/react/src/ReactServer.experimental.js
+++ b/packages/react/src/ReactServer.experimental.js
@@ -30,7 +30,6 @@ import {
   useCallback,
   useDebugValue,
   useMemo,
-  useActionState,
   getCacheForType,
 } from './ReactHooks';
 import {forwardRef} from './ReactForwardRef';
@@ -77,7 +76,6 @@ export {
   useCallback,
   useDebugValue,
   useMemo,
-  useActionState,
   version,
   // Experimental
   REACT_SUSPENSE_LIST_TYPE as unstable_SuspenseList,


### PR DESCRIPTION
This Hook is not available in RSC environments. This is already the case in stable but not in experimental for some reason. Probably an oversight.
