### PR TITLE
Trigger Discord notification when draft PR is set to "ready for review"

### DIFF
--- a/.github/workflows/runtime_discord_notify.yml
+++ b/.github/workflows/runtime_discord_notify.yml
@@ -2,7 +2,7 @@ name: (Runtime) Discord Notify
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, ready_for_review]
     paths-ignore:
       - compiler/**
       - .github/workflows/compiler_**.yml


### PR DESCRIPTION
Follow-up for #32332. The Discord webhook seems to ignore draft PRs, which is a good thing. But when a draft PR is then later set to "ready for review" we do want to send another notification that should not be filtered out.