### PR TITLE
[react-native] Suppress Flow nonstrict-import check in ReactNativeTypes

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -10,6 +10,7 @@
  */
 
 import type {ElementRef, ElementType, MixedElement} from 'react';
+// $FlowFixMe[nonstrict-import] TODO(@rubennorte)
 import {type PublicRootInstance} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
 
 export type MeasureOnSuccessCallback = (


### PR DESCRIPTION

Summary: Unblock internal sync.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:
