### PR TITLE
Add useSwipeTransition Hook Behind Experimental Flag

### DIFF
--- a/fixtures/view-transition/src/components/Page.css
+++ b/fixtures/view-transition/src/components/Page.css
@@ -6,3 +6,14 @@
   font-variation-settings:
     "wdth" 100;
 }
+
+.swipe-recognizer {
+  width: 200px;
+  overflow-x: scroll;
+  border: 1px solid #333333;
+  border-radius: 10px;
+}
+
+.swipe-overscroll {
+  width: 200%;
+}

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -14,6 +14,7 @@ import type {
   Usable,
   Thenable,
   ReactDebugInfo,
+  StartGesture,
 } from 'shared/ReactTypes';
 import type {
   ContextDependency,
@@ -130,6 +131,9 @@ function getPrimitiveStackCache(): Map<string, Array<any>> {
 
       if (typeof Dispatcher.useEffectEvent === 'function') {
         Dispatcher.useEffectEvent((args: empty) => {});
+      }
+      if (typeof Dispatcher.useSwipeTransition === 'function') {
+        Dispatcher.useSwipeTransition(null, null, null);
       }
     } finally {
       readHookLog = hookLog;
@@ -752,31 +756,50 @@ function useEffectEvent<Args, F: (...Array<Args>) => mixed>(callback: F): F {
   return callback;
 }
 
+function useSwipeTransition<T>(
+  previous: T,
+  current: T,
+  next: T,
+): [T, StartGesture] {
+  nextHook();
+  hookLog.push({
+    displayName: null,
+    primitive: 'SwipeTransition',
+    stackError: new Error(),
+    value: current,
+    debugInfo: null,
+    dispatcherHookName: 'SwipeTransition',
+  });
+  return [current, () => () => {}];
+}
+
 const Dispatcher: DispatcherType = {
-  use,
   readContext,
-  useCacheRefresh,
+
+  use,
   useCallback,
   useContext,
   useEffect,
   useImperativeHandle,
-  useDebugValue,
   useLayoutEffect,
   useInsertionEffect,
   useMemo,
-  useMemoCache,
-  useOptimistic,
   useReducer,
   useRef,
   useState,
+  useDebugValue,
+  useDeferredValue,
   useTransition,
   useSyncExternalStore,
-  useDeferredValue,
   useId,
+  useHostTransitionStatus,
   useFormState,
   useActionState,
-  useHostTransitionStatus,
+  useOptimistic,
+  useMemoCache,
+  useCacheRefresh,
   useEffectEvent,
+  useSwipeTransition,
 };
 
 // create a proxy to throw a custom error

--- a/packages/react-reconciler/src/ReactFiberGestureScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberGestureScheduler.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {scheduleMicrotask} from './ReactFiberConfig';
+
+export function scheduleGesture(root: FiberRoot): void {}

--- a/packages/react-reconciler/src/ReactFiberGestureScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberGestureScheduler.js
@@ -7,6 +7,77 @@
  * @flow
  */
 
+import type {FiberRoot} from './ReactInternalTypes';
+import type {GestureProvider} from 'shared/ReactTypes';
+
 import {scheduleMicrotask} from './ReactFiberConfig';
 
-export function scheduleGesture(root: FiberRoot): void {}
+// This type keeps track of any scheduled or active gestures.
+export type ScheduledGesture = {
+  provider: GestureProvider,
+  count: number, // The number of times this same provider has been started.
+  prev: null | ScheduledGesture, // The previous scheduled gesture in the queue for this root.
+  next: null | ScheduledGesture, // The next scheduled gesture in the queue for this root.
+};
+
+export function scheduleGesture(
+  root: FiberRoot,
+  provider: GestureProvider,
+): ScheduledGesture {
+  let prev = root.gestures;
+  while (prev !== null) {
+    if (prev.provider === provider) {
+      // Existing instance found.
+      prev.count++;
+      return prev;
+    }
+    const next = prev.next;
+    if (next === null) {
+      break;
+    }
+    prev = next;
+  }
+  // Add new instance to the end of the queue.
+  const gesture: ScheduledGesture = {
+    provider: provider,
+    count: 1,
+    prev: prev,
+    next: null,
+  };
+  if (prev === null) {
+    root.gestures = gesture;
+  } else {
+    prev.next = gesture;
+  }
+  // Schedule a microtask to perform the work. This lets us batch multiple starts into
+  // one transition. This must be a microtask though because it can be important to
+  // synchronously perform the work in this event depending on the caller.
+  scheduleMicrotask(performWorkOnScheduledGestures.bind(null, root));
+  return gesture;
+}
+
+export function cancelScheduledGesture(
+  root: FiberRoot,
+  gesture: ScheduledGesture,
+) {
+  gesture.count--;
+  if (gesture.count === 0) {
+    // Delete the scheduled gesture from the queue.
+    if (gesture.prev === null) {
+      if (root.gestures === gesture) {
+        root.gestures = gesture.next;
+      }
+    } else {
+      gesture.prev.next = gesture.next;
+      if (gesture.next !== null) {
+        gesture.next.prev = gesture.prev;
+      }
+      gesture.prev = null;
+      gesture.next = null;
+    }
+  }
+}
+
+function performWorkOnScheduledGestures(root: FiberRoot) {
+  // TODO
+}

--- a/packages/react-reconciler/src/ReactFiberGestureScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberGestureScheduler.js
@@ -10,7 +10,8 @@
 import type {FiberRoot} from './ReactInternalTypes';
 import type {GestureProvider} from 'shared/ReactTypes';
 
-import {scheduleMicrotask} from './ReactFiberConfig';
+import {GestureLane} from './ReactFiberLane';
+import {ensureRootIsScheduled} from './ReactFiberRootScheduler';
 
 // This type keeps track of any scheduled or active gestures.
 export type ScheduledGesture = {
@@ -49,35 +50,41 @@ export function scheduleGesture(
   } else {
     prev.next = gesture;
   }
-  // Schedule a microtask to perform the work. This lets us batch multiple starts into
-  // one transition. This must be a microtask though because it can be important to
-  // synchronously perform the work in this event depending on the caller.
-  scheduleMicrotask(performWorkOnScheduledGestures.bind(null, root));
+  ensureRootIsScheduled(root);
   return gesture;
 }
 
 export function cancelScheduledGesture(
   root: FiberRoot,
   gesture: ScheduledGesture,
-) {
+): void {
   gesture.count--;
   if (gesture.count === 0) {
     // Delete the scheduled gesture from the queue.
-    if (gesture.prev === null) {
-      if (root.gestures === gesture) {
-        root.gestures = gesture.next;
-      }
-    } else {
-      gesture.prev.next = gesture.next;
-      if (gesture.next !== null) {
-        gesture.next.prev = gesture.prev;
-      }
-      gesture.prev = null;
-      gesture.next = null;
-    }
+    deleteScheduledGesture(root, gesture);
   }
 }
 
-function performWorkOnScheduledGestures(root: FiberRoot) {
-  // TODO
+export function deleteScheduledGesture(
+  root: FiberRoot,
+  gesture: ScheduledGesture,
+): void {
+  if (gesture.prev === null) {
+    if (root.gestures === gesture) {
+      root.gestures = gesture.next;
+      if (root.gestures === null) {
+        // Gestures don't clear their lanes while the gesture is still active but it
+        // might not be scheduled to do any more renders and so we shouldn't schedule
+        // any more gesture lane work until a new gesture is scheduled.
+        root.pendingLanes &= ~GestureLane;
+      }
+    }
+  } else {
+    gesture.prev.next = gesture.next;
+    if (gesture.next !== null) {
+      gesture.next.prev = gesture.prev;
+    }
+    gesture.prev = null;
+    gesture.next = null;
+  }
 }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -133,6 +133,7 @@ import {
   enqueueConcurrentHookUpdate,
   enqueueConcurrentHookUpdateAndEagerlyBailout,
   enqueueConcurrentRenderForLane,
+  enqueueGestureRender,
 } from './ReactFiberConcurrentUpdates';
 import {getTreeId} from './ReactFiberTreeContext';
 import {now} from './Scheduler';
@@ -155,6 +156,8 @@ import {isCurrentTreeHidden} from './ReactFiberHiddenContext';
 import {requestCurrentTransition} from './ReactFiberTransition';
 
 import {callComponentInDEV} from './ReactFiberCallUserSpace';
+
+import {scheduleGesture} from './ReactFiberGestureScheduler';
 
 export type Update<S, A> = {
   lane: Lane,
@@ -3972,6 +3975,8 @@ function startGesture(
   queue: SwipeTransitionUpdateQueue,
   gestureProvider: GestureProvider,
 ): () => void {
+  const root = enqueueGestureRender(fiber);
+  scheduleGesture(root);
   return function cancelGesture() {};
 }
 

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -54,23 +54,24 @@ export const DefaultLane: Lane = /*                     */ 0b0000000000000000000
 export const SyncUpdateLanes: Lane =
   SyncLane | InputContinuousLane | DefaultLane;
 
-const TransitionHydrationLane: Lane = /*                */ 0b0000000000000000000000001000000;
-const TransitionLanes: Lanes = /*                       */ 0b0000000001111111111111110000000;
-const TransitionLane1: Lane = /*                        */ 0b0000000000000000000000010000000;
-const TransitionLane2: Lane = /*                        */ 0b0000000000000000000000100000000;
-const TransitionLane3: Lane = /*                        */ 0b0000000000000000000001000000000;
-const TransitionLane4: Lane = /*                        */ 0b0000000000000000000010000000000;
-const TransitionLane5: Lane = /*                        */ 0b0000000000000000000100000000000;
-const TransitionLane6: Lane = /*                        */ 0b0000000000000000001000000000000;
-const TransitionLane7: Lane = /*                        */ 0b0000000000000000010000000000000;
-const TransitionLane8: Lane = /*                        */ 0b0000000000000000100000000000000;
-const TransitionLane9: Lane = /*                        */ 0b0000000000000001000000000000000;
-const TransitionLane10: Lane = /*                       */ 0b0000000000000010000000000000000;
-const TransitionLane11: Lane = /*                       */ 0b0000000000000100000000000000000;
-const TransitionLane12: Lane = /*                       */ 0b0000000000001000000000000000000;
-const TransitionLane13: Lane = /*                       */ 0b0000000000010000000000000000000;
-const TransitionLane14: Lane = /*                       */ 0b0000000000100000000000000000000;
-const TransitionLane15: Lane = /*                       */ 0b0000000001000000000000000000000;
+export const GestureLane: Lane = /*                     */ 0b0000000000000000000000001000000;
+
+const TransitionHydrationLane: Lane = /*                */ 0b0000000000000000000000010000000;
+const TransitionLanes: Lanes = /*                       */ 0b0000000001111111111111100000000;
+const TransitionLane1: Lane = /*                        */ 0b0000000000000000000000100000000;
+const TransitionLane2: Lane = /*                        */ 0b0000000000000000000001000000000;
+const TransitionLane3: Lane = /*                        */ 0b0000000000000000000010000000000;
+const TransitionLane4: Lane = /*                        */ 0b0000000000000000000100000000000;
+const TransitionLane5: Lane = /*                        */ 0b0000000000000000001000000000000;
+const TransitionLane6: Lane = /*                        */ 0b0000000000000000010000000000000;
+const TransitionLane7: Lane = /*                        */ 0b0000000000000000100000000000000;
+const TransitionLane8: Lane = /*                        */ 0b0000000000000001000000000000000;
+const TransitionLane9: Lane = /*                        */ 0b0000000000000010000000000000000;
+const TransitionLane10: Lane = /*                       */ 0b0000000000000100000000000000000;
+const TransitionLane11: Lane = /*                       */ 0b0000000000001000000000000000000;
+const TransitionLane12: Lane = /*                       */ 0b0000000000010000000000000000000;
+const TransitionLane13: Lane = /*                       */ 0b0000000000100000000000000000000;
+const TransitionLane14: Lane = /*                       */ 0b0000000001000000000000000000000;
 
 const RetryLanes: Lanes = /*                            */ 0b0000011110000000000000000000000;
 const RetryLane1: Lane = /*                             */ 0b0000000010000000000000000000000;
@@ -191,7 +192,6 @@ function getHighestPriorityLanes(lanes: Lanes | Lane): Lanes {
     case TransitionLane12:
     case TransitionLane13:
     case TransitionLane14:
-    case TransitionLane15:
       return lanes & TransitionLanes;
     case RetryLane1:
     case RetryLane2:
@@ -209,6 +209,10 @@ function getHighestPriorityLanes(lanes: Lanes | Lane): Lanes {
     case DeferredLane:
       // This shouldn't be reachable because deferred work is always entangled
       // with something else.
+      return NoLanes;
+    case GestureLane:
+      // This shouldn't typically be reached because we should've already finished this
+      // work before starting a regular render.
       return NoLanes;
     default:
       if (__DEV__) {
@@ -459,6 +463,7 @@ function computeExpirationTime(lane: Lane, currentTime: number) {
     case SyncLane:
     case InputContinuousHydrationLane:
     case InputContinuousLane:
+    case GestureLane:
       // User interactions should expire slightly more quickly.
       //
       // NOTE: This is set to the corresponding constant as in Scheduler.js.
@@ -486,7 +491,6 @@ function computeExpirationTime(lane: Lane, currentTime: number) {
     case TransitionLane12:
     case TransitionLane13:
     case TransitionLane14:
-    case TransitionLane15:
       return currentTime + transitionLaneExpirationMs;
     case RetryLane1:
     case RetryLane2:
@@ -1053,7 +1057,6 @@ export function getBumpedLaneForHydrationByLane(lane: Lane): Lane {
     case TransitionLane12:
     case TransitionLane13:
     case TransitionLane14:
-    case TransitionLane15:
     case RetryLane1:
     case RetryLane2:
     case RetryLane3:
@@ -1197,7 +1200,8 @@ export function getGroupNameOfHighestPriorityLane(lanes: Lanes): string {
       InputContinuousHydrationLane |
       InputContinuousLane |
       DefaultHydrationLane |
-      DefaultLane)
+      DefaultLane |
+      GestureLane)
   ) {
     return 'Blocking';
   }

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -176,6 +176,8 @@ function getHighestPriorityLanes(lanes: Lanes | Lane): Lanes {
       return DefaultHydrationLane;
     case DefaultLane:
       return DefaultLane;
+    case GestureLane:
+      return GestureLane;
     case TransitionHydrationLane:
       return TransitionHydrationLane;
     case TransitionLane1:
@@ -209,10 +211,6 @@ function getHighestPriorityLanes(lanes: Lanes | Lane): Lanes {
     case DeferredLane:
       // This shouldn't be reachable because deferred work is always entangled
       // with something else.
-      return NoLanes;
-    case GestureLane:
-      // This shouldn't typically be reached because we should've already finished this
-      // work before starting a regular render.
       return NoLanes;
     default:
       if (__DEV__) {
@@ -644,7 +642,8 @@ export function includesBlockingLane(lanes: Lanes): boolean {
     InputContinuousHydrationLane |
     InputContinuousLane |
     DefaultHydrationLane |
-    DefaultLane;
+    DefaultLane |
+    GestureLane;
   return (lanes & SyncDefaultLanes) !== NoLanes;
 }
 

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -667,6 +667,11 @@ export function isTransitionLane(lane: Lane): boolean {
   return (lane & TransitionLanes) !== NoLanes;
 }
 
+export function isGestureRender(lanes: Lanes): boolean {
+  // This should render only the one lane.
+  return lanes === GestureLane;
+}
+
 export function claimNextTransitionLane(): Lane {
   // Cycle through the lanes, assigning each new transition to the next lane.
   // In most cases, this means every transition gets its own lane, until we

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -33,6 +33,7 @@ import {
   enableUpdaterTracking,
   enableTransitionTracing,
   disableLegacyMode,
+  enableSwipeTransition,
 } from 'shared/ReactFeatureFlags';
 import {initializeUpdateQueue} from './ReactFiberClassUpdateQueue';
 import {LegacyRoot, ConcurrentRoot} from './ReactRootTags';
@@ -96,6 +97,10 @@ function FiberRootNode(
   }
 
   this.formState = formState;
+
+  if (enableSwipeTransition) {
+    this.gestures = null;
+  }
 
   this.incompleteTransitions = new Map();
   if (enableTransitionTracing) {

--- a/packages/react-reconciler/src/ReactFiberRootScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberRootScheduler.js
@@ -20,6 +20,7 @@ import {
   enableComponentPerformanceTrack,
   enableSiblingPrerendering,
   enableYieldingBeforePassive,
+  enableSwipeTransition,
 } from 'shared/ReactFeatureFlags';
 import {
   NoLane,
@@ -32,6 +33,7 @@ import {
   claimNextTransitionLane,
   getNextLanesToFlushSync,
   checkIfRootIsPrerendering,
+  isGestureRender,
 } from './ReactFiberLane';
 import {
   CommitContext,
@@ -211,7 +213,8 @@ function flushSyncWorkAcrossRoots_impl(
             rootHasPendingCommit,
           );
           if (
-            includesSyncLane(nextLanes) &&
+            (includesSyncLane(nextLanes) ||
+              (enableSwipeTransition && isGestureRender(nextLanes))) &&
             !checkIfRootIsPrerendering(root, nextLanes)
           ) {
             // This root has pending sync work. Flush it now.
@@ -296,7 +299,8 @@ function processRootScheduleInMicrotask() {
         syncTransitionLanes !== NoLanes ||
         // Common case: we're not treating any extra lanes as synchronous, so we
         // can just check if the next lanes are sync.
-        includesSyncLane(nextLanes)
+        includesSyncLane(nextLanes) ||
+        (enableSwipeTransition && isGestureRender(nextLanes))
       ) {
         mightHavePendingSyncWork = true;
       }

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -17,6 +17,7 @@ import type {
   Awaited,
   ReactComponentInfo,
   ReactDebugInfo,
+  StartGesture,
 } from 'shared/ReactTypes';
 import type {WorkTag} from './ReactWorkTags';
 import type {TypeOfMode} from './ReactTypeOfMode';
@@ -60,7 +61,8 @@ export type HookType =
   | 'useCacheRefresh'
   | 'useOptimistic'
   | 'useFormState'
-  | 'useActionState';
+  | 'useActionState'
+  | 'useSwipeTransition';
 
 export type ContextDependency<T> = {
   context: ReactContext<T>,
@@ -442,6 +444,12 @@ export type Dispatcher = {
     initialState: Awaited<S>,
     permalink?: string,
   ) => [Awaited<S>, (P) => void, boolean],
+  // TODO: Non-nullable once `enableSwipeTransition` is on everywhere.
+  useSwipeTransition?: <T>(
+    previous: T,
+    current: T,
+    next: T,
+  ) => [T, StartGesture],
 };
 
 export type AsyncDispatcher = {

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -39,6 +39,7 @@ import type {
 import type {ConcurrentUpdate} from './ReactFiberConcurrentUpdates';
 import type {ComponentStackNode} from 'react-server/src/ReactFizzComponentStack';
 import type {ThenableState} from './ReactFiberThenable';
+import type {ScheduledGesture} from './ReactFiberGestureScheduler';
 
 // Unwind Circular: moved from ReactFiberHooks.old
 export type HookType =
@@ -281,6 +282,9 @@ type BaseFiberRootProperties = {
   ) => void,
 
   formState: ReactFormState<any, any> | null,
+
+  // enableSwipeTransition only
+  gestures: null | ScheduledGesture,
 };
 
 // The following attributes are only used by DevTools and are only present in DEV builds.

--- a/packages/react-server/src/ReactFlightHooks.js
+++ b/packages/react-server/src/ReactFlightHooks.js
@@ -17,6 +17,10 @@ import {
 } from 'shared/ReactSymbols';
 import {createThenableState, trackUsedThenable} from './ReactFlightThenable';
 import {isClientReference} from './ReactFlightServerConfig';
+import {
+  enableUseEffectEventHook,
+  enableSwipeTransition,
+} from 'shared/ReactFeatureFlags';
 
 let currentRequest = null;
 let thenableIndexCounter = 0;
@@ -58,33 +62,32 @@ export function getThenableStateAfterSuspending(): ThenableState {
 }
 
 export const HooksDispatcher: Dispatcher = {
-  useMemo<T>(nextCreate: () => T): T {
-    return nextCreate();
-  },
+  readContext: (unsupportedContext: any),
+
+  use,
   useCallback<T>(callback: T): T {
     return callback;
   },
-  useDebugValue(): void {},
-  useDeferredValue: (unsupportedHook: any),
-  useTransition: (unsupportedHook: any),
-  readContext: (unsupportedContext: any),
   useContext: (unsupportedContext: any),
+  useEffect: (unsupportedHook: any),
+  useImperativeHandle: (unsupportedHook: any),
+  useLayoutEffect: (unsupportedHook: any),
+  useInsertionEffect: (unsupportedHook: any),
+  useMemo<T>(nextCreate: () => T): T {
+    return nextCreate();
+  },
   useReducer: (unsupportedHook: any),
   useRef: (unsupportedHook: any),
   useState: (unsupportedHook: any),
-  useInsertionEffect: (unsupportedHook: any),
-  useLayoutEffect: (unsupportedHook: any),
-  useImperativeHandle: (unsupportedHook: any),
-  useEffect: (unsupportedHook: any),
+  useDebugValue(): void {},
+  useDeferredValue: (unsupportedHook: any),
+  useTransition: (unsupportedHook: any),
+  useSyncExternalStore: (unsupportedHook: any),
   useId,
   useHostTransitionStatus: (unsupportedHook: any),
-  useOptimistic: (unsupportedHook: any),
   useFormState: (unsupportedHook: any),
   useActionState: (unsupportedHook: any),
-  useSyncExternalStore: (unsupportedHook: any),
-  useCacheRefresh(): <T>(?() => T, ?T) => void {
-    return unsupportedRefresh;
-  },
+  useOptimistic: (unsupportedHook: any),
   useMemoCache(size: number): Array<any> {
     const data = new Array<any>(size);
     for (let i = 0; i < size; i++) {
@@ -92,8 +95,16 @@ export const HooksDispatcher: Dispatcher = {
     }
     return data;
   },
-  use,
+  useCacheRefresh(): <T>(?() => T, ?T) => void {
+    return unsupportedRefresh;
+  },
 };
+if (enableUseEffectEventHook) {
+  HooksDispatcher.useEffectEvent = (unsupportedHook: any);
+}
+if (enableSwipeTransition) {
+  HooksDispatcher.useSwipeTransition = (unsupportedHook: any);
+}
 
 function unsupportedHook(): void {
   throw new Error('This Hook is not supported in Server Components.');

--- a/packages/react/index.experimental.development.js
+++ b/packages/react/index.experimental.development.js
@@ -33,6 +33,7 @@ export {
   unstable_getCacheForType,
   unstable_SuspenseList,
   unstable_ViewTransition,
+  unstable_useSwipeTransition,
   unstable_addTransitionType,
   unstable_useCacheRefresh,
   useId,

--- a/packages/react/index.experimental.js
+++ b/packages/react/index.experimental.js
@@ -33,6 +33,7 @@ export {
   unstable_getCacheForType,
   unstable_SuspenseList,
   unstable_ViewTransition,
+  unstable_useSwipeTransition,
   unstable_addTransitionType,
   unstable_useCacheRefresh,
   useId,

--- a/packages/react/src/ReactClient.js
+++ b/packages/react/src/ReactClient.js
@@ -57,6 +57,7 @@ import {
   use,
   useOptimistic,
   useActionState,
+  useSwipeTransition,
 } from './ReactHooks';
 import ReactSharedInternals from './ReactSharedInternalsClient';
 import {startTransition} from './ReactStartTransition';
@@ -126,7 +127,10 @@ export {
   // enableViewTransition
   REACT_VIEW_TRANSITION_TYPE as unstable_ViewTransition,
   addTransitionType as unstable_addTransitionType,
+  // enableSwipeTransition
+  useSwipeTransition as unstable_useSwipeTransition,
+  // DEV-only
   useId,
-  act, // DEV-only
-  captureOwnerStack, // DEV-only
+  act,
+  captureOwnerStack,
 };

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -13,12 +13,16 @@ import type {
   StartTransitionOptions,
   Usable,
   Awaited,
+  StartGesture,
 } from 'shared/ReactTypes';
 import {REACT_CONSUMER_TYPE} from 'shared/ReactSymbols';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 
-import {enableUseEffectCRUDOverload} from 'shared/ReactFeatureFlags';
+import {
+  enableUseEffectCRUDOverload,
+  enableSwipeTransition,
+} from 'shared/ReactFeatureFlags';
 
 type BasicStateAction<S> = (S => S) | S;
 type Dispatch<A> = A => void;
@@ -260,4 +264,17 @@ export function useActionState<S, P>(
 ): [Awaited<S>, (P) => void, boolean] {
   const dispatcher = resolveDispatcher();
   return dispatcher.useActionState(action, initialState, permalink);
+}
+
+export function useSwipeTransition<T>(
+  previous: T,
+  current: T,
+  next: T,
+): [T, StartGesture] {
+  if (!enableSwipeTransition) {
+    throw new Error('Not implemented.');
+  }
+  const dispatcher = resolveDispatcher();
+  // $FlowFixMe[not-a-function] This is unstable, thus optional
+  return dispatcher.useSwipeTransition(previous, current, next);
 }

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -92,6 +92,8 @@ export const enableHalt = __EXPERIMENTAL__;
 
 export const enableViewTransition = __EXPERIMENTAL__;
 
+export const enableSwipeTransition = __EXPERIMENTAL__;
+
 /**
  * Switches Fiber creation to a simple object instead of a constructor.
  */

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -168,6 +168,12 @@ export type ReactFormState<S, ReferenceId> = [
   number /* number of bound arguments */,
 ];
 
+// Intrinsic GestureProvider. This type varies by Environment whether a particular
+// renderer supports it.
+export type GestureProvider = AnimationTimeline; // TODO: More provider types.
+
+export type StartGesture = (gestureProvider: GestureProvider) => () => void;
+
 export type Awaited<T> = T extends null | void
   ? T // special case for `null | undefined` when not in `--strictNullChecks` mode
   : T extends Object // `await` only unwraps object types with a callable then. Non-object types are not unwrapped.

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -82,6 +82,7 @@ export const enableHydrationLaneScheduling = true;
 export const enableYieldingBeforePassive = false;
 export const enableThrottledScheduling = false;
 export const enableViewTransition = false;
+export const enableSwipeTransition = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -71,6 +71,7 @@ export const enableYieldingBeforePassive = false;
 
 export const enableThrottledScheduling = false;
 export const enableViewTransition = false;
+export const enableSwipeTransition = false;
 export const enableFastAddPropertiesInDiffing = false;
 export const enableLazyPublicInstanceInFabric = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -70,6 +70,7 @@ export const enableYieldingBeforePassive = true;
 
 export const enableThrottledScheduling = false;
 export const enableViewTransition = false;
+export const enableSwipeTransition = false;
 export const enableFastAddPropertiesInDiffing = true;
 export const enableLazyPublicInstanceInFabric = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -67,6 +67,7 @@ export const enableHydrationLaneScheduling = true;
 export const enableYieldingBeforePassive = false;
 export const enableThrottledScheduling = false;
 export const enableViewTransition = false;
+export const enableSwipeTransition = false;
 export const enableRemoveConsolePatches = false;
 export const enableFastAddPropertiesInDiffing = false;
 export const enableLazyPublicInstanceInFabric = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -82,6 +82,7 @@ export const enableYieldingBeforePassive = false;
 
 export const enableThrottledScheduling = false;
 export const enableViewTransition = false;
+export const enableSwipeTransition = false;
 export const enableRemoveConsolePatches = false;
 export const enableFastAddPropertiesInDiffing = false;
 export const enableLazyPublicInstanceInFabric = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -112,5 +112,7 @@ export const enableShallowPropDiffing = false;
 
 export const enableLazyPublicInstanceInFabric = false;
 
+export const enableSwipeTransition = false;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -531,5 +531,6 @@
   "543": "Expected a ResourceEffectUpdate to be pushed together with ResourceEffectIdentity. This is a bug in React.",
   "544": "Found a pair with an auto name. This is a bug in React.",
   "545": "The %s tag may only be rendered once.",
-  "546": "useEffect CRUD overload is not enabled in this build of React."
+  "546": "useEffect CRUD overload is not enabled in this build of React.",
+  "547": "startGesture cannot be called during server rendering."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -532,5 +532,6 @@
   "544": "Found a pair with an auto name. This is a bug in React.",
   "545": "The %s tag may only be rendered once.",
   "546": "useEffect CRUD overload is not enabled in this build of React.",
-  "547": "startGesture cannot be called during server rendering."
+  "547": "startGesture cannot be called during server rendering.",
+  "548": "Finished rendering the gesture lane but there were no pending gestures. React should not have started a render in this case. This is a bug in React."
 }


### PR DESCRIPTION
This Hook will be used to drive a View Transition based on a gesture.

```js
const [value, startGesture] = useSwipeTransition(prev, current, next);
```

The `enableSwipeTransition` flag will depend on `enableViewTransition` flag but we may decide to ship them independently. This PR doesn't do anything interesting yet. There will be a lot more PRs to build out the actual functionality. This is just wiring up the plumbing for the new Hook.

This first PR is mainly concerned with how the whole starts (and stops). The core API is the `startGesture` function (although there will be other conveniences added in the future). You can call this to start a gesture with a source provider. You can call this multiple times in one event to batch multiple Hooks listening to the same provider. However, each render can only handle one source provider at a time and so it does one render per scheduled gesture provider.

This uses a separate `GestureLane` to drive gesture renders by marking the Hook as having an update on that lane. Then schedule a render. These renders should be blocking and in the same microtask as the `startGesture` to ensure it can block the paint. So it's similar to sync.

It may not be possible to finish it synchronously e.g. if something suspends. If so, it just tries again later when it can like any other render. This can also happen because it also may not be possible to drive more than one gesture at a time like if we're limited to one View Transition per document. So right now you can only run one gesture at a time in practice.

These renders never commit. This means that we can't clear the `GestureLane` the normal way. Instead, we have to clear only the root's `pendingLanes` if we don't have any new renders scheduled. Then wait until something else updates the Fiber after all gestures on it have stopped before it really clears.