### PR TITLE
Rerender useSwipeTransition when direction changes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -614,6 +614,7 @@ module.exports = {
     KeyframeAnimationOptions: 'readonly',
     GetAnimationsOptions: 'readonly',
     Animatable: 'readonly',
+    ScrollTimeline: 'readonly',
 
     spyOnDev: 'readonly',
     spyOnDevAndProd: 'readonly',

--- a/fixtures/view-transition/src/components/Page.js
+++ b/fixtures/view-transition/src/components/Page.js
@@ -68,10 +68,12 @@ export default function Page({url, navigate}) {
       activeGesture.current = null;
       cancelGesture();
     }
+    // Reset scroll
+    swipeRecognizer.current.scrollLeft = !show ? 0 : 10000;
   }
 
   useLayoutEffect(() => {
-    swipeRecognizer.current.scrollLeft = show ? 0 : 10000;
+    swipeRecognizer.current.scrollLeft = !show ? 0 : 10000;
   }, [show]);
 
   const exclamation = (

--- a/packages/react-art/src/ReactFiberConfigART.js
+++ b/packages/react-art/src/ReactFiberConfigART.js
@@ -508,10 +508,10 @@ export function createViewTransitionInstance(
   return null;
 }
 
-export type GestureProvider = null;
+export type GestureTimeline = null;
 
 export function subscribeToGestureDirection(
-  provider: GestureProvider,
+  provider: GestureTimeline,
   directionCallback: (direction: boolean) => void,
 ): () => void {
   throw new Error('useSwipeTransition is not yet supported in react-art.');

--- a/packages/react-art/src/ReactFiberConfigART.js
+++ b/packages/react-art/src/ReactFiberConfigART.js
@@ -508,6 +508,15 @@ export function createViewTransitionInstance(
   return null;
 }
 
+export type GestureProvider = null;
+
+export function subscribeToGestureDirection(
+  provider: GestureProvider,
+  directionCallback: (direction: boolean) => void,
+): () => void {
+  throw new Error('useSwipeTransition is not yet supported in react-art.');
+}
+
 export function clearContainer(container) {
   // TODO Implement this
 }

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -1478,10 +1478,10 @@ export function createViewTransitionInstance(
   };
 }
 
-export type GestureProvider = AnimationTimeline; // TODO: More provider types.
+export type GestureTimeline = AnimationTimeline; // TODO: More provider types.
 
 export function subscribeToGestureDirection(
-  provider: GestureProvider,
+  provider: GestureTimeline,
   directionCallback: (direction: boolean) => void,
 ): () => void {
   const time = provider.currentTime;

--- a/packages/react-native-renderer/src/ReactFiberConfigNative.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigNative.js
@@ -605,10 +605,10 @@ export function createViewTransitionInstance(
   return null;
 }
 
-export type GestureProvider = null;
+export type GestureTimeline = null;
 
 export function subscribeToGestureDirection(
-  provider: GestureProvider,
+  provider: GestureTimeline,
   directionCallback: (direction: boolean) => void,
 ): () => void {
   throw new Error('useSwipeTransition is not yet supported in React Native.');

--- a/packages/react-native-renderer/src/ReactFiberConfigNative.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigNative.js
@@ -605,6 +605,15 @@ export function createViewTransitionInstance(
   return null;
 }
 
+export type GestureProvider = null;
+
+export function subscribeToGestureDirection(
+  provider: GestureProvider,
+  directionCallback: (direction: boolean) => void,
+): () => void {
+  throw new Error('useSwipeTransition is not yet supported in React Native.');
+}
+
 export function clearContainer(container: Container): void {
   // TODO Implement this for React Native
   // UIManager does not expose a "remove all" type method.

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -95,7 +95,7 @@ export type FormInstance = Instance;
 
 export type ViewTransitionInstance = null | {name: string, ...};
 
-export type GestureProvider = null;
+export type GestureTimeline = null;
 
 const NO_CONTEXT = {};
 const UPPERCASE_CONTEXT = {};
@@ -797,7 +797,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         },
 
         subscribeToGestureDirection(
-          provider: GestureProvider,
+          provider: GestureTimeline,
           directionCallback: (direction: boolean) => void,
         ): () => void {
           return () => {};

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -95,6 +95,8 @@ export type FormInstance = Instance;
 
 export type ViewTransitionInstance = null | {name: string, ...};
 
+export type GestureProvider = null;
+
 const NO_CONTEXT = {};
 const UPPERCASE_CONTEXT = {};
 if (__DEV__) {
@@ -792,6 +794,13 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
         createViewTransitionInstance(name: string): ViewTransitionInstance {
           return null;
+        },
+
+        subscribeToGestureDirection(
+          provider: GestureProvider,
+          directionCallback: (direction: boolean) => void,
+        ): () => void {
+          return () => {};
         },
 
         resetTextContent(instance: Instance): void {

--- a/packages/react-reconciler/src/ReactFiberConfigWithNoMutation.js
+++ b/packages/react-reconciler/src/ReactFiberConfigWithNoMutation.js
@@ -48,5 +48,5 @@ export const hasInstanceAffectedParent = shim;
 export const startViewTransition = shim;
 export type ViewTransitionInstance = null | {name: string, ...};
 export const createViewTransitionInstance = shim;
-export type GestureProvider = any;
+export type GestureTimeline = any;
 export const subscribeToGestureDirection = shim;

--- a/packages/react-reconciler/src/ReactFiberConfigWithNoMutation.js
+++ b/packages/react-reconciler/src/ReactFiberConfigWithNoMutation.js
@@ -48,3 +48,5 @@ export const hasInstanceAffectedParent = shim;
 export const startViewTransition = shim;
 export type ViewTransitionInstance = null | {name: string, ...};
 export const createViewTransitionInstance = shim;
+export type GestureProvider = any;
+export const subscribeToGestureDirection = shim;

--- a/packages/react-reconciler/src/ReactFiberGestureScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberGestureScheduler.js
@@ -8,7 +8,7 @@
  */
 
 import type {FiberRoot} from './ReactInternalTypes';
-import type {GestureProvider} from 'shared/ReactTypes';
+import type {GestureTimeline} from './ReactFiberConfig';
 
 import {GestureLane} from './ReactFiberLane';
 import {ensureRootIsScheduled} from './ReactFiberRootScheduler';
@@ -16,7 +16,7 @@ import {subscribeToGestureDirection} from './ReactFiberConfig';
 
 // This type keeps track of any scheduled or active gestures.
 export type ScheduledGesture = {
-  provider: GestureProvider,
+  provider: GestureTimeline,
   count: number, // The number of times this same provider has been started.
   direction: boolean, // false = previous, true = next
   cancel: () => void, // Cancel the subscription to direction change.
@@ -26,7 +26,7 @@ export type ScheduledGesture = {
 
 export function scheduleGesture(
   root: FiberRoot,
-  provider: GestureProvider,
+  provider: GestureTimeline,
   initialDirection: boolean,
 ): ScheduledGesture {
   let prev = root.gestures;

--- a/packages/react-reconciler/src/ReactFiberGestureScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberGestureScheduler.js
@@ -91,6 +91,8 @@ export function cancelScheduledGesture(
     cancelDirectionSubscription();
     // Delete the scheduled gesture from the queue.
     deleteScheduledGesture(root, gesture);
+    // TODO: If we're currently rendering this gesture, we need to restart the render
+    // on a different gesture or cancel the render..
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -27,7 +27,7 @@ import type {
 import type {Lanes, Lane} from './ReactFiberLane';
 import type {HookFlags} from './ReactHookEffectTags';
 import type {Flags} from './ReactFiberFlags';
-import type {TransitionStatus} from './ReactFiberConfig';
+import type {TransitionStatus, GestureTimeline} from './ReactFiberConfig';
 import type {ScheduledGesture} from './ReactFiberGestureScheduler';
 
 import {
@@ -3997,13 +3997,14 @@ function startGesture(
       // Noop.
     };
   }
+  const gestureTimeline: GestureTimeline = gestureProvider;
   const scheduledGesture = scheduleGesture(
     root,
-    gestureProvider,
+    gestureTimeline,
     queue.initialDirection,
   );
   // Add this particular instance to the queue.
-  // We add multiple of the same provider even if they get batched so
+  // We add multiple of the same timeline even if they get batched so
   // that if we cancel one but not the other we can keep track of this.
   // Order doesn't matter but we insert in the beginning to avoid two fields.
   const update: SwipeTransitionGestureUpdate = {

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
@@ -43,6 +43,7 @@ export opaque type FormInstance = mixed;
 export type ViewTransitionInstance = null | {name: string, ...};
 export opaque type InstanceMeasurement = mixed;
 export type EventResponder = any;
+export type GestureProvider = any;
 
 export const rendererVersion = $$$config.rendererVersion;
 export const rendererPackageName = $$$config.rendererPackageName;
@@ -144,6 +145,8 @@ export const wasInstanceInViewport = $$$config.wasInstanceInViewport;
 export const hasInstanceChanged = $$$config.hasInstanceChanged;
 export const hasInstanceAffectedParent = $$$config.hasInstanceAffectedParent;
 export const startViewTransition = $$$config.startViewTransition;
+export const subscribeToGestureDirection =
+  $$$config.subscribeToGestureDirection;
 export const createViewTransitionInstance =
   $$$config.createViewTransitionInstance;
 export const clearContainer = $$$config.clearContainer;

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
@@ -43,7 +43,7 @@ export opaque type FormInstance = mixed;
 export type ViewTransitionInstance = null | {name: string, ...};
 export opaque type InstanceMeasurement = mixed;
 export type EventResponder = any;
-export type GestureProvider = any;
+export type GestureTimeline = any;
 
 export const rendererVersion = $$$config.rendererVersion;
 export const rendererPackageName = $$$config.rendererPackageName;

--- a/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
+++ b/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
@@ -391,6 +391,15 @@ export function getInstanceFromNode(mockNode: Object): Object | null {
   return null;
 }
 
+export type GestureProvider = null;
+
+export function subscribeToGestureDirection(
+  provider: GestureProvider,
+  directionCallback: (direction: boolean) => void,
+): () => void {
+  return () => {};
+}
+
 export function beforeActiveInstanceBlur(internalInstanceHandle: Object) {
   // noop
 }

--- a/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
+++ b/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
@@ -391,10 +391,10 @@ export function getInstanceFromNode(mockNode: Object): Object | null {
   return null;
 }
 
-export type GestureProvider = null;
+export type GestureTimeline = null;
 
 export function subscribeToGestureDirection(
-  provider: GestureProvider,
+  provider: GestureTimeline,
   directionCallback: (direction: boolean) => void,
 ): () => void {
   return () => {};

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -170,7 +170,7 @@ export type ReactFormState<S, ReferenceId> = [
 
 // Intrinsic GestureProvider. This type varies by Environment whether a particular
 // renderer supports it.
-export type GestureProvider = AnimationTimeline; // TODO: More provider types.
+export type GestureProvider = any;
 
 export type StartGesture = (gestureProvider: GestureProvider) => () => void;
 

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -533,5 +533,8 @@
   "545": "The %s tag may only be rendered once.",
   "546": "useEffect CRUD overload is not enabled in this build of React.",
   "547": "startGesture cannot be called during server rendering.",
-  "548": "Finished rendering the gesture lane but there were no pending gestures. React should not have started a render in this case. This is a bug in React."
+  "548": "Finished rendering the gesture lane but there were no pending gestures. React should not have started a render in this case. This is a bug in React.",
+  "549": "Cannot start a gesture with a disconnected AnimationTimeline.",
+  "550": "useSwipeTransition is not yet supported in react-art.",
+  "551": "useSwipeTransition is not yet supported in React Native."
 }

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -33,6 +33,18 @@ declare interface ConsoleTask {
   run<T>(f: () => T): T;
 }
 
+type ScrollTimelineOptions = {
+  source: Element,
+  axis?: 'block' | 'inline' | 'x' | 'y',
+  ...
+};
+
+declare class ScrollTimeline extends AnimationTimeline {
+  constructor(options?: ScrollTimelineOptions): void;
+  axis: 'block' | 'inline' | 'x' | 'y';
+  source: Element;
+}
+
 // Flow hides the props of React$Element, this overrides it to unhide
 // them for React internals.
 // prettier-ignore

--- a/scripts/rollup/validate/eslintrc.cjs.js
+++ b/scripts/rollup/validate/eslintrc.cjs.js
@@ -34,6 +34,8 @@ module.exports = {
 
     FinalizationRegistry: 'readonly',
 
+    ScrollTimeline: 'readonly',
+
     // Vendor specific
     MSApp: 'readonly',
     __REACT_DEVTOOLS_GLOBAL_HOOK__: 'readonly',

--- a/scripts/rollup/validate/eslintrc.cjs2015.js
+++ b/scripts/rollup/validate/eslintrc.cjs2015.js
@@ -32,6 +32,7 @@ module.exports = {
     Reflect: 'readonly',
     globalThis: 'readonly',
     FinalizationRegistry: 'readonly',
+    ScrollTimeline: 'readonly',
     // Vendor specific
     MSApp: 'readonly',
     __REACT_DEVTOOLS_GLOBAL_HOOK__: 'readonly',

--- a/scripts/rollup/validate/eslintrc.esm.js
+++ b/scripts/rollup/validate/eslintrc.esm.js
@@ -34,6 +34,8 @@ module.exports = {
 
     FinalizationRegistry: 'readonly',
 
+    ScrollTimeline: 'readonly',
+
     // Vendor specific
     MSApp: 'readonly',
     __REACT_DEVTOOLS_GLOBAL_HOOK__: 'readonly',

--- a/scripts/rollup/validate/eslintrc.fb.js
+++ b/scripts/rollup/validate/eslintrc.fb.js
@@ -34,6 +34,8 @@ module.exports = {
 
     FinalizationRegistry: 'readonly',
 
+    ScrollTimeline: 'readonly',
+
     // Vendor specific
     MSApp: 'readonly',
     __REACT_DEVTOOLS_GLOBAL_HOOK__: 'readonly',

--- a/scripts/rollup/validate/eslintrc.rn.js
+++ b/scripts/rollup/validate/eslintrc.rn.js
@@ -34,6 +34,8 @@ module.exports = {
 
     FinalizationRegistry: 'readonly',
 
+    ScrollTimeline: 'readonly',
+
     // Vendor specific
     MSApp: 'readonly',
     __REACT_DEVTOOLS_GLOBAL_HOOK__: 'readonly',


### PR DESCRIPTION
We can only render one direction at a time with View Transitions. When the direction changes we need to do another render in the new direction (returning previous or next).

To determine direction we store the position we started at and anything moving to a lower value (left/up) is "previous" direction (`false`) and anything else is "next" (`true`) direction.

For the very first render we won't know which direction you're going since you're still on the initial position. It's useful to start the render to allow the view transition to take control before anything shifts around so we start from the original position. This is not guaranteed though if the render suspends.

For now we start the first render by guessing the direction such as if we know that prev/next are the same as current. With the upcoming auto start mode we can guess more accurately there before we start. We can also add explicit APIs to `startGesture` but ideally it wouldn't matter. Ideally we could just start after the first change in direction from the starting point.