### PR TITLE
Change TouchedViewDataAtPoint type in ReactNativeTypes to use supported by Flow tooling syntax

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -164,18 +164,19 @@ export type InspectorData = $ReadOnly<{
   componentStack: string,
 }>;
 
-export type TouchedViewDataAtPoint = $ReadOnly<{
-  pointerY: number,
-  touchedViewTag?: number,
-  frame: $ReadOnly<{
-    top: number,
-    left: number,
-    width: number,
-    height: number,
-  }>,
-  closestPublicInstance?: PublicInstance,
-  ...InspectorData,
-}>;
+export type TouchedViewDataAtPoint = $ReadOnly<
+  {
+    pointerY: number,
+    touchedViewTag?: number,
+    frame: $ReadOnly<{
+      top: number,
+      left: number,
+      width: number,
+      height: number,
+    }>,
+    closestPublicInstance?: PublicInstance,
+  } & InspectorData,
+>;
 
 export type RenderRootOptions = {
   onUncaughtError?: (


### PR DESCRIPTION
## Summary

The `flow-api-translator` from the `hermes` repo does not support flow type spreads. It is currently not able to digest the ReactNativeTypes file as it contains unsupported syntax. The simplest solution is to change the type of the `TouchedViewDataAtPoint` to equivalent, yet supported by the Flow tooling. In this case the intersection can be used as 
the `TouchedViewDataAtPoint` and `InspectorData` have no common property.

## How did you test this change?

Run yarn flow native
