### PR TITLE
ci: add workflow for running the eslint plugin e2e tests

### DIFF
--- a/.github/workflows/runtime_eslint_plugin_e2e.yml
+++ b/.github/workflows/runtime_eslint_plugin_e2e.yml
@@ -1,0 +1,56 @@
+name: (Runtime) ESLint Plugin E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths-ignore:
+      - compiler/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  TZ: /usr/share/zoneinfo/America/Los_Angeles
+
+jobs:
+  # ----- TESTS -----
+  test:
+    name: ESLint v${{ matrix.eslint_major }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        eslint_major:
+          - "6"
+          - "7"
+          - "8"
+          - "9"
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+          cache-dependency-path: yarn.lock
+      - name: Restore cached node_modules
+        uses: actions/cache@v4
+        id: node_modules
+        with:
+          path: "**/node_modules"
+          key: runtime-eslint_e2e-node_modules-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Ensure clean build directory
+        run: rm -rf build
+      - run: yarn install --frozen-lockfile
+      - name: Build plugin
+        working-directory: fixtures/eslint-v${{ matrix.eslint_major }}
+        run: node build.mjs
+      - name: Install fixture dependencies
+        working-directory: ./fixtures/eslint-v${{ matrix.eslint_major }}
+        run: yarn --frozen-lockfile
+      - name: Run lint test
+        working-directory: ./fixtures/eslint-v${{ matrix.eslint_major }}
+        run: yarn lint

--- a/fixtures/eslint-v6/build.mjs
+++ b/fixtures/eslint-v6/build.mjs
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
 import {exec} from 'node:child_process';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
 
-exec('cd ../.. && yarn build -r stable eslint-plugin-react-hooks');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+exec('yarn build -r stable eslint-plugin-react-hooks', {
+  cwd: resolve(__dirname, '..', '..'),
+});

--- a/fixtures/eslint-v6/package.json
+++ b/fixtures/eslint-v6/package.json
@@ -3,7 +3,7 @@
   "name": "eslint-v6",
   "dependencies": {
     "eslint": "^6",
-    "eslint-plugin-react-hooks": "link:../../build/node_modules/eslint-plugin-react-hooks"
+    "eslint-plugin-react-hooks": "link:../../build/oss-stable/eslint-plugin-react-hooks"
   },
   "scripts": {
     "build": "node build.mjs && yarn",

--- a/fixtures/eslint-v6/yarn.lock
+++ b/fixtures/eslint-v6/yarn.lock
@@ -205,7 +205,7 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-"eslint-plugin-react-hooks@link:../../build/node_modules/eslint-plugin-react-hooks":
+"eslint-plugin-react-hooks@link:../../build/oss-stable/eslint-plugin-react-hooks":
   version "0.0.0"
   uid ""
 

--- a/fixtures/eslint-v7/build.mjs
+++ b/fixtures/eslint-v7/build.mjs
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
 import {exec} from 'node:child_process';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
 
-exec('cd ../.. && yarn build -r stable eslint-plugin-react-hooks');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+exec('yarn build -r stable eslint-plugin-react-hooks', {
+  cwd: resolve(__dirname, '..', '..'),
+});

--- a/fixtures/eslint-v7/package.json
+++ b/fixtures/eslint-v7/package.json
@@ -3,7 +3,7 @@
   "name": "eslint-v7",
   "dependencies": {
     "eslint": "^7",
-    "eslint-plugin-react-hooks": "link:../../build/node_modules/eslint-plugin-react-hooks"
+    "eslint-plugin-react-hooks": "link:../../build/oss-stable/eslint-plugin-react-hooks"
   },
   "scripts": {
     "build": "node build.mjs && yarn",

--- a/fixtures/eslint-v7/yarn.lock
+++ b/fixtures/eslint-v7/yarn.lock
@@ -234,7 +234,7 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-"eslint-plugin-react-hooks@link:../../build/node_modules/eslint-plugin-react-hooks":
+"eslint-plugin-react-hooks@link:../../build/oss-stable/eslint-plugin-react-hooks":
   version "0.0.0"
   uid ""
 

--- a/fixtures/eslint-v8/build.mjs
+++ b/fixtures/eslint-v8/build.mjs
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
 import {exec} from 'node:child_process';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
 
-exec('cd ../.. && yarn build -r stable eslint-plugin-react-hooks');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+exec('yarn build -r stable eslint-plugin-react-hooks', {
+  cwd: resolve(__dirname, '..', '..'),
+});

--- a/fixtures/eslint-v8/package.json
+++ b/fixtures/eslint-v8/package.json
@@ -3,7 +3,7 @@
   "name": "eslint-v8",
   "dependencies": {
     "eslint": "^8",
-    "eslint-plugin-react-hooks": "link:../../build/node_modules/eslint-plugin-react-hooks"
+    "eslint-plugin-react-hooks": "link:../../build/oss-stable/eslint-plugin-react-hooks"
   },
   "scripts": {
     "build": "node build.mjs && yarn",

--- a/fixtures/eslint-v8/yarn.lock
+++ b/fixtures/eslint-v8/yarn.lock
@@ -192,7 +192,7 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-"eslint-plugin-react-hooks@link:../../build/node_modules/eslint-plugin-react-hooks":
+"eslint-plugin-react-hooks@link:../../build/oss-stable/eslint-plugin-react-hooks":
   version "0.0.0"
   uid ""
 

--- a/fixtures/eslint-v9/build.mjs
+++ b/fixtures/eslint-v9/build.mjs
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
 import {exec} from 'node:child_process';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
 
-exec('cd ../.. && yarn build -r stable eslint-plugin-react-hooks');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+exec('yarn build -r stable eslint-plugin-react-hooks', {
+  cwd: resolve(__dirname, '..', '..'),
+});

--- a/fixtures/eslint-v9/package.json
+++ b/fixtures/eslint-v9/package.json
@@ -3,7 +3,7 @@
   "name": "eslint-v9",
   "dependencies": {
     "eslint": "^9",
-    "eslint-plugin-react-hooks": "link:../../build/node_modules/eslint-plugin-react-hooks"
+    "eslint-plugin-react-hooks": "link:../../build/oss-stable/eslint-plugin-react-hooks"
   },
   "scripts": {
     "build": "node build.mjs && yarn",

--- a/fixtures/eslint-v9/yarn.lock
+++ b/fixtures/eslint-v9/yarn.lock
@@ -209,7 +209,7 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-"eslint-plugin-react-hooks@link:../../build/node_modules/eslint-plugin-react-hooks":
+"eslint-plugin-react-hooks@link:../../build/oss-stable/eslint-plugin-react-hooks":
   version "0.0.0"
   uid ""
 


### PR DESCRIPTION
This change adds a workflow for PR builds, that runs the e2e tests for `eslint-plugin-react-hooks` created in #32396

![screenshot of ci tests running](https://github.com/user-attachments/assets/307a878c-92b5-44cf-84f2-3b21979b262a)
