### PR TITLE
[eslint] Target ES5

### DIFF
--- a/packages/eslint-plugin-react-hooks/tsconfig.json
+++ b/packages/eslint-plugin-react-hooks/tsconfig.json
@@ -2,12 +2,13 @@
   "extends": "@tsconfig/strictest/tsconfig.json",
   "compilerOptions": {
     "module": "ES2015",
-    "target": "ES2015",
+    "target": "ES5",
     "moduleResolution": "Bundler",
     "lib": ["ES2020"],
     "rootDir": ".",
     "sourceMap": false,
-    "types": ["estree-jsx", "node"]
+    "types": ["estree-jsx", "node"],
+    "downlevelIteration": true
   },
   "exclude": ["node_modules"],
   "include": ["src/**/*.ts"]


### PR DESCRIPTION

Update eslint-plugin-react-hooks to be built targetting ES5 instead. For various reasons our internal infra relies on these files being built already downleveled.
