### PR TITLE
Add ref to Fragment

### DIFF
--- a/packages/react-art/src/ReactFiberConfigART.js
+++ b/packages/react-art/src/ReactFiberConfigART.js
@@ -310,6 +310,20 @@ export function createTextInstance(
   return text;
 }
 
+export type FragmentInstance = null | {...};
+
+export function createFragmentInstance(parentInstance): null {
+  return null;
+}
+
+export function appendChildToFragmentInstance(child, fragmentInstance): void {
+  // Noop
+}
+
+export function removeChildFromFragmentInstance(child, fragmentInstance): void {
+  // Noop
+}
+
 export function finalizeInitialChildren(domElement, type, props) {
   return false;
 }

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -1478,6 +1478,171 @@ export function createViewTransitionInstance(
   };
 }
 
+type EventListenerOptionsOrUseCapture =
+  | boolean
+  | {
+      capture?: boolean,
+      once?: boolean,
+      passive?: boolean,
+      signal?: AbortSignal,
+      ...
+    };
+
+type StoredEventListener = {
+  type: string,
+  listener: EventListener,
+  optionsOrUseCapture: void | EventListenerOptionsOrUseCapture,
+};
+
+export type FragmentInstance = {
+  _children: Set<Element>,
+  _eventListeners: Array<StoredEventListener>,
+  parentInstance: Instance | Container,
+  appendChild(child: Element): void,
+  removeChild(child: Element): void,
+  addEventListener(
+    type: string,
+    listener: EventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void,
+  removeEventListener(
+    type: string,
+    listener: EventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void,
+};
+
+function FragmentInstancePseudoElement(
+  this: FragmentInstance,
+  parentInstance: Container,
+) {
+  this.parentInstance = parentInstance || document.documentElement;
+  if (this.parentInstance === null) {
+    throw new Error(
+      'React expected a Fragment Ref to have a parent HTMLElement or to fallback to an <html> element ' +
+        '(document.documentElement). But no parent or <html> element was found. React never removes the ' +
+        'documentElement for any Document it renders into so the cause is likely in some other script ' +
+        'running on this page.',
+    );
+  }
+  this._children = new Set();
+  this._eventListeners = [];
+}
+// $FlowFixMe[prop-missing]
+FragmentInstancePseudoElement.prototype.appendChild = function (
+  this: FragmentInstance,
+  child: Element,
+): void {
+  this._children.add(child);
+  for (let i = 0; i < this._eventListeners.length; i++) {
+    const {type, listener, optionsOrUseCapture} = this._eventListeners[i];
+    child.addEventListener(type, listener, optionsOrUseCapture);
+  }
+};
+// $FlowFixMe[prop-missing]
+FragmentInstancePseudoElement.prototype.removeChild = function (
+  this: FragmentInstance,
+  child: Element,
+): void {
+  this._children.delete(child);
+  for (let i = 0; i < this._eventListeners.length; i++) {
+    const {type, listener, optionsOrUseCapture} = this._eventListeners[i];
+    child.removeEventListener(type, listener, optionsOrUseCapture);
+  }
+};
+// $FlowFixMe[prop-missing]
+FragmentInstancePseudoElement.prototype.addEventListener = function (
+  this: FragmentInstance,
+  type: string,
+  listener: EventListener,
+  optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+): void {
+  // Element.addEventListener will only apply uniquely new event listeners by default. Since we
+  // need to collect the listeners to apply to appended children, we track them ourselves and use
+  // custom equality check for the options.
+  const isNewEventListener =
+    indexOfEventListener(this._eventListeners, {
+      type,
+      listener,
+      optionsOrUseCapture,
+    }) === -1;
+  if (isNewEventListener) {
+    this._eventListeners.push({type, listener, optionsOrUseCapture});
+    this._children.forEach(child => {
+      child.addEventListener(type, listener, optionsOrUseCapture);
+    });
+  }
+};
+// $FlowFixMe[prop-missing]
+FragmentInstancePseudoElement.prototype.removeEventListener = function (
+  this: FragmentInstance,
+  type: string,
+  listener: EventListener,
+  optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+): void {
+  this._children.forEach(child => {
+    child.removeEventListener(type, listener, optionsOrUseCapture);
+  });
+  const index = indexOfEventListener(this._eventListeners, {
+    type,
+    listener,
+    optionsOrUseCapture,
+  });
+  this._eventListeners.splice(index, 1);
+};
+
+function normalizeListenerOptions(
+  opts: ?EventListenerOptionsOrUseCapture,
+): string {
+  if (opts == null) {
+    return '0';
+  }
+
+  if (typeof opts === 'boolean') {
+    return `c=${opts ? '1' : '0'}`;
+  }
+
+  return `c=${opts.capture ? '1' : '0'}&o=${opts.once ? '1' : '0'}&p=${opts.passive ? '1' : '0'}`;
+}
+
+function indexOfEventListener(
+  eventListeners: Array<StoredEventListener>,
+  eventListenerToFind: StoredEventListener,
+): number {
+  for (let i = 0; i < eventListeners.length; i++) {
+    const item = eventListeners[i];
+    if (
+      item.type === eventListenerToFind.type &&
+      item.listener === eventListenerToFind.listener &&
+      normalizeListenerOptions(item.optionsOrUseCapture) ===
+        normalizeListenerOptions(eventListenerToFind.optionsOrUseCapture)
+    ) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+export function createFragmentInstance(
+  parentInstance: Instance | Container,
+): FragmentInstance {
+  return new (FragmentInstancePseudoElement: any)(parentInstance);
+}
+
+export function appendChildToFragmentInstance(
+  childElement: Element,
+  fragmentInstance: FragmentInstance,
+): void {
+  fragmentInstance.appendChild(childElement);
+}
+
+export function removeChildFromFragmentInstance(
+  childElement: Element,
+  fragmentInstance: FragmentInstance,
+): void {
+  fragmentInstance.removeChild(childElement);
+}
+
 export function clearContainer(container: Container): void {
   const nodeType = container.nodeType;
   if (nodeType === DOCUMENT_NODE) {

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -1,0 +1,393 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails reactcore
+ */
+
+'use strict';
+
+let React;
+let ReactDOMClient;
+let act;
+let container;
+
+describe('FragmentRefs', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactDOMClient = require('react-dom/client');
+    act = require('internal-test-utils').act;
+    container = document.createElement('div');
+  });
+
+  // @gate enableFragmentRefs
+  it('attaches a ref to Fragment', async () => {
+    const fragmentRef = React.createRef();
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(() =>
+      root.render(
+        <div id="parent">
+          <React.Fragment ref={fragmentRef}>
+            <div id="child">Hi</div>
+          </React.Fragment>
+        </div>,
+      ),
+    );
+    expect(container.innerHTML).toEqual(
+      '<div id="parent"><div id="child">Hi</div></div>',
+    );
+
+    expect(fragmentRef.current).not.toBe(null);
+  });
+
+  // @gate enableFragmentRefs
+  it('tracks added and removed children', async () => {
+    let addChild;
+    let removeChild;
+    const fragmentRef = React.createRef();
+
+    function Test() {
+      const [extraChildCount, setExtraChildCount] = React.useState(0);
+      addChild = () => {
+        setExtraChildCount(prev => prev + 1);
+      };
+      removeChild = () => {
+        setExtraChildCount(prev => prev - 1);
+      };
+
+      return (
+        <div id="root">
+          <React.Fragment ref={fragmentRef}>
+            {Array.from({length: extraChildCount}).map((_, index) => (
+              <div id={'extra-child-' + index} key={index}>
+                Extra Child {index}
+              </div>
+            ))}
+          </React.Fragment>
+        </div>
+      );
+    }
+
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => root.render(<Test />));
+    expect(fragmentRef.current._children.size).toBe(0);
+    await act(() => addChild());
+    expect(fragmentRef.current._children.size).toBe(1);
+    await act(() => removeChild());
+    expect(fragmentRef.current._children.size).toBe(0);
+  });
+
+  // @gate enableFragmentRefs
+  it('tracks nested host children', async () => {
+    const fragmentRef = React.createRef();
+    const root = ReactDOMClient.createRoot(container);
+
+    function Wrapper({children}) {
+      return children;
+    }
+
+    await act(() => {
+      root.render(
+        <React.Fragment ref={fragmentRef}>
+          <Wrapper>
+            <div id="child-a" />
+          </Wrapper>
+          <Wrapper>
+            <div id="child-b" />
+            <Wrapper>
+              <div id="child-c">
+                <div id="child-nested" />
+              </div>
+            </Wrapper>
+          </Wrapper>
+          <Wrapper>
+            <div id="child-d" />
+          </Wrapper>
+          <div id="child-e" />
+        </React.Fragment>,
+      );
+    });
+
+    expect(fragmentRef.current._children.size).toBe(5);
+  });
+
+  // @gate enableFragmentRefs
+  it('handles empty children', async () => {
+    const fragmentRef = React.createRef();
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(() => {
+      root.render(<React.Fragment ref={fragmentRef}></React.Fragment>);
+    });
+
+    expect(fragmentRef.current._children.size).toBe(0);
+  });
+
+  // @gate enableFragmentRefs
+  it('accepts a ref callback', async () => {
+    let fragmentRef;
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(() => {
+      root.render(
+        <React.Fragment ref={ref => (fragmentRef = ref)}>
+          <div id="child">Hi</div>
+        </React.Fragment>,
+      );
+    });
+
+    expect(fragmentRef).not.toBe(null);
+  });
+
+  // @gate enableFragmentRefs
+  it('is available in effects', async () => {
+    function Test() {
+      const fragmentRef = React.useRef(null);
+      React.useLayoutEffect(() => {
+        expect(fragmentRef.current).not.toBe(null);
+      });
+      React.useEffect(() => {
+        expect(fragmentRef.current).not.toBe(null);
+      });
+      return (
+        <React.Fragment ref={fragmentRef}>
+          <div />
+        </React.Fragment>
+      );
+    }
+
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => root.render(<Test />));
+  });
+
+  describe('event listeners', () => {
+    // @gate enableFragmentRefs
+    it('adds and removes event listeners from children', async () => {
+      const parentRef = React.createRef();
+      const fragmentRef = React.createRef();
+      const childARef = React.createRef();
+      const childBRef = React.createRef();
+      const root = ReactDOMClient.createRoot(container);
+
+      let logs = [];
+
+      function handleFragmentRefClicks() {
+        logs.push('fragmentRef');
+      }
+
+      function Test() {
+        React.useEffect(() => {
+          fragmentRef.current.addEventListener(
+            'click',
+            handleFragmentRefClicks,
+          );
+
+          return () => {
+            // TODO: This is a noop here because the tracked child nodes were deleted and they
+            // remove their own event listeners. Decide if we want to change the timing of this.
+            // instance._children is currently empty at this point.
+            fragmentRef.current.removeEventListener(
+              'click',
+              handleFragmentRefClicks,
+            );
+          };
+        }, []);
+        return (
+          <div ref={parentRef}>
+            <React.Fragment ref={fragmentRef}>
+              <div ref={childARef}>A</div>
+              <div ref={childBRef}>B</div>
+            </React.Fragment>
+          </div>
+        );
+      }
+
+      await act(() => {
+        root.render(<Test />);
+      });
+
+      childARef.current.addEventListener('click', () => {
+        logs.push('A');
+      });
+
+      childBRef.current.addEventListener('click', () => {
+        logs.push('B');
+      });
+
+      // Clicking on the parent should not trigger any listeners
+      parentRef.current.click();
+      expect(logs).toEqual([]);
+
+      // Clicking a child triggers its own listeners and the Fragment's
+      childARef.current.click();
+      expect(logs).toEqual(['fragmentRef', 'A']);
+
+      logs = [];
+
+      childBRef.current.click();
+      expect(logs).toEqual(['fragmentRef', 'B']);
+
+      logs = [];
+
+      fragmentRef.current.removeEventListener('click', handleFragmentRefClicks);
+
+      childARef.current.click();
+      expect(logs).toEqual(['A']);
+
+      logs = [];
+
+      childBRef.current.click();
+      expect(logs).toEqual(['B']);
+    });
+
+    // @gate enableFragmentRefs
+    it('adds and removes event listeners from children with multiple fragments', async () => {
+      const fragmentRef = React.createRef();
+      const nestedFragmentRef = React.createRef();
+      const childARef = React.createRef();
+      const childBRef = React.createRef();
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <div>
+            <React.Fragment ref={fragmentRef}>
+              <div ref={childARef}>A</div>
+              <div>
+                <React.Fragment ref={nestedFragmentRef}>
+                  <div ref={childBRef}>B</div>
+                </React.Fragment>
+              </div>
+            </React.Fragment>
+          </div>,
+        );
+      });
+
+      let logs = [];
+
+      function handleFragmentRefClicks() {
+        logs.push('fragmentRef');
+      }
+
+      function handleNestedFragmentRefClicks() {
+        logs.push('nestedFragmentRef');
+      }
+
+      fragmentRef.current.addEventListener('click', handleFragmentRefClicks);
+      nestedFragmentRef.current.addEventListener(
+        'click',
+        handleNestedFragmentRefClicks,
+      );
+
+      childBRef.current.click();
+      // Event bubbles to the parent fragment
+      expect(logs).toEqual(['nestedFragmentRef', 'fragmentRef']);
+
+      logs = [];
+
+      childARef.current.click();
+      expect(logs).toEqual(['fragmentRef']);
+
+      logs = [];
+
+      fragmentRef.current.removeEventListener('click', handleFragmentRefClicks);
+      nestedFragmentRef.current.removeEventListener(
+        'click',
+        handleNestedFragmentRefClicks,
+      );
+      childBRef.current.click();
+      expect(logs).toEqual([]);
+    });
+
+    // @gate enableFragmentRefs
+    it('adds an event listener to a newly added child', async () => {
+      const fragmentRef = React.createRef();
+      const childRef = React.createRef();
+      const root = ReactDOMClient.createRoot(container);
+      let showChild;
+
+      function Component() {
+        const [shouldShowChild, setShouldShowChild] = React.useState(false);
+        showChild = () => {
+          setShouldShowChild(true);
+        };
+
+        return (
+          <div>
+            <React.Fragment ref={fragmentRef}>
+              <div id="a">A</div>
+              {shouldShowChild && (
+                <div ref={childRef} id="b">
+                  B
+                </div>
+              )}
+            </React.Fragment>
+          </div>
+        );
+      }
+
+      await act(() => {
+        root.render(<Component />);
+      });
+
+      expect(fragmentRef.current).not.toBe(null);
+      expect(childRef.current).toBe(null);
+
+      let hasClicked = false;
+      fragmentRef.current.addEventListener('click', () => {
+        hasClicked = true;
+      });
+
+      await act(() => {
+        showChild();
+      });
+      expect(childRef.current).not.toBe(null);
+
+      childRef.current.click();
+      expect(hasClicked).toBe(true);
+    });
+
+    // @gate enableFragmentRefs
+    it('applies event listeners to host children nested within non-host children', async () => {
+      const fragmentRef = React.createRef();
+      const childRef = React.createRef();
+      const nestedChildRef = React.createRef();
+      const root = ReactDOMClient.createRoot(container);
+
+      function Wrapper({children}) {
+        return children;
+      }
+
+      await act(() => {
+        root.render(
+          <div>
+            <React.Fragment ref={fragmentRef}>
+              <div ref={childRef}>Host A</div>
+              <Wrapper>
+                <Wrapper>
+                  <Wrapper>
+                    <div ref={nestedChildRef}>Host B</div>
+                  </Wrapper>
+                </Wrapper>
+              </Wrapper>
+            </React.Fragment>
+          </div>,
+        );
+      });
+      const logs = [];
+      fragmentRef.current.addEventListener('click', e => {
+        logs.push(e.target.textContent);
+      });
+
+      expect(logs).toEqual([]);
+      childRef.current.click();
+      expect(logs).toEqual(['Host A']);
+      nestedChildRef.current.click();
+      expect(logs).toEqual(['Host A', 'Host B']);
+    });
+  });
+});

--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -585,6 +585,20 @@ export function waitForCommitToBeReady(): null {
   return null;
 }
 
+export type FragmentInstance = null | {...};
+
+export function createFragmentInstance(parentInstance): FragmentInstance {
+  return null;
+}
+
+export function appendChildToFragmentInstance(child, fragmentInstance): void {
+  // Noop
+}
+
+export function removeChildFromFragmentInstance(child, fragmentInstance): void {
+  // Noop
+}
+
 export const NotPendingTransition: TransitionStatus = null;
 export const HostTransitionContext: ReactContext<TransitionStatus> = {
   $$typeof: REACT_CONTEXT_TYPE,

--- a/packages/react-native-renderer/src/ReactFiberConfigNative.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigNative.js
@@ -189,6 +189,20 @@ export function createTextInstance(
   return tag;
 }
 
+export type FragmentInstance = null | {...};
+
+export function createFragmentInstance(parentInstance): FragmentInstance {
+  return null;
+}
+
+export function appendChildToFragmentInstance(child, fragmentInstance): void {
+  // Noop
+}
+
+export function removeChildFromFragmentInstance(child, fragmentInstance): void {
+  // Noop
+}
+
 export function finalizeInitialChildren(
   parentInstance: Instance,
   type: string,

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -500,6 +500,18 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       return inst;
     },
 
+    createFragmentInstance(parentInstance) {
+      return null;
+    },
+
+    appendChildToFragmentInstance(child, fragmentInstance) {
+      // Noop
+    },
+
+    removeChildFromFragmentInstance(child, fragmentInstance) {
+      // Noop
+    },
+
     scheduleTimeout: setTimeout,
     cancelTimeout: clearTimeout,
     noTimeout: -1,

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -117,6 +117,7 @@ import {
   enableOwnerStacks,
   enableHydrationLaneScheduling,
   enableViewTransition,
+  enableFragmentRefs,
 } from 'shared/ReactFeatureFlags';
 import isArray from 'shared/isArray';
 import shallowEqual from 'shared/shallowEqual';
@@ -988,6 +989,9 @@ function updateFragment(
   renderLanes: Lanes,
 ) {
   const nextChildren = workInProgress.pendingProps;
+  if (enableFragmentRefs) {
+    markRef(current, workInProgress);
+  }
   reconcileChildren(current, workInProgress, nextChildren, renderLanes);
   return workInProgress.child;
 }
@@ -2356,6 +2360,7 @@ function mountSuspenseFallbackChildren(
       mode,
       renderLanes,
       null,
+      false,
     );
   } else {
     primaryChildFragment = mountWorkInProgressOffscreenFiber(
@@ -2368,6 +2373,7 @@ function mountSuspenseFallbackChildren(
       mode,
       renderLanes,
       null,
+      false,
     );
   }
 
@@ -2510,6 +2516,7 @@ function updateSuspenseFallbackChildren(
       mode,
       renderLanes,
       null,
+      false,
     );
     // Needs a placement effect because the parent (the Suspense boundary) already
     // mounted but this is a new fiber.
@@ -2574,6 +2581,7 @@ function mountSuspenseFallbackAfterRetryWithoutHydrating(
     fiberMode,
     renderLanes,
     null,
+    false,
   );
   // Needs a placement effect because the parent (the Suspense
   // boundary) already mounted but this is a new fiber.

--- a/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
@@ -24,6 +24,7 @@ import {
   HostText,
   HostPortal,
   DehydratedFragment,
+  Fragment,
 } from './ReactWorkTags';
 import {ContentReset, Placement} from './ReactFiberFlags';
 import {
@@ -50,11 +51,14 @@ import {
   acquireSingletonInstance,
   releaseSingletonInstance,
   isSingletonScope,
+  appendChildToFragmentInstance,
 } from './ReactFiberConfig';
 import {captureCommitPhaseError} from './ReactFiberWorkLoop';
 import {trackHostMutation} from './ReactFiberMutationTracking';
 
 import {runWithFiberInDEV} from './ReactCurrentFiber';
+import {enableFragmentRefs} from 'shared/ReactFeatureFlags';
+import type {FragmentInstance} from './ReactFiberFragmentComponent';
 
 export function commitHostMount(finishedWork: Fiber) {
   const type = finishedWork.type;
@@ -199,7 +203,7 @@ export function commitShowHideHostTextInstance(node: Fiber, isHidden: boolean) {
   }
 }
 
-function getHostParentFiber(fiber: Fiber): Fiber {
+export function getHostParentFiber(fiber: Fiber): Fiber {
   let parent = fiber.return;
   while (parent !== null) {
     if (isHostParent(parent)) {
@@ -214,6 +218,25 @@ function getHostParentFiber(fiber: Fiber): Fiber {
   );
 }
 
+export function getFragmentInstanceParent(
+  fiber: Fiber,
+): null | FragmentInstance {
+  let parent = fiber.return;
+  while (parent !== null) {
+    if (isFragmentInstanceParent(parent)) {
+      return parent.stateNode.ref;
+    }
+
+    if (isHostParent(parent)) {
+      return null;
+    }
+
+    parent = parent.return;
+  }
+
+  return null;
+}
+
 function isHostParent(fiber: Fiber): boolean {
   return (
     fiber.tag === HostComponent ||
@@ -224,6 +247,34 @@ function isHostParent(fiber: Fiber): boolean {
       : false) ||
     fiber.tag === HostPortal
   );
+}
+
+function isFragmentInstanceParent(fiber: Fiber): boolean {
+  return (
+    fiber &&
+    fiber.tag === Fragment &&
+    fiber.stateNode !== null &&
+    fiber.stateNode.ref !== null
+  );
+}
+
+export function appendHostChildrenToFragmentInstance(
+  child: Fiber | null,
+  instance: FragmentInstance,
+): void {
+  if (child === null) {
+    return;
+  }
+  if (child.sibling !== null) {
+    appendHostChildrenToFragmentInstance(child.sibling, instance);
+  }
+
+  if (child.tag === HostComponent) {
+    instance.appendChild(child.stateNode);
+    return;
+  }
+
+  appendHostChildrenToFragmentInstance(child.child, instance);
 }
 
 function getHostSibling(fiber: Fiber): ?Instance {
@@ -299,6 +350,12 @@ function insertOrAppendPlacementNodeIntoContainer(
       appendChildToContainer(parent, stateNode);
     }
     trackHostMutation();
+    if (enableFragmentRefs && tag === HostComponent) {
+      const parentFragmentInstance = getFragmentInstanceParent(node);
+      if (parentFragmentInstance !== null) {
+        appendChildToFragmentInstance(node.stateNode, parentFragmentInstance);
+      }
+    }
     return;
   } else if (tag === HostPortal) {
     // If the insertion itself is a portal, then we don't want to traverse
@@ -343,6 +400,12 @@ function insertOrAppendPlacementNode(
       appendChild(parent, stateNode);
     }
     trackHostMutation();
+    if (enableFragmentRefs && tag === HostComponent) {
+      const parentFragmentInstance = getFragmentInstanceParent(node);
+      if (parentFragmentInstance !== null) {
+        appendChildToFragmentInstance(node.stateNode, parentFragmentInstance);
+      }
+    }
     return;
   } else if (tag === HostPortal) {
     // If the insertion itself is a portal, then we don't want to traverse

--- a/packages/react-reconciler/src/ReactFiberFragmentComponent.js
+++ b/packages/react-reconciler/src/ReactFiberFragmentComponent.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {FragmentInstance as _FragmentInstance} from './ReactFiberConfig';
+
+export type FragmentInstance = _FragmentInstance;
+
+export type FragmentState = {
+  ref: null | FragmentInstance,
+};

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
@@ -43,6 +43,7 @@ export opaque type FormInstance = mixed;
 export type ViewTransitionInstance = null | {name: string, ...};
 export opaque type InstanceMeasurement = mixed;
 export type EventResponder = any;
+export type FragmentInstance = null | {...};
 
 export const rendererVersion = $$$config.rendererVersion;
 export const rendererPackageName = $$$config.rendererPackageName;
@@ -147,6 +148,11 @@ export const startViewTransition = $$$config.startViewTransition;
 export const createViewTransitionInstance =
   $$$config.createViewTransitionInstance;
 export const clearContainer = $$$config.clearContainer;
+export const createFragmentInstance = $$$config.createFragmentInstance;
+export const appendChildToFragmentInstance =
+  $$$config.appendChildToFragmentInstance;
+export const removeChildFromFragmentInstance =
+  $$$config.removeChildFromFragmentInstance;
 
 // -------------------
 //     Persistence

--- a/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
+++ b/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
@@ -383,6 +383,20 @@ export function createViewTransitionInstance(
   return null;
 }
 
+export type FragmentInstance = null | {...};
+
+export function createFragmentInstance(parentInstance): FragmentInstance {
+  return null;
+}
+
+export function appendChildToFragmentInstance(child): void {
+  // noop
+}
+
+export function removeChildFromFragmentInstance(child, fragmentInstance): void {
+  // Noop
+}
+
 export function getInstanceFromNode(mockNode: Object): Object | null {
   const instance = nodeToInstanceMap.get(mockNode);
   if (instance !== undefined) {

--- a/packages/react/src/__tests__/ReactElementValidator-test.internal.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.internal.js
@@ -495,9 +495,13 @@ describe('ReactElementValidator', () => {
     const root = ReactDOMClient.createRoot(document.createElement('div'));
     await act(() => root.render(React.createElement(Foo)));
     assertConsoleErrorDev([
-      'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
-        'can only have `key` and `children` props.\n' +
-        '    in Foo (at **)',
+      gate('enableFragmentRefs')
+        ? 'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
+          'can only have `key`, `ref`, and `children` props.\n' +
+          '    in Foo (at **)'
+        : 'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
+          'can only have `key` and `children` props.\n' +
+          '    in Foo (at **)',
     ]);
   });
 

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -255,12 +255,17 @@ describe('ReactJSXElementValidator', () => {
       root.render(<Foo />);
     });
     assertConsoleErrorDev([
-      'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
-        'can only have `key` and `children` props.\n' +
-        '    in Foo (at **)',
+      gate('enableFragmentRefs')
+        ? 'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
+          'can only have `key`, `ref`, and `children` props.\n' +
+          '    in Foo (at **)'
+        : 'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
+          'can only have `key` and `children` props.\n' +
+          '    in Foo (at **)',
     ]);
   });
 
+  // @gate !enableFragmentRefs
   it('warns for fragments with refs', async () => {
     class Foo extends React.Component {
       render() {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -133,7 +133,7 @@ export const enableOwnerStacks = true;
 
 export const enableShallowPropDiffing = false;
 
-export const enableSiblingPrerendering = true;
+export const enableSiblingPrerendering = false;
 
 /**
  * Enables an expiration time for retry lanes to avoid starvation.
@@ -155,8 +155,9 @@ export const enableInfiniteRenderLoopDetection = false;
 export const enableUseEffectCRUDOverload = false;
 
 export const enableFastAddPropertiesInDiffing = true;
-
 export const enableLazyPublicInstanceInFabric = false;
+
+export const enableFragmentRefs = false;
 
 // -----------------------------------------------------------------------------
 // Ready for next major.

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -133,7 +133,7 @@ export const enableOwnerStacks = true;
 
 export const enableShallowPropDiffing = false;
 
-export const enableSiblingPrerendering = false;
+export const enableSiblingPrerendering = true;
 
 /**
  * Enables an expiration time for retry lanes to avoid starvation.

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -85,6 +85,7 @@ export const enableYieldingBeforePassive = false;
 export const enableThrottledScheduling = false;
 export const enableViewTransition = false;
 export const enableSwipeTransition = false;
+export const enableFragmentRefs = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -75,6 +75,8 @@ export const enableSwipeTransition = false;
 export const enableFastAddPropertiesInDiffing = false;
 export const enableLazyPublicInstanceInFabric = false;
 
+export const enableFragmentRefs = false;
+
 // Profiling Only
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -74,6 +74,8 @@ export const enableSwipeTransition = false;
 export const enableFastAddPropertiesInDiffing = true;
 export const enableLazyPublicInstanceInFabric = false;
 
+export const enableFragmentRefs = false;
+
 // TODO: This must be in sync with the main ReactFeatureFlags file because
 // the Test Renderer's value must be the same as the one used by the
 // react package.

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -71,6 +71,7 @@ export const enableRemoveConsolePatches = true;
 export const enableSwipeTransition = false;
 export const enableFastAddPropertiesInDiffing = false;
 export const enableLazyPublicInstanceInFabric = false;
+export const enableFragmentRefs = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -87,5 +87,7 @@ export const enableSwipeTransition = false;
 export const enableFastAddPropertiesInDiffing = false;
 export const enableLazyPublicInstanceInFabric = false;
 
+export const enableFragmentRefs = false;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -39,6 +39,7 @@ export const enableUseEffectCRUDOverload = __VARIANT__;
 export const enableFastAddPropertiesInDiffing = __VARIANT__;
 export const enableLazyPublicInstanceInFabric = false;
 export const enableViewTransition = __VARIANT__;
+export const enableFragmentRefs = __VARIANT__;
 
 // TODO: These flags are hard-coded to the default values used in open source.
 // Update the tests so that they pass in either mode, then set these

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -116,5 +116,7 @@ export const enableLazyPublicInstanceInFabric = false;
 
 export const enableSwipeTransition = false;
 
+export const enableFragmentRefs = false;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -37,6 +37,7 @@ export const {
   transitionLaneExpirationMs,
   enableFastAddPropertiesInDiffing,
   enableViewTransition,
+  enableFragmentRefs,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.
@@ -115,8 +116,6 @@ export const enableShallowPropDiffing = false;
 export const enableLazyPublicInstanceInFabric = false;
 
 export const enableSwipeTransition = false;
-
-export const enableFragmentRefs = false;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -533,5 +533,6 @@
   "545": "The %s tag may only be rendered once.",
   "546": "useEffect CRUD overload is not enabled in this build of React.",
   "547": "startGesture cannot be called during server rendering.",
-  "548": "Finished rendering the gesture lane but there were no pending gestures. React should not have started a render in this case. This is a bug in React."
+  "548": "Finished rendering the gesture lane but there were no pending gestures. React should not have started a render in this case. This is a bug in React.",
+  "549": "React expected a Fragment Ref to have a parent HTMLElement or to fallback to an <html> element (document.documentElement). But no parent or <html> element was found. React never removes the documentElement for any Document it renders into so the cause is likely in some other script running on this page."
 }


### PR DESCRIPTION
*This API is experimental and subject to change or removal.*

**Fragment Refs**

This PR extends React's Fragment component to accept a `ref` prop. The Fragment's ref will attach to a custom host instance, which will provide an Element-like API for working with the Fragment's host parent and host children.

Here I've implemented `addEventListener` and `removeEventListener` to get started but we'll be iterating on this by adding additional APIs in future PRs. This sets up the mechanism to attach refs and track children. The FragmentInstance is implemented in `react-dom` here but is planned for Fabric as well.

The API works by targeting the first level of host children and proxying Element-like APIs to allow developers to manage groups of elements or elements that cannot be easily accessed such as from a third-party library or deep in a tree of Functional Component wrappers.

```javascript
import {Fragment, useRef} from 'react';

const fragmentRef = useRef(null);

<Fragment ref={fragmentRef}>
  <div id="A" />
  <Wrapper>
    <div id="B">
      <div id="C" />
    </div>
  </Wrapper>
  <div id="D" />
</Fragment>
```

In this case, calling `fragmentRef.current.addEventListener()` would apply an event listener to `A`, `B`, and `D`. `C` is skipped because it is nested under the first level of Host Component. If another Host Component was appended as a sibling to `A`, `B`, or `D`, the event listener would be applied to that element as well and any other APIs would also affect the newly added child.

This is an implementation of the basic feature to collect early feedback. There are still areas to explore regarding the timing of tracking/untracking children, adding listeners, and interactions with effects. As well as additional feature work on the FragmentInstance API methods.