### PR TITLE
Fix beforeinput event bug in Firefox

### DIFF
--- a/packages/react-dom-bindings/src/events/DOMEventProperties.js
+++ b/packages/react-dom-bindings/src/events/DOMEventProperties.js
@@ -38,6 +38,7 @@ const simpleEventPluginEvents = [
   'abort',
   'auxClick',
   'beforeToggle',
+  'beforeInput',
   'cancel',
   'canPlay',
   'canPlayThrough',

--- a/packages/react-dom-bindings/src/events/plugins/BeforeInputEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/BeforeInputEventPlugin.js
@@ -61,6 +61,7 @@ function registerEvents() {
     'keypress',
     'textInput',
     'paste',
+    'input',
   ]);
   registerTwoPhaseEvent('onCompositionEnd', [
     'compositionend',
@@ -295,6 +296,12 @@ function getNativeBeforeInputChars(
 
       return chars;
 
+    case 'input':
+      // Handle text replacement scenarios
+      if (nativeEvent.inputType === 'insertReplacementText') {
+        return nativeEvent.data;
+      }
+
     default:
       // For other native event types, do nothing.
       return null;
@@ -367,6 +374,11 @@ function getFallbackBeforeInputChars(
       return useFallbackCompositionData && !isUsingKoreanIME(nativeEvent)
         ? null
         : nativeEvent.data;
+    case 'input':
+      // Handle text replacement scenarios
+      if (nativeEvent.inputType === 'insertReplacementText') {
+        return nativeEvent.data;
+      }
     default:
       return null;
   }


### PR DESCRIPTION
Related to #24358

Fix the `beforeinput` event to fire correctly during text replacement scenarios in Firefox.

* **BeforeInputEventPlugin.js**
  - Update `extractBeforeInputEvent` function to handle text replacement scenarios.
  - Ensure `beforeinput` event fires correctly during MacOS accent popup and spellcheck replacement.
  - Modify `getNativeBeforeInputChars` and `getFallbackBeforeInputChars` functions to account for text replacement.

* **DOMEventProperties.js**
  - Add `beforeinput` to the list of `DOMEventName` types.

