### PR TITLE
feat(eslint-plugin-react-hooks): update `engines` declaration

### DIFF
--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -31,7 +31,7 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "homepage": "https://react.dev/",
   "peerDependencies": {


### PR DESCRIPTION
In preparation for the merging of the compiler plugin into this one (#32416), this change proactively updates the plugin's `engines` declaration to require Node versions greater than or equal to 18

BREAKING CHANGE