### PR TITLE
[release] Update publishing scripts to make publishing allowlisted packages easier

### DIFF
--- a/scripts/release/prepare-release-from-npm-commands/parse-params.js
+++ b/scripts/release/prepare-release-from-npm-commands/parse-params.js
@@ -14,6 +14,13 @@ const paramDefinitions = [
     defaultValue: false,
   },
   {
+    name: 'onlyPackages',
+    type: String,
+    multiple: true,
+    description: 'Packages to include in publishing',
+    defaultValue: [],
+  },
+  {
     name: 'skipPackages',
     type: String,
     multiple: true,

--- a/scripts/release/prepare-release-from-npm.js
+++ b/scripts/release/prepare-release-from-npm.js
@@ -28,6 +28,9 @@ const run = async () => {
 
     params.packages = await getPublicPackages(isExperimental);
     params.packages = params.packages.filter(packageName => {
+      if (params.onlyPackages.length > 0) {
+        return params.onlyPackages.includes(packageName);
+      }
       return !params.skipPackages.includes(packageName);
     });
 

--- a/scripts/release/publish-commands/parse-params.js
+++ b/scripts/release/publish-commands/parse-params.js
@@ -20,6 +20,13 @@ const paramDefinitions = [
     defaultValue: ['untagged'],
   },
   {
+    name: 'onlyPackages',
+    type: String,
+    multiple: true,
+    description: 'Packages to include in publishing',
+    defaultValue: [],
+  },
+  {
     name: 'skipPackages',
     type: String,
     multiple: true,
@@ -31,6 +38,11 @@ const paramDefinitions = [
     type: Boolean,
     description: 'Run in automated environment, without interactive prompts.',
     defaultValue: false,
+  },
+  {
+    name: 'publishVersion',
+    type: String,
+    description: 'Version to publish',
   },
 ];
 

--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -23,13 +23,19 @@ const run = async () => {
   try {
     const params = parseParams();
 
-    const version = readJsonSync(
-      './build/node_modules/react/package.json'
-    ).version;
+    const version =
+      params.publishVersion ??
+      readJsonSync('./build/node_modules/react/package.json').version;
     const isExperimental = version.includes('experimental');
 
     params.cwd = join(__dirname, '..', '..');
     params.packages = await getPublicPackages(isExperimental);
+
+    if (params.onlyPackages.length > 0) {
+      params.packages = params.packages.filter(packageName => {
+        return params.onlyPackages.includes(packageName);
+      });
+    }
 
     // Pre-filter any skipped packages to simplify the following commands.
     // As part of doing this we can also validate that none of the skipped packages were misspelled.


### PR DESCRIPTION

It's getting unwieldy to list every single package to skip in these commands when you only want to publish one, ie eslint-plugin-react-hooks.

This adds a new `onlyPackages` and `publishVersion` option to the publish commands to make that easier.
