### PR TITLE
[ci] Fix --dry not being passed correctly

### DIFF
--- a/.github/workflows/runtime_releases_from_npm_manual.yml
+++ b/.github/workflows/runtime_releases_from_npm_manual.yml
@@ -50,7 +50,7 @@ jobs:
           embed-author-name: ${{ github.event.sender.login }}
           embed-author-url: ${{ github.event.sender.html_url }}
           embed-author-icon-url: ${{ github.event.sender.avatar_url }}
-          embed-title: '⚠️ Publishing release from NPM'
+          embed-title: "⚠️ Publishing release from NPM${{ inputs.dry && ' (dry run)' }}"
           embed-description: |
             ```json
             ${{ toJson(inputs) }}
@@ -80,44 +80,40 @@ jobs:
         working-directory: scripts/release
       - run: cp ./scripts/release/ci-npmrc ~/.npmrc
       - if: '${{ inputs.only_packages }}'
-        name: 'Prepare and publish ${{ inputs.only_packages }}'
+        name: 'Prepare ${{ inputs.only_packages }} from NPM'
         run: |
-          echo -e "===== Preparing release from NPM =====\n"
           scripts/release/prepare-release-from-npm.js \
             --ci \
             --skipTests \
             --version=${{ inputs.version_to_promote }} \
             --publishVersion=${{ inputs.version_to_publish }} \
             --onlyPackages=${{ inputs.only_packages }}
-
-          echo -e "\n\n===== Check prepared files =====\n"
-          ls -R build/node_modules
-
-          echo -e "\n\n===== Publishing to NPM =====\n"
-          scripts/release/publish.js \
-            --ci \
-            --tags=${{ inputs.tags }} \
-            --publishVersion=${{ inputs.version_to_publish }} \
-            --onlyPackages=${{ inputs.only_packages }} \
-            --dry=${{ inputs.dry }}
       - if: '${{ inputs.skip_packages }}'
-        name: 'Prepare and publish all packages EXCEPT ${{ inputs.skip_packages }}'
+        name: 'Prepare all packages EXCEPT ${{ inputs.skip_packages }} from NPM'
         run: |
-          echo -e "===== Preparing release from NPM =====\n"
           scripts/release/prepare-release-from-npm.js \
             --ci \
             --skipTests \
             --version=${{ inputs.version_to_promote }} \
             --publishVersion=${{ inputs.version_to_publish }} \
             --skipPackages=${{ inputs.skip_packages }}
-
-          echo -e "\n\n===== Check prepared files =====\n"
-          ls -R build/node_modules
-
-          echo -e "\n\n===== Publishing to NPM =====\n"
+      - name: Check prepared files
+        run: ls -R build/node_modules
+      - if: '${{ inputs.only_packages }}'
+        name: 'Publish ${{ inputs.only_packages }}'
+        run: |
           scripts/release/publish.js \
             --ci \
             --tags=${{ inputs.tags }} \
             --publishVersion=${{ inputs.version_to_publish }} \
-            --skipPackages=${{ inputs.skip_packages }} \
-            --dry=${{ inputs.dry }}
+            --onlyPackages=${{ inputs.only_packages }} ${{ (inputs.dry && '') || '\'}}
+            ${{ inputs.dry && '--dry'}}
+      - if: '${{ inputs.skip_packages }}'
+        name: 'Publish all packages EXCEPT ${{ inputs.skip_packages }}'
+        run: |
+          scripts/release/publish.js \
+            --ci \
+            --tags=${{ inputs.tags }} \
+            --publishVersion=${{ inputs.version_to_publish }} \
+            --skipPackages=${{ inputs.skip_packages }} ${{ (inputs.dry && '') || '\'}}
+            ${{ inputs.dry && '--dry'}}


### PR DESCRIPTION

Boolean params for dry runs are true if the param exists at all, so only add it if we're in dry run mode.
