### PR TITLE
[ci] Don't erroneously mark failures as successes

### DIFF
--- a/.github/workflows/compiler_typescript.yml
+++ b/.github/workflows/compiler_typescript.yml
@@ -75,8 +75,8 @@ jobs:
     name: Test ${{ matrix.workspace_name }}
     needs: discover_yarn_workspaces
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         workspace_name: ${{ fromJSON(needs.discover_yarn_workspaces.outputs.matrix) }}
     steps:

--- a/.github/workflows/devtools_regression_tests.yml
+++ b/.github/workflows/devtools_regression_tests.yml
@@ -100,6 +100,7 @@ jobs:
     needs: build_devtools_and_process_artifacts
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         version:
           - "16.0"
@@ -108,7 +109,6 @@ jobs:
           - "17.0"
           - "18.0"
           - "18.2" # compiler polyfill
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -135,6 +135,7 @@ jobs:
     needs: build_devtools_and_process_artifacts
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         version:
           - "16.0"
@@ -142,7 +143,6 @@ jobs:
           - "16.8" # hooks
           - "17.0"
           - "18.0"
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -38,8 +38,8 @@ jobs:
     name: Flow check ${{ matrix.flow_inline_config_shortname }}
     needs: discover_flow_inline_configs
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         flow_inline_config_shortname: ${{ fromJSON(needs.discover_flow_inline_configs.outputs.matrix) }}
     steps:
@@ -117,6 +117,7 @@ jobs:
     name: yarn test ${{ matrix.params }} (Shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         params:
           - "-r=stable --env=development"
@@ -144,7 +145,6 @@ jobs:
           - 3/5
           - 4/5
           - 5/5
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -170,6 +170,7 @@ jobs:
     name: yarn build and lint
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         # yml is dumb. update the --total arg to yarn build if you change the number of workers
         worker_id: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]
@@ -215,6 +216,7 @@ jobs:
     name: yarn test-build
     needs: build_and_lint
     strategy:
+      fail-fast: false
       matrix:
         test_params: [
           # Intentionally passing these as strings instead of creating a
@@ -250,7 +252,6 @@ jobs:
           - 1/3
           - 2/3
           - 3/3
-    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -500,6 +501,7 @@ jobs:
     needs: build_and_lint
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         browser: [chrome, firefox, edge]
     steps:

--- a/.github/workflows/runtime_eslint_plugin_e2e.yml
+++ b/.github/workflows/runtime_eslint_plugin_e2e.yml
@@ -20,13 +20,13 @@ jobs:
     name: ESLint v${{ matrix.eslint_major }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         eslint_major:
           - "6"
           - "7"
           - "8"
           - "9"
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION

Randomly noticed this when I looked at a recent [DevTools regression test run](https://github.com/facebook/react/actions/runs/13578385011).

I don't recall why we added `continue-on-error` previously, but I believe it was to keep all jobs in the matrix running even if one were to fail, in order to fully identify any failures from code changes like build or test failures.

There is now a `fail-fast` option which does this. [`continue-on-error`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error) now means:

> Prevents a workflow run from failing when a job fails. Set to true to allow a workflow run to pass when this job fails.

so it's not correct to use it.
