### PR TITLE
docs(eslint-plugin-react-hooks): clarify config details for prior versions

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -20,26 +20,56 @@ yarn add eslint-plugin-react-hooks --dev
 
 ### Flat Config (eslint.config.js|ts)
 
-For [ESLint 9.0.0 and above](https://eslint.org/blog/2024/04/eslint-v9.0.0-released/), add the `recommended` config.
+#### >= 6.0.0
+
+For users of 6.0 and beyond, simply add the `recommended` config.
 
 ```js
 import * as reactHooks from 'eslint-plugin-react-hooks';
 
 export default [
   // ...
-  reactHooks.configs['recommended'],
+  reactHooks.configs.recommended,
+];
+```
+
+#### 5.2.0
+
+For users of 5.2.0 (the first version with flat config support), add the `recommended-latest` config.
+
+```js
+import * as reactHooks from 'eslint-plugin-react-hooks';
+
+export default [
+  // ...
+  reactHooks.configs['recommended-latest'],
 ];
 ```
 
 ### Legacy Config (.eslintrc)
 
-If you are still using ESLint below 9.0.0, you can use `recommended-legacy` for accessing the recommended config.
+#### >= 5.2.0
+
+If you are still using ESLint below 9.0.0, you can use `recommended-legacy` for accessing a legacy version of the recommended config.
 
 ```js
 {
   "extends": [
     // ...
     "plugin:react-hooks/recommended-legacy"
+  ]
+}
+```
+
+#### < 5.2.0
+
+If you're using a version earlier than 5.2.0, the legacy config was simply `recommended`.
+
+```js
+{
+  "extends": [
+    // ...
+    "plugin:react-hooks/recommended"
   ]
 }
 ```

--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -20,19 +20,6 @@ yarn add eslint-plugin-react-hooks --dev
 
 ### Flat Config (eslint.config.js|ts)
 
-#### >= 6.0.0
-
-For users of 6.0 and beyond, simply add the `recommended` config.
-
-```js
-import * as reactHooks from 'eslint-plugin-react-hooks';
-
-export default [
-  // ...
-  reactHooks.configs.recommended,
-];
-```
-
 #### 5.2.0
 
 For users of 5.2.0 (the first version with flat config support), add the `recommended-latest` config.


### PR DESCRIPTION
This change adds more details about prior versions of the plugin's config, to help people as they migrate from legacy to flat configs across multiple versions of this plugin. At some point in the 6.0 or 7.0 cycle, it would probably make sense to re-consolidate this into a single version.

Closes #32494