### PR TITLE
During a Swipe Gesture Render a Clone Offscreen and Animate it Onscreen

### DIFF
--- a/fixtures/view-transition/src/components/Page.js
+++ b/fixtures/view-transition/src/components/Page.js
@@ -2,6 +2,8 @@ import React, {
   unstable_ViewTransition as ViewTransition,
   unstable_Activity as Activity,
   unstable_useSwipeTransition as useSwipeTransition,
+  useEffect,
+  useState,
 } from 'react';
 
 import SwipeRecognizer from './SwipeRecognizer';
@@ -53,6 +55,13 @@ export default function Page({url, navigate}) {
     navigate(show ? '/?a' : '/?b');
   }
 
+  const [counter, setCounter] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => setCounter(c => c + 1), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
   const exclamation = (
     <ViewTransition name="exclamation" onShare={onTransition}>
       <span>!</span>
@@ -76,7 +85,7 @@ export default function Page({url, navigate}) {
               'navigation-back': transitions['slide-right'],
               'navigation-forward': transitions['slide-left'],
             }}>
-            <h1>{!show ? 'A' : 'B'}</h1>
+            <h1>{!show ? 'A' + counter : 'B' + counter}</h1>
           </ViewTransition>
           {show ? (
             <div>

--- a/packages/react-art/src/ReactFiberConfigART.js
+++ b/packages/react-art/src/ReactFiberConfigART.js
@@ -302,12 +302,20 @@ export function createInstance(type, props, internalInstanceHandle) {
   return instance;
 }
 
+export function cloneMutableInstance(instance, keepChildren) {
+  return instance;
+}
+
 export function createTextInstance(
   text,
   rootContainerInstance,
   internalInstanceHandle,
 ) {
   return text;
+}
+
+export function cloneMutableTextInstance(textInstance) {
+  return textInstance;
 }
 
 export function finalizeInitialChildren(domElement, type, props) {
@@ -473,6 +481,10 @@ export function cancelRootViewTransitionName(rootContainer) {
 
 export function restoreRootViewTransitionName(rootContainer) {
   // Noop
+}
+
+export function cloneRootViewTransitionContainer(rootContainer) {
+  throw new Error('Not implemented.');
 }
 
 export type InstanceMeasurement = null;

--- a/packages/react-art/src/ReactFiberConfigART.js
+++ b/packages/react-art/src/ReactFiberConfigART.js
@@ -487,6 +487,10 @@ export function cloneRootViewTransitionContainer(rootContainer) {
   throw new Error('Not implemented.');
 }
 
+export function removeRootViewTransitionClone(rootContainer, clone) {
+  throw new Error('Not implemented.');
+}
+
 export type InstanceMeasurement = null;
 
 export function measureInstance(instance) {

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -544,6 +544,13 @@ export function createInstance(
   return domElement;
 }
 
+export function cloneMutableInstance(
+  instance: Instance,
+  keepChildren: boolean,
+): Instance {
+  return instance.cloneNode(keepChildren);
+}
+
 export function appendInitialChild(
   parentInstance: Instance,
   child: Instance | TextInstance,
@@ -607,6 +614,12 @@ export function createTextInstance(
   ).createTextNode(text);
   precacheFiberNode(internalInstanceHandle, textNode);
   return textNode;
+}
+
+export function cloneMutableTextInstance(
+  textInstance: TextInstance,
+): TextInstance {
+  return textInstance.cloneNode(false);
 }
 
 let currentPopstateTransitionEvent: Event | null = null;
@@ -1219,6 +1232,12 @@ export function restoreRootViewTransitionName(rootContainer: Container): void {
     // $FlowFixMe[prop-missing]
     documentElement.style.viewTransitionName = '';
   }
+}
+
+export function cloneRootViewTransitionContainer(
+  rootContainer: Container,
+): Instance {
+  return (rootContainer: any);
 }
 
 export type InstanceMeasurement = {

--- a/packages/react-native-renderer/src/ReactFiberConfigNative.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigNative.js
@@ -165,6 +165,13 @@ export function createInstance(
   return ((component: any): Instance);
 }
 
+export function cloneMutableInstance(
+  instance: Instance,
+  keepChildren: boolean,
+): Instance {
+  throw new Error('Not yet implemented.');
+}
+
 export function createTextInstance(
   text: string,
   rootContainerInstance: Container,
@@ -187,6 +194,12 @@ export function createTextInstance(
   precacheFiberNode(internalInstanceHandle, tag);
 
   return tag;
+}
+
+export function cloneMutableTextInstance(
+  textInstance: TextInstance,
+): TextInstance {
+  throw new Error('Not yet implemented.');
 }
 
 export function finalizeInitialChildren(
@@ -556,6 +569,12 @@ export function cancelRootViewTransitionName(rootContainer: Container): void {
 
 export function restoreRootViewTransitionName(rootContainer: Container): void {
   // Not yet implemented
+}
+
+export function cloneRootViewTransitionContainer(
+  rootContainer: Container,
+): Instance {
+  throw new Error('Not implemented.');
 }
 
 export type InstanceMeasurement = null;

--- a/packages/react-native-renderer/src/ReactFiberConfigNative.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigNative.js
@@ -577,6 +577,13 @@ export function cloneRootViewTransitionContainer(
   throw new Error('Not implemented.');
 }
 
+export function removeRootViewTransitionClone(
+  rootContainer: Container,
+  clone: Instance,
+): void {
+  throw new Error('Not implemented.');
+}
+
 export type InstanceMeasurement = null;
 
 export function measureInstance(instance: Instance): InstanceMeasurement {

--- a/packages/react-native-renderer/src/ReactFiberConfigNative.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigNative.js
@@ -627,6 +627,9 @@ export type RunningGestureTransition = null;
 
 export function startGestureTransition(
   rootContainer: Container,
+  timeline: GestureTimeline,
+  rangeStart: number,
+  rangeEnd: number,
   transitionTypes: null | TransitionTypes,
   mutationCallback: () => void,
   animateCallback: () => void,

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -773,6 +773,13 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           throw new Error('Not yet implemented.');
         },
 
+        removeRootViewTransitionClone(
+          rootContainer: Container,
+          clone: Instance,
+        ): void {
+          throw new Error('Not implemented.');
+        },
+
         measureInstance(instance: Instance): InstanceMeasurement {
           return null;
         },

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -453,6 +453,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       return inst;
     },
 
+    cloneMutableInstance(instance: Instance, keepChildren: boolean): Instance {
+      throw new Error('Not yet implemented.');
+    },
+
     appendInitialChild(
       parentInstance: Instance,
       child: Instance | TextInstance,
@@ -502,6 +506,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         enumerable: false,
       });
       return inst;
+    },
+
+    cloneMutableTextInstance(textInstance: TextInstance): TextInstance {
+      throw new Error('Not yet implemented.');
     },
 
     scheduleTimeout: setTimeout,
@@ -760,6 +768,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         cancelRootViewTransitionName(rootContainer: Container): void {},
 
         restoreRootViewTransitionName(rootContainer: Container): void {},
+
+        cloneRootViewTransitionContainer(rootContainer: Container): Instance {
+          throw new Error('Not yet implemented.');
+        },
 
         measureInstance(instance: Instance): InstanceMeasurement {
           return null;

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -815,6 +815,9 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
         startGestureTransition(
           rootContainer: Container,
+          timeline: GestureTimeline,
+          rangeStart: number,
+          rangeEnd: number,
           transitionTypes: null | TransitionTypes,
           mutationCallback: () => void,
           animateCallback: () => void,

--- a/packages/react-reconciler/src/ReactFiberApplyGesture.js
+++ b/packages/react-reconciler/src/ReactFiberApplyGesture.js
@@ -9,10 +9,292 @@
 
 import type {Fiber, FiberRoot} from './ReactInternalTypes';
 
+import type {Instance, TextInstance} from './ReactFiberConfig';
+
+import type {OffscreenState} from './ReactFiberActivityComponent';
+
 import {
   cancelRootViewTransitionName,
   restoreRootViewTransitionName,
+  appendChild,
+  commitUpdate,
+  commitTextUpdate,
+  resetTextContent,
+  supportsResources,
+  supportsSingletons,
 } from './ReactFiberConfig';
+import {
+  popMutationContext,
+  pushMutationContext,
+  viewTransitionMutationContext,
+} from './ReactFiberMutationTracking';
+import {MutationMask, Update, ContentReset, NoFlags} from './ReactFiberFlags';
+import {
+  HostComponent,
+  HostHoistable,
+  HostSingleton,
+  HostText,
+  HostPortal,
+  OffscreenComponent,
+  ViewTransitionComponent,
+} from './ReactWorkTags';
+
+let didWarnForRootClone = false;
+
+function detectMutationOrInsertClones(finishedWork: Fiber): boolean {
+  return true;
+}
+
+function recursivelyInsertClonesFromExistingTree(
+  parentFiber: Fiber,
+  hostParentClone: Instance,
+): void {
+  let child = parentFiber.child;
+  while (child !== null) {
+    switch (child.tag) {
+      case HostComponent: {
+        const instance: Instance = child.stateNode;
+        // If we have no mutations in this subtree, we just need to make a deep clone.
+        const clone: Instance = instance.cloneNode(true); // TODO: Make this a Config.
+        appendChild(hostParentClone, clone);
+        // TODO: We may need to transfer some DOM state such as scroll position
+        // for the deep clones.
+        // TODO: If there's a manual view-transition-name inside the clone we
+        // should ideally remove it from the original and then restore it in mutation
+        // phase. Otherwise it leads to duplicate names.
+        break;
+      }
+      case HostText: {
+        const textInstance: TextInstance = child.stateNode;
+        if (textInstance === null) {
+          throw new Error(
+            'This should have a text node initialized. This error is likely ' +
+              'caused by a bug in React. Please file an issue.',
+          );
+        }
+        const clone = textInstance.cloneNode(false); // TODO: Make this a Config.
+        appendChild(hostParentClone, clone);
+        break;
+      }
+      case HostPortal: {
+        // TODO: Consider what should happen to Portals. For now we exclude them.
+        break;
+      }
+      case OffscreenComponent: {
+        const newState: OffscreenState | null = child.memoizedState;
+        const isHidden = newState !== null;
+        if (!isHidden) {
+          // Only insert clones if this tree is going to be visible. No need to
+          // clone invisible content.
+          // TODO: If this is visible but detached it should still be cloned.
+          recursivelyInsertClonesFromExistingTree(child, hostParentClone);
+        }
+        break;
+      }
+      case ViewTransitionComponent:
+        const prevMutationContext = pushMutationContext();
+        // TODO: If this was already cloned by a previous pass we can reuse those clones.
+        recursivelyInsertClonesFromExistingTree(child, hostParentClone);
+        // TODO: Do we need to track whether this should have a name applied?
+        // child.flags |= Update;
+        popMutationContext(prevMutationContext);
+        break;
+      default: {
+        recursivelyInsertClonesFromExistingTree(child, hostParentClone);
+        break;
+      }
+    }
+    child = child.sibling;
+  }
+}
+
+function recursivelyInsertClones(
+  parentFiber: Fiber,
+  hostParentClone: Instance,
+) {
+  const deletions = parentFiber.deletions;
+  if (deletions !== null) {
+    for (let i = 0; i < deletions.length; i++) {
+      // const childToDelete = deletions[i];
+      // TODO
+    }
+  }
+
+  if (
+    parentFiber.alternate === null ||
+    (parentFiber.subtreeFlags & MutationMask) !== NoFlags
+  ) {
+    // If we have mutations or if this is a newly inserted tree, clone as we go.
+    let child = parentFiber.child;
+    while (child !== null) {
+      insertDestinationClonesOfFiber(child, hostParentClone);
+      child = child.sibling;
+    }
+  } else {
+    // Once we reach a subtree with no more mutations we can bail out.
+    // However, we must still insert deep clones of the HostComponents.
+    recursivelyInsertClonesFromExistingTree(parentFiber, hostParentClone);
+  }
+}
+
+function insertDestinationClonesOfFiber(
+  finishedWork: Fiber,
+  hostParentClone: Instance,
+) {
+  const current = finishedWork.alternate;
+  const flags = finishedWork.flags;
+  // The effect flag should be checked *after* we refine the type of fiber,
+  // because the fiber tag is more specific. An exception is any flag related
+  // to reconciliation, because those can be set on all fiber types.
+  switch (finishedWork.tag) {
+    case HostHoistable: {
+      if (supportsResources) {
+        // TODO: Hoistables should get optimistically inserted and then removed.
+        recursivelyInsertClones(finishedWork, hostParentClone);
+        break;
+      }
+      // Fall through
+    }
+    case HostSingleton: {
+      if (supportsSingletons) {
+        recursivelyInsertClones(finishedWork, hostParentClone);
+        if (__DEV__) {
+          // We cannot apply mutations to Host Singletons since by definition
+          // they cannot be cloned. Therefore we warn in DEV if this commit
+          // had any effect.
+          if (flags & Update) {
+            if (current === null) {
+              console.error(
+                'useSwipeTransition() caused something to render a new <%s>. ' +
+                  'This is not possible in the current implementation. ' +
+                  "Make sure that the swipe doesn't mount any new <%s> elements.",
+                finishedWork.type,
+                finishedWork.type,
+              );
+            } else {
+              const newProps = finishedWork.memoizedProps;
+              const oldProps = current.memoizedProps;
+              const instance = finishedWork.stateNode;
+              const type = finishedWork.type;
+              const prev = pushMutationContext();
+
+              try {
+                // Since we currently don't have a separate diffing algorithm for
+                // individual properties, the Update flag can be a false positive.
+                // We have to apply the new props first o detect any mutations and
+                // then revert them.
+                commitUpdate(instance, type, oldProps, newProps, finishedWork);
+                if (viewTransitionMutationContext) {
+                  console.error(
+                    'useSwipeTransition() caused something to mutate <%s>. ' +
+                      'This is not possible in the current implementation. ' +
+                      "Make sure that the swipe doesn't update any state which " +
+                      'causes <%s> to change.',
+                    finishedWork.type,
+                    finishedWork.type,
+                  );
+                }
+                // Revert
+                commitUpdate(instance, type, newProps, oldProps, finishedWork);
+              } finally {
+                popMutationContext(prev);
+              }
+            }
+          }
+        }
+        break;
+      }
+      // Fall through
+    }
+    case HostComponent: {
+      const instance: Instance = finishedWork.stateNode;
+      if (current === null) {
+        // For insertions we don't need to clone. It's already new state node.
+        // TODO: Do we need to visit it for ViewTransitions though?
+        appendChild(hostParentClone, instance);
+      } else {
+        let clone: Instance;
+        if (finishedWork.child === null) {
+          // This node is terminal. We still do a deep clone in case this has user
+          // inserted content, text content or dangerouslySetInnerHTML.
+          clone = instance.cloneNode(true); // TODO: Make this a Config.
+          if (finishedWork.flags & ContentReset) {
+            resetTextContent(clone);
+          }
+        } else {
+          // If we have children we'll clone them as we walk the tree so we just
+          // do a shallow clone here.
+          clone = instance.cloneNode(false); // TODO: Make this a Config.
+        }
+
+        if (flags & Update) {
+          const newProps = finishedWork.memoizedProps;
+          const oldProps = current.memoizedProps;
+          const type = finishedWork.type;
+          // Apply the delta to the clone.
+          commitUpdate(clone, type, oldProps, newProps, finishedWork);
+        }
+
+        recursivelyInsertClones(finishedWork, clone);
+
+        appendChild(hostParentClone, clone);
+      }
+      break;
+    }
+    case HostText: {
+      const textInstance: TextInstance = finishedWork.stateNode;
+      if (textInstance === null) {
+        throw new Error(
+          'This should have a text node initialized. This error is likely ' +
+            'caused by a bug in React. Please file an issue.',
+        );
+      }
+      if (current === null) {
+        // For insertions we don't need to clone. It's already new state node.
+        appendChild(hostParentClone, textInstance);
+      } else {
+        const clone = textInstance.cloneNode(false); // TODO: Make this a Config.
+        if (flags & Update) {
+          const newText: string = finishedWork.memoizedProps;
+          const oldText: string = current.memoizedProps;
+          commitTextUpdate(clone, newText, oldText);
+        }
+        appendChild(hostParentClone, clone);
+      }
+      break;
+    }
+    case HostPortal: {
+      // TODO: Consider what should happen to Portals. For now we exclude them.
+      break;
+    }
+    case OffscreenComponent: {
+      const newState: OffscreenState | null = finishedWork.memoizedState;
+      const isHidden = newState !== null;
+      if (!isHidden) {
+        // Only insert clones if this tree is going to be visible. No need to
+        // clone invisible content.
+        // TODO: If this is visible but detached it should still be cloned.
+        recursivelyInsertClones(finishedWork, hostParentClone);
+      }
+      break;
+    }
+    case ViewTransitionComponent:
+      const prevMutationContext = pushMutationContext();
+      // TODO: If this was already cloned by a previous pass we can reuse those clones.
+      recursivelyInsertClones(finishedWork, hostParentClone);
+      if (viewTransitionMutationContext) {
+        // Track that this boundary had a mutation and therefore needs to animate
+        // whether it resized or not.
+        finishedWork.flags |= Update;
+      }
+      popMutationContext(prevMutationContext);
+      break;
+    default: {
+      recursivelyInsertClones(finishedWork, hostParentClone);
+      break;
+    }
+  }
+}
 
 // Clone View Transition boundaries that have any mutations or might have had their
 // layout affected by child insertions.
@@ -20,7 +302,24 @@ export function insertDestinationClones(
   root: FiberRoot,
   finishedWork: Fiber,
 ): void {
-  // TODO
+  const needsClone = detectMutationOrInsertClones(finishedWork);
+  if (needsClone) {
+    if (__DEV__) {
+      if (!didWarnForRootClone) {
+        didWarnForRootClone = true;
+        console.warn(
+          'useSwipeTransition() caused something to mutate or relayout the root. ' +
+            'This currently requires a clone of the whole document. Make sure to ' +
+            'add a <ViewTransition> directly around an absolutely positioned DOM node ' +
+            'to minimize the impact of any changes caused by the Swipe Transition.',
+        );
+      }
+    }
+    // Clone the whole root
+    // TODO: Create a cloned root container to insert stuff into.
+    const hostParentClone = root.containerInfo; // Insert into the root container
+    recursivelyInsertClones(finishedWork, hostParentClone);
+  }
 }
 
 // Revert insertions and apply view transition names to the "new" (current) state.

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -247,7 +247,6 @@ import {
   restoreNestedViewTransitions,
   measureUpdateViewTransition,
   measureNestedViewTransitions,
-  resetShouldStartViewTransition,
   resetAppearingViewTransitions,
   trackAppearingViewTransition,
   viewTransitionCancelableChildren,
@@ -289,8 +288,6 @@ export function commitBeforeMutationEffects(
 ): void {
   focusedInstanceHandle = prepareForCommit(root.containerInfo);
   shouldFireAfterActiveInstanceBlur = false;
-
-  resetShouldStartViewTransition();
 
   const isViewTransitionEligible =
     enableViewTransition &&

--- a/packages/react-reconciler/src/ReactFiberConfigWithNoMutation.js
+++ b/packages/react-reconciler/src/ReactFiberConfigWithNoMutation.js
@@ -20,6 +20,8 @@ function shim(...args: any): empty {
 
 // Mutation (when unsupported)
 export const supportsMutation = false;
+export const cloneMutableInstance = shim;
+export const cloneMutableTextInstance = shim;
 export const appendChild = shim;
 export const appendChildToContainer = shim;
 export const commitTextUpdate = shim;
@@ -40,6 +42,7 @@ export const restoreViewTransitionName = shim;
 export const cancelViewTransitionName = shim;
 export const cancelRootViewTransitionName = shim;
 export const restoreRootViewTransitionName = shim;
+export const cloneRootViewTransitionContainer = shim;
 export type InstanceMeasurement = null;
 export const measureInstance = shim;
 export const wasInstanceInViewport = shim;

--- a/packages/react-reconciler/src/ReactFiberConfigWithNoMutation.js
+++ b/packages/react-reconciler/src/ReactFiberConfigWithNoMutation.js
@@ -43,6 +43,7 @@ export const cancelViewTransitionName = shim;
 export const cancelRootViewTransitionName = shim;
 export const restoreRootViewTransitionName = shim;
 export const cloneRootViewTransitionContainer = shim;
+export const removeRootViewTransitionClone = shim;
 export type InstanceMeasurement = null;
 export const measureInstance = shim;
 export const wasInstanceInViewport = shim;

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -101,6 +101,7 @@ function FiberRootNode(
   if (enableSwipeTransition) {
     this.pendingGestures = null;
     this.stoppingGestures = null;
+    this.gestureClone = null;
   }
 
   this.incompleteTransitions = new Map();

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -228,6 +228,7 @@ import {
   invokePassiveEffectUnmountInDEV,
   accumulateSuspenseyCommit,
 } from './ReactFiberCommitWork';
+import {resetShouldStartViewTransition} from './ReactFiberCommitViewTransitions';
 import {shouldStartViewTransition} from './ReactFiberCommitViewTransitions';
 import {
   insertDestinationClones,
@@ -3448,6 +3449,8 @@ function commitRoot(
       }
     }
   }
+
+  resetShouldStartViewTransition();
 
   // The commit phase is broken into several sub-phases. We do a separate pass
   // of the effect list for each phase: all mutation effects come before all

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -3900,6 +3900,11 @@ function commitGestureOnRoot(
 
   finishedGesture.running = startGestureTransition(
     root.containerInfo,
+    finishedGesture.provider,
+    finishedGesture.rangeCurrent,
+    finishedGesture.direction
+      ? finishedGesture.rangeNext
+      : finishedGesture.rangePrevious,
     pendingTransitionTypes,
     flushGestureMutations,
     flushGestureAnimations,

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -26,6 +26,7 @@ import type {Lane, Lanes, LaneMap} from './ReactFiberLane';
 import type {RootTag} from './ReactRootTags';
 import type {
   Container,
+  Instance,
   TimeoutHandle,
   NoTimeout,
   SuspenseInstance,
@@ -286,6 +287,7 @@ type BaseFiberRootProperties = {
   // enableSwipeTransition only
   pendingGestures: null | ScheduledGesture,
   stoppingGestures: null | ScheduledGesture,
+  gestureClone: null | Instance,
 };
 
 // The following attributes are only used by DevTools and are only present in DEV builds.

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
@@ -56,10 +56,12 @@ export const getChildHostContext = $$$config.getChildHostContext;
 export const prepareForCommit = $$$config.prepareForCommit;
 export const resetAfterCommit = $$$config.resetAfterCommit;
 export const createInstance = $$$config.createInstance;
+export const cloneMutableInstance = $$$config.cloneMutableInstance;
 export const appendInitialChild = $$$config.appendInitialChild;
 export const finalizeInitialChildren = $$$config.finalizeInitialChildren;
 export const shouldSetTextContent = $$$config.shouldSetTextContent;
 export const createTextInstance = $$$config.createTextInstance;
+export const cloneMutableTextInstance = $$$config.cloneMutableTextInstance;
 export const scheduleTimeout = $$$config.scheduleTimeout;
 export const cancelTimeout = $$$config.cancelTimeout;
 export const noTimeout = $$$config.noTimeout;
@@ -141,6 +143,8 @@ export const cancelRootViewTransitionName =
   $$$config.cancelRootViewTransitionName;
 export const restoreRootViewTransitionName =
   $$$config.restoreRootViewTransitionName;
+export const cloneRootViewTransitionContainer =
+  $$$config.cloneRootViewTransitionContainer;
 export const measureInstance = $$$config.measureInstance;
 export const wasInstanceInViewport = $$$config.wasInstanceInViewport;
 export const hasInstanceChanged = $$$config.hasInstanceChanged;

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
@@ -145,6 +145,8 @@ export const restoreRootViewTransitionName =
   $$$config.restoreRootViewTransitionName;
 export const cloneRootViewTransitionContainer =
   $$$config.cloneRootViewTransitionContainer;
+export const removeRootViewTransitionClone =
+  $$$config.removeRootViewTransitionClone;
 export const measureInstance = $$$config.measureInstance;
 export const wasInstanceInViewport = $$$config.wasInstanceInViewport;
 export const hasInstanceChanged = $$$config.hasInstanceChanged;

--- a/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
+++ b/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
@@ -376,6 +376,13 @@ export function cloneRootViewTransitionContainer(
   };
 }
 
+export function removeRootViewTransitionClone(
+  rootContainer: Container,
+  clone: Instance,
+): void {
+  // Noop since it was never inserted anywhere.
+}
+
 export type InstanceMeasurement = null;
 
 export function measureInstance(instance: Instance): InstanceMeasurement {

--- a/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
+++ b/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
@@ -425,6 +425,9 @@ export type RunningGestureTransition = null;
 
 export function startGestureTransition(
   rootContainer: Container,
+  timeline: GestureTimeline,
+  rangeStart: number,
+  rangeEnd: number,
   transitionTypes: null | TransitionTypes,
   mutationCallback: () => void,
   animateCallback: () => void,

--- a/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
+++ b/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
@@ -172,6 +172,21 @@ export function createInstance(
   };
 }
 
+export function cloneMutableInstance(
+  instance: Instance,
+  keepChildren: boolean,
+): Instance {
+  return {
+    type: instance.type,
+    props: instance.props,
+    isHidden: instance.isHidden,
+    children: keepChildren ? instance.children : [],
+    internalInstanceHandle: null,
+    rootContainerInstance: instance.rootContainerInstance,
+    tag: 'INSTANCE',
+  };
+}
+
 export function appendInitialChild(
   parentInstance: Instance,
   child: Instance | TextInstance,
@@ -206,6 +221,16 @@ export function createTextInstance(
   return {
     text,
     isHidden: false,
+    tag: 'TEXT',
+  };
+}
+
+export function cloneMutableTextInstance(
+  textInstance: TextInstance,
+): TextInstance {
+  return {
+    text: textInstance.text,
+    isHidden: textInstance.isHidden,
     tag: 'TEXT',
   };
 }
@@ -335,6 +360,20 @@ export function cancelRootViewTransitionName(rootContainer: Container): void {
 
 export function restoreRootViewTransitionName(rootContainer: Container): void {
   // Noop
+}
+
+export function cloneRootViewTransitionContainer(
+  rootContainer: Container,
+): Instance {
+  return {
+    type: 'ROOT',
+    props: {},
+    isHidden: false,
+    children: [],
+    internalInstanceHandle: null,
+    rootContainerInstance: rootContainer,
+    tag: 'INSTANCE',
+  };
 }
 
 export type InstanceMeasurement = null;

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -536,5 +536,6 @@
   "548": "Finished rendering the gesture lane but there were no pending gestures. React should not have started a render in this case. This is a bug in React.",
   "549": "Cannot start a gesture with a disconnected AnimationTimeline.",
   "550": "useSwipeTransition is not yet supported in react-art.",
-  "551": "useSwipeTransition is not yet supported in React Native."
+  "551": "useSwipeTransition is not yet supported in React Native.",
+  "552": "Cannot use a useSwipeTransition() in a detached root."
 }


### PR DESCRIPTION
This is really the essence mechanism of the `useSwipeTransition` feature.

We don't want to immediately switch to the destination state when starting a gesture. The effects remain mounted on the current state. We want the current state to be "live". This is important to for example allow a video to keeping playing while starting a swipe (think TikTok/Reels) and not stop until you've committed the action. The only thing that can be live is the "new" state. Therefore we treat the destination as the "old" state and perform a reverse animation from there.

Ideally we could apply the old state to the DOM tree, take a snapshot and then revert it back in the mutation of `startViewTransition`. Unfortunately, the way `startViewTransition` was designed it always paints one frame of the "old" state which would lead this to cause a flicker.

To work around this, we need to create a clone of any View Transition boundary that might be mutated and then render that offscreen. That way we can render the "current" state on screen and the "destination" state offscreen for the screenshots. Being mutated can be either due to React doing a DOM mutation or if a child boundary resizes that causes the parent to relayout. We don't have to do this for insertions or deletions since they only appear on one side.

The worst case scenario is that we have to clone the whole root. That's what this first PR implements. We clone the container and if it's not absolutely positioned, we position it on top of the current one. If the container is `document` or `<html>` we instead clone the `<body>` tag since it's the only one we can insert a duplicate of. If the container is deep in the tree we clone just that even though technically we should probably clone the whole document in that case. We just keep the impact smaller. Ideally though we'd never hit this case. In fact, if we clone the document we issue a warning (always for now) since you probably should optimize this. In the future I intend to add optimizations when affected View Transition boundaries are absolutely positioned since they cannot possibly relayout the parent. This would be the ideal way to use this feature most efficiently but it still works without it.

Since we render the "old" state outside the viewport, we need to then adjust the animation to put it back into the viewport. This is the trickiest part to get right while still preserving any customization of the View Transitions done using CSS. This current approach reapplies all the animations with adjusted keyframes.

In the case of an "exit" the pseudo-element itself is positioned outside the viewport but since we can't programmatically update the style of the pseudo-element itself we instead adjust all the keyframes to put it back into the viewport. If there is no animation on the group we add one.

In the case of an "update" the pseudo-element is positioned on the new state which is already inside the viewport. However, the auto-generated animation of the group has a starting keyframe that starts outside the viewport. In this case we need to adjust that keyframe.

In the future I might explore a technique that inserts stylesheets instead of mutating the animations. It might be simpler. But whatever hacks work to maximize the compatibility is best.