### PR TITLE
[compiler] Check ref access in useState initializer function

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccesInRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccesInRender.ts
@@ -401,7 +401,9 @@ function validateNoRefAccessInRenderImpl(
               }
             }
             for (const operand of eachInstructionValueOperand(instr.value)) {
-              if (hookKind != null) {
+              if (hookKind === 'useState') {
+                validateNoRefValueAccess(errors, env, operand);
+              } else if (hookKind != null) {
                 validateNoDirectRefValueAccess(errors, operand, env);
               } else {
                 validateNoRefAccess(errors, env, operand, operand.loc);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-ref-in-useState.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-ref-in-useState.expect.md
@@ -1,0 +1,27 @@
+
+## Input
+
+```javascript
+// @validateRefAccessDuringRender
+function Component(props) {
+  const ref = useRef(1);
+  const [state] = useState(() => ref.current);
+  return <div>{state}</div>;
+}
+
+```
+
+
+## Error
+
+```
+  2 | function Component(props) {
+  3 |   const ref = useRef(1);
+> 4 |   const [state] = useState(() => ref.current);
+    |                            ^^^^^^^^^^^^^^^^^ InvalidReact: Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef) (4:4)
+  5 |   return <div>{state}</div>;
+  6 | }
+  7 |
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-ref-in-useState.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-ref-in-useState.js
@@ -1,0 +1,6 @@
+// @validateRefAccessDuringRender
+function Component(props) {
+  const ref = useRef(1);
+  const [state] = useState(() => ref.current);
+  return <div>{state}</div>;
+}

--- a/compiler/packages/eslint-plugin-react-compiler/__tests__/ReactCompilerRule-test.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/__tests__/ReactCompilerRule-test.ts
@@ -104,6 +104,18 @@ const tests: CompilerTestCases = {
         }
       `,
     },
+    {
+      name: 'Ref access in useEffect hook',
+      code: normalizeIndent`
+        function Component() {
+          const ref = useRef(1);
+          useEffect(() => {
+            ref.current = 2 * ref.current;
+          }, []);
+          return <div>Hello world</div>;
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -112,6 +124,22 @@ const tests: CompilerTestCases = {
         function Component(props) {
           const ref = useRef(null);
           const value = ref.current;
+          return value;
+        }
+      `,
+      errors: [
+        {
+          message:
+            'Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef)',
+        },
+      ],
+    },
+    {
+      name: '[InvalidInput] Ref access in useState initial value function',
+      code: normalizeIndent`
+        function Component(props) {
+          const ref = useRef(1);
+          const [value] = useState(() => ref.current);
           return value;
         }
       `,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

This PR fixes #31418 .

The compiler did not throw an error when a useState initializer function accessed a ref value during render.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

I added new tests using useState initializer functions to the babel-plugin-react-compiler and eslint-plugin-react-compiler packages and ran `yarn test`.

I also built the compilers and checked they worked in a small project with babel and the vs code eslint plugin.
The babel-plugin-react-compiler logged an error due to the ref access:
![babel-plugin](https://github.com/user-attachments/assets/3b024408-8e9b-4aa4-80bb-8e840c3afea3)

The eslint-plugin-react-compiler also reported an error:
![eslint-plugin](https://github.com/user-attachments/assets/55325dca-6df6-4500-841c-b5b185e89428)

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
