### PR TITLE
Add Owner Stack to attribute hydration mismatches

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js
@@ -201,25 +201,24 @@ describe('ReactDOMFizzForm', () => {
     await act(async () => {
       ReactDOMClient.hydrateRoot(container, <App isClient={true} />);
     });
-    assertConsoleErrorDev(
-      [
-        "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. " +
-          "This won't be patched up. This can happen if a SSR-ed Client Component used:\n\n" +
-          "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
-          "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
-          "- Date formatting in a user's locale which doesn't match the server.\n" +
-          '- External changing data without sending a snapshot of it along with the HTML.\n' +
-          '- Invalid HTML tag nesting.\n\n' +
-          'It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.\n\n' +
-          'https://react.dev/link/hydration-mismatch\n\n' +
-          '  <App isClient={true}>\n' +
-          '    <form\n' +
-          '+     action="action"\n' +
-          '-     action="function"\n' +
-          '    >\n',
-      ],
-      {withoutStack: true},
-    );
+    assertConsoleErrorDev([
+      "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. " +
+        "This won't be patched up. This can happen if a SSR-ed Client Component used:\n\n" +
+        "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
+        "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
+        "- Date formatting in a user's locale which doesn't match the server.\n" +
+        '- External changing data without sending a snapshot of it along with the HTML.\n' +
+        '- Invalid HTML tag nesting.\n\n' +
+        'It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.\n\n' +
+        'https://react.dev/link/hydration-mismatch\n\n' +
+        '  <App isClient={true}>\n' +
+        '    <form\n' +
+        '+     action="action"\n' +
+        '-     action="function"\n' +
+        '    >\n' +
+        '\n    in form (at **)' +
+        '\n    in App (at **)',
+    ]);
   });
 
   it('should ideally warn when passing a string during SSR and function during hydration', async () => {
@@ -392,40 +391,39 @@ describe('ReactDOMFizzForm', () => {
     await act(async () => {
       root = ReactDOMClient.hydrateRoot(container, <App />);
     });
-    assertConsoleErrorDev(
-      [
-        "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. " +
-          "This won't be patched up. This can happen if a SSR-ed Client Component used:\n\n" +
-          "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
-          "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
-          "- Date formatting in a user's locale which doesn't match the server.\n" +
-          '- External changing data without sending a snapshot of it along with the HTML.\n' +
-          '- Invalid HTML tag nesting.\n\n' +
-          'It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.\n\n' +
-          'https://react.dev/link/hydration-mismatch\n\n' +
-          '  <App>\n' +
-          '    <form\n' +
-          '      action={function action}\n' +
-          '      ref={{current:null}}\n' +
-          '+     method="DELETE"\n' +
-          '-     method={null}\n' +
-          '    >\n' +
-          '      <input\n' +
-          '        type="submit"\n' +
-          '        formAction={function action}\n' +
-          '        ref={{current:null}}\n' +
-          '+       formTarget="elsewhere"\n' +
-          '-       formTarget={null}\n' +
-          '      >\n' +
-          '      <button\n' +
-          '        formAction={function action}\n' +
-          '        ref={{current:null}}\n' +
-          '+       formEncType="text/plain"\n' +
-          '-       formEncType={null}\n' +
-          '      >\n',
-      ],
-      {withoutStack: true},
-    );
+    assertConsoleErrorDev([
+      "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. " +
+        "This won't be patched up. This can happen if a SSR-ed Client Component used:\n\n" +
+        "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
+        "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
+        "- Date formatting in a user's locale which doesn't match the server.\n" +
+        '- External changing data without sending a snapshot of it along with the HTML.\n' +
+        '- Invalid HTML tag nesting.\n\n' +
+        'It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.\n\n' +
+        'https://react.dev/link/hydration-mismatch\n\n' +
+        '  <App>\n' +
+        '    <form\n' +
+        '      action={function action}\n' +
+        '      ref={{current:null}}\n' +
+        '+     method="DELETE"\n' +
+        '-     method={null}\n' +
+        '    >\n' +
+        '      <input\n' +
+        '        type="submit"\n' +
+        '        formAction={function action}\n' +
+        '        ref={{current:null}}\n' +
+        '+       formTarget="elsewhere"\n' +
+        '-       formTarget={null}\n' +
+        '      >\n' +
+        '      <button\n' +
+        '        formAction={function action}\n' +
+        '        ref={{current:null}}\n' +
+        '+       formEncType="text/plain"\n' +
+        '-       formEncType={null}\n' +
+        '      >\n' +
+        '\n    in input (at **)' +
+        '\n    in App (at **)',
+    ]);
     await act(async () => {
       root.render(<App isUpdate={true} />);
     });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -10233,7 +10233,7 @@ describe('ReactDOMFizzServer', () => {
           '\n+         client' +
           '\n-         server' +
           '\n' +
-          '\n    in Suspense (at **)' +
+          '\n    in meta (at **)' +
           '\n    in ClientApp (at **)',
       ]);
     }

--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -23,6 +23,7 @@ function errorHandler() {
 
 describe('ReactDOMServerHydration', () => {
   let container;
+  let ownerStacks;
 
   beforeEach(() => {
     jest.resetModules();
@@ -32,7 +33,15 @@ describe('ReactDOMServerHydration', () => {
     act = React.act;
 
     window.addEventListener('error', errorHandler);
-    console.error = jest.fn();
+    ownerStacks = [];
+    console.error = jest.fn(() => {
+      const ownerStack = React.captureOwnerStack();
+      if (typeof ownerStack === 'string') {
+        ownerStacks.push(ownerStack === '' ? ' <empty>' : ownerStack);
+      } else {
+        ownerStacks.push(' ' + String(ownerStack));
+      }
+    });
     container = document.createElement('div');
     document.body.appendChild(container);
   });
@@ -44,15 +53,25 @@ describe('ReactDOMServerHydration', () => {
   });
 
   function normalizeCodeLocInfo(str) {
-    return (
-      typeof str === 'string' &&
-      str.replace(/\n +(?:at|in) ([\S]+)[^\n]*/g, function (m, name) {
-        return '\n    in ' + name + ' (at **)';
-      })
-    );
+    return typeof str === 'string'
+      ? str.replace(/\n +(?:at|in) ([\S]+)[^\n]*/g, function (m, name) {
+          return '\n    in ' + name + ' (at **)';
+        })
+      : str;
   }
 
-  function formatMessage(args) {
+  function formatMessage(args, index) {
+    const ownerStack = ownerStacks[index];
+
+    if (ownerStack === undefined) {
+      throw new Error(
+        'Expected an owner stack for message ' +
+          index +
+          ':\n' +
+          util.format(...args),
+      );
+    }
+
     const [format, ...rest] = args;
     if (format instanceof Error) {
       if (format.cause instanceof Error) {
@@ -61,13 +80,23 @@ describe('ReactDOMServerHydration', () => {
           format.message +
           ']\n  Cause [' +
           format.cause.message +
-          ']'
+          ']\n  Owner Stack:' +
+          normalizeCodeLocInfo(ownerStack)
         );
       }
-      return 'Caught [' + format.message + ']';
+      return (
+        'Caught [' +
+        format.message +
+        ']\n  Owner Stack:' +
+        normalizeCodeLocInfo(ownerStack)
+      );
     }
     rest[rest.length - 1] = normalizeCodeLocInfo(rest[rest.length - 1]);
-    return util.format(format, ...rest);
+    return (
+      util.format(format, ...rest) +
+      '\n  Owner Stack:' +
+      normalizeCodeLocInfo(ownerStack)
+    );
   }
 
   function formatConsoleErrors() {
@@ -115,7 +144,10 @@ describe('ReactDOMServerHydration', () => {
                 <main className="child">
           +       client
           -       server
-          ]",
+          ]
+            Owner Stack:
+              in main (at **)
+              in Mismatch (at **)",
           ]
         `);
       } else {
@@ -138,7 +170,8 @@ describe('ReactDOMServerHydration', () => {
                 <main className="child">
           +       client
           -       server
-          ",
+
+            Owner Stack: <empty>",
           ]
         `);
       }
@@ -177,7 +210,10 @@ describe('ReactDOMServerHydration', () => {
               <div>
           +     This markup contains an nbsp entity:   client text
           -     This markup contains an nbsp entity:   server text
-          ]",
+          ]
+            Owner Stack:
+              in div (at **)
+              in Mismatch (at **)",
           ]
         `);
       } else {
@@ -199,7 +235,8 @@ describe('ReactDOMServerHydration', () => {
               <div>
           +     This markup contains an nbsp entity:   client text
           -     This markup contains an nbsp entity:   server text
-          ",
+
+            Owner Stack: <empty>",
           ]
         `);
       }
@@ -245,7 +282,8 @@ describe('ReactDOMServerHydration', () => {
         -         __html: "<span>server</span>"
                 }}
               >
-        ",
+
+          Owner Stack: <empty>",
         ]
       `);
     });
@@ -286,7 +324,8 @@ describe('ReactDOMServerHydration', () => {
         +       dir="ltr"
         -       dir="rtl"
               >
-        ",
+
+          Owner Stack: <empty>",
         ]
       `);
     });
@@ -327,7 +366,8 @@ describe('ReactDOMServerHydration', () => {
         +       dir="ltr"
         -       dir={null}
               >
-        ",
+
+          Owner Stack: <empty>",
         ]
       `);
     });
@@ -368,7 +408,8 @@ describe('ReactDOMServerHydration', () => {
         +       dir={null}
         -       dir="rtl"
               >
-        ",
+
+          Owner Stack: <empty>",
         ]
       `);
     });
@@ -409,7 +450,8 @@ describe('ReactDOMServerHydration', () => {
         +       dir={null}
         -       dir="rtl"
               >
-        ",
+
+          Owner Stack: <empty>",
         ]
       `);
     });
@@ -449,7 +491,8 @@ describe('ReactDOMServerHydration', () => {
         +       style={{opacity:1}}
         -       style={{opacity:"0"}}
               >
-        ",
+
+          Owner Stack: <empty>",
         ]
       `);
     });
@@ -483,7 +526,10 @@ describe('ReactDOMServerHydration', () => {
             <Mismatch isClient={true}>
               <div className="parent">
           +     <main className="only">
-          ]",
+          ]
+            Owner Stack:
+              in main (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -518,7 +564,10 @@ describe('ReactDOMServerHydration', () => {
           +     <header className="1">
           -     <main className="2">
                 ...
-          ]",
+          ]
+            Owner Stack:
+              in header (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -554,7 +603,10 @@ describe('ReactDOMServerHydration', () => {
           +     <main className="2">
           -     <footer className="3">
                 ...
-          ]",
+          ]
+            Owner Stack:
+              in main (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -589,7 +641,10 @@ describe('ReactDOMServerHydration', () => {
                 <header>
                 <main>
           +     <footer className="3">
-          ]",
+          ]
+            Owner Stack:
+              in footer (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -620,7 +675,10 @@ describe('ReactDOMServerHydration', () => {
                 <div className="parent">
             +     only
             -     
-            ]",
+            ]
+              Owner Stack:
+                in div (at **)
+                in Mismatch (at **)",
             ]
           `);
         } else {
@@ -642,7 +700,8 @@ describe('ReactDOMServerHydration', () => {
                 <div className="parent">
             +     only
             -     
-            ",
+
+              Owner Stack: <empty>",
             ]
           `);
         }
@@ -679,7 +738,10 @@ describe('ReactDOMServerHydration', () => {
           +     second
           -     <footer className="3">
                 ...
-          ]",
+          ]
+            Owner Stack:
+              in div (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -714,7 +776,10 @@ describe('ReactDOMServerHydration', () => {
           +     first
           -     <main className="2">
                 ...
-          ]",
+          ]
+            Owner Stack:
+              in div (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -749,7 +814,10 @@ describe('ReactDOMServerHydration', () => {
                 <header>
                 <main>
           +     third
-          ]",
+          ]
+            Owner Stack:
+              in div (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -784,7 +852,10 @@ describe('ReactDOMServerHydration', () => {
             <Mismatch isClient={true}>
               <div className="parent">
           -     <main className="only">
-          ]",
+          ]
+            Owner Stack:
+              in div (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -819,7 +890,10 @@ describe('ReactDOMServerHydration', () => {
           +     <main className="2">
           -     <header className="1">
                 ...
-          ]",
+          ]
+            Owner Stack:
+              in main (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -854,7 +928,10 @@ describe('ReactDOMServerHydration', () => {
                 <header>
           +     <footer className="3">
           -     <main className="2">
-          ]",
+          ]
+            Owner Stack:
+              in footer (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -887,7 +964,10 @@ describe('ReactDOMServerHydration', () => {
             <Mismatch isClient={true}>
               <div className="parent">
           -     <footer className="3">
-          ]",
+          ]
+            Owner Stack:
+              in div (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -916,7 +996,10 @@ describe('ReactDOMServerHydration', () => {
             <Mismatch isClient={true}>
               <div className="parent">
           -     only
-          ]",
+          ]
+            Owner Stack:
+              in div (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -951,7 +1034,10 @@ describe('ReactDOMServerHydration', () => {
           +     <main className="2">
           -     first
                 ...
-          ]",
+          ]
+            Owner Stack:
+              in main (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -986,7 +1072,10 @@ describe('ReactDOMServerHydration', () => {
                 <header>
           +     <footer className="3">
           -     second
-          ]",
+          ]
+            Owner Stack:
+              in footer (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -1019,7 +1108,10 @@ describe('ReactDOMServerHydration', () => {
             <Mismatch isClient={true}>
               <div className="parent">
           -     third
-          ]",
+          ]
+            Owner Stack:
+              in div (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -1062,7 +1154,10 @@ describe('ReactDOMServerHydration', () => {
             <Mismatch isClient={true}>
               <div className="parent">
           +     <Suspense fallback={<p>}>
-          ]",
+          ]
+            Owner Stack:
+              in Suspense (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -1097,7 +1192,10 @@ describe('ReactDOMServerHydration', () => {
             <Mismatch isClient={true}>
               <div className="parent">
           -     <Suspense>
-          ]",
+          ]
+            Owner Stack:
+              in div (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -1134,7 +1232,10 @@ describe('ReactDOMServerHydration', () => {
             <Mismatch isClient={true}>
               <div className="parent">
           +     <Suspense fallback={<p>}>
-          ]",
+          ]
+            Owner Stack:
+              in Suspense (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -1175,7 +1276,10 @@ describe('ReactDOMServerHydration', () => {
             <Mismatch isClient={true}>
               <div className="parent">
           -     <Suspense>
-          ]",
+          ]
+            Owner Stack:
+              in div (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -1214,7 +1318,10 @@ describe('ReactDOMServerHydration', () => {
           +       <main className="second">
           -       <footer className="3">
                   ...
-          ]",
+          ]
+            Owner Stack:
+              in main (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -1252,7 +1359,10 @@ describe('ReactDOMServerHydration', () => {
                   <header>
           +       <footer className="3">
           -       <main className="second">
-          ]",
+          ]
+            Owner Stack:
+              in footer (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -1280,7 +1390,8 @@ describe('ReactDOMServerHydration', () => {
           [
             "Caught [Switched to client rendering because the server rendering aborted due to:
 
-          The server used "renderToString" which does not support Suspense. If you intended for this Suspense boundary to render the fallback content on the server consider throwing an Error somewhere within the Suspense boundary. If you intended to have the server wait for the suspended component please switch to "renderToPipeableStream" which supports Suspense on the server]",
+          The server used "renderToString" which does not support Suspense. If you intended for this Suspense boundary to render the fallback content on the server consider throwing an Error somewhere within the Suspense boundary. If you intended to have the server wait for the suspended component please switch to "renderToPipeableStream" which supports Suspense on the server]
+            Owner Stack: null",
           ]
         `);
       });
@@ -1308,7 +1419,8 @@ describe('ReactDOMServerHydration', () => {
           [
             "Caught [Switched to client rendering because the server rendering aborted due to:
 
-          The server used "renderToString" which does not support Suspense. If you intended for this Suspense boundary to render the fallback content on the server consider throwing an Error somewhere within the Suspense boundary. If you intended to have the server wait for the suspended component please switch to "renderToPipeableStream" which supports Suspense on the server]",
+          The server used "renderToString" which does not support Suspense. If you intended for this Suspense boundary to render the fallback content on the server consider throwing an Error somewhere within the Suspense boundary. If you intended to have the server wait for the suspended component please switch to "renderToPipeableStream" which supports Suspense on the server]
+            Owner Stack: null",
           ]
         `);
       });
@@ -1348,7 +1460,10 @@ describe('ReactDOMServerHydration', () => {
               <div className="parent">
           +     <header className="1">
                 ...
-          ]",
+          ]
+            Owner Stack:
+              in header (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -1387,7 +1502,10 @@ describe('ReactDOMServerHydration', () => {
           -     <header className="1">
           -     <main className="2">
           -     <footer className="3">
-          ]",
+          ]
+            Owner Stack:
+              in div (at **)
+              in Mismatch (at **)",
           ]
         `);
       });
@@ -1451,7 +1569,12 @@ describe('ReactDOMServerHydration', () => {
                   <header>
                   <main>
         +         <footer className="3">
-        ]",
+        ]
+          Owner Stack:
+            in footer (at **)
+            in Panel (at **)
+            in ProfileSettings (at **)
+            in Mismatch (at **)",
         ]
       `);
     });
@@ -1508,7 +1631,11 @@ describe('ReactDOMServerHydration', () => {
             <ProfileSettings>
               <div className="parent">
         -       <footer className="3">
-        ]",
+        ]
+          Owner Stack:
+            in div (at **)
+            in ProfileSettings (at **)
+            in Mismatch (at **)",
         ]
       `);
     });

--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -171,7 +171,9 @@ describe('ReactDOMServerHydration', () => {
           +       client
           -       server
 
-            Owner Stack: <empty>",
+            Owner Stack:
+              in main (at **)
+              in Mismatch (at **)",
           ]
         `);
       }
@@ -236,7 +238,9 @@ describe('ReactDOMServerHydration', () => {
           +     This markup contains an nbsp entity:   client text
           -     This markup contains an nbsp entity:   server text
 
-            Owner Stack: <empty>",
+            Owner Stack:
+              in div (at **)
+              in Mismatch (at **)",
           ]
         `);
       }
@@ -283,7 +287,9 @@ describe('ReactDOMServerHydration', () => {
                 }}
               >
 
-          Owner Stack: <empty>",
+          Owner Stack:
+            in main (at **)
+            in Mismatch (at **)",
         ]
       `);
     });
@@ -325,7 +331,9 @@ describe('ReactDOMServerHydration', () => {
         -       dir="rtl"
               >
 
-          Owner Stack: <empty>",
+          Owner Stack:
+            in main (at **)
+            in Mismatch (at **)",
         ]
       `);
     });
@@ -367,7 +375,9 @@ describe('ReactDOMServerHydration', () => {
         -       dir={null}
               >
 
-          Owner Stack: <empty>",
+          Owner Stack:
+            in main (at **)
+            in Mismatch (at **)",
         ]
       `);
     });
@@ -409,7 +419,9 @@ describe('ReactDOMServerHydration', () => {
         -       dir="rtl"
               >
 
-          Owner Stack: <empty>",
+          Owner Stack:
+            in main (at **)
+            in Mismatch (at **)",
         ]
       `);
     });
@@ -451,7 +463,9 @@ describe('ReactDOMServerHydration', () => {
         -       dir="rtl"
               >
 
-          Owner Stack: <empty>",
+          Owner Stack:
+            in main (at **)
+            in Mismatch (at **)",
         ]
       `);
     });
@@ -492,7 +506,77 @@ describe('ReactDOMServerHydration', () => {
         -       style={{opacity:"0"}}
               >
 
-          Owner Stack: <empty>",
+          Owner Stack:
+            in main (at **)
+            in Mismatch (at **)",
+        ]
+      `);
+    });
+
+    // @gate __DEV__
+    it('picks the DFS-first Fiber as the error Owner', () => {
+      function LeftMismatch({isClient}) {
+        return <div className={isClient ? 'client' : 'server'} />;
+      }
+
+      function LeftIndirection({isClient}) {
+        return <LeftMismatch isClient={isClient} />;
+      }
+
+      function MiddleMismatch({isClient}) {
+        return <span className={isClient ? 'client' : 'server'} />;
+      }
+
+      function RightMisMatch({isClient}) {
+        return <p className={isClient ? 'client' : 'server'} />;
+      }
+
+      function App({isClient}) {
+        return (
+          <>
+            <LeftIndirection isClient={isClient} />
+            <MiddleMismatch isClient={isClient} />
+            <RightMisMatch isClient={isClient} />
+          </>
+        );
+      }
+      expect(testMismatch(App)).toMatchInlineSnapshot(`
+        [
+          "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
+
+        - A server/client branch \`if (typeof window !== 'undefined')\`.
+        - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
+        - Date formatting in a user's locale which doesn't match the server.
+        - External changing data without sending a snapshot of it along with the HTML.
+        - Invalid HTML tag nesting.
+
+        It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.
+
+        https://react.dev/link/hydration-mismatch
+
+          <App isClient={true}>
+            <LeftIndirection isClient={true}>
+              <LeftMismatch isClient={true}>
+                <div
+        +         className="client"
+        -         className="server"
+                >
+            <MiddleMismatch isClient={true}>
+              <span
+        +       className="client"
+        -       className="server"
+              >
+            <RightMisMatch isClient={true}>
+              <p
+        +       className="client"
+        -       className="server"
+              >
+
+          Owner Stack:
+            in div (at **)
+            in LeftMismatch (at **)
+            in LeftIndirection (at **)
+            in App (at **)",
         ]
       `);
     });
@@ -701,7 +785,9 @@ describe('ReactDOMServerHydration', () => {
             +     only
             -     
 
-              Owner Stack: <empty>",
+              Owner Stack:
+                in div (at **)
+                in Mismatch (at **)",
             ]
           `);
         }

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -164,28 +164,26 @@ describe('ReactDOMRoot', () => {
       </div>,
     );
     await waitForAll([]);
-    assertConsoleErrorDev(
-      [
-        "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. " +
-          "This won't be patched up. This can happen if a SSR-ed Client Component used:\n" +
-          '\n' +
-          "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
-          "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
-          "- Date formatting in a user's locale which doesn't match the server.\n" +
-          '- External changing data without sending a snapshot of it along with the HTML.\n' +
-          '- Invalid HTML tag nesting.\n' +
-          '\n' +
-          'It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.\n' +
-          '\n' +
-          'https://react.dev/link/hydration-mismatch\n' +
-          '\n' +
-          '  <div>\n' +
-          '    <span\n' +
-          '-     className="extra"\n' +
-          '    >\n',
-      ],
-      {withoutStack: true},
-    );
+    assertConsoleErrorDev([
+      "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. " +
+        "This won't be patched up. This can happen if a SSR-ed Client Component used:\n" +
+        '\n' +
+        "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
+        "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
+        "- Date formatting in a user's locale which doesn't match the server.\n" +
+        '- External changing data without sending a snapshot of it along with the HTML.\n' +
+        '- Invalid HTML tag nesting.\n' +
+        '\n' +
+        'It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.\n' +
+        '\n' +
+        'https://react.dev/link/hydration-mismatch\n' +
+        '\n' +
+        '  <div>\n' +
+        '    <span\n' +
+        '-     className="extra"\n' +
+        '    >\n' +
+        '\n    in span (at **)',
+    ]);
   });
 
   it('clears existing children', async () => {

--- a/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
@@ -547,32 +547,30 @@ describe('ReactDOM HostSingleton', () => {
     );
     expect(hydrationErrors).toEqual([]);
     await waitForAll([]);
-    assertConsoleErrorDev(
-      [
-        "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. " +
-          "This won't be patched up. This can happen if a SSR-ed Client Component used:\n" +
-          '\n' +
-          "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
-          "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
-          "- Date formatting in a user's locale which doesn't match the server.\n" +
-          '- External changing data without sending a snapshot of it along with the HTML.\n' +
-          '- Invalid HTML tag nesting.\n\nIt can also happen if the client has a browser extension installed ' +
-          'which messes with the HTML before React loaded.\n' +
-          '\n' +
-          'https://react.dev/link/hydration-mismatch\n' +
-          '\n' +
-          '  <html\n' +
-          '+   data-client-foo="foo"\n' +
-          '-   data-client-foo={null}\n' +
-          '  >\n' +
-          '    <head>\n' +
-          '    <body\n' +
-          '+     data-client-baz="baz"\n' +
-          '-     data-client-baz={null}\n' +
-          '    >\n',
-      ],
-      {withoutStack: true},
-    );
+    assertConsoleErrorDev([
+      "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. " +
+        "This won't be patched up. This can happen if a SSR-ed Client Component used:\n" +
+        '\n' +
+        "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
+        "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
+        "- Date formatting in a user's locale which doesn't match the server.\n" +
+        '- External changing data without sending a snapshot of it along with the HTML.\n' +
+        '- Invalid HTML tag nesting.\n\nIt can also happen if the client has a browser extension installed ' +
+        'which messes with the HTML before React loaded.\n' +
+        '\n' +
+        'https://react.dev/link/hydration-mismatch\n' +
+        '\n' +
+        '  <html\n' +
+        '+   data-client-foo="foo"\n' +
+        '-   data-client-foo={null}\n' +
+        '  >\n' +
+        '    <head>\n' +
+        '    <body\n' +
+        '+     data-client-baz="baz"\n' +
+        '-     data-client-baz={null}\n' +
+        '    >\n' +
+        '\n    in body (at **)',
+    ]);
     expect(persistentElements).toEqual([
       document.documentElement,
       document.head,

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -311,9 +311,10 @@ describe('rendering React components at document', () => {
                 '+       Hello world\n' +
                 '-       Goodbye world\n' +
                 '+       Hello world\n' +
-                '-       Goodbye world\n',
+                '-       Goodbye world\n' +
+                '\n    in body (at **)' +
+                '\n    in Component (at **)',
             ],
-        {withoutStack: true},
       );
 
       assertLog(

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -163,9 +163,10 @@ describe('ReactDOMServerHydration', () => {
                 '  <TestComponent name="y" ref={function ref}>\n' +
                 '    <span ref={{current:null}} onClick={function}>\n' +
                 '+     y\n' +
-                '-     x\n',
+                '-     x\n' +
+                '\n    in span (at **)' +
+                '\n    in TestComponent (at **)',
             ],
-        {withoutStack: true},
       );
       expect(mountCount).toEqual(4);
       expect(element.innerHTML.length > 0).toBe(true);
@@ -269,9 +270,9 @@ describe('ReactDOMServerHydration', () => {
               '\n' +
               '  <button autoFocus={false} onFocus={function mockConstructor}>\n' +
               '+   client\n' +
-              '-   server\n',
+              '-   server\n' +
+              '\n    in button (at **)',
           ],
-      {withoutStack: true},
     );
 
     expect(onFocusBeforeHydration).not.toHaveBeenCalled();
@@ -294,31 +295,29 @@ describe('ReactDOMServerHydration', () => {
         />,
       );
     });
-    assertConsoleErrorDev(
-      [
-        "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. " +
-          "This won't be patched up. This can happen if a SSR-ed Client Component used:\n" +
-          '\n' +
-          "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
-          "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
-          "- Date formatting in a user's locale which doesn't match the server.\n" +
-          '- External changing data without sending a snapshot of it along with the HTML.\n' +
-          '- Invalid HTML tag nesting.\n\nIt can also happen if the client has a browser extension ' +
-          'installed which messes with the HTML before React loaded.\n' +
-          '\n' +
-          'https://react.dev/link/hydration-mismatch\n' +
-          '\n' +
-          '  <div\n    style={{\n+     textDecoration: "none"\n' +
-          '+     color: "white"\n' +
-          '-     color: "black"\n' +
-          '+     height: "10px"\n' +
-          '-     height: "10px"\n' +
-          '-     text-decoration: "none"\n' +
-          '    }}\n' +
-          '  >\n',
-      ],
-      {withoutStack: true},
-    );
+    assertConsoleErrorDev([
+      "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. " +
+        "This won't be patched up. This can happen if a SSR-ed Client Component used:\n" +
+        '\n' +
+        "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
+        "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
+        "- Date formatting in a user's locale which doesn't match the server.\n" +
+        '- External changing data without sending a snapshot of it along with the HTML.\n' +
+        '- Invalid HTML tag nesting.\n\nIt can also happen if the client has a browser extension ' +
+        'installed which messes with the HTML before React loaded.\n' +
+        '\n' +
+        'https://react.dev/link/hydration-mismatch\n' +
+        '\n' +
+        '  <div\n    style={{\n+     textDecoration: "none"\n' +
+        '+     color: "white"\n' +
+        '-     color: "black"\n' +
+        '+     height: "10px"\n' +
+        '-     height: "10px"\n' +
+        '-     text-decoration: "none"\n' +
+        '    }}\n' +
+        '  >\n' +
+        '\n    in div (at **)',
+    ]);
   });
 
   it('should not warn when the style property differs on whitespace or order in IE', async () => {
@@ -362,33 +361,31 @@ describe('ReactDOMServerHydration', () => {
         />,
       );
     });
-    assertConsoleErrorDev(
-      [
-        "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. " +
-          "This won't be patched up. This can happen if a SSR-ed Client Component used:\n" +
-          '\n' +
-          "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
-          "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
-          "- Date formatting in a user's locale which doesn't match the server.\n" +
-          '- External changing data without sending a snapshot of it along with the HTML.\n' +
-          '- Invalid HTML tag nesting.\n\nIt can also happen if the client has a browser extension ' +
-          'installed which messes with the HTML before React loaded.\n' +
-          '\n' +
-          'https://react.dev/link/hydration-mismatch\n' +
-          '\n' +
-          '  <div\n' +
-          '    style={{\n' +
-          '+     textDecoration: "none"\n' +
-          '+     color: "black"\n' +
-          '-     color: "black"\n' +
-          '+     height: "10px"\n' +
-          '-     height: "10px"\n' +
-          '-     text-decoration: "none"\n' +
-          '    }}\n' +
-          '  >\n',
-      ],
-      {withoutStack: true},
-    );
+    assertConsoleErrorDev([
+      "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. " +
+        "This won't be patched up. This can happen if a SSR-ed Client Component used:\n" +
+        '\n' +
+        "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
+        "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
+        "- Date formatting in a user's locale which doesn't match the server.\n" +
+        '- External changing data without sending a snapshot of it along with the HTML.\n' +
+        '- Invalid HTML tag nesting.\n\nIt can also happen if the client has a browser extension ' +
+        'installed which messes with the HTML before React loaded.\n' +
+        '\n' +
+        'https://react.dev/link/hydration-mismatch\n' +
+        '\n' +
+        '  <div\n' +
+        '    style={{\n' +
+        '+     textDecoration: "none"\n' +
+        '+     color: "black"\n' +
+        '-     color: "black"\n' +
+        '+     height: "10px"\n' +
+        '-     height: "10px"\n' +
+        '-     text-decoration: "none"\n' +
+        '    }}\n' +
+        '  >\n' +
+        '\n    in div (at **)',
+    ]);
   });
 
   it('should throw rendering portals on the server', () => {
@@ -652,9 +649,9 @@ describe('ReactDOMServerHydration', () => {
               '  <div dangerouslySetInnerHTML={undefined}>\n' +
               '    <p>\n' +
               '+     client\n' +
-              '-     server\n',
+              '-     server\n' +
+              '\n    in p (at **)',
           ],
-      {withoutStack: true},
     );
 
     if (favorSafetyOverHydrationPerf) {

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -67,6 +67,7 @@ import {
 import {queueRecoverableErrors} from './ReactFiberWorkLoop';
 import {getRootHostContainer, getHostContext} from './ReactFiberHostContext';
 import {describeDiff} from './ReactFiberHydrationDiffs';
+import {runWithFiberInDEV} from './ReactCurrentFiber';
 
 // The deepest Fiber on the stack involved in a hydration context.
 // This may have been an insertion or a hydration.
@@ -749,22 +750,32 @@ export function emitPendingHydrationWarnings() {
     if (diffRoot !== null) {
       hydrationDiffRootDEV = null;
       const diff = describeDiff(diffRoot);
-      console.error(
-        "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. " +
-          'This can happen if a SSR-ed Client Component used:\n' +
-          '\n' +
-          "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
-          "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
-          "- Date formatting in a user's locale which doesn't match the server.\n" +
-          '- External changing data without sending a snapshot of it along with the HTML.\n' +
-          '- Invalid HTML tag nesting.\n' +
-          '\n' +
-          'It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.\n' +
-          '\n' +
-          '%s%s',
-        'https://react.dev/link/hydration-mismatch',
-        diff,
-      );
+
+      // Just pick the DFS-first leaf as the owner.
+      // Should be good enough since most warnings only have a single error.
+      let diffOwner: HydrationDiffNode = diffRoot;
+      while (diffOwner.children.length > 0) {
+        diffOwner = diffOwner.children[0];
+      }
+
+      runWithFiberInDEV(diffOwner.fiber, () => {
+        console.error(
+          "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. " +
+            'This can happen if a SSR-ed Client Component used:\n' +
+            '\n' +
+            "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
+            "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
+            "- Date formatting in a user's locale which doesn't match the server.\n" +
+            '- External changing data without sending a snapshot of it along with the HTML.\n' +
+            '- Invalid HTML tag nesting.\n' +
+            '\n' +
+            'It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.\n' +
+            '\n' +
+            '%s%s',
+          'https://react.dev/link/hydration-mismatch',
+          diff,
+        );
+      });
     }
   }
 }


### PR DESCRIPTION
Based on https://github.com/facebook/react/pull/32537

## Summary

Adds an Owner Stack to attribute hydration mismatches e.g. `<div className={isClient ? 'client' : 'server'} />`. We choose a Fiber depth-first as the Owner. I personally prefer something as close as possible to the origin and then work my way upwards if the fault is somewhere earlier. But we could also use a different heuristic based on the specific error.

## How did you test this change?

- updated tests
- added more involved test case showing that we use DFS to pick the Owner of this error.
