### PR TITLE
[compiler] Make CompilerError compatible with reflection

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/CompilerError.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/CompilerError.ts
@@ -188,6 +188,7 @@ export class CompilerError extends Error {
   constructor(...args: Array<any>) {
     super(...args);
     this.name = 'ReactCompilerError';
+    this.details = [];
   }
 
   override get message(): string {
@@ -197,7 +198,10 @@ export class CompilerError extends Error {
   override set message(_message: string) {}
 
   override toString(): string {
-    return this.details.map(detail => detail.toString()).join('\n\n');
+    if (Array.isArray(this.details)) {
+      return this.details.map(detail => detail.toString()).join('\n\n');
+    }
+    return this.name;
   }
 
   push(options: CompilerErrorDetailOptions): CompilerErrorDetail {


### PR DESCRIPTION

In #32416, @michaelfaith discovered that https://github.com/facebook/react/blob/029e8bd618af23fbdd9efdac565ad81f7d4640d8/scripts/jest/setupTests.js#L82 would fail on the merged compiler eslint rule.

Upon further investigation I discovered that our CompilerError implementation doesn't play nicely with Reflect, so `Reflect.construct` would fail as `.toString` would error:

```
TypeError: Cannot read properties of undefined (reading 'map')
          at _CompilerError.toString (/Users/.../code/react/node_modules/babel-plugin-react-compiler/src/CompilerError.ts:200:25)
          at _CompilerError.get message [as message] (/Users/.../code/react/node_modules/babel-plugin-react-compiler/src/CompilerError.ts:194:17)
          at Object.construct (/Users/.../code/react/scripts/jest/setupTests.js:153:52)
```

I tested this fix using my local copy of the built babel-plugin-react-compiler to verify that this fixes those tests.
