### PR TITLE
Enable moveBefore in experimental releases

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -193,7 +193,7 @@ export const disableLegacyContext = true;
 export const disableLegacyContextForFunctionComponents = true;
 
 // Enable the moveBefore() alternative to insertBefore(). This preserves states of moves.
-export const enableMoveBefore = false;
+export const enableMoveBefore = __EXPERIMENTAL__;
 
 // Disabled caching behavior of `react/cache` in client runtimes.
 export const disableClientCache = true;


### PR DESCRIPTION
Enabling feature detection of early DOM features in a framework is reckless. I'm not judging other frameworks (but also a little bit). Because if you do something like `if (moveBefore) moveBefore(a, b) else insertBefore(a, b)` like we do and then the implementation has to change there are still too many websites out there that it becomes impossible to change it. It would break the web. It would instead have to change to a different name. That's what happened with `contains` -> `includes`. Counter to popular belief it didn't have anything to do with patching prototypes. Therefore, ideally frameworks shouldn't start rely on it until there's two implementations so that there's time for feedback.

That's why we didn't immediately enable this even in experimental. However, at this point there's probably enough feature detection and it has shipped long enough in Chrome that it's unlikely to be able to change at this point.

We can enable it now. For now just in `@experimental` to see if we can flush out issues with it before bringing it to stable.