### PR TITLE
[Flight]: Client-side `registerServerReference` must not break `.bind()`

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -309,6 +309,13 @@ describe('ReactFlightDOMEdge', () => {
       greet,
     });
 
+    // Registering the server reference also with the client must not break
+    // subsequent `.bind` calls.
+    ReactServerDOMClient.registerServerReference(
+      ServerModule.greet,
+      ServerModule.greet.$$id,
+    );
+
     const stream = await serverAct(() =>
       ReactServerDOMServer.renderToReadableStream(
         {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReplyEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReplyEdge-test.js
@@ -333,4 +333,27 @@ describe('ReactFlightDOMReplyEdge', () => {
     expect(replyResult.method).toBe(greet);
     expect(replyResult.boundMethod()).toBe('hi, there');
   });
+
+  it('can pass a bound registered server reference', async () => {
+    function greet(greeting, name) {
+      return greeting + ', ' + name;
+    }
+    const ServerModule = serverExports({
+      greet,
+    });
+
+    const boundGreet = ServerModule.greet.bind(null, 'hi');
+
+    ReactServerDOMClient.registerServerReference(boundGreet, boundGreet.$$id);
+
+    const body = await ReactServerDOMClient.encodeReply({
+      method: boundGreet,
+      boundMethod: boundGreet.bind(null, 'there'),
+    });
+    const replyResult = await ReactServerDOMServer.decodeReply(
+      body,
+      webpackServerMap,
+    );
+    expect(replyResult.boundMethod()).toBe('hi, there');
+  });
 });

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReplyEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReplyEdge-test.js
@@ -333,27 +333,4 @@ describe('ReactFlightDOMReplyEdge', () => {
     expect(replyResult.method).toBe(greet);
     expect(replyResult.boundMethod()).toBe('hi, there');
   });
-
-  it('can pass a bound registered server reference', async () => {
-    function greet(greeting, name) {
-      return greeting + ', ' + name;
-    }
-    const ServerModule = serverExports({
-      greet,
-    });
-
-    const boundGreet = ServerModule.greet.bind(null, 'hi');
-
-    ReactServerDOMClient.registerServerReference(boundGreet, boundGreet.$$id);
-
-    const body = await ReactServerDOMClient.encodeReply({
-      method: boundGreet,
-      boundMethod: boundGreet.bind(null, 'there'),
-    });
-    const replyResult = await ReactServerDOMServer.decodeReply(
-      body,
-      webpackServerMap,
-    );
-    expect(replyResult.boundMethod()).toBe('hi, there');
-  });
 });


### PR DESCRIPTION
This is a follow-up for #32534 to ensure that calling `registerServerReference` from the client builds with a server reference does not overwrite the `bind` method that was previously defined by the Flight Server.

As was already the case with #32534, the compiler must ensure that the client-side `registerServerReference` is called after the server-side `registerServerReference` is called.