### PR TITLE
Check if a child is a new child before calling moveBefore

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -808,7 +808,7 @@ export function appendChild(
   parentInstance: Instance,
   child: Instance | TextInstance,
 ): void {
-  if (supportsMoveBefore) {
+  if (supportsMoveBefore && child.parentNode !== null) {
     // $FlowFixMe[prop-missing]: We've checked this with supportsMoveBefore.
     parentInstance.moveBefore(child, null);
   } else {
@@ -828,7 +828,7 @@ export function appendChildToContainer(
     container.nodeType === COMMENT_NODE
   ) {
     parentNode = (container.parentNode: any);
-    if (supportsMoveBefore) {
+    if (supportsMoveBefore && child.parentNode !== null) {
       // $FlowFixMe[prop-missing]: We've checked this with supportsMoveBefore.
       parentNode.moveBefore(child, container);
     } else {
@@ -840,7 +840,7 @@ export function appendChildToContainer(
   } else {
     parentNode = (container: any);
   }
-  if (supportsMoveBefore) {
+  if (supportsMoveBefore && child.parentNode !== null) {
     // $FlowFixMe[prop-missing]: We've checked this with supportsMoveBefore.
     parentNode.moveBefore(child, null);
   } else {
@@ -870,7 +870,7 @@ export function insertBefore(
   child: Instance | TextInstance,
   beforeChild: Instance | TextInstance | SuspenseInstance,
 ): void {
-  if (supportsMoveBefore) {
+  if (supportsMoveBefore && child.parentNode !== null) {
     // $FlowFixMe[prop-missing]: We've checked this with supportsMoveBefore.
     parentInstance.moveBefore(child, beforeChild);
   } else {
@@ -896,7 +896,7 @@ export function insertInContainerBefore(
   } else {
     parentNode = (container: any);
   }
-  if (supportsMoveBefore) {
+  if (supportsMoveBefore && child.parentNode !== null) {
     // $FlowFixMe[prop-missing]: We've checked this with supportsMoveBefore.
     parentNode.moveBefore(child, beforeChild);
   } else {


### PR DESCRIPTION
This fixes a critical issue with moveBefore. I was told that the disconnected -> connected case was going to be relaxed and not be an error but apparently that is not the case.

This means that we can't use this for initial insertions. Only moves.

Unfortunately React's internals doesn't distinguish these cases. This adds a hack that checks each nodes but this is pretty bad for performance. We should only call this in one or the other case.

Given that we still need feature detection. Both of which means that these calls are no longer inlined and this extra code. I wonder if it's even worth it given that you can't even rely on it working anyway since not all browsers have it. Kind of don't want to ship this until all browsers have it.

Even then we'd ideally refactor React to use separate code paths for initial insertion vs moves. Which leads to some unfortunate code duplication.