### PR TITLE
feat: [React Compiler] Allow to customise reanimated library import name

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -571,6 +571,14 @@ const EnvironmentConfigSchema = z.object({
    */
   enableCustomTypeDefinitionForReanimated: z.boolean().default(false),
 
+
+  /**
+   * The import name of React Native Reanimated library, by default, it's `react-native-reanimated`.
+   * In case if you use a custom wrapper around the library, you can specify it here, so
+   * React Compiler will work with Reanimated Babel plugin
+   */
+  reanimatedImportNames: z.array(z.string()).optional(),
+
   /**
    * If specified, this value is used as a pattern for determing which global values should be
    * treated as hooks. The pattern should have a single capture group, which will be used as
@@ -917,7 +925,11 @@ export class Environment {
 
     if (config.enableCustomTypeDefinitionForReanimated) {
       const reanimatedModuleType = getReanimatedModuleType(this.#shapes);
-      this.#moduleTypes.set(REANIMATED_MODULE_NAME, reanimatedModuleType);
+      const reanimatedImportNames: Array<string> = config.reanimatedImportNames ?? [REANIMATED_MODULE_NAME];
+
+      reanimatedImportNames.forEach((importName) => {
+        this.#moduleTypes.set(importName, reanimatedModuleType);
+      });
     }
 
     this.#contextIdentifiers = contextIdentifiers;


### PR DESCRIPTION

## Summary

In our code I use a custom wrapper around `react-native-reanimated` to be able to turn off animation on low-end devises 

```tsx
import { useSharedValue, useAnimatedStyle } from 'my-reanimated';

const useFadeAnimationDefault123456789 = () => {
  'use memo';
  const sv = useSharedValue(0);
  return useAnimatedStyle(() => ({
    opacity: sv.value,
  }));
};
```

so when reanimated hooks will be imported from a non `react-native-reanimated` module 
the compiler will apply own optimisations and a reanimated babel plugin won't transforms code correctly 

## How did you test this change?

locally 
