### PR TITLE
Add more phases to the ReactFiberApplyGesture

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -878,6 +878,7 @@ export function createFiberFromViewTransition(
   const instance: ViewTransitionState = {
     autoName: null,
     paired: null,
+    clones: null,
     ref: null,
   };
   fiber.stateNode = instance;

--- a/packages/react-reconciler/src/ReactFiberApplyGesture.js
+++ b/packages/react-reconciler/src/ReactFiberApplyGesture.js
@@ -202,13 +202,6 @@ function recursivelyInsertNewFiber(
       // For insertions we don't need to clone. It's already new state node.
       if (visitPhase !== INSERT_APPEARING_PAIR) {
         appendChild(hostParentClone, instance);
-        if (parentViewTransition !== null) {
-          if (parentViewTransition.clones === null) {
-            parentViewTransition.clones = [instance];
-          } else {
-            parentViewTransition.clones.push(instance);
-          }
-        }
         recursivelyInsertNew(
           finishedWork,
           instance,
@@ -217,6 +210,13 @@ function recursivelyInsertNewFiber(
         );
       } else {
         recursivelyInsertNew(finishedWork, instance, null, visitPhase);
+      }
+      if (parentViewTransition !== null) {
+        if (parentViewTransition.clones === null) {
+          parentViewTransition.clones = [instance];
+        } else {
+          parentViewTransition.clones.push(instance);
+        }
       }
       break;
     }

--- a/packages/react-reconciler/src/ReactFiberApplyGesture.js
+++ b/packages/react-reconciler/src/ReactFiberApplyGesture.js
@@ -132,6 +132,7 @@ function recursivelyInsertNew(
 ): void {
   if (
     visitPhase === INSERT_APPEARING_PAIR &&
+    parentViewTransition === null &&
     (parentFiber.subtreeFlags & ViewTransitionNamedStatic) === NoFlags
   ) {
     // We're just searching for pairs but we have reached the end.

--- a/packages/react-reconciler/src/ReactFiberApplyGesture.js
+++ b/packages/react-reconciler/src/ReactFiberApplyGesture.js
@@ -767,7 +767,7 @@ function applyEnterViewTransitions(deletion: Fiber): void {
   }
 }
 
-function measureEnterViewTransitions(placement: Fiber): void {
+function measureExitViewTransitions(placement: Fiber): void {
   if (placement.tag === ViewTransitionComponent) {
     // const state: ViewTransitionState = placement.stateNode;
     const props: ViewTransitionProps = placement.memoizedProps;
@@ -779,7 +779,7 @@ function measureEnterViewTransitions(placement: Fiber): void {
     // TODO: Check if this is a hidden Offscreen or a Portal.
     let child = placement.child;
     while (child !== null) {
-      measureEnterViewTransitions(child);
+      measureExitViewTransitions(child);
       child = child.sibling;
     }
   } else {
@@ -804,6 +804,13 @@ function measureNestedViewTransitions(changedParent: Fiber): void {
     }
     child = child.sibling;
   }
+}
+
+function measureUpdateViewTransition(
+  current: Fiber,
+  finishedWork: Fiber,
+): void {
+  // TODO
 }
 
 function recursivelyApplyViewTransitions(parentFiber: Fiber) {
@@ -836,7 +843,7 @@ function recursivelyApplyViewTransitions(parentFiber: Fiber) {
 function applyViewTransitionsOnFiber(finishedWork: Fiber) {
   const current = finishedWork.alternate;
   if (current === null) {
-    measureEnterViewTransitions(finishedWork);
+    measureExitViewTransitions(finishedWork);
     return;
   }
 
@@ -863,7 +870,7 @@ function applyViewTransitionsOnFiber(finishedWork: Fiber) {
         const newState: OffscreenState | null = finishedWork.memoizedState;
         const isHidden = newState !== null;
         if (!isHidden) {
-          measureEnterViewTransitions(finishedWork);
+          measureExitViewTransitions(finishedWork);
         } else if (current !== null && current.memoizedState === null) {
           // Was previously mounted as visible but is now hidden.
           applyEnterViewTransitions(current);
@@ -872,6 +879,7 @@ function applyViewTransitionsOnFiber(finishedWork: Fiber) {
       break;
     }
     case ViewTransitionComponent:
+      measureUpdateViewTransition(current, finishedWork);
       const viewTransitionState: ViewTransitionState = finishedWork.stateNode;
       viewTransitionState.clones = null; // Reset
       recursivelyApplyViewTransitions(finishedWork);

--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -514,37 +514,20 @@ function restorePairedViewTransitions(parent: Fiber): void {
   }
 }
 
-export function restoreEnterViewTransitions(placement: Fiber): void {
-  if (placement.tag === ViewTransitionComponent) {
-    const instance: ViewTransitionState = placement.stateNode;
+export function restoreEnterOrExitViewTransitions(fiber: Fiber): void {
+  if (fiber.tag === ViewTransitionComponent) {
+    const instance: ViewTransitionState = fiber.stateNode;
     instance.paired = null;
-    restoreViewTransitionOnHostInstances(placement.child, false);
-    restorePairedViewTransitions(placement);
-  } else if ((placement.subtreeFlags & ViewTransitionStatic) !== NoFlags) {
-    let child = placement.child;
+    restoreViewTransitionOnHostInstances(fiber.child, false);
+    restorePairedViewTransitions(fiber);
+  } else if ((fiber.subtreeFlags & ViewTransitionStatic) !== NoFlags) {
+    let child = fiber.child;
     while (child !== null) {
-      restoreEnterViewTransitions(child);
+      restoreEnterOrExitViewTransitions(child);
       child = child.sibling;
     }
   } else {
-    restorePairedViewTransitions(placement);
-  }
-}
-
-export function restoreExitViewTransitions(deletion: Fiber): void {
-  if (deletion.tag === ViewTransitionComponent) {
-    const instance: ViewTransitionState = deletion.stateNode;
-    instance.paired = null;
-    restoreViewTransitionOnHostInstances(deletion.child, false);
-    restorePairedViewTransitions(deletion);
-  } else if ((deletion.subtreeFlags & ViewTransitionStatic) !== NoFlags) {
-    let child = deletion.child;
-    while (child !== null) {
-      restoreExitViewTransitions(child);
-      child = child.sibling;
-    }
-  } else {
-    restorePairedViewTransitions(deletion);
+    restorePairedViewTransitions(fiber);
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -246,8 +246,7 @@ import {
   commitExitViewTransitions,
   commitBeforeUpdateViewTransition,
   commitNestedViewTransitions,
-  restoreEnterViewTransitions,
-  restoreExitViewTransitions,
+  restoreEnterOrExitViewTransitions,
   restoreUpdateViewTransition,
   restoreNestedViewTransitions,
   measureUpdateViewTransition,
@@ -3228,7 +3227,7 @@ function commitPassiveMountOnFiber(
     // This was a new mount. This means we could've triggered an enter animation on
     // the content. Restore the view transitions if there were any assigned in the
     // snapshot phase.
-    restoreEnterViewTransitions(finishedWork);
+    restoreEnterOrExitViewTransitions(finishedWork);
   }
 
   // When updating this function, also update reconnectPassiveEffects, which does
@@ -3529,7 +3528,7 @@ function commitPassiveMountOnFiber(
           // Content is now hidden but wasn't before. This means we could've
           // triggered an exit animation on the content. Restore the view
           // transitions if there were any assigned in the snapshot phase.
-          restoreExitViewTransitions(current);
+          restoreEnterOrExitViewTransitions(current);
         }
         if (instance._visibility & OffscreenPassiveEffectsConnected) {
           // The effects are currently connected. Update them.
@@ -3576,7 +3575,7 @@ function commitPassiveMountOnFiber(
           // Content is now visible but wasn't before. This means we could've
           // triggered an enter animation on the content. Restore the view
           // transitions if there were any assigned in the snapshot phase.
-          restoreEnterViewTransitions(finishedWork);
+          restoreEnterOrExitViewTransitions(finishedWork);
         }
         if (instance._visibility & OffscreenPassiveEffectsConnected) {
           // The effects are currently connected. Update them.

--- a/packages/react-reconciler/src/ReactFiberViewTransitionComponent.js
+++ b/packages/react-reconciler/src/ReactFiberViewTransitionComponent.js
@@ -9,7 +9,7 @@
 
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {FiberRoot} from './ReactInternalTypes';
-import type {ViewTransitionInstance} from './ReactFiberConfig';
+import type {ViewTransitionInstance, Instance} from './ReactFiberConfig';
 
 import {
   getWorkInProgressRoot,
@@ -45,6 +45,7 @@ export type ViewTransitionProps = {
 export type ViewTransitionState = {
   autoName: null | string, // the view-transition-name to use when an explicit one is not specified
   paired: null | ViewTransitionState, // a temporary state during the commit phase if we have paired this with another instance
+  clones: null | Array<Instance>, // a temporary state during the apply gesture phase if we cloned this boundary
   ref: null | ViewTransitionInstance, // the current ref instance. This can change through the lifetime of the instance.
 };
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -3927,6 +3927,9 @@ function commitGestureOnRoot(
 }
 
 function flushGestureMutations(): void {
+  if (!enableSwipeTransition) {
+    return;
+  }
   if (pendingEffectsStatus !== PENDING_GESTURE_MUTATION_PHASE) {
     return;
   }
@@ -3953,6 +3956,9 @@ function flushGestureMutations(): void {
 }
 
 function flushGestureAnimations(): void {
+  if (!enableSwipeTransition) {
+    return;
+  }
   // If we get canceled before we start we might not have applied
   // mutations yet. We need to apply them first.
   flushGestureMutations();


### PR DESCRIPTION
Stacked on #32585 and #32605.

This adds more loops for the phases of "Apply Gesture". It doesn't implement the interesting bit yet like adding view-transition-names and measurements. I'll do that in a separate PR to keep reviewing easier.

The three phases of this approach is roughly:

- Clone and apply names to the "old" state.
- Inside startViewTransition: Apply names to the "new" state. Measure both the "old" and "new" state to know whether to cancel some of them. Delete the clones which will include all the "old" names.
- After startViewTransition: Restore "new" names back to no view-transition-name.

Since we don't have any other Effects in these phases we have a bit more flexibility and we can avoid extra phases that traverse the tree. I've tried to avoid any additional passes.

An interesting consequence of this approach is that we could measure both the "old" and "new" state before `startViewTransition`. This would be more efficient because we wouldn't need to take View Transition snapshots of parts of the tree that won't actually animate. However, that would require an extra pass and force layout earlier. It would also have different semantics from the fire-and-forget View Transitions because we could optimize better which can be visible. It would also not account for any late mutations. So I decided to instead let the layout be computed by painting as usual and then measure both "old" and "new" inside the startViewTransition instead. Then canceling anything that doesn't animate to keep it consistent.

Unfortunately, though there's not a lot of code sharing possible in these phases because the strategy is so different with the cloning and because the animation is performed in reverse. The "finishedWork" Fiber represents the "old" state and the "current" Fiber represents the "new" state.

The most complicated phase is the cloning. I actually ended up having to make a very different pattern from the other phases and CommitWork in general. Because we have to clone as we go and also do other things like apply names and finding pairs, it has more phases. I ended up with an approach that uses three different loops. The outer one for updated trees, one for inserted trees that don't need cloning (doesn't include reappearing offscreen) and one for not updated trees that still need cloning. Inside each loop it can also be in different phases which I track with the `visitPhase` enum - this pattern is kind of new.

Additionally, we need to measure the cloned nodes after we've applied mutations to them and we have to wait until the whole tree is inserted. We don't have a reference to these DOM elements in the Fiber tree since that still refers to the original ones. We need to store the cloned elements somewhere. So I added a temporary field on the ViewTransitionState to keep track of any clones owned by that ViewTransition.

When we deep clone an unchanged subtree we don't have DOM element instances. It wouldn't be quite safe to try to find them from the tree structure. So we need to avoid the deep clones if we might need DOM elements. Therefore we keep traversing in the case where we need to find nested ViewTransition boundaries that are either potentially affected by layout or a "pair".

For the other two phases the pattern there's a lot of code duplication since it's slightly different from the commit ones but they at least follow the same pattern. For the restore phase I was actually able to reuse most of the code.

I don't love how much code this is.
