### PR TITLE
[compiler][ez] Stop bailing out early for hoisted gated functions

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Gating.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Gating.ts
@@ -8,6 +8,7 @@
 import {NodePath} from '@babel/core';
 import * as t from '@babel/types';
 import {PluginOptions} from './Options';
+import {CompilerError} from '../CompilerError';
 
 export function insertGatedFunctionDeclaration(
   fnPath: NodePath<
@@ -18,47 +19,59 @@ export function insertGatedFunctionDeclaration(
     | t.ArrowFunctionExpression
     | t.FunctionExpression,
   gating: NonNullable<PluginOptions['gating']>,
+  referencedBeforeDeclaration: boolean,
 ): void {
-  const gatingExpression = t.conditionalExpression(
-    t.callExpression(t.identifier(gating.importSpecifierName), []),
-    buildFunctionExpression(compiled),
-    buildFunctionExpression(fnPath.node),
-  );
-
-  /*
-   * Convert function declarations to named variables *unless* this is an
-   * `export default function ...` since `export default const ...` is
-   * not supported. For that case we fall through to replacing w the raw
-   * conditional expression
-   */
-  if (
-    fnPath.parentPath.node.type !== 'ExportDefaultDeclaration' &&
-    fnPath.node.type === 'FunctionDeclaration' &&
-    fnPath.node.id != null
-  ) {
-    fnPath.replaceWith(
-      t.variableDeclaration('const', [
-        t.variableDeclarator(fnPath.node.id, gatingExpression),
-      ]),
-    );
-  } else if (
-    fnPath.parentPath.node.type === 'ExportDefaultDeclaration' &&
-    fnPath.node.type !== 'ArrowFunctionExpression' &&
-    fnPath.node.id != null
-  ) {
-    fnPath.insertAfter(
-      t.exportDefaultDeclaration(t.identifier(fnPath.node.id.name)),
-    );
-    fnPath.parentPath.replaceWith(
-      t.variableDeclaration('const', [
-        t.variableDeclarator(
-          t.identifier(fnPath.node.id.name),
-          gatingExpression,
-        ),
-      ]),
-    );
+  if (referencedBeforeDeclaration) {
+    const identifier =
+      fnPath.node.type === 'FunctionDeclaration' ? fnPath.node.id : null;
+    CompilerError.invariant(false, {
+      reason: `Encountered a function used before its declaration, which breaks Forget's gating codegen due to hoisting`,
+      description: `Rewrite the reference to ${identifier?.name ?? 'this function'} to not rely on hoisting to fix this issue`,
+      loc: identifier?.loc ?? null,
+      suggestions: null,
+    });
   } else {
-    fnPath.replaceWith(gatingExpression);
+    const gatingExpression = t.conditionalExpression(
+      t.callExpression(t.identifier(gating.importSpecifierName), []),
+      buildFunctionExpression(compiled),
+      buildFunctionExpression(fnPath.node),
+    );
+
+    /*
+     * Convert function declarations to named variables *unless* this is an
+     * `export default function ...` since `export default const ...` is
+     * not supported. For that case we fall through to replacing w the raw
+     * conditional expression
+     */
+    if (
+      fnPath.parentPath.node.type !== 'ExportDefaultDeclaration' &&
+      fnPath.node.type === 'FunctionDeclaration' &&
+      fnPath.node.id != null
+    ) {
+      fnPath.replaceWith(
+        t.variableDeclaration('const', [
+          t.variableDeclarator(fnPath.node.id, gatingExpression),
+        ]),
+      );
+    } else if (
+      fnPath.parentPath.node.type === 'ExportDefaultDeclaration' &&
+      fnPath.node.type !== 'ArrowFunctionExpression' &&
+      fnPath.node.id != null
+    ) {
+      fnPath.insertAfter(
+        t.exportDefaultDeclaration(t.identifier(fnPath.node.id.name)),
+      );
+      fnPath.parentPath.replaceWith(
+        t.variableDeclaration('const', [
+          t.variableDeclarator(
+            t.identifier(fnPath.node.id.name),
+            gatingExpression,
+          ),
+        ]),
+      );
+    } else {
+      fnPath.replaceWith(gatingExpression);
+    }
   }
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
@@ -12,6 +12,7 @@ import {
   EnvironmentConfig,
   ExternalFunction,
   parseEnvironmentConfig,
+  tryParseExternalFunction,
 } from '../HIR/Environment';
 import {hasOwnProperty} from '../Utils/utils';
 import {fromZodError} from 'zod-validation-error';
@@ -269,6 +270,14 @@ export function parsePluginOptions(obj: unknown): PluginOptions {
         }
         case 'target': {
           parsedOptions[key] = parseTargetConfig(value);
+          break;
+        }
+        case 'gating': {
+          if (value == null) {
+            parsedOptions[key] = null;
+          } else {
+            parsedOptions[key] = tryParseExternalFunction(value);
+          }
           break;
         }
         default: {


### PR DESCRIPTION

Some code movement for the next PR
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32597).
* #32598
* __->__ #32597