### PR TITLE
Gate flushGestureMutations and flushGestureAnimations

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -3927,6 +3927,9 @@ function commitGestureOnRoot(
 }
 
 function flushGestureMutations(): void {
+  if (!enableSwipeTransition) {
+    return;
+  }
   if (pendingEffectsStatus !== PENDING_GESTURE_MUTATION_PHASE) {
     return;
   }
@@ -3953,6 +3956,9 @@ function flushGestureMutations(): void {
 }
 
 function flushGestureAnimations(): void {
+  if (!enableSwipeTransition) {
+    return;
+  }
   // If we get canceled before we start we might not have applied
   // mutations yet. We need to apply them first.
   flushGestureMutations();


### PR DESCRIPTION
Normally these are gated by the whole commitGestureOnRoot path but in the case of an early commit these phases may need to be invoked. Earlier. Those paths weren't gated which I noticed when I started adding code to them.
