### PR TITLE
[DevTools] Use Popover API for TraceUpdates highlighting

### DIFF
--- a/packages/react-devtools-extensions/chrome/manifest.json
+++ b/packages/react-devtools-extensions/chrome/manifest.json
@@ -4,7 +4,7 @@
   "description": "Adds React debugging tools to the Chrome Developer Tools.",
   "version": "6.1.1",
   "version_name": "6.1.1",
-  "minimum_chrome_version": "102",
+  "minimum_chrome_version": "114",
   "icons": {
     "16": "icons/16-production.png",
     "32": "icons/32-production.png",

--- a/packages/react-devtools-extensions/edge/manifest.json
+++ b/packages/react-devtools-extensions/edge/manifest.json
@@ -4,7 +4,7 @@
   "description": "Adds React debugging tools to the Microsoft Edge Developer Tools.",
   "version": "6.1.1",
   "version_name": "6.1.1",
-  "minimum_chrome_version": "102",
+  "minimum_chrome_version": "114",
   "icons": {
     "16": "icons/16-production.png",
     "32": "icons/32-production.png",

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -45,6 +45,12 @@ function drawNative(nodeToData: Map<HostInstance, Data>, agent: Agent) {
 function drawWeb(nodeToData: Map<HostInstance, Data>) {
   if (canvas === null) {
     initialize();
+  } else {
+    try {
+      if (canvas.hasAttribute('popover') && !canvas.matches(':popover-open')) {
+        canvas.showPopover();
+      }
+    } catch (e) {}
   }
 
   const dpr = window.devicePixelRatio || 1;
@@ -191,6 +197,12 @@ function destroyNative(agent: Agent) {
 
 function destroyWeb() {
   if (canvas !== null) {
+    try {
+      if (canvas.hasAttribute('popover')) {
+        canvas.hidePopover();
+      }
+    } catch (e) {}
+
     if (canvas.parentNode != null) {
       canvas.parentNode.removeChild(canvas);
     }
@@ -204,6 +216,7 @@ export function destroy(agent: Agent): void {
 
 function initialize(): void {
   canvas = window.document.createElement('canvas');
+  canvas.setAttribute('popover', 'auto');
   canvas.style.cssText = `
     xx-background-color: red;
     xx-opacity: 0.5;
@@ -214,8 +227,13 @@ function initialize(): void {
     right: 0;
     top: 0;
     z-index: 1000000000;
+    background-color: transparent;
   `;
 
   const root = window.document.documentElement;
   root.insertBefore(canvas, root.firstChild);
+
+  try {
+    canvas.showPopover();
+  } catch (e) {}
 }

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -68,12 +68,19 @@ function drawWeb(nodeToData: Map<HostInstance, Data>) {
 
   if (canvas !== null) {
     if (nodeToData.size === 0 && canvas.matches(':popover-open')) {
+      // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
+      // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
       canvas.hidePopover();
       return;
     }
+    // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
     if (canvas.matches(':popover-open')) {
+      // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
+      // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
       canvas.hidePopover();
     }
+    // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
+    // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
     canvas.showPopover();
   }
 }

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -58,13 +58,11 @@ function drawWeb(nodeToData: Map<HostInstance, Data>) {
   if (canvas === null) {
     initialize();
   } else {
-    try {
-      if (!canvas.matches(':popover-open')) {
-        // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
-        // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
-        canvas.showPopover();
-      }
-    } catch (e) {}
+    if (!canvas.matches(':popover-open')) {
+      // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
+      // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
+      canvas.showPopover();
+    }
   }
 
   const dpr = window.devicePixelRatio || 1;
@@ -211,11 +209,9 @@ function destroyNative(agent: Agent) {
 
 function destroyWeb() {
   if (canvas !== null) {
-    try {
-      // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
-      // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
-      canvas.hidePopover();
-    } catch (e) {}
+    // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
+    // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
+    canvas.hidePopover();
 
     // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API and loses canvas nullability tracking
     if (canvas.parentNode != null) {
@@ -253,9 +249,7 @@ function initialize(): void {
   const root = window.document.documentElement;
   root.insertBefore(canvas, root.firstChild);
 
-  try {
-    // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
-    // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
-    canvas.showPopover();
-  } catch (e) {}
+  // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
+  // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
+  canvas.showPopover();
 }

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -43,26 +43,8 @@ function drawNative(nodeToData: Map<HostInstance, Data>, agent: Agent) {
 }
 
 function drawWeb(nodeToData: Map<HostInstance, Data>) {
-  // if there are no nodes to draw, detach from top layer
-  if (nodeToData.size === 0) {
-    if (canvas !== null) {
-      if (canvas.matches(':popover-open')) {
-        // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
-        // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
-        canvas.hidePopover();
-      }
-    }
-    return;
-  }
-
   if (canvas === null) {
     initialize();
-  } else {
-    if (!canvas.matches(':popover-open')) {
-      // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
-      // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
-      canvas.showPopover();
-    }
   }
 
   const dpr = window.devicePixelRatio || 1;
@@ -83,6 +65,17 @@ function drawWeb(nodeToData: Map<HostInstance, Data>) {
     drawGroupBorders(context, group);
     drawGroupLabel(context, group);
   });
+
+  if (canvas !== null) {
+    if (nodeToData.size === 0 && canvas.matches(':popover-open')) {
+      canvas.hidePopover();
+      return;
+    }
+    if (canvas.matches(':popover-open')) {
+      canvas.hidePopover();
+    }
+    canvas.showPopover();
+  }
 }
 
 type GroupItem = {
@@ -209,9 +202,11 @@ function destroyNative(agent: Agent) {
 
 function destroyWeb() {
   if (canvas !== null) {
-    // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
-    // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
-    canvas.hidePopover();
+    if (canvas.matches(':popover-open')) {
+      // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
+      // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
+      canvas.hidePopover();
+    }
 
     // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API and loses canvas nullability tracking
     if (canvas.parentNode != null) {
@@ -248,8 +243,4 @@ function initialize(): void {
 
   const root = window.document.documentElement;
   root.insertBefore(canvas, root.firstChild);
-
-  // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
-  // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
-  canvas.showPopover();
 }

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -48,6 +48,8 @@ function drawWeb(nodeToData: Map<HostInstance, Data>) {
     if (canvas !== null) {
       try {
         if (canvas.matches(':popover-open')) {
+          // $FlowFixMe[prop-missing]
+          // $FlowFixMe[incompatible-use]
           canvas.hidePopover();
         }
       } catch (e) {}
@@ -60,6 +62,8 @@ function drawWeb(nodeToData: Map<HostInstance, Data>) {
   } else {
     try {
       if (!canvas.matches(':popover-open')) {
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-use]
         canvas.showPopover();
       }
     } catch (e) {}
@@ -209,9 +213,15 @@ function destroyNative(agent: Agent) {
 
 function destroyWeb() {
   if (canvas !== null) {
-    canvas.hidePopover();
+    try {
+      // $FlowFixMe[prop-missing]
+      // $FlowFixMe[incompatible-use]
+      canvas.hidePopover();
+    } catch (e) {}
 
+    // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API and loses canvas nullability tracking
     if (canvas.parentNode != null) {
+      // $FlowFixMe[incompatible-call]: Flow doesn't track that canvas is non-null here
       canvas.parentNode.removeChild(canvas);
     }
     canvas = null;
@@ -224,8 +234,9 @@ export function destroy(agent: Agent): void {
 
 function initialize(): void {
   canvas = window.document.createElement('canvas');
-  canvas.setAttribute('popover', 'manual');
+  // canvas.setAttribute('popover', 'manual');
 
+  // $FlowFixMe[incompatible-use]
   canvas.style.cssText = `
     xx-background-color: red;
     xx-opacity: 0.5;
@@ -236,15 +247,17 @@ function initialize(): void {
     right: 0;
     top: 0;
     background-color: transparent;
-    outline: none !important;
-    box-shadow: none !important;
-    border: none !important;
+    outline: none;
+    box-shadow: none;
+    border: none;
   `;
 
   const root = window.document.documentElement;
   root.insertBefore(canvas, root.firstChild);
 
   try {
+    // $FlowFixMe[prop-missing]
+    // $FlowFixMe[incompatible-use]
     canvas.showPopover();
   } catch (e) {}
 }

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -43,11 +43,23 @@ function drawNative(nodeToData: Map<HostInstance, Data>, agent: Agent) {
 }
 
 function drawWeb(nodeToData: Map<HostInstance, Data>) {
+  // if there are no nodes to draw, detach from top layer
+  if (nodeToData.size === 0) {
+    if (canvas !== null) {
+      try {
+        if (canvas.matches(':popover-open')) {
+          canvas.hidePopover();
+        }
+      } catch (e) {}
+    }
+    return;
+  }
+
   if (canvas === null) {
     initialize();
   } else {
     try {
-      if (canvas.hasAttribute('popover') && !canvas.matches(':popover-open')) {
+      if (!canvas.matches(':popover-open')) {
         canvas.showPopover();
       }
     } catch (e) {}
@@ -197,11 +209,7 @@ function destroyNative(agent: Agent) {
 
 function destroyWeb() {
   if (canvas !== null) {
-    try {
-      if (canvas.hasAttribute('popover')) {
-        canvas.hidePopover();
-      }
-    } catch (e) {}
+    canvas.hidePopover();
 
     if (canvas.parentNode != null) {
       canvas.parentNode.removeChild(canvas);
@@ -216,7 +224,8 @@ export function destroy(agent: Agent): void {
 
 function initialize(): void {
   canvas = window.document.createElement('canvas');
-  canvas.setAttribute('popover', 'auto');
+  canvas.setAttribute('popover', 'manual');
+
   canvas.style.cssText = `
     xx-background-color: red;
     xx-opacity: 0.5;
@@ -226,8 +235,10 @@ function initialize(): void {
     position: fixed;
     right: 0;
     top: 0;
-    z-index: 1000000000;
     background-color: transparent;
+    outline: none !important;
+    box-shadow: none !important;
+    border: none !important;
   `;
 
   const root = window.document.documentElement;

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -46,13 +46,11 @@ function drawWeb(nodeToData: Map<HostInstance, Data>) {
   // if there are no nodes to draw, detach from top layer
   if (nodeToData.size === 0) {
     if (canvas !== null) {
-      try {
-        if (canvas.matches(':popover-open')) {
-          // $FlowFixMe[prop-missing]
-          // $FlowFixMe[incompatible-use]
-          canvas.hidePopover();
-        }
-      } catch (e) {}
+      if (canvas.matches(':popover-open')) {
+        // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
+        // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
+        canvas.hidePopover();
+      }
     }
     return;
   }
@@ -62,8 +60,8 @@ function drawWeb(nodeToData: Map<HostInstance, Data>) {
   } else {
     try {
       if (!canvas.matches(':popover-open')) {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
+        // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
+        // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
         canvas.showPopover();
       }
     } catch (e) {}
@@ -214,8 +212,8 @@ function destroyNative(agent: Agent) {
 function destroyWeb() {
   if (canvas !== null) {
     try {
-      // $FlowFixMe[prop-missing]
-      // $FlowFixMe[incompatible-use]
+      // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
+      // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
       canvas.hidePopover();
     } catch (e) {}
 
@@ -234,9 +232,9 @@ export function destroy(agent: Agent): void {
 
 function initialize(): void {
   canvas = window.document.createElement('canvas');
-  // canvas.setAttribute('popover', 'manual');
+  canvas.setAttribute('popover', 'manual');
 
-  // $FlowFixMe[incompatible-use]
+  // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
   canvas.style.cssText = `
     xx-background-color: red;
     xx-opacity: 0.5;
@@ -256,8 +254,8 @@ function initialize(): void {
   root.insertBefore(canvas, root.firstChild);
 
   try {
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-use]
+    // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
+    // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
     canvas.showPopover();
   } catch (e) {}
 }

--- a/packages/react-devtools-shell/src/app/TraceUpdatesTest/index.js
+++ b/packages/react-devtools-shell/src/app/TraceUpdatesTest/index.js
@@ -57,7 +57,7 @@ function RegularComponent() {
   );
 }
 
-export default function TraceUpdatesTest() {
+export default function TraceUpdatesTest(): React.Node {
   return (
     <div>
       <h2>TraceUpdates Test</h2>

--- a/packages/react-devtools-shell/src/app/TraceUpdatesTest/index.js
+++ b/packages/react-devtools-shell/src/app/TraceUpdatesTest/index.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+import {useRef, useState} from 'react';
+
+const Counter = () => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+      <h3>Count: {count}</h3>
+      <button onClick={() => setCount(c => c + 1)}>Increment</button>
+    </div>
+  );
+};
+
+function DialogComponent() {
+  const dialogRef = useRef(null);
+
+  const openDialog = () => {
+    if (dialogRef.current) {
+      dialogRef.current.showModal();
+    }
+  };
+
+  const closeDialog = () => {
+    if (dialogRef.current) {
+      dialogRef.current.close();
+    }
+  };
+
+  return (
+    <div style={{margin: '10px 0'}}>
+      <button onClick={openDialog}>Open Dialog</button>
+      <dialog ref={dialogRef} style={{padding: '20px'}}>
+        <h3>Dialog Content</h3>
+        <Counter />
+        <button onClick={closeDialog}>Close</button>
+      </dialog>
+    </div>
+  );
+}
+
+function RegularComponent() {
+  return (
+    <div style={{margin: '10px 0'}}>
+      <h3>Regular Component</h3>
+      <Counter />
+    </div>
+  );
+}
+
+export default function TraceUpdatesTest() {
+  return (
+    <div>
+      <h2>TraceUpdates Test</h2>
+
+      <div style={{marginBottom: '20px'}}>
+        <h3>Standard Component</h3>
+        <RegularComponent />
+      </div>
+
+      <div style={{marginBottom: '20px'}}>
+        <h3>Dialog Component (top-layer element)</h3>
+        <DialogComponent />
+      </div>
+
+      <div
+        style={{marginTop: '20px', padding: '10px', border: '1px solid #ddd'}}>
+        <h3>How to Test:</h3>
+        <ol>
+          <li>Open DevTools Components panel</li>
+          <li>Enable "Highlight updates when components render" in settings</li>
+          <li>Click increment buttons and observe highlights</li>
+          <li>Open the dialog and test increments there as well</li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/packages/react-devtools-shell/src/app/index.js
+++ b/packages/react-devtools-shell/src/app/index.js
@@ -19,6 +19,7 @@ import Toggle from './Toggle';
 import ErrorBoundaries from './ErrorBoundaries';
 import PartiallyStrictApp from './PartiallyStrictApp';
 import SuspenseTree from './SuspenseTree';
+import TraceUpdatesTest from './TraceUpdatesTest';
 import {ignoreErrors, ignoreLogs, ignoreWarnings} from './console';
 
 import './styles.css';
@@ -112,6 +113,7 @@ function mountTestApp() {
   mountApp(SuspenseTree);
   mountApp(DeeplyNestedComponents);
   mountApp(Iframe);
+  mountApp(TraceUpdatesTest);
 
   if (shouldRenderLegacy) {
     mountLegacyApp(PartiallyStrictApp);


### PR DESCRIPTION
## Summary

When using React DevTools to highlight component updates, the highlights would sometimes appear behind elements that use the browser's [top-layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer) (such as `<dialog>` elements or components using the Popover API). This made it difficult to see which components were updating when they were inside or behind top-layer elements.

  This PR fixes the issue by using the Popover API to ensure that highlighting appears on top of all content, including elements in the top-layer. The implementation maintains backward compatibility with browsers that don't support the Popover API.

## How did you test this change?

I tested this change in the following ways:

1. Manually tested in Chrome (which supports the Popover API) with:
   - Created a test application with React components inside `<dialog>` elements and custom elements using the Popover API
   - Verified that component highlighting appears above these elements when they update
   - Confirmed that highlighting displays correctly for nested components within top-layer elements

2. Verified backward compatibility:
   - Tested in browsers without Popover API support to ensure fallback behavior works correctly
   - Confirmed that no errors occur and highlighting still functions as before

3. Ran the React DevTools test suite:
   - All tests pass successfully
   - No regressions were introduced

[demo-page](https://devtools-toplayer-demo.vercel.app/)
[demo-repo](https://github.com/yongsk0066/devtools-toplayer-demo)

### AS-IS
https://github.com/user-attachments/assets/dc2e1281-969f-4f61-82c3-480153916969

### TO-BE
https://github.com/user-attachments/assets/dd52ce35-816c-42f0-819b-0d5d0a8a21e5