### PR TITLE
Add observer methods to fragment instances

### DIFF
--- a/fixtures/dom/src/components/fixtures/fragment-refs/EventListenerCase.js
+++ b/fixtures/dom/src/components/fixtures/fragment-refs/EventListenerCase.js
@@ -1,0 +1,96 @@
+import TestCase from '../../TestCase';
+import Fixture from '../../Fixture';
+
+const React = window.React;
+const {Fragment, useEffect, useRef, useState} = React;
+
+function WrapperComponent(props) {
+  return props.children;
+}
+
+function handler(e) {
+  const text = e.currentTarget.innerText;
+  alert('You clicked: ' + text);
+}
+
+export default function EventListenerCase() {
+  const fragmentRef = useRef(null);
+  const [extraChildCount, setExtraChildCount] = useState(0);
+
+  useEffect(() => {
+    fragmentRef.current.addEventListener('click', handler);
+
+    const lastFragmentRefValue = fragmentRef.current;
+    return () => {
+      lastFragmentRefValue.removeEventListener('click', handler);
+    };
+  });
+
+  return (
+    <TestCase title="Event Registration">
+      <TestCase.Steps>
+        <li>Click one of the children, observe the alert</li>
+        <li>Add a new child, click it, observe the alert</li>
+        <li>Remove the event listeners, click a child, observe no alert</li>
+        <li>Add the event listeners back, click a child, observe the alert</li>
+      </TestCase.Steps>
+
+      <TestCase.ExpectedResult>
+        <p>
+          Fragment refs can manage event listeners on the first level of host
+          children. This page loads with an effect that sets up click event
+          hanndlers on each child card. Clicking on a card will show an alert
+          with the card's text.
+        </p>
+        <p>
+          New child nodes will also have event listeners applied. Removed nodes
+          will have their listeners cleaned up.
+        </p>
+      </TestCase.ExpectedResult>
+
+      <Fixture>
+        <div className="control-box">
+          <div>Target count: {extraChildCount + 3}</div>
+          <button
+            onClick={() => {
+              setExtraChildCount(prev => prev + 1);
+            }}>
+            Add Child
+          </button>
+          <button
+            onClick={() => {
+              fragmentRef.current.addEventListener('click', handler);
+            }}>
+            Add click event listeners
+          </button>
+          <button
+            onClick={() => {
+              fragmentRef.current.removeEventListener('click', handler);
+            }}>
+            Remove click event listeners
+          </button>
+          <div class="card-container">
+            <Fragment ref={fragmentRef}>
+              <div className="card" id="child-a">
+                Child A
+              </div>
+              <div className="card" id="child-b">
+                Child B
+              </div>
+              <WrapperComponent>
+                <div className="card" id="child-c">
+                  Child C
+                </div>
+                {Array.from({length: extraChildCount}).map((_, index) => (
+                  <div className="card" id={'extra-child-' + index} key={index}>
+                    Extra Child {index}
+                  </div>
+                ))}
+              </WrapperComponent>
+            </Fragment>
+          </div>
+        </div>
+      </Fixture>
+    </TestCase>
+  );
+}

--- a/fixtures/dom/src/components/fixtures/fragment-refs/IntersectionObserverCase.js
+++ b/fixtures/dom/src/components/fixtures/fragment-refs/IntersectionObserverCase.js
@@ -54,6 +54,7 @@ export default function IntersectionObserverCase() {
     const lastFragmentRefValue = fragmentRef.current;
     return () => {
       lastFragmentRefValue.unobserveUsing(observerRef.current);
+      observerRef.current = null;
     };
   }, []);
 

--- a/fixtures/dom/src/components/fixtures/fragment-refs/IntersectionObserverCase.js
+++ b/fixtures/dom/src/components/fixtures/fragment-refs/IntersectionObserverCase.js
@@ -1,0 +1,152 @@
+import TestCase from '../../TestCase';
+import Fixture from '../../Fixture';
+
+const React = window.React;
+const {Fragment, useEffect, useRef, useState} = React;
+
+function WrapperComponent(props) {
+  return props.children;
+}
+
+function ObservedChild({id}) {
+  return (
+    <div id={id} className="observable-card">
+      {id}
+    </div>
+  );
+}
+
+const initialItems = [
+  ['A', false],
+  ['B', false],
+  ['C', false],
+];
+
+export default function IntersectionObserverCase() {
+  const fragmentRef = useRef(null);
+  const [items, setItems] = useState(initialItems);
+  const addedItems = items.slice(3);
+  const anyOnScreen = items.some(([, onScreen]) => onScreen);
+  const observerRef = useRef(null);
+
+  useEffect(() => {
+    if (observerRef.current === null) {
+      observerRef.current = new IntersectionObserver(
+        entries => {
+          setItems(prev => {
+            const newItems = [...prev];
+            entries.forEach(entry => {
+              const index = newItems.findIndex(
+                ([id]) => id === entry.target.id
+              );
+              newItems[index] = [entry.target.id, entry.isIntersecting];
+            });
+            return newItems;
+          });
+        },
+        {
+          threshold: [0.5],
+        }
+      );
+    }
+    fragmentRef.current.observeUsing(observerRef.current);
+
+    const lastFragmentRefValue = fragmentRef.current;
+    return () => {
+      lastFragmentRefValue.unobserveUsing(observerRef.current);
+    };
+  }, []);
+
+  return (
+    <TestCase title="Intersection Observer">
+      <TestCase.Steps>
+        <li>
+          Scroll the children into view, observe the sidebar appears and shows
+          which children are in the viewport
+        </li>
+        <li>
+          Add a new child and observe that the Intersection Observer is applied
+        </li>
+        <li>
+          Click Unobserve and observe that the state of children in the viewport
+          is no longer updated
+        </li>
+        <li>
+          Click Observe and observe that the state of children in the viewport
+          is updated again
+        </li>
+      </TestCase.Steps>
+
+      <TestCase.ExpectedResult>
+        <p>
+          Fragment refs manage Intersection Observers on the first level of host
+          children. This page loads with an effect that sets up an Inersection
+          Observer applied to each child card.
+        </p>
+        <p>
+          New child nodes will also have the observer applied. Removed nodes
+          will be unobserved.
+        </p>
+      </TestCase.ExpectedResult>
+      <Fixture>
+        <button
+          onClick={() => {
+            setItems(prev => [
+              ...prev,
+              [`Extra child: ${prev.length + 1}`, false],
+            ]);
+          }}>
+          Add Child
+        </button>
+        <button
+          onClick={() => {
+            setItems(prev => {
+              if (prev.length === 3) {
+                return prev;
+              }
+              return prev.slice(0, prev.length - 1);
+            });
+          }}>
+          Remove Child
+        </button>
+        <button
+          onClick={() => {
+            fragmentRef.current.observeUsing(observerRef.current);
+          }}>
+          Observe
+        </button>
+        <button
+          onClick={() => {
+            fragmentRef.current.unobserveUsing(observerRef.current);
+            setItems(prev => {
+              return prev.map(item => [item[0], false]);
+            });
+          }}>
+          Unobserve
+        </button>
+        {anyOnScreen && (
+          <div className="fixed-sidebar card-container">
+            <p>
+              <strong>Children on screen:</strong>
+            </p>
+            {items.map(item => (
+              <div className={`card ${item[1] ? 'onscreen' : null}`}>
+                {item[0]}
+              </div>
+            ))}
+          </div>
+        )}
+        <Fragment ref={fragmentRef}>
+          <ObservedChild id="A" />
+          <WrapperComponent>
+            <ObservedChild id="B" />
+          </WrapperComponent>
+          <ObservedChild id="C" />
+          {addedItems.map((_, index) => (
+            <ObservedChild id={`Extra child: ${index + 4}`} />
+          ))}
+        </Fragment>
+      </Fixture>
+    </TestCase>
+  );
+}

--- a/fixtures/dom/src/components/fixtures/fragment-refs/ResizeObserverCase.js
+++ b/fixtures/dom/src/components/fixtures/fragment-refs/ResizeObserverCase.js
@@ -1,0 +1,63 @@
+import TestCase from '../../TestCase';
+import Fixture from '../../Fixture';
+
+const React = window.React;
+const {Fragment, useEffect, useRef, useState} = React;
+
+export default function ResizeObserverCase() {
+  const fragmentRef = useRef(null);
+  const [width, setWidth] = useState([0, 0, 0]);
+
+  useEffect(() => {
+    const resizeObserver = new window.ResizeObserver(entries => {
+      if (entries.length > 0) {
+        setWidth(prev => {
+          const newWidth = [...prev];
+          entries.forEach(entry => {
+            const index = parseInt(entry.target.id, 10);
+            newWidth[index] = Math.round(entry.contentRect.width);
+          });
+          return newWidth;
+        });
+      }
+    });
+
+    fragmentRef.current.observeUsing(resizeObserver);
+    const lastFragmentRefValue = fragmentRef.current;
+    return () => {
+      lastFragmentRefValue.unobserveUsing(resizeObserver);
+    };
+  }, []);
+
+  return (
+    <TestCase title="Resize Observer">
+      <TestCase.Steps>
+        <li>Resize the viewport width until the children respond</li>
+        <li>See that the width data updates as they elements resize</li>
+      </TestCase.Steps>
+      <TestCase.ExpectedResult>
+        The Fragment Ref has a ResizeObserver attached which has a callback to
+        update the width state of each child node.
+      </TestCase.ExpectedResult>
+      <Fixture>
+        <Fragment ref={fragmentRef}>
+          <div className="card" id="0" style={{width: '100%'}}>
+            <p>
+              Width: <b>{width[0]}px</b>
+            </p>
+          </div>
+          <div className="card" id="1" style={{width: '80%'}}>
+            <p>
+              Width: <b>{width[1]}px</b>
+            </p>
+          </div>
+          <div className="card" id="2" style={{width: '50%'}}>
+            <p>
+              Width: <b>{width[2]}px</b>
+            </p>
+          </div>
+        </Fragment>
+      </Fixture>
+    </TestCase>
+  );
+}

--- a/fixtures/dom/src/components/fixtures/fragment-refs/index.js
+++ b/fixtures/dom/src/components/fixtures/fragment-refs/index.js
@@ -1,104 +1,16 @@
-import Fixture from '../../Fixture';
 import FixtureSet from '../../FixtureSet';
-import TestCase from '../../TestCase';
+import EventListenerCase from './EventListenerCase';
+import IntersectionObserverCase from './IntersectionObserverCase';
+import ResizeObserverCase from './ResizeObserverCase';
 
 const React = window.React;
-const {Fragment, useEffect, useRef, useState} = React;
-
-function WrapperComponent(props) {
-  return props.children;
-}
-
-function handler(e) {
-  const text = e.currentTarget.innerText;
-  alert('You clicked: ' + text);
-}
 
 export default function FragmentRefsPage() {
-  const fragmentRef = useRef(null);
-  const [extraChildCount, setExtraChildCount] = useState(0);
-
-  React.useEffect(() => {
-    fragmentRef.current.addEventListener('click', handler);
-
-    const lastFragmentRefValue = fragmentRef.current;
-    return () => {
-      lastFragmentRefValue.removeEventListener('click', handler);
-    };
-  });
-
   return (
     <FixtureSet title="Fragment Refs">
-      <TestCase title="Event registration">
-        <TestCase.Steps>
-          <li>Click one of the children, observe the alert</li>
-          <li>Add a new child, click it, observe the alert</li>
-          <li>Remove the event listeners, click a child, observe no alert</li>
-          <li>
-            Add the event listeners back, click a child, observe the alert
-          </li>
-        </TestCase.Steps>
-
-        <TestCase.ExpectedResult>
-          <p>
-            Fragment refs can manage event listeners on the first level of host
-            children. This page loads with an effect that sets up click event
-            hanndlers on each child card. Clicking on a card will show an alert
-            with the card's text.
-          </p>
-          <p>
-            New child nodes will also have event listeners applied. Removed
-            nodes will have their listeners cleaned up.
-          </p>
-        </TestCase.ExpectedResult>
-
-        <Fixture>
-          <div className="control-box" id="control-box">
-            <div>Target count: {extraChildCount + 3}</div>
-            <button
-              onClick={() => {
-                setExtraChildCount(prev => prev + 1);
-              }}>
-              Add Child
-            </button>
-            <button
-              onClick={() => {
-                fragmentRef.current.addEventListener('click', handler);
-              }}>
-              Add click event listeners
-            </button>
-            <button
-              onClick={() => {
-                fragmentRef.current.removeEventListener('click', handler);
-              }}>
-              Remove click event listeners
-            </button>
-            <div class="card-container">
-              <Fragment ref={fragmentRef}>
-                <div className="card" id="child-a">
-                  Child A
-                </div>
-                <div className="card" id="child-b">
-                  Child B
-                </div>
-                <WrapperComponent>
-                  <div className="card" id="child-c">
-                    Child C
-                  </div>
-                  {Array.from({length: extraChildCount}).map((_, index) => (
-                    <div
-                      className="card"
-                      id={'extra-child-' + index}
-                      key={index}>
-                      Extra Child {index}
-                    </div>
-                  ))}
-                </WrapperComponent>
-              </Fragment>
-            </div>
-          </div>
-        </Fixture>
-      </TestCase>
+      <EventListenerCase />
+      <IntersectionObserverCase />
+      <ResizeObserverCase />
     </FixtureSet>
   );
 }

--- a/fixtures/dom/src/style.css
+++ b/fixtures/dom/src/style.css
@@ -322,3 +322,39 @@ tbody tr:nth-child(even) {
   margin: 10px;
   padding: 10px;
 }
+
+.observable-card {
+  height: 200px;
+  border: 1px solid black;
+  background: #e0e0e0;
+  padding: 20px;
+  font-size: 18px;
+  overflow: auto;
+  margin-bottom: 50px;
+  position: relative;
+}
+
+.observable-card::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  border-top: 1px dotted red;
+}
+
+.fixed-sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 200px;
+  z-index: 1000;
+  background-color: gray;
+  display: flex;
+  flex-direction: column;
+}
+
+.onscreen {
+  background-color: green;
+}

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2297,12 +2297,7 @@ FragmentInstance.prototype.observeUsing = function (
     this._observers = new Set();
   }
   this._observers.add(observer);
-  traverseFragmentInstanceChildren(
-    this,
-    this._fragmentFiber.child,
-    observeChild,
-    observer,
-  );
+  traverseFragmentInstance(this._fragmentFiber, observeChild, observer);
 };
 function observeChild(
   child: Instance,
@@ -2325,12 +2320,7 @@ FragmentInstance.prototype.unobserveUsing = function (
     }
   } else {
     this._observers.delete(observer);
-    traverseFragmentInstanceChildren(
-      this,
-      this._fragmentFiber.child,
-      unobserveChild,
-      observer,
-    );
+    traverseFragmentInstance(this._fragmentFiber, unobserveChild, observer);
   }
 };
 function unobserveChild(

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2186,6 +2186,7 @@ type StoredEventListener = {
 export type FragmentInstanceType = {
   _fragmentFiber: Fiber,
   _eventListeners: null | Array<StoredEventListener>,
+  _observer: null | IntersectionObserver | ResizeObserver,
   addEventListener(
     type: string,
     listener: EventListener,
@@ -2197,11 +2198,14 @@ export type FragmentInstanceType = {
     optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
   ): void,
   focus(): void,
+  observeUsing(observer: IntersectionObserver | ResizeObserver): void,
+  unobserveUsing(observer: IntersectionObserver | ResizeObserver): void,
 };
 
 function FragmentInstance(this: FragmentInstanceType, fragmentFiber: Fiber) {
   this._fragmentFiber = fragmentFiber;
   this._eventListeners = null;
+  this._observer = null;
 }
 // $FlowFixMe[prop-missing]
 FragmentInstance.prototype.addEventListener = function (
@@ -2284,6 +2288,62 @@ function removeEventListenerFromChild(
 FragmentInstance.prototype.focus = function (this: FragmentInstanceType) {
   traverseFragmentInstance(this._fragmentFiber, setFocusIfFocusable);
 };
+// $FlowFixMe[prop-missing]
+FragmentInstance.prototype.observeUsing = function (
+  this: FragmentInstanceType,
+  observer: IntersectionObserver | ResizeObserver,
+): void {
+  if (this._observer !== null && this._observer !== observer) {
+    throw new Error(
+      'You are attaching an observer to a fragment instance that already has one. Fragment instances ' +
+        'can only have one observer. Use multiple fragment instances or first call unobserveUsing() to ' +
+        'remove the previous observer.',
+    );
+  }
+  this._observer = observer;
+  traverseFragmentInstanceChildren(
+    this,
+    this._fragmentFiber.child,
+    observeChild,
+    observer,
+  );
+};
+function observeChild(
+  child: Instance,
+  observer: IntersectionObserver | ResizeObserver,
+) {
+  observer.observe(child);
+  return false;
+}
+// $FlowFixMe[prop-missing]
+FragmentInstance.prototype.unobserveUsing = function (
+  this: FragmentInstanceType,
+  observer: IntersectionObserver | ResizeObserver,
+): void {
+  if (this._observer === null || this._observer !== observer) {
+    if (__DEV__) {
+      console.error(
+        'You are calling unobserveUsing() with an observer that is not being observed with this fragment ' +
+          'instance. First attach the observer with observeUsing()',
+      );
+    }
+  } else {
+    traverseFragmentInstanceChildren(
+      this,
+      this._fragmentFiber.child,
+      unobserveChild,
+      observer,
+    );
+    this._observer = null;
+  }
+};
+function unobserveChild(
+  child: Instance,
+  observer: IntersectionObserver | ResizeObserver,
+) {
+  observer.unobserve(child);
+  return false;
+}
 
 function normalizeListenerOptions(
   opts: ?EventListenerOptionsOrUseCapture,
@@ -2342,6 +2402,9 @@ export function commitNewChildToFragmentInstance(
       const {type, listener, optionsOrUseCapture} = eventListeners[i];
       childElement.addEventListener(type, listener, optionsOrUseCapture);
     }
+  }
+  if (fragmentInstance._observer !== null) {
+    fragmentInstance._observer.observe(childElement);
   }
 }
 

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -15,6 +15,9 @@ let act;
 let container;
 let Fragment;
 let Activity;
+let mockIntersectionObserver;
+let simulateIntersection;
+let assertConsoleErrorDev;
 
 describe('FragmentRefs', () => {
   beforeEach(() => {
@@ -24,6 +27,12 @@ describe('FragmentRefs', () => {
     Activity = React.unstable_Activity;
     ReactDOMClient = require('react-dom/client');
     act = require('internal-test-utils').act;
+    const IntersectionMocks = require('./utils/IntersectionMocks');
+    mockIntersectionObserver = IntersectionMocks.mockIntersectionObserver;
+    simulateIntersection = IntersectionMocks.simulateIntersection;
+    assertConsoleErrorDev =
+      require('internal-test-utils').assertConsoleErrorDev;
+
     container = document.createElement('div');
     document.body.appendChild(container);
   });
@@ -615,6 +624,139 @@ describe('FragmentRefs', () => {
         // Event order is flipped here because the nested child re-registers first
         expect(logs).toEqual(['clicked 2', 'clicked 1']);
       });
+    });
+  });
+
+  describe('observers', () => {
+    beforeEach(() => {
+      mockIntersectionObserver();
+    });
+
+    // @gate enableFragmentRefs
+    it('attaches intersection observers to children', async () => {
+      let logs = [];
+      const observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+          logs.push(entry.target.id);
+        });
+      });
+      function Test({showB}) {
+        const fragmentRef = React.useRef(null);
+        React.useEffect(() => {
+          fragmentRef.current.observeUsing(observer);
+          const lastRefValue = fragmentRef.current;
+          return () => {
+            lastRefValue.unobserveUsing(observer);
+          };
+        }, []);
+        return (
+          <div id="parent">
+            <React.Fragment ref={fragmentRef}>
+              <div id="childA">A</div>
+              {showB && <div id="childB">B</div>}
+            </React.Fragment>
+          </div>
+        );
+      }
+
+      function simulateAllChildrenIntersecting() {
+        const parent = container.firstChild;
+        if (parent) {
+          const children = Array.from(parent.children).map(child => {
+            return [child, {y: 0, x: 0, width: 1, height: 1}, 1];
+          });
+          simulateIntersection(...children);
+        }
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => root.render(<Test showB={false} />));
+      simulateAllChildrenIntersecting();
+      expect(logs).toEqual(['childA']);
+
+      // Reveal child and expect it to be observed
+      logs = [];
+      await act(() => root.render(<Test showB={true} />));
+      simulateAllChildrenIntersecting();
+      expect(logs).toEqual(['childA', 'childB']);
+
+      // Hide child and expect it to be unobserved
+      logs = [];
+      await act(() => root.render(<Test showB={false} />));
+      simulateAllChildrenIntersecting();
+      expect(logs).toEqual(['childA']);
+
+      // Unmount component and expect all children to be unobserved
+      logs = [];
+      await act(() => root.render(null));
+      simulateAllChildrenIntersecting();
+      expect(logs).toEqual([]);
+    });
+
+    // @gate enableFragmentRefs
+    it('errors when observeUsing() is called with multiple observers', async () => {
+      const fragmentRef = React.createRef();
+      const observer = new IntersectionObserver(() => {});
+      const observer2 = new IntersectionObserver(() => {});
+      function Test() {
+        return (
+          <React.Fragment ref={fragmentRef}>
+            <div />
+          </React.Fragment>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => root.render(<Test />));
+      fragmentRef.current.observeUsing(observer);
+      // Same observer doesn't throw
+      fragmentRef.current.observeUsing(observer);
+      // Different observer throws
+      expect(() => {
+        fragmentRef.current.observeUsing(observer2);
+      }).toThrowError(
+        'You are attaching an observer to a fragment instance that already has one. Fragment instances ' +
+          'can only have one observer. Use multiple fragment instances or first call unobserveUsing() to ' +
+          'remove the previous observer.',
+      );
+    });
+
+    // @gate enableFragmentRefs
+    it('warns when unobserveUsing() is called with an observer that was not observed', async () => {
+      const fragmentRef = React.createRef();
+      const observer = new IntersectionObserver(() => {});
+      const observer2 = new IntersectionObserver(() => {});
+      function Test() {
+        return (
+          <React.Fragment ref={fragmentRef}>
+            <div />
+          </React.Fragment>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => root.render(<Test />));
+
+      // Warning when there is no attached observer
+      fragmentRef.current.unobserveUsing(observer);
+      assertConsoleErrorDev(
+        [
+          'You are calling unobserveUsing() with an observer that is not being observed with this fragment ' +
+            'instance. First attach the observer with observeUsing()',
+        ],
+        {withoutStack: true},
+      );
+
+      // Warning when the attached observer does not match
+      fragmentRef.current.observeUsing(observer);
+      fragmentRef.current.unobserveUsing(observer2);
+      assertConsoleErrorDev(
+        [
+          'You are calling unobserveUsing() with an observer that is not being observed with this fragment ' +
+            'instance. First attach the observer with observeUsing()',
+        ],
+        {withoutStack: true},
+      );
     });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -694,34 +694,6 @@ describe('FragmentRefs', () => {
     });
 
     // @gate enableFragmentRefs
-    it('errors when observeUsing() is called with multiple observers', async () => {
-      const fragmentRef = React.createRef();
-      const observer = new IntersectionObserver(() => {});
-      const observer2 = new IntersectionObserver(() => {});
-      function Test() {
-        return (
-          <React.Fragment ref={fragmentRef}>
-            <div />
-          </React.Fragment>
-        );
-      }
-
-      const root = ReactDOMClient.createRoot(container);
-      await act(() => root.render(<Test />));
-      fragmentRef.current.observeUsing(observer);
-      // Same observer doesn't throw
-      fragmentRef.current.observeUsing(observer);
-      // Different observer throws
-      expect(() => {
-        fragmentRef.current.observeUsing(observer2);
-      }).toThrowError(
-        'You are attaching an observer to a fragment instance that already has one. Fragment instances ' +
-          'can only have one observer. Use multiple fragment instances or first call unobserveUsing() to ' +
-          'remove the previous observer.',
-      );
-    });
-
-    // @gate enableFragmentRefs
     it('warns when unobserveUsing() is called with an observer that was not observed', async () => {
       const fragmentRef = React.createRef();
       const observer = new IntersectionObserver(() => {});

--- a/packages/react-dom/src/__tests__/utils/IntersectionMocks.js
+++ b/packages/react-dom/src/__tests__/utils/IntersectionMocks.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+const intersectionObserverMock = {callback: null, observedTargets: []};
+
+/**
+ * This is a broken polyfill.
+ * It is only intended to provide bare minimum test coverage.
+ * More meaningful tests will require the use of fixtures.
+ */
+export function mockIntersectionObserver() {
+  intersectionObserverMock.callback = null;
+  intersectionObserverMock.observedTargets = [];
+
+  class IntersectionObserver {
+    constructor() {
+      intersectionObserverMock.callback = arguments[0];
+    }
+
+    disconnect() {
+      intersectionObserverMock.callback = null;
+      intersectionObserverMock.observedTargets.splice(0);
+    }
+
+    observe(target) {
+      intersectionObserverMock.observedTargets.push(target);
+    }
+
+    unobserve(target) {
+      const index = intersectionObserverMock.observedTargets.indexOf(target);
+      if (index >= 0) {
+        intersectionObserverMock.observedTargets.splice(index, 1);
+      }
+    }
+  }
+
+  window.IntersectionObserver = IntersectionObserver;
+
+  return intersectionObserverMock;
+}
+
+export function simulateIntersection(...entries) {
+  intersectionObserverMock.callback(
+    entries.map(([target, rect, ratio]) => ({
+      boundingClientRect: {
+        top: rect.y,
+        left: rect.x,
+        width: rect.width,
+        height: rect.height,
+      },
+      intersectionRatio: ratio,
+      target,
+    })),
+  );
+}
+
+/**
+ * Stub out getBoundingClientRect for the specified target.
+ * This API is required by the test selectors but it isn't implemented by jsdom.
+ */
+export function setBoundingClientRect(target, {x, y, width, height}) {
+  target.getBoundingClientRect = function () {
+    return {
+      width,
+      height,
+      left: x,
+      right: x + width,
+      top: y,
+      bottom: y + height,
+    };
+  };
+}

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -537,6 +537,5 @@
   "549": "Cannot start a gesture with a disconnected AnimationTimeline.",
   "550": "useSwipeTransition is not yet supported in react-art.",
   "551": "useSwipeTransition is not yet supported in React Native.",
-  "552": "Cannot use a useSwipeTransition() in a detached root.",
-  "553": "You are attaching an observer to a fragment instance that already has one. Fragment instances can only have one observer. Use multiple fragment instances or first call unobserveUsing() to remove the previous observer."
+  "552": "Cannot use a useSwipeTransition() in a detached root."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -537,5 +537,6 @@
   "549": "Cannot start a gesture with a disconnected AnimationTimeline.",
   "550": "useSwipeTransition is not yet supported in react-art.",
   "551": "useSwipeTransition is not yet supported in React Native.",
-  "552": "Cannot use a useSwipeTransition() in a detached root."
+  "552": "Cannot use a useSwipeTransition() in a detached root.",
+  "553": "You are attaching an observer to a fragment instance that already has one. Fragment instances can only have one observer. Use multiple fragment instances or first call unobserveUsing() to remove the previous observer."
 }


### PR DESCRIPTION
This implements `observeUsing(observer)` and `unobserverUsing(observer)` on fragment instances. IntersectionObservers and ResizeObservers can be passed to observe each host child of the fragment. This is the equivalent to calling `observer.observe(child)` or `observer.unobserve(child)` for each child target.

Just like the addEventListener, the observer is held on the fragment instance and applied to any newly mounted child. So you can do things like wrap a paginated list in a fragment and have each child automatically observed as they commit in.

Unlike, the event listeners though, we don't `unobserve` when a child is removed. If a removed child is currently intersecting, the observer callback will be called when it is removed with an empty rect. This lets you track all the currently intersecting elements by setting state from the observer callback and either adding or removing them from your list depending on the intersecting state. If you want to track the removal of items offscreen, you'd have to maintain that state separately and append intersecting data to it in the observer callback. This is what the fixture example does.

There could be more convenient ways of managing the state of multiple child intersections, but basic examples are able to be modeled with the simple implementation. Let's see how the usage goes as we integrate this with more advanced loggers and other features.

For now you can only attach one observer to an instance. This could change based on usage but the fragments are composable and could be stacked as one way to apply multiple observers to the same elements.

In practice, one pattern we expect to enable is more composable logging such as

```javascript
function Feed({ items }) {
  return (
    <ImpressionLogger>
      {items.map((item) => (
        <FeedItem />
      ))}
    </ImpressionLogger>
  );
}
```

where `ImpressionLogger` would set up the IntersectionObserver using a fragment ref with the required business logic and various components could layer it wherever the logging is needed. Currently most callsites use a hook form, which can require wiring up refs through the tree and merging refs for multiple loggers.