### PR TITLE
Partially revert #32588

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,8 +4,7 @@ module.exports = {
   plugins: [
     '@babel/plugin-syntax-jsx',
     '@babel/plugin-transform-flow-strip-types',
-    ['@babel/plugin-transform-class-properties', {loose: true}],
-    '@babel/plugin-transform-classes',
+    ['@babel/plugin-proposal-class-properties', {loose: true}],
     'syntax-trailing-function-commas',
     [
       '@babel/plugin-proposal-object-rest-spread',

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@babel/plugin-transform-block-scoped-functions": "^7.10.4",
     "@babel/plugin-transform-block-scoping": "^7.11.1",
     "@babel/plugin-transform-class-properties": "^7.25.9",
-    "@babel/plugin-transform-classes": "^7.25.9",
+    "@babel/plugin-transform-classes": "^7.10.4",
     "@babel/plugin-transform-computed-properties": "^7.10.4",
     "@babel/plugin-transform-destructuring": "^7.10.4",
     "@babel/plugin-transform-for-of": "^7.10.4",


### PR DESCRIPTION
https://github.com/facebook/react/pull/32588 changed the babel config impacting local tests, and I'm not able to run test:

<img width="1354" alt="Screenshot 2025-03-15 at 2 37 00 PM" src="https://github.com/user-attachments/assets/2d4afe39-6ab6-4c83-87a9-ceb0ee5f8df5" />


This PR reverts those changes until we can re-land with a fix.