### PR TITLE
[devtools] add filters for internal builds

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Settings/ComponentsSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/ComponentsSettings.js
@@ -42,6 +42,8 @@ import {
   ElementTypeOtherOrUnknown,
   ElementTypeProfiler,
   ElementTypeSuspense,
+  ElementTypeActivity,
+  ElementTypeViewTransition,
 } from 'react-devtools-shared/src/frontend/types';
 import {getDefaultOpenInEditorURL} from 'react-devtools-shared/src/utils';
 
@@ -56,6 +58,7 @@ import type {
   RegExpComponentFilter,
   EnvironmentNameComponentFilter,
 } from 'react-devtools-shared/src/frontend/types';
+import {isInternalFacebookBuild} from 'react-devtools-feature-flags';
 
 const vscodeFilepath = 'vscode://file/{path}:{line}';
 
@@ -472,8 +475,9 @@ export default function ComponentsSettings({
                         ((parseInt(currentTarget.value, 10): any): ElementType),
                       )
                     }>
-                    {/* TODO: currently only experimental, only list this if it's available */}
-                    {/*<option value={ElementTypeActivity}>activity</option>*/}
+                    {isInternalFacebookBuild && (
+                      <option value={ElementTypeActivity}>activity</option>
+                    )}
                     <option value={ElementTypeClass}>class</option>
                     <option value={ElementTypeContext}>context</option>
                     <option value={ElementTypeFunction}>function</option>
@@ -487,10 +491,11 @@ export default function ComponentsSettings({
                     <option value={ElementTypeOtherOrUnknown}>other</option>
                     <option value={ElementTypeProfiler}>profiler</option>
                     <option value={ElementTypeSuspense}>suspense</option>
-                    {/* TODO: currently only experimental, only list this if it's available */}
-                    {/*<option value={ElementTypeViewTransition}>*/}
-                    {/*  view transition*/}
-                    {/*</option>*/}
+                    {isInternalFacebookBuild && (
+                      <option value={ElementTypeViewTransition}>
+                        view transition
+                      </option>
+                    )}
                   </select>
                 )}
                 {(componentFilter.type === ComponentFilterLocation ||


### PR DESCRIPTION
We don't have an experimental-only build of devtools, but we can at least add these filters to the internal build.

A better way would be to use feature detection, but I'm not sure how and this isn't a very heavily used feautre.