### PR TITLE
Fix COMMIT_SHA when generating PR artifacts

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -330,7 +330,7 @@ jobs:
           merge-multiple: true
       - name: Display structure of build
         run: ls -R build
-      - run: echo ${{ github.sha }} >> build/COMMIT_SHA
+      - run: echo ${{ github.event.pull_request.head.sha || github.sha }} >> build/COMMIT_SHA
       - name: Scrape warning messages
         run: |
           mkdir -p ./build/__test_utils__
@@ -664,7 +664,7 @@ jobs:
           node ./scripts/print-warnings/print-warnings.js > build/__test_utils__/ReactAllWarnings.js
       - name: Display structure of build for PR
         run: ls -R build
-      - run: echo ${{ github.sha }} >> build/COMMIT_SHA
+      - run: echo ${{ github.event.pull_request.head.sha || github.sha }} >> build/COMMIT_SHA
       - run: node ./scripts/tasks/danger
       - name: Archive sizebot results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Follow-up to #31850. We want to build using the original commit SHA, not the merge commit that GitHub Actions creates behind the scenes. We were already checking out the correct commit object, but the COMMIT_SHA artifact was still pointing to the merge commit.

This should fix the sizebot links to point to working URLs, too.