### PR TITLE
[ci] Pin Discord webhook action to specific commit sha

### DIFF
--- a/.github/workflows/compiler_discord_notify.yml
+++ b/.github/workflows/compiler_discord_notify.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Discord Webhook Action
-        uses: tsickert/discord-webhook@v6.0.0
+        uses: tsickert/discord-webhook@86dc739f3f165f16dadc5666051c367efa1692f4
         with:
           webhook-url: ${{ secrets.COMPILER_DISCORD_WEBHOOK_URL }}
           embed-author-name: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/runtime_commit_artifacts.yml
+++ b/.github/workflows/runtime_commit_artifacts.yml
@@ -16,6 +16,11 @@ on:
         required: true
         default: false
         type: boolean
+      dry_run:
+        description: Perform a dry run (run everything except push)
+        required: true
+        default: false
+        type: boolean
 
 env:
   TZ: /usr/share/zoneinfo/America/Los_Angeles
@@ -246,16 +251,16 @@ jobs:
           git status -u
       - name: Commit changes to branch
         if: inputs.force == true || steps.check_should_commit.outputs.should_commit == 'true'
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: |
-            ${{ github.event.workflow_run.head_commit.message || format('Manual build of {0}', github.event.workflow_run.head_sha || github.sha) }}
+        run: |
+          git config --global user.email "${{ format('{0}@users.noreply.github.com', github.triggering_actor) }}"
+          git config --global user.name "${{ github.triggering_actor }}"
 
-            DiffTrain build for [${{ github.event.workflow_run.head_sha || github.sha }}](https://github.com/facebook/react/commit/${{ github.event.workflow_run.head_sha || github.sha }})
-          branch: builds/facebook-www
-          commit_user_name: ${{ github.triggering_actor }}
-          commit_user_email: ${{ format('{0}@users.noreply.github.com', github.triggering_actor) }}
-          create_branch: true
+          git commit -m "${{ github.event.workflow_run.head_commit.message || format('Manual build of {0}', github.event.workflow_run.head_sha || github.sha) }}
+
+          DiffTrain build for [${{ github.event.workflow_run.head_sha || github.sha }}](https://github.com/facebook/react/commit/${{ github.event.workflow_run.head_sha || github.sha }})" || echo "No changes to commit"
+      - name: Push changes to branch
+        if: inputs.dry_run == false && (inputs.force == true || steps.check_should_commit.outputs.should_commit == 'true')
+        run: git push
 
   commit_fbsource_artifacts:
     needs: download_artifacts
@@ -413,13 +418,13 @@ jobs:
           git status
       - name: Commit changes to branch
         if: inputs.force == true || steps.check_should_commit.outputs.should_commit == 'true'
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: |
-            ${{ github.event.workflow_run.head_commit.message || format('Manual build of {0}', github.event.workflow_run.head_sha || github.sha) }}
+        run: |
+          git config --global user.email "${{ format('{0}@users.noreply.github.com', github.triggering_actor) }}"
+          git config --global user.name "${{ github.triggering_actor }}"
 
-            DiffTrain build for [${{ github.event.workflow_run.head_sha || github.sha }}](https://github.com/facebook/react/commit/${{ github.event.workflow_run.head_sha || github.sha }})
-          branch: builds/facebook-fbsource
-          commit_user_name: ${{ github.triggering_actor }}
-          commit_user_email: ${{ format('{0}@users.noreply.github.com', github.triggering_actor) }}
-          create_branch: true
+          git commit -m "${{ github.event.workflow_run.head_commit.message || format('Manual build of {0}', github.event.workflow_run.head_sha || github.sha) }}
+
+          DiffTrain build for [${{ github.event.workflow_run.head_sha || github.sha }}](https://github.com/facebook/react/commit/${{ github.event.workflow_run.head_sha || github.sha }})" || echo "No changes to commit"
+      - name: Push changes to branch
+        if: inputs.dry_run == false && (inputs.force == true || steps.check_should_commit.outputs.should_commit == 'true')
+        run: git push

--- a/.github/workflows/runtime_discord_notify.yml
+++ b/.github/workflows/runtime_discord_notify.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Discord Webhook Action
-        uses: tsickert/discord-webhook@v6.0.0
+        uses: tsickert/discord-webhook@86dc739f3f165f16dadc5666051c367efa1692f4
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           embed-author-name: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/runtime_releases_from_npm_manual.yml
+++ b/.github/workflows/runtime_releases_from_npm_manual.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Discord Webhook Action
-        uses: tsickert/discord-webhook@v6.0.0
+        uses: tsickert/discord-webhook@86dc739f3f165f16dadc5666051c367efa1692f4
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           embed-author-name: ${{ github.event.sender.login }}


### PR DESCRIPTION

Pins the discord webhook action to `86dc739f3f165f16dadc5666051c367efa1692f4`, which is what the v6 tag points to.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32649).
* #32650
* __->__ #32649
* #32648