### PR TITLE
Don't auto-start browser in SSR fixtures

### DIFF
--- a/fixtures/ssr/package.json
+++ b/fixtures/ssr/package.json
@@ -20,7 +20,7 @@
     "prestart": "cp -r ../../build/oss-experimental/* ./node_modules/",
     "prebuild": "cp -r ../../build/oss-experimental/* ./node_modules/",
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
-    "dev:client": "PORT=3001 react-scripts start",
+    "dev:client": "BROWSER=none PORT=3001 react-scripts start",
     "dev:server": "NODE_ENV=development node server",
     "start": "react-scripts build && NODE_ENV=production node server",
     "build": "react-scripts build",

--- a/fixtures/view-transition/package.json
+++ b/fixtures/view-transition/package.json
@@ -26,7 +26,7 @@
     "prestart": "cp -r ../../build/oss-experimental/* ./node_modules/",
     "prebuild": "cp -r ../../build/oss-experimental/* ./node_modules/",
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
-    "dev:client": "PORT=3001 react-scripts start",
+    "dev:client": "BROWSER=none PORT=3001 react-scripts start",
     "dev:server": "NODE_ENV=development node server",
     "start": "react-scripts build && NODE_ENV=production node server",
     "build": "react-scripts build",


### PR DESCRIPTION
I end up restarting these a lot and it's annoying to have it open another tab each time.

The flight fixture already doesn't auto-start.
