### PR TITLE
Add blur() and focusLast() to fragment instances

### DIFF
--- a/fixtures/dom/src/components/fixtures/fragment-refs/FocusCase.js
+++ b/fixtures/dom/src/components/fixtures/fragment-refs/FocusCase.js
@@ -1,0 +1,55 @@
+import TestCase from '../../TestCase';
+import Fixture from '../../Fixture';
+
+const React = window.React;
+
+const {Fragment, useEffect, useRef, useState} = React;
+
+export default function FocusCase() {
+  const fragmentRef = useRef(null);
+
+  return (
+    <TestCase title="Focus Management">
+      <TestCase.Steps>
+        <li>Click to focus the first child</li>
+        <li>Click to focus the last child</li>
+        <li>Click to blur any focus within the fragment</li>
+      </TestCase.Steps>
+
+      <TestCase.ExpectedResult>
+        <p>
+          The focus method will focus the first focusable child within the
+          fragment, skipping any unfocusable children.
+        </p>
+        <p>
+          The focusLast method is the reverse, focusing the last focusable
+          child.
+        </p>
+        <p>
+          Blur will call blur on the document, only if one of the children
+          within the fragment is the active element.
+        </p>
+      </TestCase.ExpectedResult>
+
+      <button onClick={() => fragmentRef.current.focus()}>
+        Focus first child
+      </button>
+      <button onClick={() => fragmentRef.current.focusLast()}>
+        Focus last child
+      </button>
+      <button onClick={() => fragmentRef.current.blur()}>Blur</button>
+
+      <Fixture>
+        <div className="highlight-focused-children" style={{display: 'flex'}}>
+          <Fragment ref={fragmentRef}>
+            <div style={{outline: '1px solid black'}}>Unfocusable div</div>
+            <button>Button 1</button>
+            <button>Button 2</button>
+            <input type="text" placeholder="Input field" />
+            <div style={{outline: '1px solid black'}}>Unfocusable div</div>
+          </Fragment>
+        </div>
+      </Fixture>
+    </TestCase>
+  );
+}

--- a/fixtures/dom/src/components/fixtures/fragment-refs/index.js
+++ b/fixtures/dom/src/components/fixtures/fragment-refs/index.js
@@ -2,6 +2,7 @@ import FixtureSet from '../../FixtureSet';
 import EventListenerCase from './EventListenerCase';
 import IntersectionObserverCase from './IntersectionObserverCase';
 import ResizeObserverCase from './ResizeObserverCase';
+import FocusCase from './FocusCase';
 
 const React = window.React;
 
@@ -11,6 +12,7 @@ export default function FragmentRefsPage() {
       <EventListenerCase />
       <IntersectionObserverCase />
       <ResizeObserverCase />
+      <FocusCase />
     </FixtureSet>
   );
 }

--- a/fixtures/dom/src/style.css
+++ b/fixtures/dom/src/style.css
@@ -358,3 +358,7 @@ tbody tr:nth-child(even) {
 .onscreen {
   background-color: green;
 }
+
+.highlight-focused-children *:focus {
+  outline: 2px solid green;
+}

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -34,6 +34,7 @@ import {getCurrentRootHostContainer} from 'react-reconciler/src/ReactFiberHostCo
 import hasOwnProperty from 'shared/hasOwnProperty';
 import {checkAttributeStringCoercion} from 'shared/CheckStringCoercion';
 import {REACT_CONTEXT_TYPE} from 'shared/ReactSymbols';
+import {traverseFragmentInstanceReverse} from 'react-reconciler/src/ReactFiberTreeReflection';
 
 export {
   setCurrentUpdatePriority,
@@ -2183,6 +2184,11 @@ type StoredEventListener = {
   optionsOrUseCapture: void | EventListenerOptionsOrUseCapture,
 };
 
+type FocusOptions = {
+  preventScroll?: boolean,
+  focusVisible?: boolean,
+};
+
 export type FragmentInstanceType = {
   _fragmentFiber: Fiber,
   _eventListeners: null | Array<StoredEventListener>,
@@ -2197,7 +2203,9 @@ export type FragmentInstanceType = {
     listener: EventListener,
     optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
   ): void,
-  focus(): void,
+  focus(focusOptions?: FocusOptions): void,
+  focusLast(focusOptions?: FocusOptions): void,
+  blur(): void,
   observeUsing(observer: IntersectionObserver | ResizeObserver): void,
   unobserveUsing(observer: IntersectionObserver | ResizeObserver): void,
 };
@@ -2285,9 +2293,46 @@ function removeEventListenerFromChild(
   return false;
 }
 // $FlowFixMe[prop-missing]
-FragmentInstance.prototype.focus = function (this: FragmentInstanceType) {
-  traverseFragmentInstance(this._fragmentFiber, setFocusIfFocusable);
+FragmentInstance.prototype.focus = function (
+  this: FragmentInstanceType,
+  focusOptions?: FocusOptions,
+): void {
+  traverseFragmentInstance(
+    this._fragmentFiber,
+    setFocusIfFocusable,
+    focusOptions,
+  );
 };
+// $FlowFixMe[prop-missing]
+FragmentInstance.prototype.focusLast = function (
+  this: FragmentInstanceType,
+  focusOptions?: FocusOptions,
+) {
+  traverseFragmentInstanceReverse(
+    this._fragmentFiber,
+    setFocusIfFocusable,
+    focusOptions,
+  );
+};
+// $FlowFixMe[prop-missing]
+FragmentInstance.prototype.blur = function (this: FragmentInstanceType): void {
+  // TODO: When we have a parent element reference, we can skip traversal if the fragment's parent
+  //   does not contain document.activeElement
+  traverseFragmentInstance(
+    this._fragmentFiber,
+    blurActiveElementWithinFragment,
+  );
+};
+function blurActiveElementWithinFragment(child: Instance): boolean {
+  // TODO: We can get the activeElement from the parent outside of the loop when we have a reference.
+  const ownerDocument = child.ownerDocument;
+  if (child === ownerDocument.activeElement) {
+    // $FlowFixMe[prop-missing]
+    child.blur();
+    return true;
+  }
+  return false;
+}
 // $FlowFixMe[prop-missing]
 FragmentInstance.prototype.observeUsing = function (
   this: FragmentInstanceType,
@@ -3168,7 +3213,10 @@ export function isHiddenSubtree(fiber: Fiber): boolean {
   return fiber.tag === HostComponent && fiber.memoizedProps.hidden === true;
 }
 
-export function setFocusIfFocusable(node: Instance): boolean {
+export function setFocusIfFocusable(
+  node: Instance,
+  focusOptions?: FocusOptions,
+): boolean {
   // The logic for determining if an element is focusable is kind of complex,
   // and since we want to actually change focus anyway- we can just skip it.
   // Instead we'll just listen for a "focus" event to verify that focus was set.
@@ -3184,7 +3232,7 @@ export function setFocusIfFocusable(node: Instance): boolean {
   try {
     element.addEventListener('focus', handleFocus);
     // $FlowFixMe[method-unbinding]
-    (element.focus || HTMLElement.prototype.focus).call(element);
+    (element.focus || HTMLElement.prototype.focus).call(element, focusOptions);
   } finally {
     element.removeEventListener('focus', handleFocus);
   }

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -326,7 +326,7 @@ export function traverseFragmentInstance<A, B, C>(
   b: B,
   c: C,
 ): void {
-  return traverseFragmentInstanceChildren(fragmentFiber.child, fn, a, b, c);
+  traverseFragmentInstanceChildren(fragmentFiber.child, fn, a, b, c);
 }
 
 function traverseFragmentInstanceChildren<A, B, C>(
@@ -351,4 +351,44 @@ function traverseFragmentInstanceChildren<A, B, C>(
     }
     child = child.sibling;
   }
+}
+
+export function traverseFragmentInstanceReverse<A, B, C>(
+  fragmentFiber: Fiber,
+  fn: (Instance, A, B, C) => boolean,
+  a: A,
+  b: B,
+  c: C,
+): void {
+  traverseFragmentInstanceChildrenReverse(fragmentFiber.child, fn, a, b, c);
+}
+
+function traverseFragmentInstanceChildrenReverse<A, B, C>(
+  child: Fiber | null,
+  fn: (Instance, A, B, C) => boolean,
+  a: A,
+  b: B,
+  c: C,
+): boolean {
+  if (child === null) {
+    return true;
+  }
+  if (child.sibling !== null) {
+    if (traverseFragmentInstanceChildrenReverse(child.sibling, fn, a, b, c)) {
+      return true;
+    }
+  }
+  if (child.tag === HostComponent) {
+    if (fn(child.stateNode, a, b, c)) {
+      return true;
+    }
+  } else if (child.tag === OffscreenComponent && child.memoizedState !== null) {
+    // Skip hidden subtrees
+  } else {
+    if (traverseFragmentInstanceChildrenReverse(child.child, fn, a, b, c)) {
+      return true;
+    }
+  }
+
+  return false;
 }


### PR DESCRIPTION
`focus()` was added in https://github.com/facebook/react/pull/32465. Here we add `focusLast()` and `blur()`. I also extended `focus` to take options.

`focus` will focus the first focusable element. `focusLast` will focus the last focusable element. We could consider a `focusFirst` naming or even the `focusWithin` used by test selector APIs as well.

`blur` will only have an effect if the current `document.activeElement` is one of the fragment children. 
