### PR TITLE
Update ViewTransition fixture to include bigger buttons/swipe

### DIFF
--- a/fixtures/view-transition/src/components/Page.css
+++ b/fixtures/view-transition/src/components/Page.css
@@ -8,7 +8,16 @@
 }
 
 .swipe-recognizer {
-  width: 200px;
-  border: 1px solid #333333;
+  width: 300px;
+  background: #eee;
   border-radius: 10px;
+  padding: 20px;
+}
+
+.button {
+  background: #000;
+  color: #fff;
+  border: 0px;
+  border-radius: 5px;
+  padding: 10px;
 }

--- a/fixtures/view-transition/src/components/Page.js
+++ b/fixtures/view-transition/src/components/Page.js
@@ -74,75 +74,80 @@ export default function Page({url, navigate}) {
     </ViewTransition>
   );
   return (
-    <div>
-      <button
-        onClick={() => {
-          navigate(url === '/?b' ? '/?a' : '/?b');
-        }}>
-        {url === '/?b' ? 'A' : 'B'}
-      </button>
-      <ViewTransition className="none">
-        <div>
-          <ViewTransition>
-            <div>
-              <ViewTransition className={transitions['slide-on-nav']}>
-                <h1>{!show ? 'A' : 'B'}</h1>
+    <div className="swipe-recognizer">
+      <SwipeRecognizer
+        action={swipeAction}
+        gesture={startGesture}
+        direction={show ? 'left' : 'right'}>
+        <button
+          className="button"
+          onClick={() => {
+            navigate(url === '/?b' ? '/?a' : '/?b');
+          }}>
+          {url === '/?b' ? 'Goto A' : 'Goto B'}
+        </button>
+        <ViewTransition className="none">
+          <div>
+            <ViewTransition>
+              <div>
+                <ViewTransition className={transitions['slide-on-nav']}>
+                  <h1>{!show ? 'A' : 'B'}</h1>
+                </ViewTransition>
+              </div>
+            </ViewTransition>
+            <ViewTransition
+              className={{
+                'navigation-back': transitions['slide-right'],
+                'navigation-forward': transitions['slide-left'],
+              }}>
+              <h1>{!show ? 'A' + counter : 'B' + counter}</h1>
+            </ViewTransition>
+            {show ? (
+              <div>
+                {a}
+                {b}
+              </div>
+            ) : (
+              <div>
+                {b}
+                {a}
+              </div>
+            )}
+            <ViewTransition>
+              {show ? (
+                <div>hello{exclamation}</div>
+              ) : (
+                <section>Loading</section>
+              )}
+            </ViewTransition>
+            <p>
+              <Id />
+            </p>
+            {show ? null : (
+              <ViewTransition>
+                <div>world{exclamation}</div>
               </ViewTransition>
-            </div>
-          </ViewTransition>
-          <ViewTransition
-            className={{
-              'navigation-back': transitions['slide-right'],
-              'navigation-forward': transitions['slide-left'],
-            }}>
-            <h1>{!show ? 'A' + counter : 'B' + counter}</h1>
-          </ViewTransition>
-          {show ? (
-            <div>
-              {a}
-              {b}
-            </div>
-          ) : (
-            <div>
-              {b}
-              {a}
-            </div>
-          )}
-          <ViewTransition>
-            {show ? <div>hello{exclamation}</div> : <section>Loading</section>}
-          </ViewTransition>
-          <p>scroll me</p>
-          <p>
-            <Id />
-          </p>
-          <p></p>
-          <p></p>
-          <p></p>
-          <p></p>
-          <p></p>
-          <div className="swipe-recognizer">
-            <SwipeRecognizer
-              action={swipeAction}
-              gesture={startGesture}
-              direction={show ? 'left' : 'right'}>
-              Swipe me
-            </SwipeRecognizer>
+            )}
+            <Activity mode={show ? 'visible' : 'hidden'}>
+              <ViewTransition>
+                <div>!!</div>
+              </ViewTransition>
+            </Activity>
+            <p>these</p>
+            <p>rows</p>
+            <p>exist</p>
+            <p>to</p>
+            <p>test</p>
+            <p>scrolling</p>
+            <p>content</p>
+            <p>out</p>
+            <p>of</p>
+            <p>the</p>
+            <p>viewport</p>
+            {show ? <Component /> : null}
           </div>
-          <p></p>
-          <p></p>
-          {show ? null : (
-            <ViewTransition>
-              <div>world{exclamation}</div>
-            </ViewTransition>
-          )}
-          <Activity mode={show ? 'visible' : 'hidden'}>
-            <ViewTransition>
-              <div>!!</div>
-            </ViewTransition>
-          </Activity>
-          {show ? <Component /> : null}
-        </div>
-      </ViewTransition>
+        </ViewTransition>
+      </SwipeRecognizer>
     </div>
   );
 }

--- a/fixtures/view-transition/src/components/Page.js
+++ b/fixtures/view-transition/src/components/Page.js
@@ -91,7 +91,7 @@ export default function Page({url, navigate}) {
             <ViewTransition>
               <div>
                 <ViewTransition className={transitions['slide-on-nav']}>
-                  <h1>{!show ? 'A' : 'B'}</h1>
+                  <h1>{!show ? 'A' : 'B' + counter}</h1>
                 </ViewTransition>
               </div>
             </ViewTransition>
@@ -100,7 +100,7 @@ export default function Page({url, navigate}) {
                 'navigation-back': transitions['slide-right'],
                 'navigation-forward': transitions['slide-left'],
               }}>
-              <h1>{!show ? 'A' + counter : 'B' + counter}</h1>
+              <h1>{!show ? 'A' + counter : 'B'}</h1>
             </ViewTransition>
             {show ? (
               <div>


### PR DESCRIPTION
I made the button a bit bigger and moved the swipe recognizer around the whole screen. Typically these are used around the whole content without any affordances and not as a standalone scrubber. Ideally the swipe would be able to be inside the animating content but it can't yet due to [this Safari bug](https://bugs.webkit.org/show_bug.cgi?id=288795).

Added back some paragraphs so that scrolling can be tested properly. It appears it's possible to get the swipe to be a bit misaligned if you scroll enough on iOS.

<img width="437" alt="Screenshot 2025-03-17 at 10 27 42 PM" src="https://github.com/user-attachments/assets/589dc828-717e-420c-83dc-94ae6ad59791" />
