### PR TITLE
Add getClientRects to fragment instances

### DIFF
--- a/fixtures/dom/src/components/Fixture.js
+++ b/fixtures/dom/src/components/Fixture.js
@@ -16,3 +16,7 @@ class Fixture extends React.Component {
 Fixture.propTypes = propTypes;
 
 export default Fixture;
+
+Fixture.Controls = function FixtureControls({children}) {
+  return <div className="test-fixture__controls">{children}</div>;
+};

--- a/fixtures/dom/src/components/fixtures/fragment-refs/EventListenerCase.js
+++ b/fixtures/dom/src/components/fixtures/fragment-refs/EventListenerCase.js
@@ -49,7 +49,7 @@ export default function EventListenerCase() {
       </TestCase.ExpectedResult>
 
       <Fixture>
-        <div className="control-box">
+        <Fixture.Controls>
           <div>Target count: {extraChildCount + 3}</div>
           <button
             onClick={() => {
@@ -69,26 +69,26 @@ export default function EventListenerCase() {
             }}>
             Remove click event listeners
           </button>
-          <div class="card-container">
-            <Fragment ref={fragmentRef}>
-              <div className="card" id="child-a">
-                Child A
+        </Fixture.Controls>
+        <div class="card-container">
+          <Fragment ref={fragmentRef}>
+            <div className="card" id="child-a">
+              Child A
+            </div>
+            <div className="card" id="child-b">
+              Child B
+            </div>
+            <WrapperComponent>
+              <div className="card" id="child-c">
+                Child C
               </div>
-              <div className="card" id="child-b">
-                Child B
-              </div>
-              <WrapperComponent>
-                <div className="card" id="child-c">
-                  Child C
+              {Array.from({length: extraChildCount}).map((_, index) => (
+                <div className="card" id={'extra-child-' + index} key={index}>
+                  Extra Child {index}
                 </div>
-                {Array.from({length: extraChildCount}).map((_, index) => (
-                  <div className="card" id={'extra-child-' + index} key={index}>
-                    Extra Child {index}
-                  </div>
-                ))}
-              </WrapperComponent>
-            </Fragment>
-          </div>
+              ))}
+            </WrapperComponent>
+          </Fragment>
         </div>
       </Fixture>
     </TestCase>

--- a/fixtures/dom/src/components/fixtures/fragment-refs/EventListenerCase.js
+++ b/fixtures/dom/src/components/fixtures/fragment-refs/EventListenerCase.js
@@ -70,7 +70,7 @@ export default function EventListenerCase() {
             Remove click event listeners
           </button>
         </Fixture.Controls>
-        <div class="card-container">
+        <div className="card-container">
           <Fragment ref={fragmentRef}>
             <div className="card" id="child-a">
               Child A

--- a/fixtures/dom/src/components/fixtures/fragment-refs/FocusCase.js
+++ b/fixtures/dom/src/components/fixtures/fragment-refs/FocusCase.js
@@ -31,15 +31,16 @@ export default function FocusCase() {
         </p>
       </TestCase.ExpectedResult>
 
-      <button onClick={() => fragmentRef.current.focus()}>
-        Focus first child
-      </button>
-      <button onClick={() => fragmentRef.current.focusLast()}>
-        Focus last child
-      </button>
-      <button onClick={() => fragmentRef.current.blur()}>Blur</button>
-
       <Fixture>
+        <Fixture.Controls>
+          <button onClick={() => fragmentRef.current.focus()}>
+            Focus first child
+          </button>
+          <button onClick={() => fragmentRef.current.focusLast()}>
+            Focus last child
+          </button>
+          <button onClick={() => fragmentRef.current.blur()}>Blur</button>
+        </Fixture.Controls>
         <div className="highlight-focused-children" style={{display: 'flex'}}>
           <Fragment ref={fragmentRef}>
             <div style={{outline: '1px solid black'}}>Unfocusable div</div>

--- a/fixtures/dom/src/components/fixtures/fragment-refs/GetClientRectsCase.js
+++ b/fixtures/dom/src/components/fixtures/fragment-refs/GetClientRectsCase.js
@@ -1,0 +1,108 @@
+import TestCase from '../../TestCase';
+import Fixture from '../../Fixture';
+
+const React = window.React;
+const {Fragment, useEffect, useRef, useState} = React;
+
+export default function GetClientRectsCase() {
+  const fragmentRef = useRef(null);
+  const [rects, setRects] = useState([]);
+  const getRects = () => {
+    const rects = fragmentRef.current.getClientRects();
+    setRects(rects);
+  };
+
+  return (
+    <TestCase title="getClientRects">
+      <TestCase.Steps>
+        <li>
+          Click the "Print Rects" button to get the client rects of the
+          elements.
+        </li>
+      </TestCase.Steps>
+      <TestCase.ExpectedResult>
+        Calling getClientRects on the fragment instance will return a list of a
+        DOMRectList for each child node.
+      </TestCase.ExpectedResult>
+      <Fixture>
+        <Fixture.Controls>
+          <button onClick={getRects}>Print Rects</button>
+          <div style={{display: 'flex'}}>
+            <div
+              style={{
+                position: 'relative',
+                width: '30vw',
+                height: '30vh',
+                border: '1px solid black',
+              }}>
+              {rects.map((rectList, index) => {
+                const scale = 0.3;
+
+                return (
+                  <div>
+                    {Array.from(rectList).map(({x, y, width, height}, idx) => (
+                      <div
+                        key={idx}
+                        style={{
+                          position: 'absolute',
+                          top: y * scale,
+                          left: x * scale,
+                          width: width * scale,
+                          height: height * scale,
+                          border: '1px solid red',
+                          boxSizing: 'border-box',
+                        }}></div>
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+            <div>
+              {rects.map((rectList, index) => {
+                return (
+                  <div>
+                    {Array.from(rectList).map(({x, y, width, height}, idx) => (
+                      <div>
+                        {index}.{idx} :: {`{`}x: {x}, y: {y}, width: {width},
+                        height: {height}
+                        {`}`}
+                      </div>
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </Fixture.Controls>
+        <Fragment ref={fragmentRef}>
+          <span
+            style={{
+              width: '300px',
+              height: '250px',
+              backgroundColor: 'lightblue',
+              fontSize: 20,
+              border: '1px solid black',
+              marginBottom: '10px',
+            }}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          </span>
+          <div
+            style={{
+              width: '150px',
+              height: '100px',
+              backgroundColor: 'lightgreen',
+              border: '1px solid black',
+            }}></div>
+          <div
+            style={{
+              width: '500px',
+              height: '50px',
+              backgroundColor: 'lightpink',
+              border: '1px solid black',
+            }}></div>
+        </Fragment>
+      </Fixture>
+    </TestCase>
+  );
+}

--- a/fixtures/dom/src/components/fixtures/fragment-refs/GetClientRectsCase.js
+++ b/fixtures/dom/src/components/fixtures/fragment-refs/GetClientRectsCase.js
@@ -35,39 +35,31 @@ export default function GetClientRectsCase() {
                 height: '30vh',
                 border: '1px solid black',
               }}>
-              {rects.map((rectList, index) => {
+              {rects.map(({x, y, width, height}, index) => {
                 const scale = 0.3;
 
                 return (
-                  <div>
-                    {Array.from(rectList).map(({x, y, width, height}, idx) => (
-                      <div
-                        key={idx}
-                        style={{
-                          position: 'absolute',
-                          top: y * scale,
-                          left: x * scale,
-                          width: width * scale,
-                          height: height * scale,
-                          border: '1px solid red',
-                          boxSizing: 'border-box',
-                        }}></div>
-                    ))}
-                  </div>
+                  <div
+                    key={index}
+                    style={{
+                      position: 'absolute',
+                      top: y * scale,
+                      left: x * scale,
+                      width: width * scale,
+                      height: height * scale,
+                      border: '1px solid red',
+                      boxSizing: 'border-box',
+                    }}></div>
                 );
               })}
             </div>
             <div>
-              {rects.map((rectList, index) => {
+              {rects.map(({x, y, width, height}, index) => {
                 return (
                   <div>
-                    {Array.from(rectList).map(({x, y, width, height}, idx) => (
-                      <div>
-                        {index}.{idx} :: {`{`}x: {x}, y: {y}, width: {width},
-                        height: {height}
-                        {`}`}
-                      </div>
-                    ))}
+                    {index} :: {`{`}x: {x}, y: {y}, width: {width}, height:{' '}
+                    {height}
+                    {`}`}
                   </div>
                 );
               })}

--- a/fixtures/dom/src/components/fixtures/fragment-refs/IntersectionObserverCase.js
+++ b/fixtures/dom/src/components/fixtures/fragment-refs/IntersectionObserverCase.js
@@ -90,53 +90,55 @@ export default function IntersectionObserverCase() {
         </p>
       </TestCase.ExpectedResult>
       <Fixture>
-        <button
-          onClick={() => {
-            setItems(prev => [
-              ...prev,
-              [`Extra child: ${prev.length + 1}`, false],
-            ]);
-          }}>
-          Add Child
-        </button>
-        <button
-          onClick={() => {
-            setItems(prev => {
-              if (prev.length === 3) {
-                return prev;
-              }
-              return prev.slice(0, prev.length - 1);
-            });
-          }}>
-          Remove Child
-        </button>
-        <button
-          onClick={() => {
-            fragmentRef.current.observeUsing(observerRef.current);
-          }}>
-          Observe
-        </button>
-        <button
-          onClick={() => {
-            fragmentRef.current.unobserveUsing(observerRef.current);
-            setItems(prev => {
-              return prev.map(item => [item[0], false]);
-            });
-          }}>
-          Unobserve
-        </button>
-        {anyOnScreen && (
-          <div className="fixed-sidebar card-container">
-            <p>
-              <strong>Children on screen:</strong>
-            </p>
-            {items.map(item => (
-              <div className={`card ${item[1] ? 'onscreen' : null}`}>
-                {item[0]}
-              </div>
-            ))}
-          </div>
-        )}
+        <Fixture.Controls>
+          <button
+            onClick={() => {
+              setItems(prev => [
+                ...prev,
+                [`Extra child: ${prev.length + 1}`, false],
+              ]);
+            }}>
+            Add Child
+          </button>
+          <button
+            onClick={() => {
+              setItems(prev => {
+                if (prev.length === 3) {
+                  return prev;
+                }
+                return prev.slice(0, prev.length - 1);
+              });
+            }}>
+            Remove Child
+          </button>
+          <button
+            onClick={() => {
+              fragmentRef.current.observeUsing(observerRef.current);
+            }}>
+            Observe
+          </button>
+          <button
+            onClick={() => {
+              fragmentRef.current.unobserveUsing(observerRef.current);
+              setItems(prev => {
+                return prev.map(item => [item[0], false]);
+              });
+            }}>
+            Unobserve
+          </button>
+          {anyOnScreen && (
+            <div className="fixed-sidebar card-container">
+              <p>
+                <strong>Children on screen:</strong>
+              </p>
+              {items.map(item => (
+                <div className={`card ${item[1] ? 'onscreen' : null}`}>
+                  {item[0]}
+                </div>
+              ))}
+            </div>
+          )}
+        </Fixture.Controls>
         <Fragment ref={fragmentRef}>
           <ObservedChild id="A" />
           <WrapperComponent>

--- a/fixtures/dom/src/components/fixtures/fragment-refs/index.js
+++ b/fixtures/dom/src/components/fixtures/fragment-refs/index.js
@@ -3,6 +3,7 @@ import EventListenerCase from './EventListenerCase';
 import IntersectionObserverCase from './IntersectionObserverCase';
 import ResizeObserverCase from './ResizeObserverCase';
 import FocusCase from './FocusCase';
+import GetClientRectsCase from './GetClientRectsCase';
 
 const React = window.React;
 
@@ -13,6 +14,7 @@ export default function FragmentRefsPage() {
       <IntersectionObserverCase />
       <ResizeObserverCase />
       <FocusCase />
+      <GetClientRectsCase />
     </FixtureSet>
   );
 }

--- a/fixtures/dom/src/style.css
+++ b/fixtures/dom/src/style.css
@@ -224,7 +224,7 @@ p {
 }
 
 .test-case__body {
-  padding: 10px;
+  padding: 10px 10px 0 10px;
 }
 
 .test-case__desc {
@@ -280,9 +280,15 @@ p {
 
 .test-fixture {
   padding: 20px;
-  margin: 0 -15px; /* opposite of .test-case padding */
+  margin: 0 -10px; /* opposite of .test-case padding */
   background-color: #f4f4f4;
   border-top: 1px solid #d9d9d9;
+}
+
+.test-fixture__controls {
+  margin: -20px -20px 20px -20px;
+  padding: 20px;
+  border: 1px solid #444;
 }
 
 .field-group {

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2210,8 +2210,6 @@ type FocusOptions = {
   focusVisible?: boolean,
 };
 
-type ChildRectLists = Array<DOMRectList>;
-
 export type FragmentInstanceType = {
   _fragmentFiber: Fiber,
   _eventListeners: null | Array<StoredEventListener>,
@@ -2231,7 +2229,7 @@ export type FragmentInstanceType = {
   blur(): void,
   observeUsing(observer: IntersectionObserver | ResizeObserver): void,
   unobserveUsing(observer: IntersectionObserver | ResizeObserver): void,
-  getClientRects(): ChildRectLists,
+  getClientRects(): Array<DOMRect>,
 };
 
 function FragmentInstance(this: FragmentInstanceType, fragmentFiber: Fiber) {
@@ -2412,14 +2410,14 @@ function unobserveChild(
 // $FlowFixMe[prop-missing]
 FragmentInstance.prototype.getClientRects = function (
   this: FragmentInstanceType,
-): ChildRectLists {
-  const rects: ChildRectLists = [];
+): Array<DOMRect> {
+  const rects: Array<DOMRect> = [];
   traverseFragmentInstance(this._fragmentFiber, collectClientRects, rects);
   return rects;
 };
-function collectClientRects(child: Instance, rects: ChildRectLists): boolean {
-  // $FlowFixMe[incompatible-call]
-  rects.push(child.getClientRects());
+function collectClientRects(child: Instance, rects: Array<DOMRect>): boolean {
+  // $FlowFixMe[method-unbinding]
+  rects.push.apply(rects, child.getClientRects());
   return false;
 }
 

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2210,6 +2210,8 @@ type FocusOptions = {
   focusVisible?: boolean,
 };
 
+type ChildRectLists = Array<DOMRectList>;
+
 export type FragmentInstanceType = {
   _fragmentFiber: Fiber,
   _eventListeners: null | Array<StoredEventListener>,
@@ -2229,6 +2231,7 @@ export type FragmentInstanceType = {
   blur(): void,
   observeUsing(observer: IntersectionObserver | ResizeObserver): void,
   unobserveUsing(observer: IntersectionObserver | ResizeObserver): void,
+  getClientRects(): ChildRectLists,
 };
 
 function FragmentInstance(this: FragmentInstanceType, fragmentFiber: Fiber) {
@@ -2404,6 +2407,19 @@ function unobserveChild(
   observer: IntersectionObserver | ResizeObserver,
 ) {
   observer.unobserve(child);
+  return false;
+}
+// $FlowFixMe[prop-missing]
+FragmentInstance.prototype.getClientRects = function (
+  this: FragmentInstanceType,
+): ChildRectLists {
+  const rects: ChildRectLists = [];
+  traverseFragmentInstance(this._fragmentFiber, collectClientRects, rects);
+  return rects;
+};
+function collectClientRects(child: Instance, rects: ChildRectLists): boolean {
+  // $FlowFixMe[incompatible-call]
+  rects.push(child.getClientRects());
   return false;
 }
 

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -878,12 +878,10 @@ describe('FragmentRefs', () => {
       ]);
       setClientRects(childBRef.current, [{x: 9, y: 10, width: 11, height: 12}]);
       const clientRects = fragmentRef.current.getClientRects();
-      const [childARects, childBRects] = clientRects;
-      expect(childARects.length).toBe(2);
-      expect(childBRects.length).toBe(1);
-      expect(childARects[0].left).toBe(1);
-      expect(childARects[1].left).toBe(5);
-      expect(childBRects[0].left).toBe(9);
+      expect(clientRects.length).toBe(3);
+      expect(clientRects[0].left).toBe(1);
+      expect(clientRects[1].left).toBe(5);
+      expect(clientRects[2].left).toBe(9);
     });
   });
 });

--- a/packages/react-dom/src/__tests__/utils/IntersectionMocks.js
+++ b/packages/react-dom/src/__tests__/utils/IntersectionMocks.js
@@ -75,3 +75,21 @@ export function setBoundingClientRect(target, {x, y, width, height}) {
     };
   };
 }
+
+/**
+ * Stub out getClientRects for the specified target.
+ */
+export function setClientRects(target, rects) {
+  target.getClientRects = function () {
+    return rects.map(({x, y, width, height}) => ({
+      width,
+      height,
+      left: x,
+      right: x + width,
+      top: y,
+      bottom: y + height,
+      x,
+      y,
+    }));
+  };
+}


### PR DESCRIPTION
Adds `getClientRects()` to fragment instances with a fixture test case. `Element.getClientRect` returns a collection of `DOMRect`s (see example of multiline span returning two `DOMRect` boxes). `fragmentInstance.getClientRects` here flattens those collections into an array of rects.
