### PR TITLE
Minor Fixes to View Transition Fixture

### DIFF
--- a/fixtures/view-transition/src/components/Chrome.css
+++ b/fixtures/view-transition/src/components/Chrome.css
@@ -7,3 +7,10 @@ body {
   padding: 0;
   font-family: sans-serif;
 }
+
+::view-transition-group(*),
+::view-transition-image-pair(*),
+::view-transition-old(*),
+::view-transition-new(*) {
+  pointer-events: none;
+}

--- a/fixtures/view-transition/src/components/SwipeRecognizer.js
+++ b/fixtures/view-transition/src/components/SwipeRecognizer.js
@@ -92,7 +92,6 @@ export default function SwipeRecognizer({
     width: axis === 'x' ? '100%' : null,
     height: axis === 'y' ? '100%' : null,
     overflow: 'scroll hidden',
-    touchAction: 'pan-' + direction,
     // Disable overscroll on Safari which moves the sticky content.
     // Unfortunately, this also means that we disable chaining. We should only disable
     // it if the parent is not scrollable in this axis.


### PR DESCRIPTION
Follow up to #32656.

Remove touchAction from SwipeRecognizer. I was under the wrong impression that this was only the touch-action applied to this particular element, but that parents would still win but in fact this blocks the parent from scrolling in the other direction. By specifying a fixed direction it also blocked rage-swiping in the other direction early on.

Disable pointer-events on view-transition so that the scroll can be hit. This means that touches hit below the items animating above. This allows swiping to happen again before momentum scroll has finished. Previously they were ignored. This only works as long as the SwipeRecognizer is itself not animating. This means you can now rage-swipe in both directions quickly.