### PR TITLE
[eslint-plugin-react-compiler] Fix type error with recommended config

### DIFF
--- a/compiler/packages/eslint-plugin-react-compiler/src/index.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/src/index.ts
@@ -25,7 +25,7 @@ const configs = {
       },
     },
     rules: {
-      'react-compiler/react-compiler': 'error',
+      'react-compiler/react-compiler': 'error' as const,
     },
   },
 };


### PR DESCRIPTION
## Summary

In the recommended configuration for `eslint-plugin-react-compiler`, i.e. `reactCompiler.configs.recommended`, the rule is typed as `string` rather than `eslint.Linter.RuleEntry` or anything assignable thereto, which results in the following type error if you type check your eslint configuration: 
```
Property ''react-compiler/react-compiler'' is incompatible with index signature.
  Type 'string' is not assignable to type 'RuleEntry | undefined'.
```
Simply adding a const assertion fixes the error.

## How did you test this change?

I emitted declarations for the module and confirmed that the rule is now typed as the string literal `'error'`