### PR TITLE
[ci] Properly format commit message

### DIFF
--- a/.github/workflows/runtime_commit_artifacts.yml
+++ b/.github/workflows/runtime_commit_artifacts.yml
@@ -252,9 +252,7 @@ jobs:
           git config --global user.email "${{ format('{0}@users.noreply.github.com', github.triggering_actor) }}"
           git config --global user.name "${{ github.triggering_actor }}"
 
-          git commit -m "${{ github.event.workflow_run.head_commit.message || format('Manual build of {0}', github.event.workflow_run.head_sha || github.sha) }}
-
-          DiffTrain build for [${{ github.event.workflow_run.head_sha || github.sha }}](https://github.com/facebook/react/commit/${{ github.event.workflow_run.head_sha || github.sha }})" || echo "No changes to commit"
+          git commit -m "$(git show --no-patch --pretty=format:'%B%n%nDiffTrain build for [${{ github.event.workflow_run.head_sha || github.sha }}](https://github.com/facebook/react/commit/${{ github.event.workflow_run.head_sha || github.sha}})')" || echo "No changes to commit"
       - name: Push changes to branch
         if: inputs.dry_run == false && (inputs.force == true || steps.check_should_commit.outputs.should_commit == 'true')
         run: git push
@@ -419,9 +417,7 @@ jobs:
           git config --global user.email "${{ format('{0}@users.noreply.github.com', github.triggering_actor) }}"
           git config --global user.name "${{ github.triggering_actor }}"
 
-          git commit -m "${{ github.event.workflow_run.head_commit.message || format('Manual build of {0}', github.event.workflow_run.head_sha || github.sha) }}
-
-          DiffTrain build for [${{ github.event.workflow_run.head_sha || github.sha }}](https://github.com/facebook/react/commit/${{ github.event.workflow_run.head_sha || github.sha }})" || echo "No changes to commit"
+          git commit -m "$(git show --no-patch --pretty=format:'%B%n%nDiffTrain build for [${{ github.event.workflow_run.head_sha || github.sha }}](https://github.com/facebook/react/commit/${{ github.event.workflow_run.head_sha || github.sha}})')" || echo "No changes to commit"
       - name: Push changes to branch
         if: inputs.dry_run == false && (inputs.force == true || steps.check_should_commit.outputs.should_commit == 'true')
         run: git push


### PR DESCRIPTION

Using the github variable for the commit message replaces the variable inline. If the commit message contains quotes or other characters that need to be escaped, this breaks the workflow.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32668).
* #32669
* __->__ #32668