### PR TITLE
Enable Fragment refs in Experimental

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -162,7 +162,7 @@ export const enableUseEffectCRUDOverload = false;
 export const enableFastAddPropertiesInDiffing = true;
 export const enableLazyPublicInstanceInFabric = false;
 
-export const enableFragmentRefs = false;
+export const enableFragmentRefs = __EXPERIMENTAL__;
 
 // -----------------------------------------------------------------------------
 // Ready for next major.


### PR DESCRIPTION
That we can test it out in Next.js router conditionally when experimental is on for other reasons.