### PR TITLE
Cleanup enableObjectFiber experiment

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -39,7 +39,6 @@ import {
   enableDO_NOT_USE_disableStrictPassiveEffect,
   enableRenderableContext,
   disableLegacyMode,
-  enableObjectFiber,
   enableViewTransition,
 } from 'shared/ReactFeatureFlags';
 import {NoFlags, Placement, StaticMask} from './ReactFiberFlags';
@@ -225,7 +224,7 @@ function FiberNode(
 //    is faster.
 // 5) It should be easy to port this to a C struct and keep a C implementation
 //    compatible.
-function createFiberImplClass(
+function createFiber(
   tag: WorkTag,
   pendingProps: mixed,
   key: null | string,
@@ -234,77 +233,6 @@ function createFiberImplClass(
   // $FlowFixMe[invalid-constructor]: the shapes are exact here but Flow doesn't like constructors
   return new FiberNode(tag, pendingProps, key, mode);
 }
-
-function createFiberImplObject(
-  tag: WorkTag,
-  pendingProps: mixed,
-  key: null | string,
-  mode: TypeOfMode,
-): Fiber {
-  const fiber: Fiber = {
-    // Instance
-    // tag, key - defined at the bottom as dynamic properties
-    elementType: null,
-    type: null,
-    stateNode: null,
-
-    // Fiber
-    return: null,
-    child: null,
-    sibling: null,
-    index: 0,
-
-    ref: null,
-    refCleanup: null,
-
-    // pendingProps - defined at the bottom as dynamic properties
-    memoizedProps: null,
-    updateQueue: null,
-    memoizedState: null,
-    dependencies: null,
-
-    // Effects
-    flags: NoFlags,
-    subtreeFlags: NoFlags,
-    deletions: null,
-
-    lanes: NoLanes,
-    childLanes: NoLanes,
-
-    alternate: null,
-
-    // dynamic properties at the end for more efficient hermes bytecode
-    tag,
-    key,
-    pendingProps,
-    mode,
-  };
-
-  if (enableProfilerTimer) {
-    fiber.actualDuration = -0;
-    fiber.actualStartTime = -1.1;
-    fiber.selfBaseDuration = -0;
-    fiber.treeBaseDuration = -0;
-  }
-
-  if (__DEV__) {
-    // This isn't directly used but is handy for debugging internals:
-    fiber._debugInfo = null;
-    fiber._debugOwner = null;
-    fiber._debugStack = null;
-    fiber._debugTask = null;
-    fiber._debugNeedsRemount = false;
-    fiber._debugHookTypes = null;
-    if (!hasBadMapPolyfill && typeof Object.preventExtensions === 'function') {
-      Object.preventExtensions(fiber);
-    }
-  }
-  return fiber;
-}
-
-const createFiber = enableObjectFiber
-  ? createFiberImplObject
-  : createFiberImplClass;
 
 function shouldConstruct(Component: Function) {
   const prototype = Component.prototype;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -101,11 +101,6 @@ export const enableScrollEndPolyfill = __EXPERIMENTAL__;
  */
 export const enableFabricCompleteRootInCommitPhase = false;
 
-/**
- * Switches Fiber creation to a simple object instead of a constructor.
- */
-export const enableObjectFiber = false;
-
 export const enableTransitionTracing = false;
 
 // FB-only usage. The new API has different semantics.

--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -18,7 +18,6 @@
 // add a test configuration for React Native.
 
 export const alwaysThrottleRetries = __VARIANT__;
-export const enableObjectFiber = __VARIANT__;
 export const enableHiddenSubtreeInsertionEffectCleanup = __VARIANT__;
 export const enablePersistedModeClonedFlag = __VARIANT__;
 export const enableShallowPropDiffing = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -22,7 +22,6 @@ export const {
   alwaysThrottleRetries,
   enableFabricCompleteRootInCommitPhase,
   enableHiddenSubtreeInsertionEffectCleanup,
-  enableObjectFiber,
   enablePersistedModeClonedFlag,
   enableShallowPropDiffing,
   enableUseEffectCRUDOverload,

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -40,7 +40,6 @@ export const enableLegacyCache = false;
 export const enableLegacyFBSupport = false;
 export const enableLegacyHidden = false;
 export const enableNoCloningMemoCache = false;
-export const enableObjectFiber = false;
 export const enablePersistedModeClonedFlag = false;
 export const enablePostpone = false;
 export const enableReactTestRendererWarning = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -92,7 +92,5 @@ export const enableRenderableContext = true;
 export const enableReactTestRendererWarning = true;
 export const disableDefaultPropsExceptForClasses = true;
 
-export const enableObjectFiber = false;
-
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -34,7 +34,6 @@ export const enableLegacyCache = false;
 export const enableLegacyFBSupport = false;
 export const enableLegacyHidden = false;
 export const enableNoCloningMemoCache = false;
-export const enableObjectFiber = false;
 export const enablePersistedModeClonedFlag = false;
 export const enablePostpone = false;
 export const enableProfilerCommitHooks = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -70,7 +70,6 @@ export const disableDefaultPropsExceptForClasses = true;
 
 export const renameElementSymbol = false;
 
-export const enableObjectFiber = false;
 export const enableShallowPropDiffing = false;
 export const enableSiblingPrerendering = true;
 

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -20,7 +20,6 @@ export const disableSchedulerTimeoutInWorkLoop = __VARIANT__;
 export const enableDO_NOT_USE_disableStrictPassiveEffect = __VARIANT__;
 export const enableHiddenSubtreeInsertionEffectCleanup = __VARIANT__;
 export const enableNoCloningMemoCache = __VARIANT__;
-export const enableObjectFiber = __VARIANT__;
 export const enableRenderableContext = __VARIANT__;
 export const enableRetryLaneExpiration = __VARIANT__;
 export const enableTransitionTracing = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -23,7 +23,6 @@ export const {
   enableHiddenSubtreeInsertionEffectCleanup,
   enableInfiniteRenderLoopDetection,
   enableNoCloningMemoCache,
-  enableObjectFiber,
   enableRenderableContext,
   enableRetryLaneExpiration,
   enableSiblingPrerendering,


### PR DESCRIPTION

We observed no signficant change in performance from this, so we can clean this up.

Keeping the class variant as that might give better values in memory profilers.
