### PR TITLE
[ci] Use correct revision for Meta builds

### DIFF
--- a/.github/workflows/compiler_playground.yml
+++ b/.github/workflows/compiler_playground.yml
@@ -50,3 +50,4 @@ jobs:
         with:
           name: test-results
           path: compiler/apps/playground/test-results
+          if-no-files-found: ignore

--- a/.github/workflows/devtools_regression_tests.yml
+++ b/.github/workflows/devtools_regression_tests.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           name: build
           path: build
+          if-no-files-found: error
 
   build_devtools_and_process_artifacts:
     name: Build DevTools and process artifacts
@@ -84,17 +85,20 @@ jobs:
         with:
           name: react-devtools
           path: build/devtools.tgz
+          if-no-files-found: error
       # Simplifies getting the extension for local testing
       - name: Archive chrome extension
         uses: actions/upload-artifact@v4
         with:
           name: react-devtools-chrome-extension
           path: build/devtools/chrome-extension.zip
+          if-no-files-found: error
       - name: Archive firefox extension
         uses: actions/upload-artifact@v4
         with:
           name: react-devtools-firefox-extension
           path: build/devtools/firefox-extension.zip
+          if-no-files-found: error
 
   run_devtools_tests_for_versions:
     name: Run DevTools tests for versions
@@ -179,3 +183,4 @@ jobs:
         with:
           name: screenshots
           path: ./tmp/screenshots
+          if-no-files-found: warn

--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -302,6 +302,7 @@ jobs:
         with:
           name: _build_${{ matrix.worker_id }}_${{ matrix.release_channel }}
           path: build
+          if-no-files-found: error
 
   test_build:
     name: yarn test-build
@@ -426,6 +427,7 @@ jobs:
           path: |
             ./build.tgz
             ./build2.tgz
+          if-no-files-found: error
 
   check_error_codes:
     name: Search build artifacts for unminified errors
@@ -603,11 +605,13 @@ jobs:
         with:
           name: flight-playwright-report
           path: fixtures/flight/playwright-report
+          if-no-files-found: warn
       - name: Archive Flight fixture artifacts
         uses: actions/upload-artifact@v4
         with:
           name: flight-test-results
           path: fixtures/flight/test-results
+          if-no-files-found: ignore
 
   # ----- DEVTOOLS -----
   build_devtools_and_process_artifacts:
@@ -655,6 +659,7 @@ jobs:
         with:
           name: react-devtools-${{ matrix.browser }}-extension
           path: build/devtools/${{ matrix.browser }}-extension.zip
+          if-no-files-found: error
 
   merge_devtools_artifacts:
     name: Merge DevTools artifacts
@@ -767,3 +772,4 @@ jobs:
         with:
           name: sizebot-message
           path: sizebot-message.md
+          if-no-files-found: ignore

--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -566,6 +566,24 @@ jobs:
         run: rm -rf build
       - run: yarn install --frozen-lockfile
         if: steps.node_modules.outputs.cache-hit != 'true'
+      - run: yarn --cwd fixtures/flight install --frozen-lockfile
+        if: steps.node_modules.outputs.cache-hit != 'true'
+      - name: Store Playwright version
+        id: playwright_version
+        run: |
+          PLAYWRIGHT_VERSION=$(npm ls @playwright/test | grep @playwright | sed 's/.*@//')
+          echo "Playwright's Version: $PLAYWRIGHT_VERSION"
+          echo "playwright_version=$PLAYWRIGHT_VERSION" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright Browsers for Playwright's Version
+        id: cache_playwright_browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-v6-${{ runner.arch }}-${{ runner.os }}-${{ steps.playwright_version.outputs.playwright_version }}
+      - name: Playwright install deps
+        if: steps.cache_playwright_browsers.outputs.cache-hit != 'true'
+        working-directory: fixtures/flight
+        run: npx playwright install --with-deps chromium
       - name: Restore archived build
         uses: actions/download-artifact@v4
         with:
@@ -574,16 +592,6 @@ jobs:
           merge-multiple: true
       - name: Display structure of build
         run: ls -R build
-      - name: Install fixture dependencies
-        working-directory: fixtures/flight
-        run: |
-          yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
-          if [ $? -ne 0 ]; then
-            yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
-          fi
-      - name: Playwright install deps
-        working-directory: fixtures/flight
-        run: npx playwright install --with-deps chromium
       - name: Run tests
         working-directory: fixtures/flight
         run: yarn test

--- a/.github/workflows/runtime_commit_artifacts.yml
+++ b/.github/workflows/runtime_commit_artifacts.yml
@@ -170,10 +170,12 @@ jobs:
         with:
           name: compiled
           path: compiled/
+          if-no-files-found: error
       - uses: actions/upload-artifact@v4
         with:
           name: compiled-rn
           path: compiled-rn/
+          if-no-files-found: error
 
   commit_www_artifacts:
     needs: download_artifacts

--- a/.github/workflows/runtime_commit_artifacts.yml
+++ b/.github/workflows/runtime_commit_artifacts.yml
@@ -151,9 +151,9 @@ jobs:
           ls -R ./compiled-rn
       - name: Add REVISION files
         run: |
-          echo ${{ github.sha }} >> ./compiled/facebook-www/REVISION
+          echo ${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha }} >> ./compiled/facebook-www/REVISION
           cp ./compiled/facebook-www/REVISION ./compiled/facebook-www/REVISION_TRANSFORMS
-          echo ${{ github.sha}} >> ./compiled-rn/facebook-fbsource/xplat/js/react-native-github/Libraries/Renderer/REVISION
+          echo ${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha }} >> ./compiled-rn/facebook-fbsource/xplat/js/react-native-github/Libraries/Renderer/REVISION
       - name: "Get current version string"
         id: get_current_version
         run: |


### PR DESCRIPTION

There was a bug previously in our commit artifacts step where the emitted REVISION hash would reference the commit on the builds branch rather than from `main`.

Given that our internal manual sync script also does this, let's align them both to always reference the commit from `main` instead.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32680).
* __->__ #32680
* #32679
* #32678