### PR TITLE
[ci] Bump number of shards for test_build to 10

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -373,9 +373,16 @@ jobs:
           # TODO: Test more persistent configurations?
         ]
         shard:
-          - 1/3
-          - 2/3
-          - 3/3
+          - 1/10
+          - 2/10
+          - 3/10
+          - 4/10
+          - 5/10
+          - 6/10
+          - 7/10
+          - 8/10
+          - 9/10
+          - 10/10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

I noticed `test_build` can take a while so let's bump the number of shards
