### PR TITLE
[DevTools] Use Popover API for component inspect overlays

### DIFF
--- a/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
@@ -40,9 +40,12 @@ class OverlayRect {
       borderColor: overlayStyles.margin,
       pointerEvents: 'none',
       position: 'fixed',
+      backgroundColor: 'transparent',
+      outline: 'none',
+      boxShadow: 'none',
     });
 
-    this.node.style.zIndex = '10000000';
+    this.node.setAttribute('popover', 'manual');
 
     this.node.appendChild(this.border);
     this.border.appendChild(this.padding);
@@ -105,7 +108,12 @@ class OverlayTip {
       position: 'fixed',
       fontSize: '12px',
       whiteSpace: 'nowrap',
+      outline: 'none',
+      boxShadow: 'none',
+      border: 'none',
     });
+
+    this.tip.setAttribute('popover', 'manual');
 
     this.nameSpan = doc.createElement('span');
     this.tip.appendChild(this.nameSpan);
@@ -121,7 +129,6 @@ class OverlayTip {
       color: '#d7d7d7',
     });
 
-    this.tip.style.zIndex = '10000000';
     container.appendChild(this.tip);
   }
 
@@ -166,7 +173,6 @@ export default class Overlay {
 
     const doc = currentWindow.document;
     this.container = doc.createElement('div');
-    this.container.style.zIndex = '10000000';
 
     this.tip = new OverlayTip(doc, this.container);
     this.rects = [];
@@ -264,6 +270,20 @@ export default class Overlay {
         width: this.tipBoundsWindow.innerWidth,
       },
     );
+
+    this.rects.forEach(rect => {
+      if (!rect.node.matches(':popover-open')) {
+        // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
+        // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
+        rect.node.showPopover();
+      }
+    });
+
+    if (!this.tip.tip.matches(':popover-open')) {
+      // $FlowFixMe[prop-missing]: Flow doesn't recognize Popover API
+      // $FlowFixMe[incompatible-use]: Flow doesn't recognize Popover API
+      this.tip.tip.showPopover();
+    }
   }
 }
 


### PR DESCRIPTION
Following the Popover API integration in https://github.com/facebook/react/pull/32614, this PR adds the same capability to Component Inspector highlighting in React DevTools.

## Summary

When selecting a component in the Components tab, the highlighting overlays currently appear behind elements that use the browser's top-layer (such as <dialog> elements or components using the Popover API). This makes it difficult to see component structure and dimensions when they are inside or behind top-layer elements.

This change modifies the Overlay.js module to use the Popover API, ensuring that component highlighting always appears above all other content, including elements in the browser's top-layer. The implementation centrally manages popover controls and follows the same pattern as the recently merged [TraceUpdates PR](https://github.com/facebook/react/pull/32614) for consistency.

## How did you test this change?

I tested this change in the following ways:

1. Manual testing with a test application that includes:
   - Components inside <dialog> elements
   - Components inside elements using the Popover API
   - Selection of complex nested component hierarchies
2. Verification steps:
   - Selected components in the Components tab with DevTools
   - Confirmed highlighting appears correctly on top of dialog and popover elements
   - Verified all highlighting elements (margins, borders, padding, content) display correctly
   - Ensured the tooltip with component name and dimensions appears properly
   - Checked that existing functionality and visual styling remains consistent

All functionality works as expected, with component highlighting now correctly appearing on top of all content, including top-layer elements.

[demo-page](https://devtools-toplayer-demo.vercel.app/)
[demo-repo](https://github.com/yongsk0066/devtools-toplayer-demo)

### AS-IS

https://github.com/user-attachments/assets/7c025ccb-3c5e-4f9e-89a3-150a7d4811b3

### TO-BE

https://github.com/user-attachments/assets/da081e59-05ce-4935-880e-93d05f8528ad