### PR TITLE
[refresh] Fix default export signatures for memo/forwardRef/hoc

### DIFF
--- a/packages/react-refresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-refresh/src/ReactFreshBabelPlugin.js
@@ -98,9 +98,20 @@ export default function (babel, opts = {}) {
             if (!foundInside) {
               return false;
             }
-            // const Foo = hoc1(hoc2(() => {}))
-            // export default memo(React.forwardRef(function() {}))
-            callback(inferredName, node, path);
+
+            // TODO: this is a hack, we should find a better way to detect this.
+            if (
+              firstArgPath.node.type === 'Identifier' &&
+              inferredName === '%default%'
+            ) {
+              // export default memo(function() {}))
+              // export default forwardRef(function() {}))
+              callback(innerName, node, path);
+            } else {
+              // const Foo = hoc1(hoc2(() => {}))
+              // export default memo(React.forwardRef(function() {}))
+              callback(inferredName, node, path);
+            }
             return true;
           }
           default: {

--- a/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -206,6 +206,44 @@ describe('ReactFreshBabelPlugin', () => {
     ).toMatchSnapshot();
   });
 
+  it('registers memo default export', () => {
+    expect(
+      transform(`
+        function Component() {}
+        export default React.memo(Component);
+    `),
+    ).toMatchSnapshot();
+  });
+
+  it('registers forwardRef default export', () => {
+    expect(
+      transform(`
+        function Component() {}
+        export default React.forwardRef(Component);
+    `),
+    ).toMatchSnapshot();
+  });
+
+  it('registers memo default export', () => {
+    expect(
+      transform(`
+        import {memo} from 'react';
+        function Component() {}
+        export default memo(Component);
+    `),
+    ).toMatchSnapshot();
+  });
+
+  it('registers forwardRef default export', () => {
+    expect(
+      transform(`
+        import {forwardRef} from 'react';
+        function Component() {}
+        export default forwardRef(Component);
+    `),
+    ).toMatchSnapshot();
+  });
+
   it('registers likely HOCs with inline functions', () => {
     expect(
       transform(`

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -274,6 +274,123 @@ describe('ReactFreshIntegration', () => {
       }
     });
 
+    it('switches memo to forwardRef with different inner', async () => {
+      if (__DEV__) {
+        await render(`
+          const Child = () => {
+            return <h1>A1</h1>;
+          };
+
+          export default Child;
+        `);
+        let lastElement = container.firstChild;
+        expect(lastElement.textContent).toBe('A1');
+        await patch(`
+          const {memo} = React;
+
+          const Child2 = () => {
+            return <h1>A2</h1>;
+          };
+
+          export default memo(Child2);
+        `);
+        expect(container.firstChild !== lastElement).toBe(true);
+        expect(container.firstChild.textContent).toBe('A2');
+        lastElement = container.firstChild;
+
+        await patch(`
+          const {forwardRef} = React;
+
+          const Child3 = () => {
+            return <h1>A3</h1>;
+          };
+
+          export default forwardRef(Child3);
+        `);
+
+        expect(container.firstChild !== lastElement).toBe(true);
+        expect(container.firstChild.textContent).toBe('A3');
+        lastElement = container.firstChild;
+
+        await patch(`
+          const {memo} = React;
+
+          const Child4 = () => {
+            return <h1>A4</h1>;
+          };
+
+          export default memo(Child4);
+        `);
+
+        expect(container.firstChild !== lastElement).toBe(true);
+        expect(container.firstChild.textContent).toBe('A4');
+        lastElement = container.firstChild;
+
+        await patch(`
+          const Child5 = () => {
+            return <h1>A5</h1>;
+          };
+
+          export default Child5;
+        `);
+
+        expect(container.firstChild !== lastElement).toBe(true);
+        expect(container.firstChild.textContent).toBe('A5');
+      }
+    });
+
+    it('switches memo to forwardRef with same inner', async () => {
+      if (__DEV__) {
+        await render(`
+          const Child = () => {
+            return <h1>A1</h1>;
+          };
+
+          export default Child;
+        `);
+        let lastElement = container.firstChild;
+        expect(lastElement.textContent).toBe('A1');
+        await patch(`
+          const {memo} = React;
+
+          const Child = () => {
+            return <h1>A1</h1>;
+          };
+
+          export default memo(Child);
+        `);
+
+        expect(container.firstChild !== lastElement).toBe(true);
+        expect(container.firstChild.textContent).toBe('A1');
+        lastElement = container.firstChild;
+
+        await patch(`
+          const {forwardRef} = React;
+
+          const Child = () => {
+            return <h1>A1</h1>;
+          };
+
+          export default forwardRef(Child);
+        `);
+
+        expect(container.firstChild !== lastElement).toBe(true);
+        expect(container.firstChild.textContent).toBe('A1');
+        lastElement = container.firstChild;
+
+        await patch(`
+          const Child = () => {
+            return <h1>A1</h1>;
+          };
+
+          export default Child;
+        `);
+
+        expect(container.firstChild !== lastElement).toBe(true);
+        expect(container.firstChild.textContent).toBe('A1');
+      }
+    });
+
     it('reloads default export with named memo', async () => {
       if (__DEV__) {
         await render(`

--- a/packages/react-refresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-refresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -268,9 +268,28 @@ const B = hoc(Foo);
 _c4 = B;
 var _c, _c2, _c3, _c4;
 $RefreshReg$(_c, "Foo");
-$RefreshReg$(_c2, "%default%");
+$RefreshReg$(_c2, "%default%$hoc");
 $RefreshReg$(_c3, "A");
 $RefreshReg$(_c4, "B");
+`;
+
+exports[`ReactFreshBabelPlugin registers forwardRef default export 1`] = `
+function Component() {}
+_c = Component;
+export default _c2 = React.forwardRef(Component);
+var _c, _c2;
+$RefreshReg$(_c, "Component");
+$RefreshReg$(_c2, "%default%$React.forwardRef");
+`;
+
+exports[`ReactFreshBabelPlugin registers forwardRef default export 2`] = `
+import { forwardRef } from 'react';
+function Component() {}
+_c = Component;
+export default _c2 = forwardRef(Component);
+var _c, _c2;
+$RefreshReg$(_c, "Component");
+$RefreshReg$(_c2, "%default%$forwardRef");
 `;
 
 exports[`ReactFreshBabelPlugin registers identifiers used in JSX at definition site 1`] = `
@@ -395,6 +414,25 @@ var _c, _c2, _c3;
 $RefreshReg$(_c, "%default%$React.memo$forwardRef");
 $RefreshReg$(_c2, "%default%$React.memo");
 $RefreshReg$(_c3, "%default%");
+`;
+
+exports[`ReactFreshBabelPlugin registers memo default export 1`] = `
+function Component() {}
+_c = Component;
+export default _c2 = React.memo(Component);
+var _c, _c2;
+$RefreshReg$(_c, "Component");
+$RefreshReg$(_c2, "%default%$React.memo");
+`;
+
+exports[`ReactFreshBabelPlugin registers memo default export 2`] = `
+import { memo } from 'react';
+function Component() {}
+_c = Component;
+export default _c2 = memo(Component);
+var _c, _c2;
+$RefreshReg$(_c, "Component");
+$RefreshReg$(_c2, "%default%$memo");
 `;
 
 exports[`ReactFreshBabelPlugin registers top-level exported function declarations 1`] = `


### PR DESCRIPTION
## Overview

Not actually sure this is the right fix. 


Fixes a bug in react-refresh that does not detect changes between default exports for memo/forwardRef/Hoc.

## Explanation of bug

Consider changing a file between these three exports:

```js    
export default Child;

// edit 1
export default memo(Child);

// edit 2
export default forwardRef(Child);

// edit 3
export default hoc(Child);
```

The babel plugin will insert `$RefreshReg$` as:

```js
$RefreshReg$(Child, "Child");

// edit 1
$RefreshReg$(Child, "Child");
$RefreshReg$(memo(Child), "%default%");       // <- same id

// edit 2
$RefreshReg$(Child, "Child");
$RefreshReg$(forwardRef(Child), "%default%"); // <- same id

// edit 3
$RefreshReg$(Child, "Child");
$RefreshReg$(hoc(Child), "%default%");        // <- same id
```

However, these need to be registered with different IDs or they will be treated like an update:

https://github.com/facebook/react/blob/86d5ac0882305c5bbff0fd7b40385e7d50d0d2b4/packages/react-refresh/src/ReactFreshRuntime.js#L319-L325

## Fix
Fixes to add the `$React.memo|forwardRef|hoc` suffix like we do when you do `memo(forwardRef))`:

https://github.com/facebook/react/blob/bc1a49d8b54990fde0d4f612c8d2ba1249afcfad/packages/react-refresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap#L404-L405

```js
$RefreshReg$(Child, "Child");

// edit 1
$RefreshReg$(Child, "Child");
$RefreshReg$(memo(Child), "%default%$React.memo");             // <- different id

// edit 2
$RefreshReg$(Child, "Child");
$RefreshReg$(forwardRef(Child), "%default%$React.forwardRef"); // <- different id

// edit 3
$RefreshReg$(Child, "Child");
$RefreshReg$(hoc(Child), "%default%hoc");                      // <- different id
```