### PR TITLE
[ci] Don't use pull_request_target

### DIFF
--- a/.github/workflows/compiler_discord_notify.yml
+++ b/.github/workflows/compiler_discord_notify.yml
@@ -1,7 +1,7 @@
 name: (Compiler) Discord Notify
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, ready_for_review]
     paths:
       - compiler/**

--- a/.github/workflows/runtime_discord_notify.yml
+++ b/.github/workflows/runtime_discord_notify.yml
@@ -1,7 +1,7 @@
 name: (Runtime) Discord Notify
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, ready_for_review]
     paths-ignore:
       - compiler/**

--- a/.github/workflows/shared_label_core_team_prs.yml
+++ b/.github/workflows/shared_label_core_team_prs.yml
@@ -1,7 +1,7 @@
 name: (Shared) Label Core Team PRs
 
 on:
-  pull_request_target:
+  pull_request:
 
 permissions: {}
 

--- a/.github/workflows/shared_label_core_team_prs.yml
+++ b/.github/workflows/shared_label_core_team_prs.yml
@@ -24,8 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_maintainer
     permissions:
-      # Used to add labels
+      # Used to add labels on issues
       issues: write
+      # Used to add labels on PRs
+      pull-requests: write
     steps:
       - name: Label PR as React Core Team
         uses: actions/github-script@v7


### PR DESCRIPTION

`pull_request_target` gives access to repository secrets and permissions for use from forks, for example to add a comment.

> Due to the dangers inherent to automatic processing of PRs, GitHub’s standard pull_request workflow trigger by default prevents write permissions and secrets access to the target repository. However, in some scenarios such access is needed to properly process the PR. To this end the pull_request_target workflow trigger was introduced.

> The reason to introduce the pull_request_target trigger was to enable workflows to label PRs (e.g. needs review) or to comment on the PR.

(via https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)

In this case there is no reason for us to allow this, so let's just use the normal `pull_request` trigger which is less permissive.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32708).
* __->__ #32708
* #32709