### PR TITLE
[ci] Add missing permissions to runtime_commit_artifacts.yml

### DIFF
--- a/.github/workflows/runtime_commit_artifacts.yml
+++ b/.github/workflows/runtime_commit_artifacts.yml
@@ -203,6 +203,9 @@ jobs:
     needs: [download_artifacts, process_artifacts]
     if: inputs.force == true || (github.ref == 'refs/heads/main' && needs.process_artifacts.outputs.www_branch_count == '0')
     runs-on: ubuntu-latest
+    permissions:
+      # Used to push a commit to builds/facebook-www
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -289,6 +292,9 @@ jobs:
 
   commit_fbsource_artifacts:
     needs: [download_artifacts, process_artifacts]
+    permissions:
+      # Used to push a commit to builds/facebook-fbsource
+      contents: write
     if: inputs.force == true || (github.ref == 'refs/heads/main' && needs.process_artifacts.outputs.fbsource_branch_count == '0')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

Turns out we need permissions to write to `contents` after all.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32710).
* #32711
* __->__ #32710