### PR TITLE
[ci] Add artifact attestation to build

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -426,6 +426,10 @@ jobs:
   process_artifacts_combined:
     name: Process artifacts combined
     needs: [build_and_lint, runtime_node_modules_cache]
+    permissions:
+      # https://github.com/actions/attest-build-provenance
+      id-token: write
+      attestations: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -468,6 +472,7 @@ jobs:
         # TODO: Migrate scripts to use `build` directory instead of `build2`
       - run: cp ./build.tgz ./build2.tgz
       - name: Archive build artifacts
+        id: upload_artifacts_combined
         uses: actions/upload-artifact@v4
         with:
           name: artifacts_combined
@@ -475,6 +480,10 @@ jobs:
             ./build.tgz
             ./build2.tgz
           if-no-files-found: error
+      - uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: artifacts_combined.zip
+          subject-digest: sha256:${{ steps.upload_artifacts_combined.outputs.artifact-digest }}
 
   check_error_codes:
     name: Search build artifacts for unminified errors


### PR DESCRIPTION

Adds a signed build provenance attestations via https://github.com/actions/attest-build-provenance
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32711).
* #32729
* #32728
* __->__ #32711