### PR TITLE
Add compareDocumentPosition to fragment instances

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2649,7 +2649,7 @@ function addEventListenerToChild(
   listener: EventListener,
   optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
 ): boolean {
-  const instance = getInstanceFromHostFiber(child);
+  const instance = getInstanceFromHostFiber<Instance>(child);
   instance.addEventListener(type, listener, optionsOrUseCapture);
   return false;
 }
@@ -2689,7 +2689,7 @@ function removeEventListenerFromChild(
   listener: EventListener,
   optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
 ): boolean {
-  const instance = getInstanceFromHostFiber(child);
+  const instance = getInstanceFromHostFiber<Instance>(child);
   instance.removeEventListener(type, listener, optionsOrUseCapture);
   return false;
 }
@@ -2708,7 +2708,7 @@ function setFocusOnFiberIfFocusable(
   fiber: Fiber,
   focusOptions?: FocusOptions,
 ): boolean {
-  const instance = getInstanceFromHostFiber(fiber);
+  const instance = getInstanceFromHostFiber<Instance>(fiber);
   return setFocusIfFocusable(instance, focusOptions);
 }
 // $FlowFixMe[prop-missing]
@@ -2740,7 +2740,7 @@ FragmentInstance.prototype.blur = function (this: FragmentInstanceType): void {
 };
 function blurActiveElementWithinFragment(child: Fiber): boolean {
   // TODO: We can get the activeElement from the parent outside of the loop when we have a reference.
-  const instance = getInstanceFromHostFiber(child);
+  const instance = getInstanceFromHostFiber<Instance>(child);
   const ownerDocument = instance.ownerDocument;
   if (instance === ownerDocument.activeElement) {
     // $FlowFixMe[prop-missing]
@@ -2764,7 +2764,7 @@ function observeChild(
   child: Fiber,
   observer: IntersectionObserver | ResizeObserver,
 ) {
-  const instance = getInstanceFromHostFiber(child);
+  const instance = getInstanceFromHostFiber<Instance>(child);
   observer.observe(instance);
   return false;
 }
@@ -2789,7 +2789,7 @@ function unobserveChild(
   child: Fiber,
   observer: IntersectionObserver | ResizeObserver,
 ) {
-  const instance = getInstanceFromHostFiber(child);
+  const instance = getInstanceFromHostFiber<Instance>(child);
   observer.unobserve(instance);
   return false;
 }
@@ -2802,7 +2802,7 @@ FragmentInstance.prototype.getClientRects = function (
   return rects;
 };
 function collectClientRects(child: Fiber, rects: Array<DOMRect>): boolean {
-  const instance = getInstanceFromHostFiber(child);
+  const instance = getInstanceFromHostFiber<Instance>(child);
   // $FlowFixMe[method-unbinding]
   rects.push.apply(rects, instance.getClientRects());
   return false;
@@ -2816,7 +2816,8 @@ FragmentInstance.prototype.getRootNode = function (
   if (parentHostFiber === null) {
     return this;
   }
-  const parentHostInstance = getInstanceFromHostFiber(parentHostFiber);
+  const parentHostInstance =
+    getInstanceFromHostFiber<Instance>(parentHostFiber);
   const rootNode =
     // $FlowFixMe[incompatible-cast] Flow expects Node
     (parentHostInstance.getRootNode(getRootNodeOptions): Document | ShadowRoot);
@@ -2838,7 +2839,8 @@ FragmentInstance.prototype.compareDocumentPosition = function (
   if (children.length === 0) {
     // If the fragment has no children, we can use the parent and
     // siblings to determine a position.
-    const parentHostInstance = getInstanceFromHostFiber(parentHostFiber);
+    const parentHostInstance =
+      getInstanceFromHostFiber<Instance>(parentHostFiber);
     const parentResult = parentHostInstance.compareDocumentPosition(otherNode);
     result = parentResult;
     if (parentHostInstance === otherNode) {
@@ -2852,7 +2854,7 @@ FragmentInstance.prototype.compareDocumentPosition = function (
           result = Node.DOCUMENT_POSITION_PRECEDING;
         } else {
           const nextSiblingInstance =
-            getInstanceFromHostFiber(nextSiblingFiber);
+            getInstanceFromHostFiber<Instance>(nextSiblingFiber);
           const nextSiblingResult =
             nextSiblingInstance.compareDocumentPosition(otherNode);
           if (
@@ -2871,8 +2873,10 @@ FragmentInstance.prototype.compareDocumentPosition = function (
     return result;
   }
 
-  const firstElement = getInstanceFromHostFiber(children[0]);
-  const lastElement = getInstanceFromHostFiber(children[children.length - 1]);
+  const firstElement = getInstanceFromHostFiber<Instance>(children[0]);
+  const lastElement = getInstanceFromHostFiber<Instance>(
+    children[children.length - 1],
+  );
   const firstResult = firstElement.compareDocumentPosition(otherNode);
   const lastResult = lastElement.compareDocumentPosition(otherNode);
   if (

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2629,6 +2629,7 @@ FragmentInstance.prototype.addEventListener = function (
     listeners.push({type, listener, optionsOrUseCapture});
     traverseFragmentInstance(
       this._fragmentFiber,
+      false,
       addEventListenerToChild,
       type,
       listener,
@@ -2660,6 +2661,7 @@ FragmentInstance.prototype.removeEventListener = function (
   if (typeof listeners !== 'undefined' && listeners.length > 0) {
     traverseFragmentInstance(
       this._fragmentFiber,
+      false,
       removeEventListenerFromChild,
       type,
       listener,
@@ -2692,6 +2694,7 @@ FragmentInstance.prototype.focus = function (
 ): void {
   traverseFragmentInstance(
     this._fragmentFiber,
+    false,
     setFocusIfFocusable,
     focusOptions,
   );
@@ -2702,7 +2705,12 @@ FragmentInstance.prototype.focusLast = function (
   focusOptions?: FocusOptions,
 ): void {
   const children: Array<Instance> = [];
-  traverseFragmentInstance(this._fragmentFiber, collectChildren, children);
+  traverseFragmentInstance(
+    this._fragmentFiber,
+    false,
+    collectChildren,
+    children,
+  );
   for (let i = children.length - 1; i >= 0; i--) {
     const child = children[i];
     if (setFocusIfFocusable(child, focusOptions)) {
@@ -2723,6 +2731,7 @@ FragmentInstance.prototype.blur = function (this: FragmentInstanceType): void {
   //   does not contain document.activeElement
   traverseFragmentInstance(
     this._fragmentFiber,
+    false,
     blurActiveElementWithinFragment,
   );
 };
@@ -2745,7 +2754,7 @@ FragmentInstance.prototype.observeUsing = function (
     this._observers = new Set();
   }
   this._observers.add(observer);
-  traverseFragmentInstance(this._fragmentFiber, observeChild, observer);
+  traverseFragmentInstance(this._fragmentFiber, false, observeChild, observer);
 };
 function observeChild(
   child: Instance,
@@ -2768,7 +2777,12 @@ FragmentInstance.prototype.unobserveUsing = function (
     }
   } else {
     this._observers.delete(observer);
-    traverseFragmentInstance(this._fragmentFiber, unobserveChild, observer);
+    traverseFragmentInstance(
+      this._fragmentFiber,
+      false,
+      unobserveChild,
+      observer,
+    );
   }
 };
 function unobserveChild(
@@ -2783,7 +2797,12 @@ FragmentInstance.prototype.getClientRects = function (
   this: FragmentInstanceType,
 ): Array<DOMRect> {
   const rects: Array<DOMRect> = [];
-  traverseFragmentInstance(this._fragmentFiber, collectClientRects, rects);
+  traverseFragmentInstance(
+    this._fragmentFiber,
+    true,
+    collectClientRects,
+    rects,
+  );
   return rects;
 };
 function collectClientRects(child: Instance, rects: Array<DOMRect>): boolean {
@@ -2816,7 +2835,12 @@ FragmentInstance.prototype.compareDocumentPosition = function (
   }
 
   const children: Array<Instance> = [];
-  traverseFragmentInstance(this._fragmentFiber, collectChildren, children);
+  traverseFragmentInstance(
+    this._fragmentFiber,
+    true,
+    collectChildren,
+    children,
+  );
 
   if (children.length === 0) {
     // If the fragment has no children, we can use the parent and

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2809,8 +2809,14 @@ FragmentInstance.prototype.compareDocumentPosition = function (
   this: FragmentInstanceType,
   otherNode: Instance,
 ): number {
+  const parentHostInstance = getFragmentParentHostInstance(this._fragmentFiber);
+  if (parentHostInstance === null) {
+    return Node.DOCUMENT_POSITION_DISCONNECTED;
+  }
+
   const children: Array<Instance> = [];
   traverseFragmentInstance(this._fragmentFiber, collectChildren, children);
+
   if (children.length === 0) {
     return (
       Node.DOCUMENT_POSITION_DISCONNECTED |

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -1193,7 +1193,7 @@ describe('FragmentRefs', () => {
     });
 
     // @gate enableFragmentRefs
-    it('returns disconnected and implementation specific for any comparison with empty fragment instances', async () => {
+    it('handles empty fragment instances', async () => {
       const fragmentRef = React.createRef();
       const beforeRef = React.createRef();
       const afterRef = React.createRef();
@@ -1215,34 +1215,34 @@ describe('FragmentRefs', () => {
       expectPosition(
         fragmentRef.current.compareDocumentPosition(document.body),
         {
-          preceding: false,
+          preceding: true,
           following: false,
-          contains: false,
+          contains: true,
           containedBy: false,
-          disconnected: true,
-          implementationSpecific: true,
+          disconnected: false,
+          implementationSpecific: false,
         },
       );
       expectPosition(
         fragmentRef.current.compareDocumentPosition(beforeRef.current),
         {
-          preceding: false,
+          preceding: true,
           following: false,
           contains: false,
           containedBy: false,
-          disconnected: true,
-          implementationSpecific: true,
+          disconnected: false,
+          implementationSpecific: false,
         },
       );
       expectPosition(
         fragmentRef.current.compareDocumentPosition(afterRef.current),
         {
           preceding: false,
-          following: false,
+          following: true,
           contains: false,
           containedBy: false,
-          disconnected: true,
-          implementationSpecific: true,
+          disconnected: false,
+          implementationSpecific: false,
         },
       );
       expectPosition(
@@ -1250,10 +1250,10 @@ describe('FragmentRefs', () => {
         {
           preceding: false,
           following: false,
-          contains: false,
+          contains: true,
           containedBy: false,
-          disconnected: true,
-          implementationSpecific: true,
+          disconnected: false,
+          implementationSpecific: false,
         },
       );
     });

--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -644,7 +644,7 @@ FragmentInstance.prototype.observeUsing = function (
   traverseFragmentInstance(this._fragmentFiber, observeChild, observer);
 };
 function observeChild(child: Fiber, observer: IntersectionObserver) {
-  const instance = getInstanceFromHostFiber(child);
+  const instance = getInstanceFromHostFiber<Instance>(child);
   const publicInstance = getPublicInstance(instance);
   if (publicInstance == null) {
     throw new Error('Expected to find a host node. This is a bug in React.');
@@ -671,7 +671,7 @@ FragmentInstance.prototype.unobserveUsing = function (
   }
 };
 function unobserveChild(child: Fiber, observer: IntersectionObserver) {
-  const instance = getInstanceFromHostFiber(child);
+  const instance = getInstanceFromHostFiber<Instance>(child);
   const publicInstance = getPublicInstance(instance);
   if (publicInstance == null) {
     throw new Error('Expected to find a host node. This is a bug in React.');

--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -24,7 +24,10 @@ import {
 } from 'react-reconciler/src/ReactEventPriorities';
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 import {HostText} from 'react-reconciler/src/ReactWorkTags';
-import {traverseFragmentInstance} from 'react-reconciler/src/ReactFiberTreeReflection';
+import {
+  getInstanceFromHostFiber,
+  traverseFragmentInstance,
+} from 'react-reconciler/src/ReactFiberTreeReflection';
 
 // Modules provided by RN:
 import {
@@ -640,7 +643,8 @@ FragmentInstance.prototype.observeUsing = function (
   this._observers.add(observer);
   traverseFragmentInstance(this._fragmentFiber, observeChild, observer);
 };
-function observeChild(instance: Instance, observer: IntersectionObserver) {
+function observeChild(child: Fiber, observer: IntersectionObserver) {
+  const instance = getInstanceFromHostFiber(child);
   const publicInstance = getPublicInstance(instance);
   if (publicInstance == null) {
     throw new Error('Expected to find a host node. This is a bug in React.');
@@ -666,7 +670,8 @@ FragmentInstance.prototype.unobserveUsing = function (
     traverseFragmentInstance(this._fragmentFiber, unobserveChild, observer);
   }
 };
-function unobserveChild(instance: Instance, observer: IntersectionObserver) {
+function unobserveChild(child: Fiber, observer: IntersectionObserver) {
+  const instance = getInstanceFromHostFiber(child);
   const publicInstance = getPublicInstance(instance);
   if (publicInstance == null) {
     throw new Error('Expected to find a host node. This is a bug in React.');
@@ -690,7 +695,7 @@ export function updateFragmentInstanceFiber(
 }
 
 export function commitNewChildToFragmentInstance(
-  child: Instance,
+  child: Fiber,
   fragmentInstance: FragmentInstanceType,
 ): void {
   if (fragmentInstance._observers !== null) {

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -12,7 +12,6 @@ import type {
   Container,
   ActivityInstance,
   SuspenseInstance,
-  Instance,
 } from './ReactFiberConfig';
 import type {ActivityState} from './ReactFiberActivityComponent';
 import type {SuspenseState} from './ReactFiberSuspenseComponent';
@@ -411,7 +410,7 @@ export function getFragmentParentHostFiber(fiber: Fiber): null | Fiber {
   return null;
 }
 
-export function getInstanceFromHostFiber(fiber: Fiber): Instance {
+export function getInstanceFromHostFiber<I>(fiber: Fiber): I {
   switch (fiber.tag) {
     case HostComponent:
       return fiber.stateNode;

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -345,59 +345,65 @@ export function doesFiberContain(
   return false;
 }
 
-export function traverseFragmentInstance<I, A, B, C>(
+export function traverseFragmentInstance<A, B, C>(
   fragmentFiber: Fiber,
-  fn: (I, A, B, C) => boolean,
-  skipPortals: boolean,
+  fn: (Fiber, A, B, C) => boolean,
   a: A,
   b: B,
   c: C,
 ): void {
-  traverseFragmentInstanceChildren(
-    fragmentFiber.child,
-    skipPortals,
-    fn,
-    a,
-    b,
-    c,
-  );
+  traverseVisibleHostChildren(fragmentFiber.child, false, fn, a, b, c);
 }
 
-function traverseFragmentInstanceChildren<I, A, B, C>(
+function traverseVisibleHostChildren<A, B, C>(
   child: Fiber | null,
-  fn: (I, A, B, C) => boolean,
-  skipPortals: boolean,
+  searchWithinHosts: boolean,
+  fn: (Fiber, A, B, C) => boolean,
   a: A,
   b: B,
   c: C,
-): void {
+): boolean {
   while (child !== null) {
     if (child.tag === HostComponent) {
-      if (fn(child.stateNode, a, b, c)) {
-        return;
+      if (fn(child, a, b, c)) {
+        return true;
+      }
+      if (searchWithinHosts) {
+        if (
+          traverseVisibleHostChildren(
+            child.child,
+            searchWithinHosts,
+            fn,
+            a,
+            b,
+            c,
+          )
+        ) {
+          return true;
+        }
       }
     } else if (
       child.tag === OffscreenComponent &&
       child.memoizedState !== null
     ) {
       // Skip hidden subtrees
-    } else if (skipPortals && child.tag === HostPortal) {
-      // Skip portals
     } else {
-      traverseFragmentInstanceChildren(child.child, skipPortals, fn, a, b, c);
+      if (
+        traverseVisibleHostChildren(child.child, searchWithinHosts, fn, a, b, c)
+      ) {
+        return true;
+      }
     }
     child = child.sibling;
   }
+  return false;
 }
 
-export function getFragmentParentHostInstance(fiber: Fiber): null | Instance {
+export function getFragmentParentHostFiber(fiber: Fiber): null | Fiber {
   let parent = fiber.return;
   while (parent !== null) {
-    if (parent.tag === HostRoot) {
-      return parent.stateNode.containerInfo;
-    }
-    if (parent.tag === HostComponent) {
-      return parent.stateNode;
+    if (parent.tag === HostRoot || parent.tag === HostComponent) {
+      return parent;
     }
     parent = parent.return;
   }
@@ -405,11 +411,186 @@ export function getFragmentParentHostInstance(fiber: Fiber): null | Instance {
   return null;
 }
 
-export function getNextSiblingHostInstance(fiber: Fiber): null | Instance {
-  let nextSibling = null;
-  traverseFragmentInstanceChildren(fiber.sibling, true, instance => {
-    nextSibling = instance;
+export function getInstanceFromHostFiber(fiber: Fiber): Instance {
+  switch (fiber.tag) {
+    case HostComponent:
+      return fiber.stateNode;
+    case HostRoot:
+      return fiber.stateNode.containerInfo;
+    default:
+      throw new Error('Expected to find a host node. This is a bug in React.');
+  }
+}
+
+export function getNextSiblingHostFiber(fiber: Fiber): null | Fiber {
+  const searchState = {next: null};
+  traverseVisibleHostChildren(
+    fiber.sibling,
+    false,
+    findNextSibling,
+    searchState,
+  );
+  return searchState.next;
+}
+
+function findNextSibling(child: Fiber, state: {next: null | Fiber}): boolean {
+  state.next = child;
+  return true;
+}
+
+export function isFiberContainedBy(
+  maybeChild: Fiber,
+  maybeParent: Fiber,
+): boolean {
+  let parent = maybeParent.return;
+  if (parent === maybeChild || parent === maybeChild.alternate) {
     return true;
-  });
-  return nextSibling;
+  }
+  while (parent !== null && parent !== maybeChild) {
+    if (
+      (parent.tag === HostComponent || parent.tag === HostRoot) &&
+      (parent.return === maybeChild || parent.return === maybeChild.alternate)
+    ) {
+      return true;
+    }
+    parent = parent.return;
+  }
+  return false;
+}
+
+export function isFiberPreceding(fiber: Fiber, otherFiber: Fiber): boolean {
+  const commonAncestor = getLowestCommonAncestor(
+    fiber,
+    otherFiber,
+    getParentForFragmentAncestors,
+  );
+  if (commonAncestor === null) {
+    return false;
+  }
+  const searchState = {found: false};
+  traverseVisibleHostChildren(
+    commonAncestor,
+    true,
+    isFiberPrecedingCheck,
+    otherFiber,
+    fiber,
+    searchState,
+  );
+  return searchState.found;
+}
+
+function isFiberPrecedingCheck(
+  child: Fiber,
+  target: Fiber,
+  boundary: Fiber,
+  state: {found: boolean},
+): boolean {
+  if (child === boundary) {
+    return true;
+  }
+  if (child === target) {
+    state.found = true;
+    return true;
+  }
+  return false;
+}
+
+export function isFiberFollowing(fiber: Fiber, otherFiber: Fiber): boolean {
+  const commonAncestor = getLowestCommonAncestor(
+    fiber,
+    otherFiber,
+    getParentForFragmentAncestors,
+  );
+  if (commonAncestor === null) {
+    return false;
+  }
+  const searchState = {foundFiber: false, foundOther: false};
+  traverseVisibleHostChildren(
+    commonAncestor,
+    true,
+    isFiberFollowingCheck,
+    otherFiber,
+    fiber,
+    searchState,
+  );
+  return searchState.foundOther;
+}
+
+function isFiberFollowingCheck(
+  child: Fiber,
+  target: Fiber,
+  boundary: Fiber,
+  state: {foundFiber: boolean, foundOther: boolean},
+): boolean {
+  if (child === boundary) {
+    state.foundFiber = true;
+    return false;
+  }
+  if (child === target) {
+    state.foundOther = state.foundFiber;
+    return true;
+  }
+  return false;
+}
+
+function getParentForFragmentAncestors(inst: Fiber | null): Fiber | null {
+  if (inst === null) {
+    return null;
+  }
+  do {
+    inst = inst === null ? null : inst.return;
+  } while (
+    inst &&
+    inst.tag !== HostComponent &&
+    inst.tag !== HostSingleton &&
+    inst.tag !== HostRoot
+  );
+  if (inst) {
+    return inst;
+  }
+  return null;
+}
+
+/**
+ * Return the lowest common ancestor of A and B, or null if they are in
+ * different trees.
+ */
+export function getLowestCommonAncestor(
+  instA: Fiber,
+  instB: Fiber,
+  getParent: (inst: Fiber | null) => Fiber | null,
+): Fiber | null {
+  let nodeA: null | Fiber = instA;
+  let nodeB: null | Fiber = instB;
+  let depthA = 0;
+  for (let tempA: null | Fiber = nodeA; tempA; tempA = getParent(tempA)) {
+    depthA++;
+  }
+  let depthB = 0;
+  for (let tempB: null | Fiber = nodeB; tempB; tempB = getParent(tempB)) {
+    depthB++;
+  }
+
+  // If A is deeper, crawl up.
+  while (depthA - depthB > 0) {
+    nodeA = getParent(nodeA);
+    depthA--;
+  }
+
+  // If B is deeper, crawl up.
+  while (depthB - depthA > 0) {
+    nodeB = getParent(nodeB);
+    depthB--;
+  }
+
+  // Walk in lockstep until we find a match.
+  let depth = depthA;
+  while (depth--) {
+    if (nodeA === nodeB || (nodeB !== null && nodeA === nodeB.alternate)) {
+      return nodeA;
+    }
+    nodeA = getParent(nodeA);
+    nodeB = getParent(nodeB);
+  }
+  return null;
 }

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -393,3 +393,12 @@ export function getFragmentParentHostInstance(fiber: Fiber): null | Instance {
 
   return null;
 }
+
+export function getNextSiblingHostInstance(fiber: Fiber): null | Instance {
+  let nextSibling = null;
+  traverseFragmentInstanceChildren(fiber.sibling, instance => {
+    nextSibling = instance;
+    return true;
+  });
+  return nextSibling;
+}

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -348,16 +348,25 @@ export function doesFiberContain(
 export function traverseFragmentInstance<I, A, B, C>(
   fragmentFiber: Fiber,
   fn: (I, A, B, C) => boolean,
+  skipPortals: boolean,
   a: A,
   b: B,
   c: C,
 ): void {
-  traverseFragmentInstanceChildren(fragmentFiber.child, fn, a, b, c);
+  traverseFragmentInstanceChildren(
+    fragmentFiber.child,
+    skipPortals,
+    fn,
+    a,
+    b,
+    c,
+  );
 }
 
 function traverseFragmentInstanceChildren<I, A, B, C>(
   child: Fiber | null,
   fn: (I, A, B, C) => boolean,
+  skipPortals: boolean,
   a: A,
   b: B,
   c: C,
@@ -372,8 +381,10 @@ function traverseFragmentInstanceChildren<I, A, B, C>(
       child.memoizedState !== null
     ) {
       // Skip hidden subtrees
+    } else if (skipPortals && child.tag === HostPortal) {
+      // Skip portals
     } else {
-      traverseFragmentInstanceChildren(child.child, fn, a, b, c);
+      traverseFragmentInstanceChildren(child.child, skipPortals, fn, a, b, c);
     }
     child = child.sibling;
   }
@@ -396,7 +407,7 @@ export function getFragmentParentHostInstance(fiber: Fiber): null | Instance {
 
 export function getNextSiblingHostInstance(fiber: Fiber): null | Instance {
   let nextSibling = null;
-  traverseFragmentInstanceChildren(fiber.sibling, instance => {
+  traverseFragmentInstanceChildren(fiber.sibling, true, instance => {
     nextSibling = instance;
     return true;
   });


### PR DESCRIPTION
This adds `compareDocumentPosition(otherNode)` to fragment instances.

The semantics implemented are meant to match typical element positioning, with some fragment specifics. See the unit tests for all expectations.

- An element preceding a fragment is `Node.DOCUMENT_POSITION_PRECEDING`
- An element after a fragment is `Node.DOCUMENT_POSITION_FOLLOWING`
- An element containing the fragment is `Node.DOCUMENT_POSITION_PRECEDING` and `Node.DOCUMENT_POSITION_CONTAINING`
- An element within the fragment is `Node.DOCUMENT_POSITION_CONTAINED_BY`
- An element compared against an empty fragment will result in `Node.DOCUMENT_POSITION_DISCONNECTED` and `Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC`

Since we assume a fragment instances target children are DOM siblings and we want to compare the full fragment as a pseudo container, we can compare against the first target child outside of handling the special cases (empty fragments and contained elements).
