### PR TITLE
Merge ViewTransition layout/onLayout props into update/onUpdate

### DIFF
--- a/packages/react-reconciler/src/ReactFiberApplyGesture.js
+++ b/packages/react-reconciler/src/ReactFiberApplyGesture.js
@@ -308,7 +308,7 @@ function applyNestedViewTransition(child: Fiber): void {
   const name = getViewTransitionName(props, state);
   const className: ?string = getViewTransitionClassName(
     props.className,
-    props.layout,
+    props.update,
   );
   if (className !== 'none') {
     const clones = state.clones;
@@ -335,17 +335,13 @@ function applyUpdateViewTransition(current: Fiber, finishedWork: Fiber): void {
   // we would use. However, since this animation is going in reverse we actually
   // want the props from "current" since that's the class that would've won if
   // it was the normal direction. To preserve the same effect in either direction.
-  let className: ?string = getViewTransitionClassName(
+  const className: ?string = getViewTransitionClassName(
     newProps.className,
     newProps.update,
   );
   if (className === 'none') {
-    className = getViewTransitionClassName(newProps.className, newProps.layout);
-    if (className === 'none') {
-      // If both update and layout are both "none" then we don't have to
-      // apply a name. Since we won't animate this boundary.
-      return;
-    }
+    // If update is "none" then we don't have to apply a name. Since we won't animate this boundary.
+    return;
   }
   const clones = state.clones;
   // If there are no clones at this point, that should mean that there are no

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2517,8 +2517,6 @@ function commitAfterMutationEffectsOnFiber(
       break;
     }
     case ViewTransitionComponent: {
-      const wasMutated = (finishedWork.flags & Update) !== NoFlags;
-
       const prevContextChanged = viewTransitionContextChanged;
       const prevCancelableChildren = pushViewTransitionCancelableScope();
       viewTransitionContextChanged = false;
@@ -2554,12 +2552,7 @@ function commitAfterMutationEffectsOnFiber(
         // then we should probably issue an event since this instance is part of it.
       } else {
         const props: ViewTransitionProps = finishedWork.memoizedProps;
-        scheduleViewTransitionEvent(
-          finishedWork,
-          wasMutated || viewTransitionContextChanged
-            ? props.onUpdate
-            : props.onLayout,
-        );
+        scheduleViewTransitionEvent(finishedWork, props.onUpdate);
 
         // If this boundary did update, we cannot cancel its children so those are dropped.
         popViewTransitionCancelableScope(prevCancelableChildren);

--- a/packages/react-reconciler/src/ReactFiberViewTransitionComponent.js
+++ b/packages/react-reconciler/src/ReactFiberViewTransitionComponent.js
@@ -32,12 +32,10 @@ export type ViewTransitionProps = {
   className?: ViewTransitionClass,
   enter?: ViewTransitionClass,
   exit?: ViewTransitionClass,
-  layout?: ViewTransitionClass,
   share?: ViewTransitionClass,
   update?: ViewTransitionClass,
   onEnter?: (instance: ViewTransitionInstance, types: Array<string>) => void,
   onExit?: (instance: ViewTransitionInstance, types: Array<string>) => void,
-  onLayout?: (instance: ViewTransitionInstance, types: Array<string>) => void,
   onShare?: (instance: ViewTransitionInstance, types: Array<string>) => void,
   onUpdate?: (instance: ViewTransitionInstance, types: Array<string>) => void,
 };


### PR DESCRIPTION
We currently have the ability to have a separate animation for a ViewTransition that relayouts but doesn't actually have any internal mutations. This can be useful if you want to separate just a move from for example flashing an update.

However, we're concerned that this might be more confusion than its worth because subtle differences in mutations can cause it to trigger the other case. The existence of the property name might also make you start looking for it to solve something that it's not meant for.

We already fallback to using the "update" property if it exists but layout doesn't. So if we ever decide to add this back it would backwards compatible. We've also shown in implementation that it can work.
