### PR TITLE
Fix ownerStackLimit feature gating for tests

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -29,7 +29,3 @@ export const enableUseEffectCRUDOverload = __VARIANT__;
 export const enableFastAddPropertiesInDiffing = __VARIANT__;
 export const enableLazyPublicInstanceInFabric = __VARIANT__;
 export const renameElementSymbol = __VARIANT__;
-export const ownerStackLimit: number = __VARIANT__
-  ? // Some value that doesn't impact existing tests
-    500
-  : 1e4;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -31,7 +31,6 @@ export const {
   enableFastAddPropertiesInDiffing,
   enableLazyPublicInstanceInFabric,
   renameElementSymbol,
-  ownerStackLimit,
 } = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.
@@ -85,6 +84,7 @@ export const enableViewTransition = false;
 export const enableSwipeTransition = false;
 export const enableScrollEndPolyfill = true;
 export const enableFragmentRefs = false;
+export const ownerStackLimit = 1e4;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -43,11 +43,6 @@ export const enableComponentPerformanceTrack = __VARIANT__;
 export const enableScrollEndPolyfill = __VARIANT__;
 export const enableFragmentRefs = __VARIANT__;
 
-export const ownerStackLimit: number = __VARIANT__
-  ? // Some value that doesn't impact existing tests
-    500
-  : 1e4;
-
 // TODO: These flags are hard-coded to the default values used in open source.
 // Update the tests so that they pass in either mode, then set these
 // to __VARIANT__.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -40,7 +40,6 @@ export const {
   enableComponentPerformanceTrack,
   enableScrollEndPolyfill,
   enableFragmentRefs,
-  ownerStackLimit,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.
@@ -114,6 +113,8 @@ export const enableShallowPropDiffing = false;
 export const enableLazyPublicInstanceInFabric = false;
 
 export const enableSwipeTransition = false;
+
+export const ownerStackLimit = 1e4;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/scripts/jest/setupTests.www.js
+++ b/scripts/jest/setupTests.www.js
@@ -17,6 +17,9 @@ jest.mock('shared/ReactFeatureFlags', () => {
   // we remove the flag.
   actual.disableClientCache = __VARIANT__;
 
+  // Some value that doesn't impact existing tests
+  actual.ownerStackLimit = __VARIANT__ ? 500 : 1e4;
+
   return actual;
 });
 

--- a/scripts/jest/setupTests.xplat.js
+++ b/scripts/jest/setupTests.xplat.js
@@ -22,6 +22,9 @@ jest.mock('shared/ReactFeatureFlags', () => {
   actual.enableScopeAPI = true;
   actual.enableTaint = false;
 
+  // Some value that doesn't impact existing tests
+  actual.ownerStackLimit = __VARIANT__ ? 500 : 1e4;
+
   return actual;
 });
 


### PR DESCRIPTION
https://github.com/facebook/react/pull/32529 added a dynamic flag for this, but that breaks tests since the flags are not defined everywhere.

However, this is a static value and the flag is only for supporting existing tests. So we can override it in the test config, and make it static at built time instead.