### PR TITLE
[ci] Make maintainer check always remote

### DIFF
--- a/.github/workflows/shared_check_maintainer.yml
+++ b/.github/workflows/shared_check_maintainer.yml
@@ -6,10 +6,6 @@ on:
       actor:
         required: true
         type: string
-      is_remote:
-        required: false
-        type: boolean
-        default: false
     outputs:
       is_core_team:
         value: ${{ jobs.check_maintainer.outputs.is_core_team }}
@@ -30,7 +26,6 @@ jobs:
     outputs:
       is_core_team: ${{ steps.check_if_actor_is_maintainer.outputs.result }}
     steps:
-      - uses: actions/checkout@v4
       - name: Check if actor is maintainer
         id: check_if_actor_is_maintainer
         uses: actions/github-script@v7
@@ -38,33 +33,20 @@ jobs:
           script: |
             const fs = require('fs');
             const actor = '${{ inputs.actor }}';
-            let isRemote = ${{ inputs.is_remote }};
-            if (typeof isRemote === 'string') {
-              isRemote = isRemote === 'true';
+            const res = await github.rest.repos.getContent({
+              owner: 'facebook',
+              repo: 'react',
+              path: 'MAINTAINERS',
+              ref: 'main',
+              headers: { Accept: 'application/vnd.github+json' }
+            });
+            if (res.status !== 200) {
+              console.error(res);
+              throw new Error('Unable to fetch MAINTAINERS file');
             }
-            if (typeof isRemote !== 'boolean') {
-              throw new Error(`Invalid \`isRemote\` input. Expected a boolean, got: ${isRemote}`);
-            }
-
-            let content = null;
-            if (isRemote === true) {
-              const res = await github.rest.repos.getContent({
-                owner: 'facebook',
-                repo: 'react',
-                path: 'MAINTAINERS',
-                ref: 'main',
-                headers: { Accept: 'application/vnd.github+json' }
-              });
-              if (res.status !== 200) {
-                console.error(res);
-                throw new Error('Unable to fetch MAINTAINERS file');
-              }
-              content = Buffer.from(res.data.content, 'base64').toString();
-            } else {
-              content = await fs.readFileSync('./MAINTAINERS', { encoding: 'utf8' });
-            }
-            if (content === null) {
-              throw new Error('Unable to retrieve local or http MAINTAINERS file');
+            content = Buffer.from(res.data.content, 'base64').toString();
+            if (content == null || typeof content !== 'string') {
+              throw new Error('Unable to retrieve MAINTAINERS file');
             }
 
             const maintainers = new Set(content.split('\n'));


### PR DESCRIPTION

To prevent local modification of the MAINTAINERS file we now always fetch from `main` instead.
