### PR TITLE
[ci] Pass GH_TOKEN to runtime_prereleases

### DIFF
--- a/.github/workflows/runtime_prereleases_manual.yml
+++ b/.github/workflows/runtime_prereleases_manual.yml
@@ -35,6 +35,7 @@ jobs:
       dist_tag: canary,next
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish_prerelease_experimental:
     name: Publish to Experimental channel
@@ -53,3 +54,4 @@ jobs:
       dist_tag: experimental
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/runtime_prereleases_nightly.yml
+++ b/.github/workflows/runtime_prereleases_nightly.yml
@@ -23,6 +23,7 @@ jobs:
       dist_tag: canary,next
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish_prerelease_experimental:
     name: Publish to Experimental channel
@@ -41,3 +42,4 @@ jobs:
       dist_tag: experimental
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

Seems like this also needs to be specified.

Note: #32732 needs to land first.
