### PR TITLE
[ci] Fix param casing

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -487,7 +487,7 @@ jobs:
         #
         # Note that this means that scripts/release/download-experimental-build.js must be run with
         # --no-verify when downloading a build from a fork.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'push' && github.ref_name == 'main' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           subject-name: artifacts_combined.zip
           subject-digest: sha256:${{ steps.upload_artifacts_combined.outputs.artifact-digest }}
@@ -818,7 +818,7 @@ jobs:
         # unverified artifact is not used. Additionally this workflow runs in the pull_request
         # trigger so only restricted permissions are available.
         run: |
-          GH_TOKEN=${{ github.token }} scripts/release/download-experimental-build.js --commit=$(git rev-parse ${{ github.event.pull_request.base.sha }}) ${{ (github.event.pull_request.head.repo.full_name != github.repository && '--no-verify') || ''}}
+          GH_TOKEN=${{ github.token }} scripts/release/download-experimental-build.js --commit=$(git rev-parse ${{ github.event.pull_request.base.sha }}) ${{ (github.event.pull_request.head.repo.full_name != github.repository && '--noVerify') || ''}}
           mv ./build ./base-build
       - name: Delete extraneous files
         # TODO: The `download-experimental-build` script copies the npm

--- a/scripts/release/download-experimental-build.js
+++ b/scripts/release/download-experimental-build.js
@@ -27,7 +27,7 @@ const argv = yargs.wrap(yargs.terminalWidth()).options({
     demandOption: true,
     type: 'string',
   },
-  'no-verify': {
+  noVerify: {
     describe: 'Skip verification',
     requiresArg: false,
     type: 'boolean',


### PR DESCRIPTION

Casing was incorrect.

Tested by running locally with a PAT.

```
$ scripts/release/download-experimental-build.js --commit=2d40460cf768071d3a70b4cdc16075d23ca1ff25
Command failed: gh attestation verify artifacts_combined.zip --repo=facebook/react

Error: failed to fetch attestations from facebook/react: HTTP 404: Not Found (https://api.github.com/repos/facebook/react/attestations/sha256:23d05644f9e49e02cbb441e3932cc4366b261826e58ce222ea249a6b786f0b5f?per_page=30)
`gh attestation verify artifacts_combined.zip --repo=facebook/react` (exited with error code 1)

$ scripts/release/download-experimental-build.js --commit=2d40460cf768071d3a70b4cdc16075d23ca1ff25 --noVerify
⠼ Downloading artifacts from GitHub for commit 2d40460cf768071d3a70b4cdc16075d23ca1ff25)  5%                  0.1m, estimated 1.6m
✓ Downloading artifacts from GitHub for commit 2d40460cf768071d3a70b4cdc16075d23ca1ff25) 9.5 secs
An experimental build has been downloaded!

You can download this build again by running:
  scripts/download-experimental-build.js --commit=2d40460cf768071d3a70b4cdc16075d23ca1ff25
```
