### PR TITLE
Avoid double logging component render time

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -3095,25 +3095,6 @@ function commitPassiveMountOnFiber(
   const prevEffectStart = pushComponentEffectStart();
   const prevEffectErrors = pushComponentEffectErrors();
 
-  // If this component rendered in Profiling mode (DEV or in Profiler component) then log its
-  // render time. We do this after the fact in the passive effect to avoid the overhead of this
-  // getting in the way of the render characteristics and avoid the overhead of unwinding
-  // uncommitted renders.
-  if (
-    enableProfilerTimer &&
-    enableComponentPerformanceTrack &&
-    (finishedWork.mode & ProfileMode) !== NoMode &&
-    ((finishedWork.actualStartTime: any): number) > 0 &&
-    (finishedWork.flags & PerformedWork) !== NoFlags
-  ) {
-    logComponentRender(
-      finishedWork,
-      ((finishedWork.actualStartTime: any): number),
-      endTime,
-      inHydratedSubtree,
-    );
-  }
-
   const isViewTransitionEligible = enableViewTransition
     ? includesOnlyViewTransitionEligibleLanes(committedLanes)
     : false;


### PR DESCRIPTION
This got moved into the functional component and class component case statements here: https://github.com/facebook/react/commit/0de1233fd180969f7ffdfc98151922f2466ceb1f. So that we could separate the error case for class components.

However, due to a faulty rebase this got restored at the top as well. Leading to double component renders being logged.

In the other offscreen reconnect passes we don't do this in each case statement but still once at the top. The reason this doesn't matter is because use the PerformedWork flag and that is only set for function and class components. Although maybe it should be set for expensive DOM components too and then we have to remember this.

