### PR TITLE
Add getComputedStyle helper to ViewTransition refs

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2079,6 +2079,7 @@ export function stopGestureTransition(transition: RunningGestureTransition) {
 interface ViewTransitionPseudoElementType extends Animatable {
   _scope: HTMLElement;
   _selector: string;
+  getComputedStyle(): CSSStyleDeclaration;
 }
 
 function ViewTransitionPseudoElement(
@@ -2131,6 +2132,14 @@ ViewTransitionPseudoElement.prototype.getAnimations = function (
     }
   }
   return result;
+};
+// $FlowFixMe[prop-missing]
+ViewTransitionPseudoElement.prototype.getComputedStyle = function (
+  this: ViewTransitionPseudoElementType,
+): CSSStyleDeclaration {
+  const scope = this._scope;
+  const selector = this._selector;
+  return getComputedStyle(scope, selector);
 };
 
 export function createViewTransitionInstance(


### PR DESCRIPTION
This is also sometimes useful to read the style of the pseudo-element itself without an animation.