### PR TITLE
fix(ReactFiberCommitEffects): cannot read properties of undefined (reading 'tag')

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitEffects.js
@@ -143,7 +143,7 @@ export function commitHookEffectListMount(
     const updateQueue: FunctionComponentUpdateQueue | null =
       (finishedWork.updateQueue: any);
     const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
-    if (lastEffect !== null) {
+    if (lastEffect !== null && lastEffect.next !== undefined) {
       const firstEffect = lastEffect.next;
       let effect = firstEffect;
       do {
@@ -251,7 +251,7 @@ export function commitHookEffectListUnmount(
     const updateQueue: FunctionComponentUpdateQueue | null =
       (finishedWork.updateQueue: any);
     const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
-    if (lastEffect !== null) {
+    if (lastEffect !== null && lastEffect.next !== undefined) {
       const firstEffect = lastEffect.next;
       let effect = firstEffect;
       do {

--- a/packages/react-reconciler/src/ReactFiberCommitEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitEffects.js
@@ -234,6 +234,11 @@ export function commitHookEffectListMount(
             }
           }
         }
+
+        if (!effect.next) {
+          break
+        }
+
         effect = effect.next;
       } while (effect !== firstEffect);
     }
@@ -290,6 +295,11 @@ export function commitHookEffectListUnmount(
             }
           }
         }
+
+        if (!effect.next) {
+          break
+        }
+
         effect = effect.next;
       } while (effect !== firstEffect);
     }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -226,7 +226,7 @@ export type Effect = {
   inst: EffectInstance,
   create: () => (() => void) | void,
   deps: Array<mixed> | void | null,
-  next: Effect,
+  next?: Effect,
 };
 
 type StoreInstance<T> = {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

- ⚠️ I don't know exactly how to reproduce the bug, my only evidence from the problem are my error logs. 
- Versions that my application uses `react@19.0.0` and `react-dom@19.0.0`.
- I got some logs from my application with the following stack trace, it was caught 4 times until now from my ErrorBoundary.

```
  | Attributes.metadata.stack.0 | webpack://_N_E/node_modules/react-dom/cjs/react-dom-client.production.js:7481:0
  | Attributes.metadata.stack.1 | webpack://_N_E/node_modules/react-dom/cjs/react-dom-client.production.js:8940:0
  | Attributes.metadata.stack.2 | webpack://_N_E/node_modules/react-dom/cjs/react-dom-client.production.js:8915:0
  | Attributes.metadata.stack.3 | webpack://_N_E/node_modules/react-dom/cjs/react-dom-client.production.js:9034:0
  | Attributes.metadata.stack.4 | webpack://_N_E/node_modules/react-dom/cjs/react-dom-client.production.js:8915:0
  | Attributes.metadata.stack.5 | webpack://_N_E/node_modules/react-dom/cjs/react-dom-client.production.js:9034:0
  | Attributes.metadata.stack.6 | webpack://_N_E/node_modules/react-dom/cjs/react-dom-client.production.js:8915:0
  | Attributes.metadata.stack.7 | webpack://_N_E/node_modules/react-dom/cjs/react-dom-client.production.js:8934:0
  | Attributes.metadata.stack.8 | webpack://_N_E/node_modules/react-dom/cjs/react-dom-client.production.js:8915:0
  | Attributes.metadata.stack.9 | webpack://_N_E/node_modules/react-dom/cjs/react-dom-client.production.js:8934:0
```

After checking the react code base, and the code generated from the `react-dom-client.production` version, I made the change on the `lastEffect.next` to garante that it will have a value before enter the `do while`.


## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
I did the following steps:
- I ran the `yarn test` command
- I ran the `yarn test --prod` command
- I ran the `yarn linc` command
