### PR TITLE
[compiler] Fix inferEffectDependencies lint false positives

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Babel/BabelPlugin.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Babel/BabelPlugin.ts
@@ -73,7 +73,7 @@ export default function BabelPluginReactCompiler(
             pass.filename ?? null,
             opts.logger,
             opts.environment,
-            result?.retryErrors ?? [],
+            result,
           );
           if (ENABLE_REACT_COMPILER_TIMINGS === true) {
             performance.mark(`${filename}:end`, {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -11,6 +11,7 @@ import {fromZodError} from 'zod-validation-error';
 import {CompilerError} from '../CompilerError';
 import {
   CompilationMode,
+  defaultOptions,
   Logger,
   PanicThresholdOptions,
   parsePluginOptions,
@@ -779,6 +780,7 @@ export function parseConfigPragmaForTests(
   const environment = parseConfigPragmaEnvironmentForTest(pragma);
   let compilationMode: CompilationMode = defaults.compilationMode;
   let panicThreshold: PanicThresholdOptions = 'all_errors';
+  let noEmit: boolean = defaultOptions.noEmit;
   for (const token of pragma.split(' ')) {
     if (!token.startsWith('@')) {
       continue;
@@ -804,12 +806,17 @@ export function parseConfigPragmaForTests(
         panicThreshold = 'none';
         break;
       }
+      case '@noEmit': {
+        noEmit = true;
+        break;
+      }
     }
   }
   return parsePluginOptions({
     environment,
     compilationMode,
     panicThreshold,
+    noEmit,
   });
 }
 
@@ -852,6 +859,7 @@ export class Environment {
   programContext: ProgramContext;
   hasFireRewrite: boolean;
   hasInferredEffect: boolean;
+  inferredEffectLocations: Set<SourceLocation> = new Set();
 
   #contextIdentifiers: Set<t.Identifier>;
   #hoistedIdentifiers: Set<t.Identifier>;

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferEffectDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferEffectDependencies.ts
@@ -217,6 +217,7 @@ export function inferEffectDependencies(fn: HIRFunction): void {
             // Step 2: push the inferred deps array as an argument of the useEffect
             value.args.push({...depsPlace, effect: Effect.Freeze});
             rewriteInstrs.set(instr.id, newInstructions);
+            fn.env.inferredEffectLocations.add(callee.loc);
           } else if (loadGlobals.has(value.args[0].identifier.id)) {
             // Global functions have no reactive dependencies, so we can insert an empty array
             newInstructions.push({
@@ -227,6 +228,7 @@ export function inferEffectDependencies(fn: HIRFunction): void {
             });
             value.args.push({...depsPlace, effect: Effect.Freeze});
             rewriteInstrs.set(instr.id, newInstructions);
+            fn.env.inferredEffectLocations.add(callee.loc);
           }
         }
       }

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -104,6 +104,7 @@ export type CodegenFunction = {
    * This is true if the compiler has compiled inferred effect dependencies
    */
   hasInferredEffect: boolean;
+  inferredEffectLocations: Set<SourceLocation>;
 
   /**
    * This is true if the compiler has compiled a fire to a useFire call
@@ -389,6 +390,7 @@ function codegenReactiveFunction(
     outlined: [],
     hasFireRewrite: fn.env.hasFireRewrite,
     hasInferredEffect: fn.env.hasInferredEffect,
+    inferredEffectLocations: fn.env.inferredEffectLocations,
   });
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-effect-dependencies/no-emit-lint-repro.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-effect-dependencies/no-emit-lint-repro.expect.md
@@ -1,0 +1,31 @@
+
+## Input
+
+```javascript
+// @inferEffectDependencies @noEmit
+import {print} from 'shared-runtime';
+import useEffectWrapper from 'useEffectWrapper';
+
+function ReactiveVariable({propVal}) {
+  const arr = [propVal];
+  useEffectWrapper(() => print(arr));
+}
+
+```
+
+## Code
+
+```javascript
+// @inferEffectDependencies @noEmit
+import { print } from "shared-runtime";
+import useEffectWrapper from "useEffectWrapper";
+
+function ReactiveVariable({ propVal }) {
+  const arr = [propVal];
+  useEffectWrapper(() => print(arr));
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-effect-dependencies/no-emit-lint-repro.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-effect-dependencies/no-emit-lint-repro.js
@@ -1,0 +1,8 @@
+// @inferEffectDependencies @noEmit
+import {print} from 'shared-runtime';
+import useEffectWrapper from 'useEffectWrapper';
+
+function ReactiveVariable({propVal}) {
+  const arr = [propVal];
+  useEffectWrapper(() => print(arr));
+}

--- a/compiler/packages/snap/src/compiler.ts
+++ b/compiler/packages/snap/src/compiler.ts
@@ -187,7 +187,6 @@ function makePluginOptions(
     },
     logger,
     gating,
-    noEmit: false,
     eslintSuppressionRules,
     flowSuppressions,
     ignoreUseNoForget,


### PR DESCRIPTION

Currently, inferred effect dependencies are considered a "compiler-required" feature. This means that untransformed callsites should escalate to a build error.

`ValidateNoUntransformedReferences` iterates 'special effect' callsites and checks that the compiler was able to successfully transform them. Prior to this PR, this relied on checking the number of arguments passed to this special effect.

This obviously doesn't work with `noEmit: true`, which is used for our eslint plugin (this avoids mutating the babel program as other linters run with the same ast). This PR adds a set of `babel.SourceLocation`s to do best effort matching in this mode.
