### PR TITLE
Warn for using a React owned node as a Container if it also has text content

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
@@ -211,7 +211,7 @@ export function getNodeFromInstance(inst: Fiber): Instance | TextInstance {
 }
 
 export function getFiberCurrentPropsFromNode(
-  node: Instance | TextInstance | SuspenseInstance,
+  node: Container | Instance | TextInstance | SuspenseInstance,
 ): Props {
   return (node: any)[internalPropsKey] || null;
 }


### PR DESCRIPTION
The problem with setting both `children` or `dangerouslySetInnerHTML` and also using a ref on a DOM node to either manually append children or using it as a Container for `createRoot` or `createPortal` is that it's ambiguous which children should win. Ideally you use one of the four options to control children. Meaning that ideally you always use a leaf container for refs like this.

Unfortunately it's very common to use a React owned thing with children as a Container of a Portal. For example `document.body` can have both regular React children and be used as a Portal container. This isn't really fully supported and has some undefined behavior like relative order isn't guaranteed but still very common.

It is extra bad if the children are a `string`/`number` or if `dangerouslySetInnerHTML` is set. Because then when ever that reactively updates it'll clear out any manually added DOM nodes. When this happens isn't guaranteed. It's always happening as far as the reactivity is concerned. See https://github.com/facebook/react/issues/31600

Therefore, we should warn for this specific pattern. This still allows non-text children as a compromise even though that behavior is also somewhat undefined.