### PR TITLE
[release] Don't lookup build-info.json when updating version numbers

### DIFF
--- a/scripts/release/prepare-release-from-npm-commands/parse-params.js
+++ b/scripts/release/prepare-release-from-npm-commands/parse-params.js
@@ -56,6 +56,7 @@ module.exports = () => {
   const params = commandLineArgs(paramDefinitions);
 
   splitCommaParams(params.skipPackages);
+  splitCommaParams(params.onlyPackages);
 
   return params;
 };

--- a/scripts/release/prepare-release-from-npm-commands/update-stable-version-numbers.js
+++ b/scripts/release/prepare-release-from-npm-commands/update-stable-version-numbers.js
@@ -114,20 +114,6 @@ const run = async ({cwd, packages, version, ci}, versionsMap) => {
   clear();
 
   if (packages.includes('react')) {
-    // A separate "React version" is used for the embedded renderer version to support DevTools,
-    // since it needs to distinguish between different version ranges of React.
-    // We need to replace it as well as the "next" version number.
-    const buildInfoPath = join(nodeModulesPath, 'react', 'build-info.json');
-    const {reactVersion} = await readJson(buildInfoPath);
-
-    if (!reactVersion) {
-      console.error(
-        theme`{error Unsupported or invalid build metadata in} {path build/node_modules/react/build-info.json}` +
-          theme`{error . This could indicate that you have specified an outdated "next" version.}`
-      );
-      process.exit(1);
-    }
-
     // We print the diff to the console for review,
     // but it can be large so let's also write it to disk.
     const diffPath = join(cwd, 'build', 'temp.diff');
@@ -151,10 +137,6 @@ const run = async ({cwd, packages, version, ci}, versionsMap) => {
         // Replace all "next" version numbers (e.g. header @license).
         while (afterContents.indexOf(version) >= 0) {
           afterContents = afterContents.replace(version, newStableVersion);
-        }
-        // Replace inline renderer version numbers (e.g. shared/ReactVersion).
-        while (afterContents.indexOf(reactVersion) >= 0) {
-          afterContents = afterContents.replace(reactVersion, newStableVersion);
         }
         if (beforeContents !== afterContents) {
           numFilesModified++;

--- a/scripts/release/publish-commands/parse-params.js
+++ b/scripts/release/publish-commands/parse-params.js
@@ -49,6 +49,7 @@ const paramDefinitions = [
 module.exports = () => {
   const params = commandLineArgs(paramDefinitions);
   splitCommaParams(params.skipPackages);
+  splitCommaParams(params.onlyPackages);
   splitCommaParams(params.tags);
   params.tags.forEach(tag => {
     switch (tag) {


### PR DESCRIPTION

From what we can see, `build-info.json` is a vestigal file that we were previously including in builds but are no longer since 2022 (see https://github.com/facebook/react/pull/23257, which removes `build-info.json` which would have broken scripts/release/build-release-locally-commands/add-build-info-json.js).

Since this file is no longer built, instead of looking it up we default to the `version` that was passed in as an argument to scripts/release/prepare-release-from-npm.js. Since `version` is what is pulled from npm, there should only be 1 consistent version for all the packages that are pulled. Therefore, only 1 version (eg canary) needs to be replaced to the new stable version.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32778).
* __->__ #32778
* #32777