### PR TITLE
[compiler][snap] Fix test filter + watch mode

### DIFF
--- a/compiler/packages/snap/src/runner-watch.ts
+++ b/compiler/packages/snap/src/runner-watch.ts
@@ -146,7 +146,7 @@ function subscribeFilterFile(
   state: RunnerState,
   onChange: (state: RunnerState) => void,
 ) {
-  watcher.subscribe(process.cwd(), async (err, events) => {
+  watcher.subscribe(PROJECT_ROOT, async (err, events) => {
     if (err) {
       console.error(err);
       process.exit(1);


### PR DESCRIPTION

Accidentally broke this when migrating our test runner to use the bundled build https://github.com/facebook/react/pull/32758

The fix is pretty simple. File watcher should listen for changes in `packages/babel-plugin-react-compiler` instead of `cwd`, which is now `packages/snap`.
