### PR TITLE
Add startGestureTransition API

### DIFF
--- a/fixtures/view-transition/src/components/Page.js
+++ b/fixtures/view-transition/src/components/Page.js
@@ -6,8 +6,10 @@ import React, {
   useEffect,
   useState,
   useId,
+  useOptimistic,
   startTransition,
 } from 'react';
+
 import {createPortal} from 'react-dom';
 
 import SwipeRecognizer from './SwipeRecognizer';
@@ -49,7 +51,13 @@ function Id() {
 }
 
 export default function Page({url, navigate}) {
-  const [renderedUrl, startGesture] = useSwipeTransition('/?a', url, '/?b');
+  const [_renderedUrl, startGesture] = useSwipeTransition('/?a', url, '/?b');
+  const [renderedUrl, optimisticNavigate] = useOptimistic(
+    url,
+    (state, direction) => {
+      return direction === 'left' ? '/?a' : '/?b';
+    }
+  );
   const show = renderedUrl === '/?b';
   function onTransition(viewTransition, types) {
     const keyframes = [
@@ -107,7 +115,10 @@ export default function Page({url, navigate}) {
     <div className="swipe-recognizer">
       <SwipeRecognizer
         action={swipeAction}
-        gesture={startGesture}
+        gesture={(direction, timeline, options) => {
+          optimisticNavigate(direction);
+          return startGesture(timeline, options);
+        }}
         direction={show ? 'left' : 'right'}>
         <button
           className="button"

--- a/fixtures/view-transition/src/components/Page.js
+++ b/fixtures/view-transition/src/components/Page.js
@@ -1,7 +1,6 @@
 import React, {
   unstable_ViewTransition as ViewTransition,
   unstable_Activity as Activity,
-  unstable_useSwipeTransition as useSwipeTransition,
   useLayoutEffect,
   useEffect,
   useState,
@@ -51,7 +50,6 @@ function Id() {
 }
 
 export default function Page({url, navigate}) {
-  const [, startGesture] = useSwipeTransition('/?a', url, '/?b');
   const [renderedUrl, optimisticNavigate] = useOptimistic(
     url,
     (state, direction) => {
@@ -115,13 +113,7 @@ export default function Page({url, navigate}) {
     <div className="swipe-recognizer">
       <SwipeRecognizer
         action={swipeAction}
-        gesture={(direction, timeline, options) => {
-          optimisticNavigate(direction);
-          const cancel = startGesture(timeline, options);
-          Promise.resolve().then(() => {
-            cancel(); // This is kept alive by the SwipeRecognizer.
-          });
-        }}
+        gesture={optimisticNavigate}
         direction={show ? 'left' : 'right'}>
         <button
           className="button"

--- a/fixtures/view-transition/src/components/Page.js
+++ b/fixtures/view-transition/src/components/Page.js
@@ -51,7 +51,7 @@ function Id() {
 }
 
 export default function Page({url, navigate}) {
-  const [_renderedUrl, startGesture] = useSwipeTransition('/?a', url, '/?b');
+  const [, startGesture] = useSwipeTransition('/?a', url, '/?b');
   const [renderedUrl, optimisticNavigate] = useOptimistic(
     url,
     (state, direction) => {
@@ -117,7 +117,10 @@ export default function Page({url, navigate}) {
         action={swipeAction}
         gesture={(direction, timeline, options) => {
           optimisticNavigate(direction);
-          return startGesture(timeline, options);
+          const cancel = startGesture(timeline, options);
+          Promise.resolve().then(() => {
+            cancel(); // This is kept alive by the SwipeRecognizer.
+          });
         }}
         direction={show ? 'left' : 'right'}>
         <button

--- a/fixtures/view-transition/src/components/SwipeRecognizer.js
+++ b/fixtures/view-transition/src/components/SwipeRecognizer.js
@@ -36,10 +36,10 @@ export default function SwipeRecognizer({
     const options = {
       range: [0, direction === 'left' || direction === 'up' ? 100 : 0, 100],
     };
-    startGestureTransition(
+    activeGesture.current = startGestureTransition(
       scrollTimeline,
       () => {
-        activeGesture.current = gesture(direction, scrollTimeline, options);
+        gesture(direction, scrollTimeline, options);
       },
       options
     );

--- a/fixtures/view-transition/src/components/SwipeRecognizer.js
+++ b/fixtures/view-transition/src/components/SwipeRecognizer.js
@@ -1,4 +1,9 @@
-import React, {useRef, useEffect, startTransition} from 'react';
+import React, {
+  useRef,
+  useEffect,
+  startTransition,
+  unstable_startGestureTransition as startGestureTransition,
+} from 'react';
 
 // Example of a Component that can recognize swipe gestures using a ScrollTimeline
 // without scrolling its own content. Allowing it to be used as an inert gesture
@@ -28,9 +33,16 @@ export default function SwipeRecognizer({
       source: scrollRef.current,
       axis: axis,
     });
-    activeGesture.current = gesture(scrollTimeline, {
+    const options = {
       range: [0, direction === 'left' || direction === 'up' ? 100 : 0, 100],
-    });
+    };
+    startGestureTransition(
+      scrollTimeline,
+      () => {
+        activeGesture.current = gesture(direction, scrollTimeline, options);
+      },
+      options
+    );
   }
   function onScrollEnd() {
     let changed;

--- a/fixtures/view-transition/src/components/SwipeRecognizer.js
+++ b/fixtures/view-transition/src/components/SwipeRecognizer.js
@@ -33,15 +33,14 @@ export default function SwipeRecognizer({
       source: scrollRef.current,
       axis: axis,
     });
-    const options = {
-      range: [0, direction === 'left' || direction === 'up' ? 100 : 0, 100],
-    };
     activeGesture.current = startGestureTransition(
       scrollTimeline,
       () => {
-        gesture(direction, scrollTimeline, options);
+        gesture(direction);
       },
-      options
+      {
+        range: [0, direction === 'left' || direction === 'up' ? 100 : 0, 100],
+      }
     );
   }
   function onScrollEnd() {

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -2138,6 +2138,9 @@ function runActionStateAction<S, P>(
     // This is a fork of startTransition
     const prevTransition = ReactSharedInternals.T;
     const currentTransition: Transition = ({}: any);
+    if (enableSwipeTransition) {
+      currentTransition.gesture = null;
+    }
     if (enableTransitionTracing) {
       currentTransition.name = null;
       currentTransition.startTime = -1;
@@ -3017,6 +3020,9 @@ function startTransition<S>(
 
   const prevTransition = ReactSharedInternals.T;
   const currentTransition: Transition = ({}: any);
+  if (enableSwipeTransition) {
+    currentTransition.gesture = null;
+  }
   if (enableTransitionTracing) {
     currentTransition.name =
       options !== undefined && options.name !== undefined ? options.name : null;

--- a/packages/react-reconciler/src/ReactFiberRootScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberRootScheduler.js
@@ -83,7 +83,7 @@ import {
 // A linked list of all the roots with pending work. In an idiomatic app,
 // there's only a single root, but we do support multi root apps, hence this
 // extra complexity. But this module is optimized for the single root case.
-let firstScheduledRoot: FiberRoot | null = null;
+export let firstScheduledRoot: FiberRoot | null = null;
 let lastScheduledRoot: FiberRoot | null = null;
 
 // Used to prevent redundant mircotasks from being scheduled.

--- a/packages/react-reconciler/src/ReactFiberTransition.js
+++ b/packages/react-reconciler/src/ReactFiberTransition.js
@@ -7,13 +7,20 @@
  * @flow
  */
 import type {Fiber, FiberRoot} from './ReactInternalTypes';
-import type {Thenable} from 'shared/ReactTypes';
+import type {
+  Thenable,
+  GestureProvider,
+  GestureOptions,
+} from 'shared/ReactTypes';
 import type {Lanes} from './ReactFiberLane';
 import type {StackCursor} from './ReactFiberStack';
 import type {Cache, SpawnedCachePool} from './ReactFiberCacheComponent';
 import type {Transition} from 'react/src/ReactStartTransition';
 
-import {enableTransitionTracing} from 'shared/ReactFeatureFlags';
+import {
+  enableTransitionTracing,
+  enableSwipeTransition,
+} from 'shared/ReactFeatureFlags';
 import {isPrimaryRenderer} from './ReactFiberConfig';
 import {createCursor, push, pop} from './ReactFiberStack';
 import {
@@ -77,6 +84,31 @@ ReactSharedInternals.S = function onStartTransitionFinishForReconciler(
     prevOnStartTransitionFinish(transition, returnValue);
   }
 };
+
+if (enableSwipeTransition) {
+  const prevOnStartGestureTransitionFinish = ReactSharedInternals.G;
+  ReactSharedInternals.G = function onStartGestureTransitionFinishForReconciler(
+    transition: Transition,
+    provider: GestureProvider,
+    options: ?GestureOptions,
+  ): () => void {
+    // TODO
+    let prevCancel = null;
+    if (prevOnStartGestureTransitionFinish !== null) {
+      prevCancel = prevOnStartGestureTransitionFinish(
+        transition,
+        provider,
+        options,
+      );
+    }
+    return function cancelGesture() {
+      // TODO
+      if (prevCancel !== null) {
+        prevCancel();
+      }
+    };
+  };
+}
 
 export function requestCurrentTransition(): Transition | null {
   return ReactSharedInternals.T;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -753,6 +753,16 @@ export function requestUpdateLane(fiber: Fiber): Lane {
 
   const transition = requestCurrentTransition();
   if (transition !== null) {
+    if (enableSwipeTransition) {
+      if (transition.gesture) {
+        throw new Error(
+          'Cannot setState on regular state inside a startGestureTransition. ' +
+            'Gestures can only update the useOptimistic() hook. There should be no ' +
+            'side-effects associated with starting a Gesture until its Action is ' +
+            'invoked. Move side-effects to the Action instead.',
+        );
+      }
+    }
     if (__DEV__) {
       if (!transition._updatedFibers) {
         transition._updatedFibers = new Set();

--- a/packages/react/index.experimental.development.js
+++ b/packages/react/index.experimental.development.js
@@ -33,6 +33,7 @@ export {
   unstable_getCacheForType,
   unstable_SuspenseList,
   unstable_ViewTransition,
+  unstable_startGestureTransition,
   unstable_useSwipeTransition,
   unstable_addTransitionType,
   unstable_useCacheRefresh,

--- a/packages/react/index.experimental.js
+++ b/packages/react/index.experimental.js
@@ -33,6 +33,7 @@ export {
   unstable_getCacheForType,
   unstable_SuspenseList,
   unstable_ViewTransition,
+  unstable_startGestureTransition,
   unstable_useSwipeTransition,
   unstable_addTransitionType,
   unstable_useCacheRefresh,

--- a/packages/react/src/ReactClient.js
+++ b/packages/react/src/ReactClient.js
@@ -60,7 +60,7 @@ import {
   useSwipeTransition,
 } from './ReactHooks';
 import ReactSharedInternals from './ReactSharedInternalsClient';
-import {startTransition} from './ReactStartTransition';
+import {startTransition, startGestureTransition} from './ReactStartTransition';
 import {addTransitionType} from './ReactTransitionType';
 import {act} from './ReactAct';
 import {captureOwnerStack} from './ReactOwnerStack';
@@ -128,6 +128,7 @@ export {
   REACT_VIEW_TRANSITION_TYPE as unstable_ViewTransition,
   addTransitionType as unstable_addTransitionType,
   // enableSwipeTransition
+  startGestureTransition as unstable_startGestureTransition,
   useSwipeTransition as unstable_useSwipeTransition,
   // DEV-only
   useId,

--- a/packages/react/src/ReactSharedInternalsClient.js
+++ b/packages/react/src/ReactSharedInternalsClient.js
@@ -11,12 +11,19 @@ import type {Dispatcher} from 'react-reconciler/src/ReactInternalTypes';
 import type {AsyncDispatcher} from 'react-reconciler/src/ReactInternalTypes';
 import type {Transition} from './ReactStartTransition';
 import type {TransitionTypes} from './ReactTransitionType';
+import type {GestureProvider, GestureOptions} from 'shared/ReactTypes';
+
+import {
+  enableViewTransition,
+  enableSwipeTransition,
+} from 'shared/ReactFeatureFlags';
 
 export type SharedStateClient = {
   H: null | Dispatcher, // ReactCurrentDispatcher for Hooks
   A: null | AsyncDispatcher, // ReactCurrentCache for Cache
   T: null | Transition, // ReactCurrentBatchConfig for Transitions
   S: null | ((Transition, mixed) => void), // onStartTransitionFinish
+  G: null | ((Transition, GestureProvider, ?GestureOptions) => () => void), // onStartGestureTransitionFinish
   V: null | TransitionTypes, // Pending Transition Types for the Next Transition
 
   // DEV-only
@@ -50,8 +57,13 @@ const ReactSharedInternals: SharedStateClient = ({
   A: null,
   T: null,
   S: null,
-  V: null,
 }: any);
+if (enableSwipeTransition) {
+  ReactSharedInternals.G = null;
+}
+if (enableViewTransition) {
+  ReactSharedInternals.V = null;
+}
 
 if (__DEV__) {
   ReactSharedInternals.actQueue = null;

--- a/packages/react/src/ReactStartTransition.js
+++ b/packages/react/src/ReactStartTransition.js
@@ -7,16 +7,24 @@
  * @flow
  */
 
-import type {StartTransitionOptions} from 'shared/ReactTypes';
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+import type {
+  StartTransitionOptions,
+  GestureProvider,
+  GestureOptions,
+} from 'shared/ReactTypes';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 
-import {enableTransitionTracing} from 'shared/ReactFeatureFlags';
+import {
+  enableTransitionTracing,
+  enableSwipeTransition,
+} from 'shared/ReactFeatureFlags';
 
 import reportGlobalError from 'shared/reportGlobalError';
 
 export type Transition = {
+  gesture: null | GestureProvider, // enableSwipeTransition
   name: null | string, // enableTransitionTracing only
   startTime: number, // enableTransitionTracing only
   _updatedFibers: Set<Fiber>, // DEV-only
@@ -26,9 +34,12 @@ export type Transition = {
 export function startTransition(
   scope: () => void,
   options?: StartTransitionOptions,
-) {
+): void {
   const prevTransition = ReactSharedInternals.T;
   const currentTransition: Transition = ({}: any);
+  if (enableSwipeTransition) {
+    currentTransition.gesture = null;
+  }
   if (enableTransitionTracing) {
     currentTransition.name =
       options !== undefined && options.name !== undefined ? options.name : null;
@@ -58,6 +69,71 @@ export function startTransition(
     warnAboutTransitionSubscriptions(prevTransition, currentTransition);
     ReactSharedInternals.T = prevTransition;
   }
+}
+
+export function startGestureTransition(
+  provider: GestureProvider,
+  scope: () => void,
+  options?: GestureOptions & StartTransitionOptions,
+): () => void {
+  if (!enableSwipeTransition) {
+    // eslint-disable-next-line react-internal/prod-error-codes
+    throw new Error(
+      'startGestureTransition should not be exported when the enableSwipeTransition flag is off.',
+    );
+  }
+  if (provider == null) {
+    // We enforce this at runtime even though the type also enforces it since we
+    // use null as a signal internally so it would lead it to be treated as a
+    // regular transition otherwise.
+    throw new Error(
+      'A Timeline is required as the first argument to startGestureTransition.',
+    );
+  }
+  const prevTransition = ReactSharedInternals.T;
+  const currentTransition: Transition = ({}: any);
+  if (enableSwipeTransition) {
+    currentTransition.gesture = provider;
+  }
+  if (enableTransitionTracing) {
+    currentTransition.name =
+      options !== undefined && options.name !== undefined ? options.name : null;
+    currentTransition.startTime = -1; // TODO: This should read the timestamp.
+  }
+  if (__DEV__) {
+    currentTransition._updatedFibers = new Set();
+  }
+  ReactSharedInternals.T = currentTransition;
+
+  try {
+    const returnValue = scope();
+    if (__DEV__) {
+      if (
+        typeof returnValue === 'object' &&
+        returnValue !== null &&
+        typeof returnValue.then === 'function'
+      ) {
+        console.error(
+          'Cannot use an async function in startGestureTransition. It must be able to start immediately.',
+        );
+      }
+    }
+    const onStartGestureTransitionFinish = ReactSharedInternals.G;
+    if (onStartGestureTransitionFinish !== null) {
+      return onStartGestureTransitionFinish(
+        currentTransition,
+        provider,
+        options,
+      );
+    }
+  } catch (error) {
+    reportGlobalError(error);
+  } finally {
+    ReactSharedInternals.T = prevTransition;
+  }
+  return function cancelGesture() {
+    // Noop
+  };
 }
 
 function warnAboutTransitionSubscriptions(

--- a/packages/react/src/ReactTransitionType.js
+++ b/packages/react/src/ReactTransitionType.js
@@ -8,14 +8,18 @@
  */
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
+import {enableViewTransition} from 'shared/ReactFeatureFlags';
 
 export type TransitionTypes = Array<string>;
 
 export function addTransitionType(type: string): void {
-  const pendingTransitionTypes: null | TransitionTypes = ReactSharedInternals.V;
-  if (pendingTransitionTypes === null) {
-    ReactSharedInternals.V = [type];
-  } else if (pendingTransitionTypes.indexOf(type) === -1) {
-    pendingTransitionTypes.push(type);
+  if (enableViewTransition) {
+    const pendingTransitionTypes: null | TransitionTypes =
+      ReactSharedInternals.V;
+    if (pendingTransitionTypes === null) {
+      ReactSharedInternals.V = [type];
+    } else if (pendingTransitionTypes.indexOf(type) === -1) {
+      pendingTransitionTypes.push(type);
+    }
   }
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -538,5 +538,7 @@
   "550": "useSwipeTransition is not yet supported in react-art.",
   "551": "useSwipeTransition is not yet supported in React Native.",
   "552": "Cannot use a useSwipeTransition() in a detached root.",
-  "553": "A Timeline is required as the first argument to startGestureTransition."
+  "553": "A Timeline is required as the first argument to startGestureTransition.",
+  "554": "Cannot setState on regular state inside a startGestureTransition. Gestures can only update the useOptimistic() hook. There should be no side-effects associated with starting a Gesture until its Action is invoked. Move side-effects to the Action instead.",
+  "555": "Cannot requestFormReset() inside a startGestureTransition. There should be no side-effects associated with starting a Gesture until its Action is invoked. Move side-effects to the Action instead."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -537,5 +537,6 @@
   "549": "Cannot start a gesture with a disconnected AnimationTimeline.",
   "550": "useSwipeTransition is not yet supported in react-art.",
   "551": "useSwipeTransition is not yet supported in React Native.",
-  "552": "Cannot use a useSwipeTransition() in a detached root."
+  "552": "Cannot use a useSwipeTransition() in a detached root.",
+  "553": "A Timeline is required as the first argument to startGestureTransition."
 }


### PR DESCRIPTION
Stacked on #32783. This will replace [the `useSwipeTransition` API](https://github.com/facebook/react/pull/32373). 

Instead, of a special Hook, you can make updates to `useOptimistic` Hooks within the `startGestureTransition` scope.

```
import {unstable_startGestureTransition as startGestureTransition} from 'react';

const cancel = startGestureTransition(timeline, () => {
  setOptimistic(...);
}, options);
```

There are some downsides to this like you can't define two directions as once and there's no "standard" direction protocol. It's instead up to libraries to come up with their own conventions (although we can suggest some).

The convention is still that a gesture recognizer has two props `action` and `gesture`. The `gesture` prop is a Gesture concept which now behaves more like an Action but 1) it can't be async 2) it shouldn't have side-effects. For example you can't call `setState()` in it except on `useOptimistic` since those can be reverted if needed. The `action` is invoked with whatever side-effects you want after the gesture fulfills.

This is isomorphic and not associated with a specific renderer nor root so it's a bit more complicated.

To implement this I unify with the `ReactSharedInternal.T` property to contain a regular Transition or a Gesture Transition (the `gesture` field). The benefit of this unification means that every time we override this based on some scope like entering `flushSync` we also override the `startGestureTransition` scope. We just have to be careful when we read it to check the `gesture` field to know which one it is. (E.g. I error for setState / requestFormReset.)

The other thing that's unique is the `cancel` return value to know when to stop the gesture. That cancellation is no longer associated with any particular Hook. It's more associated with the scope of the `startGestureTransition`. Since the schedule of whether a particular gesture has rendered or committed is associated with a root, we need to somehow associate any scheduled gestures with a root.

We could track which roots we update inside the scope but instead, I went with a model where I check all the roots and see if there's a scheduled gesture matching the timeline. This means that you could "retain" a gesture across roots. Meaning this wouldn't cancel until both are cancelled:

```
const cancelA = startGestureTransition(timeline, () => {
  setOptimisticOnRootA(...);
}, options);

const cancelB = startGestureTransition(timeline, () => {
  setOptimisticOnRootB(...);
}, options);
```

It's more like it's a global transition than associated with the roots that were updated.

Optimistic updates mostly just work but I now associate them with a specific "ScheduledGesture" instance since we can only render one at a time and so if it's not the current one, we leave it for later.

Clean up of optimistic updates is now lazy rather than when we cancel. Allowing the cancel closure not to have to be associated with each particular update.