### PR TITLE
Get rid of the directional gesture options

### DIFF
--- a/fixtures/view-transition/src/components/SwipeRecognizer.js
+++ b/fixtures/view-transition/src/components/SwipeRecognizer.js
@@ -38,9 +38,15 @@ export default function SwipeRecognizer({
       () => {
         gesture(direction);
       },
-      {
-        range: [0, direction === 'left' || direction === 'up' ? 100 : 0, 100],
-      }
+      direction === 'left' || direction === 'up'
+        ? {
+            rangeStart: 100,
+            rangeEnd: 0,
+          }
+        : {
+            rangeStart: 0,
+            rangeEnd: 100,
+          }
     );
   }
   function onScrollEnd() {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -3932,10 +3932,8 @@ function commitGestureOnRoot(
   pendingViewTransition = finishedGesture.running = startGestureTransition(
     root.containerInfo,
     finishedGesture.provider,
-    finishedGesture.rangeCurrent,
-    finishedGesture.direction
-      ? finishedGesture.rangeNext
-      : finishedGesture.rangePrevious,
+    finishedGesture.rangeStart,
+    finishedGesture.rangeEnd,
     pendingTransitionTypes,
     flushGestureMutations,
     flushGestureAnimations,

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -172,8 +172,8 @@ export type ReactFormState<S, ReferenceId> = [
 export type GestureProvider = any;
 
 export type GestureOptions = {
-  direction?: 'previous' | 'next',
-  range?: [/*previous*/ number, /*current*/ number, /*next*/ number],
+  rangeStart?: number,
+  rangeEnd?: number,
 };
 
 export type Awaited<T> = T extends null | void


### PR DESCRIPTION
Stacked on #32786.

`startGestureTransition` doesn't have a concept of two directions. It's just a start and end range now.