### PR TITLE
Adjust range start/end based on the duration and delay of the animation

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -1943,6 +1943,7 @@ export function startGestureTransition(
           const timing = effect.getTiming();
           const duration =
             typeof timing.duration === 'number' ? timing.duration : 0;
+          // TODO: Consider interation count higher than 1.
           const durationWithDelay = timing.delay + duration;
           if (durationWithDelay > longestDuration) {
             longestDuration = durationWithDelay;
@@ -2003,10 +2004,19 @@ export function startGestureTransition(
           const timing = effect.getTiming();
           const duration =
             typeof timing.duration === 'number' ? timing.duration : 0;
-          const adjustedRangeStart =
+          let adjustedRangeStart =
             rangeEnd - (duration + timing.delay) * durationToRangeMultipler;
-          const adjustedRangeEnd =
+          let adjustedRangeEnd =
             rangeEnd - timing.delay * durationToRangeMultipler;
+          if (
+            timing.direction === 'reverse' ||
+            timing.direction === 'alternate-reverse'
+          ) {
+            // This animation was originally in reverse so we have to play it in flipped range.
+            const temp = adjustedRangeStart;
+            adjustedRangeStart = adjustedRangeEnd;
+            adjustedRangeEnd = temp;
+          }
           animateGesture(
             effect.getKeyframes(),
             // $FlowFixMe: Always documentElement atm.


### PR DESCRIPTION
When different animations in a View Transition have different durations, we shouldn't stretch them out to run the full range of swipe. Because then they wouldn't line up the same way as when played using plain time.

This adjusts the range start/end to be what it would've been when played by time. Except since we are playing animations in reverse, the animation-delay is actually applied from the range end and then the duration from there to get closer to the start.

Reverse the range if the original animation was reversed.

Interestingly, the range it takes can be adjusted by what is in the viewport since if a long duration animation is excluded then everything else adjusts too.

I left some todos too. We really should also handle if the original animation has multiple iterations. Currently we only play those once.
