### PR TITLE
Fix Bugs Measuring Performance Track for Effects

### DIFF
--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -272,7 +272,6 @@ export function pushComponentEffectStart(): number {
   }
   const prevEffectStart = componentEffectStartTime;
   componentEffectStartTime = -1.1; // Track the next start.
-  componentEffectDuration = -0; // Reset component level duration.
   return prevEffectStart;
 }
 
@@ -284,6 +283,26 @@ export function popComponentEffectStart(prevEffectStart: number): void {
   if (prevEffectStart >= 0) {
     // Otherwise, we restore the previous parent's start time.
     componentEffectStartTime = prevEffectStart;
+  }
+}
+
+export function pushComponentEffectDuration(): number {
+  if (!enableProfilerTimer || !enableProfilerCommitHooks) {
+    return 0;
+  }
+  const prevEffectDuration = componentEffectDuration;
+  componentEffectDuration = -0; // Reset component level duration.
+  return prevEffectDuration;
+}
+
+export function popComponentEffectDuration(prevEffectDuration: number): void {
+  if (!enableProfilerTimer || !enableProfilerCommitHooks) {
+    return;
+  }
+  // If the parent component didn't have a start time, we let this current time persist.
+  if (prevEffectDuration >= 0) {
+    // Otherwise, we restore the previous parent's start time.
+    componentEffectDuration = prevEffectDuration;
   }
 }
 


### PR DESCRIPTION
This fixes two bugs with commit phase effect tracking.

I missed, or messed up the rebase for, deletion effects when a subtree was deleted and for passive disconnects when a subtree was hidden.

The other bug is that when I started using self time (componentEffectDuration) for color and for determining whether to bother logging an entry, I didn't consider that the component with effects can have children which end up resetting this duration before we log. Which lead to most effects not having their components logged since they almost always have children.

We don't necessarily have to push/pop but we have to store at least one thing on the stack unfortunately. That's because we have to do the actual log after the children to get the right end time. So might as well use the push/pop strategy like the rest of them.