### PR TITLE
Fix `Failed to execute 'measure' on 'Performance'` error

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -3861,7 +3861,7 @@ function commitPassiveMountOnFiber(
     if (isMount) {
       // Log the mount in the render phase.
       const startTime = ((finishedWork.actualStartTime: any): number);
-      if (endTime - startTime > 0.05) {
+      if (startTime >= 0 && endTime - startTime > 0.05) {
         logComponentMount(finishedWork, startTime, endTime);
       }
     }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -3756,7 +3756,7 @@ function commitPassiveMountOnFiber(
           ) {
             // Log the reappear in the render phase.
             const startTime = ((finishedWork.actualStartTime: any): number);
-            if (endTime - startTime > 0.05) {
+            if (startTime >= 0 && endTime - startTime > 0.05) {
               logComponentReappeared(finishedWork, startTime, endTime);
             }
             if (


### PR DESCRIPTION
When `startTime` still has its initial value of `-1.1` we must not call `logComponentMount`. This can occur when rendering a `'next/dynamic'` component with `{ssr: false}` in a client component, for example. Unfortunately, I didn't manage to reproduce this scenario in a unit test.