### PR TITLE
Add strict mode option to Fabric root

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -119,6 +119,7 @@ function render(
     let onUncaughtError = nativeOnUncaughtError;
     let onCaughtError = nativeOnCaughtError;
     let onRecoverableError = defaultOnRecoverableError;
+    let isStrictMode = false;
 
     if (options && options.onUncaughtError !== undefined) {
       onUncaughtError = options.onUncaughtError;
@@ -128,6 +129,9 @@ function render(
     }
     if (options && options.onRecoverableError !== undefined) {
       onRecoverableError = options.onRecoverableError;
+    }
+    if (options && options.unstable_strictMode !== undefined) {
+      isStrictMode = options.unstable_strictMode;
     }
 
     const publicRootInstance = createPublicRootInstance(containerTag);
@@ -142,7 +146,7 @@ function render(
       rootInstance,
       concurrentRoot ? ConcurrentRoot : LegacyRoot,
       null,
-      false,
+      isStrictMode,
       null,
       '',
       onUncaughtError,

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -147,6 +147,7 @@ export type RenderRootOptions = {
     error: mixed,
     errorInfo: {+componentStack?: ?string},
   ) => void,
+  unstable_strictMode?: boolean,
 };
 
 /**


### PR DESCRIPTION
Adds `unstable_strictMode` to `RenderRootOptions`.

Unstable in naming to match ReactDOM's options, but also because we are starting to experiment with opting RN code into strict mode and this is not yet a recommended way to configure roots.