### PR TITLE
Add unstable_Activity to server entrypoint

### DIFF
--- a/packages/react/src/ReactServer.experimental.js
+++ b/packages/react/src/ReactServer.experimental.js
@@ -17,6 +17,7 @@ import {
   REACT_SUSPENSE_TYPE,
   REACT_SUSPENSE_LIST_TYPE,
   REACT_VIEW_TRANSITION_TYPE,
+  REACT_ACTIVITY_TYPE,
 } from 'shared/ReactSymbols';
 import {
   cloneElement,
@@ -80,4 +81,5 @@ export {
   // Experimental
   REACT_SUSPENSE_LIST_TYPE as unstable_SuspenseList,
   REACT_VIEW_TRANSITION_TYPE as unstable_ViewTransition,
+  REACT_ACTIVITY_TYPE as unstable_Activity,
 };


### PR DESCRIPTION
Activity is a client component, but you should still be able to import it and render it from a Server Component. Same as what we do with other types like Suspense and ViewTransition.