### PR TITLE
Set hidden Offscreen to the shellBoundary regardless of previous state

### DIFF
--- a/packages/react-reconciler/src/ReactFiberSuspenseContext.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseContext.js
@@ -11,7 +11,6 @@ import type {SuspenseProps} from 'shared/ReactTypes';
 import type {Fiber} from './ReactInternalTypes';
 import type {StackCursor} from './ReactFiberStack';
 import type {SuspenseState} from './ReactFiberSuspenseComponent';
-import type {OffscreenState} from './ReactFiberOffscreenComponent';
 
 import {enableSuspenseAvoidThisFallback} from 'shared/ReactFeatureFlags';
 import {createCursor, push, pop} from './ReactFiberStack';
@@ -115,19 +114,10 @@ export function pushOffscreenSuspenseHandler(fiber: Fiber): void {
     // into separate functions for Suspense and Offscreen.
     pushSuspenseListContext(fiber, suspenseStackCursor.current);
     push(suspenseHandlerStackCursor, fiber, fiber);
-    if (shellBoundary !== null) {
-      // A parent boundary is showing a fallback, so we've already rendered
-      // deeper than the shell.
-    } else {
-      const current = fiber.alternate;
-      if (current !== null) {
-        const prevState: OffscreenState = current.memoizedState;
-        if (prevState !== null) {
-          // This is the first boundary in the stack that's already showing
-          // a fallback. So everything outside is considered the shell.
-          shellBoundary = fiber;
-        }
-      }
+    if (shellBoundary === null) {
+      // We're rendering hidden content. If it suspends, we can handle it by
+      // just not committing the offscreen boundary.
+      shellBoundary = fiber;
     }
   } else {
     // This is a LegacyHidden component.


### PR DESCRIPTION
I think this was probably just copy-paste from the Suspense path.

It shouldn't matter what the previous state of an Offscreen boundary was. What matters is that it's now hidden and therefore if it suspends, we can just leave it as is without the tree becoming inconsistent.
