### PR TITLE
Clear Update flag for unchanged trees in the beginning of the commit phase

### DIFF
--- a/packages/react-reconciler/src/ReactFiberApplyGesture.js
+++ b/packages/react-reconciler/src/ReactFiberApplyGesture.js
@@ -631,6 +631,12 @@ function recursivelyInsertClonesFromExistingTree(
         const viewTransitionState: ViewTransitionState = child.stateNode;
         // TODO: If this was already cloned by a previous pass we can reuse those clones.
         viewTransitionState.clones = null;
+        // "Existing" view transitions are in subtrees that didn't update so
+        // this is a "current". We normally clear this upon rerendering
+        // but we use this flag to track changes from layout in the commit.
+        // So we need it to be cleared before we do that.
+        // TODO: Use some other temporary state to track this.
+        child.flags &= ~Update;
         let nextPhase;
         if (visitPhase === CLONE_EXIT) {
           // This was an Enter of a ViewTransition. We now move onto unhiding the inner

--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -510,6 +510,12 @@ export function commitNestedViewTransitions(changedParent: Fiber): void {
         props.default,
         props.update,
       );
+      // "Nested" view transitions are in subtrees that didn't update so
+      // this is a "current". We normally clear this upon rerendering
+      // but we use this flag to track changes from layout in the commit.
+      // So we need it to be cleared before we do that.
+      // TODO: Use some other temporary state to track this.
+      child.flags &= ~Update;
       if (className !== 'none') {
         applyViewTransitionToHostInstances(
           child.child,


### PR DESCRIPTION
We use the Update flag to track if a View Transition had any mutations or relayout. Unlike the other usage of it, this is just temporary state during the commit phase.

Normally the flags gets used in the render phase and we reset it when we rerender but in the case of "nested" updates, those trees didn't update. We're only looking for relayouts. So we need to manually reset it before we start using it.

We probably shouldn't abuse the Update flag for this and instead use something like temporary state on ViewTransitionState.