### PR TITLE
Emit Preamble Contribution inline instead of the end of a boundary

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOMLegacy.js
@@ -224,12 +224,11 @@ export function pushStartActivityBoundary(
 export function pushEndActivityBoundary(
   target: Array<Chunk | PrecomputedChunk>,
   renderState: RenderState,
-  preambleState: null | PreambleState,
 ): void {
   if (renderState.generateStaticMarkup) {
     return;
   }
-  pushEndActivityBoundaryImpl(target, renderState, preambleState);
+  pushEndActivityBoundaryImpl(target, renderState);
 }
 
 export function writeStartCompletedSuspenseBoundary(
@@ -269,30 +268,20 @@ export function writeStartClientRenderedSuspenseBoundary(
 export function writeEndCompletedSuspenseBoundary(
   destination: Destination,
   renderState: RenderState,
-  preambleState: null | PreambleState,
 ): boolean {
   if (renderState.generateStaticMarkup) {
     return true;
   }
-  return writeEndCompletedSuspenseBoundaryImpl(
-    destination,
-    renderState,
-    preambleState,
-  );
+  return writeEndCompletedSuspenseBoundaryImpl(destination, renderState);
 }
 export function writeEndClientRenderedSuspenseBoundary(
   destination: Destination,
   renderState: RenderState,
-  preambleState: null | PreambleState,
 ): boolean {
   if (renderState.generateStaticMarkup) {
     return true;
   }
-  return writeEndClientRenderedSuspenseBoundaryImpl(
-    destination,
-    renderState,
-    preambleState,
-  );
+  return writeEndClientRenderedSuspenseBoundaryImpl(destination, renderState);
 }
 
 export type TransitionStatus = FormStatus;

--- a/packages/react-markup/src/ReactFizzConfigMarkup.js
+++ b/packages/react-markup/src/ReactFizzConfigMarkup.js
@@ -162,7 +162,6 @@ export function pushStartActivityBoundary(
 export function pushEndActivityBoundary(
   target: Array<Chunk | PrecomputedChunk>,
   renderState: RenderState,
-  preambleState: null | PreambleState,
 ): void {
   // Markup doesn't have any instructions.
   return;
@@ -192,7 +191,6 @@ export function writeStartClientRenderedSuspenseBoundary(
 export function writeEndCompletedSuspenseBoundary(
   destination: Destination,
   renderState: RenderState,
-  preambleState: null | PreambleState,
 ): boolean {
   // Markup doesn't have any instructions.
   return true;
@@ -200,7 +198,6 @@ export function writeEndCompletedSuspenseBoundary(
 export function writeEndClientRenderedSuspenseBoundary(
   destination: Destination,
   renderState: RenderState,
-  preambleState: null | PreambleState,
 ): boolean {
   // Markup doesn't have any instructions.
   return true;

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -181,7 +181,6 @@ const ReactNoopServer = ReactFizzServer({
   pushEndActivityBoundary(
     target: Array<Uint8Array>,
     renderState: RenderState,
-    preambleState: null | PreambleState,
   ): void {
     target.push(POP);
   },

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -2243,11 +2243,7 @@ function renderActivity(
       renderNode(request, task, props.children, -1);
       task.keyPath = prevKeyPath;
     }
-    pushEndActivityBoundary(
-      segment.chunks,
-      request.renderState,
-      task.blockedPreamble,
-    );
+    pushEndActivityBoundary(segment.chunks, request.renderState);
     segment.lastPushedText = false;
   }
 }
@@ -4908,7 +4904,6 @@ function flushSegment(
     return writeEndClientRenderedSuspenseBoundary(
       destination,
       request.renderState,
-      boundary.fallbackPreamble,
     );
   } else if (boundary.status !== COMPLETED) {
     if (boundary.status === PENDING) {
@@ -4979,11 +4974,7 @@ function flushSegment(
     const contentSegment = completedSegments[0];
     flushSegment(request, destination, contentSegment, hoistableState);
 
-    return writeEndCompletedSuspenseBoundary(
-      destination,
-      request.renderState,
-      boundary.contentPreamble,
-    );
+    return writeEndCompletedSuspenseBoundary(destination, request.renderState);
   }
 }
 


### PR DESCRIPTION
This lets us write them early in the render phase.

This should be safe because even if we write them deeply, then they still can't be wrapped by a element because then they'd no longer be in the document scope anymore. They end up flat in the body and so when we search the content we'll discover them.