### PR TITLE
[Cleanup] Remove unused renderLanes argument from prepareToReadContext

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -754,7 +754,7 @@ function createChildReconciler(
         const context: ReactContext<mixed> = (newChild: any);
         return createChild(
           returnFiber,
-          readContextDuringReconciliation(returnFiber, context, lanes),
+          readContextDuringReconciliation(returnFiber, context),
           lanes,
         );
       }
@@ -891,7 +891,7 @@ function createChildReconciler(
         return updateSlot(
           returnFiber,
           oldFiber,
-          readContextDuringReconciliation(returnFiber, context, lanes),
+          readContextDuringReconciliation(returnFiber, context),
           lanes,
         );
       }
@@ -1023,7 +1023,7 @@ function createChildReconciler(
           existingChildren,
           returnFiber,
           newIdx,
-          readContextDuringReconciliation(returnFiber, context, lanes),
+          readContextDuringReconciliation(returnFiber, context),
           lanes,
         );
       }
@@ -1900,7 +1900,7 @@ function createChildReconciler(
         return reconcileChildFibersImpl(
           returnFiber,
           currentFirstChild,
-          readContextDuringReconciliation(returnFiber, context, lanes),
+          readContextDuringReconciliation(returnFiber, context),
           lanes,
         );
       }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -436,7 +436,7 @@ function updateForwardRef(
   }
 
   // The rest is a fork of updateFunctionComponent
-  prepareToReadContext(workInProgress, renderLanes);
+  prepareToReadContext(workInProgress);
   if (enableSchedulingProfiler) {
     markComponentRenderStarted(workInProgress);
   }
@@ -912,7 +912,7 @@ function updateCacheComponent(
   workInProgress: Fiber,
   renderLanes: Lanes,
 ) {
-  prepareToReadContext(workInProgress, renderLanes);
+  prepareToReadContext(workInProgress);
   const parentCache = readContext(CacheContext);
 
   if (current === null) {
@@ -1183,7 +1183,7 @@ function updateFunctionComponent(
 
   let nextChildren;
   let hasId;
-  prepareToReadContext(workInProgress, renderLanes);
+  prepareToReadContext(workInProgress);
   if (enableSchedulingProfiler) {
     markComponentRenderStarted(workInProgress);
   }
@@ -1239,7 +1239,7 @@ export function replayFunctionComponent(
   // after its data resolves. It's a simplified version of
   // updateFunctionComponent that reuses the hooks from the previous attempt.
 
-  prepareToReadContext(workInProgress, renderLanes);
+  prepareToReadContext(workInProgress);
   if (enableSchedulingProfiler) {
     markComponentRenderStarted(workInProgress);
   }
@@ -1330,7 +1330,7 @@ function updateClassComponent(
   } else {
     hasContext = false;
   }
-  prepareToReadContext(workInProgress, renderLanes);
+  prepareToReadContext(workInProgress);
 
   const instance = workInProgress.stateNode;
   let shouldUpdate;
@@ -1908,7 +1908,7 @@ function mountIncompleteClassComponent(
   } else {
     hasContext = false;
   }
-  prepareToReadContext(workInProgress, renderLanes);
+  prepareToReadContext(workInProgress);
 
   constructClassInstance(workInProgress, Component, nextProps);
   mountClassInstance(workInProgress, Component, nextProps, renderLanes);
@@ -3415,7 +3415,7 @@ function updateContextConsumer(
     }
   }
 
-  prepareToReadContext(workInProgress, renderLanes);
+  prepareToReadContext(workInProgress);
   const newValue = readContext(context);
   if (enableSchedulingProfiler) {
     markComponentRenderStarted(workInProgress);

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -492,10 +492,7 @@ export function checkIfContextChanged(
   return false;
 }
 
-export function prepareToReadContext(
-  workInProgress: Fiber,
-  renderLanes: Lanes,
-): void {
+export function prepareToReadContext(workInProgress: Fiber): void {
   currentlyRenderingFiber = workInProgress;
   lastContextDependency = null;
 
@@ -525,10 +522,9 @@ export function readContext<T>(context: ReactContext<T>): T {
 export function readContextDuringReconciliation<T>(
   consumer: Fiber,
   context: ReactContext<T>,
-  renderLanes: Lanes,
 ): T {
   if (currentlyRenderingFiber === null) {
-    prepareToReadContext(consumer, renderLanes);
+    prepareToReadContext(consumer);
   }
   return readContextForConsumer(consumer, context);
 }


### PR DESCRIPTION
Use of this argument was removed in https://github.com/facebook/react/pull/31810 but we neglected to remove the actual argument.

## Test Plan

```
flow
```