### PR TITLE
Implement Partial Hydration for Activity

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -3746,11 +3746,7 @@ describe('ReactDOMServerPartialHydration', () => {
         <span>
           Visible
         </span>
-        <!--&-->
-        <!--/&-->
         <!--$-->
-        <!--&-->
-        <!--/&-->
         <!--/$-->
       </div>
     `);
@@ -3767,10 +3763,6 @@ describe('ReactDOMServerPartialHydration', () => {
       await waitForPaint([]);
     }
 
-    // Commit just the Activity boundary
-    // TODO: Optimize this
-    await waitForPaint([]);
-
     // Subsequently, the hidden child is prerendered on the client
     // along with hydrating the Suspense boundary outside the Activity.
     await waitForPaint(['HiddenChild']);
@@ -3779,11 +3771,7 @@ describe('ReactDOMServerPartialHydration', () => {
         <span>
           Visible
         </span>
-        <!--&-->
-        <!--/&-->
         <!--$-->
-        <!--&-->
-        <!--/&-->
         <!--/$-->
         <span
           style="display: none;"
@@ -3801,11 +3789,7 @@ describe('ReactDOMServerPartialHydration', () => {
         <span>
           Visible
         </span>
-        <!--&-->
-        <!--/&-->
         <!--$-->
-        <!--&-->
-        <!--/&-->
         <!--/$-->
         <span
           style="display: none;"

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -3766,6 +3766,11 @@ describe('ReactDOMServerPartialHydration', () => {
       // Passive effects.
       await waitForPaint([]);
     }
+
+    // Commit just the Activity boundary
+    // TODO: Optimize this
+    await waitForPaint([]);
+
     // Subsequently, the hidden child is prerendered on the client
     // along with hydrating the Suspense boundary outside the Activity.
     await waitForPaint(['HiddenChild']);

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydrationActivity-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydrationActivity-test.internal.js
@@ -86,18 +86,7 @@ function dispatchMouseEvent(to, from) {
   }
 }
 
-class TestAppClass extends React.Component {
-  render() {
-    return (
-      <div>
-        <>{''}</>
-        <>{'Hello'}</>
-      </div>
-    );
-  }
-}
-
-describe('ReactDOMServerPartialHydration', () => {
+describe('ReactDOMServerPartialHydrationActivity', () => {
   beforeEach(() => {
     jest.resetModules();
 
@@ -124,6 +113,7 @@ describe('ReactDOMServerPartialHydration', () => {
     IdleEventPriority = require('react-reconciler/constants').IdleEventPriority;
   });
 
+  // @gate enableActivity
   it('hydrates a parent even if a child Activity boundary is blocked', async () => {
     let suspend = false;
     let resolve;
@@ -179,6 +169,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(ref.current).toBe(span);
   });
 
+  // @gate enableActivity
   it('can hydrate siblings of a suspended component without errors', async () => {
     let suspend = false;
     let resolve;
@@ -237,6 +228,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(container.textContent).toBe('HelloHello');
   });
 
+  // @gate enableActivity
   it('falls back to client rendering boundary on mismatch', async () => {
     let client = false;
     let suspend = false;
@@ -329,6 +321,7 @@ describe('ReactDOMServerPartialHydration', () => {
     );
   });
 
+  // @gate enableActivity
   it('handles if mismatch is after suspending', async () => {
     let client = false;
     let suspend = false;
@@ -408,6 +401,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(container.innerHTML).toBe('Hello<article>Mismatch</article>');
   });
 
+  // @gate enableActivity
   it('handles if mismatch is child of suspended component', async () => {
     let client = false;
     let suspend = false;
@@ -488,6 +482,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(container.innerHTML).toBe('<div><article>Mismatch</article></div>');
   });
 
+  // @gate enableActivity
   it('handles if mismatch is parent and first child suspends', async () => {
     let client = false;
     let suspend = false;
@@ -580,6 +575,7 @@ describe('ReactDOMServerPartialHydration', () => {
     );
   });
 
+  // @gate enableActivity
   it('does show a parent fallback if mismatch is parent and second child suspends', async () => {
     let client = false;
     let suspend = false;
@@ -680,6 +676,7 @@ describe('ReactDOMServerPartialHydration', () => {
     );
   });
 
+  // @gate enableActivity
   it('does show a parent fallback if mismatch is in parent element only', async () => {
     let client = false;
     let suspend = false;
@@ -768,6 +765,7 @@ describe('ReactDOMServerPartialHydration', () => {
     );
   });
 
+  // @gate enableActivity
   it('does show a parent fallback if mismatch is before suspending', async () => {
     let client = false;
     let suspend = false;
@@ -855,6 +853,7 @@ describe('ReactDOMServerPartialHydration', () => {
     );
   });
 
+  // @gate enableActivity
   it('does show a parent fallback if mismatch is before suspending in a child', async () => {
     let client = false;
     let suspend = false;
@@ -944,6 +943,7 @@ describe('ReactDOMServerPartialHydration', () => {
     );
   });
 
+  // @gate enableActivity
   it('calls the hydration callbacks after hydration or deletion', async () => {
     let suspend = false;
     let resolve;
@@ -1035,6 +1035,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(deleted.length).toBe(1);
   });
 
+  // @gate enableActivity
   it('hydrates an empty activity boundary', async () => {
     function App() {
       return (
@@ -1056,6 +1057,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(container.innerHTML).toContain('<div>Sibling</div>');
   });
 
+  // @gate enableActivity
   it('recovers with client render when server rendered additional nodes at suspense root', async () => {
     function CheckIfHydrating({children}) {
       // This is a trick to check whether we're hydrating or not, since React
@@ -1125,6 +1127,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(ref.current).not.toBe(span);
   });
 
+  // @gate enableActivity
   it('recovers with client render when server rendered additional nodes at suspense root after unsuspending', async () => {
     const ref = React.createRef();
     let shouldSuspend = false;
@@ -1189,6 +1192,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(ref.current).not.toBe(span);
   });
 
+  // @gate enableActivity
   it('recovers with client render when server rendered additional nodes deep inside suspense root', async () => {
     const ref = React.createRef();
     function App({hasB}) {
@@ -1235,6 +1239,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(ref.current).not.toBe(span);
   });
 
+  // @gate enableActivity
   it('calls the onDeleted hydration callback if the parent gets deleted', async () => {
     let suspend = false;
     const promise = new Promise(() => {});
@@ -1288,6 +1293,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(deleted.length).toBe(1);
   });
 
+  // @gate enableActivity
   it('can insert siblings before the dehydrated boundary', async () => {
     let suspend = false;
     const promise = new Promise(() => {});
@@ -1345,6 +1351,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(container.firstChild.firstChild.textContent).toBe('First');
   });
 
+  // @gate enableActivity
   it('can delete the dehydrated boundary before it is hydrated', async () => {
     let suspend = false;
     const promise = new Promise(() => {});
@@ -1400,6 +1407,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(container.firstChild.children[1].textContent).toBe('After');
   });
 
+  // @gate enableActivity
   it('blocks updates to hydrate the content first if props have changed', async () => {
     let suspend = false;
     let resolve;
@@ -1471,7 +1479,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(span.className).toBe('hi');
   });
 
-  // @gate www
+  // @gate enableActivity && www
   it('blocks updates to hydrate the content first if props changed at idle priority', async () => {
     let suspend = false;
     let resolve;
@@ -1545,6 +1553,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(span.className).toBe('hi');
   });
 
+  // @gate enableActivity
   it('shows the fallback of the parent if props have changed before hydration completes and is still suspended', async () => {
     let suspend = false;
     let resolve;
@@ -1631,6 +1640,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(container.textContent).toBe('Hi');
   });
 
+  // @gate enableActivity
   it('clears nested activity boundaries if they did not hydrate yet', async () => {
     let suspend = false;
     const promise = new Promise(() => {});
@@ -1698,6 +1708,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(container.textContent).toBe('Hi Hi');
   });
 
+  // @gate enableActivity
   it('hydrates first if props changed but we are able to resolve within a timeout', async () => {
     let suspend = false;
     let resolve;
@@ -1771,6 +1782,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(span.className).toBe('hi');
   });
 
+  // @gate enableActivity
   it('warns but works if setState is called before commit in a dehydrated component', async () => {
     let suspend = false;
     let resolve;
@@ -1845,6 +1857,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(container.textContent).toBe('Hello');
   });
 
+  // @gate enableActivity
   it('blocks the update to hydrate first if context has changed', async () => {
     let suspend = false;
     let resolve;
@@ -1927,6 +1940,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(span.className).toBe('hi');
   });
 
+  // @gate enableActivity
   it('shows the parent fallback if context has changed before hydration completes and is still suspended', async () => {
     let suspend = false;
     let resolve;
@@ -2017,6 +2031,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(container.textContent).toBe('Hi');
   });
 
+  // @gate enableActivity
   it('can hydrate TWO activity boundaries', async () => {
     const ref1 = React.createRef();
     const ref2 = React.createRef();
@@ -2054,6 +2069,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(ref2.current).toBe(span2);
   });
 
+  // @gate enableActivity
   it('regenerates if it cannot hydrate before changes to props/context expire', async () => {
     let suspend = false;
     const promise = new Promise(resolvePromise => {});
@@ -2141,6 +2157,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(newSpan.className).toBe('hi');
   });
 
+  // @gate enableActivity
   it('does not invoke an event on a hydrated node until it commits', async () => {
     let suspend = false;
     let resolve;
@@ -2220,7 +2237,7 @@ describe('ReactDOMServerPartialHydration', () => {
     document.body.removeChild(container);
   });
 
-  // @gate www
+  // @gate enableActivity && www
   it('does not invoke an event on a hydrated event handle until it commits', async () => {
     const setClick = ReactDOM.unstable_createEventHandle('click');
     let suspend = false;
@@ -2302,6 +2319,7 @@ describe('ReactDOMServerPartialHydration', () => {
     document.body.removeChild(container);
   });
 
+  // @gate enableActivity
   it('invokes discrete events on nested activity boundaries in a root (legacy system)', async () => {
     let suspend = false;
     let resolve;
@@ -2382,7 +2400,7 @@ describe('ReactDOMServerPartialHydration', () => {
     document.body.removeChild(container);
   });
 
-  // @gate www
+  // @gate enableActivity && www
   it('invokes discrete events on nested activity boundaries in a root (createEventHandle)', async () => {
     let suspend = false;
     let isServerRendering = true;
@@ -2467,6 +2485,7 @@ describe('ReactDOMServerPartialHydration', () => {
     document.body.removeChild(container);
   });
 
+  // @gate enableActivity
   it('does not invoke the parent of dehydrated boundary event', async () => {
     let suspend = false;
     let resolve;
@@ -2539,6 +2558,7 @@ describe('ReactDOMServerPartialHydration', () => {
     document.body.removeChild(container);
   });
 
+  // @gate enableActivity
   it('does not invoke an event on a parent tree when a subtree is dehydrated', async () => {
     let suspend = false;
     let resolve;
@@ -2611,6 +2631,7 @@ describe('ReactDOMServerPartialHydration', () => {
     document.body.removeChild(parentContainer);
   });
 
+  // @gate enableActivity
   it('blocks only on the last continuous event (legacy system)', async () => {
     let suspend1 = false;
     let resolve1;
@@ -2711,6 +2732,7 @@ describe('ReactDOMServerPartialHydration', () => {
     document.body.removeChild(container);
   });
 
+  // @gate enableActivity
   it('finishes normal pri work before continuing to hydrate a retry', async () => {
     let suspend = false;
     let resolve;
@@ -2794,6 +2816,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(ref.current).not.toBe(null);
   });
 
+  // @gate enableActivity
   it('regression test: does not overfire non-bubbling browser events', async () => {
     let suspend = false;
     let resolve;
@@ -2878,50 +2901,7 @@ describe('ReactDOMServerPartialHydration', () => {
     document.body.removeChild(container);
   });
 
-  function itHydratesWithoutMismatch(msg, App) {
-    it('hydrates without mismatch ' + msg, async () => {
-      const container = document.createElement('div');
-      document.body.appendChild(container);
-      const finalHTML = ReactDOMServer.renderToString(<App />);
-      container.innerHTML = finalHTML;
-
-      await act(() => ReactDOMClient.hydrateRoot(container, <App />));
-    });
-  }
-
-  itHydratesWithoutMismatch('an empty string with neighbors', function App() {
-    return (
-      <div>
-        <div id="test">Test</div>
-        {'' && <div>Test</div>}
-        {'Test'}
-      </div>
-    );
-  });
-
-  itHydratesWithoutMismatch('an empty string', function App() {
-    return '';
-  });
-  itHydratesWithoutMismatch(
-    'an empty string simple in fragment',
-    function App() {
-      return (
-        <>
-          {''}
-          {'sup'}
-        </>
-      );
-    },
-  );
-  itHydratesWithoutMismatch(
-    'an empty string simple in suspense',
-    function App() {
-      return <Activity>{'' && false}</Activity>;
-    },
-  );
-
-  itHydratesWithoutMismatch('an empty string in class component', TestAppClass);
-
+  // @gate enableActivity
   it('fallback to client render on hydration mismatch at root', async () => {
     let suspend = true;
     let resolve;

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydrationActivity-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydrationActivity-test.internal.js
@@ -1,0 +1,2990 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment ./scripts/jest/ReactDOMServerIntegrationEnvironment
+ */
+
+'use strict';
+
+let Activity;
+let React = require('react');
+let ReactDOM;
+let ReactDOMClient;
+let ReactDOMServer;
+let ReactFeatureFlags;
+let Scheduler;
+let Suspense;
+let useSyncExternalStore;
+let act;
+let IdleEventPriority;
+let waitForAll;
+let waitFor;
+let assertLog;
+let assertConsoleErrorDev;
+
+function normalizeError(msg) {
+  // Take the first sentence to make it easier to assert on.
+  const idx = msg.indexOf('.');
+  if (idx > -1) {
+    return msg.slice(0, idx + 1);
+  }
+  return msg;
+}
+
+function dispatchMouseEvent(to, from) {
+  if (!to) {
+    to = null;
+  }
+  if (!from) {
+    from = null;
+  }
+  if (from) {
+    const mouseOutEvent = document.createEvent('MouseEvents');
+    mouseOutEvent.initMouseEvent(
+      'mouseout',
+      true,
+      true,
+      window,
+      0,
+      50,
+      50,
+      50,
+      50,
+      false,
+      false,
+      false,
+      false,
+      0,
+      to,
+    );
+    from.dispatchEvent(mouseOutEvent);
+  }
+  if (to) {
+    const mouseOverEvent = document.createEvent('MouseEvents');
+    mouseOverEvent.initMouseEvent(
+      'mouseover',
+      true,
+      true,
+      window,
+      0,
+      50,
+      50,
+      50,
+      50,
+      false,
+      false,
+      false,
+      false,
+      0,
+      from,
+    );
+    to.dispatchEvent(mouseOverEvent);
+  }
+}
+
+class TestAppClass extends React.Component {
+  render() {
+    return (
+      <div>
+        <>{''}</>
+        <>{'Hello'}</>
+      </div>
+    );
+  }
+}
+
+describe('ReactDOMServerPartialHydration', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableSuspenseCallback = true;
+    ReactFeatureFlags.enableCreateEventHandleAPI = true;
+
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactDOMClient = require('react-dom/client');
+    act = require('internal-test-utils').act;
+    ReactDOMServer = require('react-dom/server');
+    Scheduler = require('scheduler');
+    Activity = React.unstable_Activity;
+    Suspense = React.Suspense;
+    useSyncExternalStore = React.useSyncExternalStore;
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
+    assertLog = InternalTestUtils.assertLog;
+    waitFor = InternalTestUtils.waitFor;
+    assertConsoleErrorDev = InternalTestUtils.assertConsoleErrorDev;
+
+    IdleEventPriority = require('react-reconciler/constants').IdleEventPriority;
+  });
+
+  it('hydrates a parent even if a child Activity boundary is blocked', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
+
+    function Child() {
+      if (suspend) {
+        throw promise;
+      } else {
+        return 'Hello';
+      }
+    }
+
+    function App() {
+      return (
+        <div>
+          <Activity>
+            <span ref={ref}>
+              <Child />
+            </span>
+          </Activity>
+        </div>
+      );
+    }
+
+    // First we render the final HTML. With the streaming renderer
+    // this may have suspense points on the server but here we want
+    // to test the completed HTML. Don't suspend on the server.
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    const span = container.getElementsByTagName('span')[0];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    ReactDOMClient.hydrateRoot(container, <App />);
+    await waitForAll([]);
+
+    expect(ref.current).toBe(null);
+
+    // Resolving the promise should continue hydration
+    suspend = false;
+    resolve();
+    await promise;
+    await waitForAll([]);
+
+    // We should now have hydrated with a ref on the existing span.
+    expect(ref.current).toBe(span);
+  });
+
+  it('can hydrate siblings of a suspended component without errors', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    function Child() {
+      if (suspend) {
+        throw promise;
+      } else {
+        return 'Hello';
+      }
+    }
+
+    function App() {
+      return (
+        <Activity>
+          <Child />
+          <Activity>
+            <div>Hello</div>
+          </Activity>
+        </Activity>
+      );
+    }
+
+    // First we render the final HTML. With the streaming renderer
+    // this may have suspense points on the server but here we want
+    // to test the completed HTML. Don't suspend on the server.
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+    expect(container.textContent).toBe('HelloHello');
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+        if (error.cause) {
+          Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+        }
+      },
+    });
+    await waitForAll([]);
+
+    // Expect the server-generated HTML to stay intact.
+    expect(container.textContent).toBe('HelloHello');
+
+    // Resolving the promise should continue hydration
+    suspend = false;
+    resolve();
+    await promise;
+    await waitForAll([]);
+    // Hydration should not change anything.
+    expect(container.textContent).toBe('HelloHello');
+  });
+
+  it('falls back to client rendering boundary on mismatch', async () => {
+    let client = false;
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+      resolve = () => {
+        suspend = false;
+        resolvePromise();
+      };
+    });
+    function Child() {
+      if (suspend) {
+        Scheduler.log('Suspend');
+        throw promise;
+      } else {
+        Scheduler.log('Hello');
+        return 'Hello';
+      }
+    }
+    function Component({shouldMismatch}) {
+      Scheduler.log('Component');
+      if (shouldMismatch && client) {
+        return <article>Mismatch</article>;
+      }
+      return <div>Component</div>;
+    }
+    function App() {
+      return (
+        <Activity>
+          <Child />
+          <Component />
+          <Component />
+          <Component />
+          <Component shouldMismatch={true} />
+        </Activity>
+      );
+    }
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('section');
+    container.innerHTML = finalHTML;
+    assertLog(['Hello', 'Component', 'Component', 'Component', 'Component']);
+
+    expect(container.innerHTML).toBe(
+      '<!--&-->Hello<div>Component</div><div>Component</div><div>Component</div><div>Component</div><!--/&-->',
+    );
+
+    suspend = true;
+    client = true;
+
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+        if (error.cause) {
+          Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+        }
+      },
+    });
+    await waitForAll(['Suspend']);
+    jest.runAllTimers();
+
+    // Unchanged
+    expect(container.innerHTML).toBe(
+      '<!--&-->Hello<div>Component</div><div>Component</div><div>Component</div><div>Component</div><!--/&-->',
+    );
+
+    suspend = false;
+    resolve();
+    await promise;
+    await waitForAll([
+      // first pass, mismatches at end
+      'Hello',
+      'Component',
+      'Component',
+      'Component',
+      'Component',
+
+      // second pass as client render
+      'Hello',
+      'Component',
+      'Component',
+      'Component',
+      'Component',
+      // Hydration mismatch is logged
+      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+    ]);
+
+    // Client rendered - suspense comment nodes removed
+    expect(container.innerHTML).toBe(
+      'Hello<div>Component</div><div>Component</div><div>Component</div><article>Mismatch</article>',
+    );
+  });
+
+  it('handles if mismatch is after suspending', async () => {
+    let client = false;
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+      resolve = () => {
+        suspend = false;
+        resolvePromise();
+      };
+    });
+    function Child() {
+      if (suspend) {
+        Scheduler.log('Suspend');
+        throw promise;
+      } else {
+        Scheduler.log('Hello');
+        return 'Hello';
+      }
+    }
+    function Component({shouldMismatch}) {
+      Scheduler.log('Component');
+      if (shouldMismatch && client) {
+        return <article>Mismatch</article>;
+      }
+      return <div>Component</div>;
+    }
+    function App() {
+      return (
+        <Activity>
+          <Child />
+          <Component shouldMismatch={true} />
+        </Activity>
+      );
+    }
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('section');
+    container.innerHTML = finalHTML;
+    assertLog(['Hello', 'Component']);
+
+    expect(container.innerHTML).toBe(
+      '<!--&-->Hello<div>Component</div><!--/&-->',
+    );
+
+    suspend = true;
+    client = true;
+
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+        if (error.cause) {
+          Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+        }
+      },
+    });
+    await waitForAll(['Suspend']);
+    jest.runAllTimers();
+
+    // !! Unchanged, continue showing server content while suspended.
+    expect(container.innerHTML).toBe(
+      '<!--&-->Hello<div>Component</div><!--/&-->',
+    );
+
+    suspend = false;
+    resolve();
+    await promise;
+    await waitForAll([
+      // first pass, mismatches at end
+      'Hello',
+      'Component',
+      'Hello',
+      'Component',
+      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+    ]);
+    jest.runAllTimers();
+
+    // Client rendered - suspense comment nodes removed.
+    expect(container.innerHTML).toBe('Hello<article>Mismatch</article>');
+  });
+
+  it('handles if mismatch is child of suspended component', async () => {
+    let client = false;
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+      resolve = () => {
+        suspend = false;
+        resolvePromise();
+      };
+    });
+    function Child({children}) {
+      if (suspend) {
+        Scheduler.log('Suspend');
+        throw promise;
+      } else {
+        Scheduler.log('Hello');
+        return <div>{children}</div>;
+      }
+    }
+    function Component({shouldMismatch}) {
+      Scheduler.log('Component');
+      if (shouldMismatch && client) {
+        return <article>Mismatch</article>;
+      }
+      return <div>Component</div>;
+    }
+    function App() {
+      return (
+        <Activity>
+          <Child>
+            <Component shouldMismatch={true} />
+          </Child>
+        </Activity>
+      );
+    }
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('section');
+    container.innerHTML = finalHTML;
+    assertLog(['Hello', 'Component']);
+
+    expect(container.innerHTML).toBe(
+      '<!--&--><div><div>Component</div></div><!--/&-->',
+    );
+
+    suspend = true;
+    client = true;
+
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+        if (error.cause) {
+          Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+        }
+      },
+    });
+    await waitForAll(['Suspend']);
+    jest.runAllTimers();
+
+    // !! Unchanged, continue showing server content while suspended.
+    expect(container.innerHTML).toBe(
+      '<!--&--><div><div>Component</div></div><!--/&-->',
+    );
+
+    suspend = false;
+    resolve();
+    await promise;
+    await waitForAll([
+      // first pass, mismatches at end
+      'Hello',
+      'Component',
+      'Hello',
+      'Component',
+      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+    ]);
+    jest.runAllTimers();
+
+    // Client rendered - suspense comment nodes removed
+    expect(container.innerHTML).toBe('<div><article>Mismatch</article></div>');
+  });
+
+  it('handles if mismatch is parent and first child suspends', async () => {
+    let client = false;
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+      resolve = () => {
+        suspend = false;
+        resolvePromise();
+      };
+    });
+    function Child({children}) {
+      if (suspend) {
+        Scheduler.log('Suspend');
+        throw promise;
+      } else {
+        Scheduler.log('Hello');
+        return <div>{children}</div>;
+      }
+    }
+    function Component({shouldMismatch, children}) {
+      Scheduler.log('Component');
+      if (shouldMismatch && client) {
+        return (
+          <div>
+            {children}
+            <article>Mismatch</article>
+          </div>
+        );
+      }
+      return (
+        <div>
+          {children}
+          <div>Component</div>
+        </div>
+      );
+    }
+    function App() {
+      return (
+        <Activity>
+          <Component shouldMismatch={true}>
+            <Child />
+          </Component>
+        </Activity>
+      );
+    }
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('section');
+    container.innerHTML = finalHTML;
+    assertLog(['Component', 'Hello']);
+
+    expect(container.innerHTML).toBe(
+      '<!--&--><div><div></div><div>Component</div></div><!--/&-->',
+    );
+
+    suspend = true;
+    client = true;
+
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+        if (error.cause) {
+          Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+        }
+      },
+    });
+    await waitForAll(['Component', 'Suspend']);
+    jest.runAllTimers();
+
+    // !! Unchanged, continue showing server content while suspended.
+    expect(container.innerHTML).toBe(
+      '<!--&--><div><div></div><div>Component</div></div><!--/&-->',
+    );
+
+    suspend = false;
+    resolve();
+    await promise;
+    await waitForAll([
+      // first pass, mismatches at end
+      'Component',
+      'Hello',
+      'Component',
+      'Hello',
+      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+    ]);
+    jest.runAllTimers();
+
+    // Client rendered - suspense comment nodes removed
+    expect(container.innerHTML).toBe(
+      '<div><div></div><article>Mismatch</article></div>',
+    );
+  });
+
+  it('does show a parent fallback if mismatch is parent and second child suspends', async () => {
+    let client = false;
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+      resolve = () => {
+        suspend = false;
+        resolvePromise();
+      };
+    });
+    function Child({children}) {
+      if (suspend) {
+        Scheduler.log('Suspend');
+        throw promise;
+      } else {
+        Scheduler.log('Hello');
+        return <div>{children}</div>;
+      }
+    }
+    function Component({shouldMismatch, children}) {
+      Scheduler.log('Component');
+      if (shouldMismatch && client) {
+        return (
+          <div>
+            <article>Mismatch</article>
+            {children}
+          </div>
+        );
+      }
+      return (
+        <div>
+          <div>Component</div>
+          {children}
+        </div>
+      );
+    }
+    function Fallback() {
+      Scheduler.log('Fallback');
+      return 'Loading...';
+    }
+    function App() {
+      return (
+        <Suspense fallback={<Fallback />}>
+          <Activity>
+            <Component shouldMismatch={true}>
+              <Child />
+            </Component>
+          </Activity>
+        </Suspense>
+      );
+    }
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('section');
+    container.innerHTML = finalHTML;
+    assertLog(['Component', 'Hello']);
+
+    const div = container.getElementsByTagName('div')[0];
+
+    expect(container.innerHTML).toBe(
+      '<!--$--><!--&--><div><div>Component</div><div></div></div><!--/&--><!--/$-->',
+    );
+
+    suspend = true;
+    client = true;
+
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+        if (error.cause) {
+          Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+        }
+      },
+    });
+    await waitForAll(['Component', 'Component', 'Suspend', 'Fallback']);
+    jest.runAllTimers();
+
+    // !! Client switches to suspense fallback. The dehydrated content is still hidden because we never
+    // committed the client rendering.
+    expect(container.innerHTML).toBe(
+      '<!--$--><!--&--><div style="display: none;"><div>Component</div><div></div></div><!--/&--><!--/$-->' +
+        'Loading...',
+    );
+
+    suspend = false;
+    resolve();
+    await promise;
+    await waitForAll(['Component', 'Component', 'Hello']);
+    jest.runAllTimers();
+
+    // Now that we've unsuspended, we can commit the failed hydration.
+    assertLog([
+      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+    ]);
+
+    // Client rendered - activity comment nodes removed
+    expect(container.innerHTML).toBe(
+      '<!--$--><!--/$--><div><article>Mismatch</article><div></div></div>',
+    );
+  });
+
+  it('does show a parent fallback if mismatch is in parent element only', async () => {
+    let client = false;
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+      resolve = () => {
+        suspend = false;
+        resolvePromise();
+      };
+    });
+    function Child({children}) {
+      if (suspend) {
+        Scheduler.log('Suspend');
+        throw promise;
+      } else {
+        Scheduler.log('Hello');
+        return <div>{children}</div>;
+      }
+    }
+    function Component({shouldMismatch, children}) {
+      Scheduler.log('Component');
+      if (shouldMismatch && client) {
+        return <article>{children}</article>;
+      }
+      return <div>{children}</div>;
+    }
+    function Fallback() {
+      Scheduler.log('Fallback');
+      return 'Loading...';
+    }
+    function App() {
+      return (
+        <Suspense fallback={<Fallback />}>
+          <Activity>
+            <Component shouldMismatch={true}>
+              <Child />
+            </Component>
+          </Activity>
+        </Suspense>
+      );
+    }
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('section');
+    container.innerHTML = finalHTML;
+    assertLog(['Component', 'Hello']);
+
+    expect(container.innerHTML).toBe(
+      '<!--$--><!--&--><div><div></div></div><!--/&--><!--/$-->',
+    );
+
+    suspend = true;
+    client = true;
+
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+        if (error.cause) {
+          Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+        }
+      },
+    });
+    await waitForAll(['Component', 'Component', 'Suspend', 'Fallback']);
+    jest.runAllTimers();
+
+    // !! Client switches to suspense fallback. The dehydrated content is still hidden because we never
+    // committed the client rendering.
+    expect(container.innerHTML).toBe(
+      '<!--$--><!--&--><div style="display: none;"><div></div></div><!--/&--><!--/$-->' +
+        'Loading...',
+    );
+
+    suspend = false;
+    resolve();
+    await promise;
+    await waitForAll(['Component', 'Component', 'Hello']);
+    jest.runAllTimers();
+
+    // Now that we've unsuspended, we can commit the failed hydration.
+    assertLog([
+      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+    ]);
+
+    // Client rendered - activity comment nodes removed
+    expect(container.innerHTML).toBe(
+      '<!--$--><!--/$--><article><div></div></article>',
+    );
+  });
+
+  it('does show a parent fallback if mismatch is before suspending', async () => {
+    let client = false;
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+      resolve = () => {
+        suspend = false;
+        resolvePromise();
+      };
+    });
+    function Child() {
+      if (suspend) {
+        Scheduler.log('Suspend');
+        throw promise;
+      } else {
+        Scheduler.log('Hello');
+        return 'Hello';
+      }
+    }
+    function Component({shouldMismatch}) {
+      Scheduler.log('Component');
+      if (shouldMismatch && client) {
+        return <article>Mismatch</article>;
+      }
+      return <div>Component</div>;
+    }
+    function Fallback() {
+      Scheduler.log('Fallback');
+      return 'Loading...';
+    }
+    function App() {
+      return (
+        <Suspense fallback={<Fallback />}>
+          <Activity>
+            <Component shouldMismatch={true} />
+            <Child />
+          </Activity>
+        </Suspense>
+      );
+    }
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('section');
+    container.innerHTML = finalHTML;
+    assertLog(['Component', 'Hello']);
+
+    expect(container.innerHTML).toBe(
+      '<!--$--><!--&--><div>Component</div>Hello<!--/&--><!--/$-->',
+    );
+
+    suspend = true;
+    client = true;
+
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+        if (error.cause) {
+          Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+        }
+      },
+    });
+    await waitForAll(['Component', 'Component', 'Suspend', 'Fallback']);
+    jest.runAllTimers();
+
+    // !! Client switches to suspense fallback. The dehydrated content is still hidden because we never
+    // committed the client rendering.
+    expect(container.innerHTML).toBe(
+      '<!--$--><!--&--><div style="display: none;">Component</div><!--/&--><!--/$-->' +
+        'Loading...',
+    );
+
+    suspend = false;
+    resolve();
+    await promise;
+    await waitForAll(['Component', 'Component', 'Hello']);
+    jest.runAllTimers();
+
+    // Now that we've unsuspended, we can commit the failed hydration.
+    assertLog([
+      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+    ]);
+
+    // Client rendered - activity comment nodes removed
+    expect(container.innerHTML).toBe(
+      '<!--$--><!--/$--><article>Mismatch</article>Hello',
+    );
+  });
+
+  it('does show a parent fallback if mismatch is before suspending in a child', async () => {
+    let client = false;
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+      resolve = () => {
+        suspend = false;
+        resolvePromise();
+      };
+    });
+    function Child() {
+      if (suspend) {
+        Scheduler.log('Suspend');
+        throw promise;
+      } else {
+        Scheduler.log('Hello');
+        return 'Hello';
+      }
+    }
+    function Component({shouldMismatch}) {
+      Scheduler.log('Component');
+      if (shouldMismatch && client) {
+        return <article>Mismatch</article>;
+      }
+      return <div>Component</div>;
+    }
+    function Fallback() {
+      Scheduler.log('Fallback');
+      return 'Loading...';
+    }
+    function App() {
+      return (
+        <Suspense fallback={<Fallback />}>
+          <Activity>
+            <Component shouldMismatch={true} />
+            <div>
+              <Child />
+            </div>
+          </Activity>
+        </Suspense>
+      );
+    }
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('section');
+    container.innerHTML = finalHTML;
+    assertLog(['Component', 'Hello']);
+
+    expect(container.innerHTML).toBe(
+      '<!--$--><!--&--><div>Component</div><div>Hello</div><!--/&--><!--/$-->',
+    );
+
+    suspend = true;
+    client = true;
+
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+        if (error.cause) {
+          Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+        }
+      },
+    });
+    await waitForAll(['Component', 'Component', 'Suspend', 'Fallback']);
+    jest.runAllTimers();
+
+    // !! Client switches to suspense fallback. The dehydrated content is still hidden because we never
+    // committed the client rendering.
+    expect(container.innerHTML).toBe(
+      '<!--$--><!--&--><div style="display: none;">Component</div><div style="display: none;">Hello</div><!--/&--><!--/$-->' +
+        'Loading...',
+    );
+
+    suspend = false;
+    resolve();
+    await promise;
+    await waitForAll(['Component', 'Component', 'Hello']);
+    jest.runAllTimers();
+
+    // Now that we've unsuspended, we can commit the failed hydration.
+    assertLog([
+      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+    ]);
+
+    // Client rendered - activity comment nodes removed
+    expect(container.innerHTML).toBe(
+      '<!--$--><!--/$--><article>Mismatch</article><div>Hello</div>',
+    );
+  });
+
+  it('calls the hydration callbacks after hydration or deletion', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    function Child() {
+      if (suspend) {
+        throw promise;
+      } else {
+        return 'Hello';
+      }
+    }
+
+    let suspend2 = false;
+    const promise2 = new Promise(() => {});
+    function Child2({value}) {
+      if (suspend2 && !value) {
+        throw promise2;
+      } else {
+        return 'World';
+      }
+    }
+
+    function App({value}) {
+      return (
+        <div>
+          <Activity>
+            <Child />
+          </Activity>
+          <Activity>
+            <Child2 value={value} />
+          </Activity>
+        </div>
+      );
+    }
+
+    // First we render the final HTML. With the streaming renderer
+    // this may have suspense points on the server but here we want
+    // to test the completed HTML. Don't suspend on the server.
+    suspend = false;
+    suspend2 = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    const hydrated = [];
+    const deleted = [];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    suspend2 = true;
+    const root = ReactDOMClient.hydrateRoot(container, <App />, {
+      onHydrated(node) {
+        hydrated.push(node);
+      },
+      onDeleted(node) {
+        deleted.push(node);
+      },
+      onRecoverableError(error) {
+        Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+        if (error.cause) {
+          Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+        }
+      },
+    });
+    await waitForAll([]);
+
+    expect(hydrated.length).toBe(0);
+    expect(deleted.length).toBe(0);
+
+    await act(async () => {
+      // Resolving the promise should continue hydration
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    expect(hydrated.length).toBe(1);
+    expect(deleted.length).toBe(0);
+
+    // Performing an update should force it to delete the boundary if
+    // it could be unsuspended by the update.
+    await act(() => {
+      root.render(<App value={true} />);
+    });
+
+    expect(hydrated.length).toBe(1);
+    expect(deleted.length).toBe(1);
+  });
+
+  it('hydrates an empty activity boundary', async () => {
+    function App() {
+      return (
+        <div>
+          <Activity />
+          <div>Sibling</div>
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    ReactDOMClient.hydrateRoot(container, <App />);
+    await waitForAll([]);
+
+    expect(container.innerHTML).toContain('<div>Sibling</div>');
+  });
+
+  it('recovers with client render when server rendered additional nodes at suspense root', async () => {
+    function CheckIfHydrating({children}) {
+      // This is a trick to check whether we're hydrating or not, since React
+      // doesn't expose that information currently except
+      // via useSyncExternalStore.
+      let serverOrClient = '(unknown)';
+      useSyncExternalStore(
+        () => {},
+        () => {
+          serverOrClient = 'Client rendered';
+          return null;
+        },
+        () => {
+          serverOrClient = 'Server rendered';
+          return null;
+        },
+      );
+      Scheduler.log(serverOrClient);
+      return null;
+    }
+
+    const ref = React.createRef();
+    function App({hasB}) {
+      return (
+        <div>
+          <Activity>
+            <span ref={ref}>A</span>
+            {hasB ? <span>B</span> : null}
+            <CheckIfHydrating />
+          </Activity>
+          <div>Sibling</div>
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App hasB={true} />);
+    assertLog(['Server rendered']);
+
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    const span = container.getElementsByTagName('span')[0];
+
+    expect(container.innerHTML).toContain('<span>A</span>');
+    expect(container.innerHTML).toContain('<span>B</span>');
+    expect(ref.current).toBe(null);
+
+    await act(() => {
+      ReactDOMClient.hydrateRoot(container, <App hasB={false} />, {
+        onRecoverableError(error) {
+          Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+          if (error.cause) {
+            Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+          }
+        },
+      });
+    });
+
+    expect(container.innerHTML).toContain('<span>A</span>');
+    expect(container.innerHTML).not.toContain('<span>B</span>');
+
+    assertLog([
+      'Server rendered',
+      'Client rendered',
+      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+    ]);
+    expect(ref.current).not.toBe(span);
+  });
+
+  it('recovers with client render when server rendered additional nodes at suspense root after unsuspending', async () => {
+    const ref = React.createRef();
+    let shouldSuspend = false;
+    let resolve;
+    const promise = new Promise(res => {
+      resolve = () => {
+        shouldSuspend = false;
+        res();
+      };
+    });
+    function Suspender() {
+      if (shouldSuspend) {
+        throw promise;
+      }
+      return <></>;
+    }
+    function App({hasB}) {
+      return (
+        <div>
+          <Activity>
+            <Suspender />
+            <span ref={ref}>A</span>
+            {hasB ? <span>B</span> : null}
+          </Activity>
+          <div>Sibling</div>
+        </div>
+      );
+    }
+    const finalHTML = ReactDOMServer.renderToString(<App hasB={true} />);
+
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    const span = container.getElementsByTagName('span')[0];
+
+    expect(container.innerHTML).toContain('<span>A</span>');
+    expect(container.innerHTML).toContain('<span>B</span>');
+    expect(ref.current).toBe(null);
+
+    shouldSuspend = true;
+    await act(() => {
+      ReactDOMClient.hydrateRoot(container, <App hasB={false} />, {
+        onRecoverableError(error) {
+          Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+          if (error.cause) {
+            Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+          }
+        },
+      });
+    });
+
+    await act(() => {
+      resolve();
+    });
+
+    assertLog([
+      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+    ]);
+
+    expect(container.innerHTML).toContain('<span>A</span>');
+    expect(container.innerHTML).not.toContain('<span>B</span>');
+    expect(ref.current).not.toBe(span);
+  });
+
+  it('recovers with client render when server rendered additional nodes deep inside suspense root', async () => {
+    const ref = React.createRef();
+    function App({hasB}) {
+      return (
+        <div>
+          <Activity>
+            <div>
+              <span ref={ref}>A</span>
+              {hasB ? <span>B</span> : null}
+            </div>
+          </Activity>
+          <div>Sibling</div>
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App hasB={true} />);
+
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    const span = container.getElementsByTagName('span')[0];
+
+    expect(container.innerHTML).toContain('<span>A</span>');
+    expect(container.innerHTML).toContain('<span>B</span>');
+    expect(ref.current).toBe(null);
+
+    await act(() => {
+      ReactDOMClient.hydrateRoot(container, <App hasB={false} />, {
+        onRecoverableError(error) {
+          Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+          if (error.cause) {
+            Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+          }
+        },
+      });
+    });
+    assertLog([
+      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+    ]);
+
+    expect(container.innerHTML).toContain('<span>A</span>');
+    expect(container.innerHTML).not.toContain('<span>B</span>');
+    expect(ref.current).not.toBe(span);
+  });
+
+  it('calls the onDeleted hydration callback if the parent gets deleted', async () => {
+    let suspend = false;
+    const promise = new Promise(() => {});
+    function Child() {
+      if (suspend) {
+        throw promise;
+      } else {
+        return 'Hello';
+      }
+    }
+
+    function App({deleted}) {
+      if (deleted) {
+        return null;
+      }
+      return (
+        <div>
+          <Activity>
+            <Child />
+          </Activity>
+        </div>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    const deleted = [];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    const root = await act(() => {
+      return ReactDOMClient.hydrateRoot(container, <App />, {
+        onDeleted(node) {
+          deleted.push(node);
+        },
+      });
+    });
+
+    expect(deleted.length).toBe(0);
+
+    await act(() => {
+      root.render(<App deleted={true} />);
+    });
+
+    // The callback should have been invoked.
+    expect(deleted.length).toBe(1);
+  });
+
+  it('can insert siblings before the dehydrated boundary', async () => {
+    let suspend = false;
+    const promise = new Promise(() => {});
+    let showSibling;
+
+    function Child() {
+      if (suspend) {
+        throw promise;
+      } else {
+        return 'Second';
+      }
+    }
+
+    function Sibling() {
+      const [visible, setVisibilty] = React.useState(false);
+      showSibling = () => setVisibilty(true);
+      if (visible) {
+        return <div>First</div>;
+      }
+      return null;
+    }
+
+    function App() {
+      return (
+        <div>
+          <Sibling />
+          <Activity>
+            <span>
+              <Child />
+            </span>
+          </Activity>
+        </div>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+
+    await act(() => {
+      ReactDOMClient.hydrateRoot(container, <App />);
+    });
+
+    expect(container.firstChild.firstChild.tagName).not.toBe('DIV');
+
+    // In this state, we can still update the siblings.
+    await act(() => showSibling());
+
+    expect(container.firstChild.firstChild.tagName).toBe('DIV');
+    expect(container.firstChild.firstChild.textContent).toBe('First');
+  });
+
+  it('can delete the dehydrated boundary before it is hydrated', async () => {
+    let suspend = false;
+    const promise = new Promise(() => {});
+    let hideMiddle;
+
+    function Child() {
+      if (suspend) {
+        throw promise;
+      } else {
+        return (
+          <>
+            <div>Middle</div>
+            Some text
+          </>
+        );
+      }
+    }
+
+    function App() {
+      const [visible, setVisibilty] = React.useState(true);
+      hideMiddle = () => setVisibilty(false);
+
+      return (
+        <div>
+          <div>Before</div>
+          {visible ? (
+            <Activity>
+              <Child />
+            </Activity>
+          ) : null}
+          <div>After</div>
+        </div>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    await act(() => {
+      ReactDOMClient.hydrateRoot(container, <App />);
+    });
+
+    expect(container.firstChild.children[1].textContent).toBe('Middle');
+
+    // In this state, we can still delete the boundary.
+    await act(() => hideMiddle());
+
+    expect(container.firstChild.children[1].textContent).toBe('After');
+  });
+
+  it('blocks updates to hydrate the content first if props have changed', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
+
+    function Child({text}) {
+      if (suspend) {
+        throw promise;
+      } else {
+        return text;
+      }
+    }
+
+    function App({text, className}) {
+      return (
+        <div>
+          <Activity>
+            <span ref={ref} className={className}>
+              <Child text={text} />
+            </span>
+          </Activity>
+        </div>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(
+      <App text="Hello" className="hello" />,
+    );
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    const span = container.getElementsByTagName('span')[0];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    const root = ReactDOMClient.hydrateRoot(
+      container,
+      <App text="Hello" className="hello" />,
+    );
+    await waitForAll([]);
+
+    expect(ref.current).toBe(null);
+    expect(span.textContent).toBe('Hello');
+
+    // Render an update, which will be higher or the same priority as pinging the hydration.
+    root.render(<App text="Hi" className="hi" />);
+
+    // At the same time, resolving the promise so that rendering can complete.
+    // This should first complete the hydration and then flush the update onto the hydrated state.
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    // The new span should be the same since we should have successfully hydrated
+    // before changing it.
+    const newSpan = container.getElementsByTagName('span')[0];
+    expect(span).toBe(newSpan);
+
+    // We should now have fully rendered with a ref on the new span.
+    expect(ref.current).toBe(span);
+    expect(span.textContent).toBe('Hi');
+    // If we ended up hydrating the existing content, we won't have properly
+    // patched up the tree, which might mean we haven't patched the className.
+    expect(span.className).toBe('hi');
+  });
+
+  // @gate www
+  it('blocks updates to hydrate the content first if props changed at idle priority', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
+
+    function Child({text}) {
+      if (suspend) {
+        throw promise;
+      } else {
+        return text;
+      }
+    }
+
+    function App({text, className}) {
+      return (
+        <div>
+          <Activity>
+            <span ref={ref} className={className}>
+              <Child text={text} />
+            </span>
+          </Activity>
+        </div>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(
+      <App text="Hello" className="hello" />,
+    );
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    const span = container.getElementsByTagName('span')[0];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    const root = ReactDOMClient.hydrateRoot(
+      container,
+      <App text="Hello" className="hello" />,
+    );
+    await waitForAll([]);
+
+    expect(ref.current).toBe(null);
+    expect(span.textContent).toBe('Hello');
+
+    // Schedule an update at idle priority
+    ReactDOM.unstable_runWithPriority(IdleEventPriority, () => {
+      root.render(<App text="Hi" className="hi" />);
+    });
+
+    // At the same time, resolving the promise so that rendering can complete.
+    suspend = false;
+    resolve();
+    await promise;
+
+    // This should first complete the hydration and then flush the update onto the hydrated state.
+    await waitForAll([]);
+
+    // The new span should be the same since we should have successfully hydrated
+    // before changing it.
+    const newSpan = container.getElementsByTagName('span')[0];
+    expect(span).toBe(newSpan);
+
+    // We should now have fully rendered with a ref on the new span.
+    expect(ref.current).toBe(span);
+    expect(span.textContent).toBe('Hi');
+    // If we ended up hydrating the existing content, we won't have properly
+    // patched up the tree, which might mean we haven't patched the className.
+    expect(span.className).toBe('hi');
+  });
+
+  it('shows the fallback of the parent if props have changed before hydration completes and is still suspended', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const outerRef = React.createRef();
+    const ref = React.createRef();
+
+    function Child({text}) {
+      if (suspend) {
+        throw promise;
+      } else {
+        return text;
+      }
+    }
+
+    function App({text, className}) {
+      return (
+        <Suspense fallback="Loading...">
+          <div ref={outerRef}>
+            <Activity>
+              <span ref={ref} className={className}>
+                <Child text={text} />
+              </span>
+            </Activity>
+          </div>
+        </Suspense>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(
+      <App text="Hello" className="hello" />,
+    );
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    const root = ReactDOMClient.hydrateRoot(
+      container,
+      <App text="Hello" className="hello" />,
+      {
+        onRecoverableError(error) {
+          Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+          if (error.cause) {
+            Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+          }
+        },
+      },
+    );
+    await waitForAll([]);
+
+    expect(container.getElementsByTagName('div').length).toBe(1); // hidden
+    const div = container.getElementsByTagName('div')[0];
+
+    expect(outerRef.current).toBe(div);
+    expect(ref.current).toBe(null);
+
+    // Render an update, but leave it still suspended.
+    await act(() => {
+      root.render(<App text="Hi" className="hi" />);
+    });
+
+    // Flushing now should hide the existing content and show the fallback.
+
+    expect(outerRef.current).toBe(null);
+    expect(div.style.display).toBe('none');
+    expect(container.getElementsByTagName('span').length).toBe(1); // hidden
+    expect(ref.current).toBe(null);
+    expect(container.textContent).toBe('HelloLoading...');
+
+    // Unsuspending shows the content.
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    const span = container.getElementsByTagName('span')[0];
+    expect(span.textContent).toBe('Hi');
+    expect(span.className).toBe('hi');
+    expect(ref.current).toBe(span);
+    expect(container.textContent).toBe('Hi');
+  });
+
+  it('clears nested activity boundaries if they did not hydrate yet', async () => {
+    let suspend = false;
+    const promise = new Promise(() => {});
+    const ref = React.createRef();
+
+    function Child({text}) {
+      if (suspend && text !== 'Hi') {
+        throw promise;
+      } else {
+        return text;
+      }
+    }
+
+    function App({text, className}) {
+      return (
+        <div>
+          <Activity>
+            <Activity>
+              <Child text={text} />
+            </Activity>{' '}
+            <span ref={ref} className={className}>
+              <Child text={text} />
+            </span>
+          </Activity>
+        </div>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(
+      <App text="Hello" className="hello" />,
+    );
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    const root = ReactDOMClient.hydrateRoot(
+      container,
+      <App text="Hello" className="hello" />,
+      {
+        onRecoverableError(error) {
+          Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+          if (error.cause) {
+            Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+          }
+        },
+      },
+    );
+    await waitForAll([]);
+
+    expect(ref.current).toBe(null);
+
+    // Render an update, that unblocks.
+    // Flushing now should delete the existing content and show the update.
+    await act(() => {
+      root.render(<App text="Hi" className="hi" />);
+    });
+
+    const span = container.getElementsByTagName('span')[0];
+    expect(span.textContent).toBe('Hi');
+    expect(span.className).toBe('hi');
+    expect(ref.current).toBe(span);
+    expect(container.textContent).toBe('Hi Hi');
+  });
+
+  it('hydrates first if props changed but we are able to resolve within a timeout', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
+
+    function Child({text}) {
+      if (suspend) {
+        throw promise;
+      } else {
+        return text;
+      }
+    }
+
+    function App({text, className}) {
+      return (
+        <div>
+          <Activity>
+            <span ref={ref} className={className}>
+              <Child text={text} />
+            </span>
+          </Activity>
+        </div>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(
+      <App text="Hello" className="hello" />,
+    );
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    const span = container.getElementsByTagName('span')[0];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    const root = ReactDOMClient.hydrateRoot(
+      container,
+      <App text="Hello" className="hello" />,
+    );
+    await waitForAll([]);
+
+    expect(ref.current).toBe(null);
+    expect(container.textContent).toBe('Hello');
+
+    // Render an update with a long timeout.
+    React.startTransition(() => root.render(<App text="Hi" className="hi" />));
+    // This shouldn't force the fallback yet.
+    await waitForAll([]);
+
+    expect(ref.current).toBe(null);
+    expect(container.textContent).toBe('Hello');
+
+    // Resolving the promise so that rendering can complete.
+    // This should first complete the hydration and then flush the update onto the hydrated state.
+    suspend = false;
+    await act(() => resolve());
+
+    // The new span should be the same since we should have successfully hydrated
+    // before changing it.
+    const newSpan = container.getElementsByTagName('span')[0];
+    expect(span).toBe(newSpan);
+
+    // We should now have fully rendered with a ref on the new span.
+    expect(ref.current).toBe(span);
+    expect(container.textContent).toBe('Hi');
+    // If we ended up hydrating the existing content, we won't have properly
+    // patched up the tree, which might mean we haven't patched the className.
+    expect(span.className).toBe('hi');
+  });
+
+  it('warns but works if setState is called before commit in a dehydrated component', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+
+    let updateText;
+
+    function Child() {
+      const [state, setState] = React.useState('Hello');
+      updateText = setState;
+      Scheduler.log('Child');
+      if (suspend) {
+        throw promise;
+      } else {
+        return state;
+      }
+    }
+
+    function Sibling() {
+      Scheduler.log('Sibling');
+      return null;
+    }
+
+    function App() {
+      return (
+        <div>
+          <Activity>
+            <Child />
+            <Sibling />
+          </Activity>
+        </div>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    assertLog(['Child', 'Sibling']);
+
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    ReactDOMClient.hydrateRoot(
+      container,
+      <App text="Hello" className="hello" />,
+    );
+
+    await act(async () => {
+      suspend = true;
+      await waitFor(['Child']);
+
+      // While we're part way through the hydration, we update the state.
+      // This will schedule an update on the children of the activity boundary.
+      updateText('Hi');
+      assertConsoleErrorDev([
+        "Can't perform a React state update on a component that hasn't mounted yet. " +
+          'This indicates that you have a side-effect in your render function that ' +
+          'asynchronously later calls tries to update the component. Move this work to useEffect instead.\n' +
+          '    in App (at **)',
+      ]);
+
+      // This will throw it away and rerender.
+      await waitForAll(['Child']);
+
+      expect(container.textContent).toBe('Hello');
+
+      suspend = false;
+      resolve();
+      await promise;
+    });
+    assertLog(['Child', 'Sibling']);
+
+    expect(container.textContent).toBe('Hello');
+  });
+
+  it('blocks the update to hydrate first if context has changed', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
+    const Context = React.createContext(null);
+
+    function Child() {
+      const {text, className} = React.useContext(Context);
+      if (suspend) {
+        throw promise;
+      } else {
+        return (
+          <span ref={ref} className={className}>
+            {text}
+          </span>
+        );
+      }
+    }
+
+    const App = React.memo(function App() {
+      return (
+        <div>
+          <Activity>
+            <Child />
+          </Activity>
+        </div>
+      );
+    });
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(
+      <Context.Provider value={{text: 'Hello', className: 'hello'}}>
+        <App />
+      </Context.Provider>,
+    );
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    const span = container.getElementsByTagName('span')[0];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    const root = ReactDOMClient.hydrateRoot(
+      container,
+      <Context.Provider value={{text: 'Hello', className: 'hello'}}>
+        <App />
+      </Context.Provider>,
+    );
+    await waitForAll([]);
+
+    expect(ref.current).toBe(null);
+    expect(span.textContent).toBe('Hello');
+
+    // Render an update, which will be higher or the same priority as pinging the hydration.
+    root.render(
+      <Context.Provider value={{text: 'Hi', className: 'hi'}}>
+        <App />
+      </Context.Provider>,
+    );
+
+    // At the same time, resolving the promise so that rendering can complete.
+    // This should first complete the hydration and then flush the update onto the hydrated state.
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    // Since this should have been hydrated, this should still be the same span.
+    const newSpan = container.getElementsByTagName('span')[0];
+    expect(newSpan).toBe(span);
+
+    // We should now have fully rendered with a ref on the new span.
+    expect(ref.current).toBe(span);
+    expect(span.textContent).toBe('Hi');
+    // If we ended up hydrating the existing content, we won't have properly
+    // patched up the tree, which might mean we haven't patched the className.
+    expect(span.className).toBe('hi');
+  });
+
+  it('shows the parent fallback if context has changed before hydration completes and is still suspended', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
+    const Context = React.createContext(null);
+
+    function Child() {
+      const {text, className} = React.useContext(Context);
+      if (suspend) {
+        throw promise;
+      } else {
+        return (
+          <span ref={ref} className={className}>
+            {text}
+          </span>
+        );
+      }
+    }
+
+    const App = React.memo(function App() {
+      return (
+        <Suspense fallback="Loading...">
+          <div>
+            <Activity>
+              <Child />
+            </Activity>
+          </div>
+        </Suspense>
+      );
+    });
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(
+      <Context.Provider value={{text: 'Hello', className: 'hello'}}>
+        <App />
+      </Context.Provider>,
+    );
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    const root = ReactDOMClient.hydrateRoot(
+      container,
+      <Context.Provider value={{text: 'Hello', className: 'hello'}}>
+        <App />
+      </Context.Provider>,
+      {
+        onRecoverableError(error) {
+          Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+          if (error.cause) {
+            Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+          }
+        },
+      },
+    );
+    await waitForAll([]);
+
+    expect(ref.current).toBe(null);
+
+    // Render an update, but leave it still suspended.
+    // Flushing now should delete the existing content and show the fallback.
+    await act(() => {
+      root.render(
+        <Context.Provider value={{text: 'Hi', className: 'hi'}}>
+          <App />
+        </Context.Provider>,
+      );
+    });
+
+    expect(container.getElementsByTagName('span').length).toBe(1); // hidden
+    expect(ref.current).toBe(null);
+    expect(container.textContent).toBe('HelloLoading...');
+
+    // Unsuspending shows the content.
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    const span = container.getElementsByTagName('span')[0];
+    expect(span.textContent).toBe('Hi');
+    expect(span.className).toBe('hi');
+    expect(ref.current).toBe(span);
+    expect(container.textContent).toBe('Hi');
+  });
+
+  it('can hydrate TWO activity boundaries', async () => {
+    const ref1 = React.createRef();
+    const ref2 = React.createRef();
+
+    function App() {
+      return (
+        <div>
+          <Activity>
+            <span ref={ref1}>1</span>
+          </Activity>
+          <Activity>
+            <span ref={ref2}>2</span>
+          </Activity>
+        </div>
+      );
+    }
+
+    // First we render the final HTML. With the streaming renderer
+    // this may have suspense points on the server but here we want
+    // to test the completed HTML. Don't suspend on the server.
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    const span1 = container.getElementsByTagName('span')[0];
+    const span2 = container.getElementsByTagName('span')[1];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    ReactDOMClient.hydrateRoot(container, <App />);
+    await waitForAll([]);
+
+    expect(ref1.current).toBe(span1);
+    expect(ref2.current).toBe(span2);
+  });
+
+  it('regenerates if it cannot hydrate before changes to props/context expire', async () => {
+    let suspend = false;
+    const promise = new Promise(resolvePromise => {});
+    const ref = React.createRef();
+    const ClassName = React.createContext(null);
+
+    function Child({text}) {
+      const className = React.useContext(ClassName);
+      if (suspend && className !== 'hi' && text !== 'Hi') {
+        // Never suspends on the newer data.
+        throw promise;
+      } else {
+        return (
+          <span ref={ref} className={className}>
+            {text}
+          </span>
+        );
+      }
+    }
+
+    function App({text, className}) {
+      return (
+        <div>
+          <Activity>
+            <Child text={text} />
+          </Activity>
+        </div>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(
+      <ClassName.Provider value={'hello'}>
+        <App text="Hello" />
+      </ClassName.Provider>,
+    );
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    const span = container.getElementsByTagName('span')[0];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    const root = ReactDOMClient.hydrateRoot(
+      container,
+      <ClassName.Provider value={'hello'}>
+        <App text="Hello" />
+      </ClassName.Provider>,
+      {
+        onRecoverableError(error) {
+          Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+          if (error.cause) {
+            Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+          }
+        },
+      },
+    );
+    await waitForAll([]);
+
+    expect(ref.current).toBe(null);
+    expect(span.textContent).toBe('Hello');
+
+    // Render an update, which will be higher or the same priority as pinging the hydration.
+    // The new update doesn't suspend.
+    // Since we're still suspended on the original data, we can't hydrate.
+    // This will force all expiration times to flush.
+    await act(() => {
+      root.render(
+        <ClassName.Provider value={'hi'}>
+          <App text="Hi" />
+        </ClassName.Provider>,
+      );
+    });
+
+    // This will now be a new span because we weren't able to hydrate before
+    const newSpan = container.getElementsByTagName('span')[0];
+    expect(newSpan).not.toBe(span);
+
+    // We should now have fully rendered with a ref on the new span.
+    expect(ref.current).toBe(newSpan);
+    expect(newSpan.textContent).toBe('Hi');
+    // If we ended up hydrating the existing content, we won't have properly
+    // patched up the tree, which might mean we haven't patched the className.
+    expect(newSpan.className).toBe('hi');
+  });
+
+  it('does not invoke an event on a hydrated node until it commits', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+
+    function Sibling({text}) {
+      if (suspend) {
+        throw promise;
+      } else {
+        return 'Hello';
+      }
+    }
+
+    let clicks = 0;
+
+    function Button() {
+      const [clicked, setClicked] = React.useState(false);
+      if (clicked) {
+        return null;
+      }
+      return (
+        <a
+          onClick={() => {
+            setClicked(true);
+            clicks++;
+          }}>
+          Click me
+        </a>
+      );
+    }
+
+    function App() {
+      return (
+        <div>
+          <Activity>
+            <Button />
+            <Sibling />
+          </Activity>
+        </div>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    const a = container.getElementsByTagName('a')[0];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    ReactDOMClient.hydrateRoot(container, <App />);
+    await waitForAll([]);
+
+    expect(container.textContent).toBe('Click meHello');
+
+    // We're now partially hydrated.
+    await act(() => {
+      a.click();
+    });
+    expect(clicks).toBe(0);
+
+    // Resolving the promise so that rendering can complete.
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    expect(clicks).toBe(0);
+    expect(container.textContent).toBe('Click meHello');
+
+    document.body.removeChild(container);
+  });
+
+  // @gate www
+  it('does not invoke an event on a hydrated event handle until it commits', async () => {
+    const setClick = ReactDOM.unstable_createEventHandle('click');
+    let suspend = false;
+    let isServerRendering = true;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+
+    function Sibling({text}) {
+      if (suspend) {
+        throw promise;
+      } else {
+        return 'Hello';
+      }
+    }
+
+    const onEvent = jest.fn();
+
+    function Button() {
+      const ref = React.useRef(null);
+      if (!isServerRendering) {
+        React.useLayoutEffect(() => {
+          return setClick(ref.current, onEvent);
+        });
+      }
+      return <a ref={ref}>Click me</a>;
+    }
+
+    function App() {
+      return (
+        <div>
+          <Activity>
+            <Button />
+            <Sibling />
+          </Activity>
+        </div>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    const a = container.getElementsByTagName('a')[0];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    isServerRendering = false;
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    // We'll do one click before hydrating.
+    a.click();
+    // This should be delayed.
+    expect(onEvent).toHaveBeenCalledTimes(0);
+
+    await waitForAll([]);
+
+    // We're now partially hydrated.
+    await act(() => {
+      a.click();
+    });
+    // We should not have invoked the event yet because we're not
+    // yet hydrated.
+    expect(onEvent).toHaveBeenCalledTimes(0);
+
+    // Resolving the promise so that rendering can complete.
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    expect(onEvent).toHaveBeenCalledTimes(0);
+
+    document.body.removeChild(container);
+  });
+
+  it('invokes discrete events on nested activity boundaries in a root (legacy system)', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+
+    let clicks = 0;
+
+    function Button() {
+      return (
+        <a
+          onClick={() => {
+            clicks++;
+          }}>
+          Click me
+        </a>
+      );
+    }
+
+    function Child() {
+      if (suspend) {
+        throw promise;
+      } else {
+        return (
+          <Activity>
+            <Button />
+          </Activity>
+        );
+      }
+    }
+
+    function App() {
+      return (
+        <Activity>
+          <Child />
+        </Activity>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    const a = container.getElementsByTagName('a')[0];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    // We'll do one click before hydrating.
+    await act(() => {
+      a.click();
+    });
+    // This should be delayed.
+    expect(clicks).toBe(0);
+
+    await waitForAll([]);
+
+    // We're now partially hydrated.
+    await act(() => {
+      a.click();
+    });
+    expect(clicks).toBe(0);
+
+    // Resolving the promise so that rendering can complete.
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    expect(clicks).toBe(0);
+
+    document.body.removeChild(container);
+  });
+
+  // @gate www
+  it('invokes discrete events on nested activity boundaries in a root (createEventHandle)', async () => {
+    let suspend = false;
+    let isServerRendering = true;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+
+    const onEvent = jest.fn();
+    const setClick = ReactDOM.unstable_createEventHandle('click');
+
+    function Button() {
+      const ref = React.useRef(null);
+
+      if (!isServerRendering) {
+        React.useLayoutEffect(() => {
+          return setClick(ref.current, onEvent);
+        });
+      }
+
+      return <a ref={ref}>Click me</a>;
+    }
+
+    function Child() {
+      if (suspend) {
+        throw promise;
+      } else {
+        return (
+          <Activity>
+            <Button />
+          </Activity>
+        );
+      }
+    }
+
+    function App() {
+      return (
+        <Activity>
+          <Child />
+        </Activity>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    const a = container.getElementsByTagName('a')[0];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    isServerRendering = false;
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    // We'll do one click before hydrating.
+    a.click();
+    // This should be delayed.
+    expect(onEvent).toHaveBeenCalledTimes(0);
+
+    await waitForAll([]);
+
+    // We're now partially hydrated.
+    await act(() => {
+      a.click();
+    });
+    // We should not have invoked the event yet because we're not
+    // yet hydrated.
+    expect(onEvent).toHaveBeenCalledTimes(0);
+
+    // Resolving the promise so that rendering can complete.
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    expect(onEvent).toHaveBeenCalledTimes(0);
+
+    document.body.removeChild(container);
+  });
+
+  it('does not invoke the parent of dehydrated boundary event', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+
+    let clicksOnParent = 0;
+    let clicksOnChild = 0;
+
+    function Child({text}) {
+      if (suspend) {
+        throw promise;
+      } else {
+        return (
+          <span
+            onClick={e => {
+              // The stopPropagation is showing an example why invoking
+              // the event on only a parent might not be correct.
+              e.stopPropagation();
+              clicksOnChild++;
+            }}>
+            Hello
+          </span>
+        );
+      }
+    }
+
+    function App() {
+      return (
+        <div onClick={() => clicksOnParent++}>
+          <Activity>
+            <Child />
+          </Activity>
+        </div>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    const span = container.getElementsByTagName('span')[0];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    ReactDOMClient.hydrateRoot(container, <App />);
+    await waitForAll([]);
+
+    // We're now partially hydrated.
+    await act(() => {
+      span.click();
+    });
+    expect(clicksOnChild).toBe(0);
+    expect(clicksOnParent).toBe(0);
+
+    // Resolving the promise so that rendering can complete.
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    expect(clicksOnChild).toBe(0);
+    expect(clicksOnParent).toBe(0);
+
+    document.body.removeChild(container);
+  });
+
+  it('does not invoke an event on a parent tree when a subtree is dehydrated', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+
+    let clicks = 0;
+    const childSlotRef = React.createRef();
+
+    function Parent() {
+      return <div onClick={() => clicks++} ref={childSlotRef} />;
+    }
+
+    function Child({text}) {
+      if (suspend) {
+        throw promise;
+      } else {
+        return <a>Click me</a>;
+      }
+    }
+
+    function App() {
+      // The root is a Suspense boundary.
+      return (
+        <Activity>
+          <Child />
+        </Activity>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    const parentContainer = document.createElement('div');
+    const childContainer = document.createElement('div');
+
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(parentContainer);
+
+    // We're going to use a different root as a parent.
+    // This lets us detect whether an event goes through React's event system.
+    const parentRoot = ReactDOMClient.createRoot(parentContainer);
+    await act(() => parentRoot.render(<Parent />));
+
+    childSlotRef.current.appendChild(childContainer);
+
+    childContainer.innerHTML = finalHTML;
+
+    const a = childContainer.getElementsByTagName('a')[0];
+
+    suspend = true;
+
+    // Hydrate asynchronously.
+    await act(() => ReactDOMClient.hydrateRoot(childContainer, <App />));
+
+    // The Suspense boundary is not yet hydrated.
+    await act(() => {
+      a.click();
+    });
+    expect(clicks).toBe(0);
+
+    // Resolving the promise so that rendering can complete.
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    expect(clicks).toBe(0);
+
+    document.body.removeChild(parentContainer);
+  });
+
+  it('blocks only on the last continuous event (legacy system)', async () => {
+    let suspend1 = false;
+    let resolve1;
+    const promise1 = new Promise(resolvePromise => (resolve1 = resolvePromise));
+    let suspend2 = false;
+    let resolve2;
+    const promise2 = new Promise(resolvePromise => (resolve2 = resolvePromise));
+
+    function First({text}) {
+      if (suspend1) {
+        throw promise1;
+      } else {
+        return 'Hello';
+      }
+    }
+
+    function Second({text}) {
+      if (suspend2) {
+        throw promise2;
+      } else {
+        return 'World';
+      }
+    }
+
+    const ops = [];
+
+    function App() {
+      return (
+        <div>
+          <Activity>
+            <span
+              onMouseEnter={() => ops.push('Mouse Enter First')}
+              onMouseLeave={() => ops.push('Mouse Leave First')}
+            />
+            {/* We suspend after to test what happens when we eager
+                attach the listener. */}
+            <First />
+          </Activity>
+          <Activity>
+            <span
+              onMouseEnter={() => ops.push('Mouse Enter Second')}
+              onMouseLeave={() => ops.push('Mouse Leave Second')}>
+              <Second />
+            </span>
+          </Activity>
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    const appDiv = container.getElementsByTagName('div')[0];
+    const firstSpan = appDiv.getElementsByTagName('span')[0];
+    const secondSpan = appDiv.getElementsByTagName('span')[1];
+    expect(firstSpan.textContent).toBe('');
+    expect(secondSpan.textContent).toBe('World');
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend1 = true;
+    suspend2 = true;
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    await waitForAll([]);
+
+    dispatchMouseEvent(appDiv, null);
+    dispatchMouseEvent(firstSpan, appDiv);
+    dispatchMouseEvent(secondSpan, firstSpan);
+
+    // Neither target is yet hydrated.
+    expect(ops).toEqual([]);
+
+    // Resolving the second promise so that rendering can complete.
+    suspend2 = false;
+    resolve2();
+    await promise2;
+
+    await waitForAll([]);
+
+    // We've unblocked the current hover target so we should be
+    // able to replay it now.
+    expect(ops).toEqual(['Mouse Enter Second']);
+
+    // Resolving the first promise has no effect now.
+    suspend1 = false;
+    resolve1();
+    await promise1;
+
+    await waitForAll([]);
+
+    expect(ops).toEqual(['Mouse Enter Second']);
+
+    document.body.removeChild(container);
+  });
+
+  it('finishes normal pri work before continuing to hydrate a retry', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
+
+    function Child() {
+      if (suspend) {
+        throw promise;
+      } else {
+        Scheduler.log('Child');
+        return 'Hello';
+      }
+    }
+
+    function Sibling() {
+      Scheduler.log('Sibling');
+      React.useLayoutEffect(() => {
+        Scheduler.log('Commit Sibling');
+      });
+      return 'World';
+    }
+
+    // Avoid rerendering the tree by hoisting it.
+    const tree = (
+      <Activity>
+        <span ref={ref}>
+          <Child />
+        </span>
+      </Activity>
+    );
+
+    function App({showSibling}) {
+      return (
+        <div>
+          {tree}
+          {showSibling ? <Sibling /> : null}
+        </div>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    assertLog(['Child']);
+
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    suspend = true;
+    const root = ReactDOMClient.hydrateRoot(
+      container,
+      <App showSibling={false} />,
+    );
+    await waitForAll([]);
+
+    expect(ref.current).toBe(null);
+    expect(container.textContent).toBe('Hello');
+
+    // Resolving the promise should continue hydration
+    suspend = false;
+    resolve();
+    await promise;
+
+    Scheduler.unstable_advanceTime(100);
+
+    // Before we have a chance to flush it, we'll also render an update.
+    root.render(<App showSibling={true} />);
+
+    // When we flush we expect the Normal pri render to take priority
+    // over hydration.
+    await waitFor(['Sibling', 'Commit Sibling']);
+
+    // We shouldn't have hydrated the child yet.
+    expect(ref.current).toBe(null);
+    // But we did have a chance to update the content.
+    expect(container.textContent).toBe('HelloWorld');
+
+    await waitForAll(['Child']);
+
+    // Now we're hydrated.
+    expect(ref.current).not.toBe(null);
+  });
+
+  it('regression test: does not overfire non-bubbling browser events', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+
+    function Sibling({text}) {
+      if (suspend) {
+        throw promise;
+      } else {
+        return 'Hello';
+      }
+    }
+
+    let submits = 0;
+
+    function Form() {
+      const [submitted, setSubmitted] = React.useState(false);
+      if (submitted) {
+        return null;
+      }
+      return (
+        <form
+          onSubmit={() => {
+            setSubmitted(true);
+            submits++;
+          }}>
+          Click me
+        </form>
+      );
+    }
+
+    function App() {
+      return (
+        <div>
+          <Activity>
+            <Form />
+            <Sibling />
+          </Activity>
+        </div>
+      );
+    }
+
+    suspend = false;
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    const form = container.getElementsByTagName('form')[0];
+
+    // On the client we don't have all data yet but we want to start
+    // hydrating anyway.
+    suspend = true;
+    ReactDOMClient.hydrateRoot(container, <App />);
+    await waitForAll([]);
+
+    expect(container.textContent).toBe('Click meHello');
+
+    // We're now partially hydrated.
+    await act(() => {
+      form.dispatchEvent(
+        new window.Event('submit', {
+          bubbles: true,
+        }),
+      );
+    });
+    expect(submits).toBe(0);
+
+    // Resolving the promise so that rendering can complete.
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    // discrete event not replayed
+    expect(submits).toBe(0);
+    expect(container.textContent).toBe('Click meHello');
+
+    document.body.removeChild(container);
+  });
+
+  function itHydratesWithoutMismatch(msg, App) {
+    it('hydrates without mismatch ' + msg, async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const finalHTML = ReactDOMServer.renderToString(<App />);
+      container.innerHTML = finalHTML;
+
+      await act(() => ReactDOMClient.hydrateRoot(container, <App />));
+    });
+  }
+
+  itHydratesWithoutMismatch('an empty string with neighbors', function App() {
+    return (
+      <div>
+        <div id="test">Test</div>
+        {'' && <div>Test</div>}
+        {'Test'}
+      </div>
+    );
+  });
+
+  itHydratesWithoutMismatch('an empty string', function App() {
+    return '';
+  });
+  itHydratesWithoutMismatch(
+    'an empty string simple in fragment',
+    function App() {
+      return (
+        <>
+          {''}
+          {'sup'}
+        </>
+      );
+    },
+  );
+  itHydratesWithoutMismatch(
+    'an empty string simple in suspense',
+    function App() {
+      return <Activity>{'' && false}</Activity>;
+    },
+  );
+
+  itHydratesWithoutMismatch('an empty string in class component', TestAppClass);
+
+  it('fallback to client render on hydration mismatch at root', async () => {
+    let suspend = true;
+    let resolve;
+    const promise = new Promise((res, rej) => {
+      resolve = () => {
+        suspend = false;
+        res();
+      };
+    });
+    function App({isClient}) {
+      return (
+        <>
+          <Activity>
+            <ChildThatSuspends id={1} isClient={isClient} />
+          </Activity>
+          {isClient ? <span>client</span> : <div>server</div>}
+          <Activity>
+            <ChildThatSuspends id={2} isClient={isClient} />
+          </Activity>
+        </>
+      );
+    }
+    function ChildThatSuspends({id, isClient}) {
+      if (isClient && suspend) {
+        throw promise;
+      }
+      return <div>{id}</div>;
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App isClient={false} />);
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    container.innerHTML = finalHTML;
+
+    await act(() => {
+      ReactDOMClient.hydrateRoot(container, <App isClient={true} />, {
+        onRecoverableError(error) {
+          Scheduler.log('onRecoverableError: ' + normalizeError(error.message));
+          if (error.cause) {
+            Scheduler.log('Cause: ' + normalizeError(error.cause.message));
+          }
+        },
+      });
+    });
+
+    // We suspend the root while we wait for the promises to resolve, leaving the
+    // existing content in place.
+    expect(container.innerHTML).toEqual(
+      '<!--&--><div>1</div><!--/&--><div>server</div><!--&--><div>2</div><!--/&-->',
+    );
+
+    await act(async () => {
+      resolve();
+      await promise;
+    });
+
+    assertLog([
+      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+    ]);
+
+    expect(container.innerHTML).toEqual(
+      '<div>1</div><span>client</span><div>2</div>',
+    );
+  });
+});

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydrationActivity-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydrationActivity-test.internal.js
@@ -662,13 +662,24 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     suspend = false;
     resolve();
     await promise;
-    await waitForAll(['Component', 'Component', 'Hello']);
+    if (gate(flags => flags.alwaysThrottleRetries)) {
+      await waitForAll(['Component', 'Component', 'Hello']);
+    } else {
+      await waitForAll([
+        'Component',
+        'Component',
+        'Hello',
+        "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+      ]);
+    }
     jest.runAllTimers();
 
-    // Now that we've unsuspended, we can commit the failed hydration.
-    assertLog([
-      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
-    ]);
+    // Now that we've hit the throttle timeout, we can commit the failed hydration.
+    if (gate(flags => flags.alwaysThrottleRetries)) {
+      assertLog([
+        "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+      ]);
+    }
 
     // Client rendered - activity comment nodes removed
     expect(container.innerHTML).toBe(
@@ -751,13 +762,24 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     suspend = false;
     resolve();
     await promise;
-    await waitForAll(['Component', 'Component', 'Hello']);
+    if (gate(flags => flags.alwaysThrottleRetries)) {
+      await waitForAll(['Component', 'Component', 'Hello']);
+    } else {
+      await waitForAll([
+        'Component',
+        'Component',
+        'Hello',
+        "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+      ]);
+    }
     jest.runAllTimers();
 
-    // Now that we've unsuspended, we can commit the failed hydration.
-    assertLog([
-      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
-    ]);
+    // Now that we've hit the throttle timeout, we can commit the failed hydration.
+    if (gate(flags => flags.alwaysThrottleRetries)) {
+      assertLog([
+        "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+      ]);
+    }
 
     // Client rendered - activity comment nodes removed
     expect(container.innerHTML).toBe(
@@ -839,13 +861,24 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     suspend = false;
     resolve();
     await promise;
-    await waitForAll(['Component', 'Component', 'Hello']);
+    if (gate(flags => flags.alwaysThrottleRetries)) {
+      await waitForAll(['Component', 'Component', 'Hello']);
+    } else {
+      await waitForAll([
+        'Component',
+        'Component',
+        'Hello',
+        "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+      ]);
+    }
     jest.runAllTimers();
 
-    // Now that we've unsuspended, we can commit the failed hydration.
-    assertLog([
-      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
-    ]);
+    // Now that we've hit the throttle timeout, we can commit the failed hydration.
+    if (gate(flags => flags.alwaysThrottleRetries)) {
+      assertLog([
+        "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+      ]);
+    }
 
     // Client rendered - activity comment nodes removed
     expect(container.innerHTML).toBe(
@@ -929,13 +962,24 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     suspend = false;
     resolve();
     await promise;
-    await waitForAll(['Component', 'Component', 'Hello']);
+    if (gate(flags => flags.alwaysThrottleRetries)) {
+      await waitForAll(['Component', 'Component', 'Hello']);
+    } else {
+      await waitForAll([
+        'Component',
+        'Component',
+        'Hello',
+        "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+      ]);
+    }
     jest.runAllTimers();
 
-    // Now that we've unsuspended, we can commit the failed hydration.
-    assertLog([
-      "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
-    ]);
+    // Now that we've hit the throttle timeout, we can commit the failed hydration.
+    if (gate(flags => flags.alwaysThrottleRetries)) {
+      assertLog([
+        "onRecoverableError: Hydration failed because the server rendered HTML didn't match the client.",
+      ]);
+    }
 
     // Client rendered - activity comment nodes removed
     expect(container.innerHTML).toBe(

--- a/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydrationActivity-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydrationActivity-test.internal.js
@@ -1,0 +1,1844 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+import {createEventTarget} from 'dom-event-testing-library';
+
+let React;
+let ReactDOM;
+let ReactDOMClient;
+let ReactDOMServer;
+let ReactFeatureFlags;
+let Scheduler;
+let Activity;
+let act;
+let assertLog;
+let waitForAll;
+let waitFor;
+let waitForPaint;
+
+let IdleEventPriority;
+let ContinuousEventPriority;
+
+function dispatchMouseHoverEvent(to, from) {
+  if (!to) {
+    to = null;
+  }
+  if (!from) {
+    from = null;
+  }
+  if (from) {
+    const mouseOutEvent = document.createEvent('MouseEvents');
+    mouseOutEvent.initMouseEvent(
+      'mouseout',
+      true,
+      true,
+      window,
+      0,
+      50,
+      50,
+      50,
+      50,
+      false,
+      false,
+      false,
+      false,
+      0,
+      to,
+    );
+    from.dispatchEvent(mouseOutEvent);
+  }
+  if (to) {
+    const mouseOverEvent = document.createEvent('MouseEvents');
+    mouseOverEvent.initMouseEvent(
+      'mouseover',
+      true,
+      true,
+      window,
+      0,
+      50,
+      50,
+      50,
+      50,
+      false,
+      false,
+      false,
+      false,
+      0,
+      from,
+    );
+    to.dispatchEvent(mouseOverEvent);
+  }
+}
+
+function dispatchClickEvent(target) {
+  const mouseOutEvent = document.createEvent('MouseEvents');
+  mouseOutEvent.initMouseEvent(
+    'click',
+    true,
+    true,
+    window,
+    0,
+    50,
+    50,
+    50,
+    50,
+    false,
+    false,
+    false,
+    false,
+    0,
+    target,
+  );
+  return target.dispatchEvent(mouseOutEvent);
+}
+
+// TODO: There's currently no React DOM API to opt into Idle priority updates,
+// and there's no native DOM event that maps to idle priority, so this is a
+// temporary workaround. Need something like ReactDOM.unstable_IdleUpdates.
+function TODO_scheduleIdleDOMSchedulerTask(fn) {
+  ReactDOM.unstable_runWithPriority(IdleEventPriority, () => {
+    const prevEvent = window.event;
+    window.event = {type: 'message'};
+    try {
+      fn();
+    } finally {
+      window.event = prevEvent;
+    }
+  });
+}
+
+function TODO_scheduleContinuousSchedulerTask(fn) {
+  ReactDOM.unstable_runWithPriority(ContinuousEventPriority, () => {
+    const prevEvent = window.event;
+    window.event = {type: 'message'};
+    try {
+      fn();
+    } finally {
+      window.event = prevEvent;
+    }
+  });
+}
+
+describe('ReactDOMServerSelectiveHydration', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableCreateEventHandleAPI = true;
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactDOMClient = require('react-dom/client');
+    ReactDOMServer = require('react-dom/server');
+    act = require('internal-test-utils').act;
+    Scheduler = require('scheduler');
+    Activity = React.unstable_Activity;
+
+    const InternalTestUtils = require('internal-test-utils');
+    assertLog = InternalTestUtils.assertLog;
+    waitForAll = InternalTestUtils.waitForAll;
+    waitFor = InternalTestUtils.waitFor;
+    waitForPaint = InternalTestUtils.waitForPaint;
+
+    IdleEventPriority = require('react-reconciler/constants').IdleEventPriority;
+    ContinuousEventPriority =
+      require('react-reconciler/constants').ContinuousEventPriority;
+  });
+
+  it('hydrates the target boundary synchronously during a click', async () => {
+    function Child({text}) {
+      Scheduler.log(text);
+      return (
+        <span
+          onClick={e => {
+            e.preventDefault();
+            Scheduler.log('Clicked ' + text);
+          }}>
+          {text}
+        </span>
+      );
+    }
+
+    function App() {
+      Scheduler.log('App');
+      return (
+        <div>
+          <Activity>
+            <Child text="A" />
+          </Activity>
+          <Activity>
+            <Child text="B" />
+          </Activity>
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    assertLog(['App', 'A', 'B']);
+
+    const container = document.createElement('div');
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    container.innerHTML = finalHTML;
+
+    const span = container.getElementsByTagName('span')[1];
+
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    // Nothing has been hydrated so far.
+    assertLog([]);
+
+    // This should synchronously hydrate the root App and the second suspense
+    // boundary.
+    const result = dispatchClickEvent(span);
+
+    // The event should have been canceled because we called preventDefault.
+    expect(result).toBe(false);
+
+    // We rendered App, B and then invoked the event without rendering A.
+    assertLog(['App', 'B', 'Clicked B']);
+
+    // After continuing the scheduler, we finally hydrate A.
+    await waitForAll(['A']);
+
+    document.body.removeChild(container);
+  });
+
+  it('hydrates at higher pri if sync did not work first time', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+
+    function Child({text}) {
+      if ((text === 'A' || text === 'D') && suspend) {
+        throw promise;
+      }
+      Scheduler.log(text);
+      return (
+        <span
+          onClick={e => {
+            e.preventDefault();
+            Scheduler.log('Clicked ' + text);
+          }}>
+          {text}
+        </span>
+      );
+    }
+
+    function App() {
+      Scheduler.log('App');
+      return (
+        <div>
+          <Activity>
+            <Child text="A" />
+          </Activity>
+          <Activity>
+            <Child text="B" />
+          </Activity>
+          <Activity>
+            <Child text="C" />
+          </Activity>
+          <Activity>
+            <Child text="D" />
+          </Activity>
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    assertLog(['App', 'A', 'B', 'C', 'D']);
+
+    const container = document.createElement('div');
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    container.innerHTML = finalHTML;
+
+    const spanD = container.getElementsByTagName('span')[3];
+
+    suspend = true;
+
+    // A and D will be suspended. We'll click on D which should take
+    // priority, after we unsuspend.
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    // Nothing has been hydrated so far.
+    assertLog([]);
+
+    // This click target cannot be hydrated yet because it's suspended.
+    await act(() => {
+      const result = dispatchClickEvent(spanD);
+      expect(result).toBe(true);
+    });
+    assertLog([
+      'App',
+      // Continuing rendering will render B next.
+      'B',
+      'C',
+    ]);
+
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    assertLog(['D', 'A']);
+
+    document.body.removeChild(container);
+  });
+
+  it('hydrates at higher pri for secondary discrete events', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+
+    function Child({text}) {
+      if ((text === 'A' || text === 'D') && suspend) {
+        throw promise;
+      }
+      Scheduler.log(text);
+      return (
+        <span
+          onClick={e => {
+            e.preventDefault();
+            Scheduler.log('Clicked ' + text);
+          }}>
+          {text}
+        </span>
+      );
+    }
+
+    function App() {
+      Scheduler.log('App');
+      return (
+        <div>
+          <Activity>
+            <Child text="A" />
+          </Activity>
+          <Activity>
+            <Child text="B" />
+          </Activity>
+          <Activity>
+            <Child text="C" />
+          </Activity>
+          <Activity>
+            <Child text="D" />
+          </Activity>
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    assertLog(['App', 'A', 'B', 'C', 'D']);
+
+    const container = document.createElement('div');
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    container.innerHTML = finalHTML;
+
+    const spanA = container.getElementsByTagName('span')[0];
+    const spanC = container.getElementsByTagName('span')[2];
+    const spanD = container.getElementsByTagName('span')[3];
+
+    suspend = true;
+
+    // A and D will be suspended. We'll click on D which should take
+    // priority, after we unsuspend.
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    // Nothing has been hydrated so far.
+    assertLog([]);
+
+    // This click target cannot be hydrated yet because the first is Suspended.
+    dispatchClickEvent(spanA);
+    dispatchClickEvent(spanC);
+    dispatchClickEvent(spanD);
+
+    assertLog(['App', 'C', 'Clicked C']);
+
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    assertLog([
+      'A',
+      'D',
+      // B should render last since it wasn't clicked.
+      'B',
+    ]);
+
+    document.body.removeChild(container);
+  });
+
+  // @gate www
+  it('hydrates the target boundary synchronously during a click (createEventHandle)', async () => {
+    const setClick = ReactDOM.unstable_createEventHandle('click');
+    let isServerRendering = true;
+
+    function Child({text}) {
+      const ref = React.useRef(null);
+      Scheduler.log(text);
+      if (!isServerRendering) {
+        React.useLayoutEffect(() => {
+          return setClick(ref.current, () => {
+            Scheduler.log('Clicked ' + text);
+          });
+        });
+      }
+
+      return <span ref={ref}>{text}</span>;
+    }
+
+    function App() {
+      Scheduler.log('App');
+      return (
+        <div>
+          <Activity>
+            <Child text="A" />
+          </Activity>
+          <Activity>
+            <Child text="B" />
+          </Activity>
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    assertLog(['App', 'A', 'B']);
+
+    const container = document.createElement('div');
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    container.innerHTML = finalHTML;
+
+    isServerRendering = false;
+
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    // Nothing has been hydrated so far.
+    assertLog([]);
+
+    const span = container.getElementsByTagName('span')[1];
+
+    const target = createEventTarget(span);
+
+    // This should synchronously hydrate the root App and the second suspense
+    // boundary.
+    target.virtualclick();
+
+    // We rendered App, B and then invoked the event without rendering A.
+    assertLog(['App', 'B', 'Clicked B']);
+
+    // After continuing the scheduler, we finally hydrate A.
+    await waitForAll(['A']);
+
+    document.body.removeChild(container);
+  });
+
+  // @gate www
+  it('hydrates at higher pri if sync did not work first time (createEventHandle)', async () => {
+    let suspend = false;
+    let isServerRendering = true;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const setClick = ReactDOM.unstable_createEventHandle('click');
+
+    function Child({text}) {
+      const ref = React.useRef(null);
+      if ((text === 'A' || text === 'D') && suspend) {
+        throw promise;
+      }
+      Scheduler.log(text);
+
+      if (!isServerRendering) {
+        React.useLayoutEffect(() => {
+          return setClick(ref.current, () => {
+            Scheduler.log('Clicked ' + text);
+          });
+        });
+      }
+
+      return <span ref={ref}>{text}</span>;
+    }
+
+    function App() {
+      Scheduler.log('App');
+      return (
+        <div>
+          <Activity>
+            <Child text="A" />
+          </Activity>
+          <Activity>
+            <Child text="B" />
+          </Activity>
+          <Activity>
+            <Child text="C" />
+          </Activity>
+          <Activity>
+            <Child text="D" />
+          </Activity>
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    assertLog(['App', 'A', 'B', 'C', 'D']);
+
+    const container = document.createElement('div');
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    container.innerHTML = finalHTML;
+
+    const spanD = container.getElementsByTagName('span')[3];
+
+    suspend = true;
+    isServerRendering = false;
+
+    // A and D will be suspended. We'll click on D which should take
+    // priority, after we unsuspend.
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    // Nothing has been hydrated so far.
+    assertLog([]);
+
+    // Continuing rendering will render B next.
+    await act(() => {
+      const target = createEventTarget(spanD);
+      target.virtualclick();
+    });
+    assertLog(['App', 'B', 'C']);
+
+    // After the click, we should prioritize D and the Click first,
+    // and only after that render A and C.
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    // no replay
+    assertLog(['D', 'A']);
+
+    document.body.removeChild(container);
+  });
+
+  // @gate www
+  it('hydrates at higher pri for secondary discrete events (createEventHandle)', async () => {
+    const setClick = ReactDOM.unstable_createEventHandle('click');
+    let suspend = false;
+    let isServerRendering = true;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+
+    function Child({text}) {
+      const ref = React.useRef(null);
+      if ((text === 'A' || text === 'D') && suspend) {
+        throw promise;
+      }
+      Scheduler.log(text);
+
+      if (!isServerRendering) {
+        React.useLayoutEffect(() => {
+          return setClick(ref.current, () => {
+            Scheduler.log('Clicked ' + text);
+          });
+        });
+      }
+      return <span ref={ref}>{text}</span>;
+    }
+
+    function App() {
+      Scheduler.log('App');
+      return (
+        <div>
+          <Activity>
+            <Child text="A" />
+          </Activity>
+          <Activity>
+            <Child text="B" />
+          </Activity>
+          <Activity>
+            <Child text="C" />
+          </Activity>
+          <Activity>
+            <Child text="D" />
+          </Activity>
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    assertLog(['App', 'A', 'B', 'C', 'D']);
+
+    const container = document.createElement('div');
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    container.innerHTML = finalHTML;
+
+    const spanA = container.getElementsByTagName('span')[0];
+    const spanC = container.getElementsByTagName('span')[2];
+    const spanD = container.getElementsByTagName('span')[3];
+
+    suspend = true;
+    isServerRendering = false;
+
+    // A and D will be suspended. We'll click on D which should take
+    // priority, after we unsuspend.
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    // Nothing has been hydrated so far.
+    assertLog([]);
+
+    // This click target cannot be hydrated yet because the first is Suspended.
+    createEventTarget(spanA).virtualclick();
+    createEventTarget(spanC).virtualclick();
+    createEventTarget(spanD).virtualclick();
+
+    assertLog(['App', 'C', 'Clicked C']);
+
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    assertLog([
+      'A',
+      'D',
+      // B should render last since it wasn't clicked.
+      'B',
+    ]);
+
+    document.body.removeChild(container);
+  });
+
+  it('hydrates the hovered targets as higher priority for continuous events', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    function Child({text}) {
+      if ((text === 'A' || text === 'D') && suspend) {
+        throw promise;
+      }
+      Scheduler.log(text);
+      return (
+        <span
+          onClick={e => {
+            e.preventDefault();
+            Scheduler.log('Clicked ' + text);
+          }}
+          onMouseEnter={e => {
+            e.preventDefault();
+            Scheduler.log('Hover ' + text);
+          }}>
+          {text}
+        </span>
+      );
+    }
+
+    function App() {
+      Scheduler.log('App');
+      return (
+        <div>
+          <Activity>
+            <Child text="A" />
+          </Activity>
+          <Activity>
+            <Child text="B" />
+          </Activity>
+          <Activity>
+            <Child text="C" />
+          </Activity>
+          <Activity>
+            <Child text="D" />
+          </Activity>
+        </div>
+      );
+    }
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    assertLog(['App', 'A', 'B', 'C', 'D']);
+    const container = document.createElement('div');
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    container.innerHTML = finalHTML;
+
+    const spanB = container.getElementsByTagName('span')[1];
+    const spanC = container.getElementsByTagName('span')[2];
+    const spanD = container.getElementsByTagName('span')[3];
+
+    suspend = true;
+
+    // A and D will be suspended. We'll click on D which should take
+    // priority, after we unsuspend.
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    // Nothing has been hydrated so far.
+    assertLog([]);
+
+    await act(() => {
+      // Click D
+      dispatchMouseHoverEvent(spanD, null);
+      dispatchClickEvent(spanD);
+
+      // Hover over B and then C.
+      dispatchMouseHoverEvent(spanB, spanD);
+      dispatchMouseHoverEvent(spanC, spanB);
+
+      assertLog(['App']);
+
+      suspend = false;
+      resolve();
+    });
+
+    // We should prioritize hydrating D first because we clicked it.
+    // but event isnt replayed
+    assertLog([
+      'D',
+      'B', // Ideally this should be later.
+      'C',
+      'Hover C',
+      'A',
+    ]);
+
+    document.body.removeChild(container);
+  });
+
+  it('replays capture phase for continuous events and respects stopPropagation', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+
+    function Child({text}) {
+      if ((text === 'A' || text === 'D') && suspend) {
+        throw promise;
+      }
+      Scheduler.log(text);
+      return (
+        <span
+          id={text}
+          onClickCapture={e => {
+            e.preventDefault();
+            Scheduler.log('Capture Clicked ' + text);
+          }}
+          onClick={e => {
+            e.preventDefault();
+            Scheduler.log('Clicked ' + text);
+          }}
+          onMouseEnter={e => {
+            e.preventDefault();
+            Scheduler.log('Mouse Enter ' + text);
+          }}
+          onMouseOut={e => {
+            e.preventDefault();
+            Scheduler.log('Mouse Out ' + text);
+          }}
+          onMouseOutCapture={e => {
+            e.preventDefault();
+            e.stopPropagation();
+            Scheduler.log('Mouse Out Capture ' + text);
+          }}
+          onMouseOverCapture={e => {
+            e.preventDefault();
+            e.stopPropagation();
+            Scheduler.log('Mouse Over Capture ' + text);
+          }}
+          onMouseOver={e => {
+            e.preventDefault();
+            Scheduler.log('Mouse Over ' + text);
+          }}>
+          <div
+            onMouseOverCapture={e => {
+              e.preventDefault();
+              Scheduler.log('Mouse Over Capture Inner ' + text);
+            }}>
+            {text}
+          </div>
+        </span>
+      );
+    }
+
+    function App() {
+      Scheduler.log('App');
+      return (
+        <div
+          onClickCapture={e => {
+            e.preventDefault();
+            Scheduler.log('Capture Clicked Parent');
+          }}
+          onMouseOverCapture={e => {
+            Scheduler.log('Mouse Over Capture Parent');
+          }}>
+          <Activity>
+            <Child text="A" />
+          </Activity>
+          <Activity>
+            <Child text="B" />
+          </Activity>
+          <Activity>
+            <Child text="C" />
+          </Activity>
+          <Activity>
+            <Child text="D" />
+          </Activity>
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    assertLog(['App', 'A', 'B', 'C', 'D']);
+
+    const container = document.createElement('div');
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    container.innerHTML = finalHTML;
+
+    const spanB = document.getElementById('B').firstChild;
+    const spanC = document.getElementById('C').firstChild;
+    const spanD = document.getElementById('D').firstChild;
+
+    suspend = true;
+
+    // A and D will be suspended. We'll click on D which should take
+    // priority, after we unsuspend.
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    // Nothing has been hydrated so far.
+    assertLog([]);
+
+    await act(async () => {
+      // Click D
+      dispatchMouseHoverEvent(spanD, null);
+      dispatchClickEvent(spanD);
+      // Hover over B and then C.
+      dispatchMouseHoverEvent(spanB, spanD);
+      dispatchMouseHoverEvent(spanC, spanB);
+
+      assertLog(['App']);
+
+      suspend = false;
+      resolve();
+    });
+
+    // We should prioritize hydrating D first because we clicked it.
+    // but event isnt replayed
+    assertLog([
+      'D',
+      'B', // Ideally this should be later.
+      'C',
+      // Mouse out events aren't replayed
+      // 'Mouse Out Capture B',
+      // 'Mouse Out B',
+      'Mouse Over Capture Parent',
+      'Mouse Over Capture C',
+      // Stop propagation stops these
+      // 'Mouse Over Capture Inner C',
+      // 'Mouse Over C',
+      'A',
+    ]);
+
+    // This test shows existing quirk where stopPropagation on mouseout
+    // prevents mouseEnter from firing
+    dispatchMouseHoverEvent(spanC, spanB);
+    assertLog([
+      'Mouse Out Capture B',
+      // stopPropagation stops these
+      // 'Mouse Out B',
+      // 'Mouse Enter C',
+      'Mouse Over Capture Parent',
+      'Mouse Over Capture C',
+      // Stop propagation stops these
+      // 'Mouse Over Capture Inner C',
+      // 'Mouse Over C',
+    ]);
+
+    document.body.removeChild(container);
+  });
+
+  describe('can handle replaying events as part of multiple instances of React', () => {
+    let resolveInner;
+    let resolveOuter;
+    let innerPromise;
+    let outerPromise;
+    let OuterScheduler;
+    let InnerScheduler;
+    let innerDiv;
+
+    let OuterTestUtils;
+    let InnerTestUtils;
+
+    beforeEach(async () => {
+      document.body.innerHTML = '';
+      jest.resetModules();
+      let OuterReactDOMClient;
+      let InnerReactDOMClient;
+
+      jest.isolateModules(() => {
+        OuterReactDOMClient = require('react-dom/client');
+        OuterScheduler = require('scheduler');
+        OuterTestUtils = require('internal-test-utils');
+      });
+      jest.isolateModules(() => {
+        InnerReactDOMClient = require('react-dom/client');
+        InnerScheduler = require('scheduler');
+        InnerTestUtils = require('internal-test-utils');
+      });
+
+      expect(OuterReactDOMClient).not.toBe(InnerReactDOMClient);
+      expect(OuterScheduler).not.toBe(InnerScheduler);
+
+      const outerContainer = document.createElement('div');
+      const innerContainer = document.createElement('div');
+
+      let suspendOuter = false;
+      outerPromise = new Promise(res => {
+        resolveOuter = () => {
+          suspendOuter = false;
+          res();
+        };
+      });
+
+      function Outer() {
+        if (suspendOuter) {
+          OuterScheduler.log('Suspend Outer');
+          throw outerPromise;
+        }
+        OuterScheduler.log('Outer');
+        const innerRoot = outerContainer.querySelector('#inner-root');
+        return (
+          <div
+            id="inner-root"
+            onMouseEnter={() => {
+              Scheduler.log('Outer Mouse Enter');
+            }}
+            dangerouslySetInnerHTML={{
+              __html: innerRoot ? innerRoot.innerHTML : '',
+            }}
+          />
+        );
+      }
+      const OuterApp = () => {
+        return (
+          <Activity>
+            <Outer />
+          </Activity>
+        );
+      };
+
+      let suspendInner = false;
+      innerPromise = new Promise(res => {
+        resolveInner = () => {
+          suspendInner = false;
+          res();
+        };
+      });
+      function Inner() {
+        if (suspendInner) {
+          InnerScheduler.log('Suspend Inner');
+          throw innerPromise;
+        }
+        InnerScheduler.log('Inner');
+        return (
+          <div
+            id="inner"
+            onMouseEnter={() => {
+              Scheduler.log('Inner Mouse Enter');
+            }}
+          />
+        );
+      }
+      const InnerApp = () => {
+        return (
+          <Activity>
+            <Inner />
+          </Activity>
+        );
+      };
+
+      document.body.appendChild(outerContainer);
+      const outerHTML = ReactDOMServer.renderToString(<OuterApp />);
+      outerContainer.innerHTML = outerHTML;
+
+      const innerWrapper = document.querySelector('#inner-root');
+      innerWrapper.appendChild(innerContainer);
+      const innerHTML = ReactDOMServer.renderToString(<InnerApp />);
+      innerContainer.innerHTML = innerHTML;
+
+      OuterTestUtils.assertLog(['Outer']);
+      InnerTestUtils.assertLog(['Inner']);
+
+      suspendOuter = true;
+      suspendInner = true;
+
+      await OuterTestUtils.act(() =>
+        OuterReactDOMClient.hydrateRoot(outerContainer, <OuterApp />),
+      );
+      await InnerTestUtils.act(() =>
+        InnerReactDOMClient.hydrateRoot(innerContainer, <InnerApp />),
+      );
+
+      OuterTestUtils.assertLog(['Suspend Outer']);
+      InnerTestUtils.assertLog(['Suspend Inner']);
+
+      innerDiv = document.querySelector('#inner');
+
+      dispatchClickEvent(innerDiv);
+
+      await act(() => {
+        jest.runAllTimers();
+        Scheduler.unstable_flushAllWithoutAsserting();
+        OuterScheduler.unstable_flushAllWithoutAsserting();
+        InnerScheduler.unstable_flushAllWithoutAsserting();
+      });
+
+      OuterTestUtils.assertLog(['Suspend Outer']);
+
+      // InnerApp doesn't see the event because OuterApp calls stopPropagation in
+      // capture phase since the event is blocked on suspended component
+      InnerTestUtils.assertLog([]);
+
+      assertLog([]);
+    });
+    afterEach(async () => {
+      document.body.innerHTML = '';
+    });
+
+    it('Inner hydrates first then Outer', async () => {
+      dispatchMouseHoverEvent(innerDiv);
+
+      await InnerTestUtils.act(async () => {
+        await OuterTestUtils.act(() => {
+          resolveInner();
+        });
+      });
+
+      OuterTestUtils.assertLog(['Suspend Outer']);
+      // Inner App renders because it is unblocked
+      InnerTestUtils.assertLog(['Inner']);
+      // No event is replayed yet
+      assertLog([]);
+
+      dispatchMouseHoverEvent(innerDiv);
+      OuterTestUtils.assertLog([]);
+      InnerTestUtils.assertLog([]);
+      // No event is replayed yet
+      assertLog([]);
+
+      await InnerTestUtils.act(async () => {
+        await OuterTestUtils.act(() => {
+          resolveOuter();
+
+          // Nothing happens to inner app yet.
+          // Its blocked on the outer app replaying the event
+          InnerTestUtils.assertLog([]);
+          // Outer hydrates and schedules Replay
+          OuterTestUtils.waitFor(['Outer']);
+          // No event is replayed yet
+          assertLog([]);
+        });
+      });
+
+      // fire scheduled Replay
+
+      // First Inner Mouse Enter fires then Outer Mouse Enter
+      assertLog(['Inner Mouse Enter', 'Outer Mouse Enter']);
+    });
+
+    it('Outer hydrates first then Inner', async () => {
+      dispatchMouseHoverEvent(innerDiv);
+
+      await act(async () => {
+        resolveOuter();
+        await outerPromise;
+        Scheduler.unstable_flushAllWithoutAsserting();
+        OuterScheduler.unstable_flushAllWithoutAsserting();
+        InnerScheduler.unstable_flushAllWithoutAsserting();
+      });
+
+      // Outer resolves and scheduled replay
+      OuterTestUtils.assertLog(['Outer']);
+      // Inner App is still blocked
+      InnerTestUtils.assertLog([]);
+
+      // Replay outer event
+      await act(() => {
+        Scheduler.unstable_flushAllWithoutAsserting();
+        OuterScheduler.unstable_flushAllWithoutAsserting();
+        InnerScheduler.unstable_flushAllWithoutAsserting();
+      });
+
+      // Inner is still blocked so when Outer replays the event in capture phase
+      // inner ends up caling stopPropagation
+      assertLog([]);
+      OuterTestUtils.assertLog([]);
+      InnerTestUtils.assertLog(['Suspend Inner']);
+
+      dispatchMouseHoverEvent(innerDiv);
+      OuterTestUtils.assertLog([]);
+      InnerTestUtils.assertLog([]);
+      assertLog([]);
+
+      await act(async () => {
+        resolveInner();
+        await innerPromise;
+        Scheduler.unstable_flushAllWithoutAsserting();
+        OuterScheduler.unstable_flushAllWithoutAsserting();
+        InnerScheduler.unstable_flushAllWithoutAsserting();
+      });
+
+      // Inner hydrates
+      InnerTestUtils.assertLog(['Inner']);
+      // Outer was hydrated earlier
+      OuterTestUtils.assertLog([]);
+
+      // First Inner Mouse Enter fires then Outer Mouse Enter
+      assertLog(['Inner Mouse Enter', 'Outer Mouse Enter']);
+
+      await act(() => {
+        Scheduler.unstable_flushAllWithoutAsserting();
+        OuterScheduler.unstable_flushAllWithoutAsserting();
+        InnerScheduler.unstable_flushAllWithoutAsserting();
+      });
+
+      assertLog([]);
+    });
+  });
+
+  it('replays event with null target when tree is dismounted', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+      resolve = () => {
+        suspend = false;
+        resolvePromise();
+      };
+    });
+
+    function Child() {
+      if (suspend) {
+        throw promise;
+      }
+      Scheduler.log('Child');
+      return (
+        <div
+          onMouseOver={() => {
+            Scheduler.log('on mouse over');
+          }}>
+          Child
+        </div>
+      );
+    }
+
+    function App() {
+      return (
+        <Activity>
+          <Child />
+        </Activity>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    assertLog(['Child']);
+
+    const container = document.createElement('div');
+
+    document.body.appendChild(container);
+    container.innerHTML = finalHTML;
+    suspend = true;
+
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    const childDiv = container.firstElementChild;
+
+    await act(async () => {
+      dispatchMouseHoverEvent(childDiv);
+
+      // Not hydrated so event is saved for replay and stopPropagation is called
+      assertLog([]);
+
+      resolve();
+      await waitFor(['Child']);
+
+      ReactDOM.flushSync(() => {
+        container.removeChild(childDiv);
+
+        const container2 = document.createElement('div');
+        container2.addEventListener('mouseover', () => {
+          Scheduler.log('container2 mouse over');
+        });
+        container2.appendChild(childDiv);
+      });
+    });
+
+    // Even though the tree is remove the event is still dispatched with native event handler
+    // on the container firing.
+    assertLog(['container2 mouse over']);
+
+    document.body.removeChild(container);
+  });
+
+  it('hydrates the last target path first for continuous events', async () => {
+    let suspend = false;
+    let resolve;
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+
+    function Child({text}) {
+      if ((text === 'A' || text === 'D') && suspend) {
+        throw promise;
+      }
+      Scheduler.log(text);
+      return (
+        <span
+          onMouseEnter={e => {
+            e.preventDefault();
+            Scheduler.log('Hover ' + text);
+          }}>
+          {text}
+        </span>
+      );
+    }
+
+    function App() {
+      Scheduler.log('App');
+      return (
+        <div>
+          <Activity>
+            <Child text="A" />
+          </Activity>
+          <Activity>
+            <div>
+              <Activity>
+                <Child text="B" />
+              </Activity>
+            </div>
+            <Child text="C" />
+          </Activity>
+          <Activity>
+            <Child text="D" />
+          </Activity>
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    assertLog(['App', 'A', 'B', 'C', 'D']);
+
+    const container = document.createElement('div');
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    container.innerHTML = finalHTML;
+
+    const spanB = container.getElementsByTagName('span')[1];
+    const spanC = container.getElementsByTagName('span')[2];
+    const spanD = container.getElementsByTagName('span')[3];
+
+    suspend = true;
+
+    // A and D will be suspended. We'll click on D which should take
+    // priority, after we unsuspend.
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    // Nothing has been hydrated so far.
+    assertLog([]);
+
+    // Hover over B and then C.
+    dispatchMouseHoverEvent(spanB, spanD);
+    dispatchMouseHoverEvent(spanC, spanB);
+
+    await act(async () => {
+      suspend = false;
+      resolve();
+      await promise;
+    });
+
+    // We should prioritize hydrating D first because we clicked it.
+    // Next we should hydrate C since that's the current hover target.
+    // Next it doesn't matter if we hydrate A or B first but as an
+    // implementation detail we're currently hydrating B first since
+    // we at one point hovered over it and we never deprioritized it.
+    assertLog(['App', 'C', 'Hover C', 'A', 'B', 'D']);
+
+    document.body.removeChild(container);
+  });
+
+  it('hydrates the last explicitly hydrated target at higher priority', async () => {
+    function Child({text}) {
+      Scheduler.log(text);
+      return <span>{text}</span>;
+    }
+
+    function App() {
+      Scheduler.log('App');
+      return (
+        <div>
+          <Activity>
+            <Child text="A" />
+          </Activity>
+          <Activity>
+            <Child text="B" />
+          </Activity>
+          <Activity>
+            <Child text="C" />
+          </Activity>
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    assertLog(['App', 'A', 'B', 'C']);
+
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    const spanB = container.getElementsByTagName('span')[1];
+    const spanC = container.getElementsByTagName('span')[2];
+
+    const root = ReactDOMClient.hydrateRoot(container, <App />);
+
+    // Nothing has been hydrated so far.
+    assertLog([]);
+
+    // Increase priority of B and then C.
+    root.unstable_scheduleHydration(spanB);
+    root.unstable_scheduleHydration(spanC);
+
+    // We should prioritize hydrating C first because the last added
+    // gets highest priority followed by the next added.
+    await waitForAll(['App', 'C', 'B', 'A']);
+  });
+
+  // @gate www
+  it('hydrates before an update even if hydration moves away from it', async () => {
+    function Child({text}) {
+      Scheduler.log(text);
+      return <span>{text}</span>;
+    }
+    const ChildWithBoundary = React.memo(function ({text}) {
+      return (
+        <Activity>
+          <Child text={text} />
+          <Child text={text.toLowerCase()} />
+        </Activity>
+      );
+    });
+
+    function App({a}) {
+      Scheduler.log('App');
+      React.useEffect(() => {
+        Scheduler.log('Commit');
+      });
+      return (
+        <div>
+          <ChildWithBoundary text={a} />
+          <ChildWithBoundary text="B" />
+          <ChildWithBoundary text="C" />
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App a="A" />);
+
+    assertLog(['App', 'A', 'a', 'B', 'b', 'C', 'c']);
+
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    const spanA = container.getElementsByTagName('span')[0];
+    const spanB = container.getElementsByTagName('span')[2];
+    const spanC = container.getElementsByTagName('span')[4];
+
+    await act(async () => {
+      const root = ReactDOMClient.hydrateRoot(container, <App a="A" />);
+      // Hydrate the shell.
+      await waitFor(['App', 'Commit']);
+
+      // Render an update at Idle priority that needs to update A.
+
+      TODO_scheduleIdleDOMSchedulerTask(() => {
+        root.render(<App a="AA" />);
+      });
+
+      // Start rendering. This will force the first boundary to hydrate
+      // by scheduling it at one higher pri than Idle.
+      await waitFor([
+        'App',
+
+        // Start hydrating A
+        'A',
+      ]);
+
+      // Hover over A which (could) schedule at one higher pri than Idle.
+      dispatchMouseHoverEvent(spanA, null);
+
+      // Before, we're done we now switch to hover over B.
+      // This is meant to test that this doesn't cause us to forget that
+      // we still have to hydrate A. The first boundary.
+      // This also tests that we don't do the -1 down-prioritization of
+      // continuous hover events because that would decrease its priority
+      // to Idle.
+      dispatchMouseHoverEvent(spanB, spanA);
+
+      // Also click C to prioritize that even higher which resets the
+      // priority levels.
+      dispatchClickEvent(spanC);
+
+      assertLog([
+        // Hydrate C first since we clicked it.
+        'C',
+        'c',
+      ]);
+
+      await waitForAll([
+        // Finish hydration of A since we forced it to hydrate.
+        'A',
+        'a',
+        // Also, hydrate B since we hovered over it.
+        // It's not important which one comes first. A or B.
+        // As long as they both happen before the Idle update.
+        'B',
+        'b',
+        // Begin the Idle update again.
+        'App',
+        'AA',
+        'aa',
+        'Commit',
+      ]);
+    });
+
+    const spanA2 = container.getElementsByTagName('span')[0];
+    // This is supposed to have been hydrated, not replaced.
+    expect(spanA).toBe(spanA2);
+
+    document.body.removeChild(container);
+  });
+
+  it('fires capture event handlers and native events if content is hydratable during discrete event', async () => {
+    spyOnDev(console, 'error');
+    function Child({text}) {
+      Scheduler.log(text);
+      const ref = React.useRef();
+      React.useLayoutEffect(() => {
+        if (!ref.current) {
+          return;
+        }
+        ref.current.onclick = () => {
+          Scheduler.log('Native Click ' + text);
+        };
+      }, [text]);
+      return (
+        <span
+          ref={ref}
+          onClickCapture={() => {
+            Scheduler.log('Capture Clicked ' + text);
+          }}
+          onClick={e => {
+            Scheduler.log('Clicked ' + text);
+          }}>
+          {text}
+        </span>
+      );
+    }
+
+    function App() {
+      Scheduler.log('App');
+      return (
+        <div>
+          <Activity>
+            <Child text="A" />
+          </Activity>
+          <Activity>
+            <Child text="B" />
+          </Activity>
+        </div>
+      );
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    assertLog(['App', 'A', 'B']);
+
+    const container = document.createElement('div');
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    container.innerHTML = finalHTML;
+
+    const span = container.getElementsByTagName('span')[1];
+
+    ReactDOMClient.hydrateRoot(container, <App />);
+
+    // Nothing has been hydrated so far.
+    assertLog([]);
+
+    // This should synchronously hydrate the root App and the second suspense
+    // boundary.
+    dispatchClickEvent(span);
+
+    // We rendered App, B and then invoked the event without rendering A.
+    assertLog(['App', 'B', 'Capture Clicked B', 'Native Click B', 'Clicked B']);
+
+    // After continuing the scheduler, we finally hydrate A.
+    await waitForAll(['A']);
+
+    document.body.removeChild(container);
+  });
+
+  it('does not propagate discrete event if it cannot be synchronously hydrated', async () => {
+    let triggeredParent = false;
+    let triggeredChild = false;
+    let suspend = false;
+    const promise = new Promise(() => {});
+    function Child() {
+      if (suspend) {
+        throw promise;
+      }
+      Scheduler.log('Child');
+      return (
+        <span
+          onClickCapture={e => {
+            e.stopPropagation();
+            triggeredChild = true;
+          }}>
+          Click me
+        </span>
+      );
+    }
+    function App() {
+      const onClick = () => {
+        triggeredParent = true;
+      };
+      Scheduler.log('App');
+      return (
+        <div
+          ref={n => {
+            if (n) n.onclick = onClick;
+          }}
+          onClick={onClick}>
+          <Activity>
+            <Child />
+          </Activity>
+        </div>
+      );
+    }
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+
+    assertLog(['App', 'Child']);
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    container.innerHTML = finalHTML;
+
+    suspend = true;
+
+    ReactDOMClient.hydrateRoot(container, <App />);
+    // Nothing has been hydrated so far.
+    assertLog([]);
+
+    const span = container.getElementsByTagName('span')[0];
+    dispatchClickEvent(span);
+
+    assertLog(['App']);
+
+    dispatchClickEvent(span);
+
+    expect(triggeredParent).toBe(false);
+    expect(triggeredChild).toBe(false);
+  });
+
+  it('can force hydration in response to sync update', async () => {
+    function Child({text}) {
+      Scheduler.log(`Child ${text}`);
+      return <span ref={ref => (spanRef = ref)}>{text}</span>;
+    }
+    function App({text}) {
+      Scheduler.log(`App ${text}`);
+      return (
+        <div>
+          <Activity>
+            <Child text={text} />
+          </Activity>
+        </div>
+      );
+    }
+
+    let spanRef;
+    const finalHTML = ReactDOMServer.renderToString(<App text="A" />);
+    assertLog(['App A', 'Child A']);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    container.innerHTML = finalHTML;
+    const initialSpan = container.getElementsByTagName('span')[0];
+    const root = ReactDOMClient.hydrateRoot(container, <App text="A" />);
+    await waitForPaint(['App A']);
+
+    await act(() => {
+      ReactDOM.flushSync(() => {
+        root.render(<App text="B" />);
+      });
+    });
+    assertLog(['App B', 'Child A', 'App B', 'Child B']);
+    expect(initialSpan).toBe(spanRef);
+  });
+
+  // @gate www
+  it('can force hydration in response to continuous update', async () => {
+    function Child({text}) {
+      Scheduler.log(`Child ${text}`);
+      return <span ref={ref => (spanRef = ref)}>{text}</span>;
+    }
+    function App({text}) {
+      Scheduler.log(`App ${text}`);
+      return (
+        <div>
+          <Activity>
+            <Child text={text} />
+          </Activity>
+        </div>
+      );
+    }
+
+    let spanRef;
+    const finalHTML = ReactDOMServer.renderToString(<App text="A" />);
+    assertLog(['App A', 'Child A']);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    container.innerHTML = finalHTML;
+    const initialSpan = container.getElementsByTagName('span')[0];
+    const root = ReactDOMClient.hydrateRoot(container, <App text="A" />);
+    await waitForPaint(['App A']);
+
+    await act(() => {
+      TODO_scheduleContinuousSchedulerTask(() => {
+        root.render(<App text="B" />);
+      });
+    });
+
+    assertLog(['App B', 'Child A', 'App B', 'Child B']);
+    expect(initialSpan).toBe(spanRef);
+  });
+
+  it('can force hydration in response to default update', async () => {
+    function Child({text}) {
+      Scheduler.log(`Child ${text}`);
+      return <span ref={ref => (spanRef = ref)}>{text}</span>;
+    }
+    function App({text}) {
+      Scheduler.log(`App ${text}`);
+      return (
+        <div>
+          <Activity>
+            <Child text={text} />
+          </Activity>
+        </div>
+      );
+    }
+
+    let spanRef;
+    const finalHTML = ReactDOMServer.renderToString(<App text="A" />);
+    assertLog(['App A', 'Child A']);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    container.innerHTML = finalHTML;
+    const initialSpan = container.getElementsByTagName('span')[0];
+    const root = ReactDOMClient.hydrateRoot(container, <App text="A" />);
+    await waitForPaint(['App A']);
+    await act(() => {
+      root.render(<App text="B" />);
+    });
+    assertLog(['App B', 'Child A', 'App B', 'Child B']);
+    expect(initialSpan).toBe(spanRef);
+  });
+
+  // @gate www
+  it('regression test: can unwind context on selective hydration interruption', async () => {
+    const Context = React.createContext('DefaultContext');
+
+    function ContextReader(props) {
+      const value = React.useContext(Context);
+      Scheduler.log(value);
+      return null;
+    }
+
+    function Child({text}) {
+      Scheduler.log(text);
+      return <span>{text}</span>;
+    }
+    const ChildWithBoundary = React.memo(function ({text}) {
+      return (
+        <Activity>
+          <Child text={text} />
+        </Activity>
+      );
+    });
+
+    function App({a}) {
+      Scheduler.log('App');
+      React.useEffect(() => {
+        Scheduler.log('Commit');
+      });
+      return (
+        <>
+          <Context.Provider value="SiblingContext">
+            <ChildWithBoundary text={a} />
+          </Context.Provider>
+          <ContextReader />
+        </>
+      );
+    }
+    const finalHTML = ReactDOMServer.renderToString(<App a="A" />);
+    assertLog(['App', 'A', 'DefaultContext']);
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+    document.body.appendChild(container);
+
+    const spanA = container.getElementsByTagName('span')[0];
+
+    await act(async () => {
+      const root = ReactDOMClient.hydrateRoot(container, <App a="A" />);
+      await waitFor(['App', 'DefaultContext', 'Commit']);
+
+      TODO_scheduleIdleDOMSchedulerTask(() => {
+        root.render(<App a="AA" />);
+      });
+      await waitFor(['App', 'A']);
+
+      dispatchClickEvent(spanA);
+      assertLog(['A']);
+      await waitForAll(['App', 'AA', 'DefaultContext', 'Commit']);
+    });
+  });
+
+  it('regression test: can unwind context on selective hydration interruption for sync updates', async () => {
+    const Context = React.createContext('DefaultContext');
+
+    function ContextReader(props) {
+      const value = React.useContext(Context);
+      Scheduler.log(value);
+      return null;
+    }
+
+    function Child({text}) {
+      Scheduler.log(text);
+      return <span>{text}</span>;
+    }
+    const ChildWithBoundary = React.memo(function ({text}) {
+      return (
+        <Activity>
+          <Child text={text} />
+        </Activity>
+      );
+    });
+
+    function App({a}) {
+      Scheduler.log('App');
+      React.useEffect(() => {
+        Scheduler.log('Commit');
+      });
+      return (
+        <>
+          <Context.Provider value="SiblingContext">
+            <ChildWithBoundary text={a} />
+          </Context.Provider>
+          <ContextReader />
+        </>
+      );
+    }
+    const finalHTML = ReactDOMServer.renderToString(<App a="A" />);
+    assertLog(['App', 'A', 'DefaultContext']);
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    await act(async () => {
+      const root = ReactDOMClient.hydrateRoot(container, <App a="A" />);
+      await waitFor(['App', 'DefaultContext', 'Commit']);
+
+      ReactDOM.flushSync(() => {
+        root.render(<App a="AA" />);
+      });
+      assertLog(['App', 'A', 'App', 'AA', 'DefaultContext', 'Commit']);
+    });
+  });
+
+  it('regression: selective hydration does not contribute to "maximum update limit" count', async () => {
+    const outsideRef = React.createRef(null);
+    const insideRef = React.createRef(null);
+    function Child() {
+      return (
+        <Activity>
+          <div ref={insideRef} />
+        </Activity>
+      );
+    }
+
+    let setIsMounted = false;
+    function App() {
+      const [isMounted, setState] = React.useState(false);
+      setIsMounted = setState;
+
+      const children = [];
+      for (let i = 0; i < 100; i++) {
+        children.push(<Child key={i} isMounted={isMounted} />);
+      }
+
+      return <div ref={outsideRef}>{children}</div>;
+    }
+
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    await act(async () => {
+      ReactDOMClient.hydrateRoot(container, <App />);
+
+      // Commit just the shell
+      await waitForPaint([]);
+
+      // Assert that the shell has hydrated, but not the children
+      expect(outsideRef.current).not.toBe(null);
+      expect(insideRef.current).toBe(null);
+
+      // Update the shell synchronously. The update will flow into the children,
+      // which haven't hydrated yet. This will trigger a cascade of commits
+      // caused by selective hydration. However, since there's really only one
+      // update, it should not be treated as an update loop.
+      // NOTE: It's unfortunate that every sibling boundary is separately
+      // committed in this case. We should be able to commit everything in a
+      // render phase, which we could do if we had resumable context stacks.
+      ReactDOM.flushSync(() => {
+        setIsMounted(true);
+      });
+    });
+
+    // Should have successfully hydrated with no errors.
+    expect(insideRef.current).not.toBe(null);
+  });
+});

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -20,7 +20,7 @@ import type {RootTag} from './ReactRootTags';
 import type {WorkTag} from './ReactWorkTags';
 import type {TypeOfMode} from './ReactTypeOfMode';
 import type {Lanes} from './ReactFiberLane';
-import type {SuspenseInstance} from './ReactFiberConfig';
+import type {ActivityInstance, SuspenseInstance} from './ReactFiberConfig';
 import type {
   LegacyHiddenProps,
   OffscreenProps,
@@ -951,7 +951,7 @@ export function createFiberFromText(
 }
 
 export function createFiberFromDehydratedFragment(
-  dehydratedNode: SuspenseInstance,
+  dehydratedNode: SuspenseInstance | ActivityInstance,
 ): Fiber {
   const fiber = createFiber(DehydratedFragment, null, null, NoMode);
   fiber.stateNode = dehydratedNode;

--- a/packages/react-reconciler/src/ReactFiberActivityComponent.js
+++ b/packages/react-reconciler/src/ReactFiberActivityComponent.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ActivityInstance} from './ReactFiberConfig';
+import type {CapturedValue} from './ReactCapturedValue';
+import type {Lane} from './ReactFiberLane';
+import type {TreeContext} from './ReactFiberTreeContext';
+
+// A non-null ActivityState represents a dehydrated Activity boundary.
+export type ActivityState = {
+  dehydrated: ActivityInstance,
+  treeContext: null | TreeContext,
+  // Represents the lane we should attempt to hydrate a dehydrated boundary at.
+  // OffscreenLane is the default for dehydrated boundaries.
+  // NoLane is the default for normal boundaries, which turns into "normal" pri.
+  retryLane: Lane,
+  // Stashed Errors that happened while attempting to hydrate this boundary.
+  hydrationErrors: Array<CapturedValue<mixed>> | null,
+};

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -22,6 +22,7 @@ import type {LazyComponent as LazyComponentType} from 'react/src/ReactLazy';
 import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {TypeOfMode} from './ReactTypeOfMode';
 import type {Lanes, Lane} from './ReactFiberLane';
+import type {ActivityState} from './ReactFiberActivityComponent';
 import type {
   SuspenseState,
   SuspenseListRenderState,
@@ -185,7 +186,7 @@ import {
   createHoistableInstance,
   HostTransitionContext,
 } from './ReactFiberConfig';
-import type {SuspenseInstance} from './ReactFiberConfig';
+import type {ActivityInstance, SuspenseInstance} from './ReactFiberConfig';
 import {shouldError, shouldSuspend} from './ReactFiberReconciler';
 import {
   pushHostContext,
@@ -201,8 +202,10 @@ import {
   setShallowSuspenseListContext,
   pushPrimaryTreeSuspenseHandler,
   pushFallbackTreeSuspenseHandler,
+  pushDehydratedActivitySuspenseHandler,
   pushOffscreenSuspenseHandler,
   reuseSuspenseHandlerOnStack,
+  popSuspenseHandler,
 } from './ReactFiberSuspenseContext';
 import {
   pushHiddenContext,
@@ -239,6 +242,7 @@ import {
 import {
   getIsHydrating,
   enterHydrationState,
+  reenterHydrationStateFromDehydratedActivityInstance,
   reenterHydrationStateFromDehydratedSuspenseInstance,
   resetHydrationState,
   claimHydratableSingleton,
@@ -875,12 +879,11 @@ function updateLegacyHiddenComponent(
   );
 }
 
-function updateActivityComponent(
-  current: null | Fiber,
+function mountActivityChildren(
   workInProgress: Fiber,
+  nextProps: ActivityProps,
   renderLanes: Lanes,
 ) {
-  const nextProps: ActivityProps = workInProgress.pendingProps;
   if (__DEV__) {
     const hiddenProp = (nextProps: any).hidden;
     if (hiddenProp !== undefined) {
@@ -904,24 +907,258 @@ function updateActivityComponent(
     mode: nextMode,
     children: nextChildren,
   };
+  const primaryChildFragment = mountWorkInProgressOffscreenFiber(
+    offscreenChildProps,
+    mode,
+    renderLanes,
+  );
+  primaryChildFragment.ref = workInProgress.ref;
+  workInProgress.child = primaryChildFragment;
+  primaryChildFragment.return = workInProgress;
+  return primaryChildFragment;
+}
 
-  if (current === null) {
-    if (getIsHydrating()) {
-      claimNextHydratableActivityInstance(workInProgress);
+function retryActivityComponentWithoutHydrating(
+  current: Fiber,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+) {
+  // Falling back to client rendering. Because this has performance
+  // implications, it's considered a recoverable error, even though the user
+  // likely won't observe anything wrong with the UI.
+
+  // This will add the old fiber to the deletion list
+  reconcileChildFibers(workInProgress, current.child, null, renderLanes);
+
+  // We're now not suspended nor dehydrated.
+  const nextProps: ActivityProps = workInProgress.pendingProps;
+  const primaryChildFragment = mountActivityChildren(
+    workInProgress,
+    nextProps,
+    renderLanes,
+  );
+  // Needs a placement effect because the parent (the Activity boundary) already
+  // mounted but this is a new fiber.
+  primaryChildFragment.flags |= Placement;
+
+  // If we're not going to hydrate we can't leave it dehydrated if something
+  // suspends. In that case we want that to bubble to the nearest parent boundary
+  // so we need to pop our own handler that we just pushed.
+  popSuspenseHandler(workInProgress);
+
+  workInProgress.memoizedState = null;
+
+  return primaryChildFragment;
+}
+
+function mountDehydratedActivityComponent(
+  workInProgress: Fiber,
+  activityInstance: ActivityInstance,
+  renderLanes: Lanes,
+): null | Fiber {
+  // During the first pass, we'll bail out and not drill into the children.
+  // Instead, we'll leave the content in place and try to hydrate it later.
+  // We'll continue hydrating the rest at offscreen priority since we'll already
+  // be showing the right content coming from the server, it is no rush.
+  workInProgress.lanes = laneToLanes(OffscreenLane);
+  return null;
+}
+
+function updateDehydratedActivityComponent(
+  current: Fiber,
+  workInProgress: Fiber,
+  didSuspend: boolean,
+  nextProps: ActivityProps,
+  activityInstance: ActivityInstance,
+  activityState: ActivityState,
+  renderLanes: Lanes,
+): null | Fiber {
+  // We'll handle suspending since if something suspends we can just leave
+  // it dehydrated. We push early and then pop if we enter non-dehydrated attempts.
+  pushDehydratedActivitySuspenseHandler(workInProgress);
+  if (!didSuspend) {
+    // This is the first render pass. Attempt to hydrate.
+
+    // We should never be hydrating at this point because it is the first pass,
+    // but after we've already committed once.
+    warnIfHydrating();
+
+    if (
+      // TODO: Factoring is a little weird, since we check this right below, too.
+      !didReceiveUpdate
+    ) {
+      // We need to check if any children have context before we decide to bail
+      // out, so propagate the changes now.
+      lazilyPropagateParentContextChanges(current, workInProgress, renderLanes);
     }
 
-    const primaryChildFragment = mountWorkInProgressOffscreenFiber(
-      offscreenChildProps,
-      mode,
-      renderLanes,
-    );
-    primaryChildFragment.ref = workInProgress.ref;
-    workInProgress.child = primaryChildFragment;
-    primaryChildFragment.return = workInProgress;
+    // We use lanes to indicate that a child might depend on context, so if
+    // any context has changed, we need to treat is as if the input might have changed.
+    const hasContextChanged = includesSomeLane(renderLanes, current.childLanes);
+    if (didReceiveUpdate || hasContextChanged) {
+      // This boundary has changed since the first render. This means that we are now unable to
+      // hydrate it. We might still be able to hydrate it using a higher priority lane.
+      const root = getWorkInProgressRoot();
+      if (root !== null) {
+        const attemptHydrationAtLane = getBumpedLaneForHydration(
+          root,
+          renderLanes,
+        );
+        if (
+          attemptHydrationAtLane !== NoLane &&
+          attemptHydrationAtLane !== activityState.retryLane
+        ) {
+          // Intentionally mutating since this render will get interrupted. This
+          // is one of the very rare times where we mutate the current tree
+          // during the render phase.
+          activityState.retryLane = attemptHydrationAtLane;
+          enqueueConcurrentRenderForLane(current, attemptHydrationAtLane);
+          scheduleUpdateOnFiber(root, current, attemptHydrationAtLane);
 
-    return primaryChildFragment;
+          // Throw a special object that signals to the work loop that it should
+          // interrupt the current render.
+          //
+          // Because we're inside a React-only execution stack, we don't
+          // strictly need to throw here — we could instead modify some internal
+          // work loop state. But using an exception means we don't need to
+          // check for this case on every iteration of the work loop. So doing
+          // it this way moves the check out of the fast path.
+          throw SelectiveHydrationException;
+        } else {
+          // We have already tried to ping at a higher priority than we're rendering with
+          // so if we got here, we must have failed to hydrate at those levels. We must
+          // now give up. Instead, we're going to delete the whole subtree and instead inject
+          // a new real Activity boundary to take its place. This might suspend for a while
+          // and if it does we might still have an opportunity to hydrate before this pass
+          // commits.
+        }
+      }
+
+      // If we did not selectively hydrate, we'll continue rendering without
+      // hydrating. Mark this tree as suspended to prevent it from committing
+      // outside a transition.
+      //
+      // This path should only happen if the hydration lane already suspended.
+      renderDidSuspendDelayIfPossible();
+      return retryActivityComponentWithoutHydrating(
+        current,
+        workInProgress,
+        renderLanes,
+      );
+    } else {
+      // This is the first attempt.
+
+      reenterHydrationStateFromDehydratedActivityInstance(
+        workInProgress,
+        activityInstance,
+        activityState.treeContext,
+      );
+
+      const primaryChildFragment = mountActivityChildren(
+        workInProgress,
+        nextProps,
+        renderLanes,
+      );
+      // Mark the children as hydrating. This is a fast path to know whether this
+      // tree is part of a hydrating tree. This is used to determine if a child
+      // node has fully mounted yet, and for scheduling event replaying.
+      // Conceptually this is similar to Placement in that a new subtree is
+      // inserted into the React tree here. It just happens to not need DOM
+      // mutations because it already exists.
+      primaryChildFragment.flags |= Hydrating;
+      return primaryChildFragment;
+    }
   } else {
+    // This is the second render pass. We already attempted to hydrated, but
+    // something either suspended or errored.
+
+    if (workInProgress.flags & ForceClientRender) {
+      // Something errored during hydration. Try again without hydrating.
+      // The error should've already been logged in throwException.
+      workInProgress.flags &= ~ForceClientRender;
+      return retryActivityComponentWithoutHydrating(
+        current,
+        workInProgress,
+        renderLanes,
+      );
+    } else if ((workInProgress.memoizedState: null | ActivityState) !== null) {
+      // Something suspended and we should still be in dehydrated mode.
+      // Leave the existing child in place.
+
+      workInProgress.child = current.child;
+      // The dehydrated completion pass expects this flag to be there
+      // but the normal offscreen pass doesn't.
+      workInProgress.flags |= DidCapture;
+      return null;
+    } else {
+      // We called retryActivityComponentWithoutHydrating and tried client rendering
+      // but now we suspended again. We should never arrive here because we should
+      // not have pushed a suspense handler during that second pass and it should
+      // instead have suspended above.
+      throw new Error(
+        'Client rendering an Activity suspended it again. This is a bug in React.',
+      );
+    }
+  }
+}
+
+function updateActivityComponent(
+  current: null | Fiber,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+) {
+  const nextProps: ActivityProps = workInProgress.pendingProps;
+
+  // Check if the first pass suspended.
+  const didSuspend = (workInProgress.flags & DidCapture) !== NoFlags;
+  workInProgress.flags &= ~DidCapture;
+
+  if (current === null) {
+    // Initial mount
+
+    // Special path for hydration
+    // If we're currently hydrating, try to hydrate this boundary.
+    if (getIsHydrating()) {
+      // We must push the suspense handler context *before* attempting to
+      // hydrate, to avoid a mismatch in case it errors.
+      pushDehydratedActivitySuspenseHandler(workInProgress);
+      const dehydrated: ActivityInstance =
+        claimNextHydratableActivityInstance(workInProgress);
+      return mountDehydratedActivityComponent(
+        workInProgress,
+        dehydrated,
+        renderLanes,
+      );
+    }
+
+    return mountActivityChildren(workInProgress, nextProps, renderLanes);
+  } else {
+    // This is an update.
+
+    // Special path for hydration
+    const prevState: null | ActivityState = current.memoizedState;
+
+    if (prevState !== null) {
+      const dehydrated = prevState.dehydrated;
+      return updateDehydratedActivityComponent(
+        current,
+        workInProgress,
+        didSuspend,
+        nextProps,
+        dehydrated,
+        prevState,
+        renderLanes,
+      );
+    }
+
     const currentChild: Fiber = (current.child: any);
+
+    const nextChildren = nextProps.children;
+    const nextMode = nextProps.mode;
+    const offscreenChildProps: OffscreenProps = {
+      mode: nextMode,
+      children: nextChildren,
+    };
 
     const primaryChildFragment = updateWorkInProgressOffscreenFiber(
       currentChild,
@@ -2801,11 +3038,6 @@ function updateDehydratedSuspenseComponent(
       // outside a transition.
       //
       // This path should only happen if the hydration lane already suspended.
-      // Currently, it also happens during sync updates because there is no
-      // hydration lane for sync updates.
-      // TODO: We should ideally have a sync hydration lane that we can apply to do
-      // a pass where we hydrate this subtree in place using the previous Context and then
-      // reapply the update afterwards.
       if (isSuspenseInstancePending(suspenseInstance)) {
         // This is a dehydrated suspense instance. We don't need to suspend
         // because we're already showing a fallback.
@@ -3705,6 +3937,16 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
         }
       }
       break;
+    case ActivityComponent: {
+      const state: ActivityState | null = workInProgress.memoizedState;
+      if (state !== null) {
+        // We're dehydrated so we're not going to render the children. This is just
+        // to maintain push/pop symmetry.
+        pushDehydratedActivitySuspenseHandler(workInProgress);
+        return null;
+      }
+      break;
+    }
     case SuspenseComponent: {
       const state: SuspenseState | null = workInProgress.memoizedState;
       if (state !== null) {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -3944,6 +3944,10 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
       if (state !== null) {
         // We're dehydrated so we're not going to render the children. This is just
         // to maintain push/pop symmetry.
+        // We know that this component will suspend again because if it has
+        // been unsuspended it has committed as a hydrated Activity component.
+        // If it needs to be retried, it should have work scheduled on it.
+        workInProgress.flags |= DidCapture;
         pushDehydratedActivitySuspenseHandler(workInProgress);
         return null;
       }

--- a/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
@@ -10,6 +10,7 @@
 import type {
   Instance,
   TextInstance,
+  ActivityInstance,
   SuspenseInstance,
   Container,
   ChildSet,
@@ -48,6 +49,7 @@ import {
   unhideInstance,
   unhideTextInstance,
   commitHydratedContainer,
+  commitHydratedActivityInstance,
   commitHydratedSuspenseInstance,
   removeChildFromContainer,
   removeChild,
@@ -676,6 +678,25 @@ export function commitHostHydratedContainer(
       );
     } else {
       commitHydratedContainer(root.containerInfo);
+    }
+  } catch (error) {
+    captureCommitPhaseError(finishedWork, finishedWork.return, error);
+  }
+}
+
+export function commitHostHydratedActivity(
+  activityInstance: ActivityInstance,
+  finishedWork: Fiber,
+) {
+  try {
+    if (__DEV__) {
+      runWithFiberInDEV(
+        finishedWork,
+        commitHydratedActivityInstance,
+        activityInstance,
+      );
+    } else {
+      commitHydratedActivityInstance(activityInstance);
     }
   } catch (error) {
     captureCommitPhaseError(finishedWork, finishedWork.return, error);

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -10,6 +10,7 @@
 import type {
   Instance,
   TextInstance,
+  ActivityInstance,
   SuspenseInstance,
   Container,
   HoistableRoot,
@@ -1508,7 +1509,9 @@ function commitDeletionEffectsOnFiber(
           try {
             const onDeleted = hydrationCallbacks.onDeleted;
             if (onDeleted) {
-              onDeleted((deletedFiber.stateNode: SuspenseInstance));
+              onDeleted(
+                (deletedFiber.stateNode: SuspenseInstance | ActivityInstance),
+              );
             }
           } catch (error) {
             captureCommitPhaseError(

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -154,6 +154,7 @@ import {popProvider} from './ReactFiberNewContext';
 import {
   prepareToHydrateHostInstance,
   prepareToHydrateHostTextInstance,
+  prepareToHydrateHostActivityInstance,
   prepareToHydrateHostSuspenseInstance,
   popHydrationState,
   resetHydrationState,
@@ -1396,7 +1397,7 @@ function completeWork(
       if (current === null) {
         const wasHydrated = popHydrationState(workInProgress);
         if (wasHydrated) {
-          // TODO: Implement prepareToHydrateActivityInstance
+          prepareToHydrateHostActivityInstance(workInProgress);
         }
       }
       bubbleProperties(workInProgress);

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -19,6 +19,7 @@ import type {
   ChildSet,
   Resource,
 } from './ReactFiberConfig';
+import type {ActivityState} from './ReactFiberActivityComponent';
 import type {
   SuspenseState,
   SuspenseListRenderState,
@@ -898,6 +899,88 @@ function bubbleProperties(completedWork: Fiber) {
   return didBailout;
 }
 
+function completeDehydratedActivityBoundary(
+  current: Fiber | null,
+  workInProgress: Fiber,
+  nextState: ActivityState | null,
+): boolean {
+  const wasHydrated = popHydrationState(workInProgress);
+
+  if (nextState !== null) {
+    // We might be inside a hydration state the first time we're picking up this
+    // Activity boundary, and also after we've reentered it for further hydration.
+    if (current === null) {
+      if (!wasHydrated) {
+        throw new Error(
+          'A dehydrated suspense component was completed without a hydrated node. ' +
+            'This is probably a bug in React.',
+        );
+      }
+      prepareToHydrateHostActivityInstance(workInProgress);
+      bubbleProperties(workInProgress);
+      if (enableProfilerTimer) {
+        if ((workInProgress.mode & ProfileMode) !== NoMode) {
+          const isTimedOutSuspense = nextState !== null;
+          if (isTimedOutSuspense) {
+            // Don't count time spent in a timed out Suspense subtree as part of the base duration.
+            const primaryChildFragment = workInProgress.child;
+            if (primaryChildFragment !== null) {
+              // $FlowFixMe[unsafe-arithmetic] Flow doesn't support type casting in combination with the -= operator
+              workInProgress.treeBaseDuration -=
+                ((primaryChildFragment.treeBaseDuration: any): number);
+            }
+          }
+        }
+      }
+      return false;
+    } else {
+      emitPendingHydrationWarnings();
+      // We might have reentered this boundary to hydrate it. If so, we need to reset the hydration
+      // state since we're now exiting out of it. popHydrationState doesn't do that for us.
+      resetHydrationState();
+      if ((workInProgress.flags & DidCapture) === NoFlags) {
+        // This boundary did not suspend so it's now hydrated and unsuspended.
+        nextState = workInProgress.memoizedState = null;
+      }
+      // If nothing suspended, we need to schedule an effect to mark this boundary
+      // as having hydrated so events know that they're free to be invoked.
+      // It's also a signal to replay events and the suspense callback.
+      // If something suspended, schedule an effect to attach retry listeners.
+      // So we might as well always mark this.
+      workInProgress.flags |= Update;
+      bubbleProperties(workInProgress);
+      if (enableProfilerTimer) {
+        if ((workInProgress.mode & ProfileMode) !== NoMode) {
+          const isTimedOutSuspense = nextState !== null;
+          if (isTimedOutSuspense) {
+            // Don't count time spent in a timed out Suspense subtree as part of the base duration.
+            const primaryChildFragment = workInProgress.child;
+            if (primaryChildFragment !== null) {
+              // $FlowFixMe[unsafe-arithmetic] Flow doesn't support type casting in combination with the -= operator
+              workInProgress.treeBaseDuration -=
+                ((primaryChildFragment.treeBaseDuration: any): number);
+            }
+          }
+        }
+      }
+      return false;
+    }
+  } else {
+    // Successfully completed this tree. If this was a forced client render,
+    // there may have been recoverable errors during first hydration
+    // attempt. If so, add them to a queue so we can log them in the
+    // commit phase. We also add them to prev state so we can get to them
+    // from the Suspense Boundary.
+    const hydrationErrors = upgradeHydrationErrorsToRecoverable();
+    if (current !== null && current.memoizedState !== null) {
+      const prevState: ActivityState = current.memoizedState;
+      prevState.hydrationErrors = hydrationErrors;
+    }
+    // Fall through to normal Offscreen path
+    return true;
+  }
+}
+
 function completeDehydratedSuspenseBoundary(
   current: Fiber | null,
   workInProgress: Fiber,
@@ -939,7 +1022,7 @@ function completeDehydratedSuspenseBoundary(
       resetHydrationState();
       if ((workInProgress.flags & DidCapture) === NoFlags) {
         // This boundary did not suspend so it's now hydrated and unsuspended.
-        workInProgress.memoizedState = null;
+        nextState = workInProgress.memoizedState = null;
       }
       // If nothing suspended, we need to schedule an effect to mark this boundary
       // as having hydrated so events know that they're free to be invoked.
@@ -1394,12 +1477,42 @@ function completeWork(
       return null;
     }
     case ActivityComponent: {
-      if (current === null) {
-        const wasHydrated = popHydrationState(workInProgress);
-        if (wasHydrated) {
-          prepareToHydrateHostActivityInstance(workInProgress);
+      const nextState: null | ActivityState = workInProgress.memoizedState;
+
+      if (current === null || current.memoizedState !== null) {
+        const fallthroughToNormalOffscreenPath =
+          completeDehydratedActivityBoundary(
+            current,
+            workInProgress,
+            nextState,
+          );
+        if (!fallthroughToNormalOffscreenPath) {
+          if (workInProgress.flags & ForceClientRender) {
+            popSuspenseHandler(workInProgress);
+            // Special case. There were remaining unhydrated nodes. We treat
+            // this as a mismatch. Revert to client rendering.
+            return workInProgress;
+          } else {
+            popSuspenseHandler(workInProgress);
+            // Did not finish hydrating, either because this is the initial
+            // render or because something suspended.
+            return null;
+          }
         }
+
+        if ((workInProgress.flags & DidCapture) !== NoFlags) {
+          // We called retryActivityComponentWithoutHydrating and tried client rendering
+          // but now we suspended again. We should never arrive here because we should
+          // not have pushed a suspense handler during that second pass and it should
+          // instead have suspended above.
+          throw new Error(
+            'Client rendering an Activity suspended it again. This is a bug in React.',
+          );
+        }
+
+        // Continue with the normal Activity path.
       }
+
       bubbleProperties(workInProgress);
       return null;
     }
@@ -1444,7 +1557,6 @@ function completeWork(
       if ((workInProgress.flags & DidCapture) !== NoFlags) {
         // Something suspended. Re-render with the fallback children.
         workInProgress.lanes = renderLanes;
-        // Do not reset the effect list.
         if (
           enableProfilerTimer &&
           (workInProgress.mode & ProfileMode) !== NoMode

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -21,6 +21,7 @@ import type {
 } from './ReactFiberConfig';
 import type {ReactNodeList, ReactFormState} from 'shared/ReactTypes';
 import type {Lane} from './ReactFiberLane';
+import type {ActivityState} from './ReactFiberActivityComponent';
 import type {SuspenseState} from './ReactFiberSuspenseComponent';
 
 import {LegacyRoot} from './ReactRootTags';
@@ -35,6 +36,7 @@ import {
   ClassComponent,
   HostRoot,
   SuspenseComponent,
+  ActivityComponent,
 } from './ReactWorkTags';
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 import isArray from 'shared/isArray';
@@ -484,6 +486,7 @@ export function attemptSynchronousHydration(fiber: Fiber): void {
       }
       break;
     }
+    case ActivityComponent:
     case SuspenseComponent: {
       const root = enqueueConcurrentRenderForLane(fiber, SyncLane);
       if (root !== null) {
@@ -501,7 +504,8 @@ export function attemptSynchronousHydration(fiber: Fiber): void {
 }
 
 function markRetryLaneImpl(fiber: Fiber, retryLane: Lane) {
-  const suspenseState: null | SuspenseState = fiber.memoizedState;
+  const suspenseState: null | SuspenseState | ActivityState =
+    fiber.memoizedState;
   if (suspenseState !== null && suspenseState.dehydrated !== null) {
     suspenseState.retryLane = higherPriorityLane(
       suspenseState.retryLane,
@@ -520,7 +524,7 @@ function markRetryLaneIfNotHydrated(fiber: Fiber, retryLane: Lane) {
 }
 
 export function attemptContinuousHydration(fiber: Fiber): void {
-  if (fiber.tag !== SuspenseComponent) {
+  if (fiber.tag !== SuspenseComponent && fiber.tag !== ActivityComponent) {
     // We ignore HostRoots here because we can't increase
     // their priority and they should not suspend on I/O,
     // since you have to wrap anything that might suspend in
@@ -536,7 +540,7 @@ export function attemptContinuousHydration(fiber: Fiber): void {
 }
 
 export function attemptHydrationAtCurrentPriority(fiber: Fiber): void {
-  if (fiber.tag !== SuspenseComponent) {
+  if (fiber.tag !== SuspenseComponent && fiber.tag !== ActivityComponent) {
     // We ignore HostRoots here because we can't increase
     // their priority other than synchronously flush it.
     return;

--- a/packages/react-reconciler/src/ReactFiberSuspenseContext.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseContext.js
@@ -106,12 +106,27 @@ export function pushFallbackTreeSuspenseHandler(fiber: Fiber): void {
   reuseSuspenseHandlerOnStack(fiber);
 }
 
+export function pushDehydratedActivitySuspenseHandler(fiber: Fiber): void {
+  // This is called when hydrating an Activity boundary. We can just leave it
+  // dehydrated if it suspends.
+  // A SuspenseList context is only pushed here to avoid a push/pop mismatch.
+  // Reuse the current value on the stack.
+  // TODO: We can avoid needing to push here by by forking popSuspenseHandler
+  // into separate functions for Activity, Suspense and Offscreen.
+  pushSuspenseListContext(fiber, suspenseStackCursor.current);
+  push(suspenseHandlerStackCursor, fiber, fiber);
+  if (shellBoundary === null) {
+    // We can contain any suspense inside the Activity boundary.
+    shellBoundary = fiber;
+  }
+}
+
 export function pushOffscreenSuspenseHandler(fiber: Fiber): void {
   if (fiber.tag === OffscreenComponent) {
     // A SuspenseList context is only pushed here to avoid a push/pop mismatch.
     // Reuse the current value on the stack.
     // TODO: We can avoid needing to push here by by forking popSuspenseHandler
-    // into separate functions for Suspense and Offscreen.
+    // into separate functions for Activity, Suspense and Offscreen.
     pushSuspenseListContext(fiber, suspenseStackCursor.current);
     push(suspenseHandlerStackCursor, fiber, fiber);
     if (shellBoundary === null) {

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -24,6 +24,7 @@ import {
   FunctionComponent,
   ForwardRef,
   SimpleMemoComponent,
+  ActivityComponent,
   SuspenseComponent,
   OffscreenComponent,
 } from './ReactWorkTags';
@@ -398,8 +399,9 @@ function throwException(
       const suspenseBoundary = getSuspenseHandler();
       if (suspenseBoundary !== null) {
         switch (suspenseBoundary.tag) {
+          case ActivityComponent:
           case SuspenseComponent: {
-            // If this suspense boundary is not already showing a fallback, mark
+            // If this suspense/activity boundary is not already showing a fallback, mark
             // the in-progress render as suspended. We try to perform this logic
             // as soon as soon as possible during the render phase, so the work
             // loop can know things like whether it's OK to switch to other tasks,
@@ -553,19 +555,19 @@ function throwException(
     (disableLegacyMode || sourceFiber.mode & ConcurrentMode)
   ) {
     markDidThrowWhileHydratingDEV();
-    const suspenseBoundary = getSuspenseHandler();
+    const hydrationBoundary = getSuspenseHandler();
     // If the error was thrown during hydration, we may be able to recover by
     // discarding the dehydrated content and switching to a client render.
     // Instead of surfacing the error, find the nearest Suspense boundary
     // and render it again without hydration.
-    if (suspenseBoundary !== null) {
-      if ((suspenseBoundary.flags & ShouldCapture) === NoFlags) {
+    if (hydrationBoundary !== null) {
+      if ((hydrationBoundary.flags & ShouldCapture) === NoFlags) {
         // Set a flag to indicate that we should try rendering the normal
         // children again, not the fallback.
-        suspenseBoundary.flags |= ForceClientRender;
+        hydrationBoundary.flags |= ForceClientRender;
       }
       markSuspenseBoundaryShouldCapture(
-        suspenseBoundary,
+        hydrationBoundary,
         returnFiber,
         sourceFiber,
         root,

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -14,6 +14,7 @@ import type {
   SuspenseInstance,
   Instance,
 } from './ReactFiberConfig';
+import type {ActivityState} from './ReactFiberActivityComponent';
 import type {SuspenseState} from './ReactFiberSuspenseComponent';
 
 import {
@@ -23,6 +24,7 @@ import {
   HostRoot,
   HostPortal,
   HostText,
+  ActivityComponent,
   SuspenseComponent,
   OffscreenComponent,
 } from './ReactWorkTags';
@@ -82,6 +84,18 @@ export function getSuspenseInstanceFromFiber(
 export function getActivityInstanceFromFiber(
   fiber: Fiber,
 ): null | ActivityInstance {
+  if (fiber.tag === ActivityComponent) {
+    let activityState: ActivityState | null = fiber.memoizedState;
+    if (activityState === null) {
+      const current = fiber.alternate;
+      if (current !== null) {
+        activityState = current.memoizedState;
+      }
+    }
+    if (activityState !== null) {
+      return activityState.dehydrated;
+    }
+  }
   // TODO: Implement this on ActivityComponent.
   return null;
 }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -12,6 +12,7 @@ import {REACT_STRICT_MODE_TYPE} from 'shared/ReactSymbols';
 import type {Wakeable, Thenable} from 'shared/ReactTypes';
 import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane';
+import type {ActivityState} from './ReactFiberActivityComponent';
 import type {SuspenseState} from './ReactFiberSuspenseComponent';
 import type {FunctionComponentUpdateQueue} from './ReactFiberHooks';
 import type {Transition} from 'react/src/ReactStartTransition';
@@ -124,6 +125,7 @@ import {
 import {
   HostRoot,
   ClassComponent,
+  ActivityComponent,
   SuspenseComponent,
   SuspenseListComponent,
   OffscreenComponent,
@@ -4489,9 +4491,11 @@ export function resolveRetryWakeable(boundaryFiber: Fiber, wakeable: Wakeable) {
   let retryLane: Lane = NoLane; // Default
   let retryCache: WeakSet<Wakeable> | Set<Wakeable> | null;
   switch (boundaryFiber.tag) {
+    case ActivityComponent:
     case SuspenseComponent:
       retryCache = boundaryFiber.stateNode;
-      const suspenseState: null | SuspenseState = boundaryFiber.memoizedState;
+      const suspenseState: null | SuspenseState | ActivityState =
+        boundaryFiber.memoizedState;
       if (suspenseState !== null) {
         retryLane = suspenseState.retryLane;
       }

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -2227,14 +2227,14 @@ function renderActivity(
     }
   } else {
     // Render
-    // An Activity boundary is delimited so that we can hydrate it separately.
-    pushStartActivityBoundary(segment.chunks, request.renderState);
-    segment.lastPushedText = false;
     const mode = props.mode;
     if (mode === 'hidden') {
       // A hidden Activity boundary is not server rendered. Prerendering happens
       // on the client.
     } else {
+      // An Activity boundary is delimited so that we can hydrate it separately.
+      pushStartActivityBoundary(segment.chunks, request.renderState);
+      segment.lastPushedText = false;
       // A visible Activity boundary has its children rendered inside the boundary.
       const prevKeyPath = task.keyPath;
       task.keyPath = keyPath;
@@ -2242,9 +2242,9 @@ function renderActivity(
       // need to pop back up and finish the end comment.
       renderNode(request, task, props.children, -1);
       task.keyPath = prevKeyPath;
+      pushEndActivityBoundary(segment.chunks, request.renderState);
+      segment.lastPushedText = false;
     }
-    pushEndActivityBoundary(segment.chunks, request.renderState);
-    segment.lastPushedText = false;
   }
 }
 

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -542,5 +542,6 @@
   "554": "Cannot setState on regular state inside a startGestureTransition. Gestures can only update the useOptimistic() hook. There should be no side-effects associated with starting a Gesture until its Action is invoked. Move side-effects to the Action instead.",
   "555": "Cannot requestFormReset() inside a startGestureTransition. There should be no side-effects associated with starting a Gesture until its Action is invoked. Move side-effects to the Action instead.",
   "556": "Expected prepareToHydrateHostActivityInstance() to never be called. This error is likely caused by a bug in React. Please file an issue.",
-  "557": "Expected to have a hydrated activity instance. This error is likely caused by a bug in React. Please file an issue."
+  "557": "Expected to have a hydrated activity instance. This error is likely caused by a bug in React. Please file an issue.",
+  "558": "Client rendering an Activity suspended it again. This is a bug in React."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -540,5 +540,7 @@
   "552": "Cannot use a startGestureTransition() on a detached root.",
   "553": "A Timeline is required as the first argument to startGestureTransition.",
   "554": "Cannot setState on regular state inside a startGestureTransition. Gestures can only update the useOptimistic() hook. There should be no side-effects associated with starting a Gesture until its Action is invoked. Move side-effects to the Action instead.",
-  "555": "Cannot requestFormReset() inside a startGestureTransition. There should be no side-effects associated with starting a Gesture until its Action is invoked. Move side-effects to the Action instead."
+  "555": "Cannot requestFormReset() inside a startGestureTransition. There should be no side-effects associated with starting a Gesture until its Action is invoked. Move side-effects to the Action instead.",
+  "556": "Expected prepareToHydrateHostActivityInstance() to never be called. This error is likely caused by a bug in React. Please file an issue.",
+  "557": "Expected to have a hydrated activity instance. This error is likely caused by a bug in React. Please file an issue."
 }


### PR DESCRIPTION
Stacked on #32862 and #32842.

This means that Activity boundaries now act as boundaries which can have their effects mounted independently. Just like Suspense boundaries, we hydrate the outer content first and then start hydrating the content in an Offscreen lane. Flowing props or interacting with the content increases the priority just like Suspense boundaries.

This skips emitting even the comments for `<Activity mode="hidden">` so we don't hydrate those. Instead those are deferred to a later client render.

The implementation are just forked copies of the SuspenseComponent branches and then carefully going through each line and tweaking it.

The main interesting bit is that, unlike Suspense, Activity boundaries don't have fallbacks so all those branches where you might commit a suspended tree disappears. Instead, if something suspends while hydration, we can just leave the dehydrated content in place. However, if something does suspend during client rendering then it should bubble up to the parent. Therefore, we have to be careful to only pushSuspenseHandler when hydrating. That's really the main difference.

This just uses the existing basic Activity tests but I've started work on port all of the applicable Suspense tests in SelectiveHydration-test and PartialHydration-test to Activity versions.