### PR TITLE
[mcp] Add inspect script

### DIFF
--- a/compiler/packages/react-mcp-server/package.json
+++ b/compiler/packages/react-mcp-server/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "build": "rimraf dist && tsup",
     "test": "echo 'no tests'",
+    "dev": "concurrently --kill-others -n build,inspect \"yarn run watch\" \"wait-on dist/index.js && yarn run inspect\"",
+    "inspect": "npx @modelcontextprotocol/inspector node dist/index.js",
     "watch": "yarn build --watch"
   },
   "dependencies": {


### PR DESCRIPTION

Uses https://github.com/modelcontextprotocol/inspector to inspect and debug the mcp server.

`yarn workspace react-mcp-server dev` will build the server in watch mode and launch the inspector. Default address is http://127.0.0.1:6274.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32928).
* #32932
* #32931
* #32930
* #32929
* __->__ #32928