### PR TITLE
[mcp] Dedupe docs

### DIFF
--- a/compiler/packages/react-mcp-server/package.json
+++ b/compiler/packages/react-mcp-server/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "build": "rimraf dist && tsup",
     "test": "echo 'no tests'",
+    "dev": "concurrently --kill-others -n build,inspect \"yarn run watch\" \"wait-on dist/index.js && yarn run inspect\"",
+    "inspect": "npx @modelcontextprotocol/inspector node dist/index.js",
     "watch": "yarn build --watch"
   },
   "dependencies": {


### PR DESCRIPTION

Previously the resource would return a bunch of dupes because the algolia results would return multiple hashes (headings) for the same url.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32929).
* #32932
* #32931
* #32930
* __->__ #32929
* #32928