### PR TITLE
[Flight] Don't hang forever when prerendering a rejected promise

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1402,7 +1402,9 @@ describe('ReactFlightDOMEdge', () => {
     const {prelude} = await ReactServerDOMStaticServer.unstable_prerender(
       {
         async *[Symbol.asyncIterator]() {
-          throw expectedError;
+          await serverAct(() => {
+            throw expectedError;
+          });
         },
       },
       webpackMap,

--- a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js
@@ -121,9 +121,6 @@ function prerender(
       const stream = new ReadableStream(
         {
           type: 'bytes',
-          start: (controller): ?Promise<void> => {
-            startWork(request);
-          },
           pull: (controller): ?Promise<void> => {
             startFlowing(request, controller);
           },

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -4328,7 +4328,6 @@ export function abort(request: Request, reason: mixed): void {
         abortableTasks.forEach(task => abortTask(task, request, errorId));
         abortableTasks.clear();
       }
-      callOnAllReadyIfReady(request);
     }
     const abortListeners = request.abortListeners;
     if (abortListeners.size > 0) {
@@ -4366,5 +4365,7 @@ export function abort(request: Request, reason: mixed): void {
   } catch (error) {
     logRecoverableError(request, error, null);
     fatalError(request, error);
+  } finally {
+    callOnAllReadyIfReady(request);
   }
 }

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -383,7 +383,6 @@ export type Request = {
   onError: (error: mixed) => ?string,
   onPostpone: (reason: string) => void,
   onAllReady: () => void,
-  onAllReadyScheduled: boolean,
   onFatalError: mixed => void,
   // Profiling-only
   timeOrigin: number,
@@ -497,7 +496,6 @@ function RequestInstance(
   this.onPostpone =
     onPostpone === undefined ? defaultPostponeHandler : onPostpone;
   this.onAllReady = onAllReady;
-  this.onAllReadyScheduled = false;
   this.onFatalError = onFatalError;
 
   if (__DEV__) {

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -705,6 +705,11 @@ function serializeThenable(
         // to do so again here.
         erroredTask(request, newTask, reason);
         enqueueFlush(request);
+
+        if (request.abortableTasks.size === 0) {
+          const onAllReady = request.onAllReady;
+          onAllReady();
+        }
       }
     },
   );

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -4360,10 +4360,9 @@ export function abort(request: Request, reason: mixed): void {
     if (request.destination !== null) {
       flushCompletedChunks(request, request.destination);
     }
+    callOnAllReadyIfReady(request);
   } catch (error) {
     logRecoverableError(request, error, null);
     fatalError(request, error);
-  } finally {
-    callOnAllReadyIfReady(request);
   }
 }


### PR DESCRIPTION
Rendering a rejected promise as the root model is already supported in `renderToReadableStream`. In this case, a stream is returned early, and reading the stream will start flowing, so that enqueued chunks are flushed.

When prerendering, flowing is only started when `onAllReady` is called. This was previously only done in `performWork`. However, if the root model is a rejected promise, `erroredTask` also needs to check if there are any abortable tasks left, and if there are none, it must call `onAllReady`. This ensures that the prerender doesn't hang, and a prelude stream is returned.

In addition, this fixes a bug where we returned the prelude early when a readable stream or async iterable were still in progress. The fix for this issue is to ensure that `abortListeners` is also empty before calling `onAllReady`.