### PR TITLE
[eprh] Bump stable version

### DIFF
--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -33,7 +33,7 @@ const canaryChannelLabel = 'canary';
 const rcNumber = 0;
 
 const stablePackages = {
-  'eslint-plugin-react-hooks': '6.0.0',
+  'eslint-plugin-react-hooks': '6.1.0',
   'jest-react': '0.17.0',
   react: ReactVersion,
   'react-art': ReactVersion,


### PR DESCRIPTION

https://www.npmjs.com/package/eslint-plugin-react-hooks/v/6.0.0 was just released, so we can bump this now.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/32978).
* #32979
* __->__ #32978