### PR TITLE
[compiler] Fix version name in publish script

### DIFF
--- a/.github/workflows/compiler_prereleases.yml
+++ b/.github/workflows/compiler_prereleases.yml
@@ -16,6 +16,9 @@ on:
       version_name:
         required: true
         type: string
+      tag_version:
+        required: false
+        type: number
     secrets:
       NPM_TOKEN:
         required: true
@@ -55,4 +58,4 @@ jobs:
       - name: Publish packages to npm
         run: |
           cp ./scripts/release/ci-npmrc ~/.npmrc
-          scripts/release/publish.js --frfr --ci --versionName=${{ inputs.version_name }} --tag ${{ inputs.dist_tag }}
+          scripts/release/publish.js --frfr --ci --versionName=${{ inputs.version_name }} --tag=${{ inputs.dist_tag }} ${{ inputs.tag_version && format('--tagVersion={0}', inputs.tag_version) || '' }}

--- a/.github/workflows/compiler_prereleases_manual.yml
+++ b/.github/workflows/compiler_prereleases_manual.yml
@@ -14,6 +14,9 @@ on:
       version_name:
         required: true
         type: string
+      tag_version:
+        required: false
+        type: number
 
 permissions: {}
 
@@ -29,5 +32,6 @@ jobs:
       release_channel: ${{ inputs.release_channel }}
       dist_tag: ${{ inputs.dist_tag }}
       version_name: ${{ inputs.version_name }}
+      tag_version: ${{ inputs.tag_version }}
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -33,7 +33,7 @@ const canaryChannelLabel = 'canary';
 const rcNumber = 0;
 
 const stablePackages = {
-  'eslint-plugin-react-hooks': '6.0.0',
+  'eslint-plugin-react-hooks': '6.1.0',
   'jest-react': '0.17.0',
   react: ReactVersion,
   'react-art': ReactVersion,

--- a/compiler/scripts/release/publish.js
+++ b/compiler/scripts/release/publish.js
@@ -65,6 +65,12 @@ async function main() {
       choices: ['experimental', 'beta', 'rc'],
       default: 'experimental',
     })
+    .option('tag-version', {
+      description:
+        'Optional tag version to append to tag name, eg `1` becomes 0.0.0-rc.1',
+      type: 'number',
+      default: null,
+    })
     .option('version-name', {
       description: 'Version name',
       type: 'string',
@@ -133,7 +139,10 @@ async function main() {
       files: {exclude: ['.DS_Store']},
     });
     const truncatedHash = hash.slice(0, 7);
-    const newVersion = `${argv.versionName}-${argv.tag}-${truncatedHash}-${dateString}`;
+    const newVersion =
+      argv.tagVersion == null || argv.tagVersion === ''
+        ? `${argv.versionName}-${argv.tag}-${truncatedHash}-${dateString}`
+        : `${argv.versionName}-${argv.tag}.${argv.tagVersion}-${truncatedHash}-${dateString}`;
 
     for (const pkgName of pkgNames) {
       const pkgDir = path.resolve(__dirname, `../../packages/${pkgName}`);


### PR DESCRIPTION

Add ability to specify an optional tagVersion which is appended to the version name + tag, eg

19.1.0-rc.1
