### PR TITLE
[ci] Change to string type

### DIFF
--- a/.github/workflows/compiler_prereleases.yml
+++ b/.github/workflows/compiler_prereleases.yml
@@ -18,7 +18,7 @@ on:
         type: string
       tag_version:
         required: false
-        type: number
+        type: string
     secrets:
       NPM_TOKEN:
         required: true

--- a/.github/workflows/compiler_prereleases_manual.yml
+++ b/.github/workflows/compiler_prereleases_manual.yml
@@ -16,7 +16,7 @@ on:
         type: string
       tag_version:
         required: false
-        type: number
+        type: string
 
 permissions: {}
 


### PR DESCRIPTION

to no one's surprise, the `number` type appears to be cursed in GH actions for workflow dispatch. switch to string
