### PR TITLE
[forgive] Add code action to remove dependency array

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
@@ -183,7 +183,8 @@ export type LoggerEvent =
   | CompileSkipEvent
   | PipelineErrorEvent
   | TimingEvent
-  | AutoDepsDecorationsEvent;
+  | AutoDepsDecorationsEvent
+  | AutoDepsEligibleEvent;
 
 export type CompileErrorEvent = {
   kind: 'CompileError';
@@ -222,8 +223,13 @@ export type TimingEvent = {
 };
 export type AutoDepsDecorationsEvent = {
   kind: 'AutoDepsDecorations';
-  useEffectCallExpr: t.SourceLocation;
+  fnLoc: t.SourceLocation;
   decorations: Array<t.SourceLocation>;
+};
+export type AutoDepsEligibleEvent = {
+  kind: 'AutoDepsEligible';
+  fnLoc: t.SourceLocation;
+  depArrayLoc: t.SourceLocation;
 };
 
 export type Logger = {

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferEffectDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferEffectDependencies.ts
@@ -230,7 +230,7 @@ export function inferEffectDependencies(fn: HIRFunction): void {
             if (typeof value.loc !== 'symbol') {
               fn.env.logger?.logEvent(fn.env.filename, {
                 kind: 'AutoDepsDecorations',
-                useEffectCallExpr: value.loc,
+                fnLoc: value.loc,
                 decorations,
               });
             }
@@ -257,6 +257,30 @@ export function inferEffectDependencies(fn: HIRFunction): void {
             value.args.push({...depsPlace, effect: Effect.Freeze});
             rewriteInstrs.set(instr.id, newInstructions);
             fn.env.inferredEffectLocations.add(callee.loc);
+          }
+        } else if (
+          value.args.length >= 2 &&
+          value.args.length - 1 === autodepFnLoads.get(callee.identifier.id) &&
+          value.args[0].kind === 'Identifier'
+        ) {
+          const penultimateArg = value.args[value.args.length - 2];
+          const depArrayArg = value.args[value.args.length - 1];
+          if (
+            depArrayArg.kind !== 'Spread' &&
+            penultimateArg.kind !== 'Spread' &&
+            typeof depArrayArg.loc !== 'symbol' &&
+            typeof penultimateArg.loc !== 'symbol' &&
+            typeof value.loc !== 'symbol'
+          ) {
+            fn.env.logger?.logEvent(fn.env.filename, {
+              kind: 'AutoDepsEligible',
+              fnLoc: value.loc,
+              depArrayLoc: {
+                ...depArrayArg.loc,
+                start: penultimateArg.loc.end,
+                end: depArrayArg.loc.end,
+              },
+            });
           }
         }
       }

--- a/compiler/packages/react-forgive/server/src/requests/autodepsdecorations.ts
+++ b/compiler/packages/react-forgive/server/src/requests/autodepsdecorations.ts
@@ -22,7 +22,7 @@ export function mapCompilerEventToLSPEvent(
   event: AutoDepsDecorationsEvent,
 ): AutoDepsDecorationsLSPEvent {
   return {
-    useEffectCallExpr: sourceLocationToRange(event.useEffectCallExpr),
+    useEffectCallExpr: sourceLocationToRange(event.fnLoc),
     decorations: event.decorations.map(sourceLocationToRange),
   };
 }

--- a/compiler/packages/react-forgive/server/src/utils/range.ts
+++ b/compiler/packages/react-forgive/server/src/utils/range.ts
@@ -2,11 +2,27 @@ import * as t from '@babel/types';
 import {type Position} from 'vscode-languageserver/node';
 
 export type Range = [Position, Position];
+
 export function isPositionWithinRange(
   position: Position,
   [start, end]: Range,
 ): boolean {
   return position.line >= start.line && position.line <= end.line;
+}
+
+export function isRangeWithinRange(aRange: Range, bRange: Range): boolean {
+  const startComparison = comparePositions(aRange[0], bRange[0]);
+  const endComparison = comparePositions(aRange[1], bRange[1]);
+  return startComparison >= 0 && endComparison <= 0;
+}
+
+function comparePositions(a: Position, b: Position): number {
+  const lineComparison = a.line - b.line;
+  if (lineComparison === 0) {
+    return a.character - b.character;
+  } else {
+    return lineComparison;
+  }
 }
 
 export function sourceLocationToRange(


### PR DESCRIPTION

Adds a new codeaction event in the compiler and handler in forgive. This allows you to remove a dependency array when you're editing a range that is within an autodep eligible function.

Co-authored-by: Jordan Brown <jmbrown@meta.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/33000).
* #33002
* #33001
* __->__ #33000