### PR TITLE
[compiler] Emit CompileSkip before CompileSuccess event

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -469,6 +469,23 @@ export function compileProgram(
       }
     }
 
+    /**
+     * Otherwise if 'use no forget/memo' is present, we still run the code through the compiler
+     * for validation but we don't mutate the babel AST. This allows us to flag if there is an
+     * unused 'use no forget/memo' directive.
+     */
+    if (pass.opts.ignoreUseNoForget === false && optOutDirectives.length > 0) {
+      for (const directive of optOutDirectives) {
+        pass.opts.logger?.logEvent(pass.filename, {
+          kind: 'CompileSkip',
+          fnLoc: fn.node.body.loc ?? null,
+          reason: `Skipped due to '${directive.value.value}' directive.`,
+          loc: directive.loc ?? null,
+        });
+      }
+      return null;
+    }
+
     pass.opts.logger?.logEvent(pass.filename, {
       kind: 'CompileSuccess',
       fnLoc: fn.node.loc ?? null,
@@ -489,23 +506,6 @@ export function compileProgram(
       /**
        * No opt-in directive in annotation mode, so don't insert the compiled function.
        */
-      return null;
-    }
-
-    /**
-     * Otherwise if 'use no forget/memo' is present, we still run the code through the compiler
-     * for validation but we don't mutate the babel AST. This allows us to flag if there is an
-     * unused 'use no forget/memo' directive.
-     */
-    if (pass.opts.ignoreUseNoForget === false && optOutDirectives.length > 0) {
-      for (const directive of optOutDirectives) {
-        pass.opts.logger?.logEvent(pass.filename, {
-          kind: 'CompileSkip',
-          fnLoc: fn.node.body.loc ?? null,
-          reason: `Skipped due to '${directive.value.value}' directive.`,
-          loc: directive.loc ?? null,
-        });
-      }
       return null;
     }
 

--- a/compiler/packages/react-forgive/server/src/compiler/index.ts
+++ b/compiler/packages/react-forgive/server/src/compiler/index.ts
@@ -33,6 +33,8 @@ export async function compile({
       plugins: ['typescript', 'jsx'],
     },
     sourceType: 'module',
+    configFile: false,
+    babelrc: false,
   });
   if (ast == null) {
     return null;
@@ -48,6 +50,8 @@ export async function compile({
     plugins,
     sourceType: 'module',
     sourceFileName: file,
+    configFile: false,
+    babelrc: false,
   });
   if (result?.code == null) {
     throw new Error(

--- a/compiler/packages/react-forgive/server/src/index.ts
+++ b/compiler/packages/react-forgive/server/src/index.ts
@@ -132,7 +132,7 @@ connection.onInitialized(() => {
 });
 
 documents.onDidChangeContent(async event => {
-  connection.console.info(`Changed: ${event.document.uri}`);
+  connection.console.info(`Compiling: ${event.document.uri}`);
   resetState();
   if (SUPPORTED_LANGUAGE_IDS.has(event.document.languageId)) {
     const text = event.document.getText();
@@ -143,8 +143,11 @@ documents.onDidChangeContent(async event => {
         options: compilerOptions,
       });
     } catch (err) {
+      connection.console.error('Failed to compile');
       if (err instanceof Error) {
-        connection.console.error(err.stack ?? '');
+        connection.console.error(err.stack ?? err.message);
+      } else {
+        connection.console.error(JSON.stringify(err, null, 2));
       }
     }
   }
@@ -192,7 +195,6 @@ connection.onCodeLensResolve(lens => {
 });
 
 connection.onCodeAction(params => {
-  connection.console.log('onCodeAction');
   const codeActions: Array<CodeAction> = [];
   for (const codeActionEvent of codeActionEvents) {
     if (
@@ -242,6 +244,7 @@ connection.onRequest(AutoDepsDecorationsRequest.type, async params => {
 });
 
 function resetState() {
+  connection.console.debug('Clearing state');
   compiledFns.clear();
   autoDepsDecorations = [];
   codeActionEvents = [];


### PR DESCRIPTION

Previously the CompileSuccess event would emit first before CompileSkip, so the lsp's codelens would incorrectly flag skipped components/hooks (via 'use no memo') as being optimized.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/33012).
* __->__ #33012
* #33011
* #33010