### PR TITLE
[ci] Reduce non-deterministic builds for eslint-plugin-react-hooks

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -393,7 +393,8 @@ function getPlugins(
               };
             },
           },
-      bundle.tsconfig != null ? commonjs() : false,
+      // See https://github.com/rollup/plugins/issues/1425
+      bundle.tsconfig != null ? commonjs({strictRequires: true}) : false,
       // Shim any modules that need forking in this environment.
       useForks(forks),
       // Ensure we don't try to bundle any fbjs modules.


### PR DESCRIPTION
See https://github.com/rollup/plugins/issues/1425

Currently, `@babel/helper-string-parser/lib/index.js` is either emitted as a wrapped esmodule or inline depending on the ordering of async functions in `rollup/commonjs`. Specifically, `@babel/types/lib/definitions/core.js` is cyclic (i.e. transitively depends upon itself), but sometimes `@babel/helper-string-parser/lib/index.js` is emitted before this is realized.


A relatively straightforward patch is to wrap all modules (see https://github.com/rollup/plugins/issues/1425#issuecomment-1465626736). This only regresses `eslint-plugin-react-hooks` bundle size by ~1.8% and is safer (see https://github.com/rollup/plugins/blob/master/packages/commonjs/README.md#strictrequires)

> The default value of true will wrap all CommonJS files in functions which are executed when they are required for the first time, preserving NodeJS semantics. This is the safest setting and should be used if the generated code does not work correctly with "auto". Note that strictRequires: true can have a small impact on the size and performance of generated code, but less so if the code is minified.

(note that we're on an earlier version of `@rollup/commonjs` which does not default to `strictRequires: true`)
