### PR TITLE
[Fizz] Outline if a boundary would add too many bytes to the next completion

### DIFF
--- a/fixtures/ssr/server/render.js
+++ b/fixtures/ssr/server/render.js
@@ -19,7 +19,7 @@ class ThrottledWritable extends Writable {
   constructor(destination) {
     super();
     this.destination = destination;
-    this.delay = 150;
+    this.delay = 10;
   }
 
   _write(chunk, encoding, callback) {
@@ -49,10 +49,10 @@ export default function render(url, res) {
     // Log fatal errors
     console.error('Fatal', error);
   });
-  console.log('hello');
   let didError = false;
   const {pipe, abort} = renderToPipeableStream(<App assets={assets} />, {
     bootstrapScripts: [assets['main.js']],
+    progressiveChunkSize: 1024,
     onShellReady() {
       // If something errored before we started streaming, we set the error code appropriately.
       res.statusCode = didError ? 500 : 200;

--- a/fixtures/ssr/src/components/Chrome.js
+++ b/fixtures/ssr/src/components/Chrome.js
@@ -39,11 +39,7 @@ export default class Chrome extends Component {
               {this.props.children}
             </Theme.Provider>
           </Suspense>
-          <p>This should appear in the first paint.</p>
-          <Suspense fallback="Loading...">
-            <p>This content should not block paint.</p>
-            <LargeContent />
-          </Suspense>
+          <LargeContent />
           <script
             dangerouslySetInnerHTML={{
               __html: `assetManifest = ${JSON.stringify(assets)};`,

--- a/fixtures/ssr/src/components/LargeContent.js
+++ b/fixtures/ssr/src/components/LargeContent.js
@@ -1,243 +1,291 @@
-import React, {Fragment} from 'react';
+import React, {Fragment, Suspense} from 'react';
 
 export default function LargeContent() {
   return (
     <Fragment>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris
-        porttitor tortor ac lectus faucibus, eget eleifend elit hendrerit.
-        Integer porttitor nisi in leo congue rutrum. Morbi sed ante posuere,
-        aliquam lorem ac, imperdiet orci. Duis malesuada gravida pharetra. Cras
-        facilisis arcu diam, id dictum lorem imperdiet a. Suspendisse aliquet
-        tempus tortor et ultricies. Aliquam libero velit, posuere tempus ante
-        sed, pellentesque tincidunt lorem. Nullam iaculis, eros a varius
-        aliquet, tortor felis tempor metus, nec cursus felis eros aliquam nulla.
-        Vivamus ut orci sed mauris congue lacinia. Cras eget blandit neque.
-        Pellentesque a massa in turpis ullamcorper volutpat vel at massa. Sed
-        ante est, auctor non diam non, vulputate ultrices metus. Maecenas dictum
-        fermentum quam id aliquam. Donec porta risus vitae pretium posuere.
-        Fusce facilisis eros in lacus tincidunt congue.
-      </p>
-      <p>
-        Pellentesque habitant morbi tristique senectus et netus et malesuada
-        fames ac turpis egestas. Phasellus dolor ante, iaculis vel nisl vitae,
-        ornare ornare orci. Praesent sit amet lobortis sapien. Suspendisse
-        pharetra posuere libero ut dapibus. Donec condimentum ante urna. Aliquam
-        laoreet tincidunt lacus, sed interdum tortor dapibus elementum. Nam sed
-        faucibus lorem. Suspendisse finibus, velit sed molestie finibus, risus
-        purus mollis ante, sit amet aliquet sapien nulla ut nibh. In eget ligula
-        metus. Duis in purus mattis, blandit magna nec, dictum nunc.
-      </p>
-      <p>
-        Sed convallis magna id tortor blandit dictum. Suspendisse in porttitor
-        neque. Integer quis metus consequat, rutrum est sit amet, finibus justo.
-        In hac habitasse platea dictumst. Nullam sagittis, risus sed vehicula
-        porta, sapien elit ultrices nibh, vel luctus odio tortor et ante. Sed
-        porta enim in hendrerit tristique. Pellentesque id feugiat libero, sit
-        amet tempor enim. Proin gravida nisl justo, vel ornare dolor bibendum
-        ac. Mauris scelerisque mattis facilisis. Praesent sodales augue mollis
-        orci vulputate aliquet. Mauris molestie luctus neque, sed congue elit
-        congue ut. Cras quis tortor augue. In auctor nulla vel turpis dapibus
-        egestas. Phasellus consequat rhoncus nisi sed dignissim. Quisque varius
-        justo non ex lobortis finibus cursus nec justo. Nulla erat neque,
-        commodo et sem convallis, tristique faucibus odio.
-      </p>
-      <p>
-        Ut condimentum volutpat sem, id accumsan augue placerat vel. Donec ac
-        efficitur turpis. Suspendisse pretium odio euismod sapien bibendum, sed
-        tempus est condimentum. Etiam nisl magna, consequat at ullamcorper at,
-        sollicitudin eu eros. In mattis ligula arcu. Sed eu consectetur turpis,
-        id molestie ligula. Vestibulum et venenatis enim. Donec condimentum
-        vitae nisi et placerat. Sed fringilla vehicula egestas. Proin
-        consectetur, nibh non ornare scelerisque, diam lorem cursus lectus, ut
-        mattis mauris purus id mi. Curabitur non ligula sit amet augue molestie
-        vulputate. Donec maximus magna at volutpat aliquet. Pellentesque
-        dignissim nulla eget odio eleifend tincidunt. Etiam diam lorem, ornare
-        vel scelerisque vel, iaculis id risus. Donec aliquet aliquam felis, ac
-        vehicula lacus suscipit vitae. Morbi eu ligula elit.
-      </p>
-      <p>
-        Praesent pellentesque, libero ut faucibus tempor, purus elit consequat
-        metus, in ornare nulla lectus at erat. Duis quis blandit turpis. Fusce
-        at ligula rutrum metus molestie tempor sit amet eu justo. Maecenas
-        tincidunt nisl nunc. Morbi ac metus tempor, pretium arcu vel, dapibus
-        velit. Nulla convallis ligula at porta mollis. Duis magna ante, mollis
-        eget nibh in, congue tempor dolor. Sed tincidunt sagittis arcu, in
-        ultricies neque tempor non. Suspendisse eget nunc neque. Nulla sit amet
-        odio volutpat, maximus purus id, dictum metus. Integer consequat, orci
-        nec ullamcorper porta, mauris libero vestibulum ipsum, nec tempor tellus
-        enim non nunc. Quisque nisl risus, dapibus sit amet purus nec, aliquam
-        finibus metus. Nullam condimentum urna viverra finibus cursus. Proin et
-        sollicitudin tellus, porta fermentum felis. Maecenas ac turpis sed dui
-        condimentum interdum sed sed erat. Mauris ut dignissim erat.
-      </p>
-      <p>
-        Proin varius porta dui, id fringilla elit lobortis eget. Integer at
-        metus elementum, efficitur eros id, euismod est. Morbi vestibulum nibh
-        ac leo luctus sagittis. Praesent rhoncus, risus sit amet mattis dictum,
-        diam sapien tempor neque, vel dignissim nulla neque eget ex. Nam
-        sollicitudin metus quis ullamcorper dapibus. Nam tristique euismod
-        efficitur. Pellentesque rhoncus vel sem eget lacinia. Pellentesque
-        volutpat velit ac dignissim luctus. Vivamus euismod tortor at ligula
-        mattis porta. Vestibulum ante ipsum primis in faucibus orci luctus et
-        ultrices posuere cubilia curae;
-      </p>
-      <p>
-        Proin blandit vulputate efficitur. Pellentesque sit amet porta odio.
-        Nunc pulvinar varius rhoncus. Mauris fermentum leo a imperdiet pretium.
-        Mauris scelerisque justo vel ante egestas, eget tempus neque malesuada.
-        Sed dictum ex vel justo dignissim, aliquam commodo diam rutrum. Integer
-        dignissim est ullamcorper augue laoreet consectetur id at diam. Vivamus
-        molestie blandit urna, eget pulvinar augue dictum vestibulum. Duis
-        maximus bibendum mauris, ut ultricies elit rhoncus eu. Praesent gravida
-        placerat mauris. Praesent tempor ipsum at nibh rhoncus sagittis. Duis
-        non sem turpis. Quisque et metus leo. Sed eu purus lorem. Pellentesque
-        dictum metus sed leo viverra interdum. Maecenas vel tincidunt mi.
-      </p>
-      <p>
-        Praesent consequat dapibus pellentesque. Fusce at enim id mauris laoreet
-        commodo. Nullam ut mauris euismod, rhoncus tellus vel, facilisis diam.
-        Aenean porta faucibus augue, a iaculis massa iaculis in. Praesent vel
-        metus purus. Etiam quis augue eget orci lobortis eleifend ac ut lorem.
-        Aenean non orci quis nisi molestie maximus. Mauris interdum, eros et
-        aliquam aliquam, lectus diam pharetra velit, in condimentum odio eros
-        non quam. Praesent bibendum pretium turpis vitae tristique. Mauris
-        convallis, massa ut fermentum fermentum, libero orci tempus ipsum,
-        malesuada ultrices metus sapien placerat lectus. Ut fringilla arcu nec
-        lorem ultrices mattis. Etiam id tortor feugiat magna gravida gravida.
-        Morbi aliquam, mi ac pellentesque mattis, erat ex venenatis erat, a
-        vestibulum eros turpis quis metus. Pellentesque tempus justo in ligula
-        ultricies porta. Phasellus congue felis sit amet dolor tristique
-        finibus. Nunc eget eros non est ultricies vestibulum.
-      </p>
-      <p>
-        Donec efficitur ligula quis odio tincidunt tristique. Duis urna dolor,
-        hendrerit quis enim at, accumsan auctor turpis. Vivamus ante lorem,
-        maximus vitae suscipit ut, congue eget velit. Maecenas sed ligula erat.
-        Aliquam mollis purus at nisi porta suscipit in ut magna. Vivamus a
-        turpis nec tellus egestas suscipit nec ornare nisi. Donec vestibulum
-        libero quis ex suscipit, sit amet luctus leo gravida.
-      </p>
-      <p>
-        Praesent pharetra dolor elit, sed volutpat lorem rhoncus non. Etiam a
-        neque ut velit dignissim sodales. Vestibulum neque risus, condimentum
-        nec consectetur vitae, ultricies ut sapien. Integer iaculis at urna sit
-        amet malesuada. Integer tincidunt, felis ac vulputate semper, velit leo
-        facilisis lorem, quis aliquet leo dui id lorem. Morbi non quam quis nisl
-        sagittis consequat nec vitae libero. Nunc molestie pretium libero, eu
-        eleifend nibh feugiat sed. Ut in bibendum diam, sit amet vehicula risus.
-        Nam ornare ac nisi ac euismod. Nullam id egestas nulla. Etiam porta
-        commodo ante sit amet pellentesque. Suspendisse eleifend purus in urna
-        euismod auctor non vel nisi. Suspendisse rutrum est nunc, sit amet
-        lacinia lacus dictum eget. Pellentesque habitant morbi tristique
-        senectus et netus et malesuada fames ac turpis egestas. Morbi a blandit
-        diam.
-      </p>
-      <p>
-        Donec eget efficitur sapien. Suspendisse diam lacus, varius eu interdum
-        et, congue ac justo. Proin ipsum odio, suscipit elementum mauris sed,
-        porttitor congue est. Cras dapibus dictum ante, vitae gravida elit
-        venenatis sed. Sed massa sem, posuere ut enim sit amet, vestibulum
-        condimentum nibh. Pellentesque pulvinar sodales lacinia. Proin id
-        pretium sapien, non convallis nulla. In mollis tincidunt sem et
-        porttitor.
-      </p>
-      <p>
-        Integer at sollicitudin sem. Suspendisse sed semper orci. Nulla at nibh
-        nec risus suscipit posuere egestas vitae enim. Nullam mauris justo,
-        mattis vel laoreet non, finibus nec nisl. Cras iaculis ultrices nibh,
-        non commodo eros aliquam non. Sed vitae mollis dui, at maximus metus. Ut
-        vestibulum, enim ut lobortis vulputate, lorem urna congue elit, non
-        dictum odio lorem eget velit. Morbi eleifend id ligula vitae vulputate.
-        Suspendisse ac laoreet justo. Proin eu mattis diam.
-      </p>
-      <p>
-        Nunc in ex quis enim ullamcorper scelerisque eget ac eros. Class aptent
-        taciti sociosqu ad litora torquent per conubia nostra, per inceptos
-        himenaeos. Aliquam turpis dui, egestas a rhoncus non, fermentum in
-        tellus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
-        posuere cubilia curae; Aenean non risus arcu. Nam ultricies lacinia
-        volutpat. Class aptent taciti sociosqu ad litora torquent per conubia
-        nostra, per inceptos himenaeos. Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit.
-      </p>
-      <p>
-        Aliquam a felis leo. Proin lorem ipsum, congue eu cursus in, rhoncus ut
-        libero. Vestibulum sit amet consequat nunc. Ut eleifend lobortis lacus,
-        vel molestie metus viverra eget. Nullam suscipit eu magna scelerisque
-        suscipit. Donec dictum in diam nec lacinia. Mauris pellentesque ex ut
-        purus facilisis, eget placerat turpis semper. Sed dapibus lorem ante, et
-        malesuada dui eleifend ac. Sed diam felis, semper ac nulla vel, posuere
-        ultricies ante.
-      </p>
-      <p>
-        Nunc elementum odio sapien, sit amet vulputate lorem varius at. Fusce
-        non sapien vitae lorem aliquam pretium sit amet congue dolor. Nunc quis
-        tortor luctus, pretium ex a, tincidunt urna. Aliquam fermentum massa a
-        erat pharetra varius. Curabitur at auctor dui. Sed posuere pellentesque
-        massa, vel bibendum urna dictum non. Fusce eget rhoncus urna. Maecenas
-        sed lectus tellus. Pellentesque convallis dapibus nisl vitae venenatis.
-        Quisque ornare a dolor ac pharetra. Nam cursus, mi a lacinia accumsan,
-        felis erat fringilla magna, ac mattis nunc ante a orci.
-      </p>
-      <p>
-        Nunc vel tortor euismod, commodo tortor non, aliquam nisi. Maecenas
-        tempus mollis velit non suscipit. Mauris sit amet dolor sed ex fringilla
-        varius. Suspendisse vel cursus risus. Vivamus pharetra massa nec dolor
-        aliquam feugiat. Fusce finibus enim commodo, scelerisque ante eu,
-        laoreet ex. Curabitur placerat magna quis imperdiet lacinia. Etiam
-        lectus mauris, porttitor ac lacinia sed, posuere eget lacus. Mauris
-        vulputate mattis imperdiet. Nunc id aliquet libero, vitae hendrerit
-        purus. Praesent vestibulum urna ac egestas tempor. In molestie, nunc sit
-        amet sagittis dapibus, ligula enim fermentum mi, lacinia molestie eros
-        dui in tortor. Mauris fermentum pulvinar faucibus. Curabitur laoreet
-        eleifend purus, non tincidunt tortor gravida nec. Nam eu lectus congue,
-        commodo libero et, porttitor est. Nullam tincidunt, nisi eu congue
-        congue, magna justo commodo massa, nec efficitur dui lectus non sem.
-      </p>
-      <p>
-        Nullam vehicula, ipsum quis lacinia tristique, elit nulla dignissim
-        augue, at pulvinar metus justo ac magna. Nullam nec nunc ac sapien
-        mollis cursus eu ac enim. Pellentesque a pharetra erat. Ut tempor magna
-        nisi, accumsan blandit lectus volutpat nec. Vivamus vel lorem nec eros
-        blandit dictum eget ac diam. Nulla nec turpis dolor. Morbi eu euismod
-        libero. Nam ut tortor at arcu porta tincidunt. In gravida ligula
-        fringilla ornare imperdiet. Nulla scelerisque ante erat, efficitur
-        dictum metus ullamcorper vel. Nam ac purus metus. Maecenas eget tempus
-        nulla. Ut magna lorem, efficitur ut ex a, semper aliquam magna. Praesent
-        lobortis, velit ac posuere mattis, justo est accumsan turpis, id
-        sagittis felis mi in lacus.
-      </p>
-      <p>
-        Aenean est mi, semper nec sem at, malesuada consectetur nunc. Aenean
-        consequat sem quis sem consequat, non aliquam est placerat. Cras
-        malesuada magna neque, et pellentesque nibh consequat at. Sed interdum
-        velit et ex interdum, vel lobortis ante vestibulum. Nam placerat lectus
-        eu commodo efficitur. Pellentesque in nunc ac massa porttitor eleifend
-        ut efficitur sem. Aenean at magna auctor, posuere augue in, ultrices
-        arcu. Praesent dignissim augue ex, malesuada maximus metus interdum a.
-        Proin nec odio in nulla vestibulum.
-      </p>
-      <p>
-        Aenean est mi, semper nec sem at, malesuada consectetur nunc. Aenean
-        consequat sem quis sem consequat, non aliquam est placerat. Cras
-        malesuada magna neque, et pellentesque nibh consequat at. Sed interdum
-        velit et ex interdum, vel lobortis ante vestibulum. Nam placerat lectus
-        eu commodo efficitur. Pellentesque in nunc ac massa porttitor eleifend
-        ut efficitur sem. Aenean at magna auctor, posuere augue in, ultrices
-        arcu. Praesent dignissim augue ex, malesuada maximus metus interdum a.
-        Proin nec odio in nulla vestibulum.
-      </p>
-      <p>
-        Aenean est mi, semper nec sem at, malesuada consectetur nunc. Aenean
-        consequat sem quis sem consequat, non aliquam est placerat. Cras
-        malesuada magna neque, et pellentesque nibh consequat at. Sed interdum
-        velit et ex interdum, vel lobortis ante vestibulum. Nam placerat lectus
-        eu commodo efficitur. Pellentesque in nunc ac massa porttitor eleifend
-        ut efficitur sem. Aenean at magna auctor, posuere augue in, ultrices
-        arcu. Praesent dignissim augue ex, malesuada maximus metus interdum a.
-        Proin nec odio in nulla vestibulum.
-      </p>
+      <Suspense fallback={null}>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris
+          porttitor tortor ac lectus faucibus, eget eleifend elit hendrerit.
+          Integer porttitor nisi in leo congue rutrum. Morbi sed ante posuere,
+          aliquam lorem ac, imperdiet orci. Duis malesuada gravida pharetra.
+          Cras facilisis arcu diam, id dictum lorem imperdiet a. Suspendisse
+          aliquet tempus tortor et ultricies. Aliquam libero velit, posuere
+          tempus ante sed, pellentesque tincidunt lorem. Nullam iaculis, eros a
+          varius aliquet, tortor felis tempor metus, nec cursus felis eros
+          aliquam nulla. Vivamus ut orci sed mauris congue lacinia. Cras eget
+          blandit neque. Pellentesque a massa in turpis ullamcorper volutpat vel
+          at massa. Sed ante est, auctor non diam non, vulputate ultrices metus.
+          Maecenas dictum fermentum quam id aliquam. Donec porta risus vitae
+          pretium posuere. Fusce facilisis eros in lacus tincidunt congue.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Pellentesque habitant morbi tristique senectus et netus et malesuada
+          fames ac turpis egestas. Phasellus dolor ante, iaculis vel nisl vitae,
+          ornare ornare orci. Praesent sit amet lobortis sapien. Suspendisse
+          pharetra posuere libero ut dapibus. Donec condimentum ante urna.
+          Aliquam laoreet tincidunt lacus, sed interdum tortor dapibus
+          elementum. Nam sed faucibus lorem. Suspendisse finibus, velit sed
+          molestie finibus, risus purus mollis ante, sit amet aliquet sapien
+          nulla ut nibh. In eget ligula metus. Duis in purus mattis, blandit
+          magna nec, dictum nunc.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Sed convallis magna id tortor blandit dictum. Suspendisse in porttitor
+          neque. Integer quis metus consequat, rutrum est sit amet, finibus
+          justo. In hac habitasse platea dictumst. Nullam sagittis, risus sed
+          vehicula porta, sapien elit ultrices nibh, vel luctus odio tortor et
+          ante. Sed porta enim in hendrerit tristique. Pellentesque id feugiat
+          libero, sit amet tempor enim. Proin gravida nisl justo, vel ornare
+          dolor bibendum ac. Mauris scelerisque mattis facilisis. Praesent
+          sodales augue mollis orci vulputate aliquet. Mauris molestie luctus
+          neque, sed congue elit congue ut. Cras quis tortor augue. In auctor
+          nulla vel turpis dapibus egestas. Phasellus consequat rhoncus nisi sed
+          dignissim. Quisque varius justo non ex lobortis finibus cursus nec
+          justo. Nulla erat neque, commodo et sem convallis, tristique faucibus
+          odio.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Ut condimentum volutpat sem, id accumsan augue placerat vel. Donec ac
+          efficitur turpis. Suspendisse pretium odio euismod sapien bibendum,
+          sed tempus est condimentum. Etiam nisl magna, consequat at ullamcorper
+          at, sollicitudin eu eros. In mattis ligula arcu. Sed eu consectetur
+          turpis, id molestie ligula. Vestibulum et venenatis enim. Donec
+          condimentum vitae nisi et placerat. Sed fringilla vehicula egestas.
+          Proin consectetur, nibh non ornare scelerisque, diam lorem cursus
+          lectus, ut mattis mauris purus id mi. Curabitur non ligula sit amet
+          augue molestie vulputate. Donec maximus magna at volutpat aliquet.
+          Pellentesque dignissim nulla eget odio eleifend tincidunt. Etiam diam
+          lorem, ornare vel scelerisque vel, iaculis id risus. Donec aliquet
+          aliquam felis, ac vehicula lacus suscipit vitae. Morbi eu ligula elit.
+        </p>
+      </Suspense>
+      <p>This should appear in the first paint.</p>
+      <Suspense fallback={null}>
+        <p>
+          Praesent pellentesque, libero ut faucibus tempor, purus elit consequat
+          metus, in ornare nulla lectus at erat. Duis quis blandit turpis. Fusce
+          at ligula rutrum metus molestie tempor sit amet eu justo. Maecenas
+          tincidunt nisl nunc. Morbi ac metus tempor, pretium arcu vel, dapibus
+          velit. Nulla convallis ligula at porta mollis. Duis magna ante, mollis
+          eget nibh in, congue tempor dolor. Sed tincidunt sagittis arcu, in
+          ultricies neque tempor non. Suspendisse eget nunc neque. Nulla sit
+          amet odio volutpat, maximus purus id, dictum metus. Integer consequat,
+          orci nec ullamcorper porta, mauris libero vestibulum ipsum, nec tempor
+          tellus enim non nunc. Quisque nisl risus, dapibus sit amet purus nec,
+          aliquam finibus metus. Nullam condimentum urna viverra finibus cursus.
+          Proin et sollicitudin tellus, porta fermentum felis. Maecenas ac
+          turpis sed dui condimentum interdum sed sed erat. Mauris ut dignissim
+          erat.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Proin varius porta dui, id fringilla elit lobortis eget. Integer at
+          metus elementum, efficitur eros id, euismod est. Morbi vestibulum nibh
+          ac leo luctus sagittis. Praesent rhoncus, risus sit amet mattis
+          dictum, diam sapien tempor neque, vel dignissim nulla neque eget ex.
+          Nam sollicitudin metus quis ullamcorper dapibus. Nam tristique euismod
+          efficitur. Pellentesque rhoncus vel sem eget lacinia. Pellentesque
+          volutpat velit ac dignissim luctus. Vivamus euismod tortor at ligula
+          mattis porta. Vestibulum ante ipsum primis in faucibus orci luctus et
+          ultrices posuere cubilia curae;
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Proin blandit vulputate efficitur. Pellentesque sit amet porta odio.
+          Nunc pulvinar varius rhoncus. Mauris fermentum leo a imperdiet
+          pretium. Mauris scelerisque justo vel ante egestas, eget tempus neque
+          malesuada. Sed dictum ex vel justo dignissim, aliquam commodo diam
+          rutrum. Integer dignissim est ullamcorper augue laoreet consectetur id
+          at diam. Vivamus molestie blandit urna, eget pulvinar augue dictum
+          vestibulum. Duis maximus bibendum mauris, ut ultricies elit rhoncus
+          eu. Praesent gravida placerat mauris. Praesent tempor ipsum at nibh
+          rhoncus sagittis. Duis non sem turpis. Quisque et metus leo. Sed eu
+          purus lorem. Pellentesque dictum metus sed leo viverra interdum.
+          Maecenas vel tincidunt mi.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Praesent consequat dapibus pellentesque. Fusce at enim id mauris
+          laoreet commodo. Nullam ut mauris euismod, rhoncus tellus vel,
+          facilisis diam. Aenean porta faucibus augue, a iaculis massa iaculis
+          in. Praesent vel metus purus. Etiam quis augue eget orci lobortis
+          eleifend ac ut lorem. Aenean non orci quis nisi molestie maximus.
+          Mauris interdum, eros et aliquam aliquam, lectus diam pharetra velit,
+          in condimentum odio eros non quam. Praesent bibendum pretium turpis
+          vitae tristique. Mauris convallis, massa ut fermentum fermentum,
+          libero orci tempus ipsum, malesuada ultrices metus sapien placerat
+          lectus. Ut fringilla arcu nec lorem ultrices mattis. Etiam id tortor
+          feugiat magna gravida gravida. Morbi aliquam, mi ac pellentesque
+          mattis, erat ex venenatis erat, a vestibulum eros turpis quis metus.
+          Pellentesque tempus justo in ligula ultricies porta. Phasellus congue
+          felis sit amet dolor tristique finibus. Nunc eget eros non est
+          ultricies vestibulum.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Donec efficitur ligula quis odio tincidunt tristique. Duis urna dolor,
+          hendrerit quis enim at, accumsan auctor turpis. Vivamus ante lorem,
+          maximus vitae suscipit ut, congue eget velit. Maecenas sed ligula
+          erat. Aliquam mollis purus at nisi porta suscipit in ut magna. Vivamus
+          a turpis nec tellus egestas suscipit nec ornare nisi. Donec vestibulum
+          libero quis ex suscipit, sit amet luctus leo gravida.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Praesent pharetra dolor elit, sed volutpat lorem rhoncus non. Etiam a
+          neque ut velit dignissim sodales. Vestibulum neque risus, condimentum
+          nec consectetur vitae, ultricies ut sapien. Integer iaculis at urna
+          sit amet malesuada. Integer tincidunt, felis ac vulputate semper,
+          velit leo facilisis lorem, quis aliquet leo dui id lorem. Morbi non
+          quam quis nisl sagittis consequat nec vitae libero. Nunc molestie
+          pretium libero, eu eleifend nibh feugiat sed. Ut in bibendum diam, sit
+          amet vehicula risus. Nam ornare ac nisi ac euismod. Nullam id egestas
+          nulla. Etiam porta commodo ante sit amet pellentesque. Suspendisse
+          eleifend purus in urna euismod auctor non vel nisi. Suspendisse rutrum
+          est nunc, sit amet lacinia lacus dictum eget. Pellentesque habitant
+          morbi tristique senectus et netus et malesuada fames ac turpis
+          egestas. Morbi a blandit diam.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Donec eget efficitur sapien. Suspendisse diam lacus, varius eu
+          interdum et, congue ac justo. Proin ipsum odio, suscipit elementum
+          mauris sed, porttitor congue est. Cras dapibus dictum ante, vitae
+          gravida elit venenatis sed. Sed massa sem, posuere ut enim sit amet,
+          vestibulum condimentum nibh. Pellentesque pulvinar sodales lacinia.
+          Proin id pretium sapien, non convallis nulla. In mollis tincidunt sem
+          et porttitor.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Integer at sollicitudin sem. Suspendisse sed semper orci. Nulla at
+          nibh nec risus suscipit posuere egestas vitae enim. Nullam mauris
+          justo, mattis vel laoreet non, finibus nec nisl. Cras iaculis ultrices
+          nibh, non commodo eros aliquam non. Sed vitae mollis dui, at maximus
+          metus. Ut vestibulum, enim ut lobortis vulputate, lorem urna congue
+          elit, non dictum odio lorem eget velit. Morbi eleifend id ligula vitae
+          vulputate. Suspendisse ac laoreet justo. Proin eu mattis diam.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Nunc in ex quis enim ullamcorper scelerisque eget ac eros. Class
+          aptent taciti sociosqu ad litora torquent per conubia nostra, per
+          inceptos himenaeos. Aliquam turpis dui, egestas a rhoncus non,
+          fermentum in tellus. Vestibulum ante ipsum primis in faucibus orci
+          luctus et ultrices posuere cubilia curae; Aenean non risus arcu. Nam
+          ultricies lacinia volutpat. Class aptent taciti sociosqu ad litora
+          torquent per conubia nostra, per inceptos himenaeos. Lorem ipsum dolor
+          sit amet, consectetur adipiscing elit.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Aliquam a felis leo. Proin lorem ipsum, congue eu cursus in, rhoncus
+          ut libero. Vestibulum sit amet consequat nunc. Ut eleifend lobortis
+          lacus, vel molestie metus viverra eget. Nullam suscipit eu magna
+          scelerisque suscipit. Donec dictum in diam nec lacinia. Mauris
+          pellentesque ex ut purus facilisis, eget placerat turpis semper. Sed
+          dapibus lorem ante, et malesuada dui eleifend ac. Sed diam felis,
+          semper ac nulla vel, posuere ultricies ante.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Nunc elementum odio sapien, sit amet vulputate lorem varius at. Fusce
+          non sapien vitae lorem aliquam pretium sit amet congue dolor. Nunc
+          quis tortor luctus, pretium ex a, tincidunt urna. Aliquam fermentum
+          massa a erat pharetra varius. Curabitur at auctor dui. Sed posuere
+          pellentesque massa, vel bibendum urna dictum non. Fusce eget rhoncus
+          urna. Maecenas sed lectus tellus. Pellentesque convallis dapibus nisl
+          vitae venenatis. Quisque ornare a dolor ac pharetra. Nam cursus, mi a
+          lacinia accumsan, felis erat fringilla magna, ac mattis nunc ante a
+          orci.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Nunc vel tortor euismod, commodo tortor non, aliquam nisi. Maecenas
+          tempus mollis velit non suscipit. Mauris sit amet dolor sed ex
+          fringilla varius. Suspendisse vel cursus risus. Vivamus pharetra massa
+          nec dolor aliquam feugiat. Fusce finibus enim commodo, scelerisque
+          ante eu, laoreet ex. Curabitur placerat magna quis imperdiet lacinia.
+          Etiam lectus mauris, porttitor ac lacinia sed, posuere eget lacus.
+          Mauris vulputate mattis imperdiet. Nunc id aliquet libero, vitae
+          hendrerit purus. Praesent vestibulum urna ac egestas tempor. In
+          molestie, nunc sit amet sagittis dapibus, ligula enim fermentum mi,
+          lacinia molestie eros dui in tortor. Mauris fermentum pulvinar
+          faucibus. Curabitur laoreet eleifend purus, non tincidunt tortor
+          gravida nec. Nam eu lectus congue, commodo libero et, porttitor est.
+          Nullam tincidunt, nisi eu congue congue, magna justo commodo massa,
+          nec efficitur dui lectus non sem.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Nullam vehicula, ipsum quis lacinia tristique, elit nulla dignissim
+          augue, at pulvinar metus justo ac magna. Nullam nec nunc ac sapien
+          mollis cursus eu ac enim. Pellentesque a pharetra erat. Ut tempor
+          magna nisi, accumsan blandit lectus volutpat nec. Vivamus vel lorem
+          nec eros blandit dictum eget ac diam. Nulla nec turpis dolor. Morbi eu
+          euismod libero. Nam ut tortor at arcu porta tincidunt. In gravida
+          ligula fringilla ornare imperdiet. Nulla scelerisque ante erat,
+          efficitur dictum metus ullamcorper vel. Nam ac purus metus. Maecenas
+          eget tempus nulla. Ut magna lorem, efficitur ut ex a, semper aliquam
+          magna. Praesent lobortis, velit ac posuere mattis, justo est accumsan
+          turpis, id sagittis felis mi in lacus.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Aenean est mi, semper nec sem at, malesuada consectetur nunc. Aenean
+          consequat sem quis sem consequat, non aliquam est placerat. Cras
+          malesuada magna neque, et pellentesque nibh consequat at. Sed interdum
+          velit et ex interdum, vel lobortis ante vestibulum. Nam placerat
+          lectus eu commodo efficitur. Pellentesque in nunc ac massa porttitor
+          eleifend ut efficitur sem. Aenean at magna auctor, posuere augue in,
+          ultrices arcu. Praesent dignissim augue ex, malesuada maximus metus
+          interdum a. Proin nec odio in nulla vestibulum.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Aenean est mi, semper nec sem at, malesuada consectetur nunc. Aenean
+          consequat sem quis sem consequat, non aliquam est placerat. Cras
+          malesuada magna neque, et pellentesque nibh consequat at. Sed interdum
+          velit et ex interdum, vel lobortis ante vestibulum. Nam placerat
+          lectus eu commodo efficitur. Pellentesque in nunc ac massa porttitor
+          eleifend ut efficitur sem. Aenean at magna auctor, posuere augue in,
+          ultrices arcu. Praesent dignissim augue ex, malesuada maximus metus
+          interdum a. Proin nec odio in nulla vestibulum.
+        </p>
+      </Suspense>
+      <Suspense fallback={null}>
+        <p>
+          Aenean est mi, semper nec sem at, malesuada consectetur nunc. Aenean
+          consequat sem quis sem consequat, non aliquam est placerat. Cras
+          malesuada magna neque, et pellentesque nibh consequat at. Sed interdum
+          velit et ex interdum, vel lobortis ante vestibulum. Nam placerat
+          lectus eu commodo efficitur. Pellentesque in nunc ac massa porttitor
+          eleifend ut efficitur sem. Aenean at magna auctor, posuere augue in,
+          ultrices arcu. Praesent dignissim augue ex, malesuada maximus metus
+          interdum a. Proin nec odio in nulla vestibulum.
+        </p>
+      </Suspense>
     </Fragment>
   );
 }

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -404,7 +404,10 @@ function isEligibleForOutlining(
   request: Request,
   boundary: SuspenseBoundary,
 ): boolean {
-  return boundary.byteSize > request.progressiveChunkSize;
+  // For very small boundaries, don't bother producing a fallback for outlining.
+  // The larger this limit is, the more we can save on preparing fallbacks in case we end up
+  // outlining.
+  return boundary.byteSize > 500;
 }
 
 function defaultErrorHandler(error: mixed) {
@@ -4902,6 +4905,10 @@ function flushSubtree(
   }
 }
 
+// Running count for how much bytes of boundaries have flushed inlined into the currently
+// flushing root or completed boundary.
+let flushedByteSize = 0;
+
 function flushSegment(
   request: Request,
   destination: Destination,
@@ -4971,9 +4978,14 @@ function flushSegment(
     flushSubtree(request, destination, segment, hoistableState);
 
     return writeEndPendingSuspenseBoundary(destination, request.renderState);
-  } else if (isEligibleForOutlining(request, boundary)) {
-    // This boundary is large and will be emitted separately so that we can progressively show
-    // other content. We add it to the queue during the flush because we have to ensure that
+  } else if (
+    isEligibleForOutlining(request, boundary) &&
+    flushedByteSize + boundary.byteSize > request.progressiveChunkSize
+  ) {
+    // Inlining this boundary would make the current sequence being written too large
+    // and block the parent for too long. Instead, it will be emitted separately so that we
+    // can progressively show other content.
+    // We add it to the queue during the flush because we have to ensure that
     // the parent flushes first so that there's something to inject it into.
     // We also have to make sure that it's emitted into the queue in a deterministic slot.
     // I.e. we can't insert it here when it completes.
@@ -4999,6 +5011,8 @@ function flushSegment(
 
     return writeEndPendingSuspenseBoundary(destination, request.renderState);
   } else {
+    // We're inlining this boundary so its bytes get counted to the current running count.
+    flushedByteSize += boundary.byteSize;
     if (hoistableState) {
       hoistHoistables(hoistableState, boundary.contentState);
     }
@@ -5071,6 +5085,7 @@ function flushCompletedBoundary(
   destination: Destination,
   boundary: SuspenseBoundary,
 ): boolean {
+  flushedByteSize = boundary.byteSize; // Start counting bytes
   const completedSegments = boundary.completedSegments;
   let i = 0;
   for (; i < completedSegments.length; i++) {
@@ -5098,6 +5113,7 @@ function flushPartialBoundary(
   destination: Destination,
   boundary: SuspenseBoundary,
 ): boolean {
+  flushedByteSize = boundary.byteSize; // Start counting bytes
   const completedSegments = boundary.completedSegments;
   let i = 0;
   for (; i < completedSegments.length; i++) {
@@ -5191,6 +5207,8 @@ function flushCompletedQueues(
         return;
       }
 
+      flushedByteSize = request.byteSize; // Start counting bytes
+      // TODO: Count the size of the preamble chunks too.
       flushPreamble(
         request,
         destination,


### PR DESCRIPTION
Follow up to #33027.

This enhances the heuristic so that we accumulate the size of the currently written boundaries. Starting from the size of the root (minus preamble) for the shell.

This ensures that if you have many small boundaries they don't all continue to get inlined. For example, you can wrap each paragraph in a document in a Suspense boundary to regain document streaming capabilities if that's what you want.

However, one consideration is if it's worth producing a fallback at all. Maybe if it's like `null` it's free but if it's like a whole alternative page, then it's not. It's possible to have completely useless Suspense boundaries such as when you nest several directly inside each other. So this uses a limit of at least 500 bytes of the content itself for it to be worth outlining at all. It also can't be too small because then for example a long list of paragraphs can never be outlined.

In the fixture I straddle this limit so some paragraphs are too small to be considered. An unfortunate effect of that is that you can end up with some of them not being outlined which means that they appear out of order. SuspenseList is supposed to address that but it's unfortunate.

The limit is still fairly high though so it's unlikely that by default you'd start outlining anything within the viewport at all. I had to reduce the `progressiveChunkSize` by an order of magnitude in my fixture to try it out properly.