### PR TITLE
[test] Intended behavior for not committing a partial tree in a Transition

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactTransition-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransition-test.js
@@ -169,7 +169,7 @@ describe('ReactTransition', () => {
   }
 
   // @gate enableLegacyCache
-  it('commits outside a suspended Suspense boundary', async () => {
+  it('does not commit outside a suspended Suspense boundary', async () => {
     const neverResolve = new Promise(() => {});
 
     function App({step, shouldSuspend}) {
@@ -198,7 +198,9 @@ describe('ReactTransition', () => {
       });
     });
     assertLog(['A1', 'Suspend! [B1]', 'Loading1']);
-    expect(root).toMatchRenderedOutput('A1');
+    // We don't commit a partial tree outside the boundary since that could lead
+    // to a teared UI.
+    expect(root).toMatchRenderedOutput('A0');
   });
 
   // @gate enableLegacyCache

--- a/packages/react-reconciler/src/__tests__/ReactTransition-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransition-test.js
@@ -168,6 +168,7 @@ describe('ReactTransition', () => {
     }
   }
 
+  // @gate enableLegacyCache
   it('commits outside a suspended Suspense boundary', async () => {
     const neverResolve = new Promise(() => {});
 


### PR DESCRIPTION

## Summary

We already have a similar assertion in https://github.com/eps1lon/react/blob/abc59fac23619b5c0354e8472d47dd0726c1cd09/packages/react-reconciler/src/__tests__/ReactTransition-test.js#L789-L790. That test does a lot more so I extracted the important bits that trip up React DevTools.
