### PR TITLE
[react-native] Pull up enableFastAddPropertiesInDiffing check

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeAttributePayloadFabric.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayloadFabric.js
@@ -219,13 +219,13 @@ function addNestedProperty(
     return updatePayload;
   }
 
+  if (enableFastAddPropertiesInDiffing) {
+    return fastAddProperties(updatePayload, nextProp, validAttributes);
+  }
+
   if (!isArray(nextProp)) {
     // Add each property of the leaf.
-    if (enableFastAddPropertiesInDiffing) {
-      return fastAddProperties(updatePayload, nextProp, validAttributes);
-    } else {
-      return addProperties(updatePayload, nextProp, validAttributes);
-    }
+    return slowAddProperties(updatePayload, nextProp, validAttributes);
   }
 
   for (let i = 0; i < nextProp.length; i++) {
@@ -516,7 +516,7 @@ function fastAddProperties(
 /**
  * addProperties adds all the valid props to the payload after being processed.
  */
-function addProperties(
+function slowAddProperties(
   updatePayload: null | Object,
   props: Object,
   validAttributes: AttributeConfiguration,


### PR DESCRIPTION
## Summary

We don't need the isArray check for this experiment, as `fastAddProperties` already does the same. Also renaming slowAddProperties to make it clearer we can fully remove this codepath once fastAddProperties is fully rolled out.

## How did you test this change?

```
yarn test packages/react-native-renderer -r=xplat --variant=true
```
