### PR TITLE
[reconciler] Mark moved fibers with placement flag granularly and cache host sibling lookups during commit

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
@@ -63,7 +63,17 @@ import {captureCommitPhaseError} from './ReactFiberWorkLoop';
 import {trackHostMutation} from './ReactFiberMutationTracking';
 
 import {runWithFiberInDEV} from './ReactCurrentFiber';
-import {enableFragmentRefs} from 'shared/ReactFeatureFlags';
+import {
+  enableFragmentRefs,
+  enablePlacementCommitCache,
+} from 'shared/ReactFeatureFlags';
+
+// Cache used during the placement commit to optimize finding host siblings.
+// Should be initialized per fiber parent and passed down when committing children.
+export type PlacementCommitCache = {
+  lastPlacedChild: Fiber | null,
+  lastPlacedChildHostSibling: ?Instance,
+};
 
 export function commitHostMount(finishedWork: Fiber) {
   const type = finishedWork.type;
@@ -346,56 +356,29 @@ function getHostSibling(fiber: Fiber): ?Instance {
   }
 }
 
-// Cache used during the placement commit to optimize finding host siblings.
-// Reset via resetPlacementCommitCache() before the walk begins.
-type PlacementCommitCacheEntry = {
-  lastPlacedChild: Fiber | null,
-  cachedNextHostSibling: ?Instance,
-};
-let placementCommitCache: Map<Fiber, PlacementCommitCacheEntry> | null = null;
-
-export function resetPlacementCommitCache() {
-  placementCommitCache = null;
-}
-
-// Retrieves or creates the placement commit cache entry for a given fiber.
-export function getPlacementCommitCacheEntry(
+function getHostSiblingCached(
   fiber: Fiber,
-): PlacementCommitCacheEntry {
-  const cache = placementCommitCache || (placementCommitCache = new Map());
-  let entry = cache.get(fiber);
-  if (entry === undefined) {
-    entry = {
-      lastPlacedChild: null,
-      cachedNextHostSibling: null,
-    };
-    cache.set(fiber, entry);
-  }
-  return entry;
-}
-
-function getHostSiblingCached(fiber: Fiber): ?Instance {
-  const parent = fiber.return;
-  if (parent === null) {
+  placementCommitCache: PlacementCommitCache | null,
+): ?Instance {
+  if (placementCommitCache === null) {
     return getHostSibling(fiber);
   }
 
-  const parentCacheEntry = getPlacementCommitCacheEntry(parent);
   // Optimization: If the current fiber is the direct sibling of the last placed child
   // under this parent, we can reuse the cached host sibling to avoid tree traversal.
   if (
-    parentCacheEntry.lastPlacedChild !== null &&
-    parentCacheEntry.lastPlacedChild.sibling === fiber
+    placementCommitCache.lastPlacedChild !== null &&
+    placementCommitCache.lastPlacedChild.sibling === fiber
   ) {
-    parentCacheEntry.lastPlacedChild = fiber;
-    return parentCacheEntry.cachedNextHostSibling;
+    placementCommitCache.lastPlacedChild = fiber;
+    return placementCommitCache.lastPlacedChildHostSibling;
   }
 
-  // Cache miss or first child for this parent in this pass.
+  // Current fiber is is the first placed child for this parent or is not a direct sibling of lastPlacedChild.
   // Find the actual host sibling by traversing and update the cache.
   const hostSibling = getHostSibling(fiber);
-  parentCacheEntry.lastPlacedChild = fiber;
-  parentCacheEntry.cachedNextHostSibling = hostSibling;
+  placementCommitCache.lastPlacedChild = fiber;
+  placementCommitCache.lastPlacedChildHostSibling = hostSibling;
 
   return hostSibling;
 }
@@ -524,7 +507,10 @@ function insertOrAppendPlacementNode(
   }
 }
 
-function commitPlacement(finishedWork: Fiber): void {
+function commitPlacement(
+  finishedWork: Fiber,
+  placementCommitCache: PlacementCommitCache | null,
+): void {
   if (!supportsMutation) {
     return;
   }
@@ -559,7 +545,9 @@ function commitPlacement(finishedWork: Fiber): void {
     case HostSingleton: {
       if (supportsSingletons) {
         const parent: Instance = hostParentFiber.stateNode;
-        const before = getHostSiblingCached(finishedWork);
+        const before = enablePlacementCommitCache
+          ? getHostSiblingCached(finishedWork, placementCommitCache)
+          : getHostSibling(finishedWork);
         // We only have the top Fiber that was inserted but we need to recurse down its
         // children to find all the terminal nodes.
         insertOrAppendPlacementNode(
@@ -581,7 +569,9 @@ function commitPlacement(finishedWork: Fiber): void {
         hostParentFiber.flags &= ~ContentReset;
       }
 
-      const before = getHostSiblingCached(finishedWork);
+      const before = enablePlacementCommitCache
+        ? getHostSiblingCached(finishedWork, placementCommitCache)
+        : getHostSibling(finishedWork);
       // We only have the top Fiber that was inserted but we need to recurse down its
       // children to find all the terminal nodes.
       insertOrAppendPlacementNode(
@@ -595,7 +585,9 @@ function commitPlacement(finishedWork: Fiber): void {
     case HostRoot:
     case HostPortal: {
       const parent: Container = hostParentFiber.stateNode.containerInfo;
-      const before = getHostSiblingCached(finishedWork);
+      const before = enablePlacementCommitCache
+        ? getHostSiblingCached(finishedWork, placementCommitCache)
+        : getHostSibling(finishedWork);
       insertOrAppendPlacementNodeIntoContainer(
         finishedWork,
         before,
@@ -612,12 +604,20 @@ function commitPlacement(finishedWork: Fiber): void {
   }
 }
 
-export function commitHostPlacement(finishedWork: Fiber) {
+export function commitHostPlacement(
+  finishedWork: Fiber,
+  placementCommitCache: PlacementCommitCache | null,
+) {
   try {
     if (__DEV__) {
-      runWithFiberInDEV(finishedWork, commitPlacement, finishedWork);
+      runWithFiberInDEV(
+        finishedWork,
+        commitPlacement,
+        finishedWork,
+        placementCommitCache,
+      );
     } else {
-      commitPlacement(finishedWork);
+      commitPlacement(finishedWork, placementCommitCache);
     }
   } catch (error) {
     captureCommitPhaseError(finishedWork, finishedWork.return, error);

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -245,6 +245,7 @@ import {
   commitHostSingletonRelease,
   commitFragmentInstanceDeletionEffects,
   commitFragmentInstanceInsertionEffects,
+  resetPlacementCommitCache,
 } from './ReactFiberCommitHostEffects';
 import {
   trackEnterViewTransitions,
@@ -1927,8 +1928,9 @@ export function commitMutationEffects(
   rootViewTransitionAffected = false;
 
   resetComponentEffectTimers();
-
+  resetPlacementCommitCache();
   commitMutationEffectsOnFiber(finishedWork, root, committedLanes);
+  resetPlacementCommitCache();
 
   inProgressLanes = null;
   inProgressRoot = null;

--- a/packages/react-reconciler/src/__tests__/findIndicesOfNumbersNotInLIS-test.js
+++ b/packages/react-reconciler/src/__tests__/findIndicesOfNumbersNotInLIS-test.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+let findIndicesOfNumbersNotInLIS;
+describe('findIndicesOfNumbersNotInLIS', () => {
+  beforeAll(() => {
+    findIndicesOfNumbersNotInLIS =
+      require('../findIndicesOfNumbersNotInLIS').default;
+  });
+  it('should return empty array for empty array input', () => {
+    const result = findIndicesOfNumbersNotInLIS([]);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array for strictly increasing number input', () => {
+    const result = findIndicesOfNumbersNotInLIS([0, 1, 2, 3, 4, 5]);
+    expect(result).toEqual([]);
+  });
+
+  it('should return indices of all numbers but the last one for strictly decreasing input', () => {
+    const result = findIndicesOfNumbersNotInLIS([5, 4, 3, 2, 1, 0]);
+    expect(result).toEqual([4, 3, 2, 1, 0]);
+  });
+
+  it('should return indices of numbers not in LIS (one item moved)', () => {
+    const result = findIndicesOfNumbersNotInLIS([
+      0, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    ]);
+    expect(result).toEqual([
+      1, // index of 10
+    ]);
+  });
+
+  it('should return indices of numbers not in LIS (swap case)', () => {
+    const result = findIndicesOfNumbersNotInLIS([
+      0, 1, 2, 3, 4, 9, 6, 7, 8, 5, 10,
+    ]); // 9 and 5 were swapped
+    expect(result).toEqual([
+      9, // index of 5
+      5, // index of 9
+    ]);
+  });
+
+  it('should prefer a longer subsequence', () => {
+    const result = findIndicesOfNumbersNotInLIS([
+      10, 11, 12, 13, 14, 0, 1, 2, 3,
+    ]); // 10, 11, 12, 13, 14 is a longer subsequence than 0, 1, 2, 3
+    expect(result).toEqual([
+      8, // index of 3
+      7, // index of 2
+      6, // index of 1
+      5, // index of 0
+    ]);
+  });
+
+  it('should prefer later values for competing subsequences', () => {
+    const result = findIndicesOfNumbersNotInLIS([0, 1, 3, 2, 4]);
+    // Will prefer 2 over 3, both form valid max length subsequences
+    // 0, 1, 2, 4 and 0, 1, 3, 4 but 2 is later in the array.
+    expect(result).toEqual([
+      2, // index of 3
+    ]);
+  });
+});

--- a/packages/react-reconciler/src/findIndicesOfNumbersNotInLIS.js
+++ b/packages/react-reconciler/src/findIndicesOfNumbersNotInLIS.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Finds the indices of numbers in the input array that do not
+// belong to a Longest Increasing Subsequence (LIS).
+//
+// In case of multiple LIS's of the same maximum length, this algorithm
+// prefers elements that appear later in the input array. For example,
+// for input [1,3,2,4,0] that has two competing LIS's it will prefer
+// 1,2,4 instead of 1,3,4.
+//
+// Time complexity:
+// Best case: O(N) - all numbers are increasing or decreasing.
+// Worst case: O(N log N) - all numbers are random.
+//
+// Example:
+// findIndicesOfNumbersNotInLIS([4, 1, 8, 2, 3, 5, 7])
+// returns [2 (index of 8), 0 (index of 4)]
+// Note: indices of non-lis numbers will be returned in reverse order
+// because we traverse the original array backwards to recover it.
+export default function findIndicesOfNumbersNotInLIS(
+  numbers: Array<number>,
+): Array<number> {
+  if (numbers.length === 0) {
+    return [];
+  }
+
+  const tails = [numbers[0]];
+  const lengths = [1];
+
+  for (let i = 1; i < numbers.length; i++) {
+    const num = numbers[i];
+    if (num >= tails[tails.length - 1]) {
+      // Extend the current increasing subsequence and
+      // optimize for all numbers increasing.
+      tails.push(num);
+      lengths.push(tails.length);
+    } else if (num <= tails[0]) {
+      // Start a new increasing subsequence and
+      // optimize for all numbers decreasing.
+      tails[0] = num;
+      lengths.push(1);
+    } else {
+      // Extend a previous but not the longest subsequence (yet).
+      // Uses binary search to find the right position to extend.
+      // We already checked low and high bounds above, so we can
+      // reduce them.
+      let low = 1;
+      let high = tails.length - 1;
+
+      while (low < high) {
+        // Unsigned right shift by 1 to divide by 2 and floor the result.
+        const mid = (low + high) >>> 1;
+        if (tails[mid] < num) {
+          low = mid + 1;
+        } else {
+          high = mid;
+        }
+      }
+      tails[low] = num;
+      lengths.push(low + 1);
+    }
+  }
+
+  let currLen = tails.length; // This is the max LIS length we found
+  const nonLISPositions: Array<number> = [];
+  for (let i = numbers.length - 1; i >= 0; i--) {
+    if (lengths[i] === currLen && currLen > 0) {
+      currLen--;
+    } else {
+      nonLISPositions.push(i);
+    }
+  }
+
+  return nonLISPositions;
+}

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -100,6 +100,10 @@ export const enableSuspenseyImages = false;
 
 export const enableSrcObject = __EXPERIMENTAL__;
 
+export const enableGranularChildrenPlacement = false;
+
+export const enablePlacementCommitCache = false;
+
 /**
  * Switches the Fabric API from doing layout in commit work instead of complete work.
  */

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -85,6 +85,8 @@ export const enableScrollEndPolyfill = true;
 export const enableSuspenseyImages = false;
 export const enableSrcObject = false;
 export const enableFragmentRefs = false;
+export const enableGranularChildrenPlacement = false;
+export const enablePlacementCommitCache = false;
 export const ownerStackLimit = 1e4;
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -76,6 +76,8 @@ export const enableLazyPublicInstanceInFabric = false;
 export const enableScrollEndPolyfill = true;
 export const enableSuspenseyImages = false;
 export const enableSrcObject = false;
+export const enableGranularChildrenPlacement = false;
+export const enablePlacementCommitCache = false;
 export const ownerStackLimit = 1e4;
 
 export const enableFragmentRefs = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -75,6 +75,8 @@ export const enableLazyPublicInstanceInFabric = false;
 export const enableScrollEndPolyfill = true;
 export const enableSuspenseyImages = false;
 export const enableSrcObject = false;
+export const enableGranularChildrenPlacement = false;
+export const enablePlacementCommitCache = false;
 export const ownerStackLimit = 1e4;
 
 export const enableFragmentRefs = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -73,6 +73,8 @@ export const enableScrollEndPolyfill = true;
 export const enableSuspenseyImages = false;
 export const enableSrcObject = false;
 export const enableFragmentRefs = false;
+export const enableGranularChildrenPlacement = false;
+export const enablePlacementCommitCache = false;
 export const ownerStackLimit = 1e4;
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -86,8 +86,9 @@ export const enableLazyPublicInstanceInFabric = false;
 export const enableScrollEndPolyfill = true;
 export const enableSuspenseyImages = false;
 export const enableSrcObject = false;
-
 export const enableFragmentRefs = false;
+export const enableGranularChildrenPlacement = false;
+export const enablePlacementCommitCache = false;
 export const ownerStackLimit = 1e4;
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -116,6 +116,9 @@ export const enableGestureTransition = false;
 export const enableSuspenseyImages = false;
 export const enableSrcObject = false;
 
+export const enableGranularChildrenPlacement = false;
+export const enablePlacementCommitCache = false;
+
 export const ownerStackLimit = 1e4;
 
 // Flow magic to verify the exports of this file match the original version.


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
This PR includes 2 small optimizations:
- **Render phase:** Mark updated moved fibers with `Placement` flag granularly by computing the longest increasing subsequence (LIS) of their old indices and finding out which fibers are not in LIS.
- **Commit phase:** Cache host sibling lookups per parent to avoid repeated tree traversals on consecutive inserts.

### Results
Here are the [js-framework-benchmark](https://github.com/krausest/js-framework-benchmark) results comparing `react-hooks-placement-opt` vs `react-hooks` built locally against the vanilla JS implementation. The lower score is better. 

This table shows significant benchmark score improvements in `swap rows` and `create many rows`. While I understand that these two metrics are edge cases and are specifically designed to stress the implementation, I still wanted to present my findings because the code changes turned out to be relatively minor. My main goal was to get familiar with some of the codebase while doing a fun project, however, if there is interest I am happy to get this over the finish line.

<img width="313" alt="test-results" src="https://github.com/user-attachments/assets/573eac8e-66f8-4f63-97f5-49e992dfa269" />


<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

### Motivation
I was looking at `reconcileChildrenArray` function in react-reconciler and found something that made me curious.

Suppose we have a list of nodes:
```
[A, B, C, D, E, F, G]
```

That got re-arranged in the following way:
```
[A, F (moved), B, C, D, E, G]
```

Ideally, only `F` should be marked as moved (Placement flag). However, the reconciler outputs this:
```
[A, F (moved), B (moved), C (moved), D (moved), E (moved), G]
```

Only `A` and `G` remain in place. I found this interesting and dug further because I had an assumption that React would try to derive the least amount of dom operations needed. It seemed to me as if there was a code complexity tradeoff being made and I was curious if there was a way to make it granular while maintaining runtime performance.

This behavior comes from the `placeChild` helper:
```ts
  function placeChild(
    newFiber: Fiber,
    lastPlacedIndex: number,
    newIndex: number,
  ): number {
     ...
    const current = newFiber.alternate;
    if (current !== null) {
      const oldIndex = current.index;
      if (oldIndex < lastPlacedIndex) {
        // This is a move.
        newFiber.flags |= Placement | PlacementDEV;
        return lastPlacedIndex;
      } else {
        // This item can stay in place.
        return oldIndex;
      }
     ...
  }
```

The above results in more work in `commitPlacement`, where for every "placed" node it will look up the closest "non-placed" stable sibling with dom (in `getHostSibling`) and insert each node before it. In our example for each "placed" node (F, B, C, D, E) React will traverse the fiber tree to lookup `G` repeatedly and call `insertBefore` to place it before `G`.

This is how this would look like in the browser when only one item is moved back:
![browser](https://github.com/user-attachments/assets/a988e4de-92fa-4b8d-88d3-911946079721)

The fact that `getHostSibling` was constantly looking up stable host nodes and had to go past pending inserts also led me to consider that it could be cached to prevent potential deep traversals that result in the same output. 

For example, if one was rendering a table and then populated the table rows, for each row in this table `getHostSibling` will be called and traverse the entire list of siblings in front but return `null` each time.

### Proposed improvements

**Granular placement of updated fiber nodes**

It's possible to derive the maximum number of updated nodes that can stay in place by looking at their indices in the old list and identifying which ones do not belong to the longest increasing subsequence when laid out in the new list order. An increasing subsequence of old indices in this case means those elements maintained their relative order.

If we look again at the previous example:
```
[A, B, C, D, E, F, G] -> [A, F (moved), B, C, D, E, G]
```

And take the old indices (alternate indices) of all updated nodes in the previous list:
```
[0 (A), 5 (F), 1 (B), 2 (C), 3 (D), 4 (E), 6 (G)]
```

After we find the LIS it results in the following indices:
```
[0 (A), 1 (B), 2 (C), 3 (D), 4 (E), 6 (G)]
```

Indices not in LIS:
```
[5 (F)] - this node was moved
```

We can proceed to mark `F` with the Placement flag and all other updated nodes can remain in place.

**Finding nodes not in LIS:**

The LIS is computed using a greedy patience sort, conceptually it can be visualized like this:
<img width="438" alt="Screenshot 2025-04-19 at 6 47 09 PM" src="https://github.com/user-attachments/assets/92ae2065-2387-4033-a90f-865146f6dbf5" />
Slide from [here](https://www.cs.princeton.edu/courses/archive/spring13/cos423/lectures/LongestIncreasingSubsequence.pdf).

The time complexity is `O(n)` in the case of all numbers increasing or decreasing (the most common cases) and O(N log N) in the case of completely random reordering of all nodes in the list.

The algorithm in this PR is modified to fit the exact use case of finding which entry is not in LIS.

**Caching of `getHostSibling`**

Let's say we have a list that originally did not have any rows and then rendered the following:
```
<List>
  <Row key='A' value='A'>
  <Row key='B' value='B'>
  <Row key='C' value='C'>
  <Row key='D' value='D'>
  <Row key='E' value='E'>
<List>
```
When committing row placement the current implementation will: 
- Look at `A` and start searching for the next sibling that `A` can be placed before
- Eventually traverse the entire list resulting in `null` (all nodes are new).

If we maintain a cache per parent node (in this case `List`), we can keep track of the last node that was placed and what `stateNode` it was placed before. 

Then when processing `B` in `commitPlacement` we can:
- Reference the cache by parent (`return`)
- Find out that the last placed node was `A` and that it was placed before `null` (end of list). 
- We verify that `A` is our direct previous sibling, and skip doing the traversal because we know it would result in the same host sibling.

## How did you test this change?
1. Ran the existing test suite
3. Ran the `js-framework-benchmark` on the modified version of React without issues
4. Introduced a test to verify reordering still works as expected in both regular and iterator versions of `reconcileChildrenArray`
5. Added a test for a helper that computes what is not in LIS
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
