### PR TITLE
Hack to recover from reading the wrong Fiber

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -3355,8 +3355,16 @@ export function requestFormReset(formFiber: Fiber) {
     );
   }
 
-  const stateHook = ensureFormComponentIsStateful(formFiber);
+  let stateHook: Hook = ensureFormComponentIsStateful(formFiber);
   const newResetState = {};
+  if (stateHook.next === null) {
+    // Hack alert. If formFiber is the workInProgress Fiber then
+    // we might get a broken intermediate state. Try the alternate
+    // instead.
+    // TODO: We should really stash the Queue somewhere stateful
+    // just like how setState binds the Queue.
+    stateHook = (formFiber.alternate: any).memoizedState;
+  }
   const resetStateHook: Hook = (stateHook.next: any);
   const resetStateQueue = resetStateHook.queue;
   dispatchSetStateInternal(


### PR DESCRIPTION
`requestFormReset` incorrectly tries to get the current dispatch queue from the Fiber. However, the Fiber might be the workInProgress which is an inconsistent state.

This hack just tries the other Fiber if it detects one of the known inconsistent states but there can be more.

Really we should stash the dispatch queue somewhere stateful which is effectively what `setState` does by binding it to the closure.
