### PR TITLE
Update on "[compiler] Null out source locations where not explicitly preserved"

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -2680,7 +2680,12 @@ function setMissingLocationsToNull(ast: any): void {
     return;
   }
   if (ast['loc'] == null) {
-    ast['loc'] = null;
+    ast['loc'] = {
+      start: {line: null, column: null, index: null},
+      end: {line: null, column: null, index: null},
+      filename: null,
+      identifierName: null,
+    };
   }
   for (const key in ast) {
     if (!hasOwnProperty(ast, key)) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/sourcemaps-simple.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/sourcemaps-simple.expect.md
@@ -1,0 +1,55 @@
+
+## Input
+
+```javascript
+// @sourceMaps
+export const Button = () => {
+  return <button>Click me</button>;
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @sourceMaps
+export const Button = () => {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = <button>Click me</button>;
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0;
+};
+
+```
+
+## Source Map
+
+```
+{
+  "version": 3,
+  "names": [
+    "Button",
+    "$",
+    "_c",
+    "t0",
+    "Symbol",
+    "for"
+  ],
+  "sources": [
+    "sourcemaps-simple.ts"
+  ],
+  "sourcesContent": [
+    "// @sourceMaps\nexport const Button = () => {\n  return <button>Click me</button>;\n};\n"
+  ],
+  "mappings": "kDAAA;AACA,OAAO,MAAMA,MAAM,GAAGA,CAAA,YAAAC,CAAA,GAAAC,EAAA,QAAAC,EAAA,KAAAF,CAAA,QAAAG,MAAA,CAAAC,GAAA;IACbF,EAAA,UAAyB,CAAjB,QAAQ,EAAhB,MAAyB,EAAAF,CAAA,MAAAE,EAAA,SAAAA,EAAA,GAAAF,CAAA,YAAzBE,EAAyB,EACjC",
+  "ignoreList": []
+}
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/sourcemaps-simple.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/sourcemaps-simple.js
@@ -1,0 +1,4 @@
+// @sourceMaps
+export const Button = () => {
+  return <button>Click me</button>;
+};

--- a/compiler/packages/snap/src/compiler.ts
+++ b/compiler/packages/snap/src/compiler.ts
@@ -306,6 +306,7 @@ export type TransformResult = {
     original: string;
     forget: string;
   } | null;
+  sourceMap: BabelCore.BabelFileResult['map'];
 };
 
 export async function transformFixtureInput(
@@ -330,6 +331,9 @@ export async function transformFixtureInput(
   // Give babel transforms an absolute path as relative paths get prefixed
   // with `cwd`, which is different across machines
   const virtualFilepath = '/' + filename;
+
+  // Check if we should emit source maps in the test fixture
+  const includeSourceMaps = firstLine.includes('@sourceMaps');
 
   const presets =
     language === 'typescript'
@@ -357,6 +361,7 @@ export async function transformFixtureInput(
       'babel-plugin-idx',
     ],
     sourceType: 'module',
+    sourceMaps: includeSourceMaps,
     ast: includeEvaluator,
     cloneInputAst: includeEvaluator,
     configFile: false,
@@ -447,6 +452,7 @@ export async function transformFixtureInput(
       forgetOutput,
       logs: formattedLogs,
       evaluatorCode,
+      sourceMap: includeSourceMaps ? forgetResult.map : null,
     },
   };
 }

--- a/compiler/packages/snap/src/reporter.ts
+++ b/compiler/packages/snap/src/reporter.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {BabelFileResult} from '@babel/core';
 import chalk from 'chalk';
 import fs from 'fs';
 import invariant from 'invariant';
@@ -24,6 +25,7 @@ export function writeOutputToString(
   evaluatorOutput: string | null,
   logs: string | null,
   errorMessage: string | null,
+  sourceMap: BabelFileResult['map'] | null,
 ) {
   // leading newline intentional
   let result = `
@@ -40,6 +42,14 @@ ${wrapWithTripleBackticks(compilerOutput, 'javascript')}
 `;
   } else {
     result += '\n';
+  }
+
+  if (sourceMap != null) {
+    result += `
+## Source Map
+
+${wrapWithTripleBackticks(JSON.stringify(sourceMap, null, 2))}
+`;
   }
 
   if (logs != null) {

--- a/compiler/packages/snap/src/runner-worker.ts
+++ b/compiler/packages/snap/src/runner-worker.ts
@@ -245,6 +245,7 @@ export async function transformFixture(
     sproutOutput,
     compileResult?.logs ?? null,
     error,
+    compileResult?.sourceMap ?? null,
   );
 
   return {


### PR DESCRIPTION


Inspired by #32950. Specifically from https://github.com/facebook/react/issues/32950#issuecomment-2837887871, it sounds like Babel by default emits source map information for all nodes, even when they don't have a `loc` property set. Code coverage tools then pick up the synthesized source location information for this, leading to the issue described.

A few google searches didn't turn up any documented way to opt-out of generating source span information, but AI tools answer that explicitly setting `node.loc = null` omits the node from source maps. This PR is a quick hack to confirm that.

[ghstack-poisoned]
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/33070).
* #33072
* #33071
* __->__ #33070
* #33069