### PR TITLE
[eslint-plugin-react-hooks] another CI update...

### DIFF
--- a/.github/workflows/runtime_commit_artifacts.yml
+++ b/.github/workflows/runtime_commit_artifacts.yml
@@ -170,9 +170,7 @@ jobs:
           # Copy eslint-plugin-react-hooks
           # NOTE: This is different from www, here we include the full package
           #       including package.json to include dependencies in fbsource.
-          mkdir $BASE_FOLDER/RKJSModules/vendor/react/eslint-plugin-react-hooks
-          cp -r build/oss-experimental/eslint-plugin-react-hooks \
-            $BASE_FOLDER/RKJSModules/vendor/react/eslint-plugin-react-hooks
+          cp -r build/oss-experimental/eslint-plugin-react-hooks $BASE_FOLDER/RKJSModules/vendor/react
 
           # Move React Native version file
           mv build/facebook-react-native/VERSION_NATIVE_FB ./compiled-rn/VERSION_NATIVE_FB


### PR DESCRIPTION
We currently created a nested directory, this should remove that.

See:
https://github.com/facebook/react/tree/builds/facebook-fbsource/compiled-rn/facebook-fbsource/xplat/js/RKJSModules/vendor/react/eslint-plugin-react-hooks/eslint-plugin-react-hooks