### PR TITLE
[mcp] Add proper web-vitals metric collection

### DIFF
--- a/compiler/packages/react-mcp-server/src/index.ts
+++ b/compiler/packages/react-mcp-server/src/index.ts
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
-import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
-import {z} from 'zod';
-import {compile, type PrintedCompilerPipelineValue} from './compiler';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { compile, type PrintedCompilerPipelineValue } from './compiler';
 import {
   CompilerPipelineValue,
   printReactiveFunctionWithOutlined,
@@ -17,10 +17,10 @@ import {
   SourceLocation,
 } from 'babel-plugin-react-compiler/src';
 import * as cheerio from 'cheerio';
-import {queryAlgolia} from './utils/algolia';
+import { queryAlgolia } from './utils/algolia';
 import assertExhaustive from './utils/assertExhaustive';
-import {convert} from 'html-to-text';
-import {measurePerformance} from './tools/runtimePerf';
+import { convert } from 'html-to-text';
+import { measurePerformance } from './tools/runtimePerf';
 
 function calculateMean(values: number[]): string {
   return values.length > 0 ? (values.reduce((acc, curr) => acc + curr, 0) / values.length) + 'ms' : 'could not collect';
@@ -37,12 +37,12 @@ server.tool(
   {
     query: z.string(),
   },
-  async ({query}) => {
+  async ({ query }) => {
     try {
       const pages = await queryAlgolia(query);
       if (pages.length === 0) {
         return {
-          content: [{type: 'text' as const, text: `No results`}],
+          content: [{ type: 'text' as const, text: `No results` }],
         };
       }
       const content = pages.map(html => {
@@ -68,7 +68,7 @@ server.tool(
     } catch (err) {
       return {
         isError: true,
-        content: [{type: 'text' as const, text: `Error: ${err.stack}`}],
+        content: [{ type: 'text' as const, text: `Error: ${err.stack}` }],
       };
     }
   },
@@ -89,7 +89,7 @@ server.tool(
     text: z.string(),
     passName: z.enum(['HIR', 'ReactiveFunction', 'All', '@DEBUG']).optional(),
   },
-  async ({text, passName}) => {
+  async ({ text, passName }) => {
     const pipelinePasses = new Map<
       string,
       Array<PrintedCompilerPipelineValue>
@@ -141,7 +141,7 @@ server.tool(
         }
       }
     };
-    const errors: Array<{message: string; loc: SourceLocation | null}> = [];
+    const errors: Array<{ message: string; loc: SourceLocation | null }> = [];
     const compilerOptions: Partial<PluginOptions> = {
       panicThreshold: 'none',
       logger: {
@@ -170,10 +170,10 @@ server.tool(
       if (result.code == null) {
         return {
           isError: true,
-          content: [{type: 'text' as const, text: 'Error: Could not compile'}],
+          content: [{ type: 'text' as const, text: 'Error: Could not compile' }],
         };
       }
-      const requestedPasses: Array<{type: 'text'; text: string}> = [];
+      const requestedPasses: Array<{ type: 'text'; text: string }> = [];
       if (passName != null) {
         switch (passName) {
           case 'All': {
@@ -274,14 +274,14 @@ server.tool(
       }
       return {
         content: [
-          {type: 'text' as const, text: result.code},
+          { type: 'text' as const, text: result.code },
           ...requestedPasses,
         ],
       };
     } catch (err) {
       return {
         isError: true,
-        content: [{type: 'text' as const, text: `Error: ${err.stack}`}],
+        content: [{ type: 'text' as const, text: `Error: ${err.stack}` }],
       };
     }
   },
@@ -290,6 +290,7 @@ server.tool(
 server.tool(
   'review-react-runtime',
   `Run this tool every time you propose a performance related change to verify if your suggestion actually improves performance.
+
   <requirements>
   This tool has some requirements on the code input:
   - The react code that is passed into this tool MUST contain an App functional component without arrow function.
@@ -310,19 +311,19 @@ server.tool(
 
   <iterate>
   (repeat until every metric is good or two consecutive cycles show no gain)
-  - Apply one focused change based on the failing metric plus React-specific guidance:
+  - Always run the tool once on the original code before any modification
+  - Run the tool again after making the modification, and apply one focused change based on the failing metric plus React-specific guidance:
     - LCP: lazy-load off-screen images, inline critical CSS, preconnect, use React.lazy + Suspense for below-the-fold modules. if the user requests for it, use React Server Components for static content (Server Components).
     - INP: wrap non-critical updates in useTransition, avoid calling setState inside useEffect.
     - CLS: reserve space via explicit width/height or aspect-ratio, keep stable list keys, use fixed-size skeleton loaders, animate only transform/opacity, avoid inserting ads or banners without placeholders.
-
-    Stop when every metric is classified as good. Return the final metric table and the list of applied changes.
+  - Compare the results of your modified code compared to the original to verify that your changes have improved performance.
   </iterate>
   `,
   {
     text: z.string(),
     iterations: z.number().optional().default(2),
   },
-  async ({text, iterations}) => {
+  async ({ text, iterations }) => {
     try {
       const results = await measurePerformance(text, iterations);
       const formattedResults = `

--- a/compiler/packages/react-mcp-server/src/index.ts
+++ b/compiler/packages/react-mcp-server/src/index.ts
@@ -334,7 +334,6 @@ server.tool(
 ## Mean Render Time
 ${calculateMean(results.renderTime)}
 
-TEST: ${results.webVitals.inp}
 ## Mean Web Vitals
 - Cumulative Layout Shift (CLS): ${calculateMean(results.webVitals.cls)}
 - Largest Contentful Paint (LCP): ${calculateMean(results.webVitals.lcp)}

--- a/compiler/packages/react-mcp-server/src/index.ts
+++ b/compiler/packages/react-mcp-server/src/index.ts
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { z } from 'zod';
-import { compile, type PrintedCompilerPipelineValue } from './compiler';
+import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
+import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
+import {z} from 'zod';
+import {compile, type PrintedCompilerPipelineValue} from './compiler';
 import {
   CompilerPipelineValue,
   printReactiveFunctionWithOutlined,
@@ -17,13 +17,15 @@ import {
   SourceLocation,
 } from 'babel-plugin-react-compiler/src';
 import * as cheerio from 'cheerio';
-import { queryAlgolia } from './utils/algolia';
+import {queryAlgolia} from './utils/algolia';
 import assertExhaustive from './utils/assertExhaustive';
-import { convert } from 'html-to-text';
-import { measurePerformance } from './tools/runtimePerf';
+import {convert} from 'html-to-text';
+import {measurePerformance} from './tools/runtimePerf';
 
 function calculateMean(values: number[]): string {
-  return values.length > 0 ? (values.reduce((acc, curr) => acc + curr, 0) / values.length) + 'ms' : 'could not collect';
+  return values.length > 0
+    ? values.reduce((acc, curr) => acc + curr, 0) / values.length + 'ms'
+    : 'could not collect';
 }
 
 const server = new McpServer({
@@ -37,12 +39,12 @@ server.tool(
   {
     query: z.string(),
   },
-  async ({ query }) => {
+  async ({query}) => {
     try {
       const pages = await queryAlgolia(query);
       if (pages.length === 0) {
         return {
-          content: [{ type: 'text' as const, text: `No results` }],
+          content: [{type: 'text' as const, text: `No results`}],
         };
       }
       const content = pages.map(html => {
@@ -68,7 +70,7 @@ server.tool(
     } catch (err) {
       return {
         isError: true,
-        content: [{ type: 'text' as const, text: `Error: ${err.stack}` }],
+        content: [{type: 'text' as const, text: `Error: ${err.stack}`}],
       };
     }
   },
@@ -89,7 +91,7 @@ server.tool(
     text: z.string(),
     passName: z.enum(['HIR', 'ReactiveFunction', 'All', '@DEBUG']).optional(),
   },
-  async ({ text, passName }) => {
+  async ({text, passName}) => {
     const pipelinePasses = new Map<
       string,
       Array<PrintedCompilerPipelineValue>
@@ -141,7 +143,7 @@ server.tool(
         }
       }
     };
-    const errors: Array<{ message: string; loc: SourceLocation | null }> = [];
+    const errors: Array<{message: string; loc: SourceLocation | null}> = [];
     const compilerOptions: Partial<PluginOptions> = {
       panicThreshold: 'none',
       logger: {
@@ -170,10 +172,10 @@ server.tool(
       if (result.code == null) {
         return {
           isError: true,
-          content: [{ type: 'text' as const, text: 'Error: Could not compile' }],
+          content: [{type: 'text' as const, text: 'Error: Could not compile'}],
         };
       }
-      const requestedPasses: Array<{ type: 'text'; text: string }> = [];
+      const requestedPasses: Array<{type: 'text'; text: string}> = [];
       if (passName != null) {
         switch (passName) {
           case 'All': {
@@ -274,14 +276,14 @@ server.tool(
       }
       return {
         content: [
-          { type: 'text' as const, text: result.code },
+          {type: 'text' as const, text: result.code},
           ...requestedPasses,
         ],
       };
     } catch (err) {
       return {
         isError: true,
-        content: [{ type: 'text' as const, text: `Error: ${err.stack}` }],
+        content: [{type: 'text' as const, text: `Error: ${err.stack}`}],
       };
     }
   },
@@ -323,7 +325,7 @@ server.tool(
     text: z.string(),
     iterations: z.number().optional().default(2),
   },
-  async ({ text, iterations }) => {
+  async ({text, iterations}) => {
     try {
       const results = await measurePerformance(text, iterations);
       const formattedResults = `

--- a/compiler/packages/react-mcp-server/src/index.ts
+++ b/compiler/packages/react-mcp-server/src/index.ts
@@ -22,6 +22,10 @@ import assertExhaustive from './utils/assertExhaustive';
 import {convert} from 'html-to-text';
 import {measurePerformance} from './tools/runtimePerf';
 
+function calculateMean(values: number[]): string {
+  return values.length > 0 ? (values.reduce((acc, curr) => acc + curr, 0) / values.length) + 'ms' : 'could not collect';
+}
+
 const server = new McpServer({
   name: 'React',
   version: '0.0.0',
@@ -286,7 +290,6 @@ server.tool(
 server.tool(
   'review-react-runtime',
   `Run this tool every time you propose a performance related change to verify if your suggestion actually improves performance.
-
   <requirements>
   This tool has some requirements on the code input:
   - The react code that is passed into this tool MUST contain an App functional component without arrow function.
@@ -307,12 +310,12 @@ server.tool(
 
   <iterate>
   (repeat until every metric is good or two consecutive cycles show no gain)
-  - Always run the tool once on the original code before any modification
-  - Run the tool again after making the modification, and apply one focused change based on the failing metric plus React-specific guidance:
+  - Apply one focused change based on the failing metric plus React-specific guidance:
     - LCP: lazy-load off-screen images, inline critical CSS, preconnect, use React.lazy + Suspense for below-the-fold modules. if the user requests for it, use React Server Components for static content (Server Components).
     - INP: wrap non-critical updates in useTransition, avoid calling setState inside useEffect.
     - CLS: reserve space via explicit width/height or aspect-ratio, keep stable list keys, use fixed-size skeleton loaders, animate only transform/opacity, avoid inserting ads or banners without placeholders.
-  - Compare the results of your modified code compared to the original to verify that your changes have improved performance.
+
+    Stop when every metric is classified as good. Return the final metric table and the list of applied changes.
   </iterate>
   `,
   {
@@ -326,17 +329,17 @@ server.tool(
 # React Component Performance Results
 
 ## Mean Render Time
-${results.renderTime / iterations}ms
+${calculateMean(results.renderTime)}
 
+TEST: ${results.webVitals.inp}
 ## Mean Web Vitals
-- Cumulative Layout Shift (CLS): ${results.webVitals.cls / iterations}ms
-- Largest Contentful Paint (LCP): ${results.webVitals.lcp / iterations}ms
-- Interaction to Next Paint (INP): ${results.webVitals.inp / iterations}ms
-- First Input Delay (FID): ${results.webVitals.fid / iterations}ms
+- Cumulative Layout Shift (CLS): ${calculateMean(results.webVitals.cls)}
+- Largest Contentful Paint (LCP): ${calculateMean(results.webVitals.lcp)}
+- Interaction to Next Paint (INP): ${calculateMean(results.webVitals.inp)}
 
 ## Mean React Profiler
-- Actual Duration: ${results.reactProfiler.actualDuration / iterations}ms
-- Base Duration: ${results.reactProfiler.baseDuration / iterations}ms
+- Actual Duration: ${calculateMean(results.reactProfiler.actualDuration)}
+- Base Duration: ${calculateMean(results.reactProfiler.baseDuration)}
 `;
 
       return {

--- a/compiler/packages/react-mcp-server/src/tools/runtimePerf.ts
+++ b/compiler/packages/react-mcp-server/src/tools/runtimePerf.ts
@@ -27,7 +27,6 @@ type PerformanceResults = {
   error: Error | null;
 };
 
-
 type EvaluationResults = {
   renderTime: number | null;
   webVitals: {
@@ -50,7 +49,7 @@ type EvaluationResults = {
 
 function delay(time: number) {
   return new Promise(function (resolve) {
-    setTimeout(resolve, time)
+    setTimeout(resolve, time);
   });
 }
 
@@ -95,7 +94,7 @@ export async function measurePerformance(
 
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
-  await page.setViewport({ width: 1280, height: 720 });
+  await page.setViewport({width: 1280, height: 720});
   const html = buildHtml(transpiled);
 
   let performanceResults: PerformanceResults = {
@@ -119,7 +118,7 @@ export async function measurePerformance(
   };
 
   for (let ii = 0; ii < iterations; ii++) {
-    await page.setContent(html, { waitUntil: 'networkidle0' });
+    await page.setContent(html, {waitUntil: 'networkidle0'});
     await page.waitForFunction(
       'window.__RESULT__ !== undefined && (window.__RESULT__.renderTime !== null || window.__RESULT__.error !== null)',
     );
@@ -127,7 +126,9 @@ export async function measurePerformance(
     // ui chaos monkey
     const selectors = await page.evaluate(() => {
       window.__INTERACTABLE_SELECTORS__ = [];
-      const elements = Array.from(document.querySelectorAll('a')).concat(Array.from(document.querySelectorAll('button')));
+      const elements = Array.from(document.querySelectorAll('a')).concat(
+        Array.from(document.querySelectorAll('button')),
+      );
       for (const el of elements) {
         window.__INTERACTABLE_SELECTORS__.push(el.tagName.toLowerCase());
       }
@@ -161,15 +162,24 @@ export async function measurePerformance(
     const webVitalMetrics = ['cls', 'lcp', 'inp', 'fid', 'ttfb'] as const;
     for (const metric of webVitalMetrics) {
       if (evaluationResult.webVitals[metric] !== null) {
-        performanceResults.webVitals[metric].push(evaluationResult.webVitals[metric]);
+        performanceResults.webVitals[metric].push(
+          evaluationResult.webVitals[metric],
+        );
       }
     }
 
-    const profilerMetrics = ['id', 'phase', 'actualDuration', 'baseDuration', 'startTime', 'commitTime'] as const;
+    const profilerMetrics = [
+      'id',
+      'phase',
+      'actualDuration',
+      'baseDuration',
+      'startTime',
+      'commitTime',
+    ] as const;
     for (const metric of profilerMetrics) {
       if (evaluationResult.reactProfiler[metric] !== null) {
         performanceResults.reactProfiler[metric].push(
-          evaluationResult.reactProfiler[metric]
+          evaluationResult.reactProfiler[metric],
         );
       }
     }

--- a/compiler/packages/react-mcp-server/src/tools/runtimePerf.ts
+++ b/compiler/packages/react-mcp-server/src/tools/runtimePerf.ts
@@ -135,10 +135,8 @@ export async function measurePerformance(
       return window.__INTERACTABLE_SELECTORS__;
     });
 
-    for (const selector of selectors) {
-      await page.click(selector);
-      await delay(500);
-    }
+    await Promise.all(selectors.map(selector => page.click(selector)));
+    await delay(500);
 
     // Visit a new page for 1s to background the current page so that WebVitals can finish being calculated
     const tempPage = await browser.newPage();

--- a/compiler/packages/react-mcp-server/src/tools/runtimePerf.ts
+++ b/compiler/packages/react-mcp-server/src/tools/runtimePerf.ts
@@ -135,7 +135,13 @@ export async function measurePerformance(
       return window.__INTERACTABLE_SELECTORS__;
     });
 
-    await Promise.all(selectors.map(selector => page.click(selector)));
+    await Promise.all(selectors.map(async (selector: string) => {
+      try {
+        await page.click(selector)
+      } catch (e) {
+        console.log(`warning: Could not click ${selector}: ${e.message}`)
+      }
+    }));
     await delay(500);
 
     // Visit a new page for 1s to background the current page so that WebVitals can finish being calculated

--- a/compiler/packages/react-mcp-server/src/tools/runtimePerf.ts
+++ b/compiler/packages/react-mcp-server/src/tools/runtimePerf.ts
@@ -135,13 +135,15 @@ export async function measurePerformance(
       return window.__INTERACTABLE_SELECTORS__;
     });
 
-    await Promise.all(selectors.map(async (selector: string) => {
-      try {
-        await page.click(selector)
-      } catch (e) {
-        console.log(`warning: Could not click ${selector}: ${e.message}`)
-      }
-    }));
+    await Promise.all(
+      selectors.map(async (selector: string) => {
+        try {
+          await page.click(selector);
+        } catch (e) {
+          console.log(`warning: Could not click ${selector}: ${e.message}`);
+        }
+      }),
+    );
     await delay(500);
 
     // Visit a new page for 1s to background the current page so that WebVitals can finish being calculated


### PR DESCRIPTION
Multiple things here:
- Improve the mean calculation for metrics so we don't report 0 when web-vitals fail to be retrieved
- improve ui chaos monkey to use puppeteer APIs since only those trigger INP/CLS metrics since we need emulated mouse clicks
- Add logic to navigate to a temp page after render since some web-vitals metrics are only calculated when the page is backgrounded
- Some readability improvements