### PR TITLE
fix: `nonce` for `ReactDOM.preloadModule`

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -6290,6 +6290,45 @@ body {
           '    in App (at **)',
       ]);
     });
+
+    it('supports nonce', async () => {
+      function App({url}) {
+        ReactDOM.preloadModule(url, {as: 'script', nonce: 'abc'});
+        return 'hello';
+      }
+
+      await act(() => {
+        renderToPipeableStream(<App url="server" />).pipe(writable);
+      });
+
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head />
+          <body>
+            <div id="container">
+              <link rel="modulepreload" href="server" nonce="abc" />
+              hello
+            </div>
+          </body>
+        </html>,
+      );
+
+      ReactDOMClient.hydrateRoot(container, <App url="client" />);
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <link rel="modulepreload" href="client" nonce="abc" />
+          </head>
+          <body>
+            <div id="container">
+              <link rel="modulepreload" href="server" nonce="abc" />
+              hello
+            </div>
+          </body>
+        </html>,
+      );
+    });
   });
 
   describe('ReactDOM.preinit(href, { as: ... })', () => {

--- a/packages/react-dom/src/shared/ReactDOMFloat.js
+++ b/packages/react-dom/src/shared/ReactDOMFloat.js
@@ -191,6 +191,7 @@ export function preloadModule(href: string, options?: ?PreloadModuleOptions) {
             typeof options.integrity === 'string'
               ? options.integrity
               : undefined,
+          nonce: typeof options.nonce === 'string' ? options.nonce : undefined,
         });
     } else {
       ReactDOMSharedInternals.d /* ReactDOMCurrentDispatcher */


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

`nonce` option is mentioned in `ReactDOM.preloadModule` documentation https://react.dev/reference/react-dom/preloadModule, but I found that it has no effect. This looks like an minor oversight and this is a one liner fix PR.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

Added a new test "ReactDOMFloat > preloadModule > supports nonce" in `packages/react-dom/src/__tests__/ReactDOMFloat-test.js`, which is a `preloadModule` equivalent of an existing test "ReactDOMFloat > preload > supports nonce".
