### PR TITLE
[Flight] Don't increase serializedSize for every recursive pass

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -2302,6 +2302,9 @@ function renderModel(
   key: string,
   value: ReactClientValue,
 ): ReactJSONValue {
+  // First time we're serializing the key, we should add it to the size.
+  serializedSize += key.length;
+
   const prevKeyPath = task.keyPath;
   const prevImplicitSlot = task.implicitSlot;
   try {
@@ -2415,8 +2418,6 @@ function renderModelDestructive(
 ): ReactJSONValue {
   // Set the currently rendering model
   task.model = value;
-
-  serializedSize += parentPropertyName.length;
 
   // Special Symbol, that's very common.
   if (value === REACT_ELEMENT_TYPE) {


### PR DESCRIPTION
I noticed that we increase this in the recursive part of the algorithm. This would mean that we'd count a key more than once if it has Server Components inside it recursively resolving. This moves it out to where we enter from toJSON. Which is called once per JSON entry (and therefore once per key).