### PR TITLE
[eslint-plugin-react-hooks] allow for underscore prefixed component names

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -248,6 +248,16 @@ const allTests = {
     },
     {
       code: normalizeIndent`
+        // Valid because hooks can be used in named function arguments to
+        // memo.
+        const MemoizedFunction = memo(function _MyComponent(props) {
+          useHook();
+          return <button {...props} />
+        });
+      `,
+    },
+    {
+      code: normalizeIndent`
         // Valid because classes can call functions.
         // We don't consider these to be hooks.
         class C {

--- a/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
@@ -45,7 +45,7 @@ function isHook(node: Node): boolean {
  * always start with an uppercase letter.
  */
 function isComponentName(node: Node): boolean {
-  return node.type === 'Identifier' && /^[A-Z]/.test(node.name);
+  return node.type === 'Identifier' && /^_?[A-Z]/.test(node.name);
 }
 
 function isReactFunction(node: Node, functionName: string): boolean {


### PR DESCRIPTION
When wrapping components in React.memo(), it's common for the "inner" component (a named function) to have the same name as the "outer" component (variable declaration) with an underscore prefixed.

This makes viewing the component hierarchy in the React DevTools much easier, as otherwise an anonymous function would have to be used which is less clear.

This solves the following currently open issue:

    https://github.com/facebook/react/issues/31722