### PR TITLE
feat(compiler): implement constant folding for unary minus

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/ConstantPropagation.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/ConstantPropagation.ts
@@ -327,6 +327,23 @@ function evaluateInstruction(
           }
           return null;
         }
+        case '-': {
+          const operand = read(constants, value.value);
+          if (
+            operand !== null &&
+            operand.kind === 'Primitive' &&
+            typeof operand.value === 'number'
+          ) {
+            const result: Primitive = {
+              kind: 'Primitive',
+              value: operand.value * -1,
+              loc: value.loc,
+            };
+            instr.value = result;
+            return result;
+          }
+          return null;
+        }
         default:
           return null;
       }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary-number.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary-number.expect.md
@@ -6,7 +6,11 @@ import {Stringify} from 'shared-runtime';
 
 function foo() {
   const a = -1;
-  return <Stringify value={[2 * a, -0]} />;
+  return (
+    <Stringify
+      value={[2 * a, -0, -Infinity, -NaN, a * NaN, a * Infinity, a * -Infinity]}
+    />
+  );
 }
 
 export const FIXTURE_ENTRYPOINT = {
@@ -27,7 +31,19 @@ function foo() {
   const $ = _c(1);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = <Stringify value={[-2, 0]} />;
+    t0 = (
+      <Stringify
+        value={[
+          -2,
+          0,
+          -Infinity,
+          -NaN,
+          -1 * NaN,
+          -1 * Infinity,
+          -1 * -Infinity,
+        ]}
+      />
+    );
     $[0] = t0;
   } else {
     t0 = $[0];
@@ -44,4 +60,4 @@ export const FIXTURE_ENTRYPOINT = {
 ```
       
 ### Eval output
-(kind: ok) <div>{"value":[-2,0]}</div>
+(kind: ok) <div>{"value":[-2,0,null,null,null,null,null]}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary-number.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary-number.expect.md
@@ -1,0 +1,47 @@
+
+## Input
+
+```javascript
+import {Stringify} from 'shared-runtime';
+
+function foo() {
+  const a = -1;
+  return <Stringify value={[2 * a, -0]} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [],
+  isComponent: false,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { Stringify } from "shared-runtime";
+
+function foo() {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = <Stringify value={[-2, 0]} />;
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [],
+  isComponent: false,
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"value":[-2,0]}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary-number.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary-number.expect.md
@@ -8,7 +8,16 @@ function foo() {
   const a = -1;
   return (
     <Stringify
-      value={[2 * a, -0, -Infinity, -NaN, a * NaN, a * Infinity, a * -Infinity]}
+      value={[
+        2 * a,
+        -0,
+        0 === -0,
+        -Infinity,
+        -NaN,
+        a * NaN,
+        a * Infinity,
+        a * -Infinity,
+      ]}
     />
   );
 }
@@ -36,8 +45,10 @@ function foo() {
         value={[
           -2,
           0,
+          true,
           -Infinity,
           -NaN,
+
           -1 * NaN,
           -1 * Infinity,
           -1 * -Infinity,
@@ -60,4 +71,4 @@ export const FIXTURE_ENTRYPOINT = {
 ```
       
 ### Eval output
-(kind: ok) <div>{"value":[-2,0,null,null,null,null,null]}</div>
+(kind: ok) <div>{"value":[-2,0,true,null,null,null,null,null]}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary-number.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary-number.js
@@ -2,7 +2,11 @@ import {Stringify} from 'shared-runtime';
 
 function foo() {
   const a = -1;
-  return <Stringify value={[2 * a, -0]} />;
+  return (
+    <Stringify
+      value={[2 * a, -0, -Infinity, -NaN, a * NaN, a * Infinity, a * -Infinity]}
+    />
+  );
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary-number.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary-number.js
@@ -1,0 +1,12 @@
+import {Stringify} from 'shared-runtime';
+
+function foo() {
+  const a = -1;
+  return <Stringify value={[2 * a, -0]} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [],
+  isComponent: false,
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary-number.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary-number.js
@@ -4,7 +4,16 @@ function foo() {
   const a = -1;
   return (
     <Stringify
-      value={[2 * a, -0, -Infinity, -NaN, a * NaN, a * Infinity, a * -Infinity]}
+      value={[
+        2 * a,
+        -0,
+        0 === -0,
+        -Infinity,
+        -NaN,
+        a * NaN,
+        a * Infinity,
+        a * -Infinity,
+      ]}
     />
   );
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary.expect.md
@@ -58,7 +58,7 @@ function foo() {
           n0: true,
           n1: false,
           n2: false,
-          n3: !-1,
+          n3: false,
           s0: true,
           s1: false,
           s2: false,


### PR DESCRIPTION
## Summary
`-constant` is represented as a `UnaryExpression` node that is currently not part of constant folding. If the operand is a constant number, the node is folded to `constant * -1`. This also coerces `-0` to `0`, resulting in `0 === -0` being folded to `true`.

## How did you test this change?
See attached tests
