### PR TITLE
[compiler][wip] Infer alias effects for function expressions

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -300,6 +300,10 @@ export type FunctionEffect =
       places: ReadonlySet<Place>;
       effect: Effect;
       loc: SourceLocation;
+    }
+  | {
+      kind: 'CaptureEffect';
+      places: ReadonlySet<Place>;
     };
 
 /*

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -546,12 +546,23 @@ export function printInstructionValue(instrValue: ReactiveValue): string {
       const effects =
         instrValue.loweredFunc.func.effects
           ?.map(effect => {
-            if (effect.kind === 'ContextMutation') {
-              return `ContextMutation places=[${[...effect.places]
-                .map(place => printPlace(place))
-                .join(', ')}] effect=${effect.effect}`;
-            } else {
-              return `GlobalMutation`;
+            switch (effect.kind) {
+              case 'ContextMutation': {
+                return `ContextMutation places=[${[...effect.places]
+                  .map(place => printPlace(place))
+                  .join(', ')}] effect=${effect.effect}`;
+              }
+              case 'GlobalMutation': {
+                return 'GlobalMutation';
+              }
+              case 'ReactMutation': {
+                return 'ReactMutation';
+              }
+              case 'CaptureEffect': {
+                return `CaptureEffect places=[${[...effect.places]
+                  .map(place => printPlace(place))
+                  .join(', ')}]`;
+              }
             }
           })
           .join(', ') ?? '';

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/AnalyseFunctions.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/AnalyseFunctions.ts
@@ -11,6 +11,7 @@ import {
   HIRFunction,
   Identifier,
   LoweredFunction,
+  Place,
   isRefOrRefValue,
   makeInstructionId,
 } from '../HIR';
@@ -19,6 +20,8 @@ import {inferReactiveScopeVariables} from '../ReactiveScopes';
 import {rewriteInstructionKindsBasedOnReassignment} from '../SSA';
 import {inferMutableRanges} from './InferMutableRanges';
 import inferReferenceEffects from './InferReferenceEffects';
+import DisjointSet from '../Utils/DisjointSet';
+import {eachInstructionValueOperand} from '../HIR/visitors';
 
 export default function analyseFunctions(func: HIRFunction): void {
   for (const [_, block] of func.body.blocks) {
@@ -26,8 +29,8 @@ export default function analyseFunctions(func: HIRFunction): void {
       switch (instr.value.kind) {
         case 'ObjectMethod':
         case 'FunctionExpression': {
-          lower(instr.value.loweredFunc.func);
-          infer(instr.value.loweredFunc);
+          const aliases = lower(instr.value.loweredFunc.func);
+          infer(instr.value.loweredFunc, aliases);
 
           /**
            * Reset mutable range for outer inferReferenceEffects
@@ -44,11 +47,11 @@ export default function analyseFunctions(func: HIRFunction): void {
   }
 }
 
-function lower(func: HIRFunction): void {
+function lower(func: HIRFunction): DisjointSet<Identifier> {
   analyseFunctions(func);
   inferReferenceEffects(func, {isFunctionExpression: true});
   deadCodeElimination(func);
-  inferMutableRanges(func);
+  const aliases = inferMutableRanges(func);
   rewriteInstructionKindsBasedOnReassignment(func);
   inferReactiveScopeVariables(func);
   func.env.logger?.debugLogIRs?.({
@@ -56,9 +59,49 @@ function lower(func: HIRFunction): void {
     name: 'AnalyseFunction (inner)',
     value: func,
   });
+  inferAliasesForCapturing(func, aliases);
+  return aliases;
 }
 
-function infer(loweredFunc: LoweredFunction): void {
+/**
+ * The alias sets returned by InferMutableRanges() accounts only for aliases that
+ * are known to mutate together. Notably this skips cases where a value is captured
+ * into some other value, but neither is subsequently mutated. An example is pushing
+ * a mutable value onto an array, where neither the array or value are subsequently
+ * mutated.
+ *
+ * This function extends the aliases sets to account for such capturing, so that we
+ * can detect cases where one of the values in a set is mutated later (in an outer function)
+ * we can correctly infer them as mutating together.
+ */
+function inferAliasesForCapturing(
+  fn: HIRFunction,
+  aliases: DisjointSet<Identifier>,
+): void {
+  for (const block of fn.body.blocks.values()) {
+    for (const instr of block.instructions) {
+      let operands: Array<Identifier> | null = null;
+      for (const operand of eachInstructionValueOperand(instr.value)) {
+        if (
+          operand.effect === Effect.Mutate ||
+          operand.effect === Effect.Store ||
+          operand.effect === Effect.Capture
+        ) {
+          operands ??= [];
+          operands.push(operand.identifier);
+        }
+      }
+      if (operands != null && operands.length > 1) {
+        aliases.union(operands);
+      }
+    }
+  }
+}
+
+function infer(
+  loweredFunc: LoweredFunction,
+  aliases: DisjointSet<Identifier>,
+): void {
   for (const operand of loweredFunc.func.context) {
     const identifier = operand.identifier;
     CompilerError.invariant(operand.effect === Effect.Unknown, {
@@ -83,6 +126,23 @@ function infer(loweredFunc: LoweredFunction): void {
       operand.effect = Effect.Capture;
     } else {
       operand.effect = Effect.Read;
+    }
+  }
+  const contextIdentifiers = new Map(
+    loweredFunc.func.context.map(place => [place.identifier, place]),
+  );
+  for (const set of aliases.buildSets()) {
+    const contextOperands: Set<Place> = new Set(
+      [...set]
+        .map(identifier => contextIdentifiers.get(identifier))
+        .filter(place => place != null) as Array<Place>,
+    );
+    if (contextOperands.size > 1) {
+      loweredFunc.func.effects ??= [];
+      loweredFunc.func.effects?.push({
+        kind: 'CaptureEffect',
+        places: contextOperands,
+      });
     }
   }
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferAlias.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferAlias.ts
@@ -60,6 +60,16 @@ function inferInstr(
       alias = instrValue.value;
       break;
     }
+    case 'ObjectMethod':
+    case 'FunctionExpression': {
+      for (const effect of instrValue.loweredFunc.func.effects ?? []) {
+        if (effect.kind !== 'CaptureEffect') {
+          continue;
+        }
+        aliases.union([...effect.places].map(place => place.identifier));
+      }
+      return;
+    }
     default:
       return;
   }

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutableRanges.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutableRanges.ts
@@ -6,6 +6,7 @@
  */
 
 import {HIRFunction, Identifier} from '../HIR/HIR';
+import DisjointSet from '../Utils/DisjointSet';
 import {inferAliasForUncalledFunctions} from './InerAliasForUncalledFunctions';
 import {inferAliases} from './InferAlias';
 import {inferAliasForPhis} from './InferAliasForPhis';
@@ -14,7 +15,7 @@ import {inferMutableLifetimes} from './InferMutableLifetimes';
 import {inferMutableRangesForAlias} from './InferMutableRangesForAlias';
 import {inferTryCatchAliases} from './InferTryCatchAliases';
 
-export function inferMutableRanges(ir: HIRFunction): void {
+export function inferMutableRanges(ir: HIRFunction): DisjointSet<Identifier> {
   // Infer mutable ranges for non fields
   inferMutableLifetimes(ir, false);
 
@@ -84,6 +85,8 @@ export function inferMutableRanges(ir: HIRFunction): void {
     }
     prevAliases = nextAliases;
   }
+
+  return aliases;
 }
 
 function areEqualMaps<T>(a: Map<T, T>, b: Map<T, T>): boolean {

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReferenceEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReferenceEffects.ts
@@ -670,11 +670,7 @@ class InferenceState {
     for (const [value, kind] of this.#values) {
       const id = identify(value);
       result.values[id] = {
-        abstract: {
-          kind: kind.kind,
-          context: [...kind.context].map(printPlace),
-          reason: [...kind.reason],
-        },
+        abstract: this.debugAbstractValue(kind),
         value: printInstructionValue(value),
       };
     }
@@ -682,6 +678,14 @@ class InferenceState {
       result.variables[`$${variable}`] = [...values].map(identify);
     }
     return result;
+  }
+
+  debugAbstractValue(value: AbstractValue): any {
+    return {
+      kind: value.kind,
+      context: [...value.context].map(printPlace),
+      reason: [...value.reason],
+    };
   }
 
   inferPhi(phi: Phi): void {
@@ -909,19 +913,11 @@ function inferBlock(
         break;
       }
       case 'ArrayExpression': {
-        const contextRefOperands = getContextRefOperand(state, instrValue);
-        const valueKind: AbstractValue =
-          contextRefOperands.length > 0
-            ? {
-                kind: ValueKind.Context,
-                reason: new Set([ValueReason.Other]),
-                context: new Set(contextRefOperands),
-              }
-            : {
-                kind: ValueKind.Mutable,
-                reason: new Set([ValueReason.Other]),
-                context: new Set(),
-              };
+        const valueKind: AbstractValue = {
+          kind: ValueKind.Mutable,
+          reason: new Set([ValueReason.Other]),
+          context: new Set(),
+        };
 
         for (const element of instrValue.elements) {
           if (element.kind === 'Spread') {
@@ -942,6 +938,7 @@ function inferBlock(
             let _: 'Hole' = element.kind;
           }
         }
+
         state.initialize(instrValue, valueKind);
         state.define(instr.lvalue, instrValue);
         instr.lvalue.effect = Effect.Store;
@@ -961,19 +958,11 @@ function inferBlock(
         break;
       }
       case 'ObjectExpression': {
-        const contextRefOperands = getContextRefOperand(state, instrValue);
-        const valueKind: AbstractValue =
-          contextRefOperands.length > 0
-            ? {
-                kind: ValueKind.Context,
-                reason: new Set([ValueReason.Other]),
-                context: new Set(contextRefOperands),
-              }
-            : {
-                kind: ValueKind.Mutable,
-                reason: new Set([ValueReason.Other]),
-                context: new Set(),
-              };
+        const valueKind: AbstractValue = {
+          kind: ValueKind.Mutable,
+          reason: new Set([ValueReason.Other]),
+          context: new Set(),
+        };
 
         for (const property of instrValue.properties) {
           switch (property.kind) {
@@ -1818,7 +1807,9 @@ function inferBlock(
         state.isDefined(operand) &&
         ((operand.identifier.type.kind === 'Function' &&
           state.isFunctionExpression) ||
-          state.kind(operand).kind === ValueKind.Context)
+          state.kind(operand).kind === ValueKind.Context ||
+          (state.kind(operand).kind === ValueKind.Mutable &&
+            state.isFunctionExpression))
       ) {
         /**
          * Returned values should only be typed as 'frozen' if they are both (1)
@@ -1843,22 +1834,6 @@ function inferBlock(
   terminalFreezeActions.forEach(({values, reason}) =>
     state.freezeValues(values, reason),
   );
-}
-
-function getContextRefOperand(
-  state: InferenceState,
-  instrValue: InstructionValue,
-): Array<Place> {
-  const result = [];
-  for (const place of eachInstructionValueOperand(instrValue)) {
-    if (state.isDefined(place)) {
-      const kind = state.kind(place);
-      if (kind.kind === ValueKind.Context) {
-        result.push(...kind.context);
-      }
-    }
-  }
-  return result;
 }
 
 export function getFunctionCallSignature(

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-map-captures-receiver-noAlias.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-map-captures-receiver-noAlias.expect.md
@@ -23,34 +23,18 @@ export const FIXTURE_ENTRYPOINT = {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
-  const $ = _c(6);
+  const $ = _c(2);
   let t0;
   if ($[0] !== props.a) {
-    t0 = { a: props.a };
+    const item = { a: props.a };
+    const items = [item];
+    t0 = items.map(_temp);
     $[0] = props.a;
     $[1] = t0;
   } else {
     t0 = $[1];
   }
-  const item = t0;
-  let t1;
-  if ($[2] !== item) {
-    t1 = [item];
-    $[2] = item;
-    $[3] = t1;
-  } else {
-    t1 = $[3];
-  }
-  const items = t1;
-  let t2;
-  if ($[4] !== items) {
-    t2 = items.map(_temp);
-    $[4] = items;
-    $[5] = t2;
-  } else {
-    t2 = $[5];
-  }
-  const mapped = t2;
+  const mapped = t0;
   return mapped;
 }
 function _temp(item_0) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-fun-alias-captured-mutate-2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-fun-alias-captured-mutate-2.expect.md
@@ -37,26 +37,26 @@ import { c as _c } from "react/compiler-runtime";
 import { mutate } from "shared-runtime";
 
 function Component(t0) {
-  const $ = _c(3);
+  const $ = _c(2);
   const { foo, bar } = t0;
-  let x;
-  if ($[0] !== bar || $[1] !== foo) {
-    x = { foo };
-    const y = { bar };
-    const f0 = function () {
-      const a = { y };
-      const b = x;
-      a.x = b;
-    };
-
-    f0();
-    mutate(y);
-    $[0] = bar;
-    $[1] = foo;
-    $[2] = x;
+  let t1;
+  if ($[0] !== foo) {
+    t1 = { foo };
+    $[0] = foo;
+    $[1] = t1;
   } else {
-    x = $[2];
+    t1 = $[1];
   }
+  const x = t1;
+  const y = { bar };
+  const f0 = function () {
+    const a = { y };
+    const b = x;
+    a.x = b;
+  };
+
+  f0();
+  mutate(y);
   return x;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-fun-alias-captured-mutate-arr-2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-fun-alias-captured-mutate-arr-2.expect.md
@@ -37,26 +37,26 @@ import { c as _c } from "react/compiler-runtime";
 import { mutate } from "shared-runtime";
 
 function Component(t0) {
-  const $ = _c(3);
+  const $ = _c(2);
   const { foo, bar } = t0;
-  let x;
-  if ($[0] !== bar || $[1] !== foo) {
-    x = { foo };
-    const y = { bar };
-    const f0 = function () {
-      const a = [y];
-      const b = x;
-      a.x = b;
-    };
-
-    f0();
-    mutate(y);
-    $[0] = bar;
-    $[1] = foo;
-    $[2] = x;
+  let t1;
+  if ($[0] !== foo) {
+    t1 = { foo };
+    $[0] = foo;
+    $[1] = t1;
   } else {
-    x = $[2];
+    t1 = $[1];
   }
+  const x = t1;
+  const y = { bar };
+  const f0 = function () {
+    const a = [y];
+    const b = x;
+    a.x = b;
+  };
+
+  f0();
+  mutate(y);
   return x;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-captured-mutate-arr.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-func-alias-captured-mutate-arr.expect.md
@@ -35,11 +35,19 @@ export const FIXTURE_ENTRYPOINT = {
 import { c as _c } from "react/compiler-runtime";
 import { mutate } from "shared-runtime";
 function Component(t0) {
-  const $ = _c(3);
+  const $ = _c(5);
   const { foo, bar } = t0;
+  let t1;
+  if ($[0] !== foo) {
+    t1 = { foo };
+    $[0] = foo;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const x = t1;
   let y;
-  if ($[0] !== bar || $[1] !== foo) {
-    const x = { foo };
+  if ($[2] !== bar || $[3] !== x) {
     y = { bar };
     const f0 = function () {
       const a = [y];
@@ -49,11 +57,11 @@ function Component(t0) {
 
     f0();
     mutate(y);
-    $[0] = bar;
-    $[1] = foo;
-    $[2] = y;
+    $[2] = bar;
+    $[3] = x;
+    $[4] = y;
   } else {
-    y = $[2];
+    y = $[4];
   }
   return y;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/context-variable-reassigned-reactive-capture.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/context-variable-reassigned-reactive-capture.expect.md
@@ -29,16 +29,16 @@ import { invoke } from "shared-runtime";
 
 function Component(t0) {
   const $ = _c(2);
-  const { value } = t0;
   let x;
-  if ($[0] !== value) {
+  if ($[0] !== t0) {
+    const { value } = t0;
     x = null;
     const reassign = () => {
       x = value;
     };
 
     invoke(reassign);
-    $[0] = value;
+    $[0] = t0;
     $[1] = x;
   } else {
     x = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-returned-inner-fn-mutates-context.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-returned-inner-fn-mutates-context.expect.md
@@ -54,10 +54,11 @@ import { Stringify } from "shared-runtime";
  */
 function Foo(t0) {
   "use memo";
-  const $ = _c(3);
-  const { a, b } = t0;
+  const $ = _c(2);
   let t1;
-  if ($[0] !== a || $[1] !== b) {
+  if ($[0] !== t0) {
+    const { a, b } = t0;
+
     const obj = {};
     const updaterFactory = () => (newValue) => {
       obj.value = newValue;
@@ -67,11 +68,10 @@ function Foo(t0) {
     const updater = updaterFactory();
     updater(b);
     t1 = <Stringify cb={obj} shouldInvokeFns={true} />;
-    $[0] = a;
-    $[1] = b;
-    $[2] = t1;
+    $[0] = t0;
+    $[1] = t1;
   } else {
-    t1 = $[2];
+    t1 = $[1];
   }
   return t1;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This is a stab at addressing a pattern that @mofeiz and I have both stumbled across. Today, FunctionExpression's context list describes values from the outer context that are accessed in the function, and with what effect they were accessed. This allows us to describe the fact that a value from the outer context is known to be mutated inside a function expression, or is known to be captured (aliased) into some other value in the function expression. However, the basic `Effect` kind is insufficient to describe the full semantics. Notably, it doesn't let us describe more complex aliasing relationships.

From an example @mofeiz added:

```js
const x = {};
const y = {};
const f = () => {
  const a = [y];
  const b = x;
  // this sets y.x = x
  a[0].x = b;
}
f();
mutate(y.x);  // which means this mutates x!
```

Here, the Effect on the context operands are `[mutate y, read x]`. The `mutate y` is bc of the array push. But the `read x` is surprising — `x` is captured into `y`, but there is no subsequent mutation of y or x, so we consider this a read. But as the comments indicate, the final line mutates x! We need to reflect the fact that even though x isn't mutated inside the function, it is aliased into y, such that if y is subsequently mutated that this should count as a mutation of x too.

The idea of this PR is to extend the FunctionEffect type with a CaptureEffect variant which lists out the aliasing groups that occur inside the function expression. This allows us to bubble up the results of alias analysis from inside a function. The idea is to:

* Return the alias sets from InferMutableRanges
* Augment them with capturing of the form above, handling cases such as the `a[0].x = b`
* For each alias group, record a CaptureEffect for any group that contains 2+ context operands
* Extend the alias sets in the _outer_ function with the CaptureEffect sets from FunctionExpression/ObjectMethod instructions.

This isn't quite right yet, just sharing early hacking.