### PR TITLE
Use a shared noop function from shared/noop

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -63,6 +63,8 @@ import {validateProperties as validateInputProperties} from '../shared/ReactDOMN
 import {validateProperties as validateUnknownProperties} from '../shared/ReactDOMUnknownPropertyHook';
 import sanitizeURL from '../shared/sanitizeURL';
 
+import noop from 'shared/noop';
+
 import {trackHostMutation} from 'react-reconciler/src/ReactFiberMutationTracking';
 
 import {
@@ -318,8 +320,6 @@ function checkForUnmatchedText(
   }
   return false;
 }
-
-function noop() {}
 
 export function trapClickOnNonInteractiveElement(node: HTMLElement) {
   // Mobile Safari does not fire properly bubble click events on

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -139,6 +139,9 @@ import {requestFormReset as requestFormResetOnFiber} from 'react-reconciler/src/
 import ReactDOMSharedInternals from 'shared/ReactDOMSharedInternals';
 
 export {default as rendererVersion} from 'shared/ReactVersion';
+
+import noop from 'shared/noop';
+
 export const rendererPackageName = 'react-dom';
 export const extraDevToolsConfig = null;
 
@@ -5628,16 +5631,14 @@ type SuspendedState = {
 };
 let suspendedState: null | SuspendedState = null;
 
-// We use a noop function when we begin suspending because if possible we want the
-// waitfor step to finish synchronously. If it doesn't we'll return a function to
-// provide the actual unsuspend function and that will get completed when the count
-// hits zero or it will get cancelled if the root starts new work.
-function noop() {}
-
 export function startSuspendingCommit(): void {
   suspendedState = {
     stylesheets: null,
     count: 0,
+    // We use a noop function when we begin suspending because if possible we want the
+    // waitfor step to finish synchronously. If it doesn't we'll return a function to
+    // provide the actual unsuspend function and that will get completed when the count
+    // hits zero or it will get cancelled if the root starts new work.
     unsuspend: noop,
   };
 }

--- a/packages/react-dom/src/ReactDOMSharedInternals.js
+++ b/packages/react-dom/src/ReactDOMSharedInternals.js
@@ -10,6 +10,8 @@
 import type {EventPriority} from 'react-reconciler/src/ReactEventPriorities';
 import type {HostDispatcher} from './shared/ReactDOMTypes';
 
+import noop from 'shared/noop';
+
 // This should line up with NoEventPriority from react-reconciler/src/ReactEventPriorities
 // but we can't depend on the react-reconciler from this isomorphic code.
 export const NoEventPriority: EventPriority = (0: any);
@@ -23,8 +25,6 @@ type ReactDOMInternals = {
         componentOrElement: React$Component<any, any>,
       ) => null | Element | Text),
 };
-
-function noop() {}
 
 function requestFormReset(element: HTMLFormElement) {
   throw new Error(

--- a/packages/react-dom/src/ReactDOMSharedInternalsFB.js
+++ b/packages/react-dom/src/ReactDOMSharedInternalsFB.js
@@ -12,6 +12,8 @@ import type {HostDispatcher} from './shared/ReactDOMTypes';
 
 import {NoEventPriority} from 'react-reconciler/src/ReactEventPriorities';
 
+import noop from 'shared/noop';
+
 type ReactDOMInternals = {
   Events: [any, any, any, any, any, any],
   d /* ReactDOMCurrentDispatcher */: HostDispatcher,
@@ -22,8 +24,6 @@ type ReactDOMInternals = {
         componentOrElement: React$Component<any, any>,
       ) => null | Element | Text),
 };
-
-function noop() {}
 
 const DefaultDispatcher: HostDispatcher = {
   f /* flushSyncWork */: noop,

--- a/packages/react-dom/src/client/ReactDOMRootFB.js
+++ b/packages/react-dom/src/client/ReactDOMRootFB.js
@@ -70,6 +70,8 @@ import {
 
 import assign from 'shared/assign';
 
+import noop from 'shared/noop';
+
 // Provided by www
 const ReactFiberErrorDialogWWW = require('ReactFiberErrorDialog');
 
@@ -206,14 +208,10 @@ function getReactRootElementInContainer(container: any) {
   }
 }
 
-function noopOnRecoverableError() {
-  // This isn't reachable because onRecoverableError isn't called in the
-  // legacy API.
-}
-
-function noopOnDefaultTransitionIndicator() {
-  // Noop
-}
+// This isn't reachable because onRecoverableError isn't called in the
+// legacy API.
+const noopOnRecoverableError = noop;
+const noopOnDefaultTransitionIndicator = noop;
 
 function legacyCreateRootFromDOMContainer(
   container: Container,

--- a/packages/react-reconciler/src/ReactFiberThenable.js
+++ b/packages/react-reconciler/src/ReactFiberThenable.js
@@ -18,6 +18,8 @@ import {getWorkInProgressRoot} from './ReactFiberWorkLoop';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 
+import noop from 'shared/noop';
+
 opaque type ThenableStateDev = {
   didWarnAboutUncachedPromise: boolean,
   thenables: Array<Thenable<any>>,
@@ -94,8 +96,6 @@ export function isThenableResolved(thenable: Thenable<mixed>): boolean {
   const status = thenable.status;
   return status === 'fulfilled' || status === 'rejected';
 }
-
-function noop(): void {}
 
 export function trackUsedThenable<T>(
   thenableState: ThenableState,

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -47,6 +47,8 @@ import {
 import {checkAttributeStringCoercion} from 'shared/CheckStringCoercion';
 import {getFormState} from './ReactFizzServer';
 
+import noop from 'shared/noop';
+
 type BasicStateAction<S> = (S => S) | S;
 type Dispatch<A> = A => void;
 
@@ -794,8 +796,6 @@ function useMemoCache(size: number): Array<mixed> {
   }
   return data;
 }
-
-function noop(): void {}
 
 function clientHookNotSupported() {
   throw new Error(

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -176,6 +176,7 @@ import {
 } from 'shared/ReactFeatureFlags';
 
 import assign from 'shared/assign';
+import noop from 'shared/noop';
 import getComponentNameFromType from 'shared/getComponentNameFromType';
 import isArray from 'shared/isArray';
 import {SuspenseException, getSuspendedThenable} from './ReactFizzThenable';
@@ -424,8 +425,6 @@ function defaultErrorHandler(error: mixed) {
   }
   return null;
 }
-
-function noop(): void {}
 
 function RequestInstance(
   this: $FlowFixMe,

--- a/packages/react-server/src/ReactFizzThenable.js
+++ b/packages/react-server/src/ReactFizzThenable.js
@@ -20,6 +20,8 @@ import type {
   RejectedThenable,
 } from 'shared/ReactTypes';
 
+import noop from 'shared/noop';
+
 export opaque type ThenableState = Array<Thenable<any>>;
 
 // An error that is thrown (e.g. by `use`) to trigger Suspense. If we
@@ -39,8 +41,6 @@ export function createThenableState(): ThenableState {
   // suspends again, we'll reuse the same state.
   return [];
 }
-
-function noop(): void {}
 
 export function trackUsedThenable<T>(
   thenableState: ThenableState,

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -105,6 +105,8 @@ import {resolveOwner, setCurrentOwner} from './flight/ReactFlightCurrentOwner';
 import {getOwnerStackByComponentInfoInDev} from 'shared/ReactComponentInfoStack';
 import {resetOwnerStackLimit} from 'shared/ReactOwnerStackReset';
 
+import noop from 'shared/noop';
+
 import {
   callComponentInDEV,
   callLazyInitInDEV,
@@ -443,9 +445,7 @@ function defaultErrorHandler(error: mixed) {
   // Don't transform to our wrapper
 }
 
-function defaultPostponeHandler(reason: string) {
-  // Noop
-}
+const defaultPostponeHandler: (reason: string) => void = noop;
 
 function RequestInstance(
   this: $FlowFixMe,
@@ -557,8 +557,6 @@ function RequestInstance(
   );
   pingedTasks.push(rootTask);
 }
-
-function noop() {}
 
 export function createRequest(
   model: ReactClientValue,

--- a/packages/react-server/src/ReactFlightThenable.js
+++ b/packages/react-server/src/ReactFlightThenable.js
@@ -20,6 +20,8 @@ import type {
   RejectedThenable,
 } from 'shared/ReactTypes';
 
+import noop from 'shared/noop';
+
 export opaque type ThenableState = Array<Thenable<any>>;
 
 // An error that is thrown (e.g. by `use`) to trigger Suspense. If we
@@ -39,8 +41,6 @@ export function createThenableState(): ThenableState {
   // suspends again, we'll reuse the same state.
   return [];
 }
-
-function noop(): void {}
 
 export function trackUsedThenable<T>(
   thenableState: ThenableState,

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -60,9 +60,9 @@ import {
   disableLegacyMode,
 } from 'shared/ReactFeatureFlags';
 
-function defaultOnDefaultTransitionIndicator(): void | (() => void) {
-  // Noop
-}
+import noop from 'shared/noop';
+
+const defaultOnDefaultTransitionIndicator: () => void | (() => void) = noop;
 
 // $FlowFixMe[prop-missing]: This is only in the development export.
 const act = React.act;

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -16,6 +16,7 @@ import type {
 } from 'shared/ReactTypes';
 
 import isArray from 'shared/isArray';
+import noop from 'shared/noop';
 import {
   getIteratorFn,
   REACT_ELEMENT_TYPE,
@@ -81,8 +82,6 @@ function getElementKey(element: any, index: number): string {
   // Implicit key determined by the index in the set
   return index.toString(36);
 }
-
-function noop() {}
 
 function resolveThenable<T>(thenable: Thenable<T>): T {
   switch (thenable.status) {

--- a/packages/react/src/ReactStartTransition.js
+++ b/packages/react/src/ReactStartTransition.js
@@ -25,6 +25,8 @@ import {
 
 import reportGlobalError from 'shared/reportGlobalError';
 
+import noop from 'shared/noop';
+
 export type Transition = {
   types: null | TransitionTypes, // enableViewTransition
   gesture: null | GestureProvider, // enableGestureTransition
@@ -177,9 +179,7 @@ export function startGestureTransition(
   } finally {
     ReactSharedInternals.T = prevTransition;
   }
-  return function cancelGesture() {
-    // Noop
-  };
+  return noop;
 }
 
 function warnAboutTransitionSubscriptions(
@@ -200,5 +200,3 @@ function warnAboutTransitionSubscriptions(
     }
   }
 }
-
-function noop() {}

--- a/packages/shared/noop.js
+++ b/packages/shared/noop.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export default function noop() {}


### PR DESCRIPTION
We use `noop` functions in a lot of places as place holders. I don't think there's any real optimizations we get from having separate instances. This moves them to use a common instance in `shared/noop`.
