### PR TITLE
Reset currentEventTransitionLane after flushing sync work

### DIFF
--- a/packages/react-reconciler/src/ReactFiberRootScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberRootScheduler.js
@@ -257,7 +257,6 @@ function processRootScheduleInMicrotask() {
       // preserve the scroll position of the previous page.
       syncTransitionLanes = currentEventTransitionLane;
     }
-    currentEventTransitionLane = NoLane;
   }
 
   const currentTime = now();
@@ -315,6 +314,9 @@ function processRootScheduleInMicrotask() {
   if (!hasPendingCommitEffects()) {
     flushSyncWorkAcrossRoots_impl(syncTransitionLanes, false);
   }
+
+  // Reset Event Transition Lane so that we allocate a new one next time.
+  currentEventTransitionLane = NoLane;
 }
 
 function scheduleTaskForRootDuringMicrotask(


### PR DESCRIPTION
This keeps track of the transition lane allocated for this event. I want to be able to use the current one within sync work flushing to know which lane needs its loading indicator cleared.

It's also a bit weird that transition work scheduled inside sync updates in the same event aren't entangled with other transitions in that event when `flushSync` is.

Therefore this moves it to reset after flushing.

It should have no impact. Just splitting it out into a separate PR for an abundance of caution.

The only thing this might affect would be if the React internals throws and it doesn't reset after. But really it doesn't really have to reset and they're all entangled anyway.