### PR TITLE
Performance: remove memory allocations in `useReducer`

### DIFF
--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -379,7 +379,7 @@ export function useReducer<S, I, A>(
         // $FlowFixMe[incompatible-use] found when upgrading Flow
         renderPhaseUpdates.delete(queue);
         // $FlowFixMe[incompatible-use] found when upgrading Flow
-        let newState = workInProgressHook.memoizedState;
+        let newState = workInProgressHook.memoizedState[0];
         let update: Update<any> = firstRenderPhaseUpdate;
         do {
           // Process this render phase update. We don't have to check the
@@ -398,13 +398,14 @@ export function useReducer<S, I, A>(
         } while (update !== null);
 
         // $FlowFixMe[incompatible-use] found when upgrading Flow
-        workInProgressHook.memoizedState = newState;
-
-        return [newState, dispatch];
+        workInProgressHook.memoizedState = [newState, dispatch];
+        if (__DEV__) {
+          Object.freeze(workInProgressHook.memoizedState);
+        }
       }
     }
     // $FlowFixMe[incompatible-use] found when upgrading Flow
-    return [workInProgressHook.memoizedState, dispatch];
+    return workInProgressHook.memoizedState;
   } else {
     if (__DEV__) {
       isInHookUserCodeInDev = true;
@@ -424,8 +425,6 @@ export function useReducer<S, I, A>(
       isInHookUserCodeInDev = false;
     }
     // $FlowFixMe[incompatible-use] found when upgrading Flow
-    workInProgressHook.memoizedState = initialState;
-    // $FlowFixMe[incompatible-use] found when upgrading Flow
     const queue: UpdateQueue<A> = (workInProgressHook.queue = {
       last: null,
       dispatch: null,
@@ -436,7 +435,12 @@ export function useReducer<S, I, A>(
       queue,
     ): any));
     // $FlowFixMe[incompatible-use] found when upgrading Flow
-    return [workInProgressHook.memoizedState, dispatch];
+    workInProgressHook.memoizedState = [initialState, dispatch];
+    if (__DEV__) {
+      Object.freeze(workInProgressHook.memoizedState);
+    }
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
+    return workInProgressHook.memoizedState;
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Take 2 for #27383. I'm once again investigating a high-performance situation, and having a state hook that doesn't needlessly allocate memory on every render would be invaluable.

This time, I've added an `Object.freeze()` in dev mode to ensure nothing unholy is happening to the `memoizedState`.

## How did you test this change?

`yarn test` and local build of React.