### PR TITLE
[Fiber] Trigger default indicator for isomorphic async actions with no root associated

### DIFF
--- a/fixtures/view-transition/src/components/Page.js
+++ b/fixtures/view-transition/src/components/Page.js
@@ -113,8 +113,8 @@ export default function Page({url, navigate}) {
     <button
       onClick={() =>
         startTransition(async () => {
-          setShowModal(true);
           await sleep(2000);
+          setShowModal(true);
         })
       }>
       Show Modal

--- a/packages/react-reconciler/src/ReactFiberAsyncAction.js
+++ b/packages/react-reconciler/src/ReactFiberAsyncAction.js
@@ -66,6 +66,7 @@ let pendingIsomorphicIndicator: null | (() => void) = null;
 // The number of roots that have pending Transitions that depend on the
 // started isomorphic indicator.
 let pendingEntangledRoots: number = 0;
+let needsIsomorphicIndicator: boolean = false;
 
 export function entangleAsyncAction<S>(
   transition: Transition,
@@ -88,6 +89,7 @@ export function entangleAsyncAction<S>(
     };
     currentEntangledActionThenable = entangledThenable;
     if (enableDefaultTransitionIndicator) {
+      needsIsomorphicIndicator = true;
       // We'll check if we need a default indicator in a microtask. Ensure
       // we have this scheduled even if no root is scheduled.
       ensureScheduleIsScheduled();
@@ -127,6 +129,7 @@ function pingEngtangledActionScope() {
       currentEntangledListeners = null;
       currentEntangledLane = NoLane;
       currentEntangledActionThenable = null;
+      needsIsomorphicIndicator = false;
       for (let i = 0; i < listeners.length; i++) {
         const listener = listeners[i];
         listener();
@@ -212,7 +215,7 @@ export function startIsomorphicDefaultIndicatorIfNeeded() {
   if (!enableDefaultTransitionIndicator) {
     return;
   }
-  if (currentEntangledLane === NoLane) {
+  if (!needsIsomorphicIndicator) {
     return;
   }
   if (
@@ -253,4 +256,8 @@ export function hasOngoingIsomorphicIndicator(): boolean {
 export function retainIsomorphicIndicator(): () => void {
   pendingEntangledRoots++;
   return releaseIsomorphicIndicator;
+}
+
+export function markIsomorphicIndicatorHandled(): void {
+  needsIsomorphicIndicator = false;
 }

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -125,6 +125,7 @@ export {
   defaultOnRecoverableError,
 } from './ReactFiberErrorLogger';
 import {getLabelForLane, TotalLanes} from 'react-reconciler/src/ReactFiberLane';
+import {registerDefaultIndicator} from './ReactFiberAsyncAction';
 
 type OpaqueRoot = FiberRoot;
 
@@ -259,7 +260,7 @@ export function createContainer(
 ): OpaqueRoot {
   const hydrate = false;
   const initialChildren = null;
-  return createFiberRoot(
+  const root = createFiberRoot(
     containerInfo,
     tag,
     hydrate,
@@ -274,6 +275,8 @@ export function createContainer(
     onDefaultTransitionIndicator,
     transitionCallbacks,
   );
+  registerDefaultIndicator(onDefaultTransitionIndicator);
+  return root;
 }
 
 export function createHydrationContainer(
@@ -322,6 +325,8 @@ export function createHydrationContainer(
     onDefaultTransitionIndicator,
     transitionCallbacks,
   );
+
+  registerDefaultIndicator(onDefaultTransitionIndicator);
 
   // TODO: Move this to FiberRoot constructor
   root.context = getContextForSubtree(null);

--- a/packages/react-reconciler/src/ReactFiberRootScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberRootScheduler.js
@@ -89,6 +89,7 @@ import {
   startIsomorphicDefaultIndicatorIfNeeded,
   hasOngoingIsomorphicIndicator,
   retainIsomorphicIndicator,
+  markIsomorphicIndicatorHandled,
 } from './ReactFiberAsyncAction';
 
 // A linked list of all the roots with pending work. In an idiomatic app,
@@ -730,5 +731,6 @@ export function markIndicatorHandled(root: FiberRoot): void {
     // Clear it from the indicator lanes. We don't need to show a separate
     // loading state for this lane.
     root.indicatorLanes &= ~currentEventTransitionLane;
+    markIsomorphicIndicatorHandled();
   }
 }


### PR DESCRIPTION
Stacked on #33160, #33162, #33186 and #33188.

We have a special case that's awkward for default indicators. When you start a new async Transition from `React.startTransition` then there's not yet any associated root with the Transition because you haven't necessarily `setState` on anything yet until the promise resolves. That's what `entangleAsyncAction` handles by creating a lane that everything entangles with until all async actions are done.

If there are no sync updates before the end of the event, we should trigger a default indicator until either the async action completes without update or if it gets entangled with some roots we should keep it going until those roots are done.
