### PR TITLE
[eslint-plugin-react-hooks] Add `ignoredHooks` to `react-hooks/exhaustive-deps` options

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1468,6 +1468,16 @@ const tests = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            console.log(props.foo?.toString());
+          }, []);
+        }
+      `,
+      options: [{ignoredHooks: 'useEffect'}],
+    }
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
@@ -58,6 +58,9 @@ const rule = {
           additionalHooks: {
             type: 'string',
           },
+          ignoredHooks: {
+            type: 'string'
+          },
           enableDangerousAutofixThisMayCauseInfiniteLoops: {
             type: 'boolean',
           },
@@ -74,6 +77,14 @@ const rule = {
         ? new RegExp(context.options[0].additionalHooks)
         : undefined;
 
+    // Parse the `ignoredHooks` regex.
+    const ignoredHooks =
+      context.options &&
+      context.options[0] &&
+      context.options[0].ignoredHooks
+        ? new RegExp(context.options[0].ignoredHooks)
+        : undefined;
+
     const enableDangerousAutofixThisMayCauseInfiniteLoops: boolean =
       (context.options &&
         context.options[0] &&
@@ -82,6 +93,7 @@ const rule = {
 
     const options = {
       additionalHooks,
+      ignoredHooks,
       enableDangerousAutofixThisMayCauseInfiniteLoops,
     };
 
@@ -1922,6 +1934,7 @@ function getReactiveHookCallbackIndex(
   calleeNode: Expression | Super,
   options?: {
     additionalHooks: RegExp | undefined;
+    ignoredHooks: RegExp | undefined;
     enableDangerousAutofixThisMayCauseInfiniteLoops?: boolean;
   },
 ): 0 | -1 | 1 {
@@ -1929,6 +1942,10 @@ function getReactiveHookCallbackIndex(
   if (node.type !== 'Identifier') {
     return -1;
   }
+
+  // Don't bother checking the hook if its ignored
+  if (options && options.ignoredHooks && options.ignoredHooks.test(node.name)) return -1
+
   switch (node.name) {
     case 'useEffect':
     case 'useLayoutEffect':


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Add an `ignoredHooks` option to `exhaustive-deps`. This allows the disabling of the rule on specific hooks such as `useEffect` or anything that matches the pattern. It works in the same way that `additionalHooks` does and overrides `additionalHooks`.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

I created this option to disable the rule for `useEffect`. A lot of the times, useEffect is using states/variables that I don't want it to retrigger on; it's only supposed to listen for specific changes. These warnings can clutter the lint output and prevent real issues from being spotted.

## How did you test this change?

I added a test that ignores useEffect and checks that there are no issues reported

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
