### PR TITLE
[compiler] Support experimental_use hook prefixes

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -1057,9 +1057,12 @@ export class Environment {
 
 const REANIMATED_MODULE_NAME = 'react-native-reanimated';
 
-// From https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js#LL18C1-L23C2
+/*
+ * From https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js#LL18C1-L23C2
+ * Augmented to support the `experimental_use` prefix we use for experimental features.
+ */
 export function isHookName(name: string): boolean {
-  return /^use[A-Z0-9]/.test(name);
+  return /^(experimental_)?use[A-Z0-9]/.test(name);
 }
 
 export function parseEnvironmentConfig(

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/experimental-hook-no-memoization.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/experimental-hook-no-memoization.expect.md
@@ -1,0 +1,66 @@
+
+## Input
+
+```javascript
+// @flow
+
+import {experimental_useEffectEvent, useEffect} from 'react';
+
+component Component(prop: number) {
+  const x = experimental_useEffectEvent(() => {
+    console.log(prop);
+  });
+  useEffect(() => x());
+  return prop;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{prop: 1}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+
+import { experimental_useEffectEvent, useEffect } from "react";
+
+function Component(t0) {
+  const $ = _c(4);
+  const { prop } = t0;
+  let t1;
+  if ($[0] !== prop) {
+    t1 = () => {
+      console.log(prop);
+    };
+    $[0] = prop;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const x = experimental_useEffectEvent(t1);
+  let t2;
+  if ($[2] !== x) {
+    t2 = () => x();
+    $[2] = x;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  useEffect(t2);
+  return prop;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ prop: 1 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) 1
+logs: [1]

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/experimental-hook-no-memoization.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/experimental-hook-no-memoization.js
@@ -1,0 +1,16 @@
+// @flow
+
+import {experimental_useEffectEvent, useEffect} from 'react';
+
+component Component(prop: number) {
+  const x = experimental_useEffectEvent(() => {
+    console.log(prop);
+  });
+  useEffect(() => x());
+  return prop;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{prop: 1}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/experimental-hook-ref-mutate.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/experimental-hook-ref-mutate.expect.md
@@ -1,0 +1,66 @@
+
+## Input
+
+```javascript
+// @flow
+
+import {experimental_useEffectEvent, useRef} from 'react';
+
+component Component(prop: number) {
+  const ref1 = useRef(null);
+  const ref2 = useRef(1);
+  experimental_useEffectEvent(ref1, () => {
+    const precomputed = prop + ref2.current;
+    return {
+      foo: () => prop + ref2.current + precomputed,
+    };
+  }, [prop]);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{prop: 1}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+
+import { experimental_useEffectEvent, useRef } from "react";
+
+function Component(t0) {
+  const $ = _c(3);
+  const { prop } = t0;
+  const ref1 = useRef(null);
+  const ref2 = useRef(1);
+  let t1;
+  let t2;
+  if ($[0] !== prop) {
+    t1 = () => {
+      const precomputed = prop + ref2.current;
+      return { foo: () => prop + ref2.current + precomputed };
+    };
+
+    t2 = [prop];
+    $[0] = prop;
+    $[1] = t1;
+    $[2] = t2;
+  } else {
+    t1 = $[1];
+    t2 = $[2];
+  }
+  experimental_useEffectEvent(ref1, t1, t2);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ prop: 1 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/experimental-hook-ref-mutate.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/experimental-hook-ref-mutate.js
@@ -1,0 +1,19 @@
+// @flow
+
+import {experimental_useEffectEvent, useRef} from 'react';
+
+component Component(prop: number) {
+  const ref1 = useRef(null);
+  const ref2 = useRef(1);
+  experimental_useEffectEvent(ref1, () => {
+    const precomputed = prop + ref2.current;
+    return {
+      foo: () => prop + ref2.current + precomputed,
+    };
+  }, [prop]);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{prop: 1}],
+};


### PR DESCRIPTION

Summary:

We often use `experimental_use` as a prefix for experimental hooks. We should treat these values as hooks
by the compiler so that we don't [accidentally compile those calls](https://0xeac7-forget.vercel.app/#N4Igzg9grgTgxgUxALhASwLYAcIwC4AEwBCAHlgjJggHZ4CGANgPpRgICiAZlwnHhwButPABoCbBACUEXAgF8CXGBAwEA5DAT1+6gNwAdGkbI58BACaz6URoS5Qa-NBBoEAsgE8AgliwAKYCwVLHkASiIjAgI4VzBCLTkAXgl2GS5-MMM3AgB6XIIAVSdVDBElXBIYFRgovILTSmo6JlZ2bl5+IRF-TIIkgD4iAkSAOjhYLTp+ghpbRj0FMLrYmniCUhnGqjKWlkkOvgFhOl6IweHVyEYEUcYIAHN-YIgsCPDs6IOeI7P+odImSydS0eFgbgAPBY0IIBgAJBCMe4EADquEYFghuWhsOy8iMIHkQA) or report
ref.current access errors in them.

--
