### PR TITLE
Fix region Type confusion through parameter tampering

### DIFF
--- a/fixtures/flight-esm/server/region.js
+++ b/fixtures/flight-esm/server/region.js
@@ -125,6 +125,10 @@ if (process.env.NODE_ENV === 'development') {
     try {
       res.set('Content-type', 'application/json');
       let requestedFilePath = req.query.name;
+      if (typeof requestedFilePath !== 'string') {
+        res.status(400).send('Invalid request: "name" query parameter must be a string.');
+        return;
+      }
 
       let isCompiledOutput = false;
       if (requestedFilePath.startsWith('file://')) {


### PR DESCRIPTION
https://github.com/facebook/react/blob/73f06e04301ab20fe4e07f56de97e3c587e4b2e1/fixtures/flight-esm/server/region.js#L180-L180

To fix the issue, we need to ensure that `req.query.name` is explicitly validated to be a string before it is used. If it is not a string, the code should handle the case appropriately, such as returning an error response. This can be achieved by adding a type check for `req.query.name` and rejecting the request if it is not a string.

The changes will be made in the `/source-maps` route handler:
1. Add a type check for `req.query.name` to ensure it is a string.
2. If `req.query.name` is not a string, return a `400 Bad Request` response with an appropriate error message.

---


#### References
[querystring](https://nodejs.org/api/querystring.html)
[CWE-843](https://cwe.mitre.org/data/definitions/843.html)