### PR TITLE
[Fizz] Unblock SuspenseList when prerendering

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
@@ -2281,17 +2281,19 @@ describe('ReactDOMFizzStaticBrowser', () => {
     }
 
     const controller = new AbortController();
-    let pendingResult;
-    await serverAct(async () => {
-      pendingResult = ReactDOMFizzStatic.prerender(<App />, {
+    const pendingResult = serverAct(() =>
+      ReactDOMFizzStatic.prerender(<App />, {
         signal: controller.signal,
         onError(x) {
           errors.push(x.message);
         },
-      });
+      }),
+    );
+
+    await serverAct(() => {
+      controller.abort();
     });
 
-    controller.abort();
     const prerendered = await pendingResult;
     const postponedState = JSON.stringify(prerendered.postponed);
 

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -4938,6 +4938,13 @@ function finishedTask(
           // preparation work during the work phase rather than the when flushing.
           preparePreamble(request);
         }
+      } else if (boundary.status === POSTPONED) {
+        const boundaryRow = boundary.row;
+        if (boundaryRow !== null) {
+          if (--boundaryRow.pendingTasks === 0) {
+            finishSuspenseListRow(request, boundaryRow);
+          }
+        }
       }
     } else {
       if (segment !== null && segment.parentFlushed) {


### PR DESCRIPTION
There's an interesting case when a SuspenseList is partially prerendered but some of the completed boundaries are blocked by rows to be resumed.

This handles it but just unblocking the future rows to avoid stalling.

However, the correct semantics will need special handling in the postponed state.