### PR TITLE
Unify serverAct helpers

### DIFF
--- a/packages/internal-test-utils/internalAct.js
+++ b/packages/internal-test-utils/internalAct.js
@@ -138,6 +138,7 @@ export async function act<T>(scope: () => Thenable<T>): Thenable<T> {
           // those will also fire now, too, which is not ideal. (The public
           // version of `act` doesn't do this.) For this reason, we should try
           // to avoid using timers in our internal tests.
+          j.runAllTicks();
           j.runOnlyPendingTimers();
           // If a committing a fallback triggers another update, it might not
           // get scheduled until a microtask. So wait one more time.
@@ -216,6 +217,7 @@ async function waitForTasksAndTimers(error: Error) {
       // those will also fire now, too, which is not ideal. (The public
       // version of `act` doesn't do this.) For this reason, we should try
       // to avoid using timers in our internal tests.
+      j.runAllTicks();
       j.runOnlyPendingTimers();
       // If a committing a fallback triggers another update, it might not
       // get scheduled until a microtask. So wait one more time.

--- a/packages/internal-test-utils/internalAct.js
+++ b/packages/internal-test-utils/internalAct.js
@@ -194,6 +194,38 @@ export async function act<T>(scope: () => Thenable<T>): Thenable<T> {
   }
 }
 
+async function waitForTasksAndTimers(error: Error) {
+  do {
+    // Wait until end of current task/microtask.
+    await waitForMicrotasks();
+
+    // $FlowFixMe[cannot-resolve-name]: Flow doesn't know about global Jest object
+    if (jest.isEnvironmentTornDown()) {
+      error.message =
+        'The Jest environment was torn down before `act` completed. This ' +
+        'probably means you forgot to `await` an `act` call.';
+      throw error;
+    }
+
+    // $FlowFixMe[cannot-resolve-name]: Flow doesn't know about global Jest object
+    const j = jest;
+    if (j.getTimerCount() > 0) {
+      // There's a pending timer. Flush it now. We only do this in order to
+      // force Suspense fallbacks to display; the fact that it's a timer
+      // is an implementation detail. If there are other timers scheduled,
+      // those will also fire now, too, which is not ideal. (The public
+      // version of `act` doesn't do this.) For this reason, we should try
+      // to avoid using timers in our internal tests.
+      j.runOnlyPendingTimers();
+      // If a committing a fallback triggers another update, it might not
+      // get scheduled until a microtask. So wait one more time.
+      await waitForMicrotasks();
+    } else {
+      break;
+    }
+  } while (true);
+}
+
 export async function serverAct<T>(scope: () => Thenable<T>): Thenable<T> {
   // We require every `act` call to assert console logs
   // with one of the assertion helpers. Fails if not empty.
@@ -233,37 +265,17 @@ export async function serverAct<T>(scope: () => Thenable<T>): Thenable<T> {
   }
 
   try {
-    const result = await scope();
-
-    do {
-      // Wait until end of current task/microtask.
-      await waitForMicrotasks();
-
-      // $FlowFixMe[cannot-resolve-name]: Flow doesn't know about global Jest object
-      if (jest.isEnvironmentTornDown()) {
-        error.message =
-          'The Jest environment was torn down before `act` completed. This ' +
-          'probably means you forgot to `await` an `act` call.';
-        throw error;
-      }
-
-      // $FlowFixMe[cannot-resolve-name]: Flow doesn't know about global Jest object
-      const j = jest;
-      if (j.getTimerCount() > 0) {
-        // There's a pending timer. Flush it now. We only do this in order to
-        // force Suspense fallbacks to display; the fact that it's a timer
-        // is an implementation detail. If there are other timers scheduled,
-        // those will also fire now, too, which is not ideal. (The public
-        // version of `act` doesn't do this.) For this reason, we should try
-        // to avoid using timers in our internal tests.
-        j.runOnlyPendingTimers();
-        // If a committing a fallback triggers another update, it might not
-        // get scheduled until a microtask. So wait one more time.
-        await waitForMicrotasks();
-      } else {
-        break;
-      }
-    } while (true);
+    const promise = scope();
+    // $FlowFixMe[prop-missing]
+    if (promise && typeof promise.catch === 'function') {
+      // $FlowFixMe[incompatible-use]
+      promise.catch(() => {}); // Handle below
+    }
+    // See if we need to do some work to unblock the promise first.
+    await waitForTasksAndTimers(error);
+    const result = await promise;
+    // Then wait to flush the result.
+    await waitForTasksAndTimers(error);
 
     if (thrownErrors.length > 0) {
       // Rethrow any errors logged by the global error handling.

--- a/packages/react-dom/src/__tests__/ReactClassComponentPropResolutionFizz-test.js
+++ b/packages/react-dom/src/__tests__/ReactClassComponentPropResolutionFizz-test.js
@@ -28,7 +28,7 @@ describe('ReactClassComponentPropResolutionFizz', () => {
   beforeEach(() => {
     jest.resetModules();
     Scheduler = require('scheduler');
-    patchMessageChannel(Scheduler);
+    patchMessageChannel();
 
     React = require('react');
     ReactDOMServer = require('react-dom/server.browser');

--- a/packages/react-dom/src/__tests__/ReactClassComponentPropResolutionFizz-test.js
+++ b/packages/react-dom/src/__tests__/ReactClassComponentPropResolutionFizz-test.js
@@ -22,18 +22,18 @@ let ReactDOMServer;
 let Scheduler;
 let assertLog;
 let container;
-let act;
+let serverAct;
 
 describe('ReactClassComponentPropResolutionFizz', () => {
   beforeEach(() => {
     jest.resetModules();
     Scheduler = require('scheduler');
     patchMessageChannel(Scheduler);
-    act = require('internal-test-utils').act;
 
     React = require('react');
     ReactDOMServer = require('react-dom/server.browser');
     assertLog = require('internal-test-utils').assertLog;
+    serverAct = require('internal-test-utils').serverAct;
     container = document.createElement('div');
     document.body.appendChild(container);
   });
@@ -41,17 +41,6 @@ describe('ReactClassComponentPropResolutionFizz', () => {
   afterEach(() => {
     document.body.removeChild(container);
   });
-
-  async function serverAct(callback) {
-    let maybePromise;
-    await act(() => {
-      maybePromise = callback();
-      if (maybePromise && typeof maybePromise.catch === 'function') {
-        maybePromise.catch(() => {});
-      }
-    });
-    return maybePromise;
-  }
 
   async function readIntoContainer(stream) {
     const reader = stream.getReader();

--- a/packages/react-dom/src/__tests__/ReactDOMFizzDeferredValue-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzDeferredValue-test.js
@@ -21,6 +21,7 @@ global.ReadableStream =
 global.TextEncoder = require('util').TextEncoder;
 
 let act;
+let serverAct;
 let assertLog;
 let waitForPaint;
 let container;
@@ -37,6 +38,7 @@ describe('ReactDOMFizzForm', () => {
     Scheduler = require('scheduler');
     patchMessageChannel(Scheduler);
     act = require('internal-test-utils').act;
+    serverAct = require('internal-test-utils').serverAct;
     React = require('react');
     ReactDOMServer = require('react-dom/server.browser');
     ReactDOMClient = require('react-dom/client');
@@ -51,17 +53,6 @@ describe('ReactDOMFizzForm', () => {
   afterEach(() => {
     document.body.removeChild(container);
   });
-
-  async function serverAct(callback) {
-    let maybePromise;
-    await act(() => {
-      maybePromise = callback();
-      if (maybePromise && typeof maybePromise.catch === 'function') {
-        maybePromise.catch(() => {});
-      }
-    });
-    return maybePromise;
-  }
 
   async function readIntoContainer(stream) {
     const reader = stream.getReader();

--- a/packages/react-dom/src/__tests__/ReactDOMFizzDeferredValue-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzDeferredValue-test.js
@@ -36,7 +36,7 @@ describe('ReactDOMFizzForm', () => {
   beforeEach(() => {
     jest.resetModules();
     Scheduler = require('scheduler');
-    patchMessageChannel(Scheduler);
+    patchMessageChannel();
     act = require('internal-test-utils').act;
     serverAct = require('internal-test-utils').serverAct;
     React = require('react');

--- a/packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js
@@ -18,6 +18,7 @@ global.ReadableStream =
 global.TextEncoder = require('util').TextEncoder;
 
 let act;
+let serverAct;
 let container;
 let React;
 let ReactDOMServer;
@@ -39,6 +40,7 @@ describe('ReactDOMFizzForm', () => {
     useFormStatus = require('react-dom').useFormStatus;
     useOptimistic = require('react').useOptimistic;
     act = require('internal-test-utils').act;
+    serverAct = require('internal-test-utils').serverAct;
     assertConsoleErrorDev =
       require('internal-test-utils').assertConsoleErrorDev;
     container = document.createElement('div');
@@ -54,14 +56,6 @@ describe('ReactDOMFizzForm', () => {
   afterEach(() => {
     document.body.removeChild(container);
   });
-
-  async function serverAct(callback) {
-    let maybePromise;
-    await act(() => {
-      maybePromise = callback();
-    });
-    return maybePromise;
-  }
 
   function submit(submitter) {
     const form = submitter.form || submitter;

--- a/packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js
@@ -26,14 +26,12 @@ let ReactDOMClient;
 let useFormStatus;
 let useOptimistic;
 let useActionState;
-let Scheduler;
 let assertConsoleErrorDev;
 
 describe('ReactDOMFizzForm', () => {
   beforeEach(() => {
     jest.resetModules();
-    Scheduler = require('scheduler');
-    patchMessageChannel(Scheduler);
+    patchMessageChannel();
     React = require('react');
     ReactDOMServer = require('react-dom/server.browser');
     ReactDOMClient = require('react-dom/client');

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -20,7 +20,7 @@ let React;
 let ReactDOMFizzServer;
 let Suspense;
 let Scheduler;
-let act;
+let serverAct;
 
 describe('ReactDOMFizzServerBrowser', () => {
   beforeEach(() => {
@@ -28,23 +28,12 @@ describe('ReactDOMFizzServerBrowser', () => {
 
     Scheduler = require('scheduler');
     patchMessageChannel(Scheduler);
-    act = require('internal-test-utils').act;
+    serverAct = require('internal-test-utils').serverAct;
 
     React = require('react');
     ReactDOMFizzServer = require('react-dom/server.browser');
     Suspense = React.Suspense;
   });
-
-  async function serverAct(callback) {
-    let maybePromise;
-    await act(() => {
-      maybePromise = callback();
-      if (maybePromise && typeof maybePromise.catch === 'function') {
-        maybePromise.catch(() => {});
-      }
-    });
-    return maybePromise;
-  }
 
   const theError = new Error('This is an error');
   function Throw() {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -19,15 +19,13 @@ global.TextEncoder = require('util').TextEncoder;
 let React;
 let ReactDOMFizzServer;
 let Suspense;
-let Scheduler;
 let serverAct;
 
 describe('ReactDOMFizzServerBrowser', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    Scheduler = require('scheduler');
-    patchMessageChannel(Scheduler);
+    patchMessageChannel();
     serverAct = require('internal-test-utils').serverAct;
 
     React = require('react');

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
@@ -31,7 +31,7 @@ let ReactDOMFizzStatic;
 let Suspense;
 let container;
 let Scheduler;
-let act;
+let serverAct;
 
 describe('ReactDOMFizzStaticBrowser', () => {
   beforeEach(() => {
@@ -43,7 +43,7 @@ describe('ReactDOMFizzStaticBrowser', () => {
 
     Scheduler = require('scheduler');
     patchMessageChannel(Scheduler);
-    act = require('internal-test-utils').act;
+    serverAct = require('internal-test-utils').serverAct;
 
     React = require('react');
     ReactDOM = require('react-dom');
@@ -60,17 +60,6 @@ describe('ReactDOMFizzStaticBrowser', () => {
     }
     document.body.removeChild(container);
   });
-
-  async function serverAct(callback) {
-    let maybePromise;
-    await act(() => {
-      maybePromise = callback();
-      if (maybePromise && typeof maybePromise.catch === 'function') {
-        maybePromise.catch(() => {});
-      }
-    });
-    return maybePromise;
-  }
 
   const theError = new Error('This is an error');
   function Throw() {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
@@ -30,7 +30,6 @@ let ReactDOMFizzServer;
 let ReactDOMFizzStatic;
 let Suspense;
 let container;
-let Scheduler;
 let serverAct;
 
 describe('ReactDOMFizzStaticBrowser', () => {
@@ -41,8 +40,7 @@ describe('ReactDOMFizzStaticBrowser', () => {
     // We need the mocked version of setTimeout inside the document.
     window.setTimeout = setTimeout;
 
-    Scheduler = require('scheduler');
-    patchMessageChannel(Scheduler);
+    patchMessageChannel();
     serverAct = require('internal-test-utils').serverAct;
 
     React = require('react');

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticFloat-test.js
@@ -27,15 +27,13 @@ let ReactDOMFizzServer;
 let ReactDOMFizzStatic;
 let Suspense;
 let container;
-let Scheduler;
 let act;
 let serverAct;
 
 describe('ReactDOMFizzStaticFloat', () => {
   beforeEach(() => {
     jest.resetModules();
-    Scheduler = require('scheduler');
-    patchMessageChannel(Scheduler);
+    patchMessageChannel();
     act = require('internal-test-utils').act;
     serverAct = require('internal-test-utils').serverAct;
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticFloat-test.js
@@ -29,6 +29,7 @@ let Suspense;
 let container;
 let Scheduler;
 let act;
+let serverAct;
 
 describe('ReactDOMFizzStaticFloat', () => {
   beforeEach(() => {
@@ -36,6 +37,7 @@ describe('ReactDOMFizzStaticFloat', () => {
     Scheduler = require('scheduler');
     patchMessageChannel(Scheduler);
     act = require('internal-test-utils').act;
+    serverAct = require('internal-test-utils').serverAct;
 
     React = require('react');
     ReactDOM = require('react-dom');
@@ -51,17 +53,6 @@ describe('ReactDOMFizzStaticFloat', () => {
   afterEach(() => {
     document.body.removeChild(container);
   });
-
-  async function serverAct(callback) {
-    let maybePromise;
-    await act(() => {
-      maybePromise = callback();
-      if (maybePromise && typeof maybePromise.catch === 'function') {
-        maybePromise.catch(() => {});
-      }
-    });
-    return maybePromise;
-  }
 
   async function readIntoContainer(stream) {
     const reader = stream.getReader();

--- a/packages/react-dom/src/test-utils/FizzTestUtils.js
+++ b/packages/react-dom/src/test-utils/FizzTestUtils.js
@@ -167,7 +167,10 @@ function getVisibleChildren(element: Element): React$Node {
           }
           props[attributes[i].name] = attributes[i].value;
         }
-        props.children = getVisibleChildren(node);
+        const nestedChildren = getVisibleChildren(node);
+        if (nestedChildren !== undefined) {
+          props.children = nestedChildren;
+        }
         children.push(
           require('react').createElement(node.tagName.toLowerCase(), props),
         );

--- a/packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackDOM-test.js
+++ b/packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackDOM-test.js
@@ -18,6 +18,7 @@ global.TextEncoder = require('util').TextEncoder;
 global.TextDecoder = require('util').TextDecoder;
 
 let act;
+let serverAct;
 let use;
 let clientExports;
 let clientExportsESM;
@@ -29,7 +30,6 @@ let ReactServerDOMServer;
 let ReactServerDOMClient;
 let Suspense;
 let ReactServerScheduler;
-let reactServerAct;
 let ErrorBoundary;
 
 describe('ReactFlightTurbopackDOM', () => {
@@ -41,7 +41,7 @@ describe('ReactFlightTurbopackDOM', () => {
 
     ReactServerScheduler = require('scheduler');
     patchSetImmediate(ReactServerScheduler);
-    reactServerAct = require('internal-test-utils').act;
+    serverAct = require('internal-test-utils').serverAct;
 
     // Simulate the condition resolution
     jest.mock('react-server-dom-turbopack/server', () =>
@@ -83,17 +83,6 @@ describe('ReactFlightTurbopackDOM', () => {
       }
     };
   });
-
-  async function serverAct(callback) {
-    let maybePromise;
-    await reactServerAct(() => {
-      maybePromise = callback();
-      if (maybePromise && typeof maybePromise.catch === 'function') {
-        maybePromise.catch(() => {});
-      }
-    });
-    return maybePromise;
-  }
 
   function getTestStream() {
     const writable = new Stream.PassThrough();

--- a/packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackDOM-test.js
+++ b/packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackDOM-test.js
@@ -29,7 +29,6 @@ let ReactDOMClient;
 let ReactServerDOMServer;
 let ReactServerDOMClient;
 let Suspense;
-let ReactServerScheduler;
 let ErrorBoundary;
 
 describe('ReactFlightTurbopackDOM', () => {
@@ -39,8 +38,7 @@ describe('ReactFlightTurbopackDOM', () => {
     // condition
     jest.resetModules();
 
-    ReactServerScheduler = require('scheduler');
-    patchSetImmediate(ReactServerScheduler);
+    patchSetImmediate();
     serverAct = require('internal-test-utils').serverAct;
 
     // Simulate the condition resolution

--- a/packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackDOMBrowser-test.js
+++ b/packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackDOMBrowser-test.js
@@ -21,7 +21,7 @@ let React;
 let ReactServerDOMServer;
 let ReactServerDOMClient;
 let ReactServerScheduler;
-let reactServerAct;
+let serverAct;
 
 describe('ReactFlightTurbopackDOMBrowser', () => {
   beforeEach(() => {
@@ -29,7 +29,7 @@ describe('ReactFlightTurbopackDOMBrowser', () => {
 
     ReactServerScheduler = require('scheduler');
     patchMessageChannel(ReactServerScheduler);
-    reactServerAct = require('internal-test-utils').act;
+    serverAct = require('internal-test-utils').serverAct;
 
     // Simulate the condition resolution
     jest.mock('react', () => require('react/react.react-server'));
@@ -45,17 +45,6 @@ describe('ReactFlightTurbopackDOMBrowser', () => {
     React = require('react');
     ReactServerDOMClient = require('react-server-dom-turbopack/client');
   });
-
-  async function serverAct(callback) {
-    let maybePromise;
-    await reactServerAct(() => {
-      maybePromise = callback();
-      if (maybePromise && typeof maybePromise.catch === 'function') {
-        maybePromise.catch(() => {});
-      }
-    });
-    return maybePromise;
-  }
 
   it('should resolve HTML using W3C streams', async () => {
     function Text({children}) {

--- a/packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackDOMNode-test.js
+++ b/packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackDOMNode-test.js
@@ -21,15 +21,13 @@ let ReactServerDOMServer;
 let ReactServerDOMClient;
 let Stream;
 let use;
-let ReactServerScheduler;
 let serverAct;
 
 describe('ReactFlightTurbopackDOMNode', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    ReactServerScheduler = require('scheduler');
-    patchSetImmediate(ReactServerScheduler);
+    patchSetImmediate();
     serverAct = require('internal-test-utils').serverAct;
 
     // Simulate the condition resolution

--- a/packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackDOMNode-test.js
+++ b/packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackDOMNode-test.js
@@ -22,7 +22,7 @@ let ReactServerDOMClient;
 let Stream;
 let use;
 let ReactServerScheduler;
-let reactServerAct;
+let serverAct;
 
 describe('ReactFlightTurbopackDOMNode', () => {
   beforeEach(() => {
@@ -30,7 +30,7 @@ describe('ReactFlightTurbopackDOMNode', () => {
 
     ReactServerScheduler = require('scheduler');
     patchSetImmediate(ReactServerScheduler);
-    reactServerAct = require('internal-test-utils').act;
+    serverAct = require('internal-test-utils').serverAct;
 
     // Simulate the condition resolution
     jest.mock('react', () => require('react/react.react-server'));
@@ -58,17 +58,6 @@ describe('ReactFlightTurbopackDOMNode', () => {
     Stream = require('stream');
     use = React.use;
   });
-
-  async function serverAct(callback) {
-    let maybePromise;
-    await reactServerAct(() => {
-      maybePromise = callback();
-      if (maybePromise && typeof maybePromise.catch === 'function') {
-        maybePromise.catch(() => {});
-      }
-    });
-    return maybePromise;
-  }
 
   function readResult(stream) {
     return new Promise((resolve, reject) => {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -38,7 +38,6 @@ let ReactDOMStaticServer;
 let Suspense;
 let ErrorBoundary;
 let JSDOM;
-let ReactServerScheduler;
 let assertConsoleErrorDev;
 
 describe('ReactFlightDOM', () => {
@@ -50,8 +49,7 @@ describe('ReactFlightDOM', () => {
 
     JSDOM = require('jsdom').JSDOM;
 
-    ReactServerScheduler = require('scheduler');
-    patchSetImmediate(ReactServerScheduler);
+    patchSetImmediate();
     serverAct = require('internal-test-utils').serverAct;
 
     // Simulate the condition resolution

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -19,6 +19,7 @@ global.TextEncoder = require('util').TextEncoder;
 global.TextDecoder = require('util').TextDecoder;
 
 let act;
+let serverAct;
 let use;
 let clientExports;
 let clientExportsESM;
@@ -38,7 +39,6 @@ let Suspense;
 let ErrorBoundary;
 let JSDOM;
 let ReactServerScheduler;
-let reactServerAct;
 let assertConsoleErrorDev;
 
 describe('ReactFlightDOM', () => {
@@ -52,7 +52,7 @@ describe('ReactFlightDOM', () => {
 
     ReactServerScheduler = require('scheduler');
     patchSetImmediate(ReactServerScheduler);
-    reactServerAct = require('internal-test-utils').act;
+    serverAct = require('internal-test-utils').serverAct;
 
     // Simulate the condition resolution
     jest.mock('react', () => require('react/react.react-server'));
@@ -110,17 +110,6 @@ describe('ReactFlightDOM', () => {
       }
     };
   });
-
-  async function serverAct(callback) {
-    let maybePromise;
-    await reactServerAct(() => {
-      maybePromise = callback();
-      if (maybePromise && typeof maybePromise.catch === 'function') {
-        maybePromise.catch(() => {});
-      }
-    });
-    return maybePromise;
-  }
 
   async function readInto(
     container: Document | HTMLElement,

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -24,6 +24,7 @@ let serverExports;
 let webpackMap;
 let webpackServerMap;
 let act;
+let serverAct;
 let React;
 let ReactDOM;
 let ReactDOMClient;
@@ -37,7 +38,6 @@ let ReactServer;
 let ReactServerDOM;
 let Scheduler;
 let ReactServerScheduler;
-let reactServerAct;
 let assertConsoleErrorDev;
 
 describe('ReactFlightDOMBrowser', () => {
@@ -46,7 +46,7 @@ describe('ReactFlightDOMBrowser', () => {
 
     ReactServerScheduler = require('scheduler');
     patchMessageChannel(ReactServerScheduler);
-    reactServerAct = require('internal-test-utils').act;
+    serverAct = require('internal-test-utils').serverAct;
 
     // Simulate the condition resolution
 
@@ -85,17 +85,6 @@ describe('ReactFlightDOMBrowser', () => {
     Suspense = React.Suspense;
     use = React.use;
   });
-
-  async function serverAct(callback) {
-    let maybePromise;
-    await reactServerAct(() => {
-      maybePromise = callback();
-      if (maybePromise && typeof maybePromise.catch === 'function') {
-        maybePromise.catch(() => {});
-      }
-    });
-    return maybePromise;
-  }
 
   function makeDelayedText(Model) {
     let error, _resolve, _reject;

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -36,7 +36,6 @@ let Suspense;
 let use;
 let ReactServer;
 let ReactServerDOM;
-let Scheduler;
 let ReactServerScheduler;
 let assertConsoleErrorDev;
 
@@ -73,8 +72,7 @@ describe('ReactFlightDOMBrowser', () => {
     __unmockReact();
     jest.resetModules();
 
-    Scheduler = require('scheduler');
-    patchMessageChannel(Scheduler);
+    patchMessageChannel();
 
     ({act, assertConsoleErrorDev} = require('internal-test-utils'));
     React = require('react');

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -36,7 +36,7 @@ let ReactServerDOMServer;
 let ReactServerDOMStaticServer;
 let ReactServerDOMClient;
 let use;
-let reactServerAct;
+let serverAct;
 let assertConsoleErrorDev;
 
 function normalizeCodeLocInfo(str) {
@@ -66,7 +66,7 @@ describe('ReactFlightDOMEdge', () => {
 
     jest.resetModules();
 
-    reactServerAct = require('internal-test-utils').serverAct;
+    serverAct = require('internal-test-utils').serverAct;
     assertConsoleErrorDev =
       require('internal-test-utils').assertConsoleErrorDev;
 
@@ -105,17 +105,6 @@ describe('ReactFlightDOMEdge', () => {
     ReactServerDOMClient = require('react-server-dom-webpack/client');
     use = React.use;
   });
-
-  async function serverAct(callback) {
-    let maybePromise;
-    await reactServerAct(() => {
-      maybePromise = callback();
-      if (maybePromise && typeof maybePromise.catch === 'function') {
-        maybePromise.catch(() => {});
-      }
-    });
-    return maybePromise;
-  }
 
   function passThrough(stream) {
     // Simulate more realistic network by splitting up and rejoining some chunks.

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -26,7 +26,6 @@ let ReactServerDOMStaticServer;
 let ReactServerDOMClient;
 let Stream;
 let use;
-let ReactServerScheduler;
 let serverAct;
 
 // We test pass-through without encoding strings but it should work without it too.
@@ -38,8 +37,7 @@ describe('ReactFlightDOMNode', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    ReactServerScheduler = require('scheduler');
-    patchSetImmediate(ReactServerScheduler);
+    patchSetImmediate();
     serverAct = require('internal-test-utils').serverAct;
 
     // Simulate the condition resolution

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -27,7 +27,7 @@ let ReactServerDOMClient;
 let Stream;
 let use;
 let ReactServerScheduler;
-let reactServerAct;
+let serverAct;
 
 // We test pass-through without encoding strings but it should work without it too.
 const streamOptions = {
@@ -40,7 +40,7 @@ describe('ReactFlightDOMNode', () => {
 
     ReactServerScheduler = require('scheduler');
     patchSetImmediate(ReactServerScheduler);
-    reactServerAct = require('internal-test-utils').act;
+    serverAct = require('internal-test-utils').serverAct;
 
     // Simulate the condition resolution
     jest.mock('react', () => require('react/react.react-server'));
@@ -75,17 +75,6 @@ describe('ReactFlightDOMNode', () => {
     Stream = require('stream');
     use = React.use;
   });
-
-  async function serverAct(callback) {
-    let maybePromise;
-    await reactServerAct(() => {
-      maybePromise = callback();
-      if (maybePromise && typeof maybePromise.catch === 'function') {
-        maybePromise.catch(() => {});
-      }
-    });
-    return maybePromise;
-  }
 
   function readResult(stream) {
     return new Promise((resolve, reject) => {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js
@@ -23,7 +23,7 @@ let React;
 let ReactServerDOMServer;
 let ReactServerDOMClient;
 let ReactServerScheduler;
-let reactServerAct;
+let serverAct;
 
 describe('ReactFlightDOMReply', () => {
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe('ReactFlightDOMReply', () => {
 
     ReactServerScheduler = require('scheduler');
     patchMessageChannel(ReactServerScheduler);
-    reactServerAct = require('internal-test-utils').act;
+    serverAct = require('internal-test-utils').serverAct;
 
     // Simulate the condition resolution
     jest.mock('react', () => require('react/react.react-server'));
@@ -47,17 +47,6 @@ describe('ReactFlightDOMReply', () => {
     __unmockReact();
     ReactServerDOMClient = require('react-server-dom-webpack/client');
   });
-
-  async function serverAct(callback) {
-    let maybePromise;
-    await reactServerAct(() => {
-      maybePromise = callback();
-      if (maybePromise && typeof maybePromise.catch === 'function') {
-        maybePromise.catch(() => {});
-      }
-    });
-    return maybePromise;
-  }
 
   // This method should exist on File but is not implemented in JSDOM
   async function arrayBuffer(file) {

--- a/scripts/jest/patchMessageChannel.js
+++ b/scripts/jest/patchMessageChannel.js
@@ -1,6 +1,6 @@
 'use strict';
 
-export function patchMessageChannel(Scheduler) {
+export function patchMessageChannel() {
   global.MessageChannel = class {
     constructor() {
       const port1 = {
@@ -11,18 +11,9 @@ export function patchMessageChannel(Scheduler) {
 
       this.port2 = {
         postMessage(msg) {
-          if (Scheduler) {
-            Scheduler.unstable_scheduleCallback(
-              Scheduler.unstable_NormalPriority,
-              () => {
-                port1.onmessage(msg);
-              }
-            );
-          } else {
-            throw new Error(
-              'MessageChannel patch was used without providing a Scheduler implementation. This is useful for tests that require this class to exist but are not actually utilizing the MessageChannel class. However it appears some test is trying to use this class so you should pass a Scheduler implemenation to the patch method'
-            );
-          }
+          setTimeout(() => {
+            port1.onmessage(msg);
+          }, 0);
         },
       };
     }

--- a/scripts/jest/patchSetImmediate.js
+++ b/scripts/jest/patchSetImmediate.js
@@ -1,13 +1,7 @@
 'use strict';
 
-export function patchSetImmediate(Scheduler) {
-  if (!Scheduler) {
-    throw new Error(
-      'setImmediate patch was used without providing a Scheduler implementation. If you are patching setImmediate you must provide a Scheduler.'
-    );
-  }
-
+export function patchSetImmediate() {
   global.setImmediate = cb => {
-    Scheduler.unstable_scheduleCallback(Scheduler.unstable_NormalPriority, cb);
+    setTimeout(cb, 0);
   };
 }


### PR DESCRIPTION
This uses the richer `serverAct` helper that we already use in other tests.

This avoids using the `Scheduler`. We don't use that package on the server so it doesn't make sense to simulate going through it. Additionally, we really should be getting rid of it on the client too to favor `postTask` polyfills.

