### PR TITLE
[Fizz] Track boundaries in future rows as postponed

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
@@ -2262,6 +2262,7 @@ describe('ReactDOMFizzStaticBrowser', () => {
               <ComponentB />
             </Suspense>
             <Suspense fallback="Loading C">C</Suspense>
+            <Suspense fallback="Loading D">D</Suspense>
           </SuspenseList>
         </div>
       );
@@ -2282,6 +2283,7 @@ describe('ReactDOMFizzStaticBrowser', () => {
     });
 
     const prerendered = await pendingResult;
+
     const postponedState = JSON.stringify(prerendered.postponed);
 
     await readIntoContainer(prerendered.prelude);
@@ -2289,7 +2291,8 @@ describe('ReactDOMFizzStaticBrowser', () => {
       <div>
         {'Loading A'}
         {'Loading B'}
-        {'C' /* TODO: This should not be resolved. */}
+        {'Loading C'}
+        {'Loading D'}
       </div>,
     );
 
@@ -2309,6 +2312,7 @@ describe('ReactDOMFizzStaticBrowser', () => {
         {'A'}
         {'B'}
         {'C'}
+        {'D'}
       </div>,
     );
   });


### PR DESCRIPTION
Follow up to #33321.

We can mark boundaries that were blocked in the prerender as postponed but without anything to replayed inside them. That way they're not emitted in the prerender but is unblocked when replayed.

Technically this does some unnecessary replaying of the path to the otherwise already completed boundary but it simplifies our model by just marking the boundary as needing replaying.