### PR TITLE
Disable moveBefore experiment

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -194,7 +194,7 @@ export const disableLegacyContext = true;
 export const disableLegacyContextForFunctionComponents = true;
 
 // Enable the moveBefore() alternative to insertBefore(). This preserves states of moves.
-export const enableMoveBefore = __EXPERIMENTAL__;
+export const enableMoveBefore = false;
 
 // Disabled caching behavior of `react/cache` in client runtimes.
 export const disableClientCache = true;


### PR DESCRIPTION
There seems to be some bugs still to work out in Chrome. See #33187.

Additionally, since you can't really rely on this function existing across browsers, it's hard to depend on its behavior anyway. In fact, you now have a source of inconsistent behaviors across browsers to deal with.

Ideally it would also be more widely spread in fake DOM implementations like JSDOM so that we can use it unconditionally. #33177.

We still want to enable this since it's a great feature but maybe not until it's more widely available cross-browsers with fewer bugs.