### PR TITLE
Add browser warning when <title> contains more than 1 child

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -61,6 +61,7 @@ import possibleStandardNames from '../shared/possibleStandardNames';
 import {validateProperties as validateARIAProperties} from '../shared/ReactDOMInvalidARIAHook';
 import {validateProperties as validateInputProperties} from '../shared/ReactDOMNullInputValuePropHook';
 import {validateProperties as validateUnknownProperties} from '../shared/ReactDOMUnknownPropertyHook';
+import {validateProperties as validateTitleProperties} from '../shared/ReactDOMTitle';
 import sanitizeURL from '../shared/sanitizeURL';
 
 import noop from 'shared/noop';
@@ -99,6 +100,7 @@ function validatePropertiesInDevelopment(type: string, props: any) {
       registrationNameDependencies,
       possibleRegistrationNames,
     });
+    validateTitleProperties(type, props);
     if (
       props.contentEditable &&
       !props.suppressContentEditableWarning &&

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -3451,53 +3451,6 @@ function pushTitle(
 ): ReactNodeList {
   const noscriptTagInScope = formatContext.tagScope & NOSCRIPT_SCOPE;
   const isFallback = formatContext.tagScope & FALLBACK_SCOPE;
-  if (__DEV__) {
-    if (hasOwnProperty.call(props, 'children')) {
-      const children = props.children;
-
-      const child = Array.isArray(children)
-        ? children.length < 2
-          ? children[0]
-          : null
-        : children;
-
-      if (Array.isArray(children) && children.length > 1) {
-        console.error(
-          'React expects the `children` prop of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found an Array with length %s instead.' +
-            ' Browsers treat all child Nodes of <title> tags as Text content and React expects to be able to convert `children` of <title> tags to a single string value' +
-            ' which is why Arrays of length greater than 1 are not supported. When using JSX it can be common to combine text nodes and value nodes.' +
-            ' For example: <title>hello {nameOfUser}</title>. While not immediately apparent, `children` in this case is an Array with length 2. If your `children` prop' +
-            ' is using this form try rewriting it using a template string: <title>{`hello ${nameOfUser}`}</title>.',
-          children.length,
-        );
-      } else if (typeof child === 'function' || typeof child === 'symbol') {
-        const childType =
-          typeof child === 'function' ? 'a Function' : 'a Sybmol';
-        console.error(
-          'React expect children of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found %s instead.' +
-            ' Browsers treat all child Nodes of <title> tags as Text content and React expects to be able to convert children of <title>' +
-            ' tags to a single string value.',
-          childType,
-        );
-      } else if (child && child.toString === {}.toString) {
-        if (child.$$typeof != null) {
-          console.error(
-            'React expects the `children` prop of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found an object that appears to be' +
-              ' a React element which never implements a suitable `toString` method. Browsers treat all child Nodes of <title> tags as Text content and React expects to' +
-              ' be able to convert children of <title> tags to a single string value which is why rendering React elements is not supported. If the `children` of <title> is' +
-              ' a React Component try moving the <title> tag into that component. If the `children` of <title> is some HTML markup change it to be Text only to be valid HTML.',
-          );
-        } else {
-          console.error(
-            'React expects the `children` prop of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found an object that does not implement' +
-              ' a suitable `toString` method. Browsers treat all child Nodes of <title> tags as Text content and React expects to be able to convert children of <title> tags' +
-              ' to a single string value. Using the default `toString` method available on every object is almost certainly an error. Consider whether the `children` of this <title>' +
-              ' is an object in error and change it to a string or number value if so. Otherwise implement a `toString` method that React can use to produce a valid <title>.',
-          );
-        }
-      }
-    }
-  }
 
   if (
     formatContext.insertionMode !== SVG_MODE &&
@@ -4066,6 +4019,7 @@ export const doctypeChunk: PrecomputedChunk =
   stringToPrecomputedChunk('<!DOCTYPE html>');
 
 import {doctypeChunk as DOCTYPE} from 'react-server/src/ReactFizzConfig';
+import {validateProperties as validateTitleProperties} from '../shared/ReactDOMTitle';
 
 export function pushStartInstance(
   target: Array<Chunk | PrecomputedChunk>,
@@ -4082,6 +4036,7 @@ export function pushStartInstance(
     validateARIAProperties(type, props);
     validateInputProperties(type, props);
     validateUnknownProperties(type, props, null);
+    validateTitleProperties(type, props);
 
     if (
       !props.suppressContentEditableWarning &&

--- a/packages/react-dom-bindings/src/shared/ReactDOMTitle.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMTitle.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import hasOwnProperty from 'shared/hasOwnProperty';
+
+export function validateProperties(type: string, props: Object) {
+  if (__DEV__) {
+    if (type !== 'title') {
+      return;
+    }
+
+    if (hasOwnProperty.call(props, 'children')) {
+      const children = props.children;
+
+      const child = Array.isArray(children)
+        ? children.length < 2
+          ? children[0]
+          : null
+        : children;
+
+      if (Array.isArray(children) && children.length > 1) {
+        console.error(
+          'React expects the `children` prop of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found an Array with length %s instead.' +
+            ' Browsers treat all child Nodes of <title> tags as Text content and React expects to be able to convert `children` of <title> tags to a single string value' +
+            ' which is why Arrays of length greater than 1 are not supported. When using JSX it can be common to combine text nodes and value nodes.' +
+            ' For example: <title>hello {nameOfUser}</title>. While not immediately apparent, `children` in this case is an Array with length 2. If your `children` prop' +
+            ' is using this form try rewriting it using a template string: <title>{`hello ${nameOfUser}`}</title>.',
+          children.length,
+        );
+      } else if (typeof child === 'function' || typeof child === 'symbol') {
+        const childType =
+          typeof child === 'function' ? 'a Function' : 'a Sybmol';
+        console.error(
+          'React expect children of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found %s instead.' +
+            ' Browsers treat all child Nodes of <title> tags as Text content and React expects to be able to convert children of <title>' +
+            ' tags to a single string value.',
+          childType,
+        );
+      } else if (child && child.toString === {}.toString) {
+        if (child.$$typeof != null) {
+          console.error(
+            'React expects the `children` prop of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found an object that appears to be' +
+              ' a React element which never implements a suitable `toString` method. Browsers treat all child Nodes of <title> tags as Text content and React expects to' +
+              ' be able to convert children of <title> tags to a single string value which is why rendering React elements is not supported. If the `children` of <title> is' +
+              ' a React Component try moving the <title> tag into that component. If the `children` of <title> is some HTML markup change it to be Text only to be valid HTML.',
+          );
+        } else {
+          console.error(
+            'React expects the `children` prop of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found an object that does not implement' +
+              ' a suitable `toString` method. Browsers treat all child Nodes of <title> tags as Text content and React expects to be able to convert children of <title> tags' +
+              ' to a single string value. Using the default `toString` method available on every object is almost certainly an error. Consider whether the `children` of this <title>' +
+              ' is an object in error and change it to a string or number value if so. Otherwise implement a `toString` method that React can use to produce a valid <title>.',
+          );
+        }
+      }
+    }
+  }
+}

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -3743,6 +3743,34 @@ describe('ReactDOMComponent', () => {
     });
   });
 
+  describe('title children', () => {
+    it('should warn if you render a <title> with multiple children', async () => {
+      const container = document.createElement('div');
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => {
+        root.render(
+          <title>
+            {'first'}
+            {'second'}
+          </title>,
+        );
+      });
+      assertConsoleErrorDev([
+        'React expects the `children` prop of <title> tags to be a string, number, bigint, ' +
+          'or object with a novel `toString` method but found an Array with length 2 instead. ' +
+          'Browsers treat all child Nodes of <title> tags as Text content and React expects ' +
+          'to be able to convert `children` of <title> tags to a single string value which is why ' +
+          'Arrays of length greater than 1 are not supported. ' +
+          'When using JSX it can be common to combine text nodes and value nodes. ' +
+          'For example: <title>hello {nameOfUser}</title>. ' +
+          'While not immediately apparent, `children` in this case is an Array with length 2. ' +
+          'If your `children` prop is using this form try rewriting it using a template string: ' +
+          '<title>{`hello ${nameOfUser}`}</title>.\n' +
+          '    in title (at **)',
+      ]);
+    });
+  });
+
   it('receives events in specific order', async () => {
     const eventOrder = [];
     const track = tag => () => eventOrder.push(tag);

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -5863,6 +5863,7 @@ describe('ReactDOMFizzServer', () => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
+      // Server error
       assertConsoleErrorDev([
         'React expects the `children` prop of <title> tags to be a string, number, bigint, ' +
           'or object with a novel `toString` method but found an Array with length 2 instead. ' +
@@ -5889,6 +5890,22 @@ describe('ReactDOMFizzServer', () => {
       expect(errors).toEqual([]);
       // with float, the title doesn't render on the client or on the server
       expect(getVisibleChildren(document.head)).toEqual(<title />);
+      // Client error
+      assertConsoleErrorDev(
+        [
+          'React expects the `children` prop of <title> tags to be a string, number, bigint, ' +
+            'or object with a novel `toString` method but found an Array with length 2 instead. ' +
+            'Browsers treat all child Nodes of <title> tags as Text content and React expects ' +
+            'to be able to convert `children` of <title> tags to a single string value which is why ' +
+            'Arrays of length greater than 1 are not supported. ' +
+            'When using JSX it can be common to combine text nodes and value nodes. ' +
+            'For example: <title>hello {nameOfUser}</title>. ' +
+            'While not immediately apparent, `children` in this case is an Array with length 2. ' +
+            'If your `children` prop is using this form try rewriting it using a template string: ' +
+            '<title>{`hello ${nameOfUser}`}</title>',
+        ],
+        {withoutStack: true},
+      );
     });
 
     it('should warn in dev if you pass a React Component as a child to <title>', async () => {
@@ -5910,6 +5927,7 @@ describe('ReactDOMFizzServer', () => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
+      // Server error
       assertConsoleErrorDev([
         'React expects the `children` prop of <title> tags to be a string, number, bigint, ' +
           'or object with a novel `toString` method but found an object that appears to be a ' +
@@ -5938,6 +5956,20 @@ describe('ReactDOMFizzServer', () => {
       expect(getVisibleChildren(document.head)).toEqual(
         <title>{'[object Object]'}</title>,
       );
+      // Client error
+      assertConsoleErrorDev(
+        [
+          'React expects the `children` prop of <title> tags to be a string, number, bigint, ' +
+            'or object with a novel `toString` method but found an object that appears to be a ' +
+            'React element which never implements a suitable `toString` method. ' +
+            'Browsers treat all child Nodes of <title> tags as Text content and React expects ' +
+            'to be able to convert children of <title> tags to a single string value which is ' +
+            'why rendering React elements is not supported. If the `children` of <title> is a ' +
+            'React Component try moving the <title> tag into that component. ' +
+            'If the `children` of <title> is some HTML markup change it to be Text only to be valid HTML.',
+        ],
+        {withoutStack: true},
+      );
     });
 
     it('should warn in dev if you pass an object that does not implement toString as a child to <title>', async () => {
@@ -5953,6 +5985,7 @@ describe('ReactDOMFizzServer', () => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
+      // Server error
       assertConsoleErrorDev([
         'React expects the `children` prop of <title> tags to be a string, number, bigint, ' +
           'or object with a novel `toString` method but found an object that does not implement a ' +
@@ -5980,6 +6013,20 @@ describe('ReactDOMFizzServer', () => {
       // object titles are toStringed when float is on
       expect(getVisibleChildren(document.head)).toEqual(
         <title>{'[object Object]'}</title>,
+      );
+      // Client error
+      assertConsoleErrorDev(
+        [
+          'React expects the `children` prop of <title> tags to be a string, number, bigint, ' +
+            'or object with a novel `toString` method but found an object that does not implement a ' +
+            'suitable `toString` method. Browsers treat all child Nodes of <title> tags as Text ' +
+            'content and React expects to be able to convert children of <title> tags to a single string value. ' +
+            'Using the default `toString` method available on every object is almost certainly an error. ' +
+            'Consider whether the `children` of this <title> is an object in error and change it to a ' +
+            'string or number value if so. Otherwise implement a `toString` method that React can ' +
+            'use to produce a valid <title>.',
+        ],
+        {withoutStack: true},
       );
     });
   });


### PR DESCRIPTION
## Summary

There is no browser warning when `<title>` contains multiple children. See #33341

There was an existing server-only warning which I applied to the client too

## How did you test this change?

Added a unit test and added more assertions to existing tests