### PR TITLE
[react-dom] Enforce 100ms delay before default Transition indicator is triggered

### DIFF
--- a/fixtures/flight/src/App.js
+++ b/fixtures/flight/src/App.js
@@ -12,6 +12,7 @@ import Button from './Button.js';
 import Form from './Form.js';
 import {Dynamic} from './Dynamic.js';
 import {Client} from './Client.js';
+import {Navigate} from './Navigate.js';
 
 import {Note} from './cjs/Note.js';
 
@@ -89,6 +90,7 @@ export default async function App({prerender}) {
           <Note />
           <Foo>{dedupedChild}</Foo>
           <Bar>{Promise.resolve([dedupedChild])}</Bar>
+          <Navigate />
         </Container>
       </body>
     </html>

--- a/fixtures/flight/src/Navigate.js
+++ b/fixtures/flight/src/Navigate.js
@@ -1,0 +1,40 @@
+'use client';
+
+import * as React from 'react';
+import Container from './Container.js';
+
+export function Navigate() {
+  /** Repro for https://issues.chromium.org/u/1/issues/419746417 */
+  function triggerChromeCrash() {
+    React.startTransition(async () => {
+      console.log('Default transition triggered');
+
+      await new Promise(resolve => {
+        setTimeout(
+          () => {
+            history.pushState(
+              {},
+              '',
+              `?chrome-crash-419746417=${performance.now()}`
+            );
+          },
+          // This needs to happen before React's default transition indicator
+          // is displayed but after it's scheduled.
+          100 + -50
+        );
+
+        setTimeout(() => {
+          console.log('Default transition completed');
+          resolve();
+        }, 1000);
+      });
+    });
+  }
+
+  return (
+    <Container>
+      <h2>Navigation fixture</h2>
+      <button onClick={triggerChromeCrash}>Trigger Chrome Crash</button>
+    </Container>
+  );
+}

--- a/fixtures/flight/src/Navigate.js
+++ b/fixtures/flight/src/Navigate.js
@@ -5,7 +5,7 @@ import Container from './Container.js';
 
 export function Navigate() {
   /** Repro for https://issues.chromium.org/u/1/issues/419746417 */
-  function triggerChromeCrash() {
+  function provokeChromeCrash() {
     React.startTransition(async () => {
       console.log('Default transition triggered');
 
@@ -34,7 +34,7 @@ export function Navigate() {
   return (
     <Container>
       <h2>Navigation fixture</h2>
-      <button onClick={triggerChromeCrash}>Trigger Chrome Crash</button>
+      <button onClick={provokeChromeCrash}>Provoke Chrome Crash (fixed)</button>
     </Container>
   );
 }

--- a/packages/react-dom/src/client/ReactDOMDefaultTransitionIndicator.js
+++ b/packages/react-dom/src/client/ReactDOMDefaultTransitionIndicator.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+const defaultTransitionIndicatorDelay = 100;
+
 export function defaultOnDefaultTransitionIndicator(): void | (() => void) {
   if (typeof navigation !== 'object') {
     // If the Navigation API is not available, then this is a noop.
@@ -15,6 +17,10 @@ export function defaultOnDefaultTransitionIndicator(): void | (() => void) {
 
   let isCancelled = false;
   let pendingResolve: null | (() => void) = null;
+
+  const scheduledAt = performance.now();
+  // Delay the start a bit in case this is a fast Transition.
+  setTimeout(startFakeNavigation, defaultTransitionIndicatorDelay);
 
   function handleNavigate(event: NavigateEvent) {
     if (event.canIntercept && event.info === 'react-transition') {
@@ -29,6 +35,7 @@ export function defaultOnDefaultTransitionIndicator(): void | (() => void) {
   }
 
   function handleNavigateComplete() {
+    const wasRunning = pendingResolve !== null;
     if (pendingResolve !== null) {
       // If this was not our navigation completing, we were probably cancelled.
       // We'll start a new one below.
@@ -38,7 +45,18 @@ export function defaultOnDefaultTransitionIndicator(): void | (() => void) {
     if (!isCancelled) {
       // Some other navigation completed but we should still be running.
       // Start another fake one to keep the loading indicator going.
-      startFakeNavigation();
+      if (wasRunning) {
+        // Restart sync to make it not janky if it was already running
+        startFakeNavigation();
+      } else {
+        // Since it hasn't started yet, we want to delay it up to a bit.
+        // There needs to be an async gap to work around https://issues.chromium.org/u/1/issues/419746417.
+        const fakeNavigationDelay = Math.max(
+          0,
+          defaultTransitionIndicatorDelay - (performance.now() - scheduledAt),
+        );
+        setTimeout(startFakeNavigation, fakeNavigationDelay);
+      }
     }
   }
 
@@ -69,9 +87,6 @@ export function defaultOnDefaultTransitionIndicator(): void | (() => void) {
       });
     }
   }
-
-  // Delay the start a bit in case this is a fast navigation.
-  setTimeout(startFakeNavigation, 100);
 
   return function () {
     isCancelled = true;


### PR DESCRIPTION
We delay the default Transition indicator by 100ms to reduce jank in case we're dealing with a fast Transition. However, this delay was previously interrupted if a navigation completed before the default Transition indicator is shown.

Instead of interrupting, we now reschedule the default Transition indicator while ensuring we don't indefinitely defer.

This also prevents a crash in Chrome (https://issues.chromium.org/u/1/issues/419746417).

## Test plan
- [x] "Provoke Chrome crash" in Flight fixture no longer crashes the page