### PR TITLE
[compiler] Add ImmutableCapture effect, CreateFrom no longer needs Capture

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -949,10 +949,13 @@ function getFunctionName(
 export function printAliasingEffect(effect: AliasingEffect): string {
   switch (effect.kind) {
     case 'Alias': {
-      return `Alias ${printPlaceForAliasEffect(effect.from)} -> ${printPlaceForAliasEffect(effect.into)}`;
+      return `Alias ${printPlaceForAliasEffect(effect.into)} = ${printPlaceForAliasEffect(effect.from)}`;
     }
     case 'Capture': {
-      return `Capture ${printPlaceForAliasEffect(effect.from)} -> ${printPlaceForAliasEffect(effect.into)}`;
+      return `Capture ${printPlaceForAliasEffect(effect.into)} <- ${printPlaceForAliasEffect(effect.from)}`;
+    }
+    case 'ImmutableCapture': {
+      return `ImmutableCapture ${printPlaceForAliasEffect(effect.into)} <- ${printPlaceForAliasEffect(effect.from)}`;
     }
     case 'Create': {
       return `Create ${printPlaceForAliasEffect(effect.into)} = ${effect.value}`;

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/AnalyseFunctions.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/AnalyseFunctions.ts
@@ -14,6 +14,7 @@ import {
   Place,
   isRefOrRefValue,
   makeInstructionId,
+  printFunction,
 } from '../HIR';
 import {deadCodeElimination} from '../Optimization';
 import {inferReactiveScopeVariables} from '../ReactiveScopes';
@@ -26,10 +27,7 @@ import {
   eachInstructionValueOperand,
 } from '../HIR/visitors';
 import {Iterable_some} from '../Utils/utils';
-import {
-  AliasingEffect,
-  inferMutationAliasingEffects,
-} from './InferMutationAliasingEffects';
+import {inferMutationAliasingEffects} from './InferMutationAliasingEffects';
 import {inferMutationAliasingFunctionEffects} from './InferMutationAliasingFunctionEffects';
 import {inferMutationAliasingRanges} from './InferMutationAliasingRanges';
 
@@ -44,7 +42,6 @@ export default function analyseFunctions(func: HIRFunction): void {
             infer(instr.value.loweredFunc, aliases);
           } else {
             lowerWithMutationAliasing(instr.value.loweredFunc.func);
-            infer(instr.value.loweredFunc, new DisjointSet());
           }
 
           /**

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/InferReactiveScopeVariables.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/InferReactiveScopeVariables.ts
@@ -376,12 +376,12 @@ export function findDisjointMutableValues(
       } else {
         for (const operand of eachInstructionOperand(instr)) {
           if (
-            isMutable(instr, operand)
+            isMutable(instr, operand) &&
             /*
              * exclude global variables from being added to scopes, we can't recreate them!
              * TODO: improve handling of module-scoped variables and globals
              */
-            // && operand.identifier.mutableRange.start > 0
+            operand.identifier.mutableRange.start > 0
           ) {
             if (
               instr.value.kind === 'FunctionExpression' ||

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-repro-named-function-with-shadowed-local-same-name.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-repro-named-function-with-shadowed-local-same-name.expect.md
@@ -22,7 +22,7 @@ function Component(props) {
    7 |     return hasErrors;
    8 |   }
 >  9 |   return hasErrors();
-     |          ^^^^^^^^^ Invariant: [hoisting] Expected value for identifier to be initialized. hasErrors_0$14 (9:9)
+     |          ^^^^^^^^^ Invariant: [hoisting] Expected value for identifier to be initialized. hasErrors_0$15 (9:9)
   10 | }
   11 |
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/basic-mutation-via-function-expression.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/basic-mutation-via-function-expression.expect.md
@@ -1,0 +1,58 @@
+
+## Input
+
+```javascript
+// @enableNewMutationAliasingModel
+function Component({a, b}) {
+  const x = {a};
+  const y = [b];
+  const f = () => {
+    y.x = x;
+    mutate(y);
+  };
+  return <div onClick={f}>{x}</div>;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableNewMutationAliasingModel
+function Component(t0) {
+  const $ = _c(7);
+  const { a, b } = t0;
+  let t1;
+  let x;
+  if ($[0] !== a || $[1] !== b) {
+    x = { a };
+    const y = [b];
+    t1 = () => {
+      y.x = x;
+      mutate(y);
+    };
+    $[0] = a;
+    $[1] = b;
+    $[2] = t1;
+    $[3] = x;
+  } else {
+    t1 = $[2];
+    x = $[3];
+  }
+  const f = t1;
+  let t2;
+  if ($[4] !== f || $[5] !== x) {
+    t2 = <div onClick={f}>{x}</div>;
+    $[4] = f;
+    $[5] = x;
+    $[6] = t2;
+  } else {
+    t2 = $[6];
+  }
+  return t2;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/basic-mutation-via-function-expression.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/basic-mutation-via-function-expression.js
@@ -1,0 +1,11 @@
+// @enableNewMutationAliasingModel
+function Component({a, b}) {
+  const x = {a};
+  const y = [b];
+  const f = () => {
+    y.x = x;
+    mutate(y);
+  };
+  f();
+  return <div>{x}</div>;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/basic-mutation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/basic-mutation.expect.md
@@ -1,0 +1,42 @@
+
+## Input
+
+```javascript
+// @enableNewMutationAliasingModel
+function Component({a, b}) {
+  const x = {a};
+  const y = [b];
+  y.x = x;
+  mutate(y);
+  return <div>{x}</div>;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableNewMutationAliasingModel
+function Component(t0) {
+  const $ = _c(3);
+  const { a, b } = t0;
+  let t1;
+  if ($[0] !== a || $[1] !== b) {
+    const x = { a };
+    const y = [b];
+    y.x = x;
+    mutate(y);
+    t1 = <div>{x}</div>;
+    $[0] = a;
+    $[1] = b;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  return t1;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/basic-mutation.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/basic-mutation.js
@@ -1,0 +1,8 @@
+// @enableNewMutationAliasingModel
+function Component({a, b}) {
+  const x = {a};
+  const y = [b];
+  y.x = x;
+  mutate(y);
+  return <div>{x}</div>;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/potential-mutation-in-function-expression.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/potential-mutation-in-function-expression.expect.md
@@ -1,0 +1,59 @@
+
+## Input
+
+```javascript
+// @enableNewMutationAliasingModel
+function Component({a, b, c}) {
+  const x = [a, b];
+  const f = () => {
+    maybeMutate(x);
+    // different dependency to force this not to merge with x's scope
+    console.log(c);
+  };
+  return <Foo onClick={f} value={x} />;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableNewMutationAliasingModel
+function Component(t0) {
+  const $ = _c(8);
+  const { a, b, c } = t0;
+  let t1;
+  let x;
+  if ($[0] !== a || $[1] !== b || $[2] !== c) {
+    x = [a, b];
+    t1 = () => {
+      maybeMutate(x);
+
+      console.log(c);
+    };
+    $[0] = a;
+    $[1] = b;
+    $[2] = c;
+    $[3] = t1;
+    $[4] = x;
+  } else {
+    t1 = $[3];
+    x = $[4];
+  }
+  const f = t1;
+  let t2;
+  if ($[5] !== f || $[6] !== x) {
+    t2 = <Foo onClick={f} value={x} />;
+    $[5] = f;
+    $[6] = x;
+    $[7] = t2;
+  } else {
+    t2 = $[7];
+  }
+  return t2;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/potential-mutation-in-function-expression.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/potential-mutation-in-function-expression.js
@@ -1,0 +1,10 @@
+// @enableNewMutationAliasingModel
+function Component({a, b, c}) {
+  const x = [a, b];
+  const f = () => {
+    maybeMutate(x);
+    // different dependency to force this not to merge with x's scope
+    console.log(c);
+  };
+  return <Foo onClick={f} value={x} />;
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #33488
* #33477
* #33471
* #33470
* #33469
* #33465
* #33458
* #33449
* #33440
* #33430
* #33429
* #33427
* #33411
* #33401
* #33386
* #33385
* #33384
* #33380
* #33379
* #33378
* #33377
* #33376
* #33371
* #33370
* #33369
* __->__ #33367
* #33365
* #33364
* #33363
* #33346
* #33350
* #33180
* #33179
* #33178
* #33164
* #33163
* #33157
* #33151
* #33114
* #33113

ImmutableCapture allows us to record information flow for escape analysis purposes, without impacting mutable range analysis. All of Alias, Capture, and CreateFrom now downgrade to ImmutableCapture if the `from` value is frozen. Globals and primitives are conceptually copy types and don't record any information flow at all. I guess we could add a `Copy` effect if we wanted but i haven't seen a need for it yet.

Related, previously CreateFrom was always paired with Capture when constructing effects. But I had also coded up the inference to sort of treat them the same. So this diff makes that official, and means CreateFrom is a valid third way to represent data flow and not just creation. When applied, CreateFrom will turn into: ImmutableCapture for frozen values, Capture for mutable values, and disappear for globals/primitives.

A final tweak is to change range inference to ensure that range.start is non-zero if the value is mutated.