### PR TITLE
Make onClick use a SyntheticPointerEvent

### DIFF
--- a/packages/react-dom-bindings/src/events/plugins/SimpleEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/SimpleEventPlugin.js
@@ -95,14 +95,6 @@ function extractEvents(
     case 'afterblur':
       SyntheticEventCtor = SyntheticFocusEvent;
       break;
-    case 'click':
-      // Firefox creates a click event on right mouse clicks. This removes the
-      // unwanted click events.
-      // TODO: Fixed in https://phabricator.services.mozilla.com/D26793. Can
-      // probably remove.
-      if (nativeEvent.button === 2) {
-        return;
-      }
     /* falls through */
     case 'auxclick':
     case 'dblclick':
@@ -152,6 +144,14 @@ function extractEvents(
     case 'paste':
       SyntheticEventCtor = SyntheticClipboardEvent;
       break;
+    case 'click':
+      // Firefox creates a click event on right mouse clicks. This removes the
+      // unwanted click events.
+      // TODO: Fixed in https://phabricator.services.mozilla.com/D26793. Can
+      // probably remove.
+      if (nativeEvent.button === 2) {
+        return;
+      }
     case 'gotpointercapture':
     case 'lostpointercapture':
     case 'pointercancel':


### PR DESCRIPTION
Just opening this for discussion.

The browser [`click` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event) was updated many years ago from a `MouseEvent` to a `PointerEvent` and is widely supported by browsers today.

However, React is still constructing a `SyntheticMouseEvent` for `onClick`, this PR is to update that to use `SyntheticPointerEvent`
