### PR TITLE
[compiler] Delay mutation of function expr context variables until function is called

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/basic-mutation-via-function-expression.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/basic-mutation-via-function-expression.expect.md
@@ -10,7 +10,8 @@ function Component({a, b}) {
     y.x = x;
     mutate(y);
   };
-  return <div onClick={f}>{x}</div>;
+  f();
+  return <div>{x}</div>;
 }
 
 ```
@@ -20,36 +21,26 @@ function Component({a, b}) {
 ```javascript
 import { c as _c } from "react/compiler-runtime"; // @enableNewMutationAliasingModel
 function Component(t0) {
-  const $ = _c(7);
+  const $ = _c(3);
   const { a, b } = t0;
   let t1;
-  let x;
   if ($[0] !== a || $[1] !== b) {
-    x = { a };
+    const x = { a };
     const y = [b];
-    t1 = () => {
+    const f = () => {
       y.x = x;
       mutate(y);
     };
+
+    f();
+    t1 = <div>{x}</div>;
     $[0] = a;
     $[1] = b;
     $[2] = t1;
-    $[3] = x;
   } else {
     t1 = $[2];
-    x = $[3];
   }
-  const f = t1;
-  let t2;
-  if ($[4] !== f || $[5] !== x) {
-    t2 = <div onClick={f}>{x}</div>;
-    $[4] = f;
-    $[5] = x;
-    $[6] = t2;
-  } else {
-    t2 = $[6];
-  }
-  return t2;
+  return t1;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/potential-mutation-in-function-expression.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/potential-mutation-in-function-expression.expect.md
@@ -20,37 +20,42 @@ function Component({a, b, c}) {
 ```javascript
 import { c as _c } from "react/compiler-runtime"; // @enableNewMutationAliasingModel
 function Component(t0) {
-  const $ = _c(8);
+  const $ = _c(9);
   const { a, b, c } = t0;
   let t1;
-  let x;
-  if ($[0] !== a || $[1] !== b || $[2] !== c) {
-    x = [a, b];
-    t1 = () => {
+  if ($[0] !== a || $[1] !== b) {
+    t1 = [a, b];
+    $[0] = a;
+    $[1] = b;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  const x = t1;
+  let t2;
+  if ($[3] !== c || $[4] !== x) {
+    t2 = () => {
       maybeMutate(x);
 
       console.log(c);
     };
-    $[0] = a;
-    $[1] = b;
-    $[2] = c;
-    $[3] = t1;
+    $[3] = c;
     $[4] = x;
+    $[5] = t2;
   } else {
-    t1 = $[3];
-    x = $[4];
+    t2 = $[5];
   }
-  const f = t1;
-  let t2;
-  if ($[5] !== f || $[6] !== x) {
-    t2 = <Foo onClick={f} value={x} />;
-    $[5] = f;
-    $[6] = x;
-    $[7] = t2;
+  const f = t2;
+  let t3;
+  if ($[6] !== f || $[7] !== x) {
+    t3 = <Foo onClick={f} value={x} />;
+    $[6] = f;
+    $[7] = x;
+    $[8] = t3;
   } else {
-    t2 = $[7];
+    t3 = $[8];
   }
-  return t2;
+  return t3;
 }
 
 ```


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #33488
* #33477
* #33471
* #33470
* #33469
* #33465
* #33458
* #33449
* #33440
* #33430
* #33429
* #33427
* #33411
* #33401
* #33386
* #33385
* #33384
* #33380
* #33379
* #33378
* #33377
* #33376
* #33371
* #33370
* __->__ #33369
* #33367
* #33365
* #33364
* #33363
* #33346
* #33350
* #33180
* #33179
* #33178
* #33164
* #33163
* #33157
* #33151
* #33114
* #33113

See comments in code. The idea is that rather than immediately processing function expression effects when declaring the function, we record Capture effects for context variables that may be captured/mutated in the function. Then, transitive mutations of the function value itself will extend the range of these values via the normal captured value comutation inference established earlier in the stack (if capture a -> b, then transitiveMutate(b) => mutate(a)). So capture contextVar -> function and transitiveMutate(function) => mutate(contextVar).