### PR TITLE
[compiler] First example of an aliasing signature (array push)

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -38,6 +38,7 @@ import {GotoVariant, InstructionKind} from './HIR';
 import {
   AliasedPlace,
   AliasingEffect,
+  AliasingSignature,
 } from '../Inference/InferMutationAliasingEffects';
 
 export type Options = {
@@ -990,4 +991,22 @@ function printPlaceForAliasEffect(place: Place): string {
 
 function printAliasedPlace(place: AliasedPlace): string {
   return place.kind + ' ' + printPlaceForAliasEffect(place.place);
+}
+
+export function printAliasingSignature(signature: AliasingSignature): string {
+  const tokens: Array<string> = ['function '];
+  tokens.push('(');
+  tokens.push('this=$' + String(signature.receiver));
+  for (const param of signature.params) {
+    tokens.push(', $' + String(param));
+  }
+  if (signature.rest != null) {
+    tokens.push(`, ...$${String(signature.rest)}`);
+  }
+  tokens.push('): ');
+  tokens.push('$' + String(signature.returns) + ':');
+  for (const effect of signature.effects) {
+    tokens.push('\n  ' + printAliasingEffect(effect));
+  }
+  return tokens.join('');
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/array-push.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/array-push.expect.md
@@ -1,0 +1,57 @@
+
+## Input
+
+```javascript
+// @enableNewMutationAliasingModel
+function Component({a, b, c}) {
+  const x = [];
+  x.push(a);
+  const merged = {b}; // could be mutated by mutate(x) below
+  x.push(merged);
+  mutate(x);
+  const independent = {c}; // can't be later mutated
+  x.push(independent);
+  return <Foo value={x} />;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableNewMutationAliasingModel
+function Component(t0) {
+  const $ = _c(6);
+  const { a, b, c } = t0;
+  let t1;
+  if ($[0] !== a || $[1] !== b || $[2] !== c) {
+    const x = [];
+    x.push(a);
+    const merged = { b };
+    x.push(merged);
+    mutate(x);
+    let t2;
+    if ($[4] !== c) {
+      t2 = { c };
+      $[4] = c;
+      $[5] = t2;
+    } else {
+      t2 = $[5];
+    }
+    const independent = t2;
+    x.push(independent);
+    t1 = <Foo value={x} />;
+    $[0] = a;
+    $[1] = b;
+    $[2] = c;
+    $[3] = t1;
+  } else {
+    t1 = $[3];
+  }
+  return t1;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/array-push.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/array-push.js
@@ -1,0 +1,11 @@
+// @enableNewMutationAliasingModel
+function Component({a, b, c}) {
+  const x = [];
+  x.push(a);
+  const merged = {b}; // could be mutated by mutate(x) below
+  x.push(merged);
+  mutate(x);
+  const independent = {c}; // can't be later mutated
+  x.push(independent);
+  return <Foo value={x} />;
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Adds an aliasing signature for Array.prototype.push and fixes up the logic for consuming these signatures during effect inference. As the test fixture shows, we correctly model the capturing. Mutable values that are captured into the array count as co-mutated if the array itself is transitively mutated later, while mutable values captured after such transitive mutation are not considered co-mutated.

The implementation is based on the fact that the final `push` call is only locally mutating the array. During the phase that looks at local mutations we are only tracking direct aliases, and the push doesn't directly alias the items to the array, it only captures them.