### PR TITLE
[react-reconciler] Clear pendingEffectsLanes in flushSpawnedWork to prevent state inconsistency

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -3708,6 +3708,8 @@ function flushSpawnedWork(): void {
     pendingEffectsStatus = NO_PENDING_EFFECTS;
     pendingEffectsRoot = (null: any); // Clear for GC purposes.
     pendingFinishedWork = (null: any); // Clear for GC purposes.
+    // Keep lanes in sync with the cleared root to avoid inconsistent state.
+    pendingEffectsLanes = NoLanes;
     // There were no passive effects, so we can immediately release the cache
     // pool for this render.
     releaseRootPooledCache(root, root.pendingLanes);


### PR DESCRIPTION
## Summary

The `flushSpawnedWork` function in `ReactFiberWorkLoop.js` previously did not fully clear all pending effect state when there were no passive effects. Specifically, while `pendingEffectsRoot` and `pendingFinishedWork` were cleared for GC purposes, `pendingEffectsLanes` was left uncleared.

This change ensures that:
- If there are no passive effects, `pendingEffectsLanes` is reset to `NoLanes` alongside other pending state cleanup
- The lanes state remains consistent with the cleared root and finished work
- Potential issues from stale lane information persisting longer than necessary are prevented

This aligns the function's behavior with other cleanup patterns throughout the codebase where pending lanes are reset when clearing related state.

## How did you test this change?

The changes were tested as follows:

1. **Existing Tests:**
   * All existing tests in the React test suite continue to pass with these changes
   * No new test cases are required as this is a defensive fix that maintains existing behavior while preventing potential edge cases

2. **Test Commands Executed:**
   * `yarn test`: Ran the entire test suite. All tests passed
   * `yarn test --prod`: Ran the test suite in production environment. All tests passed  
   * `yarn lint`: Checked for linting issues. No issues found
   * `yarn flow`: Ran Flow type checks. No issues found

The fix maintains backward compatibility while preventing potential state inconsistency issues that could arise from stale `pendingEffectsLanes` values.