### PR TITLE
[compiler] Effect inference across signatures and user-provided callbacks

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -246,7 +246,7 @@ export const EnvironmentConfigSchema = z.object({
   /**
    * Enable a new model for mutability and aliasing inference
    */
-  enableNewMutationAliasingModel: z.boolean().default(false),
+  enableNewMutationAliasingModel: z.boolean().default(true),
 
   /**
    * Enables inference of optional dependency chains. Without this flag

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -972,6 +972,8 @@ export function printAliasingEffect(effect: AliasingEffect): string {
         .map(arg => {
           if (arg.kind === 'Identifier') {
             return printPlaceForAliasEffect(arg);
+          } else if (arg.kind === 'Hole') {
+            return ' ';
           }
           return `...${printPlaceForAliasEffect(arg.place)}`;
         })
@@ -985,6 +987,9 @@ export function printAliasingEffect(effect: AliasingEffect): string {
         }
       }
       return `Apply ${printPlaceForAliasEffect(effect.into)} = ${receiverCallee}(${args})${signature != '' ? '\n     ' : ''}${signature}`;
+    }
+    case 'CreateFunction': {
+      return `Function ${printPlaceForAliasEffect(effect.into)} = Function captures=[${effect.captures.map(printPlaceForAliasEffect).join(', ')}]`;
     }
     case 'Freeze': {
       return `Freeze ${printPlaceForAliasEffect(effect.value)} ${effect.reason}`;
@@ -1007,6 +1012,13 @@ function printPlaceForAliasEffect(place: Place): string {
 
 export function printAliasingSignature(signature: AliasingSignature): string {
   const tokens: Array<string> = ['function '];
+  if (signature.temporaries.length !== 0) {
+    tokens.push('<');
+    tokens.push(
+      signature.temporaries.map(temp => `$${temp.identifier.id}`).join(', '),
+    );
+    tokens.push('>');
+  }
   tokens.push('(');
   tokens.push('this=$' + String(signature.receiver));
   for (const param of signature.params) {

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/AnalyseFunctions.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/AnalyseFunctions.ts
@@ -96,6 +96,7 @@ function lowerWithMutationAliasing(fn: HIRFunction): void {
         capturedOrMutated.add(effect.value.identifier.id);
         break;
       }
+      case 'CreateFunction':
       case 'Create':
       case 'Freeze':
       case 'ImmutableCapture': {

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingRanges.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingRanges.ts
@@ -174,6 +174,7 @@ export function inferMutationAliasingRanges(fn: HIRFunction): void {
             operandEffects.set(effect.from.identifier.id, Effect.Read);
             break;
           }
+          case 'CreateFunction':
           case 'Create': {
             break;
           }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/array-map-captures-receiver-noAlias.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/array-map-captures-receiver-noAlias.expect.md
@@ -1,0 +1,71 @@
+
+## Input
+
+```javascript
+// @enableNewMutationAliasingModel
+function Component(props) {
+  // This item is part of the receiver, should be memoized
+  const item = {a: props.a};
+  const items = [item];
+  const mapped = items.map(item => item);
+  // mapped[0].a = null;
+  return mapped;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{a: {id: 42}}],
+  isComponent: false,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableNewMutationAliasingModel
+function Component(props) {
+  const $ = _c(6);
+  let t0;
+  if ($[0] !== props.a) {
+    t0 = { a: props.a };
+    $[0] = props.a;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  const item = t0;
+  let t1;
+  if ($[2] !== item) {
+    t1 = [item];
+    $[2] = item;
+    $[3] = t1;
+  } else {
+    t1 = $[3];
+  }
+  const items = t1;
+  let t2;
+  if ($[4] !== items) {
+    t2 = items.map(_temp);
+    $[4] = items;
+    $[5] = t2;
+  } else {
+    t2 = $[5];
+  }
+  const mapped = t2;
+  return mapped;
+}
+function _temp(item_0) {
+  return item_0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ a: { id: 42 } }],
+  isComponent: false,
+};
+
+```
+      
+### Eval output
+(kind: ok) [{"a":{"id":42}}]

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/array-map-captures-receiver-noAlias.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/array-map-captures-receiver-noAlias.js
@@ -1,0 +1,15 @@
+// @enableNewMutationAliasingModel
+function Component(props) {
+  // This item is part of the receiver, should be memoized
+  const item = {a: props.a};
+  const items = [item];
+  const mapped = items.map(item => item);
+  // mapped[0].a = null;
+  return mapped;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{a: {id: 42}}],
+  isComponent: false,
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/reactive-ref.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/reactive-ref.expect.md
@@ -1,0 +1,48 @@
+
+## Input
+
+```javascript
+// @enableNewMutationAliasingModel
+function ReactiveRefInEffect(props) {
+  const ref1 = useRef('initial value');
+  const ref2 = useRef('initial value');
+  let ref;
+  if (props.foo) {
+    ref = ref1;
+  } else {
+    ref = ref2;
+  }
+  useEffect(() => print(ref));
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableNewMutationAliasingModel
+function ReactiveRefInEffect(props) {
+  const $ = _c(2);
+  const ref1 = useRef("initial value");
+  const ref2 = useRef("initial value");
+  let ref;
+  if (props.foo) {
+    ref = ref1;
+  } else {
+    ref = ref2;
+  }
+  let t0;
+  if ($[0] !== ref) {
+    t0 = () => print(ref);
+    $[0] = ref;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  useEffect(t0);
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/reactive-ref.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/reactive-ref.js
@@ -1,0 +1,12 @@
+// @enableNewMutationAliasingModel
+function ReactiveRefInEffect(props) {
+  const ref1 = useRef('initial value');
+  const ref2 = useRef('initial value');
+  let ref;
+  if (props.foo) {
+    ref = ref1;
+  } else {
+    ref = ref2;
+  }
+  useEffect(() => print(ref));
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #33488
* #33477
* #33471
* #33470
* #33469
* #33465
* #33458
* #33449
* #33440
* #33430
* #33429
* #33427
* #33411
* #33401
* #33386
* #33385
* __->__ #33384
* #33380
* #33379
* #33378
* #33377
* #33376
* #33371
* #33370
* #33369
* #33367
* #33365
* #33364
* #33363
* #33346
* #33350
* #33180
* #33179
* #33178
* #33164
* #33163
* #33157
* #33151
* #33114
* #33113

This ties all the ideas together, showing the promise of the new inference. When applying effects, when we encounter an Apply effect we now check to see if the function we're calling is a locally defined FunctionExpression. If so, we construct a signature for it on the fly (we already have created the effects in AnalyzeFunctions), substitute in the args to get a set of effects we can apply, and then recursively apply those effects.

This required adding an ability for signatures to declare additional temporary places that they can reference. For example, Array.prototype.map needs a temporary to represent the items it extracts from the receiver array, and another temporary for the result of calling the user-provided function.

This also meant adding a `CreateFunction` effect which a) allows us to preserve the FunctionExpression value in the inference state (the previous Create effect meant we just created a dummy ObjectExpression) and b) allows dynamically constructing the ValueKind of the function based on whether it actually captures any mutable values.

Lots of other little fixes as well, such as changing function related effects (and PropertyLoad) to use Alias instead of Capture so that subsequent mutations of the output count as mutations of the input.