### PR TITLE
[compiler] Distinguish Alias/Assign effects

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -246,7 +246,7 @@ export const EnvironmentConfigSchema = z.object({
   /**
    * Enable a new model for mutability and aliasing inference
    */
-  enableNewMutationAliasingModel: z.boolean().default(true),
+  enableNewMutationAliasingModel: z.boolean().default(false),
 
   /**
    * Enables inference of optional dependency chains. Without this flag

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
@@ -569,6 +569,32 @@ addObject(BUILTIN_SHAPES, BuiltInSetId, [
       calleeEffect: Effect.Store,
       // returnValueKind is technically dependent on the ValueKind of the set itself
       returnValueKind: ValueKind.Mutable,
+      aliasing: {
+        receiver: makeIdentifierId(0),
+        params: [],
+        rest: makeIdentifierId(1),
+        returns: makeIdentifierId(2),
+        temporaries: [],
+        effects: [
+          // Set.add returns the receiver Set
+          {
+            kind: 'Assign',
+            from: signatureArgument(0),
+            into: signatureArgument(2),
+          },
+          // Set.add mutates the set itself
+          {
+            kind: 'Mutate',
+            value: signatureArgument(0),
+          },
+          // Captures the rest params into the set
+          {
+            kind: 'Capture',
+            from: signatureArgument(1),
+            into: signatureArgument(0),
+          },
+        ],
+      },
     }),
   ],
   [

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -948,6 +948,9 @@ function getFunctionName(
 
 export function printAliasingEffect(effect: AliasingEffect): string {
   switch (effect.kind) {
+    case 'Assign': {
+      return `Assign ${printPlaceForAliasEffect(effect.into)} = ${printPlaceForAliasEffect(effect.from)}`;
+    }
     case 'Alias': {
       return `Alias ${printPlaceForAliasEffect(effect.into)} = ${printPlaceForAliasEffect(effect.from)}`;
     }
@@ -962,6 +965,9 @@ export function printAliasingEffect(effect: AliasingEffect): string {
     }
     case 'CreateFrom': {
       return `Create ${printPlaceForAliasEffect(effect.into)} = kindOf(${printPlaceForAliasEffect(effect.from)})`;
+    }
+    case 'CreateFunction': {
+      return `Function ${printPlaceForAliasEffect(effect.into)} = Function captures=[${effect.captures.map(printPlaceForAliasEffect).join(', ')}]`;
     }
     case 'Apply': {
       const receiverCallee =
@@ -987,9 +993,6 @@ export function printAliasingEffect(effect: AliasingEffect): string {
         }
       }
       return `Apply ${printPlaceForAliasEffect(effect.into)} = ${receiverCallee}(${args})${signature != '' ? '\n     ' : ''}${signature}`;
-    }
-    case 'CreateFunction': {
-      return `Function ${printPlaceForAliasEffect(effect.into)} = Function captures=[${effect.captures.map(printPlaceForAliasEffect).join(', ')}]`;
     }
     case 'Freeze': {
       return `Freeze ${printPlaceForAliasEffect(effect.value)} ${effect.reason}`;

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/AnalyseFunctions.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/AnalyseFunctions.ts
@@ -77,6 +77,7 @@ function lowerWithMutationAliasing(fn: HIRFunction): void {
   const capturedOrMutated = new Set<IdentifierId>();
   for (const effect of effects ?? []) {
     switch (effect.kind) {
+      case 'Assign':
       case 'Alias':
       case 'Capture':
       case 'CreateFrom': {

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingRanges.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingRanges.ts
@@ -53,6 +53,7 @@ export function inferMutationAliasingRanges(fn: HIRFunction): void {
       if (instr.effects == null) continue;
       for (const effect of instr.effects) {
         if (
+          effect.kind === 'Assign' ||
           effect.kind === 'Alias' ||
           effect.kind === 'CreateFrom' ||
           effect.kind === 'Capture'
@@ -109,7 +110,11 @@ export function inferMutationAliasingRanges(fn: HIRFunction): void {
     for (const instr of block.instructions) {
       if (instr.effects == null) continue;
       for (const effect of instr.effects) {
-        if (effect.kind === 'Alias' || effect.kind === 'CreateFrom') {
+        if (
+          effect.kind === 'Assign' ||
+          effect.kind === 'Alias' ||
+          effect.kind === 'CreateFrom'
+        ) {
           aliases.union([effect.from.identifier, effect.into.identifier]);
         } else if (
           effect.kind === 'Mutate' ||
@@ -156,6 +161,7 @@ export function inferMutationAliasingRanges(fn: HIRFunction): void {
       const operandEffects = new Map<IdentifierId, Effect>();
       for (const effect of instr.effects) {
         switch (effect.kind) {
+          case 'Assign':
           case 'Alias':
           case 'Capture':
           case 'CreateFrom': {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #33488
* #33477
* #33471
* #33470
* #33469
* #33465
* #33458
* #33449
* #33440
* #33430
* #33429
* #33427
* #33411
* #33401
* #33386
* __->__ #33385
* #33384
* #33380
* #33379
* #33378
* #33377
* #33376
* #33371
* #33370
* #33369
* #33367
* #33365
* #33364
* #33363
* #33346
* #33350
* #33180
* #33179
* #33178
* #33164
* #33163
* #33157
* #33151
* #33114
* #33113

Alias was akward becuase it had a specific data flow / mutability relationship — direct mutations affect both sides - but also populated the output. We need the ability to express the aliasing dataflwo/mutability relationship w/o expressing actual assignment.

An example of this is that for an unknown method call `const z = x.y()`, we want to express the Alias-style mutability relationship btw z and x (Muate(z) => Mutate(x)), but we want to assume that `z !== x`.

This ends up being really clean, the places that should use Assign are very obvious (LoadLocal, StoreLocal) and most places keep using Alias.