### PR TITLE
[compiler] InferMutationAliasingRanges precisely models which values mutate when

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/ssa-renaming-ternary-destruction.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/ssa-renaming-ternary-destruction.expect.md
@@ -1,0 +1,70 @@
+
+## Input
+
+```javascript
+// @enablePropagateDepsInHIR @enableNewMutationAliasingModel
+function useFoo(props) {
+  let x = [];
+  x.push(props.bar);
+  // todo: the below should memoize separately from the above
+  // my guess is that the phi causes the different `x` identifiers
+  // to get added to an alias group. this is where we need to track
+  // the actual state of the alias groups at the time of the mutation
+  props.cond ? (({x} = {x: {}}), ([x] = [[]]), x.push(props.foo)) : null;
+  return x;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: useFoo,
+  params: [{cond: false, foo: 2, bar: 55}],
+  sequentialRenders: [
+    {cond: false, foo: 2, bar: 55},
+    {cond: false, foo: 3, bar: 55},
+    {cond: true, foo: 3, bar: 55},
+  ],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enablePropagateDepsInHIR @enableNewMutationAliasingModel
+function useFoo(props) {
+  const $ = _c(5);
+  let x;
+  if ($[0] !== props.bar) {
+    x = [];
+    x.push(props.bar);
+    $[0] = props.bar;
+    $[1] = x;
+  } else {
+    x = $[1];
+  }
+  if ($[2] !== props.cond || $[3] !== props.foo) {
+    props.cond ? (([x] = [[]]), x.push(props.foo)) : null;
+    $[2] = props.cond;
+    $[3] = props.foo;
+    $[4] = x;
+  } else {
+    x = $[4];
+  }
+  return x;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: useFoo,
+  params: [{ cond: false, foo: 2, bar: 55 }],
+  sequentialRenders: [
+    { cond: false, foo: 2, bar: 55 },
+    { cond: false, foo: 3, bar: 55 },
+    { cond: true, foo: 3, bar: 55 },
+  ],
+};
+
+```
+      
+### Eval output
+(kind: ok) [55]
+[55]
+[3]

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/ssa-renaming-ternary-destruction.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/ssa-renaming-ternary-destruction.js
@@ -1,0 +1,21 @@
+// @enablePropagateDepsInHIR @enableNewMutationAliasingModel
+function useFoo(props) {
+  let x = [];
+  x.push(props.bar);
+  // todo: the below should memoize separately from the above
+  // my guess is that the phi causes the different `x` identifiers
+  // to get added to an alias group. this is where we need to track
+  // the actual state of the alias groups at the time of the mutation
+  props.cond ? (({x} = {x: {}}), ([x] = [[]]), x.push(props.foo)) : null;
+  return x;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: useFoo,
+  params: [{cond: false, foo: 2, bar: 55}],
+  sequentialRenders: [
+    {cond: false, foo: 2, bar: 55},
+    {cond: false, foo: 3, bar: 55},
+    {cond: true, foo: 3, bar: 55},
+  ],
+};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #33488
* #33477
* #33471
* #33470
* #33469
* #33465
* #33458
* #33449
* #33440
* #33430
* #33429
* #33427
* #33411
* __->__ #33401
* #33386
* #33385
* #33384
* #33380
* #33379
* #33378
* #33377
* #33376
* #33371
* #33370
* #33369
* #33367
* #33365
* #33364
* #33363
* #33346
* #33350
* #33180
* #33179
* #33178
* #33164
* #33163
* #33157
* #33151
* #33114
* #33113

It turns out that InferMutationAliasingRanges does need a fixpoint loop, but the approach is arguably simpler overall and more precise than the previous implementation. Like InferMutationAliasingEffects (which is the new InferReferenceEffects), we build an abstract model of the heap. But here we know what the effects are, so we can do abstract interpretation of the effects. Each abstract value stores a set of values that it has captured (for transitive mutation), while each variable keeps a set of values it may directly mutate (for assign/alias/capturefrom).

This means that at each mutation, we can mark _exactly_ the set of variables/values that are affected by that specific instruction. This means we can correctly infer that `mutate(b)` can't impact `a` here:

```
a = make();
b = make();
mutate(b); // when we interpret the mutation here, a isn't captured yet
b.a = a;
```

We will need to make this a fixpoint, but only if there are backedges in the CFG.