### PR TITLE
[Flight] Emit the time we awaited something inside a Server Component

### DIFF
--- a/packages/react-client/src/ReactFlightPerformanceTrack.js
+++ b/packages/react-client/src/ReactFlightPerformanceTrack.js
@@ -9,7 +9,11 @@
 
 /* eslint-disable react-internal/no-production-logging */
 
-import type {ReactComponentInfo, ReactIOInfo} from 'shared/ReactTypes';
+import type {
+  ReactComponentInfo,
+  ReactIOInfo,
+  ReactAsyncInfo,
+} from 'shared/ReactTypes';
 
 import {enableProfilerTimer} from 'shared/ReactFeatureFlags';
 
@@ -221,6 +225,48 @@ function getIOColor(
       return 'tertiary';
     default:
       return 'tertiary-dark';
+  }
+}
+
+export function logComponentAwait(
+  asyncInfo: ReactAsyncInfo,
+  trackIdx: number,
+  startTime: number,
+  endTime: number,
+  rootEnv: string,
+): void {
+  if (supportsUserTiming && endTime > 0) {
+    const env = asyncInfo.env;
+    const name = asyncInfo.awaited.name;
+    const isPrimaryEnv = env === rootEnv;
+    const color = getIOColor(name);
+    const entryName =
+      'await ' +
+      (isPrimaryEnv || env === undefined ? name : name + ' [' + env + ']');
+    const debugTask = asyncInfo.debugTask;
+    if (__DEV__ && debugTask) {
+      debugTask.run(
+        // $FlowFixMe[method-unbinding]
+        console.timeStamp.bind(
+          console,
+          entryName,
+          startTime < 0 ? 0 : startTime,
+          endTime,
+          trackNames[trackIdx],
+          COMPONENTS_TRACK,
+          color,
+        ),
+      );
+    } else {
+      console.timeStamp(
+        entryName,
+        startTime < 0 ? 0 : startTime,
+        endTime,
+        trackNames[trackIdx],
+        COMPONENTS_TRACK,
+        color,
+      );
+    }
   }
 }
 

--- a/packages/react-server/src/ReactFlightAsyncSequence.js
+++ b/packages/react-server/src/ReactFlightAsyncSequence.js
@@ -37,8 +37,8 @@ export type AwaitNode = {
   tag: 2,
   owner: null | ReactComponentInfo,
   stack: Error, // callsite that awaited (using await, .then(), Promise.all(), ...)
-  start: -1.1, // not used. We use the timing of the awaited promise.
-  end: -1.1, // not used.
+  start: number, // when we started blocking. This might be later than the I/O started.
+  end: number, // when we unblocked. This might be later than the I/O resolved if there's CPU time.
   awaited: null | AsyncSequence, // the promise we were waiting on
   previous: null | AsyncSequence, // the sequence that was blocking us from awaiting in the first place
 };

--- a/packages/react-server/src/ReactFlightServerConfigDebugNode.js
+++ b/packages/react-server/src/ReactFlightServerConfigDebugNode.js
@@ -49,8 +49,8 @@ export function initAsyncDebugInfo(): void {
               tag: AWAIT_NODE,
               owner: resolveOwner(),
               stack: new Error(),
-              start: -1.1,
-              end: -1.1,
+              start: performance.now(),
+              end: -1.1, // set when resolved.
               awaited: trigger, // The thing we're awaiting on. Might get overrriden when we resolve.
               previous: current === undefined ? null : current, // The path that led us here.
             }: AwaitNode);
@@ -118,10 +118,8 @@ export function initAsyncDebugInfo(): void {
               'A Promise should never be an IO_NODE. This is a bug in React.',
             );
           }
-          if (resolvedNode.tag === PROMISE_NODE) {
-            // Log the end time when we resolved the promise.
-            resolvedNode.end = performance.now();
-          }
+          // Log the end time when we resolved the promise.
+          resolvedNode.end = performance.now();
           const currentAsyncId = executionAsyncId();
           if (asyncId !== currentAsyncId) {
             // If the promise was not resolved by itself, then that means that

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
@@ -171,6 +171,9 @@ describe('ReactFlightAsyncDebugInfo', () => {
             ],
           },
           {
+            "time": 0,
+          },
+          {
             "awaited": {
               "end": 0,
               "env": "Server",
@@ -256,6 +259,12 @@ describe('ReactFlightAsyncDebugInfo', () => {
                 5,
               ],
             ],
+          },
+          {
+            "time": 0,
+          },
+          {
+            "time": 0,
           },
           {
             "awaited": {
@@ -347,6 +356,9 @@ describe('ReactFlightAsyncDebugInfo', () => {
           {
             "time": 0,
           },
+          {
+            "time": 0,
+          },
         ]
       `);
     }
@@ -398,12 +410,15 @@ describe('ReactFlightAsyncDebugInfo', () => {
               [
                 "Object.<anonymous>",
                 "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js",
-                368,
+                380,
                 109,
-                355,
+                367,
                 67,
               ],
             ],
+          },
+          {
+            "time": 0,
           },
           {
             "awaited": {
@@ -420,9 +435,9 @@ describe('ReactFlightAsyncDebugInfo', () => {
                   [
                     "Object.<anonymous>",
                     "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js",
-                    368,
+                    380,
                     109,
-                    355,
+                    367,
                     67,
                   ],
                 ],
@@ -431,15 +446,18 @@ describe('ReactFlightAsyncDebugInfo', () => {
                 [
                   "Component",
                   "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js",
-                  358,
+                  370,
                   7,
-                  356,
+                  368,
                   5,
                 ],
               ],
               "start": 0,
             },
             "env": "Server",
+          },
+          {
+            "time": 0,
           },
           {
             "time": 0,


### PR DESCRIPTION
Stacked on #33400. 

<img width="1261" alt="Screenshot 2025-06-01 at 10 27 47 PM" src="https://github.com/user-attachments/assets/a5a73ee2-49e0-4851-84ac-e0df6032efb5" />

This is emitted with the start/end time and stack of the "await". Which may be different than the thing that started the I/O.

These awaits aren't quite as simple as just every await since you can start a sequence in parallel there can actually be multiple overlapping awaits and there can be CPU work interleaved with the await on the same component.

```js
function getData() {
  await fetch(...);
  await fetch(...);
}
const promise = getData();
doWork();
await promise;
```

This has two "I/O" awaits but those are actually happening in parallel with `doWork()`.

Since these also could have started before we started rendering this sequence (e.g. a component) we have to clamp it so that we don't consider awaits that start before the component.

What we're conceptually trying to convey is the time this component was blocked due to that I/O resource. Whether it's blocked from completing the last result or if it's blocked from issuing a waterfall request.