### PR TITLE
[compiler]: fix link-compiler.sh and 4 tests breaking on pwd /w spaces

### DIFF
--- a/compiler/apps/playground/scripts/link-compiler.sh
+++ b/compiler/apps/playground/scripts/link-compiler.sh
@@ -8,8 +8,8 @@ set -eo pipefail
 
 HERE=$(pwd)
 
-cd ../../packages/react-compiler-runtime && yarn --silent link && cd $HERE
-cd ../../packages/babel-plugin-react-compiler && yarn --silent link && cd $HERE
+cd ../../packages/react-compiler-runtime && yarn --silent link && cd "$HERE"
+cd ../../packages/babel-plugin-react-compiler && yarn --silent link && cd "$HERE"
 
 yarn --silent link babel-plugin-react-compiler
 yarn --silent link react-compiler-runtime

--- a/scripts/react-compiler/link-compiler.sh
+++ b/scripts/react-compiler/link-compiler.sh
@@ -12,6 +12,6 @@ fi
 
 HERE=$(pwd)
 
-cd compiler/packages/babel-plugin-react-compiler && yarn --silent link && cd $HERE
+cd compiler/packages/babel-plugin-react-compiler && yarn --silent link && cd "$HERE"
 
 yarn --silent link babel-plugin-react-compiler


### PR DESCRIPTION
## Summary

Problem #1: Running the `link-compiler.sh` bash script via `"prebuild"` script fails if the developer cloned the `react` repository into a folder that contains any spaces.

Problem #2: 4 tests fail that normally wouldn't if the current folder has no spaces.

For example, my current folder is:
`/Users/wes/Development/Open Source Contributions/react`

The link compiler error is:
`./scripts/react-compiler/link-compiler.sh: line 15: cd: /Users/wes/Development/Open: No such file or directory`

The 4 failing tests are:

<img width="1003" alt="fail-1" src="https://github.com/user-attachments/assets/1fbfa9ce-4f84-48d7-b49c-b6e967b8c7ca" />
<img width="1011" alt="fail-2" src="https://github.com/user-attachments/assets/0a8c6371-a2df-4276-af98-38f4784cf0da" />
<img width="1027" alt="fail-3" src="https://github.com/user-attachments/assets/1c4f4429-800c-4b44-b3da-a59ac85a16b9" />
<img width="987" alt="fail-4" src="https://github.com/user-attachments/assets/56a673bc-513f-4458-95b2-224129c77144" />

These same tests pass if I hyphenate my local folder:
`/Users/wes/Development/Open-Source-Contributions/react`

Looking into this, it appears the existing stack trace regex is a bit too aggressive, causing paths with spaces to be broken. 

Change 1:
The existing regex matches stack trace lines that start with at or in and captures the function or file name, even if it contains spaces.

Change 2:
The new `normalizeStackTrace` function further normalizes stack trace lines by replacing the full file path and line/column numbers with a generic placeholder (**/$2:**:**), while keeping the component or function name ($1) intact. This ensures that stack traces are consistent and not dependent on absolute file paths or specific line numbers, making test output stable across environments.

## How did you test this change?

**Change 1: "npx yarn prebuild"**

Before:
<img width="896" alt="Screenshot at Jun 01 11-42-56" src="https://github.com/user-attachments/assets/4692775c-1e5c-4851-9bd7-e12ed5455e47" />

After:
<img width="420" alt="Screenshot at Jun 01 11-43-42" src="https://github.com/user-attachments/assets/4e303c00-02b7-4540-ba19-927b2d7034fb" />

**Change 2: "npx yarn test"**

Before:
<img width="438" alt="before" src="https://github.com/user-attachments/assets/f5eedb22-18c3-4124-a04b-daa95c0f7652" />

After:
<img width="439" alt="after" src="https://github.com/user-attachments/assets/a94218ba-7c6a-4f08-85d3-57540e9d0029" />

Also mostly used this while testing changes:
npx yarn test ./packages/react/src/__tests__/ReactChildren-test.js

<img width="650" alt="Screenshot at Jun 02 18-03-39" src="https://github.com/user-attachments/assets/3eae993c-a56b-46c8-ae02-d249cb053fe7" />

*Also updated the Playground link-compiler which would also have the same issue with just using $HERE without quotations.