### PR TITLE
[compiler] Further improve new range inference

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/CompilerError.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/CompilerError.ts
@@ -115,6 +115,14 @@ export class CompilerErrorDetail {
 export class CompilerError extends Error {
   details: Array<CompilerErrorDetail> = [];
 
+  static from(details: Array<CompilerErrorDetailOptions>): CompilerError {
+    const error = new CompilerError();
+    for (const detail of details) {
+      error.push(detail);
+    }
+    return error;
+  }
+
   static invariant(
     condition: unknown,
     options: Omit<CompilerErrorDetailOptions, 'severity'>,

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -1003,6 +1003,12 @@ export function printAliasingEffect(effect: AliasingEffect): string {
     case 'MutateTransitiveConditionally': {
       return `${effect.kind} ${printPlaceForAliasEffect(effect.value)}`;
     }
+    case 'MutateFrozen': {
+      return `MutateFrozen ${printPlaceForAliasEffect(effect.place)} reason=${JSON.stringify(effect.error.reason)}`;
+    }
+    case 'MutateGlobal': {
+      return `MutateGlobal ${printPlaceForAliasEffect(effect.place)} reason=${JSON.stringify(effect.error.reason)}`;
+    }
     default: {
       assertExhaustive(effect, `Unexpected kind '${(effect as any).kind}'`);
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/bug-object-expression-computed-key-modified-during-after-construction-hoisted-sequence-expr.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/bug-object-expression-computed-key-modified-during-after-construction-hoisted-sequence-expr.expect.md
@@ -1,0 +1,87 @@
+
+## Input
+
+```javascript
+// @enableNewMutationAliasingModel
+import {identity, mutate} from 'shared-runtime';
+
+/**
+ * Bug: copy of error.todo-object-expression-computed-key-modified-during-after-construction-sequence-expr
+ * with the mutation hoisted to a named variable instead of being directly
+ * inlined into the Object key.
+ *
+ * Found differences in evaluator results
+ *   Non-forget (expected):
+ *   (kind: ok) [{"[object Object]":[42]},{"wat0":"joe","wat1":"joe"}]
+ *   [{"[object Object]":[42]},{"wat0":"joe","wat1":"joe"}]
+ *   Forget:
+ *   (kind: ok) [{"[object Object]":[42]},{"wat0":"joe","wat1":"joe"}]
+ *   [{"[object Object]":[42]},{"wat0":"joe","wat1":"joe","wat2":"joe"}]
+ */
+function Component(props) {
+  const key = {};
+  const tmp = (mutate(key), key);
+  const context = {
+    // Here, `tmp` is frozen (as it's inferred to be a primitive/string)
+    [tmp]: identity([props.value]),
+  };
+  mutate(key);
+  return [context, key];
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 42}],
+  sequentialRenders: [{value: 42}, {value: 42}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableNewMutationAliasingModel
+import { identity, mutate } from "shared-runtime";
+
+/**
+ * Bug: copy of error.todo-object-expression-computed-key-modified-during-after-construction-sequence-expr
+ * with the mutation hoisted to a named variable instead of being directly
+ * inlined into the Object key.
+ *
+ * Found differences in evaluator results
+ *   Non-forget (expected):
+ *   (kind: ok) [{"[object Object]":[42]},{"wat0":"joe","wat1":"joe"}]
+ *   [{"[object Object]":[42]},{"wat0":"joe","wat1":"joe"}]
+ *   Forget:
+ *   (kind: ok) [{"[object Object]":[42]},{"wat0":"joe","wat1":"joe"}]
+ *   [{"[object Object]":[42]},{"wat0":"joe","wat1":"joe","wat2":"joe"}]
+ */
+function Component(props) {
+  const $ = _c(2);
+  let t0;
+  if ($[0] !== props.value) {
+    const key = {};
+    const tmp = (mutate(key), key);
+    const context = { [tmp]: identity([props.value]) };
+
+    mutate(key);
+    t0 = [context, key];
+    $[0] = props.value;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ value: 42 }],
+  sequentialRenders: [{ value: 42 }, { value: 42 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) [{"[object Object]":[42]},{"wat0":"joe","wat1":"joe"}]
+[{"[object Object]":[42]},{"wat0":"joe","wat1":"joe"}]

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/bug-object-expression-computed-key-modified-during-after-construction-hoisted-sequence-expr.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/bug-object-expression-computed-key-modified-during-after-construction-hoisted-sequence-expr.js
@@ -1,0 +1,32 @@
+// @enableNewMutationAliasingModel
+import {identity, mutate} from 'shared-runtime';
+
+/**
+ * Bug: copy of error.todo-object-expression-computed-key-modified-during-after-construction-sequence-expr
+ * with the mutation hoisted to a named variable instead of being directly
+ * inlined into the Object key.
+ *
+ * Found differences in evaluator results
+ *   Non-forget (expected):
+ *   (kind: ok) [{"[object Object]":[42]},{"wat0":"joe","wat1":"joe"}]
+ *   [{"[object Object]":[42]},{"wat0":"joe","wat1":"joe"}]
+ *   Forget:
+ *   (kind: ok) [{"[object Object]":[42]},{"wat0":"joe","wat1":"joe"}]
+ *   [{"[object Object]":[42]},{"wat0":"joe","wat1":"joe","wat2":"joe"}]
+ */
+function Component(props) {
+  const key = {};
+  const tmp = (mutate(key), key);
+  const context = {
+    // Here, `tmp` is frozen (as it's inferred to be a primitive/string)
+    [tmp]: identity([props.value]),
+  };
+  mutate(key);
+  return [context, key];
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 42}],
+  sequentialRenders: [{value: 42}, {value: 42}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/iife-return-modified-later-phi.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/iife-return-modified-later-phi.expect.md
@@ -1,0 +1,58 @@
+
+## Input
+
+```javascript
+function Component(props) {
+  const items = (() => {
+    if (props.cond) {
+      return [];
+    } else {
+      return null;
+    }
+  })();
+  items?.push(props.a);
+  return items;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{a: {}}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component(props) {
+  const $ = _c(3);
+  let items;
+  if ($[0] !== props.a || $[1] !== props.cond) {
+    let t0;
+    if (props.cond) {
+      t0 = [];
+    } else {
+      t0 = null;
+    }
+    items = t0;
+
+    items?.push(props.a);
+    $[0] = props.a;
+    $[1] = props.cond;
+    $[2] = items;
+  } else {
+    items = $[2];
+  }
+  return items;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ a: {} }],
+};
+
+```
+      
+### Eval output
+(kind: ok) null

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/iife-return-modified-later-phi.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/iife-return-modified-later-phi.js
@@ -1,0 +1,16 @@
+function Component(props) {
+  const items = (() => {
+    if (props.cond) {
+      return [];
+    } else {
+      return null;
+    }
+  })();
+  items?.push(props.a);
+  return items;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{a: {}}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/transitive-mutation-before-capturing-value-created-earlier.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/transitive-mutation-before-capturing-value-created-earlier.expect.md
@@ -1,0 +1,50 @@
+
+## Input
+
+```javascript
+// @enableNewMutationAliasingModel
+function Component({a, b}) {
+  const x = [a];
+  const y = {b};
+  mutate(y);
+  y.x = x;
+  return <div>{y}</div>;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableNewMutationAliasingModel
+function Component(t0) {
+  const $ = _c(5);
+  const { a, b } = t0;
+  let t1;
+  if ($[0] !== a) {
+    t1 = [a];
+    $[0] = a;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const x = t1;
+  let t2;
+  if ($[2] !== b || $[3] !== x) {
+    const y = { b };
+    mutate(y);
+    y.x = x;
+    t2 = <div>{y}</div>;
+    $[2] = b;
+    $[3] = x;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  return t2;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/transitive-mutation-before-capturing-value-created-earlier.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/transitive-mutation-before-capturing-value-created-earlier.js
@@ -1,0 +1,8 @@
+// @enableNewMutationAliasingModel
+function Component({a, b}) {
+  const x = [a];
+  const y = {b};
+  mutate(y);
+  y.x = x;
+  return <div>{y}</div>;
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #33488
* #33477
* #33471
* #33470
* #33469
* #33465
* #33458
* #33449
* #33440
* #33430
* #33429
* #33427
* __->__ #33411
* #33401
* #33386
* #33385
* #33384
* #33380
* #33379
* #33378
* #33377
* #33376
* #33371
* #33370
* #33369
* #33367
* #33365
* #33364
* #33363
* #33346
* #33350
* #33180
* #33179
* #33178
* #33164
* #33163
* #33157
* #33151
* #33114
* #33113

Further refine the abstract interpretation for InferMutationAliasingRanges to account for forward data flow: Alias/Capture a -> b, mutate(a) => mutate(b) ie mutation affects aliases of the place being mutated, not just things that place aliased.

Fixes inference of which context vars of a function mutate, using the precise inference from the Range pass.

Adds MutateFrozen and MutateGlobal effects but they're not fully hooked up yet.