### PR TITLE
[devtools] Prevent incorrect render detection for user components in didFiberRender (#33423)

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -1885,7 +1885,20 @@ export function attach(
         // releasing DevTools in lockstep with React, we should import a
         // function from the reconciler instead.
         const PerformedWork = 0b000000000000000000000000001;
-        return (getFiberFlags(nextFiber) & PerformedWork) === PerformedWork;
+        if ((getFiberFlags(nextFiber) & PerformedWork) === 0) {
+          return false;
+        }
+        if (
+          prevFiber != null &&
+          prevFiber.memoizedProps === nextFiber.memoizedProps &&
+          prevFiber.memoizedState === nextFiber.memoizedState &&
+          prevFiber.ref === nextFiber.ref
+        ) {
+          // React may mark PerformedWork even if we bailed out. Double check
+          // that inputs actually changed before reporting a render.
+          return false;
+        }
+        return true;
       // Note: ContextConsumer only gets PerformedWork effect in 16.3.3+
       // so it won't get highlighted with React 16.3.0 to 16.3.2.
       default:


### PR DESCRIPTION
## Summary

Fixes false positive rendering detection in React DevTools Profiler by improving the `didFiberRender` function to accurately detect when user components actually re-render, preventing misleading "The parent component rendered" messages.

## Problem

Previously, React DevTools would incorrectly mark components as "rendered" even when they didn't actually re-render due to bailouts. This happened because the `didFiberRender` function only checked the `PerformedWork` flag, but React can set this flag even during bailout scenarios.

Example scenario:
- Parent component state changes  
- Sibling component with unchanged props shows "The parent component rendered"
- But the sibling component console.log shows it didn't actually re-render

## Solution

Enhanced `didFiberRender` function for user components (ClassComponent, FunctionComponent, etc.):

```javascript
// Before
const PerformedWork = 0b000000000000000000000000001;
return (getFiberFlags(nextFiber) & PerformedWork) === PerformedWork;

// After  
if ((getFiberFlags(nextFiber) & PerformedWork) === 0) {
  return false;
}
if (
  prevFiber != null &&
  prevFiber.memoizedProps === nextFiber.memoizedProps &&
  prevFiber.memoizedState === nextFiber.memoizedState &&
  prevFiber.ref === nextFiber.ref
) {
  // React may mark PerformedWork even if we bailed out. Double check
  // that inputs actually changed before reporting a render.
  return false;
}
return true;
```

This change ensures that:
1. We first check the `PerformedWork` flag (performance optimization)
2. Then verify that props/state/ref actually changed (accuracy check)
3. Only report rendering when inputs genuinely changed

## Testing

**Test Setup:**
Used the following test case with independent Count and Greeting components:

```javascript
const Count = () => {
    const [count, setCount] = useState(0);
    console.log('Count Component Rerendered');
    return (
        <button onClick={() => setCount(c => c + 1)}>
            Count: {count}
        </button>
    );
};

const Greeting = () => {
    console.log('Greeting Component Rerendered');
    return <span>Hello World!</span>;
};

const App = () => {
    const [appState, setAppState] = useState(0);
    console.log('App Component Rerendered');
    
    return (
        <main>
            <div>App State: {appState}</div>
            <button onClick={() => setAppState(s => s + 1)}>
                App Rerender Trigger (All children rerender)
            </button>
            <hr />
            <Count />
            <div>
                <Greeting />
            </div>
        </main>
    );
};
```

**Test Results:**
✅ **Tested and verified with this code**

// Before


https://github.com/user-attachments/assets/14bd6a1a-c100-4c65-80c0-1b70f5e9169d




// After

https://github.com/user-attachments/assets/7d8aed85-7e98-49c2-8b49-bc62a964aa9b




**Before Fix:**
- Click Count button → Console shows only "Count Component Rerendered" 
- DevTools Profiler → Greeting component incorrectly shows "The parent component rendered"

**After Fix:**  
- Click Count button → Console shows only "Count Component Rerendered"
- DevTools Profiler → Greeting component correctly shows no rendering information


## Related

This change specifically targets user components (Function/Class components) and maintains existing behavior for host components, ensuring accurate rendering detection across the React component tree.



Fixes https://github.com/facebook/react/issues/33423 , https://github.com/facebook/react/issues/19732