### PR TITLE
test breaking function name transform

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -2588,7 +2588,7 @@ function buildFakeTask(
 }
 
 const createFakeJSXCallStack = {
-  'react-stack-bottom-frame': function (
+  'react-stack-bottom-frame': true && function (
     response: Response,
     stack: ReactStackTrace,
     environmentName: string,
@@ -2715,7 +2715,7 @@ function getCurrentStackInDEV(): string {
 }
 
 const replayConsoleWithCallStack = {
-  'react-stack-bottom-frame': function (
+  'react-stack-bottom-frame': true && function (
     response: Response,
     methodName: string,
     stackTrace: ReactStackTrace,

--- a/packages/react-reconciler/src/ReactFiberCallUserSpace.js
+++ b/packages/react-reconciler/src/ReactFiberCallUserSpace.js
@@ -19,7 +19,7 @@ import {captureCommitPhaseError} from './ReactFiberWorkLoop';
 // TODO: Consider marking the whole bundle instead of these boundaries.
 
 const callComponent = {
-  'react-stack-bottom-frame': function <Props, Arg, R>(
+  'react-stack-bottom-frame': true && function <Props, Arg, R>(
     Component: (p: Props, arg: Arg) => R,
     props: Props,
     secondArg: Arg,
@@ -57,7 +57,7 @@ interface ClassInstance<R> {
 }
 
 const callRender = {
-  'react-stack-bottom-frame': function <R>(instance: ClassInstance<R>): R {
+  'react-stack-bottom-frame': true && function <R>(instance: ClassInstance<R>): R {
     const wasRendering = isRendering;
     setIsRendering(true);
     try {
@@ -76,7 +76,7 @@ export const callRenderInDEV: <R>(instance: ClassInstance<R>) => R => R =
     : (null: any);
 
 const callComponentDidMount = {
-  'react-stack-bottom-frame': function (
+  'react-stack-bottom-frame': true && function (
     finishedWork: Fiber,
     instance: ClassInstance<any>,
   ): void {
@@ -99,7 +99,7 @@ export const callComponentDidMountInDEV: (
   : (null: any);
 
 const callComponentDidUpdate = {
-  'react-stack-bottom-frame': function (
+  'react-stack-bottom-frame': true && function (
     finishedWork: Fiber,
     instance: ClassInstance<any>,
     prevProps: Object,
@@ -128,7 +128,7 @@ export const callComponentDidUpdateInDEV: (
   : (null: any);
 
 const callComponentDidCatch = {
-  'react-stack-bottom-frame': function (
+  'react-stack-bottom-frame': true && function (
     instance: ClassInstance<any>,
     errorInfo: CapturedValue<mixed>,
   ): void {
@@ -151,7 +151,7 @@ export const callComponentDidCatchInDEV: (
   : (null: any);
 
 const callComponentWillUnmount = {
-  'react-stack-bottom-frame': function (
+  'react-stack-bottom-frame': true && function (
     current: Fiber,
     nearestMountedAncestor: Fiber | null,
     instance: ClassInstance<any>,
@@ -176,7 +176,7 @@ export const callComponentWillUnmountInDEV: (
   : (null: any);
 
 const callCreate = {
-  'react-stack-bottom-frame': function (
+  'react-stack-bottom-frame': true && function (
     effect: Effect,
   ): (() => void) | {...} | void | null {
     const create = effect.create;
@@ -193,7 +193,7 @@ export const callCreateInDEV: (effect: Effect) => (() => void) | void = __DEV__
   : (null: any);
 
 const callDestroy = {
-  'react-stack-bottom-frame': function (
+  'react-stack-bottom-frame': true && function (
     current: Fiber,
     nearestMountedAncestor: Fiber | null,
     destroy: () => void,
@@ -216,7 +216,7 @@ export const callDestroyInDEV: (
   : (null: any);
 
 const callLazyInit = {
-  'react-stack-bottom-frame': function (lazy: LazyComponent<any, any>): any {
+  'react-stack-bottom-frame': true && function (lazy: LazyComponent<any, any>): any {
     const payload = lazy._payload;
     const init = lazy._init;
     return init(payload);

--- a/packages/react-server/src/ReactFizzCallUserSpace.js
+++ b/packages/react-server/src/ReactFizzCallUserSpace.js
@@ -13,7 +13,7 @@ import type {LazyComponent} from 'react/src/ReactLazy';
 // TODO: Consider marking the whole bundle instead of these boundaries.
 
 const callComponent = {
-  'react-stack-bottom-frame': function <Props, Arg, R>(
+  'react-stack-bottom-frame': true && function <Props, Arg, R>(
     Component: (p: Props, arg: Arg) => R,
     props: Props,
     secondArg: Arg,
@@ -36,7 +36,7 @@ interface ClassInstance<R> {
 }
 
 const callRender = {
-  'react-stack-bottom-frame': function <R>(instance: ClassInstance<R>): R {
+  'react-stack-bottom-frame': true && function <R>(instance: ClassInstance<R>): R {
     return instance.render();
   },
 };
@@ -48,7 +48,7 @@ export const callRenderInDEV: <R>(instance: ClassInstance<R>) => R => R =
     : (null: any);
 
 const callLazyInit = {
-  'react-stack-bottom-frame': function (lazy: LazyComponent<any, any>): any {
+  'react-stack-bottom-frame': true && function (lazy: LazyComponent<any, any>): any {
     const payload = lazy._payload;
     const init = lazy._init;
     return init(payload);

--- a/packages/react-server/src/ReactFlightCallUserSpace.js
+++ b/packages/react-server/src/ReactFlightCallUserSpace.js
@@ -19,7 +19,7 @@ import {setCurrentOwner} from './flight/ReactFlightCurrentOwner';
 // TODO: Consider marking the whole bundle instead of these boundaries.
 
 const callComponent = {
-  'react-stack-bottom-frame': function <Props, R>(
+  'react-stack-bottom-frame': true && function <Props, R>(
     Component: (p: Props, arg: void) => R,
     props: Props,
     componentDebugInfo: ReactComponentInfo,
@@ -45,7 +45,7 @@ export const callComponentInDEV: <Props, R>(
   : (null: any);
 
 const callLazyInit = {
-  'react-stack-bottom-frame': function (lazy: LazyComponent<any, any>): any {
+  'react-stack-bottom-frame': true && function (lazy: LazyComponent<any, any>): any {
     const payload = lazy._payload;
     const init = lazy._init;
     return init(payload);
@@ -58,7 +58,7 @@ export const callLazyInitInDEV: (lazy: LazyComponent<any, any>) => any = __DEV__
   : (null: any);
 
 const callIterator = {
-  'react-stack-bottom-frame': function (
+  'react-stack-bottom-frame': true && function (
     iterator: $AsyncIterator<ReactClientValue, ReactClientValue, void>,
     progress: (
       entry:

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -66,7 +66,7 @@ function UnknownOwner() {
   return (() => Error('react-stack-top-frame'))();
 }
 const createFakeCallStack = {
-  'react-stack-bottom-frame': function (callStackForError) {
+  'react-stack-bottom-frame': true && function (callStackForError) {
     return callStackForError();
   },
 };


### PR DESCRIPTION
`babel/plugin-transform-function-name` breaks owner stacks ([Playground](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=MYewdgzgLgBMBOBTAhlRAxZBrRBhZANgQMpTLBYwC8MA3gFAwwDkS5UAtNOVhwEYgoUEAFsOAM3jIRzAFwxxAVzDAoAS3AwAFMEIkyFdCHgBRePGMBKOoyYwkURfDBw9pHkdPnjWywG5bAF8AGnpAvyA&forceAllTransforms=false&modules=commonjs&shippedProposals=false&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=&prettier=false&targets=&version=7.27.5&externalPlugins=%40babel%2Fplugin-transform-function-name%407.27.1&assumptions=%7B%7D)). 

Going to try a few ways to trick it:

Idea 1 (gcc strips): `function (){...} || undefined` [Playground](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=MYewdgzgLgBMBOBTAhlRAxZBrRBhZANgQMpTLBYwC8MA3gFAwwDkS5UAtNOVhwEYgoUEAFsOAM3jIRiZgC4Y4gK5hgUAJbgYACmCESZCuhDwAovHgmAlHUZMYSKEvhg4-0j2NmLJ7VYDcdgC-MAA-oTAqACaI4upgiFEANPRB_kA&forceAllTransforms=false&modules=commonjs&shippedProposals=false&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=&prettier=false&targets=&version=7.27.5&externalPlugins=%40babel%2Fplugin-transform-function-name%407.27.1&assumptions=%7B%7D). 

Idea 2 (gcc strips): `[key]: function (){...}` [Playground](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=MYewdgzgLgBA1gUwJ4wLwwOQCcEENhQC00-chARiFFCALaEBmWutCGA3AFCiSzA64oCAGK5EAYVwAbKQGUopNDADenGDADaiJAF0AXDAYBXMAQCW4GAApg0uQuBxhILAFEsWFwEoVa9TBwoIywwGFsZeVJnNw8XKy8udQBfABpOJPYgA&forceAllTransforms=false&modules=commonjs&shippedProposals=false&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=&prettier=false&targets=&version=7.27.5&externalPlugins=%40babel%2Fplugin-transform-function-name%407.27.1&assumptions=%7B%7D).

Idea 3 (stack changes): `'react-stack-bottom-frame': (() => function(){})()` [Playground](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=MYewdgzgLgBMBOBTAhlRAxZBrRBhZANgQMpTLBYwC8MA3gFAwwDkS5UAtNOVhwEYgoUEAFsOAM3jIRiZgC4YACkUBKagD4Y4gK5hgUAJbglwQiTIV0IeAFF48a2oZMmSKNvhg4Z0jyu37a1UAbkYYAF8VABp6cOCgA&forceAllTransforms=false&modules=commonjs&shippedProposals=false&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=&prettier=false&targets=&version=7.27.5&externalPlugins=%40babel%2Fplugin-transform-function-name%407.27.1&assumptions=%7B%7D). Changes to `in Object.<anonymous>.react-stack-bottom-frame`

Idead 4 (stack changes): `[key]: function() {...}` [Playground](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=MYewdgzgLgBA1gUwJ4wLwwOQCcEENhQC00-chARiFFCALaEBmWutCGA3AFCiSzA64oCAGK5EAYVwAbKQGUopNDADenGDADaiJAF0AXDAYBXMAQCW4GAApg0uQuBxhILAFEsWFwEoVa9TBwoIywwGFsZeVJnNw8XKy8udQBfABpOJPYgA&forceAllTransforms=false&modules=commonjs&shippedProposals=false&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=&prettier=false&targets=&version=7.27.5&externalPlugins=%40babel%2Fplugin-transform-function-name%407.27.1&assumptions=%7B%7D). Changes to `in Object.react-stack-bottom-frame`