### PR TITLE
[compiler][newinference] Fix for phi types, extracting primitives from objects

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
@@ -25,6 +25,7 @@ import {
   InstructionValue,
   isArrayType,
   isMapType,
+  isPrimitiveType,
   isSetType,
   makeIdentifierId,
   ObjectMethod,
@@ -464,12 +465,15 @@ function applyEffect(
           break;
         }
         default: {
-          effects.push({
-            // OK: recording information flow
-            kind: 'CreateFrom', // prev Alias
-            from: effect.from,
-            into: effect.into,
-          });
+          // Even if the source is non-primitive, the destination may be. skip primitives.
+          if (!isPrimitiveType(effect.into.identifier)) {
+            effects.push({
+              // OK: recording information flow
+              kind: 'CreateFrom', // prev Alias
+              from: effect.from,
+              into: effect.into,
+            });
+          }
         }
       }
       break;
@@ -1622,6 +1626,7 @@ function computeSignatureForInstruction(
           suggestions: null,
         },
       });
+      effects.push({kind: 'Assign', from: value.value, into: lvalue});
       break;
     }
     case 'TypeCastExpression': {

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -44,7 +44,7 @@ import {
   getHookKind,
   makeIdentifierName,
 } from '../HIR/HIR';
-import {printIdentifier, printPlace} from '../HIR/PrintHIR';
+import {printIdentifier, printInstruction, printPlace} from '../HIR/PrintHIR';
 import {eachPatternOperand} from '../HIR/visitors';
 import {Err, Ok, Result} from '../Utils/Result';
 import {GuardKind} from '../Utils/RuntimeDiagnosticConstants';
@@ -1310,7 +1310,7 @@ function codegenInstructionNullable(
         });
         CompilerError.invariant(value?.type === 'FunctionExpression', {
           reason: 'Expected a function as a function declaration value',
-          description: null,
+          description: `Got ${value == null ? String(value) : value.type} at ${printInstruction(instr)}`,
           loc: instr.value.loc,
           suggestions: null,
         });

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-boxing-unboxing-function-call-indirections-2.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-boxing-unboxing-function-call-indirections-2.expect.md
@@ -1,0 +1,67 @@
+
+## Input
+
+```javascript
+// @enableNewMutationAliasingModel
+import {Stringify} from 'shared-runtime';
+
+function Component({a, b}) {
+  const x = {a, b};
+  const f = () => {
+    const y = [x];
+    return y[0];
+  };
+  const x0 = f();
+  const z = [x0];
+  const x1 = z[0];
+  x1.key = 'value';
+  return <Stringify x={x} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{a: 0, b: 1}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableNewMutationAliasingModel
+import { Stringify } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(3);
+  const { a, b } = t0;
+  let t1;
+  if ($[0] !== a || $[1] !== b) {
+    const x = { a, b };
+    const f = () => {
+      const y = [x];
+      return y[0];
+    };
+
+    const x0 = f();
+    const z = [x0];
+    const x1 = z[0];
+    x1.key = "value";
+    t1 = <Stringify x={x} />;
+    $[0] = a;
+    $[1] = b;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  return t1;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ a: 0, b: 1 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"x":{"a":0,"b":1,"key":"value"}}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-boxing-unboxing-function-call-indirections-2.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-boxing-unboxing-function-call-indirections-2.js
@@ -1,0 +1,20 @@
+// @enableNewMutationAliasingModel
+import {Stringify} from 'shared-runtime';
+
+function Component({a, b}) {
+  const x = {a, b};
+  const f = () => {
+    const y = [x];
+    return y[0];
+  };
+  const x0 = f();
+  const z = [x0];
+  const x1 = z[0];
+  x1.key = 'value';
+  return <Stringify x={x} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{a: 0, b: 1}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-boxing-unboxing-function-call-indirections.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-boxing-unboxing-function-call-indirections.expect.md
@@ -1,0 +1,67 @@
+
+## Input
+
+```javascript
+// @enableNewMutationAliasingModel
+import {Stringify} from 'shared-runtime';
+
+function Component({a, b}) {
+  const x = {a, b};
+  const y = [x];
+  const f = () => {
+    const x0 = y[0];
+    return [x0];
+  };
+  const z = f();
+  const x1 = z[0];
+  x1.key = 'value';
+  return <Stringify x={x} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{a: 0, b: 1}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableNewMutationAliasingModel
+import { Stringify } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(3);
+  const { a, b } = t0;
+  let t1;
+  if ($[0] !== a || $[1] !== b) {
+    const x = { a, b };
+    const y = [x];
+    const f = () => {
+      const x0 = y[0];
+      return [x0];
+    };
+
+    const z = f();
+    const x1 = z[0];
+    x1.key = "value";
+    t1 = <Stringify x={x} />;
+    $[0] = a;
+    $[1] = b;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  return t1;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ a: 0, b: 1 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"x":{"a":0,"b":1,"key":"value"}}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-boxing-unboxing-function-call-indirections.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-boxing-unboxing-function-call-indirections.js
@@ -1,0 +1,20 @@
+// @enableNewMutationAliasingModel
+import {Stringify} from 'shared-runtime';
+
+function Component({a, b}) {
+  const x = {a, b};
+  const y = [x];
+  const f = () => {
+    const x0 = y[0];
+    return [x0];
+  };
+  const z = f();
+  const x1 = z[0];
+  x1.key = 'value';
+  return <Stringify x={x} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{a: 0, b: 1}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-boxing-unboxing-indirections.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-boxing-unboxing-indirections.expect.md
@@ -1,0 +1,60 @@
+
+## Input
+
+```javascript
+// @enableNewMutationAliasingModel
+import {Stringify} from 'shared-runtime';
+
+function Component({a, b}) {
+  const x = {a, b};
+  const y = [x];
+  const x0 = y[0];
+  const z = [x0];
+  const x1 = z[0];
+  x1.key = 'value';
+  return <Stringify x={x} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{a: 0, b: 1}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableNewMutationAliasingModel
+import { Stringify } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(3);
+  const { a, b } = t0;
+  let t1;
+  if ($[0] !== a || $[1] !== b) {
+    const x = { a, b };
+    const y = [x];
+    const x0 = y[0];
+    const z = [x0];
+    const x1 = z[0];
+    x1.key = "value";
+    t1 = <Stringify x={x} />;
+    $[0] = a;
+    $[1] = b;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  return t1;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ a: 0, b: 1 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"x":{"a":0,"b":1,"key":"value"}}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-boxing-unboxing-indirections.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-boxing-unboxing-indirections.js
@@ -1,0 +1,17 @@
+// @enableNewMutationAliasingModel
+import {Stringify} from 'shared-runtime';
+
+function Component({a, b}) {
+  const x = {a, b};
+  const y = [x];
+  const x0 = y[0];
+  const z = [x0];
+  const x1 = z[0];
+  x1.key = 'value';
+  return <Stringify x={x} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{a: 0, b: 1}],
+};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #33488
* #33477
* #33471
* #33470
* #33469
* #33465
* #33458
* #33449
* __->__ #33440
* #33430
* #33429
* #33427
* #33411
* #33401
* #33386
* #33385
* #33384
* #33380
* #33379
* #33378
* #33377
* #33376
* #33371
* #33370
* #33369
* #33367
* #33365
* #33364
* #33363
* #33346
* #33350
* #33180
* #33179
* #33178
* #33164
* #33163
* #33157
* #33151
* #33114
* #33113

First a quick fix: if we have a known type for the lvalue of CreateFrom, we can drop the effect. This is a bit awkward generally because the types and abstract values overlap a bit, and i'd prefer to only look at types during one phase. So maybe move all the type-checking to where we generate effects, and then after that applyEffect() doesn't have to consider types.

The larger fix is for InferMutationAliasingRanges. When processing a mutation we have to walk the graph in both forward and backwards directions. Consider `alias a -> b, mutate(b)`. We have to walk back the alias chain from b to a, and mark a as mutated too. But for `alias a -> b, mutate(a)`, we also have to mark b as mutated — walking forwards along the alias chain.

But phis are a bit different. You can have a mutation of one of the phi operands, such that you have `a, b -> phi c, mutate(a)`. Here, we do need to mark c as mutated, but we should not walk back to b — it's a different operand! a and b don't alias together.

There are now about 150 fixtures failing, but they're in a few categories and all of them are addressable:
* Infinite loops. `applyEffect()` creates new un-memoized effect values which means that any input with a backedge (loop) will spin until my infinite loop detection throws. This is somewhat tedious to address but it's a pragmatic concern and not a flaw in the model. I also need to convince myself that the approach in InferMutationAliasingRanges is safe for loops, but first i have to get inputs w loops to even reach that phase.
* LoadContext/StoreContext - i currently treat these too similarly to regular load/store, ie assuming the mutations happen in order. One idea is to treat LoadContext as a mutate instead of an alias, just to make sure all instances get grouped together.
* InvalidReact detection. We already synthesize MutateFrozen/MutateGlobal effects but we don't throw these as errors yet. This is probably the largest category of failing tests, which means overall this is actually "pretty close" (so, 50% of the way there).