### PR TITLE
chore: fix typo 'diasbled' to 'disabled' in ESLint config comment

### DIFF
--- a/compiler/.eslintrc.js
+++ b/compiler/.eslintrc.js
@@ -99,7 +99,7 @@ module.exports = {
   },
   /*
    * If rules need to be disabled then the rule is insufficiently high signal
-   * and should be diasbled altogether or customized (in either case via a standalone PR)
+   * and should be disabled altogether or customized (in either case via a standalone PR)
    */
   noInlineConfig: true,
   reportUnusedDisableDirectives: true,


### PR DESCRIPTION
## Summary

Fix a typo in a comment in compiler/.eslintrc.js (`diasbled` → `disabled`).

## How did you test this change?

No code logic changed. Confirmed the typo fix in the comment.