### PR TITLE
Eslint private ident

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
@@ -1919,7 +1919,11 @@ function analyzePropertyChain(
   node: Node,
   optionalChains: Map<string, boolean> | null,
 ): string {
-  if (node.type === 'Identifier' || node.type === 'JSXIdentifier') {
+  if (
+    node.type === 'Identifier' ||
+    node.type === 'PrivateIdentifier' ||
+    node.type === 'JSXIdentifier'
+  ) {
     const result = node.name;
     if (optionalChains) {
       // Mark as required.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->


## Summary

The PR fixes "Unsupported node type: PrivateIdentifier" error in the `react-hooks/exhaustive-deps` ESLint rule.

I.e. ESLint throws the errors in the following code:

```tsx
export class Form<Payload> {
  static use<Payload>(
    value: Payload,
    options?: Form.Options<Payload>,
  ): Form<Payload> {
    const id = useId();
    const form = useMemo(() => new Form(id, value, options), [id]);
    const rerender = useRerender();

    useEffect(
      () =>
        form.#field.watch((_, event) => {
          // Only react to form-specific changes, as everything else is
          // handled by the field's useBind hook below.
          if (
            !maskedChanges(
              event.changes,
              formChange.formSubmitting |
                formChange.formSubmitted |
                formChange.formValid |
                formChange.formInvalid,
            )
          )
            return;

          rerender();
        }),
      [form, rerender],
    );

    form.#field.useBind();

    return form;
  }

  // ...
```


```
Error: Unsupported node type: PrivateIdentifier
Occurred while linting /wrkspc/enso/src/form/index.tsx:20
Rule: "react-hooks/exhaustive-deps"
    at analyzePropertyChain (/wrkspc/enso/node_modules/.pnpm/eslint-plugin-react-hooks@5.2.0_eslint@9.28.0/node_modules/eslint-plugin-react-hooks/cjs/eslint-plugin-react-hooks.development.js:2532:15)
    at analyzePropertyChain (/wrkspc/enso/node_modules/.pnpm/eslint-plugin-react-hooks@5.2.0_eslint@9.28.0/node_modules/eslint-plugin-react-hooks/cjs/eslint-plugin-react-hooks.development.js:2506:24)
    at gatherDependenciesRecursively (/wrkspc/enso/node_modules/.pnpm/eslint-plugin-react-hooks@5.2.0_eslint@9.28.0/node_modules/eslint-plugin-react-hooks/cjs/eslint-plugin-react-hooks.development.js:1272:42)
    at visitFunctionWithDependencies (/wrkspc/enso/node_modules/.pnpm/eslint-plugin-react-hooks@5.2.0_eslint@9.28.0/node_modules/eslint-plugin-react-hooks/cjs/eslint-plugin-react-hooks.development.js:1250:13)
    at visitCallExpression (/wrkspc/enso/node_modules/.pnpm/eslint-plugin-react-hooks@5.2.0_eslint@9.28.0/node_modules/eslint-plugin-react-hooks/cjs/eslint-plugin-react-hooks.development.js:2045:21)
    at ruleErrorHandler (/wrkspc/enso/node_modules/.pnpm/eslint@9.28.0/node_modules/eslint/lib/linter/linter.js:1307:33)
    at /wrkspc/enso/node_modules/.pnpm/eslint@9.28.0/node_modules/eslint/lib/linter/safe-emitter.js:45:46
    at Array.forEach (<anonymous>)
    at Object.emit (/wrkspc/enso/node_modules/.pnpm/eslint@9.28.0/node_modules/eslint/lib/linter/safe-emitter.js:45:26)
    at #applySelector (/wrkspc/enso/node_modules/.pnpm/eslint@9.28.0/node_modules/eslint/lib/linter/source-code-traverser.js:148:17)
```

Luckily, it is an easy fix, albeit required some tinkering in tests as `babel-eslint` doesn't support private methods at all.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

I tested it on my codebase that actively uses private class properties, and also committed a failing test separately for easier verification.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
