### PR TITLE
[compiler] fixes for effects capturing context vars, hoisted functions

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Globals.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Globals.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {Effect, ValueKind, ValueReason} from './HIR';
+import {Effect, makeIdentifierId, ValueKind, ValueReason} from './HIR';
 import {
   BUILTIN_SHAPES,
   BuiltInArrayId,
@@ -32,6 +32,7 @@ import {
   addFunction,
   addHook,
   addObject,
+  signatureArgument,
 } from './ObjectShape';
 import {BuiltInType, ObjectType, PolyType} from './Types';
 import {TypeConfig} from './TypeSchema';
@@ -642,6 +643,41 @@ const REACT_APIS: Array<[string, BuiltInType]> = [
         calleeEffect: Effect.Read,
         hookKind: 'useEffect',
         returnValueKind: ValueKind.Frozen,
+        aliasing: {
+          receiver: makeIdentifierId(0),
+          params: [],
+          rest: makeIdentifierId(1),
+          returns: makeIdentifierId(2),
+          temporaries: [signatureArgument(3)],
+          effects: [
+            // Freezes the function and deps
+            {
+              kind: 'Freeze',
+              value: signatureArgument(1),
+              reason: ValueReason.Effect,
+            },
+            // Internally creates an effect object that captures the function and deps
+            {
+              kind: 'Create',
+              into: signatureArgument(3),
+              value: ValueKind.Frozen,
+              reason: ValueReason.KnownReturnSignature,
+            },
+            // The effect stores the function and dependencies
+            {
+              kind: 'Capture',
+              from: signatureArgument(1),
+              into: signatureArgument(3),
+            },
+            // Returns undefined
+            {
+              kind: 'Create',
+              into: signatureArgument(2),
+              value: ValueKind.Primitive,
+              reason: ValueReason.KnownReturnSignature,
+            },
+          ],
+        },
       },
       BuiltInUseEffectHookId,
     ),

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -1397,6 +1397,11 @@ export enum ValueReason {
   JsxCaptured = 'jsx-captured',
 
   /**
+   * Passed to an effect
+   */
+  Effect = 'effect',
+
+  /**
    * Return value of a function with known frozen return value, e.g. `useState`.
    */
   KnownReturnSignature = 'known-return-signature',

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferFunctionEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferFunctionEffects.ts
@@ -357,6 +357,8 @@ export function getWriteErrorReason(abstractValue: AbstractValue): string {
     return "Mutating a value returned from 'useState()', which should not be mutated. Use the setter function to update instead";
   } else if (abstractValue.reason.has(ValueReason.ReducerState)) {
     return "Mutating a value returned from 'useReducer()', which should not be mutated. Use the dispatch function to update instead";
+  } else if (abstractValue.reason.has(ValueReason.Effect)) {
+    return 'Updating a value used previously in an effect function or as an effect dependency is not allowed. Consider moving the mutation before calling useEffect()';
   } else {
     return 'This mutates a variable that React considers immutable';
   }

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
@@ -66,6 +66,8 @@ import {getWriteErrorReason} from './InferFunctionEffects';
 import prettyFormat from 'pretty-format';
 import {createTemporaryPlace} from '../HIR/HIRBuilder';
 
+const DEBUG = false;
+
 export function inferMutationAliasingEffects(
   fn: HIRFunction,
   {isFunctionExpression}: {isFunctionExpression: boolean} = {
@@ -849,7 +851,7 @@ function applyEffect(
       ) {
         const value = state.kind(effect.value);
         if (DEBUG) {
-          console.log(printAliasingEffect(effect));
+          console.log(`invalid mutation: ${printAliasingEffect(effect)}`);
           console.log(prettyFormat(state.debugAbstractValue(value)));
         }
 
@@ -890,8 +892,6 @@ function applyEffect(
     }
   }
 }
-
-const DEBUG = false;
 
 class InferenceState {
   env: Environment;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #33488
* #33477
* #33471
* #33470
* __->__ #33469
* #33465
* #33458
* #33449
* #33440
* #33430
* #33429
* #33427
* #33411
* #33401
* #33386
* #33385
* #33384
* #33380
* #33379
* #33378
* #33377
* #33376
* #33371
* #33370
* #33369
* #33367
* #33365
* #33364
* #33363
* #33346
* #33350
* #33180
* #33179
* #33178
* #33164
* #33163
* #33157
* #33151
* #33114
* #33113

