### PR TITLE
Re-export ReactFlightDOMClientEdge from ReactFlightDOMClientNode

### DIFF
--- a/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientNode.js
@@ -19,9 +19,7 @@ import {
   close,
 } from 'react-client/src/ReactFlightClient';
 
-import {createServerReference as createServerReferenceImpl} from 'react-client/src/ReactFlightReplyClient';
-
-export {registerServerReference} from 'react-client/src/ReactFlightReplyClient';
+export * from './ReactFlightDOMClientEdge';
 
 function findSourceMapURL(filename: string, environmentName: string) {
   const devServer = parcelRequire.meta.devServer;
@@ -39,19 +37,6 @@ function noServerCall() {
     'Server Functions cannot be called during initial render. ' +
       'This would create a fetch waterfall. Try to use a Server Component ' +
       'to pass data to Client Components instead.',
-  );
-}
-
-export function createServerReference<A: Iterable<any>, T>(
-  id: string,
-  exportName: string,
-): (...A) => Promise<T> {
-  return createServerReferenceImpl(
-    id + '#' + exportName,
-    noServerCall,
-    undefined,
-    findSourceMapURL,
-    exportName,
   );
 }
 

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
@@ -36,9 +36,7 @@ import {
   close,
 } from 'react-client/src/ReactFlightClient';
 
-import {createServerReference as createServerReferenceImpl} from 'react-client/src/ReactFlightReplyClient';
-
-export {registerServerReference} from 'react-client/src/ReactFlightReplyClient';
+export * from './ReactFlightDOMClientEdge';
 
 function noServerCall() {
   throw new Error(
@@ -46,13 +44,6 @@ function noServerCall() {
       'This would create a fetch waterfall. Try to use a Server Component ' +
       'to pass data to Client Components instead.',
   );
-}
-
-export function createServerReference<A: Iterable<any>, T>(
-  id: any,
-  callServer: any,
-): (...A) => Promise<T> {
-  return createServerReferenceImpl(id, noServerCall);
 }
 
 type EncodeFormActionCallback = <A>(

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
@@ -37,9 +37,7 @@ import {
   close,
 } from 'react-client/src/ReactFlightClient';
 
-import {createServerReference as createServerReferenceImpl} from 'react-client/src/ReactFlightReplyClient';
-
-export {registerServerReference} from 'react-client/src/ReactFlightReplyClient';
+export * from './ReactFlightDOMClientEdge';
 
 function noServerCall() {
   throw new Error(
@@ -47,13 +45,6 @@ function noServerCall() {
       'This would create a fetch waterfall. Try to use a Server Component ' +
       'to pass data to Client Components instead.',
   );
-}
-
-export function createServerReference<A: Iterable<any>, T>(
-  id: any,
-  callServer: any,
-): (...A) => Promise<T> {
-  return createServerReferenceImpl(id, noServerCall);
 }
 
 type EncodeFormActionCallback = <A>(

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -89,6 +89,7 @@ module.exports = [
       'react-server-dom-webpack/server.node.unbundled',
       'react-server-dom-webpack/static',
       'react-server-dom-webpack/static.node.unbundled',
+      'react-server-dom-webpack/src/client/ReactFlightDOMClientEdge.js', // react-server-dom-webpack/client.node
       'react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js', // react-server-dom-webpack/client.node
       'react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerNode.js',
       'react-server-dom-webpack/src/client/react-flight-dom-client.node.unbundled',
@@ -131,7 +132,8 @@ module.exports = [
       'react-server-dom-webpack/server.node',
       'react-server-dom-webpack/static',
       'react-server-dom-webpack/static.node',
-      'react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js', // react-server-dom-turbopack/client.node
+      'react-server-dom-webpack/src/client/ReactFlightDOMClientEdge.js', // react-server-dom-webpack/client.node
+      'react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js', // react-server-dom-webpack/client.node
       'react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpack.js',
       'react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpackServer.js',
       'react-server-dom-webpack/src/client/react-flight-dom-client.node',
@@ -176,6 +178,7 @@ module.exports = [
       'react-server-dom-turbopack/server.node',
       'react-server-dom-turbopack/static',
       'react-server-dom-turbopack/static.node',
+      'react-server-dom-turbopack/src/client/ReactFlightDOMClientEdge.js', // react-server-dom-turbopack/client.node
       'react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js', // react-server-dom-turbopack/client.node
       'react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopack.js',
       'react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopackServer.js',
@@ -221,6 +224,7 @@ module.exports = [
       'react-server-dom-parcel/server.node',
       'react-server-dom-parcel/static',
       'react-server-dom-parcel/static.node',
+      'react-server-dom-parcel/src/client/ReactFlightDOMClientEdge.js', // react-server-dom-parcel/client.node
       'react-server-dom-parcel/src/client/ReactFlightDOMClientNode.js', // react-server-dom-parcel/client.node
       'react-server-dom-parcel/src/client/ReactFlightClientConfigBundlerParcel.js',
       'react-server-dom-parcel/src/client/react-flight-dom-client.node',


### PR DESCRIPTION
This effectively lets us consume Web Streams in a Node build. In fact the Node entry point is now just adding Node stream APIs.

For the client, this is simple because the configs are not actually stream type specific. The server is a little trickier.
