### PR TITLE
Format `ReactNativeAttributePayloadFabric.js` with Prettier

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeAttributePayloadFabric.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayloadFabric.js
@@ -255,7 +255,9 @@ function diffProperties(
     nextProp = nextProps[propKey];
 
     if (typeof nextProp === 'function') {
-      const attributeConfigHasProcess = typeof attributeConfig === 'object' && typeof attributeConfig.process === 'function';
+      const attributeConfigHasProcess =
+        typeof attributeConfig === 'object' &&
+        typeof attributeConfig.process === 'function';
       if (!attributeConfigHasProcess) {
         // functions are converted to booleans as markers that the associated
         // events should be sent from native.


### PR DESCRIPTION
The prettier check for this file is currently failing on `main`, after #32119 was merged.