### PR TITLE
[compiler][newinference] Impure/Render effects

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
@@ -416,6 +416,7 @@ addObject(BUILTIN_SHAPES, BuiltInArrayId, [
             into: signatureArgument(4),
             signature: null,
             mutatesFunction: false,
+            loc: GeneratedSource,
           },
           // captures the result of the callback into the return array
           {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -1015,6 +1015,12 @@ export function printAliasingEffect(effect: AliasingEffect): string {
     case 'MutateGlobal': {
       return `MutateGlobal ${printPlaceForAliasEffect(effect.place)} reason=${JSON.stringify(effect.error.reason)}`;
     }
+    case 'Impure': {
+      return `Impure ${printPlaceForAliasEffect(effect.place)} reason=${JSON.stringify(effect.error.reason)}`;
+    }
+    case 'Render': {
+      return `Render ${printPlaceForAliasEffect(effect.place)}`;
+    }
     default: {
       assertExhaustive(effect, `Unexpected kind '${(effect as any).kind}'`);
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/AnalyseFunctions.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/AnalyseFunctions.ts
@@ -100,6 +100,8 @@ function lowerWithMutationAliasing(fn: HIRFunction): void {
         capturedOrMutated.add(effect.value.identifier.id);
         break;
       }
+      case 'Impure':
+      case 'Render':
       case 'MutateFrozen':
       case 'MutateGlobal':
       case 'CreateFunction':

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingFunctionEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingFunctionEffects.ts
@@ -108,7 +108,9 @@ export function inferMutationAliasingFunctionEffects(
           ]);
         } else if (
           effect.kind === 'MutateFrozen' ||
-          effect.kind === 'MutateGlobal'
+          effect.kind === 'MutateGlobal' ||
+          effect.kind === 'Impure' ||
+          effect.kind === 'Render'
         ) {
           effects.push(effect);
         }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.assign-global-in-jsx-spread-attribute.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.assign-global-in-jsx-spread-attribute.expect.md
@@ -2,6 +2,7 @@
 ## Input
 
 ```javascript
+// @enableNewMutationAliasingModel:false
 function Component() {
   const foo = () => {
     someGlobal = true;
@@ -15,13 +16,13 @@ function Component() {
 ## Error
 
 ```
-  1 | function Component() {
-  2 |   const foo = () => {
-> 3 |     someGlobal = true;
-    |     ^^^^^^^^^^ InvalidReact: Unexpected reassignment of a variable which was defined outside of the component. Components and hooks should be pure and side-effect free, but variable reassignment is a form of side-effect. If this variable is used in rendering, use useState instead. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render) (3:3)
-  4 |   };
-  5 |   return <div {...foo} />;
-  6 | }
+  2 | function Component() {
+  3 |   const foo = () => {
+> 4 |     someGlobal = true;
+    |     ^^^^^^^^^^ InvalidReact: Unexpected reassignment of a variable which was defined outside of the component. Components and hooks should be pure and side-effect free, but variable reassignment is a form of side-effect. If this variable is used in rendering, use useState instead. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render) (4:4)
+  5 |   };
+  6 |   return <div {...foo} />;
+  7 | }
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.assign-global-in-jsx-spread-attribute.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.assign-global-in-jsx-spread-attribute.js
@@ -1,3 +1,4 @@
+// @enableNewMutationAliasingModel:false
 function Component() {
   const foo = () => {
     someGlobal = true;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-impure-functions-in-render.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-impure-functions-in-render.expect.md
@@ -20,7 +20,7 @@ function Component() {
   2 |
   3 | function Component() {
 > 4 |   const date = Date.now();
-    |                ^^^^^^^^ InvalidReact: Calling an impure function can produce unstable results. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent). `Date.now` is an impure function whose results may change on every call (4:4)
+    |                ^^^^^^^^^^ InvalidReact: Calling an impure function can produce unstable results. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent). `Date.now` is an impure function whose results may change on every call (4:4)
 
 InvalidReact: Calling an impure function can produce unstable results. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent). `performance.now` is an impure function whose results may change on every call (5:5)
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.object-capture-global-mutation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.object-capture-global-mutation.expect.md
@@ -2,6 +2,7 @@
 ## Input
 
 ```javascript
+// @enableNewMutationAliasingModel:false
 function Foo() {
   const x = () => {
     window.href = 'foo';
@@ -21,13 +22,13 @@ export const FIXTURE_ENTRYPOINT = {
 ## Error
 
 ```
-  1 | function Foo() {
-  2 |   const x = () => {
-> 3 |     window.href = 'foo';
-    |     ^^^^^^ InvalidReact: Writing to a variable defined outside a component or hook is not allowed. Consider using an effect (3:3)
-  4 |   };
-  5 |   const y = {x};
-  6 |   return <Bar y={y} />;
+  2 | function Foo() {
+  3 |   const x = () => {
+> 4 |     window.href = 'foo';
+    |     ^^^^^^ InvalidReact: Writing to a variable defined outside a component or hook is not allowed. Consider using an effect (4:4)
+  5 |   };
+  6 |   const y = {x};
+  7 |   return <Bar y={y} />;
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.object-capture-global-mutation.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.object-capture-global-mutation.js
@@ -1,3 +1,4 @@
+// @enableNewMutationAliasingModel:false
 function Foo() {
   const x = () => {
     window.href = 'foo';

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/capture-backedge-phi-with-later-mutation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/capture-backedge-phi-with-later-mutation.expect.md
@@ -8,7 +8,6 @@ import {arrayPush, Stringify} from 'shared-runtime';
 function Component({prop1, prop2}) {
   'use memo';
 
-  // we'll ultimately extract the item from this array as z, and mutate later
   let x = [{value: prop1}];
   let z;
   while (x.length < 2) {
@@ -17,27 +16,25 @@ function Component({prop1, prop2}) {
     // this mutation occurs before the reassigned value
     arrayPush(x, {value: prop2});
 
-    // this condition will never be true, so x doesn't get reassigned
-    if (x[0].value === null) {
+    if (x[0].value === prop1) {
       x = [{value: prop2}];
       const y = x;
       z = y[0];
     }
   }
-  // the code is set up so that z will always be the value from the original x
   z.other = true;
   return <Stringify z={z} />;
 }
 
 export const FIXTURE_ENTRYPOINT = {
   fn: Component,
-  params: [{prop1: 0, prop2: 0}],
+  params: [{prop1: 0, prop2: 'a'}],
   sequentialRenders: [
-    {prop1: 0, prop2: 0},
-    {prop1: 1, prop2: 0},
-    {prop1: 1, prop2: 1},
-    {prop1: 0, prop2: 1},
-    {prop1: 0, prop2: 0},
+    {prop1: 0, prop2: 'a'},
+    {prop1: 1, prop2: 'a'},
+    {prop1: 1, prop2: 'b'},
+    {prop1: 0, prop2: 'b'},
+    {prop1: 0, prop2: 'a'},
   ],
 };
 
@@ -58,7 +55,7 @@ function Component(t0) {
     let x = [{ value: prop1 }];
     while (x.length < 2) {
       arrayPush(x, { value: prop2 });
-      if (x[0].value === null) {
+      if (x[0].value === prop1) {
         x = [{ value: prop2 }];
         const y = x;
         z = y[0];
@@ -85,21 +82,21 @@ function Component(t0) {
 
 export const FIXTURE_ENTRYPOINT = {
   fn: Component,
-  params: [{ prop1: 0, prop2: 0 }],
+  params: [{ prop1: 0, prop2: "a" }],
   sequentialRenders: [
-    { prop1: 0, prop2: 0 },
-    { prop1: 1, prop2: 0 },
-    { prop1: 1, prop2: 1 },
-    { prop1: 0, prop2: 1 },
-    { prop1: 0, prop2: 0 },
+    { prop1: 0, prop2: "a" },
+    { prop1: 1, prop2: "a" },
+    { prop1: 1, prop2: "b" },
+    { prop1: 0, prop2: "b" },
+    { prop1: 0, prop2: "a" },
   ],
 };
 
 ```
       
 ### Eval output
-(kind: ok) [[ (exception in render) TypeError: Cannot set properties of undefined (setting 'other') ]]
-[[ (exception in render) TypeError: Cannot set properties of undefined (setting 'other') ]]
-[[ (exception in render) TypeError: Cannot set properties of undefined (setting 'other') ]]
-[[ (exception in render) TypeError: Cannot set properties of undefined (setting 'other') ]]
-[[ (exception in render) TypeError: Cannot set properties of undefined (setting 'other') ]]
+(kind: ok) <div>{"z":{"value":"a","other":true}}</div>
+<div>{"z":{"value":"a","other":true}}</div>
+<div>{"z":{"value":"b","other":true}}</div>
+<div>{"z":{"value":"b","other":true}}</div>
+<div>{"z":{"value":"a","other":true}}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/capture-backedge-phi-with-later-mutation.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/capture-backedge-phi-with-later-mutation.js
@@ -22,14 +22,14 @@ function Component({prop1, prop2}) {
   return <Stringify z={z} />;
 }
 
-// export const FIXTURE_ENTRYPOINT = {
-//   fn: Component,
-//   params: [{prop1: 0, prop2: 0}],
-//   sequentialRenders: [
-//     {prop1: 0, prop2: 0},
-//     {prop1: 1, prop2: 0},
-//     {prop1: 1, prop2: 1},
-//     {prop1: 0, prop2: 1},
-//     {prop1: 0, prop2: 0},
-//   ],
-// };
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{prop1: 0, prop2: 'a'}],
+  sequentialRenders: [
+    {prop1: 0, prop2: 'a'},
+    {prop1: 1, prop2: 'a'},
+    {prop1: 1, prop2: 'b'},
+    {prop1: 0, prop2: 'b'},
+    {prop1: 0, prop2: 'a'},
+  ],
+};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #33488
* #33477
* #33471
* #33470
* #33469
* #33465
* #33458
* #33449
* #33440
* #33430
* #33429
* #33427
* #33411
* #33401
* #33386
* #33385
* #33384
* #33380
* #33379
* #33378
* #33377
* #33376
* #33371
* #33370
* #33369
* #33367
* #33365
* #33364
* #33363
* #33346
* #33350
* #33180
* #33179
* #33178
* #33164
* #33163
* #33157
* #33151
* #33114
* #33113

Adds two new effects:
- `Impure` is for builtin functions that are known to be impure and not safe to call during render. This is already implemented via an optional `impure` flag on function declarations and ValidateNoImpureFunctionsInRender. That validation still exists, but we can avoid the need for the special validation pass by relying on the function effect.
- `Render` is an effect that indicates a value is assumed to be called at render time, even if it would not normally appear to be called. Examples are JSX tags and children — if these values are functions, they are definitely called at render (tag) or almost certainly called in render (children). Any function that transitively flows into a Render effect must not have MutateGlobal or Impure effects. We can also extend this to include other APIs that should be pure, for example we could consider adding it to `useReducer()` callbacks or `useState()` initializers.