### PR TITLE
Stringify context as SomeContext instead of SomeContext.Provider

### DIFF
--- a/packages/react-reconciler/src/getComponentNameFromFiber.js
+++ b/packages/react-reconciler/src/getComponentNameFromFiber.js
@@ -94,7 +94,7 @@ export default function getComponentNameFromFiber(fiber: Fiber): string | null {
       return getContextName(consumer._context) + '.Consumer';
     case ContextProvider:
       const context: ReactContext<any> = (type: any);
-      return getContextName(context) + '.Provider';
+      return getContextName(context);
     case DehydratedFragment:
       return 'DehydratedFragment';
     case ForwardRef:

--- a/packages/shared/getComponentNameFromType.js
+++ b/packages/shared/getComponentNameFromType.js
@@ -106,7 +106,7 @@ export default function getComponentNameFromType(type: mixed): string | null {
         return 'Portal';
       case REACT_CONTEXT_TYPE:
         const context: ReactContext<any> = (type: any);
-        return getContextName(context) + '.Provider';
+        return getContextName(context);
       case REACT_CONSUMER_TYPE:
         const consumer: ReactConsumerType<any> = (type: any);
         return getContextName(consumer._context) + '.Consumer';


### PR DESCRIPTION

This matches the change in React 19 to use `<SomeContext>` as the preferred way to provide a context.
