### PR TITLE
[eprh] Enable react-compiler rule by default

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -21,6 +21,7 @@ const rules = {
 const configRules = {
   'react-hooks/rules-of-hooks': 'error',
   'react-hooks/exhaustive-deps': 'warn',
+  'react-hooks/react-compiler': 'error',
 } satisfies Linter.RulesRecord;
 
 // Flat config


### PR DESCRIPTION

Updates eslint-plugin-react-hooks to enable the compiler rule by default.
