### PR TITLE
Adds Compiler support for remaining Array methods - sort, reduce, and more

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
@@ -444,7 +444,281 @@ addObject(BUILTIN_SHAPES, BuiltInArrayId, [
       returnValueKind: ValueKind.Primitive,
     }),
   ],
-  // TODO: rest of Array properties
+  [
+    'copyWithin',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.Read,
+      returnType: {kind: 'Object', shapeId: BuiltInArrayId},
+      calleeEffect: Effect.Store,
+      returnValueKind: ValueKind.Mutable,
+    }),
+  ],
+  [
+    'fill',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.Capture,
+      returnType: {kind: 'Object', shapeId: BuiltInArrayId},
+      calleeEffect: Effect.Store,
+      returnValueKind: ValueKind.Mutable,
+    }),
+  ],
+  [
+    'findLast',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.ConditionallyMutate,
+      returnType: {kind: 'Poly'},
+      /*
+       * callee is ConditionallyMutate because items of the array
+       * flow into the lambda and may be mutated there, even though
+       * the array object itself is not modified
+       */
+      calleeEffect: Effect.ConditionallyMutate,
+      returnValueKind: ValueKind.Mutable,
+      noAlias: true,
+      mutableOnlyIfOperandsAreMutable: true,
+    }),
+  ],
+  [
+    'findLastIndex',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.ConditionallyMutate,
+      returnType: PRIMITIVE_TYPE,
+      /*
+       * callee is ConditionallyMutate because items of the array
+       * flow into the lambda and may be mutated there, even though
+       * the array object itself is not modified
+       */
+      calleeEffect: Effect.ConditionallyMutate,
+      returnValueKind: ValueKind.Primitive,
+      noAlias: true,
+      mutableOnlyIfOperandsAreMutable: true,
+    }),
+  ],
+  [
+    'flat',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.Read,
+      returnType: {kind: 'Object', shapeId: BuiltInArrayId},
+      calleeEffect: Effect.Capture,
+      returnValueKind: ValueKind.Mutable,
+    }),
+  ],
+  [
+    'forEach',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.ConditionallyMutate,
+      returnType: PRIMITIVE_TYPE,
+      /*
+       * callee is ConditionallyMutate because items of the array
+       * flow into the lambda and may be mutated there, even though
+       * the array object itself is not modified
+       */
+      calleeEffect: Effect.ConditionallyMutate,
+      returnValueKind: ValueKind.Primitive,
+      noAlias: true,
+      mutableOnlyIfOperandsAreMutable: true,
+    }),
+  ],
+  [
+    'lastIndexOf',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.Read,
+      returnType: PRIMITIVE_TYPE,
+      calleeEffect: Effect.Read,
+      returnValueKind: ValueKind.Primitive,
+    }),
+  ],
+  [
+    'reduce',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.ConditionallyMutate,
+      returnType: {kind: 'Poly'},
+      /*
+       * callee is ConditionallyMutate because items of the array
+       * flow into the lambda and may be mutated there, even though
+       * the array object itself is not modified
+       */
+      calleeEffect: Effect.ConditionallyMutate,
+      returnValueKind: ValueKind.Mutable,
+      noAlias: true,
+      mutableOnlyIfOperandsAreMutable: true,
+    }),
+  ],
+  [
+    'reduceRight',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.ConditionallyMutate,
+      returnType: {kind: 'Poly'},
+      /*
+       * callee is ConditionallyMutate because items of the array
+       * flow into the lambda and may be mutated there, even though
+       * the array object itself is not modified
+       */
+      calleeEffect: Effect.ConditionallyMutate,
+      returnValueKind: ValueKind.Mutable,
+      noAlias: true,
+      mutableOnlyIfOperandsAreMutable: true,
+    }),
+  ],
+  [
+    'reverse',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: null,
+      returnType: {kind: 'Object', shapeId: BuiltInArrayId},
+      calleeEffect: Effect.Store,
+      returnValueKind: ValueKind.Mutable,
+    }),
+  ],
+  [
+    'shift',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: null,
+      returnType: {kind: 'Poly'},
+      calleeEffect: Effect.Store,
+      returnValueKind: ValueKind.Mutable,
+    }),
+  ],
+  [
+    'sort',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.ConditionallyMutate,
+      returnType: {kind: 'Object', shapeId: BuiltInArrayId},
+      calleeEffect: Effect.Store,
+      returnValueKind: ValueKind.Mutable,
+      noAlias: true,
+    }),
+  ],
+  [
+    'splice',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.Capture,
+      returnType: {kind: 'Object', shapeId: BuiltInArrayId},
+      calleeEffect: Effect.Store,
+      returnValueKind: ValueKind.Mutable,
+    }),
+  ],
+  [
+    'toLocaleString',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.Read,
+      returnType: PRIMITIVE_TYPE,
+      calleeEffect: Effect.Read,
+      returnValueKind: ValueKind.Primitive,
+    }),
+  ],
+  [
+    'toReversed',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: null,
+      returnType: {kind: 'Object', shapeId: BuiltInArrayId},
+      calleeEffect: Effect.Read,
+      returnValueKind: ValueKind.Mutable,
+    }),
+  ],
+  [
+    'toSorted',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.ConditionallyMutate,
+      returnType: {kind: 'Object', shapeId: BuiltInArrayId},
+      /*
+       * callee is ConditionallyMutate because items of the array
+       * flow into the lambda and may be mutated there, even though
+       * the array object itself is not modified
+       */
+      calleeEffect: Effect.ConditionallyMutate,
+      returnValueKind: ValueKind.Mutable,
+      mutableOnlyIfOperandsAreMutable: true,
+    }),
+  ],
+  [
+    'toSpliced',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.Capture,
+      returnType: {kind: 'Object', shapeId: BuiltInArrayId},
+      calleeEffect: Effect.Read,
+      returnValueKind: ValueKind.Mutable,
+    }),
+  ],
+  [
+    'toString',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: null,
+      returnType: PRIMITIVE_TYPE,
+      calleeEffect: Effect.Read,
+      returnValueKind: ValueKind.Primitive,
+    }),
+  ],
+  [
+    'unshift',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.Capture,
+      returnType: PRIMITIVE_TYPE,
+      calleeEffect: Effect.Store,
+      returnValueKind: ValueKind.Primitive,
+    }),
+  ],
+  [
+    'with',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: Effect.Capture,
+      returnType: {kind: 'Object', shapeId: BuiltInArrayId},
+      calleeEffect: Effect.Read,
+      returnValueKind: ValueKind.Mutable,
+    }),
+  ],
+  /**
+   * Iterators
+   */
+  [
+    'entries',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: null,
+      returnType: {kind: 'Poly'},
+      calleeEffect: Effect.Capture,
+      returnValueKind: ValueKind.Mutable,
+    }),
+  ],
+  [
+    'keys',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: null,
+      returnType: {kind: 'Poly'},
+      calleeEffect: Effect.Capture,
+      returnValueKind: ValueKind.Mutable,
+    }),
+  ],
+  [
+    'values',
+    addFunction(BUILTIN_SHAPES, [], {
+      positionalParams: [],
+      restParam: null,
+      returnType: {kind: 'Poly'},
+      calleeEffect: Effect.Capture,
+      returnValueKind: ValueKind.Mutable,
+    }),
+  ],
 ]);
 
 /* Built-in Object shape */

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-copy-within.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-copy-within.expect.md
@@ -1,0 +1,43 @@
+
+## Input
+
+```javascript
+function Component() {
+  const array = ['c', 'b', 'a'];
+  return useMemo(() => {
+    return [...array].copyWithin(0, 2);
+  }, [array]);
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component() {
+  const $ = _c(2);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = ["c", "b", "a"];
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const array = t0;
+  let t1;
+  let t2;
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = [...array].copyWithin(0, 2);
+    $[1] = t2;
+  } else {
+    t2 = $[1];
+  }
+  t1 = t2;
+  return t1;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-copy-within.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-copy-within.js
@@ -1,0 +1,6 @@
+function Component() {
+  const array = ['c', 'b', 'a'];
+  return useMemo(() => {
+    return [...array].copyWithin(0, 2);
+  }, [array]);
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-fill.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-fill.expect.md
@@ -1,0 +1,43 @@
+
+## Input
+
+```javascript
+function Component() {
+  const array = ['c', 'b', 'a'];
+  return useMemo(() => {
+    return [...array].fill(0);
+  }, [array]);
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component() {
+  const $ = _c(2);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = ["c", "b", "a"];
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const array = t0;
+  let t1;
+  let t2;
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = [...array].fill(0);
+    $[1] = t2;
+  } else {
+    t2 = $[1];
+  }
+  t1 = t2;
+  return t1;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-fill.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-fill.js
@@ -1,0 +1,6 @@
+function Component() {
+  const array = ['c', 'b', 'a'];
+  return useMemo(() => {
+    return [...array].fill(0);
+  }, [array]);
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-find-last-index.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-find-last-index.expect.md
@@ -1,0 +1,28 @@
+
+## Input
+
+```javascript
+function Component() {
+  const array = ['c', 'b', 'a'];
+  return useMemo(() => {
+    return array.findLastIndex('b');
+  }, [array]);
+}
+
+```
+
+## Code
+
+```javascript
+function Component() {
+  const array = ["c", "b", "a"];
+  let t0;
+
+  t0 = array.findLastIndex("b");
+  return t0;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-find-last-index.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-find-last-index.js
@@ -1,0 +1,6 @@
+function Component() {
+  const array = ['c', 'b', 'a'];
+  return useMemo(() => {
+    return array.findLastIndex('b');
+  }, [array]);
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-find-last.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-find-last.expect.md
@@ -1,0 +1,46 @@
+
+## Input
+
+```javascript
+function Component() {
+  const array = ['c', 'b', 'a'];
+  return useMemo(() => {
+    return array.findLast(el => el === 'a');
+  }, [array]);
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component() {
+  const $ = _c(2);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = ["c", "b", "a"];
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const array = t0;
+  let t1;
+  let t2;
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = array.findLast(_temp);
+    $[1] = t2;
+  } else {
+    t2 = $[1];
+  }
+  t1 = t2;
+  return t1;
+}
+function _temp(el) {
+  return el === "a";
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-find-last.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-find-last.js
@@ -1,0 +1,6 @@
+function Component() {
+  const array = ['c', 'b', 'a'];
+  return useMemo(() => {
+    return array.findLast(el => el === 'a');
+  }, [array]);
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-flat.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-flat.expect.md
@@ -1,0 +1,41 @@
+
+## Input
+
+```javascript
+function Component() {
+  const array = [0, 1, 2, [3, 4]];
+  return useMemo(() => array.flat(), [array]);
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component() {
+  const $ = _c(2);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = [0, 1, 2, [3, 4]];
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const array = t0;
+  let t1;
+  let t2;
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = array.flat();
+    $[1] = t2;
+  } else {
+    t2 = $[1];
+  }
+  t1 = t2;
+  return t1;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-flat.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-flat.js
@@ -1,0 +1,4 @@
+function Component() {
+  const array = [0, 1, 2, [3, 4]];
+  return useMemo(() => array.flat(), [array]);
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-sort.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-sort.expect.md
@@ -1,0 +1,41 @@
+
+## Input
+
+```javascript
+function Component() {
+  const array = ['c', 'b', 'a'];
+  return useMemo(() => [...array].sort(), [array]);
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component() {
+  const $ = _c(2);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = ["c", "b", "a"];
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const array = t0;
+  let t1;
+  let t2;
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = [...array].sort();
+    $[1] = t2;
+  } else {
+    t2 = $[1];
+  }
+  t1 = t2;
+  return t1;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-sort.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-sort.js
@@ -1,0 +1,4 @@
+function Component() {
+  const array = ['c', 'b', 'a'];
+  return useMemo(() => [...array].sort(), [array]);
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-to-sorted.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-to-sorted.expect.md
@@ -1,0 +1,41 @@
+
+## Input
+
+```javascript
+function Component() {
+  const array = ['c', 'b', 'a'];
+  return useMemo(() => array.toSorted(), [array]);
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component() {
+  const $ = _c(2);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = ["c", "b", "a"];
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const array = t0;
+  let t1;
+  let t2;
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = array.toSorted();
+    $[1] = t2;
+  } else {
+    t2 = $[1];
+  }
+  t1 = t2;
+  return t1;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-to-sorted.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/array-to-sorted.js
@@ -1,0 +1,4 @@
+function Component() {
+  const array = ['c', 'b', 'a'];
+  return useMemo(() => array.toSorted(), [array]);
+}


### PR DESCRIPTION
## Summary

Was discussing some unexpected bailouts I'd run into with the Compiler with @josephsavona on Bluesky https://bsky.app/profile/en-js.bsky.social/post/3lrlh3rdbok2s and he kindly pointed me towards where I could fix them myself 😄 

These changes cover the cases of using array methods like `sort` in a `useMemo`, the Compiler will keep them memoized and won't bail on optimizing the component as is the current behavior.

## How did you test this change?

- Ran the Playground app locally and tested that patterns that would get bailed on before now didn't
- Added Compiler test fixtures, updating the expected fixtures after running the tests. I don't think I got this part quite right, I don't know why the "(kind: exception) Fixture not implemented" section at the end of all of them is there. I didn't add them for every single array method I added, either.
