### PR TITLE
build: make enableComponentPerformanceTrack dynamic for native-fb

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -26,3 +26,4 @@ export const passChildrenWhenCloningPersistedNodes = __VARIANT__;
 export const enableLazyPublicInstanceInFabric = __VARIANT__;
 export const renameElementSymbol = __VARIANT__;
 export const enableFragmentRefs = __VARIANT__;
+export const enableComponentPerformanceTrack = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -59,7 +59,6 @@ export const enableProfilerTimer = __PROFILE__;
 export const enableReactTestRendererWarning = false;
 export const enableRetryLaneExpiration = false;
 export const enableSchedulingProfiler = __PROFILE__;
-export const enableComponentPerformanceTrack = false;
 export const enableScopeAPI = false;
 export const enableSuspenseAvoidThisFallback = false;
 export const enableSuspenseCallback = true;
@@ -84,6 +83,8 @@ export const enableSrcObject = false;
 export const enableHydrationChangeEvent = true;
 export const enableDefaultTransitionIndicator = false;
 export const ownerStackLimit = 1e4;
+export const enableComponentPerformanceTrack: boolean =
+  __PROFILE__ && dynamicFlags.enableComponentPerformanceTrack;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);


### PR DESCRIPTION
## Summary

Make this flag dynamic, so it can be controlled internally.

## How did you test this change?

Build, observe that `console.timeStamp` is only present in FB artifacts and `enableComponentPerformanceTrack` is referenced.
