### PR TITLE
Add warning for bad Map/Set polyfills

### DIFF
--- a/packages/react/src/BadMapPolyfill.js
+++ b/packages/react/src/BadMapPolyfill.js
@@ -17,7 +17,11 @@ if (__DEV__) {
     new Set([frozenObject]);
     /* eslint-enable no-new */
   } catch (e) {
-    // TODO: Consider warning about bad polyfills
+    // Warn about bad polyfills that don't support frozen objects
+    console['warn'](
+      'React detected a Map/Set polyfill that cannot handle frozen objects. ' +
+        'This might cause issues with React\'s internals.'
+    );
     hasBadMapPolyfill = true;
   }
 }

--- a/packages/react/src/__tests__/BadMapPolyfill-test.js
+++ b/packages/react/src/__tests__/BadMapPolyfill-test.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+describe('BadMapPolyfill', () => {
+  let consoleWarnSpy;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  // @gate __DEV__
+  it('should warn when a bad Map/Set polyfill is detected', () => {
+    // Mock a Map/Set that fails with frozen objects
+    const originalMap = global.Map;
+    const originalSet = global.Set;
+
+    global.Map = function BadMap() {
+      if (arguments.length > 0 && arguments[0]) {
+        const entries = arguments[0];
+        for (let i = 0; i < entries.length; i++) {
+          if (Object.isFrozen(entries[i][0])) {
+            throw new Error('Cannot handle frozen object');
+          }
+        }
+      }
+    };
+
+    global.Set = function BadSet() {
+      if (arguments.length > 0 && arguments[0]) {
+        const values = arguments[0];
+        for (let i = 0; i < values.length; i++) {
+          if (Object.isFrozen(values[i])) {
+            throw new Error('Cannot handle frozen object');
+          }
+        }
+      }
+    };
+
+    // Re-require the module to trigger the polyfill detection
+    jest.resetModules();
+    require('../BadMapPolyfill');
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'React detected a Map/Set polyfill that cannot handle frozen objects. ' +
+        'This might cause issues with React\'s internals.'
+    );
+
+    // Restore original Map/Set
+    global.Map = originalMap;
+    global.Set = originalSet;
+  });
+
+  // @gate __DEV__
+  it('should not warn when Map/Set polyfill works correctly', () => {
+    // Re-require the module to trigger the polyfill detection with good polyfill
+    jest.resetModules();
+    require('../BadMapPolyfill');
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Addresses the TODO in BadMapPolyfill.js by adding a console warning when React detects a Map/Set polyfill that cannot handle frozen objects.

## Changes
- ✨ Add console warning when bad polyfill is detected  
- ✅ Add comprehensive test coverage for the warning
- 🔧 Use React's standard warning format with `console['warn']`
- 📝 Keep warning message concise and focused on the core issue

## Why?
This helps developers identify potentially problematic polyfills that might cause issues with React's internals. Previously, React would silently detect bad polyfills but provide no feedback to developers.

The warning message is intentionally concise to follow React's established patterns for developer warnings.

## Test plan
- [x] Added unit tests for both good and bad polyfill scenarios
- [x] Tests pass: `yarn test BadMapPolyfill`
- [x] Lint passes: `yarn lint`  
- [x] Warning appears only when bad polyfill is detected
- [x] No warning appears with standard Map/Set implementations
- [x] Warning message follows React's established format and tone