### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -301,9 +301,6 @@ jobs:
           path: |
             **/node_modules
           key: runtime-and-compiler-node_modules-v6-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('yarn.lock', 'compiler/yarn.lock') }}
-          restore-keys: |
-            runtime-and-compiler-node_modules-v6-${{ runner.arch }}-${{ runner.os }}-
-            runtime-and-compiler-node_modules-v6-
       - name: Install runtime dependencies
         run: yarn install --frozen-lockfile
         if: steps.node_modules.outputs.cache-hit != 'true'

--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -304,7 +304,12 @@ jobs:
           restore-keys: |
             runtime-and-compiler-node_modules-v6-${{ runner.arch }}-${{ runner.os }}-
             runtime-and-compiler-node_modules-v6-
-      - run: yarn install --frozen-lockfile
+      - name: Install runtime dependencies
+        run: yarn install --frozen-lockfile
+        if: steps.node_modules.outputs.cache-hit != 'true'
+      - name: Install compiler dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: compiler
         if: steps.node_modules.outputs.cache-hit != 'true'
       - run: ./scripts/react-compiler/build-compiler.sh && ./scripts/react-compiler/link-compiler.sh
       - run: yarn workspace eslint-plugin-react-hooks test


### PR DESCRIPTION
The cache wants to restore runtime and compiler dependencies. If we miss, we need to install both. 

## test plan

```console
$ git clean -fdx
$ yarn install --frozen-lockfile
$ ./scripts/react-compiler/build-compiler.sh && ./scripts/react-compiler/link-compiler.sh
# fails
$ cd compiler
$ yarn install --frozen-lockfile
$ cd ..
$ ./scripts/react-compiler/build-compiler.sh && ./scripts/react-compiler/link-compiler.sh
# passes
```
