### PR TITLE
[Fizz] Clean up the replay nodes if we're already rendered past an element 

### DIFF
--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -4127,6 +4127,8 @@ function renderNode(
   const segment = task.blockedSegment;
   if (segment === null) {
     // Replay
+    task = ((task: any): ReplayTask); // Refined
+    const previousReplaySet: ReplaySet = task.replay;
     try {
       return renderNodeDestructive(request, task, node, childIndex);
     } catch (thrownValue) {
@@ -4166,6 +4168,7 @@ function renderNode(
           task.keyPath = previousKeyPath;
           task.treeContext = previousTreeContext;
           task.componentStack = previousComponentStack;
+          task.replay = previousReplaySet;
           if (__DEV__) {
             task.debugTask = previousDebugTask;
           }
@@ -4199,6 +4202,7 @@ function renderNode(
           task.keyPath = previousKeyPath;
           task.treeContext = previousTreeContext;
           task.componentStack = previousComponentStack;
+          task.replay = previousReplaySet;
           if (__DEV__) {
             task.debugTask = previousDebugTask;
           }

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -3099,6 +3099,9 @@ function replayElement(
           if (task.node === currentNode) {
             // This same element suspended so we need to pop the replay we just added.
             task.replay = replay;
+          } else {
+            // We finished rendering this node, so now we can consume this slot.
+            replayNodes.splice(i, 1);
           }
           throw x;
         }


### PR DESCRIPTION
Follow up to #27513. There's two issues here.

First, we didn't restore the ReplaySet when calling `renderNode()` so it was not safe to invoke since future siblings might observe the mutated replay. This could skip replays which covered up errors.

Second, this was covering up that we weren't properly cleaning up the replay nodes when we were able to render through one node and then mutated the `.node` on the task but then suspended deeper.

I don't love the solution from #27513 in general because it feels hacky to compare the mutated node. It should probably be structured different. There's also another case that's basically the same case which has neither of these fixes in it. It's probably a bug too but haven't been able to repro yet:

https://github.com/facebook/react/blob/a947eba4f2c8741d2c61a3b33fd79cf13bf9f39d/packages/react-server/src/ReactFizzServer.js#L3612-L3613