### PR TITLE
33610 Added error for reading ref.current during render

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
@@ -403,7 +403,9 @@ function validateNoRefAccessInRenderImpl(
               }
             }
             for (const operand of eachInstructionValueOperand(instr.value)) {
-              if (hookKind != null) {
+              if (hookKind === 'useState') {
+                validateNoRefValueAccess(errors, env, operand);
+              } else if (hookKind != null) {
                 validateNoDirectRefValueAccess(errors, operand, env);
               } else {
                 validateNoRefAccess(errors, env, operand, operand.loc);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-ref-in-useState.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-ref-in-useState.expect.md
@@ -1,0 +1,27 @@
+
+## Input
+
+```javascript
+// @validateRefAccessDuringRender
+function Component(props) {
+  const ref = useRef(1);
+  const [state] = useState(() => ref.current);
+  return <div>{state}</div>;
+}
+
+```
+
+
+## Error
+
+```
+  2 | function Component(props) {
+  3 |   const ref = useRef(1);
+> 4 |   const [state] = useState(() => ref.current);
+    |                            ^^^^^^^^^^^^^^^^^ InvalidReact: Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef) (4:4)
+  5 |   return <div>{state}</div>;
+  6 | }
+  7 |
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-ref-in-useState.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-ref-in-useState.js
@@ -1,0 +1,6 @@
+// @validateRefAccessDuringRender
+function Component(props) {
+  const ref = useRef(1);
+  const [state] = useState(() => ref.current);
+  return <div>{state}</div>;
+}

--- a/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRule-test.ts
+++ b/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRule-test.ts
@@ -94,8 +94,37 @@ const tests: CompilerTestCases = {
         }
       `,
     },
+    {
+      name: 'Ref access in useEffect hook',
+      code: normalizeIndent`
+        function Component() {
+          const ref = useRef(1);
+          useEffect(() => {
+            ref.current = 2 * ref.current;
+          }, []);
+          return <div>Hello world</div>;
+        }
+      `,
+    },
   ],
+
   invalid: [
+    {
+      name: '[InvalidInput] Ref access in useState initial value function',
+      code: normalizeIndent`
+        function Component(props) {
+          const ref = useRef(1);
+          const [value] = useState(() => ref.current);
+          return value;
+        }
+      `,
+      errors: [
+        {
+          message:
+            'Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef)',
+        },
+      ],
+    },
     {
       name: 'Reportable levels can be configured',
       options: [{reportableLevels: new Set([ErrorSeverity.Todo])}],


### PR DESCRIPTION

## Summary

This PR adds ref access error to be thrown while using the react compiler

## How did you test this change?

Added test in the fixtures/compiler and the same passed
<img width="890" alt="Screenshot 2025-06-22 at 3 38 27 PM" src="https://github.com/user-attachments/assets/2c2e2413-400d-4971-b81f-8c5e2cc5e239" />


