### PR TITLE
[compiler] log if a compiler error was opted out of

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts
@@ -225,6 +225,7 @@ export type CompileErrorEvent = {
   kind: 'CompileError';
   fnLoc: t.SourceLocation | null;
   detail: CompilerErrorDetailOptions;
+  optedOut?: boolean;
 };
 export type CompileDiagnosticEvent = {
   kind: 'CompileDiagnostic';

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -174,6 +174,7 @@ function logError(
     filename: string | null;
   },
   fnLoc: t.SourceLocation | null,
+  optedOut: boolean,
 ): void {
   if (context.opts.logger) {
     if (err instanceof CompilerError) {
@@ -182,6 +183,7 @@ function logError(
           kind: 'CompileError',
           fnLoc,
           detail: detail.options,
+          optedOut,
         });
       }
     } else {
@@ -208,7 +210,7 @@ function handleError(
   },
   fnLoc: t.SourceLocation | null,
 ): void {
-  logError(err, context, fnLoc);
+  logError(err, context, fnLoc, false);
   if (
     context.opts.panicThreshold === 'all_errors' ||
     (context.opts.panicThreshold === 'critical_errors' &&
@@ -592,7 +594,7 @@ function processFn(
   const compileResult = tryCompileFunction(fn, fnType, programContext);
   if (compileResult.kind === 'error') {
     if (directives.optOut != null) {
-      logError(compileResult.error, programContext, fn.node.loc ?? null);
+      logError(compileResult.error, programContext, fn.node.loc ?? null, true);
     } else {
       handleError(compileResult.error, programContext, fn.node.loc ?? null);
     }


### PR DESCRIPTION
## Summary

(This is likely not a finished plugin, but a grounds for discussion around this feature.)

In `logEvent`, I would like to be able to distinguish between errors that I already opted out via "use no memo"/"use no forget" and new, unhandled errors.

## How did you test this change?

No tests yet, I want to know if this is something worth pursuing first before I put more work into this.