### PR TITLE
[Flight] Use cacheController instead of abortListeners for Streams

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -986,6 +986,7 @@ function serializeReadableStream(
       haltTask(streamTask, request);
       request.abortableTasks.delete(streamTask);
     } else {
+      // TODO: Make this use abortTask() instead.
       erroredTask(request, streamTask, reason);
       enqueueFlush(request);
     }
@@ -1114,6 +1115,7 @@ function serializeAsyncIterable(
       haltTask(streamTask, request);
       request.abortableTasks.delete(streamTask);
     } else {
+      // TODO: Make this use abortTask() instead.
       erroredTask(request, streamTask, signal.reason);
       enqueueFlush(request);
     }
@@ -2706,6 +2708,7 @@ function serializeBlob(request: Request, blob: Blob): string {
     if (enableHalt && request.type === PRERENDER) {
       haltTask(newTask, request);
     } else {
+      // TODO: Make this use abortTask() instead.
       erroredTask(request, newTask, reason);
       enqueueFlush(request);
     }


### PR DESCRIPTION
Now that we have `cacheSignal()` we can just use that instead of the `abortListeners` concept which was really just the same thing for cancelling the streams (ReadableStream, Blob, AsyncIterable).
