### PR TITLE
[Flight] Add tests for component and owner stacks of halted components

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -32,6 +32,7 @@ let webpackModuleLoading;
 let React;
 let ReactServer;
 let ReactDOMServer;
+let ReactDOMServerStatic;
 let ReactServerDOMServer;
 let ReactServerDOMStaticServer;
 let ReactServerDOMClient;
@@ -102,6 +103,7 @@ describe('ReactFlightDOMEdge', () => {
     );
     React = require('react');
     ReactDOMServer = require('react-dom/server.edge');
+    ReactDOMServerStatic = require('react-dom/static.edge');
     ReactServerDOMClient = require('react-server-dom-webpack/client');
     use = React.use;
   });
@@ -1777,4 +1779,127 @@ describe('ReactFlightDOMEdge', () => {
     expect(error).not.toBe(null);
     expect(error.message).toBe(expectedMessage);
   });
+
+  // @gate __DEV__ && enableHalt && enableAsyncDebugInfo
+  it.failing(
+    'includes source locations in component stacks for halted components',
+    async () => {
+      async function Component() {
+        await new Promise(() => {});
+        return null;
+      }
+
+      function App() {
+        return ReactServer.createElement(
+          'html',
+          null,
+          ReactServer.createElement(
+            'body',
+            null,
+            ReactServer.createElement(
+              ReactServer.Suspense,
+              {fallback: 'Loading...'},
+              ReactServer.createElement(Component, null),
+            ),
+          ),
+        );
+      }
+
+      const serverAbortController = new AbortController();
+      const errors = [];
+      const prerenderResult = ReactServerDOMStaticServer.unstable_prerender(
+        ReactServer.createElement(App, null),
+        webpackMap,
+        {
+          signal: serverAbortController.signal,
+          onError(err) {
+            errors.push(err);
+          },
+        },
+      );
+
+      await new Promise(resolve => {
+        setImmediate(() => {
+          serverAbortController.abort();
+          resolve();
+        });
+      });
+
+      const {prelude} = await prerenderResult;
+
+      expect(errors).toEqual([]);
+
+      function ClientRoot({response}) {
+        return use(response);
+      }
+
+      const prerenderResponse = ReactServerDOMClient.createFromReadableStream(
+        await createBufferedUnclosingStream(prelude),
+        {
+          serverConsumerManifest: {
+            moduleMap: null,
+            moduleLoading: null,
+          },
+        },
+      );
+
+      let componentStack;
+      let ownerStack;
+
+      const clientAbortController = new AbortController();
+
+      const fizzPrerenderStreamResult = ReactDOMServerStatic.prerender(
+        React.createElement(ClientRoot, {response: prerenderResponse}),
+        {
+          signal: clientAbortController.signal,
+          onError(error, errorInfo) {
+            componentStack = errorInfo.componentStack;
+            ownerStack = ReactServer.captureOwnerStack();
+          },
+        },
+      );
+
+      await new Promise(resolve => {
+        setImmediate(() => {
+          clientAbortController.abort();
+          resolve();
+        });
+      });
+
+      const fizzPrerenderStream = await fizzPrerenderStreamResult;
+      const prerenderHTML = await readResult(fizzPrerenderStream.prelude);
+
+      expect(prerenderHTML).toContain('Loading...');
+
+      expect(normalizeCodeLocInfo(componentStack)).toBe(
+        '\n    in Component (at **)\n    in Suspense\n    in body\n    in html\n    in ClientRoot (at **)',
+      );
+
+      expect(normalizeCodeLocInfo(ownerStack)).toBe('\n    in App (at **)');
+    },
+  );
 });
+
+async function createBufferedUnclosingStream(
+  prelude: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> {
+  const chunks: Array<Uint8Array> = [];
+  const reader = prelude.getReader();
+  while (true) {
+    const {done, value} = await reader.read();
+    if (done) {
+      break;
+    } else {
+      chunks.push(value);
+    }
+  }
+
+  let i = 0;
+  return new ReadableStream({
+    async pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(chunks[i++]);
+      }
+    },
+  });
+}

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1780,7 +1780,7 @@ describe('ReactFlightDOMEdge', () => {
     expect(error.message).toBe(expectedMessage);
   });
 
-  // @gate __DEV__ && enableHalt && enableAsyncDebugInfo
+  // @gate enableHalt && enableAsyncDebugInfo
   it('does not include source locations in component stacks for halted components', async () => {
     // We only support adding source locations for halted components in the Node.js builds.
 
@@ -1854,7 +1854,9 @@ describe('ReactFlightDOMEdge', () => {
         signal: clientAbortController.signal,
         onError(error, errorInfo) {
           componentStack = errorInfo.componentStack;
-          ownerStack = React.captureOwnerStack();
+          ownerStack = React.captureOwnerStack
+            ? React.captureOwnerStack()
+            : null;
         },
       },
     );
@@ -1871,11 +1873,21 @@ describe('ReactFlightDOMEdge', () => {
 
     expect(prerenderHTML).toContain('Loading...');
 
-    expect(normalizeCodeLocInfo(componentStack)).toBe(
-      '\n    in Component\n    in Suspense\n    in body\n    in html\n    in ClientRoot (at **)',
-    );
+    if (__DEV__) {
+      expect(normalizeCodeLocInfo(componentStack)).toBe(
+        '\n    in Component\n    in Suspense\n    in body\n    in html\n    in ClientRoot (at **)',
+      );
+    } else {
+      expect(normalizeCodeLocInfo(componentStack)).toBe(
+        '\n    in Suspense\n    in body\n    in html\n    in ClientRoot (at **)',
+      );
+    }
 
-    expect(normalizeCodeLocInfo(ownerStack)).toBe('\n    in App (at **)');
+    if (__DEV__) {
+      expect(normalizeCodeLocInfo(ownerStack)).toBe('\n    in App (at **)');
+    } else {
+      expect(ownerStack).toBeNull();
+    }
   });
 });
 

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1804,7 +1804,7 @@ describe('ReactFlightDOMEdge', () => {
     expect(error.message).toBe(expectedMessage);
   });
 
-  // @gate enableHalt && enableAsyncDebugInfo
+  // @gate enableHalt
   it('does not include source locations in component stacks for halted components', async () => {
     // We only support adding source locations for halted components in the Node.js builds.
 

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -32,7 +32,7 @@ let webpackModuleLoading;
 let React;
 let ReactServer;
 let ReactDOMServer;
-let ReactDOMServerStatic;
+let ReactDOMFizzStatic;
 let ReactServerDOMServer;
 let ReactServerDOMStaticServer;
 let ReactServerDOMClient;
@@ -103,7 +103,7 @@ describe('ReactFlightDOMEdge', () => {
     );
     React = require('react');
     ReactDOMServer = require('react-dom/server.edge');
-    ReactDOMServerStatic = require('react-dom/static.edge');
+    ReactDOMFizzStatic = require('react-dom/static.edge');
     ReactServerDOMClient = require('react-server-dom-webpack/client');
     use = React.use;
   });
@@ -1872,7 +1872,7 @@ describe('ReactFlightDOMEdge', () => {
 
     const clientAbortController = new AbortController();
 
-    const fizzPrerenderStreamResult = ReactDOMServerStatic.prerender(
+    const fizzPrerenderStreamResult = ReactDOMFizzStatic.prerender(
       React.createElement(ClientRoot, {response: prerenderResponse}),
       {
         signal: clientAbortController.signal,

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -21,7 +21,7 @@ let webpackModules;
 let webpackModuleLoading;
 let React;
 let ReactDOMServer;
-let ReactDOMServerStatic;
+let ReactDOMFizzStatic;
 let ReactServer;
 let ReactServerDOMServer;
 let ReactServerDOMStaticServer;
@@ -48,7 +48,6 @@ describe('ReactFlightDOMNode', () => {
       require('react-server-dom-webpack/server.node'),
     );
     ReactServer = require('react');
-    ReactDOMServerStatic = require('react-dom/static');
     ReactServerDOMServer = require('react-server-dom-webpack/server');
     if (__EXPERIMENTAL__) {
       jest.mock('react-server-dom-webpack/static', () =>
@@ -72,6 +71,7 @@ describe('ReactFlightDOMNode', () => {
 
     React = require('react');
     ReactDOMServer = require('react-dom/server.node');
+    ReactDOMFizzStatic = require('react-dom/static');
     ReactServerDOMClient = require('react-server-dom-webpack/client');
     Stream = require('stream');
     use = React.use;
@@ -665,7 +665,7 @@ describe('ReactFlightDOMNode', () => {
 
     const clientAbortController = new AbortController();
 
-    const fizzPrerenderStreamResult = ReactDOMServerStatic.prerender(
+    const fizzPrerenderStreamResult = ReactDOMFizzStatic.prerender(
       React.createElement(ClientRoot, {response: prerenderResponse}),
       {
         signal: clientAbortController.signal,

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -48,7 +48,7 @@ describe('ReactFlightDOMNode', () => {
       require('react-server-dom-webpack/server.node'),
     );
     ReactServer = require('react');
-    ReactDOMServerStatic = require('react-dom/static.node');
+    ReactDOMServerStatic = require('react-dom/static');
     ReactServerDOMServer = require('react-server-dom-webpack/server');
     if (__EXPERIMENTAL__) {
       jest.mock('react-server-dom-webpack/static', () =>

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -614,6 +614,7 @@ describe('ReactFlightDOMNode', () => {
       );
     }
 
+    const errors = [];
     const serverAbortController = new AbortController();
     const {pendingResult} = await serverAct(async () => {
       // destructure trick to avoid the act scope from awaiting the returned value
@@ -623,6 +624,9 @@ describe('ReactFlightDOMNode', () => {
           webpackMap,
           {
             signal: serverAbortController.signal,
+            onError(error) {
+              errors.push(error);
+            },
           },
         ),
       };
@@ -639,6 +643,8 @@ describe('ReactFlightDOMNode', () => {
     );
 
     const {prelude} = await pendingResult;
+
+    expect(errors).toEqual([]);
 
     function ClientRoot({response}) {
       return use(response);

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -591,7 +591,7 @@ describe('ReactFlightDOMNode', () => {
     expect(result).toContain('loading...');
   });
 
-  // @gate __DEV__ && enableHalt && enableAsyncDebugInfo
+  // @gate enableHalt && enableAsyncDebugInfo
   it('includes source locations in component and owner stacks for halted components', async () => {
     async function Component() {
       await new Promise(() => {});
@@ -665,7 +665,9 @@ describe('ReactFlightDOMNode', () => {
         signal: clientAbortController.signal,
         onError(error, errorInfo) {
           componentStack = errorInfo.componentStack;
-          ownerStack = React.captureOwnerStack();
+          ownerStack = React.captureOwnerStack
+            ? React.captureOwnerStack()
+            : null;
         },
       },
     );
@@ -685,12 +687,22 @@ describe('ReactFlightDOMNode', () => {
 
     expect(prerenderHTML).toContain('Loading...');
 
-    expect(normalizeCodeLocInfo(componentStack)).toBe(
-      '\n    in Component (at **)\n    in Suspense\n    in body\n    in html\n    in ClientRoot (at **)',
-    );
+    if (__DEV__) {
+      expect(normalizeCodeLocInfo(componentStack)).toBe(
+        '\n    in Component (at **)\n    in Suspense\n    in body\n    in html\n    in ClientRoot (at **)',
+      );
+    } else {
+      expect(normalizeCodeLocInfo(componentStack)).toBe(
+        '\n    in Suspense\n    in body\n    in html\n    in ClientRoot (at **)',
+      );
+    }
 
-    expect(normalizeCodeLocInfo(ownerStack)).toBe(
-      '\n    in Component (at **)\n    in App (at **)',
-    );
+    if (__DEV__) {
+      expect(normalizeCodeLocInfo(ownerStack)).toBe(
+        '\n    in Component (at **)\n    in App (at **)',
+      );
+    } else {
+      expect(ownerStack).toBeNull();
+    }
   });
 });


### PR DESCRIPTION
This PR adds tests for the Node.js and Edge builds to verify that component stacks and owner stacks of halted components appear as expected, now that recent enhancements for those have been implemented (the latest one being #33634).