### PR TITLE
[Flight] Use a heuristic to extract a useful description of I/O from the Promise value

### DIFF
--- a/packages/react-client/src/ReactFlightPerformanceTrack.js
+++ b/packages/react-client/src/ReactFlightPerformanceTrack.js
@@ -371,7 +371,7 @@ function getIOLongName(
   rootEnv: string,
 ): string {
   const name = ioInfo.name;
-  const longName = description === '' ? name : name + '(' + description + ')';
+  const longName = description === '' ? name : name + ' (' + description + ')';
   const isPrimaryEnv = env === rootEnv;
   return isPrimaryEnv || env === undefined
     ? longName
@@ -393,7 +393,7 @@ function getIOShortName(
     const l = description.length;
     if (l > 0 && l <= descMaxLength) {
       // We can fit the full description
-      desc = '(' + description + ')';
+      desc = ' (' + description + ')';
     } else if (
       description.startsWith('http://') ||
       description.startsWith('https://') ||
@@ -412,7 +412,7 @@ function getIOShortName(
       const slashIdx = description.lastIndexOf('/', queryIdx - 1);
       if (queryIdx - slashIdx < descMaxLength) {
         // This may now be either the file name or the host.
-        desc = '(' + description.slice(slashIdx + 1, queryIdx) + ')';
+        desc = ' (' + description.slice(slashIdx + 1, queryIdx) + ')';
       }
     }
   }


### PR DESCRIPTION
It's useful to be able to distinguish between different invocations of common helper libraries (like fetch) without having to click through each one.

This adds a heuristic to extract a useful description of I/O from the Promise value. We try to find things like getUser(id) -> User where User.id is the id or fetch(url) -> Response where Response.url is the url.

For urls we use the filename (or hostname if there is none) as the short name if it can fit. The full url is in the tooltip.

<img width="845" alt="Screenshot 2025-06-27 at 7 58 20 PM" src="https://github.com/user-attachments/assets/95f10c08-13a8-449e-97e8-52f0083a65dc" />
