### PR TITLE
Add regression test for ref access inconsistency (#33617)

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRule-test.ts
+++ b/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRule-test.ts
@@ -248,6 +248,43 @@ const tests: CompilerTestCases = {
         },
       ],
     },
+    {
+      name: 'useDeepMemo accessing ref.current during render (JS)',
+      code: normalizeIndent`
+        import { equal } from "@wry/equality";
+        import * as React from "react";
+
+        function useDeepMemo(memoFn, deps) {
+          const ref = React.useRef();
+          if (!ref.current || !equal(ref.current.deps, deps)) {
+            ref.current = { value: memoFn(), deps };
+          }
+          return ref.current.value;
+        }
+      `,
+      errors: [
+        {
+          message:
+            'Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef)',
+          line: 7,
+        },
+        {
+          message:
+            'Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef)',
+          line: 7,
+        },
+        {
+          message:
+            'Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef)',
+          line: 8,
+        },
+        {
+          message:
+            'Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef)',
+          line: 10,
+        },
+      ],
+    },
   ],
 };
 

--- a/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleTypescript-test.ts
+++ b/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleTypescript-test.ts
@@ -69,6 +69,48 @@ const tests: CompilerTestCases = {
         },
       ],
     },
+    {
+      name: 'useDeepMemo accessing ref.current during render',
+      filename: 'test.tsx',
+      code: normalizeIndent`
+        import { equal } from "@wry/equality";
+        import type { DependencyList } from "react";
+        import * as React from "react";
+
+        export function useDeepMemo<TValue>(
+          memoFn: () => TValue,
+          deps: DependencyList
+        ) {
+          const ref = React.useRef<{ deps: DependencyList; value: TValue }>(void 0);
+          if (!ref.current || !equal(ref.current.deps, deps)) {
+            ref.current = { value: memoFn(), deps };
+          }
+          return ref.current.value;
+        }
+      `,
+      errors: [
+        {
+          message:
+            'Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef)',
+          line: 11,
+        },
+        {
+          message:
+            'Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef)',
+          line: 11,
+        },
+        {
+          message:
+            'Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef)',
+          line: 12,
+        },
+        {
+          message:
+            'Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef)',
+          line: 14,
+        },
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
## Summary

This pull request adds a regression test that reproduces the bug described in [#33617](https://github.com/facebook/react/issues/33617).

The issue is caused by inconsistent behavior between `babel-plugin-react-compiler` and `eslint-plugin-react-compiler`. Specifically, `ref` access during render is allowed in one but disallowed in the other. The included test demonstrates this inconsistency.

I found that enabling the internal flag `validateRefAccessDuringRender = true` resolves the issue in this case. However, doing so breaks several other existing tests, suggesting that a deeper fix or design clarification is needed.

This PR does not attempt to fix the root cause but provides a failing test to help guide future investigation and regression protection.

## How did you test this change?

- Added a test case that reproduces the failure.
- Verified that the test fails under current behavior.
- Confirmed that the test passes if `validateRefAccessDuringRender` is set to `true`, although doing so causes other unrelated tests to fail.
- Ran the tests:

```bash
yarn test packages/eslint-plugin-react-hooks
yarn test
```
