### PR TITLE
[Flight] Don't double badge consoles that are replayed from a third party

### DIFF
--- a/packages/react-client/src/ReactClientConsoleConfigPlain.js
+++ b/packages/react-client/src/ReactClientConsoleConfigPlain.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+// Keep in sync with ReactServerConsoleConfig
 const badgeFormat = '[%s] ';
 const pad = ' ';
 

--- a/packages/react-server/src/ReactServerConsoleConfigBrowser.js
+++ b/packages/react-server/src/ReactServerConsoleConfigBrowser.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-// Keep in sync with ReactServerConsoleConfig
+// Keep in sync with ReactClientConsoleConfig
 const badgeFormat = '%c%s%c ';
 // Same badge styling as DevTools.
 const badgeStyle =
@@ -18,16 +18,16 @@ const badgeStyle =
   'color: #000000;' +
   'color: light-dark(#000000, #ffffff);' +
   'border-radius: 2px';
-const resetStyle = '';
-const pad = ' ';
 
-const bind = Function.prototype.bind;
+const padLength = 1;
 
-export function bindToConsole(
+// This mutates the args to remove any badges that was added by a FlightClient and
+// returns the name in the badge. This is used when a FlightClient replays inside
+// a FlightServer and we capture those replays.
+export function unbadgeConsole(
   methodName: string,
   args: Array<any>,
-  badgeName: string,
-): () => any {
+): null | string {
   let offset = 0;
   switch (methodName) {
     case 'dir':
@@ -35,39 +35,27 @@ export function bindToConsole(
     case 'groupEnd':
     case 'table': {
       // These methods cannot be colorized because they don't take a formatting string.
+      // So we wouldn't have added any badge in the first place.
       // $FlowFixMe
-      return bind.apply(console[methodName], [console].concat(args)); // eslint-disable-line react-internal/no-production-logging
+      return null;
     }
     case 'assert': {
       // assert takes formatting options as the second argument.
       offset = 1;
     }
   }
-
-  const newArgs = args.slice(0);
-  if (typeof newArgs[offset] === 'string') {
-    newArgs.splice(
-      offset,
-      1,
-      badgeFormat + newArgs[offset],
-      badgeStyle,
-      pad + badgeName + pad,
-      resetStyle,
-    );
-  } else {
-    newArgs.splice(
-      offset,
-      0,
-      badgeFormat,
-      badgeStyle,
-      pad + badgeName + pad,
-      resetStyle,
-    );
+  const format = args[offset];
+  const style = args[offset + 1];
+  const badge = args[offset + 2];
+  if (
+    typeof format === 'string' &&
+    format.startsWith(badgeFormat) &&
+    style === badgeStyle &&
+    typeof badge === 'string'
+  ) {
+    // Remove our badging from the arguments.
+    args.splice(offset, 4, format.slice(badgeFormat.length));
+    return badge.slice(padLength, badge.length - padLength - padLength);
   }
-
-  // The "this" binding in the "bind";
-  newArgs.unshift(console);
-
-  // $FlowFixMe
-  return bind.apply(console[methodName], newArgs); // eslint-disable-line react-internal/no-production-logging
+  return null;
 }

--- a/packages/react-server/src/ReactServerConsoleConfigBrowser.js
+++ b/packages/react-server/src/ReactServerConsoleConfigBrowser.js
@@ -55,7 +55,7 @@ export function unbadgeConsole(
   ) {
     // Remove our badging from the arguments.
     args.splice(offset, 4, format.slice(badgeFormat.length));
-    return badge.slice(padLength, badge.length - padLength - padLength);
+    return badge.slice(padLength, badge.length - padLength);
   }
   return null;
 }

--- a/packages/react-server/src/ReactServerConsoleConfigPlain.js
+++ b/packages/react-server/src/ReactServerConsoleConfigPlain.js
@@ -46,7 +46,7 @@ export function unbadgeConsole(
   ) {
     // Remove our badging from the arguments.
     args.splice(offset, 2, format.slice(badgeFormat.length));
-    return badge.slice(padLength, badge.length - padLength - padLength);
+    return badge.slice(padLength, badge.length - padLength);
   }
   return null;
 }

--- a/packages/react-server/src/ReactServerConsoleConfigPlain.js
+++ b/packages/react-server/src/ReactServerConsoleConfigPlain.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Keep in sync with ReactClientConsoleConfig
+const badgeFormat = '[%s] ';
+const padLength = 1;
+const pad = ' ';
+
+// This mutates the args to remove any badges that was added by a FlightClient and
+// returns the name in the badge. This is used when a FlightClient replays inside
+// a FlightServer and we capture those replays.
+export function unbadgeConsole(
+  methodName: string,
+  args: Array<any>,
+): null | string {
+  let offset = 0;
+  switch (methodName) {
+    case 'dir':
+    case 'dirxml':
+    case 'groupEnd':
+    case 'table': {
+      // These methods cannot be colorized because they don't take a formatting string.
+      // So we wouldn't have added any badge in the first place.
+      // $FlowFixMe
+      return null;
+    }
+    case 'assert': {
+      // assert takes formatting options as the second argument.
+      offset = 1;
+    }
+  }
+  const format = args[offset];
+  const badge = args[offset + 1];
+  if (
+    typeof format === 'string' &&
+    format.startsWith(badgeFormat) &&
+    typeof badge === 'string' &&
+    badge.startsWith(pad) &&
+    badge.endsWith(pad)
+  ) {
+    // Remove our badging from the arguments.
+    args.splice(offset, 2, format.slice(badgeFormat.length));
+    return badge.slice(padLength, badge.length - padLength - padLength);
+  }
+  return null;
+}

--- a/packages/react-server/src/ReactServerConsoleConfigServer.js
+++ b/packages/react-server/src/ReactServerConsoleConfigServer.js
@@ -54,7 +54,7 @@ export function unbadgeConsole(
   ) {
     // Remove our badging from the arguments.
     args.splice(offset, 4, format.slice(badgeFormat.length));
-    return badge.slice(padLength, badge.length - padLength - padLength);
+    return badge.slice(padLength, badge.length - padLength);
   }
   return null;
 }

--- a/packages/react-server/src/ReactServerConsoleConfigServer.js
+++ b/packages/react-server/src/ReactServerConsoleConfigServer.js
@@ -7,8 +7,7 @@
  * @flow
  */
 
-// Keep in sync with ReactServerConsoleConfig
-// This flips color using ANSI, then sets a color styling, then resets.
+// Keep in sync with ReactClientConsoleConfig
 const badgeFormat = '\x1b[0m\x1b[7m%c%s\x1b[0m%c ';
 // Same badge styling as DevTools.
 const badgeStyle =
@@ -19,16 +18,15 @@ const badgeStyle =
   'color: #000000;' +
   'color: light-dark(#000000, #ffffff);' +
   'border-radius: 2px';
-const resetStyle = '';
-const pad = ' ';
+const padLength = 1;
 
-const bind = Function.prototype.bind;
-
-export function bindToConsole(
+// This mutates the args to remove any badges that was added by a FlightClient and
+// returns the name in the badge. This is used when a FlightClient replays inside
+// a FlightServer and we capture those replays.
+export function unbadgeConsole(
   methodName: string,
   args: Array<any>,
-  badgeName: string,
-): () => any {
+): null | string {
   let offset = 0;
   switch (methodName) {
     case 'dir':
@@ -36,39 +34,27 @@ export function bindToConsole(
     case 'groupEnd':
     case 'table': {
       // These methods cannot be colorized because they don't take a formatting string.
+      // So we wouldn't have added any badge in the first place.
       // $FlowFixMe
-      return bind.apply(console[methodName], [console].concat(args)); // eslint-disable-line react-internal/no-production-logging
+      return null;
     }
     case 'assert': {
       // assert takes formatting options as the second argument.
       offset = 1;
     }
   }
-
-  const newArgs = args.slice(0);
-  if (typeof newArgs[offset] === 'string') {
-    newArgs.splice(
-      offset,
-      1,
-      badgeFormat + newArgs[offset],
-      badgeStyle,
-      pad + badgeName + pad,
-      resetStyle,
-    );
-  } else {
-    newArgs.splice(
-      offset,
-      0,
-      badgeFormat,
-      badgeStyle,
-      pad + badgeName + pad,
-      resetStyle,
-    );
+  const format = args[offset];
+  const style = args[offset + 1];
+  const badge = args[offset + 2];
+  if (
+    typeof format === 'string' &&
+    format.startsWith(badgeFormat) &&
+    style === badgeStyle &&
+    typeof badge === 'string'
+  ) {
+    // Remove our badging from the arguments.
+    args.splice(offset, 4, format.slice(badgeFormat.length));
+    return badge.slice(padLength, badge.length - padLength - padLength);
   }
-
-  // The "this" binding in the "bind";
-  newArgs.unshift(console);
-
-  // $FlowFixMe
-  return bind.apply(console[methodName], newArgs); // eslint-disable-line react-internal/no-production-logging
+  return null;
 }

--- a/packages/react-server/src/forks/ReactFlightServerConfig.custom.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.custom.js
@@ -15,6 +15,7 @@ export * from '../ReactFlightServerConfigBundlerCustom';
 export * from '../ReactFlightServerConfigDebugNoop';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigPlain';
 
 export type Hints = any;
 export type HintCode = any;

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser-esm.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser-esm.js
@@ -23,3 +23,4 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
 export * from '../ReactFlightServerConfigDebugNoop';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigBrowser';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser-parcel.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser-parcel.js
@@ -23,3 +23,4 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
 export * from '../ReactFlightServerConfigDebugNoop';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigBrowser';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser-turbopack.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser-turbopack.js
@@ -23,3 +23,4 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
 export * from '../ReactFlightServerConfigDebugNoop';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigBrowser';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser.js
@@ -23,3 +23,4 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
 export * from '../ReactFlightServerConfigDebugNoop';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigBrowser';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-bun.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-bun.js
@@ -23,3 +23,4 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
 export * from '../ReactFlightServerConfigDebugNoop';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigPlain';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge-parcel.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge-parcel.js
@@ -25,3 +25,4 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
 export * from '../ReactFlightServerConfigDebugNoop';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigServer';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge-turbopack.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge-turbopack.js
@@ -25,3 +25,4 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
 export * from '../ReactFlightServerConfigDebugNoop';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigServer';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge.js
@@ -26,3 +26,4 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
 export * from '../ReactFlightServerConfigDebugNoop';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigServer';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-legacy.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-legacy.js
@@ -15,6 +15,7 @@ export * from '../ReactFlightServerConfigBundlerCustom';
 export * from '../ReactFlightServerConfigDebugNoop';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigServer';
 
 export type Hints = any;
 export type HintCode = any;

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-node-esm.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-node-esm.js
@@ -26,3 +26,4 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
 export * from '../ReactFlightServerConfigDebugNode';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigServer';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-node-parcel.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-node-parcel.js
@@ -26,3 +26,4 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
 export * from '../ReactFlightServerConfigDebugNode';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigServer';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-node-turbopack.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-node-turbopack.js
@@ -26,3 +26,4 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
 export * from '../ReactFlightServerConfigDebugNode';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigServer';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-node.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-node.js
@@ -26,3 +26,4 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
 export * from '../ReactFlightServerConfigDebugNode';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigServer';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.markup.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.markup.js
@@ -29,6 +29,7 @@ export const componentStorage: AsyncLocalStorage<ReactComponentInfo | void> =
 export * from '../ReactFlightServerConfigDebugNoop';
 
 export * from '../ReactFlightStackConfigV8';
+export * from '../ReactServerConsoleConfigPlain';
 
 export type ClientManifest = null;
 export opaque type ClientReference<T> = null; // eslint-disable-line no-unused-vars


### PR DESCRIPTION
If a FlightClient runs inside a FlightServer like fetching from a third party and that logs, then we currently double badge them since we just add on another badge. The issue is that this might be unnecessarily noisy but we also transfer the original format of the current server into the second badge.

This extracts our own badge and then adds the environment name as structured data which lets the client decide how to format it.

Before:

<img width="599" alt="Screenshot 2025-07-02 at 2 30 07 PM" src="https://github.com/user-attachments/assets/4bf26a29-b3a8-4024-8eb9-a3f90dbff97a" />

After:

<img width="590" alt="Screenshot 2025-07-02 at 2 32 56 PM" src="https://github.com/user-attachments/assets/f06bbb6d-fbb1-4ae6-b0e3-775849fe3c53" />
