### PR TITLE
[devtools] fix: support optionality of structured stack trace function name

### DIFF
--- a/packages/react-devtools-shared/src/backend/utils/index.js
+++ b/packages/react-devtools-shared/src/backend/utils/index.js
@@ -360,8 +360,9 @@ function collectStackTrace(
     const callSite = structuredStackTrace[i];
     const name = callSite.getFunctionName();
     if (
-      name.includes('react_stack_bottom_frame') ||
-      name.includes('react-stack-bottom-frame')
+      name != null &&
+      (name.includes('react_stack_bottom_frame') ||
+        name.includes('react-stack-bottom-frame'))
     ) {
       // We pick the last frame that matches before the bottom frame since
       // that will be immediately inside the component as opposed to some helper.


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/33680.

Turns out `.getFunctionName` not always returns string.