### PR TITLE
[Flight] Pass line/column to filterStackFrame

### DIFF
--- a/packages/react-client/src/ReactFlightReplyClient.js
+++ b/packages/react-client/src/ReactFlightReplyClient.js
@@ -1106,7 +1106,7 @@ function createFakeServerFunction<A: Iterable<any>, T>(
       '\n//# sourceURL=rsc://React/' +
       encodeURIComponent(environmentName) +
       '/' +
-      filename +
+      encodeURI(filename) +
       '?s' + // We add an extra s here to distinguish from the fake stack frames
       fakeServerFunctionIdx++;
     code += '\n//# sourceMappingURL=' + sourceMap;

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -1306,6 +1306,9 @@ describe('ReactFlight', () => {
         '    at file:///testing.js:42:3',
         // async anon function (https://github.com/ChromeDevTools/devtools-frontend/blob/831be28facb4e85de5ee8c1acc4d98dfeda7a73b/test/unittests/front_end/panels/console/ErrorStackParser_test.ts#L130C9-L130C41)
         '    at async file:///testing.js:42:3',
+        // third-party RSC frame
+        // Ideally this would be a real frame produced by React not a mocked one.
+        '    at ThirdParty (rsc://React/ThirdParty/file:///code/%5Broot%2520of%2520the%2520server%5D.js?42:1:1)',
         // host component in parent stack
         '    at div (<anonymous>)',
         ...originalStackLines.slice(2),
@@ -1360,7 +1363,10 @@ describe('ReactFlight', () => {
           return functionName === 'div';
         }
         return (
-          !filename.startsWith('node:') && !filename.includes('node_modules')
+          !filename.startsWith('node:') &&
+          !filename.includes('node_modules') &&
+          // sourceURL from an ES module in `/code/[root of the server].js`
+          filename !== 'file:///code/[root%20of%20the%20server].js'
         );
       },
     });

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -1309,6 +1309,8 @@ describe('ReactFlight', () => {
         // third-party RSC frame
         // Ideally this would be a real frame produced by React not a mocked one.
         '    at ThirdParty (rsc://React/ThirdParty/file:///code/%5Broot%2520of%2520the%2520server%5D.js?42:1:1)',
+        // We'll later filter this out based on line/column in `filterStackFrame`.
+        '    at ThirdPartyModule (file:///file-with-index-source-map.js:52656:16374)',
         // host component in parent stack
         '    at div (<anonymous>)',
         ...originalStackLines.slice(2),
@@ -1357,7 +1359,10 @@ describe('ReactFlight', () => {
         }
         return `digest(${String(x)})`;
       },
-      filterStackFrame(filename, functionName) {
+      filterStackFrame(filename, functionName, lineNumber, columnNumber) {
+        if (lineNumber === 52656 && columnNumber === 16374) {
+          return false;
+        }
         if (!filename) {
           // Allow anonymous
           return functionName === 'div';
@@ -3682,7 +3687,7 @@ describe('ReactFlight', () => {
         onError(x) {
           return `digest("${x.message}")`;
         },
-        filterStackFrame(url, functionName) {
+        filterStackFrame(url, functionName, lineNumber, columnNumber) {
           return functionName !== 'intermediate';
         },
       },

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -184,10 +184,10 @@ function devirtualizeURL(url: string): string {
     // We need to reverse it back into the original location by stripping its prefix
     // and suffix. We don't need the environment name because it's available on the
     // parent object that will contain the stack.
-    const envIdx = url.indexOf('/', 12);
+    const envIdx = url.indexOf('/', 'rsc://React/'.length);
     const suffixIdx = url.lastIndexOf('?');
     if (envIdx > -1 && suffixIdx > -1) {
-      return url.slice(envIdx + 1, suffixIdx);
+      return decodeURI(url.slice(envIdx + 1, suffixIdx));
     }
   }
   return url;

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -204,7 +204,18 @@ function findCalledFunctionNameFromStackTrace(
     const callsite = stack[i];
     const functionName = callsite[0];
     const url = devirtualizeURL(callsite[1]);
-    if (filterStackFrame(url, functionName)) {
+    const lineNumber = callsite[2];
+    const columnNumber = callsite[3];
+    const enclosingLineNumber = callsite[4];
+    const enclosingColumnNumber = callsite[5];
+    if (
+      filterStackFrame(
+        url,
+        functionName,
+        enclosingLineNumber || lineNumber,
+        enclosingColumnNumber || columnNumber,
+      )
+    ) {
       if (bestMatch === '') {
         // If we had no good stack frames for internal calls, just use the last
         // first party function name.
@@ -235,8 +246,19 @@ function filterStackTrace(
   for (let i = 0; i < stack.length; i++) {
     const callsite = stack[i];
     const functionName = callsite[0];
+    const lineNumber = callsite[2];
+    const columnNumber = callsite[3];
+    const enclosingLineNumber = callsite[4];
+    const enclosingColumnNumber = callsite[5];
     const url = devirtualizeURL(callsite[1]);
-    if (filterStackFrame(url, functionName)) {
+    if (
+      filterStackFrame(
+        url,
+        functionName,
+        enclosingLineNumber || lineNumber,
+        enclosingColumnNumber || columnNumber,
+      )
+    ) {
       // Use a clone because the Flight protocol isn't yet resilient to deduping
       // objects in the debug info. TODO: Support deduping stacks.
       const clone: ReactCallSite = (callsite.slice(0): any);
@@ -465,7 +487,12 @@ export type Request = {
   // DEV-only
   completedDebugChunks: Array<Chunk | BinaryChunk>,
   environmentName: () => string,
-  filterStackFrame: (url: string, functionName: string) => boolean,
+  filterStackFrame: (
+    url: string,
+    functionName: string,
+    lineNumber: number,
+    columnNumber: number,
+  ) => boolean,
   didWarnForKey: null | WeakSet<ReactComponentInfo>,
   writtenDebugObjects: WeakMap<Reference, string>,
   deferredDebugObjects: null | DeferredDebugStore,
@@ -2139,7 +2166,16 @@ function visitAsyncNode(
               const callsite = fullStack[0];
               const functionName = callsite[0];
               const url = devirtualizeURL(callsite[1]);
-              isAwaitInUserspace = filterStackFrame(url, functionName);
+              const lineNumber = callsite[2];
+              const columnNumber = callsite[3];
+              const enclosingLineNumber = callsite[4];
+              const enclosingColumnNumber = callsite[5];
+              isAwaitInUserspace = filterStackFrame(
+                url,
+                functionName,
+                enclosingLineNumber || lineNumber,
+                enclosingColumnNumber || columnNumber,
+              );
             }
             if (!isAwaitInUserspace) {
               // If this await was fully filtered out, then it was inside third party code


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/33706

`filterStackFrame` implementations can fast-path ignore-listing by checking if the corresponding source map ignore-lists everything. However, this check requires checking every section for [Index Source Maps](https://tc39.es/ecma426/#sec-index-source-map) which deopts the fast-path check from a constant check (comparing `.length`) to looping through every section (i.e. `O(N)`).

By passing in the relevant line and column, a `filterStackFrame` implementation can find the relevant section with binary search (`O(log N)`).