### PR TITLE
[Flight] Keep a separate ref count for debug chunks

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -5751,7 +5751,7 @@ export function closeDebugChannel(request: Request): void {
     );
   }
   deferredDebugObjects.retained.forEach((value, id) => {
-    request.pendingChunks--;
+    request.pendingDebugChunks--;
     deferredDebugObjects.retained.delete(id);
     deferredDebugObjects.existing.delete(value);
   });


### PR DESCRIPTION
Same as #33716 but without the separate close signal.

We'll need the ref count for separate debug channel anyway but I'm not sure we'll need the separate close signal.