### PR TITLE
Unnecessary cheks for __DEV__

### DIFF
--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -382,7 +382,6 @@ export function jsxProdSignatureRunningInDevWithDynamicChildren(
   if (__DEV__) {
     const isStaticChildren = false;
     const trackActualOwner =
-      __DEV__ &&
       ReactSharedInternals.recentlyCreatedOwnerStacks++ < ownerStackLimit;
     return jsxDEVImpl(
       type,
@@ -391,14 +390,12 @@ export function jsxProdSignatureRunningInDevWithDynamicChildren(
       isStaticChildren,
       source,
       self,
-      __DEV__ &&
-        (trackActualOwner
+      trackActualOwner
           ? Error('react-stack-top-frame')
-          : unknownOwnerDebugStack),
-      __DEV__ &&
-        (trackActualOwner
+          : unknownOwnerDebugStack,
+      trackActualOwner
           ? createTask(getTaskName(type))
-          : unknownOwnerDebugTask),
+          : unknownOwnerDebugTask,
     );
   }
 }


### PR DESCRIPTION
In one of the files of react package there are checks of the form: `__DEV__ && ...` inside of an if whose condition is that `__DEV__` is true so && will always return the second operand.
This pull requests simply deltes those redundant checks