### PR TITLE
[compiler] Improve IIFE inlining

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/MergeConsecutiveBlocks.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/MergeConsecutiveBlocks.ts
@@ -107,6 +107,17 @@ export function mergeConsecutiveBlocks(fn: HIRFunction): void {
     merged.merge(block.id, predecessorId);
     fn.body.blocks.delete(block.id);
   }
+  for (const [, block] of fn.body.blocks) {
+    for (const phi of block.phis) {
+      for (const [predecessorId, operand] of phi.operands) {
+        const mapped = merged.get(predecessorId);
+        if (mapped !== predecessorId) {
+          phi.operands.delete(predecessorId);
+          phi.operands.set(mapped, operand);
+        }
+      }
+    }
+  }
   markPredecessors(fn.body);
   for (const [, {terminal}] of fn.body.blocks) {
     if (terminalHasFallthrough(terminal)) {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -715,7 +715,7 @@ export function printInstructionValue(instrValue: ReactiveValue): string {
       break;
     }
     case 'FinishMemoize': {
-      value = `FinishMemoize decl=${printPlace(instrValue.decl)}`;
+      value = `FinishMemoize decl=${printPlace(instrValue.decl)}${instrValue.pruned ? ' pruned' : ''}`;
       break;
     }
     default: {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/align-scopes-iife-return-modified-later-logical.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/align-scopes-iife-return-modified-later-logical.expect.md
@@ -26,20 +26,16 @@ import { c as _c } from "react/compiler-runtime";
 import { getNull } from "shared-runtime";
 
 function Component(props) {
-  const $ = _c(3);
-  let t0;
+  const $ = _c(2);
   let items;
   if ($[0] !== props.a) {
-    t0 = getNull() ?? [];
-    items = t0;
+    items = getNull() ?? [];
 
     items.push(props.a);
     $[0] = props.a;
     $[1] = items;
-    $[2] = t0;
   } else {
     items = $[1];
-    t0 = $[2];
   }
   return items;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-modify-global-in-callback-jsx.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-modify-global-in-callback-jsx.expect.md
@@ -52,15 +52,13 @@ function Component(t0) {
   }
   const onClick = t1;
   let t2;
-  let t3;
   if ($[2] !== onClick) {
-    t3 = <div onClick={onClick}>{someGlobal.value}</div>;
+    t2 = <div onClick={onClick}>{someGlobal.value}</div>;
     $[2] = onClick;
-    $[3] = t3;
+    $[3] = t2;
   } else {
-    t3 = $[3];
+    t2 = $[3];
   }
-  t2 = t3;
   return t2;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/babel-existing-react-import.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/babel-existing-react-import.expect.md
@@ -30,50 +30,46 @@ function Component(props) {
   const $ = _c(4);
   const [x] = useState(0);
   let t0;
-  let t1;
   if ($[0] !== x) {
-    t1 = calculateExpensiveNumber(x);
+    t0 = calculateExpensiveNumber(x);
     $[0] = x;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   const expensiveNumber = t0;
-  let t2;
+  let t1;
   if ($[2] !== expensiveNumber) {
-    t2 = <div>{expensiveNumber}</div>;
+    t1 = <div>{expensiveNumber}</div>;
     $[2] = expensiveNumber;
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  return t2;
+  return t1;
 }
 
 function Component2(props) {
   const $ = _c(4);
   const [x] = useState(0);
   let t0;
-  let t1;
   if ($[0] !== x) {
-    t1 = calculateExpensiveNumber(x);
+    t0 = calculateExpensiveNumber(x);
     $[0] = x;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   const expensiveNumber = t0;
-  let t2;
+  let t1;
   if ($[2] !== expensiveNumber) {
-    t2 = <div>{expensiveNumber}</div>;
+    t1 = <div>{expensiveNumber}</div>;
     $[2] = expensiveNumber;
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  return t2;
+  return t1;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/babel-existing-react-kitchensink-import.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/babel-existing-react-kitchensink-import.expect.md
@@ -32,50 +32,46 @@ function Component(props) {
   const $ = _c(4);
   const [x] = useState(0);
   let t0;
-  let t1;
   if ($[0] !== x) {
-    t1 = calculateExpensiveNumber(x);
+    t0 = calculateExpensiveNumber(x);
     $[0] = x;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   const expensiveNumber = t0;
-  let t2;
+  let t1;
   if ($[2] !== expensiveNumber) {
-    t2 = <div>{expensiveNumber}</div>;
+    t1 = <div>{expensiveNumber}</div>;
     $[2] = expensiveNumber;
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  return t2;
+  return t1;
 }
 
 function Component2(props) {
   const $ = _c(4);
   const [x] = useState(0);
   let t0;
-  let t1;
   if ($[0] !== x) {
-    t1 = calculateExpensiveNumber(x);
+    t0 = calculateExpensiveNumber(x);
     $[0] = x;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   const expensiveNumber = t0;
-  let t2;
+  let t1;
   if ($[2] !== expensiveNumber) {
-    t2 = <div>{expensiveNumber}</div>;
+    t1 = <div>{expensiveNumber}</div>;
     $[2] = expensiveNumber;
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  return t2;
+  return t1;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/babel-existing-react-namespace-import.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/babel-existing-react-namespace-import.expect.md
@@ -30,25 +30,23 @@ function Component(props) {
   const $ = _c(4);
   const [x] = React.useState(0);
   let t0;
-  let t1;
   if ($[0] !== x) {
-    t1 = calculateExpensiveNumber(x);
+    t0 = calculateExpensiveNumber(x);
     $[0] = x;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   const expensiveNumber = t0;
-  let t2;
+  let t1;
   if ($[2] !== expensiveNumber) {
-    t2 = <div>{expensiveNumber}</div>;
+    t1 = <div>{expensiveNumber}</div>;
     $[2] = expensiveNumber;
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  return t2;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/babel-existing-react-runtime-import.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/babel-existing-react-runtime-import.expect.md
@@ -36,30 +36,28 @@ function Component(props) {
   const $ = _c(4);
   const [x] = React.useState(0);
   let t0;
-  let t1;
   if ($[0] !== x) {
-    t1 = calculateExpensiveNumber(x);
+    t0 = calculateExpensiveNumber(x);
     $[0] = x;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   const expensiveNumber = t0;
-  let t2;
+  let t1;
   if ($[2] !== expensiveNumber) {
-    t2 = (
+    t1 = (
       <div>
         {expensiveNumber}
         {`${someImport}`}
       </div>
     );
     $[2] = expensiveNumber;
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  return t2;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/block-scoping-switch-variable-scoping.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/block-scoping-switch-variable-scoping.expect.md
@@ -36,15 +36,14 @@ import { useMemo } from "react";
 function Component(props) {
   const $ = _c(2);
   let t0;
-  let t1;
   if ($[0] !== props.value) {
-    t1 = { value: props.value };
+    t0 = { value: props.value };
     $[0] = props.value;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  const handlers = t1;
+  const handlers = t0;
   bb0: switch (props.test) {
     case true: {
       console.log(handlers.value);
@@ -52,9 +51,7 @@ function Component(props) {
     }
     default:
   }
-
-  t0 = handlers;
-  const outerHandlers = t0;
+  const outerHandlers = handlers;
   return outerHandlers;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/codegen-inline-iife-reassign.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/codegen-inline-iife-reassign.expect.md
@@ -37,11 +37,9 @@ function useTest() {
 
     const t1 = (w = 42);
     const t2 = w;
-    let t3;
 
     w = 999;
-    t3 = 2;
-    t0 = makeArray(t1, t2, t3);
+    t0 = makeArray(t1, t2, 2);
     $[0] = t0;
   } else {
     t0 = $[0];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/codegen-inline-iife-storeprop.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/codegen-inline-iife-storeprop.expect.md
@@ -37,11 +37,9 @@ function useTest() {
 
     const t1 = (w.x = 42);
     const t2 = w.x;
-    let t3;
 
     w.x = 999;
-    t3 = 2;
-    t0 = makeArray(t1, t2, t3);
+    t0 = makeArray(t1, t2, 2);
     $[0] = t0;
   } else {
     t0 = $[0];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/codegen-inline-iife.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/codegen-inline-iife.expect.md
@@ -32,11 +32,9 @@ function useTest() {
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     const t1 = print(1);
-    let t2;
 
     print(2);
-    t2 = 2;
-    t0 = makeArray(t1, t2);
+    t0 = makeArray(t1, 2);
     $[0] = t0;
   } else {
     t0 = $[0];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/consecutive-use-memo.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/consecutive-use-memo.expect.md
@@ -29,37 +29,33 @@ function useHook(t0) {
   const $ = _c(7);
   const { a, b } = t0;
   let t1;
-  let t2;
   if ($[0] !== a) {
-    t2 = identity({ a });
+    t1 = identity({ a });
     $[0] = a;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   const valA = t1;
-  let t3;
-  let t4;
+  let t2;
   if ($[2] !== b) {
-    t4 = identity([b]);
+    t2 = identity([b]);
     $[2] = b;
-    $[3] = t4;
+    $[3] = t2;
   } else {
-    t4 = $[3];
+    t2 = $[3];
   }
-  t3 = t4;
-  const valB = t3;
-  let t5;
+  const valB = t2;
+  let t3;
   if ($[4] !== valA || $[5] !== valB) {
-    t5 = [valA, valB];
+    t3 = [valA, valB];
     $[4] = valA;
     $[5] = valB;
-    $[6] = t5;
+    $[6] = t3;
   } else {
-    t5 = $[6];
+    t3 = $[6];
   }
-  return t5;
+  return t3;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/context-variable-as-jsx-element-tag.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/context-variable-as-jsx-element-tag.expect.md
@@ -34,10 +34,8 @@ function Component(props) {
   let Component;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     Component = Stringify;
-    let t0;
 
-    t0 = Component;
-    Component = t0;
+    Component = Component;
     $[0] = Component;
   } else {
     Component = $[0];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/deeply-nested-function-expressions-with-params.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/deeply-nested-function-expressions-with-params.expect.md
@@ -28,20 +28,18 @@ import { c as _c } from "react/compiler-runtime";
 function Foo() {
   const $ = _c(1);
   let t0;
-  let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = function a(t2) {
-      const x_0 = t2 === undefined ? _temp : t2;
-      return (function b(t3) {
-        const y_0 = t3 === undefined ? [] : t3;
+    t0 = function a(t1) {
+      const x_0 = t1 === undefined ? _temp : t1;
+      return (function b(t2) {
+        const y_0 = t2 === undefined ? [] : t2;
         return [x_0, y_0];
       })();
     };
-    $[0] = t1;
+    $[0] = t0;
   } else {
-    t1 = $[0];
+    t0 = $[0];
   }
-  t0 = t1;
   return t0;
 }
 function _temp() {}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/drop-methodcall-usememo.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/drop-methodcall-usememo.expect.md
@@ -28,7 +28,6 @@ import * as React from "react";
 
 function Component(props) {
   const $ = _c(2);
-  let t0;
   let x;
   if ($[0] !== props.value) {
     x = [];
@@ -38,8 +37,7 @@ function Component(props) {
   } else {
     x = $[1];
   }
-  t0 = x;
-  const x_0 = t0;
+  const x_0 = x;
   return x_0;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/existing-variables-with-c-name.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/existing-variables-with-c-name.expect.md
@@ -42,34 +42,32 @@ function Component(props) {
   const c1 = __c;
   const $c = c1;
   let t0;
-  let t1;
   if ($[0] !== $c) {
-    t1 = [$c];
+    t0 = [$c];
     $[0] = $c;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   const array = t0;
-  let t2;
+  let t1;
   if ($[2] !== state) {
-    t2 = [state];
+    t1 = [state];
     $[2] = state;
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  let t3;
-  if ($[4] !== array || $[5] !== t2) {
-    t3 = <ValidateMemoization inputs={t2} output={array} />;
+  let t2;
+  if ($[4] !== array || $[5] !== t1) {
+    t2 = <ValidateMemoization inputs={t1} output={array} />;
     $[4] = array;
-    $[5] = t2;
-    $[6] = t3;
+    $[5] = t1;
+    $[6] = t2;
   } else {
-    t3 = $[6];
+    t2 = $[6];
   }
-  return t3;
+  return t2;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fast-refresh-dont-refresh-const-changes-prod.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fast-refresh-dont-refresh-const-changes-prod.expect.md
@@ -63,23 +63,21 @@ function Component() {
 
   unsafeUpdateConst();
   let t0;
-  let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = [{ pretendConst }];
-    $[0] = t1;
+    t0 = [{ pretendConst }];
+    $[0] = t0;
   } else {
-    t1 = $[0];
+    t0 = $[0];
   }
-  t0 = t1;
   const value = t0;
-  let t2;
+  let t1;
   if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-    t2 = <ValidateMemoization inputs={[]} output={value} />;
-    $[1] = t2;
+    t1 = <ValidateMemoization inputs={[]} output={value} />;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  return t2;
+  return t1;
 }
 function _temp() {
   unsafeResetConst();

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fast-refresh-refresh-on-const-changes-dev.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fast-refresh-refresh-on-const-changes-dev.expect.md
@@ -74,23 +74,21 @@ function Component() {
 
   unsafeUpdateConst();
   let t0;
-  let t1;
   if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = [{ pretendConst }];
-    $[1] = t1;
+    t0 = [{ pretendConst }];
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   const value = t0;
-  let t2;
+  let t1;
   if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
-    t2 = <ValidateMemoization inputs={[pretendConst]} output={value} />;
-    $[2] = t2;
+    t1 = <ValidateMemoization inputs={[pretendConst]} output={value} />;
+    $[2] = t1;
   } else {
-    t2 = $[2];
+    t1 = $[2];
   }
-  return t2;
+  return t1;
 }
 function _temp() {
   unsafeResetConst();

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fast-refresh-reloading.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fast-refresh-reloading.expect.md
@@ -38,36 +38,34 @@ function Component(props) {
     $[0] = "20945b0193e529df490847c66111b38d7b02485d5b53d0829ff3b23af87b105c";
   }
   const [state] = useState(0);
-  let t0;
-  const t1 = state * 2;
+  const t0 = state * 2;
+  let t1;
+  if ($[1] !== t0) {
+    t1 = [t0];
+    $[1] = t0;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  const doubled = t1;
   let t2;
-  if ($[1] !== t1) {
-    t2 = [t1];
-    $[1] = t1;
-    $[2] = t2;
-  } else {
-    t2 = $[2];
-  }
-  t0 = t2;
-  const doubled = t0;
-  let t3;
   if ($[3] !== state) {
-    t3 = [state];
+    t2 = [state];
     $[3] = state;
-    $[4] = t3;
+    $[4] = t2;
   } else {
-    t3 = $[4];
+    t2 = $[4];
   }
-  let t4;
-  if ($[5] !== doubled || $[6] !== t3) {
-    t4 = <ValidateMemoization inputs={t3} output={doubled} />;
+  let t3;
+  if ($[5] !== doubled || $[6] !== t2) {
+    t3 = <ValidateMemoization inputs={t2} output={doubled} />;
     $[5] = doubled;
-    $[6] = t3;
-    $[7] = t4;
+    $[6] = t2;
+    $[7] = t3;
   } else {
-    t4 = $[7];
+    t3 = $[7];
   }
-  return t4;
+  return t3;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-repro-invalid-mutable-range-destructured-prop.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fbt/fbt-repro-invalid-mutable-range-destructured-prop.expect.md
@@ -40,36 +40,34 @@ function Component(t0) {
   const $ = _c(7);
   const { data } = t0;
   let t1;
-  let t2;
   if ($[0] !== data.name) {
-    t2 = fbt._("{name}", [fbt._param("name", data.name ?? "")], {
+    t1 = fbt._("{name}", [fbt._param("name", data.name ?? "")], {
       hk: "csQUH",
     });
     $[0] = data.name;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   const el = t1;
-  let t3;
+  let t2;
   if ($[2] !== data.name) {
-    t3 = [data.name];
+    t2 = [data.name];
     $[2] = data.name;
-    $[3] = t3;
+    $[3] = t2;
   } else {
-    t3 = $[3];
+    t2 = $[3];
   }
-  let t4;
-  if ($[4] !== el || $[5] !== t3) {
-    t4 = <ValidateMemoization inputs={t3} output={el} />;
+  let t3;
+  if ($[4] !== el || $[5] !== t2) {
+    t3 = <ValidateMemoization inputs={t2} output={el} />;
     $[4] = el;
-    $[5] = t3;
-    $[6] = t4;
+    $[5] = t2;
+    $[6] = t3;
   } else {
-    t4 = $[6];
+    t3 = $[6];
   }
-  return t4;
+  return t3;
 }
 
 const props1 = { data: { name: "Mike" } };

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/for-of-nonmutating-loop-local-collection.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/for-of-nonmutating-loop-local-collection.expect.md
@@ -47,17 +47,14 @@ function Component(t0) {
   const $ = _c(19);
   const { a, b } = t0;
   let t1;
-  let t2;
   if ($[0] !== a) {
-    t2 = [a];
+    t1 = [a];
     $[0] = a;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   const x = t1;
-  let t3;
   let items;
   if ($[2] !== b || $[3] !== x) {
     items = [b];
@@ -70,59 +67,57 @@ function Component(t0) {
   } else {
     items = $[4];
   }
-
-  t3 = items;
-  const y = t3;
-  let t4;
+  const y = items;
+  let t2;
   if ($[5] !== a) {
-    t4 = [a];
+    t2 = [a];
     $[5] = a;
-    $[6] = t4;
+    $[6] = t2;
   } else {
-    t4 = $[6];
+    t2 = $[6];
   }
-  let t5;
-  if ($[7] !== t4 || $[8] !== x) {
-    t5 = <ValidateMemoization inputs={t4} output={x} />;
-    $[7] = t4;
+  let t3;
+  if ($[7] !== t2 || $[8] !== x) {
+    t3 = <ValidateMemoization inputs={t2} output={x} />;
+    $[7] = t2;
     $[8] = x;
-    $[9] = t5;
+    $[9] = t3;
   } else {
-    t5 = $[9];
+    t3 = $[9];
   }
-  let t6;
+  let t4;
   if ($[10] !== b || $[11] !== x) {
-    t6 = [x, b];
+    t4 = [x, b];
     $[10] = b;
     $[11] = x;
-    $[12] = t6;
+    $[12] = t4;
   } else {
-    t6 = $[12];
+    t4 = $[12];
   }
-  let t7;
-  if ($[13] !== t6 || $[14] !== y) {
-    t7 = <ValidateMemoization inputs={t6} output={y} />;
-    $[13] = t6;
+  let t5;
+  if ($[13] !== t4 || $[14] !== y) {
+    t5 = <ValidateMemoization inputs={t4} output={y} />;
+    $[13] = t4;
     $[14] = y;
-    $[15] = t7;
+    $[15] = t5;
   } else {
-    t7 = $[15];
+    t5 = $[15];
   }
-  let t8;
-  if ($[16] !== t5 || $[17] !== t7) {
-    t8 = (
+  let t6;
+  if ($[16] !== t3 || $[17] !== t5) {
+    t6 = (
       <>
+        {t3}
         {t5}
-        {t7}
       </>
     );
-    $[16] = t5;
-    $[17] = t7;
-    $[18] = t8;
+    $[16] = t3;
+    $[17] = t5;
+    $[18] = t6;
   } else {
-    t8 = $[18];
+    t6 = $[18];
   }
-  return t8;
+  return t6;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-expression-prototype-call-mutating.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-expression-prototype-call-mutating.expect.md
@@ -34,7 +34,6 @@ import { ValidateMemoization } from "shared-runtime";
 
 function Component(props) {
   const $ = _c(7);
-  let t0;
   let a;
   if ($[0] !== props.name) {
     a = [];
@@ -48,26 +47,25 @@ function Component(props) {
   } else {
     a = $[1];
   }
-  t0 = a;
-  const a_0 = t0;
-  let t1;
+  const a_0 = a;
+  let t0;
   if ($[2] !== props.name) {
-    t1 = [props.name];
+    t0 = [props.name];
     $[2] = props.name;
-    $[3] = t1;
+    $[3] = t0;
   } else {
-    t1 = $[3];
+    t0 = $[3];
   }
-  let t2;
-  if ($[4] !== a_0 || $[5] !== t1) {
-    t2 = <ValidateMemoization inputs={t1} output={a_0} />;
+  let t1;
+  if ($[4] !== a_0 || $[5] !== t0) {
+    t1 = <ValidateMemoization inputs={t0} output={a_0} />;
     $[4] = a_0;
-    $[5] = t1;
-    $[6] = t2;
+    $[5] = t0;
+    $[6] = t1;
   } else {
-    t2 = $[6];
+    t1 = $[6];
   }
-  return t2;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/hooks-with-prefix.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/hooks-with-prefix.expect.md
@@ -46,7 +46,7 @@ const React$useMemo = React.useMemo;
 const Internal$Reassigned$useHook = useHook;
 
 function Component() {
-  const $ = _c(8);
+  const $ = _c(7);
   const [state] = React$useState(0);
   const object = Internal$Reassigned$useHook();
   let t0;
@@ -59,34 +59,30 @@ function Component() {
   }
   const json = t0;
   let t1;
-  let t2;
   if ($[2] !== state) {
-    t1 = makeArray(state);
-    const doubledArray = t1;
+    const doubledArray = makeArray(state);
 
-    t2 = doubledArray.join("");
+    t1 = doubledArray.join("");
     $[2] = state;
-    $[3] = t2;
-    $[4] = t1;
+    $[3] = t1;
   } else {
-    t2 = $[3];
-    t1 = $[4];
+    t1 = $[3];
   }
-  let t3;
-  if ($[5] !== json || $[6] !== t2) {
-    t3 = (
+  let t2;
+  if ($[4] !== json || $[5] !== t1) {
+    t2 = (
       <div>
-        {t2}
+        {t1}
         {json}
       </div>
     );
-    $[5] = json;
+    $[4] = json;
+    $[5] = t1;
     $[6] = t2;
-    $[7] = t3;
   } else {
-    t3 = $[7];
+    t2 = $[6];
   }
-  return t3;
+  return t2;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/iife-return-modified-later.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/iife-return-modified-later.expect.md
@@ -22,20 +22,16 @@ export const FIXTURE_ENTRYPOINT = {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
-  const $ = _c(3);
-  let t0;
+  const $ = _c(2);
   let items;
   if ($[0] !== props.a) {
-    t0 = [];
-    items = t0;
+    items = [];
 
     items.push(props.a);
     $[0] = props.a;
     $[1] = items;
-    $[2] = t0;
   } else {
     items = $[1];
-    t0 = $[2];
   }
   return items;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/use-memo-returned.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/use-memo-returned.expect.md
@@ -50,19 +50,17 @@ function useMakeCallback(t0) {
 
   const [, setState] = useState(0);
   let t1;
-  let t2;
   if ($[0] !== obj.value) {
-    t2 = () => {
+    t1 = () => {
       if (obj.value !== 0) {
         setState(obj.value);
       }
     };
     $[0] = obj.value;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   const cb = t1;
 
   useIdentity(null);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nested-function-with-param-as-captured-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nested-function-with-param-as-captured-dep.expect.md
@@ -26,17 +26,15 @@ import { c as _c } from "react/compiler-runtime";
 function Foo() {
   const $ = _c(1);
   let t0;
-  let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = function a(t2) {
-      const x_0 = t2 === undefined ? _temp : t2;
+    t0 = function a(t1) {
+      const x_0 = t1 === undefined ? _temp : t1;
       return x_0;
     };
-    $[0] = t1;
+    $[0] = t0;
   } else {
-    t1 = $[0];
+    t0 = $[0];
   }
-  t0 = t1;
   return t0;
 }
 function _temp() {}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-identity-function-expression.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-identity-function-expression.expect.md
@@ -37,13 +37,11 @@ import { useMemo } from "react";
 import { identity, ValidateMemoization } from "shared-runtime";
 
 function Component(t0) {
-  const $ = _c(10);
+  const $ = _c(9);
   const { a, b } = t0;
-  let t1;
   let x;
   if ($[0] !== a || $[1] !== b) {
-    t1 = { a };
-    x = t1;
+    x = { a };
     const f = () => identity(x);
 
     const x2 = f();
@@ -51,30 +49,28 @@ function Component(t0) {
     $[0] = a;
     $[1] = b;
     $[2] = x;
-    $[3] = t1;
   } else {
     x = $[2];
-    t1 = $[3];
+  }
+  let t1;
+  if ($[3] !== a || $[4] !== b) {
+    t1 = [a, b];
+    $[3] = a;
+    $[4] = b;
+    $[5] = t1;
+  } else {
+    t1 = $[5];
   }
   let t2;
-  if ($[4] !== a || $[5] !== b) {
-    t2 = [a, b];
-    $[4] = a;
-    $[5] = b;
-    $[6] = t2;
+  if ($[6] !== t1 || $[7] !== x) {
+    t2 = <ValidateMemoization inputs={t1} output={x} />;
+    $[6] = t1;
+    $[7] = x;
+    $[8] = t2;
   } else {
-    t2 = $[6];
+    t2 = $[8];
   }
-  let t3;
-  if ($[7] !== t2 || $[8] !== x) {
-    t3 = <ValidateMemoization inputs={t2} output={x} />;
-    $[7] = t2;
-    $[8] = x;
-    $[9] = t3;
-  } else {
-    t3 = $[9];
-  }
-  return t3;
+  return t2;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-identity.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/mutate-through-identity.expect.md
@@ -34,42 +34,38 @@ import { useMemo } from "react";
 import { identity, ValidateMemoization } from "shared-runtime";
 
 function Component(t0) {
-  const $ = _c(10);
+  const $ = _c(9);
   const { a, b } = t0;
-  let t1;
   let x;
   if ($[0] !== a || $[1] !== b) {
-    t1 = { a };
-    x = t1;
+    x = { a };
     const x2 = identity(x);
     x2.b = b;
     $[0] = a;
     $[1] = b;
     $[2] = x;
-    $[3] = t1;
   } else {
     x = $[2];
-    t1 = $[3];
+  }
+  let t1;
+  if ($[3] !== a || $[4] !== b) {
+    t1 = [a, b];
+    $[3] = a;
+    $[4] = b;
+    $[5] = t1;
+  } else {
+    t1 = $[5];
   }
   let t2;
-  if ($[4] !== a || $[5] !== b) {
-    t2 = [a, b];
-    $[4] = a;
-    $[5] = b;
-    $[6] = t2;
+  if ($[6] !== t1 || $[7] !== x) {
+    t2 = <ValidateMemoization inputs={t1} output={x} />;
+    $[6] = t1;
+    $[7] = x;
+    $[8] = t2;
   } else {
-    t2 = $[6];
+    t2 = $[8];
   }
-  let t3;
-  if ($[7] !== t2 || $[8] !== x) {
-    t3 = <ValidateMemoization inputs={t2} output={x} />;
-    $[7] = t2;
-    $[8] = x;
-    $[9] = t3;
-  } else {
-    t3 = $[9];
-  }
-  return t3;
+  return t2;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/todo-control-flow-sensitive-mutation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/todo-control-flow-sensitive-mutation.expect.md
@@ -60,13 +60,11 @@ import {
 } from "shared-runtime";
 
 function Component(t0) {
-  const $ = _c(22);
+  const $ = _c(21);
   const { a, b, c } = t0;
-  let t1;
   let x;
   if ($[0] !== a || $[1] !== b || $[2] !== c) {
-    t1 = [{ value: a }];
-    x = t1;
+    x = [{ value: a }];
     if (b === 0) {
       x.push({ value: c });
     } else {
@@ -76,63 +74,61 @@ function Component(t0) {
     $[1] = b;
     $[2] = c;
     $[3] = x;
-    $[4] = t1;
   } else {
     x = $[3];
-    t1 = $[4];
+  }
+  let t1;
+  if ($[4] !== a || $[5] !== b || $[6] !== c) {
+    t1 = [a, b, c];
+    $[4] = a;
+    $[5] = b;
+    $[6] = c;
+    $[7] = t1;
+  } else {
+    t1 = $[7];
   }
   let t2;
-  if ($[5] !== a || $[6] !== b || $[7] !== c) {
-    t2 = [a, b, c];
-    $[5] = a;
-    $[6] = b;
-    $[7] = c;
-    $[8] = t2;
+  if ($[8] !== t1 || $[9] !== x) {
+    t2 = <ValidateMemoization inputs={t1} output={x} />;
+    $[8] = t1;
+    $[9] = x;
+    $[10] = t2;
   } else {
-    t2 = $[8];
+    t2 = $[10];
   }
   let t3;
-  if ($[9] !== t2 || $[10] !== x) {
-    t3 = <ValidateMemoization inputs={t2} output={x} />;
-    $[9] = t2;
-    $[10] = x;
-    $[11] = t3;
+  if ($[11] !== a || $[12] !== b || $[13] !== c) {
+    t3 = [a, b, c];
+    $[11] = a;
+    $[12] = b;
+    $[13] = c;
+    $[14] = t3;
   } else {
-    t3 = $[11];
+    t3 = $[14];
   }
   let t4;
-  if ($[12] !== a || $[13] !== b || $[14] !== c) {
-    t4 = [a, b, c];
-    $[12] = a;
-    $[13] = b;
-    $[14] = c;
-    $[15] = t4;
+  if ($[15] !== t3 || $[16] !== x[0]) {
+    t4 = <ValidateMemoization inputs={t3} output={x[0]} />;
+    $[15] = t3;
+    $[16] = x[0];
+    $[17] = t4;
   } else {
-    t4 = $[15];
+    t4 = $[17];
   }
   let t5;
-  if ($[16] !== t4 || $[17] !== x[0]) {
-    t5 = <ValidateMemoization inputs={t4} output={x[0]} />;
-    $[16] = t4;
-    $[17] = x[0];
-    $[18] = t5;
-  } else {
-    t5 = $[18];
-  }
-  let t6;
-  if ($[19] !== t3 || $[20] !== t5) {
-    t6 = (
+  if ($[18] !== t2 || $[19] !== t4) {
+    t5 = (
       <>
-        {t3};{t5};
+        {t2};{t4};
       </>
     );
-    $[19] = t3;
+    $[18] = t2;
+    $[19] = t4;
     $[20] = t5;
-    $[21] = t6;
   } else {
-    t6 = $[21];
+    t5 = $[20];
   }
-  return t6;
+  return t5;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/todo-transitivity-createfrom-capture-lambda.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/todo-transitivity-createfrom-capture-lambda.expect.md
@@ -51,13 +51,11 @@ import {
 } from "shared-runtime";
 
 function Component(t0) {
-  const $ = _c(10);
+  const $ = _c(9);
   const { a, b } = t0;
-  let t1;
   let x;
   if ($[0] !== a || $[1] !== b) {
-    t1 = [{ a }];
-    x = t1;
+    x = [{ a }];
     const f = () => {
       const y = typedCreateFrom(x);
       const z = typedCapture(y);
@@ -70,30 +68,28 @@ function Component(t0) {
     $[0] = a;
     $[1] = b;
     $[2] = x;
-    $[3] = t1;
   } else {
     x = $[2];
-    t1 = $[3];
+  }
+  let t1;
+  if ($[3] !== a || $[4] !== b) {
+    t1 = [a, b];
+    $[3] = a;
+    $[4] = b;
+    $[5] = t1;
+  } else {
+    t1 = $[5];
   }
   let t2;
-  if ($[4] !== a || $[5] !== b) {
-    t2 = [a, b];
-    $[4] = a;
-    $[5] = b;
-    $[6] = t2;
+  if ($[6] !== t1 || $[7] !== x) {
+    t2 = <ValidateMemoization inputs={t1} output={x} />;
+    $[6] = t1;
+    $[7] = x;
+    $[8] = t2;
   } else {
-    t2 = $[6];
+    t2 = $[8];
   }
-  let t3;
-  if ($[7] !== t2 || $[8] !== x) {
-    t3 = <ValidateMemoization inputs={t2} output={x} />;
-    $[7] = t2;
-    $[8] = x;
-    $[9] = t3;
-  } else {
-    t3 = $[9];
-  }
-  return t3;
+  return t2;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/transitivity-add-captured-array-to-itself.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/transitivity-add-captured-array-to-itself.expect.md
@@ -52,24 +52,20 @@ import {
 } from "shared-runtime";
 
 function Component(t0) {
-  const $ = _c(20);
+  const $ = _c(19);
   const { a, b } = t0;
   let t1;
-  let t2;
   if ($[0] !== a) {
-    t2 = { a };
+    t1 = { a };
     $[0] = a;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   const o = t1;
-  let t3;
   let x;
   if ($[2] !== b || $[3] !== o) {
-    t3 = [o];
-    x = t3;
+    x = [o];
     const y = typedCapture(x);
     const z = typedCapture(y);
     x.push(z);
@@ -77,60 +73,58 @@ function Component(t0) {
     $[2] = b;
     $[3] = o;
     $[4] = x;
-    $[5] = t3;
   } else {
     x = $[4];
-    t3 = $[5];
+  }
+  let t2;
+  if ($[5] !== a) {
+    t2 = [a];
+    $[5] = a;
+    $[6] = t2;
+  } else {
+    t2 = $[6];
+  }
+  let t3;
+  if ($[7] !== o || $[8] !== t2) {
+    t3 = <ValidateMemoization inputs={t2} output={o} />;
+    $[7] = o;
+    $[8] = t2;
+    $[9] = t3;
+  } else {
+    t3 = $[9];
   }
   let t4;
-  if ($[6] !== a) {
-    t4 = [a];
-    $[6] = a;
-    $[7] = t4;
+  if ($[10] !== a || $[11] !== b) {
+    t4 = [a, b];
+    $[10] = a;
+    $[11] = b;
+    $[12] = t4;
   } else {
-    t4 = $[7];
+    t4 = $[12];
   }
   let t5;
-  if ($[8] !== o || $[9] !== t4) {
-    t5 = <ValidateMemoization inputs={t4} output={o} />;
-    $[8] = o;
-    $[9] = t4;
-    $[10] = t5;
+  if ($[13] !== t4 || $[14] !== x) {
+    t5 = <ValidateMemoization inputs={t4} output={x} />;
+    $[13] = t4;
+    $[14] = x;
+    $[15] = t5;
   } else {
-    t5 = $[10];
+    t5 = $[15];
   }
   let t6;
-  if ($[11] !== a || $[12] !== b) {
-    t6 = [a, b];
-    $[11] = a;
-    $[12] = b;
-    $[13] = t6;
-  } else {
-    t6 = $[13];
-  }
-  let t7;
-  if ($[14] !== t6 || $[15] !== x) {
-    t7 = <ValidateMemoization inputs={t6} output={x} />;
-    $[14] = t6;
-    $[15] = x;
-    $[16] = t7;
-  } else {
-    t7 = $[16];
-  }
-  let t8;
-  if ($[17] !== t5 || $[18] !== t7) {
-    t8 = (
+  if ($[16] !== t3 || $[17] !== t5) {
+    t6 = (
       <>
-        {t5};{t7};
+        {t3};{t5};
       </>
     );
+    $[16] = t3;
     $[17] = t5;
-    $[18] = t7;
-    $[19] = t8;
+    $[18] = t6;
   } else {
-    t8 = $[19];
+    t6 = $[18];
   }
-  return t8;
+  return t6;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/transitivity-capture-createfrom-lambda.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/transitivity-capture-createfrom-lambda.expect.md
@@ -50,13 +50,11 @@ import {
 } from "shared-runtime";
 
 function Component(t0) {
-  const $ = _c(10);
+  const $ = _c(9);
   const { a, b } = t0;
-  let t1;
   let x;
   if ($[0] !== a || $[1] !== b) {
-    t1 = { a };
-    x = t1;
+    x = { a };
     const f = () => {
       const y = typedCapture(x);
       const z = typedCreateFrom(y);
@@ -69,30 +67,28 @@ function Component(t0) {
     $[0] = a;
     $[1] = b;
     $[2] = x;
-    $[3] = t1;
   } else {
     x = $[2];
-    t1 = $[3];
+  }
+  let t1;
+  if ($[3] !== a || $[4] !== b) {
+    t1 = [a, b];
+    $[3] = a;
+    $[4] = b;
+    $[5] = t1;
+  } else {
+    t1 = $[5];
   }
   let t2;
-  if ($[4] !== a || $[5] !== b) {
-    t2 = [a, b];
-    $[4] = a;
-    $[5] = b;
-    $[6] = t2;
+  if ($[6] !== t1 || $[7] !== x) {
+    t2 = <ValidateMemoization inputs={t1} output={x} />;
+    $[6] = t1;
+    $[7] = x;
+    $[8] = t2;
   } else {
-    t2 = $[6];
+    t2 = $[8];
   }
-  let t3;
-  if ($[7] !== t2 || $[8] !== x) {
-    t3 = <ValidateMemoization inputs={t2} output={x} />;
-    $[7] = t2;
-    $[8] = x;
-    $[9] = t3;
-  } else {
-    t3 = $[9];
-  }
-  return t3;
+  return t2;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/transitivity-capture-createfrom.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/transitivity-capture-createfrom.expect.md
@@ -46,13 +46,11 @@ import {
 } from "shared-runtime";
 
 function Component(t0) {
-  const $ = _c(10);
+  const $ = _c(9);
   const { a, b } = t0;
-  let t1;
   let x;
   if ($[0] !== a || $[1] !== b) {
-    t1 = { a };
-    x = t1;
+    x = { a };
     const y = typedCapture(x);
     const z = typedCreateFrom(y);
 
@@ -60,30 +58,28 @@ function Component(t0) {
     $[0] = a;
     $[1] = b;
     $[2] = x;
-    $[3] = t1;
   } else {
     x = $[2];
-    t1 = $[3];
+  }
+  let t1;
+  if ($[3] !== a || $[4] !== b) {
+    t1 = [a, b];
+    $[3] = a;
+    $[4] = b;
+    $[5] = t1;
+  } else {
+    t1 = $[5];
   }
   let t2;
-  if ($[4] !== a || $[5] !== b) {
-    t2 = [a, b];
-    $[4] = a;
-    $[5] = b;
-    $[6] = t2;
+  if ($[6] !== t1 || $[7] !== x) {
+    t2 = <ValidateMemoization inputs={t1} output={x} />;
+    $[6] = t1;
+    $[7] = x;
+    $[8] = t2;
   } else {
-    t2 = $[6];
+    t2 = $[8];
   }
-  let t3;
-  if ($[7] !== t2 || $[8] !== x) {
-    t3 = <ValidateMemoization inputs={t2} output={x} />;
-    $[7] = t2;
-    $[8] = x;
-    $[9] = t3;
-  } else {
-    t3 = $[9];
-  }
-  return t3;
+  return t2;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/transitivity-createfrom-capture.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/transitivity-createfrom-capture.expect.md
@@ -49,38 +49,36 @@ function Component(t0) {
   const $ = _c(7);
   const { a, b } = t0;
   let t1;
-  let t2;
   if ($[0] !== a) {
-    t2 = [{ a }];
+    t1 = [{ a }];
     $[0] = a;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   const x = t1;
   const y = typedCreateFrom(x);
   const z = typedCapture(y);
 
   typedMutate(z, b);
-  let t3;
+  let t2;
   if ($[2] !== a) {
-    t3 = [a];
+    t2 = [a];
     $[2] = a;
-    $[3] = t3;
+    $[3] = t2;
   } else {
-    t3 = $[3];
+    t2 = $[3];
   }
-  let t4;
-  if ($[4] !== t3 || $[5] !== x) {
-    t4 = <ValidateMemoization inputs={t3} output={x} />;
-    $[4] = t3;
+  let t3;
+  if ($[4] !== t2 || $[5] !== x) {
+    t3 = <ValidateMemoization inputs={t2} output={x} />;
+    $[4] = t2;
     $[5] = x;
-    $[6] = t4;
+    $[6] = t3;
   } else {
-    t4 = $[6];
+    t3 = $[6];
   }
-  return t4;
+  return t3;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/transitivity-phi-assign-or-capture.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/transitivity-phi-assign-or-capture.expect.md
@@ -50,21 +50,19 @@ import {
 } from "shared-runtime";
 
 function Component(t0) {
-  const $ = _c(12);
+  const $ = _c(11);
   const { a, b } = t0;
   let t1;
-  let t2;
   if ($[0] !== a) {
-    t2 = { a };
+    t1 = { a };
     $[0] = a;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
   let x;
-  if ($[2] !== b || $[3] !== t2) {
-    t1 = [t2];
-    x = t1;
+  if ($[2] !== b || $[3] !== t1) {
+    x = [t1];
     let z;
     if (b) {
       z = x;
@@ -74,32 +72,30 @@ function Component(t0) {
 
     typedMutate(z, b);
     $[2] = b;
-    $[3] = t2;
+    $[3] = t1;
     $[4] = x;
-    $[5] = t1;
   } else {
     x = $[4];
-    t1 = $[5];
+  }
+  let t2;
+  if ($[5] !== a || $[6] !== b) {
+    t2 = [a, b];
+    $[5] = a;
+    $[6] = b;
+    $[7] = t2;
+  } else {
+    t2 = $[7];
   }
   let t3;
-  if ($[6] !== a || $[7] !== b) {
-    t3 = [a, b];
-    $[6] = a;
-    $[7] = b;
-    $[8] = t3;
+  if ($[8] !== t2 || $[9] !== x) {
+    t3 = <ValidateMemoization inputs={t2} output={x} />;
+    $[8] = t2;
+    $[9] = x;
+    $[10] = t3;
   } else {
-    t3 = $[8];
+    t3 = $[10];
   }
-  let t4;
-  if ($[9] !== t3 || $[10] !== x) {
-    t4 = <ValidateMemoization inputs={t3} output={x} />;
-    $[9] = t3;
-    $[10] = x;
-    $[11] = t4;
-  } else {
-    t4 = $[11];
-  }
-  return t4;
+  return t3;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/typed-identity-function-frozen-input.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/typed-identity-function-frozen-input.expect.md
@@ -63,15 +63,13 @@ function Component(t0) {
   const $ = _c(7);
   const { a, b } = t0;
   let t1;
-  let t2;
   if ($[0] !== a) {
-    t2 = makeObject_Primitives(a);
+    t1 = makeObject_Primitives(a);
     $[0] = a;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   const x = t1;
 
   useIdentity(x);
@@ -79,24 +77,24 @@ function Component(t0) {
   const x2 = typedIdentity(x);
 
   identity(x2, b);
-  let t3;
+  let t2;
   if ($[2] !== a) {
-    t3 = [a];
+    t2 = [a];
     $[2] = a;
-    $[3] = t3;
+    $[3] = t2;
   } else {
-    t3 = $[3];
+    t2 = $[3];
   }
-  let t4;
-  if ($[4] !== t3 || $[5] !== x) {
-    t4 = <ValidateMemoization inputs={t3} output={x} />;
-    $[4] = t3;
+  let t3;
+  if ($[4] !== t2 || $[5] !== x) {
+    t3 = <ValidateMemoization inputs={t2} output={x} />;
+    $[4] = t2;
     $[5] = x;
-    $[6] = t4;
+    $[6] = t3;
   } else {
-    t4 = $[6];
+    t3 = $[6];
   }
-  return t4;
+  return t3;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/useMemo-reordering-depslist-assignment.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/useMemo-reordering-depslist-assignment.expect.md
@@ -51,15 +51,13 @@ function useFoo(arr1, arr2) {
     y = $[4];
   }
   let t1;
-  let t2;
   if ($[5] !== y) {
-    t2 = { y };
+    t1 = { y };
     $[5] = y;
-    $[6] = t2;
+    $[6] = t1;
   } else {
-    t2 = $[6];
+    t1 = $[6];
   }
-  t1 = t2;
   return t1;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optional-member-expression-as-memo-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optional-member-expression-as-memo-dep.expect.md
@@ -42,36 +42,34 @@ function Component(t0) {
 
   arg?.items.edges?.nodes;
   let t1;
-  let t2;
   if ($[0] !== arg?.items.edges?.nodes) {
-    t2 = arg?.items.edges?.nodes.map(identity);
+    t1 = arg?.items.edges?.nodes.map(identity);
     $[0] = arg?.items.edges?.nodes;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   const data = t1;
 
-  const t3 = arg?.items.edges?.nodes;
+  const t2 = arg?.items.edges?.nodes;
+  let t3;
+  if ($[2] !== t2) {
+    t3 = [t2];
+    $[2] = t2;
+    $[3] = t3;
+  } else {
+    t3 = $[3];
+  }
   let t4;
-  if ($[2] !== t3) {
-    t4 = [t3];
-    $[2] = t3;
-    $[3] = t4;
-  } else {
-    t4 = $[3];
-  }
-  let t5;
-  if ($[4] !== data || $[5] !== t4) {
-    t5 = <ValidateMemoization inputs={t4} output={data} />;
+  if ($[4] !== data || $[5] !== t3) {
+    t4 = <ValidateMemoization inputs={t3} output={data} />;
     $[4] = data;
-    $[5] = t4;
-    $[6] = t5;
+    $[5] = t3;
+    $[6] = t4;
   } else {
-    t5 = $[6];
+    t4 = $[6];
   }
-  return t5;
+  return t4;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optional-member-expression-inverted-optionals-parallel-paths.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optional-member-expression-inverted-optionals-parallel-paths.expect.md
@@ -23,21 +23,19 @@ import { c as _c } from "react/compiler-runtime"; // @validatePreserveExistingMe
 import { ValidateMemoization } from "shared-runtime";
 function Component(props) {
   const $ = _c(2);
-  let t0;
 
   const x$0 = [];
   x$0.push(props?.a.b?.c.d?.e);
   x$0.push(props.a?.b.c?.d.e);
-  t0 = x$0;
-  let t1;
+  let t0;
   if ($[0] !== props.a.b.c.d.e) {
-    t1 = <ValidateMemoization inputs={[props.a.b.c.d.e]} output={x} />;
+    t0 = <ValidateMemoization inputs={[props.a.b.c.d.e]} output={x} />;
     $[0] = props.a.b.c.d.e;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  return t1;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optional-member-expression-single-with-unconditional.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optional-member-expression-single-with-unconditional.expect.md
@@ -23,7 +23,6 @@ import { c as _c } from "react/compiler-runtime"; // @validatePreserveExistingMe
 import { ValidateMemoization } from "shared-runtime";
 function Component(props) {
   const $ = _c(7);
-  let t0;
   let x;
   if ($[0] !== props.items) {
     x = [];
@@ -34,26 +33,25 @@ function Component(props) {
   } else {
     x = $[1];
   }
-  t0 = x;
-  const data = t0;
-  let t1;
+  const data = x;
+  let t0;
   if ($[2] !== props.items) {
-    t1 = [props.items];
+    t0 = [props.items];
     $[2] = props.items;
-    $[3] = t1;
+    $[3] = t0;
   } else {
-    t1 = $[3];
+    t0 = $[3];
   }
-  let t2;
-  if ($[4] !== data || $[5] !== t1) {
-    t2 = <ValidateMemoization inputs={t1} output={data} />;
+  let t1;
+  if ($[4] !== data || $[5] !== t0) {
+    t1 = <ValidateMemoization inputs={t0} output={data} />;
     $[4] = data;
-    $[5] = t1;
-    $[6] = t2;
+    $[5] = t0;
+    $[6] = t1;
   } else {
-    t2 = $[6];
+    t1 = $[6];
   }
-  return t2;
+  return t1;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optional-member-expression-single.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optional-member-expression-single.expect.md
@@ -38,7 +38,6 @@ function Component(t0) {
   const { arg } = t0;
 
   arg?.items;
-  let t1;
   let x;
   if ($[0] !== arg?.items) {
     x = [];
@@ -48,27 +47,26 @@ function Component(t0) {
   } else {
     x = $[1];
   }
-  t1 = x;
-  const data = t1;
-  const t2 = arg?.items;
+  const data = x;
+  const t1 = arg?.items;
+  let t2;
+  if ($[2] !== t1) {
+    t2 = [t1];
+    $[2] = t1;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
   let t3;
-  if ($[2] !== t2) {
-    t3 = [t2];
-    $[2] = t2;
-    $[3] = t3;
-  } else {
-    t3 = $[3];
-  }
-  let t4;
-  if ($[4] !== data || $[5] !== t3) {
-    t4 = <ValidateMemoization inputs={t3} output={data} />;
+  if ($[4] !== data || $[5] !== t2) {
+    t3 = <ValidateMemoization inputs={t2} output={data} />;
     $[4] = data;
-    $[5] = t3;
-    $[6] = t4;
+    $[5] = t2;
+    $[6] = t3;
   } else {
-    t4 = $[6];
+    t3 = $[6];
   }
-  return t4;
+  return t3;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/maybe-invalid-useMemo-no-memoblock-sideeffect.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/maybe-invalid-useMemo-no-memoblock-sideeffect.expect.md
@@ -36,11 +36,9 @@ import { useMemo } from "react";
 // (i.e. inferred non-mutable or non-escaping values don't get memoized)
 function useFoo(t0) {
   const { minWidth, styles, setStyles } = t0;
-  let t1;
   if (styles.width > minWidth) {
     setStyles(styles);
   }
-  t1 = undefined;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/prune-nonescaping-useMemo.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/prune-nonescaping-useMemo.expect.md
@@ -34,10 +34,7 @@ import { identity } from "shared-runtime";
  * This is technically a false positive, although it makes sense
  * to bailout as source code might be doing something sketchy.
  */
-function useFoo(x) {
-  let t0;
-  t0 = identity(x);
-}
+function useFoo(x) {}
 
 export const FIXTURE_ENTRYPOINT = {
   fn: useFoo,

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/todo-ensure-constant-prop-decls-get-removed.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/todo-ensure-constant-prop-decls-get-removed.expect.md
@@ -40,14 +40,12 @@ function useFoo() {
   const $ = _c(1);
   const constVal = 0;
   let t0;
-  let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = [0];
-    $[0] = t1;
+    t0 = [0];
+    $[0] = t0;
   } else {
-    t1 = $[0];
+    t0 = $[0];
   }
-  t0 = t1;
   return t0;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-alias-property-load-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-alias-property-load-dep.expect.md
@@ -32,16 +32,14 @@ function Component(t0) {
   const { propA, propB } = t0;
   const x = propB.x.y;
   let t1;
-  let t2;
   if ($[0] !== propA.x || $[1] !== x) {
-    t2 = sum(propA.x, x);
+    t1 = sum(propA.x, x);
     $[0] = propA.x;
     $[1] = x;
-    $[2] = t2;
+    $[2] = t1;
   } else {
-    t2 = $[2];
+    t1 = $[2];
   }
-  t1 = t2;
   return t1;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-conditional-access-alloc.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-conditional-access-alloc.expect.md
@@ -32,28 +32,26 @@ import { identity } from "shared-runtime";
 function Component(t0) {
   const $ = _c(5);
   const { propA, propB } = t0;
-  let t1;
 
-  const t2 = propB?.x.y;
+  const t1 = propB?.x.y;
+  let t2;
+  if ($[0] !== t1) {
+    t2 = identity(t1);
+    $[0] = t1;
+    $[1] = t2;
+  } else {
+    t2 = $[1];
+  }
   let t3;
-  if ($[0] !== t2) {
-    t3 = identity(t2);
-    $[0] = t2;
-    $[1] = t3;
-  } else {
-    t3 = $[1];
-  }
-  let t4;
-  if ($[2] !== propA || $[3] !== t3) {
-    t4 = { value: t3, other: propA };
+  if ($[2] !== propA || $[3] !== t2) {
+    t3 = { value: t2, other: propA };
     $[2] = propA;
-    $[3] = t3;
-    $[4] = t4;
+    $[3] = t2;
+    $[4] = t3;
   } else {
-    t4 = $[4];
+    t3 = $[4];
   }
-  t1 = t4;
-  return t1;
+  return t3;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-conditional-access-noAlloc.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-conditional-access-noAlloc.expect.md
@@ -30,20 +30,18 @@ import { useMemo } from "react";
 function Component(t0) {
   const $ = _c(3);
   const { propA, propB } = t0;
-  let t1;
 
-  const t2 = propB?.x.y;
-  let t3;
-  if ($[0] !== propA || $[1] !== t2) {
-    t3 = { value: t2, other: propA };
+  const t1 = propB?.x.y;
+  let t2;
+  if ($[0] !== propA || $[1] !== t1) {
+    t2 = { value: t1, other: propA };
     $[0] = propA;
-    $[1] = t2;
-    $[2] = t3;
+    $[1] = t1;
+    $[2] = t2;
   } else {
-    t3 = $[2];
+    t2 = $[2];
   }
-  t1 = t3;
-  return t1;
+  return t2;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-constant-prop.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-constant-prop.expect.md
@@ -37,39 +37,35 @@ function useFoo(cond) {
   const $ = _c(5);
   const sourceDep = 0;
   let t0;
-  let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = identity(0);
-    $[0] = t1;
+    t0 = identity(0);
+    $[0] = t0;
   } else {
-    t1 = $[0];
+    t0 = $[0];
   }
-  t0 = t1;
   const derived1 = t0;
 
   const derived2 = (cond ?? Math.min(0, 1)) ? 1 : 2;
-  let t2;
-  let t3;
+  let t1;
   if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-    t3 = identity(0);
-    $[1] = t3;
+    t1 = identity(0);
+    $[1] = t1;
   } else {
-    t3 = $[1];
+    t1 = $[1];
   }
-  t2 = t3;
-  const derived3 = t2;
+  const derived3 = t1;
 
   const derived4 = (Math.min(0, -1) ?? cond) ? 1 : 2;
-  let t4;
+  let t2;
   if ($[2] !== derived2 || $[3] !== derived4) {
-    t4 = [derived1, derived2, derived3, derived4];
+    t2 = [derived1, derived2, derived3, derived4];
     $[2] = derived2;
     $[3] = derived4;
-    $[4] = t4;
+    $[4] = t2;
   } else {
-    t4 = $[4];
+    t2 = $[4];
   }
-  return t4;
+  return t2;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-dep-array-literal-access.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-dep-array-literal-access.expect.md
@@ -48,15 +48,13 @@ function Foo(props) {
   }
   const x = t0;
   let t1;
-  let t2;
   if ($[2] !== x[0]) {
-    t2 = [x[0]];
+    t1 = [x[0]];
     $[2] = x[0];
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  t1 = t2;
   return t1;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-in-other-reactive-block.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-in-other-reactive-block.expect.md
@@ -42,19 +42,17 @@ function useFoo(minWidth, otherProp) {
   let t0;
   if ($[0] !== minWidth || $[1] !== otherProp || $[2] !== width) {
     const x = [];
-    let t1;
 
-    const t2 = Math.max(minWidth, width);
-    let t3;
-    if ($[4] !== t2) {
-      t3 = { width: t2 };
-      $[4] = t2;
-      $[5] = t3;
+    const t1 = Math.max(minWidth, width);
+    let t2;
+    if ($[4] !== t1) {
+      t2 = { width: t1 };
+      $[4] = t1;
+      $[5] = t2;
     } else {
-      t3 = $[5];
+      t2 = $[5];
     }
-    t1 = t3;
-    const style = t1;
+    const style = t2;
 
     arrayPush(x, otherProp);
     t0 = [style, x];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-infer-fewer-deps.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-infer-fewer-deps.expect.md
@@ -29,15 +29,13 @@ import { useMemo } from "react";
 function useFoo(a, b) {
   const $ = _c(2);
   let t0;
-  let t1;
   if ($[0] !== a) {
-    t1 = [a];
+    t0 = [a];
     $[0] = a;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   return t0;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-infer-more-specific.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-infer-more-specific.expect.md
@@ -37,15 +37,13 @@ import { useMemo } from "react";
 function useHook(x) {
   const $ = _c(2);
   let t0;
-  let t1;
   if ($[0] !== x.y.z) {
-    t1 = [x.y.z];
+    t0 = [x.y.z];
     $[0] = x.y.z;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   return t0;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-infer-nonallocating.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-infer-nonallocating.expect.md
@@ -29,9 +29,7 @@ import { useMemo } from "react";
 // It's correct to infer a useMemo value is non-allocating
 // and not provide it with a reactive scope
 function useFoo(num1, num2) {
-  let t0;
-  t0 = Math.min(num1, num2);
-  return t0;
+  return Math.min(num1, num2);
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-infer-scope-global.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-infer-scope-global.expect.md
@@ -31,14 +31,12 @@ import { CONST_STRING0 } from "shared-runtime";
 function useFoo() {
   const $ = _c(1);
   let t0;
-  let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = [CONST_STRING0];
-    $[0] = t1;
+    t0 = [CONST_STRING0];
+    $[0] = t0;
   } else {
-    t1 = $[0];
+    t0 = $[0];
   }
-  t0 = t1;
   return t0;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-inner-decl.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-inner-decl.expect.md
@@ -30,25 +30,23 @@ import { identity } from "shared-runtime";
 function useFoo(data) {
   const $ = _c(4);
   let t0;
-  let t1;
   if ($[0] !== data.a) {
-    t1 = identity(data.a);
+    t0 = identity(data.a);
     $[0] = data.a;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  const temp = t1;
-  let t2;
+  const temp = t0;
+  let t1;
   if ($[2] !== temp) {
-    t2 = { temp };
+    t1 = { temp };
     $[2] = temp;
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  t0 = t2;
-  return t0;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-invoke-prop.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-invoke-prop.expect.md
@@ -35,15 +35,13 @@ function useFoo(t0) {
   const $ = _c(2);
   const { callback } = t0;
   let t1;
-  let t2;
   if ($[0] !== callback) {
-    t2 = new Array(callback());
+    t1 = new Array(callback());
     $[0] = callback;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   return t1;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-reordering-depslist-assignment.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-reordering-depslist-assignment.expect.md
@@ -50,15 +50,13 @@ function useFoo(arr1, arr2) {
     y = $[4];
   }
   let t1;
-  let t2;
   if ($[5] !== y) {
-    t2 = { y };
+    t1 = { y };
     $[5] = y;
-    $[6] = t2;
+    $[6] = t1;
   } else {
-    t2 = $[6];
+    t1 = $[6];
   }
-  t1 = t2;
   return t1;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-reordering-depslist-controlflow.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-reordering-depslist-controlflow.expect.md
@@ -49,14 +49,12 @@ function Foo(t0) {
 
     let y = [];
     let t2;
-    let t3;
     if ($[5] === Symbol.for("react.memo_cache_sentinel")) {
-      t3 = { x: 2 };
-      $[5] = t3;
+      t2 = { x: 2 };
+      $[5] = t2;
     } else {
-      t3 = $[5];
+      t2 = $[5];
     }
-    t2 = t3;
     val1 = t2;
 
     foo ? (y = x.concat(arr2)) : y;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-with-no-depslist.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-with-no-depslist.expect.md
@@ -33,15 +33,13 @@ function Component(t0) {
   const $ = _c(2);
   const { propA } = t0;
   let t1;
-  let t2;
   if ($[0] !== propA) {
-    t2 = [propA];
+    t1 = [propA];
     $[0] = propA;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   return t1;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/optional-member-expression-as-memo-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/optional-member-expression-as-memo-dep.expect.md
@@ -42,36 +42,34 @@ function Component(t0) {
 
   arg?.items.edges?.nodes;
   let t1;
-  let t2;
   if ($[0] !== arg?.items.edges?.nodes) {
-    t2 = arg?.items.edges?.nodes.map(identity);
+    t1 = arg?.items.edges?.nodes.map(identity);
     $[0] = arg?.items.edges?.nodes;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   const data = t1;
 
-  const t3 = arg?.items.edges?.nodes;
+  const t2 = arg?.items.edges?.nodes;
+  let t3;
+  if ($[2] !== t2) {
+    t3 = [t2];
+    $[2] = t2;
+    $[3] = t3;
+  } else {
+    t3 = $[3];
+  }
   let t4;
-  if ($[2] !== t3) {
-    t4 = [t3];
-    $[2] = t3;
-    $[3] = t4;
-  } else {
-    t4 = $[3];
-  }
-  let t5;
-  if ($[4] !== data || $[5] !== t4) {
-    t5 = <ValidateMemoization inputs={t4} output={data} />;
+  if ($[4] !== data || $[5] !== t3) {
+    t4 = <ValidateMemoization inputs={t3} output={data} />;
     $[4] = data;
-    $[5] = t4;
-    $[6] = t5;
+    $[5] = t3;
+    $[6] = t4;
   } else {
-    t5 = $[6];
+    t4 = $[6];
   }
-  return t5;
+  return t4;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/optional-member-expression-inverted-optionals-parallel-paths.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/optional-member-expression-inverted-optionals-parallel-paths.expect.md
@@ -23,21 +23,19 @@ import { c as _c } from "react/compiler-runtime"; // @validatePreserveExistingMe
 import { ValidateMemoization } from "shared-runtime";
 function Component(props) {
   const $ = _c(2);
-  let t0;
 
   const x$0 = [];
   x$0.push(props?.a.b?.c.d?.e);
   x$0.push(props.a?.b.c?.d.e);
-  t0 = x$0;
-  let t1;
+  let t0;
   if ($[0] !== props.a.b.c.d.e) {
-    t1 = <ValidateMemoization inputs={[props.a.b.c.d.e]} output={x} />;
+    t0 = <ValidateMemoization inputs={[props.a.b.c.d.e]} output={x} />;
     $[0] = props.a.b.c.d.e;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  return t1;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/optional-member-expression-single-with-unconditional.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/optional-member-expression-single-with-unconditional.expect.md
@@ -23,7 +23,6 @@ import { c as _c } from "react/compiler-runtime"; // @validatePreserveExistingMe
 import { ValidateMemoization } from "shared-runtime";
 function Component(props) {
   const $ = _c(7);
-  let t0;
   let x;
   if ($[0] !== props.items) {
     x = [];
@@ -34,26 +33,25 @@ function Component(props) {
   } else {
     x = $[1];
   }
-  t0 = x;
-  const data = t0;
-  let t1;
+  const data = x;
+  let t0;
   if ($[2] !== props.items) {
-    t1 = [props.items];
+    t0 = [props.items];
     $[2] = props.items;
-    $[3] = t1;
+    $[3] = t0;
   } else {
-    t1 = $[3];
+    t0 = $[3];
   }
-  let t2;
-  if ($[4] !== data || $[5] !== t1) {
-    t2 = <ValidateMemoization inputs={t1} output={data} />;
+  let t1;
+  if ($[4] !== data || $[5] !== t0) {
+    t1 = <ValidateMemoization inputs={t0} output={data} />;
     $[4] = data;
-    $[5] = t1;
-    $[6] = t2;
+    $[5] = t0;
+    $[6] = t1;
   } else {
-    t2 = $[6];
+    t1 = $[6];
   }
-  return t2;
+  return t1;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/optional-member-expression-single.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/optional-member-expression-single.expect.md
@@ -38,7 +38,6 @@ function Component(t0) {
   const { arg } = t0;
 
   arg?.items;
-  let t1;
   let x;
   if ($[0] !== arg?.items) {
     x = [];
@@ -48,27 +47,26 @@ function Component(t0) {
   } else {
     x = $[1];
   }
-  t1 = x;
-  const data = t1;
-  const t2 = arg?.items;
+  const data = x;
+  const t1 = arg?.items;
+  let t2;
+  if ($[2] !== t1) {
+    t2 = [t1];
+    $[2] = t1;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
   let t3;
-  if ($[2] !== t2) {
-    t3 = [t2];
-    $[2] = t2;
-    $[3] = t3;
-  } else {
-    t3 = $[3];
-  }
-  let t4;
-  if ($[4] !== data || $[5] !== t3) {
-    t4 = <ValidateMemoization inputs={t3} output={data} />;
+  if ($[4] !== data || $[5] !== t2) {
+    t3 = <ValidateMemoization inputs={t2} output={data} />;
     $[4] = data;
-    $[5] = t3;
-    $[6] = t4;
+    $[5] = t2;
+    $[6] = t3;
   } else {
-    t4 = $[6];
+    t3 = $[6];
   }
-  return t4;
+  return t3;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/props-method-dependency.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/props-method-dependency.expect.md
@@ -31,34 +31,32 @@ import { ValidateMemoization } from "shared-runtime";
 function Component(props) {
   const $ = _c(7);
   let t0;
-  let t1;
   if ($[0] !== props.x) {
-    t1 = props.x();
+    t0 = props.x();
     $[0] = props.x;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   const x = t0;
-  let t2;
+  let t1;
   if ($[2] !== props.x) {
-    t2 = [props.x];
+    t1 = [props.x];
     $[2] = props.x;
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  let t3;
-  if ($[4] !== t2 || $[5] !== x) {
-    t3 = <ValidateMemoization inputs={t2} output={x} />;
-    $[4] = t2;
+  let t2;
+  if ($[4] !== t1 || $[5] !== x) {
+    t2 = <ValidateMemoization inputs={t1} output={x} />;
+    $[4] = t1;
     $[5] = x;
-    $[6] = t3;
+    $[6] = t2;
   } else {
-    t3 = $[6];
+    t2 = $[6];
   }
-  return t3;
+  return t2;
 }
 
 const f = () => ["React"];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/recursive-function.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/recursive-function.expect.md
@@ -23,9 +23,7 @@ function foo(x) {
   if (x <= 0) {
     return 0;
   }
-  let t0;
-  t0 = foo(x - 2);
-  return x + foo(x - 1) + t0;
+  return x + foo(x - 1) + foo(x - 2);
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reordering-across-blocks.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reordering-across-blocks.expect.md
@@ -59,48 +59,46 @@ function Component(t0) {
   const $ = _c(9);
   const { config } = t0;
   let t1;
-  let t2;
   if ($[0] !== config) {
-    t2 = (event) => {
+    t1 = (event) => {
       config?.onA?.(event);
     };
     $[0] = config;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  const a = t2;
-  let t3;
+  const a = t1;
+  let t2;
   if ($[2] !== config) {
-    t3 = (event_0) => {
+    t2 = (event_0) => {
       config?.onB?.(event_0);
     };
     $[2] = config;
-    $[3] = t3;
+    $[3] = t2;
   } else {
-    t3 = $[3];
+    t2 = $[3];
   }
-  const b = t3;
-  let t4;
+  const b = t2;
+  let t3;
   if ($[4] !== a || $[5] !== b) {
-    t4 = { b, a };
+    t3 = { b, a };
     $[4] = a;
     $[5] = b;
-    $[6] = t4;
+    $[6] = t3;
   } else {
-    t4 = $[6];
+    t3 = $[6];
   }
-  t1 = t4;
-  const object = t1;
-  let t5;
+  const object = t3;
+  let t4;
   if ($[7] !== object) {
-    t5 = <Stringify value={object} />;
+    t4 = <Stringify value={object} />;
     $[7] = object;
-    $[8] = t5;
+    $[8] = t4;
   } else {
-    t5 = $[8];
+    t4 = $[8];
   }
-  return t5;
+  return t4;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-missing-memoization-lack-of-phi-types-explicit-types.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-missing-memoization-lack-of-phi-types-explicit-types.expect.md
@@ -65,20 +65,18 @@ function Component() {
   }
   const filtered = t2;
   let t3;
-  let t4;
   if ($[6] !== filtered) {
-    t4 = filtered.map();
+    t3 = filtered.map();
     $[6] = filtered;
-    $[7] = t4;
+    $[7] = t3;
   } else {
-    t4 = $[7];
+    t3 = $[7];
   }
-  t3 = t4;
   const map = t3;
   const index = filtered.findIndex(_temp3);
-  let t5;
+  let t4;
   if ($[8] !== index || $[9] !== map) {
-    t5 = (
+    t4 = (
       <div>
         {map}
         {index}
@@ -86,11 +84,11 @@ function Component() {
     );
     $[8] = index;
     $[9] = map;
-    $[10] = t5;
+    $[10] = t4;
   } else {
-    t5 = $[10];
+    t4 = $[10];
   }
-  return t5;
+  return t4;
 }
 function _temp3(x) {
   return x === null;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-missing-memoization-lack-of-phi-types.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-missing-memoization-lack-of-phi-types.expect.md
@@ -62,20 +62,18 @@ function Component() {
   }
   const filtered = t2;
   let t3;
-  let t4;
   if ($[6] !== filtered) {
-    t4 = filtered.map();
+    t3 = filtered.map();
     $[6] = filtered;
-    $[7] = t4;
+    $[7] = t3;
   } else {
-    t4 = $[7];
+    t3 = $[7];
   }
-  t3 = t4;
   const map = t3;
   const index = filtered.findIndex(_temp3);
-  let t5;
+  let t4;
   if ($[8] !== index || $[9] !== map) {
-    t5 = (
+    t4 = (
       <div>
         {map}
         {index}
@@ -83,11 +81,11 @@ function Component() {
     );
     $[8] = index;
     $[9] = map;
-    $[10] = t5;
+    $[10] = t4;
   } else {
-    t5 = $[10];
+    t4 = $[10];
   }
-  return t5;
+  return t4;
 }
 function _temp3(x) {
   return x === null;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-missing-phi-after-dce-merge-scopes.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-missing-phi-after-dce-merge-scopes.expect.md
@@ -1,0 +1,52 @@
+
+## Input
+
+```javascript
+function Component() {
+  let v3, v4, acc;
+  v3 = false;
+  v4 = v3;
+  acc = v3;
+  if (acc) {
+    acc = true;
+    v3 = acc;
+  }
+  if (acc) {
+    v3 = v4;
+  }
+  v4 = v3;
+  return [acc, v3, v4];
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component() {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = [false, false, false];
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};
+
+```
+      
+### Eval output
+(kind: ok) [false,false,false]

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-missing-phi-after-dce-merge-scopes.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-missing-phi-after-dce-merge-scopes.js
@@ -1,0 +1,20 @@
+function Component() {
+  let v3, v4, acc;
+  v3 = false;
+  v4 = v3;
+  acc = v3;
+  if (acc) {
+    acc = true;
+    v3 = acc;
+  }
+  if (acc) {
+    v3 = v4;
+  }
+  v4 = v3;
+  return [acc, v3, v4];
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-no-declarations-in-reactive-scope-with-early-return.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-no-declarations-in-reactive-scope-with-early-return.expect.md
@@ -39,55 +39,51 @@ function Component() {
 ```javascript
 import { c as _c } from "react/compiler-runtime"; // @enableAssumeHooksFollowRulesOfReact @enableTransitivelyFreezeFunctionExpressions
 function Component() {
-  const $ = _c(7);
+  const $ = _c(6);
   const items = useItems();
   let t0;
   let t1;
-  let t2;
   if ($[0] !== items) {
-    t2 = Symbol.for("react.early_return_sentinel");
+    t1 = Symbol.for("react.early_return_sentinel");
     bb0: {
-      t0 = items.filter(_temp);
-      const filteredItems = t0;
+      const filteredItems = items.filter(_temp);
       if (filteredItems.length === 0) {
-        let t3;
-        if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
-          t3 = (
+        let t2;
+        if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
+          t2 = (
             <div>
               <span />
             </div>
           );
-          $[4] = t3;
+          $[3] = t2;
         } else {
-          t3 = $[4];
+          t2 = $[3];
         }
-        t2 = t3;
+        t1 = t2;
         break bb0;
       }
 
-      t1 = filteredItems.map(_temp2);
+      t0 = filteredItems.map(_temp2);
     }
     $[0] = items;
-    $[1] = t1;
-    $[2] = t2;
-    $[3] = t0;
+    $[1] = t0;
+    $[2] = t1;
   } else {
-    t1 = $[1];
-    t2 = $[2];
-    t0 = $[3];
+    t0 = $[1];
+    t1 = $[2];
   }
-  if (t2 !== Symbol.for("react.early_return_sentinel")) {
-    return t2;
+  if (t1 !== Symbol.for("react.early_return_sentinel")) {
+    return t1;
   }
-  let t3;
-  if ($[5] !== t1) {
-    t3 = <>{t1}</>;
-    $[5] = t1;
-    $[6] = t3;
+  let t2;
+  if ($[4] !== t0) {
+    t2 = <>{t0}</>;
+    $[4] = t0;
+    $[5] = t2;
   } else {
-    t3 = $[6];
+    t2 = $[5];
   }
-  return t3;
+  return t2;
 }
 function _temp2(t0) {
   const [item_0] = t0;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-renaming-conflicting-decls.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-renaming-conflicting-decls.expect.md
@@ -45,87 +45,83 @@ import { Stringify, identity, makeArray, toJSON } from "shared-runtime";
 import { useMemo } from "react";
 
 function Component(props) {
-  const $ = _c(13);
+  const $ = _c(12);
   let t0;
   let t1;
-  let t2;
   if ($[0] !== props) {
-    t2 = Symbol.for("react.early_return_sentinel");
+    t1 = Symbol.for("react.early_return_sentinel");
     bb0: {
-      t0 = toJSON(props);
-      const propsString = t0;
+      const propsString = toJSON(props);
       if (propsString.length <= 2) {
-        t2 = null;
+        t1 = null;
         break bb0;
       }
 
-      t1 = identity(propsString);
+      t0 = identity(propsString);
     }
     $[0] = props;
-    $[1] = t1;
-    $[2] = t2;
+    $[1] = t0;
+    $[2] = t1;
+  } else {
+    t0 = $[1];
+    t1 = $[2];
+  }
+  if (t1 !== Symbol.for("react.early_return_sentinel")) {
+    return t1;
+  }
+  let t2;
+  if ($[3] !== t0) {
+    t2 = { url: t0 };
     $[3] = t0;
+    $[4] = t2;
   } else {
-    t1 = $[1];
-    t2 = $[2];
-    t0 = $[3];
+    t2 = $[4];
   }
-  if (t2 !== Symbol.for("react.early_return_sentinel")) {
-    return t2;
-  }
+  const linkProps = t2;
   let t3;
-  if ($[4] !== t1) {
-    t3 = { url: t1 };
-    $[4] = t1;
-    $[5] = t3;
-  } else {
-    t3 = $[5];
-  }
-  const linkProps = t3;
-  let t4;
-  if ($[6] !== linkProps) {
+  if ($[5] !== linkProps) {
     const x = {};
+    let t4;
     let t5;
     let t6;
     let t7;
     let t8;
-    let t9;
-    if ($[8] === Symbol.for("react.memo_cache_sentinel")) {
-      t5 = [1];
-      t6 = [2];
-      t7 = [3];
-      t8 = [4];
-      t9 = [5];
+    if ($[7] === Symbol.for("react.memo_cache_sentinel")) {
+      t4 = [1];
+      t5 = [2];
+      t6 = [3];
+      t7 = [4];
+      t8 = [5];
+      $[7] = t4;
       $[8] = t5;
       $[9] = t6;
       $[10] = t7;
       $[11] = t8;
-      $[12] = t9;
     } else {
+      t4 = $[7];
       t5 = $[8];
       t6 = $[9];
       t7 = $[10];
       t8 = $[11];
-      t9 = $[12];
     }
-    t4 = (
+    t3 = (
       <Stringify
         link={linkProps}
-        val1={t5}
-        val2={t6}
-        val3={t7}
-        val4={t8}
-        val5={t9}
+        val1={t4}
+        val2={t5}
+        val3={t6}
+        val4={t7}
+        val5={t8}
       >
         {makeArray(x, 2)}
       </Stringify>
     );
-    $[6] = linkProps;
-    $[7] = t4;
+    $[5] = linkProps;
+    $[6] = t3;
   } else {
-    t4 = $[7];
+    t3 = $[6];
   }
-  return t4;
+  return t3;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro.expect.md
@@ -24,10 +24,9 @@ function Component(props) {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
-  const $ = _c(7);
+  const $ = _c(6);
   const item = props.item;
   let baseVideos;
-  let t0;
   let thumbnails;
   if ($[0] !== item) {
     thumbnails = [];
@@ -41,24 +40,21 @@ function Component(props) {
     });
     $[0] = item;
     $[1] = baseVideos;
-    $[2] = t0;
-    $[3] = thumbnails;
+    $[2] = thumbnails;
   } else {
     baseVideos = $[1];
-    t0 = $[2];
-    thumbnails = $[3];
+    thumbnails = $[2];
   }
-  t0 = undefined;
-  let t1;
-  if ($[4] !== baseVideos || $[5] !== thumbnails) {
-    t1 = <FlatList baseVideos={baseVideos} items={thumbnails} />;
-    $[4] = baseVideos;
-    $[5] = thumbnails;
-    $[6] = t1;
+  let t0;
+  if ($[3] !== baseVideos || $[4] !== thumbnails) {
+    t0 = <FlatList baseVideos={baseVideos} items={thumbnails} />;
+    $[3] = baseVideos;
+    $[4] = thumbnails;
+    $[5] = t0;
   } else {
-    t1 = $[6];
+    t0 = $[5];
   }
-  return t1;
+  return t0;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/type-provider-log-default-import.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/type-provider-log-default-import.expect.md
@@ -47,77 +47,73 @@ export function Component(t0) {
   const $ = _c(17);
   const { a, b } = t0;
   let t1;
-  let t2;
   if ($[0] !== a) {
-    t2 = { a };
+    t1 = { a };
     $[0] = a;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   const item1 = t1;
-  let t3;
-  let t4;
+  let t2;
   if ($[2] !== b) {
-    t4 = { b };
+    t2 = { b };
     $[2] = b;
-    $[3] = t4;
+    $[3] = t2;
   } else {
-    t4 = $[3];
+    t2 = $[3];
   }
-  t3 = t4;
-  const item2 = t3;
+  const item2 = t2;
   typedLog(item1, item2);
-  let t5;
+  let t3;
   if ($[4] !== a) {
-    t5 = [a];
+    t3 = [a];
     $[4] = a;
-    $[5] = t5;
+    $[5] = t3;
   } else {
-    t5 = $[5];
+    t3 = $[5];
+  }
+  let t4;
+  if ($[6] !== item1 || $[7] !== t3) {
+    t4 = <ValidateMemoization inputs={t3} output={item1} />;
+    $[6] = item1;
+    $[7] = t3;
+    $[8] = t4;
+  } else {
+    t4 = $[8];
+  }
+  let t5;
+  if ($[9] !== b) {
+    t5 = [b];
+    $[9] = b;
+    $[10] = t5;
+  } else {
+    t5 = $[10];
   }
   let t6;
-  if ($[6] !== item1 || $[7] !== t5) {
-    t6 = <ValidateMemoization inputs={t5} output={item1} />;
-    $[6] = item1;
-    $[7] = t5;
-    $[8] = t6;
+  if ($[11] !== item2 || $[12] !== t5) {
+    t6 = <ValidateMemoization inputs={t5} output={item2} />;
+    $[11] = item2;
+    $[12] = t5;
+    $[13] = t6;
   } else {
-    t6 = $[8];
+    t6 = $[13];
   }
   let t7;
-  if ($[9] !== b) {
-    t7 = [b];
-    $[9] = b;
-    $[10] = t7;
-  } else {
-    t7 = $[10];
-  }
-  let t8;
-  if ($[11] !== item2 || $[12] !== t7) {
-    t8 = <ValidateMemoization inputs={t7} output={item2} />;
-    $[11] = item2;
-    $[12] = t7;
-    $[13] = t8;
-  } else {
-    t8 = $[13];
-  }
-  let t9;
-  if ($[14] !== t6 || $[15] !== t8) {
-    t9 = (
+  if ($[14] !== t4 || $[15] !== t6) {
+    t7 = (
       <>
+        {t4}
         {t6}
-        {t8}
       </>
     );
-    $[14] = t6;
-    $[15] = t8;
-    $[16] = t9;
+    $[14] = t4;
+    $[15] = t6;
+    $[16] = t7;
   } else {
-    t9 = $[16];
+    t7 = $[16];
   }
-  return t9;
+  return t7;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/type-provider-log.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/type-provider-log.expect.md
@@ -45,77 +45,73 @@ export function Component(t0) {
   const $ = _c(17);
   const { a, b } = t0;
   let t1;
-  let t2;
   if ($[0] !== a) {
-    t2 = { a };
+    t1 = { a };
     $[0] = a;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   const item1 = t1;
-  let t3;
-  let t4;
+  let t2;
   if ($[2] !== b) {
-    t4 = { b };
+    t2 = { b };
     $[2] = b;
-    $[3] = t4;
+    $[3] = t2;
   } else {
-    t4 = $[3];
+    t2 = $[3];
   }
-  t3 = t4;
-  const item2 = t3;
+  const item2 = t2;
   typedLog(item1, item2);
-  let t5;
+  let t3;
   if ($[4] !== a) {
-    t5 = [a];
+    t3 = [a];
     $[4] = a;
-    $[5] = t5;
+    $[5] = t3;
   } else {
-    t5 = $[5];
+    t3 = $[5];
+  }
+  let t4;
+  if ($[6] !== item1 || $[7] !== t3) {
+    t4 = <ValidateMemoization inputs={t3} output={item1} />;
+    $[6] = item1;
+    $[7] = t3;
+    $[8] = t4;
+  } else {
+    t4 = $[8];
+  }
+  let t5;
+  if ($[9] !== b) {
+    t5 = [b];
+    $[9] = b;
+    $[10] = t5;
+  } else {
+    t5 = $[10];
   }
   let t6;
-  if ($[6] !== item1 || $[7] !== t5) {
-    t6 = <ValidateMemoization inputs={t5} output={item1} />;
-    $[6] = item1;
-    $[7] = t5;
-    $[8] = t6;
+  if ($[11] !== item2 || $[12] !== t5) {
+    t6 = <ValidateMemoization inputs={t5} output={item2} />;
+    $[11] = item2;
+    $[12] = t5;
+    $[13] = t6;
   } else {
-    t6 = $[8];
+    t6 = $[13];
   }
   let t7;
-  if ($[9] !== b) {
-    t7 = [b];
-    $[9] = b;
-    $[10] = t7;
-  } else {
-    t7 = $[10];
-  }
-  let t8;
-  if ($[11] !== item2 || $[12] !== t7) {
-    t8 = <ValidateMemoization inputs={t7} output={item2} />;
-    $[11] = item2;
-    $[12] = t7;
-    $[13] = t8;
-  } else {
-    t8 = $[13];
-  }
-  let t9;
-  if ($[14] !== t6 || $[15] !== t8) {
-    t9 = (
+  if ($[14] !== t4 || $[15] !== t6) {
+    t7 = (
       <>
+        {t4}
         {t6}
-        {t8}
       </>
     );
-    $[14] = t6;
-    $[15] = t8;
-    $[16] = t9;
+    $[14] = t4;
+    $[15] = t6;
+    $[16] = t7;
   } else {
-    t9 = $[16];
+    t7 = $[16];
   }
-  return t9;
+  return t7;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/type-provider-store-capture-namespace-import.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/type-provider-store-capture-namespace-import.expect.md
@@ -51,28 +51,23 @@ export function Component(t0) {
   const $ = _c(27);
   const { a, b } = t0;
   let t1;
-  let t2;
   if ($[0] !== a) {
-    t2 = { a };
+    t1 = { a };
     $[0] = a;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   const item1 = t1;
-  let t3;
-  let t4;
+  let t2;
   if ($[2] !== b) {
-    t4 = { b };
+    t2 = { b };
     $[2] = b;
-    $[3] = t4;
+    $[3] = t2;
   } else {
-    t4 = $[3];
+    t2 = $[3];
   }
-  t3 = t4;
-  const item2 = t3;
-  let t5;
+  const item2 = t2;
   let items;
   if ($[4] !== item1 || $[5] !== item2) {
     items = [];
@@ -84,77 +79,76 @@ export function Component(t0) {
   } else {
     items = $[6];
   }
-  t5 = items;
-  const items_0 = t5;
-  let t6;
+  const items_0 = items;
+  let t3;
   if ($[7] !== a) {
-    t6 = [a];
+    t3 = [a];
     $[7] = a;
-    $[8] = t6;
+    $[8] = t3;
   } else {
-    t6 = $[8];
+    t3 = $[8];
+  }
+  let t4;
+  if ($[9] !== items_0[0] || $[10] !== t3) {
+    t4 = <SharedRuntime.ValidateMemoization inputs={t3} output={items_0[0]} />;
+    $[9] = items_0[0];
+    $[10] = t3;
+    $[11] = t4;
+  } else {
+    t4 = $[11];
+  }
+  let t5;
+  if ($[12] !== b) {
+    t5 = [b];
+    $[12] = b;
+    $[13] = t5;
+  } else {
+    t5 = $[13];
+  }
+  let t6;
+  if ($[14] !== items_0[1] || $[15] !== t5) {
+    t6 = <SharedRuntime.ValidateMemoization inputs={t5} output={items_0[1]} />;
+    $[14] = items_0[1];
+    $[15] = t5;
+    $[16] = t6;
+  } else {
+    t6 = $[16];
   }
   let t7;
-  if ($[9] !== items_0[0] || $[10] !== t6) {
-    t7 = <SharedRuntime.ValidateMemoization inputs={t6} output={items_0[0]} />;
-    $[9] = items_0[0];
-    $[10] = t6;
-    $[11] = t7;
-  } else {
-    t7 = $[11];
-  }
-  let t8;
-  if ($[12] !== b) {
-    t8 = [b];
-    $[12] = b;
-    $[13] = t8;
-  } else {
-    t8 = $[13];
-  }
-  let t9;
-  if ($[14] !== items_0[1] || $[15] !== t8) {
-    t9 = <SharedRuntime.ValidateMemoization inputs={t8} output={items_0[1]} />;
-    $[14] = items_0[1];
-    $[15] = t8;
-    $[16] = t9;
-  } else {
-    t9 = $[16];
-  }
-  let t10;
   if ($[17] !== a || $[18] !== b) {
-    t10 = [a, b];
+    t7 = [a, b];
     $[17] = a;
     $[18] = b;
-    $[19] = t10;
+    $[19] = t7;
   } else {
-    t10 = $[19];
+    t7 = $[19];
   }
-  let t11;
-  if ($[20] !== items_0 || $[21] !== t10) {
-    t11 = <SharedRuntime.ValidateMemoization inputs={t10} output={items_0} />;
+  let t8;
+  if ($[20] !== items_0 || $[21] !== t7) {
+    t8 = <SharedRuntime.ValidateMemoization inputs={t7} output={items_0} />;
     $[20] = items_0;
-    $[21] = t10;
-    $[22] = t11;
+    $[21] = t7;
+    $[22] = t8;
   } else {
-    t11 = $[22];
+    t8 = $[22];
   }
-  let t12;
-  if ($[23] !== t11 || $[24] !== t7 || $[25] !== t9) {
-    t12 = (
+  let t9;
+  if ($[23] !== t4 || $[24] !== t6 || $[25] !== t8) {
+    t9 = (
       <>
-        {t7}
-        {t9}
-        {t11}
+        {t4}
+        {t6}
+        {t8}
       </>
     );
-    $[23] = t11;
-    $[24] = t7;
-    $[25] = t9;
-    $[26] = t12;
+    $[23] = t4;
+    $[24] = t6;
+    $[25] = t8;
+    $[26] = t9;
   } else {
-    t12 = $[26];
+    t9 = $[26];
   }
-  return t12;
+  return t9;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/type-provider-store-capture.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/type-provider-store-capture.expect.md
@@ -51,28 +51,23 @@ export function Component(t0) {
   const $ = _c(27);
   const { a, b } = t0;
   let t1;
-  let t2;
   if ($[0] !== a) {
-    t2 = { a };
+    t1 = { a };
     $[0] = a;
-    $[1] = t2;
+    $[1] = t1;
   } else {
-    t2 = $[1];
+    t1 = $[1];
   }
-  t1 = t2;
   const item1 = t1;
-  let t3;
-  let t4;
+  let t2;
   if ($[2] !== b) {
-    t4 = { b };
+    t2 = { b };
     $[2] = b;
-    $[3] = t4;
+    $[3] = t2;
   } else {
-    t4 = $[3];
+    t2 = $[3];
   }
-  t3 = t4;
-  const item2 = t3;
-  let t5;
+  const item2 = t2;
   let items;
   if ($[4] !== item1 || $[5] !== item2) {
     items = [];
@@ -84,77 +79,76 @@ export function Component(t0) {
   } else {
     items = $[6];
   }
-  t5 = items;
-  const items_0 = t5;
-  let t6;
+  const items_0 = items;
+  let t3;
   if ($[7] !== a) {
-    t6 = [a];
+    t3 = [a];
     $[7] = a;
-    $[8] = t6;
+    $[8] = t3;
   } else {
-    t6 = $[8];
+    t3 = $[8];
+  }
+  let t4;
+  if ($[9] !== items_0[0] || $[10] !== t3) {
+    t4 = <ValidateMemoization inputs={t3} output={items_0[0]} />;
+    $[9] = items_0[0];
+    $[10] = t3;
+    $[11] = t4;
+  } else {
+    t4 = $[11];
+  }
+  let t5;
+  if ($[12] !== b) {
+    t5 = [b];
+    $[12] = b;
+    $[13] = t5;
+  } else {
+    t5 = $[13];
+  }
+  let t6;
+  if ($[14] !== items_0[1] || $[15] !== t5) {
+    t6 = <ValidateMemoization inputs={t5} output={items_0[1]} />;
+    $[14] = items_0[1];
+    $[15] = t5;
+    $[16] = t6;
+  } else {
+    t6 = $[16];
   }
   let t7;
-  if ($[9] !== items_0[0] || $[10] !== t6) {
-    t7 = <ValidateMemoization inputs={t6} output={items_0[0]} />;
-    $[9] = items_0[0];
-    $[10] = t6;
-    $[11] = t7;
-  } else {
-    t7 = $[11];
-  }
-  let t8;
-  if ($[12] !== b) {
-    t8 = [b];
-    $[12] = b;
-    $[13] = t8;
-  } else {
-    t8 = $[13];
-  }
-  let t9;
-  if ($[14] !== items_0[1] || $[15] !== t8) {
-    t9 = <ValidateMemoization inputs={t8} output={items_0[1]} />;
-    $[14] = items_0[1];
-    $[15] = t8;
-    $[16] = t9;
-  } else {
-    t9 = $[16];
-  }
-  let t10;
   if ($[17] !== a || $[18] !== b) {
-    t10 = [a, b];
+    t7 = [a, b];
     $[17] = a;
     $[18] = b;
-    $[19] = t10;
+    $[19] = t7;
   } else {
-    t10 = $[19];
+    t7 = $[19];
   }
-  let t11;
-  if ($[20] !== items_0 || $[21] !== t10) {
-    t11 = <ValidateMemoization inputs={t10} output={items_0} />;
+  let t8;
+  if ($[20] !== items_0 || $[21] !== t7) {
+    t8 = <ValidateMemoization inputs={t7} output={items_0} />;
     $[20] = items_0;
-    $[21] = t10;
-    $[22] = t11;
+    $[21] = t7;
+    $[22] = t8;
   } else {
-    t11 = $[22];
+    t8 = $[22];
   }
-  let t12;
-  if ($[23] !== t11 || $[24] !== t7 || $[25] !== t9) {
-    t12 = (
+  let t9;
+  if ($[23] !== t4 || $[24] !== t6 || $[25] !== t8) {
+    t9 = (
       <>
-        {t7}
-        {t9}
-        {t11}
+        {t4}
+        {t6}
+        {t8}
       </>
     );
-    $[23] = t11;
-    $[24] = t7;
-    $[25] = t9;
-    $[26] = t12;
+    $[23] = t4;
+    $[24] = t6;
+    $[25] = t8;
+    $[26] = t9;
   } else {
-    t12 = $[26];
+    t9 = $[26];
   }
-  return t12;
+  return t9;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-operator-call-expression.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-operator-call-expression.expect.md
@@ -70,34 +70,32 @@ function Inner(props) {
   const $ = _c(7);
   const input = use(FooContext);
   let t0;
-  let t1;
   if ($[0] !== input) {
-    t1 = [input];
+    t0 = [input];
     $[0] = input;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   const output = t0;
-  let t2;
+  let t1;
   if ($[2] !== input) {
-    t2 = [input];
+    t1 = [input];
     $[2] = input;
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  let t3;
-  if ($[4] !== output || $[5] !== t2) {
-    t3 = <ValidateMemoization inputs={t2} output={output} />;
+  let t2;
+  if ($[4] !== output || $[5] !== t1) {
+    t2 = <ValidateMemoization inputs={t1} output={output} />;
     $[4] = output;
-    $[5] = t2;
-    $[6] = t3;
+    $[5] = t1;
+    $[6] = t2;
   } else {
-    t3 = $[6];
+    t2 = $[6];
   }
-  return t3;
+  return t2;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-operator-conditional.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-operator-conditional.expect.md
@@ -86,34 +86,32 @@ function Inner(props) {
 
   input;
   let t0;
-  let t1;
   if ($[0] !== input) {
-    t1 = [input];
+    t0 = [input];
     $[0] = input;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   const output = t0;
-  let t2;
+  let t1;
   if ($[2] !== input) {
-    t2 = [input];
+    t1 = [input];
     $[2] = input;
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  let t3;
-  if ($[4] !== output || $[5] !== t2) {
-    t3 = <ValidateMemoization inputs={t2} output={output} />;
+  let t2;
+  if ($[4] !== output || $[5] !== t1) {
+    t2 = <ValidateMemoization inputs={t1} output={output} />;
     $[4] = output;
-    $[5] = t2;
-    $[6] = t3;
+    $[5] = t1;
+    $[6] = t2;
   } else {
-    t3 = $[6];
+    t2 = $[6];
   }
-  return t3;
+  return t2;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-operator-method-call.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-operator-method-call.expect.md
@@ -72,34 +72,32 @@ function Inner(props) {
   const $ = _c(7);
   const input = React.use(FooContext);
   let t0;
-  let t1;
   if ($[0] !== input) {
-    t1 = [input];
+    t0 = [input];
     $[0] = input;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   const output = t0;
-  let t2;
+  let t1;
   if ($[2] !== input) {
-    t2 = [input];
+    t1 = [input];
     $[2] = input;
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  let t3;
-  if ($[4] !== output || $[5] !== t2) {
-    t3 = <ValidateMemoization inputs={t2} output={output} />;
+  let t2;
+  if ($[4] !== output || $[5] !== t1) {
+    t2 = <ValidateMemoization inputs={t1} output={output} />;
     $[4] = output;
-    $[5] = t2;
-    $[6] = t3;
+    $[5] = t1;
+    $[6] = t2;
   } else {
-    t3 = $[6];
+    t2 = $[6];
   }
-  return t3;
+  return t2;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useEffect-global-pruned.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useEffect-global-pruned.expect.md
@@ -37,23 +37,21 @@ import { useEffect } from "react";
 function someGlobal() {}
 function useFoo() {
   const $ = _c(2);
+  const fn = _temp;
   let t0;
-  t0 = _temp;
-  const fn = t0;
   let t1;
-  let t2;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = () => {
+    t0 = () => {
       fn();
     };
-    t2 = [fn];
-    $[0] = t1;
-    $[1] = t2;
+    t1 = [fn];
+    $[0] = t0;
+    $[1] = t1;
   } else {
-    t1 = $[0];
-    t2 = $[1];
+    t0 = $[0];
+    t1 = $[1];
   }
-  useEffect(t1, t2);
+  useEffect(t0, t1);
   return null;
 }
 function _temp() {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useEffect-namespace-pruned.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useEffect-namespace-pruned.expect.md
@@ -37,23 +37,21 @@ import * as React from "react";
 function someGlobal() {}
 function useFoo() {
   const $ = _c(2);
+  const fn = _temp;
   let t0;
-  t0 = _temp;
-  const fn = t0;
   let t1;
-  let t2;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = () => {
+    t0 = () => {
       fn();
     };
-    t2 = [fn];
-    $[0] = t1;
-    $[1] = t2;
+    t1 = [fn];
+    $[0] = t0;
+    $[1] = t1;
   } else {
-    t1 = $[0];
-    t2 = $[1];
+    t0 = $[0];
+    t1 = $[1];
   }
-  React.useEffect(t1, t2);
+  React.useEffect(t0, t1);
   return null;
 }
 function _temp() {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-independently-memoizeable.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-independently-memoizeable.expect.md
@@ -21,45 +21,43 @@ import { c as _c } from "react/compiler-runtime";
 function Component(props) {
   const $ = _c(10);
   let t0;
-  let t1;
   if ($[0] !== props.a) {
-    t1 = makeObject(props.a);
+    t0 = makeObject(props.a);
     $[0] = props.a;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  const a = t1;
-  let t2;
+  const a = t0;
+  let t1;
   if ($[2] !== props.b) {
-    t2 = makeObject(props.b);
+    t1 = makeObject(props.b);
     $[2] = props.b;
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  const b = t2;
-  let t3;
+  const b = t1;
+  let t2;
   if ($[4] !== a || $[5] !== b) {
-    t3 = [a, b];
+    t2 = [a, b];
     $[4] = a;
     $[5] = b;
-    $[6] = t3;
+    $[6] = t2;
   } else {
-    t3 = $[6];
+    t2 = $[6];
   }
-  t0 = t3;
-  const [a_0, b_0] = t0;
-  let t4;
+  const [a_0, b_0] = t2;
+  let t3;
   if ($[7] !== a_0 || $[8] !== b_0) {
-    t4 = [a_0, b_0];
+    t3 = [a_0, b_0];
     $[7] = a_0;
     $[8] = b_0;
-    $[9] = t4;
+    $[9] = t3;
   } else {
-    t4 = $[9];
+    t3 = $[9];
   }
-  return t4;
+  return t3;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-labeled-statement-unconditional-return.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-labeled-statement-unconditional-return.expect.md
@@ -23,10 +23,7 @@ export const FIXTURE_ENTRYPOINT = {
 
 ```javascript
 function Component(props) {
-  let t0;
-
-  t0 = props.value;
-  const x = t0;
+  const x = props.value;
   return x;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-logical.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-logical.expect.md
@@ -19,9 +19,7 @@ export const FIXTURE_ENTRYPOINT = {
 
 ```javascript
 function Component(props) {
-  let t0;
-  t0 = props.a && props.b;
-  const x = t0;
+  const x = props.a && props.b;
   return x;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-mabye-modified-free-variable-dont-preserve-memoization-guarantees.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-mabye-modified-free-variable-dont-preserve-memoization-guarantees.expect.md
@@ -51,13 +51,11 @@ function Component(props) {
   const part = free2.part;
 
   useHook();
-  let t0;
 
   const x = makeObject_Primitives();
   x.value = props.value;
   mutate(x, free, part);
-  t0 = x;
-  const object = t0;
+  const object = x;
 
   identity(free);
   identity(part);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-mabye-modified-free-variable-preserve-memoization-guarantees.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-mabye-modified-free-variable-preserve-memoization-guarantees.expect.md
@@ -71,7 +71,6 @@ function Component(props) {
   const part = free2.part;
 
   useHook();
-  let t2;
   let x;
   if ($[2] !== props.value) {
     x = makeObject_Primitives();
@@ -82,8 +81,7 @@ function Component(props) {
   } else {
     x = $[3];
   }
-  t2 = x;
-  const object = t2;
+  const object = x;
 
   identity(free);
   identity(part);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-maybe-modified-later-dont-preserve-memoization-guarantees.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-maybe-modified-later-dont-preserve-memoization-guarantees.expect.md
@@ -27,18 +27,14 @@ import { useMemo } from "react";
 import { identity, makeObject_Primitives, mutate } from "shared-runtime";
 
 function Component(props) {
-  const $ = _c(2);
-  let t0;
+  const $ = _c(1);
   let object;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = makeObject_Primitives();
-    object = t0;
+    object = makeObject_Primitives();
     identity(object);
     $[0] = object;
-    $[1] = t0;
   } else {
     object = $[0];
-    t0 = $[1];
   }
   return object;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-maybe-modified-later-preserve-memoization-guarantees.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-maybe-modified-later-preserve-memoization-guarantees.expect.md
@@ -29,14 +29,12 @@ import { identity, makeObject_Primitives, mutate } from "shared-runtime";
 function Component(props) {
   const $ = _c(1);
   let t0;
-  let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = makeObject_Primitives();
-    $[0] = t1;
+    t0 = makeObject_Primitives();
+    $[0] = t0;
   } else {
-    t1 = $[0];
+    t0 = $[0];
   }
-  t0 = t1;
   const object = t0;
   identity(object);
   return object;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-nested-ifs.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-nested-ifs.expect.md
@@ -24,12 +24,10 @@ export const FIXTURE_ENTRYPOINT = {
 
 ```javascript
 function Component(props) {
-  let t0;
   if (props.cond) {
     if (props.cond) {
     }
   }
-  t0 = undefined;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-return-empty.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-return-empty.expect.md
@@ -15,10 +15,7 @@ function component(a) {
 
 ```javascript
 function component(a) {
-  let t0;
-
   mutate(a);
-  t0 = undefined;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-simple.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useMemo-simple.expect.md
@@ -16,25 +16,23 @@ import { c as _c } from "react/compiler-runtime";
 function component(a) {
   const $ = _c(4);
   let t0;
-  let t1;
   if ($[0] !== a) {
-    t1 = [a];
+    t0 = [a];
     $[0] = a;
-    $[1] = t1;
+    $[1] = t0;
   } else {
-    t1 = $[1];
+    t0 = $[1];
   }
-  t0 = t1;
   const x = t0;
-  let t2;
+  let t1;
   if ($[2] !== x) {
-    t2 = <Foo x={x} />;
+    t1 = <Foo x={x} />;
     $[2] = x;
-    $[3] = t2;
+    $[3] = t1;
   } else {
-    t2 = $[3];
+    t1 = $[3];
   }
-  return t2;
+  return t1;
 }
 
 ```


### PR DESCRIPTION

We currently inline IIFEs by creating a temporary and a labeled block w the original code. The original return statements turn into an assignment to the temporary and  break out of the label. However, many cases of IIFEs are due to inlining of manual `useMemo()`, and these cases often have only a single return statement. Here, the output is cleaner if we avoid the temporary and label - so that's what we do in this PR.

Note that the most complex part of the change is actually around ValidatePreserveExistingMemo - we have some logic to track the IIFE temporary reassignmetns which needs to be updated to handle the simpler version of inlining.
