### PR TITLE
[Flight] Don't track Promise stack if there's no owner

### DIFF
--- a/packages/react-server/src/ReactFlightAsyncSequence.js
+++ b/packages/react-server/src/ReactFlightAsyncSequence.js
@@ -26,7 +26,7 @@ type PromiseWithDebugInfo = interface extends Promise<any> {
 export type IONode = {
   tag: 0,
   owner: null | ReactComponentInfo,
-  stack: null, // callsite that spawned the I/O
+  stack: null | ReactStackTrace, // callsite that spawned the I/O
   start: number, // start time when the first part of the I/O sequence started
   end: number, // we typically don't use this. only when there's no promise intermediate.
   promise: null, // not used on I/O

--- a/packages/react-server/src/ReactFlightServerConfigDebugNode.js
+++ b/packages/react-server/src/ReactFlightServerConfigDebugNode.js
@@ -149,10 +149,11 @@ export function initAsyncDebugInfo(): void {
               previous: current === undefined ? null : current, // The path that led us here.
             }: UnresolvedAwaitNode);
           } else {
+            const owner = resolveOwner();
             node = ({
               tag: UNRESOLVED_PROMISE_NODE,
-              owner: resolveOwner(),
-              stack: parseStackTrace(new Error(), 5),
+              owner: owner,
+              stack: owner === null ? null : parseStackTrace(new Error(), 5),
               start: performance.now(),
               end: -1.1, // Set when we resolve.
               promise: new WeakRef((resource: Promise<any>)),
@@ -170,10 +171,11 @@ export function initAsyncDebugInfo(): void {
         ) {
           if (trigger === undefined) {
             // We have begun a new I/O sequence.
+            const owner = resolveOwner();
             node = ({
               tag: IO_NODE,
-              owner: resolveOwner(),
-              stack: null,
+              owner: owner,
+              stack: owner === null ? parseStackTrace(new Error(), 3) : null,
               start: performance.now(),
               end: -1.1, // Only set when pinged.
               promise: null,
@@ -185,10 +187,11 @@ export function initAsyncDebugInfo(): void {
             trigger.tag === UNRESOLVED_AWAIT_NODE
           ) {
             // We have begun a new I/O sequence after the await.
+            const owner = resolveOwner();
             node = ({
               tag: IO_NODE,
-              owner: resolveOwner(),
-              stack: null,
+              owner: owner,
+              stack: owner === null ? parseStackTrace(new Error(), 3) : null,
               start: performance.now(),
               end: -1.1, // Only set when pinged.
               promise: null,


### PR DESCRIPTION
This is a compromise because there can be a lot of Promise instances created. They're useful because they generally provide a better stack when batching/pooled connections are used.

This restores stack collection for I/O nodes so we have something to fallback on if there's no owner.

That way we can at least get a name or something out of I/O that was spawned outside a render but mostly avoids collecting starting I/O outside of render.