### PR TITLE
Add logger for potential nested infinite loop before throwing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -633,6 +633,8 @@ module.exports = {
     __PROFILE__: 'readonly',
     __TEST__: 'readonly',
     __VARIANT__: 'readonly',
+    __LOGGER__: 'readonly',
+    __TEST_LOGS__: 'writable',
     __unmockReact: 'readonly',
     gate: 'readonly',
     trustedTypes: 'readonly',

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -150,6 +150,13 @@ export const transitionLaneExpirationMs = 5000;
  * by setState or similar outside of the component owning the state.
  */
 export const enableInfiniteRenderLoopDetection = false;
+/**
+ * Experimental warning logger for enableInfiniteRenderLoopDetection
+ * This is a function that will be called with a warning string and connect
+ * to a production logger.
+ * If null, no warning will be logged.
+ */
+export const logInfiniteRenderLoopDetectionWarning: null | ((string) => void) = null;
 
 export const enableLazyPublicInstanceInFabric = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -47,6 +47,7 @@ export const enableMoveBefore = true;
 export const enableFizzExternalRuntime = true;
 export const enableHalt = false;
 export const enableInfiniteRenderLoopDetection = false;
+export const logInfiniteRenderLoopDetectionWarning: null | ((string) => void) = null;
 export const enableLegacyCache = false;
 export const enableLegacyFBSupport = false;
 export const enableLegacyHidden = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -33,6 +33,7 @@ export const enableFizzExternalRuntime = true;
 export const enableHalt = false;
 export const enableHiddenSubtreeInsertionEffectCleanup = false;
 export const enableInfiniteRenderLoopDetection = false;
+export const logInfiniteRenderLoopDetectionWarning: null | ((string) => void) = null;
 export const enableLegacyCache = false;
 export const enableLegacyFBSupport = false;
 export const enableLegacyHidden = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -57,6 +57,7 @@ export const enablePersistedModeClonedFlag = false;
 export const disableClientCache = true;
 
 export const enableInfiniteRenderLoopDetection = false;
+export const logInfiniteRenderLoopDetectionWarning: null | ((string) => void) = null;
 
 export const renameElementSymbol = true;
 export const enableEagerAlternateStateNodeCleanup = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -28,6 +28,7 @@ export const enableMoveBefore = false;
 export const enableFizzExternalRuntime = true;
 export const enableHalt = false;
 export const enableInfiniteRenderLoopDetection = false;
+export const logInfiniteRenderLoopDetectionWarning: null | ((string) => void) = null;
 export const enableHiddenSubtreeInsertionEffectCleanup = true;
 export const enableLegacyCache = false;
 export const enableLegacyFBSupport = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -58,6 +58,7 @@ export const enablePersistedModeClonedFlag = false;
 export const disableClientCache = true;
 
 export const enableInfiniteRenderLoopDetection = false;
+export const logInfiniteRenderLoopDetectionWarning: null | ((string) => void) = null;
 
 export const enableReactTestRendererWarning = false;
 export const disableLegacyMode = true;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -29,6 +29,7 @@ export const transitionLaneExpirationMs = 5000;
 export const enableSchedulingProfiler = __VARIANT__;
 
 export const enableInfiniteRenderLoopDetection = __VARIANT__;
+export const logInfiniteRenderLoopDetectionWarning = __LOGGER__;
 
 export const enableFastAddPropertiesInDiffing = __VARIANT__;
 export const enableLazyPublicInstanceInFabric = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -20,6 +20,7 @@ export const {
   disableSchedulerTimeoutInWorkLoop,
   enableHiddenSubtreeInsertionEffectCleanup,
   enableInfiniteRenderLoopDetection,
+  logInfiniteRenderLoopDetectionWarning,
   enableNoCloningMemoCache,
   enableObjectFiber,
   enableRetryLaneExpiration,

--- a/scripts/flags/flags.js
+++ b/scripts/flags/flags.js
@@ -153,6 +153,7 @@ function mockDynamicallyFeatureFlags() {
 }
 // Set the globals to string values to output them to the table.
 global.__VARIANT__ = 'gk';
+global.__LOGGER__ = 'gk';
 global.__PROFILE__ = 'profile';
 global.__DEV__ = 'dev';
 global.__EXPERIMENTAL__ = 'experimental';

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -12,6 +12,8 @@
 declare const __PROFILE__: boolean;
 declare const __EXPERIMENTAL__: boolean;
 declare const __VARIANT__: boolean;
+declare const __LOGGER__: null | ((string) => void);
+declare const __TEST_LOGS__: Array<string>;
 
 declare const __REACT_DEVTOOLS_GLOBAL_HOOK__: any; /*?{
   inject: ?((stuff: Object) => void)

--- a/scripts/jest/setupEnvironment.js
+++ b/scripts/jest/setupEnvironment.js
@@ -20,6 +20,9 @@ global.__EXPERIMENTAL__ =
 
 global.__VARIANT__ = !!process.env.VARIANT;
 
+global.__TEST_LOGS__ = [];
+global.__LOGGER__ = !!process.env.VARIANT ? (message) => {__TEST_LOGS__.push(message)} : null;
+
 if (typeof window !== 'undefined') {
 } else {
   global.AbortController =


### PR DESCRIPTION
Gather production data in a `enableInfiniteLoopDetection` experiment around existing potential infinite loops.

We disabled `enableInfiniteLoopDetection` with https://github.com/facebook/react/pull/31088 as it was introducing new crashes that were hard to debug, especially with sibling prewarming.

One issue with the previous rollout is that we were introducing new crashes for components that may have settled after the 50 pass limit, but before a real crash or infinite loop. This happened more frequently after enabling sibling prewarming which in some cases increased render counts that may have already been close to the limit.

This change enables a console error where we expect to throw (at 50 nested renders) while continuing to throw an error if that is hit 10 times (500 total nested renders being the new limit for throwing).

This is a temporary approach to allow us to collect more data about potential crashes in production, without introducing too many new crashes ourselves. We can measure the delta of warnings and crashes. The goal will be to make the mechanism smarter, maybe not counting prewarming passes for example, and/or adjusting the final limit to make it easier to enable this on existing apps.
