### PR TITLE
[Flight] Treat empty message as a close signal

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -5808,6 +5808,10 @@ export function resolveDebugMessage(request: Request, message: string): void {
       "resolveDebugMessage/closeDebugChannel should not be called for a Request that wasn't kept alive. This is a bug in React.",
     );
   }
+  if (message === '') {
+    closeDebugChannel(request);
+    return;
+  }
   // This function lets the client ask for more data lazily through the debug channel.
   const command = message.charCodeAt(0);
   const ids = message.slice(2).split(',').map(fromHex);


### PR DESCRIPTION
We typically treat an empty message as closing the debug channel stream but for the Noop renderer we don't use an intermediate stream but just pass the message through.

https://github.com/facebook/react/blob/bbc13fa17be8eebef3e6ee47f48c76c0c44e2f36/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientBrowser.js#L59-L60

For that simple case we should just treat it as a close without an intermediate stream.