### PR TITLE
[Flight] Switch to `__turbopack_load_by_url__`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -474,7 +474,7 @@ module.exports = {
     {
       files: ['packages/react-server-dom-turbopack/**/*.js'],
       globals: {
-        __turbopack_load__: 'readonly',
+        __turbopack_load_by_url__: 'readonly',
         __turbopack_require__: 'readonly',
       },
     },

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopackBrowser.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopackBrowser.js
@@ -8,5 +8,5 @@
  */
 
 export function loadChunk(filename: string): Promise<mixed> {
-  return __turbopack_load__(filename);
+  return __turbopack_load_by_url__(filename);
 }

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopackServer.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopackServer.js
@@ -8,5 +8,5 @@
  */
 
 export function loadChunk(filename: string): Promise<mixed> {
-  return __turbopack_load__(filename);
+  return __turbopack_load_by_url__(filename);
 }

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -150,7 +150,7 @@ declare const __webpack_require__: ((id: string) => any) & {
   u: string => string,
 };
 
-declare function __turbopack_load__(id: string): Promise<mixed>;
+declare function __turbopack_load_by_url__(id: string): Promise<mixed>;
 declare const __turbopack_require__: ((id: string) => any) & {
   u: string => string,
 };

--- a/scripts/rollup/validate/eslintrc.cjs.js
+++ b/scripts/rollup/validate/eslintrc.cjs.js
@@ -65,7 +65,7 @@ module.exports = {
     __webpack_require__: 'readonly',
 
     // Flight Turbopack
-    __turbopack_load__: 'readonly',
+    __turbopack_load_by_url__: 'readonly',
     __turbopack_require__: 'readonly',
 
     // Flight Parcel

--- a/scripts/rollup/validate/eslintrc.cjs2015.js
+++ b/scripts/rollup/validate/eslintrc.cjs2015.js
@@ -62,7 +62,7 @@ module.exports = {
     __webpack_require__: 'readonly',
 
     // Flight Turbopack
-    __turbopack_load__: 'readonly',
+    __turbopack_load_by_url__: 'readonly',
     __turbopack_require__: 'readonly',
 
     // Flight Parcel

--- a/scripts/rollup/validate/eslintrc.esm.js
+++ b/scripts/rollup/validate/eslintrc.esm.js
@@ -65,7 +65,7 @@ module.exports = {
     __webpack_require__: 'readonly',
 
     // Flight Turbopack
-    __turbopack_load__: 'readonly',
+    __turbopack_load_by_url__: 'readonly',
     __turbopack_require__: 'readonly',
 
     // Flight Parcel


### PR DESCRIPTION
We haven't used `__turbopack_load__` for a while now and instead [switched to `__turbopack_load_by_url__`](https://github.com/vercel/next.js/pull/76814)