### PR TITLE
Replace `rm -rf` with `fs-extra.remove` for cross-platform script compatibility

### DIFF
--- a/scripts/devtools/build-and-test.js
+++ b/scripts/devtools/build-and-test.js
@@ -4,6 +4,7 @@
 
 const chalk = require('chalk');
 const {exec} = require('child-process-promise');
+const {remove} = require('fs-extra');
 const inquirer = require('inquirer');
 const {homedir} = require('os');
 const {join, relative} = require('path');
@@ -115,7 +116,7 @@ async function buildAndTestStandalonePackage() {
   const corePackagePath = join(ROOT_PATH, 'packages', 'react-devtools-core');
   const corePackageDest = join(corePackagePath, 'dist');
 
-  await exec(`rm -rf ${corePackageDest}`);
+  await remove(corePackageDest);
   const buildCorePromise = exec('yarn build', {cwd: corePackagePath});
 
   await logger(
@@ -158,7 +159,7 @@ async function buildAndTestInlinePackage() {
   );
   const inlinePackageDest = join(inlinePackagePath, 'dist');
 
-  await exec(`rm -rf ${inlinePackageDest}`);
+  await remove(corePackageDest);
   const buildPromise = exec('yarn build', {cwd: inlinePackagePath});
 
   await logger(


### PR DESCRIPTION
## Problem
### Cross-platform compatibility
The `rm -rf` command is currently used in one of the scripts.
While it works on Unix-like systems (macOS and Linux), it is not natively supported on Windows, which may lead to errors in cross-platform development environments.
## Fix
To make the script cross-platform, I replaced the `rm -rf` command with the `fs-extra.remove` function, which provides equivalent functionality and works consistently across macOS, Linux, and Windows.

This ensures the script behaves the same regardless of the operating system and avoids potential build failures for Windows contributors.
