### PR TITLE
fix: log renders from passive effects for only newly finished work

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -4155,6 +4155,7 @@ export function reconnectPassiveEffects(
   if (
     enableProfilerTimer &&
     enableComponentPerformanceTrack &&
+    includeWorkInProgressEffects &&
     (finishedWork.mode & ProfileMode) !== NoMode &&
     ((finishedWork.actualStartTime: any): number) > 0 &&
     (finishedWork.flags & PerformedWork) !== NoFlags


### PR DESCRIPTION
This fixes displaying incorrect component render entries on a timeline, when we are reconnecting passive effects.

### Before
<img width="2318" height="1127" alt="1" src="https://github.com/user-attachments/assets/9b6b2824-d2de-43a3-8615-2c45d67c3668" />

The cloned nodes will persist original `actualStartTime`, when these were first mounted. When we "replay", the end time will be "now" or whatever the actual start time of the sibling. Depending on when this is being recorded, the diff between end and start could be tens of seconds and doesn't represent what React was doing.

We shouldn't log these entries at all.

### After
We are only logging newly finished renders, but could potentially loose renders that never commit.
