### PR TITLE
[Fiber] Fix false-positive hydration mismatch on script `nonce`

### DIFF
--- a/packages/react-dom-bindings/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom-bindings/src/client/DOMPropertyOperations.js
@@ -42,7 +42,6 @@ export function getValueForAttribute(
       }
       return expected === undefined ? undefined : null;
     }
-
     const tagName = node.tagName.toLowerCase();
     const scriptNonce = tagName === "script" && name === "nonce";
     const value = scriptNonce ? node.nonce : node.getAttribute(name);

--- a/packages/react-dom-bindings/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom-bindings/src/client/DOMPropertyOperations.js
@@ -42,7 +42,10 @@ export function getValueForAttribute(
       }
       return expected === undefined ? undefined : null;
     }
-    const value = node.getAttribute(name);
+
+    const tagName = node.tagName.toLowerCase();
+    const scriptNonce = tagName === "script" && name === "nonce";
+    const value = scriptNonce ? node.nonce : node.getAttribute(name);
     if (__DEV__) {
       checkAttributeStringCoercion(expected, name);
     }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

In dev mode (only) React complains about hydration issues when a server component's nonce does not match the client component's nonce. This happens due to the use of `.getAttribute("nonce")` which returns `""` for security reasons.

https://github.com/whatwg/html/issues/2369#issuecomment-280622702

This link has a more information on the issue more specifically, but the change here is to use the `.nonce` _property_ (accessible) vs _attribute_ (inaccessible).

While I don't have a reproduction case for it, it's possible that this also affects `style` tags, too. Because I was unable to test it, I've omitted that use case for now, though it should be easy enough to add.

## How did you test this change?

I copied the output file into the reproduction example (see below) and the problem is fixed.

```
yarn build
cp build/node_modules/react-dom/cjs/react-dom-client.development.js ../with-strict-csp/node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
```

Steps to reproduce

1. clone https://github.com/snyamathi/with-strict-csp
2. npm ci
3. npm run dev
4. open dev page and observe hydration mismatch

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<img width="1014" height="999" alt="image" src="https://github.com/user-attachments/assets/c7664409-513f-4659-88de-f9c4befc5194" />
