### PR TITLE
[Flight] Use the Promise of the first await even if that is cut off

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -2318,6 +2318,21 @@ function visitAsyncNode(
             // then this gets I/O ignored, which is what we want because it means it was likely
             // just part of a previous component's rendering.
             match = ioNode;
+            if (
+              node.stack !== null &&
+              isAwaitInUserspace(request, node.stack)
+            ) {
+              // This await happened earlier but it was done in user space. This is the first time
+              // that user space saw the value of the I/O. We know we'll emit the I/O eventually
+              // but if we do it now we can override the promise value of the I/O entry to the
+              // one observed by this await which will be a better value than the internals of
+              // the I/O entry. If it's still alive that is.
+              const promise =
+                awaited.promise === null ? undefined : awaited.promise.deref();
+              if (promise !== undefined) {
+                serializeIONode(request, ioNode, awaited.promise);
+              }
+            }
           } else {
             if (
               node.stack === null ||

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
@@ -491,7 +491,7 @@ describe('ReactFlightAsyncDebugInfo', () => {
               ],
               "start": 0,
               "value": {
-                "status": "halted",
+                "value": undefined,
               },
             },
             "env": "Server",


### PR DESCRIPTION
We need a "value" to represent the I/O that was loaded. We don't normally actually use the Promise at the callsite that started the I/O because that's usually deep inside internals. Instead we override the value of the I/O entry with the Promise that was first awaited in user space. This means that you could potentially have different values depending on if multiple things await the same I/O. We just take one of them. (Maybe we should actually just write the first user space awaited Promise as the I/O entry? This might instead have other implications like less deduping.)

When you pass a Promise forward, we may skip the awaits that happened in earlier components because they're not part of the currently rendering component. That's mainly for the stack and time stamps though. The value is still probably conceptually the best value because it represents the I/O value as far user space is concerned.

This writes the I/O early with the first await we find in user space even if we're not going to use that particular await for the stack.