### PR TITLE
[Flight] Remove superfluous whitespace when console method is called with non-strings

### DIFF
--- a/packages/react-client/src/ReactClientConsoleConfigBrowser.js
+++ b/packages/react-client/src/ReactClientConsoleConfigBrowser.js
@@ -8,7 +8,7 @@
  */
 
 // Keep in sync with ReactServerConsoleConfig
-const badgeFormat = '%c%s%c ';
+const badgeFormat = '%c%s%c';
 // Same badge styling as DevTools.
 const badgeStyle =
   // We use a fixed background if light-dark is not supported, otherwise
@@ -49,7 +49,7 @@ export function bindToConsole(
     newArgs.splice(
       offset,
       1,
-      badgeFormat + newArgs[offset],
+      badgeFormat + ' ' + newArgs[offset],
       badgeStyle,
       pad + badgeName + pad,
       resetStyle,

--- a/packages/react-client/src/ReactClientConsoleConfigPlain.js
+++ b/packages/react-client/src/ReactClientConsoleConfigPlain.js
@@ -8,7 +8,7 @@
  */
 
 // Keep in sync with ReactServerConsoleConfig
-const badgeFormat = '[%s] ';
+const badgeFormat = '[%s]';
 const pad = ' ';
 
 const bind = Function.prototype.bind;
@@ -39,7 +39,7 @@ export function bindToConsole(
     newArgs.splice(
       offset,
       1,
-      badgeFormat + newArgs[offset],
+      badgeFormat + ' ' + newArgs[offset],
       pad + badgeName + pad,
     );
   } else {

--- a/packages/react-client/src/ReactClientConsoleConfigServer.js
+++ b/packages/react-client/src/ReactClientConsoleConfigServer.js
@@ -9,7 +9,7 @@
 
 // Keep in sync with ReactServerConsoleConfig
 // This flips color using ANSI, then sets a color styling, then resets.
-const badgeFormat = '\x1b[0m\x1b[7m%c%s\x1b[0m%c ';
+const badgeFormat = '\x1b[0m\x1b[7m%c%s\x1b[0m%c';
 // Same badge styling as DevTools.
 const badgeStyle =
   // We use a fixed background if light-dark is not supported, otherwise
@@ -50,7 +50,7 @@ export function bindToConsole(
     newArgs.splice(
       offset,
       1,
-      badgeFormat + newArgs[offset],
+      badgeFormat + ' ' + newArgs[offset],
       badgeStyle,
       pad + badgeName + pad,
       resetStyle,

--- a/packages/react-server/src/ReactServerConsoleConfigBrowser.js
+++ b/packages/react-server/src/ReactServerConsoleConfigBrowser.js
@@ -8,7 +8,7 @@
  */
 
 // Keep in sync with ReactClientConsoleConfig
-const badgeFormat = '%c%s%c ';
+const badgeFormat = '%c%s%c';
 // Same badge styling as DevTools.
 const badgeStyle =
   // We use a fixed background if light-dark is not supported, otherwise

--- a/packages/react-server/src/ReactServerConsoleConfigBrowser.js
+++ b/packages/react-server/src/ReactServerConsoleConfigBrowser.js
@@ -54,7 +54,12 @@ export function unbadgeConsole(
     typeof badge === 'string'
   ) {
     // Remove our badging from the arguments.
-    args.splice(offset, 4, format.slice(badgeFormat.length));
+    let unbadgedFormat = format.slice(badgeFormat.length);
+    if (unbadgedFormat[0] === ' ') {
+      // Spacing added on the Client if the original argument was a string.
+      unbadgedFormat = unbadgedFormat.slice(1);
+    }
+    args.splice(offset, 4, unbadgedFormat);
     return badge.slice(padLength, badge.length - padLength);
   }
   return null;

--- a/packages/react-server/src/ReactServerConsoleConfigPlain.js
+++ b/packages/react-server/src/ReactServerConsoleConfigPlain.js
@@ -45,7 +45,12 @@ export function unbadgeConsole(
     badge.endsWith(pad)
   ) {
     // Remove our badging from the arguments.
-    args.splice(offset, 2, format.slice(badgeFormat.length));
+    let unbadgedFormat = format.slice(badgeFormat.length);
+    if (unbadgedFormat[0] === ' ') {
+      // Spacing added on the Client if the original argument was a string.
+      unbadgedFormat = unbadgedFormat.slice(1);
+    }
+    args.splice(offset, 4, unbadgedFormat);
     return badge.slice(padLength, badge.length - padLength);
   }
   return null;

--- a/packages/react-server/src/ReactServerConsoleConfigPlain.js
+++ b/packages/react-server/src/ReactServerConsoleConfigPlain.js
@@ -8,7 +8,7 @@
  */
 
 // Keep in sync with ReactClientConsoleConfig
-const badgeFormat = '[%s] ';
+const badgeFormat = '[%s]';
 const padLength = 1;
 const pad = ' ';
 

--- a/packages/react-server/src/ReactServerConsoleConfigServer.js
+++ b/packages/react-server/src/ReactServerConsoleConfigServer.js
@@ -53,7 +53,12 @@ export function unbadgeConsole(
     typeof badge === 'string'
   ) {
     // Remove our badging from the arguments.
-    args.splice(offset, 4, format.slice(badgeFormat.length));
+    let unbadgedFormat = format.slice(badgeFormat.length);
+    if (unbadgedFormat[0] === ' ') {
+      // Spacing added on the Client if the original argument was a string.
+      unbadgedFormat = unbadgedFormat.slice(1);
+    }
+    args.splice(offset, 4, unbadgedFormat);
     return badge.slice(padLength, badge.length - padLength);
   }
   return null;

--- a/packages/react-server/src/ReactServerConsoleConfigServer.js
+++ b/packages/react-server/src/ReactServerConsoleConfigServer.js
@@ -8,7 +8,7 @@
  */
 
 // Keep in sync with ReactClientConsoleConfig
-const badgeFormat = '\x1b[0m\x1b[7m%c%s\x1b[0m%c ';
+const badgeFormat = '\x1b[0m\x1b[7m%c%s\x1b[0m%c';
 // Same badge styling as DevTools.
 const badgeStyle =
   // We use a fixed background if light-dark is not supported, otherwise


### PR DESCRIPTION
Runtimes will put spacing between console arguments by themselves (checked with Chrome, Firefox, Safari and Node.js). React only needs to add spacing if it logs the badge and the original template string as a single argument.

Before:
<img width="596" height="102" alt="CleanShot 2025-07-21 at 17 57 28@2x" src="https://github.com/user-attachments/assets/921c9d5c-525b-47cf-bc7c-ed97f29ebb2d" />

After:

<img width="596" height="138" alt="CleanShot 2025-07-21 at 17 54 29@2x" src="https://github.com/user-attachments/assets/f460f932-0873-4f12-8051-37911fad0ddb" />
