### PR TITLE
[DevTools] Add a Code Editor Sidebar Pane in the Chrome Sources Tab

### DIFF
--- a/packages/react-devtools-extensions/src/main/index.js
+++ b/packages/react-devtools-extensions/src/main/index.js
@@ -326,7 +326,7 @@ function createSourcesEditorPanel() {
     editorPane = createdPane;
 
     createdPane.setPage('panel.html');
-    createdPane.setHeight('100px');
+    createdPane.setHeight('42px');
 
     createdPane.onShown.addListener(portal => {
       editorPortalContainer = portal.container;

--- a/packages/react-devtools-shared/src/devtools/views/ButtonLabel.css
+++ b/packages/react-devtools-shared/src/devtools/views/ButtonLabel.css
@@ -1,0 +1,7 @@
+.ButtonLabel {
+  padding-left: 1.5rem;
+  margin-left: -1rem;
+  user-select: none;
+  flex: 1 0 auto;
+  text-align: center;
+}

--- a/packages/react-devtools-shared/src/devtools/views/ButtonLabel.js
+++ b/packages/react-devtools-shared/src/devtools/views/ButtonLabel.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+
+import styles from './ButtonLabel.css';
+
+type Props = {
+  children: React$Node,
+};
+
+export default function ButtonLabel({children}: Props): React.Node {
+  return <span className={styles.ButtonLabel}>{children}</span>;
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/OpenInEditorButton.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/OpenInEditorButton.js
@@ -14,63 +14,13 @@ import ButtonIcon from 'react-devtools-shared/src/devtools/views/ButtonIcon';
 
 import type {ReactFunctionLocation} from 'shared/ReactTypes';
 
+import {checkConditions} from '../Editor/utils';
+
 type Props = {
   editorURL: string,
   source: ReactFunctionLocation,
   symbolicatedSourcePromise: Promise<ReactFunctionLocation | null>,
 };
-
-function checkConditions(
-  editorURL: string,
-  source: ReactFunctionLocation,
-): {url: URL | null, shouldDisableButton: boolean} {
-  try {
-    const url = new URL(editorURL);
-
-    const [, sourceURL, line] = source;
-    let filePath;
-
-    // Check if sourceURL is a correct URL, which has a protocol specified
-    if (sourceURL.startsWith('file:///')) {
-      filePath = new URL(sourceURL).pathname;
-    } else if (sourceURL.includes('://')) {
-      // $FlowFixMe[cannot-resolve-name]
-      if (!__IS_INTERNAL_VERSION__) {
-        // In this case, we can't really determine the path to a file, disable a button
-        return {url: null, shouldDisableButton: true};
-      } else {
-        const endOfSourceMapURLPattern = '.js/';
-        const endOfSourceMapURLIndex = sourceURL.lastIndexOf(
-          endOfSourceMapURLPattern,
-        );
-
-        if (endOfSourceMapURLIndex === -1) {
-          return {url: null, shouldDisableButton: true};
-        } else {
-          filePath = sourceURL.slice(
-            endOfSourceMapURLIndex + endOfSourceMapURLPattern.length,
-            sourceURL.length,
-          );
-        }
-      }
-    } else {
-      filePath = sourceURL;
-    }
-
-    const lineNumberAsString = String(line);
-
-    url.href = url.href
-      .replace('{path}', filePath)
-      .replace('{line}', lineNumberAsString)
-      .replace('%7Bpath%7D', filePath)
-      .replace('%7Bline%7D', lineNumberAsString);
-
-    return {url, shouldDisableButton: false};
-  } catch (e) {
-    // User has provided incorrect editor url
-    return {url: null, shouldDisableButton: true};
-  }
-}
 
 function OpenInEditorButton({
   editorURL,

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.js
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.js
@@ -52,6 +52,7 @@ import type {HookNamesModuleLoaderFunction} from 'react-devtools-shared/src/devt
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
 import type {BrowserTheme} from 'react-devtools-shared/src/frontend/types';
 import type {ReactFunctionLocation} from 'shared/ReactTypes';
+import type {SourceSelection} from './Editor/EditorPane';
 
 export type TabID = 'components' | 'profiler';
 
@@ -99,6 +100,7 @@ export type Props = {
   componentsPortalContainer?: Element,
   profilerPortalContainer?: Element,
   editorPortalContainer?: Element,
+  currentSelectedSource?: null | SourceSelection,
 
   // Loads and parses source maps for function components
   // and extracts hook "names" based on the variables the hook return values get assigned to.
@@ -130,6 +132,7 @@ export default function DevTools({
   componentsPortalContainer,
   profilerPortalContainer,
   editorPortalContainer,
+  currentSelectedSource,
   defaultTab = 'components',
   enabledInspectedElementContextMenu = false,
   fetchFileWithCaching,
@@ -321,6 +324,7 @@ export default function DevTools({
                                 </div>
                                 {editorPortalContainer ? (
                                   <EditorPane
+                                    selectedSource={currentSelectedSource}
                                     portalContainer={editorPortalContainer}
                                   />
                                 ) : null}

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.js
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.js
@@ -24,6 +24,7 @@ import {
 import Components from './Components/Components';
 import Profiler from './Profiler/Profiler';
 import TabBar from './TabBar';
+import EditorPane from './Editor/EditorPane';
 import {SettingsContextController} from './Settings/SettingsContext';
 import {TreeContextController} from './Components/TreeContext';
 import ViewElementSourceContext from './Components/ViewElementSourceContext';
@@ -97,6 +98,7 @@ export type Props = {
   // but individual tabs (e.g. Components, Profiling) can be rendered into portals within their browser panels.
   componentsPortalContainer?: Element,
   profilerPortalContainer?: Element,
+  editorPortalContainer?: Element,
 
   // Loads and parses source maps for function components
   // and extracts hook "names" based on the variables the hook return values get assigned to.
@@ -126,12 +128,13 @@ export default function DevTools({
   browserTheme = 'light',
   canViewElementSourceFunction,
   componentsPortalContainer,
+  profilerPortalContainer,
+  editorPortalContainer,
   defaultTab = 'components',
   enabledInspectedElementContextMenu = false,
   fetchFileWithCaching,
   hookNamesModuleLoaderFunction,
   overrideTab,
-  profilerPortalContainer,
   showTabBar = false,
   store,
   warnIfLegacyBackendDetected = false,
@@ -316,6 +319,11 @@ export default function DevTools({
                                     />
                                   </div>
                                 </div>
+                                {editorPortalContainer ? (
+                                  <EditorPane
+                                    portalContainer={editorPortalContainer}
+                                  />
+                                ) : null}
                               </ThemeProvider>
                             </InspectedElementContextController>
                           </TimelineContextController>

--- a/packages/react-devtools-shared/src/devtools/views/Editor/EditorPane.css
+++ b/packages/react-devtools-shared/src/devtools/views/Editor/EditorPane.css
@@ -1,0 +1,15 @@
+.EditorPane {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  background-color: var(--color-background);
+  color: var(--color-text);
+  font-family: var(--font-family-sans);
+}
+
+.EditorPane, .EditorPane * {
+  box-sizing: border-box;
+  -webkit-font-smoothing: var(--font-smoothing);
+}

--- a/packages/react-devtools-shared/src/devtools/views/Editor/EditorPane.css
+++ b/packages/react-devtools-shared/src/devtools/views/Editor/EditorPane.css
@@ -1,15 +1,28 @@
 .EditorPane {
   position: relative;
-  width: 100%;
-  height: 100%;
   display: flex;
   flex-direction: row;
   background-color: var(--color-background);
   color: var(--color-text);
   font-family: var(--font-family-sans);
+  align-items: center;
+  padding: 0.5rem;
 }
 
 .EditorPane, .EditorPane * {
   box-sizing: border-box;
   -webkit-font-smoothing: var(--font-smoothing);
+}
+
+.VRule {
+  height: 20px;
+  width: 1px;
+  flex: 0 0 1px;
+  margin: 0 0.5rem;
+  background-color: var(--color-border);
+}
+
+.WideButton {
+  flex: 1 0 auto;
+  display: flex;
 }

--- a/packages/react-devtools-shared/src/devtools/views/Editor/EditorPane.js
+++ b/packages/react-devtools-shared/src/devtools/views/Editor/EditorPane.js
@@ -8,15 +8,20 @@
  */
 
 import * as React from 'react';
-import {useSyncExternalStore} from 'react';
+import {useSyncExternalStore, useState, startTransition} from 'react';
 
 import portaledContent from '../portaledContent';
 
 import styles from './EditorPane.css';
 
+import Button from 'react-devtools-shared/src/devtools/views/Button';
+import ButtonIcon from 'react-devtools-shared/src/devtools/views/ButtonIcon';
+
 import OpenInEditorButton from './OpenInEditorButton';
 import {getOpenInEditorURL} from '../../../utils';
 import {LOCAL_STORAGE_OPEN_IN_EDITOR_URL} from '../../../constants';
+
+import EditorSettings from './EditorSettings';
 
 export type SourceSelection = {
   url: string,
@@ -30,6 +35,8 @@ export type SourceSelection = {
 export type Props = {selectedSource: ?SourceSelection};
 
 function EditorPane({selectedSource}: Props) {
+  const [showSettings, setShowSettings] = useState(false);
+
   const editorURL = useSyncExternalStore(
     function subscribe(callback) {
       window.addEventListener(LOCAL_STORAGE_OPEN_IN_EDITOR_URL, callback);
@@ -42,9 +49,34 @@ function EditorPane({selectedSource}: Props) {
     },
   );
 
+  if (showSettings) {
+    return (
+      <div className={styles.EditorPane}>
+        <EditorSettings />
+        <div className={styles.VRule} />
+        <Button onClick={() => startTransition(() => setShowSettings(false))}>
+          <ButtonIcon type="close" />
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <div className={styles.EditorPane}>
-      <OpenInEditorButton editorURL={editorURL} source={selectedSource} />
+      <OpenInEditorButton
+        className={styles.WideButton}
+        editorURL={editorURL}
+        source={selectedSource}
+      />
+      <div className={styles.VRule} />
+      <Button
+        onClick={() => startTransition(() => setShowSettings(true))}
+        // We don't use the title here because we don't have enough space to show it.
+        // Once we expand this pane we can add it.
+        // title="Configure code editor"
+      >
+        <ButtonIcon type="settings" />
+      </Button>
     </div>
   );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Editor/EditorPane.js
+++ b/packages/react-devtools-shared/src/devtools/views/Editor/EditorPane.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+import portaledContent from '../portaledContent';
+
+import styles from './EditorPane.css';
+
+function EditorPane(_: {}) {
+  return <div className={styles.EditorPane}>Hello World</div>;
+}
+export default (portaledContent(EditorPane): React$ComponentType<{}>);

--- a/packages/react-devtools-shared/src/devtools/views/Editor/EditorPane.js
+++ b/packages/react-devtools-shared/src/devtools/views/Editor/EditorPane.js
@@ -8,9 +8,15 @@
  */
 
 import * as React from 'react';
+import {useSyncExternalStore} from 'react';
+
 import portaledContent from '../portaledContent';
 
 import styles from './EditorPane.css';
+
+import OpenInEditorButton from './OpenInEditorButton';
+import {getOpenInEditorURL} from '../../../utils';
+import {LOCAL_STORAGE_OPEN_IN_EDITOR_URL} from '../../../constants';
 
 export type SourceSelection = {
   url: string,
@@ -21,7 +27,25 @@ export type SourceSelection = {
   },
 };
 
-function EditorPane(props: {selectedSource: ?SourceSelection}) {
-  return <div className={styles.EditorPane}>Hello World</div>;
+export type Props = {selectedSource: ?SourceSelection};
+
+function EditorPane({selectedSource}: Props) {
+  const editorURL = useSyncExternalStore(
+    function subscribe(callback) {
+      window.addEventListener(LOCAL_STORAGE_OPEN_IN_EDITOR_URL, callback);
+      return function unsubscribe() {
+        window.removeEventListener(LOCAL_STORAGE_OPEN_IN_EDITOR_URL, callback);
+      };
+    },
+    function getState() {
+      return getOpenInEditorURL();
+    },
+  );
+
+  return (
+    <div className={styles.EditorPane}>
+      <OpenInEditorButton editorURL={editorURL} source={selectedSource} />
+    </div>
+  );
 }
 export default (portaledContent(EditorPane): React$ComponentType<{}>);

--- a/packages/react-devtools-shared/src/devtools/views/Editor/EditorPane.js
+++ b/packages/react-devtools-shared/src/devtools/views/Editor/EditorPane.js
@@ -12,7 +12,16 @@ import portaledContent from '../portaledContent';
 
 import styles from './EditorPane.css';
 
-function EditorPane(_: {}) {
+export type SourceSelection = {
+  url: string,
+  // The selection is a ref so that we don't have to rerender every keystroke.
+  selectionRef: {
+    line: number,
+    column: number,
+  },
+};
+
+function EditorPane(props: {selectedSource: ?SourceSelection}) {
   return <div className={styles.EditorPane}>Hello World</div>;
 }
 export default (portaledContent(EditorPane): React$ComponentType<{}>);

--- a/packages/react-devtools-shared/src/devtools/views/Editor/EditorSettings.css
+++ b/packages/react-devtools-shared/src/devtools/views/Editor/EditorSettings.css
@@ -2,3 +2,8 @@
   display: flex;
   flex: 1 0 auto;
 }
+
+.EditorLabel {
+  display: inline;
+  margin-right: 0.5rem;
+}

--- a/packages/react-devtools-shared/src/devtools/views/Editor/EditorSettings.css
+++ b/packages/react-devtools-shared/src/devtools/views/Editor/EditorSettings.css
@@ -1,0 +1,4 @@
+.EditorSettings {
+  display: flex;
+  flex: 1 0 auto;
+}

--- a/packages/react-devtools-shared/src/devtools/views/Editor/EditorSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Editor/EditorSettings.js
@@ -11,10 +11,19 @@ import * as React from 'react';
 
 import styles from './EditorSettings.css';
 
+import CodeEditorOptions from '../Settings/CodeEditorOptions';
+
 type Props = {};
 
 function EditorSettings(_: Props): React.Node {
-  return <div className={styles.EditorSettings}>Settings</div>;
+  return (
+    <div className={styles.EditorSettings}>
+      <label>
+        <div className={styles.EditorLabel}>Editor</div>
+        <CodeEditorOptions />
+      </label>
+    </div>
+  );
 }
 
 export default EditorSettings;

--- a/packages/react-devtools-shared/src/devtools/views/Editor/EditorSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Editor/EditorSettings.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+
+import styles from './EditorSettings.css';
+
+type Props = {};
+
+function EditorSettings(_: Props): React.Node {
+  return <div className={styles.EditorSettings}>Settings</div>;
+}
+
+export default EditorSettings;

--- a/packages/react-devtools-shared/src/devtools/views/Editor/OpenInEditorButton.js
+++ b/packages/react-devtools-shared/src/devtools/views/Editor/OpenInEditorButton.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import Button from 'react-devtools-shared/src/devtools/views/Button';
 import ButtonIcon from 'react-devtools-shared/src/devtools/views/ButtonIcon';
+import ButtonLabel from 'react-devtools-shared/src/devtools/views/ButtonLabel';
 
 import type {SourceSelection} from './EditorPane';
 import type {ReactFunctionLocation} from 'shared/ReactTypes';
@@ -20,9 +21,10 @@ import {checkConditions} from './utils';
 type Props = {
   editorURL: string,
   source: ?SourceSelection,
+  className?: string,
 };
 
-function OpenInEditorButton({editorURL, source}: Props): React.Node {
+function OpenInEditorButton({editorURL, source, className}: Props): React.Node {
   let disable;
   if (source == null) {
     disable = true;
@@ -40,6 +42,7 @@ function OpenInEditorButton({editorURL, source}: Props): React.Node {
   return (
     <Button
       disabled={disable}
+      className={className}
       onClick={() => {
         if (source == null) {
           return;
@@ -58,9 +61,9 @@ function OpenInEditorButton({editorURL, source}: Props): React.Node {
         if (!shouldDisableButton) {
           window.open(url);
         }
-      }}
-      title="Open in editor">
-      <ButtonIcon type="editor" /> Open in editor
+      }}>
+      <ButtonIcon type="editor" />
+      <ButtonLabel>Open in editor</ButtonLabel>
     </Button>
   );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Editor/OpenInEditorButton.js
+++ b/packages/react-devtools-shared/src/devtools/views/Editor/OpenInEditorButton.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+
+import Button from 'react-devtools-shared/src/devtools/views/Button';
+import ButtonIcon from 'react-devtools-shared/src/devtools/views/ButtonIcon';
+
+import type {SourceSelection} from './EditorPane';
+import type {ReactFunctionLocation} from 'shared/ReactTypes';
+
+import {checkConditions} from './utils';
+
+type Props = {
+  editorURL: string,
+  source: ?SourceSelection,
+};
+
+function OpenInEditorButton({editorURL, source}: Props): React.Node {
+  let disable;
+  if (source == null) {
+    disable = true;
+  } else {
+    const staleLocation: ReactFunctionLocation = [
+      '',
+      source.url,
+      // This is not live but we just use any line/column to validate whether this can be opened.
+      // We'll call checkConditions again when we click it to get the latest line number.
+      source.selectionRef.line,
+      source.selectionRef.column,
+    ];
+    disable = checkConditions(editorURL, staleLocation).shouldDisableButton;
+  }
+  return (
+    <Button
+      disabled={disable}
+      onClick={() => {
+        if (source == null) {
+          return;
+        }
+        const latestLocation: ReactFunctionLocation = [
+          '',
+          source.url,
+          // These might have changed since we last read it.
+          source.selectionRef.line,
+          source.selectionRef.column,
+        ];
+        const {url, shouldDisableButton} = checkConditions(
+          editorURL,
+          latestLocation,
+        );
+        if (!shouldDisableButton) {
+          window.open(url);
+        }
+      }}
+      title="Open in editor">
+      <ButtonIcon type="editor" /> Open in editor
+    </Button>
+  );
+}
+
+export default OpenInEditorButton;

--- a/packages/react-devtools-shared/src/devtools/views/Editor/utils.js
+++ b/packages/react-devtools-shared/src/devtools/views/Editor/utils.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ReactFunctionLocation} from 'shared/ReactTypes';
+
+export function checkConditions(
+  editorURL: string,
+  source: ReactFunctionLocation,
+): {url: URL | null, shouldDisableButton: boolean} {
+  try {
+    const url = new URL(editorURL);
+
+    const [, sourceURL, line] = source;
+    let filePath;
+
+    // Check if sourceURL is a correct URL, which has a protocol specified
+    if (sourceURL.startsWith('file:///')) {
+      filePath = new URL(sourceURL).pathname;
+    } else if (sourceURL.includes('://')) {
+      // $FlowFixMe[cannot-resolve-name]
+      if (!__IS_INTERNAL_VERSION__) {
+        // In this case, we can't really determine the path to a file, disable a button
+        return {url: null, shouldDisableButton: true};
+      } else {
+        const endOfSourceMapURLPattern = '.js/';
+        const endOfSourceMapURLIndex = sourceURL.lastIndexOf(
+          endOfSourceMapURLPattern,
+        );
+
+        if (endOfSourceMapURLIndex === -1) {
+          return {url: null, shouldDisableButton: true};
+        } else {
+          filePath = sourceURL.slice(
+            endOfSourceMapURLIndex + endOfSourceMapURLPattern.length,
+            sourceURL.length,
+          );
+        }
+      }
+    } else {
+      filePath = sourceURL;
+    }
+
+    const lineNumberAsString = String(line);
+
+    url.href = url.href
+      .replace('{path}', filePath)
+      .replace('{line}', lineNumberAsString)
+      .replace('%7Bpath%7D', filePath)
+      .replace('%7Bline%7D', lineNumberAsString);
+
+    return {url, shouldDisableButton: false};
+  } catch (e) {
+    // User has provided incorrect editor url
+    return {url: null, shouldDisableButton: true};
+  }
+}

--- a/packages/react-devtools-shared/src/devtools/views/Settings/CodeEditorOptions.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/CodeEditorOptions.js
@@ -34,8 +34,7 @@ export default function ComponentsSettings({
   );
 
   return (
-    <label className={styles.OpenInURLSetting}>
-      Open in Editor URL:{' '}
+    <>
       <select
         value={openInEditorURLPreset}
         onChange={({currentTarget}) => {
@@ -61,6 +60,6 @@ export default function ComponentsSettings({
           }}
         />
       )}
-    </label>
+    </>
   );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Settings/CodeEditorOptions.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/CodeEditorOptions.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+import {
+  LOCAL_STORAGE_OPEN_IN_EDITOR_URL,
+  LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PRESET,
+} from '../../../constants';
+import {useLocalStorage} from '../hooks';
+import {getDefaultOpenInEditorURL} from 'react-devtools-shared/src/utils';
+
+import styles from './SettingsShared.css';
+
+const vscodeFilepath = 'vscode://file/{path}:{line}';
+
+export default function ComponentsSettings({
+  environmentNames,
+}: {
+  environmentNames: Promise<Array<string>>,
+}): React.Node {
+  const [openInEditorURLPreset, setOpenInEditorURLPreset] = useLocalStorage<
+    'vscode' | 'custom',
+  >(LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PRESET, 'custom');
+
+  const [openInEditorURL, setOpenInEditorURL] = useLocalStorage<string>(
+    LOCAL_STORAGE_OPEN_IN_EDITOR_URL,
+    getDefaultOpenInEditorURL(),
+  );
+
+  return (
+    <label className={styles.OpenInURLSetting}>
+      Open in Editor URL:{' '}
+      <select
+        value={openInEditorURLPreset}
+        onChange={({currentTarget}) => {
+          const selectedValue = currentTarget.value;
+          setOpenInEditorURLPreset(selectedValue);
+          if (selectedValue === 'vscode') {
+            setOpenInEditorURL(vscodeFilepath);
+          } else if (selectedValue === 'custom') {
+            setOpenInEditorURL('');
+          }
+        }}>
+        <option value="vscode">VS Code</option>
+        <option value="custom">Custom</option>
+      </select>
+      {openInEditorURLPreset === 'custom' && (
+        <input
+          className={styles.Input}
+          type="text"
+          placeholder={process.env.EDITOR_URL ? process.env.EDITOR_URL : ''}
+          value={openInEditorURL}
+          onChange={event => {
+            setOpenInEditorURL(event.target.value);
+          }}
+        />
+      )}
+    </label>
+  );
+}

--- a/packages/react-devtools-shared/src/devtools/views/Settings/ComponentsSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/ComponentsSettings.js
@@ -23,7 +23,6 @@ import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import Toggle from '../Toggle';
 import {SettingsContext} from '../Settings/SettingsContext';
-import CodeEditorOptions from './CodeEditorOptions';
 import {
   ComponentFilterDisplayName,
   ComponentFilterElementType,
@@ -350,8 +349,6 @@ export default function ComponentsSettings({
           <span className={styles.Warning}>(may be slow)</span>
         </label>
       </div>
-
-      <CodeEditorOptions />
 
       <div className={styles.Header}>Hide components where...</div>
 

--- a/packages/react-devtools-shared/src/devtools/views/Settings/ComponentsSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/ComponentsSettings.js
@@ -17,16 +17,13 @@ import {
   useState,
   use,
 } from 'react';
-import {
-  LOCAL_STORAGE_OPEN_IN_EDITOR_URL,
-  LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PRESET,
-} from '../../../constants';
-import {useLocalStorage, useSubscription} from '../hooks';
+import {useSubscription} from '../hooks';
 import {StoreContext} from '../context';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import Toggle from '../Toggle';
 import {SettingsContext} from '../Settings/SettingsContext';
+import CodeEditorOptions from './CodeEditorOptions';
 import {
   ComponentFilterDisplayName,
   ComponentFilterElementType,
@@ -45,7 +42,6 @@ import {
   ElementTypeActivity,
   ElementTypeViewTransition,
 } from 'react-devtools-shared/src/frontend/types';
-import {getDefaultOpenInEditorURL} from 'react-devtools-shared/src/utils';
 
 import styles from './SettingsShared.css';
 
@@ -59,8 +55,6 @@ import type {
   EnvironmentNameComponentFilter,
 } from 'react-devtools-shared/src/frontend/types';
 import {isInternalFacebookBuild} from 'react-devtools-feature-flags';
-
-const vscodeFilepath = 'vscode://file/{path}:{line}';
 
 export default function ComponentsSettings({
   environmentNames,
@@ -96,15 +90,6 @@ export default function ComponentsSettings({
       setParseHookNames(currentTarget.checked);
     },
     [setParseHookNames],
-  );
-
-  const [openInEditorURLPreset, setOpenInEditorURLPreset] = useLocalStorage<
-    'vscode' | 'custom',
-  >(LOCAL_STORAGE_OPEN_IN_EDITOR_URL_PRESET, 'custom');
-
-  const [openInEditorURL, setOpenInEditorURL] = useLocalStorage<string>(
-    LOCAL_STORAGE_OPEN_IN_EDITOR_URL,
-    getDefaultOpenInEditorURL(),
   );
 
   const [componentFilters, setComponentFilters] = useState<
@@ -366,34 +351,7 @@ export default function ComponentsSettings({
         </label>
       </div>
 
-      <label className={styles.OpenInURLSetting}>
-        Open in Editor URL:{' '}
-        <select
-          value={openInEditorURLPreset}
-          onChange={({currentTarget}) => {
-            const selectedValue = currentTarget.value;
-            setOpenInEditorURLPreset(selectedValue);
-            if (selectedValue === 'vscode') {
-              setOpenInEditorURL(vscodeFilepath);
-            } else if (selectedValue === 'custom') {
-              setOpenInEditorURL('');
-            }
-          }}>
-          <option value="vscode">VS Code</option>
-          <option value="custom">Custom</option>
-        </select>
-        {openInEditorURLPreset === 'custom' && (
-          <input
-            className={styles.Input}
-            type="text"
-            placeholder={process.env.EDITOR_URL ? process.env.EDITOR_URL : ''}
-            value={openInEditorURL}
-            onChange={event => {
-              setOpenInEditorURL(event.target.value);
-            }}
-          />
-        )}
-      </label>
+      <CodeEditorOptions />
 
       <div className={styles.Header}>Hide components where...</div>
 

--- a/packages/react-devtools-shared/src/devtools/views/Settings/GeneralSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/GeneralSettings.js
@@ -13,6 +13,7 @@ import {SettingsContext} from './SettingsContext';
 import {StoreContext} from '../context';
 import {CHANGE_LOG_URL} from 'react-devtools-shared/src/devtools/constants';
 import {isInternalFacebookBuild} from 'react-devtools-feature-flags';
+import CodeEditorOptions from './CodeEditorOptions';
 
 import styles from './SettingsShared.css';
 
@@ -74,6 +75,13 @@ export default function GeneralSettings(_: {}): React.Node {
           <option value="compact">Compact</option>
           <option value="comfortable">Comfortable</option>
         </select>
+      </div>
+
+      <div className={styles.SettingWrapper}>
+        <label className={styles.SettingRow}>
+          <div className={styles.RadioLabel}>Open in Editor URL</div>
+          <CodeEditorOptions />
+        </label>
       </div>
 
       {supportsTraceUpdates && (

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsShared.css
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsShared.css
@@ -26,10 +26,6 @@
   margin: 0.125rem 0.25rem 0.125rem 0;
 }
 
-.OpenInURLSetting {
-  margin: 0.5rem 0;
-}
-
 .OptionGroup {
   display: inline-flex;
   flex-direction: row;


### PR DESCRIPTION
This adds a "Code Editor" pane for the Chrome extension in the bottom right corner of the "Sources" panel. If you end up getting linked to the "Sources" panel from stack traces in console, performance tab, stacks in React Component tab like the one added in #33954 basically everywhere there's a link to source code. Then going from there to open in a code editor should be more convenient. This adds a button to open the current file.

<img width="1387" height="389" alt="Screenshot 2025-07-22 at 10 22 19 PM" src="https://github.com/user-attachments/assets/fe01f84c-83c2-4639-9b64-4af1a90c3f7d" />

This only makes sense in the extensions since in standalone it needs to always open by default in an editor. Unfortunately Firefox doesn't support extending the Sources panel.

Chrome is also a bit buggy where it doesn't send a selection update event when you switch tabs in the Sources panel. Only when the actual cursor position changes. This means that the link can be lagging behind sometimes. We also have some general bugs where if React DevTools loses connection it can break the UI which includes this pane too.

This has a small inline configuration too so that it's discoverable:

<img width="559" height="143" alt="Screenshot 2025-07-22 at 10 22 42 PM" src="https://github.com/user-attachments/assets/1270bda8-ce10-4f9d-9fcb-080c0198366a" />

<img width="527" height="123" alt="Screenshot 2025-07-22 at 10 22 30 PM" src="https://github.com/user-attachments/assets/45848c95-afd8-495f-a7cf-eb2f46e698f2" />

Since we can't add a separate link to open-in-editor or open-in-sources everywhere I plan on adding an option to open in editor by default in a follow up. That option needs to be even more discoverable.

I moved the configuration from the Components settings to the General settings since this is now a much more general features for opening links to resources in all types of panes.

<img width="673" height="311" alt="Screenshot 2025-07-22 at 10 22 57 PM" src="https://github.com/user-attachments/assets/ea2c0871-942c-4b55-a362-025835d2c2bd" />