### PR TITLE
[Flight] `module.findSourceMap` compatible source URLs when `findSourceMapURL` is not implemented

### DIFF
--- a/fixtures/flight/src/App.js
+++ b/fixtures/flight/src/App.js
@@ -21,9 +21,10 @@ import {Note} from './cjs/Note.js';
 
 import {GenerateImage} from './GenerateImage.js';
 
-import {like, greet, increment} from './actions.js';
+import {like, greet, increment, triggerServerReplayError} from './actions.js';
 
 import {getServerState} from './ServerState.js';
+import {ReplayServerErrorOnDemand} from './ReplayServerErrorOnDemand.js';
 
 const promisedText = new Promise(resolve =>
   setTimeout(() => resolve('deferred text'), 50)
@@ -149,6 +150,7 @@ export default async function App({prerender, noCache}) {
           <Counter incrementAction={increment} />
           <Counter2 incrementAction={increment} />
           <Counter3 incrementAction={increment} />
+          <ReplayServerErrorOnDemand action={triggerServerReplayError} />
           <ul>
             {todos.map(todo => (
               <li key={todo.id}>{todo.text}</li>

--- a/fixtures/flight/src/ReplayServerErrorOnDemand.js
+++ b/fixtures/flight/src/ReplayServerErrorOnDemand.js
@@ -1,0 +1,13 @@
+'use client';
+
+import * as React from 'react';
+
+export function ReplayServerErrorOnDemand({action}) {
+  const [children, formAction] = React.useActionState(action, null);
+  return (
+    <form>
+      <button formAction={formAction}>Trigger</button>
+      {children}
+    </form>
+  );
+}

--- a/fixtures/flight/src/[root of the server]/page.js
+++ b/fixtures/flight/src/[root of the server]/page.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export function Page({slug}) {
+  console.log(new Error(slug));
+
+  return <p>{slug}</p>;
+}

--- a/fixtures/flight/src/actions.js
+++ b/fixtures/flight/src/actions.js
@@ -1,6 +1,8 @@
 'use server';
 
+import * as React from 'react';
 import {setServerState} from './ServerState.js';
+import {Page} from './[root of the server]/page.js';
 
 async function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -29,4 +31,8 @@ export async function increment(n) {
   // Test loading state
   await sleep(1000);
   return n + 1;
+}
+
+export function triggerServerReplayError() {
+  return <Page slug="server-replay-error" />;
 }

--- a/packages/react-client/src/ReactClientStackConfigBun.js
+++ b/packages/react-client/src/ReactClientStackConfigBun.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+export {getSourceURL} from './ReactClientStackConfigNode';

--- a/packages/react-client/src/ReactClientStackConfigNode.js
+++ b/packages/react-client/src/ReactClientStackConfigNode.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+import {pathToFileURL, URL} from 'url';
+
+// Compatible with Bun which implements the `url` module.
+export function getSourceURL(stackFilename: string): string {
+  const leadingURLProtocol = /^\w+:\/\//;
+  if (!leadingURLProtocol.test(stackFilename)) {
+    // Node.js will key absolute file paths like this in their sourcemap cache.
+    try {
+      // This will throw on invalid paths.
+      return pathToFileURL(stackFilename).href;
+    } catch {}
+  } else {
+    try {
+      // avoid over-encoding if the stackFilename is already a valid URL.
+      return new URL(stackFilename).toString();
+    } catch {}
+  }
+  return encodeURI(stackFilename);
+}

--- a/packages/react-client/src/ReactClientStackConfigWeb.js
+++ b/packages/react-client/src/ReactClientStackConfigWeb.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export function getSourceURL(stackFilename: string): string {
+  if (stackFilename.startsWith('/')) {
+    // If the filename starts with `/` we assume that it is a file system file
+    // rather than relative to the current host. Since on the server fully qualified
+    // stack traces use the file path.
+    // TODO: What does this look like on Windows?
+    try {
+      return new URL('file://' + stackFilename).toString();
+    } catch {}
+  } else {
+    try {
+      // avoid over-encoding if the stackFilename is already a valid URL.
+      return new URL(stackFilename).toString();
+    } catch {}
+  }
+  return encodeURI(stackFilename);
+}

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -52,6 +52,7 @@ import {
 } from 'shared/ReactFeatureFlags';
 
 import {
+  getSourceURL,
   resolveClientReference,
   resolveServerReference,
   preloadModule,
@@ -2752,14 +2753,6 @@ function createFakeFunction<T>(
     code = comment + code;
   }
 
-  if (filename.startsWith('/')) {
-    // If the filename starts with `/` we assume that it is a file system file
-    // rather than relative to the current host. Since on the server fully qualified
-    // stack traces use the file path.
-    // TODO: What does this look like on Windows?
-    filename = 'file://' + filename;
-  }
-
   if (sourceMap) {
     // We use the prefix rsc://React/ to separate these from other files listed in
     // the Chrome DevTools. We need a "host name" and not just a protocol because
@@ -2777,7 +2770,7 @@ function createFakeFunction<T>(
       fakeFunctionIdx++;
     code += '\n//# sourceMappingURL=' + sourceMap;
   } else if (filename) {
-    code += '\n//# sourceURL=' + encodeURI(filename);
+    code += '\n//# sourceURL=' + getSourceURL(filename);
   } else {
     code += '\n//# sourceURL=<anonymous>';
   }

--- a/packages/react-client/src/ReactFlightReplyClient.js
+++ b/packages/react-client/src/ReactFlightReplyClient.js
@@ -39,7 +39,7 @@ import getPrototypeOf from 'shared/getPrototypeOf';
 
 const ObjectPrototype = Object.prototype;
 
-import {usedWithSSR} from './ReactFlightClientConfig';
+import {getSourceURL, usedWithSSR} from './ReactFlightClientConfig';
 
 type ReactJSONValue =
   | string
@@ -1086,14 +1086,6 @@ function createFakeServerFunction<A: Iterable<any>, T>(
       '})';
   }
 
-  if (filename.startsWith('/')) {
-    // If the filename starts with `/` we assume that it is a file system file
-    // rather than relative to the current host. Since on the server fully qualified
-    // stack traces use the file path.
-    // TODO: What does this look like on Windows?
-    filename = 'file://' + filename;
-  }
-
   if (sourceMap) {
     // We use the prefix rsc://React/ to separate these from other files listed in
     // the Chrome DevTools. We need a "host name" and not just a protocol because
@@ -1111,7 +1103,7 @@ function createFakeServerFunction<A: Iterable<any>, T>(
       fakeServerFunctionIdx++;
     code += '\n//# sourceMappingURL=' + sourceMap;
   } else if (filename) {
-    code += '\n//# sourceURL=' + filename;
+    code += '\n//# sourceURL=' + getSourceURL(filename);
   }
 
   try {

--- a/packages/react-client/src/forks/ReactFlightClientConfig.custom.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.custom.js
@@ -52,3 +52,5 @@ export const bindToConsole = $$$config.bindToConsole;
 
 export const rendererVersion = $$$config.rendererVersion;
 export const rendererPackageName = $$$config.rendererPackageName;
+
+export const getSourceURL = $$$config.getSourceURL;

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser-esm.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser-esm.js
@@ -10,6 +10,7 @@
 export {default as rendererVersion} from 'shared/ReactVersion';
 export const rendererPackageName = 'react-server-dom-esm';
 
+export * from 'react-client/src/ReactClientStackConfigWeb';
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
 export * from 'react-client/src/ReactClientConsoleConfigBrowser';
 export * from 'react-server-dom-esm/src/client/ReactFlightClientConfigBundlerESM';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser-parcel.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser-parcel.js
@@ -10,6 +10,7 @@
 export {default as rendererVersion} from 'shared/ReactVersion';
 export const rendererPackageName = 'react-server-dom-parcel';
 
+export * from 'react-client/src/ReactClientStackConfigWeb';
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
 export * from 'react-client/src/ReactClientConsoleConfigBrowser';
 export * from 'react-server-dom-parcel/src/client/ReactFlightClientConfigBundlerParcel';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser-turbopack.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser-turbopack.js
@@ -10,6 +10,7 @@
 export {default as rendererVersion} from 'shared/ReactVersion';
 export const rendererPackageName = 'react-server-dom-turbopack';
 
+export * from 'react-client/src/ReactClientStackConfigWeb';
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
 export * from 'react-client/src/ReactClientConsoleConfigBrowser';
 export * from 'react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopack';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-browser.js
@@ -10,6 +10,7 @@
 export {default as rendererVersion} from 'shared/ReactVersion';
 export const rendererPackageName = 'react-server-dom-webpack';
 
+export * from 'react-client/src/ReactClientStackConfigWeb';
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
 export * from 'react-client/src/ReactClientConsoleConfigBrowser';
 export * from 'react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpack';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-bun.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-bun.js
@@ -10,6 +10,7 @@
 export {default as rendererVersion} from 'shared/ReactVersion';
 export const rendererPackageName = 'react-server-dom-bun';
 
+export * from 'react-client/src/ReactClientStackConfigBun';
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
 export * from 'react-client/src/ReactClientConsoleConfigPlain';
 export * from 'react-dom-bindings/src/shared/ReactFlightClientConfigDOM';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-parcel.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-parcel.js
@@ -10,6 +10,7 @@
 export {default as rendererVersion} from 'shared/ReactVersion';
 export const rendererPackageName = 'react-server-dom-parcel';
 
+export * from 'react-client/src/ReactClientStackConfigWeb';
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
 export * from 'react-client/src/ReactClientConsoleConfigServer';
 export * from 'react-server-dom-parcel/src/client/ReactFlightClientConfigBundlerParcel';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-turbopack.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-turbopack.js
@@ -10,6 +10,7 @@
 export {default as rendererVersion} from 'shared/ReactVersion';
 export const rendererPackageName = 'react-server-dom-turbopack';
 
+export * from 'react-client/src/ReactClientStackConfigWeb';
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
 export * from 'react-client/src/ReactClientConsoleConfigServer';
 export * from 'react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopack';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-webpack.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-edge-webpack.js
@@ -10,6 +10,7 @@
 export {default as rendererVersion} from 'shared/ReactVersion';
 export const rendererPackageName = 'react-server-dom-webpack';
 
+export * from 'react-client/src/ReactClientStackConfigWeb';
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
 export * from 'react-client/src/ReactClientConsoleConfigServer';
 export * from 'react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpack';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-legacy.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-legacy.js
@@ -10,6 +10,7 @@
 export {default as rendererVersion} from 'shared/ReactVersion';
 export const rendererPackageName = 'not-used';
 
+export * from 'react-client/src/ReactClientStackConfigWeb';
 export * from 'react-client/src/ReactFlightClientStreamConfigWeb';
 export * from 'react-client/src/ReactClientConsoleConfigBrowser';
 

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-esm.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-esm.js
@@ -10,6 +10,7 @@
 export {default as rendererVersion} from 'shared/ReactVersion';
 export const rendererPackageName = 'react-server-dom-esm';
 
+export * from 'react-client/src/ReactClientStackConfigNode';
 export * from 'react-client/src/ReactFlightClientStreamConfigNode';
 export * from 'react-client/src/ReactClientConsoleConfigServer';
 export * from 'react-server-dom-esm/src/client/ReactFlightClientConfigBundlerESM';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-parcel.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-parcel.js
@@ -10,6 +10,7 @@
 export {default as rendererVersion} from 'shared/ReactVersion';
 export const rendererPackageName = 'react-server-dom-parcel';
 
+export * from 'react-client/src/ReactClientStackConfigNode';
 export * from 'react-client/src/ReactFlightClientStreamConfigNode';
 export * from 'react-client/src/ReactClientConsoleConfigServer';
 export * from 'react-server-dom-parcel/src/client/ReactFlightClientConfigBundlerParcel';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-turbopack.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-turbopack.js
@@ -10,6 +10,7 @@
 export {default as rendererVersion} from 'shared/ReactVersion';
 export const rendererPackageName = 'react-server-dom-turbopack';
 
+export * from 'react-client/src/ReactClientStackConfigNode';
 export * from 'react-client/src/ReactFlightClientStreamConfigNode';
 export * from 'react-client/src/ReactClientConsoleConfigServer';
 export * from 'react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopack';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-webpack.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-node-webpack.js
@@ -9,6 +9,7 @@
 export {default as rendererVersion} from 'shared/ReactVersion';
 export const rendererPackageName = 'react-server-dom-webpack';
 
+export * from 'react-client/src/ReactClientStackConfigNode';
 export * from 'react-client/src/ReactFlightClientStreamConfigNode';
 export * from 'react-client/src/ReactClientConsoleConfigServer';
 export * from 'react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpack';

--- a/packages/react-client/src/forks/ReactFlightClientConfig.dom-node.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.dom-node.js
@@ -10,6 +10,7 @@
 export {default as rendererVersion} from 'shared/ReactVersion';
 export const rendererPackageName = 'react-server-dom-webpack';
 
+export * from 'react-client/src/ReactClientStackConfigNode';
 export * from 'react-client/src/ReactFlightClientStreamConfigNode';
 export * from 'react-client/src/ReactClientConsoleConfigServer';
 export * from 'react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerNode';

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -460,7 +460,7 @@ const bundles = [
     global: 'ReactServerDOMServer',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
-    externals: ['react', 'util', 'crypto', 'async_hooks', 'react-dom'],
+    externals: ['react', 'url', 'util', 'crypto', 'async_hooks', 'react-dom'],
   },
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
@@ -472,7 +472,7 @@ const bundles = [
     global: 'ReactServerDOMServer',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
-    externals: ['react', 'util', 'crypto', 'async_hooks', 'react-dom'],
+    externals: ['react', 'url', 'util', 'crypto', 'async_hooks', 'react-dom'],
   },
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
@@ -506,7 +506,7 @@ const bundles = [
     global: 'ReactServerDOMClient',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
-    externals: ['react', 'react-dom', 'util', 'crypto'],
+    externals: ['react', 'react-dom', 'url', 'util', 'crypto'],
   },
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
@@ -517,7 +517,7 @@ const bundles = [
     global: 'ReactServerDOMClient',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
-    externals: ['react', 'react-dom', 'util', 'crypto'],
+    externals: ['react', 'react-dom', 'url', 'util', 'crypto'],
   },
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
@@ -588,7 +588,7 @@ const bundles = [
     global: 'ReactServerDOMServer',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
-    externals: ['react', 'util', 'async_hooks', 'react-dom'],
+    externals: ['react', 'url', 'util', 'async_hooks', 'react-dom'],
   },
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
@@ -622,7 +622,7 @@ const bundles = [
     global: 'ReactServerDOMClient',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
-    externals: ['react', 'react-dom', 'util'],
+    externals: ['react', 'react-dom', 'url', 'util'],
   },
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
@@ -656,7 +656,7 @@ const bundles = [
     global: 'ReactServerDOMServer',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
-    externals: ['react', 'util', 'async_hooks', 'react-dom'],
+    externals: ['react', 'url', 'util', 'async_hooks', 'react-dom'],
   },
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
@@ -729,7 +729,7 @@ const bundles = [
     entry: 'react-server-dom-esm/client.node',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
-    externals: ['react', 'react-dom', 'util', 'crypto'],
+    externals: ['react', 'react-dom', 'url', 'util', 'crypto'],
   },
 
   /******* React Server DOM ESM Node.js Loader *******/


### PR DESCRIPTION
Implementing `findSourceMapURL` is still preferred since it prevents debuggers from overriding the source in the sources panel

When Client and Server run in the same VM, the Client could reuse the original source URL to get the source map. This isn't possible at the moment since React alters the value from `StructuredCallSite#getScriptNameOrSourceURL` in a way that is incompatible with how Node.js uses this value as a key in its internal source map cache. This mostly works for files with just alphanumeric characters. But it breaks when e.g. square brackets or spaces are used in file paths.

The only alternative in Node.js is implementing `findSourceMapURL` by getting the source map payload based on the original source URL and serializing that into a `data:` URL. Not only is this wasteful due to the added serialization+deserialization step, it also significantly increases memory consumption since Node.js holds onto source maps forever and doesn't deduplicate sourcemaps on source mapping URLs. Deduplication based on source map URLs is definitely something we should contribute upstream regardless. GCing source maps may be more involved. And then we'd still have the overhead of added serialization+deserialization. 



Alternate to https://github.com/facebook/react/pull/33731