### PR TITLE
[Flight] Properly close stream when no chunks need to be written after prerender

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -5762,6 +5762,7 @@ function flushCompletedChunks(request: Request): void {
           // TODO: If this destination is not currently flowing we'll not close it when it resumes flowing.
           // We should keep a separate status for this.
           if (request.destination !== null) {
+            request.status = CLOSED;
             close(request.destination);
             request.destination = null;
           }
@@ -5779,8 +5780,8 @@ function flushCompletedChunks(request: Request): void {
       );
       request.cacheController.abort(abortReason);
     }
-    request.status = CLOSED;
     if (request.destination !== null) {
+      request.status = CLOSED;
       close(request.destination);
       request.destination = null;
     }


### PR DESCRIPTION
There is an edge case when prerendering where if you have nothing to write you can end up in a state where the prerender is in status closed before you can provide a destination. In this case the destination is never closed becuase it assumes it already would have been.

This condition can happen now because of the introduction of the deubg stream. Before this a request would never entere closed status if there was no active destination. When a destination was added it would perform a flush and possibly close the stream. Now, it is possible to flush without a destination because you might have debug chunks to stream and you can end up closing the stream independent of an active destination.

There are a number of ways we can solve this but the one that seems to adhere best to the original design is to only set the status to CLOSED when a destination is active. This means that if you don't have an active destination when the pendingChunks count hits zero it will not enter CLOSED status until you startFlowing.