### PR TITLE
[DevTools] Feature detect sources panel

### DIFF
--- a/packages/react-devtools-extensions/src/main/index.js
+++ b/packages/react-devtools-extensions/src/main/index.js
@@ -111,7 +111,7 @@ function createBridge() {
     chrome.devtools.panels.elements.onSelectionChanged.removeListener(
       onBrowserElementSelectionChanged,
     );
-    if (sourcesPanel) {
+    if (sourcesPanel && sourcesPanel.onSelectionChanged) {
       currentSelectedSource = null;
       sourcesPanel.onSelectionChanged.removeListener(
         onBrowserSourceSelectionChanged,
@@ -124,7 +124,7 @@ function createBridge() {
   chrome.devtools.panels.elements.onSelectionChanged.addListener(
     onBrowserElementSelectionChanged,
   );
-  if (sourcesPanel) {
+  if (sourcesPanel && sourcesPanel.onSelectionChanged) {
     sourcesPanel.onSelectionChanged.addListener(
       onBrowserSourceSelectionChanged,
     );


### PR DESCRIPTION
I broke Firefox DevTools extension in #33968.

It turns out the Firefox has a placeholder object for the sources panel which is empty. We need to detect the actual event handler.