### PR TITLE
[DevTools] Add column to vscode editor preset

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Editor/utils.js
+++ b/packages/react-devtools-shared/src/devtools/views/Editor/utils.js
@@ -16,7 +16,7 @@ export function checkConditions(
   try {
     const url = new URL(editorURL);
 
-    const [, sourceURL, line] = source;
+    const [, sourceURL, line, column] = source;
     let filePath;
 
     // Check if sourceURL is a correct URL, which has a protocol specified
@@ -47,12 +47,15 @@ export function checkConditions(
     }
 
     const lineNumberAsString = String(line);
+    const columnNumberAsString = String(column);
 
     url.href = url.href
       .replace('{path}', filePath)
       .replace('{line}', lineNumberAsString)
+      .replace('{column}', columnNumberAsString)
       .replace('%7Bpath%7D', filePath)
-      .replace('%7Bline%7D', lineNumberAsString);
+      .replace('%7Bline%7D', lineNumberAsString)
+      .replace('%7Bcolumn%7D', columnNumberAsString);
 
     return {url, shouldDisableButton: false};
   } catch (e) {

--- a/packages/react-devtools-shared/src/devtools/views/Settings/CodeEditorOptions.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/CodeEditorOptions.js
@@ -17,7 +17,7 @@ import {getDefaultOpenInEditorURL} from 'react-devtools-shared/src/utils';
 
 import styles from './SettingsShared.css';
 
-const vscodeFilepath = 'vscode://file/{path}:{line}';
+const vscodeFilepath = 'vscode://file/{path}:{line}:{column}';
 
 export default function ComponentsSettings({
   environmentNames,


### PR DESCRIPTION
We should jump to the right column.

Unfortunately, the way presets are set up now you have to switch off and switch to the preset for this to take effect.