### PR TITLE
fix: memory leak when with setState returning the same value

### DIFF
--- a/packages/react-reconciler/src/ReactFiberConcurrentUpdates.js
+++ b/packages/react-reconciler/src/ReactFiberConcurrentUpdates.js
@@ -24,7 +24,13 @@ import {
   throwIfInfiniteUpdateLoopDetected,
   getWorkInProgressRoot,
 } from './ReactFiberWorkLoop';
-import {NoLane, NoLanes, mergeLanes, markHiddenUpdate} from './ReactFiberLane';
+import {
+  NoLane,
+  NoLanes,
+  mergeLanes,
+  markHiddenUpdate,
+  DefaultLane,
+} from './ReactFiberLane';
 import {NoFlags, Placement, Hydrating} from './ReactFiberFlags';
 import {HostRoot, OffscreenComponent} from './ReactWorkTags';
 import {OffscreenVisible} from './ReactFiberOffscreenComponent';
@@ -78,6 +84,8 @@ export function finishQueueingConcurrentUpdates(): void {
 
     if (lane !== NoLane) {
       markUpdateLaneFromFiberToRoot(fiber, update, lane);
+    } else if (typeof update.action === 'function') {
+      markUpdateLaneFromFiberToRoot(fiber, update, DefaultLane);
     }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

- Functional `setState` still leaks memory in React 19

Related to https://github.com/facebook/react/issues/28981, https://github.com/facebook/react/issues/21706, https://github.com/facebook/react/issues/21692

## How did you test this change?



Simple test app to demonstrate the issue (only works in Chrome as it uses `performance.memory` to show the memory usage in the app)

- https://tzj22j.csb.app/

For ease of reviewing, the actual code is just

```javascript
export function App() {
  const [, setY] = useState({});
  useEffect(() => {
    const int = setInterval(() => {
      const xs = new Array(1000000);
      setY((y0) => xs && y0);
    }, 100);
    return () => clearInterval(int);
  }, []);
  return (
    <>
      <MemoryGauge />
    </>
  );
}
```

The `next.next.next.next.next` issue mentioned in https://github.com/facebook/react/issues/21692 is still reproducible with React 19

<img width="1363" height="732" alt="image" src="https://github.com/user-attachments/assets/dfefa807-ba3a-4179-bb95-50648d2e8f71" />