### PR TITLE
[Runtime] Fix CI

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRule-test.ts
+++ b/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRule-test.ts
@@ -247,9 +247,10 @@ const tests: CompilerTestCases = {
       name: 'Pipeline errors are reported',
       code: normalizeIndent`
         import useMyEffect from 'useMyEffect';
+        import {AUTODEPS} from 'react';
         function Component({a}) {
           'use no memo';
-          useMyEffect(() => console.log(a.b));
+          useMyEffect(() => console.log(a.b), AUTODEPS);
           return <div>Hello world</div>;
         }
       `,
@@ -262,7 +263,7 @@ const tests: CompilerTestCases = {
                   source: 'useMyEffect',
                   importSpecifierName: 'default',
                 },
-                numRequiredArgs: 1,
+                autodepsIndex: 1,
               },
             ],
           },


### PR DESCRIPTION
Matches https://github.com/facebook/react/blob/e985c063dbd20d9d672e88fb41b16ede23fbdb7d/compiler/packages/eslint-plugin-react-compiler/__tests__/ReactCompilerRule-test.ts#L244-L275


https://github.com/facebook/react/pull/33800 conflicted with https://github.com/facebook/react/pull/33751/files#diff-97f51f298984cfcdbb6068bbe1985c312017015c9baca674d6daec451a43fe50R247

Not sure if we need to duplicate `packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRule-test.ts` and `compiler/packages/eslint-plugin-react-compiler/__tests__/ReactCompilerRule-test.ts`. Ideally we'd only have `compiler/packages/eslint-plugin-react-compiler/__tests__/ReactCompilerRule-test.ts` so that compiler issues don't infect the runtime pipeline. 

A failing runtime pipeline blocks nightly releases.