### PR TITLE
[compiler] Aggregate all errors reported from DropManualMemoization

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.useMemo-non-literal-depslist.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.useMemo-non-literal-depslist.expect.md
@@ -32,6 +32,8 @@ Found 1 error:
 
 Error: Expected the dependency list for useMemo to be an array literal
 
+Expected the dependency list for useMemo to be an array literal
+
 error.useMemo-non-literal-depslist.ts:10:4
    8 |       return text.toUpperCase();
    9 |     },

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.validate-useMemo-named-function.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.validate-useMemo-named-function.expect.md
@@ -24,6 +24,8 @@ Found 1 error:
 
 Error: Expected the first argument to be an inline function expression
 
+Expected the first argument to be an inline function expression
+
 error.validate-useMemo-named-function.ts:9:20
    7 | // for now.
    8 | function Component(props) {


### PR DESCRIPTION

Noticed this from my previous PR that this pass was throwing on the first error. This PR is a small refactor to aggregate every violation and report them all at once.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/34002).
* #34022
* __->__ #34002