### PR TITLE
[DevTools] Add "suspended by" Section to Component Inspector Sidebar

### DIFF
--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -755,6 +755,10 @@ export function attach(
       inspectedElement.state,
       createIsPathAllowed('state'),
     );
+    inspectedElement.suspendedBy = cleanForBridge(
+      inspectedElement.suspendedBy,
+      createIsPathAllowed('suspendedBy'),
+    );
 
     return {
       id,

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -847,6 +847,9 @@ export function attach(
       errors,
       warnings,
 
+      // Not supported in legacy renderers.
+      suspendedBy: [],
+
       // List of owners
       owners,
 

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -32,7 +32,7 @@ import type {
 import type {InitBackend} from 'react-devtools-shared/src/backend';
 import type {TimelineDataExport} from 'react-devtools-timeline/src/types';
 import type {BackendBridge} from 'react-devtools-shared/src/bridge';
-import type {ReactFunctionLocation} from 'shared/ReactTypes';
+import type {ReactFunctionLocation, ReactStackTrace} from 'shared/ReactTypes';
 import type Agent from './agent';
 
 type BundleType =
@@ -232,6 +232,25 @@ export type PathMatch = {
   isFullMatch: boolean,
 };
 
+// Serialized version of ReactIOInfo
+export type SerializedIOInfo = {
+  name: string,
+  start: number,
+  end: number,
+  value: null | Promise<mixed>,
+  env: null | string,
+  owner: null | SerializedElement,
+  stack: null | ReactStackTrace,
+};
+
+// Serialized version of ReactAsyncInfo
+export type SerializedAsyncInfo = {
+  awaited: SerializedIOInfo,
+  env: null | string,
+  owner: null | SerializedElement,
+  stack: null | ReactStackTrace,
+};
+
 export type SerializedElement = {
   displayName: string | null,
   id: number,
@@ -268,13 +287,16 @@ export type InspectedElement = {
   hasLegacyContext: boolean,
 
   // Inspectable properties.
-  context: Object | null,
-  hooks: Object | null,
-  props: Object | null,
-  state: Object | null,
+  context: Object | null, // DehydratedData or {[string]: mixed}
+  hooks: Object | null, // DehydratedData or {[string]: mixed}
+  props: Object | null, // DehydratedData or {[string]: mixed}
+  state: Object | null, // DehydratedData or {[string]: mixed}
   key: number | string | null,
   errors: Array<[string, number]>,
   warnings: Array<[string, number]>,
+
+  // Things that suspended this Instances
+  suspendedBy: Object, // DehydratedData or Array<SerializedAsyncInfo>
 
   // List of owners
   owners: Array<SerializedElement> | null,

--- a/packages/react-devtools-shared/src/backendAPI.js
+++ b/packages/react-devtools-shared/src/backendAPI.js
@@ -16,6 +16,7 @@ import ElementPollingCancellationError from 'react-devtools-shared/src/errors/El
 import type {
   InspectedElement as InspectedElementBackend,
   InspectedElementPayload,
+  SerializedAsyncInfo as SerializedAsyncInfoBackend,
 } from 'react-devtools-shared/src/backend/types';
 import type {
   BackendEvents,
@@ -24,6 +25,7 @@ import type {
 import type {
   DehydratedData,
   InspectedElement as InspectedElementFrontend,
+  SerializedAsyncInfo as SerializedAsyncInfoFrontend,
 } from 'react-devtools-shared/src/frontend/types';
 import type {InspectedElementPath} from 'react-devtools-shared/src/frontend/types';
 
@@ -209,6 +211,32 @@ export function cloneInspectedElementWithPath(
   return clonedInspectedElement;
 }
 
+function backendToFrontendSerializedAsyncInfo(
+  asyncInfo: SerializedAsyncInfoBackend,
+): SerializedAsyncInfoFrontend {
+  const ioInfo = asyncInfo.awaited;
+  return {
+    awaited: {
+      name: ioInfo.name,
+      start: ioInfo.start,
+      end: ioInfo.end,
+      value: ioInfo.value,
+      env: ioInfo.env,
+      owner:
+        ioInfo.owner === null
+          ? null
+          : backendToFrontendSerializedElementMapper(ioInfo.owner),
+      stack: ioInfo.stack,
+    },
+    env: asyncInfo.env,
+    owner:
+      asyncInfo.owner === null
+        ? null
+        : backendToFrontendSerializedElementMapper(asyncInfo.owner),
+    stack: asyncInfo.stack,
+  };
+}
+
 export function convertInspectedElementBackendToFrontend(
   inspectedElementBackend: InspectedElementBackend,
 ): InspectedElementFrontend {
@@ -238,8 +266,12 @@ export function convertInspectedElementBackendToFrontend(
     key,
     errors,
     warnings,
+    suspendedBy,
     nativeTag,
   } = inspectedElementBackend;
+
+  const hydratedSuspendedBy: null | Array<SerializedAsyncInfoBackend> =
+    hydrateHelper(suspendedBy);
 
   const inspectedElement: InspectedElementFrontend = {
     canEditFunctionProps,
@@ -272,6 +304,10 @@ export function convertInspectedElementBackendToFrontend(
     state: hydrateHelper(state),
     errors,
     warnings,
+    suspendedBy:
+      hydratedSuspendedBy == null // backwards compat
+        ? []
+        : hydratedSuspendedBy.map(backendToFrontendSerializedAsyncInfo),
     nativeTag,
   };
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSharedStyles.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSharedStyles.css
@@ -51,3 +51,41 @@
 .EditableValue {
   min-width: 1rem;
 }
+
+.CollapsableRow {
+  border-top: 1px solid var(--color-border);
+}
+
+.CollapsableRow:last-child {
+  margin-bottom: -0.25rem;
+}
+
+.CollapsableHeader {
+  width: 100%;
+  padding: 0.25rem;
+  display: flex;
+}
+
+.CollapsableHeaderIcon {
+  flex: 0 0 1rem;
+  margin-left: -0.25rem;
+  width: 1rem;
+  height: 1rem;
+  padding: 0;
+  color: var(--color-expand-collapse-toggle);
+}
+
+.CollapsableHeaderTitle {
+  flex: 1 1 auto;
+  font-family: var(--font-family-monospace);
+  font-size: var(--font-size-monospace-normal);
+  text-align: left;
+}
+
+.CollapsableContent {
+  padding: 0.25rem 0;
+}
+
+.PreviewContainer {
+  padding: 0 0.25rem 0.25rem 0.25rem;
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {copy} from 'clipboard-js';
+import * as React from 'react';
+import Button from '../Button';
+import ButtonIcon from '../ButtonIcon';
+import KeyValue from './KeyValue';
+import {serializeDataForCopy} from '../utils';
+import Store from '../../store';
+import styles from './InspectedElementSharedStyles.css';
+import {withPermissionsCheck} from 'react-devtools-shared/src/frontend/utils/withPermissionsCheck';
+import OwnerView from './OwnerView';
+
+import type {InspectedElement} from 'react-devtools-shared/src/frontend/types';
+import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
+import type {SerializedAsyncInfo} from 'react-devtools-shared/src/frontend/types';
+
+type RowProps = {
+  bridge: FrontendBridge,
+  element: Element,
+  inspectedElement: InspectedElement,
+  store: Store,
+  asyncInfo: SerializedAsyncInfo,
+  index: number,
+};
+
+function SuspendedByRow({
+  bridge,
+  element,
+  inspectedElement,
+  store,
+  asyncInfo,
+  index,
+}: RowProps) {
+  const name = asyncInfo.awaited.name;
+  let stack;
+  let owner;
+  if (asyncInfo.stack === null || asyncInfo.stack.length === 0) {
+    stack = asyncInfo.awaited.stack;
+    owner = asyncInfo.awaited.owner;
+  } else {
+    stack = asyncInfo.stack;
+    owner = asyncInfo.owner;
+  }
+  return (
+    <div>
+      <div>{name}</div>
+      <KeyValue
+        alphaSort={true}
+        bridge={bridge}
+        canDeletePaths={false}
+        canEditValues={false}
+        canRenamePaths={false}
+        depth={1}
+        element={element}
+        hidden={false}
+        inspectedElement={inspectedElement}
+        name={'Promise'}
+        path={[index, 'awaited', 'value']}
+        pathRoot="suspendedBy"
+        store={store}
+        value={asyncInfo.awaited.value}
+      />
+      <div>
+        {stack !== null &&
+          stack.map(callsite => {
+            return <div>{callsite[0]}</div>;
+          })}
+      </div>
+      {owner !== null && owner.id !== inspectedElement.id ? (
+        <OwnerView
+          key={owner.id}
+          displayName={owner.displayName || 'Anonymous'}
+          hocDisplayNames={owner.hocDisplayNames}
+          compiledWithForget={owner.compiledWithForget}
+          id={owner.id}
+          isInStore={store.containsElement(owner.id)}
+          type={owner.type}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+type Props = {
+  bridge: FrontendBridge,
+  element: Element,
+  inspectedElement: InspectedElement,
+  store: Store,
+};
+
+export default function InspectedElementSuspendedBy({
+  bridge,
+  element,
+  inspectedElement,
+  store,
+}: Props): React.Node {
+  const {suspendedBy} = inspectedElement;
+
+  // Skip the section if nothing suspended this component.
+  if (suspendedBy == null || suspendedBy.length === 0) {
+    return null;
+  }
+
+  const handleCopy = withPermissionsCheck(
+    {permissions: ['clipboardWrite']},
+    () => copy(serializeDataForCopy(suspendedBy)),
+  );
+
+  return (
+    <div>
+      <div className={styles.HeaderRow}>
+        <div className={styles.Header}>suspended by</div>
+        <Button onClick={handleCopy} title="Copy to clipboard">
+          <ButtonIcon type="copy" />
+        </Button>
+      </div>
+      {suspendedBy.map((asyncInfo, index) => (
+        <SuspendedByRow
+          key={index}
+          index={index}
+          asyncInfo={asyncInfo}
+          bridge={bridge}
+          element={element}
+          inspectedElement={inspectedElement}
+          store={store}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
@@ -9,6 +9,7 @@
 
 import {copy} from 'clipboard-js';
 import * as React from 'react';
+import {useState} from 'react';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import KeyValue from './KeyValue';
@@ -40,6 +41,7 @@ function SuspendedByRow({
   asyncInfo,
   index,
 }: RowProps) {
+  const [isOpen, setIsOpen] = useState(false);
   const name = asyncInfo.awaited.name;
   let stack;
   let owner;
@@ -51,36 +53,53 @@ function SuspendedByRow({
     owner = asyncInfo.owner;
   }
   return (
-    <div>
-      <div>{name}</div>
-      <KeyValue
-        alphaSort={true}
-        bridge={bridge}
-        canDeletePaths={false}
-        canEditValues={false}
-        canRenamePaths={false}
-        depth={1}
-        element={element}
-        hidden={false}
-        inspectedElement={inspectedElement}
-        name={'Promise'}
-        path={[index, 'awaited', 'value']}
-        pathRoot="suspendedBy"
-        store={store}
-        value={asyncInfo.awaited.value}
-      />
-      {stack !== null && stack.length > 0 && <StackTraceView stack={stack} />}
-      {owner !== null && owner.id !== inspectedElement.id ? (
-        <OwnerView
-          key={owner.id}
-          displayName={owner.displayName || 'Anonymous'}
-          hocDisplayNames={owner.hocDisplayNames}
-          compiledWithForget={owner.compiledWithForget}
-          id={owner.id}
-          isInStore={store.containsElement(owner.id)}
-          type={owner.type}
+    <div className={styles.CollapsableRow}>
+      <Button
+        className={styles.CollapsableHeader}
+        onClick={() => setIsOpen(prevIsOpen => !prevIsOpen)}
+        title={`${isOpen ? 'Collapse' : 'Expand'}`}>
+        <ButtonIcon
+          className={styles.CollapsableHeaderIcon}
+          type={isOpen ? 'expanded' : 'collapsed'}
         />
-      ) : null}
+        <span className={styles.CollapsableHeaderTitle}>{name}</span>
+      </Button>
+      {isOpen && (
+        <div className={styles.CollapsableContent}>
+          <div className={styles.PreviewContainer}>
+            <KeyValue
+              alphaSort={true}
+              bridge={bridge}
+              canDeletePaths={false}
+              canEditValues={false}
+              canRenamePaths={false}
+              depth={1}
+              element={element}
+              hidden={false}
+              inspectedElement={inspectedElement}
+              name={'Promise'}
+              path={[index, 'awaited', 'value']}
+              pathRoot="suspendedBy"
+              store={store}
+              value={asyncInfo.awaited.value}
+            />
+          </div>
+          {stack !== null && stack.length > 0 && (
+            <StackTraceView stack={stack} />
+          )}
+          {owner !== null && owner.id !== inspectedElement.id ? (
+            <OwnerView
+              key={owner.id}
+              displayName={owner.displayName || 'Anonymous'}
+              hocDisplayNames={owner.hocDisplayNames}
+              compiledWithForget={owner.compiledWithForget}
+              id={owner.id}
+              isInStore={store.containsElement(owner.id)}
+              type={owner.type}
+            />
+          ) : null}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
@@ -16,6 +16,7 @@ import {serializeDataForCopy} from '../utils';
 import Store from '../../store';
 import styles from './InspectedElementSharedStyles.css';
 import {withPermissionsCheck} from 'react-devtools-shared/src/frontend/utils/withPermissionsCheck';
+import StackTraceView from './StackTraceView';
 import OwnerView from './OwnerView';
 
 import type {InspectedElement} from 'react-devtools-shared/src/frontend/types';
@@ -68,12 +69,7 @@ function SuspendedByRow({
         store={store}
         value={asyncInfo.awaited.value}
       />
-      <div>
-        {stack !== null &&
-          stack.map(callsite => {
-            return <div>{callsite[0]}</div>;
-          })}
-      </div>
+      {stack !== null && stack.length > 0 && <StackTraceView stack={stack} />}
       {owner !== null && owner.id !== inspectedElement.id ? (
         <OwnerView
           key={owner.id}

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.css
@@ -2,16 +2,6 @@
   font-family: var(--font-family-sans);
 }
 
-.Owner {
-  color: var(--color-component-name);
-  font-family: var(--font-family-monospace);
-  font-size: var(--font-size-monospace-normal);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 100%;
-}
-
 .InspectedElement {
   overflow-x: hidden;
   overflow-y: auto;
@@ -26,41 +16,6 @@
   &:not(:last-of-type) {
     border-bottom: 1px solid var(--color-border);
   }
-}
-
-.Owner {
-  border-radius: 0.25rem;
-  padding: 0.125rem 0.25rem;
-  background: none;
-  border: none;
-  display: block;
-}
-.Owner:focus {
-  outline: none;
-  background-color: var(--color-button-background-focus);
-}
-
-.NotInStore {
-  color: var(--color-dim);
-  cursor: default;
-}
-
-.OwnerButton {
-  cursor: pointer;
-  width: 100%;
-  padding: 0;
-}
-
-.OwnerContent {
-  display: flex;
-  align-items: center;
-  padding-left: 1rem;
-  width: 100%;
-  border-radius: 0.25rem;
-}
-
-.OwnerContent:hover {
-  background-color: var(--color-background-hover);
 }
 
 .OwnersMetaField {

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
@@ -18,6 +18,7 @@ import InspectedElementPropsTree from './InspectedElementPropsTree';
 import InspectedElementStateTree from './InspectedElementStateTree';
 import InspectedElementStyleXPlugin from './InspectedElementStyleXPlugin';
 import InspectedElementSuspenseToggle from './InspectedElementSuspenseToggle';
+import InspectedElementSuspendedBy from './InspectedElementSuspendedBy';
 import NativeStyleEditor from './NativeStyleEditor';
 import {enableStyleXFeatures} from 'react-devtools-feature-flags';
 import InspectedElementSourcePanel from './InspectedElementSourcePanel';
@@ -150,6 +151,15 @@ export default function InspectedElementView({
 
         <div className={styles.InspectedElementSection}>
           <NativeStyleEditor />
+        </div>
+
+        <div className={styles.InspectedElementSection}>
+          <InspectedElementSuspendedBy
+            bridge={bridge}
+            element={element}
+            inspectedElement={inspectedElement}
+            store={store}
+          />
         </div>
 
         {showRenderedBy && (

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
@@ -8,10 +8,8 @@
  */
 
 import * as React from 'react';
-import {Fragment, useCallback, useContext} from 'react';
-import {TreeDispatcherContext} from './TreeContext';
+import {Fragment, useContext} from 'react';
 import {BridgeContext, StoreContext} from '../context';
-import Button from '../Button';
 import InspectedElementBadges from './InspectedElementBadges';
 import InspectedElementContextTree from './InspectedElementContextTree';
 import InspectedElementErrorsAndWarningsTree from './InspectedElementErrorsAndWarningsTree';
@@ -21,11 +19,9 @@ import InspectedElementStateTree from './InspectedElementStateTree';
 import InspectedElementStyleXPlugin from './InspectedElementStyleXPlugin';
 import InspectedElementSuspenseToggle from './InspectedElementSuspenseToggle';
 import NativeStyleEditor from './NativeStyleEditor';
-import ElementBadges from './ElementBadges';
-import {useHighlightHostInstance} from '../hooks';
 import {enableStyleXFeatures} from 'react-devtools-feature-flags';
-import {logEvent} from 'react-devtools-shared/src/Logger';
 import InspectedElementSourcePanel from './InspectedElementSourcePanel';
+import OwnerView from './OwnerView';
 
 import styles from './InspectedElementView.css';
 
@@ -194,59 +190,5 @@ export default function InspectedElementView({
         )}
       </div>
     </Fragment>
-  );
-}
-
-type OwnerViewProps = {
-  displayName: string,
-  hocDisplayNames: Array<string> | null,
-  compiledWithForget: boolean,
-  id: number,
-  isInStore: boolean,
-};
-
-function OwnerView({
-  displayName,
-  hocDisplayNames,
-  compiledWithForget,
-  id,
-  isInStore,
-}: OwnerViewProps) {
-  const dispatch = useContext(TreeDispatcherContext);
-  const {highlightHostInstance, clearHighlightHostInstance} =
-    useHighlightHostInstance();
-
-  const handleClick = useCallback(() => {
-    logEvent({
-      event_name: 'select-element',
-      metadata: {source: 'owner-view'},
-    });
-    dispatch({
-      type: 'SELECT_ELEMENT_BY_ID',
-      payload: id,
-    });
-  }, [dispatch, id]);
-
-  return (
-    <Button
-      key={id}
-      className={styles.OwnerButton}
-      disabled={!isInStore}
-      onClick={handleClick}
-      onMouseEnter={() => highlightHostInstance(id)}
-      onMouseLeave={clearHighlightHostInstance}>
-      <span className={styles.OwnerContent}>
-        <span
-          className={`${styles.Owner} ${isInStore ? '' : styles.NotInStore}`}
-          title={displayName}>
-          {displayName}
-        </span>
-
-        <ElementBadges
-          hocDisplayNames={hocDisplayNames}
-          compiledWithForget={compiledWithForget}
-        />
-      </span>
-    </Button>
   );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Components/OwnerView.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/OwnerView.css
@@ -1,0 +1,41 @@
+.Owner {
+  color: var(--color-component-name);
+  font-family: var(--font-family-monospace);
+  font-size: var(--font-size-monospace-normal);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.25rem;
+  background: none;
+  border: none;
+  display: block;
+}
+.Owner:focus {
+  outline: none;
+  background-color: var(--color-button-background-focus);
+}
+
+.OwnerButton {
+  cursor: pointer;
+  width: 100%;
+  padding: 0;
+}
+
+.OwnerContent {
+  display: flex;
+  align-items: center;
+  padding-left: 1rem;
+  width: 100%;
+  border-radius: 0.25rem;
+}
+
+.OwnerContent:hover {
+  background-color: var(--color-background-hover);
+}
+
+.NotInStore {
+  color: var(--color-dim);
+  cursor: default;
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/OwnerView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/OwnerView.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+import {useCallback, useContext} from 'react';
+import {TreeDispatcherContext} from './TreeContext';
+import Button from '../Button';
+import ElementBadges from './ElementBadges';
+import {useHighlightHostInstance} from '../hooks';
+import {logEvent} from 'react-devtools-shared/src/Logger';
+
+import styles from './OwnerView.css';
+
+type OwnerViewProps = {
+  displayName: string,
+  hocDisplayNames: Array<string> | null,
+  compiledWithForget: boolean,
+  id: number,
+  isInStore: boolean,
+};
+
+export default function OwnerView({
+  displayName,
+  hocDisplayNames,
+  compiledWithForget,
+  id,
+  isInStore,
+}: OwnerViewProps): React.Node {
+  const dispatch = useContext(TreeDispatcherContext);
+  const {highlightHostInstance, clearHighlightHostInstance} =
+    useHighlightHostInstance();
+
+  const handleClick = useCallback(() => {
+    logEvent({
+      event_name: 'select-element',
+      metadata: {source: 'owner-view'},
+    });
+    dispatch({
+      type: 'SELECT_ELEMENT_BY_ID',
+      payload: id,
+    });
+  }, [dispatch, id]);
+
+  return (
+    <Button
+      key={id}
+      className={styles.OwnerButton}
+      disabled={!isInStore}
+      onClick={handleClick}
+      onMouseEnter={() => highlightHostInstance(id)}
+      onMouseLeave={clearHighlightHostInstance}>
+      <span className={styles.OwnerContent}>
+        <span
+          className={`${styles.Owner} ${isInStore ? '' : styles.NotInStore}`}
+          title={displayName}>
+          {displayName}
+        </span>
+
+        <ElementBadges
+          hocDisplayNames={hocDisplayNames}
+          compiledWithForget={compiledWithForget}
+        />
+      </span>
+    </Button>
+  );
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
@@ -1,0 +1,19 @@
+.CallSite {
+  display: block;
+}
+
+.Link {
+  color: var(--color-link);
+  white-space: pre;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  cursor: pointer;
+  border-radius: 0.125rem;
+  padding: 0px 2px;
+}
+
+.Link:hover {
+  background-color: var(--color-background-hover);
+}
+

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
@@ -1,5 +1,10 @@
+.StackTraceView {
+  padding: 0.25rem;
+}
+
 .CallSite {
   display: block;
+  padding-left: 1rem;
 }
 
 .Link {

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+
+import useOpenResource from '../useOpenResource';
+
+import styles from './StackTraceView.css';
+
+import type {ReactStackTrace, ReactCallSite} from 'shared/ReactTypes';
+
+import formatLocationForDisplay from './formatLocationForDisplay';
+
+type CallSiteViewProps = {
+  callSite: ReactCallSite,
+};
+
+export function CallSiteView({callSite}: CallSiteViewProps): React.Node {
+  const symbolicatedCallSite: null | ReactCallSite = null; // TODO
+  const [linkIsEnabled, viewSource] = useOpenResource(
+    callSite,
+    symbolicatedCallSite,
+  );
+  const [functionName, url, line, column] =
+    symbolicatedCallSite !== null ? symbolicatedCallSite : callSite;
+  return (
+    <div className={styles.CallSite}>
+      {functionName}
+      {' @ '}
+      <span
+        className={linkIsEnabled ? styles.Link : null}
+        onClick={viewSource}
+        title={url + ':' + line}>
+        {formatLocationForDisplay(url, line, column)}
+      </span>
+    </div>
+  );
+}
+
+type Props = {
+  stack: ReactStackTrace,
+};
+
+export default function StackTraceView({stack}: Props): React.Node {
+  return stack.map((callSite, index) => (
+    <CallSiteView key={index} callSite={callSite} />
+  ));
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
@@ -48,7 +48,11 @@ type Props = {
 };
 
 export default function StackTraceView({stack}: Props): React.Node {
-  return stack.map((callSite, index) => (
-    <CallSiteView key={index} callSite={callSite} />
-  ));
+  return (
+    <div className={styles.StackTraceView}>
+      {stack.map((callSite, index) => (
+        <CallSiteView key={index} callSite={callSite} />
+      ))}
+    </div>
+  );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Components/formatLocationForDisplay.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/formatLocationForDisplay.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {toNormalUrl} from 'jsc-safe-url';
+
+// This function is based on describeComponentFrame() in packages/shared/ReactComponentStackFrame
+export default function formatLocationForDisplay(
+  sourceURL: string,
+  line: number,
+  column: number,
+): string {
+  // Metro can return JSC-safe URLs, which have `//&` as a delimiter
+  // https://www.npmjs.com/package/jsc-safe-url
+  const sanitizedSourceURL = sourceURL.includes('//&')
+    ? toNormalUrl(sourceURL)
+    : sourceURL;
+
+  // Note: this RegExp doesn't work well with URLs from Metro,
+  // which provides bundle URL with query parameters prefixed with /&
+  const BEFORE_SLASH_RE = /^(.*)[\\\/]/;
+
+  let nameOnly = sanitizedSourceURL.replace(BEFORE_SLASH_RE, '');
+
+  // In DEV, include code for a common special case:
+  // prefer "folder/index.js" instead of just "index.js".
+  if (/^index\./.test(nameOnly)) {
+    const match = sanitizedSourceURL.match(BEFORE_SLASH_RE);
+    if (match) {
+      const pathBeforeSlash = match[1];
+      if (pathBeforeSlash) {
+        const folderName = pathBeforeSlash.replace(BEFORE_SLASH_RE, '');
+        nameOnly = folderName + '/' + nameOnly;
+      }
+    }
+  }
+
+  return `${nameOnly}:${line}`;
+}

--- a/packages/react-devtools-shared/src/devtools/views/utils.js
+++ b/packages/react-devtools-shared/src/devtools/views/utils.js
@@ -121,7 +121,7 @@ function sanitize(data: Object): void {
 }
 
 export function serializeDataForCopy(props: Object): string {
-  const cloned = Object.assign({}, props);
+  const cloned = isArray(props) ? props.slice(0) : Object.assign({}, props);
 
   sanitize(cloned);
 

--- a/packages/react-devtools-shared/src/frontend/types.js
+++ b/packages/react-devtools-shared/src/frontend/types.js
@@ -18,7 +18,7 @@ import type {
   Dehydrated,
   Unserializable,
 } from 'react-devtools-shared/src/hydration';
-import type {ReactFunctionLocation} from 'shared/ReactTypes';
+import type {ReactFunctionLocation, ReactStackTrace} from 'shared/ReactTypes';
 
 export type BrowserTheme = 'dark' | 'light';
 
@@ -184,6 +184,25 @@ export type Element = {
   compiledWithForget: boolean,
 };
 
+// Serialized version of ReactIOInfo
+export type SerializedIOInfo = {
+  name: string,
+  start: number,
+  end: number,
+  value: null | Promise<mixed>,
+  env: null | string,
+  owner: null | SerializedElement,
+  stack: null | ReactStackTrace,
+};
+
+// Serialized version of ReactAsyncInfo
+export type SerializedAsyncInfo = {
+  awaited: SerializedIOInfo,
+  env: null | string,
+  owner: null | SerializedElement,
+  stack: null | ReactStackTrace,
+};
+
 export type SerializedElement = {
   displayName: string | null,
   id: number,
@@ -238,6 +257,9 @@ export type InspectedElement = {
   key: number | string | null,
   errors: Array<[string, number]>,
   warnings: Array<[string, number]>,
+
+  // Things that suspended this Instances
+  suspendedBy: Object,
 
   // List of owners
   owners: Array<SerializedElement> | null,


### PR DESCRIPTION
This collects the ReactAsyncInfo between instances. It associates it with the parent. Typically this would be a Server Component's Promise return value but it can also be Promises in a fragment. It can also be associated with a client component when you pass a Promise into the child position e.g. `<div>{promise}</div>` then it's associated with the div. If an instance is filtered, then it gets associated with the parent of that's unfiltered.

The stack trace currently isn't source mapped. I'll do that in a follow up.

We also need to add a "short name" from the Promise for the description (e.g. url). I'll also add a little marker showing the relative time span of each entry.

<img width="447" height="591" alt="Screenshot 2025-07-26 at 7 56 00 PM" src="https://github.com/user-attachments/assets/7c966540-7b1b-4568-8cb9-f25cefd5a918" />
<img width="446" height="570" alt="Screenshot 2025-07-26 at 7 55 23 PM" src="https://github.com/user-attachments/assets/4eac235b-e735-41e8-9c6e-a7633af64e4b" />
