### PR TITLE
[DevTools] Skeleton for Suspense tab

### DIFF
--- a/packages/react-devtools-shared/src/Logger.js
+++ b/packages/react-devtools-shared/src/Logger.js
@@ -26,6 +26,9 @@ export type LoggerEvent =
       +event_name: 'selected-profiler-tab',
     }
   | {
+      +event_name: 'selected-suspense-tab',
+    }
+  | {
       +event_name: 'load-hook-names',
       +event_status: 'success' | 'error' | 'timeout' | 'unknown',
       +duration_ms: number,

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -710,6 +710,16 @@ export default class Agent extends EventEmitter<{
 
     rendererInterface.setTraceUpdatesEnabled(this._traceUpdatesEnabled);
 
+    const renderer = rendererInterface.renderer;
+    if (renderer !== null) {
+      const devRenderer = renderer.bundleType === 1;
+      const enableSuspenseTab =
+        devRenderer && renderer.version.includes('-experimental-');
+      if (enableSuspenseTab) {
+        this._bridge.send('enableSuspenseTab');
+      }
+    }
+
     // When the renderer is attached, we need to tell it whether
     // we remember the previous selection that we'd like to restore.
     // It'll start tracking mounts for matches to the last selection path.

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -178,6 +178,7 @@ export type BackendEvents = {
   backendInitialized: [],
   backendVersion: [string],
   bridgeProtocol: [BridgeProtocol],
+  enableSuspenseTab: [],
   extensionBackendInitialized: [],
   fastRefreshScheduled: [],
   getSavedPreferences: [],

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -95,6 +95,7 @@ export default class Store extends EventEmitter<{
   backendVersion: [],
   collapseNodesByDefault: [],
   componentFilters: [],
+  enableSuspenseTab: [],
   error: [Error],
   hookSettings: [$ReadOnly<DevToolsHookSettings>],
   hostInstanceSelected: [Element['id']],
@@ -172,6 +173,8 @@ export default class Store extends EventEmitter<{
   _supportsClickToInspect: boolean = false;
   _supportsTimeline: boolean = false;
   _supportsTraceUpdates: boolean = false;
+  // Dynamically set if the renderer supports the Suspense tab.
+  _supportsSuspenseTab: boolean = false;
 
   _isReloadAndProfileFrontendSupported: boolean = false;
   _isReloadAndProfileBackendSupported: boolean = false;
@@ -275,6 +278,7 @@ export default class Store extends EventEmitter<{
     bridge.addListener('hookSettings', this.onHookSettings);
     bridge.addListener('backendInitialized', this.onBackendInitialized);
     bridge.addListener('selectElement', this.onHostInstanceSelected);
+    bridge.addListener('enableSuspenseTab', this.onEnableSuspenseTab);
   }
 
   // This is only used in tests to avoid memory leaks.
@@ -1623,6 +1627,15 @@ export default class Store extends EventEmitter<{
       this.emit('mutated', [[], new Map()]);
     }
   }
+
+  get supportsSuspenseTab(): boolean {
+    return this._supportsSuspenseTab;
+  }
+
+  onEnableSuspenseTab = (): void => {
+    this._supportsSuspenseTab = true;
+    this.emit('enableSuspenseTab');
+  };
 
   // The Store should never throw an Error without also emitting an event.
   // Otherwise Store errors will be invisible to users,

--- a/packages/react-devtools-shared/src/devtools/views/Icon.js
+++ b/packages/react-devtools-shared/src/devtools/views/Icon.js
@@ -26,6 +26,7 @@ export type IconType =
   | 'settings'
   | 'store-as-global-variable'
   | 'strict-mode-non-compliant'
+  | 'suspense'
   | 'warning';
 
 type Props = {
@@ -40,6 +41,7 @@ export default function Icon({
   type,
 }: Props): React.Node {
   let pathData = null;
+  let viewBox = '0 0 24 24';
   switch (type) {
     case 'arrow':
       pathData = PATH_ARROW;
@@ -86,6 +88,10 @@ export default function Icon({
     case 'strict-mode-non-compliant':
       pathData = PATH_STRICT_MODE_NON_COMPLIANT;
       break;
+    case 'suspense':
+      pathData = PATH_SUSPEND;
+      viewBox = '-2 -2 28 28';
+      break;
     case 'warning':
       pathData = PATH_WARNING;
       break;
@@ -100,7 +106,7 @@ export default function Icon({
       className={`${styles.Icon} ${className}`}
       width="24"
       height="24"
-      viewBox="0 0 24 24">
+      viewBox={viewBox}>
       {title && <title>{title}</title>}
       <path d="M0 0h24v24H0z" fill="none" />
       <path fill="currentColor" d={pathData} />
@@ -183,6 +189,11 @@ const PATH_STORE_AS_GLOBAL_VARIABLE = `
 const PATH_STRICT_MODE_NON_COMPLIANT = `
   M4.47 21h15.06c1.54 0 2.5-1.67 1.73-3L13.73 4.99c-.77-1.33-2.69-1.33-3.46 0L2.74 18c-.77 1.33.19 3 1.73 3zM12
   14c-.55 0-1-.45-1-1v-2c0-.55.45-1 1-1s1 .45 1 1v2c0 .55-.45 1-1 1zm1 4h-2v-2h2v2z
+`;
+
+const PATH_SUSPEND = `
+  M15 1H9v2h6V1zm-4 13h2V8h-2v6zm8.03-6.61l1.42-1.42c-.43-.51-.9-.99-1.41-1.41l-1.42 1.42C16.07 4.74 14.12 4 12 4c-4.97
+  0-9 4.03-9 9s4.02 9 9 9 9-4.03 9-9c0-2.12-.74-4.07-1.97-5.61zM12 20c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z
 `;
 
 const PATH_WARNING = `M12 1l-12 22h24l-12-22zm-1 8h2v7h-2v-7zm1 11.25c-.69 0-1.25-.56-1.25-1.25s.56-1.25 1.25-1.25 1.25.56 1.25 1.25-.56 1.25-1.25 1.25z`;

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -83,6 +83,7 @@ type Props = {
   children: React$Node,
   componentsPortalContainer?: Element,
   profilerPortalContainer?: Element,
+  suspensePortalContainer?: Element,
 };
 
 function SettingsContextController({
@@ -90,6 +91,7 @@ function SettingsContextController({
   children,
   componentsPortalContainer,
   profilerPortalContainer,
+  suspensePortalContainer,
 }: Props): React.Node {
   const bridge = useContext(BridgeContext);
 
@@ -128,8 +130,18 @@ function SettingsContextController({
           .documentElement: any): HTMLElement),
       );
     }
+    if (suspensePortalContainer != null) {
+      array.push(
+        ((suspensePortalContainer.ownerDocument
+          .documentElement: any): HTMLElement),
+      );
+    }
     return array;
-  }, [componentsPortalContainer, profilerPortalContainer]);
+  }, [
+    componentsPortalContainer,
+    profilerPortalContainer,
+    suspensePortalContainer,
+  ]);
 
   useLayoutEffect(() => {
     switch (displayDensity) {

--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseTab.js
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseTab.js
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import portaledContent from '../portaledContent';
+
+function SuspenseTab() {
+  return 'Under construction';
+}
+
+export default (portaledContent(SuspenseTab): React.ComponentType<{}>);


### PR DESCRIPTION
This adds an additional, experimental tab to React DevTools. We'll add Suspense-centric tools to this tab in follow-up PRs.

The tab is enabled if at least on renderer uses an experimental dev build. We can't hide panels in Chrome so the tab will stay even if you navigate to pages without an experimental dev build. Once the tab is stable, we'll enable it permanently like the Components and Profiler tab. 