### PR TITLE
Clean up 19.1.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 ## 19.1.1 (July 28, 2025)
 
 ### React
-* Fixed Owner Stacks to work with ES2015 function.name semantics (#33680 by @hoxyq)
-* Move the Fabric completeRoot call from `finalizeContainerChildren` to `replaceContainerChildren` to align how JS API and Fabric interpret `completeRoot` (#30513, #33064 by @kassens and @jackpope)
-* Fix React retaining shadow nodes longer that it needs to (#33161, #33447 by @sammy-SC and @yungsters)
+* Fixed Owner Stacks to work with ES2015 function.name semantics ([#33680](https://github.com/facebook/react/pull/33680) by @hoxyq)
 
 ## 19.1.0 (March 28, 2025)
 


### PR DESCRIPTION
See https://github.com/facebook/react/pull/34021#issuecomment-3128006800.

The purpose of the changelog is to communicate to React users what changed in the release.

Therefore, it is important that the changelog is written oriented towards React end users. Historically this means that we omit internal-only changes, i.e. changes that have no effect on the end user behavior. If internal changes are mentioned in the changelog (e.g. if they affect end user behavior), they should be phrased in a way that is understandable to the end user — in particular, they should not refer to internal API names or concepts.

We also try to group changes according to the publicly known packages.

In this PR:

- Make #33680 an actual link (otherwise it isn't linkified in CHANGELOG.md on GitHub).
- Remove two changelog entries listed under "React" that don't affect anyone who upgrades the "React" package, that are phrased using terminology and internal function names unfamiliar to React users, and that seem to be RN-specific changes (so should probably go into the RN changelog that goes out with the next renderer sync that includes these changes).