### PR TITLE
[DevTools] Silence unactionable bundle warnings in shell

### DIFF
--- a/packages/react-devtools-shell/webpack-server.js
+++ b/packages/react-devtools-shell/webpack-server.js
@@ -47,7 +47,31 @@ const E2E_APP_BUILD_DIR = process.env.REACT_VERSION
 const makeConfig = (entry, alias) => ({
   mode: __DEV__ ? 'development' : 'production',
   devtool: __DEV__ ? 'cheap-source-map' : 'source-map',
-  stats: 'normal',
+  stats: {
+    preset: 'normal',
+    warningsFilter: [
+      warning => {
+        const message = warning.message;
+        // We use ReactDOM legacy APIs conditionally based on the React version.
+        // react-native-web also accesses legacy APIs statically but we don't end
+        // up using them at runtime.
+        return (
+          message.startsWith(
+            `export 'findDOMNode' (imported as 'findDOMNode') was not found in 'react-dom'`,
+          ) ||
+          message.startsWith(
+            `export 'hydrate' (reexported as 'hydrate') was not found in 'react-dom'`,
+          ) ||
+          message.startsWith(
+            `export 'render' (imported as 'render') was not found in 'react-dom'`,
+          ) ||
+          message.startsWith(
+            `export 'unmountComponentAtNode' (imported as 'unmountComponentAtNode') was not found in 'react-dom'`,
+          )
+        );
+      },
+    ],
+  },
   entry,
   output: {
     publicPath: '/dist/',


### PR DESCRIPTION
We access legacy APIs conditionally based on the React version which Webpack flags as accessing non-existent exports in development. react-native-web also accesses these legacy APIs statically.

The warnings are just noise when working with `react-devtools-shell`.