### PR TITLE
[DevTools] Swap Components tab layout based on container size

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.css
@@ -38,7 +38,7 @@
   cursor: ew-resize;
 }
 
-@media screen and (max-width: 600px) {
+@container devtools (width < 600px) {
   .Components {
     flex-direction: column;
   }

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.css
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.css
@@ -5,6 +5,8 @@
   flex-direction: column;
   background-color: var(--color-background);
   color: var(--color-text);
+  container-name: devtools;
+  container-type: inline-size;
 }
 
 .TabBar {

--- a/packages/react-devtools-shared/src/devtools/views/portaledContent.js
+++ b/packages/react-devtools-shared/src/devtools/views/portaledContent.js
@@ -36,7 +36,12 @@ export default function portaledContent(
         <ThemeProvider>
           <div
             data-react-devtools-portal-root={true}
-            style={{width: '100vw', height: '100vh'}}>
+            style={{
+              width: '100vw',
+              height: '100vh',
+              containerName: 'devtools',
+              containerType: 'inline-size',
+            }}>
             {children}
           </div>
         </ThemeProvider>


### PR DESCRIPTION

This is mostly relevant for using React DevTools inline where the devtools container width is not equal to the viewport width (e.g. in the test fixture).

[Container queries are available in all evergreen browsers and iOS 16](https://developer.mozilla.org/en-US/docs/Web/CSS/@container#browser_compatibility)

Before:

https://github.com/user-attachments/assets/43b6cb3c-98f4-4898-857f-0820fb2e5ab9



After:

https://github.com/user-attachments/assets/9082c11b-b0be-43fb-b0ba-a17e023c2513



