### PR TITLE
[eslint] Disallow usage within try/catch blocks

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -1324,6 +1324,34 @@ const allTests = {
       `,
       errors: [asyncComponentHookError('use')],
     },
+    {
+      code: normalizeIndent`
+        function App({p1, p2}) {
+          try {
+            use(p1);
+          } catch (error) {
+            console.error(error);
+          }
+          use(p2);
+          return <div>App</div>;
+        }
+      `,
+      errors: [tryCatchUseError('use')],
+    },
+    {
+      code: normalizeIndent`
+        function App({p1, p2}) {
+          try {
+            doSomething();
+          } catch {
+            use(p1);
+          }
+          use(p2);
+          return <div>App</div>;
+        }
+      `,
+      errors: [tryCatchUseError('use')],
+    },
   ],
 };
 
@@ -1383,7 +1411,7 @@ if (__EXPERIMENTAL__) {
           const onEvent = useEffectEvent((text) => {
             console.log(text);
           });
-          
+
           useEffect(() => {
             onEvent('Hello world');
           });
@@ -1421,7 +1449,7 @@ if (__EXPERIMENTAL__) {
           });
           return <Child onClick={() => onClick()} />
         }
-          
+
         // The useEffectEvent function shares an identifier name with the above
         function MyLastComponent({theme}) {
           const onClick = useEffectEvent(() => {
@@ -1570,6 +1598,12 @@ function useEffectEventError(fn, called) {
 function asyncComponentHookError(fn) {
   return {
     message: `React Hook "${fn}" cannot be called in an async function.`,
+  };
+}
+
+function tryCatchUseError(fn) {
+  return {
+    message: `React Hook "${fn}" cannot be called in a try/catch block.`,
   };
 }
 

--- a/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
@@ -111,6 +111,16 @@ function isInsideDoWhileLoop(node: Node | undefined): node is DoWhileStatement {
   return false;
 }
 
+function isInsideTryCatch(node: Node | undefined): boolean {
+  while (node) {
+    if (node.type === 'TryStatement' || node.type === 'CatchClause') {
+      return true;
+    }
+    node = node.parent;
+  }
+  return false;
+}
+
 function isUseEffectEventIdentifier(node: Node): boolean {
   if (__EXPERIMENTAL__) {
     return node.type === 'Identifier' && node.name === 'useEffectEvent';
@@ -530,6 +540,16 @@ const rule = {
             // Skip reporting if this hook already has a relevant flow suppression.
             if (hasFlowSuppression(hook, 'react-rule-hook')) {
               continue;
+            }
+
+            // Report an error if use() is called inside try/catch/finally.
+            if (isUseIdentifier(hook) && isInsideTryCatch(hook)) {
+              context.report({
+                node: hook,
+                message: `React Hook "${getSourceCode().getText(
+                  hook,
+                )}" cannot be called in a try/catch/finally block.`,
+              });
             }
 
             // Report an error if a hook may be called more then once.


### PR DESCRIPTION



Follow up to #34032. The linter now ensures that `use` cannot be used within try/catch.
