### PR TITLE
[DevTools] Clean up Virtual Instances from id map

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -2732,6 +2732,8 @@ export function attach(
 
     const id = instance.id;
     pendingRealUnmountedIDs.push(id);
+
+    idToDevToolsInstanceMap.delete(instance.id);
   }
 
   function getSecondaryEnvironmentName(


### PR DESCRIPTION
This was a pretty glaring memory leak. 🙈

I forgot to clean up the VirtualInstances from the id map so the Server Component instances always leaked in DEV.