### PR TITLE
bugfix: fix eager state miss https://github.com/facebook/react/issues…

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -4098,187 +4098,193 @@ function beginWork(
   // move this assignment out of the common path and into each branch.
   workInProgress.lanes = NoLanes;
 
-  switch (workInProgress.tag) {
-    case LazyComponent: {
-      const elementType = workInProgress.elementType;
-      return mountLazyComponent(
-        current,
-        workInProgress,
-        elementType,
-        renderLanes,
-      );
-    }
-    case FunctionComponent: {
-      const Component = workInProgress.type;
-      return updateFunctionComponent(
-        current,
-        workInProgress,
-        Component,
-        workInProgress.pendingProps,
-        renderLanes,
-      );
-    }
-    case ClassComponent: {
-      const Component = workInProgress.type;
-      const unresolvedProps = workInProgress.pendingProps;
-      const resolvedProps = resolveClassComponentProps(
-        Component,
-        unresolvedProps,
-      );
-      return updateClassComponent(
-        current,
-        workInProgress,
-        Component,
-        resolvedProps,
-        renderLanes,
-      );
-    }
-    case HostRoot:
-      return updateHostRoot(current, workInProgress, renderLanes);
-    case HostHoistable:
-      if (supportsResources) {
-        return updateHostHoistable(current, workInProgress, renderLanes);
-      }
-    // Fall through
-    case HostSingleton:
-      if (supportsSingletons) {
-        return updateHostSingleton(current, workInProgress, renderLanes);
-      }
-    // Fall through
-    case HostComponent:
-      return updateHostComponent(current, workInProgress, renderLanes);
-    case HostText:
-      return updateHostText(current, workInProgress);
-    case SuspenseComponent:
-      return updateSuspenseComponent(current, workInProgress, renderLanes);
-    case HostPortal:
-      return updatePortalComponent(current, workInProgress, renderLanes);
-    case ForwardRef: {
-      return updateForwardRef(
-        current,
-        workInProgress,
-        workInProgress.type,
-        workInProgress.pendingProps,
-        renderLanes,
-      );
-    }
-    case Fragment:
-      return updateFragment(current, workInProgress, renderLanes);
-    case Mode:
-      return updateMode(current, workInProgress, renderLanes);
-    case Profiler:
-      return updateProfiler(current, workInProgress, renderLanes);
-    case ContextProvider:
-      return updateContextProvider(current, workInProgress, renderLanes);
-    case ContextConsumer:
-      return updateContextConsumer(current, workInProgress, renderLanes);
-    case MemoComponent: {
-      return updateMemoComponent(
-        current,
-        workInProgress,
-        workInProgress.type,
-        workInProgress.pendingProps,
-        renderLanes,
-      );
-    }
-    case SimpleMemoComponent: {
-      return updateSimpleMemoComponent(
-        current,
-        workInProgress,
-        workInProgress.type,
-        workInProgress.pendingProps,
-        renderLanes,
-      );
-    }
-    case IncompleteClassComponent: {
-      if (disableLegacyMode) {
-        break;
-      }
-      const Component = workInProgress.type;
-      const unresolvedProps = workInProgress.pendingProps;
-      const resolvedProps = resolveClassComponentProps(
-        Component,
-        unresolvedProps,
-      );
-      return mountIncompleteClassComponent(
-        current,
-        workInProgress,
-        Component,
-        resolvedProps,
-        renderLanes,
-      );
-    }
-    case IncompleteFunctionComponent: {
-      if (disableLegacyMode) {
-        break;
-      }
-      const Component = workInProgress.type;
-      const unresolvedProps = workInProgress.pendingProps;
-      const resolvedProps = resolveClassComponentProps(
-        Component,
-        unresolvedProps,
-      );
-      return mountIncompleteFunctionComponent(
-        current,
-        workInProgress,
-        Component,
-        resolvedProps,
-        renderLanes,
-      );
-    }
-    case SuspenseListComponent: {
-      return updateSuspenseListComponent(current, workInProgress, renderLanes);
-    }
-    case ScopeComponent: {
-      if (enableScopeAPI) {
-        return updateScopeComponent(current, workInProgress, renderLanes);
-      }
-      break;
-    }
-    case ActivityComponent: {
-      return updateActivityComponent(current, workInProgress, renderLanes);
-    }
-    case OffscreenComponent: {
-      return updateOffscreenComponent(
-        current,
-        workInProgress,
-        renderLanes,
-        workInProgress.pendingProps,
-      );
-    }
-    case LegacyHiddenComponent: {
-      if (enableLegacyHidden) {
-        return updateLegacyHiddenComponent(
+  try {
+    switch (workInProgress.tag) {
+      case LazyComponent: {
+        const elementType = workInProgress.elementType;
+        return mountLazyComponent(
           current,
           workInProgress,
+          elementType,
           renderLanes,
         );
       }
-      break;
-    }
-    case CacheComponent: {
-      return updateCacheComponent(current, workInProgress, renderLanes);
-    }
-    case TracingMarkerComponent: {
-      if (enableTransitionTracing) {
-        return updateTracingMarkerComponent(
+      case FunctionComponent: {
+        const Component = workInProgress.type;
+        return updateFunctionComponent(
           current,
           workInProgress,
+          Component,
+          workInProgress.pendingProps,
           renderLanes,
         );
       }
-      break;
-    }
-    case ViewTransitionComponent: {
-      if (enableViewTransition) {
-        return updateViewTransition(current, workInProgress, renderLanes);
+      case ClassComponent: {
+        const Component = workInProgress.type;
+        const unresolvedProps = workInProgress.pendingProps;
+        const resolvedProps = resolveClassComponentProps(
+          Component,
+          unresolvedProps,
+        );
+        return updateClassComponent(
+          current,
+          workInProgress,
+          Component,
+          resolvedProps,
+          renderLanes,
+        );
       }
-      break;
+      case HostRoot:
+        return updateHostRoot(current, workInProgress, renderLanes);
+      case HostHoistable:
+        if (supportsResources) {
+          return updateHostHoistable(current, workInProgress, renderLanes);
+        }
+      // Fall through
+      case HostSingleton:
+        if (supportsSingletons) {
+          return updateHostSingleton(current, workInProgress, renderLanes);
+        }
+      // Fall through
+      case HostComponent:
+        return updateHostComponent(current, workInProgress, renderLanes);
+      case HostText:
+        return updateHostText(current, workInProgress);
+      case SuspenseComponent:
+        return updateSuspenseComponent(current, workInProgress, renderLanes);
+      case HostPortal:
+        return updatePortalComponent(current, workInProgress, renderLanes);
+      case ForwardRef: {
+        return updateForwardRef(
+          current,
+          workInProgress,
+          workInProgress.type,
+          workInProgress.pendingProps,
+          renderLanes,
+        );
+      }
+      case Fragment:
+        return updateFragment(current, workInProgress, renderLanes);
+      case Mode:
+        return updateMode(current, workInProgress, renderLanes);
+      case Profiler:
+        return updateProfiler(current, workInProgress, renderLanes);
+      case ContextProvider:
+        return updateContextProvider(current, workInProgress, renderLanes);
+      case ContextConsumer:
+        return updateContextConsumer(current, workInProgress, renderLanes);
+      case MemoComponent: {
+        return updateMemoComponent(
+          current,
+          workInProgress,
+          workInProgress.type,
+          workInProgress.pendingProps,
+          renderLanes,
+        );
+      }
+      case SimpleMemoComponent: {
+        return updateSimpleMemoComponent(
+          current,
+          workInProgress,
+          workInProgress.type,
+          workInProgress.pendingProps,
+          renderLanes,
+        );
+      }
+      case IncompleteClassComponent: {
+        if (disableLegacyMode) {
+          break;
+        }
+        const Component = workInProgress.type;
+        const unresolvedProps = workInProgress.pendingProps;
+        const resolvedProps = resolveClassComponentProps(
+          Component,
+          unresolvedProps,
+        );
+        return mountIncompleteClassComponent(
+          current,
+          workInProgress,
+          Component,
+          resolvedProps,
+          renderLanes,
+        );
+      }
+      case IncompleteFunctionComponent: {
+        if (disableLegacyMode) {
+          break;
+        }
+        const Component = workInProgress.type;
+        const unresolvedProps = workInProgress.pendingProps;
+        const resolvedProps = resolveClassComponentProps(
+          Component,
+          unresolvedProps,
+        );
+        return mountIncompleteFunctionComponent(
+          current,
+          workInProgress,
+          Component,
+          resolvedProps,
+          renderLanes,
+        );
+      }
+      case SuspenseListComponent: {
+        return updateSuspenseListComponent(current, workInProgress, renderLanes);
+      }
+      case ScopeComponent: {
+        if (enableScopeAPI) {
+          return updateScopeComponent(current, workInProgress, renderLanes);
+        }
+        break;
+      }
+      case ActivityComponent: {
+        return updateActivityComponent(current, workInProgress, renderLanes);
+      }
+      case OffscreenComponent: {
+        return updateOffscreenComponent(
+          current,
+          workInProgress,
+          renderLanes,
+          workInProgress.pendingProps,
+        );
+      }
+      case LegacyHiddenComponent: {
+        if (enableLegacyHidden) {
+          return updateLegacyHiddenComponent(
+            current,
+            workInProgress,
+            renderLanes,
+          );
+        }
+        break;
+      }
+      case CacheComponent: {
+        return updateCacheComponent(current, workInProgress, renderLanes);
+      }
+      case TracingMarkerComponent: {
+        if (enableTransitionTracing) {
+          return updateTracingMarkerComponent(
+            current,
+            workInProgress,
+            renderLanes,
+          );
+        }
+        break;
+      }
+      case ViewTransitionComponent: {
+        if (enableViewTransition) {
+          return updateViewTransition(current, workInProgress, renderLanes);
+        }
+        break;
+      }
+      case Throw: {
+        // This represents a Component that threw in the reconciliation phase.
+        // So we'll rethrow here. This might be a Thenable.
+        throw workInProgress.pendingProps;
+      }
     }
-    case Throw: {
-      // This represents a Component that threw in the reconciliation phase.
-      // So we'll rethrow here. This might be a Thenable.
-      throw workInProgress.pendingProps;
+  } finally {
+    if (current !== null) {
+      workInProgress.lanes = removeLanes(workInProgress.lanes, renderLanes);
     }
   }
 


### PR DESCRIPTION
…/34061

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

I open a issue to explain this: https://github.com/facebook/react/issues/34061

==== the issue content  ======
```js

import React, { useState } from 'react';

export function App(props) {
  console.log('App');
  return <Child0 />;
}

function Child0(props) {
  let [state, setState] = useState(0);
  console.log('child0', state);
  return (
    <div onClick={() => setState(1)}>
      child0
      <Child1 />
    </div>
  );
}

function Child1(props) {
  console.log('child1');
  console.log('=======');
  return <div>child1</div>;
}
```

console:
```
App 
child0 0
child1 
=======  (first click)
child0 1
child1 
======= (second click) 
child0 1

(rest click: noop, eager state)
```
Strange, why is child0 1 printed one more time here?

Isn't there eager state? If the state hasn't changed, it shouldn't re-render, right?

I didn't use StrictMode

I debug react: 
```js
 function dispatchSetStateInternal(fiber, queue, action, lane) {
      var update = {
        lane: lane,
        revertLane: 0,
        action: action,
        hasEagerState: !1,
        eagerState: null,
        next: null
      };
      if (isRenderPhaseUpdate(fiber)) enqueueRenderPhaseUpdate(queue, update);
      else {
        var alternate = fiber.alternate;
        if (
          0 === fiber.lanes &&
          (null === alternate || 0 === alternate.lanes) &&
          ((alternate = queue.lastRenderedReducer), null !== alternate)
        ) {
          var prevDispatcher = ReactSharedInternals.H;
          ReactSharedInternals.H = InvalidNestedHooksDispatcherOnUpdateInDEV;
          try {
            var currentState = queue.lastRenderedState,
              eagerState = alternate(currentState, action);
            update.hasEagerState = !0;
            update.eagerState = eagerState;
            if (objectIs(eagerState, currentState))
              return (
                enqueueUpdate$1(fiber, queue, update, 0),
                null === workInProgressRoot &&
                  finishQueueingConcurrentUpdates(),
                !1
              );
          } catch (error) {
          } finally {
            ReactSharedInternals.H = prevDispatcher;
          }
        }
        action = enqueueConcurrentHookUpdate(fiber, queue, update, lane);
        if (null !== action)
          return (
            scheduleUpdateOnFiber(action, fiber, lane),
            entangleTransitionUpdate(action, queue, lane),
            !0
          );
      }
      return !1;
    }
```

I'm not using concurrent rendering either—so why does the 0 === fiber.lanes check fail?

Isn't fiber.lanes supposed to be cleared after the update is finished?

======
## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->


very small change, I use `yarn test` to run tests on my code.

Then I build it with the following command:

```bash
node ./scripts/rollup/build.js react/index,react/jsx,react.react-server,react-dom/index,react-dom/client,react-dom/server,react-dom.react-server,react-dom-server.node,react-dom-server-legacy.node,scheduler,react-server-dom-webpack/ --type=NODE_DEV,ESM_PROD,NODE_ES2015

```
After building, I link the react and react-dom packages to a project created with create-react-app. I initially tried linking them to a Vite project, but Vite threw some errors that vite can't use commonJS package.

However, the create-react-app project also throws an error:

```ts
Uncaught TypeError: Cannot read properties of null (reading 'useState')
    at exports.useState (react.development.js:1222:1)
    at Child0 (App.js:10:1)
    at Object.react_stack_bottom_frame (react-dom-client.development.js:28836:1)
    at renderWithHooks (react-dom-client.development.js:7742:1)
    at updateFunctionComponent (react-dom-client.development.js:10173:1)
    at beginWork (react-dom-client.development.js:11838:1)
    at runWithFiberInDEV (react-dom-client.development.js:990:1)
    at performUnitOfWork (react-dom-client.development.js:19212:1)
    at workLoopSync (react-dom-client.development.js:19042:1)
    at renderRootSync (react-dom-client.development.js:19023:1)

```

I didn’t modify useState, so this is really strange. Maybe I built it incorrectly?

but I run `yarn test`, only a few test didn't pass(17), like original project that i didn't modify anything.