### PR TITLE
Fix form status reset when component state is updated

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -181,6 +181,7 @@ import {
   isPrimaryRenderer,
   getResource,
   createHoistableInstance,
+  HostTransitionContext,
 } from './ReactFiberConfig';
 import type {ActivityInstance, SuspenseInstance} from './ReactFiberConfig';
 import {shouldError, shouldSuspend} from './ReactFiberReconciler';
@@ -1935,6 +1936,8 @@ function updateHostComponent(
     tryToClaimNextHydratableInstance(workInProgress);
   }
 
+  pushHostContext(workInProgress);
+
   const type = workInProgress.type;
   const nextProps = workInProgress.pendingProps;
   const prevProps = current !== null ? current.memoizedProps : null;
@@ -1962,14 +1965,30 @@ function updateHostComponent(
     //
     // Once a fiber is upgraded to be stateful, it remains stateful for the
     // rest of its lifetime.
-    renderTransitionAwareHostComponentWithHooks(
+    const newState = renderTransitionAwareHostComponentWithHooks(
       current,
       workInProgress,
       renderLanes,
     );
-  }
 
-  pushHostContext(workInProgress);
+    // If the transition state changed, propagate the change to all the
+    // descendents. We use Context as an implementation detail for this.
+    //
+    // We need to update it here because
+    // pushHostContext gets called before we process the state hook, to avoid
+    // a state mismatch in the event that something suspends.
+    //
+    // NOTE: This assumes that there cannot be nested transition providers,
+    // because the only renderer that implements this feature is React DOM,
+    // and forms cannot be nested. If we did support nested providers, then
+    // we would need to push a context value even for host fibers that
+    // haven't been upgraded yet.
+    if (isPrimaryRenderer) {
+      HostTransitionContext._currentValue = newState;
+    } else {
+      HostTransitionContext._currentValue2 = newState;
+    }
+  }
 
   markRef(current, workInProgress);
   reconcileChildren(current, workInProgress, nextChildren, renderLanes);

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -181,7 +181,6 @@ import {
   isPrimaryRenderer,
   getResource,
   createHoistableInstance,
-  HostTransitionContext,
 } from './ReactFiberConfig';
 import type {ActivityInstance, SuspenseInstance} from './ReactFiberConfig';
 import {shouldError, shouldSuspend} from './ReactFiberReconciler';
@@ -1936,8 +1935,6 @@ function updateHostComponent(
     tryToClaimNextHydratableInstance(workInProgress);
   }
 
-  pushHostContext(workInProgress);
-
   const type = workInProgress.type;
   const nextProps = workInProgress.pendingProps;
   const prevProps = current !== null ? current.memoizedProps : null;
@@ -1965,30 +1962,14 @@ function updateHostComponent(
     //
     // Once a fiber is upgraded to be stateful, it remains stateful for the
     // rest of its lifetime.
-    const newState = renderTransitionAwareHostComponentWithHooks(
+    renderTransitionAwareHostComponentWithHooks(
       current,
       workInProgress,
       renderLanes,
     );
-
-    // If the transition state changed, propagate the change to all the
-    // descendents. We use Context as an implementation detail for this.
-    //
-    // This is intentionally set here instead of pushHostContext because
-    // pushHostContext gets called before we process the state hook, to avoid
-    // a state mismatch in the event that something suspends.
-    //
-    // NOTE: This assumes that there cannot be nested transition providers,
-    // because the only renderer that implements this feature is React DOM,
-    // and forms cannot be nested. If we did support nested providers, then
-    // we would need to push a context value even for host fibers that
-    // haven't been upgraded yet.
-    if (isPrimaryRenderer) {
-      HostTransitionContext._currentValue = newState;
-    } else {
-      HostTransitionContext._currentValue2 = newState;
-    }
   }
+
+  pushHostContext(workInProgress);
 
   markRef(current, workInProgress);
   reconcileChildren(current, workInProgress, nextChildren, renderLanes);

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -857,8 +857,8 @@ export function renderTransitionAwareHostComponentWithHooks(
   current: Fiber | null,
   workInProgress: Fiber,
   lanes: Lanes,
-): TransitionStatus {
-  return renderWithHooks(
+): void {
+  renderWithHooks(
     current,
     workInProgress,
     TransitionAwareHostComponent,

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -857,8 +857,8 @@ export function renderTransitionAwareHostComponentWithHooks(
   current: Fiber | null,
   workInProgress: Fiber,
   lanes: Lanes,
-): void {
-  renderWithHooks(
+): TransitionStatus {
+  return renderWithHooks(
     current,
     workInProgress,
     TransitionAwareHostComponent,

--- a/packages/react-reconciler/src/ReactFiberHostContext.js
+++ b/packages/react-reconciler/src/ReactFiberHostContext.js
@@ -126,14 +126,19 @@ function popHostContext(fiber: Fiber): void {
     // should be fine.
     pop(hostTransitionProviderCursor, fiber);
 
-    // When popping the transition provider, we reset the context value back
-    // to `NotPendingTransition`. We can do this because you're not allowed to nest forms. If
-    // we allowed for multiple nested host transition providers, then we'd
-    // need to reset this to the parent provider's status.
-    if (isPrimaryRenderer) {
-      HostTransitionContext._currentValue = NotPendingTransition;
-    } else {
-      HostTransitionContext._currentValue2 = NotPendingTransition;
+    // When popping the transition provider, we make sure that the entire queue of
+    // the current transition is completed. This is necessary because popping is also
+    // executed when the state changes for children subscribed to the transition provider
+    if (!fiber.memoizedState.memoizedState.pending) {
+      // When popping the transition provider, we reset the context value back
+      // to `NotPendingTransition`. We can do this because you're not allowed to nest forms. If
+      // we allowed for multiple nested host transition providers, then we'd
+      // need to reset this to the parent provider's status.
+      if (isPrimaryRenderer) {
+        HostTransitionContext._currentValue = NotPendingTransition;
+      } else {
+        HostTransitionContext._currentValue2 = NotPendingTransition;
+      }
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberHostContext.js
+++ b/packages/react-reconciler/src/ReactFiberHostContext.js
@@ -96,7 +96,7 @@ function getHostContext(): HostContext {
 function pushHostContext(fiber: Fiber): void {
   const stateHook: Hook | null = fiber.memoizedState;
   if (stateHook !== null) {
-    // Propagate the state to all the descendents.
+    // Propagate the current state to all the descendents.
     // We use Context as an implementation detail for this.
     //
     // NOTE: This assumes that there cannot be nested transition providers,


### PR DESCRIPTION
Alternate to https://github.com/facebook/react/pull/33351 without the regression highlighted in https://github.com/facebook/react/pull/33351#discussion_r2247272687

Host context is now updated in `pushHostContext` (similar to normal React Context) in addition to during `updateHostComponent`.

Closes https://github.com/facebook/react/issues/30368
Closes https://github.com/facebook/react/pull/33351