### PR TITLE
[Flight] Fix debug info leaking to outer handler

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -879,7 +879,7 @@ function initializeDebugChunk(
             waitForReference(
               debugChunk,
               {}, // noop, since we'll have already added an entry to debug info
-              '', // noop
+              'debug', // noop, but we need it to not be empty string since that indicates the root object
               response,
               initializeDebugInfo,
               [''], // path


### PR DESCRIPTION
The `waitForReference` call for debug info can trigger inside a different object's initializingHandler. In that case, we can get confused by which one is the root object.

We have this special case to detect if the initializing handler's object is `null` and we have an empty string key, then we should replace the root object's value with the resolved value.

https://github.com/facebook/react/blob/52612a7cbdd8e1fee9599478247f78725869ebad/packages/react-client/src/ReactFlightClient.js#L1374

However, if the initializing handler actually should have the value `null` then we might get confused by this and replace it with the resolved value from a debug object. This fixes it by just using a non-empty string as the key for the waitForReference on debug value since we're not going to use it anyway.

It used to be impossible to get into this state since a `null` value at the root couldn't have any reference inside itself but now the debug info for a `null` value can have outstanding references.

However, a better fix might be using a placeholder marker object instead of null or better yet ensuring that we know which root we're initializing in the debug model.