### PR TITLE
[DevTools] Disconnect and Reconnect children of Suspense boundaries instead of Unmounting and Mounting

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -3356,7 +3356,12 @@ export function attach(
     let child: null | DevToolsInstance = parentInstance.firstChild;
     while (child !== null) {
       if (child.kind === FILTERED_FIBER_INSTANCE) {
-        addUnfilteredChildrenIDs(child, nextChildren);
+        const fiber = child.data;
+        if (fiber.tag === OffscreenComponent && fiber.memoizedState !== null) {
+          // The children of this Offscreen are hidden so they don't get added.
+        } else {
+          addUnfilteredChildrenIDs(child, nextChildren);
+        }
       } else {
         nextChildren.push(child.id);
       }

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -3945,7 +3945,7 @@ export function attach(
         const stashedDisconnected = isInDisconnectedSubtree;
         isInDisconnectedSubtree = true;
         try {
-          updateChildrenRecursively(prevFiber.child, nextFiber.child, false);
+          updateChildrenRecursively(nextFiber.child, prevFiber.child, false);
         } finally {
           isInDisconnectedSubtree = stashedDisconnected;
         }
@@ -3957,8 +3957,8 @@ export function attach(
         if (nextFiber.child !== null) {
           if (
             updateChildrenRecursively(
-              prevFiber.child,
               nextFiber.child,
+              prevFiber.child,
               traceNearestHostComponentUpdate,
             )
           ) {


### PR DESCRIPTION
Stacked on #34082.

This keeps the DevToolsInstance children alive inside Offscreen trees while they're hidden. However, they're sent as unmounted to the front end store.

This allows DevTools state to be preserved between these two states.

Such as it keeps the "suspended by" set on the SuspenseNode alive since the children are still mounted. So now you when you resuspend, you can see what in the children was suspended. This is useful when you're simulating a suspense but can also be a bit misleading when something suspended for real since it'll only show the previous suspended set and not what is currently suspending it since that hasn't committed yet.

SuspenseNodes inside resuspended trees are now kept alive too. That way they can contribute to the timeline even when resuspended. We can choose whether to keep them visible in the rects while hidden or not.

In the future we'll also need to add more special cases around Activity. Because right now if SuspenseNodes are kept alive in the Suspense tab UI while hidden, then they're also alive inside Activity that are hidden which maybe we don't want. Maybe simplest would be that they both disappear from the Suspense tab UI but can be considered for the timeline.

Another case is that when Activity goes hidden, Fiber will no longer cause its content to suspend the parent but that's not modeled here. So hidden Activity will show up as "suspended by" in a parent Suspense. When they disconnect, they should really be removed from the "suspended by" set of the parent (and perhaps be shown only on the Activity boundary itself).