### PR TITLE
[DevTools] Only show state for ClassComponents

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -969,7 +969,6 @@ export function attach(
   } = getInternalReactConstants(version);
   const {
     ActivityComponent,
-    CacheComponent,
     ClassComponent,
     ContextConsumer,
     DehydratedSuspenseComponent,
@@ -4618,7 +4617,8 @@ export function attach(
 
     // TODO Show custom UI for Cache like we do for Suspense
     // For now, just hide state data entirely since it's not meant to be inspected.
-    const showState = !usesHooks && tag !== CacheComponent;
+    const showState =
+      tag === ClassComponent || tag === IncompleteClassComponent;
 
     const typeSymbol = getTypeSymbol(type);
 


### PR DESCRIPTION
The only thing that uses `memoizedState` as a public API is ClassComponents. Everything else uses it as internals. We shouldn't ever show those internals.

Before those internals showed up for example on a suspended Suspense boundary:

<img width="436" height="370" alt="Screenshot 2025-08-03 at 8 13 37 PM" src="https://github.com/user-attachments/assets/7fe275a7-d5da-421d-a000-523825916630" />
