### PR TITLE
Add compareDocumentPosition to Fabric FragmentInstance

### DIFF
--- a/packages/shared/ReactDOMFragmentRefShared.js
+++ b/packages/shared/ReactDOMFragmentRefShared.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Shared logic for Fragment Ref operations for DOM and Fabric configs
+ *
+ * @flow
+ */
+
+import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+
+import {getNextSiblingHostFiber} from 'react-reconciler/src/ReactFiberTreeReflection';
+
+export function compareDocumentPositionForEmptyFragment<TPublicInstance>(
+  fragmentFiber: Fiber,
+  parentHostInstance: TPublicInstance,
+  otherNode: TPublicInstance,
+  getPublicInstance: (fiber: Fiber) => TPublicInstance,
+): number {
+  let result;
+  // If the fragment has no children, we can use the parent and
+  // siblings to determine a position.
+  // $FlowFixMe[incompatible-use] Fabric PublicInstance is opaque
+  // $FlowFixMe[prop-missing]
+  const parentResult = parentHostInstance.compareDocumentPosition(otherNode);
+  result = parentResult;
+  if (parentHostInstance === otherNode) {
+    result = Node.DOCUMENT_POSITION_CONTAINS;
+  } else {
+    if (parentResult & Node.DOCUMENT_POSITION_CONTAINED_BY) {
+      // otherNode is one of the fragment's siblings. Use the next
+      // sibling to determine if its preceding or following.
+      const nextSiblingFiber = getNextSiblingHostFiber(fragmentFiber);
+      if (nextSiblingFiber === null) {
+        result = Node.DOCUMENT_POSITION_PRECEDING;
+      } else {
+        const nextSiblingInstance = getPublicInstance(nextSiblingFiber);
+        const nextSiblingResult =
+          // $FlowFixMe[incompatible-use] Fabric PublicInstance is opaque
+          // $FlowFixMe[prop-missing]
+          nextSiblingInstance.compareDocumentPosition(otherNode);
+        if (
+          nextSiblingResult === 0 ||
+          nextSiblingResult & Node.DOCUMENT_POSITION_FOLLOWING
+        ) {
+          result = Node.DOCUMENT_POSITION_FOLLOWING;
+        } else {
+          result = Node.DOCUMENT_POSITION_PRECEDING;
+        }
+      }
+    }
+  }
+
+  result |= Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
+  return result;
+}


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/34069

Same basic semantics as the react-dom for determining document position of a Fragment compared to a given node. It's simpler here because we don't have to deal with inserted nodes or portals. So we can skip a bunch of the validation logic.

The logic for handling empty fragments is the same so I've split out `compareDocumentPositionForEmptyFragment` into a shared module. There doesn't seem to be a great place to put shared DOM logic between Fabric and DOM configs at the moment. There may be more of this coming as we add more and more DOM APIs to RN.

For testing I've written Fantom tests internally which pass the basic cases on this build. The renderer we have configured for Fabric tests in the repo doesn't support the Element APIs we need like `compareDocumentPosition`.