### PR TITLE
[DevTools] Don't bailout update for filtered instance

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -3917,7 +3917,10 @@ export function attach(
           }
         } else {
           // Children are unchanged.
-          if (fiberInstance !== null) {
+          if (
+            fiberInstance !== null &&
+            fiberInstance.kind !== FILTERED_FIBER_INSTANCE
+          ) {
             // All the remaining children will be children of this same fiber so we can just reuse them.
             // I.e. we just restore them by undoing what we did above.
             fiberInstance.firstChild = remainingReconcilingChildren;


### PR DESCRIPTION
Instead, we just continue to collect the unfiltered children.

