### PR TITLE
Replace `withErrorOrWarnings` with existing console matchers

### DIFF
--- a/packages/internal-test-utils/ReactInternalTestUtils.js
+++ b/packages/internal-test-utils/ReactInternalTestUtils.js
@@ -328,16 +328,19 @@ export const assertConsoleLogDev = createLogAssertion(
   'log',
   'assertConsoleLogDev',
   clearLogs,
+  __DEV__,
 );
 export const assertConsoleWarnDev = createLogAssertion(
   'warn',
   'assertConsoleWarnDev',
   clearWarnings,
+  __DEV__,
 );
 export const assertConsoleErrorDev = createLogAssertion(
   'error',
   'assertConsoleErrorDev',
   clearErrors,
+  __DEV__,
 );
 
 // Simulates dispatching events, waiting for microtasks in between.

--- a/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
+++ b/packages/internal-test-utils/__tests__/ReactInternalTestUtils-test.js
@@ -389,7 +389,7 @@ describe('ReactInternalTestUtils console assertions', () => {
         + B
         + C
 
-        You must call one of the assertConsoleDev helpers between each act call."
+        You must call one of the console assertion helpers between each act call."
       `);
     });
 
@@ -608,7 +608,8 @@ describe('ReactInternalTestUtils console assertions', () => {
         "assertConsoleLogDev(expected)
 
         Received 2 arguments for a message with 1 placeholders:
-          "Hi %s""
+          message: "Hi %s"
+          placeholders: ["Sara", "extra"]"
       `);
     });
 
@@ -623,10 +624,12 @@ describe('ReactInternalTestUtils console assertions', () => {
         "assertConsoleLogDev(expected)
 
         Received 2 arguments for a message with 1 placeholders:
-          "Hi %s"
+          message: "Hi %s"
+          placeholders: ["Sara", "extra"]
 
         Received 2 arguments for a message with 1 placeholders:
-          "Bye %s""
+          message: "Bye %s"
+          placeholders: ["Sara", "extra"]"
       `);
     });
 
@@ -640,7 +643,8 @@ describe('ReactInternalTestUtils console assertions', () => {
         "assertConsoleLogDev(expected)
 
         Received 0 arguments for a message with 1 placeholders:
-          "Hi %s""
+          message: "Hi %s"
+          placeholders: []"
       `);
     });
 
@@ -655,10 +659,12 @@ describe('ReactInternalTestUtils console assertions', () => {
         "assertConsoleLogDev(expected)
 
         Received 0 arguments for a message with 1 placeholders:
-          "Hi %s"
+          message: "Hi %s"
+          placeholders: []
 
         Received 0 arguments for a message with 1 placeholders:
-          "Bye %s""
+          message: "Bye %s"
+          placeholders: []"
       `);
     });
 
@@ -706,7 +712,7 @@ describe('ReactInternalTestUtils console assertions', () => {
         console.log was called without assertConsoleLogDev:
         + Not asserted
 
-        You must call one of the assertConsoleDev helpers between each act call."
+        You must call one of the console assertion helpers between each act call."
       `);
 
       await waitForAll(['foo', 'bar', 'baz']);
@@ -748,7 +754,7 @@ describe('ReactInternalTestUtils console assertions', () => {
         console.log was called without assertConsoleLogDev:
         + Not asserted
 
-        You must call one of the assertConsoleDev helpers between each act call."
+        You must call one of the console assertion helpers between each act call."
       `);
 
       await waitForAll(['A', 'B', 'A', 'B']);
@@ -783,7 +789,7 @@ describe('ReactInternalTestUtils console assertions', () => {
         console.log was called without assertConsoleLogDev:
         + Not asserted
 
-        You must call one of the assertConsoleDev helpers between each act call."
+        You must call one of the console assertion helpers between each act call."
       `);
 
       await waitForAll(['Urgent: B, Deferred: A', 'Urgent: B, Deferred: B']);
@@ -817,7 +823,7 @@ describe('ReactInternalTestUtils console assertions', () => {
         console.log was called without assertConsoleLogDev:
         + Not asserted
 
-        You must call one of the assertConsoleDev helpers between each act call."
+        You must call one of the console assertion helpers between each act call."
       `);
 
       await waitForAll(['foo', 'bar', 'baz']);
@@ -855,7 +861,7 @@ describe('ReactInternalTestUtils console assertions', () => {
           + Not asserted
           + Not asserted
 
-          You must call one of the assertConsoleDev helpers between each act call."
+          You must call one of the console assertion helpers between each act call."
         `);
       } else {
         expect(message).toMatchInlineSnapshot(`
@@ -866,7 +872,7 @@ describe('ReactInternalTestUtils console assertions', () => {
           + Not asserted
           + Not asserted
 
-          You must call one of the assertConsoleDev helpers between each act call."
+          You must call one of the console assertion helpers between each act call."
         `);
       }
 
@@ -926,21 +932,18 @@ describe('ReactInternalTestUtils console assertions', () => {
           + B
           + C
 
-          You must call one of the assertConsoleDev helpers between each act call."
+          You must call one of the console assertion helpers between each act call."
         `);
       } else {
         expect(message).toMatchInlineSnapshot(`
           "asserConsoleLogsCleared(expected)
 
           console.warn was called without assertConsoleWarnDev:
-          + A%s,
-          +     in App (at **)
-          + B%s,
-          +     in App (at **)
-          + C%s,
-          +     in App (at **)
+          + A
+          + B
+          + C
 
-          You must call one of the assertConsoleDev helpers between each act call."
+          You must call one of the console assertion helpers between each act call."
         `);
       }
     });
@@ -992,7 +995,7 @@ describe('ReactInternalTestUtils console assertions', () => {
           + B
           + C
 
-          You must call one of the assertConsoleDev helpers between each act call."
+          You must call one of the console assertion helpers between each act call."
         `);
       } else {
         expect(message).toMatchInlineSnapshot(`
@@ -1004,22 +1007,16 @@ describe('ReactInternalTestUtils console assertions', () => {
           + C
 
           console.warn was called without assertConsoleWarnDev:
-          + A%s,
-          +     in App (at **)
-          + B%s,
-          +     in App (at **)
-          + C%s,
-          +     in App (at **)
+          + A
+          + B
+          + C
 
           console.error was called without assertConsoleErrorDev:
-          + A%s,
-          +     in App (at **)
-          + B%s,
-          +     in App (at **)
-          + C%s,
-          +     in App (at **)
+          + A
+          + B
+          + C
 
-          You must call one of the assertConsoleDev helpers between each act call."
+          You must call one of the console assertion helpers between each act call."
         `);
       }
     });
@@ -1548,7 +1545,8 @@ describe('ReactInternalTestUtils console assertions', () => {
         "assertConsoleWarnDev(expected)
 
         Received 2 arguments for a message with 1 placeholders:
-          "Hi %s""
+          message: "Hi %s"
+          placeholders: ["Sara", "extra"]"
       `);
     });
 
@@ -1563,10 +1561,12 @@ describe('ReactInternalTestUtils console assertions', () => {
         "assertConsoleWarnDev(expected)
 
         Received 2 arguments for a message with 1 placeholders:
-          "Hi %s"
+          message: "Hi %s"
+          placeholders: ["Sara", "extra"]
 
         Received 2 arguments for a message with 1 placeholders:
-          "Bye %s""
+          message: "Bye %s"
+          placeholders: ["Sara", "extra"]"
       `);
     });
 
@@ -1580,7 +1580,8 @@ describe('ReactInternalTestUtils console assertions', () => {
         "assertConsoleWarnDev(expected)
 
         Received 0 arguments for a message with 1 placeholders:
-          "Hi %s""
+          message: "Hi %s"
+          placeholders: []"
       `);
     });
 
@@ -1595,10 +1596,12 @@ describe('ReactInternalTestUtils console assertions', () => {
         "assertConsoleWarnDev(expected)
 
         Received 0 arguments for a message with 1 placeholders:
-          "Hi %s"
+          message: "Hi %s"
+          placeholders: []
 
         Received 0 arguments for a message with 1 placeholders:
-          "Bye %s""
+          message: "Bye %s"
+          placeholders: []"
       `);
     });
 
@@ -1708,7 +1711,7 @@ describe('ReactInternalTestUtils console assertions', () => {
         console.warn was called without assertConsoleWarnDev:
         + Not asserted
 
-        You must call one of the assertConsoleDev helpers between each act call."
+        You must call one of the console assertion helpers between each act call."
       `);
 
       await waitForAll(['foo', 'bar', 'baz']);
@@ -1750,7 +1753,7 @@ describe('ReactInternalTestUtils console assertions', () => {
         console.warn was called without assertConsoleWarnDev:
         + Not asserted
 
-        You must call one of the assertConsoleDev helpers between each act call."
+        You must call one of the console assertion helpers between each act call."
       `);
 
       await waitForAll(['A', 'B', 'A', 'B']);
@@ -1785,7 +1788,7 @@ describe('ReactInternalTestUtils console assertions', () => {
         console.warn was called without assertConsoleWarnDev:
         + Not asserted
 
-        You must call one of the assertConsoleDev helpers between each act call."
+        You must call one of the console assertion helpers between each act call."
       `);
 
       await waitForAll(['Urgent: B, Deferred: A', 'Urgent: B, Deferred: B']);
@@ -1819,7 +1822,7 @@ describe('ReactInternalTestUtils console assertions', () => {
         console.warn was called without assertConsoleWarnDev:
         + Not asserted
 
-        You must call one of the assertConsoleDev helpers between each act call."
+        You must call one of the console assertion helpers between each act call."
       `);
 
       await waitForAll(['foo', 'bar', 'baz']);
@@ -1857,21 +1860,18 @@ describe('ReactInternalTestUtils console assertions', () => {
           + Not asserted
           + Not asserted
 
-          You must call one of the assertConsoleDev helpers between each act call."
+          You must call one of the console assertion helpers between each act call."
         `);
       } else {
         expect(message).toMatchInlineSnapshot(`
           "asserConsoleLogsCleared(expected)
 
           console.warn was called without assertConsoleWarnDev:
-          + Not asserted%s,
-          +     in Yield (at **)
-          + Not asserted%s,
-          +     in Yield (at **)
-          + Not asserted%s,
-          +     in Yield (at **)
+          + Not asserted
+          + Not asserted
+          + Not asserted
 
-          You must call one of the assertConsoleDev helpers between each act call."
+          You must call one of the console assertion helpers between each act call."
         `);
       }
 
@@ -1931,22 +1931,19 @@ describe('ReactInternalTestUtils console assertions', () => {
           + B
           + C
 
-          You must call one of the assertConsoleDev helpers between each act call."
+          You must call one of the console assertion helpers between each act call."
         `);
       } else {
         expect(message).toMatchInlineSnapshot(`
-                  "asserConsoleLogsCleared(expected)
+          "asserConsoleLogsCleared(expected)
 
-                  console.error was called without assertConsoleErrorDev:
-                  + A%s,
-                  +     in App (at **)
-                  + B%s,
-                  +     in App (at **)
-                  + C%s,
-                  +     in App (at **)
+          console.error was called without assertConsoleErrorDev:
+          + A
+          + B
+          + C
 
-                  You must call one of the assertConsoleDev helpers between each act call."
-              `);
+          You must call one of the console assertion helpers between each act call."
+        `);
       }
     });
 
@@ -1997,35 +1994,29 @@ describe('ReactInternalTestUtils console assertions', () => {
           + B
           + C
 
-          You must call one of the assertConsoleDev helpers between each act call."
+          You must call one of the console assertion helpers between each act call."
         `);
       } else {
         expect(message).toMatchInlineSnapshot(`
-                  "asserConsoleLogsCleared(expected)
+          "asserConsoleLogsCleared(expected)
 
-                  console.log was called without assertConsoleLogDev:
-                  + A
-                  + B
-                  + C
+          console.log was called without assertConsoleLogDev:
+          + A
+          + B
+          + C
 
-                  console.warn was called without assertConsoleWarnDev:
-                  + A%s,
-                  +     in App (at **)
-                  + B%s,
-                  +     in App (at **)
-                  + C%s,
-                  +     in App (at **)
+          console.warn was called without assertConsoleWarnDev:
+          + A
+          + B
+          + C
 
-                  console.error was called without assertConsoleErrorDev:
-                  + A%s,
-                  +     in App (at **)
-                  + B%s,
-                  +     in App (at **)
-                  + C%s,
-                  +     in App (at **)
+          console.error was called without assertConsoleErrorDev:
+          + A
+          + B
+          + C
 
-                  You must call one of the assertConsoleDev helpers between each act call."
-              `);
+          You must call one of the console assertion helpers between each act call."
+        `);
       }
     });
 
@@ -2597,7 +2588,8 @@ describe('ReactInternalTestUtils console assertions', () => {
         "assertConsoleErrorDev(expected)
 
         Received 2 arguments for a message with 1 placeholders:
-          "Hi %s""
+          message: "Hi %s"
+          placeholders: ["Sara", "extra"]"
       `);
     });
 
@@ -2612,10 +2604,12 @@ describe('ReactInternalTestUtils console assertions', () => {
         "assertConsoleErrorDev(expected)
 
         Received 2 arguments for a message with 1 placeholders:
-          "Hi %s"
+          message: "Hi %s"
+          placeholders: ["Sara", "extra"]
 
         Received 2 arguments for a message with 1 placeholders:
-          "Bye %s""
+          message: "Bye %s"
+          placeholders: ["Sara", "extra"]"
       `);
     });
 
@@ -2629,7 +2623,8 @@ describe('ReactInternalTestUtils console assertions', () => {
         "assertConsoleErrorDev(expected)
 
         Received 0 arguments for a message with 1 placeholders:
-          "Hi %s""
+          message: "Hi %s"
+          placeholders: []"
       `);
     });
 
@@ -2644,10 +2639,12 @@ describe('ReactInternalTestUtils console assertions', () => {
         "assertConsoleErrorDev(expected)
 
         Received 0 arguments for a message with 1 placeholders:
-          "Hi %s"
+          message: "Hi %s"
+          placeholders: []
 
         Received 0 arguments for a message with 1 placeholders:
-          "Bye %s""
+          message: "Bye %s"
+          placeholders: []"
       `);
     });
 
@@ -2757,7 +2754,7 @@ describe('ReactInternalTestUtils console assertions', () => {
         console.error was called without assertConsoleErrorDev:
         + Not asserted
 
-        You must call one of the assertConsoleDev helpers between each act call."
+        You must call one of the console assertion helpers between each act call."
       `);
 
       await waitForAll(['foo', 'bar', 'baz']);
@@ -2799,7 +2796,7 @@ describe('ReactInternalTestUtils console assertions', () => {
         console.error was called without assertConsoleErrorDev:
         + Not asserted
 
-        You must call one of the assertConsoleDev helpers between each act call."
+        You must call one of the console assertion helpers between each act call."
       `);
 
       await waitForAll(['A', 'B', 'A', 'B']);
@@ -2834,7 +2831,7 @@ describe('ReactInternalTestUtils console assertions', () => {
         console.error was called without assertConsoleErrorDev:
         + Not asserted
 
-        You must call one of the assertConsoleDev helpers between each act call."
+        You must call one of the console assertion helpers between each act call."
       `);
 
       await waitForAll(['Urgent: B, Deferred: A', 'Urgent: B, Deferred: B']);
@@ -2868,7 +2865,7 @@ describe('ReactInternalTestUtils console assertions', () => {
         console.error was called without assertConsoleErrorDev:
         + Not asserted
 
-        You must call one of the assertConsoleDev helpers between each act call."
+        You must call one of the console assertion helpers between each act call."
       `);
 
       await waitForAll(['foo', 'bar', 'baz']);
@@ -2906,21 +2903,18 @@ describe('ReactInternalTestUtils console assertions', () => {
           + Not asserted
           + Not asserted
 
-          You must call one of the assertConsoleDev helpers between each act call."
+          You must call one of the console assertion helpers between each act call."
         `);
       } else {
         expect(message).toMatchInlineSnapshot(`
           "asserConsoleLogsCleared(expected)
 
           console.error was called without assertConsoleErrorDev:
-          + Not asserted%s,
-          +     in Yield (at **)
-          + Not asserted%s,
-          +     in Yield (at **)
-          + Not asserted%s,
-          +     in Yield (at **)
+          + Not asserted
+          + Not asserted
+          + Not asserted
 
-          You must call one of the assertConsoleDev helpers between each act call."
+          You must call one of the console assertion helpers between each act call."
         `);
       }
 

--- a/packages/react-devtools-shared/src/__tests__/FastRefreshDevToolsIntegration-test.js
+++ b/packages/react-devtools-shared/src/__tests__/FastRefreshDevToolsIntegration-test.js
@@ -13,11 +13,12 @@ describe('Fast Refresh', () => {
   let React;
   let ReactFreshRuntime;
   let act;
+  let assertConsoleError;
+  let assertConsoleWarn;
   let babel;
   let exportsObj;
   let freshPlugin;
   let store;
-  let withErrorsOrWarningsIgnored;
 
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
@@ -36,7 +37,8 @@ describe('Fast Refresh', () => {
 
     const utils = require('./utils');
     act = utils.act;
-    withErrorsOrWarningsIgnored = utils.withErrorsOrWarningsIgnored;
+    assertConsoleError = utils.assertConsoleError;
+    assertConsoleWarn = utils.assertConsoleWarn;
   });
 
   const {render: renderImplementation, getContainer} =
@@ -189,8 +191,7 @@ describe('Fast Refresh', () => {
   // @reactVersion < 18.0
   // @reactVersion >= 16.9
   it('should not break when there are warnings in between patching (before post commit hook)', () => {
-    withErrorsOrWarningsIgnored(['Expected:'], () => {
-      render(`
+    render(`
       const {useState} = React;
 
       export default function Component() {
@@ -199,15 +200,14 @@ describe('Fast Refresh', () => {
         return null;
       }
     `);
-    });
+    assertConsoleError(['Expected: warning during render']);
     expect(store).toMatchInlineSnapshot(`
       ✕ 0, ⚠ 1
       [root]
           <Component> ⚠
     `);
 
-    withErrorsOrWarningsIgnored(['Expected:'], () => {
-      patch(`
+    patch(`
       const {useEffect, useState} = React;
 
       export default function Component() {
@@ -216,15 +216,14 @@ describe('Fast Refresh', () => {
         return null;
       }
     `);
-    });
+    assertConsoleError(['Expected: warning during render']);
     expect(store).toMatchInlineSnapshot(`
       ✕ 0, ⚠ 2
       [root]
           <Component> ⚠
     `);
 
-    withErrorsOrWarningsIgnored(['Expected:'], () => {
-      patch(`
+    patch(`
       const {useEffect, useState} = React;
 
       export default function Component() {
@@ -236,15 +235,14 @@ describe('Fast Refresh', () => {
         return null;
       }
     `);
-    });
+    assertConsoleError(['Expected: warning during render']);
     expect(store).toMatchInlineSnapshot(`
       ✕ 0, ⚠ 1
       [root]
           <Component> ⚠
     `);
 
-    withErrorsOrWarningsIgnored(['Expected:'], () => {
-      patch(`
+    patch(`
       const {useEffect, useState} = React;
 
       export default function Component() {
@@ -253,7 +251,7 @@ describe('Fast Refresh', () => {
         return null;
       }
     `);
-    });
+    assertConsoleError(['Expected: warning during render']);
     expect(store).toMatchInlineSnapshot(`
       ✕ 0, ⚠ 1
       [root]
@@ -263,8 +261,7 @@ describe('Fast Refresh', () => {
 
   // @reactVersion >= 18.0
   it('should not break when there are warnings in between patching (with post commit hook)', () => {
-    withErrorsOrWarningsIgnored(['Expected:'], () => {
-      render(`
+    render(`
       const {useState} = React;
 
       export default function Component() {
@@ -273,15 +270,14 @@ describe('Fast Refresh', () => {
         return null;
       }
     `);
-    });
+    assertConsoleWarn(['Expected: warning during render']);
     expect(store).toMatchInlineSnapshot(`
       ✕ 0, ⚠ 1
       [root]
           <Component> ⚠
     `);
 
-    withErrorsOrWarningsIgnored(['Expected:'], () => {
-      patch(`
+    patch(`
       const {useEffect, useState} = React;
 
       export default function Component() {
@@ -290,15 +286,14 @@ describe('Fast Refresh', () => {
         return null;
       }
     `);
-    });
+    assertConsoleWarn(['Expected: warning during render']);
     expect(store).toMatchInlineSnapshot(`
       ✕ 0, ⚠ 2
       [root]
           <Component> ⚠
     `);
 
-    withErrorsOrWarningsIgnored(['Expected:'], () => {
-      patch(`
+    patch(`
       const {useEffect, useState} = React;
 
       export default function Component() {
@@ -310,15 +305,15 @@ describe('Fast Refresh', () => {
         return null;
       }
     `);
-    });
+    assertConsoleWarn(['Expected: warning during render']);
+    assertConsoleError(['Expected: error during effect']);
     expect(store).toMatchInlineSnapshot(`
       ✕ 1, ⚠ 1
       [root]
           <Component> ✕⚠
     `);
 
-    withErrorsOrWarningsIgnored(['Expected:'], () => {
-      patch(`
+    patch(`
       const {useEffect, useState} = React;
 
       export default function Component() {
@@ -327,7 +322,7 @@ describe('Fast Refresh', () => {
         return null;
       }
     `);
-    });
+    assertConsoleWarn(['Expected: warning during render']);
     expect(store).toMatchInlineSnapshot(`
       ✕ 0, ⚠ 1
       [root]

--- a/packages/react-devtools-shared/src/__tests__/componentStacks-test.js
+++ b/packages/react-devtools-shared/src/__tests__/componentStacks-test.js
@@ -7,19 +7,22 @@
  * @flow
  */
 
-import {
-  getVersionedRenderImplementation,
-  normalizeCodeLocInfo,
-} from 'react-devtools-shared/src/__tests__/utils';
+import {getVersionedRenderImplementation} from 'react-devtools-shared/src/__tests__/utils';
 
 describe('component stack', () => {
   let React;
   let act;
+  let assertConsoleError;
+  let assertConsoleWarn;
   let supportsOwnerStacks;
 
   beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    jest.resetAllMocks();
     const utils = require('./utils');
     act = utils.act;
+    assertConsoleError = utils.assertConsoleError;
+    assertConsoleWarn = utils.assertConsoleWarn;
 
     React = require('react');
     if (
@@ -44,17 +47,14 @@ describe('component stack', () => {
 
     act(() => render(<Grandparent />));
 
-    expect(
-      global.consoleErrorMock.mock.calls[0].map(normalizeCodeLocInfo),
-    ).toEqual([
+    assertConsoleError([
       'Test error.',
       '\n    in Child (at **)' +
         '\n    in Parent (at **)' +
         '\n    in Grandparent (at **)',
     ]);
-    expect(
-      global.consoleWarnMock.mock.calls[0].map(normalizeCodeLocInfo),
-    ).toEqual([
+
+    assertConsoleWarn([
       'Test warning.',
       '\n    in Child (at **)' +
         '\n    in Parent (at **)' +
@@ -83,11 +83,9 @@ describe('component stack', () => {
 
     expect(useEffectCount).toBe(1);
 
-    expect(
-      global.consoleWarnMock.mock.calls[0].map(normalizeCodeLocInfo),
-    ).toEqual([
-      'Warning to trigger appended component stacks.',
-      '\n    in Example (at **)',
+    assertConsoleWarn([
+      'Warning to trigger appended component stacks.' +
+        '\n    in Example (at **)',
     ]);
   });
 
@@ -113,9 +111,7 @@ describe('component stack', () => {
 
     act(() => render(<Grandparent />));
 
-    expect(
-      global.consoleErrorMock.mock.calls[0].map(normalizeCodeLocInfo),
-    ).toEqual([
+    assertConsoleError([
       'Test error.',
       supportsOwnerStacks
         ? '\n    in Child (at **)'
@@ -124,9 +120,7 @@ describe('component stack', () => {
           '\n    in Parent (at **)' +
           '\n    in Grandparent (at **)',
     ]);
-    expect(
-      global.consoleWarnMock.mock.calls[0].map(normalizeCodeLocInfo),
-    ).toEqual([
+    assertConsoleWarn([
       'Test warning.',
       supportsOwnerStacks
         ? '\n    in Child (at **)'

--- a/packages/react-devtools-shared/src/__tests__/editing-test.js
+++ b/packages/react-devtools-shared/src/__tests__/editing-test.js
@@ -18,6 +18,7 @@ describe('editing interface', () => {
   let bridge: FrontendBridge;
   let store: Store;
   let utils;
+  let assertConsoleErrorDev;
 
   const flushPendingUpdates = () => {
     utils.act(() => jest.runOnlyPendingTimers());
@@ -33,6 +34,8 @@ describe('editing interface', () => {
 
     PropTypes = require('prop-types');
     React = require('react');
+    assertConsoleErrorDev =
+      require('internal-test-utils').assertConsoleErrorDev;
   });
 
   const {render} = getVersionedRenderImplementation();
@@ -918,6 +921,10 @@ describe('editing interface', () => {
           </LegacyContextProvider>,
         ),
       );
+      assertConsoleErrorDev([
+        'LegacyContextProvider uses the legacy childContextTypes API which was removed in React 19.',
+        'ClassComponent uses the legacy contextTypes API which was removed in React 19.',
+      ]);
 
       // This test only covers Class components.
       // Function components using legacy context are not editable.

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -9,7 +9,8 @@
 
 import typeof ReactTestRenderer from 'react-test-renderer';
 import {
-  withErrorsOrWarningsIgnored,
+  assertConsoleError,
+  assertConsoleWarn,
   getLegacyRenderImplementation,
   getModernRenderImplementation,
   getVersionedRenderImplementation,
@@ -24,6 +25,7 @@ describe('InspectedElement', () => {
   let ReactDOMClient;
   let PropTypes;
   let TestRenderer: ReactTestRenderer;
+  let assertConsoleErrorDev;
   let bridge: FrontendBridge;
   let store: Store;
   let utils;
@@ -45,9 +47,13 @@ describe('InspectedElement', () => {
   let ErrorBoundary;
   let errorBoundaryInstance;
 
+  let previousAppendComponentStackSetting;
+
   global.IS_REACT_ACT_ENVIRONMENT = true;
 
   beforeEach(() => {
+    previousAppendComponentStackSetting =
+      global.__REACT_DEVTOOLS_GLOBAL_HOOK__.settings.appendComponentStack;
     utils = require('./utils');
     utils.beforeEachProfiling();
 
@@ -62,6 +68,8 @@ describe('InspectedElement', () => {
     TestUtilsAct = require('internal-test-utils').act;
     TestRenderer = utils.requireTestRenderer();
     TestRendererAct = require('internal-test-utils').act;
+    assertConsoleErrorDev =
+      require('internal-test-utils').assertConsoleErrorDev;
 
     BridgeContext =
       require('react-devtools-shared/src/devtools/views/context').BridgeContext;
@@ -106,6 +114,8 @@ describe('InspectedElement', () => {
   });
 
   afterEach(() => {
+    global.__REACT_DEVTOOLS_GLOBAL_HOOK__.settings.appendComponentStack =
+      previousAppendComponentStackSetting;
     jest.restoreAllMocks();
   });
 
@@ -327,6 +337,17 @@ describe('InspectedElement', () => {
       ),
     );
 
+    assertConsoleErrorDev([
+      [
+        'LegacyContextProvider uses the legacy childContextTypes API which was removed in React 19.',
+        {withoutStack: true},
+      ],
+      [
+        'LegacyContextConsumer uses the legacy contextTypes API which was removed in React 19.',
+        {withoutStack: true},
+      ],
+    ]);
+
     const cases = [
       {
         // <LegacyContextConsumer />
@@ -357,16 +378,17 @@ describe('InspectedElement', () => {
       // from props like defaultInspectedElementID and it's easier to reset here than
       // to read the TreeDispatcherContext and update the selected ID that way.
       // We're testing the inspected values here, not the context wiring, so that's ok.
-      withErrorsOrWarningsIgnored(
-        ['An update to %s inside a test was not wrapped in act'],
-        () => {
-          testRendererInstance = TestRenderer.create(null, {
-            unstable_isConcurrent: true,
-          });
-        },
-      );
+      testRendererInstance = TestRenderer.create(null, {
+        unstable_isConcurrent: true,
+      });
 
       const inspectedElement = await inspectElementAtIndex(index);
+      assertConsoleErrorDev([
+        [
+          'An update to Root inside a test was not wrapped in act',
+          {withoutStack: true},
+        ],
+      ]);
 
       expect(inspectedElement.context).not.toBe(null);
       expect(inspectedElement.hasLegacyContext).toBe(shouldHaveLegacyContext);
@@ -504,21 +526,14 @@ describe('InspectedElement', () => {
 
     const prevInspectedElement = inspectedElement;
 
-    // This test causes an intermediate error to be logged but we can ignore it.
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-
     // Clear the frontend cache to simulate DevTools being closed and re-opened.
     // The backend still thinks the most recently-inspected element is still cached,
     // so the frontend needs to tell it to resend a full value.
     // We can verify this by asserting that the component is re-rendered again.
-    withErrorsOrWarningsIgnored(
-      ['An update to %s inside a test was not wrapped in act'],
-      () => {
-        testRendererInstance = TestRenderer.create(null, {
-          unstable_isConcurrent: true,
-        });
-      },
-    );
+
+    testRendererInstance = TestRenderer.create(null, {
+      unstable_isConcurrent: true,
+    });
 
     const {
       clearCacheForTests,
@@ -527,6 +542,13 @@ describe('InspectedElement', () => {
 
     targetRenderCount = 0;
     inspectedElement = await inspectElementAtIndex(1);
+    assertConsoleErrorDev([
+      [
+        'An update to Root inside a test was not wrapped in act',
+        {withoutStack: true},
+      ],
+      'Error: Cached data for element "3" not found',
+    ]);
     expect(targetRenderCount).toBe(1);
     expect(inspectedElement).toEqual(prevInspectedElement);
   });
@@ -874,6 +896,7 @@ describe('InspectedElement', () => {
         </>,
       ),
     );
+    assertConsoleError(['Error: test-error-do-not-surface']);
 
     const inspectedElement = await inspectElementAtIndex(0);
 
@@ -2182,30 +2205,26 @@ describe('InspectedElement', () => {
     `);
 
     await utils.actAsync(async () => {
-      // Ignore transient warning this causes
-      withErrorsOrWarningsIgnored(['No element found with id'], () => {
-        store.componentFilters = [];
+      store.componentFilters = [];
 
-        // Flush events to the renderer.
-        jest.runOnlyPendingTimers();
-      });
+      // Flush events to the renderer.
+      jest.runOnlyPendingTimers();
     }, false);
+    // Ignore transient warning this causes
+    assertConsoleError(['No element found with id']);
 
     // HACK: Recreate TestRenderer instance because we rely on default state values
     // from props like defaultInspectedElementID and it's easier to reset here than
     // to read the TreeDispatcherContext and update the selected ID that way.
     // We're testing the inspected values here, not the context wiring, so that's ok.
-    withErrorsOrWarningsIgnored(
-      ['An update to %s inside a test was not wrapped in act'],
-      () => {
-        testRendererInstance = TestRenderer.create(null, {
-          unstable_isConcurrent: true,
-        });
-      },
-    );
+
+    testRendererInstance = TestRenderer.create(null, {
+      unstable_isConcurrent: true,
+    });
 
     // Select/inspect the same element again
     inspectedElement = await inspectElementAtIndex(0);
+
     expect(inspectedElement).toMatchInlineSnapshot(`
       {
         "context": null,
@@ -2242,30 +2261,28 @@ describe('InspectedElement', () => {
     `);
 
     await utils.actAsync(async () => {
-      // Ignore transient warning this causes
-      withErrorsOrWarningsIgnored(['No element found with id'], () => {
-        store.componentFilters = [];
+      store.componentFilters = [];
 
-        // Flush events to the renderer.
-        jest.runOnlyPendingTimers();
-      });
+      // Flush events to the renderer.
+      jest.runOnlyPendingTimers();
     }, false);
 
     // HACK: Recreate TestRenderer instance because we rely on default state values
     // from props like defaultInspectedElementID and it's easier to reset here than
     // to read the TreeDispatcherContext and update the selected ID that way.
     // We're testing the inspected values here, not the context wiring, so that's ok.
-    withErrorsOrWarningsIgnored(
-      ['An update to %s inside a test was not wrapped in act'],
-      () => {
-        testRendererInstance = TestRenderer.create(null, {
-          unstable_isConcurrent: true,
-        });
-      },
-    );
+    testRendererInstance = TestRenderer.create(null, {
+      unstable_isConcurrent: true,
+    });
 
     // Select/inspect the same element again
     inspectedElement = await inspectElementAtIndex(0);
+    assertConsoleErrorDev([
+      [
+        'An update to Root inside a test was not wrapped in act(...)',
+        {withoutStack: true},
+      ],
+    ]);
     expect(inspectedElement).toMatchInlineSnapshot(`
       {
         "context": null,
@@ -2289,12 +2306,10 @@ describe('InspectedElement', () => {
     await utils.actAsync(() => {
       const container = document.createElement('div');
       container.innerHTML = '<div></div>';
-      withErrorsOrWarningsIgnored(
-        ['ReactDOM.hydrate has not been supported since React 18'],
-        () => {
-          ReactDOM.hydrate(<Example />, container);
-        },
-      );
+      ReactDOM.hydrate(<Example />, container);
+      assertConsoleErrorDev([
+        'ReactDOM.hydrate has not been supported since React 18',
+      ]);
     }, false);
 
     const inspectedElement = await inspectElementAtIndex(0);
@@ -2341,8 +2356,6 @@ describe('InspectedElement', () => {
   });
 
   it('should gracefully surface backend errors on the frontend rather than timing out', async () => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-
     let shouldThrow = false;
 
     const Example = () => {
@@ -2362,6 +2375,7 @@ describe('InspectedElement', () => {
     shouldThrow = true;
 
     const value = await inspectElementAtIndex(0, noop, true);
+    assertConsoleError(['Error rendering inspected element.']);
 
     expect(value).toBe(null);
 
@@ -2554,9 +2568,9 @@ describe('InspectedElement', () => {
         return null;
       };
 
-      await withErrorsOrWarningsIgnored(['test-only: '], async () => {
-        await utils.actAsync(() => render(<Example repeatWarningCount={1} />));
-      });
+      await utils.actAsync(() => render(<Example repeatWarningCount={1} />));
+      assertConsoleError(['test-only: render error']);
+      assertConsoleWarn(['test-only: render warning']);
 
       const data = await getErrorsAndWarningsForElementAtIndex(0);
       expect(data).toMatchInlineSnapshot(`
@@ -2587,9 +2601,16 @@ describe('InspectedElement', () => {
         return null;
       };
 
-      await withErrorsOrWarningsIgnored(['test-only:'], async () => {
-        await utils.actAsync(() => render(<Example repeatWarningCount={1} />));
-      });
+      await utils.actAsync(() => render(<Example repeatWarningCount={1} />));
+      assertConsoleError([
+        'test-only: render error',
+        'test-only: render error',
+      ]);
+      assertConsoleWarn([
+        'test-only: render warning',
+        'test-only: render warning',
+        'test-only: render warning',
+      ]);
       const data = await getErrorsAndWarningsForElementAtIndex(0);
       expect(data).toMatchInlineSnapshot(`
         {
@@ -2620,9 +2641,9 @@ describe('InspectedElement', () => {
         return null;
       };
 
-      await withErrorsOrWarningsIgnored(['test-only:'], async () => {
-        await utils.actAsync(() => render(<Example repeatWarningCount={1} />));
-      });
+      await utils.actAsync(() => render(<Example repeatWarningCount={1} />));
+      assertConsoleError(['test-only: useLayoutEffect error']);
+      assertConsoleWarn(['test-only: useLayoutEffect warning']);
 
       const data = await getErrorsAndWarningsForElementAtIndex(0);
       expect(data).toMatchInlineSnapshot(`
@@ -2654,9 +2675,9 @@ describe('InspectedElement', () => {
         return null;
       };
 
-      await withErrorsOrWarningsIgnored(['test-only:'], async () => {
-        await utils.actAsync(() => render(<Example repeatWarningCount={1} />));
-      });
+      await utils.actAsync(() => render(<Example repeatWarningCount={1} />));
+      assertConsoleError(['test-only: useEffect error']);
+      assertConsoleWarn(['test-only: useEffect warning']);
 
       const data = await getErrorsAndWarningsForElementAtIndex(0);
       expect(data).toMatchInlineSnapshot(`
@@ -2678,17 +2699,16 @@ describe('InspectedElement', () => {
     });
 
     it('from react get recorded without a component stack', async () => {
+      global.__REACT_DEVTOOLS_GLOBAL_HOOK__.settings.appendComponentStack =
+        false;
       const Example = () => {
         return [<div />];
       };
 
-      await withErrorsOrWarningsIgnored(
+      await utils.actAsync(() => render(<Example />));
+      assertConsoleErrorDev(
         ['Each child in a list should have a unique "key" prop.'],
-        async () => {
-          await utils.actAsync(() =>
-            render(<Example repeatWarningCount={1} />),
-          );
-        },
+        {withoutStack: true},
       );
 
       const data = await getErrorsAndWarningsForElementAtIndex(0);
@@ -2707,9 +2727,9 @@ describe('InspectedElement', () => {
         return null;
       };
 
-      await withErrorsOrWarningsIgnored(['test-only:'], async () => {
-        await utils.actAsync(() => render(<Example repeatWarningCount={1} />));
-      });
+      await utils.actAsync(() => render(<Example repeatWarningCount={1} />));
+      assertConsoleError(['test-only: render error']);
+      assertConsoleWarn(['test-only: render warning']);
 
       const {
         clearErrorsAndWarnings,
@@ -2735,16 +2755,22 @@ describe('InspectedElement', () => {
         return null;
       };
 
-      await withErrorsOrWarningsIgnored(['test-only:'], async () => {
-        await utils.actAsync(() =>
-          render(
-            <React.Fragment>
-              <Example id={1} />
-              <Example id={2} />
-            </React.Fragment>,
-          ),
-        );
-      });
+      await utils.actAsync(() =>
+        render(
+          <React.Fragment>
+            <Example id={1} />
+            <Example id={2} />
+          </React.Fragment>,
+        ),
+      );
+      assertConsoleError([
+        'test-only: render error #1',
+        'test-only: render error #2',
+      ]);
+      assertConsoleWarn([
+        'test-only: render warning #1',
+        'test-only: render warning #2',
+      ]);
 
       let id = ((store.getElementIDAtIndex(1): any): number);
       const rendererID = store.getRendererIDForElement(id);
@@ -2830,16 +2856,22 @@ describe('InspectedElement', () => {
         return null;
       };
 
-      await withErrorsOrWarningsIgnored(['test-only:'], async () => {
-        await utils.actAsync(() =>
-          render(
-            <React.Fragment>
-              <Example id={1} />
-              <Example id={2} />
-            </React.Fragment>,
-          ),
-        );
-      });
+      await utils.actAsync(() =>
+        render(
+          <React.Fragment>
+            <Example id={1} />
+            <Example id={2} />
+          </React.Fragment>,
+        ),
+      );
+      assertConsoleError([
+        'test-only: render error #1',
+        'test-only: render error #2',
+      ]);
+      assertConsoleWarn([
+        'test-only: render warning #1',
+        'test-only: render warning #2',
+      ]);
 
       let id = ((store.getElementIDAtIndex(1): any): number);
       const rendererID = store.getRendererIDForElement(id);
@@ -2981,8 +3013,6 @@ describe('InspectedElement', () => {
   });
 
   it('inspecting nested renderers should not throw (createRoot)', async () => {
-    // Ignoring react art warnings
-    jest.spyOn(console, 'error').mockImplementation(() => {});
     const ReactArt = require('react-art');
     const ArtSVGMode = require('art/modes/svg');
     const ARTCurrentMode = require('art/modes/current');
@@ -3005,6 +3035,10 @@ describe('InspectedElement', () => {
     await utils.actAsync(() => {
       modernRender(<App />);
     });
+    assertConsoleError([
+      // react-art
+      'Error: Not implemented:',
+    ]);
     expect(store).toMatchInlineSnapshot(`
       [root]
         ▾ <App>
@@ -3069,30 +3103,17 @@ describe('InspectedElement', () => {
       ): any): number);
       const inspect = index => {
         // HACK: Recreate TestRenderer instance so we can inspect different elements
-        withErrorsOrWarningsIgnored(
-          ['An update to %s inside a test was not wrapped in act'],
-          () => {
-            testRendererInstance = TestRenderer.create(null, {
-              unstable_isConcurrent: true,
-            });
-          },
-        );
-        return inspectElementAtIndex(index);
-      };
-      const toggleError = async forceError => {
-        await withErrorsOrWarningsIgnored(['ErrorBoundary'], async () => {
-          await TestUtilsAct(async () => {
-            bridge.send('overrideError', {
-              id: targetErrorBoundaryID,
-              rendererID: store.getRendererIDForElement(targetErrorBoundaryID),
-              forceError,
-            });
-          });
+        testRendererInstance = TestRenderer.create(null, {
+          unstable_isConcurrent: true,
         });
-
-        await TestUtilsAct(async () => {
-          jest.runOnlyPendingTimers();
-        });
+        const element = inspectElementAtIndex(index);
+        assertConsoleErrorDev([
+          [
+            'An update to Root inside a test was not wrapped in act',
+            {withoutStack: true},
+          ],
+        ]);
+        return element;
       };
 
       // Inspect <ErrorBoundary /> and see that we cannot toggle error state
@@ -3105,31 +3126,49 @@ describe('InspectedElement', () => {
       expect(inspectedElement.canToggleError).toBe(true);
       expect(inspectedElement.isErrored).toBe(false);
 
-      // Suppress expected error and warning.
-      const consoleErrorMock = jest
-        .spyOn(console, 'error')
-        .mockImplementation(() => {});
-      const consoleWarnMock = jest
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {});
-
       // now force error state on <Example />
-      await toggleError(true);
+      await TestUtilsAct(async () => {
+        bridge.send('overrideError', {
+          id: targetErrorBoundaryID,
+          rendererID: store.getRendererIDForElement(targetErrorBoundaryID),
+          forceError: true,
+        });
+      });
+      assertConsoleWarn([
+        ['Could not find DevToolsInstance with id "3"', {withoutStack: true}],
+        ['Could not find DevToolsInstance with id "3"', {withoutStack: true}],
+      ]);
+      assertConsoleError(['Error: Simulated error coming from DevTools']);
 
-      consoleErrorMock.mockRestore();
-      consoleWarnMock.mockRestore();
-
-      // we are in error state now, <Example /> won't show up
-      withErrorsOrWarningsIgnored(['Invalid index'], () => {
-        expect(store.getElementIDAtIndex(1)).toBe(null);
+      await TestUtilsAct(async () => {
+        jest.runOnlyPendingTimers();
       });
 
-      // Inpsect <ErrorBoundary /> to toggle off the error state
+      // we are in error state now, <Example /> won't show up
+      expect(store.getElementIDAtIndex(1)).toBe(null);
+      assertConsoleWarn([
+        [
+          'Invalid index 1 specified; store contains 1 items.',
+          {withoutStack: true},
+        ],
+      ]);
+
+      // Inspect <ErrorBoundary /> to toggle off the error state
       inspectedElement = await inspect(0);
       expect(inspectedElement.canToggleError).toBe(true);
       expect(inspectedElement.isErrored).toBe(true);
 
-      await toggleError(false);
+      await TestUtilsAct(async () => {
+        bridge.send('overrideError', {
+          id: targetErrorBoundaryID,
+          rendererID: store.getRendererIDForElement(targetErrorBoundaryID),
+          forceError: false,
+        });
+      });
+
+      await TestUtilsAct(async () => {
+        jest.runOnlyPendingTimers();
+      });
 
       // We can now inspect <Example /> with ability to toggle again
       inspectedElement = await inspect(1);
@@ -3177,22 +3216,21 @@ describe('InspectedElement', () => {
       );
     }
 
-    withErrorsOrWarningsIgnored(['test-only:'], () =>
-      utils.act(() =>
-        render(
-          <React.Fragment>
+    utils.act(() =>
+      render(
+        <React.Fragment>
+          <Wrapper>
+            <Child logWarning={true} />
+          </Wrapper>
+          <Wrapper>
             <Wrapper>
               <Child logWarning={true} />
             </Wrapper>
-            <Wrapper>
-              <Wrapper>
-                <Child logWarning={true} />
-              </Wrapper>
-            </Wrapper>
-          </React.Fragment>,
-        ),
+          </Wrapper>
+        </React.Fragment>,
       ),
     );
+    assertConsoleWarn(['test-only: warning', 'test-only: warning']);
 
     utils.act(() =>
       TestRenderer.create(

--- a/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
@@ -22,6 +22,8 @@ describe('Store component filters', () => {
   let store: Store;
   let utils;
   let actAsync;
+  let assertConsoleError;
+  let assertConsoleWarn;
 
   beforeEach(() => {
     bridge = global.bridge;
@@ -33,6 +35,8 @@ describe('Store component filters', () => {
     React = require('react');
     Types = require('react-devtools-shared/src/frontend/types');
     utils = require('./utils');
+    assertConsoleError = utils.assertConsoleError;
+    assertConsoleWarn = utils.assertConsoleWarn;
 
     actAsync = utils.actAsync;
   });
@@ -576,15 +580,15 @@ describe('Store component filters', () => {
             utils.createDisplayNameFilter('Error'),
           ]),
       );
-      utils.withErrorsOrWarningsIgnored(['test-only:'], () => {
-        legacyRender(
-          <React.Fragment>
-            <ComponentWithError />
-            <ComponentWithWarning />
-            <ComponentWithWarningAndError />
-          </React.Fragment>,
-        );
-      });
+      legacyRender(
+        <React.Fragment>
+          <ComponentWithError />
+          <ComponentWithWarning />
+          <ComponentWithWarningAndError />
+        </React.Fragment>,
+      );
+      assertConsoleError(['test-only: render error']);
+      assertConsoleError(['test-only: render warning']);
 
       expect(store).toMatchInlineSnapshot(``);
       expect(store.componentWithErrorCount).toBe(0);
@@ -664,17 +668,23 @@ describe('Store component filters', () => {
           ]),
       );
 
-      utils.withErrorsOrWarningsIgnored(['test-only:'], () => {
-        utils.act(() => {
-          render(
-            <React.Fragment>
-              <ComponentWithError />
-              <ComponentWithWarning />
-              <ComponentWithWarningAndError />
-            </React.Fragment>,
-          );
-        }, false);
-      });
+      utils.act(() => {
+        render(
+          <React.Fragment>
+            <ComponentWithError />
+            <ComponentWithWarning />
+            <ComponentWithWarningAndError />
+          </React.Fragment>,
+        );
+      }, false);
+      assertConsoleError([
+        'test-only: render error',
+        'test-only: render error',
+      ]);
+      assertConsoleWarn([
+        'test-only: render warning',
+        'test-only: render warning',
+      ]);
 
       expect(store).toMatchInlineSnapshot(``);
       expect(store.componentWithErrorCount).toBe(0);

--- a/packages/react-devtools-shared/src/__tests__/storeStressTestConcurrent-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeStressTestConcurrent-test.js
@@ -409,7 +409,7 @@ describe('StoreStressConcurrent', () => {
     let container = document.createElement('div');
     for (let i = 0; i < steps.length; i++) {
       const root = ReactDOMClient.createRoot(container);
-      await act(() =>
+      await actAsync(() =>
         root.render(
           <Root>
             <X />
@@ -511,7 +511,7 @@ describe('StoreStressConcurrent', () => {
     // 2. Verify check Suspense can render same steps as initial fallback content.
     for (let i = 0; i < steps.length; i++) {
       const root = ReactDOMClient.createRoot(container);
-      await act(() =>
+      await actAsync(() =>
         root.render(
           <Root>
             <X />
@@ -535,7 +535,7 @@ describe('StoreStressConcurrent', () => {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
         const root = ReactDOMClient.createRoot(container);
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -546,7 +546,7 @@ describe('StoreStressConcurrent', () => {
         );
         expect(print(store)).toEqual(snapshots[i]);
         // Re-render with steps[j].
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -558,7 +558,7 @@ describe('StoreStressConcurrent', () => {
         // Verify the successful transition to steps[j].
         expect(print(store)).toEqual(snapshots[j]);
         // Check that we can transition back again.
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -580,7 +580,7 @@ describe('StoreStressConcurrent', () => {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
         const root = ReactDOMClient.createRoot(container);
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -595,7 +595,7 @@ describe('StoreStressConcurrent', () => {
         );
         expect(print(store)).toEqual(snapshots[i]);
         // Re-render with steps[j].
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -611,7 +611,7 @@ describe('StoreStressConcurrent', () => {
         // Verify the successful transition to steps[j].
         expect(print(store)).toEqual(snapshots[j]);
         // Check that we can transition back again.
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -637,7 +637,7 @@ describe('StoreStressConcurrent', () => {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
         const root = ReactDOMClient.createRoot(container);
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -648,7 +648,7 @@ describe('StoreStressConcurrent', () => {
         );
         expect(print(store)).toEqual(snapshots[i]);
         // Re-render with steps[j].
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -664,7 +664,7 @@ describe('StoreStressConcurrent', () => {
         // Verify the successful transition to steps[j].
         expect(print(store)).toEqual(snapshots[j]);
         // Check that we can transition back again.
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -686,7 +686,7 @@ describe('StoreStressConcurrent', () => {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
         const root = ReactDOMClient.createRoot(container);
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -701,7 +701,7 @@ describe('StoreStressConcurrent', () => {
         );
         expect(print(store)).toEqual(snapshots[i]);
         // Re-render with steps[j].
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -713,7 +713,7 @@ describe('StoreStressConcurrent', () => {
         // Verify the successful transition to steps[j].
         expect(print(store)).toEqual(snapshots[j]);
         // Check that we can transition back again.
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -739,7 +739,7 @@ describe('StoreStressConcurrent', () => {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
         const root = ReactDOMClient.createRoot(container);
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -776,7 +776,7 @@ describe('StoreStressConcurrent', () => {
         expect(print(store)).toEqual(snapshots[i]);
 
         // Trigger actual fallback.
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -792,7 +792,7 @@ describe('StoreStressConcurrent', () => {
         expect(print(store)).toEqual(snapshots[j]);
 
         // Force fallback while we're in fallback mode.
-        await act(() => {
+        await actAsync(() => {
           bridge.send('overrideSuspense', {
             id: suspenseID,
             rendererID: store.getRendererIDForElement(suspenseID),
@@ -803,7 +803,7 @@ describe('StoreStressConcurrent', () => {
         expect(print(store)).toEqual(snapshots[j]);
 
         // Switch to primary mode.
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -898,7 +898,7 @@ describe('StoreStressConcurrent', () => {
     let container = document.createElement('div');
     for (let i = 0; i < steps.length; i++) {
       const root = ReactDOMClient.createRoot(container);
-      await act(() =>
+      await actAsync(() =>
         root.render(
           <Root>
             <X />
@@ -921,7 +921,7 @@ describe('StoreStressConcurrent', () => {
     const fallbackSnapshots = [];
     for (let i = 0; i < steps.length; i++) {
       const root = ReactDOMClient.createRoot(container);
-      await act(() =>
+      await actAsync(() =>
         root.render(
           <Root>
             <X />
@@ -1054,7 +1054,7 @@ describe('StoreStressConcurrent', () => {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
         const root = ReactDOMClient.createRoot(container);
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -1067,7 +1067,7 @@ describe('StoreStressConcurrent', () => {
         );
         expect(print(store)).toEqual(snapshots[i]);
         // Re-render with steps[j].
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -1081,7 +1081,7 @@ describe('StoreStressConcurrent', () => {
         // Verify the successful transition to steps[j].
         expect(print(store)).toEqual(snapshots[j]);
         // Check that we can transition back again.
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -1105,7 +1105,7 @@ describe('StoreStressConcurrent', () => {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
         const root = ReactDOMClient.createRoot(container);
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -1123,7 +1123,7 @@ describe('StoreStressConcurrent', () => {
         );
         expect(print(store)).toEqual(fallbackSnapshots[i]);
         // Re-render with steps[j].
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -1142,7 +1142,7 @@ describe('StoreStressConcurrent', () => {
         // Verify the successful transition to steps[j].
         expect(print(store)).toEqual(fallbackSnapshots[j]);
         // Check that we can transition back again.
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -1171,7 +1171,7 @@ describe('StoreStressConcurrent', () => {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
         const root = ReactDOMClient.createRoot(container);
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -1184,7 +1184,7 @@ describe('StoreStressConcurrent', () => {
         );
         expect(print(store)).toEqual(snapshots[i]);
         // Re-render with steps[j].
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -1198,7 +1198,7 @@ describe('StoreStressConcurrent', () => {
         // Verify the successful transition to steps[j].
         expect(print(store)).toEqual(fallbackSnapshots[j]);
         // Check that we can transition back again.
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -1222,7 +1222,7 @@ describe('StoreStressConcurrent', () => {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
         const root = ReactDOMClient.createRoot(container);
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -1235,7 +1235,7 @@ describe('StoreStressConcurrent', () => {
         );
         expect(print(store)).toEqual(fallbackSnapshots[i]);
         // Re-render with steps[j].
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -1249,7 +1249,7 @@ describe('StoreStressConcurrent', () => {
         // Verify the successful transition to steps[j].
         expect(print(store)).toEqual(snapshots[j]);
         // Check that we can transition back again.
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -1273,7 +1273,7 @@ describe('StoreStressConcurrent', () => {
         // Always start with a fresh container and steps[i].
         container = document.createElement('div');
         const root = ReactDOMClient.createRoot(container);
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -1312,7 +1312,7 @@ describe('StoreStressConcurrent', () => {
         expect(print(store)).toEqual(snapshots[i]);
 
         // Trigger actual fallback.
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />
@@ -1326,7 +1326,7 @@ describe('StoreStressConcurrent', () => {
         expect(print(store)).toEqual(fallbackSnapshots[j]);
 
         // Force fallback while we're in fallback mode.
-        await act(() => {
+        await actAsync(() => {
           bridge.send('overrideSuspense', {
             id: suspenseID,
             rendererID: store.getRendererIDForElement(suspenseID),
@@ -1337,7 +1337,7 @@ describe('StoreStressConcurrent', () => {
         expect(print(store)).toEqual(fallbackSnapshots[j]);
 
         // Switch to primary mode.
-        await act(() =>
+        await actAsync(() =>
           root.render(
             <Root>
               <X />

--- a/packages/react-devtools-shared/src/__tests__/treeContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/treeContext-test.js
@@ -23,7 +23,8 @@ describe('TreeListContext', () => {
   let bridge: FrontendBridge;
   let store: Store;
   let utils;
-  let withErrorsOrWarningsIgnored;
+  let assertConsoleError;
+  let assertConsoleWarn;
 
   let BridgeContext;
   let StoreContext;
@@ -37,8 +38,8 @@ describe('TreeListContext', () => {
 
     utils = require('./utils');
     utils.beforeEachProfiling();
-
-    withErrorsOrWarningsIgnored = utils.withErrorsOrWarningsIgnored;
+    assertConsoleError = utils.assertConsoleError;
+    assertConsoleWarn = utils.assertConsoleWarn;
 
     bridge = global.bridge;
     store = global.store;
@@ -1524,19 +1525,19 @@ describe('TreeListContext', () => {
     });
 
     it('should cycle through the next errors/warnings and wrap around', () => {
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
-              <Child />
-              <Child logWarning={true} />
-              <Child />
-              <Child logError={true} />
-              <Child />
-            </React.Fragment>,
-          ),
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <Child />
+            <Child logWarning={true} />
+            <Child />
+            <Child logError={true} />
+            <Child />
+          </React.Fragment>,
         ),
       );
+      assertConsoleError(['test-only: error']);
+      assertConsoleWarn(['test-only: warning']);
 
       utils.act(() => TestRenderer.create(<Contexts />));
       expect(state).toMatchInlineSnapshot(`
@@ -1584,19 +1585,19 @@ describe('TreeListContext', () => {
     });
 
     it('should cycle through the previous errors/warnings and wrap around', () => {
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
-              <Child />
-              <Child logWarning={true} />
-              <Child />
-              <Child logError={true} />
-              <Child />
-            </React.Fragment>,
-          ),
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <Child />
+            <Child logWarning={true} />
+            <Child />
+            <Child logError={true} />
+            <Child />
+          </React.Fragment>,
         ),
       );
+      assertConsoleError(['test-only: error']);
+      assertConsoleWarn(['test-only: warning']);
 
       utils.act(() => TestRenderer.create(<Contexts />));
       expect(state).toMatchInlineSnapshot(`
@@ -1644,26 +1645,26 @@ describe('TreeListContext', () => {
     });
 
     it('should cycle through the next errors/warnings and wrap around with multiple roots', () => {
-      withErrorsOrWarningsIgnored(['test-only:'], () => {
-        utils.act(() => {
-          render(
-            <React.Fragment>
-              <Child />
-              <Child logWarning={true} />,
-            </React.Fragment>,
-          );
+      utils.act(() => {
+        render(
+          <React.Fragment>
+            <Child />
+            <Child logWarning={true} />,
+          </React.Fragment>,
+        );
 
-          createContainer();
+        createContainer();
 
-          render(
-            <React.Fragment>
-              <Child />
-              <Child logError={true} />
-              <Child />
-            </React.Fragment>,
-          );
-        });
+        render(
+          <React.Fragment>
+            <Child />
+            <Child logError={true} />
+            <Child />
+          </React.Fragment>,
+        );
       });
+      assertConsoleError(['test-only: error']);
+      assertConsoleWarn(['test-only: warning']);
 
       utils.act(() => TestRenderer.create(<Contexts />));
       expect(state).toMatchInlineSnapshot(`
@@ -1715,26 +1716,26 @@ describe('TreeListContext', () => {
     });
 
     it('should cycle through the previous errors/warnings and wrap around with multiple roots', () => {
-      withErrorsOrWarningsIgnored(['test-only:'], () => {
-        utils.act(() => {
-          render(
-            <React.Fragment>
-              <Child />
-              <Child logWarning={true} />,
-            </React.Fragment>,
-          );
+      utils.act(() => {
+        render(
+          <React.Fragment>
+            <Child />
+            <Child logWarning={true} />,
+          </React.Fragment>,
+        );
 
-          createContainer();
+        createContainer();
 
-          render(
-            <React.Fragment>
-              <Child />
-              <Child logError={true} />
-              <Child />
-            </React.Fragment>,
-          );
-        });
+        render(
+          <React.Fragment>
+            <Child />
+            <Child logError={true} />
+            <Child />
+          </React.Fragment>,
+        );
       });
+      assertConsoleError(['test-only: error']);
+      assertConsoleWarn(['test-only: warning']);
 
       utils.act(() => TestRenderer.create(<Contexts />));
       expect(state).toMatchInlineSnapshot(`
@@ -1786,19 +1787,19 @@ describe('TreeListContext', () => {
     });
 
     it('should select the next or previous element relative to the current selection', () => {
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
-              <Child />
-              <Child logWarning={true} />
-              <Child />
-              <Child logError={true} />
-              <Child />
-            </React.Fragment>,
-          ),
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <Child />
+            <Child logWarning={true} />
+            <Child />
+            <Child logError={true} />
+            <Child />
+          </React.Fragment>,
         ),
       );
+      assertConsoleError(['test-only: error']);
+      assertConsoleWarn(['test-only: warning']);
 
       utils.act(() => TestRenderer.create(<Contexts />));
       utils.act(() => dispatch({type: 'SELECT_ELEMENT_AT_INDEX', payload: 2}));
@@ -1847,18 +1848,18 @@ describe('TreeListContext', () => {
     });
 
     it('should update correctly when errors/warnings are cleared for a fiber in the list', () => {
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
-              <Child logWarning={true} />
-              <Child logError={true} />
-              <Child logError={true} />
-              <Child logWarning={true} />
-            </React.Fragment>,
-          ),
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <Child logWarning={true} />
+            <Child logError={true} />
+            <Child logError={true} />
+            <Child logWarning={true} />
+          </React.Fragment>,
         ),
       );
+      assertConsoleError(['test-only: error', 'test-only: error']);
+      assertConsoleWarn(['test-only: warning', 'test-only: warning']);
 
       utils.act(() => TestRenderer.create(<Contexts />));
       expect(state).toMatchInlineSnapshot(`
@@ -1919,16 +1920,16 @@ describe('TreeListContext', () => {
     });
 
     it('should update correctly when errors/warnings are cleared for the currently selected fiber', () => {
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
-              <Child logWarning={true} />
-              <Child logError={true} />
-            </React.Fragment>,
-          ),
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <Child logWarning={true} />
+            <Child logError={true} />
+          </React.Fragment>,
         ),
       );
+      assertConsoleError(['test-only: error']);
+      assertConsoleWarn(['test-only: warning']);
 
       utils.act(() => TestRenderer.create(<Contexts />));
       expect(state).toMatchInlineSnapshot(`
@@ -1957,18 +1958,18 @@ describe('TreeListContext', () => {
     });
 
     it('should update correctly when new errors/warnings are added', () => {
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
-              <Child logWarning={true} />
-              <Child />
-              <Child />
-              <Child logError={true} />
-            </React.Fragment>,
-          ),
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <Child logWarning={true} />
+            <Child />
+            <Child />
+            <Child logError={true} />
+          </React.Fragment>,
         ),
       );
+      assertConsoleError(['test-only: error']);
+      assertConsoleWarn(['test-only: warning']);
 
       utils.act(() => TestRenderer.create(<Contexts />));
       expect(state).toMatchInlineSnapshot(`
@@ -1990,18 +1991,17 @@ describe('TreeListContext', () => {
              <Child> ✕
       `);
 
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
-              <Child />
-              <Child logWarning={true} />
-              <Child />
-              <Child />
-            </React.Fragment>,
-          ),
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <Child />
+            <Child logWarning={true} />
+            <Child />
+            <Child />
+          </React.Fragment>,
         ),
       );
+      assertConsoleWarn(['test-only: warning']);
 
       selectNextErrorOrWarning();
       expect(state).toMatchInlineSnapshot(`
@@ -2035,16 +2035,16 @@ describe('TreeListContext', () => {
     });
 
     it('should update correctly when all errors/warnings are cleared', () => {
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
-              <Child logWarning={true} />
-              <Child logError={true} />
-            </React.Fragment>,
-          ),
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <Child logWarning={true} />
+            <Child logError={true} />
+          </React.Fragment>,
         ),
       );
+      assertConsoleError(['test-only: error']);
+      assertConsoleWarn(['test-only: warning']);
 
       utils.act(() => TestRenderer.create(<Contexts />));
       expect(state).toMatchInlineSnapshot(`
@@ -2088,15 +2088,14 @@ describe('TreeListContext', () => {
         }
         return null;
       }
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
-              <ErrorOnce key="error" />
-            </React.Fragment>,
-          ),
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <ErrorOnce key="error" />
+          </React.Fragment>,
         ),
       );
+      assertConsoleError(['test-only:one-time-error']);
 
       let renderer;
       utils.act(() => (renderer = TestRenderer.create(<Contexts />)));
@@ -2106,14 +2105,12 @@ describe('TreeListContext', () => {
              <ErrorOnce key="error"> ✕
       `);
 
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
-              <Child />
-              <ErrorOnce key="error" />
-            </React.Fragment>,
-          ),
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <Child />
+            <ErrorOnce key="error" />
+          </React.Fragment>,
         ),
       );
 
@@ -2143,18 +2140,20 @@ describe('TreeListContext', () => {
         }
         return null;
       }
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
-              <Child key="A" />
-              <ErrorOnce key="B" />
-              <Child key="C" />
-              <ErrorOnce key="D" />
-            </React.Fragment>,
-          ),
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <Child key="A" />
+            <ErrorOnce key="B" />
+            <Child key="C" />
+            <ErrorOnce key="D" />
+          </React.Fragment>,
         ),
       );
+      assertConsoleError([
+        'test-only:one-time-error',
+        'test-only:one-time-error',
+      ]);
 
       let renderer;
       utils.act(() => (renderer = TestRenderer.create(<Contexts />)));
@@ -2180,16 +2179,14 @@ describe('TreeListContext', () => {
       `);
 
       // Re-order the tree and ensure indices are updated.
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
-              <ErrorOnce key="B" />
-              <Child key="A" />
-              <ErrorOnce key="D" />
-              <Child key="C" />
-            </React.Fragment>,
-          ),
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <ErrorOnce key="B" />
+            <Child key="A" />
+            <ErrorOnce key="D" />
+            <Child key="C" />
+          </React.Fragment>,
         ),
       );
       expect(state).toMatchInlineSnapshot(`
@@ -2213,16 +2210,14 @@ describe('TreeListContext', () => {
       `);
 
       // Re-order the tree and ensure indices are updated.
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
-              <ErrorOnce key="D" />
-              <ErrorOnce key="B" />
-              <Child key="A" />
-              <Child key="C" />
-            </React.Fragment>,
-          ),
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <ErrorOnce key="D" />
+            <ErrorOnce key="B" />
+            <Child key="A" />
+            <Child key="C" />
+          </React.Fragment>,
         ),
       );
       expect(state).toMatchInlineSnapshot(`
@@ -2240,22 +2235,21 @@ describe('TreeListContext', () => {
 
       store.collapseNodesByDefault = true;
 
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <Wrapper>
+              <Child logWarning={true} />
+            </Wrapper>
+            <Wrapper>
               <Wrapper>
                 <Child logWarning={true} />
               </Wrapper>
-              <Wrapper>
-                <Wrapper>
-                  <Child logWarning={true} />
-                </Wrapper>
-              </Wrapper>
-            </React.Fragment>,
-          ),
+            </Wrapper>
+          </React.Fragment>,
         ),
       );
+      assertConsoleWarn(['test-only: warning', 'test-only: warning']);
 
       utils.act(() => TestRenderer.create(<Contexts />));
       expect(state).toMatchInlineSnapshot(`
@@ -2289,22 +2283,21 @@ describe('TreeListContext', () => {
     it('should preserve errors for fibers even if they are filtered out of the tree initially', () => {
       const Wrapper = ({children}) => children;
 
-      withErrorsOrWarningsIgnored(['test-only:'], () =>
-        utils.act(() =>
-          render(
-            <React.Fragment>
+      utils.act(() =>
+        render(
+          <React.Fragment>
+            <Wrapper>
+              <Child logWarning={true} />
+            </Wrapper>
+            <Wrapper>
               <Wrapper>
                 <Child logWarning={true} />
               </Wrapper>
-              <Wrapper>
-                <Wrapper>
-                  <Child logWarning={true} />
-                </Wrapper>
-              </Wrapper>
-            </React.Fragment>,
-          ),
+            </Wrapper>
+          </React.Fragment>,
         ),
       );
+      assertConsoleWarn(['test-only: warning', 'test-only: warning']);
 
       store.componentFilters = [utils.createDisplayNameFilter('Child')];
 
@@ -2346,16 +2339,15 @@ describe('TreeListContext', () => {
       it('should properly handle errors/warnings from components inside of delayed Suspense', async () => {
         const NeverResolves = React.lazy(() => new Promise(() => {}));
 
-        withErrorsOrWarningsIgnored(['test-only:'], () =>
-          utils.act(() =>
-            render(
-              <React.Suspense fallback={null}>
-                <Child logWarning={true} />
-                <NeverResolves />
-              </React.Suspense>,
-            ),
+        utils.act(() =>
+          render(
+            <React.Suspense fallback={null}>
+              <Child logWarning={true} />
+              <NeverResolves />
+            </React.Suspense>,
           ),
         );
+        assertConsoleWarn(['test-only: warning', 'test-only: warning']);
         utils.act(() => TestRenderer.create(<Contexts />));
 
         jest.runAllTimers();
@@ -2379,14 +2371,12 @@ describe('TreeListContext', () => {
         }
         const LazyComponent = React.lazy(() => fakeImport(Child));
 
-        withErrorsOrWarningsIgnored(['test-only:'], () =>
-          utils.act(() =>
-            render(
-              <React.Suspense fallback={null}>
-                <Child logWarning={true} />
-                <LazyComponent />
-              </React.Suspense>,
-            ),
+        utils.act(() =>
+          render(
+            <React.Suspense fallback={null}>
+              <Child logWarning={true} />
+              <LazyComponent />
+            </React.Suspense>,
           ),
         );
         utils.act(() => TestRenderer.create(<Contexts />));
@@ -2396,17 +2386,12 @@ describe('TreeListContext', () => {
                        <Suspense>
               `);
 
-        await Promise.resolve();
-        withErrorsOrWarningsIgnored(['test-only:'], () =>
-          utils.act(() =>
-            render(
-              <React.Suspense fallback={null}>
-                <Child logWarning={true} />
-                <LazyComponent />
-              </React.Suspense>,
-            ),
-          ),
-        );
+        await utils.actAsync(() => {});
+        assertConsoleWarn([
+          'test-only: warning',
+          'test-only: warning',
+          'test-only: warning',
+        ]);
 
         expect(state).toMatchInlineSnapshot(`
           ✕ 0, ⚠ 1
@@ -2418,22 +2403,24 @@ describe('TreeListContext', () => {
       });
 
       it('should properly show errors/warnings from components in the Suspense fallback tree', async () => {
+        let resolveLazyComponent;
         async function fakeImport(result) {
-          return {default: result};
+          return new Promise(resolve => {
+            resolveLazyComponent = () => resolve({default: result});
+          });
         }
         const LazyComponent = React.lazy(() => fakeImport(Child));
 
         const Fallback = () => <Child logError={true} />;
 
-        withErrorsOrWarningsIgnored(['test-only:'], () =>
-          utils.act(() =>
-            render(
-              <React.Suspense fallback={<Fallback />}>
-                <LazyComponent />
-              </React.Suspense>,
-            ),
+        utils.act(() =>
+          render(
+            <React.Suspense fallback={<Fallback />}>
+              <LazyComponent />
+            </React.Suspense>,
           ),
         );
+        assertConsoleError(['test-only: error']);
         utils.act(() => TestRenderer.create(<Contexts />));
 
         expect(state).toMatchInlineSnapshot(`
@@ -2444,16 +2431,9 @@ describe('TreeListContext', () => {
                    <Child> ✕
         `);
 
-        await Promise.resolve();
-        withErrorsOrWarningsIgnored(['test-only:'], () =>
-          utils.act(() =>
-            render(
-              <React.Suspense fallback={<Fallback />}>
-                <LazyComponent />
-              </React.Suspense>,
-            ),
-          ),
-        );
+        await utils.actAsync(() => {
+          resolveLazyComponent();
+        });
 
         expect(state).toMatchInlineSnapshot(`
                   [root]
@@ -2464,7 +2444,7 @@ describe('TreeListContext', () => {
     });
 
     describe('error boundaries', () => {
-      it('should properly handle errors from components that dont mount because of an error', () => {
+      it('should properly handle errors from components that dont mount because of an error', async () => {
         class ErrorBoundary extends React.Component {
           state = {error: null};
           static getDerivedStateFromError(error) {
@@ -2485,18 +2465,14 @@ describe('TreeListContext', () => {
           }
         }
 
-        withErrorsOrWarningsIgnored(
-          ['test-only:', 'React will try to recreate this component tree'],
-          () => {
-            utils.act(() =>
-              render(
-                <ErrorBoundary>
-                  <BadRender />
-                </ErrorBoundary>,
-              ),
-            );
-          },
+        await utils.actAsync(() =>
+          render(
+            <ErrorBoundary>
+              <BadRender />
+            </ErrorBoundary>,
+          ),
         );
+        assertConsoleError(['test-only: error']);
 
         utils.act(() => TestRenderer.create(<Contexts />));
 
@@ -2545,18 +2521,18 @@ describe('TreeListContext', () => {
           }
         }
 
-        withErrorsOrWarningsIgnored(
-          ['test-only:', 'React will try to recreate this component tree'],
-          () => {
-            utils.act(() =>
-              render(
-                <ErrorBoundary>
-                  <LogsWarning />
-                </ErrorBoundary>,
-              ),
-            );
-          },
+        utils.act(() =>
+          render(
+            <ErrorBoundary>
+              <LogsWarning />
+            </ErrorBoundary>,
+          ),
         );
+        assertConsoleError(['test-only: error']);
+        assertConsoleWarn([
+          'test-only: I am about to throw!',
+          'test-only: I am about to throw!',
+        ]);
 
         utils.act(() => TestRenderer.create(<Contexts />));
 
@@ -2600,18 +2576,14 @@ describe('TreeListContext', () => {
           }
         }
 
-        withErrorsOrWarningsIgnored(
-          ['test-only:', 'React will try to recreate this component tree'],
-          () => {
-            utils.act(() =>
-              render(
-                <ErrorBoundary>
-                  <BadRender />
-                </ErrorBoundary>,
-              ),
-            );
-          },
+        utils.act(() =>
+          render(
+            <ErrorBoundary>
+              <BadRender />
+            </ErrorBoundary>,
+          ),
         );
+        assertConsoleError(['test-only: I am about to throw!']);
 
         utils.act(() => TestRenderer.create(<Contexts />));
 

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -63,7 +63,7 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
   });
 
   // Patch the console to assert that all console error/warn/log calls assert.
-  patchConsoleMethods({includeLog: !!process.env.CI});
+  patchConsoleMethods({appendOwnerStack: true, includeLog: !!process.env.CI});
   beforeEach(resetAllUnexpectedConsoleCalls);
   afterEach(assertConsoleLogsCleared);
 


### PR DESCRIPTION
Reuses the existing `assertConsole*` helpers for DevTools tests.

`withErrorOrWarnings` hid some test issues where we relied on scheduler timings.