### PR TITLE
bugfix: fix hook amount check fail

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -555,9 +555,7 @@ export function renderWithHooks<Props, SecondArg>(
     }
   } else {
     ReactSharedInternals.H =
-      current === null
-        ? HooksDispatcherOnMount
-        : HooksDispatcherOnUpdate;
+      current === null ? HooksDispatcherOnMount : HooksDispatcherOnUpdate;
   }
 
   // In Strict Mode, during development, user functions are double invoked to

--- a/packages/react-reconciler/src/__tests__/ConditionalHooksError-test.js
+++ b/packages/react-reconciler/src/__tests__/ConditionalHooksError-test.js
@@ -4,8 +4,7 @@ const React = require('react');
 const ReactNoop = require('react-noop-renderer');
 const act = require('internal-test-utils').act;
 
-
-function TestComponent({ i }) {
+function TestComponent({i}) {
   if (i % 2 === 0) {
     React.useEffect(() => {}, []);
   }


### PR DESCRIPTION
> My modification is meant to fix a logical error inside React.
>
> It allows React to catch the error of "inconsistent number of hooks before and after." 
>
> I'm not trying to make React support conditional hooks, I'm trying to make React able to catch inconsistent hook amounts.

## Summary

> please forgive me poor English. My native language is not English, sorry.

Bug Description:

```jsx
import React, { useEffect, useState } from 'react';

export function App() {
  const [state, setState] = useState(0);

  return (
    <div>
      <div onClick={() => setState(state + 1)}>App</div>
      <Child state={state} />
    </div>
  );
}

function Child({ state }) {
  if (state % 2 === 0) {
    useEffect(() => {
      console.log('hello world');
    }, []);
  }

  return <div>Child</div>;
}

export default App;


```

Bug: When I click App Component, react **didn't** report error.

I debug react. Child Component didn't call `updateWorkInProgressHook`, it call `mountWorkInProgressHook` in every time.

`mountWorkInProgressHook` didn't report any error. But the problem is **why Child Component call `mountWorkInProgressHook`**, Child Component has `current fiber (alternate)`, it should call `updateWorkInProgressHook`.

`updateWorkInProgressHook` will check hook obj number (memorizedState);

### why Child Component call `mountWorkInProgressHook`

```ts
export function renderWithHooks<Props, SecondArg>(
  current: Fiber | null,
  workInProgress: Fiber,
  Component: (p: Props, arg: SecondArg) => any,
  props: Props,
  secondArg: SecondArg,
  nextRenderLanes: Lanes,
): any {
  renderLanes = nextRenderLanes;
  currentlyRenderingFiber = workInProgress;

 //...

  workInProgress.memoizedState = null;
  workInProgress.updateQueue = null;
  workInProgress.lanes = NoLanes;

  if (__DEV__) {
    if (current !== null && current.memoizedState !== null /* THIS!!!*/) {
      ReactSharedInternals.H = HooksDispatcherOnUpdateInDEV;
    } else if (hookTypesDev !== null) {
      ReactSharedInternals.H = HooksDispatcherOnMountWithHookTypesInDEV;
    } else {
      ReactSharedInternals.H = HooksDispatcherOnMountInDEV;
    }
  } else {
    ReactSharedInternals.H =
      current === null || current.memoizedState === null  /* THIS!!!*/
        ? HooksDispatcherOnMount
        : HooksDispatcherOnUpdate;
  }
```

Child Component's `current.memoizedState` maybe null, it cased Child Component use `HooksDispatcherOnMount`, `mountWorkInProgressHook` didn't check hook amount, and it cased this bug;

### finishRenderingHooks check fail

When Child Component's `current.memoizedState` is not null (it called useEffect). `finishRenderingHooks` check didn't work.

becase Chid Component didn't call any hook, and currentHook is null. so `didRenderTooFewHooks` is false.

```ts
function finishRenderingHooks<Props, SecondArg>(
  current: Fiber | null,
  workInProgress: Fiber,
  Component: (p: Props, arg: SecondArg) => any,
): void {
  // ...

  const didRenderTooFewHooks =
    currentHook !== null && currentHook.next !== null; /* This!!*/

  renderLanes = NoLanes; 
  currentlyRenderingFiber = (null: any);

  currentHook = null; /* This, if function component didn't call any hook, it will always null*/
  workInProgressHook = null;

  // ...

}
```



## How did you test this change?

Before I made any modifications to the project, I ran 'yarn test':

```
Test Suites: 8 failed, 317 passed, 325 total
Tests:       23 failed, 23 skipped, 6715 passed, 6761 total
Snapshots:   12 failed, 318 passed, 330 total
Time:        230.64 s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After I made the modifications to the project, I ran the "yarn test" command.

```
Test Suites: 8 failed, 317 passed, 325 total
Tests:       21 failed, 23 skipped, 6717 passed, 6761 total
Snapshots:   12 failed, 318 passed, 330 total
Time:        235.116 s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```

I use this command to build (https://legacy.reactjs.org/docs/how-to-contribute.html):

```
 yarn build react/index,react/jsx,react-dom/index,react-dom/client,scheduler --type=NODE
```

And I setup a github project  **to prove that my modifications are effective, I have conducted tests**.

https://github.com/HHsomeHand/react-hook-detect-issue

you can download it. And `yarn install`

and `yarn link` the three packages in `[root]/local_packages`: react, react-dom, scheduler

https://github.com/HHsomeHand/react-hook-detect-issue/tree/main/local_packages

and `yarn link` them to the project. And `yarn start`, you will see the result. It works!