### PR TITLE
[DevTools] fix: handle store mutations synchronously in TreeContext

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js
@@ -954,7 +954,7 @@ function TreeContextController({
       Array<number>,
       Map<number, number>,
     ]) => {
-      transitionDispatch({
+      dispatch({
         type: 'HANDLE_STORE_MUTATION',
         payload: [addedElementIDs, removedElementIDs],
       });
@@ -965,7 +965,7 @@ function TreeContextController({
       // At the moment, we can treat this as a mutation.
       // We don't know which Elements were newly added/removed, but that should be okay in this case.
       // It would only impact the search state, which is unlikely to exist yet at this point.
-      transitionDispatch({
+      dispatch({
         type: 'HANDLE_STORE_MUTATION',
         payload: [[], new Map()],
       });


### PR DESCRIPTION
If there is a commit that removes the currently inspected (selected) elements in the Components tree, we are going to kick off the transition to re-render the Tree. The elements will be re-rendered with the previous inspectedElementID, which was just removed and all consecutive calls to store object with this id would produce errors, since this element was just removed.

We should handle store mutations synchronously. Doesn't make sense to start a transition in this case, because Elements depend on the TreeState and could make calls to store in render function.

Before:
<img width="2286" height="1734" alt="Screenshot 2025-08-06 at 17 41 14" src="https://github.com/user-attachments/assets/97d92220-3488-47b2-aa6b-70fa39345f6b" />


After:

https://github.com/user-attachments/assets/3da36aff-6987-4b76-b741-ca59f829f8e6