### PR TITLE
Bug: Improve error message when function is passed as JSX child

### DIFF
--- a/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
+++ b/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
@@ -71,9 +71,10 @@ describe('ReactChildReconciler', () => {
       );
     });
     assertConsoleErrorDev([
-      'Functions are not valid as a React child. ' +
-        'This may happen if you return fn instead of <fn /> from render. ' +
-        'Or maybe you meant to call this function rather than return it.\n' +
+      'Functions are not valid as a React child. This may happen if:\n' +
+        '- You forgot to call the function: use {fn()} instead of {fn}\n' +
+        '- You meant to render a component: use <fn /> instead of {fn}\n' +
+        '- You intended to pass the function as a prop to a child component.\n' +
         '  <h1>{fn}</h1>\n' +
         '    in h1 (at **)',
     ]);

--- a/packages/react-dom/src/__tests__/ReactComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponent-test.js
@@ -596,11 +596,12 @@ describe('ReactComponent', () => {
         root.render(<Foo />);
       });
       assertConsoleErrorDev([
-        'Functions are not valid as a React child. This may happen if ' +
-          'you return Foo instead of <Foo /> from render. ' +
-          'Or maybe you meant to call this function rather than return it.\n' +
-          '  <Foo>{Foo}</Foo>\n' +
-          '    in Foo (at **)',
+        'Functions are not valid as a React child. This may happen if:\n' +
+        '- You forgot to call the function: use {Foo()} instead of {Foo}\n' +
+        '- You meant to render a component: use <Foo /> instead of {Foo}\n' +
+        '- You intended to pass the function as a prop to a child component.\n' +
+        '  <Foo>{Foo}</Foo>\n' +
+        '    in Foo (at **)',
       ]);
     });
 
@@ -617,11 +618,12 @@ describe('ReactComponent', () => {
         root.render(<Foo />);
       });
       assertConsoleErrorDev([
-        'Functions are not valid as a React child. This may happen if ' +
-          'you return Foo instead of <Foo /> from render. ' +
-          'Or maybe you meant to call this function rather than return it.\n' +
-          '  <Foo>{Foo}</Foo>\n' +
-          '    in Foo (at **)',
+        'Functions are not valid as a React child. This may happen if:\n' +
+        '- You forgot to call the function: use {Foo()} instead of {Foo}\n' +
+        '- You meant to render a component: use <Foo /> instead of {Foo}\n' +
+        '- You intended to pass the function as a prop to a child component.\n' +
+        '  <Foo>{Foo}</Foo>\n' +
+        '    in Foo (at **)',
       ]);
     });
 
@@ -639,12 +641,13 @@ describe('ReactComponent', () => {
         root.render(<Foo />);
       });
       assertConsoleErrorDev([
-        'Functions are not valid as a React child. This may happen if ' +
-          'you return Foo instead of <Foo /> from render. ' +
-          'Or maybe you meant to call this function rather than return it.\n' +
-          '  <span>{Foo}</span>\n' +
-          '    in span (at **)\n' +
-          '    in Foo (at **)',
+        'Functions are not valid as a React child. This may happen if:\n' +
+        '- You forgot to call the function: use {Foo()} instead of {Foo}\n' +
+        '- You meant to render a component: use <Foo /> instead of {Foo}\n' +
+        '- You intended to pass the function as a prop to a child component.\n' +
+        '  <span>{Foo}</span>\n' +
+        '    in span (at **)\n' +
+        '    in Foo (at **)',
       ]);
     });
 
@@ -690,18 +693,20 @@ describe('ReactComponent', () => {
         root.render(<Foo ref={current => (component = current)} />);
       });
       assertConsoleErrorDev([
-        'Functions are not valid as a React child. This may happen if ' +
-          'you return Foo instead of <Foo /> from render. ' +
-          'Or maybe you meant to call this function rather than return it.\n' +
-          '  <div>{Foo}</div>\n' +
-          '    in div (at **)\n' +
-          '    in Foo (at **)',
-        'Functions are not valid as a React child. This may happen if ' +
-          'you return Foo instead of <Foo /> from render. ' +
-          'Or maybe you meant to call this function rather than return it.\n' +
-          '  <span>{Foo}</span>\n' +
-          '    in span (at **)\n' +
-          '    in Foo (at **)',
+        'Functions are not valid as a React child. This may happen if:\n' +
+        '- You forgot to call the function: use {Foo()} instead of {Foo}\n' +
+        '- You meant to render a component: use <Foo /> instead of {Foo}\n' +
+        '- You intended to pass the function as a prop to a child component.\n' +
+        '  <div>{Foo}</div>\n' +
+        '    in div (at **)\n' +
+        '    in Foo (at **)',
+        'Functions are not valid as a React child. This may happen if:\n' +
+        '- You forgot to call the function: use {Foo()} instead of {Foo}\n' +
+        '- You meant to render a component: use <Foo /> instead of {Foo}\n' +
+        '- You intended to pass the function as a prop to a child component.\n' +
+        '  <span>{Foo}</span>\n' +
+        '    in span (at **)\n' +
+        '    in Foo (at **)',
       ]);
       await act(() => {
         component.setState({type: 'portobello mushrooms'});

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -454,10 +454,11 @@ describe('ReactDOMRoot', () => {
     });
     assertConsoleErrorDev(
       [
-        'Functions are not valid as a React child. ' +
-          'This may happen if you return Component instead of <Component /> from render. ' +
-          'Or maybe you meant to call this function rather than return it.\n' +
-          '  root.render(Component)',
+        'Functions are not valid as a React child. This may happen if:\n' +
+        '- You forgot to call the function: use {Component()} instead of {Component}\n' +
+        '- You meant to render a component: use <Component /> instead of {Component}\n' +
+        '- You intended to pass the function as a prop to a child component.\n' +
+        '  root.render(Component)',
       ],
       {withoutStack: true},
     );

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -312,25 +312,31 @@ function warnOnFunctionType(returnFiber: Fiber, invalidChild: Function) {
 
     if (returnFiber.tag === HostRoot) {
       console.error(
-        'Functions are not valid as a React child. This may happen if ' +
-          'you return %s instead of <%s /> from render. ' +
-          'Or maybe you meant to call this function rather than return it.\n' +
-          '  root.render(%s)',
+        'Functions are not valid as a React child. This may happen if:\n' +
+        '- You forgot to call the function: use {%s()} instead of {%s}\n' +
+        '- You meant to render a component: use <%s /> instead of {%s}\n' +
+        '- You intended to pass the function as a prop to a child component.\n' +
+        '  root.render(%s)',
         name,
         name,
         name,
+        name,
+        name
       );
     } else {
       console.error(
-        'Functions are not valid as a React child. This may happen if ' +
-          'you return %s instead of <%s /> from render. ' +
-          'Or maybe you meant to call this function rather than return it.\n' +
-          '  <%s>{%s}</%s>',
+        'Functions are not valid as a React child. This may happen if:\n' +
+        '- You forgot to call the function: use {%s()} instead of {%s}\n' +
+        '- You meant to render a component: use <%s /> instead of {%s}\n' +
+        '- You intended to pass the function as a prop to a child component.\n' +
+        '  <%s>{%s}</%s>',
+        name,
+        name,
         name,
         name,
         parentName,
         name,
-        parentName,
+        parentName
       );
     }
   }

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -3255,11 +3255,10 @@ function warnOnFunctionType(invalidChild: Function) {
   if (__DEV__) {
     const name = invalidChild.displayName || invalidChild.name || 'Component';
     console.error(
-      'Functions are not valid as a React child. This may happen if ' +
-        'you return %s instead of <%s /> from render. ' +
-        'Or maybe you meant to call this function rather than return it.',
-      name,
-      name,
+      'Functions are not valid as a React child. This may happen if:\n' +
+      '- You forgot to call the function: use {' + name + '()} instead of {' + name + '}\n' +
+      '- You meant to render a component: use <' + name + ' /> instead of {' + name + '}\n' +
+      '- You intended to pass the function as a prop to a child component.'
     );
   }
 }


### PR DESCRIPTION
## Summary
This PR improves the error message that is shown when a function is passed as a React child, addressing [issue #34007](https://github.com/facebook/react/issues/34007). The previous message was technically correct, but could be more helpful for beginners. The new message provides more actionable suggestions for mistakes that beginners would commonly make, like forgetting to call a function ( passing handleDelete instead of handleDelete() ), rendering a component incorrectly ( using {MyComponent} instead of <MyComponent /> ), or intending to pass a function as a prop ( <Button onClick={handleDelete} /> ).

## How did you test this change?

- Updated and ran the relevant test suites:
  - yarn test
  - yarn test --prod
- Verified that all affected tests in ReactChildReconciler, ReactComponent, and ReactDOMRoot pass and expect the new error message.
- Ran yarn lint, yarn linc, and yarn flow to ensure code style and type checks pass