### PR TITLE
[DevTools] Don't show "awaited by" if there's nothing to show

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
@@ -104,11 +104,15 @@ function SuspendedByRow({
   // Only show the awaited stack if the I/O started in a different owner
   // than where it was awaited. If it's started by the same component it's
   // probably easy enough to infer and less noise in the common case.
+  const canShowAwaitStack =
+    (asyncInfo.stack !== null && asyncInfo.stack.length > 0) ||
+    (asyncOwner !== null && asyncOwner.id !== inspectedElement.id);
   const showAwaitStack =
-    !showIOStack ||
-    (ioOwner === null
-      ? asyncOwner !== null
-      : asyncOwner === null || ioOwner.id !== asyncOwner.id);
+    canShowAwaitStack &&
+    (!showIOStack ||
+      (ioOwner === null
+        ? asyncOwner !== null
+        : asyncOwner === null || ioOwner.id !== asyncOwner.id));
 
   const value: any = ioInfo.value;
   const metaName =


### PR DESCRIPTION
E.g. if the owner is null or the same as current component and no stack. This happens for example when you return a plain Promise in the child position and inspect the component it was returned in since there's no hook stack and the owner is the same as the instance itself so there's nothing new to link to.

Before:

<img width="267" height="99" alt="Screenshot 2025-08-10 at 10 28 32 PM" src="https://github.com/user-attachments/assets/23341ab2-2888-457d-a1d1-128f3e0bd5ec" />

After:

<img width="253" height="91" alt="Screenshot 2025-08-10 at 10 29 04 PM" src="https://github.com/user-attachments/assets/b33bb38b-891a-4f46-bc16-15604b033cdb" />
