### PR TITLE
[DevTools] Always skip 1 frame

### DIFF
--- a/packages/react-devtools-shared/src/backend/utils/parseStackTrace.js
+++ b/packages/react-devtools-shared/src/backend/utils/parseStackTrace.js
@@ -284,7 +284,7 @@ export function parseStackTrace(
 export function extractLocationFromOwnerStack(
   error: Error,
 ): ReactFunctionLocation | null {
-  const stackTrace = parseStackTrace(error, 0);
+  const stackTrace = parseStackTrace(error, 1);
   const stack = error.stack;
   if (
     !stack.includes('react_stack_bottom_frame') &&


### PR DESCRIPTION
Follow up to #34093.

There's an issue where the skipFrames argument isn't part of the cache key so the other parsers that expect skipping one frame might skip zero and show the internal `fakeJSXDEV` callsite. Ideally we should include the skipFrames as part of the cache key but we can also always just skip one.
