### PR TITLE
Remove unused arguments from ReactElement

### DIFF
--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -159,27 +159,11 @@ function elementRefGetterWithDeprecationWarning() {
  * @param {*} type
  * @param {*} props
  * @param {*} key
- * @param {string|object} ref
+ * @param {object} ref
  * @param {*} owner
- * @param {*} self A *temporary* helper to detect places where `this` is
- * different from the `owner` when React.createElement is called, so that we
- * can warn. We want to get rid of owner and replace string `ref`s with arrow
- * functions, and as long as `this` and owner are the same, there will be no
- * change in behavior.
- * @param {*} source An annotation object (added by a transpiler or otherwise)
- * indicating filename, line number, and/or other information.
  * @internal
  */
-function ReactElement(
-  type,
-  key,
-  self,
-  source,
-  owner,
-  props,
-  debugStack,
-  debugTask,
-) {
+function ReactElement(type, key, owner, props, debugStack, debugTask) {
   // Ignore whatever was passed as the ref argument and treat `props.ref` as
   // the source of truth. The only thing we use this for is `element.ref`,
   // which will log a deprecation warning on access. In the next release, we
@@ -348,16 +332,7 @@ export function jsxProd(type, config, maybeKey) {
     }
   }
 
-  return ReactElement(
-    type,
-    key,
-    undefined,
-    undefined,
-    getOwner(),
-    props,
-    undefined,
-    undefined,
-  );
+  return ReactElement(type, key, getOwner(), props, undefined, undefined);
 }
 
 // While `jsxDEV` should never be called when running in production, we do
@@ -376,8 +351,6 @@ export function jsxProdSignatureRunningInDevWithDynamicChildren(
   type,
   config,
   maybeKey,
-  source,
-  self,
 ) {
   if (__DEV__) {
     const isStaticChildren = false;
@@ -389,8 +362,6 @@ export function jsxProdSignatureRunningInDevWithDynamicChildren(
       config,
       maybeKey,
       isStaticChildren,
-      source,
-      self,
       __DEV__ &&
         (trackActualOwner
           ? Error('react-stack-top-frame')
@@ -407,8 +378,6 @@ export function jsxProdSignatureRunningInDevWithStaticChildren(
   type,
   config,
   maybeKey,
-  source,
-  self,
 ) {
   if (__DEV__) {
     const isStaticChildren = true;
@@ -420,8 +389,6 @@ export function jsxProdSignatureRunningInDevWithStaticChildren(
       config,
       maybeKey,
       isStaticChildren,
-      source,
-      self,
       __DEV__ &&
         (trackActualOwner
           ? Error('react-stack-top-frame')
@@ -442,7 +409,7 @@ const didWarnAboutKeySpread = {};
  * @param {object} props
  * @param {string} key
  */
-export function jsxDEV(type, config, maybeKey, isStaticChildren, source, self) {
+export function jsxDEV(type, config, maybeKey, isStaticChildren) {
   const trackActualOwner =
     __DEV__ &&
     ReactSharedInternals.recentlyCreatedOwnerStacks++ < ownerStackLimit;
@@ -451,8 +418,6 @@ export function jsxDEV(type, config, maybeKey, isStaticChildren, source, self) {
     config,
     maybeKey,
     isStaticChildren,
-    source,
-    self,
     __DEV__ &&
       (trackActualOwner
         ? Error('react-stack-top-frame')
@@ -469,8 +434,6 @@ function jsxDEVImpl(
   config,
   maybeKey,
   isStaticChildren,
-  source,
-  self,
   debugStack,
   debugTask,
 ) {
@@ -491,7 +454,7 @@ function jsxDEVImpl(
       if (isStaticChildren) {
         if (isArray(children)) {
           for (let i = 0; i < children.length; i++) {
-            validateChildKeys(children[i], type);
+            validateChildKeys(children[i]);
           }
 
           if (Object.freeze) {
@@ -505,7 +468,7 @@ function jsxDEVImpl(
           );
         }
       } else {
-        validateChildKeys(children, type);
+        validateChildKeys(children);
       }
     }
 
@@ -591,16 +554,7 @@ function jsxDEVImpl(
       defineKeyPropWarningGetter(props, displayName);
     }
 
-    return ReactElement(
-      type,
-      key,
-      self,
-      source,
-      getOwner(),
-      props,
-      debugStack,
-      debugTask,
-    );
+    return ReactElement(type, key, getOwner(), props, debugStack, debugTask);
   }
 }
 
@@ -620,7 +574,7 @@ export function createElement(type, config, children) {
     // prod. (Rendering will throw with a helpful message and as soon as the
     // type is fixed, the key warnings will appear.)
     for (let i = 2; i < arguments.length; i++) {
-      validateChildKeys(arguments[i], type);
+      validateChildKeys(arguments[i]);
     }
 
     // Unlike the jsx() runtime, createElement() doesn't warn about key spread.
@@ -721,8 +675,6 @@ export function createElement(type, config, children) {
   return ReactElement(
     type,
     key,
-    undefined,
-    undefined,
     getOwner(),
     props,
     __DEV__ &&
@@ -740,8 +692,6 @@ export function cloneAndReplaceKey(oldElement, newKey) {
   const clonedElement = ReactElement(
     oldElement.type,
     newKey,
-    undefined,
-    undefined,
     !__DEV__ ? undefined : oldElement._owner,
     oldElement.props,
     __DEV__ && oldElement._debugStack,
@@ -829,8 +779,6 @@ export function cloneElement(element, config, children) {
   const clonedElement = ReactElement(
     element.type,
     key,
-    undefined,
-    undefined,
     owner,
     props,
     __DEV__ && element._debugStack,
@@ -838,7 +786,7 @@ export function cloneElement(element, config, children) {
   );
 
   for (let i = 2; i < arguments.length; i++) {
-    validateChildKeys(arguments[i], clonedElement.type);
+    validateChildKeys(arguments[i]);
   }
 
   return clonedElement;
@@ -853,10 +801,9 @@ export function cloneElement(element, config, children) {
  * @param {ReactNode} node Statically passed child of any type.
  * @param {*} parentType node's parent's type.
  */
-function validateChildKeys(node, parentType) {
+function validateChildKeys(node) {
   if (__DEV__) {
-    // With owner stacks is, no warnings happens. All we do is
-    // mark elements as being in a valid static child position so they
+    // Mark elements as being in a valid static child position so they
     // don't need keys.
     if (isValidElement(node)) {
       if (node._store) {


### PR DESCRIPTION

After various feature flag removals recently, these arguments became unused and can be deleted.
