### PR TITLE
[DevTools] Handle dehydrated Suspense boundaries

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1796,7 +1796,7 @@ function updateHostRoot(
   }
 
   const nextProps = workInProgress.pendingProps;
-  const prevState = workInProgress.memoizedState;
+  const prevState: RootState = workInProgress.memoizedState;
   const prevChildren = prevState.element;
   cloneUpdateQueue(current, workInProgress);
   processUpdateQueue(workInProgress, nextProps, null, renderLanes);


### PR DESCRIPTION
The [Fibers of dehydrated Suspense boundaries have no child Offscreen Fiber](https://github.com/facebook/react/blob/07a899d48e22609c84a9986cef13d71a7ecdafce/packages/react-reconciler/src/ReactFiberBeginWork.js#L2922) (yet).

We now handle newly hydrated boundaries in the mount and update path.

This doesn't handle Activity yet which also doesn't have children when dehydrated yet.

Stacked on https://github.com/facebook/react/pull/34199