### PR TITLE
Use `yarn run` in Flight fixture

### DIFF
--- a/fixtures/flight/package.json
+++ b/fixtures/flight/package.json
@@ -71,10 +71,10 @@
   "scripts": {
     "predev": "cp -r ../../build/oss-experimental/* ./node_modules/ && rm -rf node_modules/.cache;",
     "prebuild": "cp -r ../../build/oss-experimental/* ./node_modules/ && rm -rf node_modules/.cache;",
-    "dev": "concurrently \"npm run dev:region\" \"npm run dev:global\"",
+    "dev": "concurrently \"yarn run dev:region\" \"yarn run dev:global\"",
     "dev:global": "NODE_ENV=development BUILD_PATH=dist node --experimental-loader ./loader/global.js --inspect=127.0.0.1:9230 server/global",
     "dev:region": "NODE_ENV=development BUILD_PATH=dist nodemon --watch src --watch dist -- --enable-source-maps --experimental-loader ./loader/region.js --conditions=react-server --inspect=127.0.0.1:9229 server/region",
-    "start": "node scripts/build.js && concurrently \"npm run start:region\" \"npm run start:global\"",
+    "start": "node scripts/build.js && concurrently \"yarn run start:region\" \"yarn run start:global\"",
     "start:global": "NODE_ENV=production node --experimental-loader ./loader/global.js server/global",
     "start:region": "NODE_ENV=production node --experimental-loader ./loader/region.js --conditions=react-server server/region",
     "build": "node scripts/build.js",


### PR DESCRIPTION

Fixes a bug I'm getting when running `yarn dev` in Node.js 22.14
```
$ concurrently "npm run dev:region" "npm run dev:global"
[0] npm error Invalid property "node"
[0] npm error A complete log of this run can be found in: /Users/sebbie/.npm/_logs/2025-08-13T13_12_02_245Z-debug-0.log
[1] npm error Invalid property "node"
[1] npm error A complete log of this run can be found in: /Users/sebbie/.npm/_logs/2025-08-13T13_12_02_245Z-debug-0.log
[0] npm run dev:region exited with code 1
[1] npm run dev:global exited with code 1
error Command failed with exit code 1.
```

Since we're using Yarn, we should really be consistent about it. 