### PR TITLE
[DevTools] Always attempt to mount dehydrated roots 

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -5278,14 +5278,9 @@ export function attach(
       // TODO: relying on this seems a bit fishy.
       const wasMounted =
         prevFiber.memoizedState != null &&
-        prevFiber.memoizedState.element != null &&
-        // A dehydrated root is not considered mounted
-        prevFiber.memoizedState.isDehydrated !== true;
+        prevFiber.memoizedState.element != null;
       const isMounted =
-        current.memoizedState != null &&
-        current.memoizedState.element != null &&
-        // A dehydrated root is not considered mounted
-        current.memoizedState.isDehydrated !== true;
+        current.memoizedState != null && current.memoizedState.element != null;
       if (!wasMounted && isMounted) {
         // Mount a new root.
         setRootPseudoKey(currentRoot.id, current);

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -300,7 +300,7 @@ export function printOperationsArray(operations: Array<number>) {
       }
       case TREE_OPERATION_SET_SUBTREE_MODE: {
         const id = operations[i + 1];
-        const mode = operations[i + 1];
+        const mode = operations[i + 2];
 
         i += 3;
 
@@ -339,11 +339,11 @@ export function printOperationsArray(operations: Array<number>) {
         const fiberID = operations[i + 1];
         const parentID = operations[i + 2];
         const nameStringID = operations[i + 3];
-        const name = stringTable[nameStringID];
         const numRects = operations[i + 4];
 
         i += 5;
 
+        const name = stringTable[nameStringID];
         let rects: string;
         if (numRects === -1) {
           rects = 'null';


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/34196

`mountFiberRecursively` bails out of hydrating dehydrated roots nowadays.
This makes the check in `handleCommitFiberRoot` redundant.

Mostly doing this because the check in `handleCommitFiberRoot` wasn't mirrored in the initial mount path.
`handleCommitFiberRoot` always attempted to mount dehydrated roots when it first encountered a HostRoot. But on updates, it treated a previously dehydrated HostRoot as newly mounted. This resulted in recording mounts twice which is not supported.

