### PR TITLE
[DevTools] Add regression test for custom hook named "useState" crash

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -2492,6 +2492,26 @@ describe('InspectedElement', () => {
       `);
     });
 
+    it('should handle custom hooks named "useState" without crashing', async () => {
+      function useState() {
+        React.useState(0);
+        React.useEffect(() => () => {});
+      }
+
+      function Counter() {
+        useState();
+        React.useState(0);
+        return null;
+      }
+
+      await utils.actAsync(() => render(<Counter />));
+
+      const inspectedElement = await inspectElementAtIndex(0);
+      
+      expect(inspectedElement).not.toBe(null);
+      expect(Array.isArray(inspectedElement.hooks)).toBe(true);
+    });
+
     it('should support class components', async () => {
       class Example extends React.Component {
         state = {


### PR DESCRIPTION
## Summary

Adds regression test for issue #20613 where DevTools crashes when inspecting components with custom hooks named "useState". This has been a known issue since 2021 affecting libraries like Hookstate that export custom hooks with this naming pattern.

## How did you test this change?

Added test case to `packages/react-devtools-shared/src/__tests__/inspectedElement-test.js` that creates a custom hook function named `useState`, uses both the custom hook and React's built-in `useState`, and verifies DevTools can inspect the component without throwing.

Ran `yarn test-build-devtools` to verify the test passes and all existing DevTools tests continue to work.