### PR TITLE
Fix auto preload <img> issue for renderToString

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -541,7 +541,11 @@ export function createRenderState(
     // like a module global for currently rendering boundary
     hoistableState: null,
     stylesToHoist: false,
+
+    disableAutoPreload: options?.disableAutoPreload,
+
   };
+  request.renderState=renderState
 
   if (bootstrapScripts !== undefined) {
     for (let i = 0; i < bootstrapScripts.length; i++) {

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -6247,7 +6247,9 @@ export function startFlowing(request: Request, destination: Destination): void {
   request.destination = destination;
 
   try {
-    flushCompletedQueues(request, destination);
+    if (!request.renderState.disableAutoPreload) {
+      flushCompletedQueues(request, destination);
+}
   } catch (error) {
     const errorInfo: ThrownInfo = {};
     logRecoverableError(request, error, errorInfo, null);


### PR DESCRIPTION
## Fix for React 19 renderToString() preload injection bug (#34217)

## Changes
- Added `disableAutoPreload` flag to `createRenderState`
- Attached `renderState` to `request` object
- Modified `flushCompletedQueues` to check flag before injecting preload links

<!-- 
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn lint` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

This PR fixes the unexpected behavior in React 19 where `renderToString(<img />)` automatically injects `<link rel="preload">` for every image. React 18 did not do this. By adding a `disableAutoPreload` flag in `createRenderState` and checking it in `flushCompletedQueues`, developers can now opt out of automatic preload injection when needed, restoring the expected SSR output.

## How did you test this change?

<!--
Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
How exactly did you verify that your PR solves the issue you wanted to solve?
If you leave this empty, your PR will very likely be closed.
-->

- Created a minimal test case with `renderToString(<img src="my/image.png" />)`  
- Verified that with `disableAutoPreload = true`, the output is:

```html
<img src="my/image.png"/>
