### PR TITLE
Fix(react-compiler): handle promoted identifiers in MethodCall codegen

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fix-nested-math-calls.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fix-nested-math-calls.js
@@ -1,0 +1,48 @@
+import {fn} from 'lib';
+
+function Component1() {
+  const value = fn();
+  return <div>{Math.floor(Math.abs(value))}</div>;
+}
+
+function Component2() {
+  const value = fn();
+  return <div>{Math.ceil(Math.abs(value))}</div>;
+}
+
+function Component3() {
+  const value = fn();
+  return <div>{Math.max(Math.abs(value), 0)}</div>;
+}
+
+// Test deeper nesting - 3 levels
+function DeepNested1() {
+  const value = fn();
+  return <div>{Math.round(Math.floor(Math.abs(value)))}</div>;
+}
+
+// Test deeper nesting - 4 levels
+function DeepNested2() {
+  const value = fn();
+  return <div>{Math.max(Math.min(Math.floor(Math.abs(value)), 100), 0)}</div>;
+}
+
+// Test with array methods
+function ArrayMethods() {
+  const arr = fn();
+  const index = fn();
+  return <div>{arr.slice(0, Math.abs(index))}</div>;
+}
+
+// Test with custom object methods
+function CustomMethods() {
+  const obj = fn();
+  const param = fn();
+  return <div>{obj.method1(obj.method2(param))}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component1,
+  params: [],
+  isComponent: true,
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fix-nested-math-calls.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fix-nested-math-calls.md
@@ -1,0 +1,49 @@
+# Fix Nested Math Calls Test
+
+## Description
+
+This test case verifies that the React Compiler can correctly handle nested function calls, including Math method calls and custom object methods. It tests various levels of nesting complexity to ensure proper dependency analysis and memoization.
+
+## Test Scenarios
+
+The test includes seven component functions covering different nesting patterns:
+
+### Basic Math Operations (2-level nesting)
+1. **Component1**: `Math.floor(Math.abs(value))` - Floor of absolute value
+2. **Component2**: `Math.ceil(Math.abs(value))` - Ceiling of absolute value  
+3. **Component3**: `Math.max(Math.abs(value), 0)` - Maximum with absolute value
+
+### Deep Math Nesting (3-4 level nesting)
+4. **DeepNested1**: `Math.round(Math.floor(Math.abs(value)))` - 3-level nested Math operations
+5. **DeepNested2**: `Math.max(Math.min(Math.floor(Math.abs(value)), 100), 0)` - 4-level nested Math operations
+
+### Array and Custom Methods
+6. **ArrayMethods**: `arr.slice(0, Math.abs(index))` - Array method with nested Math call
+7. **CustomMethods**: `obj.method1(obj.method2(param))` - Custom object method chaining
+
+## Expected Behavior
+
+The compiler should be able to:
+- Correctly identify and handle nested function calls at various depths
+- Apply appropriate memoization to JSX expressions containing complex nested calls
+- Ensure function dependencies are properly tracked (such as the `fn` function)
+- Handle both built-in methods (Math, Array) and custom object methods
+- Preserve call order and semantics in nested expressions
+
+## Compilation Output
+
+The compiled code should:
+- Use memoization cache (`const $ = _c(2)`)
+- Correctly track all function dependencies (`fn`, object methods)
+- Cache the entire JSX expression as a single unit
+- Preserve the original nested call structure and execution order
+- Handle both synchronous and potentially asynchronous nested calls
+
+## Related Issues
+
+This comprehensive test case addresses:
+- Dependency analysis for multi-level nested function calls
+- Memoization strategies for complex mathematical and method expressions
+- Special handling of Math object methods and array operations
+- Custom object method chaining and dependency tracking
+- Performance optimization for deeply nested expressions


### PR DESCRIPTION
fix(react-compiler): handle promoted identifiers in MethodCall codegen

Fix internal compiler error when generating code for nested method calls
like Math.floor(Math.abs(value)) and Math.ceil(Math.abs(value)).

Fixes #34072

**Problem:**
- Error: "MethodCall::property must be an unpromoted + unmemoized MemberExpression. Got a `Identifier`"
- Triggered by nested Math operations: Math.floor(Math.abs(value)), Math.ceil(Math.abs(value))
- Caused compilation to fail with invariant violation in nested method calls

**Root Cause:**
In complex nested method calls, the inner MethodCall.property gets promoted
to an identifier despite logic in PromoteUsedTemporaries trying to prevent it.
The codegen phase expects MethodCall.property to always be a MemberExpression
but receives an Identifier instead.

**Solution:**
Add fallback logic in codegenInstructionValue for MethodCall case:
- Detect when MethodCall.property has been promoted to an identifier
- Convert the MethodCall to a regular CallExpression in these cases
- Preserve original validation and behavior for non-promoted cases
- Maintain semantic correctness while preventing compiler crashes

**Testing:**
- ✅ Original reported cases: Math.floor(Math.abs(value)), Math.ceil(Math.abs(value))
- ✅ 3-layer nesting: Math.round(Math.floor(Math.abs(value)))
- ✅ 4-layer nesting: Math.max(Math.min(Math.floor(Math.abs(value)), 100), 0)
- ✅ Plugin loads and builds correctly
- ✅ No regressions in basic functionality

**Files Changed:**
- compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
- compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/fix-nested-math-calls.js (test case)