### PR TITLE
[DevTools] Avoid uncached Promise when symbolicating sources in environments without file fetching

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElement.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElement.js
@@ -34,6 +34,8 @@ export type Props = {};
 
 // TODO Make edits and deletes also use transition API!
 
+const noSourcePromise = Promise.resolve(null);
+
 export default function InspectedElementWrapper(_: Props): React.Node {
   const {inspectedElementID} = useContext(TreeStateContext);
   const bridge = useContext(BridgeContext);
@@ -59,11 +61,11 @@ export default function InspectedElementWrapper(_: Props): React.Node {
           ? inspectedElement.stack[0]
           : null;
 
-  const symbolicatedSourcePromise: null | Promise<ReactFunctionLocation | null> =
+  const symbolicatedSourcePromise: Promise<ReactFunctionLocation | null> =
     React.useMemo(() => {
-      if (fetchFileWithCaching == null) return Promise.resolve(null);
+      if (fetchFileWithCaching == null) return noSourcePromise;
 
-      if (source == null) return Promise.resolve(null);
+      if (source == null) return noSourcePromise;
 
       const [, sourceURL, line, column] = source;
       return symbolicateSourceWithCache(
@@ -291,7 +293,7 @@ export default function InspectedElementWrapper(_: Props): React.Node {
         <div className={styles.Loading}>Loading...</div>
       )}
 
-      {inspectedElement !== null && symbolicatedSourcePromise != null && (
+      {inspectedElement !== null && (
         <InspectedElementView
           element={element}
           hookNames={hookNames}


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/34208

Returning `Promise.resolve(null)` from `useMemo` is effectively returning an uncached Promise.

Mostly a fix for developing in the DevTools fixture I believe.



https://github.com/user-attachments/assets/d0fb6de5-7178-4467-a81e-7bf4dd85a430



