### PR TITLE
[compiler] Stop publishing eslint-plugin-react-compiler to npm

### DIFF
--- a/compiler/scripts/release/shared/packages.js
+++ b/compiler/scripts/release/shared/packages.js
@@ -7,7 +7,6 @@
 
 const PUBLISHABLE_PACKAGES = [
   'babel-plugin-react-compiler',
-  'eslint-plugin-react-compiler',
   'react-compiler-healthcheck',
   'react-compiler-runtime',
 ];


### PR DESCRIPTION

While we still use this package internally, we now ask users to install eslint-plugin-react-hooks instead, so this package can now be deprecated on npm.
