### PR TITLE
[compiler] RFC: Add reactiveSourceIdentifiers option

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -650,6 +650,14 @@ export const EnvironmentConfigSchema = z.object({
    *   useMemo(() => { ... }, [...]);
    */
   validateNoVoidUseMemo: z.boolean().default(false),
+
+  /**
+   * A list of function identifier names that are considered sources of
+   * reactivity. Calls to any identifier with a name in this list behave like
+   * the `use` operator: they may be called conditionally and are never skipped
+   * by memoization/flattening optimizations.
+   */
+  reactiveSourceIdentifiers: z.array(z.string()).default([]),
 });
 
 export type EnvironmentConfig = z.infer<typeof EnvironmentConfigSchema>;

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -1915,6 +1915,22 @@ export function isUseOperator(id: Identifier): boolean {
   );
 }
 
+export function isCustomReactiveSourceIdentifier(
+  env: Environment,
+  id: Identifier,
+): boolean {
+  const list = env.config.reactiveSourceIdentifiers;
+  if (list == null || list.length === 0) {
+    return false;
+  }
+  const loc = id.loc;
+  return (
+    typeof loc !== 'symbol' &&
+    typeof loc.identifierName === 'string' &&
+    list.includes(loc.identifierName)
+  );
+}
+
 export function getHookKindForType(
   env: Environment,
   type: Type,

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReactivePlaces.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReactivePlaces.ts
@@ -21,6 +21,7 @@ import {
   isStableType,
   isStableTypeContainer,
   isUseOperator,
+  isCustomReactiveSourceIdentifier,
 } from '../HIR';
 import {PostDominator} from '../HIR/Dominator';
 import {
@@ -302,13 +303,15 @@ export function inferReactivePlaces(fn: HIRFunction): void {
         if (
           value.kind === 'CallExpression' &&
           (getHookKind(fn.env, value.callee.identifier) != null ||
-            isUseOperator(value.callee.identifier))
+            isUseOperator(value.callee.identifier) ||
+            isCustomReactiveSourceIdentifier(fn.env, value.callee.identifier))
         ) {
           hasReactiveInput = true;
         } else if (
           value.kind === 'MethodCall' &&
           (getHookKind(fn.env, value.property.identifier) != null ||
-            isUseOperator(value.property.identifier))
+            isUseOperator(value.property.identifier) ||
+            isCustomReactiveSourceIdentifier(fn.env, value.property.identifier))
         ) {
           hasReactiveInput = true;
         }

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/FlattenScopesWithHooksOrUseHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/FlattenScopesWithHooksOrUseHIR.ts
@@ -12,6 +12,7 @@ import {
   LabelTerminal,
   PrunedScopeTerminal,
   getHookKind,
+  isCustomReactiveSourceIdentifier,
   isUseOperator,
 } from '../HIR';
 import {retainWhere} from '../Utils/utils';
@@ -53,7 +54,8 @@ export function flattenScopesWithHooksOrUseHIR(fn: HIRFunction): void {
             value.kind === 'MethodCall' ? value.property : value.callee;
           if (
             getHookKind(fn.env, callee.identifier) != null ||
-            isUseOperator(callee.identifier)
+            isUseOperator(callee.identifier) ||
+            isCustomReactiveSourceIdentifier(fn.env, callee.identifier)
           ) {
             prune.push(...activeScopes.map(entry => entry.block));
             activeScopes.length = 0;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reactive-source-identifier.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reactive-source-identifier.expect.md
@@ -1,0 +1,74 @@
+
+## Input
+
+```javascript
+// @reactiveSourceIdentifiers:["reactiveSource"]
+function reactiveSource() {
+  console.log('reactiveSource');
+}
+
+function Component({prop}) {
+  const value1 = reactiveSource();
+  const value2 = reactiveSource(value);
+  const value3 = prop > 0.5 ? reactiveSource() : null;
+  return (
+    <div>
+      {value1}
+      {value2}
+      {value3}
+    </div>
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{prop: 1}],
+  isComponent: true,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @reactiveSourceIdentifiers:["reactiveSource"]
+function reactiveSource() {
+  console.log("reactiveSource");
+}
+
+function Component(t0) {
+  const $ = _c(4);
+  const { prop } = t0;
+  const value1 = reactiveSource();
+  const value2 = reactiveSource(value);
+  const value3 = prop > 0.5 ? reactiveSource() : null;
+  let t1;
+  if ($[0] !== value1 || $[1] !== value2 || $[2] !== value3) {
+    t1 = (
+      <div>
+        {value1}
+        {value2}
+        {value3}
+      </div>
+    );
+    $[0] = value1;
+    $[1] = value2;
+    $[2] = value3;
+    $[3] = t1;
+  } else {
+    t1 = $[3];
+  }
+  return t1;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ prop: 1 }],
+  isComponent: true,
+};
+
+```
+      
+### Eval output
+(kind: exception) value is not defined
+logs: ['reactiveSource','reactiveSource']

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reactive-source-identifier.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reactive-source-identifier.js
@@ -1,0 +1,23 @@
+// @reactiveSourceIdentifiers:["reactiveSource"]
+function reactiveSource() {
+  console.log('reactiveSource');
+}
+
+function Component({prop}) {
+  const value1 = reactiveSource();
+  const value2 = reactiveSource(value);
+  const value3 = prop > 0.5 ? reactiveSource() : null;
+  return (
+    <div>
+      {value1}
+      {value2}
+      {value3}
+    </div>
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{prop: 1}],
+  isComponent: true,
+};


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

This adds `reactiveSourceIdentifiers` as an React compiler babel plugin option. This is a list of strings that cause matching identifiers to be treated as sources of reactivity so they are never skipped by React compiler.

This is useful for integration with libraries like MobX for annotating certain pieces of code that cannot be skipped. In MobX's case, reading observable values cannot be skipped for tracking reactivity.

Another use case is annotating functions that call `use` but do not look like a hook to the compiler.

## How did you test this change?

Added babel compiler test

Used in codebase. Annotate an `observe` function as a reactive source and see that it is not skipped by React compiler.