### PR TITLE
[DevTools] Fix crash when inspecting Components suspended on data awaited in anonymous functions

### DIFF
--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -752,7 +752,7 @@ describe('ReactHooksInspection', () => {
             "hookSource": {
               "columnNumber": 0,
               "fileName": "**",
-              "functionName": undefined,
+              "functionName": null,
               "lineNumber": 0,
             },
             "id": null,

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -720,6 +720,53 @@ describe('ReactHooksInspection', () => {
     );
   });
 
+  it('should inspect use() calls in anonymous loops', () => {
+    function Foo({entries}) {
+      const values = Object.fromEntries(
+        Object.entries(entries).map(([key, value]) => {
+          return [key, React.use(value)];
+        }),
+      );
+      return <div>{values}</div>;
+    }
+    const tree = ReactDebugTools.inspectHooks(Foo, {
+      entries: {one: Promise.resolve('one'), two: Promise.resolve('two')},
+    });
+    const results = normalizeSourceLoc(tree);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchInlineSnapshot(`
+      {
+        "debugInfo": null,
+        "hookSource": {
+          "columnNumber": 0,
+          "fileName": "**",
+          "functionName": "Foo",
+          "lineNumber": 0,
+        },
+        "id": null,
+        "isStateEditable": false,
+        "name": "",
+        "subHooks": [
+          {
+            "debugInfo": null,
+            "hookSource": {
+              "columnNumber": 0,
+              "fileName": "**",
+              "functionName": undefined,
+              "lineNumber": 0,
+            },
+            "id": null,
+            "isStateEditable": false,
+            "name": "Use",
+            "subHooks": [],
+            "value": Promise {},
+          },
+        ],
+        "value": undefined,
+      }
+    `);
+  });
+
   describe('useDebugValue', () => {
     it('should be ignored when called outside of a custom hook', () => {
       function Foo(props) {

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
@@ -885,7 +885,7 @@ describe('ReactHooksInspectionIntegration', () => {
           "hookSource": {
             "columnNumber": 0,
             "fileName": "**",
-            "functionName": undefined,
+            "functionName": null,
             "lineNumber": 0,
           },
           "id": 0,

--- a/packages/react-devtools-timeline/src/content-views/utils/moduleFilters.js
+++ b/packages/react-devtools-timeline/src/content-views/utils/moduleFilters.js
@@ -51,12 +51,16 @@ export function isInternalModule(
       const [startStackFrame, stopStackFrame] = ranges[i];
 
       const isAfterStart =
+        // $FlowFixMe[invalid-compare] -- TODO: Revealed when adding types to error-stack-parser
         locationLine > startStackFrame.lineNumber ||
         (locationLine === startStackFrame.lineNumber &&
+          // $FlowFixMe[invalid-compare]
           locationColumn >= startStackFrame.columnNumber);
       const isBeforeStop =
+        // $FlowFixMe[invalid-compare]
         locationLine < stopStackFrame.lineNumber ||
         (locationLine === stopStackFrame.lineNumber &&
+          // $FlowFixMe[invalid-compare]
           locationColumn <= stopStackFrame.columnNumber);
 
       if (isAfterStart && isBeforeStop) {

--- a/packages/react-devtools-timeline/src/types.js
+++ b/packages/react-devtools-timeline/src/types.js
@@ -6,7 +6,7 @@
  *
  * @flow
  */
-
+import type {StackFrame as ErrorStackFrame} from 'error-stack-parser';
 import type {ScrollState} from './view-base/utils/scrollState';
 
 // Source: https://github.com/facebook/flow/issues/4002#issuecomment-323612798
@@ -16,12 +16,7 @@ type Return_<R, F: (...args: Array<any>) => R> = R;
 export type Return<T> = Return_<mixed, T>;
 
 // Project types
-
-export type ErrorStackFrame = {
-  fileName: string,
-  lineNumber: number,
-  columnNumber: number,
-};
+export type {ErrorStackFrame};
 
 export type Milliseconds = number;
 
@@ -192,7 +187,7 @@ export type ViewState = {
 };
 
 export type InternalModuleSourceToRanges = Map<
-  string,
+  string | void,
   Array<[ErrorStackFrame, ErrorStackFrame]>,
 >;
 
@@ -224,7 +219,7 @@ export type TimelineDataExport = {
   duration: number,
   flamechart: Flamechart,
   internalModuleSourceToRanges: Array<
-    [string, Array<[ErrorStackFrame, ErrorStackFrame]>],
+    [string | void, Array<[ErrorStackFrame, ErrorStackFrame]>],
   >,
   laneToLabelKeyValueArray: Array<[ReactLane, string]>,
   laneToReactMeasureKeyValueArray: Array<[ReactLane, ReactMeasure[]]>,

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -29,6 +29,67 @@ declare module 'create-react-class' {
   declare const exports: $FlowFixMe;
 }
 
+declare module 'error-stack-parser' {
+  // flow-typed signature: 132e48034ef4756600e1d98681a166b5
+  // flow-typed version: c6154227d1/error-stack-parser_v2.x.x/flow_>=v0.104.x
+
+  declare interface StackFrame {
+    constructor(object: StackFrame): StackFrame;
+
+    isConstructor?: boolean;
+    getIsConstructor(): boolean;
+    setIsConstructor(): void;
+
+    isEval?: boolean;
+    getIsEval(): boolean;
+    setIsEval(): void;
+
+    isNative?: boolean;
+    getIsNative(): boolean;
+    setIsNative(): void;
+
+    isTopLevel?: boolean;
+    getIsTopLevel(): boolean;
+    setIsTopLevel(): void;
+
+    columnNumber?: number;
+    getColumnNumber(): number;
+    setColumnNumber(): void;
+
+    lineNumber?: number;
+    getLineNumber(): number;
+    setLineNumber(): void;
+
+    fileName?: string;
+    getFileName(): string;
+    setFileName(): void;
+
+    functionName?: string;
+    getFunctionName(): string;
+    setFunctionName(): void;
+
+    source?: string;
+    getSource(): string;
+    setSource(): void;
+
+    args?: any[];
+    getArgs(): any[];
+    setArgs(): void;
+
+    evalOrigin?: StackFrame;
+    getEvalOrigin(): StackFrame;
+    setEvalOrigin(): void;
+
+    toString(): string;
+  }
+
+  declare class ErrorStackParser {
+    parse(error: Error): Array<StackFrame>;
+  }
+
+  declare module.exports: ErrorStackParser;
+}
+
 declare interface ConsoleTask {
   run<T>(f: () => T): T;
 }


### PR DESCRIPTION
`error-stack-parser` can return `undefined` in parsed function names while we expect `null` for bottom values instead. We need to choose the right bottom value before we consider it a `ReactStackTrace`