### PR TITLE
[DevTools] fix: always send a response to fetch-file request in the extension

### DIFF
--- a/packages/react-devtools-extensions/src/background/messageHandlers.js
+++ b/packages/react-devtools-extensions/src/background/messageHandlers.js
@@ -46,21 +46,25 @@ export function handleDevToolsPageMessage(message) {
         payload: {tabId, url},
       } = message;
 
-      if (!tabId) {
-        throw new Error("Couldn't fetch file sources: tabId not specified");
+      if (!tabId || !url) {
+        // Send a response straight away to get the Promise fulfilled.
+        chrome.runtime.sendMessage({
+          source: 'react-devtools-background',
+          payload: {
+            type: 'fetch-file-with-cache-error',
+            url,
+            value: null,
+          },
+        });
+      } else {
+        chrome.tabs.sendMessage(tabId, {
+          source: 'devtools-page',
+          payload: {
+            type: 'fetch-file-with-cache',
+            url,
+          },
+        });
       }
-
-      if (!url) {
-        throw new Error("Couldn't fetch file sources: url not specified");
-      }
-
-      chrome.tabs.sendMessage(tabId, {
-        source: 'devtools-page',
-        payload: {
-          type: 'fetch-file-with-cache',
-          url,
-        },
-      });
 
       break;
     }


### PR DESCRIPTION
This fixes the displaying of "rendered by" section if owner stacks contained any native frames. This regressed after https://github.com/facebook/react/pull/34185, where we added the Suspense boundary for the StackTraceView.

This fails because the Promise that is responsible for symbolication of the source is never getting resolved or rejected.
Previously, we would just throw an Error without sending a corresponding message to the `main` script, and it would just cache a Promise that is never resolved, hence the Suspense boundary for "rendered by" section is never resolved.

In a separate change, I think we need to update StackTraceView component to display `native` as location, instead of `:0`:
<img width="712" height="118" alt="Screenshot 2025-08-20 at 00 20 42" src="https://github.com/user-attachments/assets/c79735c9-fdd2-467c-96cd-2bc29d38c4e0" />

