### PR TITLE
Rollout passChildrenWhenCloningPersistedNodes flag

### DIFF
--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -46,9 +46,7 @@ const {
   cloneNodeWithNewChildren,
   cloneNodeWithNewChildrenAndProps,
   cloneNodeWithNewProps,
-  createChildSet: createChildNodeSet,
   appendChild: appendChildNode,
-  appendChildToSet: appendChildNodeToSet,
   completeRoot,
   registerEventHandler,
   unstable_DefaultEventPriority: FabricDefaultPriority,
@@ -67,7 +65,6 @@ import {
   getInspectorDataForInstance,
 } from './ReactNativeFiberInspector';
 
-import {passChildrenWhenCloningPersistedNodes} from 'shared/ReactFeatureFlags';
 import {REACT_CONTEXT_TYPE} from 'shared/ReactSymbols';
 import type {ReactContext} from 'shared/ReactTypes';
 
@@ -524,22 +521,14 @@ export function cloneHiddenTextInstance(
 }
 
 export function createContainerChildSet(): ChildSet {
-  if (passChildrenWhenCloningPersistedNodes) {
-    return [];
-  } else {
-    return createChildNodeSet();
-  }
+  return [];
 }
 
 export function appendChildToContainerChildSet(
   childSet: ChildSet,
   child: Instance | TextInstance,
 ): void {
-  if (passChildrenWhenCloningPersistedNodes) {
-    childSet.push(child.node);
-  } else {
-    appendChildNodeToSet(childSet, child.node);
-  }
+  childSet.push(child.node);
 }
 
 export function finalizeContainerChildren(

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager.js
@@ -87,13 +87,7 @@ const RCTFabricUIManager = {
     },
   ),
   cloneNodeWithNewChildrenAndProps: jest.fn(
-    function cloneNodeWithNewChildrenAndProps(node, newPropsDiff) {
-      let children = [];
-      if (arguments.length === 3) {
-        children = newPropsDiff;
-        newPropsDiff = arguments[2];
-      }
-
+    function cloneNodeWithNewChildrenAndProps(node, children, newPropsDiff) {
       return {
         reactTag: node.reactTag,
         viewName: node.viewName,
@@ -104,14 +98,6 @@ const RCTFabricUIManager = {
   ),
   appendChild: jest.fn(function appendChild(parentNode, childNode) {
     parentNode.children.push(childNode);
-  }),
-
-  createChildSet: jest.fn(function createChildSet() {
-    return [];
-  }),
-
-  appendChildToSet: jest.fn(function appendChildToSet(childSet, childNode) {
-    childSet.push(childNode);
   }),
 
   completeRoot: jest.fn(function completeRoot(rootTag, newChildSet) {

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -220,13 +220,8 @@ describe('ReactFabric', () => {
         true,
       );
     });
-    const argIndex = gate(flags => flags.passChildrenWhenCloningPersistedNodes)
-      ? 2
-      : 1;
     expect(
-      nativeFabricUIManager.cloneNodeWithNewChildrenAndProps.mock.calls[0][
-        argIndex
-      ],
+      nativeFabricUIManager.cloneNodeWithNewChildrenAndProps.mock.calls[0][2],
     ).toEqual({
       foo: 'b',
     });
@@ -268,19 +263,11 @@ describe('ReactFabric', () => {
     expect(
       nativeFabricUIManager.cloneNodeWithNewChildren,
     ).toHaveBeenCalledTimes(1);
-    if (gate(flags => flags.passChildrenWhenCloningPersistedNodes)) {
-      expect(
-        nativeFabricUIManager.cloneNodeWithNewChildren,
-      ).toHaveBeenCalledWith(expect.anything(), [
-        expect.objectContaining({props: {foo: false}}),
-      ]);
-      expect(nativeFabricUIManager.appendChild).not.toBeCalled();
-    } else {
-      expect(
-        nativeFabricUIManager.cloneNodeWithNewChildren,
-      ).toHaveBeenCalledWith(expect.anything());
-      expect(nativeFabricUIManager.appendChild).toHaveBeenCalledTimes(1);
-    }
+    expect(nativeFabricUIManager.cloneNodeWithNewChildren).toHaveBeenCalledWith(
+      expect.anything(),
+      [expect.objectContaining({props: {foo: false}})],
+    );
+    expect(nativeFabricUIManager.appendChild).not.toBeCalled();
     expect(
       nativeFabricUIManager.cloneNodeWithNewChildrenAndProps,
     ).not.toBeCalled();

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -37,7 +37,6 @@ import {
   enableScopeAPI,
   enableProfilerTimer,
   enableTransitionTracing,
-  passChildrenWhenCloningPersistedNodes,
   disableLegacyMode,
   enableViewTransition,
   enableSuspenseyImages,
@@ -484,7 +483,7 @@ function updateHostComponent(
 
     let newChildSet = null;
     let hasOffscreenComponentChild = false;
-    if (requiresClone && passChildrenWhenCloningPersistedNodes) {
+    if (requiresClone) {
       markCloned(workInProgress);
       newChildSet = createContainerChildSet();
       // If children might have changed, we have to add them all to the set.
@@ -522,10 +521,7 @@ function updateHostComponent(
       markUpdate(workInProgress);
     }
     workInProgress.stateNode = newInstance;
-    if (
-      requiresClone &&
-      (!passChildrenWhenCloningPersistedNodes || hasOffscreenComponentChild)
-    ) {
+    if (requiresClone && hasOffscreenComponentChild) {
       // If children have changed, we have to add them all to the set.
       appendAllChildren(
         newInstance,

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -127,8 +127,6 @@ export const enableFizzExternalRuntime = __EXPERIMENTAL__;
 
 export const alwaysThrottleRetries: boolean = true;
 
-export const passChildrenWhenCloningPersistedNodes: boolean = false;
-
 export const enableEagerAlternateStateNodeCleanup: boolean = true;
 
 /**

--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -21,7 +21,6 @@ export const alwaysThrottleRetries = __VARIANT__;
 export const enableObjectFiber = __VARIANT__;
 export const enableHiddenSubtreeInsertionEffectCleanup = __VARIANT__;
 export const enableEagerAlternateStateNodeCleanup = __VARIANT__;
-export const passChildrenWhenCloningPersistedNodes = __VARIANT__;
 export const renameElementSymbol = __VARIANT__;
 export const enableFragmentRefs = __VARIANT__;
 export const enableFragmentRefsScrollIntoView = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -23,7 +23,6 @@ export const {
   enableHiddenSubtreeInsertionEffectCleanup,
   enableObjectFiber,
   enableEagerAlternateStateNodeCleanup,
-  passChildrenWhenCloningPersistedNodes,
   renameElementSymbol,
   enableFragmentRefs,
   enableFragmentRefsScrollIntoView,

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -51,7 +51,6 @@ export const enableTaint: boolean = true;
 export const enableTransitionTracing: boolean = false;
 export const enableTrustedTypesIntegration: boolean = false;
 export const enableUseEffectEventHook: boolean = true;
-export const passChildrenWhenCloningPersistedNodes: boolean = false;
 export const renameElementSymbol: boolean = true;
 export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -52,7 +52,6 @@ export const enableFizzExternalRuntime: boolean = true;
 
 export const alwaysThrottleRetries: boolean = true;
 
-export const passChildrenWhenCloningPersistedNodes: boolean = false;
 export const disableClientCache: boolean = true;
 
 export const enableInfiniteRenderLoopDetection: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -50,7 +50,6 @@ export const enableTransitionTracing = false;
 export const enableTrustedTypesIntegration = false;
 export const enableUpdaterTracking = false;
 export const enableUseEffectEventHook = true;
-export const passChildrenWhenCloningPersistedNodes = false;
 export const renameElementSymbol = false;
 export const retryLaneExpirationMs = 5000;
 export const syncLaneExpirationMs = 250;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -53,7 +53,6 @@ export const enableFizzExternalRuntime: boolean = false;
 
 export const alwaysThrottleRetries: boolean = true;
 
-export const passChildrenWhenCloningPersistedNodes: boolean = false;
 export const disableClientCache: boolean = true;
 
 export const enableInfiniteRenderLoopDetection: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -91,8 +91,6 @@ export const disableTextareaChildren = __EXPERIMENTAL__;
 
 export const enableFizzExternalRuntime: boolean = true;
 
-export const passChildrenWhenCloningPersistedNodes: boolean = false;
-
 export const disableClientCache: boolean = true;
 
 export const enableReactTestRendererWarning: boolean = false;

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -247,13 +247,10 @@ declare const nativeFabricUIManager: {
   cloneNodeWithNewProps: (node: Object, newProps: ?Object) => Object,
   cloneNodeWithNewChildrenAndProps: (
     node: Object,
-    newPropsOrChildren: ?Object | $ReadOnlyArray<Object>,
+    newChildren: $ReadOnlyArray<Object>,
     newProps?: ?Object,
   ) => Object,
   appendChild: (node: Object, childNode: Object) => void,
-
-  createChildSet: () => Object,
-  appendChildToSet: (childSet: Object, childNode: Object) => void,
   completeRoot: (rootTag: number, childSet: Object) => void,
   registerEventHandler: (
     callback: (


### PR DESCRIPTION
## Summary

passChildrenWhenCloningPersistedNodes was evaluated internally at Meta and all known regressions have been resolved. This is a valuable performance improvement for React Native performance and it should be rolled out everywhere.

This change does not have user-visible behaviour, it just affects how Fabric keeps track of the ShadowTree internally.

## How did you test this change?

Unit tests updated