### PR TITLE
[ci] Fix permissions for direct sync branch PRs workflow

### DIFF
--- a/.github/workflows/shared_close_direct_sync_branch_prs.yml
+++ b/.github/workflows/shared_close_direct_sync_branch_prs.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       # Used to create a review and close PRs
       pull-requests: write
+      contents: write
     steps:
       - name: Close PR
         uses: actions/github-script@v7


### PR DESCRIPTION

Because we sync built artifacts into Meta, we can't support edits from inside www/fbsource to be synced back into OSS as it would cause merge conflicts for future OSS PRs.

We have a workflow that should automatically catch and close these PRs, but it looks like this one was missing one permission.
