### PR TITLE
[DevTools] Include `name` prop when highlighting host instances

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/hooks.js
+++ b/packages/react-devtools-shared/src/devtools/views/hooks.js
@@ -355,8 +355,12 @@ export function useHighlightHostInstance(): {
       const element = store.getElementByID(id);
       const rendererID = store.getRendererIDForElement(id);
       if (element !== null && rendererID !== null) {
+        let displayName = element.displayName;
+        if (displayName !== null && element.nameProp !== null) {
+          displayName += ` name="${element.nameProp}"`;
+        }
         bridge.send('highlightHostInstance', {
-          displayName: element.displayName,
+          displayName,
           hideAfterTimeout: false,
           id,
           openBuiltinElementsPanel: false,


### PR DESCRIPTION
This helps identifying individual Suspense and Activity boundaries if they're named. We already show the name in the Components tab since https://github.com/facebook/react/pull/34135

Using the rects as a strawman even though we'll probably show the name in the rects view as well. But nice being able to not constantly flip back and forth to get the name. The timeline will also highlight host instances on hover and there we might not have the real estate to display the name at all.

https://github.com/user-attachments/assets/e72261c6-12a7-49bc-bc2d-58bf5c496175

