### PR TITLE
Fix formatting issue in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ An Owner Stack is a string representing the components that are directly respons
 
 ### React DOM
 * Fixed double warning when the `href` attribute is an empty string [#31783](https://github.com/facebook/react/pull/31783)
- * Fixed an edge case where `getHoistableRoot()` didn’t work properly when the container was a Document [#32321](https://github.com/facebook/react/pull/32321)
+* Fixed an edge case where `getHoistableRoot()` didn't work properly when the container was a Document [#32321](https://github.com/facebook/react/pull/32321)
 * Removed support for using HTML comments (e.g. `<!-- -->`) as a DOM container. [#32250](https://github.com/facebook/react/pull/32250)
 * Added support for `<script>` and `<template>` tags to be nested within `<select>` tags. [#31837](https://github.com/facebook/react/pull/31837)
 * Fixed responsive images to be preloaded as HTML instead of headers [#32445](https://github.com/facebook/react/pull/32445)


### PR DESCRIPTION
[38;5;255m## Summary[0m
[38;5;255m- Fixed a minor formatting issue in CHANGELOG.md where there was an extra leading space in a React DOM section bullet point[0m

[38;5;255m## Test plan[0m
[38;5;255mThis is a documentation-only change that fixes formatting consistency. No functional changes were made.[0m

[38;5;255m🤖 Generated with [Claude Code](https://claude.ai/code)[0m