### PR TITLE
[compiler] Fix missing dependency in eslint-plugin-react-hooks

### DIFF
--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@babel/core": "^7.24.4",
     "@babel/parser": "^7.24.4",
-    "@babel/plugin-transform-private-methods": "^7.24.4",
+    "@babel/plugin-proposal-private-methods": "^7.18.6",
     "hermes-parser": "^0.25.1",
     "zod": "^3.22.4",
     "zod-validation-error": "^3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,6 +1122,14 @@
     "@babel/helper-create-class-features-plugin" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-proposal-private-methods@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz#5209de7d213457548a98436fa2882f52f4be6bea"
+  integrity sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.18.6"
+
 "@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2":
   version "7.21.0-placeholder-for-preset-env.2"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz#7844f9289546efa9febac2de4cfe358a050bd703"
@@ -1882,7 +1890,7 @@
     "@babel/helper-create-class-features-plugin" "^7.27.1"
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-private-methods@^7.24.4", "@babel/plugin-transform-private-methods@^7.25.9":
+"@babel/plugin-transform-private-methods@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz#847f4139263577526455d7d3223cd8bda51e3b57"
   integrity sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==


### PR DESCRIPTION
## Summary

https://github.com/facebook/react/pull/34176 introduced `@babel/plugin-proposal-private-methods`: https://github.com/facebook/react/blob/63feb9436ba0cd0e8ab8b53b0789a233c22fddb4/packages/eslint-plugin-react-hooks/src/shared/RunReactCompiler.ts#L13

However, the declared dependencies of `eslint-plugin-react-hooks` weren't updated.

This mostly worked for package managers that hoist everything but breaks when node_modules are strictly isolated to the set of declared dependencies.

I declared the used dependency in this PR. Could also be possible to use the transform directly.

Fixes
```
Oops! Something went wrong! :(

ESLint: 9.12.0

Error: Failed to load plugin 'react-hooks' declared in '--config » ./.eslintrc.json': Cannot find module '@babel/plugin-proposal-private-methods'
Require stack:
- ~/node_modules/.pnpm/eslint-plugin-react-hooks@0.0.0-experimental-6de32a5a-20250822_eslint@9.12.0/node_modules/eslint-plugin-react-hooks/cjs/eslint-plugin-react-hooks.development.js
```

## Test plan

- [x] Applied patch via `packageExtensions` to make the error go away (https://github.com/vercel/next.js/pull/82946/commits/5b2b3a50e94b1e2307ef9cac59805aaa0853fc48)