### PR TITLE
[DevTools] Fix symbolication with Index Source Maps

### DIFF
--- a/packages/react-devtools-shared/src/hooks/SourceMapTypes.js
+++ b/packages/react-devtools-shared/src/hooks/SourceMapTypes.js
@@ -29,7 +29,7 @@ export type BasicSourceMap = {
 };
 
 export type IndexSourceMapSection = {
-  map: IndexSourceMap | BasicSourceMap,
+  map: BasicSourceMap,
   offset: {
     line: number,
     column: number,


### PR DESCRIPTION
Symbolicating with Index Source Maps needs to consider that the mappings in a section are relative to its offset.

Before:
<img width="976" height="392" alt="CleanShot 2025-08-26 at 14 39 18@2x" src="https://github.com/user-attachments/assets/476fe828-3db8-42ef-83b6-51edcf861bac" />

After:

<img width="702" height="386" alt="CleanShot 2025-08-26 at 14 44 25@2x" src="https://github.com/user-attachments/assets/32ec9b25-8c2b-489e-905f-930b69710b59" />
