### PR TITLE
[Flight] Wait for both streams to end before closing the response

### DIFF
--- a/packages/react-server-dom-esm/src/client/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-esm/src/client/ReactFlightDOMClientBrowser.js
@@ -187,7 +187,7 @@ function createFromReadableStream<T>(
     );
     startReadingFromStream(response, stream, handleDone);
   } else {
-    startReadingFromStream(response, stream, () => close(response));
+    startReadingFromStream(response, stream, close.bind(null, response));
   }
   return getRoot(response);
 }
@@ -218,7 +218,11 @@ function createFromFetch<T>(
         );
         startReadingFromStream(response, (r.body: any), handleDone);
       } else {
-        startReadingFromStream(response, (r.body: any), () => close(response));
+        startReadingFromStream(
+          response,
+          (r.body: any),
+          close.bind(null, response),
+        );
       }
     },
     function (e) {

--- a/packages/react-server-dom-esm/src/client/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-esm/src/client/ReactFlightDOMClientBrowser.js
@@ -101,6 +101,7 @@ function createResponseFromOptions(options: void | Options) {
 function startReadingFromUniversalStream(
   response: FlightResponse,
   stream: ReadableStream,
+  onDone: () => void,
 ): void {
   // This is the same as startReadingFromStream except this allows WebSocketStreams which
   // return ArrayBuffer and string chunks instead of Uint8Array chunks. We could potentially
@@ -116,8 +117,7 @@ function startReadingFromUniversalStream(
     ...
   }): void | Promise<void> {
     if (done) {
-      close(response);
-      return;
+      return onDone();
     }
     if (value instanceof ArrayBuffer) {
       // WebSockets can produce ArrayBuffer values in ReadableStreams.
@@ -139,7 +139,7 @@ function startReadingFromUniversalStream(
 function startReadingFromStream(
   response: FlightResponse,
   stream: ReadableStream,
-  isSecondaryStream: boolean,
+  onDone: () => void,
 ): void {
   const streamState = createStreamState();
   const reader = stream.getReader();
@@ -152,11 +152,7 @@ function startReadingFromStream(
     ...
   }): void | Promise<void> {
     if (done) {
-      // If we're the secondary stream, then we don't close the response until the debug channel closes.
-      if (!isSecondaryStream) {
-        close(response);
-      }
-      return;
+      return onDone();
     }
     const buffer: Uint8Array = (value: any);
     processBinaryChunk(response, streamState, buffer);
@@ -178,10 +174,20 @@ function createFromReadableStream<T>(
     options.debugChannel &&
     options.debugChannel.readable
   ) {
-    startReadingFromUniversalStream(response, options.debugChannel.readable);
-    startReadingFromStream(response, stream, true);
+    let streamDoneCount = 0;
+    const handleDone = () => {
+      if (++streamDoneCount === 2) {
+        close(response);
+      }
+    };
+    startReadingFromUniversalStream(
+      response,
+      options.debugChannel.readable,
+      handleDone,
+    );
+    startReadingFromStream(response, stream, handleDone);
   } else {
-    startReadingFromStream(response, stream, false);
+    startReadingFromStream(response, stream, () => close(response));
   }
   return getRoot(response);
 }
@@ -199,13 +205,20 @@ function createFromFetch<T>(
         options.debugChannel &&
         options.debugChannel.readable
       ) {
+        let streamDoneCount = 0;
+        const handleDone = () => {
+          if (++streamDoneCount === 2) {
+            close(response);
+          }
+        };
         startReadingFromUniversalStream(
           response,
           options.debugChannel.readable,
+          handleDone,
         );
-        startReadingFromStream(response, (r.body: any), true);
+        startReadingFromStream(response, (r.body: any), handleDone);
       } else {
-        startReadingFromStream(response, (r.body: any), false);
+        startReadingFromStream(response, (r.body: any), () => close(response));
       }
     },
     function (e) {

--- a/packages/react-server-dom-esm/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-esm/src/client/ReactFlightDOMClientNode.js
@@ -115,7 +115,7 @@ function createFromNodeStream<T>(
     startReadingFromStream(response, options.debugChannel, handleEnd);
     startReadingFromStream(response, stream, handleEnd);
   } else {
-    startReadingFromStream(response, stream, () => close(response));
+    startReadingFromStream(response, stream, close.bind(null, response));
   }
 
   return getRoot(response);

--- a/packages/react-server-dom-esm/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-esm/src/client/ReactFlightDOMClientNode.js
@@ -63,7 +63,7 @@ export type Options = {
 function startReadingFromStream(
   response: Response,
   stream: Readable,
-  isSecondaryStream: boolean,
+  onEnd: () => void,
 ): void {
   const streamState = createStreamState();
 
@@ -79,13 +79,7 @@ function startReadingFromStream(
     reportGlobalError(response, error);
   });
 
-  stream.on('end', () => {
-    // If we're the secondary stream, then we don't close the response until the
-    // debug channel closes.
-    if (!isSecondaryStream) {
-      close(response);
-    }
-  });
+  stream.on('end', onEnd);
 }
 
 function createFromNodeStream<T>(
@@ -112,10 +106,16 @@ function createFromNodeStream<T>(
   );
 
   if (__DEV__ && options && options.debugChannel) {
-    startReadingFromStream(response, options.debugChannel, false);
-    startReadingFromStream(response, stream, true);
+    let streamEndedCount = 0;
+    const handleEnd = () => {
+      if (++streamEndedCount === 2) {
+        close(response);
+      }
+    };
+    startReadingFromStream(response, options.debugChannel, handleEnd);
+    startReadingFromStream(response, stream, handleEnd);
   } else {
-    startReadingFromStream(response, stream, false);
+    startReadingFromStream(response, stream, () => close(response));
   }
 
   return getRoot(response);

--- a/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientBrowser.js
@@ -217,7 +217,7 @@ export function createFromReadableStream<T>(
     );
     startReadingFromStream(response, stream, handleDone);
   } else {
-    startReadingFromStream(response, stream, () => close(response));
+    startReadingFromStream(response, stream, close.bind(null, response));
   }
   return getRoot(response);
 }
@@ -269,7 +269,11 @@ export function createFromFetch<T>(
         );
         startReadingFromStream(response, (r.body: any), handleDone);
       } else {
-        startReadingFromStream(response, (r.body: any), () => close(response));
+        startReadingFromStream(
+          response,
+          (r.body: any),
+          close.bind(null, response),
+        );
       }
     },
     function (e) {

--- a/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientBrowser.js
@@ -102,6 +102,7 @@ function createDebugCallbackFromWritableStream(
 function startReadingFromUniversalStream(
   response: FlightResponse,
   stream: ReadableStream,
+  onDone: () => void,
 ): void {
   // This is the same as startReadingFromStream except this allows WebSocketStreams which
   // return ArrayBuffer and string chunks instead of Uint8Array chunks. We could potentially
@@ -117,8 +118,7 @@ function startReadingFromUniversalStream(
     ...
   }): void | Promise<void> {
     if (done) {
-      close(response);
-      return;
+      return onDone();
     }
     if (value instanceof ArrayBuffer) {
       // WebSockets can produce ArrayBuffer values in ReadableStreams.
@@ -140,7 +140,7 @@ function startReadingFromUniversalStream(
 function startReadingFromStream(
   response: FlightResponse,
   stream: ReadableStream,
-  isSecondaryStream: boolean,
+  onDone: () => void,
 ): void {
   const streamState = createStreamState();
   const reader = stream.getReader();
@@ -153,11 +153,7 @@ function startReadingFromStream(
     ...
   }): void | Promise<void> {
     if (done) {
-      // If we're the secondary stream, then we don't close the response until the debug channel closes.
-      if (!isSecondaryStream) {
-        close(response);
-      }
-      return;
+      return onDone();
     }
     const buffer: Uint8Array = (value: any);
     processBinaryChunk(response, streamState, buffer);
@@ -208,10 +204,20 @@ export function createFromReadableStream<T>(
     options.debugChannel &&
     options.debugChannel.readable
   ) {
-    startReadingFromUniversalStream(response, options.debugChannel.readable);
-    startReadingFromStream(response, stream, true);
+    let streamDoneCount = 0;
+    const handleDone = () => {
+      if (++streamDoneCount === 2) {
+        close(response);
+      }
+    };
+    startReadingFromUniversalStream(
+      response,
+      options.debugChannel.readable,
+      handleDone,
+    );
+    startReadingFromStream(response, stream, handleDone);
   } else {
-    startReadingFromStream(response, stream, false);
+    startReadingFromStream(response, stream, () => close(response));
   }
   return getRoot(response);
 }
@@ -250,13 +256,20 @@ export function createFromFetch<T>(
         options.debugChannel &&
         options.debugChannel.readable
       ) {
+        let streamDoneCount = 0;
+        const handleDone = () => {
+          if (++streamDoneCount === 2) {
+            close(response);
+          }
+        };
         startReadingFromUniversalStream(
           response,
           options.debugChannel.readable,
+          handleDone,
         );
-        startReadingFromStream(response, (r.body: any), true);
+        startReadingFromStream(response, (r.body: any), handleDone);
       } else {
-        startReadingFromStream(response, (r.body: any), false);
+        startReadingFromStream(response, (r.body: any), () => close(response));
       }
     },
     function (e) {

--- a/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientEdge.js
@@ -148,7 +148,7 @@ export function createFromReadableStream<T>(
     startReadingFromStream(response, options.debugChannel.readable, handleDone);
     startReadingFromStream(response, stream, handleDone);
   } else {
-    startReadingFromStream(response, stream, () => close(response));
+    startReadingFromStream(response, stream, close.bind(null, response));
   }
 
   return getRoot(response);
@@ -180,7 +180,11 @@ export function createFromFetch<T>(
         );
         startReadingFromStream(response, (r.body: any), handleDone);
       } else {
-        startReadingFromStream(response, (r.body: any), () => close(response));
+        startReadingFromStream(
+          response,
+          (r.body: any),
+          close.bind(null, response),
+        );
       }
     },
     function (e) {

--- a/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientEdge.js
@@ -102,7 +102,7 @@ function createResponseFromOptions(options?: Options) {
 function startReadingFromStream(
   response: FlightResponse,
   stream: ReadableStream,
-  isSecondaryStream: boolean,
+  onDone: () => void,
 ): void {
   const streamState = createStreamState();
   const reader = stream.getReader();
@@ -115,12 +115,7 @@ function startReadingFromStream(
     ...
   }): void | Promise<void> {
     if (done) {
-      // If we're the secondary stream, then we don't close the response until
-      // the debug channel closes.
-      if (!isSecondaryStream) {
-        close(response);
-      }
-      return;
+      return onDone();
     }
     const buffer: Uint8Array = (value: any);
     processBinaryChunk(response, streamState, buffer);
@@ -144,10 +139,16 @@ export function createFromReadableStream<T>(
     options.debugChannel &&
     options.debugChannel.readable
   ) {
-    startReadingFromStream(response, options.debugChannel.readable, false);
-    startReadingFromStream(response, stream, true);
+    let streamDoneCount = 0;
+    const handleDone = () => {
+      if (++streamDoneCount === 2) {
+        close(response);
+      }
+    };
+    startReadingFromStream(response, options.debugChannel.readable, handleDone);
+    startReadingFromStream(response, stream, handleDone);
   } else {
-    startReadingFromStream(response, stream, false);
+    startReadingFromStream(response, stream, () => close(response));
   }
 
   return getRoot(response);
@@ -166,10 +167,20 @@ export function createFromFetch<T>(
         options.debugChannel &&
         options.debugChannel.readable
       ) {
-        startReadingFromStream(response, options.debugChannel.readable, false);
-        startReadingFromStream(response, (r.body: any), true);
+        let streamDoneCount = 0;
+        const handleDone = () => {
+          if (++streamDoneCount === 2) {
+            close(response);
+          }
+        };
+        startReadingFromStream(
+          response,
+          options.debugChannel.readable,
+          handleDone,
+        );
+        startReadingFromStream(response, (r.body: any), handleDone);
       } else {
-        startReadingFromStream(response, (r.body: any), false);
+        startReadingFromStream(response, (r.body: any), () => close(response));
       }
     },
     function (e) {

--- a/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientNode.js
@@ -59,7 +59,7 @@ export type Options = {
 function startReadingFromStream(
   response: Response,
   stream: Readable,
-  isSecondaryStream: boolean,
+  onEnd: () => void,
 ): void {
   const streamState = createStreamState();
 
@@ -75,13 +75,7 @@ function startReadingFromStream(
     reportGlobalError(response, error);
   });
 
-  stream.on('end', () => {
-    // If we're the secondary stream, then we don't close the response until the
-    // debug channel closes.
-    if (!isSecondaryStream) {
-      close(response);
-    }
-  });
+  stream.on('end', onEnd);
 }
 
 export function createFromNodeStream<T>(
@@ -104,10 +98,16 @@ export function createFromNodeStream<T>(
   );
 
   if (__DEV__ && options && options.debugChannel) {
-    startReadingFromStream(response, options.debugChannel, false);
-    startReadingFromStream(response, stream, true);
+    let streamEndedCount = 0;
+    const handleEnd = () => {
+      if (++streamEndedCount === 2) {
+        close(response);
+      }
+    };
+    startReadingFromStream(response, options.debugChannel, handleEnd);
+    startReadingFromStream(response, stream, handleEnd);
   } else {
-    startReadingFromStream(response, stream, false);
+    startReadingFromStream(response, stream, () => close(response));
   }
 
   return getRoot(response);

--- a/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientNode.js
@@ -107,7 +107,7 @@ export function createFromNodeStream<T>(
     startReadingFromStream(response, options.debugChannel, handleEnd);
     startReadingFromStream(response, stream, handleEnd);
   } else {
-    startReadingFromStream(response, stream, () => close(response));
+    startReadingFromStream(response, stream, close.bind(null, response));
   }
 
   return getRoot(response);

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientBrowser.js
@@ -100,6 +100,7 @@ function createResponseFromOptions(options: void | Options) {
 function startReadingFromUniversalStream(
   response: FlightResponse,
   stream: ReadableStream,
+  onDone: () => void,
 ): void {
   // This is the same as startReadingFromStream except this allows WebSocketStreams which
   // return ArrayBuffer and string chunks instead of Uint8Array chunks. We could potentially
@@ -115,8 +116,7 @@ function startReadingFromUniversalStream(
     ...
   }): void | Promise<void> {
     if (done) {
-      close(response);
-      return;
+      return onDone();
     }
     if (value instanceof ArrayBuffer) {
       // WebSockets can produce ArrayBuffer values in ReadableStreams.
@@ -138,7 +138,7 @@ function startReadingFromUniversalStream(
 function startReadingFromStream(
   response: FlightResponse,
   stream: ReadableStream,
-  isSecondaryStream: boolean,
+  onDone: () => void,
 ): void {
   const streamState = createStreamState();
   const reader = stream.getReader();
@@ -151,11 +151,7 @@ function startReadingFromStream(
     ...
   }): void | Promise<void> {
     if (done) {
-      // If we're the secondary stream, then we don't close the response until the debug channel closes.
-      if (!isSecondaryStream) {
-        close(response);
-      }
-      return;
+      return onDone();
     }
     const buffer: Uint8Array = (value: any);
     processBinaryChunk(response, streamState, buffer);
@@ -178,10 +174,20 @@ function createFromReadableStream<T>(
     options.debugChannel &&
     options.debugChannel.readable
   ) {
-    startReadingFromUniversalStream(response, options.debugChannel.readable);
-    startReadingFromStream(response, stream, true);
+    let streamDoneCount = 0;
+    const handleDone = () => {
+      if (++streamDoneCount === 2) {
+        close(response);
+      }
+    };
+    startReadingFromUniversalStream(
+      response,
+      options.debugChannel.readable,
+      handleDone,
+    );
+    startReadingFromStream(response, stream, handleDone);
   } else {
-    startReadingFromStream(response, stream, false);
+    startReadingFromStream(response, stream, () => close(response));
   }
   return getRoot(response);
 }
@@ -199,13 +205,20 @@ function createFromFetch<T>(
         options.debugChannel &&
         options.debugChannel.readable
       ) {
+        let streamDoneCount = 0;
+        const handleDone = () => {
+          if (++streamDoneCount === 2) {
+            close(response);
+          }
+        };
         startReadingFromUniversalStream(
           response,
           options.debugChannel.readable,
+          handleDone,
         );
-        startReadingFromStream(response, (r.body: any), true);
+        startReadingFromStream(response, (r.body: any), handleDone);
       } else {
-        startReadingFromStream(response, (r.body: any), false);
+        startReadingFromStream(response, (r.body: any), () => close(response));
       }
     },
     function (e) {

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientBrowser.js
@@ -187,7 +187,7 @@ function createFromReadableStream<T>(
     );
     startReadingFromStream(response, stream, handleDone);
   } else {
-    startReadingFromStream(response, stream, () => close(response));
+    startReadingFromStream(response, stream, close.bind(null, response));
   }
   return getRoot(response);
 }
@@ -218,7 +218,11 @@ function createFromFetch<T>(
         );
         startReadingFromStream(response, (r.body: any), handleDone);
       } else {
-        startReadingFromStream(response, (r.body: any), () => close(response));
+        startReadingFromStream(
+          response,
+          (r.body: any),
+          close.bind(null, response),
+        );
       }
     },
     function (e) {

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientEdge.js
@@ -152,7 +152,7 @@ function createFromReadableStream<T>(
     startReadingFromStream(response, options.debugChannel.readable, handleDone);
     startReadingFromStream(response, stream, handleDone);
   } else {
-    startReadingFromStream(response, stream, () => close(response));
+    startReadingFromStream(response, stream, close.bind(null, response));
   }
 
   return getRoot(response);
@@ -184,7 +184,11 @@ function createFromFetch<T>(
         );
         startReadingFromStream(response, (r.body: any), handleDone);
       } else {
-        startReadingFromStream(response, (r.body: any), () => close(response));
+        startReadingFromStream(
+          response,
+          (r.body: any),
+          close.bind(null, response),
+        );
       }
     },
     function (e) {

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientEdge.js
@@ -106,7 +106,7 @@ function createResponseFromOptions(options: Options) {
 function startReadingFromStream(
   response: FlightResponse,
   stream: ReadableStream,
-  isSecondaryStream: boolean,
+  onDone: () => void,
 ): void {
   const streamState = createStreamState();
   const reader = stream.getReader();
@@ -119,12 +119,7 @@ function startReadingFromStream(
     ...
   }): void | Promise<void> {
     if (done) {
-      // If we're the secondary stream, then we don't close the response until
-      // the debug channel closes.
-      if (!isSecondaryStream) {
-        close(response);
-      }
-      return;
+      return onDone();
     }
     const buffer: Uint8Array = (value: any);
     processBinaryChunk(response, streamState, buffer);
@@ -148,10 +143,16 @@ function createFromReadableStream<T>(
     options.debugChannel &&
     options.debugChannel.readable
   ) {
-    startReadingFromStream(response, options.debugChannel.readable, false);
-    startReadingFromStream(response, stream, true);
+    let streamDoneCount = 0;
+    const handleDone = () => {
+      if (++streamDoneCount === 2) {
+        close(response);
+      }
+    };
+    startReadingFromStream(response, options.debugChannel.readable, handleDone);
+    startReadingFromStream(response, stream, handleDone);
   } else {
-    startReadingFromStream(response, stream, false);
+    startReadingFromStream(response, stream, () => close(response));
   }
 
   return getRoot(response);
@@ -170,10 +171,20 @@ function createFromFetch<T>(
         options.debugChannel &&
         options.debugChannel.readable
       ) {
-        startReadingFromStream(response, options.debugChannel.readable, false);
-        startReadingFromStream(response, (r.body: any), true);
+        let streamDoneCount = 0;
+        const handleDone = () => {
+          if (++streamDoneCount === 2) {
+            close(response);
+          }
+        };
+        startReadingFromStream(
+          response,
+          options.debugChannel.readable,
+          handleDone,
+        );
+        startReadingFromStream(response, (r.body: any), handleDone);
       } else {
-        startReadingFromStream(response, (r.body: any), false);
+        startReadingFromStream(response, (r.body: any), () => close(response));
       }
     },
     function (e) {

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
@@ -117,7 +117,7 @@ function createFromNodeStream<T>(
     startReadingFromStream(response, options.debugChannel, handleEnd);
     startReadingFromStream(response, stream, handleEnd);
   } else {
-    startReadingFromStream(response, stream, () => close(response));
+    startReadingFromStream(response, stream, close.bind(null, response));
   }
 
   return getRoot(response);

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
@@ -66,7 +66,7 @@ export type Options = {
 function startReadingFromStream(
   response: Response,
   stream: Readable,
-  isSecondaryStream: boolean,
+  onEnd: () => void,
 ): void {
   const streamState = createStreamState();
 
@@ -82,13 +82,7 @@ function startReadingFromStream(
     reportGlobalError(response, error);
   });
 
-  stream.on('end', () => {
-    // If we're the secondary stream, then we don't close the response until the
-    // debug channel closes.
-    if (!isSecondaryStream) {
-      close(response);
-    }
-  });
+  stream.on('end', onEnd);
 }
 
 function createFromNodeStream<T>(
@@ -114,10 +108,16 @@ function createFromNodeStream<T>(
   );
 
   if (__DEV__ && options && options.debugChannel) {
-    startReadingFromStream(response, options.debugChannel, false);
-    startReadingFromStream(response, stream, true);
+    let streamEndedCount = 0;
+    const handleEnd = () => {
+      if (++streamEndedCount === 2) {
+        close(response);
+      }
+    };
+    startReadingFromStream(response, options.debugChannel, handleEnd);
+    startReadingFromStream(response, stream, handleEnd);
   } else {
-    startReadingFromStream(response, stream, false);
+    startReadingFromStream(response, stream, () => close(response));
   }
 
   return getRoot(response);

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientBrowser.js
@@ -100,6 +100,7 @@ function createResponseFromOptions(options: void | Options) {
 function startReadingFromUniversalStream(
   response: FlightResponse,
   stream: ReadableStream,
+  onDone: () => void,
 ): void {
   // This is the same as startReadingFromStream except this allows WebSocketStreams which
   // return ArrayBuffer and string chunks instead of Uint8Array chunks. We could potentially
@@ -115,8 +116,7 @@ function startReadingFromUniversalStream(
     ...
   }): void | Promise<void> {
     if (done) {
-      close(response);
-      return;
+      return onDone();
     }
     if (value instanceof ArrayBuffer) {
       // WebSockets can produce ArrayBuffer values in ReadableStreams.
@@ -138,7 +138,7 @@ function startReadingFromUniversalStream(
 function startReadingFromStream(
   response: FlightResponse,
   stream: ReadableStream,
-  isSecondaryStream: boolean,
+  onDone: () => void,
 ): void {
   const streamState = createStreamState();
   const reader = stream.getReader();
@@ -151,11 +151,7 @@ function startReadingFromStream(
     ...
   }): void | Promise<void> {
     if (done) {
-      // If we're the secondary stream, then we don't close the response until the debug channel closes.
-      if (!isSecondaryStream) {
-        close(response);
-      }
-      return;
+      return onDone();
     }
     const buffer: Uint8Array = (value: any);
     processBinaryChunk(response, streamState, buffer);
@@ -178,10 +174,20 @@ function createFromReadableStream<T>(
     options.debugChannel &&
     options.debugChannel.readable
   ) {
-    startReadingFromUniversalStream(response, options.debugChannel.readable);
-    startReadingFromStream(response, stream, true);
+    let streamDoneCount = 0;
+    const handleDone = () => {
+      if (++streamDoneCount === 2) {
+        close(response);
+      }
+    };
+    startReadingFromUniversalStream(
+      response,
+      options.debugChannel.readable,
+      handleDone,
+    );
+    startReadingFromStream(response, stream, handleDone);
   } else {
-    startReadingFromStream(response, stream, false);
+    startReadingFromStream(response, stream, () => close(response));
   }
   return getRoot(response);
 }
@@ -199,13 +205,20 @@ function createFromFetch<T>(
         options.debugChannel &&
         options.debugChannel.readable
       ) {
+        let streamDoneCount = 0;
+        const handleDone = () => {
+          if (++streamDoneCount === 2) {
+            close(response);
+          }
+        };
         startReadingFromUniversalStream(
           response,
           options.debugChannel.readable,
+          handleDone,
         );
-        startReadingFromStream(response, (r.body: any), true);
+        startReadingFromStream(response, (r.body: any), handleDone);
       } else {
-        startReadingFromStream(response, (r.body: any), false);
+        startReadingFromStream(response, (r.body: any), () => close(response));
       }
     },
     function (e) {

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientBrowser.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientBrowser.js
@@ -187,7 +187,7 @@ function createFromReadableStream<T>(
     );
     startReadingFromStream(response, stream, handleDone);
   } else {
-    startReadingFromStream(response, stream, () => close(response));
+    startReadingFromStream(response, stream, close.bind(null, response));
   }
   return getRoot(response);
 }
@@ -218,7 +218,11 @@ function createFromFetch<T>(
         );
         startReadingFromStream(response, (r.body: any), handleDone);
       } else {
-        startReadingFromStream(response, (r.body: any), () => close(response));
+        startReadingFromStream(
+          response,
+          (r.body: any),
+          close.bind(null, response),
+        );
       }
     },
     function (e) {

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientEdge.js
@@ -152,7 +152,7 @@ function createFromReadableStream<T>(
     startReadingFromStream(response, options.debugChannel.readable, handleDone);
     startReadingFromStream(response, stream, handleDone);
   } else {
-    startReadingFromStream(response, stream, () => close(response));
+    startReadingFromStream(response, stream, close.bind(null, response));
   }
 
   return getRoot(response);
@@ -184,7 +184,11 @@ function createFromFetch<T>(
         );
         startReadingFromStream(response, (r.body: any), handleDone);
       } else {
-        startReadingFromStream(response, (r.body: any), () => close(response));
+        startReadingFromStream(
+          response,
+          (r.body: any),
+          close.bind(null, response),
+        );
       }
     },
     function (e) {

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientEdge.js
@@ -106,7 +106,7 @@ function createResponseFromOptions(options: Options) {
 function startReadingFromStream(
   response: FlightResponse,
   stream: ReadableStream,
-  isSecondaryStream: boolean,
+  onDone: () => void,
 ): void {
   const streamState = createStreamState();
   const reader = stream.getReader();
@@ -119,12 +119,7 @@ function startReadingFromStream(
     ...
   }): void | Promise<void> {
     if (done) {
-      // If we're the secondary stream, then we don't close the response until
-      // the debug channel closes.
-      if (!isSecondaryStream) {
-        close(response);
-      }
-      return;
+      return onDone();
     }
     const buffer: Uint8Array = (value: any);
     processBinaryChunk(response, streamState, buffer);
@@ -148,10 +143,16 @@ function createFromReadableStream<T>(
     options.debugChannel &&
     options.debugChannel.readable
   ) {
-    startReadingFromStream(response, options.debugChannel.readable, false);
-    startReadingFromStream(response, stream, true);
+    let streamDoneCount = 0;
+    const handleDone = () => {
+      if (++streamDoneCount === 2) {
+        close(response);
+      }
+    };
+    startReadingFromStream(response, options.debugChannel.readable, handleDone);
+    startReadingFromStream(response, stream, handleDone);
   } else {
-    startReadingFromStream(response, stream, false);
+    startReadingFromStream(response, stream, () => close(response));
   }
 
   return getRoot(response);
@@ -170,10 +171,20 @@ function createFromFetch<T>(
         options.debugChannel &&
         options.debugChannel.readable
       ) {
-        startReadingFromStream(response, options.debugChannel.readable, false);
-        startReadingFromStream(response, (r.body: any), true);
+        let streamDoneCount = 0;
+        const handleDone = () => {
+          if (++streamDoneCount === 2) {
+            close(response);
+          }
+        };
+        startReadingFromStream(
+          response,
+          options.debugChannel.readable,
+          handleDone,
+        );
+        startReadingFromStream(response, (r.body: any), handleDone);
       } else {
-        startReadingFromStream(response, (r.body: any), false);
+        startReadingFromStream(response, (r.body: any), () => close(response));
       }
     },
     function (e) {

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
@@ -117,7 +117,7 @@ function createFromNodeStream<T>(
     startReadingFromStream(response, options.debugChannel, handleEnd);
     startReadingFromStream(response, stream, handleEnd);
   } else {
-    startReadingFromStream(response, stream, () => close(response));
+    startReadingFromStream(response, stream, close.bind(null, response));
   }
 
   return getRoot(response);

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
@@ -66,7 +66,7 @@ export type Options = {
 function startReadingFromStream(
   response: Response,
   stream: Readable,
-  isSecondaryStream: boolean,
+  onEnd: () => void,
 ): void {
   const streamState = createStreamState();
 
@@ -82,13 +82,7 @@ function startReadingFromStream(
     reportGlobalError(response, error);
   });
 
-  stream.on('end', () => {
-    // If we're the secondary stream, then we don't close the response until the
-    // debug channel closes.
-    if (!isSecondaryStream) {
-      close(response);
-    }
-  });
+  stream.on('end', onEnd);
 }
 
 function createFromNodeStream<T>(
@@ -114,10 +108,16 @@ function createFromNodeStream<T>(
   );
 
   if (__DEV__ && options && options.debugChannel) {
-    startReadingFromStream(response, options.debugChannel, false);
-    startReadingFromStream(response, stream, true);
+    let streamEndedCount = 0;
+    const handleEnd = () => {
+      if (++streamEndedCount === 2) {
+        close(response);
+      }
+    };
+    startReadingFromStream(response, options.debugChannel, handleEnd);
+    startReadingFromStream(response, stream, handleEnd);
   } else {
-    startReadingFromStream(response, stream, false);
+    startReadingFromStream(response, stream, () => close(response));
   }
 
   return getRoot(response);


### PR DESCRIPTION
When a debug channel is defined, we must ensure that we don't close the Flight Client's response when the debug channel's readable is done, but the RSC stream is still flowing. Now, we wait for both streams to end before closing the response.