### PR TITLE
[compiler] Emit better error for unsupported syntax `this`

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIRBuilder.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIRBuilder.ts
@@ -323,6 +323,22 @@ export default class HIRBuilder {
         ],
       });
     }
+    if (node.name === 'this') {
+      CompilerError.throwDiagnostic({
+        severity: ErrorSeverity.UnsupportedJS,
+        category: ErrorCategory.UnsupportedSyntax,
+        reason: '`this` is not supported syntax',
+        description:
+          'React Compiler does not support compiling functions that use `this`',
+        details: [
+          {
+            kind: 'error',
+            message: '`this` was used here',
+            loc: node.loc ?? GeneratedSource,
+          },
+        ],
+      });
+    }
     const originalName = node.name;
     let name = originalName;
     let index = 0;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ecma/error.reserved-words.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ecma/error.reserved-words.expect.md
@@ -24,9 +24,18 @@ function useThing(fn) {
 ```
 Found 1 error:
 
-Error: Expected a non-reserved identifier name
+Error: `this` is not supported syntax
 
-`this` is a reserved word in JavaScript and cannot be used as an identifier name.
+React Compiler does not support compiling functions that use `this`
+
+error.reserved-words.ts:8:28
+   6 |
+   7 |   if (ref.current === null) {
+>  8 |     ref.current = function (this: unknown, ...args) {
+     |                             ^^^^^^^^^^^^^ `this` was used here
+   9 |       return fnRef.current.call(this, ...args);
+  10 |     };
+  11 |   }
 ```
           
       


### PR DESCRIPTION
Our previous error message was correctly identifying the generation of identifiers where the name is a reserved keyword in JS. That error still makes sense (we don't want to generate invalid identifiers) as an invariant, but in some cases can be a confusing error as it's not helpful to tell the user that eg `this` is a reserved identifier name.

This PR adds a specific check for `this` up into HIRBuilder, denoting that `this` is not syntax that is supported by React Compiler. Note that this also catches the case where `this` is used in parameter position (a [TS feature](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#specifying-the-type-of-this-for-functions)) even if it might not actually use `this` in the block statement, but it's unlikely someone would type `this` and not use it so I opted to just have a single error message and not special case the `this` type annotation.

Closes #34311