### PR TITLE
docs: outdated Flow URL in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
   6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
   7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
   8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
-  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
+  9. Run the [Flow](https://flow.org/) type checks (`yarn flow`).
   10. If you haven't already, complete the CLA.
 
   Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html


### PR DESCRIPTION
## Summary

This PR updates the outdated Flow URL in the pull request template from `flowtype.org` to `flow.org`. The Flow static type checker's official website has moved from the old `flowtype.org` domain to `flow.org`, but the pull request template still references the old URL.

This change ensures that contributors are directed to the correct and current Flow documentation website when following the contribution guidelines.

## How did you test this change?

I verified this change by:

1. **Confirming the domain change**: Verified that `flowtype.org` is the old domain and `flow.org` is the current official Flow website

| flowtype.org | flow.org |
|:------:|:-----:|
|   <img width="1472" height="626" alt="스크린샷 2025-08-28 오후 11 22 14" src="https://github.com/user-attachments/assets/46ca2977-7b7f-4f06-b003-d4e8bc9c1f6c" />|  <img width="1288" height="664" alt="스크린샷 2025-08-28 오후 11 22 32" src="https://github.com/user-attachments/assets/f2bf7b97-e181-4aa1-9100-30b611cd020d" />|

2. **Checking URL accessibility**: Confirmed that `flow.org` is accessible and contains the current Flow documentation
3. **Template validation**: Ensured the markdown formatting and link structure remain intact after the URL update
4. **Cross-reference check**: Verified that other references to Flow in the codebase use the updated domain

The change is purely a URL update with no functional code changes, so no additional testing of React functionality was required.
