### PR TITLE
[eslint-plugin-react-hooks] test standardize ref cleanup test case formatting and structure

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -4763,7 +4763,7 @@ const tests = {
       ],
     },
     {
-      code: `
+      code: normalizeIndent`
         function MyComponent() {
           const myRef = useRef();
           useLayoutEffect_SAFE_FOR_SSR(() => {
@@ -4777,10 +4777,14 @@ const tests = {
       // No changes
       output: null,
       errors: [
-        `The ref value 'myRef.current' will likely have changed by the time ` +
-          `this effect cleanup function runs. If this ref points to a node ` +
-          `rendered by React, copy 'myRef.current' to a variable inside the effect, ` +
-          `and use that variable in the cleanup function.`,
+        {
+          message:
+            `The ref value 'myRef.current' will likely have changed by the time ` +
+            `this effect cleanup function runs. If this ref points to a node ` +
+            `rendered by React, copy 'myRef.current' to a variable inside the effect, ` +
+            `and use that variable in the cleanup function.`,
+          suggestions: undefined,
+        },
       ],
       options: [{additionalHooks: 'useLayoutEffect_SAFE_FOR_SSR'}],
     },


### PR DESCRIPTION
## Summary

This PR standardizes the formatting and structure of test cases that validate ref cleanup warnings in the React Hooks ESLint plugin, ensuring consistency across the entire test suite.

**Issues addressed:**
1. **Inconsistent code formatting**: One test case was using plain template literals instead of `normalizeIndent`, breaking consistency with other test cases
2. **Inconsistent error format**: The `errors` array was using plain string format instead of the standardized object format with `message` and `suggestions` properties
3. **Test suite maintainability**: Mixed formatting patterns make the test suite harder to maintain and understand

**Motivation:**
The `exhaustive-deps` rule includes several test cases that validate ref cleanup warnings. These test cases should follow consistent patterns to ensure:
- Easy maintenance and updates
- Clear understanding of expected behavior
- Consistent structure that matches the rest of the test suite

Currently, some test cases use different formatting patterns, which creates inconsistency and potential confusion for contributors.

## How did you test this change?

1. **Verify Format Consistency**: I verified now use normalizeIndent consistently with the other test cases in the file.
2. **Error object structure validation**: Confirmed that both test cases now follow the standard error format:

- as-is
```ts
errors: [
  `The ref value 'myRef.current' will likely have changed by the time ` +
  `this effect cleanup function runs. If this ref points to a node ` +
  `rendered by React, copy 'myRef.current' to a variable inside the effect, ` +
  `and use that variable in the cleanup function.`,
],
```

- to-be
```ts
errors: [
  {
    message:
      `The ref value 'myRef.current' will likely have changed by the time ` +
      `this effect cleanup function runs. If this ref points to a node ` +
      `rendered by React, copy 'myRef.current' to a variable inside the effect, ` +
      `and use that variable in the cleanup function.`,
    suggestions: undefined,
  },
],
```

3. **Test case functionality**: Validated that the test cases still correctly test the intended scenarios:
4. **No behavioral changes**: Ensured that the standardization doesn't change the actual test logic or expected outcomes

<img width="801" height="281" alt="스크린샷 2025-08-29 오전 1 41 07" src="https://github.com/user-attachments/assets/ca82f1e9-f2ee-4209-b631-098f5894ab6d" />


The changes are purely structural improvements that enhance code consistency without altering the test logic or coverage.
