### PR TITLE
Update Code Sandbox CI to Node 20 to Match .nvmrc

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,7 +1,7 @@
 {
   "packages": ["packages/react", "packages/react-dom", "packages/react-server-dom-webpack", "packages/scheduler"],
   "buildCommand": "download-build-in-codesandbox-ci",
-  "node": "18",
+  "node": "20",
   "publishDirectory": {
     "react": "build/oss-experimental/react",
     "react-dom": "build/oss-experimental/react-dom",


### PR DESCRIPTION
## Summary
Update the CodeSandbox CI configuration to use Node 20 instead of Node 18, so that it matches the Node version specified in .nvmrc. This ensures consistency between local development environments and CI builds, reducing the risk of version-related build issues.

Closes #34328

## How did you test this change?
- Verified that .nvmrc specifies Node 20 and .codesandbox/ci.json is updated accordingly.
- Locally switched to Node 20 using nvm use 20 and successfully ran build scripts for all packages: `react`, `react-dom`, `react-server-dom-webpack`, and `scheduler`.
- Confirmed there are no Node 20–specific build errors or warnings locally.
- CI on the feature branch will now run with Node 20, and all builds are expected to succeed.
