### PR TITLE
[compiler] Preserve memoization for destructured props

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -1445,6 +1445,7 @@ export enum ValueKind {
   Primitive = 'primitive',
   Global = 'global',
   Mutable = 'mutable',
+  ShallowMutable = 'shallowmutable',
   Context = 'context',
 }
 
@@ -1454,6 +1455,7 @@ export const ValueKindSchema = z.enum([
   ValueKind.Primitive,
   ValueKind.Global,
   ValueKind.Mutable,
+  ValueKind.ShallowMutable,
   ValueKind.Context,
 ]);
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/destructured-with-rest-props.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/destructured-with-rest-props.expect.md
@@ -1,0 +1,139 @@
+
+## Input
+
+```javascript
+import {useMemo} from 'react';
+
+function useTheme() {
+  return {primary: '#blue', secondary: '#green'};
+}
+
+function computeStyles(
+  specialProp: string | undefined,
+  restProps: any,
+  theme: any,
+) {
+  return {
+    color: specialProp ? theme.primary : theme.secondary,
+    ...restProps.style,
+  };
+}
+
+export function SpecialButton({
+  specialProp,
+  ...restProps
+}: {
+  specialProp?: string;
+  style?: Record<string, string>;
+  onClick?: () => void;
+}) {
+  const theme = useTheme();
+
+  const styles = useMemo(
+    () => computeStyles(specialProp, restProps, theme),
+    [specialProp, restProps, theme],
+  );
+
+  return (
+    <button style={styles} onClick={restProps.onClick}>
+      Click me
+    </button>
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: SpecialButton,
+  params: [{specialProp: 'test', style: {fontSize: '16px'}, onClick: () => {}}],
+  isComponent: true,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { useMemo } from "react";
+
+function useTheme() {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = { primary: "#blue", secondary: "#green" };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0;
+}
+
+function computeStyles(specialProp, restProps, theme) {
+  const $ = _c(3);
+
+  const t0 = specialProp ? theme.primary : theme.secondary;
+  let t1;
+  if ($[0] !== restProps.style || $[1] !== t0) {
+    t1 = { color: t0, ...restProps.style };
+    $[0] = restProps.style;
+    $[1] = t0;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  return t1;
+}
+
+export function SpecialButton(t0) {
+  const $ = _c(10);
+  let restProps;
+  let specialProp;
+  if ($[0] !== t0) {
+    ({ specialProp, ...restProps } = t0);
+    $[0] = t0;
+    $[1] = restProps;
+    $[2] = specialProp;
+  } else {
+    restProps = $[1];
+    specialProp = $[2];
+  }
+
+  const theme = useTheme();
+  let t1;
+  if ($[3] !== restProps || $[4] !== specialProp || $[5] !== theme) {
+    t1 = computeStyles(specialProp, restProps, theme);
+    $[3] = restProps;
+    $[4] = specialProp;
+    $[5] = theme;
+    $[6] = t1;
+  } else {
+    t1 = $[6];
+  }
+  const styles = t1;
+  let t2;
+  if ($[7] !== restProps.onClick || $[8] !== styles) {
+    t2 = (
+      <button style={styles} onClick={restProps.onClick}>
+        Click me
+      </button>
+    );
+    $[7] = restProps.onClick;
+    $[8] = styles;
+    $[9] = t2;
+  } else {
+    t2 = $[9];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: SpecialButton,
+  params: [
+    { specialProp: "test", style: { fontSize: "16px" }, onClick: () => {} },
+  ],
+  isComponent: true,
+};
+
+```
+      
+### Eval output
+(kind: ok) <button style="font-size: 16px;">Click me</button>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/destructured-with-rest-props.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/destructured-with-rest-props.tsx
@@ -1,0 +1,44 @@
+import {useMemo} from 'react';
+
+function useTheme() {
+  return {primary: '#blue', secondary: '#green'};
+}
+
+function computeStyles(
+  specialProp: string | undefined,
+  restProps: any,
+  theme: any,
+) {
+  return {
+    color: specialProp ? theme.primary : theme.secondary,
+    ...restProps.style,
+  };
+}
+
+export function SpecialButton({
+  specialProp,
+  ...restProps
+}: {
+  specialProp?: string;
+  style?: Record<string, string>;
+  onClick?: () => void;
+}) {
+  const theme = useTheme();
+
+  const styles = useMemo(
+    () => computeStyles(specialProp, restProps, theme),
+    [specialProp, restProps, theme],
+  );
+
+  return (
+    <button style={styles} onClick={restProps.onClick}>
+      Click me
+    </button>
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: SpecialButton,
+  params: [{specialProp: 'test', style: {fontSize: '16px'}, onClick: () => {}}],
+  isComponent: true,
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/regular-props.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/regular-props.expect.md
@@ -1,0 +1,95 @@
+
+## Input
+
+```javascript
+import {useMemo} from 'react';
+
+function useSession() {
+  return {user: {userCode: 'ABC123'}};
+}
+
+function getDefaultFromValue(
+  defaultValues: string | undefined,
+  userCode: string,
+) {
+  return defaultValues ? `${defaultValues}-${userCode}` : userCode;
+}
+
+export function UpSertField(props: {defaultValues?: string}) {
+  const {
+    user: {userCode},
+  } = useSession();
+
+  const defaultValues = useMemo(
+    () => getDefaultFromValue(props.defaultValues, userCode),
+    [props.defaultValues, userCode],
+  );
+
+  return <div>{defaultValues}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: UpSertField,
+  params: [{defaultValues: 'test'}],
+  isComponent: true,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { useMemo } from "react";
+
+function useSession() {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = { user: { userCode: "ABC123" } };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0;
+}
+
+function getDefaultFromValue(defaultValues, userCode) {
+  return defaultValues ? `${defaultValues}-${userCode}` : userCode;
+}
+
+export function UpSertField(props) {
+  const $ = _c(5);
+  const { user: t0 } = useSession();
+  const { userCode } = t0;
+  let t1;
+  if ($[0] !== props.defaultValues || $[1] !== userCode) {
+    t1 = getDefaultFromValue(props.defaultValues, userCode);
+    $[0] = props.defaultValues;
+    $[1] = userCode;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  const defaultValues = t1;
+  let t2;
+  if ($[3] !== defaultValues) {
+    t2 = <div>{defaultValues}</div>;
+    $[3] = defaultValues;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: UpSertField,
+  params: [{ defaultValues: "test" }],
+  isComponent: true,
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>test-ABC123</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/regular-props.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/regular-props.tsx
@@ -1,0 +1,31 @@
+import {useMemo} from 'react';
+
+function useSession() {
+  return {user: {userCode: 'ABC123'}};
+}
+
+function getDefaultFromValue(
+  defaultValues: string | undefined,
+  userCode: string,
+) {
+  return defaultValues ? `${defaultValues}-${userCode}` : userCode;
+}
+
+export function UpSertField(props: {defaultValues?: string}) {
+  const {
+    user: {userCode},
+  } = useSession();
+
+  const defaultValues = useMemo(
+    () => getDefaultFromValue(props.defaultValues, userCode),
+    [props.defaultValues, userCode],
+  );
+
+  return <div>{defaultValues}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: UpSertField,
+  params: [{defaultValues: 'test'}],
+  isComponent: true,
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/spread-props.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/spread-props.expect.md
@@ -1,0 +1,103 @@
+
+## Input
+
+```javascript
+import {useMemo} from 'react';
+
+function useSession() {
+  return {user: {userCode: 'ABC123'}};
+}
+
+function getDefaultFromValue(
+  defaultValues: string | undefined,
+  userCode: string,
+) {
+  return defaultValues ? `${defaultValues}-${userCode}` : userCode;
+}
+
+export function UpSertField({...props}: {defaultValues?: string}) {
+  const {
+    user: {userCode},
+  } = useSession();
+
+  const defaultValues = useMemo(
+    () => getDefaultFromValue(props.defaultValues, userCode),
+    [props.defaultValues, userCode],
+  );
+
+  return <div>{defaultValues}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: UpSertField,
+  params: [{defaultValues: 'test'}],
+  isComponent: true,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { useMemo } from "react";
+
+function useSession() {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = { user: { userCode: "ABC123" } };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0;
+}
+
+function getDefaultFromValue(defaultValues, userCode) {
+  return defaultValues ? `${defaultValues}-${userCode}` : userCode;
+}
+
+export function UpSertField(t0) {
+  const $ = _c(7);
+  let props;
+  if ($[0] !== t0) {
+    ({ ...props } = t0);
+    $[0] = t0;
+    $[1] = props;
+  } else {
+    props = $[1];
+  }
+  const { user: t1 } = useSession();
+  const { userCode } = t1;
+  let t2;
+  if ($[2] !== props.defaultValues || $[3] !== userCode) {
+    t2 = getDefaultFromValue(props.defaultValues, userCode);
+    $[2] = props.defaultValues;
+    $[3] = userCode;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  const defaultValues = t2;
+  let t3;
+  if ($[5] !== defaultValues) {
+    t3 = <div>{defaultValues}</div>;
+    $[5] = defaultValues;
+    $[6] = t3;
+  } else {
+    t3 = $[6];
+  }
+  return t3;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: UpSertField,
+  params: [{ defaultValues: "test" }],
+  isComponent: true,
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>test-ABC123</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/spread-props.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/spread-props.tsx
@@ -1,0 +1,31 @@
+import {useMemo} from 'react';
+
+function useSession() {
+  return {user: {userCode: 'ABC123'}};
+}
+
+function getDefaultFromValue(
+  defaultValues: string | undefined,
+  userCode: string,
+) {
+  return defaultValues ? `${defaultValues}-${userCode}` : userCode;
+}
+
+export function UpSertField({...props}: {defaultValues?: string}) {
+  const {
+    user: {userCode},
+  } = useSession();
+
+  const defaultValues = useMemo(
+    () => getDefaultFromValue(props.defaultValues, userCode),
+    [props.defaultValues, userCode],
+  );
+
+  return <div>{defaultValues}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: UpSertField,
+  params: [{defaultValues: 'test'}],
+  isComponent: true,
+};


### PR DESCRIPTION

The compiler currently fails to preserve manual memoization when components use rest spread destructuring for props:

```js
// OK
function Component(props) {
  const value = useMemo(() => compute(props.foo), [props.foo]);
}

// Manual memo could not be preserved
function Component({...props}) {
  const value = useMemo(() => compute(props.foo), [props.foo]);
}
```

The issue is that property accesses on rest-spread objects are treated as fully mutable.

This PR introduces a new `ShallowMutable` ValueKind for rest spreads that come specifically from props. When we access properties from a `ShallowMutable` value, they're treated as Frozen.

Closes #34313
