### PR TITLE
[Flight] Fix wrong missing key warning when static child is blocked

### DIFF
--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -60,6 +60,8 @@ export type LazyComponent<T, P> = {
   _payload: P,
   _init: (payload: P) => T,
   _debugInfo?: null | ReactDebugInfo,
+  // __DEV__
+  _store?: {validated: 0 | 1 | 2, ...}, // 0: not validated, 1: validated, 2: force fail
 };
 
 function lazyInitializer<T>(payload: Payload<T>): T {

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -804,6 +804,14 @@ function validateChildKeys(node) {
       if (node._store) {
         node._store.validated = 1;
       }
+    } else if (isLazyType(node)) {
+      if (node._payload.status === 'fulfilled') {
+        if (isValidElement(node._payload.value) && node._payload.value._store) {
+          node._payload.value._store.validated = 1;
+        }
+      } else if (node._store) {
+        node._store.validated = 1;
+      }
     }
   }
 }
@@ -820,5 +828,13 @@ export function isValidElement(object) {
     typeof object === 'object' &&
     object !== null &&
     object.$$typeof === REACT_ELEMENT_TYPE
+  );
+}
+
+export function isLazyType(object) {
+  return (
+    typeof object === 'object' &&
+    object !== null &&
+    object.$$typeof === REACT_LAZY_TYPE
   );
 }


### PR DESCRIPTION
When a static JSX child in a client component is blocked, e.g. on debug info, we must ensure that the key validation that's done by the JSX runtime also handles lazy types. Otherwise, a false-positive missing key warning is printed.