### PR TITLE
[Flight] Only assign `_store` in dev mode when creating lazy types

### DIFF
--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -59,8 +59,9 @@ export type LazyComponent<T, P> = {
   $$typeof: symbol | number,
   _payload: P,
   _init: (payload: P) => T,
-  _debugInfo?: null | ReactDebugInfo,
+
   // __DEV__
+  _debugInfo?: null | ReactDebugInfo,
   _store?: {validated: 0 | 1 | 2, ...}, // 0: not validated, 1: validated, 2: force fail
 };
 


### PR DESCRIPTION
Small follow-up to #34350. The `_store` property is now only assigned in development mode when creating lazy types. It also uses the `validated` value that was passed to `createElement`, if applicable.