### PR TITLE
Add a missing `@types` package to `eslint-plugin-react-hooks`

### DIFF
--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -44,7 +44,8 @@
     "@babel/plugin-proposal-private-methods": "^7.18.6",
     "hermes-parser": "^0.25.1",
     "zod": "^3.22.4",
-    "zod-validation-error": "^3.0.3"
+    "zod-validation-error": "^3.0.3",
+    "@types/estree": "^1.0.6"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.11.4",
@@ -56,7 +57,6 @@
     "@typescript-eslint/parser-v4": "npm:@typescript-eslint/parser@^4.1.0",
     "@typescript-eslint/parser-v5": "npm:@typescript-eslint/parser@^5.62.0",
     "@types/eslint": "^8.56.12",
-    "@types/estree": "^1.0.6",
     "@types/estree-jsx": "^1.0.5",
     "@types/node": "^20.2.5",
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
## Summary

https://stackblitz.com/edit/vitejs-vite-vyfjfdtd?file=package.json&startScript=build

After installing the plugin with `npm i --install-strategy shallow`, `tsc -b` reports that it can't find types for `estree`. I suppose the problem is that the plugin has `@types/estree` in `devDependencies` instead of having them in `dependencies`. A workaround is to add `@types/estree` to dependencies of the above example project, or enabling `skipLibCheck` for TS, but the plugin probably should install `@types/estree` on its own, which is enforced by this PR.

## How did you test this change?

I'm not sure how to build/bundle just `eslint-plugin-react-hooks` to test this out in my projects, the contribution guide seems incomplete/outdated. I'll appreciate a hint on this.