### PR TITLE
Performance Tracks: log properties diff for renders in DEV if no console task available

### DIFF
--- a/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
+++ b/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
@@ -228,9 +228,20 @@ export function logComponentRender(
               ? 'tertiary-dark'
               : 'primary-dark'
             : 'error';
-    const debugTask = fiber._debugTask;
-    if (__DEV__ && debugTask) {
+
+    if (!__DEV__) {
+      console.timeStamp(
+        name,
+        startTime,
+        endTime,
+        COMPONENTS_TRACK,
+        undefined,
+        color,
+      );
+    } else {
       const props = fiber.memoizedProps;
+      const debugTask = fiber._debugTask;
+
       if (
         props !== null &&
         alternate !== null &&
@@ -268,38 +279,45 @@ export function logComponentRender(
           reusableComponentDevToolDetails.properties = properties;
           reusableComponentOptions.start = startTime;
           reusableComponentOptions.end = endTime;
+
+          if (debugTask != null) {
+            debugTask.run(
+              // $FlowFixMe[method-unbinding]
+              performance.measure.bind(
+                performance,
+                '\u200b' + name,
+                reusableComponentOptions,
+              ),
+            );
+          } else {
+            performance.measure('\u200b' + name, reusableComponentOptions);
+          }
+        }
+      } else {
+        if (debugTask != null) {
           debugTask.run(
             // $FlowFixMe[method-unbinding]
-            performance.measure.bind(
-              performance,
-              '\u200b' + name,
-              reusableComponentOptions,
+            console.timeStamp.bind(
+              console,
+              name,
+              startTime,
+              endTime,
+              COMPONENTS_TRACK,
+              undefined,
+              color,
             ),
           );
-          return;
+        } else {
+          console.timeStamp(
+            name,
+            startTime,
+            endTime,
+            COMPONENTS_TRACK,
+            undefined,
+            color,
+          );
         }
       }
-      debugTask.run(
-        // $FlowFixMe[method-unbinding]
-        console.timeStamp.bind(
-          console,
-          name,
-          startTime,
-          endTime,
-          COMPONENTS_TRACK,
-          undefined,
-          color,
-        ),
-      );
-    } else {
-      console.timeStamp(
-        name,
-        startTime,
-        endTime,
-        COMPONENTS_TRACK,
-        undefined,
-        color,
-      );
     }
   }
 }


### PR DESCRIPTION
React Native doesn't support `console.createTask` yet, but it does support `performance.measure` and extensibility APIs for Performance panel, including `detail.devtools` field.

Previously, this logic was gated with `if (__DEV__ && debugTask)`, now `debugTask` is no longer required to log render. If there is no console task, we will just call `performance.measure(...)`. The same pattern is used in other reporters.