### PR TITLE
[DevTools] Allow inspecting root when navigating Suspense timeline

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseTimeline.js
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseTimeline.js
@@ -45,10 +45,9 @@ function getSuspendableDocumentOrderSuspense(
       if (current === undefined) {
         continue;
       }
-      // Don't include the root. It's currently not supported to suspend the shell.
-      if (current !== suspense) {
-        suspenseTreeList.push(current);
-      }
+      // Include the root even if we won't suspend it.
+      // You should be able to see what suspended the shell.
+      suspenseTreeList.push(current);
       // Add children in reverse order to maintain document order
       for (let j = current.children.length - 1; j >= 0; j--) {
         const childSuspense = store.getSuspenseByID(current.children[j]);
@@ -139,7 +138,7 @@ function SuspenseTimelineInput({rootID}: {rootID: Element['id'] | void}) {
 
     const pendingValue = +event.currentTarget.value;
     const suspendedSet = timeline
-      .slice(pendingValue + 1)
+      .slice(pendingValue)
       .map(suspense => suspense.id);
 
     bridge.send('overrideSuspenseMilestone', {


### PR DESCRIPTION
This helps identifying what suspended the shell like in https://github.com/facebook/react/pull/34381
We should probably add more affordances to inspect the root in other places since whatever is suspending the shell is responsible for first-contentful-paint.

