### PR TITLE
[DevTools] Don't suspend shell while retrieving original source for "open-in-editor"

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/OpenInEditorButton.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/OpenInEditorButton.js
@@ -23,7 +23,7 @@ type Props = {
   symbolicatedSourcePromise: Promise<SourceMappedLocation | null>,
 };
 
-function OpenInEditorButton({
+function OpenSymbolicatedSourceInEditorButton({
   editorURL,
   source,
   symbolicatedSourcePromise,
@@ -42,6 +42,19 @@ function OpenInEditorButton({
       title="Open in editor">
       <ButtonIcon type="editor" />
     </Button>
+  );
+}
+
+function OpenInEditorButton(props: Props): React.Node {
+  return (
+    <React.Suspense
+      fallback={
+        <Button disabled={true} title="retrieving original source…">
+          <ButtonIcon type="editor" />
+        </Button>
+      }>
+      <OpenSymbolicatedSourceInEditorButton {...props} />
+    </React.Suspense>
   );
 }
 


### PR DESCRIPTION
I noticed in internal apps that inspecting an element took a while on the first click. I used the new Suspense tab to find what was suspending the shell :taps-head:

Before:

https://github.com/user-attachments/assets/26bcb5d0-c89e-4a11-8d49-06b7ca52ae21




After:


https://github.com/user-attachments/assets/f3839eda-cebb-445d-b329-92d7b13278c0

