### PR TITLE
[DevTools] Avoid renders of stale Suspense store

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseBreadcrumbs.js
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseBreadcrumbs.js
@@ -8,6 +8,7 @@
  */
 
 import type {SuspenseNode} from 'react-devtools-shared/src/frontend/types';
+import typeof {SyntheticMouseEvent} from 'react-dom-bindings/src/events/SyntheticEvent';
 
 import * as React from 'react';
 import {useContext} from 'react';
@@ -15,13 +16,12 @@ import {
   TreeDispatcherContext,
   TreeStateContext,
 } from '../Components/TreeContext';
-import {StoreContext} from '../context';
 import {useHighlightHostInstance} from '../hooks';
 import styles from './SuspenseBreadcrumbs.css';
-import typeof {SyntheticMouseEvent} from 'react-dom-bindings/src/events/SyntheticEvent';
+import {useSuspenseStore} from './SuspenseTreeContext';
 
 export default function SuspenseBreadcrumbs(): React$Node {
-  const store = useContext(StoreContext);
+  const store = useSuspenseStore();
   const dispatch = useContext(TreeDispatcherContext);
   const {inspectedElementID} = useContext(TreeStateContext);
 


### PR DESCRIPTION
Reading from the `StoreContext` for suspense related stuff is quite the footgun right now because the Store is mutable. I'm going with a single Hook for reading Suspense related data for now that ensures a re-render until I come up with a better factoring.

Still dangerous to close over `useSuspenseStore` in memoized functions. But that can be avoided with putting `suspenseRevision` into deps.