### PR TITLE
[playground] Fix CompilerError mismatch

### DIFF
--- a/compiler/apps/playground/components/Editor/EditorImpl.tsx
+++ b/compiler/apps/playground/components/Editor/EditorImpl.tsx
@@ -13,6 +13,7 @@ import BabelPluginReactCompiler, {
   CompilerErrorDetail,
   CompilerDiagnostic,
   Effect,
+  ErrorCategory,
   parseConfigPragmaForTests,
   ValueKind,
   type Hook,
@@ -47,7 +48,6 @@ import {
 import {transformFromAstSync} from '@babel/core';
 import {LoggerEvent} from 'babel-plugin-react-compiler/dist/Entrypoint';
 import {useSearchParams} from 'next/navigation';
-import {ErrorCategory} from 'babel-plugin-react-compiler/dist/CompilerError';
 
 function parseInput(
   input: string,

--- a/compiler/packages/babel-plugin-react-compiler/src/index.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/index.ts
@@ -12,6 +12,7 @@ export {
   CompilerDiagnostic,
   CompilerSuggestionOperation,
   ErrorSeverity,
+  ErrorCategory,
   LintRules,
   type CompilerErrorDetailOptions,
   type CompilerDiagnosticOptions,


### PR DESCRIPTION
The compiler playground was crashing at any small syntax errors in the `Input` panel due to updating the `CompilerErrorDetailOptions` type in #34401. Updated the option to take in a `ErrorCategory` instead.