### PR TITLE
[compiler] Have react-compiler eslint plugin return a RuleModule

### DIFF
--- a/compiler/packages/eslint-plugin-react-compiler/src/index.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/src/index.ts
@@ -34,4 +34,8 @@ const configs = {
   },
 };
 
-export {configs, allRules as rules, meta};
+const rules = Object.fromEntries(
+  Object.entries(allRules).map(([name, {rule}]) => [name, rule]),
+);
+
+export {configs, rules, meta};


### PR DESCRIPTION
Eslint is expecting a map of [string] => RuleModule. Before we were passing {rule: RuleModule, severity: ErrorSeverity} which was breaking legacy Eslint configurations