### PR TITLE
[DevTools] Preserve Suspense lineage when clicking through breadcrumbs

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseBreadcrumbs.css
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseBreadcrumbs.css
@@ -19,6 +19,9 @@
   background: var(--color-button-background);
   border: none;
   border-radius: 0.25rem;
+  color: var(--color-button);
+  font-family: var(--font-family-monospace);
+  font-size: var(--font-size-monospace-normal);
   padding: 0.25rem;
   white-space: nowrap;
 }

--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseRects.js
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseRects.js
@@ -19,9 +19,13 @@ import {
   TreeDispatcherContext,
   TreeStateContext,
 } from '../Components/TreeContext';
+import {StoreContext} from '../context';
 import {useHighlightHostInstance} from '../hooks';
 import styles from './SuspenseRects.css';
-import {useSuspenseStore} from './SuspenseTreeContext';
+import {
+  SuspenseTreeStateContext,
+  SuspenseTreeDispatcherContext,
+} from './SuspenseTreeContext';
 import typeof {
   SyntheticMouseEvent,
   SyntheticPointerEvent,
@@ -44,8 +48,9 @@ function SuspenseRects({
 }: {
   suspenseID: SuspenseNode['id'],
 }): React$Node {
-  const dispatch = useContext(TreeDispatcherContext);
-  const store = useSuspenseStore();
+  const store = useContext(StoreContext);
+  const treeDispatch = useContext(TreeDispatcherContext);
+  const suspenseTreeDispatch = useContext(SuspenseTreeDispatcherContext);
 
   const {inspectedElementID} = useContext(TreeStateContext);
 
@@ -64,7 +69,11 @@ function SuspenseRects({
       return;
     }
     event.preventDefault();
-    dispatch({type: 'SELECT_ELEMENT_BY_ID', payload: suspenseID});
+    treeDispatch({type: 'SELECT_ELEMENT_BY_ID', payload: suspenseID});
+    suspenseTreeDispatch({
+      type: 'SET_SUSPENSE_LINEAGE',
+      payload: suspenseID,
+    });
   }
 
   function handlePointerOver(event: SyntheticPointerEvent) {
@@ -157,7 +166,7 @@ function SuspenseRectsShell({
 }: {
   rootID: SuspenseNode['id'],
 }): React$Node {
-  const store = useSuspenseStore();
+  const store = useContext(StoreContext);
   const root = store.getSuspenseByID(rootID);
   if (root === null) {
     console.warn(`<Element> Could not find suspense node id ${rootID}`);
@@ -174,9 +183,9 @@ function SuspenseRectsShell({
 }
 
 function SuspenseRectsContainer(): React$Node {
-  const store = useSuspenseStore();
+  const store = useContext(StoreContext);
   // TODO: This relies on a full re-render of all children when the Suspense tree changes.
-  const roots = store.roots;
+  const {roots} = useContext(SuspenseTreeStateContext);
 
   const boundingRect = getDocumentBoundingRect(store, roots);
 

--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseTimeline.js
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseTimeline.js
@@ -7,70 +7,34 @@
  * @flow
  */
 
-import type {Element, SuspenseNode} from '../../../frontend/types';
-import type Store from '../../store';
-
 import * as React from 'react';
-import {useContext, useLayoutEffect, useMemo, useRef, useState} from 'react';
-import {BridgeContext} from '../context';
+import {useContext, useLayoutEffect, useRef} from 'react';
+import {BridgeContext, StoreContext} from '../context';
 import {TreeDispatcherContext} from '../Components/TreeContext';
 import {useHighlightHostInstance} from '../hooks';
-import {useSuspenseStore} from './SuspenseTreeContext';
+import {
+  SuspenseTreeDispatcherContext,
+  SuspenseTreeStateContext,
+} from './SuspenseTreeContext';
 import styles from './SuspenseTimeline.css';
 import typeof {
   SyntheticEvent,
   SyntheticPointerEvent,
 } from 'react-dom-bindings/src/events/SyntheticEvent';
 
-function getSuspendableDocumentOrderSuspense(
-  store: Store,
-  rootID: Element['id'] | void,
-): Array<SuspenseNode> {
-  if (rootID === undefined) {
-    return [];
-  }
-  const root = store.getElementByID(rootID);
-  if (root === null) {
-    return [];
-  }
-  if (!store.supportsTogglingSuspense(root.id)) {
-    return [];
-  }
-  const suspenseTreeList: SuspenseNode[] = [];
-  const suspense = store.getSuspenseByID(root.id);
-  if (suspense !== null) {
-    const stack = [suspense];
-    while (stack.length > 0) {
-      const current = stack.pop();
-      if (current === undefined) {
-        continue;
-      }
-      // Include the root even if we won't suspend it.
-      // You should be able to see what suspended the shell.
-      suspenseTreeList.push(current);
-      // Add children in reverse order to maintain document order
-      for (let j = current.children.length - 1; j >= 0; j--) {
-        const childSuspense = store.getSuspenseByID(current.children[j]);
-        if (childSuspense !== null) {
-          stack.push(childSuspense);
-        }
-      }
-    }
-  }
-
-  return suspenseTreeList;
-}
-
-function SuspenseTimelineInput({rootID}: {rootID: Element['id'] | void}) {
+function SuspenseTimelineInput() {
   const bridge = useContext(BridgeContext);
-  const store = useSuspenseStore();
-  const dispatch = useContext(TreeDispatcherContext);
+  const store = useContext(StoreContext);
+  const treeDispatch = useContext(TreeDispatcherContext);
+  const suspenseTreeDispatch = useContext(SuspenseTreeDispatcherContext);
   const {highlightHostInstance, clearHighlightHostInstance} =
     useHighlightHostInstance();
 
-  const timeline = useMemo(() => {
-    return getSuspendableDocumentOrderSuspense(store, rootID);
-  }, [store, store.revisionSuspense, rootID]);
+  const {
+    selectedRootID: rootID,
+    timeline,
+    timelineIndex,
+  } = useContext(SuspenseTreeStateContext);
 
   const inputRef = useRef<HTMLElement | null>(null);
   const inputBBox = useRef<ClientRect | null>(null);
@@ -97,15 +61,11 @@ function SuspenseTimelineInput({rootID}: {rootID: Element['id'] | void}) {
 
   const min = 0;
   const max = timeline.length > 0 ? timeline.length - 1 : 0;
-  const [value, setValue] = useState(max);
 
-  if (value > max) {
-    // TODO: Handle timeline changes
-    setValue(max);
-  }
-
-  if (rootID === undefined) {
-    return <div className={styles.SuspenseTimelineInput}>Root not found.</div>;
+  if (rootID === null) {
+    return (
+      <div className={styles.SuspenseTimelineInput}>No root selected.</div>
+    );
   }
 
   if (!store.supportsTogglingSuspense(rootID)) {
@@ -124,8 +84,21 @@ function SuspenseTimelineInput({rootID}: {rootID: Element['id'] | void}) {
     );
   }
 
+  function switchSuspenseNode(nextTimelineIndex: number) {
+    const nextSelectedSuspenseID = timeline[nextTimelineIndex];
+    highlightHostInstance(nextSelectedSuspenseID);
+    treeDispatch({
+      type: 'SELECT_ELEMENT_BY_ID',
+      payload: nextSelectedSuspenseID,
+    });
+    suspenseTreeDispatch({
+      type: 'SUSPENSE_SET_TIMELINE_INDEX',
+      payload: nextTimelineIndex,
+    });
+  }
+
   function handleChange(event: SyntheticEvent) {
-    if (rootID === undefined) {
+    if (rootID === null) {
       return;
     }
     const rendererID = store.getRendererIDForElement(rootID);
@@ -136,10 +109,8 @@ function SuspenseTimelineInput({rootID}: {rootID: Element['id'] | void}) {
       return;
     }
 
-    const pendingValue = +event.currentTarget.value;
-    const suspendedSet = timeline
-      .slice(pendingValue)
-      .map(suspense => suspense.id);
+    const pendingTimelineIndex = +event.currentTarget.value;
+    const suspendedSet = timeline.slice(pendingTimelineIndex);
 
     bridge.send('overrideSuspenseMilestone', {
       rendererID,
@@ -147,11 +118,7 @@ function SuspenseTimelineInput({rootID}: {rootID: Element['id'] | void}) {
       suspendedSet,
     });
 
-    const suspense = timeline[pendingValue];
-    const elementID = suspense.id;
-    highlightHostInstance(elementID);
-    dispatch({type: 'SELECT_ELEMENT_BY_ID', payload: elementID});
-    setValue(pendingValue);
+    switchSuspenseNode(pendingTimelineIndex);
   }
 
   function handleBlur() {
@@ -159,10 +126,7 @@ function SuspenseTimelineInput({rootID}: {rootID: Element['id'] | void}) {
   }
 
   function handleFocus() {
-    const suspense = timeline[value];
-
-    dispatch({type: 'SELECT_ELEMENT_BY_ID', payload: suspense.id});
-    highlightHostInstance(suspense.id);
+    switchSuspenseNode(timelineIndex);
   }
 
   function handlePointerMove(event: SyntheticPointerEvent) {
@@ -180,19 +144,19 @@ function SuspenseTimelineInput({rootID}: {rootID: Element['id'] | void}) {
         max,
       ),
     );
-    const suspense = timeline[hoveredValue];
-    if (suspense === undefined) {
+    const suspenseID = timeline[hoveredValue];
+    if (suspenseID === undefined) {
       throw new Error(
         `Suspense node not found for value ${hoveredValue} in timeline when on ${event.clientX} in bounding box ${JSON.stringify(bbox)}.`,
       );
     }
-    highlightHostInstance(suspense.id);
+    highlightHostInstance(suspenseID);
   }
 
   return (
     <>
       <div>
-        {value}/{max}
+        {timelineIndex}/{max}
       </div>
       <div className={styles.SuspenseTimelineInput}>
         <input
@@ -200,7 +164,7 @@ function SuspenseTimelineInput({rootID}: {rootID: Element['id'] | void}) {
           type="range"
           min={min}
           max={max}
-          value={value}
+          value={timelineIndex}
           onBlur={handleBlur}
           onChange={handleChange}
           onFocus={handleFocus}
@@ -214,38 +178,37 @@ function SuspenseTimelineInput({rootID}: {rootID: Element['id'] | void}) {
 }
 
 export default function SuspenseTimeline(): React$Node {
-  const store = useSuspenseStore();
-
-  const roots = store.roots;
-  const defaultSelectedRootID = roots.find(rootID => {
-    const suspense = store.getSuspenseByID(rootID);
-    return (
-      store.supportsTogglingSuspense(rootID) &&
-      suspense !== null &&
-      suspense.children.length > 1
-    );
-  });
-  const [selectedRootID, setSelectedRootID] = useState(defaultSelectedRootID);
-
-  if (selectedRootID === undefined && defaultSelectedRootID !== undefined) {
-    setSelectedRootID(defaultSelectedRootID);
-  }
+  const store = useContext(StoreContext);
+  const {roots, selectedRootID} = useContext(SuspenseTreeStateContext);
+  const treeDispatch = useContext(TreeDispatcherContext);
+  const suspenseTreeDispatch = useContext(SuspenseTreeDispatcherContext);
 
   function handleChange(event: SyntheticEvent) {
     const newRootID = +event.currentTarget.value;
     // TODO: scrollIntoView both suspense rects and host instance.
-    setSelectedRootID(newRootID);
+    const nextTimeline = store.getSuspendableDocumentOrderSuspense(newRootID);
+    suspenseTreeDispatch({
+      type: 'SET_SUSPENSE_TIMELINE',
+      payload: [nextTimeline, newRootID],
+    });
+    if (nextTimeline.length > 0) {
+      const milestone = nextTimeline[nextTimeline.length - 1];
+      treeDispatch({type: 'SELECT_ELEMENT_BY_ID', payload: milestone});
+    }
   }
 
   return (
     <div className={styles.SuspenseTimelineContainer}>
-      <SuspenseTimelineInput key={selectedRootID} rootID={selectedRootID} />
+      <SuspenseTimelineInput key={selectedRootID} />
       {roots.length > 0 && (
         <select
           aria-label="Select Suspense Root"
           className={styles.SuspenseTimelineRootSwitcher}
           onChange={handleChange}
-          value={selectedRootID}>
+          value={selectedRootID === null ? -1 : selectedRootID}>
+          <option disabled={true} value={-1}>
+            ----
+          </option>
           {roots.map(rootID => {
             // TODO: Use name
             const name = '#' + rootID;

--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseTreeContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseTreeContext.js
@@ -7,6 +7,10 @@
  * @flow
  */
 import type {ReactContext} from 'shared/ReactTypes';
+import type {
+  Element,
+  SuspenseNode,
+} from 'react-devtools-shared/src/frontend/types';
 import type Store from '../../store';
 
 import * as React from 'react';
@@ -20,10 +24,45 @@ import {
 } from 'react';
 import {StoreContext} from '../context';
 
-export type SuspenseTreeState = {};
+export type SuspenseTreeState = {
+  lineage: $ReadOnlyArray<SuspenseNode['id']> | null,
+  roots: $ReadOnlyArray<SuspenseNode['id']>,
+  selectedRootID: SuspenseNode['id'] | null,
+  selectedSuspenseID: SuspenseNode['id'] | null,
+  timeline: $ReadOnlyArray<SuspenseNode['id']>,
+  timelineIndex: number | -1,
+};
 
-// unused for now
-export type SuspenseTreeAction = {type: 'unused'};
+type ACTION_SUSPENSE_TREE_MUTATION = {
+  type: 'HANDLE_SUSPENSE_TREE_MUTATION',
+  payload: [Map<SuspenseNode['id'], SuspenseNode['id']>],
+};
+type ACTION_SET_SUSPENSE_LINEAGE = {
+  type: 'SET_SUSPENSE_LINEAGE',
+  payload: SuspenseNode['id'],
+};
+type ACTION_SELECT_SUSPENSE_BY_ID = {
+  type: 'SELECT_SUSPENSE_BY_ID',
+  payload: SuspenseNode['id'],
+};
+type ACTION_SET_SUSPENSE_TIMELINE = {
+  type: 'SET_SUSPENSE_TIMELINE',
+  payload: [
+    $ReadOnlyArray<SuspenseNode['id']>,
+    // The next Suspense ID to select in the timeline
+    SuspenseNode['id'] | null,
+  ],
+};
+type ACTION_SUSPENSE_SET_TIMELINE_INDEX = {
+  type: 'SUSPENSE_SET_TIMELINE_INDEX',
+  payload: number,
+};
+export type SuspenseTreeAction =
+  | ACTION_SUSPENSE_TREE_MUTATION
+  | ACTION_SET_SUSPENSE_LINEAGE
+  | ACTION_SELECT_SUSPENSE_BY_ID
+  | ACTION_SET_SUSPENSE_TIMELINE
+  | ACTION_SUSPENSE_SET_TIMELINE_INDEX;
 export type SuspenseTreeDispatch = (action: SuspenseTreeAction) => void;
 
 const SuspenseTreeStateContext: ReactContext<SuspenseTreeState> =
@@ -38,39 +77,56 @@ type Props = {
   children: React$Node,
 };
 
-/**
- * The Store is mutable. This Hook ensures renders read the latest Suspense related
- * data.
- */
-function useSuspenseStore(): Store {
-  const store = useContext(StoreContext);
-  const [, storeUpdated] = useReducer<number, number, void>(
-    (x: number) => (x + 1) % Number.MAX_SAFE_INTEGER,
-    0,
-  );
-  const initialRevision = useMemo(() => store.revisionSuspense, [store]);
-  // We're currently storing everything Suspense related in the same Store as
-  // Components. However, most reads are currently stateless. This ensures
-  // the latest state is always read from the Store.
-  useEffect(() => {
-    const handleSuspenseTreeMutated = () => {
-      storeUpdated();
+function getDefaultRootID(store: Store): Element['id'] | null {
+  const designatedRootID = store.roots.find(rootID => {
+    const suspense = store.getSuspenseByID(rootID);
+    return (
+      store.supportsTogglingSuspense(rootID) &&
+      suspense !== null &&
+      suspense.children.length > 1
+    );
+  });
+
+  return designatedRootID === undefined ? null : designatedRootID;
+}
+
+function getInitialState(store: Store): SuspenseTreeState {
+  let initialState: SuspenseTreeState;
+  const selectedRootID = getDefaultRootID(store);
+  // TODO: Default to nearest from inspected
+  if (selectedRootID === null) {
+    initialState = {
+      selectedSuspenseID: null,
+      lineage: null,
+      roots: store.roots,
+      selectedRootID,
+      timeline: [],
+      timelineIndex: -1,
     };
+  } else {
+    const timeline = store.getSuspendableDocumentOrderSuspense(selectedRootID);
+    const timelineIndex = timeline.length - 1;
+    const selectedSuspenseID =
+      timelineIndex === -1 ? null : timeline[timelineIndex];
+    const lineage =
+      selectedSuspenseID !== null
+        ? store.getSuspenseLineage(selectedSuspenseID)
+        : [];
+    initialState = {
+      selectedSuspenseID,
+      lineage,
+      roots: store.roots,
+      selectedRootID,
+      timeline,
+      timelineIndex,
+    };
+  }
 
-    // Since this is a passive effect, the tree may have been mutated before our initial subscription.
-    if (store.revisionSuspense !== initialRevision) {
-      // At the moment, we can treat this as a mutation.
-      handleSuspenseTreeMutated();
-    }
-
-    store.addListener('suspenseTreeMutated', handleSuspenseTreeMutated);
-    return () =>
-      store.removeListener('suspenseTreeMutated', handleSuspenseTreeMutated);
-  }, [initialRevision, store]);
-  return store;
+  return initialState;
 }
 
 function SuspenseTreeContextController({children}: Props): React.Node {
+  const store = useContext(StoreContext);
   // This reducer is created inline because it needs access to the Store.
   // The store is mutable, but the Store itself is global and lives for the lifetime of the DevTools,
   // so it's okay for the reducer to have an empty dependencies array.
@@ -80,17 +136,192 @@ function SuspenseTreeContextController({children}: Props): React.Node {
         state: SuspenseTreeState,
         action: SuspenseTreeAction,
       ): SuspenseTreeState => {
-        const {type} = action;
-        switch (type) {
+        switch (action.type) {
+          case 'HANDLE_SUSPENSE_TREE_MUTATION': {
+            let {selectedSuspenseID} = state;
+            // If the currently-selected Element has been removed from the tree, update selection state.
+            const removedIDs = action.payload[0];
+            // Find the closest parent that wasn't removed during this batch.
+            // We deduce the parent-child mapping from removedIDs (id -> parentID)
+            // because by now it's too late to read them from the store.
+
+            while (
+              selectedSuspenseID !== null &&
+              removedIDs.has(selectedSuspenseID)
+            ) {
+              // $FlowExpectedError[incompatible-type]
+              selectedSuspenseID = removedIDs.get(selectedSuspenseID);
+            }
+            if (selectedSuspenseID === 0) {
+              // The whole root was removed.
+              selectedSuspenseID = null;
+            }
+
+            let selectedTimelineID =
+              state.timeline === null
+                ? null
+                : state.timeline[state.timelineIndex];
+            while (
+              selectedTimelineID !== null &&
+              removedIDs.has(selectedTimelineID)
+            ) {
+              // $FlowExpectedError[incompatible-type]
+              selectedTimelineID = removedIDs.get(selectedTimelineID);
+            }
+
+            let nextRootID = state.selectedRootID;
+            if (selectedTimelineID !== null && selectedTimelineID !== 0) {
+              nextRootID =
+                store.getSuspenseRootIDForSuspense(selectedTimelineID);
+            }
+            if (nextRootID === null) {
+              nextRootID = getDefaultRootID(store);
+            }
+
+            const nextTimeline =
+              nextRootID === null
+                ? []
+                : // TODO: Handle different timeline modes (e.g. random order)
+                  store.getSuspendableDocumentOrderSuspense(nextRootID);
+
+            let nextTimelineIndex =
+              selectedTimelineID === null || nextTimeline.length === 0
+                ? -1
+                : nextTimeline.indexOf(selectedTimelineID);
+            if (nextTimeline.length > 0 && nextTimelineIndex === -1) {
+              nextTimelineIndex = nextTimeline.length - 1;
+              selectedSuspenseID = nextTimeline[nextTimelineIndex];
+            }
+
+            if (selectedSuspenseID === null && nextTimeline.length > 0) {
+              selectedSuspenseID = nextTimeline[nextTimeline.length - 1];
+            }
+
+            const nextLineage =
+              selectedSuspenseID !== null &&
+              state.selectedSuspenseID !== selectedSuspenseID
+                ? store.getSuspenseLineage(selectedSuspenseID)
+                : state.lineage;
+
+            return {
+              ...state,
+              lineage: nextLineage,
+              roots: store.roots,
+              selectedRootID: nextRootID,
+              selectedSuspenseID,
+              timeline: nextTimeline,
+              timelineIndex: nextTimelineIndex,
+            };
+          }
+          case 'SELECT_SUSPENSE_BY_ID': {
+            const selectedSuspenseID = action.payload;
+            const selectedRootID =
+              store.getSuspenseRootIDForSuspense(selectedSuspenseID);
+
+            return {
+              ...state,
+              selectedSuspenseID,
+              selectedRootID,
+            };
+          }
+          case 'SET_SUSPENSE_LINEAGE': {
+            const suspenseID = action.payload;
+            const lineage = store.getSuspenseLineage(suspenseID);
+            const selectedRootID =
+              store.getSuspenseRootIDForSuspense(suspenseID);
+
+            return {
+              ...state,
+              lineage,
+              selectedSuspenseID: suspenseID,
+              selectedRootID,
+            };
+          }
+          case 'SET_SUSPENSE_TIMELINE': {
+            const previousMilestoneIndex = state.timelineIndex;
+            const previousTimeline = state.timeline;
+            const nextTimeline = action.payload[0];
+            const nextRootID: SuspenseNode['id'] | null = action.payload[1];
+            let nextLineage = state.lineage;
+            let nextMilestoneIndex: number | -1 = -1;
+            let nextSelectedSuspenseID = state.selectedSuspenseID;
+            // Action has indicated it has no preference for the selected Node.
+            // Try to reconcile the new timeline with the previous index.
+            if (
+              nextRootID === null &&
+              previousTimeline !== null &&
+              previousMilestoneIndex !== null
+            ) {
+              const previousMilestoneID =
+                previousTimeline[previousMilestoneIndex];
+              nextMilestoneIndex = nextTimeline.indexOf(previousMilestoneID);
+              if (nextMilestoneIndex === -1) {
+                nextMilestoneIndex = nextTimeline.length - 1;
+              }
+            } else if (nextRootID !== null) {
+              nextMilestoneIndex = nextTimeline.length - 1;
+              nextSelectedSuspenseID = nextTimeline[nextMilestoneIndex];
+              nextLineage = store.getSuspenseLineage(nextSelectedSuspenseID);
+            }
+
+            return {
+              ...state,
+              selectedSuspenseID: nextSelectedSuspenseID,
+              lineage: nextLineage,
+              selectedRootID:
+                nextRootID === null ? state.selectedRootID : nextRootID,
+              timeline: nextTimeline,
+              timelineIndex: nextMilestoneIndex,
+            };
+          }
+          case 'SUSPENSE_SET_TIMELINE_INDEX': {
+            const nextTimelineIndex = action.payload;
+            const nextSelectedSuspenseID = state.timeline[nextTimelineIndex];
+            const nextLineage = store.getSuspenseLineage(
+              nextSelectedSuspenseID,
+            );
+
+            return {
+              ...state,
+              lineage: nextLineage,
+              selectedSuspenseID: nextSelectedSuspenseID,
+              timelineIndex: nextTimelineIndex,
+            };
+          }
           default:
-            throw new Error(`Unrecognized action "${type}"`);
+            throw new Error(`Unrecognized action "${action.type}"`);
         }
       },
     [],
   );
 
-  const initialState: SuspenseTreeState = {};
-  const [state, dispatch] = useReducer(reducer, initialState);
+  const [state, dispatch] = useReducer(reducer, store, getInitialState);
+
+  const initialRevision = useMemo(() => store.revisionSuspense, [store]);
+  // We're currently storing everything Suspense related in the same Store as
+  // Components. However, most reads are currently stateless. This ensures
+  // the latest state is always read from the Store.
+  useEffect(() => {
+    const handleSuspenseTreeMutated = ([removedElementIDs]: [
+      Map<number, number>,
+    ]) => {
+      dispatch({
+        type: 'HANDLE_SUSPENSE_TREE_MUTATION',
+        payload: [removedElementIDs],
+      });
+    };
+
+    // Since this is a passive effect, the tree may have been mutated before our initial subscription.
+    if (store.revisionSuspense !== initialRevision) {
+      // At the moment, we can treat this as a mutation.
+      handleSuspenseTreeMutated([new Map()]);
+    }
+
+    store.addListener('suspenseTreeMutated', handleSuspenseTreeMutated);
+    return () =>
+      store.removeListener('suspenseTreeMutated', handleSuspenseTreeMutated);
+  }, [initialRevision, store]);
+
   const transitionDispatch = useMemo(
     () => (action: SuspenseTreeAction) =>
       startTransition(() => {
@@ -112,5 +343,4 @@ export {
   SuspenseTreeDispatcherContext,
   SuspenseTreeStateContext,
   SuspenseTreeContextController,
-  useSuspenseStore,
 };


### PR DESCRIPTION
Moves timeline and lineage into state so that we can better reconcile them during Suspense tree changes.

That state could live in TreeStateContext given that we always change inspected Suspense and Element ID together in the Suspense Tab. They're still split for now to avoid re-renders of the Suspense Tab when we're changing Components tab state. Bug mid term they probably end up together. Especially once we implement selecting the nearest Suspense boundary of the inspected Element when navigating to the Suspense tab.

https://github.com/user-attachments/assets/e91ac476-c055-4554-90bc-507d01db4970


