### PR TITLE
Allow naming roots

### DIFF
--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -82,6 +82,7 @@ class Surface extends React.Component {
       null,
       false,
       false,
+      'new Surface()',
       '',
       defaultOnUncaughtError,
       defaultOnCaughtError,

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -2338,6 +2338,21 @@ describe('InspectedElement', () => {
     expect(inspectedElement.rootType).toMatchInlineSnapshot(`"hydrateRoot()"`);
   });
 
+  it('should display the root type for named ReactDOMClient.hydrateRoot', async () => {
+    const Example = () => <div />;
+
+    await utils.actAsync(() => {
+      const container = document.createElement('div');
+      container.innerHTML = '<div></div>';
+      ReactDOMClient.hydrateRoot(container, <Example />, {displayName: 'App'});
+    }, false);
+
+    const inspectedElement = await inspectElementAtIndex(0);
+    expect(inspectedElement.rootType).toMatchInlineSnapshot(
+      `"hydrateRoot(App)"`,
+    );
+  });
+
   it('should display the root type for ReactDOMClient.createRoot', async () => {
     const Example = () => <div />;
 
@@ -2348,6 +2363,22 @@ describe('InspectedElement', () => {
 
     const inspectedElement = await inspectElementAtIndex(0);
     expect(inspectedElement.rootType).toMatchInlineSnapshot(`"createRoot()"`);
+  });
+
+  it('should display the root type for named ReactDOMClient.createRoot', async () => {
+    const Example = () => <div />;
+
+    await utils.actAsync(() => {
+      const container = document.createElement('div');
+      ReactDOMClient.createRoot(container, {
+        displayName: 'App',
+      }).render(<Example />);
+    }, false);
+
+    const inspectedElement = await inspectElementAtIndex(0);
+    expect(inspectedElement.rootType).toMatchInlineSnapshot(
+      `"createRoot(App)"`,
+    );
   });
 
   it('should gracefully surface backend errors on the frontend rather than timing out', async () => {

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -2381,6 +2381,19 @@ describe('InspectedElement', () => {
     );
   });
 
+  it('should display the inferred root type for unnamed ReactDOMClient.createRoot', async () => {
+    const Example = () => <div />;
+
+    await utils.actAsync(() => {
+      const container = document.createElement('div');
+      container.id = 'react-root';
+      ReactDOMClient.createRoot(container).render(<Example />);
+    }, false);
+
+    const inspectedElement = await inspectElementAtIndex(0);
+    expect(inspectedElement.rootType).toEqual('createRoot(#react-root)');
+  });
+
   it('should gracefully surface backend errors on the frontend rather than timing out', async () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -734,8 +734,14 @@ export function getInternalReactConstants(version: string): {
         );
       case HostRoot:
         const fiberRoot = fiber.stateNode;
-        if (fiberRoot != null && fiberRoot._debugRootType !== null) {
-          return fiberRoot._debugRootType;
+        if (fiberRoot != null) {
+          // Old versions without displayName
+          if (typeof fiberRoot._debugRootType === 'string') {
+            return fiberRoot._debugRootType;
+          }
+          if (typeof fiberRoot.displayName === 'string') {
+            return fiberRoot.displayName;
+          }
         }
         return null;
       case HostComponent:
@@ -6232,8 +6238,14 @@ export function attach(
       }
     }
     const fiberRoot = current.stateNode;
-    if (fiberRoot != null && fiberRoot._debugRootType !== null) {
-      rootType = fiberRoot._debugRootType;
+    if (fiberRoot != null) {
+      // Old versions without displayName
+      if (typeof fiberRoot._debugRootType === 'string') {
+        rootType = fiberRoot._debugRootType;
+      }
+      if (typeof fiberRoot.displayName === 'string') {
+        rootType = fiberRoot.displayName;
+      }
     }
 
     const isTimedOutSuspense =
@@ -6432,8 +6444,14 @@ export function attach(
         }
       }
       const fiberRoot = current.stateNode;
-      if (fiberRoot != null && fiberRoot._debugRootType !== null) {
-        rootType = fiberRoot._debugRootType;
+      if (fiberRoot != null) {
+        // Old versions without displayName
+        if (typeof fiberRoot._debugRootType === 'string') {
+          rootType = fiberRoot._debugRootType;
+        }
+        if (typeof fiberRoot.displayName === 'string') {
+          rootType = fiberRoot.displayName;
+        }
       }
     }
 

--- a/packages/react-dom-bindings/src/client/ReactDOMContainer.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMContainer.js
@@ -16,6 +16,30 @@ import {
   DOCUMENT_FRAGMENT_NODE,
 } from './HTMLNodeType';
 
+export function getDefaultDisplayNameDEV(
+  node: Element | Document | DocumentFragment,
+): string {
+  if (!__DEV__) {
+    // These errors should never make it into a build so we don't need to encode them in codes.json
+    // eslint-disable-next-line react-internal/prod-error-codes
+    throw new Error(
+      'getDefaultDisplayNameDEV should never be called in production mode. This is a bug in React.',
+    );
+  }
+
+  if (node.nodeType === DOCUMENT_NODE) {
+    return 'document';
+  }
+  if (node.nodeType === ELEMENT_NODE) {
+    const element = ((node: any): Element);
+    if (element.id !== '') {
+      return '#' + element.id;
+    }
+  }
+
+  return '';
+}
+
 export function isValidContainer(node: any): boolean {
   return !!(
     node &&

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -30,6 +30,7 @@ export type RootType = {
 export type CreateRootOptions = {
   unstable_strictMode?: boolean,
   unstable_transitionCallbacks?: TransitionTracingCallbacks,
+  displayName?: string,
   identifierPrefix?: string,
   onUncaughtError?: (
     error: mixed,
@@ -56,6 +57,7 @@ export type HydrateRootOptions = {
   // Options for all roots
   unstable_strictMode?: boolean,
   unstable_transitionCallbacks?: TransitionTracingCallbacks,
+  displayName?: string,
   identifierPrefix?: string,
   onUncaughtError?: (
     error: mixed,
@@ -179,6 +181,7 @@ export function createRoot(
   warnIfReactDOMContainerInDEV(container);
 
   const concurrentUpdatesByDefaultOverride = false;
+  let displayName = '';
   let isStrictMode = false;
   let identifierPrefix = '';
   let onUncaughtError = defaultOnUncaughtError;
@@ -212,6 +215,9 @@ export function createRoot(
     if (options.unstable_strictMode === true) {
       isStrictMode = true;
     }
+    if (options.displayName !== undefined) {
+      displayName = options.displayName;
+    }
     if (options.identifierPrefix !== undefined) {
       identifierPrefix = options.identifierPrefix;
     }
@@ -240,6 +246,7 @@ export function createRoot(
     null,
     isStrictMode,
     concurrentUpdatesByDefaultOverride,
+    'createRoot(' + displayName + ')',
     identifierPrefix,
     onUncaughtError,
     onCaughtError,
@@ -297,6 +304,7 @@ export function hydrateRoot(
 
   const concurrentUpdatesByDefaultOverride = false;
   let isStrictMode = false;
+  let displayName = '';
   let identifierPrefix = '';
   let onUncaughtError = defaultOnUncaughtError;
   let onCaughtError = defaultOnCaughtError;
@@ -307,6 +315,9 @@ export function hydrateRoot(
   if (options !== null && options !== undefined) {
     if (options.unstable_strictMode === true) {
       isStrictMode = true;
+    }
+    if (options.displayName !== undefined) {
+      displayName = options.displayName;
     }
     if (options.identifierPrefix !== undefined) {
       identifierPrefix = options.identifierPrefix;
@@ -341,6 +352,7 @@ export function hydrateRoot(
     hydrationCallbacks,
     isStrictMode,
     concurrentUpdatesByDefaultOverride,
+    'hydrateRoot(' + displayName + ')',
     identifierPrefix,
     onUncaughtError,
     onCaughtError,

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -13,7 +13,10 @@ import type {
   TransitionTracingCallbacks,
 } from 'react-reconciler/src/ReactInternalTypes';
 
-import {isValidContainer} from 'react-dom-bindings/src/client/ReactDOMContainer';
+import {
+  isValidContainer,
+  getDefaultDisplayNameDEV,
+} from 'react-dom-bindings/src/client/ReactDOMContainer';
 import {queueExplicitHydrationTarget} from 'react-dom-bindings/src/events/ReactDOMEventReplaying';
 import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 import {
@@ -217,6 +220,9 @@ export function createRoot(
     }
     if (options.displayName !== undefined) {
       displayName = options.displayName;
+    } else if (__DEV__) {
+      // Guess some useful default
+      displayName = getDefaultDisplayNameDEV(container);
     }
     if (options.identifierPrefix !== undefined) {
       identifierPrefix = options.identifierPrefix;
@@ -238,6 +244,9 @@ export function createRoot(
     if (options.unstable_transitionCallbacks !== undefined) {
       transitionCallbacks = options.unstable_transitionCallbacks;
     }
+  } else if (__DEV__) {
+    // Guess some useful default
+    displayName = getDefaultDisplayNameDEV(container);
   }
 
   const root = createContainer(

--- a/packages/react-dom/src/client/ReactDOMRootFB.js
+++ b/packages/react-dom/src/client/ReactDOMRootFB.js
@@ -239,6 +239,7 @@ function legacyCreateRootFromDOMContainer(
       null, // hydrationCallbacks
       false, // isStrictMode
       false, // concurrentUpdatesByDefaultOverride,
+      'hydrate()', // displayName
       '', // identifierPrefix
       wwwOnUncaughtError,
       wwwOnCaughtError,
@@ -278,6 +279,7 @@ function legacyCreateRootFromDOMContainer(
       null, // hydrationCallbacks
       false, // isStrictMode
       false, // concurrentUpdatesByDefaultOverride,
+      'render()', // displayName
       '', // identifierPrefix
       wwwOnUncaughtError,
       wwwOnCaughtError,

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -119,6 +119,7 @@ function render(
   let root = roots.get(containerTag);
 
   if (!root) {
+    let displayName = '';
     // TODO: these defaults are for backwards compatibility.
     // Once RN implements these options internally,
     // we can remove the defaults and ReactFiberErrorDialog.
@@ -126,6 +127,9 @@ function render(
     let onCaughtError = nativeOnCaughtError;
     let onRecoverableError = defaultOnRecoverableError;
 
+    if (options && options.displayName !== undefined) {
+      displayName = options.displayName;
+    }
     if (options && options.onUncaughtError !== undefined) {
       onUncaughtError = options.onUncaughtError;
     }
@@ -148,6 +152,8 @@ function render(
       containerTag,
     };
 
+    const containerDisplayName =
+      (concurrentRoot ? '' : 'legacy ') + 'render(' + displayName + ')';
     // TODO (bvaughn): If we decide to keep the wrapper component,
     // We could create a wrapper for containerTag as well to reduce special casing.
     root = createContainer(
@@ -156,6 +162,7 @@ function render(
       null,
       false,
       null,
+      containerDisplayName,
       '',
       onUncaughtError,
       onCaughtError,

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -130,6 +130,7 @@ function render(
   let root = roots.get(containerTag);
 
   if (!root) {
+    let displayName = '';
     // TODO: these defaults are for backwards compatibility.
     // Once RN implements these options internally,
     // we can remove the defaults and ReactFiberErrorDialog.
@@ -137,6 +138,9 @@ function render(
     let onCaughtError = nativeOnCaughtError;
     let onRecoverableError = defaultOnRecoverableError;
 
+    if (options && options.displayName !== undefined) {
+      displayName = options.displayName;
+    }
     if (options && options.onUncaughtError !== undefined) {
       onUncaughtError = options.onUncaughtError;
     }
@@ -161,6 +165,7 @@ function render(
       null,
       false,
       null,
+      'legacy render(' + displayName + ')',
       '',
       onUncaughtError,
       onCaughtError,

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -117,6 +117,7 @@ export type TouchedViewDataAtPoint = $ReadOnly<
 >;
 
 export type RenderRootOptions = {
+  displayName?: string,
   onUncaughtError?: (
     error: mixed,
     errorInfo: {+componentStack?: ?string},

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -78,6 +78,7 @@ type TextInstance = {
 type HostContext = Object;
 type CreateRootOptions = {
   unstable_transitionCallbacks?: TransitionTracingCallbacks,
+  displayName?: string,
   onUncaughtError?: (error: mixed, errorInfo: {componentStack: string}) => void,
   onCaughtError?: (error: mixed, errorInfo: {componentStack: string}) => void,
   onDefaultTransitionIndicator?: () => void | (() => void),
@@ -1194,6 +1195,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           null,
           null,
           false,
+          null,
           '',
           NoopRenderer.defaultOnUncaughtError,
           NoopRenderer.defaultOnCaughtError,
@@ -1213,12 +1215,17 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         pendingChildren: [],
         children: [],
       };
+      let displayName = '';
+      if (options && options.displayName !== undefined) {
+        displayName = options.displayName;
+      }
       const fiberRoot = NoopRenderer.createContainer(
         container,
         ConcurrentRoot,
         null,
         null,
         false,
+        'createRoot(' + displayName + ')',
         '',
         options && options.onUncaughtError
           ? options.onUncaughtError
@@ -1264,6 +1271,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         null,
         null,
         false,
+        'createLegacyRoot()',
         '',
         NoopRenderer.defaultOnUncaughtError,
         NoopRenderer.defaultOnCaughtError,

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -239,6 +239,7 @@ export function createContainer(
   isStrictMode: boolean,
   // TODO: Remove `concurrentUpdatesByDefaultOverride`. It is now ignored.
   concurrentUpdatesByDefaultOverride: null | boolean,
+  displayName: string | null,
   identifierPrefix: string,
   onUncaughtError: (
     error: mixed,
@@ -267,6 +268,7 @@ export function createContainer(
     initialChildren,
     hydrationCallbacks,
     isStrictMode,
+    displayName,
     identifierPrefix,
     null,
     onUncaughtError,
@@ -289,6 +291,7 @@ export function createHydrationContainer(
   isStrictMode: boolean,
   // TODO: Remove `concurrentUpdatesByDefaultOverride`. It is now ignored.
   concurrentUpdatesByDefaultOverride: null | boolean,
+  displayName: string | null,
   identifierPrefix: string,
   onUncaughtError: (
     error: mixed,
@@ -317,6 +320,7 @@ export function createHydrationContainer(
     initialChildren,
     hydrationCallbacks,
     isStrictMode,
+    displayName,
     identifierPrefix,
     formState,
     onUncaughtError,
@@ -346,7 +350,10 @@ export function createHydrationContainer(
   update.callback =
     callback !== undefined && callback !== null ? callback : null;
   enqueueUpdate(current, update, lane);
-  startUpdateTimerByLane(lane, 'hydrateRoot()');
+  startUpdateTimerByLane(
+    lane,
+    'hydrateRoot(' + (displayName === null ? '' : displayName) + ')',
+  );
   scheduleInitialHydrationOnRoot(root, lane);
 
   return root;

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -138,7 +138,7 @@ function FiberRootNode(
     }
   }
 
-  this._debugRootType = displayName;
+  this.displayName = displayName;
 }
 
 export function createFiberRoot(

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -38,7 +38,7 @@ import {
   enableDefaultTransitionIndicator,
 } from 'shared/ReactFeatureFlags';
 import {initializeUpdateQueue} from './ReactFiberClassUpdateQueue';
-import {LegacyRoot, ConcurrentRoot} from './ReactRootTags';
+import {ConcurrentRoot} from './ReactRootTags';
 import {createCache, retainCache} from './ReactFiberCacheComponent';
 
 export type RootState = {
@@ -52,7 +52,7 @@ function FiberRootNode(
   containerInfo: any,
   // $FlowFixMe[missing-local-annot]
   tag,
-  hydrate: any,
+  displayName: string | null,
   identifierPrefix: any,
   onUncaughtError: any,
   onCaughtError: any,
@@ -138,21 +138,7 @@ function FiberRootNode(
     }
   }
 
-  if (__DEV__) {
-    if (disableLegacyMode) {
-      // TODO: This varies by each renderer.
-      this._debugRootType = hydrate ? 'hydrateRoot()' : 'createRoot()';
-    } else {
-      switch (tag) {
-        case ConcurrentRoot:
-          this._debugRootType = hydrate ? 'hydrateRoot()' : 'createRoot()';
-          break;
-        case LegacyRoot:
-          this._debugRootType = hydrate ? 'hydrate()' : 'render()';
-          break;
-      }
-    }
-  }
+  this._debugRootType = displayName;
 }
 
 export function createFiberRoot(
@@ -166,6 +152,7 @@ export function createFiberRoot(
   // host config, but because they are passed in at runtime, we have to thread
   // them through the root constructor. Perhaps we should put them all into a
   // single type, like a DynamicHostConfig that is defined by the renderer.
+  displayName: string | null,
   identifierPrefix: string,
   formState: ReactFormState<any, any> | null,
   onUncaughtError: (
@@ -190,7 +177,7 @@ export function createFiberRoot(
   const root: FiberRoot = (new FiberRootNode(
     containerInfo,
     tag,
-    hydrate,
+    displayName,
     identifierPrefix,
     onUncaughtError,
     onCaughtError,

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -293,6 +293,8 @@ type BaseFiberRootProperties = {
   pendingGestures: null | ScheduledGesture,
   stoppingGestures: null | ScheduledGesture,
   gestureClone: null | Instance,
+
+  _debugRootType: null | string,
 };
 
 // The following attributes are only used by DevTools and are only present in DEV builds.

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -294,7 +294,7 @@ type BaseFiberRootProperties = {
   stoppingGestures: null | ScheduledGesture,
   gestureClone: null | Instance,
 
-  _debugRootType: null | string,
+  displayName: null | string,
 };
 
 // The following attributes are only used by DevTools and are only present in DEV builds.

--- a/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
@@ -121,6 +121,7 @@ describe('ReactFiberHostContext', () => {
       null,
       false,
       null,
+      null,
       '',
       () => {},
       () => {},

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -517,6 +517,7 @@ function create(
     null,
     isStrictMode,
     false,
+    'create()',
     '',
     defaultOnUncaughtError,
     defaultOnCaughtError,

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -94,6 +94,7 @@ describe('ReactTestRenderer', () => {
         null,
         expect.anything(),
         false,
+        'create()',
         expect.anything(),
         expect.anything(),
         expect.anything(),


### PR DESCRIPTION
React roots can now receive a `displayName` option that will be picked up by DevTools.
The renderer can now control how that display name is used i.e. each renderer has a custom root naming scheme.

`react-dom/client#createRoot`: `createRoot($displayName)` e.g. `createRoot(App)`
`react-dom/client#hydrateRoot`: `hydrateRoot($displayName)` e.g. `hydrateRoot(App)`
`react-native`: `render($displayName)` or `legacy render($displayName)`
`react-art` (no `displayName` support): `new Surface()`
`react-test-renderer` (no `displayName` support): `create()`

The name will be set in prod as well in case you have production roots rendered while developing on your main app (e.g. from extensions or framework devtools). You could always decide to hide your specific name from production e.g. `createRoot(<App />, { displayName: __DEV__ ? 'MyExperimentalApp' : undefined })`.

For `react-dom/client` we'll try to infer a name in development when none is provided. `createRoot(document)` will be displayed as `"createRoot(document)"` and `createRoot(element)` will be displayed as `"createRoot(#id)"` if the element has an `id` property. We could've also inferred a name from the element being rendered. However, this would only work if the named thing is the single element you
created the root from.