### PR TITLE
Add missing Activity export to development mode

### DIFF
--- a/packages/react/src/ReactServer.experimental.development.js
+++ b/packages/react/src/ReactServer.experimental.development.js
@@ -17,6 +17,7 @@ import {
   REACT_SUSPENSE_TYPE,
   REACT_SUSPENSE_LIST_TYPE,
   REACT_VIEW_TRANSITION_TYPE,
+  REACT_ACTIVITY_TYPE,
 } from 'shared/ReactSymbols';
 import {
   cloneElement,
@@ -82,5 +83,6 @@ export {
   // Experimental
   REACT_SUSPENSE_LIST_TYPE as unstable_SuspenseList,
   REACT_VIEW_TRANSITION_TYPE as unstable_ViewTransition,
+  REACT_ACTIVITY_TYPE as unstable_Activity,
   captureOwnerStack, // DEV-only
 };


### PR DESCRIPTION
This is exported in the prod version of ReactServer experimental but not the development version so we can't use it in fixtures from Server Components.