### PR TITLE
Allow running `download_devtools_regression_build.js` on a clean repo

### DIFF
--- a/scripts/ci/download_devtools_regression_build.js
+++ b/scripts/ci/download_devtools_regression_build.js
@@ -25,7 +25,7 @@ async function downloadRegressionBuild() {
   const reactVersion = semver.coerce(version).version;
   const installPackages = ['react-dom', 'react', 'react-test-renderer'];
   if (semver.gte(reactVersion, '16.3.0')) {
-    installPackages.push('16.3.0');
+    installPackages.push('react-is');
   }
 
   console.log(chalk.bold.white(`Downloading React v${version}\n`));

--- a/scripts/ci/download_devtools_regression_build.js
+++ b/scripts/ci/download_devtools_regression_build.js
@@ -63,7 +63,7 @@ async function downloadRegressionBuild() {
         .join(' ')}\n`
     )
   );
-  await exec(`rm -r ${removePackagesStr}`);
+  await exec(`rm -rf ${removePackagesStr}`);
 
   // Move all packages that we downloaded to the original build folder
   // We need to separately move the scheduler package because it might
@@ -80,6 +80,7 @@ async function downloadRegressionBuild() {
         .join(' ')} to ${chalk.underline.blue(buildPath)}\n`
     )
   );
+  fs.mkdirSync(buildPath, {recursive: true});
   await exec(`mv ${movePackageString} ${buildPath}`);
 
   const reactVersion = semver.coerce(version).version;
@@ -100,7 +101,7 @@ async function downloadRegressionBuild() {
     );
   } else {
     console.log(chalk.white(`Downloading scheduler\n`));
-    await exec(`rm -r ${join(buildPath, 'scheduler')}`);
+    await exec(`rm -rf ${join(buildPath, 'scheduler')}`);
     await exec(
       `mv ${join(
         regressionBuildPath,

--- a/scripts/ci/download_devtools_regression_build.js
+++ b/scripts/ci/download_devtools_regression_build.js
@@ -9,7 +9,12 @@ const semver = require('semver');
 const yargs = require('yargs');
 const fs = require('fs');
 
-const INSTALL_PACKAGES = ['react-dom', 'react', 'react-test-renderer'];
+const INSTALL_PACKAGES = [
+  'react-dom',
+  'react',
+  'react-is',
+  'react-test-renderer',
+];
 const REGRESSION_FOLDER = 'build-regression';
 
 const ROOT_PATH = join(__dirname, '..', '..');
@@ -135,8 +140,6 @@ async function main() {
       return;
     }
     await downloadRegressionBuild();
-  } catch (e) {
-    console.log(chalk.red(e));
   } finally {
     // We shouldn't remove the regression-build folder unless we're using
     // it to replace the build folder


### PR DESCRIPTION
Previous version relied on having built something before. These changes make the script work on a fresh clone/worktree. Technically you do need to run `yarn build react-debug-tools react-refresh internal-test-utils` because we're not actually doing regression tests for those packages but that's an issue for the tests using those package. The other tests should be able to run on a clean worktree.

This is also fixing a bug where we were using the built `react-is` not the published one.

## Test plan

`node ./scripts/ci/download_devtools_regression_build.js 16.0 --replaceBuild` on
- only a fresh worktree
- repeatedly