### PR TITLE
[Flight] Ensure async info owners are outlined properly

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -2384,6 +2384,11 @@ function visitAsyncNode(
               // Promise that was ultimately awaited by the user space await.
               serializeIONode(request, ioNode, awaited.promise);
 
+              // Ensure the owner is already outlined.
+              if (node.owner != null) {
+                outlineComponentInfo(request, node.owner);
+              }
+
               // We log the environment at the time when the last promise pigned ping which may
               // be later than what the environment was when we actually started awaiting.
               const env = (0, request.environmentName)();
@@ -5133,6 +5138,10 @@ function forwardDebugInfo(
         } else {
           // Outline the IO info in case the same I/O is awaited in more than one place.
           outlineIOInfo(request, ioInfo);
+          // Ensure the owner is already outlined.
+          if (info.owner != null) {
+            outlineComponentInfo(request, info.owner);
+          }
           // We can't serialize the ConsoleTask/Error objects so we need to omit them before serializing.
           let debugStack;
           if (info.stack == null && info.debugStack != null) {


### PR DESCRIPTION
When we emit objects of type `ReactAsyncInfo`, we need to make sure that their owners are outlined, using `outlineComponentInfo`. Otherwise we would end up accidentally emitting stashed fields that are not part of the transport protocol, specifically `debugStack`, `debugTask`, and `debugLocation`. This would lead to runtime errors in the client, when for example, the stack for a `debugLocation` is processed in `buildFakeCallStack`, but the stack was actually omitted from the RSC payload, because for those fields we don't ensure that the object limit is increased by the length of the stack, as we do when we're emitting the `stack` of a `ReactComponentInfo` object in `outlineComponentInfo`.