### PR TITLE
[DevTools] fix(source-symbolication): don't consolidate empty lines

### DIFF
--- a/packages/react-devtools-shared/src/symbolicateSource.js
+++ b/packages/react-devtools-shared/src/symbolicateSource.js
@@ -57,7 +57,7 @@ export async function symbolicateSource(
     return null;
   }
 
-  const resourceLines = resource.split(/[\r\n]+/);
+  const resourceLines = resource.split(/[\r\n]/);
   for (let i = resourceLines.length - 1; i >= 0; --i) {
     const resourceLine = resourceLines[i];
 


### PR DESCRIPTION
We don't want to consolidate multiple newlines, because this would mess up the mappings for the specific line.