### PR TITLE
[DevTools] Update ReadMe Docs For WebExtensions

### DIFF
--- a/packages/react-devtools-extensions/chrome/README.md
+++ b/packages/react-devtools-extensions/chrome/README.md
@@ -1,6 +1,6 @@
 # The Chrome extension
 
-The source code for this extension has moved to `shells/webextension`.
+The source code for this extension has moved to ~~`shells/webextension`~~.
 
 Modify the source code there and then rebuild this extension by running `node build` from this directory or `yarn run build:extension:chrome` from the root directory.
 

--- a/packages/react-devtools-extensions/edge/README.md
+++ b/packages/react-devtools-extensions/edge/README.md
@@ -1,6 +1,6 @@
 # The Microsoft Edge extension
 
-The source code for this extension has moved to `shells/webextension`.
+The source code for this extension has moved to ~~`shells/webextension`~~.
 
 Modify the source code there and then rebuild this extension by running `node build` from this directory or `yarn run build:extension:edge` from the root directory.
 

--- a/packages/react-devtools-extensions/firefox/README.md
+++ b/packages/react-devtools-extensions/firefox/README.md
@@ -1,6 +1,6 @@
 # The Firefox extension
 
-The source code for this extension has moved to `shells/webextension`.
+The source code for this extension has moved to ~~`shells/webextension`~~.
 
 Modify the source code there and then rebuild this extension by running `node build` from this directory or `yarn run build:firefox` from the root directory.
 


### PR DESCRIPTION
## Summary

All three browser extension ReadMe files reference a path (`shells/webextension`) for common source code that I believe no longer exists. 

<img width="1609" height="952" alt="Screenshot 2025-09-15 at 11 40 51 AM" src="https://github.com/user-attachments/assets/cb40fa9a-8bf9-464c-9f75-ddb6d8e218eb" />

I have a guess where the correct path now is, but given it should be easy for the maintainers to make this correction themselves (accurately and without guessing), I'm simply flagging it. 

Thus for this PR to be completed it would need to replace the struck out characters with an updated, correct path. If I have made a mistake I apologize, but as you can see in that screenshot I could not find `shells/webextension`... I was able to find a top-level `shells` directory in the git history, but I must admit the git history is a little confusing, perhaps because this code [used to live in a separate repo](https://github.com/facebook/react-devtools) once upon a time?

In any event, it would be great if one of the maintainers could spend a few minutes confirm the issue and give a quick update for people coming to this fresh who want to dive into this particular aspect of the source code. Thanks for your time!

## How did you test this change?

N/A
