### PR TITLE
Add forwards fill mode to animations in view transition fixture

### DIFF
--- a/fixtures/view-transition/src/components/Transitions.module.css
+++ b/fixtures/view-transition/src/components/Transitions.module.css
@@ -56,10 +56,10 @@
 }
 
 ::view-transition-new(.enter-slide-right):only-child {
-  animation: enter-slide-right ease-in 0.25s;
+  animation: enter-slide-right ease-in 0.25s forwards;
 }
 ::view-transition-old(.exit-slide-left):only-child {
-  animation: exit-slide-left ease-in 0.25s;
+  animation: exit-slide-left ease-in 0.25s forwards;
 }
 
 :root:active-view-transition-type(navigation-back) {


### PR DESCRIPTION
It turns out that View Transitions can sometimes overshoot and then we need to ensure it fills. It can otherwise sometimes flash in Chrome.

This is something users might hit as well.