### PR TITLE
[compiler][rfc] enablePreserveMemo treats manual deps as non-nullable

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/CompilerError.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/CompilerError.ts
@@ -282,6 +282,30 @@ export class CompilerError extends Error {
   disabledDetails: Array<CompilerErrorDetail | CompilerDiagnostic> = [];
   printedMessage: string | null = null;
 
+  static simpleInvariant(
+    condition: unknown,
+    options: {
+      reason: CompilerDiagnosticOptions['reason'];
+      description?: CompilerDiagnosticOptions['description'];
+      loc: SourceLocation;
+    },
+  ): asserts condition {
+    if (!condition) {
+      const errors = new CompilerError();
+      errors.pushDiagnostic(
+        CompilerDiagnostic.create({
+          reason: options.reason,
+          description: options.description ?? null,
+          category: ErrorCategory.Invariant,
+        }).withDetails({
+          kind: 'error',
+          loc: options.loc,
+          message: options.reason,
+        }),
+      );
+      throw errors;
+    }
+  }
   static invariant(
     condition: unknown,
     options: Omit<CompilerDiagnosticOptions, 'category'>,

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
@@ -104,6 +104,7 @@ import {inferMutationAliasingEffects} from '../Inference/InferMutationAliasingEf
 import {inferMutationAliasingRanges} from '../Inference/InferMutationAliasingRanges';
 import {validateNoDerivedComputationsInEffects} from '../Validation/ValidateNoDerivedComputationsInEffects';
 import {nameAnonymousFunctions} from '../Transform/NameAnonymousFunctions';
+import {validateExhaustiveDependencies} from '../Validation/ValidateExhaustiveDependencies';
 
 export type CompilerPipelineValue =
   | {kind: 'ast'; name: string; value: CodegenFunction}
@@ -292,6 +293,11 @@ function runWithEnvironment(
 
   inferReactivePlaces(hir);
   log({kind: 'hir', name: 'InferReactivePlaces', value: hir});
+
+  if (env.config.validateExhaustiveMemoizationDependencies) {
+    // NOTE: this relies on reactivity inference running first
+    validateExhaustiveDependencies(hir).unwrap();
+  }
 
   rewriteInstructionKindsBasedOnReassignment(hir);
   log({

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -228,6 +228,11 @@ export const EnvironmentConfigSchema = z.object({
   validatePreserveExistingMemoizationGuarantees: z.boolean().default(true),
 
   /**
+   * Validate that dependencies supplied to manual memoization calls are exhaustive.
+   */
+  validateExhaustiveMemoizationDependencies: z.boolean().default(false),
+
+  /**
    * When this is true, rather than pruning existing manual memoization but ensuring or validating
    * that the memoized values remain memoized, the compiler will simply not prune existing calls to
    * useMemo/useCallback.

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -1680,6 +1680,28 @@ export function areEqualPaths(a: DependencyPath, b: DependencyPath): boolean {
     )
   );
 }
+export function isSubPath(
+  subpath: DependencyPath,
+  path: DependencyPath,
+): boolean {
+  return (
+    subpath.length <= path.length &&
+    subpath.every(
+      (item, ix) =>
+        item.property === path[ix].property &&
+        item.optional === path[ix].optional,
+    )
+  );
+}
+export function isSubPathIgnoringOptionals(
+  subpath: DependencyPath,
+  path: DependencyPath,
+): boolean {
+  return (
+    subpath.length <= path.length &&
+    subpath.every((item, ix) => item.property === path[ix].property)
+  );
+}
 
 export function getPlaceScope(
   id: InstructionId,

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -817,6 +817,11 @@ export type StartMemoize = {
    * (e.g. useMemo without a second arg)
    */
   deps: Array<ManualMemoDependency> | null;
+  /**
+   * The source location of the dependencies argument. Used for
+   * emitting diagnostics with a suggested replacement
+   */
+  depsLoc: SourceLocation | null;
   loc: SourceLocation;
 };
 export type FinishMemoize = {

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/DropManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/DropManualMemoization.ts
@@ -42,7 +42,7 @@ type IdentifierSidemap = {
   functions: Map<IdentifierId, TInstruction<FunctionExpression>>;
   manualMemos: Map<IdentifierId, ManualMemoCallee>;
   react: Set<IdentifierId>;
-  maybeDepsLists: Map<IdentifierId, Array<Place>>;
+  maybeDepsLists: Map<IdentifierId, {loc: SourceLocation; deps: Array<Place>}>;
   maybeDeps: Map<IdentifierId, ManualMemoDependency>;
   optionals: Set<IdentifierId>;
 };
@@ -159,10 +159,10 @@ function collectTemporaries(
     }
     case 'ArrayExpression': {
       if (value.elements.every(e => e.kind === 'Identifier')) {
-        sidemap.maybeDepsLists.set(
-          instr.lvalue.identifier.id,
-          value.elements as Array<Place>,
-        );
+        sidemap.maybeDepsLists.set(instr.lvalue.identifier.id, {
+          loc: value.loc,
+          deps: value.elements as Array<Place>,
+        });
       }
       break;
     }
@@ -182,6 +182,7 @@ function makeManualMemoizationMarkers(
   fnExpr: Place,
   env: Environment,
   depsList: Array<ManualMemoDependency> | null,
+  depsLoc: SourceLocation | null,
   memoDecl: Place,
   manualMemoId: number,
 ): [TInstruction<StartMemoize>, TInstruction<FinishMemoize>] {
@@ -197,6 +198,7 @@ function makeManualMemoizationMarkers(
          * as dependencies
          */
         deps: depsList,
+        depsLoc,
         loc: fnExpr.loc,
       },
       effects: null,
@@ -287,86 +289,85 @@ function extractManualMemoizationArgs(
   sidemap: IdentifierSidemap,
   errors: CompilerError,
 ): {
-  fnPlace: Place | null;
+  fnPlace: Place;
   depsList: Array<ManualMemoDependency> | null;
-} {
+  depsLoc: SourceLocation | null;
+} | null {
   const [fnPlace, depsListPlace] = instr.value.args as Array<
     Place | SpreadPattern | undefined
   >;
-  if (fnPlace == null) {
+  if (fnPlace == null || fnPlace.kind !== 'Identifier') {
     errors.pushDiagnostic(
       CompilerDiagnostic.create({
         category: ErrorCategory.UseMemo,
         reason: `Expected a callback function to be passed to ${kind}`,
-        description: `Expected a callback function to be passed to ${kind}`,
+        description:
+          kind === 'useCallback'
+            ? 'The first argument to useCallback() must be a function to cache'
+            : 'The first argument to useMemo() must be a function that calculates a result to cache',
         suggestions: null,
       }).withDetails({
         kind: 'error',
         loc: instr.value.loc,
-        message: `Expected a callback function to be passed to ${kind}`,
+        message:
+          kind === 'useCallback'
+            ? `Expected a callback function`
+            : `Expected a memoization function`,
       }),
     );
-    return {fnPlace: null, depsList: null};
+    return null;
   }
-  if (fnPlace.kind === 'Spread' || depsListPlace?.kind === 'Spread') {
+  if (depsListPlace == null) {
+    return {
+      fnPlace,
+      depsList: null,
+      depsLoc: null,
+    };
+  }
+  const maybeDepsList =
+    depsListPlace.kind === 'Identifier'
+      ? sidemap.maybeDepsLists.get(depsListPlace.identifier.id)
+      : null;
+  if (maybeDepsList == null) {
     errors.pushDiagnostic(
       CompilerDiagnostic.create({
         category: ErrorCategory.UseMemo,
-        reason: `Unexpected spread argument to ${kind}`,
-        description: `Unexpected spread argument to ${kind}`,
+        reason: `Expected the dependency list for ${kind} to be an array literal`,
+        description: `Expected the dependency list for ${kind} to be an array literal`,
         suggestions: null,
       }).withDetails({
         kind: 'error',
-        loc: instr.value.loc,
-        message: `Unexpected spread argument to ${kind}`,
+        loc:
+          depsListPlace?.kind === 'Identifier' ? depsListPlace.loc : instr.loc,
+        message: `Expected the dependency list for ${kind} to be an array literal`,
       }),
     );
-    return {fnPlace: null, depsList: null};
+    return null;
   }
-  let depsList: Array<ManualMemoDependency> | null = null;
-  if (depsListPlace != null) {
-    const maybeDepsList = sidemap.maybeDepsLists.get(
-      depsListPlace.identifier.id,
-    );
-    if (maybeDepsList == null) {
+  const depsList: Array<ManualMemoDependency> = [];
+  for (const dep of maybeDepsList.deps) {
+    const maybeDep = sidemap.maybeDeps.get(dep.identifier.id);
+    if (maybeDep == null) {
       errors.pushDiagnostic(
         CompilerDiagnostic.create({
           category: ErrorCategory.UseMemo,
-          reason: `Expected the dependency list for ${kind} to be an array literal`,
-          description: `Expected the dependency list for ${kind} to be an array literal`,
+          reason: `Expected the dependency list to be an array of simple expressions (e.g. \`x\`, \`x.y.z\`, \`x?.y?.z\`)`,
+          description: `Expected the dependency list to be an array of simple expressions (e.g. \`x\`, \`x.y.z\`, \`x?.y?.z\`)`,
           suggestions: null,
         }).withDetails({
           kind: 'error',
-          loc: depsListPlace.loc,
-          message: `Expected the dependency list for ${kind} to be an array literal`,
+          loc: dep.loc,
+          message: `Expected the dependency list to be an array of simple expressions (e.g. \`x\`, \`x.y.z\`, \`x?.y?.z\`)`,
         }),
       );
-      return {fnPlace, depsList: null};
-    }
-    depsList = [];
-    for (const dep of maybeDepsList) {
-      const maybeDep = sidemap.maybeDeps.get(dep.identifier.id);
-      if (maybeDep == null) {
-        errors.pushDiagnostic(
-          CompilerDiagnostic.create({
-            category: ErrorCategory.UseMemo,
-            reason: `Expected the dependency list to be an array of simple expressions (e.g. \`x\`, \`x.y.z\`, \`x?.y?.z\`)`,
-            description: `Expected the dependency list to be an array of simple expressions (e.g. \`x\`, \`x.y.z\`, \`x?.y?.z\`)`,
-            suggestions: null,
-          }).withDetails({
-            kind: 'error',
-            loc: dep.loc,
-            message: `Expected the dependency list to be an array of simple expressions (e.g. \`x\`, \`x.y.z\`, \`x?.y?.z\`)`,
-          }),
-        );
-      } else {
-        depsList.push(maybeDep);
-      }
+    } else {
+      depsList.push(maybeDep);
     }
   }
   return {
     fnPlace,
     depsList,
+    depsLoc: maybeDepsList.loc,
   };
 }
 
@@ -427,16 +428,17 @@ export function dropManualMemoization(
 
         const manualMemo = sidemap.manualMemos.get(id);
         if (manualMemo != null) {
-          const {fnPlace, depsList} = extractManualMemoizationArgs(
+          const memoDetails = extractManualMemoizationArgs(
             instr as TInstruction<CallExpression> | TInstruction<MethodCall>,
             manualMemo.kind,
             sidemap,
             errors,
           );
 
-          if (fnPlace == null) {
+          if (memoDetails == null) {
             continue;
           }
+          const {fnPlace, depsList, depsLoc} = memoDetails;
 
           /**
            * Bailout on void return useMemos. This is an anti-pattern where code might be using
@@ -521,6 +523,7 @@ export function dropManualMemoization(
               fnPlace,
               func.env,
               depsList,
+              depsLoc,
               memoDecl,
               nextManualMemoId++,
             );

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateExhaustiveDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateExhaustiveDependencies.ts
@@ -1,0 +1,749 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import prettyFormat from 'pretty-format';
+import {CompilerDiagnostic, CompilerError, SourceLocation} from '..';
+import {ErrorCategory} from '../CompilerError';
+import {
+  areEqualPaths,
+  BlockId,
+  DependencyPath,
+  FinishMemoize,
+  HIRFunction,
+  Identifier,
+  IdentifierId,
+  InstructionKind,
+  isSubPath,
+  LoadGlobal,
+  ManualMemoDependency,
+  Place,
+  StartMemoize,
+} from '../HIR';
+import {
+  eachInstructionLValue,
+  eachInstructionValueLValue,
+  eachInstructionValueOperand,
+  eachTerminalOperand,
+} from '../HIR/visitors';
+import {Result} from '../Utils/Result';
+import {retainWhere} from '../Utils/utils';
+
+const DEBUG = false;
+
+/**
+ * Validates that existing manual memoization had exhaustive dependencies.
+ * Memoization with missing or extra reactive dependencies is invalid React
+ * and compilation can change behavior, causing a value to be computed more
+ * or less times.
+ *
+ * TODOs:
+ * - Better handling of cases where we infer multiple dependencies related to a single
+ *   variable. Eg if the user has dep `x` and we inferred `x.y, x.z`, the user's dep
+ *   is sufficient.
+ * - Handle cases where the user deps were not simple identifiers + property chains.
+ *   We try to detect this in ValidateUseMemo but we miss some cases. The problem
+ *   is that invalid forms can be value blocks or function calls that don't get
+ *   removed by DCE, leaving a structure like:
+ *
+ * StartMemoize
+ * t0 = <value to memoize>
+ * ...non-DCE'd code for manual deps...
+ * FinishMemoize decl=t0
+ *
+ * When we go to compute the dependencies, we then think that the user's manual dep
+ * logic is part of what the memo computation logic.
+ */
+export function validateExhaustiveDependencies(
+  fn: HIRFunction,
+): Result<void, CompilerError> {
+  const reactive = collectReactiveIdentifiersHIR(fn);
+
+  const temporaries: Map<IdentifierId, Temporary> = new Map();
+  for (const param of fn.params) {
+    const place = param.kind === 'Identifier' ? param : param.place;
+    temporaries.set(place.identifier.id, {
+      kind: 'Local',
+      identifier: place.identifier,
+      path: [],
+      context: false,
+      loc: place.loc,
+    });
+  }
+  const error = new CompilerError();
+  let startMemo: StartMemoize | null = null;
+
+  function onStartMemoize(
+    value: StartMemoize,
+    dependencies: Set<InferredDependency>,
+    locals: Set<IdentifierId>,
+  ): void {
+    CompilerError.simpleInvariant(startMemo == null, {
+      reason: 'Unexpected nested memo calls',
+      loc: value.loc,
+    });
+    startMemo = value;
+    dependencies.clear();
+    locals.clear();
+  }
+  function onFinishMemoize(
+    value: FinishMemoize,
+    dependencies: Set<InferredDependency>,
+    locals: Set<IdentifierId>,
+  ): void {
+    CompilerError.simpleInvariant(
+      startMemo != null && startMemo.manualMemoId === value.manualMemoId,
+      {
+        reason: 'Found FinishMemoize without corresponding StartMemoize',
+        loc: value.loc,
+      },
+    );
+    visitCandidateDependency(value.decl, temporaries, dependencies, locals);
+    const inferred: Array<InferredDependency> = Array.from(dependencies);
+    // Sort dependencies by name, and path, with shorter/non-optional paths first
+    inferred.sort((a, b) => {
+      if (a.kind === 'Global' && b.kind == 'Global') {
+        return a.binding.name.localeCompare(b.binding.name);
+      } else if (a.kind == 'Local' && b.kind == 'Local') {
+        CompilerError.simpleInvariant(
+          a.identifier.name != null &&
+            a.identifier.name.kind === 'named' &&
+            b.identifier.name != null &&
+            b.identifier.name.kind === 'named',
+          {
+            reason: 'Expected dependencies to be named variables',
+            loc: a.loc,
+          },
+        );
+        if (a.identifier.id !== b.identifier.id) {
+          return a.identifier.name.value.localeCompare(b.identifier.name.value);
+        }
+        if (a.path.length !== b.path.length) {
+          // if a's path is shorter this returns a negative, sorting a first
+          return a.path.length - b.path.length;
+        }
+        for (let i = 0; i < a.path.length; i++) {
+          const aProperty = a.path[i];
+          const bProperty = b.path[i];
+          const aOptional = aProperty.optional ? 0 : 1;
+          const bOptional = bProperty.optional ? 0 : 1;
+          if (aOptional !== bOptional) {
+            // sort non-optionals first
+            return aOptional - bOptional;
+          } else if (aProperty.property !== bProperty.property) {
+            return String(aProperty.property).localeCompare(
+              String(bProperty.property),
+            );
+          }
+        }
+        return 0;
+      } else {
+        const aName =
+          a.kind === 'Global' ? a.binding.name : a.identifier.name?.value;
+        const bName =
+          b.kind === 'Global' ? b.binding.name : b.identifier.name?.value;
+        if (aName != null && bName != null) {
+          return aName.localeCompare(bName);
+        }
+        return 0;
+      }
+    });
+    // remove redundant inferred dependencies
+    retainWhere(inferred, (dep, ix) => {
+      const match = inferred.findIndex(prevDep => {
+        return (
+          isEqualTemporary(prevDep, dep) ||
+          (prevDep.kind === 'Local' &&
+            dep.kind === 'Local' &&
+            prevDep.identifier.id === dep.identifier.id &&
+            isSubPath(prevDep.path, dep.path))
+        );
+      });
+      // only retain entries that don't have a prior match
+      return match === -1 || match >= ix;
+    });
+    // Validate that all manual dependencies belong there
+    if (DEBUG) {
+      console.log('manual');
+      console.log(
+        (startMemo.deps ?? [])
+          .map(x => '  ' + printManualMemoDependency(x))
+          .join('\n'),
+      );
+      console.log('inferred');
+      console.log(
+        inferred.map(x => '  ' + printInferredDependency(x)).join('\n'),
+      );
+    }
+    const manualDependencies = startMemo.deps ?? [];
+    const matched: Set<ManualMemoDependency> = new Set();
+    const missing: Array<Extract<InferredDependency, {kind: 'Local'}>> = [];
+    const extra: Array<ManualMemoDependency> = [];
+    for (const inferredDependency of inferred) {
+      if (inferredDependency.kind === 'Global') {
+        for (const manualDependency of manualDependencies) {
+          if (
+            manualDependency.root.kind === 'Global' &&
+            manualDependency.root.identifierName ===
+              inferredDependency.binding.name
+          ) {
+            matched.add(manualDependency);
+            extra.push(manualDependency);
+          }
+        }
+        continue;
+      }
+      CompilerError.simpleInvariant(inferredDependency.kind === 'Local', {
+        reason: 'Unexpected function dependency',
+        loc: value.loc,
+      });
+      let hasMatchingManualDependency = false;
+      for (const manualDependency of manualDependencies) {
+        if (
+          manualDependency.root.kind === 'NamedLocal' &&
+          manualDependency.root.value.identifier.id ===
+            inferredDependency.identifier.id &&
+          (areEqualPaths(manualDependency.path, inferredDependency.path) ||
+            isSubPath(manualDependency.path, inferredDependency.path))
+        ) {
+          hasMatchingManualDependency = true;
+          matched.add(manualDependency);
+        }
+      }
+      if (!hasMatchingManualDependency) {
+        missing.push(inferredDependency);
+      }
+    }
+
+    for (const dep of startMemo.deps ?? []) {
+      if (
+        matched.has(dep) ||
+        (dep.root.kind === 'NamedLocal' &&
+          !reactive.has(dep.root.value.identifier.id))
+      ) {
+        continue;
+      }
+      extra.push(dep);
+    }
+
+    if (missing.length !== 0) {
+      // Error
+      const diagnostic = CompilerDiagnostic.create({
+        category: ErrorCategory.PreserveManualMemo,
+        reason: 'Found non-exhaustive dependencies',
+        description:
+          'Missing dependencies can cause a value not to update when those inputs change, ' +
+          'resulting in stale UI. This memoization cannot be safely rewritten by the compiler.',
+      });
+      for (const dep of missing) {
+        diagnostic.withDetails({
+          kind: 'error',
+          message: `Missing dependency \`${printInferredDependency(dep)}\``,
+          loc: dep.loc,
+        });
+      }
+      error.pushDiagnostic(diagnostic);
+    } else if (extra.length !== 0) {
+      const diagnostic = CompilerDiagnostic.create({
+        category: ErrorCategory.PreserveManualMemo,
+        reason: 'Found unnecessary memoization dependencies',
+        description:
+          'Unnecessary dependencies can cause a value to update more often than necessary, ' +
+          'which can cause effects to run more than expected. This memoization cannot be safely ' +
+          'rewritten by the compiler',
+      });
+      diagnostic.withDetails({
+        kind: 'error',
+        message: `Unnecessary dependencies ${extra.map(dep => `\`${printManualMemoDependency(dep)}\``).join(', ')}`,
+        loc: value.loc,
+      });
+      error.pushDiagnostic(diagnostic);
+    }
+
+    dependencies.clear();
+    locals.clear();
+    startMemo = null;
+  }
+
+  collectDependencies(fn, temporaries, {
+    onStartMemoize,
+    onFinishMemoize,
+  });
+  return error.asResult();
+}
+
+function addDependency(
+  dep: Temporary,
+  dependencies: Set<InferredDependency>,
+  locals: Set<IdentifierId>,
+): void {
+  if (dep.kind === 'Function') {
+    for (const x of dep.dependencies) {
+      addDependency(x, dependencies, locals);
+    }
+  } else if (dep.kind === 'Global') {
+    dependencies.add(dep);
+  } else if (!locals.has(dep.identifier.id)) {
+    dependencies.add(dep);
+  }
+}
+
+function visitCandidateDependency(
+  place: Place,
+  temporaries: Map<IdentifierId, Temporary>,
+  dependencies: Set<InferredDependency>,
+  locals: Set<IdentifierId>,
+): void {
+  const dep = temporaries.get(place.identifier.id);
+  if (dep != null) {
+    addDependency(dep, dependencies, locals);
+  }
+}
+
+/**
+ * This function determines the dependencies of the given function relative to
+ * its external context. Dependencies are collected eagerly, the first time an
+ * external variable is referenced, as opposed to trying to delay or aggregate
+ * calculation of dependencies until they are later "used".
+ *
+ * For example, in
+ *
+ * ```
+ * function f() {
+ *   let x = y; // we record a dependency on `y` here
+ *   ...
+ *   use(x); // as opposed to trying to delay that dependency until here
+ * }
+ * ```
+ *
+ * That said, LoadLocal/LoadContext does not immediately take a dependency,
+ * we store the dependency in a temporary and set it as used when that temporary
+ * is referenced as an operand.
+ *
+ * As we proceed through the function we track local variables that it creates
+ * and don't consider later references to these variables as dependencies.
+ *
+ * For function expressions we first collect the function's dependencies by
+ * calling this function recursively, _without_ taking into account whether
+ * the "external" variables it accesses are actually external or just locals
+ * in the parent. We then prune any locals and immediately consider any
+ * remaining externals that it accesses as a dependency:
+ *
+ * ```
+ * function Component() {
+ *   const local = ...;
+ *   const f = () => { return [external, local] };
+ * }
+ * ```
+ *
+ * Here we calculate `f` as having dependencies `external, `local` and save
+ * this into `temporaries`. We then also immediately take these as dependencies
+ * at the Component scope, at which point we filter out `local` as a local variable,
+ * leaving just a dependency on `external`.
+ *
+ * When calling this function on a top-level component or hook, the collected dependencies
+ * will only contain the globals that it accesses which isn't useful. Instead, passing
+ * onStartMemoize/onFinishMemoize callbacks allows looking at the dependencies within
+ * blocks of manual memoization.
+ */
+function collectDependencies(
+  fn: HIRFunction,
+  temporaries: Map<IdentifierId, Temporary>,
+  callbacks: {
+    onStartMemoize: (
+      startMemo: StartMemoize,
+      dependencies: Set<InferredDependency>,
+      locals: Set<IdentifierId>,
+    ) => void;
+    onFinishMemoize: (
+      finishMemo: FinishMemoize,
+      dependencies: Set<InferredDependency>,
+      locals: Set<IdentifierId>,
+    ) => void;
+  } | null,
+): Extract<Temporary, {kind: 'Function'}> {
+  const optionals = findOptionalPlaces(fn);
+  if (DEBUG) {
+    console.log(prettyFormat(optionals));
+  }
+  const locals: Set<IdentifierId> = new Set();
+  const dependencies: Set<InferredDependency> = new Set();
+  function visit(place: Place): void {
+    visitCandidateDependency(place, temporaries, dependencies, locals);
+  }
+  for (const block of fn.body.blocks.values()) {
+    for (const phi of block.phis) {
+      let deps: Array<Temporary> | null = null;
+      for (const operand of phi.operands.values()) {
+        const dep = temporaries.get(operand.identifier.id);
+        if (dep == null) {
+          continue;
+        }
+        if (deps == null) {
+          deps = [dep];
+        } else {
+          deps.push(dep);
+        }
+      }
+      if (deps == null) {
+        continue;
+      } else if (deps.length === 1) {
+        temporaries.set(phi.place.identifier.id, deps[0]!);
+      } else {
+        temporaries.set(phi.place.identifier.id, {
+          kind: 'Function',
+          dependencies: new Set(deps),
+        });
+      }
+    }
+
+    for (const instr of block.instructions) {
+      const {lvalue, value} = instr;
+      switch (value.kind) {
+        case 'LoadGlobal': {
+          temporaries.set(lvalue.identifier.id, {
+            kind: 'Global',
+            binding: value.binding,
+          });
+          break;
+        }
+        case 'LoadContext':
+        case 'LoadLocal': {
+          if (locals.has(value.place.identifier.id)) {
+            break;
+          }
+          const temp = temporaries.get(value.place.identifier.id);
+          if (temp != null) {
+            if (temp.kind === 'Local') {
+              const local: Temporary = {...temp, loc: value.place.loc};
+              temporaries.set(lvalue.identifier.id, local);
+            } else {
+              temporaries.set(lvalue.identifier.id, temp);
+            }
+          }
+          break;
+        }
+        case 'DeclareLocal': {
+          const local: Temporary = {
+            kind: 'Local',
+            identifier: value.lvalue.place.identifier,
+            path: [],
+            context: false,
+            loc: value.lvalue.place.loc,
+          };
+          temporaries.set(value.lvalue.place.identifier.id, local);
+          locals.add(value.lvalue.place.identifier.id);
+          break;
+        }
+        case 'StoreLocal': {
+          if (value.lvalue.place.identifier.name == null) {
+            const temp = temporaries.get(value.value.identifier.id);
+            if (temp != null) {
+              temporaries.set(value.lvalue.place.identifier.id, temp);
+            }
+            break;
+          }
+          visit(value.value);
+          if (value.lvalue.kind !== InstructionKind.Reassign) {
+            const local: Temporary = {
+              kind: 'Local',
+              identifier: value.lvalue.place.identifier,
+              path: [],
+              context: false,
+              loc: value.lvalue.place.loc,
+            };
+            temporaries.set(value.lvalue.place.identifier.id, local);
+            locals.add(value.lvalue.place.identifier.id);
+          }
+          break;
+        }
+        case 'DeclareContext': {
+          const local: Temporary = {
+            kind: 'Local',
+            identifier: value.lvalue.place.identifier,
+            path: [],
+            context: true,
+            loc: value.lvalue.place.loc,
+          };
+          temporaries.set(value.lvalue.place.identifier.id, local);
+          break;
+        }
+        case 'StoreContext': {
+          visit(value.value);
+          if (value.lvalue.kind !== InstructionKind.Reassign) {
+            const local: Temporary = {
+              kind: 'Local',
+              identifier: value.lvalue.place.identifier,
+              path: [],
+              context: true,
+              loc: value.lvalue.place.loc,
+            };
+            temporaries.set(value.lvalue.place.identifier.id, local);
+            locals.add(value.lvalue.place.identifier.id);
+          }
+          break;
+        }
+        case 'Destructure': {
+          visit(value.value);
+          if (value.lvalue.kind !== InstructionKind.Reassign) {
+            for (const lvalue of eachInstructionValueLValue(value)) {
+              const local: Temporary = {
+                kind: 'Local',
+                identifier: lvalue.identifier,
+                path: [],
+                context: false,
+                loc: lvalue.loc,
+              };
+              temporaries.set(lvalue.identifier.id, local);
+              locals.add(lvalue.identifier.id);
+            }
+          }
+          break;
+        }
+        case 'PropertyLoad': {
+          if (typeof value.property === 'number') {
+            visit(value.object);
+            break;
+          }
+          const object = temporaries.get(value.object.identifier.id);
+          if (object != null && object.kind === 'Local') {
+            const optional = optionals.get(value.object.identifier.id) ?? false;
+            const local: Temporary = {
+              kind: 'Local',
+              identifier: object.identifier,
+              context: object.context,
+              path: [
+                ...object.path,
+                {
+                  optional,
+                  property: value.property,
+                },
+              ],
+              loc: value.loc,
+            };
+            temporaries.set(lvalue.identifier.id, local);
+          }
+          break;
+        }
+        case 'FunctionExpression':
+        case 'ObjectMethod': {
+          const functionDeps = collectDependencies(
+            value.loweredFunc.func,
+            temporaries,
+            null,
+          );
+          temporaries.set(lvalue.identifier.id, functionDeps);
+          addDependency(functionDeps, dependencies, locals);
+          break;
+        }
+        case 'StartMemoize': {
+          const onStartMemoize = callbacks?.onStartMemoize;
+          if (onStartMemoize != null) {
+            onStartMemoize(value, dependencies, locals);
+          }
+          break;
+        }
+        case 'FinishMemoize': {
+          const onFinishMemoize = callbacks?.onFinishMemoize;
+          if (onFinishMemoize != null) {
+            onFinishMemoize(value, dependencies, locals);
+          }
+          break;
+        }
+        case 'MethodCall': {
+          // Ignore the method itself
+          for (const operand of eachInstructionValueOperand(value)) {
+            if (operand.identifier.id === value.property.identifier.id) {
+              continue;
+            }
+            visit(operand);
+          }
+          break;
+        }
+        default: {
+          for (const operand of eachInstructionValueOperand(value)) {
+            visit(operand);
+          }
+          for (const lvalue of eachInstructionLValue(instr)) {
+            locals.add(lvalue.identifier.id);
+          }
+        }
+      }
+    }
+    for (const operand of eachTerminalOperand(block.terminal)) {
+      if (optionals.has(operand.identifier.id)) {
+        continue;
+      }
+      visit(operand);
+    }
+  }
+  return {kind: 'Function', dependencies};
+}
+
+function printInferredDependency(dep: InferredDependency): string {
+  switch (dep.kind) {
+    case 'Global': {
+      return dep.binding.name;
+    }
+    case 'Local': {
+      CompilerError.simpleInvariant(
+        dep.identifier.name != null && dep.identifier.name.kind === 'named',
+        {
+          reason: 'Expected dependencies to be named variables',
+          loc: dep.loc,
+        },
+      );
+      return `${dep.identifier.name.value}${dep.path.map(p => (p.optional ? '?' : '') + '.' + p.property).join('')}`;
+    }
+  }
+}
+
+function printManualMemoDependency(dep: ManualMemoDependency): string {
+  let identifierName: string;
+  if (dep.root.kind === 'Global') {
+    identifierName = dep.root.identifierName;
+  } else {
+    const name = dep.root.value.identifier.name;
+    CompilerError.simpleInvariant(name != null && name.kind === 'named', {
+      reason: 'Expected manual dependencies to be named variables',
+      loc: dep.root.value.loc,
+    });
+    identifierName = name.value;
+  }
+  return `${identifierName}${dep.path.map(p => (p.optional ? '?' : '') + '.' + p.property).join('')}`;
+}
+
+function isEqualTemporary(a: Temporary, b: Temporary): boolean {
+  switch (a.kind) {
+    case 'Function': {
+      return false;
+    }
+    case 'Global': {
+      return b.kind === 'Global' && a.binding.name === b.binding.name;
+    }
+    case 'Local': {
+      return (
+        b.kind === 'Local' &&
+        a.identifier.id === b.identifier.id &&
+        areEqualPaths(a.path, b.path)
+      );
+    }
+  }
+}
+
+type Temporary =
+  | {kind: 'Global'; binding: LoadGlobal['binding']}
+  | {
+      kind: 'Local';
+      identifier: Identifier;
+      path: DependencyPath;
+      context: boolean;
+      loc: SourceLocation;
+    }
+  | {kind: 'Function'; dependencies: Set<Temporary>};
+type InferredDependency = Extract<Temporary, {kind: 'Local' | 'Global'}>;
+
+function collectReactiveIdentifiersHIR(fn: HIRFunction): Set<IdentifierId> {
+  const reactive = new Set<IdentifierId>();
+  for (const block of fn.body.blocks.values()) {
+    for (const instr of block.instructions) {
+      for (const lvalue of eachInstructionLValue(instr)) {
+        if (lvalue.reactive) {
+          reactive.add(lvalue.identifier.id);
+        }
+      }
+      for (const operand of eachInstructionValueOperand(instr.value)) {
+        if (operand.reactive) {
+          reactive.add(operand.identifier.id);
+        }
+      }
+    }
+    for (const operand of eachTerminalOperand(block.terminal)) {
+      if (operand.reactive) {
+        reactive.add(operand.identifier.id);
+      }
+    }
+  }
+  return reactive;
+}
+
+export function findOptionalPlaces(
+  fn: HIRFunction,
+): Map<IdentifierId, boolean> {
+  const optionals = new Map<IdentifierId, boolean>();
+  const visited: Set<BlockId> = new Set();
+  for (const [, block] of fn.body.blocks) {
+    if (visited.has(block.id)) {
+      continue;
+    }
+    if (block.terminal.kind === 'optional') {
+      visited.add(block.id);
+      const optionalTerminal = block.terminal;
+      let testBlock = fn.body.blocks.get(block.terminal.test)!;
+      const queue: Array<boolean | null> = [block.terminal.optional];
+      loop: while (true) {
+        visited.add(testBlock.id);
+        const terminal = testBlock.terminal;
+        switch (terminal.kind) {
+          case 'branch': {
+            const isOptional = queue.pop();
+            CompilerError.simpleInvariant(isOptional !== undefined, {
+              reason:
+                'Expected an optional value for each optional test condition',
+              loc: terminal.test.loc,
+            });
+            if (isOptional != null) {
+              optionals.set(terminal.test.identifier.id, isOptional);
+            }
+            if (terminal.fallthrough === optionalTerminal.fallthrough) {
+              // found it
+              const consequent = fn.body.blocks.get(terminal.consequent)!;
+              const last = consequent.instructions.at(-1);
+              if (last !== undefined && last.value.kind === 'StoreLocal') {
+                if (isOptional != null) {
+                  optionals.set(last.value.value.identifier.id, isOptional);
+                }
+              }
+              break loop;
+            } else {
+              testBlock = fn.body.blocks.get(terminal.fallthrough)!;
+            }
+            break;
+          }
+          case 'optional': {
+            queue.push(terminal.optional);
+            testBlock = fn.body.blocks.get(terminal.test)!;
+            break;
+          }
+          case 'logical':
+          case 'ternary': {
+            queue.push(null);
+            testBlock = fn.body.blocks.get(terminal.test)!;
+            break;
+          }
+
+          case 'sequence': {
+            // Do we need sequence?? In any case, don't push to queue bc there is no corresponding branch terminal
+            testBlock = fn.body.blocks.get(terminal.block)!;
+            break;
+          }
+          default: {
+            CompilerError.simpleInvariant(false, {
+              reason: `Unexpected terminal in optional`,
+              loc: terminal.loc,
+            });
+          }
+        }
+      }
+      CompilerError.simpleInvariant(queue.length === 0, {
+        reason:
+          'Expected a matching number of conditional blocks and branch points',
+        loc: block.terminal.loc,
+      });
+    }
+  }
+  return optionals;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateExhaustiveDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateExhaustiveDependencies.ts
@@ -22,7 +22,9 @@ import {
   Identifier,
   IdentifierId,
   InstructionKind,
+  isStableType,
   isSubPath,
+  isUseRefType,
   LoadGlobal,
   ManualMemoDependency,
   Place,
@@ -46,9 +48,10 @@ const DEBUG = false;
  * or less times.
  *
  * TODOs:
- * - Better handling of cases where we infer multiple dependencies related to a single
- *   variable. Eg if the user has dep `x` and we inferred `x.y, x.z`, the user's dep
- *   is sufficient.
+ * - Handle cases of mixed optional and non-optional versions of the same path,
+ *   eg referecing both x.y.z and x.y?.z in the same memo block. we should collapse
+ *   this into a single canonical dep that we look for in the manual deps. see the
+ *   existing exhaustive deps rule for implementation.
  * - Handle cases where the user deps were not simple identifiers + property chains.
  *   We try to detect this in ValidateUseMemo but we miss some cases. The problem
  *   is that invalid forms can be value blocks or function calls that don't get
@@ -108,7 +111,7 @@ export function validateExhaustiveDependencies(
     );
     visitCandidateDependency(value.decl, temporaries, dependencies, locals);
     const inferred: Array<InferredDependency> = Array.from(dependencies);
-    // Sort dependencies by name, and path, with shorter/non-optional paths first
+    // Sort dependencies by name and path, with shorter/non-optional paths first
     inferred.sort((a, b) => {
       if (a.kind === 'Global' && b.kind == 'Global') {
         return a.binding.name.localeCompare(b.binding.name);
@@ -205,6 +208,31 @@ export function validateExhaustiveDependencies(
         reason: 'Unexpected function dependency',
         loc: value.loc,
       });
+      /**
+       * Dependencies technically only need to include reactive values. However,
+       * reactivity inference for general values is subtle since it involves all
+       * of our complex control and data flow analysis. To keep results more
+       * stable and predictable to developers, we intentionally stay closer to
+       * the rules of the classic exhaustive-deps rule. Values should be included
+       * as dependencies if either of the following is true:
+       * - They're reactive
+       * - They're non-reactive and not a known-stable value type.
+       *
+       * Thus `const ref: Ref = cond ? ref1 : ref2` has to be a dependency
+       * (assuming `cond` is reactive) since it's reactive despite being a ref.
+       *
+       * Similarly, `const x = [1,2,3]` has to be a dependency since even
+       * though it's non reactive, it's not a known stable type.
+       *
+       * TODO: consider reimplementing a simpler form of reactivity inference.
+       * Ideally we'd consider `const ref: Ref = cond ? ref1 : ref2` as a required
+       * dependency even if our data/control flow tells us that `cond` is non-reactive.
+       * It's simpler for developers to reason about based on a more structural/AST
+       * driven approach.
+       */
+      const isRequiredDependency =
+        reactive.has(inferredDependency.identifier.id) ||
+        !isStableType(inferredDependency.identifier);
       let hasMatchingManualDependency = false;
       for (const manualDependency of manualDependencies) {
         if (
@@ -216,19 +244,18 @@ export function validateExhaustiveDependencies(
         ) {
           hasMatchingManualDependency = true;
           matched.add(manualDependency);
+          if (!isRequiredDependency) {
+            extra.push(manualDependency);
+          }
         }
       }
-      if (!hasMatchingManualDependency) {
+      if (isRequiredDependency && !hasMatchingManualDependency) {
         missing.push(inferredDependency);
       }
     }
 
     for (const dep of startMemo.deps ?? []) {
-      if (
-        matched.has(dep) ||
-        (dep.root.kind === 'NamedLocal' &&
-          !reactive.has(dep.root.value.identifier.id))
-      ) {
+      if (matched.has(dep)) {
         continue;
       }
       extra.push(dep);
@@ -247,19 +274,23 @@ export function validateExhaustiveDependencies(
         ];
       }
       if (missing.length !== 0) {
-        // Error
         const diagnostic = CompilerDiagnostic.create({
           category: ErrorCategory.PreserveManualMemo,
           reason: 'Found non-exhaustive dependencies',
           description:
             'Missing dependencies can cause a value not to update when those inputs change, ' +
-            'resulting in stale UI. This memoization cannot be safely rewritten by the compiler.',
+            'resulting in stale UI',
           suggestions,
         });
         for (const dep of missing) {
+          let reactiveStableValueHint = '';
+          if (isStableType(dep.identifier)) {
+            reactiveStableValueHint =
+              '. Refs, setState functions, and other "stable" values generally do not need to be added as dependencies, but this variable may change over time to point to different values';
+          }
           diagnostic.withDetails({
             kind: 'error',
-            message: `Missing dependency \`${printInferredDependency(dep)}\``,
+            message: `Missing dependency \`${printInferredDependency(dep)}\`${reactiveStableValueHint}`,
             loc: dep.loc,
           });
         }
@@ -270,13 +301,12 @@ export function validateExhaustiveDependencies(
           reason: 'Found unnecessary memoization dependencies',
           description:
             'Unnecessary dependencies can cause a value to update more often than necessary, ' +
-            'which can cause effects to run more than expected. This memoization cannot be safely ' +
-            'rewritten by the compiler',
+            'which can cause effects to run more than expected',
         });
         diagnostic.withDetails({
           kind: 'error',
           message: `Unnecessary dependencies ${extra.map(dep => `\`${printManualMemoDependency(dep)}\``).join(', ')}`,
-          loc: value.loc,
+          loc: startMemo.depsLoc ?? value.loc,
         });
         error.pushDiagnostic(diagnostic);
       }
@@ -287,10 +317,15 @@ export function validateExhaustiveDependencies(
     startMemo = null;
   }
 
-  collectDependencies(fn, temporaries, {
-    onStartMemoize,
-    onFinishMemoize,
-  });
+  collectDependencies(
+    fn,
+    temporaries,
+    {
+      onStartMemoize,
+      onFinishMemoize,
+    },
+    false, // isFunctionExpression
+  );
   return error.asResult();
 }
 
@@ -383,12 +418,20 @@ function collectDependencies(
       locals: Set<IdentifierId>,
     ) => void;
   } | null,
+  isFunctionExpression: boolean,
 ): Extract<Temporary, {kind: 'Function'}> {
   const optionals = findOptionalPlaces(fn);
   if (DEBUG) {
     console.log(prettyFormat(optionals));
   }
   const locals: Set<IdentifierId> = new Set();
+  if (isFunctionExpression) {
+    for (const param of fn.params) {
+      const place = param.kind === 'Identifier' ? param : param.place;
+      locals.add(place.identifier.id);
+    }
+  }
+
   const dependencies: Set<InferredDependency> = new Set();
   function visit(place: Place): void {
     visitCandidateDependency(place, temporaries, dependencies, locals);
@@ -523,7 +566,11 @@ function collectDependencies(
           break;
         }
         case 'PropertyLoad': {
-          if (typeof value.property === 'number') {
+          if (
+            typeof value.property === 'number' ||
+            (isUseRefType(value.object.identifier) &&
+              value.property === 'current')
+          ) {
             visit(value.object);
             break;
           }
@@ -553,6 +600,7 @@ function collectDependencies(
             value.loweredFunc.func,
             temporaries,
             null,
+            true, // isFunctionExpression
           );
           temporaries.set(lvalue.identifier.id, functionDeps);
           addDependency(functionDeps, dependencies, locals);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-exhaustive-deps.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-exhaustive-deps.expect.md
@@ -26,8 +26,16 @@ function Component({x, y, z}) {
   }, [x]);
   const f = useMemo(() => {
     return [];
-  }, [x, y.z, z?.y?.a]);
-  return <Stringify results={[a, b, c, d, e, f]} />;
+  }, [x, y.z, z?.y?.a, UNUSED_GLOBAL]);
+  const ref1 = useRef(null);
+  const ref2 = useRef(null);
+  const ref = z ? ref1 : ref2;
+  const cb = useMemo(() => {
+    return () => {
+      return ref.current;
+    };
+  }, []);
+  return <Stringify results={[a, b, c, d, e, f, cb]} />;
 }
 
 ```
@@ -36,11 +44,11 @@ function Component({x, y, z}) {
 ## Error
 
 ```
-Found 4 errors:
+Found 5 errors:
 
 Compilation Skipped: Found non-exhaustive dependencies
 
-Missing dependencies can cause a value not to update when those inputs change, resulting in stale UI. This memoization cannot be safely rewritten by the compiler..
+Missing dependencies can cause a value not to update when those inputs change, resulting in stale UI.
 
 error.invalid-exhaustive-deps.ts:7:11
    5 | function Component({x, y, z}) {
@@ -53,7 +61,7 @@ error.invalid-exhaustive-deps.ts:7:11
 
 Compilation Skipped: Found non-exhaustive dependencies
 
-Missing dependencies can cause a value not to update when those inputs change, resulting in stale UI. This memoization cannot be safely rewritten by the compiler..
+Missing dependencies can cause a value not to update when those inputs change, resulting in stale UI.
 
 error.invalid-exhaustive-deps.ts:10:11
    8 |   }, [x?.y.z?.a.b]);
@@ -66,7 +74,7 @@ error.invalid-exhaustive-deps.ts:10:11
 
 Compilation Skipped: Found non-exhaustive dependencies
 
-Missing dependencies can cause a value not to update when those inputs change, resulting in stale UI. This memoization cannot be safely rewritten by the compiler..
+Missing dependencies can cause a value not to update when those inputs change, resulting in stale UI.
 
 error.invalid-exhaustive-deps.ts:13:11
   11 |   }, [x.y.z.a]);
@@ -79,20 +87,29 @@ error.invalid-exhaustive-deps.ts:13:11
 
 Compilation Skipped: Found unnecessary memoization dependencies
 
-Unnecessary dependencies can cause a value to update more often than necessary, which can cause effects to run more than expected. This memoization cannot be safely rewritten by the compiler.
+Unnecessary dependencies can cause a value to update more often than necessary, which can cause effects to run more than expected.
 
-error.invalid-exhaustive-deps.ts:23:20
-  21 |     return e;
-  22 |   }, [x]);
-> 23 |   const f = useMemo(() => {
-     |                     ^^^^^^^
-> 24 |     return [];
-     | ^^^^^^^^^^^^^^
-> 25 |   }, [x, y.z, z?.y?.a]);
-     | ^^^^ Unnecessary dependencies `x`, `y.z`, `z?.y?.a`
-  26 |   return <Stringify results={[a, b, c, d, e, f]} />;
-  27 | }
-  28 |
+error.invalid-exhaustive-deps.ts:25:5
+  23 |   const f = useMemo(() => {
+  24 |     return [];
+> 25 |   }, [x, y.z, z?.y?.a, UNUSED_GLOBAL]);
+     |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary dependencies `x`, `y.z`, `z?.y?.a`, `UNUSED_GLOBAL`
+  26 |   const ref1 = useRef(null);
+  27 |   const ref2 = useRef(null);
+  28 |   const ref = z ? ref1 : ref2;
+
+Compilation Skipped: Found non-exhaustive dependencies
+
+Missing dependencies can cause a value not to update when those inputs change, resulting in stale UI.
+
+error.invalid-exhaustive-deps.ts:31:13
+  29 |   const cb = useMemo(() => {
+  30 |     return () => {
+> 31 |       return ref.current;
+     |              ^^^ Missing dependency `ref`. Refs, setState functions, and other "stable" values generally do not need to be added as dependencies, but this variable may change over time to point to different values
+  32 |     };
+  33 |   }, []);
+  34 |   return <Stringify results={[a, b, c, d, e, f, cb]} />;
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-exhaustive-deps.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-exhaustive-deps.expect.md
@@ -1,0 +1,98 @@
+
+## Input
+
+```javascript
+// @validateExhaustiveMemoizationDependencies
+import {useMemo} from 'react';
+import {Stringify} from 'shared-runtime';
+
+function Component({x, y, z}) {
+  const a = useMemo(() => {
+    return x?.y.z?.a;
+  }, [x?.y.z?.a.b]);
+  const b = useMemo(() => {
+    return x.y.z?.a;
+  }, [x.y.z.a]);
+  const c = useMemo(() => {
+    return x?.y.z.a?.b;
+  }, [x?.y.z.a?.b.z]);
+  const d = useMemo(() => {
+    return x?.y?.[(console.log(y), z?.b)];
+  }, [x?.y, y, z?.b]);
+  const e = useMemo(() => {
+    const e = [];
+    e.push(x);
+    return e;
+  }, [x]);
+  const f = useMemo(() => {
+    return [];
+  }, [x, y.z, z?.y?.a]);
+  return <Stringify results={[a, b, c, d, e, f]} />;
+}
+
+```
+
+
+## Error
+
+```
+Found 4 errors:
+
+Compilation Skipped: Found non-exhaustive dependencies
+
+Missing dependencies can cause a value not to update when those inputs change, resulting in stale UI. This memoization cannot be safely rewritten by the compiler..
+
+error.invalid-exhaustive-deps.ts:7:11
+   5 | function Component({x, y, z}) {
+   6 |   const a = useMemo(() => {
+>  7 |     return x?.y.z?.a;
+     |            ^^^^^^^^^ Missing dependency `x?.y.z?.a`
+   8 |   }, [x?.y.z?.a.b]);
+   9 |   const b = useMemo(() => {
+  10 |     return x.y.z?.a;
+
+Compilation Skipped: Found non-exhaustive dependencies
+
+Missing dependencies can cause a value not to update when those inputs change, resulting in stale UI. This memoization cannot be safely rewritten by the compiler..
+
+error.invalid-exhaustive-deps.ts:10:11
+   8 |   }, [x?.y.z?.a.b]);
+   9 |   const b = useMemo(() => {
+> 10 |     return x.y.z?.a;
+     |            ^^^^^^^^ Missing dependency `x.y.z?.a`
+  11 |   }, [x.y.z.a]);
+  12 |   const c = useMemo(() => {
+  13 |     return x?.y.z.a?.b;
+
+Compilation Skipped: Found non-exhaustive dependencies
+
+Missing dependencies can cause a value not to update when those inputs change, resulting in stale UI. This memoization cannot be safely rewritten by the compiler..
+
+error.invalid-exhaustive-deps.ts:13:11
+  11 |   }, [x.y.z.a]);
+  12 |   const c = useMemo(() => {
+> 13 |     return x?.y.z.a?.b;
+     |            ^^^^^^^^^^^ Missing dependency `x?.y.z.a?.b`
+  14 |   }, [x?.y.z.a?.b.z]);
+  15 |   const d = useMemo(() => {
+  16 |     return x?.y?.[(console.log(y), z?.b)];
+
+Compilation Skipped: Found unnecessary memoization dependencies
+
+Unnecessary dependencies can cause a value to update more often than necessary, which can cause effects to run more than expected. This memoization cannot be safely rewritten by the compiler.
+
+error.invalid-exhaustive-deps.ts:23:20
+  21 |     return e;
+  22 |   }, [x]);
+> 23 |   const f = useMemo(() => {
+     |                     ^^^^^^^
+> 24 |     return [];
+     | ^^^^^^^^^^^^^^
+> 25 |   }, [x, y.z, z?.y?.a]);
+     | ^^^^ Unnecessary dependencies `x`, `y.z`, `z?.y?.a`
+  26 |   return <Stringify results={[a, b, c, d, e, f]} />;
+  27 | }
+  28 |
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-exhaustive-deps.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-exhaustive-deps.js
@@ -1,0 +1,27 @@
+// @validateExhaustiveMemoizationDependencies
+import {useMemo} from 'react';
+import {Stringify} from 'shared-runtime';
+
+function Component({x, y, z}) {
+  const a = useMemo(() => {
+    return x?.y.z?.a;
+  }, [x?.y.z?.a.b]);
+  const b = useMemo(() => {
+    return x.y.z?.a;
+  }, [x.y.z.a]);
+  const c = useMemo(() => {
+    return x?.y.z.a?.b;
+  }, [x?.y.z.a?.b.z]);
+  const d = useMemo(() => {
+    return x?.y?.[(console.log(y), z?.b)];
+  }, [x?.y, y, z?.b]);
+  const e = useMemo(() => {
+    const e = [];
+    e.push(x);
+    return e;
+  }, [x]);
+  const f = useMemo(() => {
+    return [];
+  }, [x, y.z, z?.y?.a]);
+  return <Stringify results={[a, b, c, d, e, f]} />;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-exhaustive-deps.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-exhaustive-deps.js
@@ -22,6 +22,14 @@ function Component({x, y, z}) {
   }, [x]);
   const f = useMemo(() => {
     return [];
-  }, [x, y.z, z?.y?.a]);
-  return <Stringify results={[a, b, c, d, e, f]} />;
+  }, [x, y.z, z?.y?.a, UNUSED_GLOBAL]);
+  const ref1 = useRef(null);
+  const ref2 = useRef(null);
+  const ref = z ? ref1 : ref2;
+  const cb = useMemo(() => {
+    return () => {
+      return ref.current;
+    };
+  }, []);
+  return <Stringify results={[a, b, c, d, e, f, cb]} />;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/exhaustive-deps.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/exhaustive-deps.expect.md
@@ -1,0 +1,151 @@
+
+## Input
+
+```javascript
+// @validateExhaustiveMemoizationDependencies
+import {useMemo} from 'react';
+import {makeObject_Primitives, Stringify} from 'shared-runtime';
+
+function Component({x, y, z}) {
+  const a = useMemo(() => {
+    return x?.y.z?.a;
+  }, [x?.y.z?.a]);
+  const b = useMemo(() => {
+    return x.y.z?.a;
+  }, [x.y.z?.a]);
+  const c = useMemo(() => {
+    return x?.y.z.a?.b;
+  }, [x?.y.z.a?.b]);
+  const d = useMemo(() => {
+    return x?.y?.[(console.log(y), z?.b)];
+  }, [x?.y, y, z?.b]);
+  const e = useMemo(() => {
+    const e = [];
+    const local = makeObject_Primitives(x);
+    const fn = () => {
+      e.push(local);
+    };
+    fn();
+    return e;
+  }, [x]);
+  const f = useMemo(() => {
+    const f = [];
+    f.push(x.y.z);
+    f.push(x.y);
+    f.push(x);
+    return f;
+  }, [x]);
+  return <Stringify results={[a, b, c, d, e, f]} />;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateExhaustiveMemoizationDependencies
+import { useMemo } from "react";
+import { makeObject_Primitives, Stringify } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(21);
+  const { x, y, z } = t0;
+
+  x?.y.z?.a;
+  const a = x?.y.z?.a;
+  let t1;
+  if ($[0] !== x.y.z.a) {
+    t1 = () => x.y.z?.a;
+    $[0] = x.y.z.a;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  x.y.z?.a;
+  let t2;
+  if ($[2] !== t1) {
+    t2 = t1();
+    $[2] = t1;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  const b = t2;
+
+  x?.y.z.a?.b;
+  const c = x?.y.z.a?.b;
+  let t3;
+  if ($[4] !== x.y || $[5] !== y || $[6] !== z?.b) {
+    t3 = () => x?.y?.[(console.log(y), z?.b)];
+    $[4] = x.y;
+    $[5] = y;
+    $[6] = z?.b;
+    $[7] = t3;
+  } else {
+    t3 = $[7];
+  }
+  x?.y;
+  z?.b;
+  let t4;
+  if ($[8] !== t3) {
+    t4 = t3();
+    $[8] = t3;
+    $[9] = t4;
+  } else {
+    t4 = $[9];
+  }
+  const d = t4;
+  let e;
+  if ($[10] !== x) {
+    e = [];
+    const local = makeObject_Primitives(x);
+    const fn = () => {
+      e.push(local);
+    };
+
+    fn();
+    $[10] = x;
+    $[11] = e;
+  } else {
+    e = $[11];
+  }
+  const e_0 = e;
+  let f;
+  if ($[12] !== x) {
+    f = [];
+    f.push(x.y.z);
+    f.push(x.y);
+    f.push(x);
+    $[12] = x;
+    $[13] = f;
+  } else {
+    f = $[13];
+  }
+  const f_0 = f;
+  let t5;
+  if (
+    $[14] !== a ||
+    $[15] !== b ||
+    $[16] !== c ||
+    $[17] !== d ||
+    $[18] !== e_0 ||
+    $[19] !== f_0
+  ) {
+    t5 = <Stringify results={[a, b, c, d, e_0, f_0]} />;
+    $[14] = a;
+    $[15] = b;
+    $[16] = c;
+    $[17] = d;
+    $[18] = e_0;
+    $[19] = f_0;
+    $[20] = t5;
+  } else {
+    t5 = $[20];
+  }
+  return t5;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/exhaustive-deps.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/exhaustive-deps.js
@@ -1,0 +1,35 @@
+// @validateExhaustiveMemoizationDependencies
+import {useMemo} from 'react';
+import {makeObject_Primitives, Stringify} from 'shared-runtime';
+
+function Component({x, y, z}) {
+  const a = useMemo(() => {
+    return x?.y.z?.a;
+  }, [x?.y.z?.a]);
+  const b = useMemo(() => {
+    return x.y.z?.a;
+  }, [x.y.z?.a]);
+  const c = useMemo(() => {
+    return x?.y.z.a?.b;
+  }, [x?.y.z.a?.b]);
+  const d = useMemo(() => {
+    return x?.y?.[(console.log(y), z?.b)];
+  }, [x?.y, y, z?.b]);
+  const e = useMemo(() => {
+    const e = [];
+    const local = makeObject_Primitives(x);
+    const fn = () => {
+      e.push(local);
+    };
+    fn();
+    return e;
+  }, [x]);
+  const f = useMemo(() => {
+    const f = [];
+    f.push(x.y.z);
+    f.push(x.y);
+    f.push(x);
+    return f;
+  }, [x]);
+  return <Stringify results={[a, b, c, d, e, f]} />;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-deps-conditional-property-chain-less-precise-deps.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-deps-conditional-property-chain-less-precise-deps.expect.md
@@ -1,0 +1,122 @@
+
+## Input
+
+```javascript
+// @enablePreserveExistingMemoizationGuarantees @validatePreserveExistingMemoizationGuarantees @enableOptionalDependencies @enableTreatFunctionDepsAsConditional:false
+
+import {useMemo} from 'react';
+import {identity, ValidateMemoization} from 'shared-runtime';
+
+function Component({x}) {
+  const object = useMemo(() => {
+    return identity({
+      callback: () => {
+        return identity(x.y.z); // accesses more levels of properties than the manual memo
+      },
+    });
+    // x.y as a manual dep only tells us that x is non-nullable, not that x.y is non-nullable
+    // we can only take a dep on x.y, not x.y.z
+  }, [x.y]);
+  const result = useMemo(() => {
+    return [object.callback()];
+  }, [object]);
+  return <ValidateMemoization inputs={[x.y]} output={result} />;
+}
+
+const input1 = {x: {y: {z: 42}}};
+const input1b = {x: {y: {z: 42}}};
+const input2 = {x: {y: {z: 3.14}}};
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [input1],
+  sequentialRenders: [
+    input1,
+    input1,
+    input1b, // should reset even though .z didn't change
+    input1,
+    input2,
+  ],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingMemoizationGuarantees @validatePreserveExistingMemoizationGuarantees @enableOptionalDependencies @enableTreatFunctionDepsAsConditional:false
+
+import { useMemo } from "react";
+import { identity, ValidateMemoization } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(11);
+  const { x } = t0;
+  let t1;
+  if ($[0] !== x.y) {
+    t1 = identity({ callback: () => identity(x.y.z) });
+    $[0] = x.y;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const object = t1;
+  let t2;
+  if ($[2] !== object) {
+    t2 = object.callback();
+    $[2] = object;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  let t3;
+  if ($[4] !== t2) {
+    t3 = [t2];
+    $[4] = t2;
+    $[5] = t3;
+  } else {
+    t3 = $[5];
+  }
+  const result = t3;
+  let t4;
+  if ($[6] !== x.y) {
+    t4 = [x.y];
+    $[6] = x.y;
+    $[7] = t4;
+  } else {
+    t4 = $[7];
+  }
+  let t5;
+  if ($[8] !== result || $[9] !== t4) {
+    t5 = <ValidateMemoization inputs={t4} output={result} />;
+    $[8] = result;
+    $[9] = t4;
+    $[10] = t5;
+  } else {
+    t5 = $[10];
+  }
+  return t5;
+}
+
+const input1 = { x: { y: { z: 42 } } };
+const input1b = { x: { y: { z: 42 } } };
+const input2 = { x: { y: { z: 3.14 } } };
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [input1],
+  sequentialRenders: [
+    input1,
+    input1,
+    input1b, // should reset even though .z didn't change
+    input1,
+    input2,
+  ],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"inputs":[{"z":42}],"output":[42]}</div>
+<div>{"inputs":[{"z":42}],"output":[42]}</div>
+<div>{"inputs":[{"z":42}],"output":[42]}</div>
+<div>{"inputs":[{"z":42}],"output":[42]}</div>
+<div>{"inputs":[{"z":3.14}],"output":[3.14]}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-deps-conditional-property-chain-less-precise-deps.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-deps-conditional-property-chain-less-precise-deps.js
@@ -1,0 +1,35 @@
+// @enablePreserveExistingMemoizationGuarantees @validatePreserveExistingMemoizationGuarantees @enableOptionalDependencies @enableTreatFunctionDepsAsConditional:false
+
+import {useMemo} from 'react';
+import {identity, ValidateMemoization} from 'shared-runtime';
+
+function Component({x}) {
+  const object = useMemo(() => {
+    return identity({
+      callback: () => {
+        return identity(x.y.z); // accesses more levels of properties than the manual memo
+      },
+    });
+    // x.y as a manual dep only tells us that x is non-nullable, not that x.y is non-nullable
+    // we can only take a dep on x.y, not x.y.z
+  }, [x.y]);
+  const result = useMemo(() => {
+    return [object.callback()];
+  }, [object]);
+  return <ValidateMemoization inputs={[x.y]} output={result} />;
+}
+
+const input1 = {x: {y: {z: 42}}};
+const input1b = {x: {y: {z: 42}}};
+const input2 = {x: {y: {z: 3.14}}};
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [input1],
+  sequentialRenders: [
+    input1,
+    input1,
+    input1b, // should reset even though .z didn't change
+    input1,
+    input2,
+  ],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-deps-conditional-property-chain.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-deps-conditional-property-chain.expect.md
@@ -1,0 +1,117 @@
+
+## Input
+
+```javascript
+// @enablePreserveExistingMemoizationGuarantees @validatePreserveExistingMemoizationGuarantees @enableOptionalDependencies @enableTreatFunctionDepsAsConditional:false
+
+import {useMemo} from 'react';
+import {identity, ValidateMemoization} from 'shared-runtime';
+
+function Component({x}) {
+  const object = useMemo(() => {
+    return identity({
+      callback: () => {
+        return identity(x.y.z);
+      },
+    });
+  }, [x.y.z]);
+  const result = useMemo(() => {
+    return [object.callback()];
+  }, [object]);
+  return <ValidateMemoization inputs={[x.y.z]} output={result} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{x: {y: {z: 42}}}],
+  sequentialRenders: [
+    {x: {y: {z: 42}}},
+    {x: {y: {z: 42}}},
+    {x: {y: {z: 3.14}}},
+    {x: {y: {z: 42}}},
+    {x: {y: {z: 3.14}}},
+    {x: {y: {z: 42}}},
+  ],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingMemoizationGuarantees @validatePreserveExistingMemoizationGuarantees @enableOptionalDependencies @enableTreatFunctionDepsAsConditional:false
+
+import { useMemo } from "react";
+import { identity, ValidateMemoization } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(11);
+  const { x } = t0;
+  let t1;
+  if ($[0] !== x.y.z) {
+    t1 = identity({ callback: () => identity(x.y.z) });
+    $[0] = x.y.z;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const object = t1;
+  let t2;
+  if ($[2] !== object) {
+    t2 = object.callback();
+    $[2] = object;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  let t3;
+  if ($[4] !== t2) {
+    t3 = [t2];
+    $[4] = t2;
+    $[5] = t3;
+  } else {
+    t3 = $[5];
+  }
+  const result = t3;
+  let t4;
+  if ($[6] !== x.y.z) {
+    t4 = [x.y.z];
+    $[6] = x.y.z;
+    $[7] = t4;
+  } else {
+    t4 = $[7];
+  }
+  let t5;
+  if ($[8] !== result || $[9] !== t4) {
+    t5 = <ValidateMemoization inputs={t4} output={result} />;
+    $[8] = result;
+    $[9] = t4;
+    $[10] = t5;
+  } else {
+    t5 = $[10];
+  }
+  return t5;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ x: { y: { z: 42 } } }],
+  sequentialRenders: [
+    { x: { y: { z: 42 } } },
+    { x: { y: { z: 42 } } },
+    { x: { y: { z: 3.14 } } },
+    { x: { y: { z: 42 } } },
+    { x: { y: { z: 3.14 } } },
+    { x: { y: { z: 42 } } },
+  ],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"inputs":[42],"output":[42]}</div>
+<div>{"inputs":[42],"output":[42]}</div>
+<div>{"inputs":[3.14],"output":[3.14]}</div>
+<div>{"inputs":[42],"output":[42]}</div>
+<div>{"inputs":[3.14],"output":[3.14]}</div>
+<div>{"inputs":[42],"output":[42]}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-deps-conditional-property-chain.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-deps-conditional-property-chain.js
@@ -1,0 +1,31 @@
+// @enablePreserveExistingMemoizationGuarantees @validatePreserveExistingMemoizationGuarantees @enableOptionalDependencies @enableTreatFunctionDepsAsConditional:false
+
+import {useMemo} from 'react';
+import {identity, ValidateMemoization} from 'shared-runtime';
+
+function Component({x}) {
+  const object = useMemo(() => {
+    return identity({
+      callback: () => {
+        return identity(x.y.z);
+      },
+    });
+  }, [x.y.z]);
+  const result = useMemo(() => {
+    return [object.callback()];
+  }, [object]);
+  return <ValidateMemoization inputs={[x.y.z]} output={result} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{x: {y: {z: 42}}}],
+  sequentialRenders: [
+    {x: {y: {z: 42}}},
+    {x: {y: {z: 42}}},
+    {x: {y: {z: 3.14}}},
+    {x: {y: {z: 42}}},
+    {x: {y: {z: 3.14}}},
+    {x: {y: {z: 42}}},
+  ],
+};


### PR DESCRIPTION

The `@enablePreserveExistingMemoizationGuarantees` mode can still fail to preserve manual memoization due to mismtached dependencies. Specifically, where the user's dependencies are more precise than the compiler infers bc the compiler is being conservative about what might be nullable. In this mode though we're intentionally using information from the manual memoization and can also rely on the deps as a signal for what's non-nullable.

The idea of the PR — which I need to test with optional chains still — is that we treat manual memo deps just like other inferred-as-non-nullable objects during PropagateScopeDeps. We're careful to not treat the full path as non-nullable, only up to the last property index. So `x.y.z` as a manual dep treats `x.y` as non-nullable, allowing us to preserve a conditional dependency on `x.y.z`.

I still need to handle optionals and think about what should happen for manual deps like `x?.y?.z`.
