### PR TITLE
[DevTools] Minify backend

### DIFF
--- a/packages/react-devtools-extensions/webpack.backend.js
+++ b/packages/react-devtools-extensions/webpack.backend.js
@@ -2,6 +2,7 @@
 
 const {resolve, isAbsolute, relative} = require('path');
 const Webpack = require('webpack');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const {resolveFeatureFlags} = require('react-devtools-shared/buildUtils');
 const SourceMapIgnoreListPlugin = require('react-devtools-shared/SourceMapIgnoreListPlugin');
@@ -56,16 +57,32 @@ module.exports = {
     },
   },
   optimization: {
-    minimize: false,
+    minimize: !__DEV__,
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          compress: {
+            unused: true,
+            dead_code: true,
+          },
+          mangle: {
+            keep_fnames: true,
+          },
+          format: {
+            comments: false,
+          },
+        },
+        extractComments: false,
+      }),
+    ],
   },
   plugins: [
     new Webpack.ProvidePlugin({
       process: 'process/browser',
     }),
     new Webpack.DefinePlugin({
-      __DEV__: true,
+      __DEV__,
       __PROFILE__: false,
-      __DEV____DEV__: true,
       // By importing `shared/` we may import ReactFeatureFlags
       __EXPERIMENTAL__: true,
       'process.env.DEVTOOLS_PACKAGE': `"react-devtools-extensions"`,


### PR DESCRIPTION
When we disabled minification for the backend in https://github.com/facebook/react/pull/19369, we didn't have sourcemaps. As of https://github.com/facebook/react/issues/28730 we do so we can minify it again.

Minification isn't just about reducing parsed size but also about reducing runtime overhead via various compiler optimizations. We only use Terser at the moment but should use Closure in the future.