### PR TITLE
[DevTools] Don't inline workers for extensions

### DIFF
--- a/.github/workflows/devtools_regression_tests.yml
+++ b/.github/workflows/devtools_regression_tests.yml
@@ -201,5 +201,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: screenshots
-          path: ./tmp/screenshots
+          path: ./tmp/playwright-artifacts
           if-no-files-found: warn

--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -831,6 +831,12 @@ jobs:
       - run: ./scripts/ci/run_devtools_e2e_tests.js
         env:
           RELEASE_CHANNEL: experimental
+      - name: Archive Playwright report
+        uses: actions/upload-artifact@v4
+        with:
+          name: devtools-playwright-artifacts
+          path: tmp/playwright-artifacts
+          if-no-files-found: warn
 
   # ----- SIZEBOT -----
   sizebot:

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ chrome-user-data
 .vscode
 *.swp
 *.swo
+/tmp
 
 packages/react-devtools-core/dist
 packages/react-devtools-extensions/chrome/build

--- a/packages/react-devtools-core/webpack.standalone.js
+++ b/packages/react-devtools-core/webpack.standalone.js
@@ -108,7 +108,8 @@ module.exports = {
           {
             loader: 'workerize-loader',
             options: {
-              inline: false,
+              // Workers would have to be exposed on a public path in order to outline them.
+              inline: true,
               name: '[name]',
             },
           },

--- a/packages/react-devtools-core/webpack.standalone.js
+++ b/packages/react-devtools-core/webpack.standalone.js
@@ -108,7 +108,7 @@ module.exports = {
           {
             loader: 'workerize-loader',
             options: {
-              inline: true,
+              inline: false,
               name: '[name]',
             },
           },

--- a/packages/react-devtools-extensions/src/main/index.js
+++ b/packages/react-devtools-extensions/src/main/index.js
@@ -24,6 +24,7 @@ import {
   normalizeUrlIfValid,
 } from 'react-devtools-shared/src/utils';
 import {checkConditions} from 'react-devtools-shared/src/devtools/views/Editor/utils';
+import * as parseHookNames from 'react-devtools-shared/src/hooks/parseHookNames';
 
 import {
   setBrowserSelectionFromReact,
@@ -39,6 +40,12 @@ import registerEventsLogger from './registerEventsLogger';
 import getProfilingFlags from './getProfilingFlags';
 import debounce from './debounce';
 import './requestAnimationFramePolyfill';
+
+const resolvedParseHookNames = Promise.resolve(parseHookNames);
+// DevTools assumes this is a dynamically imported module. Since we outline
+// workers in this bundle, we can sync require the module since it's just a thin
+// wrapper around calling the worker.
+const hookNamesModuleLoaderFunction = () => resolvedParseHookNames;
 
 function createBridge() {
   bridge = new Bridge({
@@ -187,12 +194,6 @@ function createBridgeAndStore() {
       column - 1,
     );
   };
-
-  // TODO (Webpack 5) Hopefully we can remove this prop after the Webpack 5 migration.
-  const hookNamesModuleLoaderFunction = () =>
-    import(
-      /* webpackChunkName: 'parseHookNames' */ 'react-devtools-shared/src/hooks/parseHookNames'
-    );
 
   root = createRoot(document.createElement('div'));
 

--- a/packages/react-devtools-extensions/webpack.config.js
+++ b/packages/react-devtools-extensions/webpack.config.js
@@ -261,7 +261,7 @@ module.exports = {
           {
             loader: 'workerize-loader',
             options: {
-              inline: true,
+              inline: false,
               name: '[name]',
             },
           },

--- a/packages/react-devtools-fusebox/webpack.config.frontend.js
+++ b/packages/react-devtools-fusebox/webpack.config.frontend.js
@@ -101,7 +101,7 @@ module.exports = {
           {
             loader: 'workerize-loader',
             options: {
-              inline: true,
+              inline: false,
               name: '[name]',
             },
           },

--- a/packages/react-devtools-fusebox/webpack.config.frontend.js
+++ b/packages/react-devtools-fusebox/webpack.config.frontend.js
@@ -101,7 +101,8 @@ module.exports = {
           {
             loader: 'workerize-loader',
             options: {
-              inline: false,
+              // Workers would have to be exposed on a public path in order to outline them.
+              inline: true,
               name: '[name]',
             },
           },

--- a/packages/react-devtools-inline/webpack.config.js
+++ b/packages/react-devtools-inline/webpack.config.js
@@ -93,7 +93,7 @@ module.exports = {
           {
             loader: 'workerize-loader',
             options: {
-              inline: true,
+              inline: false,
               name: '[name]',
             },
           },

--- a/packages/react-devtools-inline/webpack.config.js
+++ b/packages/react-devtools-inline/webpack.config.js
@@ -93,7 +93,8 @@ module.exports = {
           {
             loader: 'workerize-loader',
             options: {
-              inline: false,
+              // Workers would have to be exposed on a public path in order to outline them.
+              inline: true,
               name: '[name]',
             },
           },

--- a/scripts/ci/run_devtools_e2e_tests.js
+++ b/scripts/ci/run_devtools_e2e_tests.js
@@ -9,7 +9,7 @@ const ROOT_PATH = join(__dirname, '..', '..');
 const reactVersion = process.argv[2];
 const inlinePackagePath = join(ROOT_PATH, 'packages', 'react-devtools-inline');
 const shellPackagePath = join(ROOT_PATH, 'packages', 'react-devtools-shell');
-const screenshotPath = join(ROOT_PATH, 'tmp', 'screenshots');
+const playwrightArtifactsPath = join(ROOT_PATH, 'tmp', 'playwright-artifacts');
 
 const {SUCCESSFUL_COMPILATION_MESSAGE} = require(
   join(shellPackagePath, 'constants.js')
@@ -125,14 +125,22 @@ function runTestShell() {
 async function runEndToEndTests() {
   logBright('Running e2e tests');
   if (!reactVersion) {
-    testProcess = spawn('yarn', ['test:e2e', `--output=${screenshotPath}`], {
-      cwd: inlinePackagePath,
-    });
+    testProcess = spawn(
+      'yarn',
+      ['test:e2e', `--output=${playwrightArtifactsPath}`],
+      {
+        cwd: inlinePackagePath,
+      }
+    );
   } else {
-    testProcess = spawn('yarn', ['test:e2e', `--output=${screenshotPath}`], {
-      cwd: inlinePackagePath,
-      env: {...process.env, REACT_VERSION: reactVersion},
-    });
+    testProcess = spawn(
+      'yarn',
+      ['test:e2e', `--output=${playwrightArtifactsPath}`],
+      {
+        cwd: inlinePackagePath,
+        env: {...process.env, REACT_VERSION: reactVersion},
+      }
+    );
   }
 
   testProcess.stdout.on('data', data => {


### PR DESCRIPTION
The source of workers was inlined since workers were introduced in https://github.com/facebook/react/pull/21902.

Inlining the worker meant it was not subject to minification. The hook name parser worker can be minified down to 839kB (from ≈1.6MB) and file fetcher to 218kB (from ≈400kB). This allows us to not create an async chunk for the worker loader. It's just 2kB that avoids a waterfall from loading the module and then loading the worker. Now we load the worker directly.

I only did this for the extensions since we have full control of the public path and where assets are placed. Can't guarantee the same for the other bundles especially because testing those is non-trivial.


## Test plan

Hook name parsing works in https://rf3fky.csb.app/ for Edge, Chrome and Firefox