### PR TITLE
Include Fizz runtime diff in CI

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -194,7 +194,7 @@ jobs:
         if: steps.node_modules.outputs.cache-hit != 'true'
       - run: |
           yarn generate-inline-fizz-runtime
-          git diff --exit-code || (echo "There was a change to the Fizz runtime. Run `yarn generate-inline-fizz-runtime` and check in the result." && false)
+          git diff --exit-code || (echo "There was a change to the Fizz runtime. Run \`yarn generate-inline-fizz-runtime\` and check in the result." && false)
 
   # ----- FEATURE FLAGS -----
   flags:

--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -194,7 +194,7 @@ jobs:
         if: steps.node_modules.outputs.cache-hit != 'true'
       - run: |
           yarn generate-inline-fizz-runtime
-          git diff --quiet || (echo "There was a change to the Fizz runtime. Run `yarn generate-inline-fizz-runtime` and check in the result." && false)
+          git diff --exit-code || (echo "There was a change to the Fizz runtime. Run `yarn generate-inline-fizz-runtime` and check in the result." && false)
 
   # ----- FEATURE FLAGS -----
   flags:
@@ -567,7 +567,7 @@ jobs:
       - name: Search build artifacts for unminified errors
         run: |
           yarn extract-errors
-          git diff --quiet || (echo "Found unminified errors. Either update the error codes map or disable error minification for the affected build, if appropriate." && false)
+          git diff --exit-code || (echo "Found unminified errors. Either update the error codes map or disable error minification for the affected build, if appropriate." && false)
 
   check_release_dependencies:
     name: Check release dependencies


### PR DESCRIPTION
The check if the inline Fizz runtime is up-to-date rarely fails but then completes on a retry e.g. https://github.com/facebook/react/actions/runs/17826035222/job/50679328390?pr=34516. We suppressed the diff so it's impossible to tell what the source of the flakiness is.

Now we run without `--quiet` which hopefully gives us a clue. I added `--exit-code` so that it still fails on changes. [`--exit-code` was previously implied by `--quiet`](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---quiet).

Unclear why it was introduced with `--quiet` in https://github.com/facebook/react/pull/25481. Probably assuming that running it locally would show you the diff or just c&p from the error codes check.

<details>
<summary>Test plan</summary>

```console
$ echo 'console.log(1)' > packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInlineShellTime.js
$ git commit -a -m 'change fizz runtime without updating inline'
$ yarn generate-inline-fizz-runtime
$ git diff --exit-code || (echo "There was a change to the Fizz runtime. Run `yarn generate-inline-fizz-runtime` and check in the result." && false)
diff --git a/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetInlineCodeStrings.js b/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetInlineCodeStrings.js
index 4e7fb4b73f..bfdfe07481 100644
--- a/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetInlineCodeStrings.js
+++ b/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetInlineCodeStrings.js
@@ -1,8 +1,7 @@
 // This is a generated file. The source files are in react-dom-bindings/src/server/fizz-instruction-set.
 // The build script is at scripts/rollup/generate-inline-fizz-runtime.js.
 // Run `yarn generate-inline-fizz-runtime` to generate.
-export const markShellTime =
-  'requestAnimationFrame(function(){$RT=performance.now()});';
+export const markShellTime = 'console.log(1);';
 export const clientRenderBoundary =
   '$RX=function(b,c,d,e,f){var a=document.getElementById(b);a&&(b=a.previousSibling,b.data="$!",a=a.dataset,c&&(a.dgst=c),d&&(a.msg=d),e&&(a.stck=e),f&&(a.cstck=f),b._reactRetry&&b._reactRetry())};';
 export const completeBoundary =
There was a change to the Fizz runtime. Run `yarn generate-inline-fizz-runtime` and check in the result.
```
</details>