### PR TITLE
Add fast path for React.memo with custom compare

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/profilerChangeDescriptions-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilerChangeDescriptions-test.js
@@ -76,8 +76,7 @@ describe('Profiler change descriptions', () => {
         ▾ <App>
           ▾ <Context.Provider>
               <Child>
-            ▾ <Child> [Memo]
-                <Child>
+              <Child> [Memo]
             ▾ <RefForwardingComponent> [ForwardRef]
                 <Child>
     `);

--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -1887,6 +1887,11 @@ describe('Store', () => {
     ForwardRefComponentWithCustomDisplayName.displayName = 'Custom';
     const MyComponent4 = (props, ref) => null;
     const MemoComponent = React.memo(MyComponent4);
+    const MyComponent5 = (props, ref) => null;
+    const MemoComponentWithCustomCompare = React.memo(
+      MyComponent5,
+      (a, b) => a === b,
+    );
     const MemoForwardRefComponent = React.memo(ForwardRefComponent);
 
     const FakeHigherOrderComponent = () => null;
@@ -1916,6 +1921,7 @@ describe('Store', () => {
         <ForwardRefComponentWithAnonymousFunction />
         <ForwardRefComponentWithCustomDisplayName />
         <MemoComponent />
+        <MemoComponentWithCustomCompare />
         <MemoForwardRefComponent />
         <FakeHigherOrderComponent />
         <MemoizedFakeHigherOrderComponent />
@@ -1942,6 +1948,7 @@ describe('Store', () => {
               <MyComponent2>
             <Custom>
             <MyComponent4> [Memo]
+            <MyComponent5> [Memo]
           ▾ <MyComponent> [Memo]
               <MyComponent> [ForwardRef]
             <Baz> [withFoo][withBar]


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Fixes https://github.com/facebook/react/issues/33793

This widens the SimpleMemoComponent fast path introduced in https://github.com/facebook/react/pull/13903 to support memoized function components with custom props comparisons. The fast path eliminates the need for the wrapper MemoComponent to be tracked as a separate Fiber, reducing performance overhead.

In addition, React DevTools will show only one node for the component instead of two (because there is only one Fiber instead of two), which makes debugging easier by reducing visual and therefore mental clutter.

I considered several approaches as discussed in the issue before settling on this one as the best combination of simplicity, safety, and performance after benchmarking and prototyping.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Per the contributing instructions:

1. `yarn test` - two tests fail ("ReactFlightAsyncDebugInfo › can track async information when awaited" and "ReactFlightDOMEdge › should execute repeated host components only once") but these also fail at `main`.
2. `yarn test --prod` - 59 test failures but again this is the same as `main`. Here they are if you want to see: https://gist.github.com/barryam3/82007cf5ef6b1c27621e0395ba9a1e71
3. `yarn prettier`
4. `yarn lint`
5. `yarn flow dom-node` (I first tried `yarn flow` as recommended by the PR template, but it told me to pick a renderer, and `dom-node` is a good default)

Additionally I updated the DevTools unit tests to reflect the component tree in DevTools.

1. `yarn run build-for-devtools`
2. `yarn run test-build-devtools` - two tests fail ("ignoreList source map extension › for dev builds › should not ignore list anything" and "ignoreList source map extension › for production builds › should include every source") but these also fail at `main`

I made the equivalent change in my own application (thousands of components, hundreds memoized with custom arePropsEqual) via a pnpm patch and have not discovered any issues after running in production for about 2 months. I verified that this solves the "extra node" problem in DevTools. (In the interest of sharing any possible caveats, my app is still on React 18.2.0 and I chose a slightly simpler implementation for the patch of just setting a `compare` field on the function instead of using a Weak Map.)

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
