### PR TITLE
Fix indices of hooks in devtools when using useSyncExternalStore

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -1967,10 +1967,8 @@ export function attach(
 
       // useSyncExternalStore creates 2 internal hooks, but we only count it as 1 user-facing hook
       if (isUseSyncExternalStoreHook(next)) {
-        if (next.next !== null) {
-          next = next.next;
-          prev = prev.next;
-        }
+        next = next.next;
+        prev = prev.next;
       }
 
       next = next.next;


### PR DESCRIPTION
## Summary

This PR updates getChangedHooksIndices to account for the fact that useSyncExternalStore internally mounts two hooks, while DevTools should treat it as a single user-facing hook.

It introduces a helper isUseSyncExternalStoreHook to detect this case and adjust iteration so the extra internal hook is skipped when counting changes.

Before:

https://github.com/user-attachments/assets/0db72a4e-21f7-44c7-ba02-669a272631e5

After:

https://github.com/user-attachments/assets/4da71392-0396-408d-86a7-6fbc82d8c4f5

## How did you test this change?

I used this component to reproduce this issue locally (I followed instructions in `packages/react-devtools/CONTRIBUTING.md`).

```ts
function Test() {
  // 1
  React.useSyncExternalStore(
    () => {},
    () => {},
    () => {},
  );
  // 2
  const [state, setState] = useState('test'); 
  return (
    <>
      <div
        onClick={() => setState(Math.random())}
        style={{backgroundColor: 'red'}}>
        {state}
      </div>
    </>
  );
}
```
