### PR TITLE
[compiler] Don't leak global `__DEV__` type

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/index.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/index.ts
@@ -51,6 +51,7 @@ export {
 } from './ReactiveScopes';
 export {parseConfigPragmaForTests} from './Utils/TestUtils';
 declare global {
+  // @internal
   let __DEV__: boolean | null | undefined;
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/tsconfig.json
+++ b/compiler/packages/babel-plugin-react-compiler/tsconfig.json
@@ -10,6 +10,7 @@
     "importsNotUsedAsValues": "remove",
     "noUncheckedIndexedAccess": false,
     "noUnusedParameters": false,
+    "stripInternal": true,
     "useUnknownInCatchVariables": true,
     "target": "ES2015",
     // ideally turn off only during dev, or on a per-file basis


### PR DESCRIPTION
`babel-plugin-react-compiler` is not providing a global `__DEV__` so it shouldn't declare its type. Whatever is providing this global should declare the types. 

This prevents including `__DEV__` in autocomplete when that variable may never be available.
This was especially problematic if you had an existing `__DEV__` declared because then `babel-plugin-react-compiler` would fail since [you can't re-declare block scoped variables](https://www.typescriptlang.org/play/?#code/CYUwxgNghgTiAEBzCB7ARlC8DeAoeB8EIALvAPrkAiAogGqUBc8aKKxUAdvAD7ycBXCFj4DOoAGYBLTiGABuXAF9coSLATJ0mHPkLEylWg3LNW7EF178hI+GMky5ilUA).

Diff for `dist/index.d.ts`
```diff
 declare global {
-  let __DEV__: boolean | null | undefined;
 }
```