### PR TITLE
[DevTools] fix: dedupe file fetch requests and define a timeout

### DIFF
--- a/packages/react-devtools-extensions/src/contentScripts/fileFetcher.js
+++ b/packages/react-devtools-extensions/src/contentScripts/fileFetcher.js
@@ -23,7 +23,7 @@ function fetchResource(url) {
     });
   };
 
-  fetch(url, {cache: 'force-cache'}).then(
+  fetch(url, {cache: 'force-cache', signal: AbortSignal.timeout(60000)}).then(
     response => {
       if (response.ok) {
         response


### PR DESCRIPTION
If there is a large owner stack, we could potentially spam multiple fetch requests for the same source map. This adds a simple deduplication logic, based on URL.

Also, this adds a timeout of 60 seconds to all fetch requests initiated by fileFetcher content script.