### PR TITLE
Fix failing React DevTools regression tests

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
+++ b/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
@@ -130,24 +130,28 @@ describe('Timeline profiler', () => {
       // @reactVersion <= 18.2
       // @reactVersion >= 18.0
       it('should mark sync render without suspends or state updates', () => {
+        utils.act(() => store.profilerStore.startProfiling());
         legacyRender(<div />);
+        utils.act(() => store.profilerStore.stopProfiling());
 
         expect(registeredMarks).toMatchInlineSnapshot(`
-                  [
-                    "--schedule-render-1",
-                    "--render-start-1",
-                    "--render-stop",
-                    "--commit-start-1",
-                    "--react-version-<filtered-version>",
-                    "--profiler-version-1",
-                    "--react-internal-module-start-  at filtered (<anonymous>:0:0)",
-                    "--react-internal-module-stop-  at filtered (<anonymous>:1:1)",
-                    "--react-lane-labels-Sync,InputContinuousHydration,InputContinuous,DefaultHydration,Default,TransitionHydration,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Retry,Retry,Retry,Retry,Retry,SelectiveHydration,IdleHydration,Idle,Offscreen",
-                    "--layout-effects-start-1",
-                    "--layout-effects-stop",
-                    "--commit-stop",
-                  ]
-              `);
+          [
+            "--react-internal-module-start-  at filtered (<anonymous>:0:0)",
+            "--react-internal-module-stop-  at filtered (<anonymous>:1:1)",
+            "--schedule-render-1",
+            "--render-start-1",
+            "--render-stop",
+            "--commit-start-1",
+            "--react-version-<filtered-version>",
+            "--profiler-version-1",
+            "--react-internal-module-start-  at filtered (<anonymous>:0:0)",
+            "--react-internal-module-stop-  at filtered (<anonymous>:1:1)",
+            "--react-lane-labels-Sync,InputContinuousHydration,InputContinuous,DefaultHydration,Default,TransitionHydration,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Retry,Retry,Retry,Retry,Retry,SelectiveHydration,IdleHydration,Idle,Offscreen",
+            "--layout-effects-start-1",
+            "--layout-effects-stop",
+            "--commit-stop",
+          ]
+        `);
       });
 
       // TODO(hoxyq): investigate why running this test with React 18 fails
@@ -260,46 +264,50 @@ describe('Timeline profiler', () => {
           throw Error('Expected error');
         }
 
+        utils.act(() => store.profilerStore.startProfiling());
         legacyRender(
           <ErrorBoundary>
             <ExampleThatThrows />
           </ErrorBoundary>,
         );
+        utils.act(() => store.profilerStore.stopProfiling());
 
         expect(registeredMarks).toMatchInlineSnapshot(`
-                  [
-                    "--schedule-render-1",
-                    "--render-start-1",
-                    "--component-render-start-ErrorBoundary",
-                    "--component-render-stop",
-                    "--component-render-start-ExampleThatThrows",
-                    "--component-render-start-ExampleThatThrows",
-                    "--component-render-stop",
-                    "--error-ExampleThatThrows-mount-Expected error",
-                    "--render-stop",
-                    "--commit-start-1",
-                    "--react-version-<filtered-version>",
-                    "--profiler-version-1",
-                    "--react-internal-module-start-  at filtered (<anonymous>:0:0)",
-                    "--react-internal-module-stop-  at filtered (<anonymous>:1:1)",
-                    "--react-lane-labels-Sync,InputContinuousHydration,InputContinuous,DefaultHydration,Default,TransitionHydration,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Retry,Retry,Retry,Retry,Retry,SelectiveHydration,IdleHydration,Idle,Offscreen",
-                    "--layout-effects-start-1",
-                    "--schedule-state-update-1-ErrorBoundary",
-                    "--layout-effects-stop",
-                    "--commit-stop",
-                    "--render-start-1",
-                    "--component-render-start-ErrorBoundary",
-                    "--component-render-stop",
-                    "--render-stop",
-                    "--commit-start-1",
-                    "--react-version-<filtered-version>",
-                    "--profiler-version-1",
-                    "--react-internal-module-start-  at filtered (<anonymous>:0:0)",
-                    "--react-internal-module-stop-  at filtered (<anonymous>:1:1)",
-                    "--react-lane-labels-Sync,InputContinuousHydration,InputContinuous,DefaultHydration,Default,TransitionHydration,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Retry,Retry,Retry,Retry,Retry,SelectiveHydration,IdleHydration,Idle,Offscreen",
-                    "--commit-stop",
-                  ]
-              `);
+          [
+            "--react-internal-module-start-  at filtered (<anonymous>:0:0)",
+            "--react-internal-module-stop-  at filtered (<anonymous>:1:1)",
+            "--schedule-render-1",
+            "--render-start-1",
+            "--component-render-start-ErrorBoundary",
+            "--component-render-stop",
+            "--component-render-start-ExampleThatThrows",
+            "--component-render-start-ExampleThatThrows",
+            "--component-render-stop",
+            "--error-ExampleThatThrows-mount-Expected error",
+            "--render-stop",
+            "--commit-start-1",
+            "--react-version-<filtered-version>",
+            "--profiler-version-1",
+            "--react-internal-module-start-  at filtered (<anonymous>:0:0)",
+            "--react-internal-module-stop-  at filtered (<anonymous>:1:1)",
+            "--react-lane-labels-Sync,InputContinuousHydration,InputContinuous,DefaultHydration,Default,TransitionHydration,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Retry,Retry,Retry,Retry,Retry,SelectiveHydration,IdleHydration,Idle,Offscreen",
+            "--layout-effects-start-1",
+            "--schedule-state-update-1-ErrorBoundary",
+            "--layout-effects-stop",
+            "--commit-stop",
+            "--render-start-1",
+            "--component-render-start-ErrorBoundary",
+            "--component-render-stop",
+            "--render-stop",
+            "--commit-start-1",
+            "--react-version-<filtered-version>",
+            "--profiler-version-1",
+            "--react-internal-module-start-  at filtered (<anonymous>:0:0)",
+            "--react-internal-module-stop-  at filtered (<anonymous>:1:1)",
+            "--react-lane-labels-Sync,InputContinuousHydration,InputContinuous,DefaultHydration,Default,TransitionHydration,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Retry,Retry,Retry,Retry,Retry,SelectiveHydration,IdleHydration,Idle,Offscreen",
+            "--commit-stop",
+          ]
+        `);
       });
     });
 
@@ -1095,24 +1103,28 @@ describe('Timeline profiler', () => {
         // @reactVersion <= 18.2
         // @reactVersion >= 18.0
         it('regression test SyncLane', () => {
+          utils.act(() => store.profilerStore.startProfiling());
           legacyRender(<div />);
+          utils.act(() => store.profilerStore.stopProfiling());
 
           expect(registeredMarks).toMatchInlineSnapshot(`
-                      [
-                        "--schedule-render-1",
-                        "--render-start-1",
-                        "--render-stop",
-                        "--commit-start-1",
-                        "--react-version-<filtered-version>",
-                        "--profiler-version-1",
-                        "--react-internal-module-start-  at filtered (<anonymous>:0:0)",
-                        "--react-internal-module-stop-  at filtered (<anonymous>:1:1)",
-                        "--react-lane-labels-Sync,InputContinuousHydration,InputContinuous,DefaultHydration,Default,TransitionHydration,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Retry,Retry,Retry,Retry,Retry,SelectiveHydration,IdleHydration,Idle,Offscreen",
-                        "--layout-effects-start-1",
-                        "--layout-effects-stop",
-                        "--commit-stop",
-                      ]
-                  `);
+            [
+              "--react-internal-module-start-  at filtered (<anonymous>:0:0)",
+              "--react-internal-module-stop-  at filtered (<anonymous>:1:1)",
+              "--schedule-render-1",
+              "--render-start-1",
+              "--render-stop",
+              "--commit-start-1",
+              "--react-version-<filtered-version>",
+              "--profiler-version-1",
+              "--react-internal-module-start-  at filtered (<anonymous>:0:0)",
+              "--react-internal-module-stop-  at filtered (<anonymous>:1:1)",
+              "--react-lane-labels-Sync,InputContinuousHydration,InputContinuous,DefaultHydration,Default,TransitionHydration,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Transition,Retry,Retry,Retry,Retry,Retry,SelectiveHydration,IdleHydration,Idle,Offscreen",
+              "--layout-effects-start-1",
+              "--layout-effects-stop",
+              "--commit-stop",
+            ]
+          `);
         });
       });
 
@@ -1432,19 +1444,19 @@ describe('Timeline profiler', () => {
           expect(timelineData.suspenseEvents).toHaveLength(1);
           const suspenseEvent = timelineData.suspenseEvents[0];
           expect(suspenseEvent).toMatchInlineSnapshot(`
-                      {
-                        "componentName": "Example",
-                        "depth": 0,
-                        "duration": 10,
-                        "id": "0",
-                        "phase": "mount",
-                        "promiseName": "",
-                        "resolution": "resolved",
-                        "timestamp": 10,
-                        "type": "suspense",
-                        "warning": null,
-                      }
-                  `);
+            {
+              "componentName": "Example",
+              "depth": 0,
+              "duration": 0,
+              "id": "0",
+              "phase": "mount",
+              "promiseName": "",
+              "resolution": "unresolved",
+              "timestamp": 10,
+              "type": "suspense",
+              "warning": null,
+            }
+          `);
 
           // There should be two batches of renders: Suspeneded and resolved.
           expect(timelineData.batchUIDToMeasuresMap.size).toBe(2);
@@ -1490,19 +1502,19 @@ describe('Timeline profiler', () => {
           expect(timelineData.suspenseEvents).toHaveLength(1);
           const suspenseEvent = timelineData.suspenseEvents[0];
           expect(suspenseEvent).toMatchInlineSnapshot(`
-                      {
-                        "componentName": "Example",
-                        "depth": 0,
-                        "duration": 10,
-                        "id": "0",
-                        "phase": "mount",
-                        "promiseName": "",
-                        "resolution": "rejected",
-                        "timestamp": 10,
-                        "type": "suspense",
-                        "warning": null,
-                      }
-                  `);
+            {
+              "componentName": "Example",
+              "depth": 0,
+              "duration": 0,
+              "id": "0",
+              "phase": "mount",
+              "promiseName": "",
+              "resolution": "unresolved",
+              "timestamp": 10,
+              "type": "suspense",
+              "warning": null,
+            }
+          `);
 
           // There should be two batches of renders: Suspeneded and resolved.
           expect(timelineData.batchUIDToMeasuresMap.size).toBe(2);


### PR DESCRIPTION
This should fix the remaining failing tests. [DevTools Regression Tests](https://github.com/facebook/react/actions/workflows/devtools_regression_tests.yml) should be green with this change.