### PR TITLE
[playground] Fix useEffect on tabify

### DIFF
--- a/compiler/apps/playground/components/Editor/Output.tsx
+++ b/compiler/apps/playground/components/Editor/Output.tsx
@@ -34,7 +34,7 @@ export default MemoizedOutput;
 export const BASIC_OUTPUT_TAB_NAMES = ['Output', 'SourceMap'];
 
 const tabifyCache = new LRUCache<Store, Promise<Map<string, ReactNode>>>({
-  max: 100,
+  max: 5,
 });
 
 export type PrintedCompilerPipelineValue =

--- a/compiler/apps/playground/components/Editor/Output.tsx
+++ b/compiler/apps/playground/components/Editor/Output.tsx
@@ -25,6 +25,7 @@ import AccordionWindow from '../AccordionWindow';
 import TabbedWindow from '../TabbedWindow';
 import {monacoOptions} from './monacoOptions';
 import {BabelFileResult} from '@babel/core';
+import {LRUCache} from 'lru-cache';
 
 const MemoizedOutput = memo(Output);
 
@@ -32,7 +33,9 @@ export default MemoizedOutput;
 
 export const BASIC_OUTPUT_TAB_NAMES = ['Output', 'SourceMap'];
 
-let tabifyCache = new Map<Store, Promise<Map<string, ReactNode>>>();
+const tabifyCache = new LRUCache<Store, Promise<Map<string, ReactNode>>>({
+  max: 100,
+});
 
 export type PrintedCompilerPipelineValue =
   | {
@@ -206,17 +209,14 @@ function tabifyCached(
   store: Store,
   compilerOutput: CompilerOutput,
 ): Promise<Map<string, ReactNode>> {
-  const key = store;
-  if (tabifyCache.has(key)) {
-    return tabifyCache.get(key)!;
-  }
+  const cached = tabifyCache.get(store);
+  if (cached) return cached;
   const result = tabify(store.source, compilerOutput, store.showInternals);
-  tabifyCache.set(key, result);
+  tabifyCache.set(store, result);
   return result;
 }
 
 function Fallback(): JSX.Element {
-  console.log('Fallback');
   return (
     <div className="w-full h-monaco_small sm:h-monaco flex items-center justify-center">
       Loading...

--- a/compiler/apps/playground/package.json
+++ b/compiler/apps/playground/package.json
@@ -32,6 +32,7 @@
     "hermes-eslint": "^0.25.0",
     "hermes-parser": "^0.25.0",
     "invariant": "^2.2.4",
+    "lru-cache": "^11.2.2",
     "lz-string": "^1.5.0",
     "monaco-editor": "^0.52.0",
     "next": "15.6.0-canary.7",

--- a/compiler/apps/playground/yarn.lock
+++ b/compiler/apps/playground/yarn.lock
@@ -3104,6 +3104,11 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
+lru-cache@^11.2.2:
+  version "11.2.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.2.2.tgz#40fd37edffcfae4b2940379c0722dc6eeaa75f24"
+  integrity sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"


### PR DESCRIPTION
There was a bug in the Compiler Playground related to the "Show Internals" toggle due to a useEffect that was causing the tab names to flicker from a rerender. Rewritten instead with a `<Suspense>` boundary + `use`.

