### PR TITLE
Match `react-dom/static` test entrypoints and published entrypoints

### DIFF
--- a/packages/react-dom/static.node.js
+++ b/packages/react-dom/static.node.js
@@ -11,19 +11,6 @@
 import ReactVersion from 'shared/ReactVersion';
 export {ReactVersion as version};
 
-export function renderToString() {
-  return require('./src/server/ReactDOMLegacyServerNode').renderToString.apply(
-    this,
-    arguments,
-  );
-}
-export function renderToStaticMarkup() {
-  return require('./src/server/ReactDOMLegacyServerNode').renderToStaticMarkup.apply(
-    this,
-    arguments,
-  );
-}
-
 export function prerenderToNodeStream() {
   return require('./src/server/react-dom-server.node').prerenderToNodeStream.apply(
     this,


### PR DESCRIPTION
Does not affect published files.

I think these were added accidentally in https://github.com/facebook/react/pull/33441/ due to copy&paste. `react-dom/static.edge` doesn't have these methods either.

Noticed this while diffing against latest stable release. The published entrypoints didn't have them. Just the entrypoints for tests.