### PR TITLE
[Flight] Support transporting URL instances

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -2380,14 +2380,17 @@ function parseModelString(
         // $NaN
         return NaN;
       }
-      case 'u': {
-        // matches "$undefined"
+      case '_': {
         // Special encoding for `undefined` which can't be serialized as JSON otherwise.
         return undefined;
       }
       case 'D': {
         // Date
         return new Date(Date.parse(value.slice(2)));
+      }
+      case 'u': {
+        // URL
+        return new URL(value.slice(2));
       }
       case 'n': {
         // BigInt
@@ -3216,7 +3219,7 @@ function startAsyncIterable<T>(
         resolveIteratorResultChunk(
           response,
           buffer[nextWriteIndex++],
-          '"$undefined"',
+          '"$_"',
           true,
         );
       }
@@ -3283,7 +3286,7 @@ function stopStream(
   }
   const streamChunk: InitializedStreamChunk<any> = (chunk: any);
   const controller = streamChunk.reason;
-  controller.close(row === '' ? '"$undefined"' : row);
+  controller.close(row === '' ? '"$_"' : row);
 }
 
 type ErrorWithDigest = Error & {digest?: string};

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -551,6 +551,22 @@ describe('ReactFlight', () => {
     expect(ReactNoop).toMatchRenderedOutput('prop: 2009-02-13T23:31:30.123Z');
   });
 
+  it('can transport URL', async () => {
+    const url = new URL('https://example.com/foo?bar=baz#qux');
+    const transport = ReactNoopFlightServer.render({url});
+    const model = await ReactNoopFlightClient.read(transport);
+
+    expect(model).toEqual({url});
+  });
+
+  it('can transport URL as top-level value', async () => {
+    const url = new URL('https://example.com/foo?bar=baz#qux');
+    const transport = ReactNoopFlightServer.render(url);
+    const model = await ReactNoopFlightClient.read(transport);
+
+    expect(model).toEqual(url);
+  });
+
   it('can transport Map', async () => {
     function ComponentClient({prop, selected}) {
       return `

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js
@@ -245,6 +245,14 @@ describe('ReactFlightDOMReply', () => {
     expect(d % 1000).toEqual(123); // double-check the milliseconds made it through
   });
 
+  it('can pass a URL as a reply', async () => {
+    const url = new URL('https://example.com/foo?bar=baz#qux');
+    const body = await ReactServerDOMClient.encodeReply(url);
+    const url2 = await ReactServerDOMServer.decodeReply(body, webpackServerMap);
+
+    expect(url).toEqual(url2);
+  });
+
   it('can pass a Map as a reply', async () => {
     const objKey = {obj: 'key'};
     const m = new Map([

--- a/packages/react-server/src/ReactFlightReplyServer.js
+++ b/packages/react-server/src/ReactFlightReplyServer.js
@@ -276,7 +276,7 @@ function resolveModelChunk<T>(
     const streamChunk: InitializedStreamChunk<any> = (chunk: any);
     const controller = streamChunk.reason;
     if (value[0] === 'C') {
-      controller.close(value === 'C' ? '"$undefined"' : value.slice(1));
+      controller.close(value === 'C' ? '"$_"' : value.slice(1));
     } else {
       controller.enqueueModel(value);
     }
@@ -714,7 +714,7 @@ function resolveStream<T: ReadableStream | $AsyncIterable<any, any, void>>(
     // We assume that this is a string entry for now.
     const value: string = (existingEntries[i]: any);
     if (value[0] === 'C') {
-      controller.close(value === 'C' ? '"$undefined"' : value.slice(1));
+      controller.close(value === 'C' ? '"$_"' : value.slice(1));
     } else {
       controller.enqueueModel(value);
     }
@@ -862,11 +862,7 @@ function parseAsyncIterable<T>(
       nextWriteIndex++;
       while (nextWriteIndex < buffer.length) {
         // In generators, any extra reads from the iterator have the value undefined.
-        resolveIteratorResultChunk(
-          buffer[nextWriteIndex++],
-          '"$undefined"',
-          true,
-        );
+        resolveIteratorResultChunk(buffer[nextWriteIndex++], '"$_"', true);
       }
     },
     error(error: Error): void {
@@ -1015,14 +1011,17 @@ function parseModelString(
         // $NaN
         return NaN;
       }
-      case 'u': {
-        // matches "$undefined"
+      case '_': {
         // Special encoding for `undefined` which can't be serialized as JSON otherwise.
         return undefined;
       }
       case 'D': {
         // Date
         return new Date(Date.parse(value.slice(2)));
+      }
+      case 'u': {
+        // URL
+        return new URL(value.slice(2));
       }
       case 'n': {
         // BigInt


### PR DESCRIPTION
Previously, `URL` objects were serialized as plain strings via `JSON.stringify`, so they lost their class identity on the receiving side. This change extends Flight to transport `URL` instances directly, using an approach similar to #26622 for `Date`.

To make room for URL serialization (prefixed with `'$u'`), we now represent `undefined` as `'$_'` instead of `'$undefined'`. Using `'$_'` not only reduces the size of the (uncompressed) RSC payload when many `undefined` values are transported, but also fits semantically: underscore is widely used in programming and linguistics as a placeholder for "something missing" or "left out".

If Flight were the only concern, we could have used `'$U'` for URLs and kept the existing encoding for `undefined`. However, this would conflict with how `Uint8ClampedArray` is serialized in the Flight Reply Client.

<img width="1482" height="840" alt="$undefined" src="https://github.com/user-attachments/assets/35a15e36-0068-4eb5-8c51-d671b1b12252" />
