### PR TITLE
[playground] Config panel quality fixes

### DIFF
--- a/compiler/apps/playground/components/Editor/ConfigEditor.tsx
+++ b/compiler/apps/playground/components/Editor/ConfigEditor.tsx
@@ -60,6 +60,7 @@ function ExpandedEditor({
   const store = useStore();
   const dispatchStore = useStoreDispatch();
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const lastValidOptionsRef = useRef<string>('');
 
   const handleChange: (value: string | undefined) => void = (
     value: string | undefined,
@@ -103,12 +104,16 @@ function ExpandedEditor({
     });
   };
 
-  const formattedAppliedOptions = appliedOptions
-    ? prettyFormat(appliedOptions, {
-        printFunctionName: false,
-        printBasicPrototype: false,
-      })
-    : 'Invalid configs';
+  let formattedAppliedOptions = '';
+  if (appliedOptions) {
+    formattedAppliedOptions = prettyFormat(appliedOptions, {
+      printFunctionName: false,
+      printBasicPrototype: false,
+    });
+    lastValidOptionsRef.current = formattedAppliedOptions;
+  } else {
+    formattedAppliedOptions = lastValidOptionsRef.current;
+  }
 
   return (
     <Resizable
@@ -137,7 +142,7 @@ function ExpandedEditor({
               Config Overrides
             </h2>
           </div>
-          <div className="flex-1 rounded-lg overflow-hidden border border-gray-300">
+          <div className="flex-1 border border-gray-300">
             <MonacoEditor
               path={'config.ts'}
               language={'typescript'}
@@ -165,7 +170,7 @@ function ExpandedEditor({
               Applied Configs
             </h2>
           </div>
-          <div className="flex-1 rounded-lg overflow-hidden border border-gray-300">
+          <div className="flex-1 border border-gray-300">
             <MonacoEditor
               path={'applied-config.js'}
               language={'javascript'}

--- a/compiler/apps/playground/components/Editor/ConfigEditor.tsx
+++ b/compiler/apps/playground/components/Editor/ConfigEditor.tsx
@@ -12,7 +12,7 @@ import * as monaco from 'monaco-editor';
 import React, {useState, useRef} from 'react';
 import {Resizable} from 're-resizable';
 import {useStore, useStoreDispatch} from '../StoreContext';
-import {monacoOptions} from './monacoOptions';
+import {monacoConfigOptions} from './monacoOptions';
 import {IconChevron} from '../Icons/IconChevron';
 import prettyFormat from 'pretty-format';
 
@@ -151,16 +151,7 @@ function ExpandedEditor({
               onChange={handleChange}
               loading={''}
               className="monaco-editor-config"
-              options={{
-                ...monacoOptions,
-                lineNumbers: 'off',
-                renderLineHighlight: 'none',
-                overviewRulerBorder: false,
-                overviewRulerLanes: 0,
-                fontSize: 12,
-                scrollBeyondLastLine: false,
-                glyphMargin: false,
-              }}
+              options={monacoConfigOptions}
             />
           </div>
         </div>
@@ -178,15 +169,8 @@ function ExpandedEditor({
               loading={''}
               className="monaco-editor-applied-config"
               options={{
-                ...monacoOptions,
-                lineNumbers: 'off',
-                renderLineHighlight: 'none',
-                overviewRulerBorder: false,
-                overviewRulerLanes: 0,
-                fontSize: 12,
-                scrollBeyondLastLine: false,
+                ...monacoConfigOptions,
                 readOnly: true,
-                glyphMargin: false,
               }}
             />
           </div>

--- a/compiler/apps/playground/components/Editor/monacoOptions.ts
+++ b/compiler/apps/playground/components/Editor/monacoOptions.ts
@@ -32,3 +32,14 @@ export const monacoOptions: Partial<EditorProps['options']> = {
 
   tabSize: 2,
 };
+
+export const monacoConfigOptions: Partial<EditorProps['options']> = {
+  ...monacoOptions,
+  lineNumbers: 'off',
+  renderLineHighlight: 'none',
+  overviewRulerBorder: false,
+  overviewRulerLanes: 0,
+  fontSize: 12,
+  scrollBeyondLastLine: false,
+  glyphMargin: false,
+};


### PR DESCRIPTION
Fixed two small issues with the config panel in the compiler playground:
1. Object descriptions were being confined in the config box and most of it would not be visible upon hover
2. Changed it so that "Applied Configs" would only display a valid set of configs, rather than switching between "Invalid Configs" and the set of options. This would be less visually jarring for users as the Output panel already displays errors. Additionally, if users want to see the list of config options but have a currently broken config, they would previously not know  how to fix it. 

Object hover before: 
<img width="702" height="481" alt="Screenshot 2025-09-26 at 10 41 03 AM" src="https://github.com/user-attachments/assets/b2ddec2f-16ba-41a1-be1f-96211f46764c" />
Hover after:
<img width="702" height="481" alt="Screenshot 2025-09-26 at 10 40 37 AM" src="https://github.com/user-attachments/assets/dc713a22-4710-46a8-a5d7-485060cc9074" />

Applied Configs always displays the last valid set of configs:

https://github.com/user-attachments/assets/2fb9232f-7388-4488-9b7a-bb48bf09e4ca


