### PR TITLE
[DevTools] Larger panel buttons and center

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/ButtonIcon.js
+++ b/packages/react-devtools-shared/src/devtools/views/ButtonIcon.js
@@ -52,7 +52,7 @@ type Props = {
   type: IconType,
 };
 
-const panelIcons = '0 -960 960 820';
+const panelIcons = '96 -864 768 768';
 export default function ButtonIcon({className = '', type}: Props): React.Node {
   let pathData = null;
   let viewBox = '0 0 24 24';


### PR DESCRIPTION
The panel icons are quite small. Especially compared to the equivalent buttons elsewhere in Chrome DevTools that otherwise use the same icons. This makes them a little bigger to make them similar size to our other button icons.

They were also a bit off center. This centers them as well.

Before:

<img width="409" height="426" alt="Screenshot 2025-09-26 at 4 23 15 PM" src="https://github.com/user-attachments/assets/4a5de032-e316-44ed-9424-8bccce00f0cd" />

After:

<img width="519" height="388" alt="Screenshot 2025-09-26 at 4 22 57 PM" src="https://github.com/user-attachments/assets/1763e522-5683-4fac-a913-27910a30a039" />
