### PR TITLE
React DOM: Add support for onFullscreenChange and onFullscreenError events

### DIFF
--- a/packages/react-dom-bindings/src/events/DOMEventNames.js
+++ b/packages/react-dom-bindings/src/events/DOMEventNames.js
@@ -51,6 +51,7 @@ export type DOMEventName =
   | 'focusin'
   | 'focusout'
   | 'fullscreenchange'
+  | 'fullscreenerror'
   | 'gotpointercapture'
   | 'hashchange'
   | 'input'

--- a/packages/react-dom-bindings/src/events/DOMEventProperties.js
+++ b/packages/react-dom-bindings/src/events/DOMEventProperties.js
@@ -62,6 +62,8 @@ const simpleEventPluginEvents = [
   'encrypted',
   'ended',
   'error',
+  'fullscreenChange',
+  'fullscreenError',
   'gotPointerCapture',
   'input',
   'invalid',

--- a/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
@@ -833,6 +833,40 @@ describe('ReactDOMEventListener', () => {
         },
       });
     });
+
+    it('onFullscreenChange', async () => {
+      await testNativeBubblingEvent({
+        type: 'div',
+        reactEvent: 'onFullscreenChange',
+        reactEventType: 'fullscreenchange',
+        nativeEvent: 'fullscreenchange',
+        dispatch(node) {
+          node.dispatchEvent(
+            new Event('fullscreenchange', {
+              bubbles: true,
+              cancelable: false,
+            }),
+          );
+        },
+      });
+    });
+
+    it('onFullscreenError', async () => {
+      await testNativeBubblingEvent({
+        type: 'div',
+        reactEvent: 'onFullscreenError',
+        reactEventType: 'fullscreenerror',
+        nativeEvent: 'fullscreenerror',
+        dispatch(node) {
+          node.dispatchEvent(
+            new Event('fullscreenerror', {
+              bubbles: true,
+              cancelable: false,
+            }),
+          );
+        },
+      });
+    });
   });
 
   describe('non-bubbling events that bubble in React', () => {


### PR DESCRIPTION
## Summary

This adds support for the [`fullscreenchange`](https://developer.mozilla.org/en-US/docs/Web/API/Element/fullscreenchange_event) and [`fullscreenerror`](https://developer.mozilla.org/en-US/docs/Web/API/Element/fullscreenerror_event) events.

These events are currently supported in Chrome and Firefox(see [browser compatibility table](https://developer.mozilla.org/en-US/docs/Web/API/Element/fullscreenchange_event#browser_compatibility)). You can read more about these events [here](https://fullscreen.spec.whatwg.org/).

---

https://github.com/facebook/react/blob/2622487a7495b2ded000e1ad8b2e292d01bdd126/packages/react-dom-bindings/src/events/ReactDOMEventListener.js#L364-L366

I omit `fullscreenerror` here so it falls back to default below.

## How did you test this change?

Added unit tests.
