### PR TITLE
[test] Fail tests on `console.error(error)`

### DIFF
--- a/packages/internal-test-utils/shouldIgnoreConsoleError.js
+++ b/packages/internal-test-utils/shouldIgnoreConsoleError.js
@@ -37,17 +37,6 @@ module.exports = function shouldIgnoreConsoleError(format, args) {
         return true;
       }
     }
-  } else {
-    if (
-      format != null &&
-      typeof format.message === 'string' &&
-      typeof format.stack === 'string' &&
-      args.length === 0
-    ) {
-      // In production, ReactFiberErrorLogger logs error objects directly.
-      // They are noisy too so we'll try to ignore them.
-      return true;
-    }
   }
   // Looks legit
   return false;


### PR DESCRIPTION
May be hard to land. Some PPR tests were not failing because we ignored `console.error(error)`. We may need a `assertConsoleErrorProd`