### PR TITLE
Allow running `yarn lint` on subset of paths

### DIFF
--- a/scripts/eslint/index.js
+++ b/scripts/eslint/index.js
@@ -72,12 +72,18 @@ function intersect(files, patterns) {
   return [...new Set(intersection)];
 }
 
-async function runESLint({onlyChanged, ...options}) {
+async function runESLint({onlyChanged, paths, ...options}) {
   if (typeof onlyChanged !== 'boolean') {
     throw new Error('Pass options.onlyChanged as a boolean.');
   }
+  if (onlyChanged && paths !== undefined) {
+    throw new Error('Cannot specify paths when onlyChanged is true.');
+  }
+  if (paths === undefined || paths.length === 0) {
+    paths = allPaths;
+  }
   const {errorCount, warningCount, output} = await runESLintOnFilesWithOptions(
-    allPaths,
+    paths,
     onlyChanged,
     options
   );

--- a/scripts/tasks/eslint.js
+++ b/scripts/tasks/eslint.js
@@ -16,9 +16,9 @@ async function main() {
     console.log('Hint: run `yarn linc` to only lint changed files.');
   }
 
-  const {_, ...cliOptions} = minimist(process.argv.slice(2));
+  const {_: paths, ...cliOptions} = minimist(process.argv.slice(2));
 
-  if (await runESLint({onlyChanged: false, ...cliOptions})) {
+  if (await runESLint({onlyChanged: false, ...cliOptions, paths})) {
     console.log('Lint passed.');
   } else {
     console.log('Lint failed.');


### PR DESCRIPTION
We always hardcoded a pattern for `yarn lint` matching the whole monorepo. This is slow when working on linting infra where `yarn linc` (i.e. just running on changed files) might not include a specific override.

Now you can run e.g. `yarn lint packages/react-devtools-*` to lint just devtools packages. This is matching how the ESLint CLI works by default. `yarn lint` will still lint everything.