### PR TITLE
[eprh] Temporarily disable compiler rules

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -7,35 +7,18 @@
 import type {Linter, Rule} from 'eslint';
 
 import ExhaustiveDeps from './rules/ExhaustiveDeps';
-import {
-  allRules,
-  mapErrorSeverityToESlint,
-  recommendedRules,
-} from './shared/ReactCompiler';
 import RulesOfHooks from './rules/RulesOfHooks';
 
 // All rules
 const rules = {
   'exhaustive-deps': ExhaustiveDeps,
   'rules-of-hooks': RulesOfHooks,
-  ...Object.fromEntries(
-    Object.entries(allRules).map(([name, config]) => [name, config.rule])
-  ),
 } satisfies Record<string, Rule.RuleModule>;
 
 // Config rules
 const ruleConfigs = {
   'react-hooks/rules-of-hooks': 'error',
   'react-hooks/exhaustive-deps': 'warn',
-  // Compiler rules
-  ...Object.fromEntries(
-    Object.entries(recommendedRules).map(([name, ruleConfig]) => {
-      return [
-        'react-hooks/' + name,
-        mapErrorSeverityToESlint(ruleConfig.severity),
-      ];
-    }),
-  ),
 } satisfies Linter.RulesRecord;
 
 const plugin = {


### PR DESCRIPTION

Temporarily disables the compiler rules in eslint-plugin-react-hooks. Will revert this later.
