### PR TITLE
[DevTools] Use the scrollWidth/Height for the root when the root is the documentElement

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -2251,8 +2251,23 @@ export function attach(
     }
     if (typeof instance.getClientRects === 'function') {
       // DOM
-      const result: Array<Rect> = [];
       const doc = instance.ownerDocument;
+      if (instance === doc.documentElement) {
+        // This is the document element. The size of this element is not actually
+        // what determines the whole scrollable area of the screen. Because any
+        // thing that overflows the document will also contribute to the scrollable.
+        // This is unlike overflow: scroll which clips those.
+        // Therefore, we use the scrollable size for this rect instead.
+        return [
+          {
+            x: 0,
+            y: 0,
+            width: instance.scrollWidth,
+            height: instance.scrollHeight,
+          },
+        ];
+      }
+      const result: Array<Rect> = [];
       const win = doc && doc.defaultView;
       const scrollX = win ? win.scrollX : 0;
       const scrollY = win ? win.scrollY : 0;


### PR DESCRIPTION
If I can scroll the document due to it overflowing, I should be able to scroll the suspense tab as much. The real rect for the root when it's the document is really the full scroll height.

This doesn't fully eliminate the need to do recursive bounding boxes for the root since it's still possible to have the rects overflow. E.g. if they're currently resuspended or inside nested scrolls.

~However, maybe we should have the actual paintable root rect just be this rectangle instead of including the recursive ones.~ Actually never mind. The root really represents the Transition so it doesn't make sense to give it any specific rectangle. It's rather the whole background.