### PR TITLE
[Fizz] Remove `nonce` option from resume-and-prerender APIs

### DIFF
--- a/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
@@ -168,7 +168,7 @@ type ResumeOptions = {
 function resumeAndPrerender(
   children: ReactNodeList,
   postponedState: PostponedState,
-  options?: ResumeOptions,
+  options?: Omit<ResumeOptions, 'nonce'>,
 ): Promise<StaticResult> {
   return new Promise((resolve, reject) => {
     const onFatalError = reject;
@@ -199,10 +199,7 @@ function resumeAndPrerender(
     const request = resumeAndPrerenderRequest(
       children,
       postponedState,
-      resumeRenderState(
-        postponedState.resumableState,
-        options ? options.nonce : undefined,
-      ),
+      resumeRenderState(postponedState.resumableState, undefined),
       options ? options.onError : undefined,
       onAllReady,
       undefined,

--- a/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
@@ -166,7 +166,7 @@ type ResumeOptions = {
 function resumeAndPrerender(
   children: ReactNodeList,
   postponedState: PostponedState,
-  options?: ResumeOptions,
+  options?: Omit<ResumeOptions, 'nonce'>,
 ): Promise<StaticResult> {
   return new Promise((resolve, reject) => {
     const onFatalError = reject;
@@ -197,10 +197,7 @@ function resumeAndPrerender(
     const request = resumeAndPrerenderRequest(
       children,
       postponedState,
-      resumeRenderState(
-        postponedState.resumableState,
-        options ? options.nonce : undefined,
-      ),
+      resumeRenderState(postponedState.resumableState, undefined),
       options ? options.onError : undefined,
       onAllReady,
       undefined,

--- a/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
@@ -294,7 +294,7 @@ type ResumeOptions = {
 function resumeAndPrerenderToNodeStream(
   children: ReactNodeList,
   postponedState: PostponedState,
-  options?: ResumeOptions,
+  options?: Omit<ResumeOptions, 'nonce'>,
 ): Promise<StaticResult> {
   return new Promise((resolve, reject) => {
     const onFatalError = reject;
@@ -316,10 +316,7 @@ function resumeAndPrerenderToNodeStream(
     const request = resumeAndPrerenderRequest(
       children,
       postponedState,
-      resumeRenderState(
-        postponedState.resumableState,
-        options ? options.nonce : undefined,
-      ),
+      resumeRenderState(postponedState.resumableState, undefined),
       options ? options.onError : undefined,
       onAllReady,
       undefined,
@@ -346,7 +343,7 @@ function resumeAndPrerenderToNodeStream(
 function resumeAndPrerender(
   children: ReactNodeList,
   postponedState: PostponedState,
-  options?: ResumeOptions,
+  options?: Omit<ResumeOptions, 'nonce'>,
 ): Promise<{
   postponed: null | PostponedState,
   prelude: ReadableStream,
@@ -385,10 +382,7 @@ function resumeAndPrerender(
     const request = resumeAndPrerenderRequest(
       children,
       postponedState,
-      resumeRenderState(
-        postponedState.resumableState,
-        options ? options.nonce : undefined,
-      ),
+      resumeRenderState(postponedState.resumableState, undefined),
       options ? options.onError : undefined,
       onAllReady,
       undefined,


### PR DESCRIPTION
`prerender` doesn't accept a nonce because the nonce wouldn't be unique to the request. The same applies to `resumeAndPrerender`.