### PR TITLE
Bump scheduler version

### DIFF
--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "art": "^0.10.1",
     "create-react-class": "^15.6.2",
-    "scheduler": "^0.26.0"
+    "scheduler": "^0.27.0"
   },
   "peerDependencies": {
     "react": "^19.2.0"

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://react.dev/",
   "dependencies": {
-    "scheduler": "^0.26.0"
+    "scheduler": "^0.27.0"
   },
   "peerDependencies": {
     "react": "^19.2.0"

--- a/packages/react-native-renderer/package.json
+++ b/packages/react-native-renderer/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/react-native-renderer"
   },
   "dependencies": {
-    "scheduler": "^0.26.0"
+    "scheduler": "^0.27.0"
   },
   "peerDependencies": {
     "react": "^18.0.0"

--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -29,6 +29,6 @@
     "react": "^19.2.0"
   },
   "dependencies": {
-    "scheduler": "^0.26.0"
+    "scheduler": "^0.27.0"
   }
 }

--- a/packages/react-server-dom-fb/package.json
+++ b/packages/react-server-dom-fb/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/react-server-dom-fb"
   },
   "dependencies": {
-    "scheduler": "^0.26.0"
+    "scheduler": "^0.27.0"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://react.dev/",
   "dependencies": {
     "react-is": "^19.2.0",
-    "scheduler": "^0.26.0"
+    "scheduler": "^0.27.0"
   },
   "peerDependencies": {
     "react": "^19.2.0"

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scheduler",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Cooperative scheduler for the browser environment.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The canaries have been published depending on 0.27-canary. Bumping scheduler just in case to be sure.