### PR TITLE
[eprh] Allow compiler rules to be opted-in but not in the preset

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -7,12 +7,16 @@
 import type {Linter, Rule} from 'eslint';
 
 import ExhaustiveDeps from './rules/ExhaustiveDeps';
+import {allRules} from './shared/ReactCompiler';
 import RulesOfHooks from './rules/RulesOfHooks';
 
 // All rules
 const rules = {
   'exhaustive-deps': ExhaustiveDeps,
   'rules-of-hooks': RulesOfHooks,
+  ...Object.fromEntries(
+    Object.entries(allRules).map(([name, config]) => [name, config.rule]),
+  ),
 } satisfies Record<string, Rule.RuleModule>;
 
 // Config rules


### PR DESCRIPTION

Follow up to #34649. This adds the compiler rules back so they can be opted-in 6.1.0, but aren't included in the presets as that would be a breaking change.
