### PR TITLE
[eprh] Add compiler rules to recommended preset

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -7,7 +7,11 @@
 import type {Linter, Rule} from 'eslint';
 
 import ExhaustiveDeps from './rules/ExhaustiveDeps';
-import {allRules} from './shared/ReactCompiler';
+import {
+  allRules,
+  mapErrorSeverityToESlint,
+  recommendedRules,
+} from './shared/ReactCompiler';
 import RulesOfHooks from './rules/RulesOfHooks';
 
 // All rules
@@ -23,6 +27,15 @@ const rules = {
 const ruleConfigs = {
   'react-hooks/rules-of-hooks': 'error',
   'react-hooks/exhaustive-deps': 'warn',
+  // Compiler rules
+  ...Object.fromEntries(
+    Object.entries(recommendedRules).map(([name, ruleConfig]) => {
+      return [
+        'react-hooks/' + name,
+        mapErrorSeverityToESlint(ruleConfig.severity),
+      ];
+    }),
+  ),
 } satisfies Linter.RulesRecord;
 
 const plugin = {


### PR DESCRIPTION

Adds back the compiler rules to the recommended preset, intended for the next release.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/34675).
* #34703
* #34700
* #34699
* __->__ #34675