### PR TITLE
Fix DevTools regression tests

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
+++ b/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
@@ -850,6 +850,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >= 19.1
       // @reactVersion < 19.2
       it('should process a sample createRoot render sequence', async () => {
         function App() {
@@ -2158,6 +2159,7 @@ describe('Timeline profiler', () => {
       `);
     });
 
+    // @reactVersion >= 19.1
     // @reactVersion < 19.2
     it('should process a sample createRoot render sequence', async () => {
       function App() {


### PR DESCRIPTION
Broke in https://github.com/facebook/react/pull/34665

Tests without pragma only run in the latest React. This specific test snapshots change due to changes in scheduling between React versions. I just pinned it to the last React version supporting the timeline profiler since that's basically how this test behaved before we removed the timeline profiler.