### PR TITLE
[playground] Report non-error-severity errors on compile failure

### DIFF
--- a/compiler/apps/playground/components/Editor/EditorImpl.tsx
+++ b/compiler/apps/playground/components/Editor/EditorImpl.tsx
@@ -207,7 +207,7 @@ function compile(
   } else {
     language = 'typescript';
   }
-  let transformOutput;
+  let transformOutput: CompilerTransformOutput;
 
   let baseOpts: PluginOptions | null = null;
   try {
@@ -302,7 +302,7 @@ function compile(
   if (!error.hasErrors() && otherErrors.length !== 0) {
     otherErrors.forEach(e => error.details.push(e));
   }
-  if (error.hasErrors()) {
+  if (error.hasErrors() || !transformOutput) {
     return [{kind: 'err', results, error}, language, baseOpts];
   }
   return [


### PR DESCRIPTION
error.hasErrors() only returns true on error-severity errors. However, non-error-severity errors (in this case, todos / hint severity) caused invokeCompiler to throw an error. This caused transformOutput to be returned as undefined, breaking the playground and hiding the errors.

Fixes #34657