### PR TITLE
feat(eslint-plugin): add Zod v4 compatibility

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/package.json
+++ b/compiler/packages/babel-plugin-react-compiler/package.json
@@ -52,8 +52,8 @@
     "react-dom": "0.0.0-experimental-4beb1fd8-20241118",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
-    "zod": "^3.22.4",
-    "zod-validation-error": "^2.1.0"
+    "zod": "^3.22.4 || ^4.0.0",
+    "zod-validation-error": "^2.1.0 || ^3.0.0"
   },
   "resolutions": {
     "./**/@babel/parser": "7.7.4",

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -159,7 +159,7 @@ export const EnvironmentConfigSchema = z.object({
    * A function that, given the name of a module, can optionally return a description
    * of that module's type signature.
    */
-  moduleTypeProvider: z.nullable(z.function().args(z.string())).default(null),
+  moduleTypeProvider: z.nullable(z.function(z.tuple([z.string()]), z.any())).default(null),
 
   /**
    * A list of functions which the application compiles as macros, where
@@ -249,7 +249,7 @@ export const EnvironmentConfigSchema = z.object({
    * Allows specifying a function that can populate HIR with type information from
    * Flow
    */
-  flowTypeProvider: z.nullable(z.function().args(z.string())).default(null),
+  flowTypeProvider: z.nullable(z.function(z.tuple([z.string()]), z.any())).default(null),
 
   /**
    * Enables inference of optional dependency chains. Without this flag

--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -43,8 +43,8 @@
     "@babel/parser": "^7.24.4",
     "@babel/plugin-proposal-private-methods": "^7.18.6",
     "hermes-parser": "^0.25.1",
-    "zod": "^3.22.4",
-    "zod-validation-error": "^3.0.3"
+    "zod": "^3.22.4 || ^4.0.0",
+    "zod-validation-error": "^3.0.3 || ^4.0.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.11.4",


### PR DESCRIPTION
Update Zod function schemas to use v4 API syntax:
- Replace z.function().args(z.string()) with z.function(z.tuple([z.string()]), z.any())
- Update moduleTypeProvider and flowTypeProvider in Environment.ts
- Allow both Zod v3 and v4 in package dependencies (^3.22.4 || ^4.0.0)

This fixes the crash when users have Zod v4 installed, where the .args() method no longer exists. The new API is compatible with both Zod v3.23+ and v4.x.

## How did you test this change?

- Built both `babel-plugin-react-compiler` and `eslint-plugin-react-hooks` successfully with the updated Zod v4 API syntax
- Verified the plugin loads correctly and exposes all 29 ESLint rules without the `TypeError: zod.z.function(...).args is not a function` crash