### PR TITLE
[ci] Fix runtime_prereleases

### DIFF
--- a/.github/workflows/runtime_prereleases.yml
+++ b/.github/workflows/runtime_prereleases.yml
@@ -82,7 +82,6 @@ jobs:
         run: |
           scripts/release/publish.js \
             --ci \
-            --skipTests \
             --tags=${{ inputs.dist_tag }} \
             --onlyPackages=${{ inputs.only_packages }} ${{ (inputs.dry && '') || '\'}}
             ${{ inputs.dry && '--dry' || '' }}
@@ -91,7 +90,6 @@ jobs:
         run: |
           scripts/release/publish.js \
             --ci \
-            --skipTests \
             --tags=${{ inputs.dist_tag }} \
             --skipPackages=${{ inputs.skip_packages }} ${{ (inputs.dry && '') || '\'}}
             ${{ inputs.dry && '--dry' || '' }}


### PR DESCRIPTION

When using the "only" or "skip" option in the workflow, we were adding the `--skipTests` param, but that isn't an actual option: https://github.com/facebook/react/blob/1de32a5e75fe96ac3c1b728a117010e11673f6ed/scripts/release/publish-commands/parse-params.js
