### PR TITLE
[playground] handle when transformOutput is null

### DIFF
--- a/compiler/apps/playground/lib/compilation.ts
+++ b/compiler/apps/playground/lib/compilation.ts
@@ -270,6 +270,19 @@ export function compile(
         },
       };
       transformOutput = invokeCompiler(source, language, opts);
+
+      // Only include logger errors if there weren't other errors
+      if (!error.hasErrors() && otherErrors.length !== 0) {
+        otherErrors.forEach(e => error.details.push(e));
+      }
+      if (error.hasErrors()) {
+        return [{kind: 'err', results, error}, language, baseOpts];
+      }
+      return [
+        {kind: 'ok', results, transformOutput, errors: error.details},
+        language,
+        baseOpts,
+      ];
     } catch (err) {
       /**
        * error might be an invariant violation or other runtime error
@@ -291,18 +304,8 @@ export function compile(
           }),
         );
       }
+
+      return [{kind: 'err', results, error}, language, baseOpts];
     }
   }
-  // Only include logger errors if there weren't other errors
-  if (!error.hasErrors() && otherErrors.length !== 0) {
-    otherErrors.forEach(e => error.details.push(e));
-  }
-  if (error.hasErrors()) {
-    return [{kind: 'err', results, error}, language, baseOpts];
-  }
-  return [
-    {kind: 'ok', results, transformOutput, errors: error.details},
-    language,
-    baseOpts,
-  ];
 }


### PR DESCRIPTION
## Summary

The React Compiler Playground was crashing for me with a error that said `"Application error: a client-side exception has occurred while loading playground.react.dev"`. I could only fix it by clearing the browser data

<img width="1025" height="334" alt="Screenshot 2025-10-03 at 3 26 20 PM" src="https://github.com/user-attachments/assets/7caeee40-ecd6-48e5-93aa-83e5ba99eb14" />


**Console error:**
```
Uncaught TypeError: Cannot read properties of undefined (reading 'code')
    at R (2718.2ef44c120f1f0fb2.js:1:2240553)
    at 2718.2ef44c120f1f0fb2.js:1:2242468
    at V (2718.2ef44c120f1f0fb2.js:1:2242518)
```    


**Problematic source code:**
```jsx
import { UIHeader } from 'somewhere';

const Header = ({
  breadcrumbs = <div className="foo" />, 
}) => {
  return (
    <UIHeader breadcrumbs={breadcrumbs}/>      
  );
};
```

I tracked this down to a bug that I _think_ should be caught by TypeScript since `CompilerTransformOutput['transformOutput']` is non-nullable. My fix was to move the return statements into the `try` and `catch` blocks. I had something slightly different in an initial fix but I was confused by `otherErrors` and `hasErrors()`. 

## How did you test this change?

Tested locally. Screen shot attached. 

<img width="1450" height="531" alt="Screenshot 2025-10-03 at 3 23 31 PM" src="https://github.com/user-attachments/assets/3f758d8f-625f-4f4d-aadd-214b39fc82ef" />



