### PR TITLE
[ci] Fix incorrect filtering logic for prereleases

### DIFF
--- a/.github/workflows/runtime_prereleases.yml
+++ b/.github/workflows/runtime_prereleases.yml
@@ -93,7 +93,7 @@ jobs:
             --tags=${{ inputs.dist_tag }} \
             --skipPackages=${{ inputs.skip_packages }} ${{ (inputs.dry && '') || '\'}}
             ${{ inputs.dry && '--dry' || '' }}
-      - if: '${{ !(inputs.skip_packages && inputs.only_packages) }}'
+      - if: '${{ !inputs.skip_packages && !inputs.only_packages }}'
         name: 'Publish all packages'
         run: |
           scripts/release/publish.js \


### PR DESCRIPTION

The workflow was correctly publishing the package(s) specified in `only`, but due to incorrect logic it would also run the 'Publish all packages' step.
