### PR TITLE
chore(reconciler): fix minor comment typos in ReactFiberHooks

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -576,7 +576,7 @@ export function renderWithHooks<Props, SecondArg>(
   //
   // We want memoized functions to run twice, too, so account for this, user
   // functions are double invoked during the *first* invocation of the component
-  // function, and are *not* double invoked during the second incovation:
+  // function, and are *not* double invoked during the second invocation:
   //
   // - First execution of component function: user functions are double invoked
   // - Second execution of component function (in Strict Mode, during
@@ -924,7 +924,7 @@ export function bailoutHooks(
 }
 
 export function resetHooksAfterThrow(): void {
-  // This is called immediaetly after a throw. It shouldn't reset the entire
+  // This is called immediately after a throw. It shouldn't reset the entire
   // module state, because the work loop might decide to replay the component
   // again without rewinding.
   //
@@ -2015,7 +2015,7 @@ function rerenderOptimistic<S, A>(
   // the passthrough value changed.
   //
   // So instead of a forked re-render implementation that knows how to handle
-  // render phase udpates, we can use the same implementation as during a
+  // render phase updates, we can use the same implementation as during a
   // regular mount or update.
   const hook = updateWorkInProgressHook();
 
@@ -2528,7 +2528,7 @@ function rerenderActionState<S, P>(
   // the passthrough value changed.
   //
   // So instead of a forked re-render implementation that knows how to handle
-  // render phase udpates, we can use the same implementation as during a
+  // render phase updates, we can use the same implementation as during a
   // regular mount or update.
   const stateHook = updateWorkInProgressHook();
   const currentStateHook = currentHook;


### PR DESCRIPTION
Summary

This PR fixes a handful of spelling/grammar typos in comments within the hooks implementation (no runtime behavior changes).
Edits are limited to packages/react-reconciler/src/ReactFiberHooks.js and improve readability for contributors.

Examples of corrections:

“incovation” → “invocation”

“immediaetly” → “immediately”

“render phase udpates” → “render phase updates”

No code paths, types, or exports are modified.

How did you test this change?

Because this PR is comments-only, the goal was to ensure zero functional impact and keep the repo formatting/lint rules green.