### PR TITLE
Revert #34719

### DIFF
--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@babel/core": "^7.24.4",
     "@babel/parser": "^7.24.4",
+    "hermes-parser": "^0.25.1",
     "zod": "^3.22.4 || ^4.0.0",
     "zod-validation-error": "^3.0.3 || ^4.0.0"
   },


### PR DESCRIPTION

Adds back HermesParser to eslint-plugin-react-hooks. There are still [external users of Flow](https://github.com/facebook/react/pull/34719#issuecomment-3368137743) using the plugin, so we shouldn't break the plugin for them. However, we still have the problem of double parsing: once from eslint (which we discard) and then another via babel/hermes parser.

In the long run we should investigate a translation layer from estree to babel (or alternatively, update the compiler to take estree as input). For now I am reverting that PR.  This does mean that [Sandpack in react.dev](https://github.com/reactjs/react.dev/blob/11cb6b591571caf5fa2a192117b6a6445c3f2027/src/components/MDX/Sandpack/runESLint.tsx#L31) cannot update to the latest eprh as HermesParser does not appear to be able to be run in a browser. I discovered this while trying to update eprh on react.dev last week, but didn't investigate deeply. I'll need to double check that again to find out more.
