### PR TITLE
[DevTools] Exclude Suspense boundaries in hidden Activity

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -3148,6 +3148,10 @@ describe('Store', () => {
     const Activity = React.Activity || React.unstable_Activity;
 
     const never = new Promise(() => {});
+    function Never() {
+      readValue(never);
+      return null;
+    }
     function Component({children}) {
       return <div>{children}</div>;
     }
@@ -3155,21 +3159,38 @@ describe('Store', () => {
     function App({hidden}) {
       return (
         <>
-          <Activity mode={hidden ? 'hidden' : 'visiible'}>
+          <Activity mode={hidden ? 'hidden' : 'visible'}>
             <React.Suspense name="inside-activity">
               <Component key="inside-activity">inside Activity</Component>
             </React.Suspense>
           </Activity>
           <React.Suspense name="outer-suspense">
-            {hidden ? never : null}
             <React.Suspense name="inner-suspense">
               <Component key="inside-suspense">inside Suspense</Component>
             </React.Suspense>
+            {hidden ? <Never /> : null}
           </React.Suspense>
         </>
       );
     }
 
+    await actAsync(() => {
+      render(<App hidden={true} />);
+    });
+
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <App>
+            <Activity>
+            <Suspense name="outer-suspense">
+      [suspense-root]  rects={[{x:1,y:2,width:15,height:1}]}
+        <Suspense name="outer-suspense" rects={null}>
+    `);
+
+    // mount as visible
+    await actAsync(() => {
+      render(null);
+    });
     await actAsync(() => {
       render(<App hidden={false} />);
     });
@@ -3199,7 +3220,6 @@ describe('Store', () => {
             <Activity>
             <Suspense name="outer-suspense">
       [suspense-root]  rects={[{x:1,y:2,width:15,height:1}, {x:1,y:2,width:15,height:1}]}
-        <Suspense name="inside-activity" rects={[{x:1,y:2,width:15,height:1}]}>
         <Suspense name="outer-suspense" rects={[{x:1,y:2,width:15,height:1}]}>
           <Suspense name="inner-suspense" rects={[{x:1,y:2,width:15,height:1}]}>
     `);


### PR DESCRIPTION
Including Suspense in hidden Activity can be confusing since that likely ends up to overlapping rects (e.g. when each tab content is in an Activity or when previous "pages" are kept in Activity for a better backwards-forwards cache.

We now differentiate between Offscreen used by Suspense and Offscreen used by Activity. Activity-Offscreen will just unmount all nodes. Suspense-Offscreen will stay as-is and unmount nodes except Suspense nodes in the Suspense tree.
