### PR TITLE
[eprh] Prepare for 7.0.0

### DIFF
--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -33,7 +33,7 @@ const canaryChannelLabel = 'canary';
 const rcNumber = 0;
 
 const stablePackages = {
-  'eslint-plugin-react-hooks': '6.2.0',
+  'eslint-plugin-react-hooks': '7.0.0',
   'jest-react': '0.18.0',
   react: ReactVersion,
   'react-art': ReactVersion,

--- a/packages/eslint-plugin-react-hooks/CHANGELOG.md
+++ b/packages/eslint-plugin-react-hooks/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.0
+
+- **Breaking:** Slim down presets to just 3 configurations. Removed `recommended-latest-legacy` and `flat/recommended` configs. The plugin now provides `recommended-legacy` (legacy config with all recommended rules), `recommended` (flat config with all recommended rules), and `recommended-experimental` (flat config with all recommended rules plus new bleeding edge experimental compiler rules). ([@poteto](https://github.com/poteto) in [#TODO](https://github.com/facebook/react/pull/TODO))
+
 ## 6.1.1
 
 **Note:** 6.1.0 accidentally allowed use of `recommended` without flat config, causing errors when used with ESLint v9's `defineConfig()` helper. This has been fixed in 6.1.1.

--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -4,8 +4,6 @@ The official ESLint plugin for [React](https://react.dev) which enforces the [Ru
 
 ## Installation
 
-**Note: If you're using Create React App, please use `react-scripts` >= 3 instead of adding it directly.**
-
 Assuming you already have ESLint installed, run:
 
 ```sh
@@ -18,9 +16,9 @@ yarn add eslint-plugin-react-hooks --dev
 
 ### Flat Config (eslint.config.js|ts)
 
-#### >= 6.0.0
+#### >= 7.0.0
 
-For users of 6.0 and beyond, add the `recommended` config.
+For users of 7.0 and beyond, add the `recommended` config for all recommended rules:
 
 ```js
 // eslint.config.js
@@ -38,11 +36,10 @@ export default defineConfig([
 ]);
 ```
 
-#### 5.2.0
-
-For users of 5.2.0 (the first version with flat config support), add the `recommended-latest` config.
+If you want to try bleeding edge experimental compiler rules, use `recommended-experimental`:
 
 ```js
+// eslint.config.js
 import reactHooks from 'eslint-plugin-react-hooks';
 import { defineConfig } from 'eslint/config';
 
@@ -52,35 +49,22 @@ export default defineConfig([
     plugins: {
       'react-hooks': reactHooks,
     },
-    extends: ['react-hooks/recommended-latest'],
+    extends: ['react-hooks/recommended-experimental'],
   },
 ]);
 ```
 
 ### Legacy Config (.eslintrc)
 
-#### >= 5.2.0
+#### >= 7.0.0
 
-If you are still using ESLint below 9.0.0, you can use `recommended-legacy` for accessing a legacy version of the recommended config.
+If you are still using ESLint below 9.0.0, you can use `recommended-legacy` for accessing a legacy version of the recommended config with all recommended rules.
 
 ```js
 {
   "extends": [
     // ...
     "plugin:react-hooks/recommended-legacy"
-  ]
-}
-```
-
-#### < 5.2.0
-
-If you're using a version earlier than 5.2.0, the legacy config was simply `recommended`.
-
-```js
-{
-  "extends": [
-    // ...
-    "plugin:react-hooks/recommended"
   ]
 }
 ```
@@ -92,7 +76,7 @@ If you want more fine-grained configuration, you can instead choose to enable sp
 #### Flat Config (eslint.config.js|ts)
 
 ```js
-import * as reactHooks from 'eslint-plugin-react-hooks';
+import reactHooks from 'eslint-plugin-react-hooks';
 
 export default [
   {
@@ -100,8 +84,26 @@ export default [
     plugins: { 'react-hooks': reactHooks },
     // ...
     rules: {
+      // Core hooks rules
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
+
+      // React Compiler rules
+      'react-hooks/config': 'error',
+      'react-hooks/error-boundaries': 'error',
+      'react-hooks/component-hook-factories': 'error',
+      'react-hooks/gating': 'error',
+      'react-hooks/globals': 'error',
+      'react-hooks/immutability': 'error',
+      'react-hooks/preserve-manual-memoization': 'error',
+      'react-hooks/purity': 'error',
+      'react-hooks/refs': 'error',
+      'react-hooks/set-state-in-effect': 'error',
+      'react-hooks/set-state-in-render': 'error',
+      'react-hooks/static-components': 'error',
+      'react-hooks/unsupported-syntax': 'warn',
+      'react-hooks/use-memo': 'error',
+      'react-hooks/incompatible-library': 'warn',
     }
   },
 ];
@@ -116,8 +118,26 @@ export default [
   ],
   "rules": {
     // ...
+    // Core hooks rules
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "warn",
+
+    // React Compiler rules
+    "react-hooks/config": "error",
+    "react-hooks/error-boundaries": "error",
+    "react-hooks/component-hook-factories": "error",
+    "react-hooks/gating": "error",
+    "react-hooks/globals": "error",
+    "react-hooks/immutability": "error",
+    "react-hooks/preserve-manual-memoization": "error",
+    "react-hooks/purity": "error",
+    "react-hooks/refs": "error",
+    "react-hooks/set-state-in-effect": "error",
+    "react-hooks/set-state-in-render": "error",
+    "react-hooks/static-components": "error",
+    "react-hooks/unsupported-syntax": "warn",
+    "react-hooks/use-memo": "error",
+    "react-hooks/incompatible-library": "warn"
   }
 }
 ```

--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-react-hooks",
   "description": "ESLint rules for React Hooks",
-  "version": "5.2.0",
+  "version": "7.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/react.git",

--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -72,24 +72,10 @@ const plugin = {
 Object.assign(plugin.configs, {
   'recommended-legacy': {
     plugins: ['react-hooks'],
-    rules: basicRuleConfigs,
-  },
-
-  'recommended-latest-legacy': {
-    plugins: ['react-hooks'],
     rules: allRuleConfigs,
   },
 
-  'flat/recommended': [
-    {
-      plugins: {
-        'react-hooks': plugin,
-      },
-      rules: basicRuleConfigs,
-    },
-  ],
-
-  'recommended-latest': [
+  'recommended-experimental': [
     {
       plugins: {
         'react-hooks': plugin,


### PR DESCRIPTION

For 7.0.0:

Slim down presets to just 3 configurations:

- `recommended-legacy`: legacy config with all recommended rules
- `recommended`: flat config with all recommended rules, and
- `recommended-experimental`: flat config with all recommended rules plus new bleeding edge experimental compiler rules

Removed:
- `recommended-latest-legacy`
- `flat/recommended configs`
