### PR TITLE
[Flight] Fix preload `as` attribute for stylesheets

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFlightServerConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFlightServerConfigDOM.js
@@ -169,7 +169,7 @@ function processLink(props: Object, formatContext: FormatContext): void {
       return;
     }
     case 'stylesheet': {
-      preload(href, 'stylesheet', {
+      preload(href, 'style', {
         crossOrigin: props.crossOrigin,
         integrity: props.integrity,
         nonce: props.nonce,

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -2087,7 +2087,7 @@ describe('ReactFlightDOM', () => {
             media="(orientation: landscape)"
           />
           <link rel="modulepreload" href="module-resource" />
-          <link rel="preload" as="stylesheet" href="css-resource" />
+          <link rel="preload" as="style" href="css-resource" />
         </head>
         <body>
           <p>hello world</p>


### PR DESCRIPTION
Follow-up to #34604. For a stylesheet, we need to render `<link rel="preload" as="style" ...>`, and not `<link rel="preload" as="stylesheet" ...>`. ([ref](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preload#what_types_of_content_can_be_preloaded))

fixes https://github.com/vercel/next.js/issues/84569