### PR TITLE
[eprh] Update plugin config to be compatible with flat and legacy

### DIFF
--- a/fixtures/eslint-v9/eslint.config.ts
+++ b/fixtures/eslint-v9/eslint.config.ts
@@ -2,6 +2,7 @@ import {defineConfig} from 'eslint/config';
 import reactHooks from 'eslint-plugin-react-hooks';
 
 export default defineConfig([
+  reactHooks.configs.flat['recommended-latest'],
   {
     languageOptions: {
       ecmaVersion: 'latest',
@@ -12,7 +13,6 @@ export default defineConfig([
         },
       },
     },
-    extends: [reactHooks.configs['recommended-latest']],
     rules: {
       'react-hooks/exhaustive-deps': 'error',
     },

--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -50,7 +50,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/types": "^7.19.0",
     "@tsconfig/strictest": "^2.0.5",
-    "@types/eslint": "^8.56.12",
+    "@types/eslint": "^9.6.1",
     "@types/estree": "^1.0.6",
     "@types/estree-jsx": "^1.0.5",
     "@types/node": "^20.2.5",

--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -14,7 +14,6 @@ import {
 } from './shared/ReactCompiler';
 import RulesOfHooks from './rules/RulesOfHooks';
 
-// All rules
 const rules = {
   'exhaustive-deps': ExhaustiveDeps,
   'rules-of-hooks': RulesOfHooks,
@@ -23,7 +22,6 @@ const rules = {
   ),
 } satisfies Record<string, Rule.RuleModule>;
 
-// Basic hooks rules (for recommended config)
 const basicRuleConfigs = {
   'react-hooks/rules-of-hooks': 'error',
   'react-hooks/exhaustive-deps': 'warn',
@@ -38,15 +36,40 @@ const compilerRuleConfigs = Object.fromEntries(
   }),
 ) as Record<`react-hooks/${string}`, Linter.RuleEntry>;
 
-// All rules including compiler rules (for recommended-latest config)
 const allRuleConfigs: Linter.RulesRecord = {
   ...basicRuleConfigs,
   ...compilerRuleConfigs,
 };
 
-type FlatConfig = {
+const plugins = ['react-hooks'];
+
+type ReactHooksFlatConfig = {
   plugins: Record<string, any>;
   rules: Linter.RulesRecord;
+};
+
+const configs = {
+  'recommended-legacy': {
+    plugins,
+    rules: basicRuleConfigs,
+  },
+  'recommended-latest-legacy': {
+    plugins,
+    rules: allRuleConfigs,
+  },
+  'flat/recommended': {
+    plugins,
+    rules: basicRuleConfigs,
+  },
+  'recommended-latest': {
+    plugins,
+    rules: allRuleConfigs,
+  },
+  recommended: {
+    plugins,
+    rules: basicRuleConfigs,
+  },
+  flat: {} as Record<string, ReactHooksFlatConfig>,
 };
 
 const plugin = {
@@ -54,58 +77,30 @@ const plugin = {
     name: 'eslint-plugin-react-hooks',
   },
   rules,
-  configs: {} as {
-    'recommended-legacy': {
-      plugins: Array<string>;
-      rules: Linter.RulesRecord;
-    };
-    'recommended-latest-legacy': {
-      plugins: Array<string>;
-      rules: Linter.RulesRecord;
-    };
-    'flat/recommended': Array<FlatConfig>;
-    'recommended-latest': Array<FlatConfig>;
-    recommended: Array<FlatConfig>;
-  },
+  configs,
 };
 
-Object.assign(plugin.configs, {
+Object.assign(configs.flat, {
   'recommended-legacy': {
-    plugins: ['react-hooks'],
-    rules: basicRuleConfigs,
+    plugins: {'react-hooks': plugin},
+    rules: configs['recommended-legacy'].rules,
   },
-
   'recommended-latest-legacy': {
-    plugins: ['react-hooks'],
-    rules: allRuleConfigs,
+    plugins: {'react-hooks': plugin},
+    rules: configs['recommended-latest-legacy'].rules,
   },
-
-  'flat/recommended': [
-    {
-      plugins: {
-        'react-hooks': plugin,
-      },
-      rules: basicRuleConfigs,
-    },
-  ],
-
-  'recommended-latest': [
-    {
-      plugins: {
-        'react-hooks': plugin,
-      },
-      rules: allRuleConfigs,
-    },
-  ],
-
-  recommended: [
-    {
-      plugins: {
-        'react-hooks': plugin,
-      },
-      rules: basicRuleConfigs,
-    },
-  ],
+  'flat/recommended': {
+    plugins: {'react-hooks': plugin},
+    rules: configs['flat/recommended'].rules,
+  },
+  'recommended-latest': {
+    plugins: {'react-hooks': plugin},
+    rules: configs['recommended-latest'].rules,
+  },
+  recommended: {
+    plugins: {'react-hooks': plugin},
+    rules: configs.recommended.rules,
+  },
 });
 
 export default plugin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3907,10 +3907,10 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/eslint@^8.56.12":
-  version "8.56.12"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.56.12.tgz#1657c814ffeba4d2f84c0d4ba0f44ca7ea1ca53a"
-  integrity sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==
+"@types/eslint@^9.6.1":
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-9.6.1.tgz#d5795ad732ce81715f27f75da913004a56751584"
+  integrity sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
@@ -10190,6 +10190,11 @@ hermes-eslint@^0.32.0:
     hermes-estree "0.32.0"
     hermes-parser "0.32.0"
 
+hermes-estree@0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.25.1.tgz#6aeec17d1983b4eabf69721f3aa3eb705b17f480"
+  integrity sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==
+
 hermes-estree@0.29.1:
   version "0.29.1"
   resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.29.1.tgz#043c7db076e0e8ef8c5f6ed23828d1ba463ebcc5"
@@ -10213,6 +10218,13 @@ hermes-parser@0.32.0, hermes-parser@^0.32.0:
   integrity sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==
   dependencies:
     hermes-estree "0.32.0"
+
+hermes-parser@^0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.25.1.tgz#5be0e487b2090886c62bd8a11724cd766d5f54d1"
+  integrity sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==
+  dependencies:
+    hermes-estree "0.25.1"
 
 homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION

This has been incredibly frustrating as [ESLint's own docs](https://eslint.org/docs/latest/extend/plugins#backwards-compatibility-for-legacy-configs) are clearly wrong (see #34679).

This PR uses [eslint-plugin-react's setup](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/index.js) as a reference, where the presets are assigned  to `configs.flat` (not documented by eslint).
