### PR TITLE
[compiler] Update release script for latest tag

### DIFF
--- a/compiler/scripts/release/publish.js
+++ b/compiler/scripts/release/publish.js
@@ -68,7 +68,7 @@ async function main() {
     .option('tag', {
       description: 'Tag to publish to npm',
       type: 'choices',
-      choices: ['experimental', 'beta', 'rc'],
+      choices: ['experimental', 'beta', 'rc', 'latest'],
       default: 'experimental',
     })
     .option('tag-version', {
@@ -181,19 +181,10 @@ async function main() {
       if (otp != null) {
         opts.push(`--otp=${otp}`);
       }
-      /**
-       * Typically, the `latest` tag is reserved for stable package versions. Since the the compiler
-       * is still pre-release, until we have a stable release let's only add the
-       * `latest` tag to non-experimental releases.
-       *
-       * `latest` is added by default, so we only override it for experimental releases so that
-       * those don't get the `latest` tag.
-       *
-       * TODO: Update this when we have a stable release.
-       */
+
       if (argv.tag === 'experimental') {
         opts.push('--tag=experimental');
-      } else {
+      } else if (argv.tag === 'latest') {
         opts.push('--tag=latest');
       }
       try {


### PR DESCRIPTION

Updates our release script so we can publish to the `latest` tag.
