### PR TITLE
[compiler] Fix incorrect version name

### DIFF
--- a/compiler/scripts/release/publish.js
+++ b/compiler/scripts/release/publish.js
@@ -145,10 +145,15 @@ async function main() {
       files: {exclude: ['.DS_Store']},
     });
     const truncatedHash = hash.slice(0, 7);
-    let newVersion =
-      argv.tagVersion == null || argv.tagVersion === ''
-        ? `${argv.versionName}-${argv.tag}`
-        : `${argv.versionName}-${argv.tag}.${argv.tagVersion}`;
+    let newVersion;
+    if (argv.tag === 'latest') {
+      newVersion = argv.versionName;
+    } else {
+      newVersion =
+        argv.tagVersion == null || argv.tagVersion === ''
+          ? `${argv.versionName}-${argv.tag}`
+          : `${argv.versionName}-${argv.tag}.${argv.tagVersion}`;
+    }
     if (argv.tag === 'experimental' || argv.tag === 'beta') {
       newVersion = `${newVersion}-${truncatedHash}-${dateString}`;
     }


### PR DESCRIPTION

Script was using the wrong version name.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/34764).
* #34765
* __->__ #34764