### PR TITLE
[ci] Dry run with debug mode

### DIFF
--- a/.github/workflows/compiler_prereleases.yml
+++ b/.github/workflows/compiler_prereleases.yml
@@ -62,7 +62,7 @@ jobs:
         name: Publish packages to npm (dry run)
         run: |
           cp ./scripts/release/ci-npmrc ~/.npmrc
-          scripts/release/publish.js --ci --versionName=${{ inputs.version_name }} --tag=${{ inputs.dist_tag }} ${{ inputs.tag_version && format('--tagVersion={0}', inputs.tag_version) || '' }}
+          scripts/release/publish.js --frfr --debug --ci --versionName=${{ inputs.version_name }} --tag=${{ inputs.dist_tag }} ${{ inputs.tag_version && format('--tagVersion={0}', inputs.tag_version) || '' }}
       - if: inputs.dry_run != true
         name: Publish packages to npm
         run: |


### PR DESCRIPTION

Adds `--debug` to our dry run command so we can see the npm dry run output
