### PR TITLE
[eprh] Ensure useMemo() has at least 1 valued return

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -739,6 +739,58 @@ const allTests = {
         }
       `,
     },
+    // useMemo()
+    {
+      code: normalizeIndent`
+        // base case 
+        function ComponentWithHook() {
+          useMemo(() => {
+            return 1
+          });
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        // case: all paths with valued return
+        function ComponentWithHook() {
+          useMemo(() => {
+            if(1 == 1){
+              return 1
+            }
+            return 2
+          });
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        // case: 1 path with valued return
+        function ComponentWithHook() {
+          useMemo(() => {
+            if(1 == 1){
+              return 1
+            }
+          });
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        // case: useMemo with no fn
+        function ComponentWithHook() {
+          useMemo();
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        // case: useMemo with non-fn arg (ie. doesn't error out)
+        function ComponentWithHook() {
+          useMemo(1);
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -1665,6 +1717,78 @@ const allTests = {
           `It cannot be assigned to a variable or passed down.`,
       ],
     },
+    // useMemo()
+    {
+      code: normalizeIndent`
+        // case: no return
+        function ComponentWithHook() {
+          useMemo(() => {});
+        }
+      `,
+      errors: [useMemoHookMissingReturnError('useMemo')],
+    },
+    {
+      code: normalizeIndent`
+        // case: empty return
+        function ComponentWithHook() {
+          useMemo(() => {
+            return  
+          });
+        }
+      `,
+      errors: [useMemoHookMissingReturnError('useMemo')],
+    },
+    {
+      code: normalizeIndent`
+        // case: no return (excludes nested function)
+        function ComponentWithHook() {
+          useMemo(() => {
+            // FunctionDeclaration
+            function A(){
+              return
+            }
+            // FunctionExpression
+            const B = function(){
+              return
+            } 
+            // ArrowFunctionExpression
+            const C = () => {
+              return
+            }  
+          });
+        }
+      `,
+      errors: [useMemoHookMissingReturnError('useMemo')],
+    },
+    {
+      code: normalizeIndent`
+        // case: no return (excludes nested function, .map)
+        function ComponentWithHook() {
+          useMemo(() => {
+            const A = someVar.map(() => {
+              return 1;
+            })  
+          });
+        }
+      `,
+      errors: [useMemoHookMissingReturnError('useMemo')],
+    },
+    {
+      code: normalizeIndent`
+        // case: no return (nested useMemo)
+        function ComponentWithHook() {
+          useMemo(() => {
+            useMemo(() => {
+            })
+            return 1;
+          });
+        }
+      `,
+      errors: [
+        useMemoHookMissingReturnError('useMemo'),
+        'React Hook "useMemo" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.',
+      ],
+    },
   ],
 };
 
@@ -1743,6 +1867,12 @@ function asyncComponentHookError(fn) {
 function tryCatchUseError(fn) {
   return {
     message: `React Hook "${fn}" cannot be called in a try/catch block.`,
+  };
+}
+
+function useMemoHookMissingReturnError(fn) {
+  return {
+    message: `React Hook "${fn}" must contain at least 1 valued return statement.`,
   };
 }
 

--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -51,6 +51,7 @@
     "@babel/types": "^7.19.0",
     "@tsconfig/strictest": "^2.0.5",
     "@types/eslint": "^9.6.1",
+    "@types/estraverse": "^5.1.7",
     "@types/estree": "^1.0.6",
     "@types/estree-jsx": "^1.0.5",
     "@types/node": "^20.2.5",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Ensures that `useMemo()` usage contains at least 1 valued `return`
- Related issue: https://github.com/facebook/react/issues/25379

In detail:
- It is possible to define a `useMemo()` that doesn't return a value (eg. developer forgot to put a return)
- Also accounts for corner cases
  - Nested `useMemo()` - Flag missing `return`
  - Nested functions - Skip traversal (ie. nested functions would capture `return` statements, so they are not relevant)
- To ensure that all `useMemo()` returns at least a value, typechecking is not necessary - we can just traverse the AST to ensure that there is at least a valued `return` in the function declaration provided to the `useMemo()`.

Open Discussion
- Is it semantically acceptable for this to fall within the remit of `rules-of-hooks`? Technically, `rules-of-hooks` is more closely related to stable invocation of hooks, no wrapping of hooks within conditional blocks, etc. 

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
IDE  (Windsurf + ESLint VSCode plugin)
<img width="635" height="580" alt="Screenshot 2025-10-08 at 12 56 37 PM" src="https://github.com/user-attachments/assets/a35cd927-e9da-47cf-88eb-2cf93b15fd25" />


https://github.com/user-attachments/assets/db0c9a70-3c96-483e-aed9-bbfb294662bf



CLI
<img width="788" height="217" alt="image" src="https://github.com/user-attachments/assets/1b173147-e012-4894-9728-17aec17318cf" />


- Tested against sandbox repo to ensure correct behavior
- Added unit tests to ensure correct ESLint behavior