### PR TITLE
[eprh]: Fix config examples and update instructions in README.md

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -24,19 +24,61 @@ For users of 6.0 and beyond, add the `recommended` config.
 
 ```js
 // eslint.config.js
-import reactHooks from 'eslint-plugin-react-hooks';
-import { defineConfig } from 'eslint/config';
+import reactHooks from "eslint-plugin-react-hooks";
+import { defineConfig } from "eslint/config";
+
+export default defineConfig([
+  {
+    files: ["src/**/*.{js,jsx}"],
+    plugins: {
+      "react-hooks": reactHooks,
+    },
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    extends: ["react-hooks/recommended"],
+  },
+]);
+```
+
+If your project uses typescript, you'll also need to install [typescript-eslint](https://typescript-eslint.io) and enable its rules:
+
+```js
+// eslint.config.js
+import reactHooks from "eslint-plugin-react-hooks";
+import { defineConfig } from "eslint/config";
+import tseslint from "typescript-eslint";
 
 export default defineConfig([
   {
     files: ["src/**/*.{js,jsx,ts,tsx}"],
     plugins: {
-      'react-hooks': reactHooks,
+      "react-hooks": reactHooks,
     },
-    extends: ['react-hooks/recommended'],
+    extends: [tseslint.configs.recommended, "react-hooks/recommended"],
   },
 ]);
 ```
+
+You can opt into the latest [compiler powered rules](https://react.dev/reference/eslint-plugin-react-hooks#additional-rules) one by one:
+
+```js
+export default defineConfig( [
+  {
+    // ...
+    extends: ["react-hooks/recommended"],
+    rules: {
+      "react-hooks/purity": "error",
+      "react-hooks/immutability": "error",
+      //...
+    },
+  },
+]);
+
+```
+Alternatively, use the `recommended-latest` preset, which enables these rules by default.
 
 #### 5.2.0
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/facebook/react/issues/34779

Also adds instructions for using latest compiler powered rules.

## How did you test this change?
- I've tested that you can copy and paste into newly created vite apps (with and without typescript) with eslint v9 and eprh v6.1.1 (i.e. will fix https://github.com/mdj-uk/vite-react-no-ts ([sandbox](https://codesandbox.io/p/github/mdj-uk/vite-react-no-ts/main?file=%2Feslint.config.js&import=true&workspaceId=ws_NWeM56rFTtP8bj8JxvwSss)) and https://github.com/mdj-uk/vite-react-ts ([sandbox](https://codesandbox.io/p/github/mdj-uk/vite-react-ts/main?file=%2Feslint.config.js&import=true&workspaceId=ws_NWeM56rFTtP8bj8JxvwSss)) 
- I've  _not_ considered legacy (non-flat) eslint config, or older versions of eprh