### PR TITLE
[eprh] Fix config.flat keys to be inferred correctly

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Linter, Rule} from 'eslint';
+import type {ESLint, Linter, Rule} from 'eslint';
 
 import ExhaustiveDeps from './rules/ExhaustiveDeps';
 import {
@@ -55,24 +55,21 @@ const recommendedLatestRuleConfigs: Linter.RulesRecord = {
   ...recommendedLatestCompilerRuleConfigs,
 };
 
-const plugins = ['react-hooks'];
-
-type ReactHooksFlatConfig = {
-  plugins: {react: any};
-  rules: Linter.RulesRecord;
+const pluginsLegacy = ['react-hooks'];
+const pluginsFlat = {
+  'react-hooks': {}, // Assign after creating the plugin object
 };
 
-const configs = {
-  recommended: {
-    plugins,
-    rules: recommendedRuleConfigs,
-  },
-  'recommended-latest': {
-    plugins,
-    rules: recommendedLatestRuleConfigs,
-  },
-  flat: {} as Record<string, ReactHooksFlatConfig>,
-};
+interface Plugin extends Omit<ESLint.Plugin, 'configs'> {
+  configs: {
+    recommended: Linter.LegacyConfig;
+    'recommended-latest': Linter.LegacyConfig;
+    flat: {
+      recommended: Linter.Config;
+      'recommended-latest': Linter.Config;
+    };
+  };
+}
 
 const plugin = {
   meta: {
@@ -80,18 +77,28 @@ const plugin = {
     version: '7.0.0',
   },
   rules,
-  configs,
-};
+  configs: {
+    recommended: {
+      plugins: pluginsLegacy,
+      rules: recommendedRuleConfigs,
+    },
+    'recommended-latest': {
+      plugins: pluginsLegacy,
+      rules: recommendedLatestRuleConfigs,
+    },
+    flat: {
+      recommended: {
+        plugins: pluginsFlat,
+        rules: recommendedRuleConfigs,
+      },
+      'recommended-latest': {
+        plugins: pluginsFlat,
+        rules: recommendedLatestRuleConfigs,
+      },
+    },
+  },
+} satisfies Plugin;
 
-Object.assign(configs.flat, {
-  'recommended-latest': {
-    plugins: {'react-hooks': plugin},
-    rules: configs['recommended-latest'].rules,
-  },
-  recommended: {
-    plugins: {'react-hooks': plugin},
-    rules: configs.recommended.rules,
-  },
-});
+pluginsFlat['react-hooks'] = plugin;
 
 export default plugin;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

- fix #34788

Fixed an issue where the TypeScript type inference for configuration keys was string in the flat config of eslint-plugin-react-hooks.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Regardless of this change, the build of eprh does not succeed in my environment, so I have not tested it.

<details>
<p>

```
Running: mkdir -p ./compiler/packages/babel-plugin-react-compiler/dist && echo "module.exports = require('../src/index.ts');" > ./compiler/packages/babel-plugin-react-compiler/dist/index.js
 BUILDING  eslint-plugin-react-hooks.development.js (node_dev)

@rollup/plugin-typescript TS7016: Could not find a declaration file for module '@babel/code-frame'. '/Users/eai/ghq/github.com/facebook/react/node_modules/@babel/code-frame/lib/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/babel__code-frame` if it exists or add a new declaration (.d.ts) file containing `declare module '@babel/code-frame';`

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

in `yarn build`

</p>
</details> 

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
