### PR TITLE
fix(devtools): remove duplicated "Display density" field in General settings

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Settings/GeneralSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/GeneralSettings.js
@@ -104,18 +104,6 @@ export default function GeneralSettings(_: {}): React.Node {
         ) : null}
       </div>
 
-      <div className={styles.SettingWrapper}>
-        <div className={styles.RadioLabel}>Display density</div>
-        <select
-          value={displayDensity}
-          onChange={({currentTarget}) =>
-            setDisplayDensity(currentTarget.value)
-          }>
-          <option value="compact">Compact</option>
-          <option value="comfortable">Comfortable</option>
-        </select>
-      </div>
-
       {supportsTraceUpdates && (
         <div className={styles.SettingWrapper}>
           <label className={styles.SettingRow}>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->
## Summary

This pull request fixes a small UI issue in the React Developer Tools settings panel.
The “Display density” field was appearing twice in the General tab.

Fix : https://github.com/facebook/react/issues/34791