### PR TITLE
devtools: fix ellipsis truncation for key values

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/Element.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Element.js
@@ -181,9 +181,7 @@ export default function Element({data, index, style}: Props): React.Node {
               className={styles.KeyValue}
               title={key}
               onDoubleClick={handleKeyDoubleClick}>
-              <pre>
-                <IndexableDisplayName displayName={key} id={id} />
-              </pre>
+              <IndexableDisplayName displayName={key} id={id} />
             </span>
             "
           </Fragment>
@@ -196,9 +194,7 @@ export default function Element({data, index, style}: Props): React.Node {
               className={styles.KeyValue}
               title={nameProp}
               onDoubleClick={handleKeyDoubleClick}>
-              <pre>
-                <IndexableDisplayName displayName={nameProp} id={id} />
-              </pre>
+              <IndexableDisplayName displayName={nameProp} id={id} />
             </span>
             "
           </Fragment>


### PR DESCRIPTION
before
<img width="349" height="73" alt="Screenshot 2025-10-09 at 11 38 03" src="https://github.com/user-attachments/assets/93fec45d-4ef2-498f-9550-36ff807b63f9" />

after
<img width="349" height="73" alt="Screenshot 2025-10-09 at 11 38 39" src="https://github.com/user-attachments/assets/cb279384-4229-4d56-a803-93c2df897754" />
