### PR TITLE
[lint] improve type safety on flat config

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -57,11 +57,6 @@ const recommendedLatestRuleConfigs: Linter.RulesRecord = {
 
 const plugins = ['react-hooks'];
 
-type ReactHooksFlatConfig = {
-  plugins: {react: any};
-  rules: Linter.RulesRecord;
-};
-
 const configs = {
   recommended: {
     plugins,
@@ -71,7 +66,7 @@ const configs = {
     plugins,
     rules: recommendedLatestRuleConfigs,
   },
-  flat: {} as Record<string, ReactHooksFlatConfig>,
+  flat: {} as typeof flatConfigs,
 };
 
 const plugin = {
@@ -83,15 +78,19 @@ const plugin = {
   configs,
 };
 
-Object.assign(configs.flat, {
+const pluginUnknown: unknown = plugin;
+
+const flatConfigs = {
   'recommended-latest': {
-    plugins: {'react-hooks': plugin},
-    rules: configs['recommended-latest'].rules,
+    plugins: {'react-hooks': pluginUnknown},
+    rules: recommendedLatestRuleConfigs,
   },
   recommended: {
-    plugins: {'react-hooks': plugin},
-    rules: configs.recommended.rules,
+    plugins: {'react-hooks': pluginUnknown},
+    rules: recommendedRuleConfigs,
   },
-});
+};
+
+configs.flat = flatConfigs;
 
 export default plugin;


### PR DESCRIPTION
## Summary

This pull request refactors the way flat ESLint configs are defined and assigned in the `eslint-plugin-react-hooks` package. The main focus is on improving type safety and clarity by restructuring how the `flat` configuration is constructed and assigned.


The flat config was typed as Record<string, ReactHooksFlatConfig>, so it lacks editor auto-completions and could lead to spelling mistakes. This change preserves config names so it's easier and safer to use.