### PR TITLE
fix(compiler): compiler workspaces setting

### DIFF
--- a/compiler/package.json
+++ b/compiler/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "workspaces": {
     "packages": [
-      "packages/*"
+      "packages/*",
+      "apps/*"
     ]
   },
   "repository": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

The 'start' and 'next' scripts in the compiler monorepo reference 'yarn workspace playground', but the playground app in compiler/apps/playground was not included in the workspaces configuration. This caused these commands to fail.
<img width="933" height="144" alt="Screenshot 2025-10-10 at 6 17 28 PM" src="https://github.com/user-attachments/assets/b0bec8d2-5a08-4079-97f6-a49dffad3502" />

This PR adds 'apps/*' to the workspaces.packages array to properly register the playground workspace.

## How did you test this change?

Verified by running 'yarn start' locally, and confirmed that the snapshot error shown above no longer appears.