### PR TITLE
[Flight] Respect displayName of Promise instances on the server

### DIFF
--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
@@ -3311,7 +3311,7 @@ describe('ReactFlightAsyncDebugInfo', () => {
   });
 
   it('can track a promise created fully outside first party code', async function internal_test() {
-    function internal_API(text, timeout) {
+    async function internal_API(text, timeout) {
       let resolve;
       const promise = new Promise(r => {
         resolve = r;
@@ -3380,17 +3380,7 @@ describe('ReactFlightAsyncDebugInfo', () => {
             "awaited": {
               "end": 0,
               "env": "Server",
-              "name": "",
-              "stack": [
-                [
-                  "new Promise",
-                  "",
-                  0,
-                  0,
-                  0,
-                  0,
-                ],
-              ],
+              "name": "greeting",
               "start": 0,
               "value": {
                 "status": "halted",


### PR DESCRIPTION
This lets you assign a name to a Promise that's passed into first party code from third party since it otherwise would have no other stack frame to indicate its name since the whole creation stack would be in third party.

We already respect the `displayName` on the client but it's more complicated on the server because we don't only consider the exact instance passed to `use()` but the whole await sequence and we can pick any Promise along the way for consideration. Therefore this also adds a change where we pick the Promise node for consideration if it has a name but no stack. Where we otherwise would've picked the I/O node.

Another thing that this PR does is treat anonymous stack frames (empty url) as third party for purposes of heuristics like "hasUnfilteredFrame" and the name assignment. This lets you include these in the actual generated stacks (by overriding `filterStackFrame`) but we don't actually want them to be considered first party code in the heuristics since it ends up favoring those stacks and using internals like `Function.all` in name assignment.