### PR TITLE
[DevTools] Filter out built-in stack frames

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
@@ -2,13 +2,17 @@
   padding: 0.25rem;
 }
 
-.CallSite, .IgnoredCallSite {
+.CallSite {
   display: block;
   padding-left: 1rem;
 }
 
-.IgnoredCallSite {
-  opacity: 0.5;
+.IgnoredCallSite, .BuiltInCallSite {
+  display: none;
+}
+
+.CallSite + .BuiltInCallSite {
+  display: block;
 }
 
 .Link {

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
@@ -60,16 +60,22 @@ export function CallSiteView({
     symbolicatedCallSite !== null ? symbolicatedCallSite.location : callSite;
   const ignored =
     symbolicatedCallSite !== null ? symbolicatedCallSite.ignored : false;
-  if (ignored) {
-    // TODO: Make an option to be able to toggle the display of ignore listed rows.
-    // Ideally this UI should be higher than a single Stack Trace so that there's not
-    // multiple buttons in a single inspection taking up space.
-    return null;
-  }
+  // TODO: Make an option to be able to toggle the display of ignore listed rows.
+  // Ideally this UI should be higher than a single Stack Trace so that there's not
+  // multiple buttons in a single inspection taking up space.
+
+  const isBuiltIn = url === '' || url.startsWith('<anonymous>'); // This looks like a fake anonymous through eval.
   return (
-    <div className={ignored ? styles.IgnoredCallSite : styles.CallSite}>
+    <div
+      className={
+        ignored
+          ? styles.IgnoredCallSite
+          : isBuiltIn
+            ? styles.BuiltInCallSite
+            : styles.CallSite
+      }>
       {functionName || virtualFunctionName}
-      {url !== '' && (
+      {!isBuiltIn && (
         <>
           {' @ '}
           <span


### PR DESCRIPTION
Treat fake eval anonymous stacks as built-in. Hide built-in stack frames unless they're used to call into a non-ignored stack frame.

The two main things to fix here is that 1) we're showing a linkified stack for fake anonymous and 2) we're showing only built-ins when the stack is completely internal. Meaning framework code is all noise.