### PR TITLE
Add MIT license header to feature flag utility script

### DIFF
--- a/scripts/flags/flags.js
+++ b/scripts/flags/flags.js
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 'use strict';
 
 const babel = require('@babel/register');


### PR DESCRIPTION
Added the standard Meta Platforms, Inc. MIT license notice to the top of the feature flag comparison script to ensure compliance with repository licensing requirements and for code consistency. 
**No functional or logic changes were made to the code.**