### PR TITLE
Fix/add missing else branch for renders with no props change

### DIFF
--- a/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
+++ b/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
@@ -305,6 +305,30 @@ export function logComponentRender(
           } else {
             performance.measure('\u200b' + name, reusableComponentOptions);
           }
+        } else {
+          if (debugTask != null) {
+            debugTask.run(
+              // $FlowFixMe[method-unbinding]
+              console.timeStamp.bind(
+                console,
+                name,
+                startTime,
+                endTime,
+                COMPONENTS_TRACK,
+                undefined,
+                color,
+              ),
+            );
+          } else {
+            console.timeStamp(
+              name,
+              startTime,
+              endTime,
+              COMPONENTS_TRACK,
+              undefined,
+              color,
+            );
+          }
         }
       } else {
         if (debugTask != null) {

--- a/packages/react-reconciler/src/__tests__/ReactPerformanceTrack-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactPerformanceTrack-test.js
@@ -350,7 +350,7 @@ describe('ReactPerformanceTracks', () => {
   });
 
   // @gate __DEV__ && enableComponentPerformanceTrack
-  it('includes spans for Components with no prop changes', async () => {
+  it('includes console.timeStamp spans for Components with no prop changes', async () => {
     function Left({value}) {
       Scheduler.unstable_advanceTime(5000);
     }
@@ -436,6 +436,7 @@ describe('ReactPerformanceTracks', () => {
     ]);
     expect(getConsoleTimestampEntries()).toEqual([
       ['Render', 16000, 31000, 'Blocking', 'Scheduler ⚛', 'primary-dark'],
+      ['Right', 21000, 31000, 'Components ⚛', undefined, 'error'],
     ]);
     performanceMeasureCalls.length = 0;
   });


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/34822.
Fixes a bug introduced in https://github.com/facebook/react/pull/34370.

Just copying the lower else branch to the `properties.length` else branch at the top.