### PR TITLE
Add readTypeof helper to `ReactPerformanceTrackProperties`

### DIFF
--- a/packages/shared/ReactPerformanceTrackProperties.js
+++ b/packages/shared/ReactPerformanceTrackProperties.js
@@ -80,6 +80,14 @@ export function addObjectToProperties(
   }
 }
 
+function readTypeof(value: any): any {
+  try {
+    return value.$$typeof;
+  } catch (error) {
+    return undefined;
+  }
+}
+
 export function addValueToProperties(
   propertyName: string,
   value: mixed,
@@ -94,7 +102,7 @@ export function addValueToProperties(
         desc = 'null';
         break;
       } else {
-        if (value.$$typeof === REACT_ELEMENT_TYPE) {
+        if (readTypeof(value) === REACT_ELEMENT_TYPE) {
           // JSX
           const typeName = getComponentNameFromType(value.type) || '\u2026';
           const key = value.key;
@@ -345,9 +353,9 @@ export function addObjectDiffToProperties(
           typeof nextValue === 'object' &&
           prevValue !== null &&
           nextValue !== null &&
-          prevValue.$$typeof === nextValue.$$typeof
+          readTypeof(prevValue) === readTypeof(nextValue)
         ) {
-          if (nextValue.$$typeof === REACT_ELEMENT_TYPE) {
+          if (readTypeof(nextValue) === REACT_ELEMENT_TYPE) {
             if (
               prevValue.type === nextValue.type &&
               prevValue.key === nextValue.key


### PR DESCRIPTION
fix #34840 

## Summary

`ReactPerformanceTrackProperties` tries to read $$typeof on every object which may throw.
Wrap reading `$$typeof` in try/catch for ReactPerformanceTrackProperties.