### PR TITLE
[DevTools] Don't hide overflow rectangles

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseRects.css
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseRects.css
@@ -19,11 +19,6 @@
 
 .SuspenseRectsBoundaryChildren {
   pointer-events: none;
-  /**
-   * So that the shadow of Boundaries within is clipped off.
-   * Otherwise it would look like this boundary is further elevated.
-   */
-   overflow: hidden;
 }
 
 .SuspenseRectsScaledRect[data-visible='false'] > .SuspenseRectsBoundaryChildren {


### PR DESCRIPTION
I get the wish to click the shadow but not all child boundaries are within the bounds of the outer Suspense boundary's node.

Sometimes they overflow naturally and if we make it overflow hidden we hide the boundaries. Maybe it would be ok if they're actually clipped by the real DOM but right now it covers up boundaries that should be there.

Additionally, there's also a common case where the parent boundary shrinks when suspending the children. That then causes the suspended child boundaries to be clipped so that you can't restore them. Maybe the virtual boundary shouldn't shrink in this case.

