### PR TITLE
[DevTools] Don't select on hover

### DIFF
--- a/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
@@ -366,8 +366,6 @@ export default function setupHighlighter(
     // Don't pass the name explicitly.
     // It will be inferred from DOM tag and Fiber owner.
     showOverlay([target], null, agent, false);
-
-    selectElementForNode(target);
   }
 
   function onPointerUp(event: MouseEvent) {


### PR DESCRIPTION
We should only persist a selection once you click. Currently, we persist the selection if you just hover which means you lose your selection immediately when just starting to inspect. That's not what Chrome Elements tab does - it selects on click.