### PR TITLE
Only capture stacks for up to 10 frames for Owner Stacks

### DIFF
--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -64,20 +64,6 @@ function getOwner() {
 // The higher the limit, the slower Error() is when not inspecting with a debugger.
 // When inspecting with a debugger, Error.stackTraceLimit has no impact on Error() performance (in v8).
 const ownerStackTraceLimit = 10;
-let supportsSettingStackTraceLimit = false;
-if (__DEV__) {
-  const descriptor = Object.getOwnPropertyDescriptor(Error, 'stackTraceLimit');
-  if (descriptor !== undefined) {
-    if (typeof descriptor.set === 'function') {
-      const previousStackTraceLimit = Error.stackTraceLimit;
-      Error.stackTraceLimit = 1;
-      Error.stackTraceLimit = previousStackTraceLimit;
-      supportsSettingStackTraceLimit = true;
-    } else {
-      supportsSettingStackTraceLimit = descriptor.writable;
-    }
-  }
-}
 
 /** @noinline */
 function UnknownOwner() {
@@ -377,15 +363,10 @@ export function jsxProdSignatureRunningInDevWithDynamicChildren(
     let debugStackDEV = false;
     if (__DEV__) {
       if (trackActualOwner) {
-        if (supportsSettingStackTraceLimit) {
-          const previousStackTraceLimit = Error.stackTraceLimit;
-          Error.stackTraceLimit = ownerStackTraceLimit;
-          debugStackDEV = Error('react-stack-top-frame');
-          Error.stackTraceLimit = previousStackTraceLimit;
-        }
-        if (!debugStackDEV) {
-          debugStackDEV = Error('react-stack-top-frame');
-        }
+        const previousStackTraceLimit = Error.stackTraceLimit;
+        Error.stackTraceLimit = ownerStackTraceLimit;
+        debugStackDEV = Error('react-stack-top-frame');
+        Error.stackTraceLimit = previousStackTraceLimit;
       } else {
         debugStackDEV = unknownOwnerDebugStack;
       }
@@ -418,15 +399,10 @@ export function jsxProdSignatureRunningInDevWithStaticChildren(
     let debugStackDEV = false;
     if (__DEV__) {
       if (trackActualOwner) {
-        if (supportsSettingStackTraceLimit) {
-          const previousStackTraceLimit = Error.stackTraceLimit;
-          Error.stackTraceLimit = ownerStackTraceLimit;
-          debugStackDEV = Error('react-stack-top-frame');
-          Error.stackTraceLimit = previousStackTraceLimit;
-        }
-        if (!debugStackDEV) {
-          debugStackDEV = Error('react-stack-top-frame');
-        }
+        const previousStackTraceLimit = Error.stackTraceLimit;
+        Error.stackTraceLimit = ownerStackTraceLimit;
+        debugStackDEV = Error('react-stack-top-frame');
+        Error.stackTraceLimit = previousStackTraceLimit;
       } else {
         debugStackDEV = unknownOwnerDebugStack;
       }
@@ -460,15 +436,10 @@ export function jsxDEV(type, config, maybeKey, isStaticChildren) {
   let debugStackDEV = false;
   if (__DEV__) {
     if (trackActualOwner) {
-      if (supportsSettingStackTraceLimit) {
-        const previousStackTraceLimit = Error.stackTraceLimit;
-        Error.stackTraceLimit = ownerStackTraceLimit;
-        debugStackDEV = Error('react-stack-top-frame');
-        Error.stackTraceLimit = previousStackTraceLimit;
-      }
-      if (!debugStackDEV) {
-        debugStackDEV = Error('react-stack-top-frame');
-      }
+      const previousStackTraceLimit = Error.stackTraceLimit;
+      Error.stackTraceLimit = ownerStackTraceLimit;
+      debugStackDEV = Error('react-stack-top-frame');
+      Error.stackTraceLimit = previousStackTraceLimit;
     } else {
       debugStackDEV = unknownOwnerDebugStack;
     }
@@ -732,15 +703,10 @@ export function createElement(type, config, children) {
   let debugStackDEV = false;
   if (__DEV__) {
     if (trackActualOwner) {
-      if (supportsSettingStackTraceLimit) {
-        const previousStackTraceLimit = Error.stackTraceLimit;
-        Error.stackTraceLimit = ownerStackTraceLimit;
-        debugStackDEV = Error('react-stack-top-frame');
-        Error.stackTraceLimit = previousStackTraceLimit;
-      }
-      if (!debugStackDEV) {
-        debugStackDEV = Error('react-stack-top-frame');
-      }
+      const previousStackTraceLimit = Error.stackTraceLimit;
+      Error.stackTraceLimit = ownerStackTraceLimit;
+      debugStackDEV = Error('react-stack-top-frame');
+      Error.stackTraceLimit = previousStackTraceLimit;
     } else {
       debugStackDEV = unknownOwnerDebugStack;
     }


### PR DESCRIPTION
Turns out `Error.stackTraceLimit` does affect `Error()` performance (in v8). But only if you're not inspecting with a debugger (e.g. ChromeDevTools is closed). Where this matters more is for SSR where you commonly aren't actively inspecting. Safari (JSC) and Firefox (SpiderMonkey) seem to have no issue with a high stack trace limit. JSC even defaults to 100 while Firefox doesn't even have `Error.stackTraceLimit`.

A higher limit is nice though for showing sync stacks. Especially with ignore-listing, a high limit can still produce nice stacks when most of the frames end up in 3rd party code. For Owner Stacks, we usually don't need very deep stacks. You mostly just have a `.map` or `useMemo` that  creates the JSX. 

So now we're setting the limit to 10 (v8 default) which allows frameworks to use a higher limit for nice sync stacks without severely degrading performance due to React Owner Stacks. 5 didn't show a meaningful difference in apps exhausting the Owner Stack limit of 10k in SSR.

The ownerstack fixture won't show the improvement since that already uses the default stack trace limit.

One thing to keep an eye out is Hermes where I haven't tested it. Only v8, JSC and SpiderMonkey.