### PR TITLE
[DevTools] Don't pluralize if already plural

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/utils.js
+++ b/packages/react-devtools-shared/src/devtools/views/utils.js
@@ -205,6 +205,27 @@ export function pluralize(word: string): string {
     return word;
   }
 
+  // Bail out if it's already plural.
+  switch (word) {
+    case 'men':
+    case 'women':
+    case 'children':
+    case 'feet':
+    case 'teeth':
+    case 'mice':
+    case 'people':
+      return word;
+  }
+
+  if (
+    /(ches|shes|ses|xes|zes)$/i.test(word) ||
+    /[^s]ies$/i.test(word) ||
+    /ves$/i.test(word) ||
+    /[^s]s$/i.test(word)
+  ) {
+    return word;
+  }
+
   switch (word) {
     case 'man':
       return 'men';


### PR DESCRIPTION
In a demo today, `cookies()` showed up as `cookieses`. While adorable, is wrong.