### PR TITLE
[DevTools] fix: dont ship source maps for css in prod builds

### DIFF
--- a/packages/react-devtools-extensions/webpack.config.js
+++ b/packages/react-devtools-extensions/webpack.config.js
@@ -285,7 +285,7 @@ module.exports = {
           {
             loader: 'css-loader',
             options: {
-              sourceMap: true,
+              sourceMap: __DEV__,
               modules: true,
               localIdentName: '[local]___[hash:base64:5]',
             },


### PR DESCRIPTION
This has been causing some issues with the submission review on Firefox store: we use OS-level paths in these source maps, which makes the build artifact different from the one that's been submitted.

Also saves ~100Kb for `main.js` artifact.