### PR TITLE
Resolve the .default export of a React.lazy as the canonical value

### DIFF
--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -102,7 +102,7 @@ function lazyInitializer<T>(payload: Payload<T>): T {
           const resolved: ResolvedPayload<T> = (payload: any);
           resolved._status = Resolved;
           resolved._result = moduleObject;
-          if (__DEV__) {
+          if (__DEV__ && enableAsyncDebugInfo) {
             const ioInfo = payload._ioInfo;
             if (ioInfo != null) {
               // Mark the end time of when we resolved.


### PR DESCRIPTION
For debug purposes this is the value that the `React.lazy` resolves to. It also lets us look at that value for descriptions like its name.