### PR TITLE
[DevTools] fix: dont ship source maps for css in prod builds

### DIFF
--- a/packages/react-devtools-extensions/src/main/cloneStyleTags.js
+++ b/packages/react-devtools-extensions/src/main/cloneStyleTags.js
@@ -1,5 +1,14 @@
-function cloneStyleTags() {
-  const linkTags = [];
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export function cloneStyleTags(): Array<HTMLLinkElement | HTMLStyleElement> {
+  const tags: Array<HTMLLinkElement | HTMLStyleElement> = [];
 
   // eslint-disable-next-line no-for-of-loops/no-for-of-loops
   for (const linkTag of document.getElementsByTagName('link')) {
@@ -11,11 +20,23 @@ function cloneStyleTags() {
         newLinkTag.setAttribute(attribute.nodeName, attribute.nodeValue);
       }
 
-      linkTags.push(newLinkTag);
+      tags.push(newLinkTag);
     }
   }
 
-  return linkTags;
-}
+  // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+  for (const styleTag of document.getElementsByTagName('style')) {
+    const newStyleTag = document.createElement('style');
 
-export default cloneStyleTags;
+    // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+    for (const attribute of styleTag.attributes) {
+      newStyleTag.setAttribute(attribute.nodeName, attribute.nodeValue);
+    }
+
+    newStyleTag.textContent = styleTag.textContent;
+
+    tags.push(newStyleTag);
+  }
+
+  return tags;
+}

--- a/packages/react-devtools-extensions/src/main/index.js
+++ b/packages/react-devtools-extensions/src/main/index.js
@@ -33,7 +33,7 @@ import {
 import {viewAttributeSource} from './sourceSelection';
 
 import {startReactPolling} from './reactPolling';
-import cloneStyleTags from './cloneStyleTags';
+import {cloneStyleTags} from './cloneStyleTags';
 import fetchFileWithCaching from './fetchFileWithCaching';
 import injectBackendManager from './injectBackendManager';
 import registerEventsLogger from './registerEventsLogger';

--- a/packages/react-devtools-extensions/webpack.config.js
+++ b/packages/react-devtools-extensions/webpack.config.js
@@ -285,7 +285,7 @@ module.exports = {
           {
             loader: 'css-loader',
             options: {
-              sourceMap: true,
+              sourceMap: __DEV__,
               modules: true,
               localIdentName: '[local]___[hash:base64:5]',
             },


### PR DESCRIPTION
This has been causing some issues with the submission review on Firefox store: we use OS-level paths in these source maps, which makes the build artifact different from the one that's been submitted.

Also saves ~100Kb for main.js artifact.