### PR TITLE
[DevTools] fix: hide scrollbar for suspense breadcrumbs

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseTab.css
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseTab.css
@@ -127,6 +127,8 @@
    * OwnerStack has more constraints that make it easier so it won't be a 1:1 port.
    */
   overflow-x: auto;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 }
 
 .SuspenseTreeViewFooter {


### PR DESCRIPTION
In Chrome, the scrollbar almost takes the whole container size. This is before:
<img width="514" height="91" alt="Screenshot 2025-10-19 at 22 49 02" src="https://github.com/user-attachments/assets/7ba0bbc7-0d54-40ad-bab6-3e39353f1f4c" />
