### PR TITLE
[DevTools] chore: read from build/COMMIT_SHA fle as fallback for commit hash

### DIFF
--- a/packages/react-devtools-extensions/utils.js
+++ b/packages/react-devtools-extensions/utils.js
@@ -6,7 +6,7 @@
  */
 
 const {execSync} = require('child_process');
-const {readFileSync} = require('fs');
+const {existsSync, readFileSync} = require('fs');
 const {resolve} = require('path');
 
 const GITHUB_URL = 'https://github.com/facebook/react';
@@ -18,8 +18,26 @@ function getGitCommit() {
       .trim();
   } catch (error) {
     // Mozilla runs this command from a git archive.
-    // In that context, there is no Git revision.
-    return null;
+    // In that context, there is no Git context.
+    // Using the commit hash specified to download-experimental-build.js script as a fallback.
+
+    // Try to read from build/COMMIT_SHA file
+    const commitShaPath = resolve(__dirname, '..', '..', 'build', 'COMMIT_SHA');
+    if (!existsSync(commitShaPath)) {
+      throw new Error(
+        'Could not find build/COMMIT_SHA file. Did you run scripts/release/download-experimental-build.js script?',
+      );
+    }
+
+    try {
+      const commitHash = readFileSync(commitShaPath, 'utf8').trim();
+      // Return short hash (first 7 characters) to match abbreviated commit hash format
+      return commitHash.slice(0, 7);
+    } catch (readError) {
+      throw new Error(
+        `Failed to read build/COMMIT_SHA file: ${readError.message}`,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
This eliminates the gap in a reproducer for the React DevTools browser extension from the source code that we submit to Firefox extension stores.

We use the commit hash as part of the Backend version, here:
https://github.com/facebook/react/blob/2cfb221937eac48209d01d5dda5664de473b1953/packages/react-devtools-extensions/utils.js#L26-L38

The problem is that we archive the source code for Mozilla extension store reviews and there is no git. But since we still download the React sources from the CI, we could reuse the hash from `build/COMMIT_HASH` file.