### PR TITLE
[DevTools] BuiltInCallSite should have padding-left

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
@@ -2,7 +2,7 @@
   padding: 0.25rem;
 }
 
-.CallSite {
+.CallSite, .BuiltInCallSite {
   display: block;
   padding-left: 1rem;
 }


### PR DESCRIPTION
We don't normally show this but when we do, it should have the same padding as other callsites.

<img width="313" height="241" alt="Screenshot 2025-10-19 at 10 46 22 PM" src="https://github.com/user-attachments/assets/7f72149e-d748-4b71-8291-889038d676e7" />
