### PR TITLE
[DevTools] Text layout fixes for stack traces with badges

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
@@ -3,8 +3,9 @@
 }
 
 .CallSite, .BuiltInCallSite {
-  display: block;
+  display: flex;
   padding-left: 1rem;
+  white-space-collapse: preserve;
 }
 
 .IgnoredCallSite, .BuiltInCallSite {
@@ -20,13 +21,15 @@
   white-space: pre;
   overflow: hidden;
   text-overflow: ellipsis;
-  flex: 1;
   cursor: pointer;
   border-radius: 0.125rem;
-  padding: 0px 2px;
 }
 
 .Link:hover {
   background-color: var(--color-background-hover);
+}
+
+.ElementBadges {
+  margin-left: 0.25rem;
 }
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
@@ -86,8 +86,10 @@ export function CallSiteView({
           </span>
         </>
       )}
-
-      <ElementBadges environmentName={environmentName} />
+      <ElementBadges
+        className={styles.ElementBadges}
+        environmentName={environmentName}
+      />
     </div>
   );
 }


### PR DESCRIPTION
The badge wasn't vertically centerred and the gap didn't match the gap in the Owner Stack. The added space after `@` also had no effect with badges. The spacing was due to hardcoded 2px padding not an actual space.

Before:
<img width="482" height="252" alt="CleanShot 2025-10-20 at 19 21 44@2x" src="https://github.com/user-attachments/assets/4f6dcb06-957b-47f5-bf9d-229131991ec4" />

After:

<img width="470" height="246" alt="CleanShot 2025-10-20 at 19 22 59@2x" src="https://github.com/user-attachments/assets/e39a487d-eea6-4891-bd06-e035e9fa0b8a" />

