### PR TITLE
refactor: renderer config to provide async stack tagging api implementation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -462,6 +462,7 @@ module.exports = {
       globals: {
         nativeFabricUIManager: 'readonly',
         RN$enableMicrotasksInReact: 'readonly',
+        RN$unstable_createTask: 'readonly',
       },
     },
     {

--- a/packages/react-art/src/ReactFiberConfigART.js
+++ b/packages/react-art/src/ReactFiberConfigART.js
@@ -402,6 +402,11 @@ export function resolveEventTimeStamp(): number {
   return -1.1;
 }
 
+// Async Stack Tagging API.
+// Chromium-only: https://developer.chrome.com/docs/devtools/console/api#createtask
+// eslint-disable-next-line react-internal/no-production-logging
+export const createTask = console.createTask;
+
 export function shouldAttemptEagerTransition() {
   return false;
 }

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -741,6 +741,11 @@ export function resolveEventTimeStamp(): number {
   return event && event !== schedulerEvent ? event.timeStamp : -1.1;
 }
 
+// Async Stack Tagging API.
+// Chromium-only: https://developer.chrome.com/docs/devtools/console/api#createtask
+// eslint-disable-next-line react-internal/no-production-logging
+export const createTask: typeof console.createTask | void = console.createTask;
+
 export const isPrimaryRenderer = true;
 export const warnsIfNotActing = true;
 // This initialization code may run even on server environments

--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -424,6 +424,13 @@ export function resolveEventTimeStamp(): number {
   return -1.1;
 }
 
+// This matches Chrome's console.createTask in terms of signature.
+// This doesn't match Chrome's console.createTask in terms of behavior and implementation.
+export const createTask: typeof console.createTask | void =
+  typeof RN$unstable_createTask === 'function'
+    ? RN$unstable_createTask
+    : undefined;
+
 export function shouldAttemptEagerTransition(): boolean {
   return false;
 }

--- a/packages/react-native-renderer/src/ReactFiberConfigNative.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigNative.js
@@ -366,6 +366,8 @@ export function resolveEventTimeStamp(): number {
   return -1.1;
 }
 
+export const createTask: typeof console.createTask | void = undefined;
+
 export function shouldAttemptEagerTransition(): boolean {
   return false;
 }

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -24,7 +24,11 @@ import {
   NoLanes,
 } from './ReactFiberLane';
 
-import {resolveEventType, resolveEventTimeStamp} from './ReactFiberConfig';
+import {
+  resolveEventType,
+  resolveEventTimeStamp,
+  createTask as createTaskFromFiberConfig,
+} from './ReactFiberConfig';
 
 import {
   enableProfilerCommitHooks,
@@ -43,10 +47,8 @@ import * as Scheduler from 'scheduler';
 const {unstable_now: now} = Scheduler;
 
 const createTask =
-  // eslint-disable-next-line react-internal/no-production-logging
-  __DEV__ && console.createTask
-    ? // eslint-disable-next-line react-internal/no-production-logging
-      console.createTask
+  __DEV__ && createTaskFromFiberConfig
+    ? createTaskFromFiberConfig
     : (name: string) => null;
 
 export const REGULAR_UPDATE: UpdateType = 0;

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
@@ -85,6 +85,7 @@ export const resolveUpdatePriority = $$$config.resolveUpdatePriority;
 export const trackSchedulerEvent = $$$config.trackSchedulerEvent;
 export const resolveEventType = $$$config.resolveEventType;
 export const resolveEventTimeStamp = $$$config.resolveEventTimeStamp;
+export const createTask = $$$config.createTask;
 export const shouldAttemptEagerTransition =
   $$$config.shouldAttemptEagerTransition;
 export const detachDeletedInstance = $$$config.detachDeletedInstance;

--- a/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
+++ b/packages/react-test-renderer/src/ReactFiberConfigTestHost.js
@@ -259,6 +259,11 @@ export function resolveEventType(): null | string {
 export function resolveEventTimeStamp(): number {
   return -1.1;
 }
+// Async Stack Tagging API.
+// Chromium-only: https://developer.chrome.com/docs/devtools/console/api#createtask
+// eslint-disable-next-line react-internal/no-production-logging
+export const createTask = console.createTask;
+
 export function shouldAttemptEagerTransition(): boolean {
   return false;
 }

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -303,3 +303,6 @@ declare const nativeFabricUIManager: {
   unstable_getCurrentEventPriority: () => number,
   ...
 };
+
+// eslint-disable-next-line no-unused-vars
+declare const RN$unstable_createTask: typeof console.createTask;

--- a/scripts/rollup/validate/eslintrc.rn.js
+++ b/scripts/rollup/validate/eslintrc.rn.js
@@ -48,6 +48,8 @@ module.exports = {
     nativeFabricUIManager: 'readonly',
     // RN flag to enable microtasks
     RN$enableMicrotasksInReact: 'readonly',
+    // RN's temporary Async Stack Tagging API.
+    RN$unstable_createTask: 'readonly',
     // Trusted Types
     trustedTypes: 'readonly',
     // RN supports this


### PR DESCRIPTION
This moves the implementation of async stack tagging API to renderer config:
- DOM: still uses `console.createTask()`.
- Fabric: will use custom experimental API called `RN$unstable_createTask()`. 

> [!NOTE]
> We want to implement `console.createTask()` in React Native as well, it will take us quite some time to support async stack traces in Hermes and then implement async stack tagging APIs properly.

The temporary React Native API will have the same signature, but it doesn't follow the same behaviour or implementation as Chromium's `console.createTask()`.

We are only going to use it at the moment for capturing updates. We won't use it for owner stacks for now, because this API won't implement proper stack tagging, and we don't support async stack traces in Hermes, so we won't be able to recreate full owner stack branches, unfortunately. We don't want to patch `console.createTask` with local host implementation, because `console.createTask` is called for every JSX invocation, and we won't get any value from it, but we will capture the stack trace for every call.

This approach aligns with other Web APIs, like `scheduleMicrotask`, `scheduleTimeout`, etc.