### PR TITLE
[eprh] Type `configs.flat` more strictly

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -71,7 +71,10 @@ const configs = {
     plugins,
     rules: recommendedLatestRuleConfigs,
   },
-  flat: {} as Record<string, ReactHooksFlatConfig>,
+  flat: {} as {
+    recommended: ReactHooksFlatConfig;
+    'recommended-latest': ReactHooksFlatConfig;
+  },
 };
 
 const plugin = {


### PR DESCRIPTION
Addresses #34801 where `configs.flat` is possibly undefined as it was typed as a record of arbitrary string keys.

<img width="990" height="125" alt="Screenshot 2025-10-22 at 1 16 44 PM" src="https://github.com/user-attachments/assets/8b0d37b9-d7b0-4fc0-aa62-1b0968dae75f" />
