### PR TITLE
Update bug report template for eslint plugin label

### DIFF
--- a/.github/ISSUE_TEMPLATE/compiler_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/compiler_bug_report.yml
@@ -11,7 +11,7 @@ body:
     options:
       - label: React Compiler core (the JS output is incorrect, or your app works incorrectly after optimization)
       - label: babel-plugin-react-compiler (build issue installing or using the Babel plugin)
-      - label: eslint-plugin-react-compiler (build issue installing or using the eslint plugin)
+      - label: eslint-plugin-react-hooks (build issue installing or using the eslint plugin)
       - label: react-compiler-healthcheck (build issue installing or using the healthcheck script)
 - type: input
   attributes:


### PR DESCRIPTION
## Summary

When creating https://github.com/facebook/react/issues/34957, I noticed a reference to `eslint-plugin-react-compiler` instead of `eslint-plugin-react-hooks`. Since the former is merged into the latter (https://github.com/facebook/react/pull/32416, https://github.com/facebook/react/pull/34228), I have decided to update the issue template to avoid confusion.