### PR TITLE
fix(number-input): preserve value on Enter with useActionState (#33667)

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMInput.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMInput.js
@@ -474,13 +474,18 @@ export function setDefaultValue(
   type: ?string,
   value: ToStringValue,
 ) {
+  const stringValue = toString(value);
   if (
     // Focused number inputs synchronize on blur. See ChangeEventPlugin.js
+    // However, if the defaultValue has actually changed, we need to update it
+    // even for focused number inputs to ensure the visual value is properly updated
+    // after form actions complete.
     type !== 'number' ||
-    getActiveElement(node.ownerDocument) !== node
+    getActiveElement(node.ownerDocument) !== node ||
+    node.defaultValue !== stringValue
   ) {
-    if (node.defaultValue !== toString(value)) {
-      node.defaultValue = toString(value);
+    if (node.defaultValue !== stringValue) {
+      node.defaultValue = stringValue;
     }
   }
 }


### PR DESCRIPTION
What changes are being made and why?

This PR fixes the issue where a type="number" input using useActionState clears its value when pressing Enter.

Previously, the input named "From:" would get cleared, even though the defaultValue contained the typed number.

The expected behavior is that the number input should behave like other inputs (e.g., "Name"), preserving its value after hitting Enter.

This change ensures that number inputs retain the typed value after form submission via Enter.

---------------------------------------------------------------------------------------------------------------------------------------------

How the changes have been QAed?

Tested locally in a React 19 environment.

Typed a number in the "From:" input and pressed Enter → value remains visible as expected.

Confirmed "Name" input behavior is unchanged.

Verified that the form submission still works correctly and useActionState continues to receive updated values.

