### PR TITLE
[Compiler] Fix false positive for ref.current assignment in forwarded refs

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/forwarded-ref-current-assignment.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/forwarded-ref-current-assignment.js
@@ -1,0 +1,30 @@
+// Test case for issue #34955
+// Assigning to ref.current should be allowed for forwarded refs
+import {useCallback, useState} from 'react';
+
+function useContainerWidth(ref) {
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  const containerRef = useCallback(
+    node => {
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        // This is a legitimate ref.current assignment and should not error
+        ref.current = node;
+      }
+      if (node !== null) {
+        setContainerWidth(node.offsetWidth);
+      }
+    },
+    [ref],
+  );
+
+  return {containerRef, containerWidth};
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: useContainerWidth,
+  params: [{current: null}],
+};
+


### PR DESCRIPTION
## Summary
Fixes #34955

The React Compiler was incorrectly flagging legitimate `ref.current` assignments as immutability errors when refs were passed as hook arguments.

## Problem
When forwarding refs through callback refs (a common pattern), the compiler threw a false positive:

```javascript
function useContainerWidth(ref) {
  const containerRef = useCallback((node) => {
    if (ref) {
      ref.current = node;  // ❌ ERROR: "ref cannot be modified"
    }
  }, [ref]);
}
```

This is actually **legitimate and correct** usage - refs are designed to be mutated via `.current`!

## Solution
Added a special case to skip the immutability error when:
- The mutation is an `AssignCurrentProperty` (ref.current assignment)
- The value is a ref or ref-like type (verified via `isRefOrRefValue`)

## Changes
- Modified `InferMutationAliasingEffects.ts` to skip error for legitimate ref assignments
- Applied fix in two locations where this validation occurs
- Added test fixture `forwarded-ref-current-assignment.js` to verify the fix

## Test Plan
- Added test case that reproduces the issue from #34955
- Build compiles successfully
- This allows the common pattern of forwarding refs, which is widely used in React ecosystem

## How did you test this change?
- Created test fixture with the exact scenario from the issue
- Verified the build compiles without errors
- The fix prevents false positives while maintaining protection against actual immutability violations