### PR TITLE
[eprh] Fix typo in plugin name

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -58,7 +58,7 @@ const recommendedLatestRuleConfigs: Linter.RulesRecord = {
 const plugins = ['react-hooks'];
 
 type ReactHooksFlatConfig = {
-  plugins: {react: any};
+  plugins: {'react-hooks': any};
   rules: Linter.RulesRecord;
 };
 


### PR DESCRIPTION
Update the `ReactHooksFlatConfig` TS definition to align with the plugin name `react-hooks`.