### PR TITLE
[DevTools] Adjust aspect ratio of "x ray" viewport to the same as the window

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseTab.css
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseTab.css
@@ -106,10 +106,23 @@
   overflow: auto;
 }
 
-.Rects {
-  padding: 0.25rem;
+.RectsBox {
+  position: relative;
   flex-grow: 1;
+  background: var(--color-border);
+}
+
+.Rects {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  margin: auto;
+  position: absolute;
+  inset: 0;
+  padding: 0.25rem;
   overflow: auto;
+  background-color: var(--color-background);
 }
 
 .SuspenseTreeViewHeader {

--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseTab.js
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseTab.js
@@ -186,6 +186,9 @@ function SynchronizedScrollContainer({
     if (element === null) {
       return;
     }
+    // Mirror the viewport aspect ratio of the real window.
+    const viewportAspectRatio = (right - left) / (bottom - top);
+    element.style.aspectRatio = viewportAspectRatio;
     const scale = scaleRef.current / element.clientWidth;
     const targetLeft = Math.round(left / scale);
     const targetTop = Math.round(top / scale);
@@ -503,11 +506,13 @@ function SuspenseTab(_: {}) {
                 orientation="horizontal"
               />
             </header>
-            <SynchronizedScrollContainer
-              className={styles.Rects}
-              scaleRef={scaleRef}>
-              <SuspenseRects scaleRef={scaleRef} />
-            </SynchronizedScrollContainer>
+            <div className={styles.RectsBox}>
+              <SynchronizedScrollContainer
+                className={styles.Rects}
+                scaleRef={scaleRef}>
+                <SuspenseRects scaleRef={scaleRef} />
+              </SynchronizedScrollContainer>
+            </div>
             <footer className={styles.SuspenseTreeViewFooter}>
               <SuspenseTimeline />
               <div className={styles.SuspenseTreeViewFooterButtons}>


### PR DESCRIPTION
This shrinks the viewport of the suspense rects to match the aspect ratio of the real viewport. The idea is that this would make it clearer that it's a mirrored view and when auto scrolling it would line up more accurately for things that are within the viewport.

I thought I'd like it but I don't think I do actually. I don't think it ended up adding anything since the aspect ratio when you anchor the devtools end up some what close enough anyway. You're just losing screen real estate for no reason. But submitting for your consideration.

<img width="1512" height="840" alt="Screenshot 2025-10-29 at 10 32 10 PM" src="https://github.com/user-attachments/assets/8f73a311-bbd5-421c-88ad-b836ed44547a" />

<img width="1512" height="849" alt="Screenshot 2025-10-29 at 10 30 35 PM" src="https://github.com/user-attachments/assets/16ced4d8-0dc1-4a70-921f-9f8faea45cbf" />
