### PR TITLE
test: add coverage for zero-length style values

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -454,6 +454,12 @@ describe('ReactDOMServerIntegration', () => {
         expect(e.style.width).toBe('30px');
       });
 
+      itRenders('no zero-length styles', async render => {
+        const e = await render(<div style={{color: '', width: '30px'}} />);
+        expect(e.style.color).toBe('');
+        expect(e.style.width).toBe('30px');
+      });
+
       itRenders('no empty styles', async render => {
         const e = await render(<div style={{color: null, width: null}} />);
         expect(e.style.color).toBe('');


### PR DESCRIPTION
This PR adds a new test case to verify that style properties with empty string values (e.g., `{ color: '' })` are correctly skipped during style serialization. This behavior prevents React from rendering invalid CSS like `style="color:"` and avoids potential hydration mismatches between server and client.

https://github.com/facebook/react/blob/main/packages/react-dom-bindings/src/client/CSSPropertyOperations.js#L35

this line seems to be doing all the heavy lifting here, we already have `undefined` & `null` test added and this PR adds the `no zero-length styles`, which completes the test coverage.

<img width="805" height="636" alt="Screenshot 2025-10-31 at 11 49 13 PM" src="https://github.com/user-attachments/assets/83796008-be26-47f1-8cb8-c5de88549f35" />
All Tests are passing.


cc @rickhanlonii @eps1lon 