### PR TITLE
[Flight] Fix `hasReadable` flag in Node.js clients' debug channel

### DIFF
--- a/packages/react-server-dom-esm/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-esm/src/client/ReactFlightDOMClientNode.js
@@ -93,10 +93,7 @@ function createFromNodeStream<T>(
 ): Thenable<T> {
   const debugChannel: void | DebugChannel =
     __DEV__ && options && options.debugChannel !== undefined
-      ? {
-          hasReadable: options.debugChannel.readable !== undefined,
-          callback: null,
-        }
+      ? {hasReadable: true, callback: null}
       : undefined;
 
   const response: Response = createResponse(

--- a/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientNode.js
@@ -86,10 +86,7 @@ export function createFromNodeStream<T>(
 ): Thenable<T> {
   const debugChannel: void | DebugChannel =
     __DEV__ && options && options.debugChannel !== undefined
-      ? {
-          hasReadable: options.debugChannel.readable !== undefined,
-          callback: null,
-        }
+      ? {hasReadable: true, callback: null}
       : undefined;
 
   const response: Response = createResponse(

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
@@ -95,10 +95,7 @@ function createFromNodeStream<T>(
 ): Thenable<T> {
   const debugChannel: void | DebugChannel =
     __DEV__ && options && options.debugChannel !== undefined
-      ? {
-          hasReadable: options.debugChannel.readable !== undefined,
-          callback: null,
-        }
+      ? {hasReadable: true, callback: null}
       : undefined;
 
   const response: Response = createResponse(

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
@@ -95,10 +95,7 @@ function createFromNodeStream<T>(
 ): Thenable<T> {
   const debugChannel: void | DebugChannel =
     __DEV__ && options && options.debugChannel !== undefined
-      ? {
-          hasReadable: options.debugChannel.readable !== undefined,
-          callback: null,
-        }
+      ? {hasReadable: true, callback: null}
       : undefined;
 
   const response: Response = createResponse(


### PR DESCRIPTION
For Edge Flight servers, that use Web Streams, we're defining the `debugChannel` option as:

```
debugChannel?: {readable?: ReadableStream, writable?: WritableStream, ...}
```

Whereas for Node.js Flight servers, that use Node.js Streams, we're defining it as:

```
debugChannel?: Readable | Writable | Duplex | WebSocket
```

For the Edge Flight clients, there is currently only one direction of the debug channel supported, so we define the option as:

```
debugChannel?: {readable?: ReadableStream, ...}
```

Consequently, for the Node.js Flight clients, we define the option as:

```
debugChannel?: Readable
```

The presence of a readable debug channel is passed to the Flight client internally via the `hasReadable` flag on the internal `debugChannel` option. For the Node.js clients, that flag was accidentally derived from the public option `debugChannel.readable`, which is conceptually incorrect, because `debugChannel` is a `Readable` stream, not an options
object with a `readable` property. However, a `Readable` also has a `readable` property, which is a boolean that indicates whether the stream is in a readable state. This meant that the `hasReadable` flag was incidentally still set correctly. Regardless, this was confusing and unintentional, so we're now fixing it to always set `hasReadable` to `true` when a `debugChannel` is provided to the Node.js clients. We'll revisit this in case we ever add support for writable debug channels in Node.js (and Edge) clients.