### PR TITLE
[compiler healthcheck] correct yargs scriptName and usage

### DIFF
--- a/compiler/packages/react-compiler-healthcheck/src/index.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/index.ts
@@ -15,8 +15,8 @@ import strictModeCheck from './checks/strictMode';
 
 async function main() {
   const argv = yargs(process.argv.slice(2))
-    .scriptName('healthcheck')
-    .usage('$ npx healthcheck <src>')
+    .scriptName('react-compiler-healthcheck')
+    .usage('$ npx react-compiler-healthcheck --src="<src>"')
     .option('src', {
       description: 'glob expression matching src files to compile',
       type: 'string',


### PR DESCRIPTION
## Summary

This is something I noticed when looking at #35046. The `healthcheck` script was renamed in 63e533026062450f7e033af1e15545eb4463fce6 but the `yargs` configuration was never updated accordingly.

## How did you test this change?

I ran the script with `--help` locally.