### PR TITLE
Remove unstable_expectedLoadTime option

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -325,7 +325,6 @@ export let didWarnAboutReassigningProps: boolean;
 let didWarnAboutRevealOrder;
 let didWarnAboutTailOptions;
 let didWarnAboutClassNameOnViewTransition;
-let didWarnAboutExpectedLoadTime = false;
 
 if (__DEV__) {
   didWarnAboutBadClass = ({}: {[string]: boolean});
@@ -2457,22 +2456,7 @@ function updateSuspenseComponent(
       }
 
       return bailoutOffscreenComponent(null, primaryChildFragment);
-    } else if (
-      enableCPUSuspense &&
-      (typeof nextProps.unstable_expectedLoadTime === 'number' ||
-        nextProps.defer === true)
-    ) {
-      if (__DEV__) {
-        if (typeof nextProps.unstable_expectedLoadTime === 'number') {
-          if (!didWarnAboutExpectedLoadTime) {
-            didWarnAboutExpectedLoadTime = true;
-            console.error(
-              '<Suspense unstable_expectedLoadTime={...}> is deprecated. ' +
-                'Use <Suspense defer={true}> instead.',
-            );
-          }
-        }
-      }
+    } else if (enableCPUSuspense && nextProps.defer === true) {
       // This is a CPU-bound tree. Skip this tree and show a placeholder to
       // unblock the surrounding content. Then immediately retry after the
       // initial commit.

--- a/packages/react-reconciler/src/__tests__/ReactCPUSuspense-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactCPUSuspense-test.js
@@ -13,7 +13,6 @@ let resolveText;
 // let rejectText;
 
 let assertLog;
-let assertConsoleErrorDev;
 let waitForPaint;
 
 describe('ReactSuspenseWithNoopRenderer', () => {
@@ -29,7 +28,6 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     const InternalTestUtils = require('internal-test-utils');
     assertLog = InternalTestUtils.assertLog;
-    assertConsoleErrorDev = InternalTestUtils.assertConsoleErrorDev;
     waitForPaint = InternalTestUtils.waitForPaint;
 
     textCache = new Map();
@@ -118,51 +116,6 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       throw promise;
     }
   }
-
-  // @gate enableCPUSuspense
-  it('warns for the old name is used', async () => {
-    function App() {
-      return (
-        <>
-          <Text text="Outer" />
-          <div>
-            <Suspense
-              unstable_expectedLoadTime={1000}
-              fallback={<Text text="Loading..." />}>
-              <Text text="Inner" />
-            </Suspense>
-          </div>
-        </>
-      );
-    }
-
-    const root = ReactNoop.createRoot();
-    await act(async () => {
-      root.render(<App />);
-      await waitForPaint(['Outer', 'Loading...']);
-      assertConsoleErrorDev([
-        '<Suspense unstable_expectedLoadTime={...}> is deprecated. ' +
-          'Use <Suspense defer={true}> instead.' +
-          '\n    in Suspense (at **)' +
-          '\n    in App (at **)',
-      ]);
-      expect(root).toMatchRenderedOutput(
-        <>
-          Outer
-          <div>Loading...</div>
-        </>,
-      );
-    });
-
-    // Inner contents finish in separate commit from outer
-    assertLog(['Inner']);
-    expect(root).toMatchRenderedOutput(
-      <>
-        Outer
-        <div>Inner</div>
-      </>,
-    );
-  });
 
   // @gate enableCPUSuspense
   it('skips CPU-bound trees on initial mount', async () => {

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -312,7 +312,6 @@ export type SuspenseProps = {
   suspenseCallback?: (Set<Wakeable> | null) => mixed,
 
   unstable_avoidThisFallback?: boolean,
-  unstable_expectedLoadTime?: number,
   defer?: boolean,
   name?: string,
 };


### PR DESCRIPTION
Follow up to #35022.

It's now replaced by the `defer` option.

Sounds like nobody is actually using this option, including Meta, so we can just delete it.