### PR TITLE
Don't skip content in visible offscreen trees for Gesture View Transitions

### DIFF
--- a/packages/react-reconciler/src/ReactFiberApplyGesture.js
+++ b/packages/react-reconciler/src/ReactFiberApplyGesture.js
@@ -146,7 +146,7 @@ function trackDeletedPairViewTransitions(deletion: Fiber): void {
   }
   let child = deletion.child;
   while (child !== null) {
-    if (child.tag === OffscreenComponent && child.memoizedState === null) {
+    if (child.tag === OffscreenComponent && child.memoizedState !== null) {
       // This tree was already hidden so we skip it.
     } else {
       if (


### PR DESCRIPTION
Follow up to #35063.

I forgot there's another variant of this in the ApplyGesture path.