### PR TITLE
[DevTools] Special case the selected root outline

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseRects.css
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseRects.css
@@ -12,6 +12,11 @@
   background-color: color-mix(in srgb, var(--color-transition) 5%, transparent);
 }
 
+.SuspenseRectsRootOutline {
+  outline-width: 4px;
+  border-radius: 0.125rem;
+}
+
 .SuspenseRectsRoot[data-hovered='true'] {
   background-color: color-mix(in srgb, var(--color-transition) 15%, transparent);
 }
@@ -98,10 +103,6 @@
   outline-width: 4px;
   border-radius: 0.125rem;
   pointer-events: none;
-}
-
-.SuspenseRectOutlineRoot {
-  outline-color: var(--color-transition);
 }
 
 .SuspenseRectsBoundary[data-selected='true'] > .SuspenseRectsRect {

--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseRects.js
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseRects.js
@@ -510,7 +510,6 @@ function SuspenseRectsContainer({
   let selectedBoundingBox = null;
   let selectedEnvironment = null;
   if (isRootSelected) {
-    selectedBoundingBox = boundingBox;
     selectedEnvironment = rootEnvironment;
   } else if (inspectedElementID !== null) {
     const selectedSuspenseNode = store.getSuspenseByID(inspectedElementID);
@@ -534,6 +533,7 @@ function SuspenseRectsContainer({
       className={
         styles.SuspenseRectsContainer +
         (hasRootSuspenders ? ' ' + styles.SuspenseRectsRoot : '') +
+        (isRootSelected ? ' ' + styles.SuspenseRectsRootOutline : '') +
         ' ' +
         getClassNameForEnvironment(rootEnvironment)
       }
@@ -551,7 +551,6 @@ function SuspenseRectsContainer({
             <ScaledRect
               className={
                 styles.SuspenseRectOutline +
-                (isRootSelected ? ' ' + styles.SuspenseRectOutlineRoot : '') +
                 ' ' +
                 getClassNameForEnvironment(selectedEnvironment)
               }


### PR DESCRIPTION
When I moved the outline to above all other rects, I thought it was clever to unify with the root so that the outline was also used for the root selection. But the root outline is not drawn like the other rects. It's outside the padding and doesn't have the 1px adjustment which leads the overlay to be slightly inside the other rect instead of above it.

This goes back to just having the selected root be drawn by the root element.

Before:

<img width="652" height="253" alt="Screenshot 2025-11-07 at 11 39 28 AM" src="https://github.com/user-attachments/assets/334237d1-f190-4995-94cc-9690ec0f7ce1" />

After:

<img width="674" height="220" alt="Screenshot 2025-11-07 at 11 44 01 AM" src="https://github.com/user-attachments/assets/afaa86d8-942a-44d8-a1a5-67c7fb642c0d" />
