### PR TITLE
[DevTools] Batch updates when updating component filters

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -1576,7 +1576,6 @@ export function attach(
       currentRoot = rootInstance;
       unmountInstanceRecursively(rootInstance);
       rootToFiberInstanceMap.delete(root);
-      flushPendingEvents();
       currentRoot = (null: any);
     });
 
@@ -1646,7 +1645,6 @@ export function attach(
       currentRoot = newRoot;
       setRootPseudoKey(currentRoot.id, root.current);
       mountFiberRecursively(root.current, false);
-      flushPendingEvents();
       currentRoot = (null: any);
     });
 
@@ -5751,11 +5749,12 @@ export function attach(
 
         mountFiberRecursively(root.current, false);
 
-        flushPendingEvents();
-
-        needsToFlushComponentLogs = false;
         currentRoot = (null: any);
       });
+
+      flushPendingEvents();
+
+      needsToFlushComponentLogs = false;
     }
   }
 


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/35107

We used to flush operations between unmounting each root and remounting each root. This could lead to focus or selection loss when the focused/selected element was temporarily removed while we were mounting the root again in the backend. Notably when keyboard navigating through the Activity list and focusing on a specific Activity. We'd flush after each root was unmounted leading to an unnmount of the Activity list since no more named Activities existed.

Looks like a leftover from when flushing operations was tied to a root. If this leads to crashes due to operations sent being too large, we should implement some streaming approach where the frontend can decide if it wants to flush between each chunk (operations for one root) or at the end.

Alternatively we could also flush after processing each root when processing unmount+mount  i.e.

```
unmount(1)
mount(1)
flush()

unmount(2)
mount(2)
flush()
```

instead of 
```
unmount(1)
flush()
unmount(2)
flush()

mount(1)
flush()
mount(2)
flush()
```