### PR TITLE
[DevTools] Fix outline alignment when root Transition has suspenders and is selected

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseRects.css
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseRects.css
@@ -1,5 +1,5 @@
 .SuspenseRectsContainer {
-  padding: .25rem;
+  margin: .25rem;
   outline-color: transparent;
   outline-style: solid;
   outline-width: 1px;


### PR DESCRIPTION
The outline of a selected root was a bit misaligned leading to gaps.

Before:

https://github.com/user-attachments/assets/d9d92e2c-1f3f-4bc5-84b1-e8e25dc3cd05



After:

https://github.com/user-attachments/assets/f02e53ea-ad36-44df-a63c-aeb16edfaeea


