### PR TITLE
[react-dom] Batch updates from `resize` until next frame

### DIFF
--- a/packages/react-dom-bindings/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom-bindings/src/events/ReactDOMEventListener.js
@@ -341,7 +341,6 @@ export function getEventPriority(domEventName: DOMEventName): EventPriority {
     case 'pointerup':
     case 'ratechange':
     case 'reset':
-    case 'resize':
     case 'seeked':
     case 'submit':
     case 'toggle':
@@ -380,6 +379,7 @@ export function getEventPriority(domEventName: DOMEventName): EventPriority {
     case 'pointermove':
     case 'pointerout':
     case 'pointerover':
+    case 'resize':
     case 'scroll':
     case 'touchmove':
     case 'wheel':


### PR DESCRIPTION
Resize is closer to scroll events which are already batched during a frame. We previously flushed state updates from resize events when new discrete events came in. Now resize is batched with other continuous events.

We stil flush before the next frame is painted.