### PR TITLE
nvm

### DIFF
--- a/packages/react/index.experimental.js
+++ b/packages/react/index.experimental.js
@@ -56,6 +56,7 @@ export {
   useTransition,
   useActionState,
   version,
+  captureOwnerStack,
 } from './src/ReactClient';
 
 import {useOptimistic} from './src/ReactClient';

--- a/packages/react/index.fb.js
+++ b/packages/react/index.fb.js
@@ -64,6 +64,7 @@ export {
   useSyncExternalStore,
   useTransition,
   version,
+  captureOwnerStack, // DEV-only
 } from './src/ReactClient';
 
 export {jsx, jsxs, jsxDEV} from './src/jsx/ReactJSX';
@@ -74,11 +75,3 @@ export {useMemoCache as unstable_useMemoCache} from './src/ReactHooks';
 // export to match the name of the OSS function typically exported from
 // react/compiler-runtime
 export {useMemoCache as c} from './src/ReactHooks';
-
-// Only export captureOwnerStack in development.
-let captureOwnerStack: ?() => null | string;
-if (__DEV__) {
-  captureOwnerStack = captureOwnerStackImpl;
-}
-
-export {captureOwnerStack};

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -71,4 +71,5 @@ export {
   useTransition,
   useActionState,
   version,
+  captureOwnerStack,
 } from './src/ReactClient';

--- a/packages/react/index.stable.js
+++ b/packages/react/index.stable.js
@@ -52,4 +52,5 @@ export {
   useTransition,
   useActionState,
   version,
+  captureOwnerStack,
 } from './src/ReactClient';


### PR DESCRIPTION
Pretty sure this was a mistake, captureOwnerStack should exist in the exports in the prod build but noop. 