### PR TITLE
fix(compiler): Handle 'using' and 'await using' declarations

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -862,20 +862,34 @@ function lowerStatement(
       );
       return;
     }
-    case 'VariableDeclaration': {
-      const stmt = stmtPath as NodePath<t.VariableDeclaration>;
-      const nodeKind: t.VariableDeclaration['kind'] = stmt.node.kind;
-      if (nodeKind === 'var') {
-        builder.errors.push({
-          reason: `(BuildHIR::lowerStatement) Handle ${nodeKind} kinds in VariableDeclaration`,
-          category: ErrorCategory.Todo,
-          loc: stmt.node.loc ?? null,
-          suggestions: null,
-        });
-        return;
-      }
+   case 'VariableDeclaration': {
+  const stmt = stmtPath as NodePath<t.VariableDeclaration>;
+  const nodeKind: t.VariableDeclaration['kind'] = stmt.node.kind;
+  if (nodeKind === 'var') {
+    builder.errors.push({
+      reason: `(BuildHIR::lowerStatement) Handle ${nodeKind} kinds in VariableDeclaration`,
+      category: ErrorCategory.Todo,
+      loc: stmt.node.loc ?? null,
+      suggestions: null,
+    });
+    return;
+  }
+  // ADD THIS NEW CHECK FOR 'using' and 'await using'
+  if (nodeKind === 'using' || nodeKind === 'await using') {
+    builder.errors.push({
+      reason: `(BuildHIR::lowerStatement) 'using' declarations are not yet supported by React Compiler`,
+      category: ErrorCategory.Todo,
+      loc: stmt.node.loc ?? null,
+      suggestions: null,
+    });
+    return;
+  }
       const kind =
-        nodeKind === 'let' ? InstructionKind.Let : InstructionKind.Const;
+  nodeKind === 'let' 
+    ? InstructionKind.Let 
+    : nodeKind === 'using' || nodeKind === 'await using'
+    ? InstructionKind.Let  // Treat 'using' similar to 'let' for now
+    : InstructionKind.Const;
       for (const declaration of stmt.get('declarations')) {
         const id = declaration.get('id');
         const init = declaration.get('init');


### PR DESCRIPTION
Fixes #35171

Hey! This PR fixes a bug where React Compiler was breaking the new JavaScript `using` syntax.

The Problem:
When you write code like this:
  using resource = new Disposable("render");

React Compiler was stripping out the `using` keyword and turning it into:
  new Disposable("render");

This completely breaks the disposal mechanism - Symbol.dispose() never gets called and you get resource leaks.

What I Did:
I added a check in BuildHIR.ts (around line 868) that makes the compiler bail out when it sees `using` or `await using` declarations. Now instead of breaking your code, it just skips compiling that component and shows a "not yet supported" message.

Changes:
- File: compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
- Added detection for `using` and `await using` 
- Compiler now bails out instead of incorrectly transforming

Testing:
I tested this with the example from issue #35171. Now the disposal works correctly and the compiler doesn't mess up the using syntax.

This is a temporary fix - in the future we could fully support `using` by properly tracking disposal through the compilation pipeline. But for now, this at least prevents the bug.