### PR TITLE
[test] Fix Error Proxy in Node.js 21+

### DIFF
--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -136,6 +136,13 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
           }
           return Reflect.set(target, key, value, receiver);
         },
+        get(target, key, receiver) {
+          if (key === 'stack') {
+            // https://github.com/nodejs/node/issues/60862
+            return Reflect.get(target, key);
+          }
+          return Reflect.get(target, key, receiver);
+        },
       });
       originalErrorInstances.set(proxy, error);
       return proxy;


### PR DESCRIPTION
In draft so that I don't accidentally merge while CI is disabled.

Only affects production tests with Node.js 21+. See https://github.com/nodejs/node/issues/60862.

Probably has to do with how v8 treats Error.prototype.stack (https://github.com/tc39/proposal-error-stacks#compatibility) and setting .stack on the wrong object.

## test plan

In Node.js 21+:
```console
$ yarn test packages/react-server/src/__tests__/ReactServer-test.js --env production
```

CI (older Node.js) still green: https://github.com/eps1lon/react/actions/runs/19782704658?pr=12
