### PR TITLE
[DevTools] Fix console links not being openable

### DIFF
--- a/packages/react-devtools-extensions/src/main/index.js
+++ b/packages/react-devtools-extensions/src/main/index.js
@@ -711,6 +711,12 @@ if (chrome.devtools.panels.setOpenResourceHandler) {
         resource.url,
         lineNumber - 1,
         columnNumber - 1,
+        maybeError => {
+          if (maybeError && maybeError.isError) {
+            // Not a resource Chrome can open. Fallback to browser default behavior.
+            window.open(resource.url);
+          }
+        },
       );
     },
   );


### PR DESCRIPTION
Fixes https://github.com/facebook/react/pull/33983#issuecomment-3582125388
See https://issues.chromium.org/u/1/issues/462747680

Seems like `chrome.devtools.panels.openResource` is not actually the default behavior for the resource handler. It's erroring when trying to open URLs that don't point to Chrome Resources and not doing anything. 

E.g. clicking on `https://google.com` does nothing. 

Falling back to `window.open` in case `openResource` errors. https://developer.chrome.com/docs/extensions/reference/api/devtools/panels#method-openResource doesn't document the parameter to the callback but it returns an error-like object. 

## Test plan

1. Load extension from CI artifact 
Click on the link from `console.log('https://google.com')`. File links also work (e.g. `console.log('file://404')`)