### PR TITLE
[test] Update ESLint e2e tests

### DIFF
--- a/fixtures/eslint-v6/index.js
+++ b/fixtures/eslint-v6/index.js
@@ -159,9 +159,9 @@ function InvalidGlobals() {
   return <div>Done</div>;
 }
 
-// Invalid: useMemo with wrong deps - triggers preserve-manual-memoization
+// Invalid: useMemo with wrong deps
 function InvalidUseMemo({items}) {
-  // eslint-disable-next-line react-hooks/preserve-manual-memoization, react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const sorted = useMemo(() => [...items].sort(), []);
   return <div>{sorted.length}</div>;
 }

--- a/fixtures/eslint-v7/index.js
+++ b/fixtures/eslint-v7/index.js
@@ -159,9 +159,9 @@ function InvalidGlobals() {
   return <div>Done</div>;
 }
 
-// Invalid: useMemo with wrong deps - triggers preserve-manual-memoization
+// Invalid: useMemo with wrong deps
 function InvalidUseMemo({items}) {
-  // eslint-disable-next-line react-hooks/preserve-manual-memoization, react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const sorted = useMemo(() => [...items].sort(), []);
   return <div>{sorted.length}</div>;
 }

--- a/fixtures/eslint-v8/index.js
+++ b/fixtures/eslint-v8/index.js
@@ -159,9 +159,9 @@ function InvalidGlobals() {
   return <div>Done</div>;
 }
 
-// Invalid: useMemo with wrong deps - triggers preserve-manual-memoization
+// Invalid: useMemo with wrong deps
 function InvalidUseMemo({items}) {
-  // eslint-disable-next-line react-hooks/preserve-manual-memoization, react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const sorted = useMemo(() => [...items].sort(), []);
   return <div>{sorted.length}</div>;
 }

--- a/fixtures/eslint-v9/index.js
+++ b/fixtures/eslint-v9/index.js
@@ -70,6 +70,7 @@ function ComponentWithoutDeclaringPropAsDep(props) {
     console.log(props.foo);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  // eslint-disable-next-line react-hooks/void-use-memo
   useMemo(() => {
     console.log(props.foo);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -82,6 +83,7 @@ function ComponentWithoutDeclaringPropAsDep(props) {
     console.log(props.foo);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  // eslint-disable-next-line react-hooks/void-use-memo
   React.useMemo(() => {
     console.log(props.foo);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -159,9 +161,9 @@ function InvalidGlobals() {
   return <div>Done</div>;
 }
 
-// Invalid: useMemo with wrong deps - triggers preserve-manual-memoization
+// Invalid: useMemo with wrong deps
 function InvalidUseMemo({items}) {
-  // eslint-disable-next-line react-hooks/preserve-manual-memoization, react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const sorted = useMemo(() => [...items].sort(), []);
   return <div>{sorted.length}</div>;
 }


### PR DESCRIPTION
Changes were necessary after https://github.com/facebook/react/pull/35201 to make e2e tests pass. CI didn't catch it because the PR got merged while CI was deactived.

Fixes https://github.com/eps1lon/react/actions/runs/19699507928/job/56432042571 and https://github.com/eps1lon/react/actions/runs/19699507928/job/56432042565

## test plan

- `cd fixtures/eslint-v9 && yarn && node build.mjs && yarn lint`
- CI