### PR TITLE
[test] Only run tests overriding fallback and error states in supported versions

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
@@ -753,7 +753,7 @@ describe('Store component filters', () => {
     });
   });
 
-  // @reactVersion >= 16.6
+  // @reactVersion >= 18.0
   it('resets forced error and fallback states when filters are changed', async () => {
     store.componentFilters = [];
     class ErrorBoundary extends React.Component {


### PR DESCRIPTION
Fixes https://github.com/eps1lon/react/actions/runs/19184729130/job/54849190660

`overrideSuspense` was only added in 16.9: https://github.com/facebook/react/commit/7a2dc4853948a70a599124b7f47513df793d472a
`overrideError` in 18.0: https://github.com/facebook/react/commit/8b4201535c6068147d61d0ed3f02d21d6dcd6927

We could separate the tests to test `overrideSuspense` for earlier versions but [this test was only recently added](https://github.com/facebook/react/issues/34929) so doesn't seem worth the extended regression test.
