### PR TITLE
[compiler] Fix computed property keys in object method shorthand

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -2104,7 +2104,7 @@ function codegenInstructionValue(
                 key,
                 fn.params,
                 fn.body,
-                false,
+                property.key.kind === 'computed',
               );
               babelNode.async = fn.async;
               babelNode.generator = fn.generator;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-shorthand-computed-key.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-shorthand-computed-key.expect.md
@@ -1,0 +1,55 @@
+
+## Input
+
+```javascript
+const computedPropKey = 'foobar';
+
+function Component(props) {
+  const obj = {
+    [computedPropKey]() {
+      return props.value;
+    },
+  };
+  return obj[computedPropKey]();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 42}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+const computedPropKey = "foobar";
+
+function Component(props) {
+  const $ = _c(2);
+  let t0;
+  if ($[0] !== props) {
+    const obj = {
+      [computedPropKey]() {
+        return props.value;
+      },
+    };
+    t0 = obj[computedPropKey]();
+    $[0] = props;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ value: 42 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) 42

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-shorthand-computed-key.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-shorthand-computed-key.js
@@ -1,0 +1,15 @@
+const computedPropKey = 'foobar';
+
+function Component(props) {
+  const obj = {
+    [computedPropKey]() {
+      return props.value;
+    },
+  };
+  return obj[computedPropKey]();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 42}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-shorthand-computed-key.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-shorthand-computed-key.tsx
@@ -1,0 +1,24 @@
+const computedPropKey = 'foobar';
+
+function Bar({obj}: {obj: any}) {
+  return <div>{obj[computedPropKey]()}</div>;
+}
+
+function Component() {
+  return (
+    <div>
+      <Bar
+        obj={{
+          [computedPropKey]() {
+            return 'Hello';
+          },
+        }}
+      />
+    </div>
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
  Fixes #35203

  The compiler was incorrectly discarding computed property key notation
  when used with method shorthand syntax, transforming `[key]() {}` into
  `key() {}`.

  Changed the hardcoded `false` parameter to `property.key.kind === 'computed'`
  in CodegenReactiveFunction.ts to preserve computed keys, matching the
  pattern already used for regular object properties.
  
## How did you test this change?

TDD, adding tests
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
