### PR TITLE
[eprh] fix react-compiler rules missing `meta.docs.url` property

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/shared/ReactCompiler.ts
+++ b/packages/eslint-plugin-react-hooks/src/shared/ReactCompiler.ts
@@ -151,6 +151,7 @@ function makeRule(rule: LintRule): Rule.RuleModule {
       docs: {
         description: rule.description,
         recommended: rule.preset === LintRulePreset.Recommended,
+        url: `https://react.dev/reference/eslint-plugin-react-hooks/lints/${rule.name}`,
       },
       fixable: 'code',
       hasSuggestions: true,


### PR DESCRIPTION
## Summary

To help people access the documentation easier, we can [add `meta.docs.url`](https://eslint.org/docs/latest/extend/custom-rules#:~:text=Specifies%20the%20URL) to the new react-compiler rules. This allows IDEs to make the rule name a clickable link. 

## How did you test this change?

`yarn test`, `yarn prettier`, `yarn lint` and in a separate project [using file:// URLs](https://stackoverflow.com/a/38417065)