### PR TITLE
fabric: reproduction completeRoot called for suspended component update

### DIFF
--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -1506,4 +1506,59 @@ describe('ReactFabric', () => {
 
     expect(publicInstanceAfterUnmount).toBe(null);
   });
+
+  it('should call completeRoot on suspend', async () => {
+    const RCTText = createReactNativeComponentClass('RCTText', () => ({
+      validAttributes: {},
+      uiViewClassName: 'RCTText',
+    }));
+
+    const promise = new Promise(r => {});
+
+    let setState;
+    class Suspending extends React.Component {
+      state = {text: 1};
+
+      componentDidMount() {
+        setState = this.setState.bind(this);
+      }
+
+      render() {
+        if (this.state.text >= 2) {
+          // We need to render once to actually be able to capture the setState function
+          throw promise;
+        }
+        return <RCTText>Step: {this.state.text}</RCTText>;
+      }
+    }
+
+    const ref = React.createRef();
+    await act(() => {
+      ReactFabric.render(
+        <React.Suspense>
+          <Suspending ref={ref} />
+        </React.Suspense>,
+        /* containerId */ 1,
+        /* callback */ null,
+        /* concurrentRoot */ true,
+      );
+    });
+
+    expect(nativeFabricUIManager.completeRoot).toHaveBeenCalledTimes(1);
+
+    // Cause the component to suspend
+    await act(() => {
+      setState({text: 2});
+    });
+
+    expect(nativeFabricUIManager.completeRoot).toHaveBeenCalledTimes(3); // note: suspending seems to induce two calls
+
+    // Triggering a state update for a suspended component that has the same fallback,
+    // and otherwise no changes to the tree are happening shouldn't call completeRoot again!
+    await act(() => {
+      setState({text: 3});
+    });
+
+    expect(nativeFabricUIManager.completeRoot).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

I noticed that when we suspend a component in fabric react and in that component a state update occurs, that we still will call `completeRoot`.

This has performance implications, as `completeRoot` will call into c++ and invoke `ShadowTree::commit`.

I think that when a suspended component has a state update and we still show the very same fallback component, then there should be no `completeRoot` call, as technically, nothing has changed about the UI output.

I believe that this is a bug with in react-reconciler / react fabric 

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

This PR merely adds a test case that demonstrates that this seems to be broken, to raise the discussion if this needs to be fixed.
