### PR TITLE
[release] Allow building single release channel with processed versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   "scripts": {
     "prebuild": "./scripts/react-compiler/link-compiler.sh",
     "build": "node ./scripts/rollup/build-all-release-channels.js",
-    "build-for-devtools": "cross-env RELEASE_CHANNEL=experimental yarn build react/index,react/jsx,react/compiler-runtime,react-dom/index,react-dom/client,react-dom/unstable_testing,react-dom/test-utils,react-is,react-debug-tools,scheduler,react-test-renderer,react-refresh,react-art --type=NODE",
+    "build-for-devtools": "cross-env yarn build react/index,react/jsx,react/compiler-runtime,react-dom/index,react-dom/client,react-dom/unstable_testing,react-dom/test-utils,react-is,react-debug-tools,scheduler,react-test-renderer,react-refresh,react-art --type=NODE --release-channel=experimental",
     "build-for-devtools-dev": "yarn build-for-devtools --type=NODE_DEV",
     "build-for-devtools-prod": "yarn build-for-devtools --type=NODE_PROD",
     "build-for-flight-dev": "cross-env RELEASE_CHANNEL=experimental node ./scripts/rollup/build.js react/index,react/jsx,react.react-server,react-dom/index,react-dom/client,react-dom/server,react-dom.react-server,react-dom-server.node,react-dom-server-legacy.node,scheduler,react-server-dom-webpack/ --type=NODE_DEV,ESM_PROD,NODE_ES2015 && mv ./build/node_modules ./build/oss-experimental",

--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -124,25 +124,34 @@ async function main() {
         throw new Error(`Unknown release channel ${argv.releaseChannel}`);
     }
   } else {
-    // Running locally, no concurrency. Move each channel's build artifacts into
-    // a temporary directory so that they don't conflict.
-    buildForChannel('stable', '', '');
-    const stableDir = tmp.dirSync().name;
-    crossDeviceRenameSync('./build', stableDir);
-    processStable(stableDir);
-    buildForChannel('experimental', '', '');
-    const experimentalDir = tmp.dirSync().name;
-    crossDeviceRenameSync('./build', experimentalDir);
-    processExperimental(experimentalDir);
+    const releaseChannel = argv.releaseChannel;
+    if (releaseChannel === 'stable') {
+      buildForChannel('stable', '', '');
+      processStable('./build');
+    } else if (releaseChannel === 'experimental') {
+      buildForChannel('experimental', '', '');
+      processExperimental('./build');
+    } else {
+      // Running locally, no concurrency. Move each channel's build artifacts into
+      // a temporary directory so that they don't conflict.
+      buildForChannel('stable', '', '');
+      const stableDir = tmp.dirSync().name;
+      crossDeviceRenameSync('./build', stableDir);
+      processStable(stableDir);
+      buildForChannel('experimental', '', '');
+      const experimentalDir = tmp.dirSync().name;
+      crossDeviceRenameSync('./build', experimentalDir);
+      processExperimental(experimentalDir);
 
-    // Then merge the experimental folder into the stable one. processExperimental
-    // will have already removed conflicting files.
-    //
-    // In CI, merging is handled by the GitHub Download Artifacts plugin.
-    mergeDirsSync(experimentalDir + '/', stableDir + '/');
+      // Then merge the experimental folder into the stable one. processExperimental
+      // will have already removed conflicting files.
+      //
+      // In CI, merging is handled by the GitHub Download Artifacts plugin.
+      mergeDirsSync(experimentalDir + '/', stableDir + '/');
 
-    // Now restore the combined directory back to its original name
-    crossDeviceRenameSync(stableDir, './build');
+      // Now restore the combined directory back to its original name
+      crossDeviceRenameSync(stableDir, './build');
+    }
   }
 }
 


### PR DESCRIPTION
Local `yarn build` always built experimental and stable locally. However, that's not always necessary. E.g. `yarn build-for-devtools` only needs experimental but you had to wait for stable to finish as well.

CI should be unaffected. `--release-channel` was already supported with `--ci`.