### PR TITLE
fix[devtools]: still show overlay, if getClientRects is not implemented

### DIFF
--- a/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
@@ -188,13 +188,12 @@ export default function setupHighlighter(
           typeof node.getClientRects === 'function'
             ? node.getClientRects()
             : [];
-        // If this is currently display: none, then try another node.
-        // This can happen when one of the host instances is a hoistable.
         if (
-          nodeRects.length > 0 &&
-          (nodeRects.length > 2 ||
-            nodeRects[0].width > 0 ||
-            nodeRects[0].height > 0)
+          typeof node.getClientRects === 'undefined' || // If Host doesn't implement getClientRects, try to show the overlay.
+          (nodeRects.length > 0 && //                      If this is currently display: none, then try another node.
+            (nodeRects.length > 2 || //                    This can happen when one of the host instances is a hoistable.
+              nodeRects[0].width > 0 ||
+              nodeRects[0].height > 0))
         ) {
           // $FlowFixMe[method-unbinding]
           if (scrollIntoView && typeof node.scrollIntoView === 'function') {


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/34653.

React Native doesn't implement `getClientRect`, since this is applicable to CSS box, which is not a concept for Native (maybe yet).

I am loosening the condition that gates `showOverlay()` call to pass if `getClientRect` is not implemented.

Conceptually, everything that is inside `react-devtools-shared/backend` should be Host-agnostic, because both on Web and Native it is installed inside the Host JavaScript runtime, be it main frame of the page, or RN instance. Since overlay & highlighting logic also lives there, it should also follow these principles.