### PR TITLE
[react-reconciler] Fix typos in comments

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -79,7 +79,7 @@ import {readContextDuringReconciliation} from './ReactFiberNewContext';
 
 import {runWithFiberInDEV} from './ReactCurrentFiber';
 
-// This tracks the thenables that are unwrapped during reconcilation.
+// This tracks the thenables that are unwrapped during reconciliation.
 let thenableState: ThenableState | null = null;
 let thenableIndexCounter: number = 0;
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -2037,7 +2037,7 @@ function updateHostHoistable(
   // the host implementation of getResource to consider children in the
   // resource construction but they will otherwise be discarded. In practice
   // this precludes all but the simplest children and Host specific warnings
-  // should be implemented to warn when children are passsed when otherwise not
+  // should be implemented to warn when children are passed when otherwise not
   // expected
   return null;
 }
@@ -4202,7 +4202,7 @@ function beginWork(
     didReceiveUpdate = false;
 
     if (getIsHydrating() && isForkedChild(workInProgress)) {
-      // Check if this child belongs to a list of muliple children in
+      // Check if this child belongs to a list of multiple children in
       // its parent.
       //
       // In a true multi-threaded implementation, we would render children on

--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -755,7 +755,7 @@ export function measureUpdateViewTransition(
   gesture: boolean,
 ): boolean {
   // If this was a gesture then which Fiber was used for the "old" vs "new" state is reversed.
-  // We still need to treat "finishedWork" as the Fiber that contains the flags for this commmit.
+  // We still need to treat "finishedWork" as the Fiber that contains the flags for this commit.
   const oldFiber = gesture ? finishedWork : current;
   const newFiber = gesture ? current : finishedWork;
   const props: ViewTransitionProps = newFiber.memoizedProps;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -5013,7 +5013,7 @@ export function disconnectPassiveEffect(finishedWork: Fiber): void {
         HookPassive,
       );
       // When disconnecting passive effects, we fire the effects in the same
-      // order as during a deletiong: parent before child
+      // order as during a deletion: parent before child
       recursivelyTraverseDisconnectPassiveEffects(finishedWork);
       break;
     }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -1258,7 +1258,7 @@ function completeWork(
                 markUpdate(workInProgress);
               }
             } else {
-              // We use the updateHostComponent path becuase it produces
+              // We use the updateHostComponent path because it produces
               // the update queue we need for Hoistables.
               updateHostComponent(
                 current,

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -2015,7 +2015,7 @@ function rerenderOptimistic<S, A>(
   // the passthrough value changed.
   //
   // So instead of a forked re-render implementation that knows how to handle
-  // render phase udpates, we can use the same implementation as during a
+  // render phase updates, we can use the same implementation as during a
   // regular mount or update.
   const hook = updateWorkInProgressHook();
 


### PR DESCRIPTION
## Summary

Fix typos in comments within the react-reconciler package:
reconcilation → reconciliation
passsed → passed
muliple → multiple
commmit → commit
deletiong → deletion
becuase → because
udpates → updates

## How did you test this change?

This change only fixes typos in code comments. No functional changes were made, so no additional testing is required.
