### PR TITLE
[compiler] Add enableVerboseNoSetStateInEffect to suggest options to user/agent

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/CompilerError.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/CompilerError.ts
@@ -854,7 +854,9 @@ function getRuleForCategoryImpl(category: ErrorCategory): LintRule {
         severity: ErrorSeverity.Error,
         name: 'set-state-in-effect',
         description:
-          'Validates against calling setState synchronously in an effect, which can lead to re-renders that degrade performance',
+          'Validates against calling setState synchronously in an effect. ' +
+          'This can indicate non-local derived data, a derived event pattern, or ' +
+          'improper external data synchronization.',
         preset: LintRulePreset.Recommended,
       };
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -696,6 +696,16 @@ export const EnvironmentConfigSchema = z.object({
   enableAllowSetStateFromRefsInEffects: z.boolean().default(true),
 
   /**
+   * When enabled, provides verbose error messages for setState calls within effects,
+   * presenting multiple possible fixes to the user/agent since we cannot statically
+   * determine which specific use-case applies:
+   * 1. Non-local derived data - requires restructuring state ownership
+   * 2. Derived event pattern - detecting when a prop changes
+   * 3. Force update / external sync - should use useSyncExternalStore
+   */
+  enableVerboseNoSetStateInEffect: z.boolean().default(false),
+
+  /**
    * Enables inference of event handler types for JSX props on built-in DOM elements.
    * When enabled, functions passed to event handler props (props starting with "on")
    * on primitive JSX tags are inferred to have the BuiltinEventHandlerId type, which

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-set-state-in-effect-verbose-derived-event.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-set-state-in-effect-verbose-derived-event.expect.md
@@ -1,0 +1,74 @@
+
+## Input
+
+```javascript
+// @validateNoSetStateInEffects @enableVerboseNoSetStateInEffect
+import {useState, useEffect} from 'react';
+
+function VideoPlayer({isPlaying}) {
+  const [wasPlaying, setWasPlaying] = useState(isPlaying);
+  useEffect(() => {
+    if (isPlaying !== wasPlaying) {
+      setWasPlaying(isPlaying);
+      console.log('Play state changed!');
+    }
+  }, [isPlaying, wasPlaying]);
+  return <video />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: VideoPlayer,
+  params: [{isPlaying: true}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateNoSetStateInEffects @enableVerboseNoSetStateInEffect
+import { useState, useEffect } from "react";
+
+function VideoPlayer(t0) {
+  const $ = _c(5);
+  const { isPlaying } = t0;
+  const [wasPlaying, setWasPlaying] = useState(isPlaying);
+  let t1;
+  let t2;
+  if ($[0] !== isPlaying || $[1] !== wasPlaying) {
+    t1 = () => {
+      if (isPlaying !== wasPlaying) {
+        setWasPlaying(isPlaying);
+        console.log("Play state changed!");
+      }
+    };
+
+    t2 = [isPlaying, wasPlaying];
+    $[0] = isPlaying;
+    $[1] = wasPlaying;
+    $[2] = t1;
+    $[3] = t2;
+  } else {
+    t1 = $[2];
+    t2 = $[3];
+  }
+  useEffect(t1, t2);
+  let t3;
+  if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
+    t3 = <video />;
+    $[4] = t3;
+  } else {
+    t3 = $[4];
+  }
+  return t3;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: VideoPlayer,
+  params: [{ isPlaying: true }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <video></video>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-set-state-in-effect-verbose-derived-event.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-set-state-in-effect-verbose-derived-event.js
@@ -1,0 +1,18 @@
+// @validateNoSetStateInEffects @enableVerboseNoSetStateInEffect
+import {useState, useEffect} from 'react';
+
+function VideoPlayer({isPlaying}) {
+  const [wasPlaying, setWasPlaying] = useState(isPlaying);
+  useEffect(() => {
+    if (isPlaying !== wasPlaying) {
+      setWasPlaying(isPlaying);
+      console.log('Play state changed!');
+    }
+  }, [isPlaying, wasPlaying]);
+  return <video />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: VideoPlayer,
+  params: [{isPlaying: true}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-set-state-in-effect-verbose-force-update.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-set-state-in-effect-verbose-force-update.expect.md
@@ -1,0 +1,97 @@
+
+## Input
+
+```javascript
+// @validateNoSetStateInEffects @enableVerboseNoSetStateInEffect
+import {useState, useEffect} from 'react';
+
+const externalStore = {
+  value: 0,
+  subscribe(callback) {
+    return () => {};
+  },
+  getValue() {
+    return this.value;
+  },
+};
+
+function ExternalDataComponent() {
+  const [, forceUpdate] = useState({});
+  useEffect(() => {
+    const unsubscribe = externalStore.subscribe(() => {
+      forceUpdate({});
+    });
+    return unsubscribe;
+  }, []);
+  return <div>{externalStore.getValue()}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: ExternalDataComponent,
+  params: [],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateNoSetStateInEffects @enableVerboseNoSetStateInEffect
+import { useState, useEffect } from "react";
+
+const externalStore = {
+  value: 0,
+  subscribe(callback) {
+    return () => {};
+  },
+  getValue() {
+    return this.value;
+  },
+};
+
+function ExternalDataComponent() {
+  const $ = _c(4);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = {};
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const [, forceUpdate] = useState(t0);
+  let t1;
+  let t2;
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t1 = () => {
+      const unsubscribe = externalStore.subscribe(() => {
+        forceUpdate({});
+      });
+      return unsubscribe;
+    };
+    t2 = [];
+    $[1] = t1;
+    $[2] = t2;
+  } else {
+    t1 = $[1];
+    t2 = $[2];
+  }
+  useEffect(t1, t2);
+  let t3;
+  if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
+    t3 = <div>{externalStore.getValue()}</div>;
+    $[3] = t3;
+  } else {
+    t3 = $[3];
+  }
+  return t3;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: ExternalDataComponent,
+  params: [],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>0</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-set-state-in-effect-verbose-force-update.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-set-state-in-effect-verbose-force-update.js
@@ -1,0 +1,28 @@
+// @validateNoSetStateInEffects @enableVerboseNoSetStateInEffect
+import {useState, useEffect} from 'react';
+
+const externalStore = {
+  value: 0,
+  subscribe(callback) {
+    return () => {};
+  },
+  getValue() {
+    return this.value;
+  },
+};
+
+function ExternalDataComponent() {
+  const [, forceUpdate] = useState({});
+  useEffect(() => {
+    const unsubscribe = externalStore.subscribe(() => {
+      forceUpdate({});
+    });
+    return unsubscribe;
+  }, []);
+  return <div>{externalStore.getValue()}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: ExternalDataComponent,
+  params: [],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-set-state-in-effect-verbose-non-local-derived.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-set-state-in-effect-verbose-non-local-derived.expect.md
@@ -1,0 +1,68 @@
+
+## Input
+
+```javascript
+// @validateNoSetStateInEffects @enableVerboseNoSetStateInEffect
+import {useState, useEffect} from 'react';
+
+function Child({firstName, lastName}) {
+  const [fullName, setFullName] = useState('');
+  useEffect(() => {
+    setFullName(firstName + ' ' + lastName);
+  }, [firstName, lastName]);
+  return <div>{fullName}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Child,
+  params: [{firstName: 'John', lastName: 'Doe'}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateNoSetStateInEffects @enableVerboseNoSetStateInEffect
+import { useState, useEffect } from "react";
+
+function Child(t0) {
+  const $ = _c(6);
+  const { firstName, lastName } = t0;
+  const [fullName, setFullName] = useState("");
+  let t1;
+  let t2;
+  if ($[0] !== firstName || $[1] !== lastName) {
+    t1 = () => {
+      setFullName(firstName + " " + lastName);
+    };
+    t2 = [firstName, lastName];
+    $[0] = firstName;
+    $[1] = lastName;
+    $[2] = t1;
+    $[3] = t2;
+  } else {
+    t1 = $[2];
+    t2 = $[3];
+  }
+  useEffect(t1, t2);
+  let t3;
+  if ($[4] !== fullName) {
+    t3 = <div>{fullName}</div>;
+    $[4] = fullName;
+    $[5] = t3;
+  } else {
+    t3 = $[5];
+  }
+  return t3;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Child,
+  params: [{ firstName: "John", lastName: "Doe" }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>John Doe</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-set-state-in-effect-verbose-non-local-derived.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-set-state-in-effect-verbose-non-local-derived.js
@@ -1,0 +1,15 @@
+// @validateNoSetStateInEffects @enableVerboseNoSetStateInEffect
+import {useState, useEffect} from 'react';
+
+function Child({firstName, lastName}) {
+  const [fullName, setFullName] = useState('');
+  useEffect(() => {
+    setFullName(firstName + ' ' + lastName);
+  }, [firstName, lastName]);
+  return <div>{fullName}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Child,
+  params: [{firstName: 'John', lastName: 'Doe'}],
+};


### PR DESCRIPTION

The current `validateNoSetStateInEffects` error has potential false positives because
we cannot fully statically detect patterns where calling setState in an effect is
actually valid. This flag `enableVerboseNoSetStateInEffect` adds a verbose error mode that presents multiple possible
use-cases, allowing an agent to reason about which fix is appropriate before acting:

1. Non-local derived data - suggests restructuring state ownership
2. Derived event pattern - suggests requesting an event callback from parent
3. Force update / external sync - suggests using `useSyncExternalStore`

This gives agents the context needed to make informed decisions rather than
blindly applying a fix that may not be correct for the specific situation.
