### PR TITLE
Run CI for backport releases

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -3,6 +3,10 @@ name: (Runtime) Build and Test
 on:
   push:
     branches: [main]
+    tags:
+      # To get CI for backport releases.
+      # This will duplicate CI for releases from main which is acceptable
+      - "v*"
   pull_request:
     paths-ignore:
       - compiler/**


### PR DESCRIPTION
By adding a trigger to pushes of tags for versions.