### PR TITLE
[test] Cleanup stack assertions in tests mixing React Server and Client

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -2820,15 +2820,16 @@ describe('ReactFlightDOMBrowser', () => {
       },
     });
 
+    const app = ReactServer.createElement(
+      ReactServer.Fragment,
+      null,
+      ReactServer.createElement(Paragraph, null, 'foo'),
+      ReactServer.createElement(Paragraph, null, 'bar'),
+    );
     const stream = await serverAct(() =>
       ReactServerDOMServer.renderToReadableStream(
         {
-          root: ReactServer.createElement(
-            ReactServer.Fragment,
-            null,
-            ReactServer.createElement(Paragraph, null, 'foo'),
-            ReactServer.createElement(Paragraph, null, 'bar'),
-          ),
+          root: app,
         },
         webpackMap,
         {
@@ -2901,26 +2902,10 @@ describe('ReactFlightDOMBrowser', () => {
             "props": {},
             "stack": [
               [
-                "",
-                "/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js",
-                2829,
-                27,
-                2823,
-                34,
-              ],
-              [
-                "serverAct",
-                "/packages/internal-test-utils/internalAct.js",
-                270,
-                19,
-                231,
-                1,
-              ],
-              [
                 "Object.<anonymous>",
                 "/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js",
-                2823,
-                18,
+                2826,
+                19,
                 2810,
                 89,
               ],

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -1216,11 +1216,7 @@ describe('ReactFlightDOMNode', () => {
         const data1 = await getDynamicData1();
         const data2 = await getDynamicData2();
 
-        return (
-          <p>
-            {data1} {data2}
-          </p>
-        );
+        return ReactServer.createElement('p', null, data1, ' ', data2);
       }
 
       function App() {
@@ -1350,8 +1346,8 @@ describe('ReactFlightDOMNode', () => {
               : '\n') +
             '    in body\n' +
             '    in html\n' +
-            '    in App (file://ReactFlightDOMNode-test.js:1233:25)\n' +
-            '    in ClientRoot (ReactFlightDOMNode-test.js:1308:16)',
+            '    in App (file://ReactFlightDOMNode-test.js:1229:25)\n' +
+            '    in ClientRoot (ReactFlightDOMNode-test.js:1304:16)',
         );
       } else {
         expect(
@@ -1360,7 +1356,7 @@ describe('ReactFlightDOMNode', () => {
           '\n' +
             '    in body\n' +
             '    in html\n' +
-            '    in ClientRoot (ReactFlightDOMNode-test.js:1308:16)',
+            '    in ClientRoot (ReactFlightDOMNode-test.js:1304:16)',
         );
       }
 
@@ -1371,7 +1367,7 @@ describe('ReactFlightDOMNode', () => {
           ).toBe(
             '\n' +
               '    in Dynamic (file://ReactFlightDOMNode-test.js:1216:27)\n' +
-              '    in App (file://ReactFlightDOMNode-test.js:1233:25)',
+              '    in App (file://ReactFlightDOMNode-test.js:1229:25)',
           );
         } else {
           expect(
@@ -1379,7 +1375,7 @@ describe('ReactFlightDOMNode', () => {
           ).toBe(
             '' +
               '\n' +
-              '    in App (file://ReactFlightDOMNode-test.js:1233:25)',
+              '    in App (file://ReactFlightDOMNode-test.js:1229:25)',
           );
         }
       } else {

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
@@ -3155,7 +3155,7 @@ describe('ReactFlightAsyncDebugInfo', () => {
     }
 
     const stream = ReactServerDOMServer.renderToPipeableStream(
-      <Component />,
+      ReactServer.createElement(Component),
       {},
     );
 
@@ -3192,7 +3192,7 @@ describe('ReactFlightAsyncDebugInfo', () => {
                 "Object.<anonymous>",
                 "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js",
                 3158,
-                40,
+                19,
                 3146,
                 36,
               ],
@@ -3216,7 +3216,7 @@ describe('ReactFlightAsyncDebugInfo', () => {
                     "Object.<anonymous>",
                     "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js",
                     3158,
-                    40,
+                    19,
                     3146,
                     36,
                   ],
@@ -3248,7 +3248,7 @@ describe('ReactFlightAsyncDebugInfo', () => {
                   "Object.<anonymous>",
                   "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js",
                   3158,
-                  40,
+                  19,
                   3146,
                   36,
                 ],


### PR DESCRIPTION
Some were using `ReactClient.createElement` instead of `ReactServer.createElement`.

Others were including an irrelevant stack frame making it harder to review diffs. I suspect most of the variation was caused by our JSX transform not sourcemapping perfectly.