### PR TITLE
Attach instance handle to DOM in DEV for enableInternalInstanceMap

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
@@ -75,6 +75,9 @@ export function detachDeletedInstance(node: Instance): void {
     delete (node: any)[internalEventHandlerListenersKey];
     delete (node: any)[internalEventHandlesSetKey];
     delete (node: any)[internalRootNodeResourcesKey];
+    if (__DEV__) {
+      delete (node: any)[internalInstanceKey];
+    }
     return;
   }
   // TODO: This function is only called on host components. I don't think all of
@@ -97,6 +100,9 @@ export function precacheFiberNode(
 ): void {
   if (enableInternalInstanceMap) {
     internalInstanceMap.set(node, hostInst);
+    if (__DEV__) {
+      (node: any)[internalInstanceKey] = hostInst;
+    }
     return;
   }
   (node: any)[internalInstanceKey] = hostInst;


### PR DESCRIPTION
Continue attaching `internalInstanceKey` to DOM nodes in DEV. This prevents breaking some internal dev tooling while we experiment with the broader change. Note that this does not reference the DOM handle within the flag, just attaches it and deletes it. Internals tracking is still done through the private map.
