### PR TITLE
fix[devtools]: feature-check document with typeof instead of direct reference

### DIFF
--- a/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
@@ -96,8 +96,11 @@ export default function setupHighlighter(
     applyingScroll = false;
   }
 
-  // $FlowFixMe[method-unbinding]
-  if (document && typeof document.addEventListener === 'function') {
+  if (
+    typeof document === 'object' &&
+    // $FlowFixMe[method-unbinding]
+    typeof document.addEventListener === 'function'
+  ) {
     document.addEventListener('scroll', () => {
       if (!scrollTimer) {
         // Periodically synchronize the scroll while scrolling.


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/35296.

We can get `ReferenceError` if this is unavailable. Using `typeof` check instead for safety.