### PR TITLE
[jest] Handle Windows backslashes in preprocessor path matching

### DIFF
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -66,12 +66,12 @@ module.exports = {
     if (filePath.match(/\.json$/)) {
       return {code: src};
     }
-    if (!filePath.match(/\/third_party\//)) {
+    if (!filePath.match(/[/\\]third_party[/\\]/)) {
       // for test files, we also apply the async-await transform, but we want to
       // make sure we don't accidentally apply that transform to product code.
-      const isTestFile = !!filePath.match(/\/__tests__\//);
+      const isTestFile = !!filePath.match(/[/\\]__tests__[/\\]/);
       const isInDevToolsPackages = !!filePath.match(
-        /\/packages\/react-devtools.*\//
+        /[/\\]packages[/\\]react-devtools.*[/\\]/
       );
       const plugins = [].concat(babelOptions.plugins);
       if (isTestFile && isInDevToolsPackages) {


### PR DESCRIPTION
## Summary

Annotations like `// @reactVersion >= 16.9` were not being handled properly by the jest preprocessor on a Windows computer. This resulted in tests running that should have been skipped. 

The root cause was that the relevant regular expressions in `preprocessor.js` were not matching the backslashes in Windows paths, so I updated them.

## How did you test this change?

I isolated some of the test cases that were running (and failing), but should have been skipped. One example is the "should handle stress test with reordering" test in the following file:
`react\packages\react-devtools-shared\src\__tests__\storeStressSync-test.js` which has the following annotations: 
```js
  // @reactVersion >= 16.9
  // @reactVersion <= 18.2
```
Here's the command I used to evaluate the fix: 
`yarn test-build-devtools --testNamePattern="should handle stress test with reordering"`

Output (Before):
```
 FAIL  packages/react-devtools-shared/src/__tests__/storeStressSync-test.js (19.716 s)
  ● StoreStress (Legacy Mode) › should handle stress test with reordering (Legacy Mode)

    TypeError: ReactDOM.render is not a function

      154 |       ['ReactDOM.render has not been supported since React 18'],
      155 |       () => {
    > 156 |         ReactDOM.render(elements, container);
          |                  ^
      157 |       },
      158 |     );
      159 |

      at packages/react-devtools-shared/src/__tests__/utils.js:156:18
      at withErrorsOrWarningsIgnored (packages/react-devtools-shared/src/__tests__/utils.js:459:25)
      at render (packages/react-devtools-shared/src/__tests__/utils.js:153:5)
      at packages/react-devtools-shared/src/__tests__/storeStressSync-test.js:358:31
      at packages/react-devtools-shared/src/__tests__/utils.js:78:7
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (build/oss-experimental/react/cjs/react.development.js:907:22)
      at packages/react-devtools-shared/src/__tests__/utils.js:77:5
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (build/oss-experimental/react/cjs/react.development.js:907:22)
      at act (packages/react-devtools-shared/src/__tests__/utils.js:76:3)
      at _loop3 (packages/react-devtools-shared/src/__tests__/storeStressSync-test.js:358:7)    
      at Object.<anonymous> (packages/react-devtools-shared/src/__tests__/storeStressSync-test.js:363:301)

 PASS  packages/react-devtools-shared/src/__tests__/storeStressTestConcurrent-test.js (16.505 s)

Summary of all failing tests
 FAIL  packages/react-devtools-shared/src/__tests__/storeStressSync-test.js (19.716 s)
  ● StoreStress (Legacy Mode) › should handle stress test with reordering (Legacy Mode)

    TypeError: ReactDOM.render is not a function

      154 |       ['ReactDOM.render has not been supported since React 18'],
      155 |       () => {
    > 156 |         ReactDOM.render(elements, container);
          |                  ^
      157 |       },
      158 |     );
      159 |

      at packages/react-devtools-shared/src/__tests__/utils.js:156:18
      at withErrorsOrWarningsIgnored (packages/react-devtools-shared/src/__tests__/utils.js:459:25)
      at render (packages/react-devtools-shared/src/__tests__/utils.js:153:5)
      at packages/react-devtools-shared/src/__tests__/storeStressSync-test.js:358:31
      at packages/react-devtools-shared/src/__tests__/utils.js:78:7
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (build/oss-experimental/react/cjs/react.development.js:907:22)
      at packages/react-devtools-shared/src/__tests__/utils.js:77:5
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (build/oss-experimental/react/cjs/react.development.js:907:22)
      at act (packages/react-devtools-shared/src/__tests__/utils.js:76:3)
      at _loop3 (packages/react-devtools-shared/src/__tests__/storeStressSync-test.js:358:7)    
      at Object.<anonymous> (packages/react-devtools-shared/src/__tests__/storeStressSync-test.js:363:301)


Test Suites: 1 failed, 41 skipped, 1 passed, 2 of 43 total
Tests:       1 failed, 517 skipped, 1 passed, 519 total
Snapshots:   1 passed, 1 total
Time:        30.984 s, estimated 123 s
Ran all test suites with tests matching "should handle stress test with reordering".
error Command failed with exit code 1.
```

Output (After):
```
 PASS  packages/react-devtools-shared/src/__tests__/storeStressTestConcurrent-test.js (16.079 s)

Test Suites: 42 skipped, 1 passed, 1 of 43 total
Tests:       518 skipped, 1 passed, 519 total
Snapshots:   1 passed, 1 total
Time:        30.221 s, estimated 123 s
Ran all test suites with tests matching "should handle stress test with reordering".
Done in 33.55s.
```
