### PR TITLE
Upgrade node-forge to ^1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,8 @@
   },
   "resolutions": {
     "react-is": "npm:react-is",
-    "jsdom": "22.1.0"
+    "jsdom": "22.1.0",
+    "node-forge": "^1.3.2"
   },
   "packageManager": "yarn@1.22.22"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12973,10 +12973,10 @@ node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^1, node-forge@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
-  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+node-forge@^1, node-forge@^1.3.1, node-forge@^1.3.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.3.tgz#0ad80f6333b3a0045e827ac20b7f735f93716751"
+  integrity sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Upgrading to address [node-forge advisory](https://github.com/digitalbazaar/forge/security/advisories/GHSA-5gfm-wpxj-wjgq?fbclid=IwZXh0bgNhZW0CMTAAYnJpZBExakkwMHNYU3FseFMxY1B5UXNydGMGYXBwX2lkEDIyMjAzOTE3ODgyMDA4OTIAAR60aDRzUo1zltAeY8g-GQ11d-4JLe9AY_FqVPLA0DBWcU5vWFjBbkny7kRIKA_aem_AfzaJZz1HC7zbOtzXhDGWg)
