### PR TITLE
Improve cyclic thenable detection in ReactFlightReplyServer

### DIFF
--- a/packages/react-server/src/ReactFlightReplyServer.js
+++ b/packages/react-server/src/ReactFlightReplyServer.js
@@ -132,21 +132,15 @@ ReactPromise.prototype.then = function <T>(
         let inspectedValue = chunk.value;
         // Recursively check if the value is itself a ReactPromise and if so if it points
         // back to itself. This helps catch recursive thenables early error.
-        const MAX_THENABLE_CYCLE_DEPTH = 1000;
         let cycleProtection = 0;
-        const visited: Set<any> = new Set<any>();
+        const visited = new Set<typeof ReactPromise>();
         while (inspectedValue instanceof ReactPromise) {
           cycleProtection++;
-          // Hard cap as a last-resort guardrail.
-          if (cycleProtection > MAX_THENABLE_CYCLE_DEPTH) {
-            if (typeof reject === 'function') {
-              reject(new Error('Cannot have cyclic thenables.'));
-            }
-            return;
-          }
-
-          // Detect self-cycles and multi-node cycles.
-          if (inspectedValue === chunk || visited.has(inspectedValue)) {
+          if (
+            inspectedValue === chunk ||
+            visited.has(inspectedValue) ||
+            cycleProtection > 1000
+          ) {
             if (typeof reject === 'function') {
               reject(new Error('Cannot have cyclic thenables.'));
             }


### PR DESCRIPTION
## Summary

This PR improves cyclic thenable detection in `ReactFlightReplyServer.js`. Fixes #35368.
The previous fix only detected direct self-references (`inspectedValue === chunk`) and relied on the `cycleProtection` counter to eventually bail out of longer cycles. This change keeps the existing MAX_THENABLE_CYCLE_DEPTH ($1000$) `cycleProtection` cap as a hard guardrail and adds a visited set so that we can detect self-cycles and multi-node cycles as soon as any `ReactPromise` is revisited and while still bounding the amount of work we do for deep acyclic chains via `cycleProtection`.

## How did you test this change?

- Ran the existing test suite for the server renderer:

  ```bash
  yarn test react-server
  yarn test --prod react-server
  yarn flow dom-node
  yarn linc
  ```