### PR TITLE
[not for merge]

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -1758,6 +1758,17 @@ const allTests = {
     {
       code: normalizeIndent`
         function MyComponent({ theme }) {
+          const onClick = React.useEffectEvent(() => {
+            showNotification(theme);
+          });
+          return <Child onClick={onClick}></Child>;
+        }
+      `,
+      errors: [useEffectEventError('onClick', false)],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent({ theme }) {
           const onClick = useEffectEvent(() => {
             showNotification(theme);
           });

--- a/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
@@ -235,7 +235,9 @@ const rule = {
           parent.init &&
           parent.init.type === 'CallExpression' &&
           parent.init.callee &&
-          isUseEffectEventIdentifier(parent.init.callee)
+          isUseEffectEventIdentifier(
+            getNodeWithoutReactNamespace(parent.init.callee),
+          )
         ) {
           if (reference.resolved === null) {
             throw new Error('Unexpected null reference.resolved');


### PR DESCRIPTION
Previously, we only checked for `useEffectEvent` but we should also check for the namespaced version, `React.useEffectEvent`.
