### PR TITLE
eslint-plugin-react-hooks: disallow hook arguments

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -951,6 +951,23 @@ const allTests = {
     },
     {
       code: normalizeIndent`
+        function Component() {
+          const items = [1, 2];
+          items.map(useCustomHook);
+        }
+      `,
+      errors: [hookArgumentError('useCustomHook')],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          doSomething(React.useState);
+        }
+      `,
+      errors: [hookArgumentError('React.useState')],
+    },
+    {
+      code: normalizeIndent`
         Hook.useState();
         Hook._useState();
         Hook.use42();
@@ -2059,6 +2076,14 @@ function genericError(hook) {
       `React Hook "${hook}" cannot be called inside a callback. React Hooks ` +
       'must be called in a React function component or a custom React ' +
       'Hook function.',
+  };
+}
+
+function hookArgumentError(hook) {
+  return {
+    message:
+      `React Hook "${hook}" cannot be passed as an argument. React Hooks ` +
+      'must be called in a React function component or a custom React Hook function.',
   };
 }
 

--- a/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
@@ -767,6 +767,25 @@ const rule = {
           reactHooks.push(node.callee);
         }
 
+        if (isInsideComponentOrHook(node)) {
+          for (const argument of node.arguments) {
+            if (
+              argument &&
+              argument.type !== 'SpreadElement' &&
+              isHook(argument)
+            ) {
+              context.report({
+                node: argument,
+                message:
+                  `React Hook "${getSourceCode().getText(
+                    argument,
+                  )}" cannot be passed as an argument. React Hooks ` +
+                  'must be called in a React function component or a custom React Hook function.',
+              });
+            }
+          }
+        }
+
         // useEffectEvent: useEffectEvent functions can be passed by reference within useEffect as well as in
         // another useEffectEvent
         // Check all `useEffect` and `React.useEffect`, `useEffectEvent`, and `React.useEffectEvent`


### PR DESCRIPTION
Fixes #22254

## Summary
- report hooks passed as arguments inside components/hooks

## Testing
- yarn workspace eslint-plugin-react-hooks test -- --runTestsByPath __tests__/ESLintRulesOfHooks-test.js