### PR TITLE
eslint-plugin-react-hooks: flag optional hook calls

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -951,6 +951,14 @@ const allTests = {
     },
     {
       code: normalizeIndent`
+        function Component({Obj}) {
+          Obj?.useCustomHook();
+        }
+      `,
+      errors: [conditionalError('Obj?.useCustomHook')],
+    },
+    {
+      code: normalizeIndent`
         Hook.useState();
         Hook._useState();
         Hook.use42();


### PR DESCRIPTION
Fixes #20196

## Summary
- treat optional-chained hook calls as conditional hook usage

## Testing
- yarn workspace eslint-plugin-react-hooks test -- --runTestsByPath __tests__/ESLintRulesOfHooks-test.js