### PR TITLE
eslint-plugin-react-hooks: allow explicit undefined deps

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1486,6 +1486,13 @@ const tests = {
       `,
     },
     {
+      code: normalizeIndent`
+        function MyComponent({byId}) {
+          return useMemo(() => Object.keys(byId), undefined);
+        }
+      `,
+    },
+    {
       // Test settings-based additionalHooks - should work with settings
       code: normalizeIndent`
         function MyComponent(props) {

--- a/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
@@ -1332,11 +1332,10 @@ const rule = {
       const reactiveHookName =
         'name' in nodeWithoutNamespace ? nodeWithoutNamespace.name : '';
       const maybeNode = node.arguments[callbackIndex + 1];
+      const isExplicitUndefined =
+        maybeNode?.type === 'Identifier' && maybeNode.name === 'undefined';
       const declaredDependenciesNode =
-        maybeNode &&
-        !(maybeNode.type === 'Identifier' && maybeNode.name === 'undefined')
-          ? maybeNode
-          : undefined;
+        maybeNode && !isExplicitUndefined ? maybeNode : undefined;
       const isEffect = /Effect($|[^a-z])/g.test(reactiveHookName);
 
       // Check whether a callback is supplied. If there is no callback supplied
@@ -1374,6 +1373,9 @@ const rule = {
             declaredDependenciesNode.value === null)) &&
         !isEffect
       ) {
+        if (isExplicitUndefined) {
+          return;
+        }
         // These are only used for optimization.
         if (
           reactiveHookName === 'useMemo' ||


### PR DESCRIPTION
Fixes #20262

## Summary
- treat explicit `undefined` dependencies for non-effect hooks as intentional

## Testing
- yarn workspace eslint-plugin-react-hooks test -- --runTestsByPath __tests__/ESLintRuleExhaustiveDeps-test.js