### PR TITLE
fix: add missing useState import in test fixture

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-use-memo-unused-state.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-use-memo-unused-state.js
@@ -1,5 +1,5 @@
 // @validatePreserveExistingMemoizationGuarantees
-import {useCallback, useTransition} from 'react';
+import {useCallback, useState, useTransition} from 'react';
 
 function useFoo() {
   const [, /* state value intentionally not captured */ setState] = useState();


### PR DESCRIPTION
## Summary

The test fixture \preserve-use-memo-unused-state.js\ uses \useState\ but was missing the import, causing the test to throw:

\\\
(kind: exception) useState is not defined
\\\

## Fix

Added \useState\ to the import statement alongside \useCallback\ and \useTransition\.

## Test Plan

The fixture should now execute without the \useState is not defined\ error.