### PR TITLE
fix: Add deprecation warning for removed flushSync API

### DIFF
--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -470,6 +470,21 @@ export {
   flushPendingEffects as flushPassiveEffects,
 };
 
+// Deprecated: Add deprecation warning for removed flushSync API
+let didWarnAboutFlushSync = false;
+export const flushSync = __DEV__
+  ? function flushSync() {
+      if (!didWarnAboutFlushSync) {
+        didWarnAboutFlushSync = true;
+        console.error(
+          'The `flushSync` export from react-reconciler has been removed. ' +
+            'Use `updateContainerSync()` followed by `flushSyncWork()` instead. ' +
+            'See https://github.com/facebook/react/pull/28500 for more details.',
+        );
+      }
+    }
+  : undefined;
+
 export function getPublicRootInstance(
   container: OpaqueRoot,
 ): component(...props: any) | PublicInstance | null {

--- a/packages/react-reconciler/src/__tests__/ReactReconcilerFlushSyncDeprecation-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactReconcilerFlushSyncDeprecation-test.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+let Reconciler;
+let assertConsoleErrorDev;
+
+describe('ReactReconciler flushSync deprecation', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    Reconciler = require('react-reconciler');
+    const InternalTestUtils = require('internal-test-utils');
+    assertConsoleErrorDev = InternalTestUtils.assertConsoleErrorDev;
+  });
+
+  // @gate __DEV__
+  it('warns when accessing the deprecated flushSync export', () => {
+    const flushSync = Reconciler.flushSync;
+    expect(typeof flushSync).toBe('function');
+    flushSync();
+    assertConsoleErrorDev([
+      'The `flushSync` export from react-reconciler has been removed. ' +
+        'Use `updateContainerSync()` followed by `flushSyncWork()` instead. ' +
+        'See https://github.com/facebook/react/pull/28500 for more details.',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

I am submitting this PR to address issue #35424 regarding the silent removal of `flushSync`. As pointed out in the issue, the renaming of `flushSync` to `flushSyncFromReconciler` in PR #28500 was a breaking change that caused `flushSync` to become `undefined` without warning, breaking custom renderers like `@opentui/react`.

To fix this usability issue, I have:

1.  **Re-introduced `flushSync`** as a deprecated stub (placeholder function) in [ReactFiberReconciler.js](cci:7://file:///c:/Users/pc/Documents/contribui%C3%A7%C3%B5es-open-source/react/packages/react-reconciler/src/ReactFiberReconciler.js:0:0-0:0).
2.  **Added a runtime warning** that I configured to trigger only when the function is *called* (and only once per session in `__DEV__`).
3.  **Provided clear guidance** in the warning message to use `updateContainerSync()` followed by `flushSyncWork()`, as requested in the issue.

This ensures that I help existing custom renderer authors receive a helpful error message instead of failing silently with undefined errors.

Closes #35424

## How did you test this change?

I added a new test file: [packages/react-reconciler/src/__tests__/ReactReconcilerFlushSyncDeprecation-test.js](cci:7://file:///c:/Users/pc/Documents/contribui%C3%A7%C3%B5es-open-source/react/packages/react-reconciler/src/__tests__/ReactReconcilerFlushSyncDeprecation-test.js:0:0-0:0) to specifically verify the deprecation logic I implemented.

**Verification Steps:**
1.  **Automated Testing:** I ran the new test via `yarn test ReactReconcilerFlushSyncDeprecation`.
    -   I verified that `Reconciler.flushSync` is exported as a `function`.
    -   I verified that calling `flushSync()` emits the expected `console.error` warning.
    -   I verified that the warning includes the migration instruction: *"Use `updateContainerSync()` followed by `flushSyncWork()` instead."*
2.  **Correctness:** I ensured the warning does not fire on module load (import), but only upon execution, preventing noise for users who might import the reconciler but not use this specific method.

**Test Output:**
PASS packages/react-reconciler/src/__tests__/ReactReconcilerFlushSyncDeprecation-test.js
  ReactReconciler flushSync deprecation
    ✓ warns when accessing the deprecated flushSync export (172 ms)