### PR TITLE
Fix: Guard against re-entry in Scheduler (Issue #17355)

### DIFF
--- a/packages/scheduler/src/forks/Scheduler.js
+++ b/packages/scheduler/src/forks/Scheduler.js
@@ -500,6 +500,14 @@ const performWorkUntilDeadline = () => {
     // remain true, and we'll continue the work loop.
     let hasMoreWork = true;
     try {
+      if (isPerformingWork) {
+        // A scheduled task triggered a host event (e.g. valid re-entry).
+        // If we process it now, we'll lose key context. Schedulers that
+        // support re-entry should verify that the queue is empty before
+        // processing.
+        // For now, we'll just yield.
+        return;
+      }
       hasMoreWork = flushWork(currentTime);
     } finally {
       if (hasMoreWork) {


### PR DESCRIPTION
Fixes #17355. This PR adds a re-entrancy guard to `performWorkUntilDeadline` in the Scheduler. This addresses an issue observed in Firefox where `MessageChannel` events may fire recursively when the main thread is paused (e.g. by `alert()` or breakpoints), causing the 'Should not already be working' invariant violation. Verified by running Scheduler tests (`yarn test scheduler`).