### PR TITLE
chore(deps): bump babel core to resolve CI inconsistencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@babel/cli": "^7.10.5",
+    "@babel/cli": "^7.26.0",
     "@babel/code-frame": "^7.10.4",
-    "@babel/core": "^7.11.1",
+    "@babel/core": "^7.26.0",
     "@babel/helper-define-map": "^7.18.6",
     "@babel/helper-module-imports": "^7.10.4",
     "@babel/parser": "^7.11.3",
@@ -40,7 +40,7 @@
     "@babel/preset-flow": "^7.10.4",
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.26.0",
-    "@babel/traverse": "^7.11.0",
+    "@babel/traverse": "^7.26.0",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^24.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",


### PR DESCRIPTION
I've been seeing some weird inconsistencies in our CI runs lately, mostly related to how certain regex patterns are being handled during transpilation. The current Babel 7.11 setup is quite dated and seems to be the bottleneck here.

Updating the core Babel packages to 7.26 seems to stabilize things and silence those annoying warnings. It's high time we moved off these older versions anyway to keep the build pipeline healthy. No changes to the actual React logic, just keeping the house clean.