### PR TITLE
[ci] Increase DevTools test shards and bump timeout

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -454,9 +454,11 @@ jobs:
       fail-fast: false
       matrix:
         shard:
-          - 1/3
-          - 2/3
-          - 3/3
+          - 1/5
+          - 2/5
+          - 3/5
+          - 4/5
+          - 5/5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/packages/react-devtools-shared/src/__tests__/profilerContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilerContext-test.js
@@ -654,7 +654,7 @@ describe('ProfilerContext', () => {
     expect(store.profilerStore.isProfilingBasedOnUserInput).toBe(false);
 
     document.body.removeChild(profilerContainer);
-  });
+  }, 20000);
 
   it('should navigate between commits when the keyboard shortcut is pressed', async () => {
     const Parent = () => <Child />;


### PR DESCRIPTION

[ci] Increase DevTools test shards and bump timeout

- Increase DevTools test shards from 3 to 5
- Bump timeout to 20s

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/35459).
* #35458
* __->__ #35459