### PR TITLE
Document Firefox pause/resume edge case for scheduler work state

### DIFF
--- a/packages/scheduler/src/forks/Scheduler.js
+++ b/packages/scheduler/src/forks/Scheduler.js
@@ -84,7 +84,11 @@ var taskIdCounter = 1;
 
 var currentTask = null;
 var currentPriorityLevel: PriorityLevel = NormalPriority;
-
+// NOTE: In Firefox, JavaScript execution can pause due to debugger breakpoints
+// or alert() calls while scheduler work is in progress.
+// When execution resumes, this flag may remain set if cleanup logic
+// does not run as expected, causing the scheduler to believe work
+// is already in progress. See issue #17355 for context.
 // This is set while performing work, to prevent re-entrance.
 var isPerformingWork = false;
 


### PR DESCRIPTION
This change documents a Firefox-specific edge case where JavaScript execution
may pause due to debugger breakpoints or alert() calls while scheduler work
is in progress.

When execution resumes, the internal isPerformingWork flag may remain set if
cleanup logic does not run as expected. This comment is related to issue #17355
and is intended to improve maintainability and debugging.
