### PR TITLE
Playground: Refactor messages types and parsing (string enums, readonly)

### DIFF
--- a/compiler/apps/playground/lib/stores/messages.ts
+++ b/compiler/apps/playground/lib/stores/messages.ts
@@ -6,22 +6,22 @@
  */
 
 export enum MessageSource {
-  Babel,
-  Forget,
-  Playground,
+  Babel = 'Babel',
+  Forget = 'Forget',
+  Playground = 'Playground',
 }
 
 export enum MessageLevel {
-  Info,
-  Warning,
-  Error,
+  Info = 'info',
+  Warning = 'warning',
+  Error = 'error',
 }
 
 export interface Message {
-  title: string;
-  level: MessageLevel;
-  source: MessageSource; // Can be used to further style messages differently.
-  codeframe: string | undefined;
+  readonly title: string;
+  readonly level: MessageLevel;
+  readonly source: MessageSource; // Can be used to further style messages differently.
+  readonly codeframe?: string;
 }
 
 export function createMessage(
@@ -29,8 +29,11 @@ export function createMessage(
   level: MessageLevel,
   source: MessageSource,
 ): Message {
-  const [title, ...body] = message.split('\n');
-  const codeframe = body.length > 0 ? body.join('\n') : undefined;
+  const normalized = message.replace(/\r\n/g, '\n').trimEnd();
+  const [titleRaw, ...body] = normalized.split('\n');
+  const title = titleRaw.trim();
+  const codeframeRaw = body.join('\n').trim();
+  const codeframe = codeframeRaw === '' ? undefined : codeframeRaw;
 
   return {
     source,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Playground: Refactor message types and parsing for stronger typing and robustness
Convert numeric enums to string enums to make runtime values explicit.
Make Message fields readonly and codeframe optional to express data intent.
Normalize message parsing to handle CRLF and trailing whitespace and to treat empty bodies as no codeframe
Confine changes to the playground to reduce risk to core packages.

## How did you test this change?

Manual smoke test (playground UI): start the playground and exercise message flows:
Send a single-line message → expect title populated and no codeframe
Send a multi-line message with trailing spaces → expect title to be first line (trimmed) and codeframe to contain trimmed remaining lines.
Send a CRLF message (\r\n) → expect codeframe normalized to LF (\n).
Verify UI: icon matches level, codeframe displays in the message body when present, and dismiss button behavior (non-Playground sources dismissible) remains unchanged.