### PR TITLE
Add the suffix to cancelled view transition names

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -711,7 +711,11 @@ function measureViewTransitionHostInstancesRecursive(
         }
         viewTransitionCancelableChildren.push(
           instance,
-          oldName,
+          viewTransitionHostInstanceIdx === 0
+            ? oldName
+            : // If we have multiple Host Instances below, we add a suffix to the name to give
+              // each one a unique name.
+              oldName + '_' + viewTransitionHostInstanceIdx,
           child.memoizedProps,
         );
       }


### PR DESCRIPTION
When a View Transition might not need to update we add it to a queue. If the parent are able to be reverted, we then cancel the already started view transitions. We do this by adding an animation that hides the "old" state and remove the view transition name from the old state.

There was a bug where if you have more than one child in a `<ViewTransition>` we didn't add the right suffix to the name we added in the queue so it wasn't adding an animation that hides the old state. The effect was that it playing an exit animation instead of being cancelled.