### PR TITLE
DevTools: Allow searching by component name in Profiler trace

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js
@@ -28,6 +28,7 @@ import RecordingInProgress from './RecordingInProgress';
 import ProcessingData from './ProcessingData';
 import ProfilingNotSupported from './ProfilingNotSupported';
 import SidebarSelectedFiberInfo from './SidebarSelectedFiberInfo';
+import ProfilerSearchInput from './ProfilerSearchInput';
 import SettingsModal from 'react-devtools-shared/src/devtools/views/Settings/SettingsModal';
 import SettingsModalContextToggle from 'react-devtools-shared/src/devtools/views/Settings/SettingsModalContextToggle';
 import {SettingsModalContextController} from 'react-devtools-shared/src/devtools/views/Settings/SettingsModalContext';
@@ -187,6 +188,9 @@ function Profiler(_: {}) {
                 ref={searchInputContainerRef}
                 className={styles.TimelineSearchInputContainer}
               />
+            )}
+            {isLegacyProfilerSelected && didRecordCommits && selectedCommitIndex !== null && (
+              <ProfilerSearchInput />
             )}
             <SettingsModalContextToggle />
             {isLegacyProfilerSelected && didRecordCommits && (

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilerSearchInput.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilerSearchInput.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+import {useState, useContext, useCallback, useEffect} from 'react';
+
+import SearchInput from 'react-devtools-shared/src/devtools/views/SearchInput';
+import {ProfilerContext} from './ProfilerContext';
+
+export default function ProfilerSearchInput(): React.Node {
+  const [localSearchQuery, setLocalSearchQuery] = useState('');
+  const {
+    searchIndex,
+    searchResults,
+    searchText,
+    setSearchText,
+    goToNextSearchResult,
+    goToPreviousSearchResult,
+  } = useContext(ProfilerContext);
+
+  // Sync local state with context when search is cleared externally (e.g., commit change)
+  useEffect(() => {
+    if (searchText === '' && localSearchQuery !== '') {
+      setLocalSearchQuery('');
+    }
+  }, [searchText, localSearchQuery]);
+
+  const search = useCallback(
+    (text: string) => {
+      setLocalSearchQuery(text);
+      setSearchText(text);
+    },
+    [setLocalSearchQuery, setSearchText],
+  );
+  const goToNextResult = useCallback(
+    () => goToNextSearchResult(),
+    [goToNextSearchResult],
+  );
+  const goToPreviousResult = useCallback(
+    () => goToPreviousSearchResult(),
+    [goToPreviousSearchResult],
+  );
+
+  return (
+    <SearchInput
+      goToNextResult={goToNextResult}
+      goToPreviousResult={goToPreviousResult}
+      placeholder="Search components (text or /regex/)"
+      search={search}
+      searchIndex={searchIndex !== null ? searchIndex : 0}
+      searchResultsCount={searchResults.length}
+      searchText={localSearchQuery}
+      testName="ProfilerSearchInput"
+    />
+  );
+}
+


### PR DESCRIPTION
## Summary
Implements component name search functionality in the Profiler trace view as requested in #32995.

## Changes
- Added search state management to `ProfilerContext`
- Created `ProfilerSearchInput` component (similar to `ComponentSearchInput`)
- Integrated search input into Profiler toolbar
- Search only considers components from the selected commit

## Features
- ✅ Cmd+f / Ctrl+f keyboard shortcut (handled by SearchInput component)
- ✅ Text and regex search support (e.g., `/^Button/`)
- ✅ Result count display (e.g., "1 | 5")
- ✅ Navigation between matches (Enter/Shift+Enter or arrow buttons)
- ✅ Auto-selects first matching result
- ✅ Clears when commit changes
- ✅ Only searches the selected commit (not the whole trace)
- ✅ Works in both Flamegraph and Ranked views

## Implementation Details
- Follows the same pattern as Components panel search
- Search input appears conditionally when:
  - Legacy profiler tabs (flame-chart/ranked-chart) are selected
  - Commits are recorded
  - A commit is selected
- Search filters components recursively through the commit tree
- Uses existing `createRegExp` utility for pattern matching

## Testing
- ✅ Linting passed
- ✅ Flow type checking passed (dom-node renderer)
- ✅ Tested locally in DevTools shell
- ✅ Follows existing codebase patterns

Fixes #32995