### PR TITLE
[Flight] Forward early debug info for lazy chunks

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -536,6 +536,7 @@ function moveDebugInfoFromChunkToInnerValue<T>(
   // value instead. This can be a React element, an array, or an uninitialized
   // Lazy.
   const resolvedValue = resolveLazy(value);
+  // NOTE: Keep this condition in sync with `copyDebugInfoProgressToResolvedValue` from `ReactFlightServer`.
   if (
     typeof resolvedValue === 'object' &&
     resolvedValue !== null &&

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -26,7 +26,7 @@ function normalizeCodeLocInfo(str) {
       if (dot !== -1) {
         name = name.slice(dot + 1);
       }
-      return '    in ' + name + (/\d/.test(m) ? ' (at **)' : '');
+      return '    in ' + name + (/:\d+:\d+/.test(m) ? ' (at **)' : '');
     })
   );
 }
@@ -2782,7 +2782,7 @@ describe('ReactFlight', () => {
                   transport: expect.arrayContaining([]),
                 },
               },
-              {time: gate(flags => flags.enableAsyncDebugInfo) ? 53 : 21},
+              {time: gate(flags => flags.enableAsyncDebugInfo) ? 46 : 21},
             ]
           : undefined,
       );
@@ -2792,7 +2792,7 @@ describe('ReactFlight', () => {
       expect(getDebugInfo(await thirdPartyChildren[0])).toEqual(
         __DEV__
           ? [
-              {time: gate(flags => flags.enableAsyncDebugInfo) ? 54 : 22}, // Clamped to the start
+              {time: gate(flags => flags.enableAsyncDebugInfo) ? 47 : 22}, // Clamped to the start
               {
                 name: 'ThirdPartyComponent',
                 env: 'third-party',
@@ -2800,15 +2800,15 @@ describe('ReactFlight', () => {
                 stack: '    in Object.<anonymous> (at **)',
                 props: {},
               },
-              {time: gate(flags => flags.enableAsyncDebugInfo) ? 54 : 22},
-              {time: gate(flags => flags.enableAsyncDebugInfo) ? 55 : 23}, // This last one is when the promise resolved into the first party.
+              {time: gate(flags => flags.enableAsyncDebugInfo) ? 47 : 22},
+              {time: gate(flags => flags.enableAsyncDebugInfo) ? 48 : 23}, // This last one is when the promise resolved into the first party.
             ]
           : undefined,
       );
       expect(getDebugInfo(thirdPartyChildren[1])).toEqual(
         __DEV__
           ? [
-              {time: gate(flags => flags.enableAsyncDebugInfo) ? 54 : 22}, // Clamped to the start
+              {time: gate(flags => flags.enableAsyncDebugInfo) ? 47 : 22}, // Clamped to the start
               {
                 name: 'ThirdPartyLazyComponent',
                 env: 'third-party',
@@ -2816,14 +2816,14 @@ describe('ReactFlight', () => {
                 stack: '    in myLazy (at **)\n    in lazyInitializer (at **)',
                 props: {},
               },
-              {time: gate(flags => flags.enableAsyncDebugInfo) ? 54 : 22},
+              {time: gate(flags => flags.enableAsyncDebugInfo) ? 47 : 22},
             ]
           : undefined,
       );
       expect(getDebugInfo(thirdPartyChildren[2])).toEqual(
         __DEV__
           ? [
-              {time: gate(flags => flags.enableAsyncDebugInfo) ? 54 : 22},
+              {time: gate(flags => flags.enableAsyncDebugInfo) ? 47 : 22},
               {
                 name: 'ThirdPartyFragmentComponent',
                 env: 'third-party',
@@ -2831,7 +2831,7 @@ describe('ReactFlight', () => {
                 stack: '    in Object.<anonymous> (at **)',
                 props: {},
               },
-              {time: gate(flags => flags.enableAsyncDebugInfo) ? 54 : 22},
+              {time: gate(flags => flags.enableAsyncDebugInfo) ? 47 : 22},
             ]
           : undefined,
       );

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -3646,21 +3646,27 @@ function renderModelDestructive(
         if (__DEV__) {
           const debugInfo: ?ReactDebugInfo = lazy._debugInfo;
           if (debugInfo) {
-            // We don't need to outlineTask -- if we needed outlining, we would've done it above.
-            const progress = forwardDebugInfoProgressive(
-              request,
-              task,
-              debugInfo,
-            );
-            // The debug info array may have been moved onto the resolved value
-            // by `moveDebugInfoFromChunkToInnerValue`.
-            // If it was, we have to make sure we skip the elements we've already emitted.
-            if (progress > 0 && debugInfo.length === 0) {
-              copyDebugInfoProgressToResolvedValue(
+            // If this came from Flight, forward any debug info into this new row.
+            if (!canEmitDebugInfo) {
+              // We don't have a chunk to assign debug info. We need to outline this
+              // component to assign it an ID.
+              return outlineTask(request, task);
+            } else {
+              const progress = forwardDebugInfoProgressive(
                 request,
-                progress,
-                resolvedModel,
+                task,
+                debugInfo,
               );
+              // The debug info array may have been moved onto the resolved value
+              // by `moveDebugInfoFromChunkToInnerValue`.
+              // If it was, we have to make sure we skip the elements we've already emitted.
+              if (progress > 0 && debugInfo.length === 0) {
+                copyDebugInfoProgressToResolvedValue(
+                  request,
+                  progress,
+                  resolvedModel,
+                );
+              }
             }
           }
         }


### PR DESCRIPTION
Currently, when we're re-encoding a lazy chunk that came from a flight stream, we wait for the chunk to resolve, and then forward the debug info. This unnecessarily delays debug info that's already available while the chunk is still pending, like the name and stack info. This PR attempts to make it so that we emit whatever debug info we have before initializing the lazy chunk (which may suspend), and then emit the rest after.

When a debug info array is partially emitted, we save the number of emitted entries we already emitted in a WeakMap `request.partialDebugInfoProgress`. That way, when we emit it again later, we know how many entries to skip.

Most debug infos are not partially emitted -- we currently only do this for lazy elements -- so to avoid the overhead of tracking the index for each debug info array, we only do this if it's emitted using`forwardDebugInfoProgressive`.

Notably, we also need to handle cases when debug entries are transferred from the lazy chunk onto the inner element (i.e. moved to a different array) via `moveDebugInfoFromChunkToInnerValue`:
https://github.com/facebook/react/blob/b546603bcb309a52343fd6a7b8751145205f8ac1/packages/react-client/src/ReactFlightClient.js#L1275-L1291
In this case, we have to make sure that new array has the same progress as the source. We do this in `copyDebugInfoProgressToResolvedValue`.