### PR TITLE
docs: improve README installation section clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ React is a JavaScript library for building user interfaces.
 React has been designed for gradual adoption from the start, and **you can use as little or as much React as you need**:
 
 * Use [Quick Start](https://react.dev/learn) to get a taste of React.
-* [Add React to an Existing Project](https://react.dev/learn/add-react-to-an-existing-project) to use as little or as much React as you need.
+* [Add React to an Existing Project](https://react.dev/learn/add-react-to-an-existing-project) to integrate React into your current codebase.
 * [Create a New React App](https://react.dev/learn/start-a-new-react-project) if you're looking for a powerful JavaScript toolchain.
 
 ## Documentation


### PR DESCRIPTION
Summary
This PR improves the clarity of the Installation section in README.md by removing redundant text. The phrase "to use as little or as much React as you need" was repeated on both line 13 (in the section introduction) and line 16 (in the bullet point for "Add React to an Existing Project").
I've updated line 16 to say "to integrate React into your current codebase" instead, which is more specific and descriptive while eliminating the redundancy.
How did you test this change?
This is a documentation-only change that improves readability. I verified:
The change maintains the same meaning and intent
The text flows better without the redundancy
No code or functionality is affected
The markdown formatting is correct