### PR TITLE
Cleanup enableEagerAlternateStateNodeCleanup feature flag

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -59,7 +59,6 @@ import {
   enableComponentPerformanceTrack,
   enableViewTransition,
   enableFragmentRefs,
-  enableEagerAlternateStateNodeCleanup,
   enableDefaultTransitionIndicator,
   enableFragmentRefsTextNodes,
 } from 'shared/ReactFeatureFlags';
@@ -2270,18 +2269,16 @@ function commitMutationEffectsOnFiber(
           }
         }
       } else {
-        if (enableEagerAlternateStateNodeCleanup) {
-          // $FlowFixMe[constant-condition]
-          if (supportsPersistence) {
-            if (finishedWork.alternate !== null) {
-              // `finishedWork.alternate.stateNode` is pointing to a stale shadow
-              // node at this point, retaining it and its subtree. To reclaim
-              // memory, point `alternate.stateNode` to new shadow node. This
-              // prevents shadow node from staying in memory longer than it
-              // needs to. The correct behaviour of this is checked by test in
-              // React Native: ShadowNodeReferenceCounter-itest.js#L150
-              finishedWork.alternate.stateNode = finishedWork.stateNode;
-            }
+        // $FlowFixMe[constant-condition]
+        if (supportsPersistence) {
+          if (finishedWork.alternate !== null) {
+            // `finishedWork.alternate.stateNode` is pointing to a stale shadow
+            // node at this point, retaining it and its subtree. To reclaim
+            // memory, point `alternate.stateNode` to new shadow node. This
+            // prevents shadow node from staying in memory longer than it
+            // needs to. The correct behaviour of this is checked by test in
+            // React Native: ShadowNodeReferenceCounter-itest.js#L150
+            finishedWork.alternate.stateNode = finishedWork.stateNode;
           }
         }
       }

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -129,8 +129,6 @@ export const enableEffectEventMutationPhase: boolean = false;
 
 export const passChildrenWhenCloningPersistedNodes: boolean = false;
 
-export const enableEagerAlternateStateNodeCleanup: boolean = true;
-
 /**
  * Enables an expiration time for retry lanes to avoid starvation.
  */

--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -19,7 +19,6 @@
 
 export const alwaysThrottleRetries = __VARIANT__;
 export const enableObjectFiber = __VARIANT__;
-export const enableEagerAlternateStateNodeCleanup = __VARIANT__;
 export const passChildrenWhenCloningPersistedNodes = __VARIANT__;
 export const enableFragmentRefs = __VARIANT__;
 export const enableFragmentRefsScrollIntoView = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -22,7 +22,6 @@ export const {
   alwaysThrottleRetries,
   enableEffectEventMutationPhase,
   enableObjectFiber,
-  enableEagerAlternateStateNodeCleanup,
   passChildrenWhenCloningPersistedNodes,
   enableFragmentRefs,
   enableFragmentRefsScrollIntoView,

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -44,7 +44,6 @@ export const enablePerformanceIssueReporting: boolean = false;
 export const enableSchedulingProfiler: boolean =
   !enableComponentPerformanceTrack && __PROFILE__;
 export const enableScopeAPI: boolean = false;
-export const enableEagerAlternateStateNodeCleanup: boolean = true;
 export const enableEffectEventMutationPhase: boolean = false;
 export const enableSuspenseAvoidThisFallback: boolean = false;
 export const enableSuspenseCallback: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -54,7 +54,6 @@ export const disableClientCache: boolean = true;
 export const enableInfiniteRenderLoopDetection: boolean = false;
 export const enableInfiniteRenderLoopDetectionForceThrow: boolean = false;
 
-export const enableEagerAlternateStateNodeCleanup: boolean = true;
 export const enableEffectEventMutationPhase: boolean = false;
 
 export const enableYieldingBeforePassive: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -41,7 +41,6 @@ export const enableSchedulingProfiler = __PROFILE__;
 export const enableComponentPerformanceTrack = false;
 export const enablePerformanceIssueReporting = false;
 export const enableScopeAPI = false;
-export const enableEagerAlternateStateNodeCleanup = true;
 export const enableEffectEventMutationPhase = false;
 export const enableSuspenseAvoidThisFallback = false;
 export const enableSuspenseCallback = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -60,7 +60,6 @@ export const enableReactTestRendererWarning: boolean = false;
 export const disableLegacyMode: boolean = true;
 
 export const enableObjectFiber: boolean = false;
-export const enableEagerAlternateStateNodeCleanup: boolean = true;
 export const enableEffectEventMutationPhase: boolean = false;
 
 export const enableYieldingBeforePassive: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -98,8 +98,6 @@ export const enableReactTestRendererWarning: boolean = false;
 
 export const disableLegacyMode: boolean = true;
 
-export const enableEagerAlternateStateNodeCleanup: boolean = true;
-
 export const enableViewTransitionForPersistenceMode: boolean = false;
 
 export const enableGestureTransition: boolean = false;


### PR DESCRIPTION
## Summary

This has been fully rolled out internally and was manually merged in the RN release in https://github.com/facebook/react-native/commit/0411c43b3a239384c778baad22c7b4c501008449

## How did you test this change?

`yarn flow fabric`
