### PR TITLE
Defer useDeferredValue updates in Gestures

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -621,7 +621,8 @@ export function includesOnlyRetries(lanes: Lanes): boolean {
 export function includesOnlyNonUrgentLanes(lanes: Lanes): boolean {
   // TODO: Should hydration lanes be included here? This function is only
   // used in `updateDeferredValueImpl`.
-  const UrgentLanes = SyncLane | InputContinuousLane | DefaultLane;
+  const UrgentLanes =
+    SyncLane | InputContinuousLane | DefaultLane | GestureLane;
   return (lanes & UrgentLanes) === NoLanes;
 }
 export function includesOnlyTransitions(lanes: Lanes): boolean {


### PR DESCRIPTION
If an initial value is specified, then it's always used regardless as part of the gesture render.

If a gesture render causes an update, then previously that was not treated as deferred and could therefore be blocking the render. However, a gesture is supposed to flush synchronously ideally. Therefore we should consider these as urgent.

The effect is that useDeferredValue renders the previous state.