### PR TITLE
[DevTools] Stop setting unused global variables

### DIFF
--- a/packages/react-devtools-inline/src/backend.js
+++ b/packages/react-devtools-inline/src/backend.js
@@ -6,7 +6,10 @@ import {initBackend} from 'react-devtools-shared/src/backend';
 import {installHook} from 'react-devtools-shared/src/hook';
 import setupNativeStyleEditor from 'react-devtools-shared/src/backend/NativeStyleEditor/setupNativeStyleEditor';
 
-import type {BackendBridge} from 'react-devtools-shared/src/bridge';
+import type {
+  BackendBridge,
+  SavedPreferencesParams,
+} from 'react-devtools-shared/src/bridge';
 import type {Wall} from 'react-devtools-shared/src/frontend/types';
 import {
   getIfReloadedAndProfiling,
@@ -16,31 +19,14 @@ import {
 } from 'react-devtools-shared/src/utils';
 
 function startActivation(contentWindow: any, bridge: BackendBridge) {
-  const onSavedPreferences = (data: $FlowFixMe) => {
+  const onSavedPreferences = (data: SavedPreferencesParams) => {
     // This is the only message we're listening for,
     // so it's safe to cleanup after we've received it.
     bridge.removeListener('savedPreferences', onSavedPreferences);
 
-    const {
-      appendComponentStack,
-      breakOnConsoleErrors,
-      componentFilters,
-      showInlineWarningsAndErrors,
-      hideConsoleLogsInStrictMode,
-      disableSecondConsoleLogDimmingInStrictMode,
-    } = data;
+    const {componentFilters} = data;
 
-    contentWindow.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ =
-      appendComponentStack;
-    contentWindow.__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__ =
-      breakOnConsoleErrors;
     contentWindow.__REACT_DEVTOOLS_COMPONENT_FILTERS__ = componentFilters;
-    contentWindow.__REACT_DEVTOOLS_SHOW_INLINE_WARNINGS_AND_ERRORS__ =
-      showInlineWarningsAndErrors;
-    contentWindow.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ =
-      hideConsoleLogsInStrictMode;
-    contentWindow.__REACT_DEVTOOLS_DISABLE_SECOND_CONSOLE_LOG_DIMMING_IN_STRICT_MODE__ =
-      disableSecondConsoleLogDimmingInStrictMode;
 
     // TRICKY
     // The backend entry point may be required in the context of an iframe or the parent window.
@@ -49,15 +35,7 @@ function startActivation(contentWindow: any, bridge: BackendBridge) {
     // Technically we don't need to store them on the contentWindow in this case,
     // but it doesn't really hurt anything to store them there too.
     if (contentWindow !== window) {
-      window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = appendComponentStack;
-      window.__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__ = breakOnConsoleErrors;
       window.__REACT_DEVTOOLS_COMPONENT_FILTERS__ = componentFilters;
-      window.__REACT_DEVTOOLS_SHOW_INLINE_WARNINGS_AND_ERRORS__ =
-        showInlineWarningsAndErrors;
-      window.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ =
-        hideConsoleLogsInStrictMode;
-      window.__REACT_DEVTOOLS_DISABLE_SECOND_CONSOLE_LOG_DIMMING_IN_STRICT_MODE__ =
-        disableSecondConsoleLogDimmingInStrictMode;
     }
 
     finishActivation(contentWindow, bridge);

--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -240,9 +240,6 @@ beforeEach(() => {
   setSavedComponentFilters(getDefaultComponentFilters());
   global.__REACT_DEVTOOLS_COMPONENT_FILTERS__ = getDefaultComponentFilters();
 
-  // Also initialize inline warnings so that we can test them.
-  global.__REACT_DEVTOOLS_SHOW_INLINE_WARNINGS_AND_ERRORS__ = true;
-
   installHook(global, {
     appendComponentStack: true,
     breakOnConsoleErrors: false,

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -191,7 +191,7 @@ type NativeStyleEditor_SetValueParams = {
   value: string,
 };
 
-type SavedPreferencesParams = {
+export type SavedPreferencesParams = {
   componentFilters: Array<ComponentFilter>,
 };
 


### PR DESCRIPTION
We no longer set the following globals since they're not read by DevTools. It also doesn't look like they had any meaningful values anymore which was hidden by missing Flow coverage.
- `__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__`
- `__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__`
- `__REACT_DEVTOOLS_SHOW_INLINE_WARNINGS_AND_ERRORS__`
- `__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__`
- `__REACT_DEVTOOLS_DISABLE_SECOND_CONSOLE_LOG_DIMMING_IN_STRICT_MODE__`

`__REACT_DEVTOOLS_COMPONENT_FILTERS__` is still set since it's still in use (although not fully functional in the browser extension which I intend to fix).
