### PR TITLE
[tests] add silent reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "jest-cli": "^29.4.2",
     "jest-diff": "^29.4.2",
     "jest-environment-jsdom": "^29.4.2",
+    "jest-silent-reporter": "^0.6.0",
     "jest-snapshot-serializer-raw": "^1.2.0",
     "minimatch": "^3.0.4",
     "minimist": "^1.2.3",

--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -112,6 +112,13 @@ const argv = yargs
       type: 'boolean',
       default: false,
     },
+    silent: {
+      alias: 's',
+      describe: 'Use silent reporter with dot progress (minimal output).',
+      requiresArg: false,
+      type: 'boolean',
+      default: false,
+    },
   }).argv;
 
 function logError(message) {
@@ -312,6 +319,12 @@ function getCommandArgs() {
     args.push('--maxConcurrency=10');
   }
 
+  // Use silent reporter if requested.
+  if (argv.silent) {
+    args.push('--reporters=jest-silent-reporter');
+    args.push('--testLocationInResults');
+  }
+
   // Push the remaining args onto the command.
   // This will send args like `--watch` to Jest.
   args.push(...argv._);
@@ -351,6 +364,12 @@ function getEnvars() {
     // This is off by default because it slows down the test runner, but it's
     // super useful when running the debugger.
     envars.JEST_ENABLE_SOURCE_MAPS = 'inline';
+  }
+
+  if (argv.silent) {
+    // Enable dot output for jest-silent-reporter so that long test runs
+    // show progress and don't appear to be hung.
+    envars.JEST_SILENT_REPORTER_DOTS = true;
   }
 
   return envars;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3144,6 +3144,17 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
 
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@jest/types@^29.6.3":
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
@@ -4165,6 +4176,13 @@
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
+
+"@types/yargs@^15.0.0":
+  version "15.0.20"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.20.tgz#6d00a124c9f757427d4ca3cbc87daea778053c68"
+  integrity sha512-KIkX+/GgfFitlASYCGoSF+T4XRXhOubJLhkLVtSfsRTe9jWMmuM2g28zQ41BtPTG7TRBb2xHW+LCNVE9QR/vsg==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@types/yargs@^17.0.8":
   version "17.0.32"
@@ -11611,6 +11629,14 @@ jest-runtime@^29.7.0:
     slash "^3.0.0"
     strip-bom "^4.0.0"
 
+jest-silent-reporter@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/jest-silent-reporter/-/jest-silent-reporter-0.6.0.tgz#e9c63a3b1e3c80571d690d998faf842f576b6a60"
+  integrity sha512-4nmS+5o7ycVlvbQOTx7CnGdbBtP2646hnDgQpQLaVhjHcQNHD+gqBAetyjRDlgpZ8+8N82MWI59K+EX2LsVk7g==
+  dependencies:
+    chalk "^4.0.0"
+    jest-util "^26.0.0"
+
 jest-snapshot-serializer-raw@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/jest-snapshot-serializer-raw/-/jest-snapshot-serializer-raw-1.2.0.tgz#cd67afb5e5cc39d88d518b45e7320dd01ce55148"
@@ -11641,6 +11667,18 @@ jest-snapshot@^29.7.0:
     natural-compare "^1.4.0"
     pretty-format "^29.7.0"
     semver "^7.5.3"
+
+jest-util@^26.0.0:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
+  integrity sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^2.0.0"
+    micromatch "^4.0.2"
 
 jest-util@^29.7.0:
   version "29.7.0"


### PR DESCRIPTION
Adds silent reporter so you can run tests and only see the failed tests

This helps reduce context agents use, if you're inclined to use agents:

<img width="630" height="292" alt="Screenshot 2026-01-17 at 12 39 58 PM" src="https://github.com/user-attachments/assets/373b9803-59a6-4b9a-99f9-d74a7b41462e" />
