### PR TITLE
[internal] add feature flag to fix event handle API in Activity

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -47,6 +47,7 @@ import type {ViewTransitionState} from './ReactFiberViewTransitionComponent';
 import {
   alwaysThrottleRetries,
   enableCreateEventHandleAPI,
+  enableEventAPIActivityFix,
   enableEffectEventMutationPhase,
   enableHiddenSubtreeInsertionEffectCleanup,
   enableProfilerTimer,
@@ -483,7 +484,6 @@ function commitBeforeMutationEffectsOnFiber(
     if (!shouldFireAfterActiveInstanceBlur && focusedInstanceHandle !== null) {
       // Check to see if the focused element was inside of a hidden (Suspense) subtree.
       // TODO: Move this out of the hot path using a dedicated effect tag.
-      // TODO: This should consider Offscreen in general and not just SuspenseComponent.
       if (
         finishedWork.tag === SuspenseComponent &&
         isSuspenseBoundaryBeingHidden(current, finishedWork) &&
@@ -492,6 +492,21 @@ function commitBeforeMutationEffectsOnFiber(
       ) {
         shouldFireAfterActiveInstanceBlur = true;
         beforeActiveInstanceBlur(finishedWork);
+      }
+
+      // Check if an OffscreenComponent (Activity) is being hidden with focus inside.
+      if (enableEventAPIActivityFix) {
+        if (
+          finishedWork.tag === OffscreenComponent &&
+          current !== null &&
+          current.memoizedState === null && // was visible
+          finishedWork.memoizedState !== null && // now hidden
+          // $FlowFixMe[incompatible-call] found when upgrading Flow
+          doesFiberContain(finishedWork, focusedInstanceHandle)
+        ) {
+          shouldFireAfterActiveInstanceBlur = true;
+          beforeActiveInstanceBlur(finishedWork);
+        }
       }
     }
   }

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -55,6 +55,9 @@ export const enableScopeAPI: boolean = false;
 // Experimental Create Event Handle API.
 export const enableCreateEventHandleAPI: boolean = false;
 
+// Fix for Activity blur events in the Event Handle API.
+export const enableEventAPIActivityFix: boolean = false;
+
 // Support legacy Primer support on internal FB www
 export const enableLegacyFBSupport: boolean = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -44,6 +44,7 @@ export const enableAsyncDebugInfo: boolean = true;
 export const enableAsyncIterableChildren: boolean = false;
 export const enableCPUSuspense: boolean = true;
 export const enableCreateEventHandleAPI: boolean = false;
+export const enableEventAPIActivityFix: boolean = false;
 export const enableMoveBefore: boolean = true;
 export const enableFizzExternalRuntime: boolean = true;
 export const enableHalt: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -28,6 +28,7 @@ export const enableAsyncDebugInfo: boolean = true;
 export const enableAsyncIterableChildren: boolean = false;
 export const enableCPUSuspense: boolean = false;
 export const enableCreateEventHandleAPI: boolean = false;
+export const enableEventAPIActivityFix: boolean = false;
 export const enableMoveBefore: boolean = true;
 export const enableFizzExternalRuntime: boolean = true;
 export const enableHalt: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -26,6 +26,7 @@ export const disableCommentsAsDOMContainers: boolean = true;
 export const disableInputAttributeSyncing: boolean = false;
 export const enableScopeAPI: boolean = false;
 export const enableCreateEventHandleAPI: boolean = false;
+export const enableEventAPIActivityFix: boolean = false;
 export const enableSuspenseCallback: boolean = false;
 export const enableTrustedTypesIntegration: boolean = false;
 export const disableTextareaChildren: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -23,6 +23,7 @@ export const enableAsyncDebugInfo = true;
 export const enableAsyncIterableChildren = false;
 export const enableCPUSuspense = true;
 export const enableCreateEventHandleAPI = false;
+export const enableEventAPIActivityFix = false;
 export const enableMoveBefore = false;
 export const enableFizzExternalRuntime = true;
 export const enableHalt = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -26,6 +26,7 @@ export const disableCommentsAsDOMContainers: boolean = true;
 export const disableInputAttributeSyncing: boolean = false;
 export const enableScopeAPI: boolean = true;
 export const enableCreateEventHandleAPI: boolean = false;
+export const enableEventAPIActivityFix: boolean = false;
 export const enableSuspenseCallback: boolean = true;
 export const disableLegacyContext: boolean = false;
 export const disableLegacyContextForFunctionComponents: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -40,6 +40,7 @@ export const enableTrustedTypesIntegration: boolean = __VARIANT__;
 export const enableParallelTransitions: boolean = __VARIANT__;
 
 export const enableEffectEventMutationPhase: boolean = __VARIANT__;
+export const enableEventAPIActivityFix: boolean = __VARIANT__;
 
 // TODO: These flags are hard-coded to the default values used in open source.
 // Update the tests so that they pass in either mode, then set these

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -18,6 +18,7 @@ export const {
   alwaysThrottleRetries,
   disableLegacyContextForFunctionComponents,
   disableSchedulerTimeoutInWorkLoop,
+  enableEventAPIActivityFix,
   enableEffectEventMutationPhase,
   enableHiddenSubtreeInsertionEffectCleanup,
   enableInfiniteRenderLoopDetection,


### PR DESCRIPTION
Noticed this TODO was never implemented, so this implements support for Activity inside the deprecated, never shipping `enableCreateEventHandleAPI` feature used internally until we remove the flag.

Also adds a bunch of test for this API with Activity and LegacyHidden, with inline gates for the differences with the flags.

Below is the claude summary.


<details>

# Fix Event Handle API blur events for Activity

## Problem

The `beforeblur` and `afterblur` events from the `createEventHandle` API were not firing when a focused element was hidden using `<React.Activity>`. This was because the blur check in `commitBeforeMutationEffectsOnFiber` only handled `SuspenseComponent`, not `OffscreenComponent` (which Activity uses internally).

## Solution

Added a check for `OffscreenComponent` visibility transitions behind a new feature flag `enableEventAPIActivityFix`.

---

## Files Modified

### 1. `packages/react-reconciler/src/ReactFiberCommitWork.js`

Added blur event handling for Activity (OffscreenComponent):

```javascript
// Check if an OffscreenComponent (Activity) is being hidden with focus inside.
if (enableEventAPIActivityFix) {
  if (
    finishedWork.tag === OffscreenComponent &&
    current !== null &&
    current.memoizedState === null && // was visible
    finishedWork.memoizedState !== null && // now hidden
    doesFiberContain(finishedWork, focusedInstanceHandle)
  ) {
    shouldFireAfterActiveInstanceBlur = true;
    beforeActiveInstanceBlur(finishedWork);
  }
}
```

### 2. Feature Flag Files

Added `enableEventAPIActivityFix` to all feature flag files:

| File | Value |
|------|-------|
| `ReactFeatureFlags.js` | `false` (default) |
| `ReactFeatureFlags.www-dynamic.js` | `__VARIANT__` (dynamic) |
| `ReactFeatureFlags.www.js` | imports from dynamic |
| `ReactFeatureFlags.test-renderer.js` | `false` |
| `ReactFeatureFlags.test-renderer.www.js` | `false` |
| `ReactFeatureFlags.test-renderer.native-fb.js` | `false` |

### 3. `packages/react-dom/src/events/__tests__/DOMPluginEventSystem-test.internal.js`

Added **22 new tests** (from 120 → 142 total):

#### Activity tests (6 tests)

- `beforeblur and afterblur are called after a focused element is hidden`
- `beforeblur and afterblur are called after a nested focused element is hidden`
- `beforeblur should skip handlers from a hidden subtree after the focused element is hidden via Activity`

#### LegacyHidden tests (6 tests)

- `beforeblur and afterblur are not called after a focused element is hidden inside LegacyHidden`
- `beforeblur and afterblur are not called after a nested focused element is hidden inside LegacyHidden`
- `beforeblur is not called after the focused element is hidden inside LegacyHidden`

#### Nested Activity + LegacyHidden tests (10 tests)

| Nesting | Scenario | Expected |
|---------|----------|----------|
| `<Activity><LegacyHidden>` | Hide outer (Activity) | blur fires |
| `<Activity><LegacyHidden>` | Hide inner (LegacyHidden) | no blur |
| `<Activity><LegacyHidden>` | Hide both simultaneously | blur fires once |
| `<Activity><LegacyHidden>` | Hide LegacyHidden, then Activity | blur on Activity |
| `<Activity><LegacyHidden>` | Hide Activity, then LegacyHidden | blur on Activity, no second blur |
| `<LegacyHidden><Activity>` | Hide outer (LegacyHidden) | no blur |
| `<LegacyHidden><Activity>` | Hide inner (Activity) | blur fires |
| `<LegacyHidden><Activity>` | Hide both simultaneously | blur fires once |
| `<LegacyHidden><Activity>` | Hide LegacyHidden, then Activity | blur on Activity |
| `<LegacyHidden><Activity>` | Hide Activity, then LegacyHidden | blur on Activity, no second blur |

---

## Key Design Decisions

1. **Activity triggers blur, LegacyHidden does not** - LegacyHidden behavior remains unchanged for backwards compatibility

2. **Inline gate pattern** - Tests use `if(gate('enableEventAPIActivityFix'))` to test both flag states in a single test

3. **Works with enableViewTransition** - The fix correctly handles the ViewTransition early exit path

---

## Test Results

- ✅ 142 tests pass with `variant=true` (enableEventAPIActivityFix ON)
- ✅ 142 tests pass with `variant=false` (enableEventAPIActivityFix OFF)
- ✅ All tests work correctly with `enableViewTransition=true`


</details>
