### PR TITLE
Cancel animation when a custom Timeline is used

### DIFF
--- a/fixtures/view-transition/src/components/Page.js
+++ b/fixtures/view-transition/src/components/Page.js
@@ -150,6 +150,8 @@ export default function Page({url, navigate}) {
       const cleanup1 = timeline.animate(animation1);
       const cleanup2 = timeline.animate(animation2);
       return () => {
+        animation1.cancel();
+        animation2.cancel();
         cleanup1();
         cleanup2();
       };

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2525,6 +2525,7 @@ function animateGesture(
       delay: reverse ? rangeEnd : rangeStart,
       duration: reverse ? rangeStart - rangeEnd : rangeEnd - rangeStart,
     });
+    viewTransitionAnimations.push(animation);
     // Let the custom timeline take control of driving the animation.
     const cleanup = timeline.animate(animation);
     if (cleanup) {


### PR DESCRIPTION
Follow up to #35559.

The clean up function of the custom timeline doesn't necessarily clean up the animation. Just the timeline's internal state.

This affects Firefox which doesn't support ScrollTimeline so uses the polyfill's custom timeline.
