### PR TITLE
[DevTools] Update inspected element on component filter changes

### DIFF
--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -1086,6 +1086,15 @@ export default class Agent extends EventEmitter<{
         }
         renderer.updateComponentFilters(componentFilters);
       }
+
+      // Due to the component filters changing, we might be able
+      // to select a closer match for the currently selected host element.
+      // The store will already select a suitable parent if the the current
+      // selection is now filtered out in which cases this will be a no-op.
+      const target = window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0;
+      if (target != null) {
+        this.selectNode(target);
+      }
     };
 
   getEnvironmentNames: () => void = () => {


### PR DESCRIPTION
## Summary

We used to only update the inspected element when selected host element changes. This is fine when Components and the browser's Elements panel are alternate. With the inspected element pane you can now have the inspected element and browsers Elements panel side-by-side.

Now we update the inspected element when the filter changes. This is mostly interestiny when the filter becomes less restrictive i.e. we can inspect an element closer to the selected host element. When the filter becomes more restrictive, the store was already selecting the nearest parent.

The new behavior may be disorienting if you're in the Components panel so we could restrict the behavior to apply only when you're changing filter from within the inspected elements pane within the browsers Elements panel. 

https://github.com/user-attachments/assets/7b0777f0-ce7b-4728-8055-4c349771fd1c

## How did you test this change?

- [x] Manually verified in Chrome
