### PR TITLE
[Devtools] add selectNodeWithViewData to agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,10 @@
   "jest": {
     "testRegex": "/scripts/jest/dont-run-jest-directly\\.js$"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sbuggay/react.git"
+  },
   "scripts": {
     "prebuild": "./scripts/react-compiler/link-compiler.sh",
     "build": "node ./scripts/rollup/build-all-release-channels.js",

--- a/package.json
+++ b/package.json
@@ -121,11 +121,6 @@
   "jest": {
     "testRegex": "/scripts/jest/dont-run-jest-directly\\.js$"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/sbuggay/react.git"
-  },
-  "version": "1.0.0",
   "scripts": {
     "prebuild": "./scripts/react-compiler/link-compiler.sh",
     "build": "node ./scripts/rollup/build-all-release-channels.js",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "type": "git",
     "url": "git+https://github.com/sbuggay/react.git"
   },
+  "version": "1.0.0",
   "scripts": {
     "prebuild": "./scripts/react-compiler/link-compiler.sh",
     "build": "node ./scripts/rollup/build-all-release-channels.js",

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -953,6 +953,12 @@ export default class Agent extends EventEmitter<{
     );
   }
 
+  selectNodeWithViewData(viewData: TouchedViewDataAtPoint): void => {
+    if (viewData !== null) {
+      this._bridge.send('viewDataAtPoint', viewData);
+    }
+  }
+
   registerRendererInterface(
     rendererID: RendererID,
     rendererInterface: RendererInterface,

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -20,6 +20,9 @@ import {
 } from './views/TraceUpdates';
 import {currentBridgeProtocol} from 'react-devtools-shared/src/bridge';
 
+import type {
+  TouchedViewDataAtPoint,
+} from './ReactNativeTypes';
 import type {BackendBridge} from 'react-devtools-shared/src/bridge';
 import type {
   InstanceAndStyle,
@@ -955,7 +958,7 @@ export default class Agent extends EventEmitter<{
 
   selectNodeWithViewData(viewData?: TouchedViewDataAtPoint): void {
     if (viewData) {
-      this._bridge.send('viewDataAtPoint', viewData);
+      this._bridge.send('selectElementWithViewData', viewData);
     }
   }
 

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -953,8 +953,8 @@ export default class Agent extends EventEmitter<{
     );
   }
 
-  selectNodeWithViewData(viewData: TouchedViewDataAtPoint): void => {
-    if (viewData !== null) {
+  selectNodeWithViewData(viewData?: TouchedViewDataAtPoint): void {
+    if (viewData) {
       this._bridge.send('viewDataAtPoint', viewData);
     }
   }

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -9,6 +9,9 @@
 
 import EventEmitter from './events';
 
+import type {
+  TouchedViewDataAtPoint,
+} from './ReactNativeTypes';
 import type {ComponentFilter, Wall} from './frontend/types';
 import type {
   InspectedElementPayload,
@@ -215,6 +218,7 @@ export type BackendEvents = {
   reloadAppForProfiling: [],
   saveToClipboard: [string],
   selectElement: [number | null],
+  selectElementWithViewData: [TouchedViewDataAtPoint | null],
   shutdown: [],
   stopInspectingHost: [boolean],
   scrollTo: [{left: number, top: number, right: number, bottom: number}],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

selectNode does not send any additional view data when an element is selected in the inspector. This change adds `selectNodeWithViewData` which let's React Native DevTools understand more about the view and it's component hierarchy. 

## How did you test this change?

Tested in an E2E flow that leverages `selectNodeWithViewData` in order to send view data to RNDT.
