### PR TITLE
Gitignore local Claude files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ chrome-user-data
 *.swo
 /tmp
 /worktrees
+.claude/*.local.*
 
 packages/react-devtools-core/dist
 packages/react-devtools-extensions/chrome/build


### PR DESCRIPTION
Matches [Claude's defaults when it would init on its own](https://code.claude.com/docs/en/settings#available-scopes). Helpful if you let it run on your checkouts.