### PR TITLE
[compiler] Collapse CompilerError.{invariant,simpleInvariant}

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/CompilerError.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/CompilerError.ts
@@ -304,11 +304,12 @@ export class CompilerError extends Error {
   disabledDetails: Array<CompilerErrorDetail | CompilerDiagnostic> = [];
   printedMessage: string | null = null;
 
-  static simpleInvariant(
+  static invariant(
     condition: unknown,
     options: {
       reason: CompilerDiagnosticOptions['reason'];
       description?: CompilerDiagnosticOptions['description'];
+      message?: string | null;
       loc: SourceLocation;
     },
   ): asserts condition {
@@ -322,24 +323,8 @@ export class CompilerError extends Error {
         }).withDetails({
           kind: 'error',
           loc: options.loc,
-          message: options.reason,
+          message: options.message ?? options.reason,
         }),
-      );
-      throw errors;
-    }
-  }
-  static invariant(
-    condition: unknown,
-    options: Omit<CompilerDiagnosticOptions, 'category'>,
-  ): asserts condition {
-    if (!condition) {
-      const errors = new CompilerError();
-      errors.pushDiagnostic(
-        CompilerDiagnostic.create({
-          reason: options.reason,
-          description: options.description,
-          category: ErrorCategory.Invariant,
-        }).withDetails(...options.details),
       );
       throw errors;
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Gating.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Gating.ts
@@ -8,6 +8,7 @@
 import {NodePath} from '@babel/core';
 import * as t from '@babel/types';
 import {CompilerError} from '../CompilerError';
+import {GeneratedSource} from '../HIR';
 import {ProgramContext} from './Imports';
 import {ExternalFunction} from '..';
 
@@ -51,26 +52,12 @@ function insertAdditionalFunctionDeclaration(
   CompilerError.invariant(originalFnName != null && compiled.id != null, {
     reason:
       'Expected function declarations that are referenced elsewhere to have a named identifier',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: fnPath.node.loc ?? null,
-        message: null,
-      },
-    ],
+    loc: fnPath.node.loc ?? GeneratedSource,
   });
   CompilerError.invariant(originalFnParams.length === compiledParams.length, {
     reason:
       'Expected React Compiler optimized function declarations to have the same number of parameters as source',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: fnPath.node.loc ?? null,
-        message: null,
-      },
-    ],
+    loc: fnPath.node.loc ?? GeneratedSource,
   });
 
   const gatingCondition = t.identifier(
@@ -154,13 +141,7 @@ export function insertGatedFunctionDeclaration(
     CompilerError.invariant(compiled.type === 'FunctionDeclaration', {
       reason: 'Expected compiled node type to match input type',
       description: `Got ${compiled.type} but expected FunctionDeclaration`,
-      details: [
-        {
-          kind: 'error',
-          loc: fnPath.node.loc ?? null,
-          message: null,
-        },
-      ],
+      loc: fnPath.node.loc ?? GeneratedSource,
     });
     insertAdditionalFunctionDeclaration(
       fnPath,

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Imports.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Imports.ts
@@ -257,14 +257,7 @@ export function addImportsToProgram(
           reason:
             'Encountered conflicting import specifiers in generated program',
           description: `Conflict from import ${loweredImport.module}:(${loweredImport.imported} as ${loweredImport.name})`,
-          details: [
-            {
-              kind: 'error',
-              loc: GeneratedSource,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: GeneratedSource,
         },
       );
       CompilerError.invariant(
@@ -274,13 +267,7 @@ export function addImportsToProgram(
           reason:
             'Found inconsistent import specifier. This is an internal bug.',
           description: `Expected import ${moduleName}:${specifierName} but found ${loweredImport.module}:${loweredImport.imported}`,
-          details: [
-            {
-              kind: 'error',
-              loc: GeneratedSource,
-              message: null,
-            },
-          ],
+          loc: GeneratedSource,
         },
       );
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -315,13 +315,7 @@ function insertNewOutlinedFunctionNode(
       CompilerError.invariant(insertedFuncDecl.isFunctionDeclaration(), {
         reason: 'Expected inserted function declaration',
         description: `Got: ${insertedFuncDecl}`,
-        details: [
-          {
-            kind: 'error',
-            loc: insertedFuncDecl.node?.loc ?? null,
-            message: null,
-          },
-        ],
+        loc: insertedFuncDecl.node?.loc ?? GeneratedSource,
       });
       return insertedFuncDecl;
     }
@@ -446,14 +440,7 @@ export function compileProgram(
       for (const outlined of compiled.outlined) {
         CompilerError.invariant(outlined.fn.outlined.length === 0, {
           reason: 'Unexpected nested outlined functions',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: outlined.fn.loc,
-              message: null,
-            },
-          ],
+          loc: outlined.fn.loc,
         });
         const fn = insertNewOutlinedFunctionNode(
           program,
@@ -1451,15 +1438,7 @@ export function getReactCompilerRuntimeModule(
         typeof target.runtimeModule === 'string',
       {
         reason: 'Expected target to already be validated',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       },
     );
     return target.runtimeModule;

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Suppression.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Suppression.ts
@@ -163,14 +163,7 @@ export function suppressionsToCompilerError(
 ): CompilerError {
   CompilerError.invariant(suppressionRanges.length !== 0, {
     reason: `Expected at least suppression comment source range`,
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: GeneratedSource,
-        message: null,
-      },
-    ],
+    loc: GeneratedSource,
   });
   const error = new CompilerError();
   for (const suppressionRange of suppressionRanges) {

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/ValidateNoUntransformedReferences.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/ValidateNoUntransformedReferences.ts
@@ -215,14 +215,7 @@ function validateImportSpecifier(
   const binding = local.scope.getBinding(local.node.name);
   CompilerError.invariant(binding != null, {
     reason: 'Expected binding to be found for import specifier',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: local.node.loc ?? null,
-        message: null,
-      },
-    ],
+    loc: local.node.loc ?? GeneratedSource,
   });
   checkFn(binding.referencePaths, state);
 }
@@ -242,14 +235,7 @@ function validateNamespacedImport(
 
   CompilerError.invariant(binding != null, {
     reason: 'Expected binding to be found for import specifier',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: local.node.loc ?? null,
-        message: null,
-      },
-    ],
+    loc: local.node.loc ?? GeneratedSource,
   });
   const filteredReferences = new Map<
     CheckInvalidReferenceFn,

--- a/compiler/packages/babel-plugin-react-compiler/src/Flood/TypeErrors.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Flood/TypeErrors.ts
@@ -46,14 +46,7 @@ export function raiseUnificationErrors(
     if (errs.length === 0) {
       CompilerError.invariant(false, {
         reason: 'Should not have array of zero errors',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc,
-            message: null,
-          },
-        ],
+        loc,
       });
     } else if (errs.length === 1) {
       CompilerError.throwInvalidJS({

--- a/compiler/packages/babel-plugin-react-compiler/src/Flood/Types.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Flood/Types.ts
@@ -151,15 +151,7 @@ export type LinearId = number & {
 export function makeLinearId(id: number): LinearId {
   CompilerError.invariant(id >= 0 && Number.isInteger(id), {
     reason: 'Expected LinearId id to be a non-negative integer',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: null,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
   return id as LinearId;
 }
@@ -172,15 +164,7 @@ export type TypeParameterId = number & {
 export function makeTypeParameterId(id: number): TypeParameterId {
   CompilerError.invariant(id >= 0 && Number.isInteger(id), {
     reason: 'Expected TypeParameterId to be a non-negative integer',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: null,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
   return id as TypeParameterId;
 }
@@ -202,15 +186,7 @@ export type VariableId = number & {
 export function makeVariableId(id: number): VariableId {
   CompilerError.invariant(id >= 0 && Number.isInteger(id), {
     reason: 'Expected VariableId id to be a non-negative integer',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: null,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
   return id as VariableId;
 }
@@ -417,14 +393,7 @@ function convertFlowType(flowType: FlowType, loc: string): ResolvedType {
               } else {
                 CompilerError.invariant(false, {
                   reason: `Unsupported property kind ${prop.kind}`,
-                  description: null,
-                  details: [
-                    {
-                      kind: 'error',
-                      loc: GeneratedSource,
-                      message: null,
-                    },
-                  ],
+                  loc: GeneratedSource,
                 });
               }
             }
@@ -493,14 +462,7 @@ function convertFlowType(flowType: FlowType, loc: string): ResolvedType {
               } else {
                 CompilerError.invariant(false, {
                   reason: `Unsupported property kind ${prop.kind}`,
-                  description: null,
-                  details: [
-                    {
-                      kind: 'error',
-                      loc: GeneratedSource,
-                      message: null,
-                    },
-                  ],
+                  loc: GeneratedSource,
                 });
               }
             }
@@ -519,14 +481,7 @@ function convertFlowType(flowType: FlowType, loc: string): ResolvedType {
                 } else {
                   CompilerError.invariant(false, {
                     reason: `Unsupported property kind ${prop.kind}`,
-                    description: null,
-                    details: [
-                      {
-                        kind: 'error',
-                        loc: GeneratedSource,
-                        message: null,
-                      },
-                    ],
+                    loc: GeneratedSource,
                   });
                 }
               }
@@ -539,14 +494,7 @@ function convertFlowType(flowType: FlowType, loc: string): ResolvedType {
             }
             CompilerError.invariant(false, {
               reason: `Unsupported class instance type ${flowType.def.type.kind}`,
-              description: null,
-              details: [
-                {
-                  kind: 'error',
-                  loc: GeneratedSource,
-                  message: null,
-                },
-              ],
+              loc: GeneratedSource,
             });
           }
           case 'Fun':
@@ -605,14 +553,7 @@ function convertFlowType(flowType: FlowType, loc: string): ResolvedType {
             } else {
               CompilerError.invariant(false, {
                 reason: `Unsupported component props type ${propsType.type.kind}`,
-                description: null,
-                details: [
-                  {
-                    kind: 'error',
-                    loc: GeneratedSource,
-                    message: null,
-                  },
-                ],
+                loc: GeneratedSource,
               });
             }
 
@@ -765,14 +706,7 @@ export class FlowTypeEnv implements ITypeEnv {
     // TODO: use flow-js only for web environments (e.g. playground)
     CompilerError.invariant(env.config.flowTypeProvider != null, {
       reason: 'Expected flowDumpTypes to be defined in environment config',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: GeneratedSource,
-          message: null,
-        },
-      ],
+      loc: GeneratedSource,
     });
     let stdout: any;
     if (source === lastFlowSource) {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/AssertConsistentIdentifiers.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/AssertConsistentIdentifiers.ts
@@ -38,28 +38,14 @@ export function assertConsistentIdentifiers(fn: HIRFunction): void {
       CompilerError.invariant(instr.lvalue.identifier.name === null, {
         reason: `Expected all lvalues to be temporaries`,
         description: `Found named lvalue \`${instr.lvalue.identifier.name}\``,
-        details: [
-          {
-            kind: 'error',
-            loc: instr.lvalue.loc,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: instr.lvalue.loc,
       });
       CompilerError.invariant(!assignments.has(instr.lvalue.identifier.id), {
         reason: `Expected lvalues to be assigned exactly once`,
         description: `Found duplicate assignment of '${printPlace(
           instr.lvalue,
         )}'`,
-        details: [
-          {
-            kind: 'error',
-            loc: instr.lvalue.loc,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: instr.lvalue.loc,
       });
       assignments.add(instr.lvalue.identifier.id);
       for (const operand of eachInstructionLValue(instr)) {
@@ -89,14 +75,7 @@ function validate(
     CompilerError.invariant(identifier === previous, {
       reason: `Duplicate identifier object`,
       description: `Found duplicate identifier object for id ${identifier.id}`,
-      details: [
-        {
-          kind: 'error',
-          loc: loc ?? GeneratedSource,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: loc ?? GeneratedSource,
     });
   }
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/AssertTerminalBlocksExist.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/AssertTerminalBlocksExist.ts
@@ -18,14 +18,7 @@ export function assertTerminalSuccessorsExist(fn: HIRFunction): void {
         description: `Block bb${successor} does not exist for terminal '${printTerminal(
           block.terminal,
         )}'`,
-        details: [
-          {
-            kind: 'error',
-            loc: (block.terminal as any).loc ?? GeneratedSource,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: (block.terminal as any).loc ?? GeneratedSource,
       });
       return successor;
     });
@@ -39,26 +32,14 @@ export function assertTerminalPredsExist(fn: HIRFunction): void {
       CompilerError.invariant(predBlock != null, {
         reason: 'Expected predecessor block to exist',
         description: `Block ${block.id} references non-existent ${pred}`,
-        details: [
-          {
-            kind: 'error',
-            loc: GeneratedSource,
-            message: null,
-          },
-        ],
+        loc: GeneratedSource,
       });
       CompilerError.invariant(
         [...eachTerminalSuccessor(predBlock.terminal)].includes(block.id),
         {
           reason: 'Terminal successor does not reference correct predecessor',
           description: `Block bb${block.id} has bb${predBlock.id} as a predecessor, but bb${predBlock.id}'s successors do not include bb${block.id}`,
-          details: [
-            {
-              kind: 'error',
-              loc: GeneratedSource,
-              message: null,
-            },
-          ],
+          loc: GeneratedSource,
         },
       );
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/AssertValidBlockNesting.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/AssertValidBlockNesting.ts
@@ -131,13 +131,7 @@ export function recursivelyTraverseItems<T, TContext>(
       CompilerError.invariant(disjoint || nested, {
         reason: 'Invalid nesting in program blocks or scopes',
         description: `Items overlap but are not nested: ${maybeParentRange.start}:${maybeParentRange.end}(${currRange.start}:${currRange.end})`,
-        details: [
-          {
-            kind: 'error',
-            loc: GeneratedSource,
-            message: null,
-          },
-        ],
+        loc: GeneratedSource,
       });
       if (disjoint) {
         exit(maybeParent, context);

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/AssertValidMutableRanges.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/AssertValidMutableRanges.ts
@@ -57,13 +57,7 @@ function validateMutableRange(
     {
       reason: `Invalid mutable range: [${range.start}:${range.end}]`,
       description: `${printPlace(place)} in ${description}`,
-      details: [
-        {
-          kind: 'error',
-          loc: place.loc,
-          message: null,
-        },
-      ],
+      loc: place.loc,
     },
   );
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -450,14 +450,7 @@ function lowerStatement(
           CompilerError.invariant(binding != null, {
             reason: 'Expected to find binding for hoisted identifier',
             description: `Could not find a binding for ${id.node.name}`,
-            suggestions: null,
-            details: [
-              {
-                kind: 'error',
-                loc: id.node.loc ?? GeneratedSource,
-                message: null,
-              },
-            ],
+            loc: id.node.loc ?? GeneratedSource,
           });
           if (builder.environment.isHoistedIdentifier(binding.identifier)) {
             // Already hoisted
@@ -499,14 +492,7 @@ function lowerStatement(
           CompilerError.invariant(identifier.kind === 'Identifier', {
             reason:
               'Expected hoisted binding to be a local identifier, not a global',
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: id.node.loc ?? GeneratedSource,
-                message: null,
-              },
-            ],
+            loc: id.node.loc ?? GeneratedSource,
           });
           const place: Place = {
             effect: Effect.Unknown,
@@ -1038,15 +1024,7 @@ function lowerStatement(
       stmt.skip();
       CompilerError.invariant(stmt.get('id').type === 'Identifier', {
         reason: 'function declarations must have a name',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: stmt.node.loc ?? null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: stmt.node.loc ?? GeneratedSource,
       });
       const id = stmt.get('id') as NodePath<t.Identifier>;
 
@@ -1144,15 +1122,7 @@ function lowerStatement(
         const declarations = left.get('declarations');
         CompilerError.invariant(declarations.length === 1, {
           reason: `Expected only one declaration in the init of a ForOfStatement, got ${declarations.length}`,
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: left.node.loc ?? null,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: left.node.loc ?? GeneratedSource,
         });
         const id = declarations[0].get('id');
         const assign = lowerAssignment(
@@ -1167,14 +1137,7 @@ function lowerStatement(
       } else {
         CompilerError.invariant(left.isLVal(), {
           reason: 'Expected ForOf init to be a variable declaration or lval',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: leftLoc,
-              message: null,
-            },
-          ],
+          loc: leftLoc,
         });
         const assign = lowerAssignment(
           builder,
@@ -1250,15 +1213,7 @@ function lowerStatement(
         const declarations = left.get('declarations');
         CompilerError.invariant(declarations.length === 1, {
           reason: `Expected only one declaration in the init of a ForInStatement, got ${declarations.length}`,
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: left.node.loc ?? null,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: left.node.loc ?? GeneratedSource,
         });
         const id = declarations[0].get('id');
         const assign = lowerAssignment(
@@ -1273,14 +1228,7 @@ function lowerStatement(
       } else {
         CompilerError.invariant(left.isLVal(), {
           reason: 'Expected ForIn init to be a variable declaration or lval',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: leftLoc,
-              message: null,
-            },
-          ],
+          loc: leftLoc,
         });
         const assign = lowerAssignment(
           builder,
@@ -2244,15 +2192,7 @@ function lowerExpression(
         } else {
           CompilerError.invariant(namePath.isJSXNamespacedName(), {
             reason: 'Refinement',
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: namePath.node.loc ?? null,
-                message: null,
-              },
-            ],
-            suggestions: null,
+            loc: namePath.node.loc ?? GeneratedSource,
           });
           const namespace = namePath.node.namespace.name;
           const name = namePath.node.name.name;
@@ -2305,15 +2245,7 @@ function lowerExpression(
           // This is already checked in builder.resolveIdentifier
           CompilerError.invariant(tagIdentifier.kind !== 'Identifier', {
             reason: `<${tagName}> tags should be module-level imports`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: openingIdentifier.node.loc ?? GeneratedSource,
-                message: null,
-              },
-            ],
-            suggestions: null,
+            loc: openingIdentifier.node.loc ?? GeneratedSource,
           });
         }
         // see `error.todo-multiple-fbt-plural` fixture for explanation
@@ -2415,15 +2347,7 @@ function lowerExpression(
       CompilerError.invariant(expr.get('quasi').get('quasis').length == 1, {
         reason:
           "there should be only one quasi as we don't support interpolations yet",
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: expr.node.loc ?? null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: expr.node.loc ?? GeneratedSource,
       });
       const value = expr.get('quasi').get('quasis').at(0)!.node.value;
       if (value.raw !== value.cooked) {
@@ -2819,15 +2743,7 @@ function lowerOptionalMemberExpression(
   });
   CompilerError.invariant(object !== null, {
     reason: 'Satisfy type checker',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: null,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
 
   /*
@@ -3399,15 +3315,7 @@ function lowerJsxMemberExpression(
   } else {
     CompilerError.invariant(object.isJSXIdentifier(), {
       reason: `TypeScript refinement fail: expected 'JsxIdentifier', got \`${object.node.type}\``,
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: object.node.loc ?? null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: object.node.loc ?? GeneratedSource,
     });
 
     const kind = getLoadKind(builder, object);
@@ -3447,15 +3355,7 @@ function lowerJsxElement(
     } else {
       CompilerError.invariant(expression.isExpression(), {
         reason: `(BuildHIR::lowerJsxElement) Expected Expression but found ${expression.type}!`,
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: expression.node.loc ?? null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: expression.node.loc ?? GeneratedSource,
       });
       return lowerExpressionToTemporary(builder, expression);
     }
@@ -3851,15 +3751,7 @@ function lowerAssignment(
       // This can only occur because of a coding error, parsers enforce this condition
       CompilerError.invariant(kind === InstructionKind.Reassign, {
         reason: 'MemberExpression may only appear in an assignment expression',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: lvaluePath.node.loc ?? null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: lvaluePath.node.loc ?? GeneratedSource,
       });
       const lvalue = lvaluePath as NodePath<t.MemberExpression>;
       const property = lvalue.get('property');

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildReactiveScopeTerminalsHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildReactiveScopeTerminalsHIR.ts
@@ -234,14 +234,7 @@ function pushEndScopeTerminal(
   const fallthroughId = context.fallthroughs.get(scope.id);
   CompilerError.invariant(fallthroughId != null, {
     reason: 'Expected scope to exist',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: GeneratedSource,
-        message: null,
-      },
-    ],
+    loc: GeneratedSource,
   });
   context.rewrites.push({
     kind: 'EndScope',

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/CollectHoistablePropertyLoads.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/CollectHoistablePropertyLoads.ts
@@ -269,14 +269,7 @@ class PropertyPathRegistry {
       CompilerError.invariant(reactive === rootNode.fullPath.reactive, {
         reason:
           '[HoistablePropertyLoads] Found inconsistencies in `reactive` flag when deduping identifier reads within the same scope',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: identifier.loc,
-            message: null,
-          },
-        ],
+        loc: identifier.loc,
       });
     }
     return rootNode;
@@ -531,14 +524,7 @@ function propagateNonNull(
     if (node == null) {
       CompilerError.invariant(false, {
         reason: `Bad node ${nodeId}, kind: ${direction}`,
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: GeneratedSource,
-            message: null,
-          },
-        ],
+        loc: GeneratedSource,
       });
     }
     const neighbors = Array.from(
@@ -610,14 +596,7 @@ function propagateNonNull(
     CompilerError.invariant(i++ < 100, {
       reason:
         '[CollectHoistablePropertyLoads] fixed point iteration did not terminate after 100 loops',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: GeneratedSource,
-          message: null,
-        },
-      ],
+      loc: GeneratedSource,
     });
 
     changed = false;
@@ -649,13 +628,7 @@ export function assertNonNull<T extends NonNullable<U>, U>(
   CompilerError.invariant(value != null, {
     reason: 'Unexpected null',
     description: source != null ? `(from ${source})` : null,
-    details: [
-      {
-        kind: 'error',
-        loc: GeneratedSource,
-        message: null,
-      },
-    ],
+    loc: GeneratedSource,
   });
   return value;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/CollectOptionalChainDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/CollectOptionalChainDependencies.ts
@@ -186,13 +186,7 @@ function matchOptionalTestBlock(
         reason:
           '[OptionalChainDeps] Inconsistent optional chaining property load',
         description: `Test=${printIdentifier(terminal.test.identifier)} PropertyLoad base=${printIdentifier(propertyLoad.value.object.identifier)}`,
-        details: [
-          {
-            kind: 'error',
-            loc: propertyLoad.loc,
-            message: null,
-          },
-        ],
+        loc: propertyLoad.loc,
       },
     );
 
@@ -200,14 +194,7 @@ function matchOptionalTestBlock(
       storeLocal.value.identifier.id === propertyLoad.lvalue.identifier.id,
       {
         reason: '[OptionalChainDeps] Unexpected storeLocal',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: propertyLoad.loc,
-            message: null,
-          },
-        ],
+        loc: propertyLoad.loc,
       },
     );
     if (
@@ -224,14 +211,7 @@ function matchOptionalTestBlock(
         alternate.instructions[1].value.kind === 'StoreLocal',
       {
         reason: 'Unexpected alternate structure',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: terminal.loc,
-            message: null,
-          },
-        ],
+        loc: terminal.loc,
       },
     );
 
@@ -267,14 +247,7 @@ function traverseOptionalBlock(
   if (maybeTest.terminal.kind === 'branch') {
     CompilerError.invariant(optional.terminal.optional, {
       reason: '[OptionalChainDeps] Expect base case to be always optional',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: optional.terminal.loc,
-          message: null,
-        },
-      ],
+      loc: optional.terminal.loc,
     });
     /**
      * Optional base expressions are currently within value blocks which cannot
@@ -312,14 +285,7 @@ function traverseOptionalBlock(
         maybeTest.instructions.at(-1)!.lvalue.identifier.id,
       {
         reason: '[OptionalChainDeps] Unexpected test expression',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: maybeTest.terminal.loc,
-            message: null,
-          },
-        ],
+        loc: maybeTest.terminal.loc,
       },
     );
     baseObject = {
@@ -408,14 +374,7 @@ function traverseOptionalBlock(
       reason:
         '[OptionalChainDeps] Unexpected instructions an inner optional block. ' +
         'This indicates that the compiler may be incorrectly concatenating two unrelated optional chains',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: optional.terminal.loc,
-          message: null,
-        },
-      ],
+      loc: optional.terminal.loc,
     });
   }
   const matchConsequentResult = matchOptionalTestBlock(test, context.blocks);
@@ -428,13 +387,7 @@ function traverseOptionalBlock(
     {
       reason: '[OptionalChainDeps] Unexpected optional goto-fallthrough',
       description: `${matchConsequentResult.consequentGoto} != ${optional.terminal.fallthrough}`,
-      details: [
-        {
-          kind: 'error',
-          loc: optional.terminal.loc,
-          message: null,
-        },
-      ],
+      loc: optional.terminal.loc,
     },
   );
   const load = {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/ComputeUnconditionalBlocks.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/ComputeUnconditionalBlocks.ts
@@ -5,7 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {BlockId, HIRFunction, computePostDominatorTree} from '.';
+import {
+  BlockId,
+  GeneratedSource,
+  HIRFunction,
+  computePostDominatorTree,
+} from '.';
 import {CompilerError} from '..';
 
 export function computeUnconditionalBlocks(fn: HIRFunction): Set<BlockId> {
@@ -24,15 +29,7 @@ export function computeUnconditionalBlocks(fn: HIRFunction): Set<BlockId> {
     CompilerError.invariant(!unconditionalBlocks.has(current), {
       reason:
         'Internal error: non-terminating loop in ComputeUnconditionalBlocks',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     unconditionalBlocks.add(current);
     current = dominators.get(current);

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/DeriveMinimalDependenciesHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/DeriveMinimalDependenciesHIR.ts
@@ -54,14 +54,7 @@ export class ReactiveScopeDependencyTreeHIR {
           prevAccessType == null || prevAccessType === accessType,
           {
             reason: 'Conflicting access types',
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: GeneratedSource,
-                message: null,
-              },
-            ],
+            loc: GeneratedSource,
           },
         );
         let nextNode = currNode.properties.get(path[i].property);
@@ -97,13 +90,7 @@ export class ReactiveScopeDependencyTreeHIR {
       CompilerError.invariant(reactive === rootNode.reactive, {
         reason: '[DeriveMinimalDependenciesHIR] Conflicting reactive root flag',
         description: `Identifier ${printIdentifier(identifier)}`,
-        details: [
-          {
-            kind: 'error',
-            loc: GeneratedSource,
-            message: null,
-          },
-        ],
+        loc: GeneratedSource,
       });
     }
     return rootNode;

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Dominator.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Dominator.ts
@@ -7,7 +7,7 @@
 
 import prettyFormat from 'pretty-format';
 import {CompilerError} from '../CompilerError';
-import {BlockId, HIRFunction} from './HIR';
+import {BlockId, GeneratedSource, HIRFunction} from './HIR';
 import {eachTerminalSuccessor} from './visitors';
 
 /*
@@ -88,15 +88,7 @@ export class Dominator<T> {
     const dominator = this.#nodes.get(id);
     CompilerError.invariant(dominator !== undefined, {
       reason: 'Unknown node',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     return dominator === id ? null : dominator;
   }
@@ -135,15 +127,7 @@ export class PostDominator<T> {
     const dominator = this.#nodes.get(id);
     CompilerError.invariant(dominator !== undefined, {
       reason: 'Unknown node',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     return dominator === id ? null : dominator;
   }
@@ -186,15 +170,7 @@ function computeImmediateDominators<T>(graph: Graph<T>): Map<T, T> {
       }
       CompilerError.invariant(newIdom !== null, {
         reason: `At least one predecessor must have been visited for block ${id}`,
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       });
 
       for (const pred of node.preds) {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -24,6 +24,7 @@ import {
   BuiltInType,
   Effect,
   FunctionType,
+  GeneratedSource,
   HIRFunction,
   IdentifierId,
   NonLocalBinding,
@@ -816,15 +817,7 @@ export class Environment {
     for (const [hookName, hook] of this.config.customHooks) {
       CompilerError.invariant(!this.#globals.has(hookName), {
         reason: `[Globals] Found existing definition in global registry for custom hook ${hookName}`,
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       });
       this.#globals.set(
         hookName,
@@ -856,14 +849,7 @@ export class Environment {
       CompilerError.invariant(code != null, {
         reason:
           'Expected Environment to be initialized with source code when a Flow type provider is specified',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
+        loc: GeneratedSource,
       });
       this.#flowTypeEnvironment.init(this, code);
     } else {
@@ -874,14 +860,7 @@ export class Environment {
   get typeContext(): FlowTypeEnv {
     CompilerError.invariant(this.#flowTypeEnvironment != null, {
       reason: 'Flow type environment not initialized',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
+      loc: GeneratedSource,
     });
     return this.#flowTypeEnvironment;
   }
@@ -1193,15 +1172,7 @@ export class Environment {
 
       CompilerError.invariant(shape !== undefined, {
         reason: `[HIR] Forget internal error: cannot resolve shape ${shapeId}`,
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       });
       return shape.properties.get('*') ?? null;
     }
@@ -1224,15 +1195,7 @@ export class Environment {
       const shape = this.#shapes.get(shapeId);
       CompilerError.invariant(shape !== undefined, {
         reason: `[HIR] Forget internal error: cannot resolve shape ${shapeId}`,
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       });
       if (typeof property === 'string') {
         return (
@@ -1255,15 +1218,7 @@ export class Environment {
       const shape = this.#shapes.get(shapeId);
       CompilerError.invariant(shape !== undefined, {
         reason: `[HIR] Forget internal error: cannot resolve shape ${shapeId}`,
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       });
       return shape.functionType;
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/FindContextIdentifiers.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/FindContextIdentifiers.ts
@@ -183,29 +183,13 @@ function handleAssignment(
           const valuePath = property.get('value');
           CompilerError.invariant(valuePath.isLVal(), {
             reason: `[FindContextIdentifiers] Expected object property value to be an LVal, got: ${valuePath.type}`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: valuePath.node.loc ?? GeneratedSource,
-                message: null,
-              },
-            ],
-            suggestions: null,
+            loc: valuePath.node.loc ?? GeneratedSource,
           });
           handleAssignment(currentFn, identifiers, valuePath);
         } else {
           CompilerError.invariant(property.isRestElement(), {
             reason: `[FindContextIdentifiers] Invalid assumptions for babel types.`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: property.node.loc ?? GeneratedSource,
-                message: null,
-              },
-            ],
-            suggestions: null,
+            loc: property.node.loc ?? GeneratedSource,
           });
           handleAssignment(currentFn, identifiers, property);
         }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -1373,14 +1373,7 @@ export function promoteTemporary(identifier: Identifier): void {
   CompilerError.invariant(identifier.name === null, {
     reason: `Expected a temporary (unnamed) identifier`,
     description: `Identifier already has a name, \`${identifier.name}\``,
-    details: [
-      {
-        kind: 'error',
-        loc: GeneratedSource,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
   identifier.name = {
     kind: 'promoted',
@@ -1403,14 +1396,7 @@ export function promoteTemporaryJsxTag(identifier: Identifier): void {
   CompilerError.invariant(identifier.name === null, {
     reason: `Expected a temporary (unnamed) identifier`,
     description: `Identifier already has a name, \`${identifier.name}\``,
-    details: [
-      {
-        kind: 'error',
-        loc: GeneratedSource,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
   identifier.name = {
     kind: 'promoted',
@@ -1576,15 +1562,7 @@ export function isMutableEffect(
     case Effect.Unknown: {
       CompilerError.invariant(false, {
         reason: 'Unexpected unknown effect',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: location,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: location,
       });
     }
     case Effect.Read:
@@ -1737,15 +1715,7 @@ export type BlockId = number & {[opaqueBlockId]: 'BlockId'};
 export function makeBlockId(id: number): BlockId {
   CompilerError.invariant(id >= 0 && Number.isInteger(id), {
     reason: 'Expected block id to be a non-negative integer',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: null,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
   return id as BlockId;
 }
@@ -1760,15 +1730,7 @@ export type ScopeId = number & {[opaqueScopeId]: 'ScopeId'};
 export function makeScopeId(id: number): ScopeId {
   CompilerError.invariant(id >= 0 && Number.isInteger(id), {
     reason: 'Expected block id to be a non-negative integer',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: null,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
   return id as ScopeId;
 }
@@ -1783,15 +1745,7 @@ export type IdentifierId = number & {[opaqueIdentifierId]: 'IdentifierId'};
 export function makeIdentifierId(id: number): IdentifierId {
   CompilerError.invariant(id >= 0 && Number.isInteger(id), {
     reason: 'Expected identifier id to be a non-negative integer',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: null,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
   return id as IdentifierId;
 }
@@ -1806,15 +1760,7 @@ export type DeclarationId = number & {[opageDeclarationId]: 'DeclarationId'};
 export function makeDeclarationId(id: number): DeclarationId {
   CompilerError.invariant(id >= 0 && Number.isInteger(id), {
     reason: 'Expected declaration id to be a non-negative integer',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: null,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
   return id as DeclarationId;
 }
@@ -1829,15 +1775,7 @@ export type InstructionId = number & {[opaqueInstructionId]: 'IdentifierId'};
 export function makeInstructionId(id: number): InstructionId {
   CompilerError.invariant(id >= 0 && Number.isInteger(id), {
     reason: 'Expected instruction id to be a non-negative integer',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: null,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
   return id as InstructionId;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIRBuilder.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIRBuilder.ts
@@ -506,15 +506,7 @@ export default class HIRBuilder {
         last.breakBlock === breakBlock,
       {
         reason: 'Mismatched label',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       },
     );
     return value;
@@ -535,15 +527,7 @@ export default class HIRBuilder {
         last.breakBlock === breakBlock,
       {
         reason: 'Mismatched label',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       },
     );
     return value;
@@ -577,15 +561,7 @@ export default class HIRBuilder {
         last.breakBlock === breakBlock,
       {
         reason: 'Mismatched loops',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       },
     );
     return value;
@@ -608,15 +584,7 @@ export default class HIRBuilder {
     }
     CompilerError.invariant(false, {
       reason: 'Expected a loop or switch to be in scope',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
   }
 
@@ -635,29 +603,13 @@ export default class HIRBuilder {
       } else if (label !== null && scope.label === label) {
         CompilerError.invariant(false, {
           reason: 'Continue may only refer to a labeled loop',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: null,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: GeneratedSource,
         });
       }
     }
     CompilerError.invariant(false, {
       reason: 'Expected a loop to be in scope',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
   }
 }
@@ -678,15 +630,7 @@ function _shrink(func: HIR): void {
     const block = func.blocks.get(blockId);
     CompilerError.invariant(block != null, {
       reason: `expected block ${blockId} to exist`,
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     target = getTargetIfIndirection(block);
     if (target !== null) {
@@ -817,13 +761,7 @@ function getReversePostorderedBlocks(func: HIR): HIR['blocks'] {
     CompilerError.invariant(block != null, {
       reason: '[HIRBuilder] Unexpected null block',
       description: `expected block ${blockId} to exist`,
-      details: [
-        {
-          kind: 'error',
-          loc: GeneratedSource,
-          message: null,
-        },
-      ],
+      loc: GeneratedSource,
     });
     const successors = [...eachTerminalSuccessor(block.terminal)].reverse();
     const fallthrough = terminalFallthrough(block.terminal);
@@ -878,15 +816,7 @@ export function markInstructionIds(func: HIR): void {
     for (const instr of block.instructions) {
       CompilerError.invariant(!visited.has(instr), {
         reason: `${printInstruction(instr)} already visited!`,
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: instr.loc,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: instr.loc,
       });
       visited.add(instr);
       instr.id = makeInstructionId(++id);
@@ -908,13 +838,7 @@ export function markPredecessors(func: HIR): void {
     CompilerError.invariant(block != null, {
       reason: 'unexpected missing block',
       description: `block ${blockId}`,
-      details: [
-        {
-          kind: 'error',
-          loc: GeneratedSource,
-          message: null,
-        },
-      ],
+      loc: GeneratedSource,
     });
     if (prevBlock) {
       block.preds.add(prevBlock.id);

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/MergeConsecutiveBlocks.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/MergeConsecutiveBlocks.ts
@@ -60,15 +60,7 @@ export function mergeConsecutiveBlocks(fn: HIRFunction): void {
     const predecessor = fn.body.blocks.get(predecessorId);
     CompilerError.invariant(predecessor !== undefined, {
       reason: `Expected predecessor ${predecessorId} to exist`,
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     if (predecessor.terminal.kind !== 'goto' || predecessor.kind !== 'block') {
       /*
@@ -82,15 +74,7 @@ export function mergeConsecutiveBlocks(fn: HIRFunction): void {
     for (const phi of block.phis) {
       CompilerError.invariant(phi.operands.size === 1, {
         reason: `Found a block with a single predecessor but where a phi has multiple (${phi.operands.size}) operands`,
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       });
       const operand = Array.from(phi.operands.values())[0]!;
       const lvalue: Place = {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
@@ -119,13 +119,7 @@ function parseAliasingSignatureConfig(
     CompilerError.invariant(!lifetimes.has(temp), {
       reason: `Invalid type configuration for module`,
       description: `Expected aliasing signature to have unique names for receiver, params, rest, returns, and temporaries in module '${moduleName}'`,
-      details: [
-        {
-          kind: 'error',
-          loc,
-          message: null,
-        },
-      ],
+      loc,
     });
     const place = signatureArgument(lifetimes.size);
     lifetimes.set(temp, place);
@@ -136,13 +130,7 @@ function parseAliasingSignatureConfig(
     CompilerError.invariant(place != null, {
       reason: `Invalid type configuration for module`,
       description: `Expected aliasing signature effects to reference known names from receiver/params/rest/returns/temporaries, but '${temp}' is not a known name in '${moduleName}'`,
-      details: [
-        {
-          kind: 'error',
-          loc,
-          message: null,
-        },
-      ],
+      loc,
     });
     return place;
   }
@@ -276,15 +264,7 @@ function addShape(
 
   CompilerError.invariant(!registry.has(id), {
     reason: `[ObjectShape] Could not add shape to registry: name ${id} already exists.`,
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: null,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
   registry.set(id, shape);
   return shape;

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -598,15 +598,7 @@ export function printInstructionValue(instrValue: ReactiveValue): string {
         instrValue.subexprs.length === instrValue.quasis.length - 1,
         {
           reason: 'Bad assumption about quasi length.',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: instrValue.loc,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: instrValue.loc,
         },
       );
       for (let i = 0; i < instrValue.subexprs.length; i++) {
@@ -874,15 +866,7 @@ export function printManualMemoDependency(
   } else {
     CompilerError.invariant(val.root.value.identifier.name?.kind === 'named', {
       reason: 'DepsValidation: expected named local variable in depslist',
-      description: null,
-      suggestions: null,
-      details: [
-        {
-          kind: 'error',
-          loc: val.root.value.loc,
-          message: null,
-        },
-      ],
+      loc: val.root.value.loc,
     });
     rootStr = nameOnly
       ? val.root.value.identifier.name.value

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PropagateScopeDependenciesHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PropagateScopeDependenciesHIR.ts
@@ -86,14 +86,7 @@ export function propagateScopeDependenciesHIR(fn: HIRFunction): void {
     const hoistables = hoistablePropertyLoads.get(scope.id);
     CompilerError.invariant(hoistables != null, {
       reason: '[PropagateScopeDependencies] Scope not found in tracked blocks',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: GeneratedSource,
-          message: null,
-        },
-      ],
+      loc: GeneratedSource,
     });
     /**
      * Step 2: Calculate hoistable dependencies.
@@ -435,14 +428,7 @@ export class DependencyCollectionContext {
     const scopedDependencies = this.#dependencies.value;
     CompilerError.invariant(scopedDependencies != null, {
       reason: '[PropagateScopeDeps]: Unexpected scope mismatch',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: scope.loc,
-          message: null,
-        },
-      ],
+      loc: scope.loc,
     });
 
     // Restore context of previous scope

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PruneUnusedLabelsHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PruneUnusedLabelsHIR.ts
@@ -53,14 +53,7 @@ export function pruneUnusedLabelsHIR(fn: HIRFunction): void {
       next.phis.size === 0 && fallthrough.phis.size === 0,
       {
         reason: 'Unexpected phis when merging label blocks',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: label.terminal.loc,
-            message: null,
-          },
-        ],
+        loc: label.terminal.loc,
       },
     );
 
@@ -71,14 +64,7 @@ export function pruneUnusedLabelsHIR(fn: HIRFunction): void {
         fallthrough.preds.has(nextId),
       {
         reason: 'Unexpected block predecessors when merging label blocks',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: label.terminal.loc,
-            message: null,
-          },
-        ],
+        loc: label.terminal.loc,
       },
     );
 

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/ScopeDependencyUtils.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/ScopeDependencyUtils.ts
@@ -202,15 +202,7 @@ function writeOptionalDependency(
     CompilerError.invariant(firstOptional !== -1, {
       reason:
         '[ScopeDependencyUtils] Internal invariant broken: expected optional path',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: dep.identifier.loc,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: dep.identifier.loc,
     });
     if (firstOptional === dep.path.length - 1) {
       // Base case: the test block is simple
@@ -244,15 +236,7 @@ function writeOptionalDependency(
   builder.enterReserved(consequent, () => {
     CompilerError.invariant(testIdentifier !== null, {
       reason: 'Satisfy type checker',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
 
     lowerValueToTemporary(builder, {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Types.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Types.ts
@@ -6,7 +6,7 @@
  */
 
 import {CompilerError} from '../CompilerError';
-import {PropertyLiteral} from './HIR';
+import {GeneratedSource, PropertyLiteral} from './HIR';
 
 export type BuiltInType = PrimitiveType | FunctionType | ObjectType;
 
@@ -86,15 +86,7 @@ export type TypeId = number & {[opaqueTypeId]: 'IdentifierId'};
 export function makeTypeId(id: number): TypeId {
   CompilerError.invariant(id >= 0 && Number.isInteger(id), {
     reason: 'Expected instruction id to be a non-negative integer',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: null,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
   return id as TypeId;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/visitors.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/visitors.ts
@@ -1260,14 +1260,7 @@ export class ScopeBlockTraversal {
       CompilerError.invariant(blockInfo.scope.id === top, {
         reason:
           'Expected traversed block fallthrough to match top-most active scope',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: block.instructions[0]?.loc ?? block.terminal.id,
-            message: null,
-          },
-        ],
+        loc: block.instructions[0]?.loc ?? block.terminal.loc,
       });
       this.#activeScopes.pop();
     }
@@ -1281,14 +1274,7 @@ export class ScopeBlockTraversal {
           !this.blockInfos.has(block.terminal.fallthrough),
         {
           reason: 'Expected unique scope blocks and fallthroughs',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: block.terminal.loc,
-              message: null,
-            },
-          ],
+          loc: block.terminal.loc,
         },
       );
       this.blockInfos.set(block.terminal.block, {

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/AnalyseFunctions.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/AnalyseFunctions.ts
@@ -78,14 +78,7 @@ function lowerWithMutationAliasing(fn: HIRFunction): void {
       case 'Apply': {
         CompilerError.invariant(false, {
           reason: `[AnalyzeFunctions] Expected Apply effects to be replaced with more precise effects`,
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: effect.function.loc,
-              message: null,
-            },
-          ],
+          loc: effect.function.loc,
         });
       }
       case 'Mutate':

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/DropManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/DropManualMemoization.ts
@@ -586,14 +586,8 @@ function findOptionalPlaces(fn: HIRFunction): Set<IdentifierId> {
           default: {
             CompilerError.invariant(false, {
               reason: `Unexpected terminal in optional`,
-              description: null,
-              details: [
-                {
-                  kind: 'error',
-                  loc: terminal.loc,
-                  message: `Unexpected ${terminal.kind} in optional`,
-                },
-              ],
+              message: `Unexpected ${terminal.kind} in optional`,
+              loc: terminal.loc,
             });
           }
         }

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferEffectDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferEffectDependencies.ts
@@ -438,14 +438,7 @@ function rewriteSplices(
         {
           reason:
             '[InferEffectDependencies] Internal invariant broken: expected block instructions to be sorted',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: originalInstrs[cursor].loc,
-              message: null,
-            },
-          ],
+          loc: originalInstrs[cursor].loc,
         },
       );
       currBlock.instructions.push(originalInstrs[cursor]);
@@ -454,14 +447,7 @@ function rewriteSplices(
     CompilerError.invariant(originalInstrs[cursor].id === rewrite.location, {
       reason:
         '[InferEffectDependencies] Internal invariant broken: splice location not found',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: originalInstrs[cursor].loc,
-          message: null,
-        },
-      ],
+      loc: originalInstrs[cursor].loc,
     });
 
     if (rewrite.kind === 'instr') {
@@ -481,14 +467,7 @@ function rewriteSplices(
           {
             reason:
               '[InferEffectDependencies] Internal invariant broken: expected entry block to have a fallthrough',
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: entryBlock.terminal.loc,
-                message: null,
-              },
-            ],
+            loc: entryBlock.terminal.loc,
           },
         );
         const originalTerminal = currBlock.terminal;
@@ -587,14 +566,7 @@ function inferMinimalDependencies(
   CompilerError.invariant(hoistableToFnEntry != null, {
     reason:
       '[InferEffectDependencies] Internal invariant broken: missing entry block',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: fnInstr.loc,
-        message: null,
-      },
-    ],
+    loc: fnInstr.loc,
   });
 
   const dependencies = inferDependencies(
@@ -650,14 +622,7 @@ function inferDependencies(
   CompilerError.invariant(resultUnfiltered != null, {
     reason:
       '[InferEffectDependencies] Internal invariant broken: missing scope dependencies',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: fn.loc,
-        message: null,
-      },
-    ],
+    loc: fn.loc,
   });
 
   const fnContext = new Set(fn.context.map(dep => dep.identifier.id));

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
@@ -134,15 +134,7 @@ export function inferMutationAliasingEffects(
     CompilerError.invariant(fn.params.length <= 2, {
       reason:
         'Expected React component to have not more than two parameters: one for props and for ref',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: fn.loc,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: fn.loc,
     });
     const [props, ref] = fn.params;
     if (props != null) {
@@ -209,13 +201,7 @@ export function inferMutationAliasingEffects(
       CompilerError.invariant(false, {
         reason: `[InferMutationAliasingEffects] Potential infinite loop`,
         description: `A value, temporary place, or effect was not cached properly`,
-        details: [
-          {
-            kind: 'error',
-            loc: fn.loc,
-            message: null,
-          },
-        ],
+        loc: fn.loc,
       });
     }
     for (const [blockId, block] of fn.body.blocks) {
@@ -528,14 +514,7 @@ function inferBlock(
       CompilerError.invariant(state.kind(handlerParam) != null, {
         reason:
           'Expected catch binding to be intialized with a DeclareLocal Catch instruction',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: terminal.loc,
-            message: null,
-          },
-        ],
+        loc: terminal.loc,
       });
       const effects: Array<AliasingEffect> = [];
       for (const instr of block.instructions) {
@@ -685,14 +664,7 @@ function applySignature(
   ) {
     CompilerError.invariant(false, {
       reason: `Expected instruction lvalue to be initialized`,
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: instruction.loc,
-          message: null,
-        },
-      ],
+      loc: instruction.loc,
     });
   }
   return effects.length !== 0 ? effects : null;
@@ -721,13 +693,7 @@ function applyEffect(
       CompilerError.invariant(!initialized.has(effect.into.identifier.id), {
         reason: `Cannot re-initialize variable within an instruction`,
         description: `Re-initialized ${printPlace(effect.into)} in ${printAliasingEffect(effect)}`,
-        details: [
-          {
-            kind: 'error',
-            loc: effect.into.loc,
-            message: null,
-          },
-        ],
+        loc: effect.into.loc,
       });
       initialized.add(effect.into.identifier.id);
 
@@ -766,13 +732,7 @@ function applyEffect(
       CompilerError.invariant(!initialized.has(effect.into.identifier.id), {
         reason: `Cannot re-initialize variable within an instruction`,
         description: `Re-initialized ${printPlace(effect.into)} in ${printAliasingEffect(effect)}`,
-        details: [
-          {
-            kind: 'error',
-            loc: effect.into.loc,
-            message: null,
-          },
-        ],
+        loc: effect.into.loc,
       });
       initialized.add(effect.into.identifier.id);
 
@@ -832,13 +792,7 @@ function applyEffect(
       CompilerError.invariant(!initialized.has(effect.into.identifier.id), {
         reason: `Cannot re-initialize variable within an instruction`,
         description: `Re-initialized ${printPlace(effect.into)} in ${printAliasingEffect(effect)}`,
-        details: [
-          {
-            kind: 'error',
-            loc: effect.into.loc,
-            message: null,
-          },
-        ],
+        loc: effect.into.loc,
       });
       initialized.add(effect.into.identifier.id);
 
@@ -916,13 +870,7 @@ function applyEffect(
           description:
             `Destination ${printPlace(effect.into)} is not initialized in this ` +
             `instruction for effect ${printAliasingEffect(effect)}`,
-          details: [
-            {
-              kind: 'error',
-              loc: effect.into.loc,
-              message: null,
-            },
-          ],
+          loc: effect.into.loc,
         },
       );
       /*
@@ -1000,13 +948,7 @@ function applyEffect(
       CompilerError.invariant(!initialized.has(effect.into.identifier.id), {
         reason: `Cannot re-initialize variable within an instruction`,
         description: `Re-initialized ${printPlace(effect.into)} in ${printAliasingEffect(effect)}`,
-        details: [
-          {
-            kind: 'error',
-            loc: effect.into.loc,
-            message: null,
-          },
-        ],
+        loc: effect.into.loc,
       });
       initialized.add(effect.into.identifier.id);
 
@@ -1406,15 +1348,7 @@ class InferenceState {
     CompilerError.invariant(value.kind !== 'LoadLocal', {
       reason:
         '[InferMutationAliasingEffects] Expected all top-level identifiers to be defined as variables, not values',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: value.loc,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: value.loc,
     });
     this.#values.set(value, kind);
   }
@@ -1424,14 +1358,8 @@ class InferenceState {
     CompilerError.invariant(values != null, {
       reason: `[InferMutationAliasingEffects] Expected value kind to be initialized`,
       description: `${printPlace(place)}`,
-      details: [
-        {
-          kind: 'error',
-          loc: place.loc,
-          message: 'this is uninitialized',
-        },
-      ],
-      suggestions: null,
+      message: 'this is uninitialized',
+      loc: place.loc,
     });
     return Array.from(values);
   }
@@ -1442,14 +1370,8 @@ class InferenceState {
     CompilerError.invariant(values != null, {
       reason: `[InferMutationAliasingEffects] Expected value kind to be initialized`,
       description: `${printPlace(place)}`,
-      details: [
-        {
-          kind: 'error',
-          loc: place.loc,
-          message: 'this is uninitialized',
-        },
-      ],
-      suggestions: null,
+      message: 'this is uninitialized',
+      loc: place.loc,
     });
     let mergedKind: AbstractValue | null = null;
     for (const value of values) {
@@ -1460,14 +1382,7 @@ class InferenceState {
     CompilerError.invariant(mergedKind !== null, {
       reason: `[InferMutationAliasingEffects] Expected at least one value`,
       description: `No value found at \`${printPlace(place)}\``,
-      details: [
-        {
-          kind: 'error',
-          loc: place.loc,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: place.loc,
     });
     return mergedKind;
   }
@@ -1478,14 +1393,8 @@ class InferenceState {
     CompilerError.invariant(values != null, {
       reason: `[InferMutationAliasingEffects] Expected value for identifier to be initialized`,
       description: `${printIdentifier(value.identifier)}`,
-      details: [
-        {
-          kind: 'error',
-          loc: value.loc,
-          message: 'Expected value for identifier to be initialized',
-        },
-      ],
-      suggestions: null,
+      message: 'Expected value for identifier to be initialized',
+      loc: value.loc,
     });
     this.#variables.set(place.identifier.id, new Set(values));
   }
@@ -1495,14 +1404,8 @@ class InferenceState {
     CompilerError.invariant(values != null, {
       reason: `[InferMutationAliasingEffects] Expected value for identifier to be initialized`,
       description: `${printIdentifier(value.identifier)}`,
-      details: [
-        {
-          kind: 'error',
-          loc: value.loc,
-          message: 'Expected value for identifier to be initialized',
-        },
-      ],
-      suggestions: null,
+      message: 'Expected value for identifier to be initialized',
+      loc: value.loc,
     });
     const prevValues = this.values(place);
     this.#variables.set(
@@ -1516,14 +1419,7 @@ class InferenceState {
     CompilerError.invariant(this.#values.has(value), {
       reason: `[InferMutationAliasingEffects] Expected value to be initialized`,
       description: printInstructionValue(value),
-      details: [
-        {
-          kind: 'error',
-          loc: value.loc,
-          message: 'Expected value for identifier to be initialized',
-        },
-      ],
-      suggestions: null,
+      loc: value.loc,
     });
     this.#variables.set(place.identifier.id, new Set([value]));
   }
@@ -2963,15 +2859,7 @@ export function isKnownMutableEffect(effect: Effect): boolean {
     case Effect.Unknown: {
       CompilerError.invariant(false, {
         reason: 'Unexpected unknown effect',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: GeneratedSource,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       });
     }
     case Effect.Read:
@@ -3079,13 +2967,7 @@ function mergeValueKinds(a: ValueKind, b: ValueKind): ValueKind {
       {
         reason: `Unexpected value kind in mergeValues()`,
         description: `Found kinds ${a} and ${b}`,
-        details: [
-          {
-            kind: 'error',
-            loc: GeneratedSource,
-            message: null,
-          },
-        ],
+        loc: GeneratedSource,
       },
     );
     return ValueKind.Primitive;

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingRanges.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingRanges.ts
@@ -229,14 +229,7 @@ export function inferMutationAliasingRanges(
         } else {
           CompilerError.invariant(effect.kind === 'Freeze', {
             reason: `Unexpected '${effect.kind}' effect for MaybeThrow terminal`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: block.terminal.loc,
-                message: null,
-              },
-            ],
+            loc: block.terminal.loc,
           });
         }
       }
@@ -385,14 +378,7 @@ export function inferMutationAliasingRanges(
           case 'Apply': {
             CompilerError.invariant(false, {
               reason: `[AnalyzeFunctions] Expected Apply effects to be replaced with more precise effects`,
-              description: null,
-              details: [
-                {
-                  kind: 'error',
-                  loc: effect.function.loc,
-                  message: null,
-                },
-              ],
+              loc: effect.function.loc,
             });
           }
           case 'MutateTransitive':
@@ -539,14 +525,7 @@ export function inferMutationAliasingRanges(
       const fromNode = state.nodes.get(from.identifier);
       CompilerError.invariant(fromNode != null, {
         reason: `Expected a node to exist for all parameters and context variables`,
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: into.loc,
-            message: null,
-          },
-        ],
+        loc: into.loc,
       });
       if (fromNode.lastMutated === mutationIndex) {
         if (into.identifier.id === fn.returns.identifier.id) {

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReactivePlaces.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferReactivePlaces.ts
@@ -310,15 +310,7 @@ export function inferReactivePlaces(fn: HIRFunction): void {
               case Effect.Unknown: {
                 CompilerError.invariant(false, {
                   reason: 'Unexpected unknown effect',
-                  description: null,
-                  details: [
-                    {
-                      kind: 'error',
-                      loc: operand.loc,
-                      message: null,
-                    },
-                  ],
-                  suggestions: null,
+                  loc: operand.loc,
                 });
               }
               default: {

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/ConstantPropagation.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/ConstantPropagation.ts
@@ -8,6 +8,7 @@
 import {isValidIdentifier} from '@babel/types';
 import {CompilerError} from '../CompilerError';
 import {
+  GeneratedSource,
   GotoVariant,
   HIRFunction,
   IdentifierId,
@@ -191,15 +192,7 @@ function evaluatePhi(phi: Phi, constants: Constants): Constant | null {
       case 'Primitive': {
         CompilerError.invariant(value.kind === 'Primitive', {
           reason: 'value kind expected to be Primitive',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: null,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: GeneratedSource,
         });
 
         // different constant values, can't constant propogate
@@ -211,15 +204,7 @@ function evaluatePhi(phi: Phi, constants: Constants): Constant | null {
       case 'LoadGlobal': {
         CompilerError.invariant(value.kind === 'LoadGlobal', {
           reason: 'value kind expected to be LoadGlobal',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: null,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: GeneratedSource,
         });
 
         // different global values, can't constant propogate

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/InlineJsxTransform.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/InlineJsxTransform.ts
@@ -709,14 +709,7 @@ function createPropsProperties(
     const spreadProp = jsxSpreadAttributes[0];
     CompilerError.invariant(spreadProp.kind === 'JsxSpreadAttribute', {
       reason: 'Spread prop attribute must be of kind JSXSpreadAttribute',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: instr.loc,
-          message: null,
-        },
-      ],
+      loc: instr.loc,
     });
     propsProperty = {
       kind: 'ObjectProperty',

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/InstructionReordering.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/InstructionReordering.ts
@@ -78,17 +78,10 @@ export function instructionReordering(fn: HIRFunction): void {
   }
   CompilerError.invariant(shared.size === 0, {
     reason: `InstructionReordering: expected all reorderable nodes to have been emitted`,
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc:
-          [...shared.values()]
-            .map(node => node.instruction?.loc)
-            .filter(loc => loc != null)[0] ?? GeneratedSource,
-        message: null,
-      },
-    ],
+    loc:
+      [...shared.values()]
+        .map(node => node.instruction?.loc)
+        .filter(loc => loc != null)[0] ?? GeneratedSource,
   });
   markInstructionIds(fn.body);
 }
@@ -309,17 +302,11 @@ function reorderBlock(
         node.reorderability === Reorderability.Reorderable,
         {
           reason: `Expected all remaining instructions to be reorderable`,
-          details: [
-            {
-              kind: 'error',
-              loc: node.instruction?.loc ?? block.terminal.loc,
-              message: null,
-            },
-          ],
           description:
             node.instruction != null
               ? `Instruction [${node.instruction.id}] was not emitted yet but is not reorderable`
               : `Lvalue $${id} was not emitted yet but is not reorderable`,
+          loc: node.instruction?.loc ?? block.terminal.loc,
         },
       );
 

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/OptimizeForSSR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/OptimizeForSSR.ts
@@ -178,14 +178,8 @@ export function optimizeForSSR(fn: HIRFunction): void {
               {
                 reason:
                   'Expected a valid destructuring pattern for inlined state',
-                description: null,
-                details: [
-                  {
-                    kind: 'error',
-                    message: 'Expected a valid destructuring pattern',
-                    loc: value.loc,
-                  },
-                ],
+                message: 'Expected a valid destructuring pattern',
+                loc: value.loc,
               },
             );
             const store: StoreLocal = {

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/PruneMaybeThrows.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/PruneMaybeThrows.ts
@@ -52,17 +52,10 @@ export function pruneMaybeThrows(fn: HIRFunction): void {
             const mappedTerminal = terminalMapping.get(predecessor);
             CompilerError.invariant(mappedTerminal != null, {
               reason: `Expected non-existing phi operand's predecessor to have been mapped to a new terminal`,
-              details: [
-                {
-                  kind: 'error',
-                  loc: GeneratedSource,
-                  message: null,
-                },
-              ],
               description: `Could not find mapping for predecessor bb${predecessor} in block bb${
                 block.id
               } for phi ${printPlace(phi.place)}`,
-              suggestions: null,
+              loc: GeneratedSource,
             });
             phi.operands.delete(predecessor);
             phi.operands.set(mappedTerminal, operand);

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/AlignObjectMethodScopes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/AlignObjectMethodScopes.ts
@@ -41,15 +41,7 @@ function findScopesToMerge(fn: HIRFunction): DisjointSet<ReactiveScope> {
               {
                 reason:
                   'Internal error: Expected all ObjectExpressions and ObjectMethods to have non-null scope.',
-                description: null,
-                suggestions: null,
-                details: [
-                  {
-                    kind: 'error',
-                    loc: GeneratedSource,
-                    message: null,
-                  },
-                ],
+                loc: GeneratedSource,
               },
             );
             mergeScopesBuilder.union([operandScope, lvalueScope]);

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/AlignReactiveScopesToBlockScopesHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/AlignReactiveScopesToBlockScopesHIR.ts
@@ -170,14 +170,7 @@ export function alignReactiveScopesToBlockScopesHIR(fn: HIRFunction): void {
 
       CompilerError.invariant(!valueBlockNodes.has(fallthrough), {
         reason: 'Expect hir blocks to have unique fallthroughs',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: terminal.loc,
-            message: null,
-          },
-        ],
+        loc: terminal.loc,
       });
       if (node != null) {
         valueBlockNodes.set(fallthrough, node);
@@ -259,14 +252,7 @@ export function alignReactiveScopesToBlockScopesHIR(fn: HIRFunction): void {
           // Transition from block->value block, derive the outer block range
           CompilerError.invariant(fallthrough !== null, {
             reason: `Expected a fallthrough for value block`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: terminal.loc,
-                message: null,
-              },
-            ],
+            loc: terminal.loc,
           });
           const fallthroughBlock = fn.body.blocks.get(fallthrough)!;
           const nextId =

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/AssertScopeInstructionsWithinScope.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/AssertScopeInstructionsWithinScope.ts
@@ -84,14 +84,7 @@ class CheckInstructionsAgainstScopesVisitor extends ReactiveFunctionVisitor<
         reason:
           'Encountered an instruction that should be part of a scope, but where that scope has already completed',
         description: `Instruction [${id}] is part of scope @${scope.id}, but that scope has already completed`,
-        details: [
-          {
-            kind: 'error',
-            loc: place.loc,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: place.loc,
       });
     }
   }

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/AssertWellFormedBreakTargets.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/AssertWellFormedBreakTargets.ts
@@ -28,14 +28,7 @@ class Visitor extends ReactiveFunctionVisitor<Set<BlockId>> {
     if (terminal.kind === 'break' || terminal.kind === 'continue') {
       CompilerError.invariant(seenLabels.has(terminal.target), {
         reason: 'Unexpected break to invalid label',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: stmt.terminal.loc,
-            message: null,
-          },
-        ],
+        loc: stmt.terminal.loc,
       });
     }
   }

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/BuildReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/BuildReactiveFunction.ts
@@ -9,6 +9,7 @@ import {CompilerError} from '../CompilerError';
 import {
   BasicBlock,
   BlockId,
+  GeneratedSource,
   GotoVariant,
   HIR,
   InstructionId,
@@ -70,15 +71,7 @@ class Driver {
   visitBlock(block: BasicBlock, blockValue: ReactiveBlock): void {
     CompilerError.invariant(!this.cx.emitted.has(block.id), {
       reason: `Cannot emit the same block twice: bb${block.id}`,
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     this.cx.emitted.add(block.id);
     for (const instruction of block.instructions) {
@@ -137,14 +130,7 @@ class Driver {
         if (this.cx.isScheduled(terminal.consequent)) {
           CompilerError.invariant(false, {
             reason: `Unexpected 'if' where the consequent is already scheduled`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: terminal.loc,
-                message: null,
-              },
-            ],
+            loc: terminal.loc,
           });
         } else {
           consequent = this.traverseBlock(
@@ -157,14 +143,7 @@ class Driver {
           if (this.cx.isScheduled(alternateId)) {
             CompilerError.invariant(false, {
               reason: `Unexpected 'if' where the alternate is already scheduled`,
-              description: null,
-              details: [
-                {
-                  kind: 'error',
-                  loc: terminal.loc,
-                  message: null,
-                },
-              ],
+              loc: terminal.loc,
             });
           } else {
             alternate = this.traverseBlock(this.cx.ir.blocks.get(alternateId)!);
@@ -217,14 +196,7 @@ class Driver {
           if (this.cx.isScheduled(case_.block)) {
             CompilerError.invariant(case_.block === terminal.fallthrough, {
               reason: `Unexpected 'switch' where a case is already scheduled and block is not the fallthrough`,
-              description: null,
-              details: [
-                {
-                  kind: 'error',
-                  loc: terminal.loc,
-                  message: null,
-                },
-              ],
+              loc: terminal.loc,
             });
             return;
           } else {
@@ -283,14 +255,7 @@ class Driver {
         } else {
           CompilerError.invariant(false, {
             reason: `Unexpected 'do-while' where the loop is already scheduled`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: terminal.loc,
-                message: null,
-              },
-            ],
+            loc: terminal.loc,
           });
         }
 
@@ -351,14 +316,7 @@ class Driver {
         } else {
           CompilerError.invariant(false, {
             reason: `Unexpected 'while' where the loop is already scheduled`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: terminal.loc,
-                message: null,
-              },
-            ],
+            loc: terminal.loc,
           });
         }
 
@@ -444,14 +402,7 @@ class Driver {
         } else {
           CompilerError.invariant(false, {
             reason: `Unexpected 'for' where the loop is already scheduled`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: terminal.loc,
-                message: null,
-              },
-            ],
+            loc: terminal.loc,
           });
         }
 
@@ -549,14 +500,7 @@ class Driver {
         } else {
           CompilerError.invariant(false, {
             reason: `Unexpected 'for-of' where the loop is already scheduled`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: terminal.loc,
-                message: null,
-              },
-            ],
+            loc: terminal.loc,
           });
         }
 
@@ -628,14 +572,7 @@ class Driver {
         } else {
           CompilerError.invariant(false, {
             reason: `Unexpected 'for-in' where the loop is already scheduled`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: terminal.loc,
-                message: null,
-              },
-            ],
+            loc: terminal.loc,
           });
         }
 
@@ -678,14 +615,7 @@ class Driver {
         if (this.cx.isScheduled(terminal.alternate)) {
           CompilerError.invariant(false, {
             reason: `Unexpected 'branch' where the alternate is already scheduled`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: terminal.loc,
-                message: null,
-              },
-            ],
+            loc: terminal.loc,
           });
         } else {
           alternate = this.traverseBlock(
@@ -723,14 +653,7 @@ class Driver {
         if (this.cx.isScheduled(terminal.block)) {
           CompilerError.invariant(false, {
             reason: `Unexpected 'label' where the block is already scheduled`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: terminal.loc,
-                message: null,
-              },
-            ],
+            loc: terminal.loc,
           });
         } else {
           block = this.traverseBlock(this.cx.ir.blocks.get(terminal.block)!);
@@ -888,14 +811,7 @@ class Driver {
         if (this.cx.isScheduled(terminal.block)) {
           CompilerError.invariant(false, {
             reason: `Unexpected 'scope' where the block is already scheduled`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: terminal.loc,
-                message: null,
-              },
-            ],
+            loc: terminal.loc,
           });
         } else {
           block = this.traverseBlock(this.cx.ir.blocks.get(terminal.block)!);
@@ -920,15 +836,7 @@ class Driver {
       case 'unsupported': {
         CompilerError.invariant(false, {
           reason: 'Unexpected unsupported terminal',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: terminal.loc,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: terminal.loc,
         });
       }
       default: {
@@ -963,15 +871,7 @@ class Driver {
           {
             reason:
               'Expected branch block to end in an instruction that sets the test value',
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: instr.lvalue.loc,
-                message: null,
-              },
-            ],
-            suggestions: null,
+            loc: instr.lvalue.loc,
           },
         );
         return {
@@ -1001,15 +901,7 @@ class Driver {
       if (instructions.length === 0) {
         CompilerError.invariant(false, {
           reason: 'Expected goto value block to have at least one instruction',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: null,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: GeneratedSource,
         });
       } else if (defaultBlock.instructions.length === 1) {
         const instr = defaultBlock.instructions[0]!;
@@ -1292,28 +1184,13 @@ class Driver {
     if (target === null) {
       CompilerError.invariant(false, {
         reason: 'Expected a break target',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       });
     }
     if (this.cx.scopeFallthroughs.has(target.block)) {
       CompilerError.invariant(target.type === 'implicit', {
         reason: 'Expected reactive scope to implicitly break to fallthrough',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc,
-            message: null,
-          },
-        ],
+        loc,
       });
       return null;
     }
@@ -1338,15 +1215,7 @@ class Driver {
     const target = this.cx.getContinueTarget(block);
     CompilerError.invariant(target !== null, {
       reason: `Expected continue target to be scheduled for bb${block}`,
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
 
     return {
@@ -1419,15 +1288,7 @@ class Context {
     const id = this.#nextScheduleId++;
     CompilerError.invariant(!this.#scheduled.has(block), {
       reason: `Break block is already scheduled: bb${block}`,
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     this.#scheduled.add(block);
     this.#controlFlowStack.push({block, id, type});
@@ -1444,15 +1305,7 @@ class Context {
     this.#scheduled.add(fallthroughBlock);
     CompilerError.invariant(!this.#scheduled.has(continueBlock), {
       reason: `Continue block is already scheduled: bb${continueBlock}`,
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     this.#scheduled.add(continueBlock);
     let ownsLoop = false;
@@ -1478,15 +1331,7 @@ class Context {
     const last = this.#controlFlowStack.pop();
     CompilerError.invariant(last !== undefined && last.id === scheduleId, {
       reason: 'Can only unschedule the last target',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     if (last.type !== 'loop' || last.ownsBlock !== null) {
       this.#scheduled.delete(last.block);
@@ -1559,15 +1404,7 @@ class Context {
 
     CompilerError.invariant(false, {
       reason: 'Expected a break target',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
   }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -297,15 +297,7 @@ export function codegenFunction(
       CompilerError.invariant(globalGating != null, {
         reason:
           'Bad config not caught! Expected at least one of gating or globalGating',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       });
       ifTest = globalGating;
     }
@@ -509,15 +501,7 @@ function codegenBlock(cx: Context, block: ReactiveBlock): t.BlockStatement {
     }
     CompilerError.invariant(temp.get(key)! === value, {
       reason: 'Expected temporary value to be unchanged',
-      description: null,
-      suggestions: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
+      loc: GeneratedSource,
     });
   }
   cx.temp = temp;
@@ -688,14 +672,7 @@ function codegenReactiveScope(
       description: `Declaration \`${printIdentifier(
         identifier,
       )}\` is unnamed in scope @${scope.id}`,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
 
     const name = convertIdentifier(identifier);
@@ -731,14 +708,7 @@ function codegenReactiveScope(
     CompilerError.invariant(firstOutputIndex !== null, {
       reason: `Expected scope to have at least one declaration`,
       description: `Scope '@${scope.id}' has no declarations`,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     testCondition = t.binaryExpression(
       '===',
@@ -760,13 +730,7 @@ function codegenReactiveScope(
       {
         reason: `Expected to not have both change detection enabled and memoization disabled`,
         description: `Incompatible config options`,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
+        loc: GeneratedSource,
       },
     );
     testCondition = t.logicalExpression(
@@ -950,15 +914,7 @@ function codegenReactiveScope(
         earlyReturnValue.value.name.kind === 'named',
       {
         reason: `Expected early return value to be promoted to a named variable`,
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: earlyReturnValue.loc,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: earlyReturnValue.loc,
       },
     );
     const name: ValidIdentifierName = earlyReturnValue.value.name.value;
@@ -1020,14 +976,7 @@ function codegenTerminal(
       CompilerError.invariant(terminal.init.kind === 'SequenceExpression', {
         reason: `Expected a sequence expression init for for..in`,
         description: `Got \`${terminal.init.kind}\` expression instead`,
-        details: [
-          {
-            kind: 'error',
-            loc: terminal.init.loc,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: terminal.init.loc,
       });
       if (terminal.init.instructions.length !== 2) {
         CompilerError.throwTodo({
@@ -1061,14 +1010,7 @@ function codegenTerminal(
           CompilerError.invariant(false, {
             reason: `Expected a StoreLocal or Destructure to be assigned to the collection`,
             description: `Found ${iterableItem.value.kind}`,
-            details: [
-              {
-                kind: 'error',
-                loc: iterableItem.value.loc,
-                message: null,
-              },
-            ],
-            suggestions: null,
+            loc: iterableItem.value.loc,
           });
       }
       let varDeclKind: 'const' | 'let';
@@ -1083,15 +1025,7 @@ function codegenTerminal(
           CompilerError.invariant(false, {
             reason:
               'Destructure should never be Reassign as it would be an Object/ArrayPattern',
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: iterableItem.loc,
-                message: null,
-              },
-            ],
-            suggestions: null,
+            loc: iterableItem.loc,
           });
         case InstructionKind.Catch:
         case InstructionKind.HoistedConst:
@@ -1100,15 +1034,7 @@ function codegenTerminal(
         case InstructionKind.Function:
           CompilerError.invariant(false, {
             reason: `Unexpected ${iterableItem.value.lvalue.kind} variable in for..in collection`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: iterableItem.loc,
-                message: null,
-              },
-            ],
-            suggestions: null,
+            loc: iterableItem.loc,
           });
         default:
           assertExhaustive(
@@ -1137,14 +1063,7 @@ function codegenTerminal(
         {
           reason: `Expected a single-expression sequence expression init for for..of`,
           description: `Got \`${terminal.init.kind}\` expression instead`,
-          details: [
-            {
-              kind: 'error',
-              loc: terminal.init.loc,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: terminal.init.loc,
         },
       );
       const iterableCollection = terminal.init.instructions[0].value;
@@ -1152,14 +1071,7 @@ function codegenTerminal(
       CompilerError.invariant(terminal.test.kind === 'SequenceExpression', {
         reason: `Expected a sequence expression test for for..of`,
         description: `Got \`${terminal.init.kind}\` expression instead`,
-        details: [
-          {
-            kind: 'error',
-            loc: terminal.test.loc,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: terminal.test.loc,
       });
       if (terminal.test.instructions.length !== 2) {
         CompilerError.throwTodo({
@@ -1192,14 +1104,7 @@ function codegenTerminal(
           CompilerError.invariant(false, {
             reason: `Expected a StoreLocal or Destructure to be assigned to the collection`,
             description: `Found ${iterableItem.value.kind}`,
-            details: [
-              {
-                kind: 'error',
-                loc: iterableItem.value.loc,
-                message: null,
-              },
-            ],
-            suggestions: null,
+            loc: iterableItem.value.loc,
           });
       }
       let varDeclKind: 'const' | 'let';
@@ -1218,15 +1123,7 @@ function codegenTerminal(
         case InstructionKind.Function:
           CompilerError.invariant(false, {
             reason: `Unexpected ${iterableItem.value.lvalue.kind} variable in for..of collection`,
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: iterableItem.loc,
-                message: null,
-              },
-            ],
-            suggestions: null,
+            loc: iterableItem.loc,
           });
         default:
           assertExhaustive(
@@ -1376,15 +1273,8 @@ function codegenInstructionNullable(
       case InstructionKind.Const: {
         CompilerError.invariant(instr.lvalue === null, {
           reason: `Const declaration cannot be referenced as an expression`,
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: instr.value.loc,
-              message: `this is ${kind}`,
-            },
-          ],
-          suggestions: null,
+          message: `this is ${kind}`,
+          loc: instr.value.loc,
         });
         return createVariableDeclaration(instr.loc, 'const', [
           createVariableDeclarator(codegenLValue(cx, lvalue), value),
@@ -1393,40 +1283,17 @@ function codegenInstructionNullable(
       case InstructionKind.Function: {
         CompilerError.invariant(instr.lvalue === null, {
           reason: `Function declaration cannot be referenced as an expression`,
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: instr.value.loc,
-              message: `this is ${kind}`,
-            },
-          ],
-          suggestions: null,
+          loc: instr.value.loc,
         });
         const genLvalue = codegenLValue(cx, lvalue);
         CompilerError.invariant(genLvalue.type === 'Identifier', {
           reason: 'Expected an identifier as a function declaration lvalue',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: instr.value.loc,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: instr.value.loc,
         });
         CompilerError.invariant(value?.type === 'FunctionExpression', {
           reason: 'Expected a function as a function declaration value',
           description: `Got ${value == null ? String(value) : value.type} at ${printInstruction(instr)}`,
-          details: [
-            {
-              kind: 'error',
-              loc: instr.value.loc,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: instr.value.loc,
         });
         return createFunctionDeclaration(
           instr.loc,
@@ -1440,15 +1307,8 @@ function codegenInstructionNullable(
       case InstructionKind.Let: {
         CompilerError.invariant(instr.lvalue === null, {
           reason: `Const declaration cannot be referenced as an expression`,
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: instr.value.loc,
-              message: 'this is const',
-            },
-          ],
-          suggestions: null,
+          message: `this is ${kind}`,
+          loc: instr.value.loc,
         });
         return createVariableDeclaration(instr.loc, 'let', [
           createVariableDeclarator(codegenLValue(cx, lvalue), value),
@@ -1457,15 +1317,7 @@ function codegenInstructionNullable(
       case InstructionKind.Reassign: {
         CompilerError.invariant(value !== null, {
           reason: 'Expected a value for reassignment',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: instr.value.loc,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: instr.value.loc,
         });
         const expr = t.assignmentExpression(
           '=',
@@ -1496,15 +1348,7 @@ function codegenInstructionNullable(
       case InstructionKind.HoistedFunction: {
         CompilerError.invariant(false, {
           reason: `Expected ${kind} to have been pruned in PruneHoistedContexts`,
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: instr.loc,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: instr.loc,
         });
       }
       default: {
@@ -1521,15 +1365,7 @@ function codegenInstructionNullable(
   } else if (instr.value.kind === 'ObjectMethod') {
     CompilerError.invariant(instr.lvalue, {
       reason: 'Expected object methods to have a temp lvalue',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     cx.objectMethods.set(instr.lvalue.identifier.id, instr.value);
     return null;
@@ -1575,15 +1411,8 @@ function codegenForInit(
             (instr.kind === 'let' || instr.kind === 'const'),
           {
             reason: 'Expected a variable declaration',
-            details: [
-              {
-                kind: 'error',
-                loc: init.loc,
-                message: null,
-              },
-            ],
             description: `Got ${instr.type}`,
-            suggestions: null,
+            loc: init.loc,
           },
         );
         if (instr.kind === 'let') {
@@ -1594,15 +1423,7 @@ function codegenForInit(
     });
     CompilerError.invariant(declarators.length > 0, {
       reason: 'Expected a variable declaration',
-      details: [
-        {
-          kind: 'error',
-          loc: init.loc,
-          message: null,
-        },
-      ],
-      description: null,
-      suggestions: null,
+      loc: init.loc,
     });
     return t.variableDeclaration(kind, declarators);
   } else {
@@ -1958,15 +1779,7 @@ function codegenInstructionValue(
         case 'CallExpression': {
           CompilerError.invariant(t.isExpression(optionalValue.callee), {
             reason: 'v8 intrinsics are validated during lowering',
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: optionalValue.callee.loc ?? null,
-                message: null,
-              },
-            ],
-            suggestions: null,
+            loc: optionalValue.callee.loc ?? GeneratedSource,
           });
           value = t.optionalCallExpression(
             optionalValue.callee,
@@ -1980,15 +1793,7 @@ function codegenInstructionValue(
           const property = optionalValue.property;
           CompilerError.invariant(t.isExpression(property), {
             reason: 'Private names are validated during lowering',
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: property.loc ?? null,
-                message: null,
-              },
-            ],
-            suggestions: null,
+            loc: property.loc ?? GeneratedSource,
           });
           value = t.optionalMemberExpression(
             optionalValue.object,
@@ -2003,14 +1808,7 @@ function codegenInstructionValue(
             reason:
               'Expected an optional value to resolve to a call expression or member expression',
             description: `Got a \`${optionalValue.type}\``,
-            details: [
-              {
-                kind: 'error',
-                loc: instrValue.loc,
-                message: null,
-              },
-            ],
-            suggestions: null,
+            loc: instrValue.loc,
           });
         }
       }
@@ -2026,15 +1824,8 @@ function codegenInstructionValue(
         {
           reason:
             '[Codegen] Internal error: MethodCall::property must be an unpromoted + unmemoized MemberExpression',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: memberExpr.loc ?? null,
-              message: `Got: '${memberExpr.type}'`,
-            },
-          ],
-          suggestions: null,
+          message: `Got: '${memberExpr.type}'`,
+          loc: memberExpr.loc ?? GeneratedSource,
         },
       );
       CompilerError.invariant(
@@ -2046,15 +1837,7 @@ function codegenInstructionValue(
           reason:
             '[Codegen] Internal error: Forget should always generate MethodCall::property ' +
             'as a MemberExpression of MethodCall::receiver',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: memberExpr.loc ?? null,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: memberExpr.loc ?? GeneratedSource,
         },
       );
       const args = instrValue.args.map(arg => codegenArgument(cx, arg));
@@ -2098,15 +1881,7 @@ function codegenInstructionValue(
               const method = cx.objectMethods.get(property.place.identifier.id);
               CompilerError.invariant(method, {
                 reason: 'Expected ObjectMethod instruction',
-                description: null,
-                details: [
-                  {
-                    kind: 'error',
-                    loc: null,
-                    message: null,
-                  },
-                ],
-                suggestions: null,
+                loc: GeneratedSource,
               });
               const loweredFunc = method.loweredFunc;
               const reactiveFunction = buildReactiveFunction(loweredFunc.func);
@@ -2175,15 +1950,7 @@ function codegenInstructionValue(
       } else {
         CompilerError.invariant(tagValue.type === 'StringLiteral', {
           reason: `Expected JSX tag to be an identifier or string, got \`${tagValue.type}\``,
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: tagValue.loc ?? null,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: tagValue.loc ?? GeneratedSource,
         });
         if (tagValue.value.indexOf(':') >= 0) {
           const [namespace, name] = tagValue.value.split(':', 2);
@@ -2202,16 +1969,8 @@ function codegenInstructionValue(
         SINGLE_CHILD_FBT_TAGS.has(tagValue.value)
       ) {
         CompilerError.invariant(instrValue.children != null, {
-          details: [
-            {
-              kind: 'error',
-              loc: instrValue.loc,
-              message: null,
-            },
-          ],
           reason: 'Expected fbt element to have children',
-          suggestions: null,
-          description: null,
+          loc: instrValue.loc,
         });
         children = instrValue.children.map(child =>
           codegenJsxFbtChildElement(cx, child),
@@ -2522,15 +2281,7 @@ function codegenInstructionValue(
         instrValue.lvalue.kind === InstructionKind.Reassign,
         {
           reason: `Unexpected StoreLocal in codegenInstructionValue`,
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: instrValue.loc,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: instrValue.loc,
         },
       );
       value = t.assignmentExpression(
@@ -2558,15 +2309,7 @@ function codegenInstructionValue(
     case 'StoreContext': {
       CompilerError.invariant(false, {
         reason: `Unexpected ${instrValue.kind} in codegenInstructionValue`,
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: instrValue.loc,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: instrValue.loc,
       });
     }
     default: {
@@ -2713,15 +2456,7 @@ function convertMemberExpressionToJsx(
 ): t.JSXMemberExpression {
   CompilerError.invariant(expr.property.type === 'Identifier', {
     reason: 'Expected JSX member expression property to be a string',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: expr.loc ?? null,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: expr.loc ?? GeneratedSource,
   });
   const property = t.jsxIdentifier(expr.property.name);
   if (expr.object.type === 'Identifier') {
@@ -2730,15 +2465,7 @@ function convertMemberExpressionToJsx(
     CompilerError.invariant(expr.object.type === 'MemberExpression', {
       reason:
         'Expected JSX member expression to be an identifier or nested member expression',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: expr.object.loc ?? null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: expr.object.loc ?? GeneratedSource,
     });
     const object = convertMemberExpressionToJsx(expr.object);
     return t.jsxMemberExpression(object, property);
@@ -2760,15 +2487,7 @@ function codegenObjectPropertyKey(
       const expr = codegenPlace(cx, key.name);
       CompilerError.invariant(t.isExpression(expr), {
         reason: 'Expected object property key to be an expression',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: key.name.loc,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: key.name.loc,
       });
       return expr;
     }
@@ -2916,14 +2635,7 @@ function codegenPlace(cx: Context, place: Place): t.Expression | t.JSXText {
     description: `Value for '${printPlace(
       place,
     )}' was not set in the codegen context`,
-    details: [
-      {
-        kind: 'error',
-        loc: place.loc,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: place.loc,
   });
   const identifier = convertIdentifier(place.identifier);
   identifier.loc = place.loc as any;
@@ -2935,15 +2647,8 @@ function convertIdentifier(identifier: Identifier): t.Identifier {
     identifier.name !== null && identifier.name.kind === 'named',
     {
       reason: `Expected temporaries to be promoted to named identifiers in an earlier pass`,
-      details: [
-        {
-          kind: 'error',
-          loc: GeneratedSource,
-          message: null,
-        },
-      ],
       description: `identifier ${identifier.id} is unnamed`,
-      suggestions: null,
+      loc: GeneratedSource,
     },
   );
   return createIdentifier(identifier.loc, identifier.name.value);
@@ -2957,14 +2662,7 @@ function compareScopeDependency(
     a.identifier.name?.kind === 'named' && b.identifier.name?.kind === 'named',
     {
       reason: '[Codegen] Expected named identifier for dependency',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: a.identifier.loc,
-          message: null,
-        },
-      ],
+      loc: a.identifier.loc,
     },
   );
   const aName = [
@@ -2988,14 +2686,7 @@ function compareScopeDeclaration(
     a.identifier.name?.kind === 'named' && b.identifier.name?.kind === 'named',
     {
       reason: '[Codegen] Expected named identifier for declaration',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: a.identifier.loc,
-          message: null,
-        },
-      ],
+      loc: a.identifier.loc,
     },
   );
   const aName = a.identifier.name.value;

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/FlattenScopesWithHooksOrUseHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/FlattenScopesWithHooksOrUseHIR.ts
@@ -75,13 +75,7 @@ export function flattenScopesWithHooksOrUseHIR(fn: HIRFunction): void {
     CompilerError.invariant(terminal.kind === 'scope', {
       reason: `Expected block to have a scope terminal`,
       description: `Expected block bb${block.id} to end in a scope terminal`,
-      details: [
-        {
-          kind: 'error',
-          loc: terminal.loc,
-          message: null,
-        },
-      ],
+      loc: terminal.loc,
     });
     const body = fn.body.blocks.get(terminal.block)!;
     if (

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/InferReactiveScopeVariables.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/InferReactiveScopeVariables.ts
@@ -162,16 +162,10 @@ export function inferReactiveScopeVariables(fn: HIRFunction): void {
       });
       CompilerError.invariant(false, {
         reason: `Invalid mutable range for scope`,
-        details: [
-          {
-            kind: 'error',
-            loc: GeneratedSource,
-            message: null,
-          },
-        ],
         description: `Scope @${scope.id} has range [${scope.range.start}:${
           scope.range.end
         }] but the valid range is [1:${maxInstruction + 1}]`,
+        loc: GeneratedSource,
       });
     }
   }

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/MergeReactiveScopesThatInvalidateTogether.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/MergeReactiveScopesThatInvalidateTogether.ts
@@ -8,6 +8,7 @@
 import {CompilerError} from '..';
 import {
   DeclarationId,
+  GeneratedSource,
   InstructionId,
   InstructionKind,
   Place,
@@ -161,15 +162,7 @@ class Transform extends ReactiveFunctionTransform<ReactiveScopeDependencies | nu
       CompilerError.invariant(current !== null, {
         reason:
           'MergeConsecutiveScopes: expected current scope to be non-null if reset()',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       });
       if (current.to > current.from + 1) {
         merged.push(current);
@@ -383,15 +376,7 @@ class Transform extends ReactiveFunctionTransform<ReactiveScopeDependencies | nu
       CompilerError.invariant(mergedScope.kind === 'scope', {
         reason:
           'MergeConsecutiveScopes: Expected scope starting index to be a scope',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       });
       nextInstructions.push(mergedScope);
       index++;

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PrintReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PrintReactiveFunction.ts
@@ -7,6 +7,7 @@
 
 import {CompilerError} from '../CompilerError';
 import {
+  GeneratedSource,
   PrunedReactiveScopeBlock,
   ReactiveFunction,
   ReactiveScope,
@@ -322,15 +323,7 @@ function writeTerminal(writer: Writer, terminal: ReactiveTerminal): void {
             const block = case_.block;
             CompilerError.invariant(block != null, {
               reason: 'Expected case to have a block',
-              description: null,
-              details: [
-                {
-                  kind: 'error',
-                  loc: case_.test?.loc ?? null,
-                  message: null,
-                },
-              ],
-              suggestions: null,
+              loc: case_.test?.loc ?? GeneratedSource,
             });
             writeReactiveInstructions(writer, block);
           });

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PromoteUsedTemporaries.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PromoteUsedTemporaries.ts
@@ -290,14 +290,7 @@ class PromoteInterposedTemporaries extends ReactiveFunctionVisitor<InterState> {
       CompilerError.invariant(lval.identifier.name != null, {
         reason:
           'PromoteInterposedTemporaries: Assignment targets not expected to be temporaries',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: instruction.loc,
-            message: null,
-          },
-        ],
+        loc: instruction.loc,
       });
     }
 
@@ -460,15 +453,7 @@ function promoteIdentifier(identifier: Identifier, state: State): void {
   CompilerError.invariant(identifier.name === null, {
     reason:
       'promoteTemporary: Expected to be called only for temporary variables',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: GeneratedSource,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
   if (state.tags.has(identifier.declarationId)) {
     promoteTemporaryJsxTag(identifier);

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneHoistedContexts.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneHoistedContexts.ts
@@ -145,14 +145,7 @@ class Visitor extends ReactiveFunctionTransform<VisitorState> {
           if (maybeHoistedFn != null) {
             CompilerError.invariant(maybeHoistedFn.kind === 'func', {
               reason: '[PruneHoistedContexts] Unexpected hoisted function',
-              description: null,
-              details: [
-                {
-                  kind: 'error',
-                  loc: instruction.loc,
-                  message: null,
-                },
-              ],
+              loc: instruction.loc,
             });
             maybeHoistedFn.definition = instruction.value.lvalue.place;
             /**

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneInitializationDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneInitializationDependencies.ts
@@ -196,14 +196,7 @@ class Visitor extends ReactiveFunctionVisitor<CreateUpdate> {
   ): void {
     CompilerError.invariant(state !== 'Create', {
       reason: "Visiting a terminal statement with state 'Create'",
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: stmt.terminal.loc,
-          message: null,
-        },
-      ],
+      loc: stmt.terminal.loc,
     });
     super.visitTerminal(stmt, state);
   }

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonEscapingScopes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonEscapingScopes.ts
@@ -9,6 +9,7 @@ import {CompilerError} from '../CompilerError';
 import {
   DeclarationId,
   Environment,
+  GeneratedSource,
   Identifier,
   InstructionId,
   Pattern,
@@ -264,14 +265,7 @@ class State {
       CompilerError.invariant(identifierNode !== undefined, {
         reason: 'Expected identifier to be initialized',
         description: `[${id}] operand=${printPlace(place)} for identifier declaration ${identifier}`,
-        details: [
-          {
-            kind: 'error',
-            loc: place.loc,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: place.loc,
       });
       identifierNode.scopes.add(scope.id);
     }
@@ -291,15 +285,7 @@ function computeMemoizedIdentifiers(state: State): Set<DeclarationId> {
     const node = state.identifiers.get(id);
     CompilerError.invariant(node !== undefined, {
       reason: `Expected a node for all identifiers, none found for \`${id}\``,
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     if (node.seen) {
       return node.memoized;
@@ -339,15 +325,7 @@ function computeMemoizedIdentifiers(state: State): Set<DeclarationId> {
     const node = state.scopes.get(id);
     CompilerError.invariant(node !== undefined, {
       reason: 'Expected a node for all scopes',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     if (node.seen) {
       return;
@@ -994,15 +972,7 @@ class CollectDependenciesVisitor extends ReactiveFunctionVisitor<
       );
       CompilerError.invariant(identifierNode !== undefined, {
         reason: 'Expected identifier to be initialized',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: stmt.terminal.loc,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: stmt.terminal.loc,
       });
       for (const scope of scopes) {
         identifierNode.scopes.add(scope.id);
@@ -1025,15 +995,7 @@ class CollectDependenciesVisitor extends ReactiveFunctionVisitor<
       );
       CompilerError.invariant(identifierNode !== undefined, {
         reason: 'Expected identifier to be initialized',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: reassignment.loc,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: reassignment.loc,
       });
       for (const scope of scopes) {
         identifierNode.scopes.add(scope.id);

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/RenameVariables.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/RenameVariables.ts
@@ -9,6 +9,7 @@ import {ProgramContext} from '..';
 import {CompilerError} from '../CompilerError';
 import {
   DeclarationId,
+  GeneratedSource,
   Identifier,
   IdentifierName,
   InstructionId,
@@ -185,15 +186,7 @@ class Scopes {
     const last = this.#stack.pop();
     CompilerError.invariant(last === next, {
       reason: 'Mismatch push/pop calls',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
   }
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/SSA/EliminateRedundantPhi.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/SSA/EliminateRedundantPhi.ts
@@ -6,7 +6,13 @@
  */
 
 import {CompilerError} from '../CompilerError';
-import {BlockId, HIRFunction, Identifier, Place} from '../HIR/HIR';
+import {
+  BlockId,
+  GeneratedSource,
+  HIRFunction,
+  Identifier,
+  Place,
+} from '../HIR/HIR';
 import {
   eachInstructionLValue,
   eachInstructionOperand,
@@ -96,15 +102,7 @@ export function eliminateRedundantPhi(
         }
         CompilerError.invariant(same !== null, {
           reason: 'Expected phis to be non-empty',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: null,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: GeneratedSource,
         });
         rewrites.set(phi.place.identifier, same);
         block.phis.delete(phi);
@@ -155,26 +153,12 @@ export function eliminateRedundantPhi(
       for (const phi of block.phis) {
         CompilerError.invariant(!rewrites.has(phi.place.identifier), {
           reason: '[EliminateRedundantPhis]: rewrite not complete',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: phi.place.loc,
-              message: null,
-            },
-          ],
+          loc: phi.place.loc,
         });
         for (const [, operand] of phi.operands) {
           CompilerError.invariant(!rewrites.has(operand.identifier), {
             reason: '[EliminateRedundantPhis]: rewrite not complete',
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: phi.place.loc,
-                message: null,
-              },
-            ],
+            loc: phi.place.loc,
           });
         }
       }

--- a/compiler/packages/babel-plugin-react-compiler/src/SSA/EnterSSA.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/SSA/EnterSSA.ts
@@ -10,6 +10,7 @@ import {Environment} from '../HIR/Environment';
 import {
   BasicBlock,
   BlockId,
+  GeneratedSource,
   HIRFunction,
   Identifier,
   IdentifierId,
@@ -69,15 +70,7 @@ class SSABuilder {
   state(): State {
     CompilerError.invariant(this.#current !== null, {
       reason: 'we need to be in a block to access state!',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     return this.#states.get(this.#current)!;
   }
@@ -258,15 +251,7 @@ function enterSSAImpl(
   for (const [blockId, block] of func.body.blocks) {
     CompilerError.invariant(!visitedBlocks.has(block), {
       reason: `found a cycle! visiting bb${block.id} again`,
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
 
     visitedBlocks.add(block);
@@ -277,15 +262,7 @@ function enterSSAImpl(
       // NOTE: func.context should be empty for the root function
       CompilerError.invariant(func.context.length === 0, {
         reason: `Expected function context to be empty for outer function declarations`,
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: func.loc,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: func.loc,
       });
       func.params = func.params.map(param => {
         if (param.kind === 'Identifier') {
@@ -312,15 +289,7 @@ function enterSSAImpl(
         CompilerError.invariant(entry.preds.size === 0, {
           reason:
             'Expected function expression entry block to have zero predecessors',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: null,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: GeneratedSource,
         });
         entry.preds.add(blockId);
         builder.defineFunction(loweredFunc);

--- a/compiler/packages/babel-plugin-react-compiler/src/SSA/RewriteInstructionKindsBasedOnReassignment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/SSA/RewriteInstructionKindsBasedOnReassignment.ts
@@ -8,6 +8,7 @@
 import {CompilerError} from '../CompilerError';
 import {
   DeclarationId,
+  GeneratedSource,
   HIRFunction,
   InstructionKind,
   LValue,
@@ -59,13 +60,7 @@ export function rewriteInstructionKindsBasedOnReassignment(
             {
               reason: `Expected variable not to be defined prior to declaration`,
               description: `${printPlace(lvalue.place)} was already defined`,
-              details: [
-                {
-                  kind: 'error',
-                  loc: lvalue.place.loc,
-                  message: null,
-                },
-              ],
+              loc: lvalue.place.loc,
             },
           );
           declarations.set(lvalue.place.identifier.declarationId, lvalue);
@@ -83,13 +78,7 @@ export function rewriteInstructionKindsBasedOnReassignment(
                 {
                   reason: `Expected variable not to be defined prior to declaration`,
                   description: `${printPlace(lvalue.place)} was already defined`,
-                  details: [
-                    {
-                      kind: 'error',
-                      loc: lvalue.place.loc,
-                      message: null,
-                    },
-                  ],
+                  loc: lvalue.place.loc,
                 },
               );
               declarations.set(lvalue.place.identifier.declarationId, lvalue);
@@ -113,14 +102,7 @@ export function rewriteInstructionKindsBasedOnReassignment(
                   description: `other places were \`${kind}\` but '${printPlace(
                     place,
                   )}' is const`,
-                  details: [
-                    {
-                      kind: 'error',
-                      loc: place.loc,
-                      message: 'Expected consistent kind for destructuring',
-                    },
-                  ],
-                  suggestions: null,
+                  loc: place.loc,
                 },
               );
               kind = InstructionKind.Const;
@@ -131,15 +113,7 @@ export function rewriteInstructionKindsBasedOnReassignment(
               if (declaration === undefined) {
                 CompilerError.invariant(block.kind !== 'value', {
                   reason: `TODO: Handle reassignment in a value block where the original declaration was removed by dead code elimination (DCE)`,
-                  description: null,
-                  details: [
-                    {
-                      kind: 'error',
-                      loc: place.loc,
-                      message: null,
-                    },
-                  ],
-                  suggestions: null,
+                  loc: place.loc,
                 });
                 declarations.set(place.identifier.declarationId, lvalue);
                 CompilerError.invariant(
@@ -149,14 +123,7 @@ export function rewriteInstructionKindsBasedOnReassignment(
                     description: `Other places were \`${kind}\` but '${printPlace(
                       place,
                     )}' is const`,
-                    details: [
-                      {
-                        kind: 'error',
-                        loc: place.loc,
-                        message: 'Expected consistent kind for destructuring',
-                      },
-                    ],
-                    suggestions: null,
+                    loc: place.loc,
                   },
                 );
                 kind = InstructionKind.Const;
@@ -168,14 +135,7 @@ export function rewriteInstructionKindsBasedOnReassignment(
                     description: `Other places were \`${kind}\` but '${printPlace(
                       place,
                     )}' is reassigned`,
-                    details: [
-                      {
-                        kind: 'error',
-                        loc: place.loc,
-                        message: 'Expected consistent kind for destructuring',
-                      },
-                    ],
-                    suggestions: null,
+                    loc: place.loc,
                   },
                 );
                 kind = InstructionKind.Reassign;
@@ -185,15 +145,7 @@ export function rewriteInstructionKindsBasedOnReassignment(
           }
           CompilerError.invariant(kind !== null, {
             reason: 'Expected at least one operand',
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: null,
-                message: null,
-              },
-            ],
-            suggestions: null,
+            loc: GeneratedSource,
           });
           lvalue.kind = kind;
           break;
@@ -205,13 +157,7 @@ export function rewriteInstructionKindsBasedOnReassignment(
           CompilerError.invariant(declaration !== undefined, {
             reason: `Expected variable to have been defined`,
             description: `No declaration for ${printPlace(lvalue)}`,
-            details: [
-              {
-                kind: 'error',
-                loc: lvalue.loc,
-                message: null,
-              },
-            ],
+            loc: lvalue.loc,
           });
           declaration.kind = InstructionKind.Let;
           break;

--- a/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
@@ -10,6 +10,7 @@ import {CompilerError} from '../CompilerError';
 import {Environment} from '../HIR';
 import {lowerType} from '../HIR/BuildHIR';
 import {
+  GeneratedSource,
   HIRFunction,
   Identifier,
   IdentifierId,
@@ -659,15 +660,7 @@ class Unifier {
     if (type.kind === 'Phi') {
       CompilerError.invariant(type.operands.length > 0, {
         reason: 'there should be at least one operand',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: GeneratedSource,
       });
 
       let candidateType: Type | null = null;

--- a/compiler/packages/babel-plugin-react-compiler/src/Utils/DisjointSet.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Utils/DisjointSet.ts
@@ -6,6 +6,7 @@
  */
 
 import {CompilerError} from '../CompilerError';
+import {GeneratedSource} from '../HIR/HIR';
 
 // Represents items which form disjoint sets.
 export default class DisjointSet<T> {
@@ -20,15 +21,7 @@ export default class DisjointSet<T> {
     const first = items.shift();
     CompilerError.invariant(first != null, {
       reason: 'Expected set to be non-empty',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: null,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     /*
      * determine an arbitrary "root" for this set: if the first

--- a/compiler/packages/babel-plugin-react-compiler/src/Utils/TestUtils.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Utils/TestUtils.ts
@@ -14,6 +14,7 @@ import {
   PluginOptions,
 } from '../Entrypoint';
 import {EnvironmentConfig} from '..';
+import {GeneratedSource} from '../HIR/HIR';
 import {
   EnvironmentConfigSchema,
   PartialEnvironmentConfig,
@@ -155,14 +156,7 @@ function parseConfigPragmaEnvironmentForTest(
   CompilerError.invariant(false, {
     reason: 'Internal error, could not parse config from pragma string',
     description: `${fromZodError(config.error)}`,
-    details: [
-      {
-        kind: 'error',
-        loc: null,
-        message: null,
-      },
-    ],
-    suggestions: null,
+    loc: GeneratedSource,
   });
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateContextVariableLValues.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateContextVariableLValues.ts
@@ -108,17 +108,9 @@ function visit(
       CompilerError.invariant(false, {
         reason:
           'Expected all references to a variable to be consistently local or context references',
-        description: `Identifier ${printPlace(
-          place,
-        )} is referenced as a ${kind} variable, but was previously referenced as a ${prev.kind} variable`,
-        suggestions: null,
-        details: [
-          {
-            kind: 'error',
-            loc: place.loc,
-            message: `this is ${prev.kind}`,
-          },
-        ],
+        description: `Identifier ${printPlace(place)} is referenced as a ${kind} variable, but was previously referenced as a ${prev.kind} variable`,
+        message: `this is ${prev.kind}`,
+        loc: place.loc,
       });
     }
   }

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateExhaustiveDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateExhaustiveDependencies.ts
@@ -111,7 +111,7 @@ export function validateExhaustiveDependencies(
     dependencies: Set<InferredDependency>,
     locals: Set<IdentifierId>,
   ): void {
-    CompilerError.simpleInvariant(startMemo == null, {
+    CompilerError.invariant(startMemo == null, {
       reason: 'Unexpected nested memo calls',
       loc: value.loc,
     });
@@ -124,7 +124,7 @@ export function validateExhaustiveDependencies(
     dependencies: Set<InferredDependency>,
     locals: Set<IdentifierId>,
   ): void {
-    CompilerError.simpleInvariant(
+    CompilerError.invariant(
       startMemo != null && startMemo.manualMemoId === value.manualMemoId,
       {
         reason: 'Found FinishMemoize without corresponding StartMemoize',
@@ -233,7 +233,7 @@ function validateDependencies(
     if (a.kind === 'Global' && b.kind == 'Global') {
       return a.binding.name.localeCompare(b.binding.name);
     } else if (a.kind == 'Local' && b.kind == 'Local') {
-      CompilerError.simpleInvariant(
+      CompilerError.invariant(
         a.identifier.name != null &&
           a.identifier.name.kind === 'named' &&
           b.identifier.name != null &&
@@ -320,7 +320,7 @@ function validateDependencies(
       }
       continue;
     }
-    CompilerError.simpleInvariant(inferredDependency.kind === 'Local', {
+    CompilerError.invariant(inferredDependency.kind === 'Local', {
       reason: 'Unexpected function dependency',
       loc: inferredDependency.loc,
     });
@@ -361,7 +361,7 @@ function validateDependencies(
       continue;
     }
     if (dep.root.kind === 'NamedLocal' && dep.root.constant) {
-      CompilerError.simpleInvariant(
+      CompilerError.invariant(
         !dep.root.value.reactive && isPrimitiveType(dep.root.value.identifier),
         {
           reason: 'Expected constant-folded dependency to be non-reactive',
@@ -871,7 +871,7 @@ function printInferredDependency(dep: InferredDependency): string {
       return dep.binding.name;
     }
     case 'Local': {
-      CompilerError.simpleInvariant(
+      CompilerError.invariant(
         dep.identifier.name != null && dep.identifier.name.kind === 'named',
         {
           reason: 'Expected dependencies to be named variables',
@@ -889,7 +889,7 @@ function printManualMemoDependency(dep: ManualMemoDependency): string {
     identifierName = dep.root.identifierName;
   } else {
     const name = dep.root.value.identifier.name;
-    CompilerError.simpleInvariant(name != null && name.kind === 'named', {
+    CompilerError.invariant(name != null && name.kind === 'named', {
       reason: 'Expected manual dependencies to be named variables',
       loc: dep.root.value.loc,
     });
@@ -976,7 +976,7 @@ export function findOptionalPlaces(
         switch (terminal.kind) {
           case 'branch': {
             const isOptional = queue.pop();
-            CompilerError.simpleInvariant(isOptional !== undefined, {
+            CompilerError.invariant(isOptional !== undefined, {
               reason:
                 'Expected an optional value for each optional test condition',
               loc: terminal.test.loc,
@@ -1017,14 +1017,15 @@ export function findOptionalPlaces(
             break;
           }
           default: {
-            CompilerError.simpleInvariant(false, {
+            CompilerError.invariant(false, {
               reason: `Unexpected terminal in optional`,
+              message: `Unexpected ${terminal.kind} in optional`,
               loc: terminal.loc,
             });
           }
         }
       }
-      CompilerError.simpleInvariant(queue.length === 0, {
+      CompilerError.invariant(queue.length === 0, {
         reason:
           'Expected a matching number of conditional blocks and branch points',
         loc: block.terminal.loc,
@@ -1091,7 +1092,7 @@ function createDiagnostic(
       break;
     }
     default: {
-      CompilerError.simpleInvariant(false, {
+      CompilerError.invariant(false, {
         reason: `Unexpected error category: ${category}`,
         loc: GeneratedSource,
       });

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateLocalsNotReassignedAfterRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateLocalsNotReassignedAfterRender.ts
@@ -191,14 +191,7 @@ function getContextReassignment(
           for (const operand of operands) {
             CompilerError.invariant(operand.effect !== Effect.Unknown, {
               reason: `Expected effects to be inferred prior to ValidateLocalsNotReassignedAfterRender`,
-              description: null,
-              details: [
-                {
-                  kind: 'error',
-                  loc: operand.loc,
-                  message: '',
-                },
-              ],
+              loc: operand.loc,
             });
             const reassignment = reassigningFunctions.get(
               operand.identifier.id,

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoDerivedComputationsInEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoDerivedComputationsInEffects.ts
@@ -83,14 +83,7 @@ export function validateNoDerivedComputationsInEffects(fn: HIRFunction): void {
             const dependencies: Array<IdentifierId> = deps.elements.map(dep => {
               CompilerError.invariant(dep.kind === 'Identifier', {
                 reason: `Dependency is checked as a place above`,
-                description: null,
-                details: [
-                  {
-                    kind: 'error',
-                    loc: value.loc,
-                    message: 'this is checked as a place above',
-                  },
-                ],
+                loc: value.loc,
               });
               return locals.get(dep.identifier.id) ?? dep.identifier.id;
             });

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoDerivedComputationsInEffects_exp.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoDerivedComputationsInEffects_exp.ts
@@ -244,13 +244,7 @@ export function validateNoDerivedComputationsInEffects_exp(
       reason:
         '[ValidateNoDerivedComputationsInEffects] Fixpoint iteration failed to converge.',
       description: `Fixpoint iteration exceeded ${MAX_FIXPOINT_ITERATIONS} iterations while tracking derivations. This suggests a cyclic dependency in the derivation cache.`,
-      details: [
-        {
-          kind: 'error',
-          loc: fn.loc,
-          message: `Exceeded ${MAX_FIXPOINT_ITERATIONS} iterations in ValidateNoDerivedComputationsInEffects`,
-        },
-      ],
+      loc: fn.loc,
     });
   } while (context.derivationCache.snapshot());
 
@@ -484,14 +478,7 @@ function recordInstructionDerivations(
       case Effect.Unknown: {
         CompilerError.invariant(false, {
           reason: 'Unexpected unknown effect',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: operand.loc,
-              message: 'Unexpected unknown effect',
-            },
-          ],
+          loc: operand.loc,
         });
       }
       default: {
@@ -539,14 +526,7 @@ function buildTreeNode(
     CompilerError.invariant(childId !== sourceId, {
       reason:
         'Unexpected self-reference: a value should not have itself as a source',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: sourceMetadata.place.loc,
-          message: null,
-        },
-      ],
+      loc: sourceMetadata.place.loc,
     });
 
     const childNodes = buildTreeNode(

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
@@ -12,6 +12,7 @@ import {
 } from '../CompilerError';
 import {
   BlockId,
+  GeneratedSource,
   HIRFunction,
   IdentifierId,
   Identifier,
@@ -58,15 +59,7 @@ type RefId = number & {[opaqueRefId]: 'RefId'};
 function makeRefId(id: number): RefId {
   CompilerError.invariant(id >= 0 && Number.isInteger(id), {
     reason: 'Expected identifier id to be a non-negative integer',
-    description: null,
-    suggestions: null,
-    details: [
-      {
-        kind: 'error',
-        loc: null,
-        message: null,
-      },
-    ],
+    loc: GeneratedSource,
   });
   return id as RefId;
 }
@@ -204,40 +197,19 @@ function tyEqual(a: RefAccessType, b: RefAccessType): boolean {
     case 'Guard':
       CompilerError.invariant(b.kind === 'Guard', {
         reason: 'Expected ref value',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
+        loc: GeneratedSource,
       });
       return a.refId === b.refId;
     case 'RefValue':
       CompilerError.invariant(b.kind === 'RefValue', {
         reason: 'Expected ref value',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
+        loc: GeneratedSource,
       });
       return a.loc == b.loc;
     case 'Structure': {
       CompilerError.invariant(b.kind === 'Structure', {
         reason: 'Expected structure',
-        description: null,
-        details: [
-          {
-            kind: 'error',
-            loc: null,
-            message: null,
-          },
-        ],
+        loc: GeneratedSource,
       });
       const fnTypesEqual =
         (a.fn === null && b.fn === null) ||
@@ -276,14 +248,7 @@ function joinRefAccessTypes(...types: Array<RefAccessType>): RefAccessType {
         a.kind === 'Structure' && b.kind === 'Structure',
         {
           reason: 'Expected structure',
-          description: null,
-          details: [
-            {
-              kind: 'error',
-              loc: null,
-              message: null,
-            },
-          ],
+          loc: GeneratedSource,
         },
       );
       const fn =
@@ -782,14 +747,7 @@ function validateNoRefAccessInRenderImpl(
 
   CompilerError.invariant(!env.hasChanged(), {
     reason: 'Ref type environment did not converge',
-    description: null,
-    details: [
-      {
-        kind: 'error',
-        loc: null,
-        message: null,
-      },
-    ],
+    loc: GeneratedSource,
   });
 
   return Ok(

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoSetStateInEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoSetStateInEffects.ts
@@ -264,15 +264,7 @@ function getSetStateCall(
               case Effect.Unknown: {
                 CompilerError.invariant(false, {
                   reason: 'Unexpected unknown effect',
-                  description: null,
-                  details: [
-                    {
-                      kind: 'error',
-                      loc: operand.loc,
-                      message: null,
-                    },
-                  ],
-                  suggestions: null,
+                  loc: operand.loc,
                 });
               }
               default: {

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoSetStateInRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoSetStateInRender.ts
@@ -102,14 +102,7 @@ function validateNoSetStateInRenderImpl(
         case 'StartMemoize': {
           CompilerError.invariant(activeManualMemoId === null, {
             reason: 'Unexpected nested StartMemoize instructions',
-            description: null,
-            details: [
-              {
-                kind: 'error',
-                loc: instr.value.loc,
-                message: null,
-              },
-            ],
+            loc: instr.value.loc,
           });
           activeManualMemoId = instr.value.manualMemoId;
           break;
@@ -120,14 +113,7 @@ function validateNoSetStateInRenderImpl(
             {
               reason:
                 'Expected FinishMemoize to align with previous StartMemoize instruction',
-              description: null,
-              details: [
-                {
-                  kind: 'error',
-                  loc: instr.value.loc,
-                  message: null,
-                },
-              ],
+              loc: instr.value.loc,
             },
           );
           activeManualMemoId = null;

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
@@ -248,15 +248,7 @@ function validateInferredDep(
     CompilerError.invariant(dep.identifier.name?.kind === 'named', {
       reason:
         'ValidatePreservedManualMemoization: expected scope dependency to be named',
-      description: null,
-      details: [
-        {
-          kind: 'error',
-          loc: GeneratedSource,
-          message: null,
-        },
-      ],
-      suggestions: null,
+      loc: GeneratedSource,
     });
     normalizedDep = {
       root: {
@@ -504,14 +496,7 @@ class Visitor extends ReactiveFunctionVisitor<VisitorState> {
       CompilerError.invariant(state.manualMemoState == null, {
         reason: 'Unexpected nested StartMemoize instructions',
         description: `Bad manual memoization ids: ${state.manualMemoState?.manualMemoId}, ${value.manualMemoId}`,
-        details: [
-          {
-            kind: 'error',
-            loc: value.loc,
-            message: null,
-          },
-        ],
-        suggestions: null,
+        loc: value.loc,
       });
 
       state.manualMemoState = {
@@ -571,14 +556,7 @@ class Visitor extends ReactiveFunctionVisitor<VisitorState> {
         {
           reason: 'Unexpected mismatch between StartMemoize and FinishMemoize',
           description: `Encountered StartMemoize id=${state.manualMemoState?.manualMemoId} followed by FinishMemoize id=${value.manualMemoId}`,
-          details: [
-            {
-              kind: 'error',
-              loc: value.loc,
-              message: null,
-            },
-          ],
-          suggestions: null,
+          loc: value.loc,
         },
       );
       const reassignments = state.manualMemoState.reassignments;


### PR DESCRIPTION
`invariant()` was a pain to use - we always record a single location, but the API required passing a compiler detail. This PR replaces `invariant()` (keeping the name) with `simpleInvariant()`s signature, and updates call sites accordingly. I've noticed that agents consistently get invariant() wrong, which aligns with it being tedious to call when you're writing code by hand. The simplified API should help a bit.
