### PR TITLE
[DevTools] Fix: Trace Updates incorrectly highlights components when filtered parent re-mounts them

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -2107,7 +2107,14 @@ export function attach(
         // releasing DevTools in lockstep with React, we should import a
         // function from the reconciler instead.
         const PerformedWork = 0b000000000000000000000000001;
-        return (getFiberFlags(nextFiber) & PerformedWork) === PerformedWork;
+        const hasPerformedWork =
+          (getFiberFlags(nextFiber) & PerformedWork) === PerformedWork;
+
+        if (nextFiber.alternate === null) {
+          return false;
+        }
+
+        return hasPerformedWork;
       // Note: ContextConsumer only gets PerformedWork effect in 16.3.3+
       // so it won't get highlighted with React 16.3.0 to 16.3.2.
       default:


### PR DESCRIPTION
## Summary

**Bug:**
When "Hide DOM nodes" filter is enabled, updating a sibling component incorrectly highlights unrelated components that share a filtered parent.

**Root Cause:**
`didFiberRender()` only checks the `PerformedWork` flag but doesn't verify if the fiber is a mount vs update. When DevTools re-mounts components after their filtered parent changes, they have `PerformedWork=true` + `alternate=null` causing them to be incorrectly marked as "rendered".

**Fix:**
Add `alternate` check in `didFiberRender()`. If `alternate === null`, the fiber is a mount (not an update) and should not be highlighted in trace updates.

---
**Before**

https://github.com/user-attachments/assets/f478f67b-0182-45bd-af85-e3b3282604b7

**After**

https://github.com/user-attachments/assets/30983bfb-51e9-4124-a3b8-8d46b96073cf

