### PR TITLE
[flags] make enableComponentPerformanceTrack static everywhere

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -25,4 +25,3 @@ export const passChildrenWhenCloningPersistedNodes = __VARIANT__;
 export const enableFragmentRefs = __VARIANT__;
 export const enableFragmentRefsScrollIntoView = __VARIANT__;
 export const enableFragmentRefsInstanceHandles = __VARIANT__;
-export const enableComponentPerformanceTrack = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -77,8 +77,7 @@ export const enableSrcObject: boolean = false;
 export const enableHydrationChangeEvent: boolean = true;
 export const enableDefaultTransitionIndicator: boolean = true;
 export const ownerStackLimit = 1e4;
-export const enableComponentPerformanceTrack: boolean =
-  __PROFILE__ && dynamicFlags.enableComponentPerformanceTrack;
+export const enableComponentPerformanceTrack: boolean = true;
 export const enablePerformanceIssueReporting: boolean =
   enableComponentPerformanceTrack;
 export const enableInternalInstanceMap: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -31,7 +31,6 @@ export const enableInfiniteRenderLoopDetection: boolean = __VARIANT__;
 
 export const enableFastAddPropertiesInDiffing: boolean = __VARIANT__;
 export const enableViewTransition: boolean = __VARIANT__;
-export const enableComponentPerformanceTrack: boolean = __VARIANT__;
 export const enableScrollEndPolyfill: boolean = __VARIANT__;
 export const enableFragmentRefs: boolean = __VARIANT__;
 export const enableFragmentRefsScrollIntoView: boolean = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -29,7 +29,6 @@ export const {
   syncLaneExpirationMs,
   transitionLaneExpirationMs,
   enableViewTransition,
-  enableComponentPerformanceTrack,
   enableScrollEndPolyfill,
   enableFragmentRefs,
   enableFragmentRefsScrollIntoView,
@@ -55,6 +54,8 @@ export const enableLegacyFBSupport: boolean = true;
 export const enableYieldingBeforePassive: boolean = false;
 
 export const enableThrottledScheduling: boolean = false;
+
+export const enableComponentPerformanceTrack: boolean = true;
 
 export const enablePerformanceIssueReporting: boolean = false;
 


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/34665.

Already gated on `enableProfilerTimer` everywhere, which is only enabled for `__PROFILE__`, except for Flight should be unified in a future.