### PR TITLE
[Flight] Fix markup types for server references

### DIFF
--- a/packages/react-client/src/forks/ReactFlightClientConfig.markup.js
+++ b/packages/react-client/src/forks/ReactFlightClientConfig.markup.js
@@ -18,7 +18,7 @@ export * from 'react-client/src/ReactClientConsoleConfigPlain';
 export type ModuleLoading = null;
 export type ServerConsumerModuleMap = null;
 export opaque type ServerManifest = null;
-export opaque type ServerReferenceId = string;
+export type ServerReferenceId = string;
 export opaque type ClientReferenceMetadata = null;
 export opaque type ClientReference<T> = null; // eslint-disable-line no-unused-vars
 
@@ -43,7 +43,7 @@ export function resolveClientReference<T>(
 
 export function resolveServerReference<T>(
   config: ServerManifest,
-  id: mixed,
+  id: ServerReferenceId,
 ): ClientReference<T> {
   throw new Error(
     'renderToHTML should not have emitted Server References. This is a bug in React.',

--- a/packages/react-server/src/ReactFlightActionServer.js
+++ b/packages/react-server/src/ReactFlightActionServer.js
@@ -46,7 +46,7 @@ function bindArgs(fn: any, args: any) {
 function loadServerReference<T>(
   bundlerConfig: ServerManifest,
   metaData: {
-    id: string,
+    id: ServerReferenceId,
     bound: null | Promise<Array<any>>,
   },
 ): Promise<T> {


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/35632/changes/d5324f41438fd58d01d5a5c2d6e4775872775b41

Flow narrows the `ServerReferenceId` to a `string` due to `typeof` check and then it can't assign the narrowed value to an opaque type.

Instead we don't make `ServerReferenceId` opaque like for the other configs.