### PR TITLE
fix(eslint-plugin-react-hooks): allow underscore prefix in component …

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -46,6 +46,14 @@ const allTests = {
       `,
     },
     {
+      code: normalizeIndent`
+        // Valid because components with underscore prefix followed by uppercase are components.
+        function _PrivateComponent() {
+          useHook();
+        }
+      `,
+    },
+    {
       syntax: 'flow',
       code: normalizeIndent`
         // Component syntax

--- a/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
@@ -55,7 +55,7 @@ function isHook(node: Node): boolean {
  * always start with an uppercase letter.
  */
 function isComponentName(node: Node): boolean {
-  return node.type === 'Identifier' && /^[A-Z]/.test(node.name);
+  return node.type === 'Identifier' && /^_?[A-Z]/.test(node.name);
 }
 
 function isReactFunction(node: Node, functionName: string): boolean {


### PR DESCRIPTION
## Summary                                                                
  - Update `isComponentName` regex from `/^[A-Z]/` to `/^_?[A-Z]/` to       
  recognize underscore-prefixed components like `_MyComponent` as valid     
  React components                                                          
  - Add test case for underscore-prefixed component                         
                                                                            
  ## Test plan                                                              
  - [x] Added test for `_PrivateComponent` using hooks                      
  - [x] All 1432 existing tests pass                                        
                                                                                   