### PR TITLE
[DevTools] Fix Profiler inaccuracy caused by stale PerformedWork flag on unvisited fibers

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -2086,6 +2086,12 @@ export function attach(
   }
 
   function didFiberRender(prevFiber: Fiber, nextFiber: Fiber): boolean {
+    // Note: prevFiber === nextFiber means the fiber was never visited this render.
+    // Any PerformedWork flag is stale because the parent bailed out entirely.
+    if (prevFiber === nextFiber) {
+      return false;
+    }
+
     switch (nextFiber.tag) {
       case ClassComponent:
       case FunctionComponent:


### PR DESCRIPTION
## Summary

Fixes an issue where DevTools Profiler reports components as "rendered" and "Highlight updates" flashes on components that were actually skipped.

This can cause confusion for developers using React Compiler, as cached components appear to be re-rendering in DevTools—making it seem like optimizations aren't working when they actually are.

When React Compiler caches JSX elements, the parent may bail out entirely (`childLanes === 0`), and child fibers are never visited by the reconciler. However, `didFiberRender` was checking the `PerformedWork` flag which could be stale from a previous render, causing false positives in the Profiler.

Here's an example to reproduce the issue (also available in my [demo repo](https://github.com/yongsk0066/devtools-rendered-demo)). Note that `ChildComponent` is wrapped with a `<div>`.

```tsx
// See: https://github.com/yongsk0066/devtools-rendered-demo/blob/main/src/WrappedCase.tsx
import { useState } from "react";

export default function WrappedCase() {
  const [count, setCount] = useState(0);
  const [text, setText] = useState("");

  return (
    <section>
      <h2>{"Child wrapped with <div>"}</h2>
      <input
        type="text"
        value={text}
        onChange={(e) => setText(e.target.value)}
        placeholder="Type here..."
      />
      <button onClick={() => setCount((c) => c + 1)}>Count: {count}</button>
      <div>
        <ChildComponent count={count} />
      </div>
    </section>
  );
}

function ChildComponent({ count }: { count: number }) {
  return <p>Child Component {count}</p>;
}
```

Compiled output (some parts omitted, full output available in [playground](https://playground.react.dev/#N4Igzg9grgTgxgUxALhASwLYAcIwC4AEwBUYCAyngIZ4IEC+BAZjBBgQDogwJVx5cA3BwB2ohAA8c+AgBMETKlAA2hJlBH80EEQQDqMKliwJZAYSpkAFAEoioggTg6whANrONeADQEyeM2gRPABdAgBeEjJKGgQrAAYbYV0nF3daCR8-BDwAFUlQiKiKalorLi4k0QcCHjxYXXKUxwAeMi0dAD4ax1aACwAmTuAuMz60ZVkCAHdDY1MZtDw+ghbZNAA3bpB6FoB6Qe7m3pa0ESwoAWPegjwATxNwrgyBEB6bgg2qZSgEcOAXvR3jcdGMqCIAOZ-YBWBB2cKdbJ5AqwgB01BgULwqK+PzhQOuvSwyj4CD6EEmCBgTxAuQedD6VIQqJZFUJeyOH1WACNLngdARQco0HAANb-WwRRH+QJeKxWODwxFwAgAagIAEYbPROrLgsgiJ5grs9ry8PyRJyPmtNlauS0xhNzGwcCIEMFUl5-ka8IwOcDVnt1lt3vt2nhtJaalURATROpNBGBY7JoFsDp3XgrMQfQwDTmgngDSIoBhuVSGHYRik6g1VlhdeNJgQ067M4bCyaG8kCSBvCBnCImGgISh0OmZPcTEQCAAFH4Qs4AeSwSZEYAYzFY7AA5NyqOXlABaYlQRciI88Ph4I-ObATKlBtCuHfJUTZmp7PZ3rATGiRgBZCB5ANLhvmUNlGDAf8wGHBAN3nM9l1XSMwCSPtwHJaYAElgipERvjAFBFGUMh6CAA) or [demo repo](https://github.com/yongsk0066/devtools-rendered-demo/blob/main/WrappedCase.md)):

```jsx
import { c as _c } from "react/compiler-runtime";
import { useState } from "react";

export default function WrappedCase() {
  const $ = _c(12);
  const [count, setCount] = useState(0);
  const [text, setText] = useState("");
  // ...
  let t4;
  let t5;
  if ($[5] !== count) {
    t4 = <button onClick={t3}>Count: {count}</button>;
    t5 = (
      <div>
        <ChildComponent count={count} />
      </div>
    );
    $[5] = count;
    $[6] = t4;
    $[7] = t5;
  } else {
    t4 = $[6];
    t5 = $[7]; // same JSX reference returned
  }
  // When text changes, Parent re-renders but t5 stays the same.
  // React bails out on the cached subtree - ChildComponent fiber is never visited.
  // But Profiler incorrectly reports ChildComponent as "rendered".
  let t6;
  if ($[8] !== t2 || $[9] !== t4 || $[10] !== t5) {
    t6 = (
      <section>
        {t0}
        {t2}
        {t4}
        {t5}
      </section>
    );
    $[8] = t2;
    $[9] = t4;
    $[10] = t5;
    $[11] = t6;
  } else {
    t6 = $[11];
  }
  return t6;
}
```

I referenced a similar comparison pattern from [renderer.js#L4936-L4940](https://github.com/facebook/react/blob/8c34556ca8df0dab34bbaf68e0dd15cd4a5e3f7f/packages/react-devtools-shared/src/backend/fiber/renderer.js#L4936-L4940) (introduced in [#30684](https://github.com/facebook/react/pull/30684)), which uses fiber identity to check if a child was not visited. This fix adds the same check before checking the `PerformedWork` flag—if the fiber is the same object, it was never visited this render, so any flag is stale.

```javascript
function didFiberRender(prevFiber, nextFiber) {
  if (prevFiber === nextFiber) {
    return false; // fiber was never visited
  }
  // ... existing flag check
}
```

Note: This is different from the ["We don't reflect bailouts"](https://github.com/facebook/react/blob/8c34556ca8df0dab34bbaf68e0dd15cd4a5e3f7f/packages/react-devtools-shared/src/backend/fiber/renderer.js#L2096-L2100) case—that's for components that were visited but bailed out via `shouldComponentUpdate` or `React.memo`, while this fix handles fibers that were **never visited** because the parent bailed out entirely with `childLanes === 0`.

## How did you test this change?

Added a test case using `useMemoCache` to simulate React Compiler's JSX caching behavior. The test verifies that cached children are not reported in `fiberActualDurations`.

I created a reproduction demo at https://github.com/yongsk0066/devtools-rendered-demo ([live demo](https://yongsk0066.github.io/devtools-rendered-demo/)). Tested with React Developer Tools 7.0.1 (10/20/2025). To reproduce the issue, enable "Highlight updates when components render" and check if highlights appear on cached children, or check in Profiler if cached components are shown without hatching.

```
yarn test-build-devtools --testPathPattern="profilerStore-test" --testNamePattern="cached"
```
I also built the DevTools extension locally with the fix

**Before fix:**
[profiling json](https://github.com/yongsk0066/devtools-rendered-demo/blob/main/assets/profiling-original-wrapped.json)

https://github.com/user-attachments/assets/92003b68-2363-44dc-8409-2356df586a61

**After fix:**
[profiling json](https://github.com/yongsk0066/devtools-rendered-demo/blob/main/assets/profiling-fixed-wrapped.json)

https://github.com/user-attachments/assets/e3f6cd04-5667-4181-a0f9-c8f54b8c2752


cc @hoxyq 
