### PR TITLE
[Perf Tracks] Use minus (`-`) instead of en dash for removed props

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactPerformanceTrack-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactPerformanceTrack-test.js
@@ -231,7 +231,7 @@ describe('ReactPerformanceTracks', () => {
               properties: [
                 ['Changed Props', ''],
                 ['  data', ''],
-                ['–   buffer', 'null'],
+                ['-   buffer', 'null'],
                 ['+   buffer', 'Uint8Array'],
                 ['+     0', '0'],
                 ['+     1', '0'],
@@ -422,7 +422,7 @@ describe('ReactPerformanceTracks', () => {
               color: 'error',
               properties: [
                 ['Changed Props', ''],
-                ['– value', '1'],
+                ['- value', '1'],
                 ['+ value', '2'],
               ],
               tooltipText: 'Left',
@@ -510,7 +510,7 @@ describe('ReactPerformanceTracks', () => {
                 ['  data', ''],
                 ['    deeply', ''],
                 ['      nested', ''],
-                ['–       numbers', 'Array'],
+                ['-       numbers', 'Array'],
                 ['+       numbers', 'Array'],
               ],
               tooltipText: 'App',

--- a/packages/shared/ReactPerformanceTrackProperties.js
+++ b/packages/shared/ReactPerformanceTrackProperties.js
@@ -279,7 +279,7 @@ export function addValueToProperties(
   properties.push([prefix + '\xa0\xa0'.repeat(indent) + propertyName, desc]);
 }
 
-const REMOVED = '\u2013\xa0';
+const REMOVED = '-\xa0';
 const ADDED = '+\xa0';
 const UNCHANGED = '\u2007\xa0';
 


### PR DESCRIPTION
Stacked on https://github.com/facebook/react/pull/35648

The [en dash is used for number ranges or connections](https://www.merriam-webster.com/grammar/em-dash-en-dash-how-to-use).

This seems not suitable for a diff. Our hydration diffs also use a minus symbol instead of en dash for removed lines. git-diff also uses minus.