### PR TITLE
[tests] Fix ReactDOMAttribute-test

### DIFF
--- a/packages/shared/CheckStringCoercion.js
+++ b/packages/shared/CheckStringCoercion.js
@@ -76,8 +76,6 @@ export function checkAttributeStringCoercion(
   attributeName: string,
 ): void | string {
   if (__DEV__) {
-    // TODO: for enableTrustedTypesIntegration we don't toString this
-    //       so we shouldn't need the DEV warning.
     if (willCoercionThrow(value)) {
       console.error(
         'The provided `%s` attribute is an unsupported type %s.' +


### PR DESCRIPTION
In https://github.com/facebook/react/pull/35646 I thought there was a bug in trusted types, but the bug is in jsdom. 

For trusted types we still want to check the coersion and throw for a good dev warning, but prod will also throw becuase the browser will implicitly coerce to a string. This ensures there's no behavior difference between dev and prod.

So the right fix is to add in the JSDOM hack that's used in `ReactDOMSelect-test.js`.