### PR TITLE
[DevTools] Fix commit index reset when switching profiler roots

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/useCommitFilteringAndNavigation.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/useCommitFilteringAndNavigation.js
@@ -45,6 +45,14 @@ export function useCommitFilteringAndNavigation(
     null,
   );
 
+  // Reset commit index when commitData changes (e.g., when switching roots).
+  const [previousCommitData, setPreviousCommitData] =
+    useState<Array<CommitDataFrontend>>(commitData);
+  if (previousCommitData !== commitData) {
+    setPreviousCommitData(commitData);
+    selectCommitIndex(commitData.length > 0 ? 0 : null);
+  }
+
   const calculateFilteredIndices = useCallback(
     (enabled: boolean, minDuration: number): Array<number> => {
       return commitData.reduce((reduced: Array<number>, commitDatum, index) => {


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/31463, https://github.com/facebook/react/issues/30114.

When switching between roots in the profiler flamegraph, the commit index was preserved from the previous root. This caused an error "Invalid commit X. There are only Y commits." when the new root had fewer commits than the selected index.

This fix resets the commit index to 0 (or null if no commits) when the commitData changes, which happens when switching roots.
