### PR TITLE
[Perf Tracks] Prevent crash when accessing `$$typeof`

### DIFF
--- a/packages/shared/ReactPerformanceTrackProperties.js
+++ b/packages/shared/ReactPerformanceTrackProperties.js
@@ -82,6 +82,13 @@ export function addObjectToProperties(
   }
 }
 
+function readReactElementTypeof(value: Object): mixed {
+  // Prevents dotting into $$typeof in opaque origin windows.
+  return '$$typeof' in value && hasOwnProperty.call(value, '$$typeof')
+    ? value.$$typeof
+    : undefined;
+}
+
 export function addValueToProperties(
   propertyName: string,
   value: mixed,
@@ -96,6 +103,65 @@ export function addValueToProperties(
         desc = 'null';
         break;
       } else {
+        if (readReactElementTypeof(value) === REACT_ELEMENT_TYPE) {
+          // JSX
+          const typeName = getComponentNameFromType(value.type) || '\u2026';
+          const key = value.key;
+          const props: any = value.props;
+          const propsKeys = Object.keys(props);
+          const propsLength = propsKeys.length;
+          if (key == null && propsLength === 0) {
+            desc = '<' + typeName + ' />';
+            break;
+          }
+          if (
+            indent < 3 ||
+            (propsLength === 1 && propsKeys[0] === 'children' && key == null)
+          ) {
+            desc = '<' + typeName + ' \u2026 />';
+            break;
+          }
+          properties.push([
+            prefix + '\xa0\xa0'.repeat(indent) + propertyName,
+            '<' + typeName,
+          ]);
+          if (key !== null) {
+            addValueToProperties('key', key, properties, indent + 1, prefix);
+          }
+          let hasChildren = false;
+          let addedProperties = 0;
+          for (const propKey in props) {
+            addedProperties++;
+            if (propKey === 'children') {
+              if (
+                props.children != null &&
+                (!isArray(props.children) || props.children.length > 0)
+              ) {
+                hasChildren = true;
+              }
+            } else if (
+              hasOwnProperty.call(props, propKey) &&
+              propKey[0] !== '_'
+            ) {
+              addValueToProperties(
+                propKey,
+                props[propKey],
+                properties,
+                indent + 1,
+                prefix,
+              );
+            }
+
+            if (addedProperties >= OBJECT_WIDTH_LIMIT) {
+              break;
+            }
+          }
+          properties.push([
+            '',
+            hasChildren ? '>\u2026</' + typeName + '>' : '/>',
+          ]);
+          return;
+        }
         // $FlowFixMe[method-unbinding]
         const objectToString = Object.prototype.toString.call(value);
         let objectName = objectToString.slice(8, objectToString.length - 1);
@@ -179,70 +245,6 @@ export function addValueToProperties(
           return;
         }
         if (objectName === 'Object') {
-          if (
-            '$$typeof' in value &&
-            hasOwnProperty.call(value, '$$typeof') &&
-            value.$$typeof === REACT_ELEMENT_TYPE
-          ) {
-            // JSX
-            const typeName = getComponentNameFromType(value.type) || '\u2026';
-            const key = value.key;
-            const props: any = value.props;
-            const propsKeys = Object.keys(props);
-            const propsLength = propsKeys.length;
-            if (key == null && propsLength === 0) {
-              desc = '<' + typeName + ' />';
-              break;
-            }
-            if (
-              indent < 3 ||
-              (propsLength === 1 && propsKeys[0] === 'children' && key == null)
-            ) {
-              desc = '<' + typeName + ' \u2026 />';
-              break;
-            }
-            properties.push([
-              prefix + '\xa0\xa0'.repeat(indent) + propertyName,
-              '<' + typeName,
-            ]);
-            if (key !== null) {
-              addValueToProperties('key', key, properties, indent + 1, prefix);
-            }
-            let hasChildren = false;
-            let addedProperties = 0;
-            for (const propKey in props) {
-              addedProperties++;
-              if (propKey === 'children') {
-                if (
-                  props.children != null &&
-                  (!isArray(props.children) || props.children.length > 0)
-                ) {
-                  hasChildren = true;
-                }
-              } else if (
-                hasOwnProperty.call(props, propKey) &&
-                propKey[0] !== '_'
-              ) {
-                addValueToProperties(
-                  propKey,
-                  props[propKey],
-                  properties,
-                  indent + 1,
-                  prefix,
-                );
-              }
-
-              if (addedProperties >= OBJECT_WIDTH_LIMIT) {
-                break;
-              }
-            }
-            properties.push([
-              '',
-              hasChildren ? '>\u2026</' + typeName + '>' : '/>',
-            ]);
-            return;
-          }
-
           const proto: any = Object.getPrototypeOf(value);
           if (proto && typeof proto.constructor === 'function') {
             objectName = proto.constructor.name;
@@ -357,9 +359,10 @@ export function addObjectDiffToProperties(
           typeof nextValue === 'object' &&
           prevValue !== null &&
           nextValue !== null &&
-          prevValue.$$typeof === nextValue.$$typeof
+          readReactElementTypeof(prevValue) ===
+            readReactElementTypeof(nextValue)
         ) {
-          if (nextValue.$$typeof === REACT_ELEMENT_TYPE) {
+          if (readReactElementTypeof(nextValue) === REACT_ELEMENT_TYPE) {
             if (
               prevValue.type === nextValue.type &&
               prevValue.key === nextValue.key


### PR DESCRIPTION
Alternate to https://github.com/facebook/react/issues/34840

Fixes https://github.com/facebook/react/issues/34840
Closes https://github.com/facebook/react/issues/34840

## Summary

Guards dotting into `$$typeof` unconditionally. The try-catch proposed in https://github.com/facebook/react/issues/34840 feels too heavy.

Original plan was to skip diffing DOM nodes entirely since they're mutable boxes anyway. That felt like too much of a stretch unless we move the check to the host config. However, that wouldn't fix the linked issue. The linked issue is caused by having a cross-origin window in props not the iframe. Perf tracks wouldn't diff `contentWindow` since it's not enumerable.

The proposed implementation is host agnostic and feels like a better fit overall. And it guards against cases where accessing an unknown `$$typeof` property would also throw.

## Test plan

- added tests (see 1st commit for crash)
- [ ] https://codesandbox.io/p/sandbox/green-fire-84qs2x?file=%2Fsrc%2Findex.js no longer crashes: https://codesandbox.io/p/sandbox/69yhcw?file=%2Fsrc%2Findex.js%3A16%2C15 (needs to be downloaded. remaining error is from CodeSandbox)