### PR TITLE
[flags] Cleanup `enableActivity`

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMActivity-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMActivity-test.js
@@ -54,7 +54,6 @@ describe('ReactDOMActivity', () => {
     return <span prop={props.text}>{props.children}</span>;
   }
 
-  // @gate enableActivity
   it(
     'hiding an Activity boundary also hides the direct children of any ' +
       'portals it contains, regardless of how deeply nested they are',
@@ -100,7 +99,6 @@ describe('ReactDOMActivity', () => {
     },
   );
 
-  // @gate enableActivity
   it(
     'revealing an Activity boundary inside a portal does not reveal the ' +
       'portal contents if has a hidden Activity parent',
@@ -151,7 +149,6 @@ describe('ReactDOMActivity', () => {
     },
   );
 
-  // @gate enableActivity
   it('hides new portals added to an already hidden tree', async () => {
     function Child() {
       return <Text text="Child" />;
@@ -218,7 +215,6 @@ describe('ReactDOMActivity', () => {
     );
   });
 
-  // @gate enableActivity
   it('hides new insertions inside an already hidden portal', async () => {
     function Child({text}) {
       useLayoutEffect(() => {
@@ -289,7 +285,6 @@ describe('ReactDOMActivity', () => {
     );
   });
 
-  // @gate enableActivity
   it('reveal an inner Suspense boundary without revealing an outer Activity on the same host child', async () => {
     const promise = new Promise(() => {});
 
@@ -390,7 +385,6 @@ describe('ReactDOMActivity', () => {
     );
   });
 
-  // @gate enableActivity
   it('mounts/unmounts layout effects in portal when visibility changes (starting visible)', async () => {
     function Child() {
       useLayoutEffect(() => {
@@ -440,7 +434,6 @@ describe('ReactDOMActivity', () => {
     );
   });
 
-  // @gate enableActivity
   it('mounts/unmounts layout effects in portal when visibility changes (starting hidden)', async () => {
     function Child() {
       useLayoutEffect(() => {

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -763,7 +763,7 @@ describe('FragmentRefs', () => {
       });
 
       describe('with activity', () => {
-        // @gate enableFragmentRefs && enableActivity
+        // @gate enableFragmentRefs
         it('does not apply event listeners to hidden trees', async () => {
           const parentRef = React.createRef();
           const fragmentRef = React.createRef();
@@ -799,7 +799,7 @@ describe('FragmentRefs', () => {
           expect(logs).toEqual(['Child 1', 'Child 3']);
         });
 
-        // @gate enableFragmentRefs && enableActivity
+        // @gate enableFragmentRefs
         it('applies event listeners to visible trees', async () => {
           const parentRef = React.createRef();
           const fragmentRef = React.createRef();
@@ -835,7 +835,7 @@ describe('FragmentRefs', () => {
           expect(logs).toEqual(['Child 1', 'Child 2', 'Child 3']);
         });
 
-        // @gate enableFragmentRefs && enableActivity
+        // @gate enableFragmentRefs
         it('handles Activity modes switching', async () => {
           const fragmentRef = React.createRef();
           const fragmentRef2 = React.createRef();

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -3668,7 +3668,6 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(ref.current.innerHTML).toBe('Hidden child');
   });
 
-  // @gate enableActivity
   it('a visible Activity component is surrounded by comment markers', async () => {
     const ref = React.createRef();
 
@@ -3706,7 +3705,6 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(ref.current).toBe(span);
   });
 
-  // @gate enableActivity
   it('a hidden Activity component is skipped over during server rendering', async () => {
     const visibleRef = React.createRef();
 

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydrationActivity-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydrationActivity-test.internal.js
@@ -113,7 +113,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     IdleEventPriority = require('react-reconciler/constants').IdleEventPriority;
   });
 
-  // @gate enableActivity
   it('hydrates a parent even if a child Activity boundary is blocked', async () => {
     let suspend = false;
     let resolve;
@@ -169,7 +168,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(ref.current).toBe(span);
   });
 
-  // @gate enableActivity
   it('can hydrate siblings of a suspended component without errors', async () => {
     let suspend = false;
     let resolve;
@@ -228,7 +226,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(container.textContent).toBe('HelloHello');
   });
 
-  // @gate enableActivity
   it('falls back to client rendering boundary on mismatch', async () => {
     let client = false;
     let suspend = false;
@@ -321,7 +318,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     );
   });
 
-  // @gate enableActivity
   it('handles if mismatch is after suspending', async () => {
     let client = false;
     let suspend = false;
@@ -401,7 +397,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(container.innerHTML).toBe('Hello<article>Mismatch</article>');
   });
 
-  // @gate enableActivity
   it('handles if mismatch is child of suspended component', async () => {
     let client = false;
     let suspend = false;
@@ -482,7 +477,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(container.innerHTML).toBe('<div><article>Mismatch</article></div>');
   });
 
-  // @gate enableActivity
   it('handles if mismatch is parent and first child suspends', async () => {
     let client = false;
     let suspend = false;
@@ -575,7 +569,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     );
   });
 
-  // @gate enableActivity
   it('does show a parent fallback if mismatch is parent and second child suspends', async () => {
     let client = false;
     let suspend = false;
@@ -687,7 +680,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     );
   });
 
-  // @gate enableActivity
   it('does show a parent fallback if mismatch is in parent element only', async () => {
     let client = false;
     let suspend = false;
@@ -787,7 +779,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     );
   });
 
-  // @gate enableActivity
   it('does show a parent fallback if mismatch is before suspending', async () => {
     let client = false;
     let suspend = false;
@@ -886,7 +877,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     );
   });
 
-  // @gate enableActivity
   it('does show a parent fallback if mismatch is before suspending in a child', async () => {
     let client = false;
     let suspend = false;
@@ -987,7 +977,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     );
   });
 
-  // @gate enableActivity
   it('calls the hydration callbacks after hydration or deletion', async () => {
     let suspend = false;
     let resolve;
@@ -1079,7 +1068,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(deleted.length).toBe(1);
   });
 
-  // @gate enableActivity
   it('hydrates an empty activity boundary', async () => {
     function App() {
       return (
@@ -1101,7 +1089,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(container.innerHTML).toContain('<div>Sibling</div>');
   });
 
-  // @gate enableActivity
   it('recovers with client render when server rendered additional nodes at suspense root', async () => {
     function CheckIfHydrating({children}) {
       // This is a trick to check whether we're hydrating or not, since React
@@ -1171,7 +1158,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(ref.current).not.toBe(span);
   });
 
-  // @gate enableActivity
   it('recovers with client render when server rendered additional nodes at suspense root after unsuspending', async () => {
     const ref = React.createRef();
     let shouldSuspend = false;
@@ -1236,7 +1222,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(ref.current).not.toBe(span);
   });
 
-  // @gate enableActivity
   it('recovers with client render when server rendered additional nodes deep inside suspense root', async () => {
     const ref = React.createRef();
     function App({hasB}) {
@@ -1283,7 +1268,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(ref.current).not.toBe(span);
   });
 
-  // @gate enableActivity
   it('calls the onDeleted hydration callback if the parent gets deleted', async () => {
     let suspend = false;
     const promise = new Promise(() => {});
@@ -1337,7 +1321,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(deleted.length).toBe(1);
   });
 
-  // @gate enableActivity
   it('can insert siblings before the dehydrated boundary', async () => {
     let suspend = false;
     const promise = new Promise(() => {});
@@ -1395,7 +1378,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(container.firstChild.firstChild.textContent).toBe('First');
   });
 
-  // @gate enableActivity
   it('can delete the dehydrated boundary before it is hydrated', async () => {
     let suspend = false;
     const promise = new Promise(() => {});
@@ -1451,7 +1433,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(container.firstChild.children[1].textContent).toBe('After');
   });
 
-  // @gate enableActivity
   it('blocks updates to hydrate the content first if props have changed', async () => {
     let suspend = false;
     let resolve;
@@ -1523,7 +1504,7 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(span.className).toBe('hi');
   });
 
-  // @gate enableActivity && www
+  // @gate www
   it('blocks updates to hydrate the content first if props changed at idle priority', async () => {
     let suspend = false;
     let resolve;
@@ -1597,7 +1578,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(span.className).toBe('hi');
   });
 
-  // @gate enableActivity
   it('shows the fallback of the parent if props have changed before hydration completes and is still suspended', async () => {
     let suspend = false;
     let resolve;
@@ -1684,7 +1664,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(container.textContent).toBe('Hi');
   });
 
-  // @gate enableActivity
   it('clears nested activity boundaries if they did not hydrate yet', async () => {
     let suspend = false;
     const promise = new Promise(() => {});
@@ -1752,7 +1731,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(container.textContent).toBe('Hi Hi');
   });
 
-  // @gate enableActivity
   it('hydrates first if props changed but we are able to resolve within a timeout', async () => {
     let suspend = false;
     let resolve;
@@ -1826,7 +1804,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(span.className).toBe('hi');
   });
 
-  // @gate enableActivity
   it('warns but works if setState is called before commit in a dehydrated component', async () => {
     let suspend = false;
     let resolve;
@@ -1901,7 +1878,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(container.textContent).toBe('Hello');
   });
 
-  // @gate enableActivity
   it('blocks the update to hydrate first if context has changed', async () => {
     let suspend = false;
     let resolve;
@@ -1984,7 +1960,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(span.className).toBe('hi');
   });
 
-  // @gate enableActivity
   it('shows the parent fallback if context has changed before hydration completes and is still suspended', async () => {
     let suspend = false;
     let resolve;
@@ -2075,7 +2050,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(container.textContent).toBe('Hi');
   });
 
-  // @gate enableActivity
   it('can hydrate TWO activity boundaries', async () => {
     const ref1 = React.createRef();
     const ref2 = React.createRef();
@@ -2113,7 +2087,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(ref2.current).toBe(span2);
   });
 
-  // @gate enableActivity
   it('regenerates if it cannot hydrate before changes to props/context expire', async () => {
     let suspend = false;
     const promise = new Promise(resolvePromise => {});
@@ -2201,7 +2174,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(newSpan.className).toBe('hi');
   });
 
-  // @gate enableActivity
   it('does not invoke an event on a hydrated node until it commits', async () => {
     let suspend = false;
     let resolve;
@@ -2281,7 +2253,7 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity && www
+  // @gate www
   it('does not invoke an event on a hydrated event handle until it commits', async () => {
     const setClick = ReactDOM.unstable_createEventHandle('click');
     let suspend = false;
@@ -2363,7 +2335,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity
   it('invokes discrete events on nested activity boundaries in a root (legacy system)', async () => {
     let suspend = false;
     let resolve;
@@ -2444,7 +2415,7 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity && www
+  // @gate www
   it('invokes discrete events on nested activity boundaries in a root (createEventHandle)', async () => {
     let suspend = false;
     let isServerRendering = true;
@@ -2529,7 +2500,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity
   it('does not invoke the parent of dehydrated boundary event', async () => {
     let suspend = false;
     let resolve;
@@ -2602,7 +2572,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity
   it('does not invoke an event on a parent tree when a subtree is dehydrated', async () => {
     let suspend = false;
     let resolve;
@@ -2675,7 +2644,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     document.body.removeChild(parentContainer);
   });
 
-  // @gate enableActivity
   it('blocks only on the last continuous event (legacy system)', async () => {
     let suspend1 = false;
     let resolve1;
@@ -2776,7 +2744,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity
   it('finishes normal pri work before continuing to hydrate a retry', async () => {
     let suspend = false;
     let resolve;
@@ -2860,7 +2827,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     expect(ref.current).not.toBe(null);
   });
 
-  // @gate enableActivity
   it('regression test: does not overfire non-bubbling browser events', async () => {
     let suspend = false;
     let resolve;
@@ -2945,7 +2911,6 @@ describe('ReactDOMServerPartialHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity
   it('fallback to client render on hydration mismatch at root', async () => {
     let suspend = true;
     let resolve;

--- a/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydrationActivity-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydrationActivity-test.internal.js
@@ -152,7 +152,6 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
       require('react-reconciler/constants').ContinuousEventPriority;
   });
 
-  // @gate enableActivity
   it('hydrates the target boundary synchronously during a click', async () => {
     function Child({text}) {
       Scheduler.log(text);
@@ -214,7 +213,6 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity
   it('hydrates at higher pri if sync did not work first time', async () => {
     let suspend = false;
     let resolve;
@@ -300,7 +298,6 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity
   it('hydrates at higher pri for secondary discrete events', async () => {
     let suspend = false;
     let resolve;
@@ -388,7 +385,7 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity && www
+  // @gate www
   it('hydrates the target boundary synchronously during a click (createEventHandle)', async () => {
     const setClick = ReactDOM.unstable_createEventHandle('click');
     let isServerRendering = true;
@@ -455,7 +452,7 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity && www
+  // @gate www
   it('hydrates at higher pri if sync did not work first time (createEventHandle)', async () => {
     let suspend = false;
     let isServerRendering = true;
@@ -544,7 +541,7 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity && www
+  // @gate www
   it('hydrates at higher pri for secondary discrete events (createEventHandle)', async () => {
     const setClick = ReactDOM.unstable_createEventHandle('click');
     let suspend = false;
@@ -636,7 +633,6 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity
   it('hydrates the hovered targets as higher priority for continuous events', async () => {
     let suspend = false;
     let resolve;
@@ -729,7 +725,6 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity
   it('replays capture phase for continuous events and respects stopPropagation', async () => {
     let suspend = false;
     let resolve;
@@ -883,7 +878,6 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity
   it('replays event with null target when tree is dismounted', async () => {
     let suspend = false;
     let resolve;
@@ -957,7 +951,6 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity
   it('hydrates the last target path first for continuous events', async () => {
     let suspend = false;
     let resolve;
@@ -1044,7 +1037,6 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity
   it('hydrates the last explicitly hydrated target at higher priority', async () => {
     function Child({text}) {
       Scheduler.log(text);
@@ -1092,7 +1084,7 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     await waitForAll(['App', 'C', 'B', 'A']);
   });
 
-  // @gate enableActivity && www
+  // @gate www
   it('hydrates before an update even if hydration moves away from it', async () => {
     function Child({text}) {
       Scheduler.log(text);
@@ -1200,7 +1192,6 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity
   it('fires capture event handlers and native events if content is hydratable during discrete event', async () => {
     spyOnDev(console, 'error');
     function Child({text}) {
@@ -1272,7 +1263,6 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableActivity
   it('does not propagate discrete event if it cannot be synchronously hydrated', async () => {
     let triggeredParent = false;
     let triggeredChild = false;
@@ -1335,7 +1325,6 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     expect(triggeredChild).toBe(false);
   });
 
-  // @gate enableActivity
   it('can force hydration in response to sync update', async () => {
     function Child({text}) {
       Scheduler.log(`Child ${text}`);
@@ -1371,7 +1360,7 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     expect(initialSpan).toBe(spanRef);
   });
 
-  // @gate enableActivity && www
+  // @gate www
   it('can force hydration in response to continuous update', async () => {
     function Child({text}) {
       Scheduler.log(`Child ${text}`);
@@ -1408,7 +1397,6 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     expect(initialSpan).toBe(spanRef);
   });
 
-  // @gate enableActivity
   it('can force hydration in response to default update', async () => {
     function Child({text}) {
       Scheduler.log(`Child ${text}`);
@@ -1441,7 +1429,7 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     expect(initialSpan).toBe(spanRef);
   });
 
-  // @gate enableActivity && www
+  // @gate www
   it('regression test: can unwind context on selective hydration interruption', async () => {
     const Context = React.createContext('DefaultContext');
 
@@ -1500,7 +1488,6 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     });
   });
 
-  // @gate enableActivity
   it('regression test: can unwind context on selective hydration interruption for sync updates', async () => {
     const Context = React.createContext('DefaultContext');
 
@@ -1552,7 +1539,6 @@ describe('ReactDOMServerSelectiveHydrationActivity', () => {
     });
   });
 
-  // @gate enableActivity
   it('regression: selective hydration does not contribute to "maximum update limit" count', async () => {
     const outsideRef = React.createRef(null);
     const insideRef = React.createRef(null);

--- a/packages/react-reconciler/src/__tests__/Activity-test.js
+++ b/packages/react-reconciler/src/__tests__/Activity-test.js
@@ -196,7 +196,6 @@ describe('Activity', () => {
     );
   });
 
-  // @gate enableActivity
   it('mounts without layout effects when hidden', async () => {
     function Child({text}) {
       useLayoutEffect(() => {
@@ -234,7 +233,6 @@ describe('Activity', () => {
     expect(root).toMatchRenderedOutput(<span prop="Child" />);
   });
 
-  // @gate enableActivity
   it('mounts/unmounts layout effects when visibility changes (starting visible)', async () => {
     function Child({text}) {
       useLayoutEffect(() => {
@@ -280,7 +278,6 @@ describe('Activity', () => {
     expect(root).toMatchRenderedOutput(<span prop="Child" />);
   });
 
-  // @gate enableActivity
   it('nested offscreen does not call componentWillUnmount when hidden', async () => {
     // This is a bug that appeared during production test of <Activity />.
     // It is a very specific scenario with nested Offscreens. The inner offscreen
@@ -384,7 +381,6 @@ describe('Activity', () => {
     assertLog(['child']);
   });
 
-  // @gate enableActivity
   it('mounts/unmounts layout effects when visibility changes (starting hidden)', async () => {
     function Child({text}) {
       useLayoutEffect(() => {
@@ -431,7 +427,6 @@ describe('Activity', () => {
     expect(root).toMatchRenderedOutput(<span hidden={true} prop="Child" />);
   });
 
-  // @gate enableActivity
   it('hides children of offscreen after layout effects are destroyed', async () => {
     const root = ReactNoop.createRoot();
     function Child({text}) {
@@ -518,7 +513,6 @@ describe('Activity', () => {
     assertLog(['Unmount layout']);
   });
 
-  // @gate enableActivity
   it('hides new insertions into an already hidden tree', async () => {
     const root = ReactNoop.createRoot();
     await act(() => {
@@ -548,7 +542,6 @@ describe('Activity', () => {
     );
   });
 
-  // @gate enableActivity
   it('hides updated nodes inside an already hidden tree', async () => {
     const root = ReactNoop.createRoot();
     await act(() => {
@@ -594,7 +587,6 @@ describe('Activity', () => {
     expect(root).toMatchRenderedOutput(<span>Hi</span>);
   });
 
-  // @gate enableActivity
   it('revealing a hidden tree at high priority does not cause tearing', async () => {
     // When revealing an offscreen tree, we need to include updates that were
     // previously deferred because the tree was hidden, even if they are lower
@@ -723,7 +715,6 @@ describe('Activity', () => {
     expect(areOuterAndInnerConsistent()).toBe(true);
   });
 
-  // @gate enableActivity
   it('regression: Activity instance is sometimes null during setState', async () => {
     let setState;
     function Child() {
@@ -774,7 +765,6 @@ describe('Activity', () => {
     expect(root).toMatchRenderedOutput(null);
   });
 
-  // @gate enableActivity
   it('class component setState callbacks do not fire until tree is visible', async () => {
     const root = ReactNoop.createRoot();
 
@@ -826,7 +816,6 @@ describe('Activity', () => {
     expect(root).toMatchRenderedOutput(<span prop="C" />);
   });
 
-  // @gate enableActivity
   it('does not call componentDidUpdate when reappearing a hidden class component', async () => {
     class Child extends React.Component {
       componentDidMount() {
@@ -876,7 +865,6 @@ describe('Activity', () => {
     assertLog(['componentDidMount']);
   });
 
-  // @gate enableActivity
   it(
     'when reusing old components (hidden -> visible), layout effects fire ' +
       'with same timing as if it were brand new',
@@ -929,7 +917,6 @@ describe('Activity', () => {
     },
   );
 
-  // @gate enableActivity
   it(
     'when reusing old components (hidden -> visible), layout effects fire ' +
       'with same timing as if it were brand new (includes setState callback)',
@@ -992,7 +979,6 @@ describe('Activity', () => {
     },
   );
 
-  // @gate enableActivity
   it('defer passive effects when prerendering a new Activity tree', async () => {
     function Child({label}) {
       useEffect(() => {
@@ -1110,7 +1096,6 @@ describe('Activity', () => {
     assertLog(['Shell', 'More']);
   });
 
-  // @gate enableActivity
   it('passive effects are connected and disconnected when the visibility changes', async () => {
     function Child({step}) {
       useEffect(() => {
@@ -1167,7 +1152,6 @@ describe('Activity', () => {
     expect(root).toMatchRenderedOutput(<span prop={2} />);
   });
 
-  // @gate enableActivity
   it('passive effects are unmounted on hide in the same order as during a deletion: parent before child', async () => {
     function Child({label}) {
       useEffect(() => {
@@ -1225,7 +1209,6 @@ describe('Activity', () => {
   // Re-enable this test once we add this ability. For example, we'll likely add
   // either an option or a heuristic to mount passive effects inside a hidden
   // tree after a delay.
-  // @gate enableActivity
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip("don't defer passive effects when prerendering in a tree whose effects are already connected", async () => {
     function Child({label}) {
@@ -1282,7 +1265,6 @@ describe('Activity', () => {
     ]);
   });
 
-  // @gate enableActivity
   it('does not mount effects when prerendering a nested Activity boundary', async () => {
     function Child({label}) {
       useEffect(() => {
@@ -1360,7 +1342,6 @@ describe('Activity', () => {
     );
   });
 
-  // @gate enableActivity
   it('reveal an outer Activity boundary without revealing an inner one', async () => {
     function Child({label}) {
       useEffect(() => {
@@ -1426,7 +1407,6 @@ describe('Activity', () => {
     );
   });
 
-  // @gate enableActivity
   it('reveal an inner Activity boundary without revealing an outer one on the same host child', async () => {
     // This ensures that no update is scheduled, which would cover up the bug if the parent
     // then re-hides the child on the way up.
@@ -1455,7 +1435,6 @@ describe('Activity', () => {
     expect(root).toMatchRenderedOutput(<div hidden={true} />);
   });
 
-  // @gate enableActivity
   it('reveal an inner Suspense boundary without revealing an outer Activity on the same host child', async () => {
     // This ensures that no update is scheduled, which would cover up the bug if the parent
     // then re-hides the child on the way up.
@@ -1492,7 +1471,6 @@ describe('Activity', () => {
     expect(root).toMatchRenderedOutput(<div hidden={true} />);
   });
 
-  // @gate enableActivity
   it('insertion effects are not disconnected when the visibility changes', async () => {
     function Child({step}) {
       useInsertionEffect(() => {
@@ -1549,7 +1527,6 @@ describe('Activity', () => {
     expect(root).toMatchRenderedOutput(<span prop={2} />);
   });
 
-  // @gate enableActivity
   it('warns if you pass a hidden prop', async () => {
     function App() {
       return (

--- a/packages/react-reconciler/src/__tests__/ActivityErrorHandling-test.js
+++ b/packages/react-reconciler/src/__tests__/ActivityErrorHandling-test.js
@@ -26,7 +26,6 @@ describe('Activity error handling', () => {
     return text;
   }
 
-  // @gate enableActivity
   it(
     'errors inside a hidden Activity do not escape in the visible part ' +
       'of the UI',

--- a/packages/react-reconciler/src/__tests__/ActivityLegacySuspense-test.js
+++ b/packages/react-reconciler/src/__tests__/ActivityLegacySuspense-test.js
@@ -98,7 +98,6 @@ describe('Activity Suspense', () => {
     return text;
   }
 
-  // @gate enableActivity
   it('basic example of suspending inside hidden tree', async () => {
     const root = ReactNoop.createRoot();
 
@@ -174,7 +173,7 @@ describe('Activity Suspense', () => {
     );
   });
 
-  // @gate __DEV__ && enableActivity
+  // @gate __DEV__
   test('Regression: Suspending on hide should not infinite loop.', async () => {
     // This regression only repros in public act.
     global.IS_REACT_ACT_ENVIRONMENT = true;
@@ -223,7 +222,6 @@ describe('Activity Suspense', () => {
     expect(root).toMatchRenderedOutput('');
   });
 
-  // @gate enableActivity
   test("suspending inside currently hidden tree that's switching to visible", async () => {
     const root = ReactNoop.createRoot();
 
@@ -282,7 +280,6 @@ describe('Activity Suspense', () => {
     );
   });
 
-  // @gate enableActivity
   test("suspending inside currently visible tree that's switching to hidden", async () => {
     const root = ReactNoop.createRoot();
 
@@ -368,7 +365,6 @@ describe('Activity Suspense', () => {
     );
   });
 
-  // @gate enableActivity
   test('update that suspends inside hidden tree', async () => {
     let setText;
     function Child() {
@@ -401,7 +397,6 @@ describe('Activity Suspense', () => {
     });
   });
 
-  // @gate enableActivity
   test('updates at multiple priorities that suspend inside hidden tree', async () => {
     let setText;
     let setStep;
@@ -458,7 +453,6 @@ describe('Activity Suspense', () => {
     expect(root).toMatchRenderedOutput(<span hidden={true}>B1</span>);
   });
 
-  // @gate enableActivity
   test('detect updates to a hidden tree during a concurrent event', async () => {
     // This is a pretty complex test case. It relates to how we detect if an
     // update is made to a hidden tree: when scheduling the update, we walk up

--- a/packages/react-reconciler/src/__tests__/ActivityStrictMode-test.js
+++ b/packages/react-reconciler/src/__tests__/ActivityStrictMode-test.js
@@ -31,7 +31,7 @@ describe('Activity StrictMode', () => {
     return <span>label</span>;
   }
 
-  // @gate __DEV__ && enableActivity
+  // @gate __DEV__
   it('should trigger strict effects when offscreen is visible', async () => {
     await act(() => {
       ReactNoop.render(
@@ -55,7 +55,7 @@ describe('Activity StrictMode', () => {
     ]);
   });
 
-  // @gate __DEV__ && enableActivity
+  // @gate __DEV__
   it('should not trigger strict effects when offscreen is hidden', async () => {
     await act(() => {
       ReactNoop.render(
@@ -154,7 +154,7 @@ describe('Activity StrictMode', () => {
     });
   });
 
-  // @gate __DEV__ && enableActivity
+  // @gate __DEV__
   it('should double invoke effects on unsuspended child', async () => {
     let shouldSuspend = true;
     let resolve;

--- a/packages/react-reconciler/src/__tests__/ActivitySuspense-test.js
+++ b/packages/react-reconciler/src/__tests__/ActivitySuspense-test.js
@@ -95,7 +95,6 @@ describe('Activity Suspense', () => {
     return text;
   }
 
-  // @gate enableActivity
   it('basic example of suspending inside hidden tree', async () => {
     const root = ReactNoop.createRoot();
 
@@ -171,7 +170,7 @@ describe('Activity Suspense', () => {
     );
   });
 
-  // @gate __DEV__ && enableActivity
+  // @gate __DEV__
   test('Regression: Suspending on hide should not infinite loop.', async () => {
     // This regression only repros in public act.
     global.IS_REACT_ACT_ENVIRONMENT = true;
@@ -220,7 +219,6 @@ describe('Activity Suspense', () => {
     expect(root).toMatchRenderedOutput('');
   });
 
-  // @gate enableActivity
   test("suspending inside currently hidden tree that's switching to visible", async () => {
     const root = ReactNoop.createRoot();
 
@@ -289,7 +287,6 @@ describe('Activity Suspense', () => {
     );
   });
 
-  // @gate enableActivity
   test("suspending inside currently visible tree that's switching to hidden", async () => {
     const root = ReactNoop.createRoot();
 
@@ -380,7 +377,6 @@ describe('Activity Suspense', () => {
     );
   });
 
-  // @gate enableActivity
   test('update that suspends inside hidden tree', async () => {
     let setText;
     function Child() {
@@ -413,7 +409,6 @@ describe('Activity Suspense', () => {
     });
   });
 
-  // @gate enableActivity
   test('updates at multiple priorities that suspend inside hidden tree', async () => {
     let setText;
     let setStep;
@@ -470,7 +465,6 @@ describe('Activity Suspense', () => {
     expect(root).toMatchRenderedOutput(<span hidden={true}>B1</span>);
   });
 
-  // @gate enableActivity
   test('detect updates to a hidden tree during a concurrent event', async () => {
     // This is a pretty complex test case. It relates to how we detect if an
     // update is made to a hidden tree: when scheduling the update, we walk up

--- a/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
@@ -696,7 +696,6 @@ describe('ReactDeferredValue', () => {
     expect(root).toMatchRenderedOutput('Content');
   });
 
-  // @gate enableActivity
   it('useDeferredValue can spawn a deferred task while prerendering a hidden tree', async () => {
     function App() {
       const text = useDeferredValue('Final', 'Preview');
@@ -742,7 +741,6 @@ describe('ReactDeferredValue', () => {
     expect(root).toMatchRenderedOutput(<div>Final</div>);
   });
 
-  // @gate enableActivity
   it('useDeferredValue can prerender the initial value inside a hidden tree', async () => {
     function App({text}) {
       const renderedText = useDeferredValue(text, `Preview [${text}]`);
@@ -805,7 +803,6 @@ describe('ReactDeferredValue', () => {
     expect(root).toMatchRenderedOutput(<div>B</div>);
   });
 
-  // @gate enableActivity
   it(
     'useDeferredValue skips the preview state when revealing a hidden tree ' +
       'if the final value is referentially identical',
@@ -845,7 +842,6 @@ describe('ReactDeferredValue', () => {
     },
   );
 
-  // @gate enableActivity
   it(
     'useDeferredValue does not skip the preview state when revealing a ' +
       'hidden tree if the final value is different from the currently rendered one',
@@ -890,7 +886,6 @@ describe('ReactDeferredValue', () => {
     },
   );
 
-  // @gate enableActivity
   it(
     'useDeferredValue does not show "previous" value when revealing a hidden ' +
       'tree (no initial value)',

--- a/packages/react-reconciler/src/__tests__/ReactErrorStacks-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactErrorStacks-test.js
@@ -202,7 +202,6 @@ describe('ReactFragment', () => {
     ]);
   });
 
-  // @gate enableActivity
   it('includes built-in for Activity', async () => {
     ReactNoop.createRoot({
       onCaughtError,

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -3044,7 +3044,6 @@ describe('ReactHooksWithNoopRenderer', () => {
       });
     });
 
-    // @gate enableActivity
     it('warns when setState is called from offscreen deleted insertion effect cleanup', async () => {
       function App(props) {
         const [, setX] = useState(0);

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -966,7 +966,6 @@ describe('ReactLazy', () => {
     );
   });
 
-  // @gate enableActivity
   it('throws with a useful error when wrapping Activity with lazy()', async () => {
     const BadLazy = lazy(() => fakeImport(React.Activity));
 

--- a/packages/react-reconciler/src/__tests__/ReactSiblingPrerendering-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSiblingPrerendering-test.js
@@ -175,7 +175,6 @@ describe('ReactSiblingPrerendering', () => {
     ]);
   });
 
-  // @gate enableActivity
   it("don't skip siblings when rendering inside a hidden tree", async () => {
     function App() {
       return (

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseyCommitPhase-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseyCommitPhase-test.js
@@ -442,7 +442,7 @@ describe('ReactSuspenseyCommitPhase', () => {
     );
   });
 
-  // @gate enableActivity && enableSuspenseyImages
+  // @gate enableSuspenseyImages
   it("host instances don't suspend during prerendering, but do suspend when they are revealed", async () => {
     function More() {
       Scheduler.log('More');

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -305,7 +305,7 @@ describe('ReactFreshIntegration', () => {
       }
     });
 
-    // @gate __DEV__ && enableActivity
+    // @gate __DEV__
     it('ignores ref for class component in hidden subtree', async () => {
       const code = `
         import {Activity} from 'react';
@@ -335,7 +335,7 @@ describe('ReactFreshIntegration', () => {
       await patch(code);
     });
 
-    // @gate __DEV__ && enableActivity
+    // @gate __DEV__
     it('ignores ref for hoistable resource in hidden subtree', async () => {
       const code = `
         import {Activity} from 'react';
@@ -357,7 +357,7 @@ describe('ReactFreshIntegration', () => {
       await patch(code);
     });
 
-    // @gate __DEV__ && enableActivity
+    // @gate __DEV__
     it('ignores ref for host component in hidden subtree', async () => {
       const code = `
         import {Activity} from 'react';
@@ -379,7 +379,7 @@ describe('ReactFreshIntegration', () => {
       await patch(code);
     });
 
-    // @gate __DEV__ && enableActivity
+    // @gate __DEV__
     it('ignores ref for Activity in hidden subtree', async () => {
       const code = `
         import {Activity} from 'react';
@@ -403,7 +403,7 @@ describe('ReactFreshIntegration', () => {
       await patch(code);
     });
 
-    // @gate __DEV__ && enableActivity
+    // @gate __DEV__
     it('ignores ref for Scope in hidden subtree', async () => {
       const code = `
         import {
@@ -430,7 +430,7 @@ describe('ReactFreshIntegration', () => {
       await patch(code);
     });
 
-    // @gate __DEV__ && enableActivity
+    // @gate __DEV__
     it('ignores ref for functional component in hidden subtree', async () => {
       const code = `
         import {Activity} from 'react';
@@ -458,7 +458,7 @@ describe('ReactFreshIntegration', () => {
       await patch(code);
     });
 
-    // @gate __DEV__ && enableActivity
+    // @gate __DEV__
     it('ignores ref for ref forwarding component in hidden subtree', async () => {
       const code = `
         import {
@@ -489,7 +489,7 @@ describe('ReactFreshIntegration', () => {
       await patch(code);
     });
 
-    // @gate __DEV__ && enableActivity
+    // @gate __DEV__
     it('ignores ref for simple memo component in hidden subtree', async () => {
       const code = `
         import {
@@ -520,7 +520,7 @@ describe('ReactFreshIntegration', () => {
       await patch(code);
     });
 
-    // @gate __DEV__ && enableActivity
+    // @gate __DEV__
     it('ignores ref for memo component in hidden subtree', async () => {
       // A custom compare function means this won't use SimpleMemoComponent.
       const code = `


### PR DESCRIPTION
The flag was hardcoded to true in tests and has no effect on the runtime anymore now that `<Activity>` is included in every entrypoint.