### PR TITLE
[flags] Turn on `enableViewTransition` in OSS `react-test-renderer`

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -60,7 +60,7 @@ export const enableEagerAlternateStateNodeCleanup: boolean = true;
 export const enableYieldingBeforePassive: boolean = true;
 
 export const enableThrottledScheduling: boolean = false;
-export const enableViewTransition: boolean = false;
+export const enableViewTransition: boolean = true;
 export const enableGestureTransition: boolean = false;
 export const enableScrollEndPolyfill: boolean = true;
 export const enableSuspenseyImages: boolean = false;


### PR DESCRIPTION
Just to get OSS builds in a consistent state. It's still dynamic in www and off in native-fb