### PR TITLE
[Flight] Fix dev-only crash when passing elements into 3rd party renderers

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -18,6 +18,7 @@ import type {
   ReactFunctionLocation,
   ReactErrorInfoDev,
 } from 'shared/ReactTypes';
+import type {ReactElement} from 'shared/ReactElementType';
 import type {LazyComponent} from 'react/src/ReactLazy';
 
 import type {
@@ -552,6 +553,10 @@ function moveDebugInfoFromChunkToInnerValue<T>(
         resolvedValue._debugInfo,
         debugInfo,
       );
+    } else if (resolvedValue._debugInfo === null) {
+      const elementOrLazy: LazyComponent<mixed, mixed> | ReactElement =
+        (resolvedValue: $FlowFixMe);
+      elementOrLazy._debugInfo = debugInfo;
     } else {
       Object.defineProperty((resolvedValue: any), '_debugInfo', {
         configurable: false,
@@ -2900,6 +2905,10 @@ function addAsyncInfo(chunk: SomeChunk<any>, asyncInfo: ReactAsyncInfo): void {
     if (isArray(value._debugInfo)) {
       // $FlowFixMe[method-unbinding]
       value._debugInfo.push(asyncInfo);
+    } else if (value._debugInfo === null) {
+      const elementOrLazy: LazyComponent<mixed, mixed> | ReactElement =
+        (value: $FlowFixMe);
+      elementOrLazy._debugInfo = [asyncInfo];
     } else {
       Object.defineProperty((value: any), '_debugInfo', {
         configurable: false,


### PR DESCRIPTION
Ran into a crash in Next.js in `addAsyncInfo` with `Cannot redefine property: _debugInfo`. 

Fix is purely motivated by the types. Need to understand crash conditions and if the defect isn't somewhere higher up.