### PR TITLE
Fix autoFocus for all elements and ReDoS in devtools   stack parsing  

### DIFF
--- a/packages/react-devtools-shared/src/backend/utils/parseStackTrace.js
+++ b/packages/react-devtools-shared/src/backend/utils/parseStackTrace.js
@@ -59,7 +59,7 @@ function parseStackTraceFromChromeStack(
   return parsedFrames;
 }
 
-const firefoxFrameRegExp = /^((?:.*".+")?[^@]*)@(.+):(\d+):(\d+)$/;
+const firefoxFrameRegExp = /^([^@"]*(?:"[^"]*"[^@"]*)*)@(.+):(\d+):(\d+)$/;
 function parseStackTraceFromFirefoxStack(
   stack: string,
   skipFrames: number,
@@ -94,7 +94,7 @@ function parseStackTraceFromFirefoxStack(
   return parsedFrames;
 }
 
-const CHROME_STACK_REGEXP = /^\s*at .*(\S+:\d+|\(native\))/m;
+const CHROME_STACK_REGEXP = /^\s*at /m;
 export function parseStackTraceFromString(
   stack: string,
   skipFrames: number,

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -661,7 +661,8 @@ export function finalizeInitialChildren(
     case 'img':
       return true;
     default:
-      return false;
+      // autoFocus is a global HTML attribute that applies to all elements.
+      return !!props.autoFocus;
   }
 }
 
@@ -888,6 +889,13 @@ export function commitMount(
         ((domElement: any): HTMLImageElement).src = src;
       } else if (newProps.srcSet) {
         ((domElement: any): HTMLImageElement).srcset = (newProps: any).srcSet;
+      }
+      return;
+    }
+    default: {
+      // autoFocus is a global HTML attribute that applies to all elements.
+      if (newProps.autoFocus) {
+        ((domElement: any): HTMLElement).focus();
       }
       return;
     }

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -386,6 +386,73 @@ describe('ReactDOM', () => {
     }
   });
 
+  it('calls focus() on autoFocus anchor elements after they have been mounted to the DOM', async () => {
+    const originalFocus = HTMLElement.prototype.focus;
+
+    try {
+      let focusedElement;
+      let anchorFocusedAfterMount = false;
+
+      HTMLElement.prototype.focus = function () {
+        focusedElement = this;
+        anchorFocusedAfterMount = !!this.parentNode;
+      };
+
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => {
+        root.render(
+          <div>
+            <h1>Auto-focus Test</h1>
+            <a href="https://react.dev" autoFocus={true}>
+              Link
+            </a>
+            <p>The above anchor should be focused after mount.</p>
+          </div>,
+        );
+      });
+
+      expect(anchorFocusedAfterMount).toBe(true);
+      expect(focusedElement.tagName).toBe('A');
+    } finally {
+      HTMLElement.prototype.focus = originalFocus;
+    }
+  });
+
+  it('calls focus() on autoFocus for any focusable element after mount', async () => {
+    const originalFocus = HTMLElement.prototype.focus;
+
+    try {
+      let focusedElement;
+      let elementFocusedAfterMount = false;
+
+      HTMLElement.prototype.focus = function () {
+        focusedElement = this;
+        elementFocusedAfterMount = !!this.parentNode;
+      };
+
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => {
+        root.render(
+          <div>
+            <div tabIndex={0} autoFocus={true} id="focusable-div">
+              Focusable div
+            </div>
+          </div>,
+        );
+      });
+
+      expect(elementFocusedAfterMount).toBe(true);
+      expect(focusedElement.tagName).toBe('DIV');
+      expect(focusedElement.id).toBe('focusable-div');
+    } finally {
+      HTMLElement.prototype.focus = originalFocus;
+    }
+  });
+
   it("shouldn't fire duplicate event handler while handling other nested dispatch", async () => {
     const actual = [];
 


### PR DESCRIPTION
 ## Summary

  This PR addresses two open issues:

  ### 1. Support autoFocus as a global HTML attribute
  (#35656)

  `autoFocus` is a [global HTML
  attribute](https://developer.mozilla.org/en-US/docs/W
  eb/HTML/Global_attributes/autofocus) per the spec,
  but React only handled it for `button`, `input`,
  `select`, and `textarea`. This change treats
  `autoFocus` as a global attribute so it works on
  **any focusable element** — anchor tags, `<div
  tabIndex={0}>`, `<dialog>`, `<details>`, etc.

  Changes:
  - `finalizeInitialChildren`: default case now returns
   `!!props.autoFocus`
  - `commitMount`: default case now calls `.focus()`
  when `autoFocus` is set
  - Added tests for `<a autoFocus>` and `<div
  tabIndex={0} autoFocus>`

  ### 2. Fix ReDoS vulnerabilities in stack trace
  parsing (#35490)

  Two regex patterns in `parseStackTrace.js` are
  vulnerable to catastrophic backtracking:

  - **`firefoxFrameRegExp`**: `(?:.*".+")?[^@]*`
  contains overlapping quantifiers. Replaced with
  `[^@"]*(?:"[^"]*"[^@"]*)*` using non-overlapping
  character classes.
  - **`CHROME_STACK_REGEXP`**: `.*(\S+:\d+|\(native\))`
   causes O(n²) backtracking. Simplified to `/^\s*at
  /m`.