### PR TITLE
[DevTools] Throw an error when attempting to clone non-existent node

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitTreeBuilder.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitTreeBuilder.js
@@ -160,11 +160,14 @@ function updateTree(
 
   // Clone nodes before mutating them so edits don't affect them.
   const getClonedNode = (id: number): CommitTreeNode => {
-    // $FlowFixMe[prop-missing] - recommended fix is to use object spread operator
-    const clonedNode = ((Object.assign(
-      {},
-      nodes.get(id),
-    ): any): CommitTreeNode);
+    const existingNode = nodes.get(id);
+    if (existingNode == null) {
+      throw new Error(
+        `Could not clone the node: commit tree does not contain fiber "${id}". This is a bug in React DevTools.`,
+      );
+    }
+
+    const clonedNode = {...existingNode};
     nodes.set(id, clonedNode);
     return clonedNode;
   };


### PR DESCRIPTION
There is an existing issue with serialisation logic for the traces from Profiler panel.

I've discovered that `TREE_OPERATION_UPDATE_TREE_BASE_DURATION` operation for some reason appears earlier in a sequence of operations, before the `TREE_OPERATION_ADD` that registers the new node. It ends up cloning non-existent node, which just creates an empty object and adds it to the map of nodes.

This change only adds additional layer of validation to cloning logic, so we don't swallow the error, if we attempt to clone non-existent node.