### PR TITLE
bug-fix: DevTools - Error logic for missing nodes while deletion

### DIFF
--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -1572,6 +1572,7 @@ export default class Store extends EventEmitter<{
             const id = operations[i];
             const element = this._idToElement.get(id);
 
+            i += 1;
             if (element === undefined) {
               /*
                 - there may be further nodes in the batch to be processed hence throwing error right now is not a good soln
@@ -1579,11 +1580,10 @@ export default class Store extends EventEmitter<{
                 - So I changed it to look for further nodes and skip removing this node 
                 - logically as it is absent so its better logically
               */
-              i += 1;
               continue;
             }
 
-            i += 1;
+        
 
             const {children, ownerID, parentID, weight} = element;
             if (children.length > 0) {

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -1573,13 +1573,14 @@ export default class Store extends EventEmitter<{
             const element = this._idToElement.get(id);
 
             if (element === undefined) {
-              this._throwAndEmitError(
-                Error(
-                  `Cannot remove node "${id}" because no matching node was found in the Store.`,
-                ),
-              );
-
-              break;
+              /*
+                - there may be further nodes in the batch to be processed hence throwing error right now is not a good soln
+                - Our store may be partially updated because of this logic 
+                - So I changed it to look for further nodes and skip removing this node 
+                - logically as it is absent so its better logically
+              */
+              i += 1;
+              continue;
             }
 
             i += 1;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
<!--
 While profiling, React DevTools can receive remove operations for nodes that are not present in the Store. This can happen due to event ordering during concurrent rendering or StrictMode, especially when profiling is started or stopped mid-update.

The current behavior throws an error when attempting to remove a missing node, which aborts the Store update and prevents remaining operations from being processed, leaving our store in a partially updated state.

Change: 

            if (element === undefined) {
              /*
                - there may be further nodes in the batch to be processed hence throwing error right now is not a good soln
                - Our store may be partially updated because of this logic 
                - So I changed it to look for further nodes and skip removing this node 
                - logically as it is absent so its better logically
              */
              i += 1;
              continue;
            }

This change treats removal of a missing node as a no-op, skips the invalid operation while preserving operation stream alignment, and allows subsequent removals to continue, preventing DevTools from crashing in this recoverable scenario. -->

## How did you test this change?

<!--
Built React DevTools locally after applying the change.
Verified that the Components and Profiler tabs continue to function normally.
Tested profiling start/stop flows to ensure DevTools no longer aborts Store updates when encountering missing nodes.
Confirmed that skipping invalid removals does not introduce regressions and that remaining operations in the batch are still processed correctly.

  How exactly did you verify that your PR solves the issue you wanted to solve?
Confirmed that skipping invalid removals does not introduce regressions and that remaining operations in the batch are still processed correctly.
-->

Fixes #35713 
