### PR TITLE
[Compiler] Fix false positive for setState after await in useEffect

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-setState-in-useEffect-after-await.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-setState-in-useEffect-after-await.expect.md
@@ -1,0 +1,53 @@
+
+## Input
+
+```javascript
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import {useCallback, useEffect, useState} from 'react';
+
+function Component() {
+  const [ready, setReady] = useState(false);
+  const f = useCallback(async () => {
+    await fetch('...');
+    setReady(true);
+  }, []);
+
+  useEffect(() => {
+    f();
+  }, [f]);
+
+  return ready;
+}
+
+```
+
+## Code
+
+```javascript
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import { useCallback, useEffect, useState } from "react";
+
+function Component() {
+  const [ready, setReady] = useState(false);
+  const f = useCallback(async () => {
+    await fetch("...");
+    setReady(true);
+  }, []);
+
+  useEffect(() => {
+    f();
+  }, [f]);
+
+  return ready;
+}
+
+```
+
+## Logs
+
+```
+{"kind":"CompileSuccess","fnLoc":{"start":{"line":4,"column":0,"index":124},"end":{"line":16,"column":1,"index":343},"filename":"allow-setState-in-useEffect-after-await.ts"},"fnName":"Component","memoSlots":3,"memoBlocks":2,"memoValues":3,"prunedMemoBlocks":0,"prunedMemoValues":0}
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-setState-in-useEffect-after-await.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-setState-in-useEffect-after-await.js
@@ -1,0 +1,16 @@
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import {useCallback, useEffect, useState} from 'react';
+
+function Component() {
+  const [ready, setReady] = useState(false);
+  const f = useCallback(async () => {
+    await fetch('...');
+    setReady(true);
+  }, []);
+
+  useEffect(() => {
+    f();
+  }, [f]);
+
+  return ready;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-setState-in-useEffect-async-callback.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-setState-in-useEffect-async-callback.expect.md
@@ -1,0 +1,49 @@
+
+## Input
+
+```javascript
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import {useEffect, useState} from 'react';
+
+function Component() {
+  const [state, setState] = useState(0);
+  useEffect(() => {
+    async function run() {
+      await fetch('...');
+      setState(s => s + 1);
+    }
+    run();
+  });
+  return state;
+}
+
+```
+
+## Code
+
+```javascript
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import { useEffect, useState } from "react";
+
+function Component() {
+  const [state, setState] = useState(0);
+  useEffect(() => {
+    async function run() {
+      await fetch("...");
+      setState((s) => s + 1);
+    }
+    run();
+  });
+  return state;
+}
+
+```
+
+## Logs
+
+```
+{"kind":"CompileSuccess","fnLoc":{"start":{"line":4,"column":0,"index":111},"end":{"line":14,"column":1,"index":316},"filename":"allow-setState-in-useEffect-async-callback.ts"},"fnName":"Component","memoSlots":1,"memoBlocks":1,"memoValues":1,"prunedMemoBlocks":0,"prunedMemoValues":0}
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-setState-in-useEffect-async-callback.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-setState-in-useEffect-async-callback.js
@@ -1,0 +1,14 @@
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import {useEffect, useState} from 'react';
+
+function Component() {
+  const [state, setState] = useState(0);
+  useEffect(() => {
+    async function run() {
+      await fetch('...');
+      setState(s => s + 1);
+    }
+    run();
+  });
+  return state;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-setState-in-useEffect-before-await.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-setState-in-useEffect-before-await.expect.md
@@ -1,0 +1,54 @@
+
+## Input
+
+```javascript
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import {useCallback, useEffect, useState} from 'react';
+
+function Component() {
+  const [state, setState] = useState(0);
+  const f = useCallback(async () => {
+    setState(s => s + 1);
+    await fetch('...');
+  }, []);
+
+  useEffect(() => {
+    f();
+  }, [f]);
+
+  return state;
+}
+
+```
+
+## Code
+
+```javascript
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import { useCallback, useEffect, useState } from "react";
+
+function Component() {
+  const [state, setState] = useState(0);
+  const f = useCallback(async () => {
+    setState((s) => s + 1);
+    await fetch("...");
+  }, []);
+
+  useEffect(() => {
+    f();
+  }, [f]);
+
+  return state;
+}
+
+```
+
+## Logs
+
+```
+{"kind":"CompileError","detail":{"options":{"category":"EffectSetState","reason":"Calling setState synchronously within an effect can trigger cascading renders","description":"Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:\n* Update external systems with the latest state from React.\n* Subscribe for updates from some external system, calling setState in a callback function when external state changes.\n\nCalling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect)","suggestions":null,"details":[{"kind":"error","loc":{"start":{"line":12,"column":4,"index":311},"end":{"line":12,"column":5,"index":312},"filename":"invalid-setState-in-useEffect-before-await.ts","identifierName":"f"},"message":"Avoid calling setState() directly within an effect"}]}},"fnLoc":null}
+{"kind":"CompileSuccess","fnLoc":{"start":{"line":4,"column":0,"index":124},"end":{"line":16,"column":1,"index":345},"filename":"invalid-setState-in-useEffect-before-await.ts"},"fnName":"Component","memoSlots":3,"memoBlocks":2,"memoValues":3,"prunedMemoBlocks":0,"prunedMemoValues":0}
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-setState-in-useEffect-before-await.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-setState-in-useEffect-before-await.js
@@ -1,0 +1,16 @@
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import {useCallback, useEffect, useState} from 'react';
+
+function Component() {
+  const [state, setState] = useState(0);
+  const f = useCallback(async () => {
+    setState(s => s + 1);
+    await fetch('...');
+  }, []);
+
+  useEffect(() => {
+    f();
+  }, [f]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary

Fixes #34905

The `set-state-in-effect` validation (`ValidateNoSetStateInEffects`) was incorrectly flagging `setState` calls that appear **after an `await`** expression inside async functions called from `useEffect`.

After an `await`, execution continues asynchronously in a microtask — meaning the `setState` call is no longer synchronous within the effect body and should not trigger this lint.

### Root cause

In `getSetStateCall()`, the function walks through the HIR of the effect callback and returns the first `setState` call it finds, without distinguishing whether that call appears after an `Await` instruction.

### Fix

Added `Await` instruction tracking within each block in `getSetStateCall()`:
- When an `Await` instruction is encountered, a `seenAwait` flag is set for the current block
- Any subsequent `setState` call in the same block after an `Await` is skipped (not reported as synchronous)

This is a conservative fix scoped to intra-block tracking. Cross-block `await` dominator analysis can be added as a follow-up if needed.

## How did you test this change?

Added 3 new test fixtures:

| Fixture | Expected | Description |
|---------|----------|-------------|
| `allow-setState-in-useEffect-after-await` | ✅ No error | setState after `await` via `useCallback` + `useEffect` (exact issue repro) |
| `allow-setState-in-useEffect-async-callback` | ✅ No error | setState after `await` in nested async function inside `useEffect` |
| `invalid-setState-in-useEffect-before-await` | ❌ Error reported | setState **before** `await` is still correctly flagged |

All existing tests continue to pass:

```
$ yarn snap -- -p "invalid-setState-in-useEffect*"
5 Tests, 5 Passed, 0 Failed

$ yarn workspace eslint-plugin-react-compiler test
Test Suites: 8 passed, 8 total
Tests:       31 passed, 31 total
```