### PR TITLE
[DevTools] Allow renaming Host Component props

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/editing-test.js
+++ b/packages/react-devtools-shared/src/__tests__/editing-test.js
@@ -82,7 +82,12 @@ describe('editing interface', () => {
               shallow="initial"
             />
             ,
-            <input ref={inputRef} onChange={jest.fn()} value="initial" />
+            <input
+              ref={inputRef}
+              onChange={jest.fn()}
+              value="initial"
+              data-foo="test"
+            />
           </>,
         ),
       );
@@ -258,6 +263,14 @@ describe('editing interface', () => {
           after: 'initial',
         },
         after: 'initial',
+      });
+      renamePath(hostComponentID, ['data-foo'], ['data-bar']);
+      expect({
+        foo: inputRef.current.dataset.foo,
+        bar: inputRef.current.dataset.bar,
+      }).toEqual({
+        foo: undefined,
+        bar: 'test',
       });
     });
 

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -7874,17 +7874,20 @@ export function attach(
           }
           break;
         case 'props':
-          if (instance === null) {
-            if (typeof overridePropsRenamePath === 'function') {
-              overridePropsRenamePath(fiber, oldPath, newPath);
-            }
-          } else {
-            fiber.pendingProps = copyWithRename(
-              instance.props,
-              oldPath,
-              newPath,
-            );
-            instance.forceUpdate();
+          switch (fiber.tag) {
+            case ClassComponent:
+              fiber.pendingProps = copyWithRename(
+                instance.props,
+                oldPath,
+                newPath,
+              );
+              instance.forceUpdate();
+              break;
+            default:
+              if (typeof overridePropsRenamePath === 'function') {
+                overridePropsRenamePath(fiber, oldPath, newPath);
+              }
+              break;
           }
           break;
         case 'state':


### PR DESCRIPTION

## Summary

Renaming props only considered Fibers without an instance (e.g. Function Components) and Class Components. However, Host Components have an instance but don't implement `forceUpdate` thus crashing the frontend. Now we only use `forceUpdate` for Class Components like we do in all the other places where we use `forceUpdate`. Otherwise we use `overridePropsRenamePath` regardless of the `instance` which allows renaming props of Host Components. 

Found with Claude + Opus 4.6

## How did you test this change?

- [x] Added test