### PR TITLE
[DevTools] Only block child Suspense boundaries if the parent has all shared suspenders removed

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -3686,7 +3686,7 @@ describe('Store', () => {
               <Component key="three">
       [suspense-root]  rects={null}
         <Suspense name="outer" uniqueSuspenders={true} rects={null}>
-          <Suspense name="inner" uniqueSuspenders={true} rects={null}>
+          <Suspense name="inner" uniqueSuspenders={false} rects={null}>
     `);
 
     // Now we remove all unique suspenders of the outer Suspense boundary.

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -3197,15 +3197,16 @@ export function attach(
                 environmentCounts.set(env, count - 1);
               }
             }
-          }
-          if (
-            suspenseNode.hasUniqueSuspenders &&
-            !ioExistsInSuspenseAncestor(suspenseNode, ioInfo)
-          ) {
-            // This entry wasn't in any ancestor and is no longer in this suspense boundary.
-            // This means that a child might now be the unique suspender for this IO.
-            // Search the child boundaries to see if we can reveal any of them.
-            unblockSuspendedBy(suspenseNode, ioInfo);
+
+            if (
+              suspenseNode.hasUniqueSuspenders &&
+              !ioExistsInSuspenseAncestor(suspenseNode, ioInfo)
+            ) {
+              // This entry wasn't in any ancestor and is no longer in this suspense boundary.
+              // This means that a child might now be the unique suspender for this IO.
+              // Search the child boundaries to see if we can reveal any of them.
+              unblockSuspendedBy(suspenseNode, ioInfo);
+            }
           }
         }
       }


### PR DESCRIPTION

## Summary

Stacked on https://github.com/facebook/react/pull/35736

A Suspense boundary is considered unblocked by I/O removal if no more children (until the next Suspense boundary) are blocked on the same I/O. However, we used to unblock if at least one children with this I/O was removed. Now we check if no more children are blocked on the same I/O.

This was probably an oversight. The unblocking should happen in the same codeblock that checks if all dependencies are removed.

Found with Claude + Opus 4.6

## How did you test this change?

- [x] added test (see first commit for current behavior vs 2nd commit for changed behavior)