### PR TITLE
Consistent handling of work tags for rename, delete, and overriding state

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -7819,6 +7819,7 @@ export function attach(
         case 'state':
           switch (fiber.tag) {
             case ClassComponent:
+            case IncompleteClassComponent:
               deletePathInObject(instance.state, path);
               instance.forceUpdate();
               break;


### PR DESCRIPTION
Mostly to make it easier to reason locally about this code. Rename and delete relied implicitly on `inspectElementRaw` to only show state for Class Components but there was already a TODO to expand that which would've crashed rename and delete.

Flagged by Claude + Opus 4.6 (which didn't make the connection with `inspectElementRaw` and assumed this fixes a crash).