### PR TITLE
[DevTools] Fix memory leak when unmounting hoistables

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -3669,6 +3669,6 @@ describe('Store', () => {
     `);
     style = document.head.querySelector('style');
     styleID = agent.getIDForHostInstance(style).id;
-    expect(store.containsElement(styleID)).toBe(false);
+    expect(store.containsElement(styleID)).toBe(true);
   });
 });

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -991,8 +991,8 @@ function releaseHostResource(
         // eslint-disable-next-line no-for-of-loops/no-for-of-loops
         for (const firstInstance of resourceInstances) {
           publicInstanceToDevToolsInstanceMap.set(
+            publicInstance,
             firstInstance,
-            nearestInstance,
           );
           break;
         }


### PR DESCRIPTION
## Summary

For Host Hoistables we have may have many devtools instances to choose from as the nearest instance since React Float may have deduplicated the public host instance. We keep an internal map from the public host instance to the chosen devtools instance. When we were unmounting a Host Hoistable, we pick the next Fiber that's also referencing the same public host instance.

Unfortunately we were using the wrong values when moving those pointers. This wasn't caught by Flow since our `HostInstance` type is any object so you can assign anything to it and assign it to anything (here we assigned a `DevToolsInstance` to a `HostInstance`).

We could improve type safety for those operations but it's quite involved. It's the only bug where we currently accidentally assign these two types. If this happens more often, we can harden the types.

Also ensures element inspection works when unmounting Hoist Hoistables. You'd have to actually inspect the DOM node to notice the bug. The memory leak you always get so I choose that bug as the headline.

Found with Claude + Opus 4.6

## How did you test this change?

- [x] Added test (1st commit has previous behavior)