### PR TITLE
compiler: fix interleaved hook chained-call memoization

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-arg-in-hook.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-arg-in-hook.expect.md
@@ -1,0 +1,52 @@
+
+## Input
+
+```javascript
+export function useFoo(id: string) {
+  const bar = useBar();
+  const value = func(bar);
+
+  const {data} = useBaz(value);
+  const a = result(data, value);
+
+  return a;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+export function useFoo(id) {
+  const $ = _c(5);
+  const bar = useBar();
+  let t0;
+  if ($[0] !== bar) {
+    t0 = func(bar);
+    $[0] = bar;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  const value = t0;
+
+  const { data } = useBaz(value);
+  let t1;
+  if ($[2] !== data || $[3] !== value) {
+    t1 = result(data, value);
+    $[2] = data;
+    $[3] = value;
+    $[4] = t1;
+  } else {
+    t1 = $[4];
+  }
+  const a = t1;
+
+  return a;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-arg-in-hook.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-arg-in-hook.ts
@@ -1,0 +1,9 @@
+export function useFoo(id: string) {
+  const bar = useBar();
+  const value = func(bar);
+
+  const {data} = useBaz(value);
+  const a = result(data, value);
+
+  return a;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-arg-used-after.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-arg-used-after.expect.md
@@ -1,0 +1,50 @@
+
+## Input
+
+```javascript
+export function useFoo(id: string) {
+  const bar = useBar();
+  const value = func(bar);
+
+  const {data} = useBaz(options(id));
+  const a = result(data, value);
+
+  return [a, value];
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+export function useFoo(id) {
+  const $ = _c(5);
+  const bar = useBar();
+  const value = func(bar);
+  let t0;
+  if ($[0] !== id) {
+    t0 = options(id);
+    $[0] = id;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  const { data } = useBaz(t0);
+  const a = result(data, value);
+  let t1;
+  if ($[2] !== a || $[3] !== value) {
+    t1 = [a, value];
+    $[2] = a;
+    $[3] = value;
+    $[4] = t1;
+  } else {
+    t1 = $[4];
+  }
+  return t1;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-arg-used-after.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-arg-used-after.ts
@@ -1,0 +1,9 @@
+export function useFoo(id: string) {
+  const bar = useBar();
+  const value = func(bar);
+
+  const {data} = useBaz(options(id));
+  const a = result(data, value);
+
+  return [a, value];
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-non-call-arg.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-non-call-arg.expect.md
@@ -1,0 +1,46 @@
+
+## Input
+
+```javascript
+export function useFoo(id: string, value: number) {
+  const {data} = useBaz(options(id));
+  const a = result(data, value);
+
+  return a;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+export function useFoo(id, value) {
+  const $ = _c(5);
+  let t0;
+  if ($[0] !== id) {
+    t0 = options(id);
+    $[0] = id;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  const { data } = useBaz(t0);
+  let t1;
+  if ($[2] !== data || $[3] !== value) {
+    t1 = result(data, value);
+    $[2] = data;
+    $[3] = value;
+    $[4] = t1;
+  } else {
+    t1 = $[4];
+  }
+  const a = t1;
+
+  return a;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-non-call-arg.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-non-call-arg.ts
@@ -1,0 +1,6 @@
+export function useFoo(id: string, value: number) {
+  const {data} = useBaz(options(id));
+  const a = result(data, value);
+
+  return a;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-non-call-use.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-non-call-use.expect.md
@@ -1,0 +1,77 @@
+
+## Input
+
+```javascript
+export function useFoo(id: string) {
+  const bar = useBar();
+  const value = func(bar);
+  const arr = [value];
+
+  const {data} = useBaz(options(id));
+  const a = result(data, value);
+
+  return [a, arr];
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+export function useFoo(id) {
+  const $ = _c(12);
+  const bar = useBar();
+  let t0;
+  if ($[0] !== bar) {
+    t0 = func(bar);
+    $[0] = bar;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  const value = t0;
+  let t1;
+  if ($[2] !== value) {
+    t1 = [value];
+    $[2] = value;
+    $[3] = t1;
+  } else {
+    t1 = $[3];
+  }
+  const arr = t1;
+  let t2;
+  if ($[4] !== id) {
+    t2 = options(id);
+    $[4] = id;
+    $[5] = t2;
+  } else {
+    t2 = $[5];
+  }
+  const { data } = useBaz(t2);
+  let t3;
+  if ($[6] !== data || $[7] !== value) {
+    t3 = result(data, value);
+    $[6] = data;
+    $[7] = value;
+    $[8] = t3;
+  } else {
+    t3 = $[8];
+  }
+  const a = t3;
+  let t4;
+  if ($[9] !== a || $[10] !== arr) {
+    t4 = [a, arr];
+    $[9] = a;
+    $[10] = arr;
+    $[11] = t4;
+  } else {
+    t4 = $[11];
+  }
+  return t4;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-non-call-use.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-non-call-use.ts
@@ -1,0 +1,10 @@
+export function useFoo(id: string) {
+  const bar = useBar();
+  const value = func(bar);
+  const arr = [value];
+
+  const {data} = useBaz(options(id));
+  const a = result(data, value);
+
+  return [a, arr];
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-triple-chain.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-triple-chain.expect.md
@@ -1,0 +1,73 @@
+
+## Input
+
+```javascript
+export function useFoo(id: string) {
+  const bar = useBar();
+  const b = transform(bar);
+
+  const {data} = useBaz(options(id));
+  const c = transform2(b, data);
+
+  useQux();
+  const d = transform3(c);
+
+  return d;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+export function useFoo(id) {
+  const $ = _c(9);
+  const bar = useBar();
+  let t0;
+  if ($[0] !== bar) {
+    t0 = transform(bar);
+    $[0] = bar;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  const b = t0;
+  let t1;
+  if ($[2] !== id) {
+    t1 = options(id);
+    $[2] = id;
+    $[3] = t1;
+  } else {
+    t1 = $[3];
+  }
+  const { data } = useBaz(t1);
+  let t2;
+  if ($[4] !== b || $[5] !== data) {
+    t2 = transform2(b, data);
+    $[4] = b;
+    $[5] = data;
+    $[6] = t2;
+  } else {
+    t2 = $[6];
+  }
+  const c = t2;
+
+  useQux();
+  let t3;
+  if ($[7] !== c) {
+    t3 = transform3(c);
+    $[7] = c;
+    $[8] = t3;
+  } else {
+    t3 = $[8];
+  }
+  const d = t3;
+
+  return d;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-triple-chain.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization-triple-chain.ts
@@ -1,0 +1,12 @@
+export function useFoo(id: string) {
+  const bar = useBar();
+  const b = transform(bar);
+
+  const {data} = useBaz(options(id));
+  const c = transform2(b, data);
+
+  useQux();
+  const d = transform3(c);
+
+  return d;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization.expect.md
@@ -1,0 +1,59 @@
+
+## Input
+
+```javascript
+export function useFoo(id: string) {
+  const bar = useBar();
+  const value = func(bar);
+
+  const {data} = useBaz(options(id));
+  const a = result(data, value);
+
+  return a;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+export function useFoo(id) {
+  const $ = _c(7);
+  const bar = useBar();
+  let t0;
+  if ($[0] !== bar) {
+    t0 = func(bar);
+    $[0] = bar;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  const value = t0;
+  let t1;
+  if ($[2] !== id) {
+    t1 = options(id);
+    $[2] = id;
+    $[3] = t1;
+  } else {
+    t1 = $[3];
+  }
+  const { data } = useBaz(t1);
+  let t2;
+  if ($[4] !== data || $[5] !== value) {
+    t2 = result(data, value);
+    $[4] = data;
+    $[5] = value;
+    $[6] = t2;
+  } else {
+    t2 = $[6];
+  }
+  const a = t2;
+
+  return a;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-hook-interleaved-chained-call-memoization.ts
@@ -1,0 +1,9 @@
+export function useFoo(id: string) {
+  const bar = useBar();
+  const value = func(bar);
+
+  const {data} = useBaz(options(id));
+  const a = result(data, value);
+
+  return a;
+}


### PR DESCRIPTION
## Summary
                                                                                                                                             
Fixes memoization instability reported in #35237, where two chained calls separated by an unrelated hook call are not memoized.

The compiler produced non-memoized output for code like:
```js
  const b = transform(a);
  useState(); // unrelated hook
  const c = transform(b);
```

Root cause: In `InferMutationAliasingEffects`, the unknown-call fallback conservatively emits `MutateTransitiveConditionally` for call operands. For chained call results separated by a hook, this over-approximates mutation on the intermediate value and extends its mutable range across the interleaved hook call, preventing scope construction from memoizing either call.

### Fix:

Add a pre-pass (`collectOperandUsageInfo`) that collects declaration usage metadata, then skip the conservative `MutateTransitiveConditionally` for an arg only when all of the following hold:
  1. The call result is consumed downstream
  2. The arg is used exclusively as call arguments
  3. The arg root is produced by a call/new/method-call
  4. A hook call exists between the arg root definition and the current call
  5. The arg has no uses after the current call

This keeps the conservative behavior everywhere else and only avoids the specific over-approximation that breaks memoization in this pattern.

The pre-pass is skipped entirely for functions with no hook calls, and uses path-compressed union-find and binary search for efficiency (it still has a perf impact tho)

## How did you test this change?

Ran the full compiler fixture suite (1844 tests, 0 failures):
```bash
  yarn snap
  # 1844 Tests, 1844 Passed, 0 Failed
```

#### Added 6 fixture tests covering the fix and its boundary conditions:

Fixture: repro-hook-interleaved-chained-call-memoization
What it tests: Original repro, both func(bar) and result(data, value) are now memoized

Fixture: ...-arg-used-after
What it tests: Arg used after the second call — optimization correctly does NOT fire, preserving conservative mutation

Fixture: ...-triple-chain
What it tests: Three chained calls with hooks between each, all three memoized independently

Fixture: ...-arg-in-hook
What it tests: Arg flows into the hook itself, both calls memoized

Fixture: ...-non-call-arg
What it tests: Arg is a function parameter (not a call result), memoized without the optimization

Fixture: ...-non-call-use
What it tests: Arg used in non-call context (array literal), memoized, confirms bug only manifests through unknown-call path