### PR TITLE
[DevTools] Dedicated empty state for roots that aren't suspended by anything

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
@@ -36,6 +36,7 @@ import {
   UNKNOWN_SUSPENDERS_REASON_OLD_VERSION,
   UNKNOWN_SUSPENDERS_REASON_THROWN_PROMISE,
 } from '../../../constants';
+import {ElementTypeRoot} from 'react-devtools-shared/src/frontend/types';
 
 type RowProps = {
   bridge: FrontendBridge,
@@ -477,7 +478,21 @@ export default function InspectedElementSuspendedBy({
         </div>
       );
     }
-    return null;
+    // For roots, show an empty state since there's nothing else to show for
+    // these elements.
+    // This can happen for older versions of React without Suspense, older versions
+    // of React with less sources for Suspense, or simple UIs that don't have any suspenders.
+    if (inspectedElement.type === ElementTypeRoot) {
+      return (
+        <div>
+          <div className={styles.HeaderRow}>
+            <div className={`${styles.Header} ${styles.Empty}`}>
+              Nothing suspended the initial paint.
+            </div>
+          </div>
+        </div>
+      );
+    }
   }
 
   const handleCopy = withPermissionsCheck(


### PR DESCRIPTION
## Summary

Stacked on https://github.com/facebook/react/pull/35768

For roots without any suspenders, the inspected element pane is completely empty. For older versions of React without Suspense, older versions of React with less sources for Suspense, or simple UIs that don't have any suspenders this can look like something isn't working. You're mostly inspecting the root in the Suspense tab so we need something to show.

## How did you test this change?

- Fallback shown in https://new.csb.app
    <img width="2218" height="236" alt="CleanShot 2026-02-12 at 09 00 55@2x" src="https://github.com/user-attachments/assets/bbe96919-3c14-4ad3-9879-92d1bbf1ad5b" />

