### PR TITLE
Fixes #35770: react-compiler-runtime missing makeReadOnly/shouldInstrument/useContext_withSelector

### DIFF
--- a/compiler/packages/react-compiler-runtime/jest.config.js
+++ b/compiler/packages/react-compiler-runtime/jest.config.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/compiler/packages/react-compiler-runtime/package.json
+++ b/compiler/packages/react-compiler-runtime/package.json
@@ -12,9 +12,14 @@
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
   },
+  "devDependencies": {
+    "@types/jest": "^28.1.6",
+    "jest": "^28.1.3",
+    "ts-jest": "^28.0.7"
+  },
   "scripts": {
     "build": "rimraf dist && tsup",
-    "test": "echo 'no tests'",
+    "test": "jest src",
     "watch": "yarn build --watch"
   },
   "repository": {

--- a/compiler/packages/react-compiler-runtime/src/__tests__/exports.test.ts
+++ b/compiler/packages/react-compiler-runtime/src/__tests__/exports.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression test for https://github.com/facebook/react/issues/35770
+ *
+ * Validates that react-compiler-runtime exports all helpers that the
+ * compiler may emit imports for (via testComplexConfigDefaults in
+ * babel-plugin-react-compiler/src/Utils/TestUtils.ts).
+ */
+
+import * as runtime from '../index';
+
+describe('react-compiler-runtime export surface', () => {
+  test('exports c (memo cache polyfill)', () => {
+    expect(typeof runtime.c).toBe('function');
+  });
+
+  test('exports $dispatcherGuard (hook guards)', () => {
+    expect(typeof runtime.$dispatcherGuard).toBe('function');
+  });
+
+  test('exports $structuralCheck (change detection)', () => {
+    expect(typeof runtime.$structuralCheck).toBe('function');
+  });
+
+  test('exports useRenderCounter (instrumentation)', () => {
+    expect(typeof runtime.useRenderCounter).toBe('function');
+  });
+
+  test('exports $reset', () => {
+    expect(typeof runtime.$reset).toBe('function');
+  });
+
+  // --- Helpers added to fix #35770 ---
+
+  test('exports makeReadOnly (enableEmitFreeze)', () => {
+    expect(typeof runtime.makeReadOnly).toBe('function');
+  });
+
+  test('exports $makeReadOnly as alias for makeReadOnly', () => {
+    expect(typeof runtime.$makeReadOnly).toBe('function');
+    expect(runtime.$makeReadOnly).toBe(runtime.makeReadOnly);
+  });
+
+  test('$makeReadOnly does not throw TODO', () => {
+    // Before the fix, $makeReadOnly threw "TODO: implement $makeReadOnly..."
+    expect(() => runtime.$makeReadOnly('hello', 'test')).not.toThrow();
+  });
+
+  test('exports shouldInstrument (enableEmitInstrumentForget gating)', () => {
+    // shouldInstrument is used as a boolean value in compiled output:
+    //   if (DEV && shouldInstrument) useRenderCounter(...)
+    expect('shouldInstrument' in runtime).toBe(true);
+    expect(typeof runtime.shouldInstrument).toBe('boolean');
+    expect(runtime.shouldInstrument).toBe(true);
+  });
+
+  test('exports useContext_withSelector (lowerContextAccess)', () => {
+    expect(typeof runtime.useContext_withSelector).toBe('function');
+  });
+});
+
+describe('makeReadOnly', () => {
+  test('returns primitive values unchanged', () => {
+    expect(runtime.makeReadOnly(42, 'test')).toBe(42);
+    expect(runtime.makeReadOnly('hello', 'test')).toBe('hello');
+    expect(runtime.makeReadOnly(true, 'test')).toBe(true);
+    expect(runtime.makeReadOnly(null, 'test')).toBe(null);
+    expect(runtime.makeReadOnly(undefined, 'test')).toBe(undefined);
+  });
+
+  test('returns same object reference', () => {
+    const obj = {a: 1, b: 2};
+    const result = runtime.makeReadOnly(obj, 'TestComponent');
+    expect(result).toBe(obj);
+  });
+
+  test('logs error on mutation of frozen property', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const obj = {x: 1};
+    runtime.makeReadOnly(obj, 'TestComponent');
+    obj.x = 2;
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  test('source parameter is optional', () => {
+    expect(() => runtime.makeReadOnly({a: 1})).not.toThrow();
+  });
+});


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
This PR resolves a compiler/runtime contract mismatch where `react-compiler-runtime` was missing exports that the React Compiler emits in compiled code when certain features are enabled.

**Problem:** The compiler's test/playground configuration (`testComplexConfigDefaults` in `TestUtils.ts`) enables three features that generate imports from `react-compiler-runtime`:
- `enableEmitFreeze` → imports `makeReadOnly` 
- `enableEmitInstrumentForget.gating` → imports `shouldInstrument`
- `lowerContextAccess` → imports `useContext_withSelector`

However, the runtime package did not export these helpers. The existing `$makeReadOnly` threw a TODO error, causing compiled code to crash at runtime.

**Solution:** This PR implements and exports the three missing helpers with correct semantics:

1. **`makeReadOnly(val, source)`** — Mutation-tracking proxy for dev-mode debugging. Implementation inlined from the existing `make-read-only-util` package (to avoid adding dependencies). Logs `console.error` when values the compiler treats as immutable are mutated. Also aliases `$makeReadOnly` to this implementation.

2. **`shouldInstrument`** — Exported as `const shouldInstrument: boolean = true`. The compiler emits this as a bare identifier in `if (DEV && shouldInstrument)`, not as a function call. Value is `true` since the `DEV` global already provides the dev/prod gate.

3. **`useContext_withSelector(context, selector)`** — Correctness-first fallback that delegates to `React.useContext(context)` (ignoring the selector). The selector enables future optimizations; this implementation is semantically correct for React 17/18/19.

This PR also adds Jest test infrastructure and comprehensive export surface tests to prevent future drift.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
### 1. New Unit Tests
```bash
cd /Users/huy/Desktop/react/compiler
yarn workspace react-compiler-runtime test
```

**Result:** [x] All 14 tests passed

**Test Coverage:**
- All required exports are present with correct types
- `makeReadOnly` handles primitives, objects, and logs mutations
- `shouldInstrument` is a boolean (not a function)  
- `$makeReadOnly` no longer throws TODO error
- `useContext_withSelector` is callable

**Output:**
```
PASS src/__tests__/exports.test.ts
  react-compiler-runtime export surface
    ✓ exports c (memo cache polyfill) (1 ms)
    ✓ exports $dispatcherGuard (hook guards) (1 ms)
    ✓ exports $structuralCheck (change detection)
    ✓ exports useRenderCounter (instrumentation)
    ✓ exports $reset
    ✓ exports makeReadOnly (enableEmitFreeze)
    ✓ exports $makeReadOnly as alias for makeReadOnly
    ✓ $makeReadOnly does not throw TODO
    ✓ exports shouldInstrument (enableEmitInstrumentForget gating)
    ✓ exports useContext_withSelector (lowerContextAccess)
  makeReadOnly
    ✓ returns primitive values unchanged (1 ms)
    ✓ returns same object reference
    ✓ logs error on mutation of frozen property
    ✓ source parameter is optional (1 ms)

Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
```

### 2. Lint Checks
```bash
cd /Users/huy/Desktop/react
yarn linc
```

**Result:** [x] Lint passed for changed files

### 3. Manual Verification

**Verify exports are present:**
```bash
yarn workspace react-compiler-runtime build
node -e "const r=require('./compiler/packages/react-compiler-runtime/dist/index.js'); \
  console.log({ \
    makeReadOnly: typeof r.makeReadOnly, \
    shouldInstrument: typeof r.shouldInstrument, \
    useContext_withSelector: typeof r.useContext_withSelector, \
    \$makeReadOnly: typeof r.\$makeReadOnly \
  })"
```

**Output:**
```javascript
{
  makeReadOnly: 'function',
  shouldInstrument: 'boolean',
  useContext_withSelector: 'function',
  $makeReadOnly: 'function'
}
```

**Verify $makeReadOnly no longer throws:**
```bash
node -e "require('./compiler/packages/react-compiler-runtime/dist/index.js').\$makeReadOnly('test', 'source')"
```
**Result:** [x] No error (previously threw: "TODO: implement $makeReadOnly")

### 4. Before/After Comparison

**Before this PR:**
- [ ] `makeReadOnly` was `undefined`
- [ ] `shouldInstrument` was `undefined`  
- [ ] `useContext_withSelector` was `undefined`
- [ ] `$makeReadOnly()` threw error: `"TODO: implement $makeReadOnly in react-compiler-runtime"`
- [ ] Compiled code with these features enabled would crash at runtime

**After this PR:**
- [x] All three helpers are properly exported
- [x] `$makeReadOnly` is now a working alias for `makeReadOnly`
- [x] Compiled code executes successfully
- [x] Mutation tracking works in dev mode (logs to console)

### 5. Files Changed

```
compiler/packages/react-compiler-runtime/jest.config.js              (new file)
compiler/packages/react-compiler-runtime/package.json               (modified)
compiler/packages/react-compiler-runtime/src/__tests__/exports.test.ts  (new file)
compiler/packages/react-compiler-runtime/src/index.ts               (modified)
```

**Total changes:** 4 files changed, 275 insertions(+), 3 deletions(-)

## Miscellaneous

**No breaking changes:** No existing public API behavior is modified (except `$makeReadOnly` which was non-functional and threw an error)

**Backward compatible:** Works with React 17/18/19 (the full peer dependency range: `^17.0.0 || ^18.0.0 || ^19.0.0`)

**Consistent semantics:** The `makeReadOnly` implementation is inlined from the repo's existing `make-read-only-util` package, ensuring consistency

**Safe fallback:** `useContext_withSelector` returns semantically correct values (full context object). Future optimizations can be added without breaking the contract

**Zero new dependencies:** Implementation is self-contained, no new packages added to `react-compiler-runtime`

**Test coverage:** Comprehensive tests prevent future regression