### PR TITLE
[react-compiler-healthcheck] Add verbose failed-component reporting

### DIFF
--- a/compiler/packages/react-compiler-healthcheck/src/index.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/index.ts
@@ -22,6 +22,11 @@ async function main() {
       type: 'string',
       default: '**/+(*.{js,mjs,jsx,ts,tsx}|package.json)',
     })
+    .option('verbose', {
+      description: 'print detailed compiler failures',
+      type: 'boolean',
+      default: false,
+    })
     .parseSync();
 
   const spinner = ora('Checking').start();
@@ -48,7 +53,7 @@ async function main() {
   }
   spinner.stop();
 
-  reactCompilerCheck.report();
+  reactCompilerCheck.report(argv.verbose);
   strictModeCheck.report();
   libraryCompatCheck.report();
 }


### PR DESCRIPTION
## Summary

This PR adds a `--verbose` flag to `react-compiler-healthcheck` so failed component compilation details are printed only when requested.

- Added a `--verbose` boolean CLI option in `react-compiler-healthcheck`.
- Kept default behavior unchanged (the existing summary line is still the default output).
- In verbose mode, failures are printed from both `ActionableFailures` and `OtherFailures`, including:
  - file path
  - location (when available)
  - reason/message
- Sorted verbose failure output deterministically for stable/debuggable output.

Fixes #35772

## How did you test this change?

I verified both build success and runtime CLI behavior in default and verbose modes.

```bash
cd compiler
yarn workspace react-compiler-healthcheck build
yarn workspace react-compiler-healthcheck test
```

```bash
# default mode (summary-only)
node ./packages/react-compiler-healthcheck/dist/index.js --src "../.sisyphus/tmp/healthcheck-failure-sample.tsx"

# verbose mode (includes failure details)
node ./packages/react-compiler-healthcheck/dist/index.js --src "../.sisyphus/tmp/healthcheck-failure-sample.tsx" --verbose
```

Observed results:

- Build succeeded.
- Default mode kept summary-only behavior (no detailed failure list).
- Verbose mode printed detailed failure entries with file/location/reason.
- For a failing sample, output included a concrete `[ActionableFailure] ...` line with source location and compiler reason.