### PR TITLE
[eslint-plugin-react-hooks] Sync meta.version with package.json

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import type {Linter, Rule} from 'eslint';
+import packageJson from '../package.json';
 
 import ExhaustiveDeps from './rules/ExhaustiveDeps';
 import {
@@ -80,7 +81,7 @@ const configs = {
 const plugin = {
   meta: {
     name: 'eslint-plugin-react-hooks',
-    version: '7.0.0',
+    version: packageJson.version,
   },
   rules,
   configs,


### PR DESCRIPTION
## Summary

This change removes the hardcoded plugin metadata version in `eslint-plugin-react-hooks` and sources it from `package.json` instead.

- Replaced `meta.version: '7.0.0'` with `meta.version: packageJson.version`.
- This keeps plugin metadata in sync with published package versioning and avoids manual drift.
- Scope is intentionally minimal: one file, no behavior changes to rules/configs.

Fixes #35722

## How did you test this change?

I validated the package with typecheck and test runs.

```bash
yarn workspace eslint-plugin-react-hooks typecheck
yarn workspace eslint-plugin-react-hooks test
```

Observed results:

- Typecheck passed.
- Test suite passed (`4` test suites, `5082` tests).