### PR TITLE
[compiler] Track locations for dependencies

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -1639,6 +1639,7 @@ export function makePropertyLiteral(value: string | number): PropertyLiteral {
 export type DependencyPathEntry = {
   property: PropertyLiteral;
   optional: boolean;
+  loc: SourceLocation;
 };
 export type DependencyPath = Array<DependencyPathEntry>;
 export type ReactiveScopeDependency = {
@@ -1656,6 +1657,7 @@ export type ReactiveScopeDependency = {
    */
   reactive: boolean;
   path: DependencyPath;
+  loc: SourceLocation;
 };
 
 export function areEqualPaths(a: DependencyPath, b: DependencyPath): boolean {

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/DropManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/DropManualMemoization.ts
@@ -74,7 +74,10 @@ export function collectMaybeMemoDependencies(
         return {
           root: object.root,
           // TODO: determine if the access is optional
-          path: [...object.path, {property: value.property, optional}],
+          path: [
+            ...object.path,
+            {property: value.property, optional, loc: value.loc},
+          ],
           loc: value.loc,
         };
       }

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/MergeReactiveScopesThatInvalidateTogether.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/MergeReactiveScopesThatInvalidateTogether.ts
@@ -470,6 +470,7 @@ function canMergeScopes(
           identifier: declaration.identifier,
           reactive: true,
           path: [],
+          loc: GeneratedSource,
         })),
       ),
       next.scope.dependencies,

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PrintReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PrintReactiveFunction.ts
@@ -22,6 +22,7 @@ import {
   printIdentifier,
   printInstructionValue,
   printPlace,
+  printSourceLocation,
   printType,
 } from '../HIR/PrintHIR';
 import {assertExhaustive} from '../Utils/utils';
@@ -114,7 +115,7 @@ export function printDependency(dependency: ReactiveScopeDependency): string {
   const identifier =
     printIdentifier(dependency.identifier) +
     printType(dependency.identifier.type);
-  return `${identifier}${dependency.path.map(token => `${token.optional ? '?.' : '.'}${token.property}`).join('')}`;
+  return `${identifier}${dependency.path.map(token => `${token.optional ? '?.' : '.'}${token.property}`).join('')}_${printSourceLocation(dependency.loc)}`;
 }
 
 export function printReactiveInstructions(

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateExhaustiveDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateExhaustiveDependencies.ts
@@ -756,6 +756,7 @@ function collectDependencies(
                 {
                   optional,
                   property: value.property,
+                  loc: value.loc,
                 },
               ],
               loc: value.loc,

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repeated-dependencies-more-precise.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repeated-dependencies-more-precise.expect.md
@@ -1,0 +1,87 @@
+
+## Input
+
+```javascript
+// @flow
+import {Stringify} from 'shared-runtime';
+
+/**
+ * Example fixture demonstrating a case where we could hoist dependencies
+ * and reuse them across scopes. Here we extract a temporary for `item.value`
+ * and reference it both in the scope for `a`. Then the scope for `c` could
+ * use `<item-value-temp>.inner` as its dependency, avoiding reloading
+ * `item.value`.
+ */
+function Test({item, index}: {item: {value: {inner: any}}, index: number}) {
+  // These scopes have the same dependency, `item.value`, and could
+  // share a hoisted expression to evaluate it
+  const a = [];
+  if (index) {
+    a.push({value: item.value, index});
+  }
+  const b = [item.value];
+
+  // This dependency is more precise (nested property), the outer
+  // `item.value` portion could use a hoisted dep for `item.value
+  const c = [item.value.inner];
+  return <Stringify value={[a, b, c]} />;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { Stringify } from "shared-runtime";
+
+function Test(t0) {
+  const $ = _c(11);
+  const { item, index } = t0;
+  let a;
+  if ($[0] !== index || $[1] !== item.value) {
+    a = [];
+    if (index) {
+      a.push({ value: item.value, index });
+    }
+    $[0] = index;
+    $[1] = item.value;
+    $[2] = a;
+  } else {
+    a = $[2];
+  }
+  let t1;
+  if ($[3] !== item.value) {
+    t1 = [item.value];
+    $[3] = item.value;
+    $[4] = t1;
+  } else {
+    t1 = $[4];
+  }
+  const b = t1;
+  let t2;
+  if ($[5] !== item.value.inner) {
+    t2 = [item.value.inner];
+    $[5] = item.value.inner;
+    $[6] = t2;
+  } else {
+    t2 = $[6];
+  }
+  const c = t2;
+  let t3;
+  if ($[7] !== a || $[8] !== b || $[9] !== c) {
+    t3 = <Stringify value={[a, b, c]} />;
+    $[7] = a;
+    $[8] = b;
+    $[9] = c;
+    $[10] = t3;
+  } else {
+    t3 = $[10];
+  }
+  return t3;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repeated-dependencies-more-precise.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repeated-dependencies-more-precise.js
@@ -1,0 +1,24 @@
+// @flow
+import {Stringify} from 'shared-runtime';
+
+/**
+ * Example fixture demonstrating a case where we could hoist dependencies
+ * and reuse them across scopes. Here we extract a temporary for `item.value`
+ * and reference it both in the scope for `a`. Then the scope for `c` could
+ * use `<item-value-temp>.inner` as its dependency, avoiding reloading
+ * `item.value`.
+ */
+function Test({item, index}: {item: {value: {inner: any}}, index: number}) {
+  // These scopes have the same dependency, `item.value`, and could
+  // share a hoisted expression to evaluate it
+  const a = [];
+  if (index) {
+    a.push({value: item.value, index});
+  }
+  const b = [item.value];
+
+  // This dependency is more precise (nested property), the outer
+  // `item.value` portion could use a hoisted dep for `item.value
+  const c = [item.value.inner];
+  return <Stringify value={[a, b, c]} />;
+}


### PR DESCRIPTION

Tracks locations for reactive scope dependencies, both on the deps and portions of the path. The immediate need for this is a non-public experiment where we're exploring type-directed compilation, and sometimes look up the types of expressions by location. We need to preserve locations accurately for that to work, including the locations of the deps.

## Test Plan

Locations for dependencies are not easy to test: i manually spot-checked the new fixture to ensure that the deps look right. This is fine as best-effort since it doesn't impact any of our core compilation logic, i may fix forward if there are issues and will think about how to test.
