### PR TITLE
fix: set private field to boolean in devtools fusebox package

### DIFF
--- a/packages/react-devtools-fusebox/package.json
+++ b/packages/react-devtools-fusebox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-devtools-fusebox",
   "version": "0.0.0",
-  "private": "true",
+  "private": true,
   "license": "MIT",
   "files": ["dist"],
   "scripts": {


### PR DESCRIPTION
## Summary

This change updates `packages/react-devtools-fusebox/package.json` to use a boolean for the `private` field instead of a string.

- Changed `"private": "true"` to `"private": true`.
- This aligns the package metadata with standard `package.json` schema expectations.
- Scope is intentionally minimal and does not change runtime behavior.

## How did you test this change?

I validated the package metadata value and type after the change.

```bash
node -e "const p=require('./packages/react-devtools-fusebox/package.json'); if (typeof p.private !== 'boolean') { throw new Error('private is not boolean'); } console.log('private is boolean:', p.private);"
```

Output:

```text
private is boolean: true
```

Additionally, this is a metadata-only change in `package.json`, so no runtime code path is affected.

---

