### PR TITLE
Fix malformed private field in package.json files

### DIFF
--- a/compiler/packages/react-forgive/client/package.json
+++ b/compiler/packages/react-forgive/client/package.json
@@ -1,5 +1,5 @@
 {
-  "private": "true",
+  "private": true,
   "name": "react-forgive-client",
   "version": "0.0.0",
   "description": "Experimental LSP client",

--- a/compiler/packages/react-forgive/server/package.json
+++ b/compiler/packages/react-forgive/server/package.json
@@ -1,5 +1,5 @@
 {
-  "private": "true",
+  "private": true,
   "name": "react-forgive-server",
   "version": "0.0.0",
   "description": "Experimental LSP server",

--- a/packages/react-devtools-fusebox/package.json
+++ b/packages/react-devtools-fusebox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-devtools-fusebox",
   "version": "0.0.0",
-  "private": "true",
+  "private": true,
   "license": "MIT",
   "files": ["dist"],
   "scripts": {


### PR DESCRIPTION
## Summary
This PR fixes a compliance issue with the npm [package.json](cci:7://file:///C:/Users/naman/.gemini/antigravity/scratch/react_openSource/package.json:0:0-0:0) specification where the `private` field was incorrectly typed as a string (`"true"`) instead of a boolean (`true`).

While some tools may handle this leniently, strict package scanners and validation pipelines (such as ScanCode.io) fail when encountering this malformed metadata. According to the [npm documentation](https://docs.npmjs.com/cli/v10/configuring-npm/package.json#private), the `private` field **must** be a boolean.

## Approach & Changes
I conducted a codebase-wide audit to identify all instances of this pattern, rather than fixing only the reported file. 

I updated the `private` field from `"true"` to `true` in the following files:
1. [packages/react-devtools-fusebox/package.json](cci:7://file:///C:/Users/naman/.gemini/antigravity/scratch/react_openSource/packages/react-devtools-fusebox/package.json:0:0-0:0) (Reported in #35793)
2. [compiler/packages/react-forgive/server/package.json](cci:7://file:///C:/Users/naman/.gemini/antigravity/scratch/react-contribution/compiler/packages/react-forgive/server/package.json:0:0-0:0) (Identified during audit)
3. [compiler/packages/react-forgive/client/package.json](cci:7://file:///C:/Users/naman/.gemini/antigravity/scratch/react-contribution/compiler/packages/react-forgive/client/package.json:0:0-0:0) (Identified during audit)

## Test Plan
- **Audit**: Executed a grep search (`grep -r "\"private\": \"true\"" .`) to confirm no other occurrences remain in the repository.
- **Validation**: Verified that the modified files remain valid JSON.
- **Impact**: Confirmed this is a metadata-only change that brings the repository into spec compliance without altering runtime behavior or build configurations.

## Related Issues
Fixes #35793