### PR TITLE
fix: correct malformed private field type in multiple package.json files

### DIFF
--- a/compiler/packages/react-forgive/client/package.json
+++ b/compiler/packages/react-forgive/client/package.json
@@ -1,5 +1,5 @@
 {
-  "private": "true",
+  "private": true,
   "name": "react-forgive-client",
   "version": "0.0.0",
   "description": "Experimental LSP client",

--- a/compiler/packages/react-forgive/server/package.json
+++ b/compiler/packages/react-forgive/server/package.json
@@ -1,5 +1,5 @@
 {
-  "private": "true",
+  "private": true,
   "name": "react-forgive-server",
   "version": "0.0.0",
   "description": "Experimental LSP server",

--- a/packages/react-devtools-fusebox/package.json
+++ b/packages/react-devtools-fusebox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-devtools-fusebox",
   "version": "0.0.0",
-  "private": "true",
+  "private": true,
   "license": "MIT",
   "files": ["dist"],
   "scripts": {


### PR DESCRIPTION
## Overview
While auditing the React monorepo for metadata compliance, I discovered that multiple `package.json` files were using a string `"true"` for the `private` field instead of the boolean `true` required by the [npm specification](https://docs.npmjs.com/cli/v11/configuring-npm/package.json#private).

## Changes
This PR corrects the `private` field type from `string` to `boolean` in the following locations to ensure consistency and prevent failures in automated package metadata scanning tools:

1. `packages/react-devtools-fusebox/package.json`
2. `compiler/packages/react-forgive/client/package.json`
3. `compiler/packages/react-forgive/server/package.json`

## Impact
Malformed metadata often causes failures in security, license, and compliance scanning tools (such as **ScanCode.io**) that strictly validate package metadata types. This fix ensures the repository remains compliant with industry-standard package specifications.

## Verification
- Audited all `package.json` files in the monorepo using `grep`.
- Verified that the `private` field is now correctly recognized as a boolean.