### PR TITLE
[compiler] Add --verbose flag to react-compiler-healthcheck

### DIFF
--- a/compiler/packages/react-compiler-healthcheck/src/index.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/index.ts
@@ -22,6 +22,12 @@ async function main() {
       type: 'string',
       default: '**/+(*.{js,mjs,jsx,ts,tsx}|package.json)',
     })
+    .option('verbose', {
+      alias: 'v',
+      description: 'display per-component failure details',
+      type: 'boolean',
+      default: false,
+    })
     .parseSync();
 
   const spinner = ora('Checking').start();
@@ -48,7 +54,7 @@ async function main() {
   }
   spinner.stop();
 
-  reactCompilerCheck.report();
+  reactCompilerCheck.report(argv.verbose);
   strictModeCheck.report();
   libraryCompatCheck.report();
 }


### PR DESCRIPTION
## Summary
- Adds a `--verbose` (`-v`) CLI flag to `react-compiler-healthcheck`
- When enabled, prints per-component failure details (file path, line/column, error reason) after the existing summary line
- Failures are grouped into "Actionable failures" (red) and "Other failures" (yellow), deduplicated by source location

## Test plan
- [ ] Build with `npx tsup` in `compiler/packages/react-compiler-healthcheck`
- [ ] Run without `--verbose` and confirm output is unchanged (summary only)
- [ ] Run with `--verbose` and confirm failure details are printed with file paths, locations, and reasons
- [ ] Run with `-v` alias and confirm it behaves the same as `--verbose`