### PR TITLE
Fix: Clear correct timeout variable in componentWillUnmount

### DIFF
--- a/fixtures/attribute-behavior/src/App.js
+++ b/fixtures/attribute-behavior/src/App.js
@@ -602,7 +602,7 @@ class Result extends React.Component {
 
   componentWillUnmount() {
     if (this.timeout) {
-      clearTimeout(this.interval);
+      clearTimeout(this.timeout);
     }
   }
 


### PR DESCRIPTION
### Description

Fixed a bug in `fixtures/attribute-behavior/src/App.js` where the `componentWillUnmount` lifecycle method was checking for `this.timeout` but incorrectly attempting to clear `this.interval`. 

Since `this.interval` is undefined on this component, the actual timeout remained active, leading to potential memory leaks and React "setState" warnings if the timeout fired after the component had unmounted.

### Fix
Changed `clearTimeout(this.interval)` to `clearTimeout(this.timeout)` to align with the conditional check and the variable used in `onMouseEnter`.

### Related Issues
Closes #35814

### Checklist
- [x] Forked the repository and created a branch from `main`
- [x] Run `yarn` in the repository root
- [x] Verified the fix in the `attribute-behavior` fixture