### PR TITLE
[DevTools] Fix alignment of breadcrumbs separator

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/OwnersStack.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/OwnersStack.css
@@ -34,6 +34,7 @@
 
 .OwnerStackFlatListContainer {
   display: inline-flex;
+  align-items: baseline;
 }
 
 .OwnerStackFlatListSeparator {

--- a/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseBreadcrumbs.css
+++ b/packages/react-devtools-shared/src/devtools/views/SuspenseTab/SuspenseBreadcrumbs.css
@@ -10,6 +10,7 @@
   display: inline-flex;
   flex-direction: row;
   flex-wrap: nowrap;
+  align-items: baseline;
 }
 
 .SuspenseBreadcrumbsListItem {


### PR DESCRIPTION

## Summary

The separator vertical alignment felt slightly off. Now we're aligning separators and items by their baseline which looks more pleasent.

## How did you test this change?

Before:
<img width="546" height="68" alt="CleanShot 2026-02-18 at 10 08 59@2x" src="https://github.com/user-attachments/assets/a85d228c-be8d-40bb-8a0a-dd3333cfec3c" />
After:

<img width="546" height="80" alt="CleanShot 2026-02-18 at 10 09 07@2x" src="https://github.com/user-attachments/assets/0e1a8799-8f4f-4144-aa87-9fdf63460628" />
