### PR TITLE
[compiler] Fix false positive in refs rule for refs stored in objects

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
@@ -151,16 +151,6 @@ function collectTemporariesSidemap(fn: HIRFunction, env: Env): void {
           break;
         }
         case 'PropertyLoad': {
-          if (
-            isUseRefType(value.object.identifier) &&
-            value.property === 'current'
-          ) {
-            continue;
-          }
-          const temp = env.lookup(value.object);
-          if (temp != null) {
-            env.define(lvalue, temp);
-          }
           break;
         }
       }
@@ -375,7 +365,7 @@ function validateNoRefAccessInRenderImpl(
             const objType = env.get(instr.value.object.identifier.id);
             let lookupType: null | RefAccessType = null;
             if (objType?.kind === 'Structure') {
-              lookupType = objType.value;
+              lookupType = objType.value ?? objType;
             } else if (objType?.kind === 'Ref') {
               lookupType = {
                 kind: 'RefValue',

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-passing-refs-in-object-as-props.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-passing-refs-in-object-as-props.expect.md
@@ -1,0 +1,52 @@
+
+## Input
+
+```javascript
+function Component() {
+  const groupRefs = {
+    group1: useRef(null),
+    group2: useRef(null),
+  };
+  return (
+    <>
+      <Child ref={groupRefs.group1} />
+      <Child ref={groupRefs.group2} />
+    </>
+  );
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component() {
+  const $ = _c(2);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = { group1: useRef(null), group2: useRef(null) };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const groupRefs = t0;
+  let t1;
+  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+    t1 = (
+      <>
+        <Child ref={groupRefs.group1} />
+        <Child ref={groupRefs.group2} />
+      </>
+    );
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  return t1;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-passing-refs-in-object-as-props.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-passing-refs-in-object-as-props.js
@@ -1,0 +1,12 @@
+function Component() {
+  const groupRefs = {
+    group1: useRef(null),
+    group2: useRef(null),
+  };
+  return (
+    <>
+      <Child ref={groupRefs.group1} />
+      <Child ref={groupRefs.group2} />
+    </>
+  );
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-use-ref-added-to-dep-without-type-info.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-use-ref-added-to-dep-without-type-info.expect.md
@@ -41,13 +41,14 @@ Error: Cannot access refs during render
 
 React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
 
-error.invalid-use-ref-added-to-dep-without-type-info.ts:12:28
-  10 |   const x = {a, val: val.ref.current};
+error.invalid-use-ref-added-to-dep-without-type-info.ts:10:21
+   8 |   // however, this is an instance of accessing a ref during render and is disallowed
+   9 |   // under React's rules, so we reject this input
+> 10 |   const x = {a, val: val.ref.current};
+     |                      ^^^^^^^^^^^^^^^ Cannot access ref value during render
   11 |
-> 12 |   return <VideoList videos={x} />;
-     |                             ^ Cannot access ref value during render
+  12 |   return <VideoList videos={x} />;
   13 | }
-  14 |
 ```
           
       


### PR DESCRIPTION
## Summary
- Fixes a false positive in the `react-hooks/refs` ESLint rule where storing multiple refs in an object (`const groupRefs = {group1: useRef(), group2: useRef()}`) and passing them as JSX props (`ref={groupRefs.group2}`) incorrectly reported "Cannot access ref value during render"
- Root cause: `collectTemporariesSidemap` aliased PropertyLoad results to the source object, so `env.set` on a property load lvalue would resolve through the temporary chain and corrupt the object's type (from `Structure{Ref}` to `Ref`), causing subsequent property loads to produce `RefValue` instead of `Ref`
- The fix removes PropertyLoad aliasing from `collectTemporariesSidemap` (the main validation loop already tracks types correctly) and adjusts PropertyLoad in the main validation to propagate function type info from Structure types when value is null

Fixes #35813

## Test plan
- [x] Added new fixture `allow-passing-refs-in-object-as-props` that reproduces the false positive
- [x] All 1840 compiler fixture tests pass
- [x] Existing error detection for true ref violations is preserved (e.g. `ref.current` during render, calling ref-accessing functions during render)
- [ ] Verify with the reproduction from the issue (StackBlitz sandbox)