### PR TITLE
[compiler] Surface all lint diagnostics instead of stopping at first validation error

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Pipeline.ts
@@ -196,10 +196,18 @@ function runWithEnvironment(
 
   if (env.enableValidations) {
     if (env.config.validateHooksUsage) {
-      validateHooksUsage(hir).unwrap();
+      if (env.outputMode === 'lint') {
+        env.logErrors(validateHooksUsage(hir));
+      } else {
+        validateHooksUsage(hir).unwrap();
+      }
     }
     if (env.config.validateNoCapitalizedCalls) {
-      validateNoCapitalizedCalls(hir).unwrap();
+      if (env.outputMode === 'lint') {
+        env.logErrors(validateNoCapitalizedCalls(hir));
+      } else {
+        validateNoCapitalizedCalls(hir).unwrap();
+      }
     }
   }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -696,7 +696,7 @@ export class Environment {
     return this.#scope;
   }
 
-  logErrors(errors: Result<void, CompilerError>): void {
+  logErrors(errors: Result<unknown, CompilerError>): void {
     if (errors.isOk() || this.logger == null) {
       return;
     }

--- a/compiler/packages/eslint-plugin-react-compiler/__tests__/PluginTest-test.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/__tests__/PluginTest-test.ts
@@ -57,7 +57,6 @@ testRule('plugin-recommended', TestRecommendedRules, {
   ],
   invalid: [
     {
-      // TODO: actually return multiple diagnostics in this case
       name: 'Multiple diagnostic kinds from the same function are surfaced',
       code: normalizeIndent`
         import Child from './Child';
@@ -70,6 +69,7 @@ testRule('plugin-recommended', TestRecommendedRules, {
       `,
       errors: [
         makeTestCaseError('Hooks must always be called in a consistent order'),
+        makeTestCaseError('Capitalized functions are reserved for components'),
       ],
     },
     {

--- a/compiler/packages/eslint-plugin-react-compiler/__tests__/Repro35394-test.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/__tests__/Repro35394-test.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {normalizeIndent, TestRecommendedRules, testRule} from './shared-utils';
+
+testRule('repro-35394', TestRecommendedRules, {
+  valid: [],
+  invalid: [
+    {
+      name: '#35394 repro - multiple violations with useState in nested component',
+      code: normalizeIndent`
+        import {useState, useEffect} from 'react';
+        export default function App() {
+          const [foo, setFoo] = useState(false);
+
+          useEffect(() => {
+            setFoo(!foo);
+          }, []);
+
+          const ViolateStaticComponents = () => {
+            const [counter, setCounter] = useState(0);
+            return <h1>Hello, World!</h1>;
+          };
+
+          return (
+            <>
+              <ViolateStaticComponents />
+            </>
+          );
+        }
+      `,
+      errors: 3,
+    },
+    {
+      name: 'Without nested useState - should show 2 errors',
+      code: normalizeIndent`
+        import {useState, useEffect} from 'react';
+        export default function App() {
+          const [foo, setFoo] = useState(false);
+
+          useEffect(() => {
+            setFoo(!foo);
+          }, []);
+
+          const ViolateStaticComponents = () => {
+            return <h1>Hello, World!</h1>;
+          };
+
+          return (
+            <>
+              <ViolateStaticComponents />
+            </>
+          );
+        }
+      `,
+      errors: 2,
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

In lint mode (ESLint plugin), the compilation pipeline stops at the first validation error. For example, if `validateHooksUsage` finds an issue, subsequent validations like `validateNoCapitalizedCalls` never run, hiding additional lint errors from the user.

This PR changes the pipeline to use `env.logErrors()` instead of `.unwrap()` for early validations (hooks usage and capitalized calls) when in lint mode. These validations are purely diagnostic — they don't modify the HIR — so it's safe to continue the pipeline after logging their errors.

### Before
A file with both a hooks violation and a capitalized-calls violation would only show the hooks error.

### After
Both errors are surfaced to the user.

## How did you test this change?

- Added new test in `Repro35394-test.ts` that reproduces the issue from #35394
- Updated existing `PluginTest-test.ts` to verify the newly surfaced diagnostics (the existing TODO comment 'actually return multiple diagnostics in this case' is now resolved)
- All 33 ESLint plugin tests pass

Fixes #35394
Fixes #31545