### PR TITLE
fix: change private field from string to boolean

### DIFF
--- a/packages/react-devtools-fusebox/package.json
+++ b/packages/react-devtools-fusebox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-devtools-fusebox",
   "version": "0.0.0",
-  "private": "true",
+  "private": true,
   "license": "MIT",
   "files": ["dist"],
   "scripts": {


### PR DESCRIPTION
## Summary

This PR fixes the malformed `private` field in `packages/react-devtools-fusebox/package.json`.

## Bug

The `private` field was set to string `"true"` instead of boolean `true`, which causes failures in package scanning tools that validate package metadata.

## Fix

Changed `"private": "true"` to `"private": true`

## Related

- Reported in issue #35793
- npm package.json specification requires boolean for private field