### PR TITLE
Refactor: Use centralized hasOwnProperty utility functions

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Utils/ComponentDeclaration.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Utils/ComponentDeclaration.ts
@@ -6,6 +6,7 @@
  */
 
 import * as t from '@babel/types';
+import {hasOwnProperty} from './utils';
 
 export type ComponentDeclaration = t.FunctionDeclaration & {
   __componentDeclaration: boolean;
@@ -14,7 +15,7 @@ export type ComponentDeclaration = t.FunctionDeclaration & {
 export function isComponentDeclaration(
   node: t.FunctionDeclaration,
 ): node is ComponentDeclaration {
-  return Object.prototype.hasOwnProperty.call(node, '__componentDeclaration');
+  return hasOwnProperty(node, '__componentDeclaration');
 }
 
 export function parseComponentDeclaration(

--- a/compiler/packages/babel-plugin-react-compiler/src/Utils/HookDeclaration.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Utils/HookDeclaration.ts
@@ -6,6 +6,7 @@
  */
 
 import * as t from '@babel/types';
+import {hasOwnProperty} from './utils';
 
 export type HookDeclaration = t.FunctionDeclaration & {
   __hookDeclaration: boolean;
@@ -14,7 +15,7 @@ export type HookDeclaration = t.FunctionDeclaration & {
 export function isHookDeclaration(
   node: t.FunctionDeclaration,
 ): node is HookDeclaration {
-  return Object.prototype.hasOwnProperty.call(node, '__hookDeclaration');
+  return hasOwnProperty(node, '__hookDeclaration');
 }
 
 export function parseHookDeclaration(

--- a/packages/react-devtools-shared/src/devtools/views/utils.js
+++ b/packages/react-devtools-shared/src/devtools/views/utils.js
@@ -11,11 +11,9 @@ import escapeStringRegExp from 'escape-string-regexp';
 import {meta} from '../../hydration';
 import {formatDataForPreview} from '../../utils';
 import isArray from 'react-devtools-shared/src/isArray';
+import hasOwnProperty from 'shared/hasOwnProperty';
 
 import type {HooksTree} from 'react-debug-tools/src/ReactDebugHooks';
-
-// $FlowFixMe[method-unbinding]
-const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 export function alphaSortEntries(
   entryA: [string, mixed],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

### Overview
This PR refactors property checking throughout the codebase to use centralized `hasOwnProperty` utility functions instead of directly accessing `Object.prototype.hasOwnProperty`.

### Changes
- **compiler/packages/babel-plugin-react-compiler/src/Utils/ComponentDeclaration.ts**: Import `hasOwnProperty` from `./utils`
- **compiler/packages/babel-plugin-react-compiler/src/Utils/HookDeclaration.ts**: Import `hasOwnProperty` from `./utils`
- **packages/react-devtools-shared/src/devtools/views/utils.js**: Import `hasOwnProperty` from `shared/hasOwnProperty` instead of defining locally


## How did you test this change?

```bash
yarn test --prod
```