### PR TITLE
[compiler] Phase 4 (batch 2), 5, 6: Update remaining passes for fault tolerance

### DIFF
--- a/compiler/fault-tolerance-overview.md
+++ b/compiler/fault-tolerance-overview.md
@@ -174,17 +174,17 @@ These passes already accumulate errors internally and return `Result<void, Compi
   - Record errors on env
   - Update Pipeline.ts call site (line 315): remove `.unwrap()`
 
-- [ ] **4.10 `validateMemoizedEffectDependencies`** (`src/Validation/ValidateMemoizedEffectDependencies.ts`)
+- [x] **4.10 `validateMemoizedEffectDependencies`** (`src/Validation/ValidateMemoizedEffectDependencies.ts`)
   - Change signature to return void (note: operates on `ReactiveFunction`)
   - Record errors on the function's env
   - Update Pipeline.ts call site (line 565): remove `.unwrap()`
 
-- [ ] **4.11 `validatePreservedManualMemoization`** (`src/Validation/ValidatePreservedManualMemoization.ts`)
+- [x] **4.11 `validatePreservedManualMemoization`** (`src/Validation/ValidatePreservedManualMemoization.ts`)
   - Change signature to return void (note: operates on `ReactiveFunction`)
   - Record errors on the function's env
   - Update Pipeline.ts call site (line 572): remove `.unwrap()`
 
-- [ ] **4.12 `validateSourceLocations`** (`src/Validation/ValidateSourceLocations.ts`)
+- [x] **4.12 `validateSourceLocations`** (`src/Validation/ValidateSourceLocations.ts`)
   - Change signature to return void
   - Record errors on env
   - Update Pipeline.ts call site (line 585): remove `.unwrap()`
@@ -202,16 +202,16 @@ These already use a soft-logging pattern and don't block compilation. They can b
 
 These throw `CompilerError` directly (not via Result). They need the most work.
 
-- [ ] **4.17 `validateContextVariableLValues`** (`src/Validation/ValidateContextVariableLValues.ts`)
+- [x] **4.17 `validateContextVariableLValues`** (`src/Validation/ValidateContextVariableLValues.ts`)
   - Currently throws via `CompilerError.throwTodo()` and `CompilerError.invariant()`
   - Change to record Todo errors on env and continue
   - Keep invariant throws (those indicate internal bugs)
 
-- [ ] **4.18 `validateLocalsNotReassignedAfterRender`** (`src/Validation/ValidateLocalsNotReassignedAfterRender.ts`)
+- [x] **4.18 `validateLocalsNotReassignedAfterRender`** (`src/Validation/ValidateLocalsNotReassignedAfterRender.ts`)
   - Currently constructs a `CompilerError` and `throw`s it directly
   - Change to record errors on env
 
-- [ ] **4.19 `validateNoDerivedComputationsInEffects`** (`src/Validation/ValidateNoDerivedComputationsInEffects.ts`)
+- [x] **4.19 `validateNoDerivedComputationsInEffects`** (`src/Validation/ValidateNoDerivedComputationsInEffects.ts`)
   - Currently throws directly
   - Change to record errors on env
 
@@ -219,14 +219,14 @@ These throw `CompilerError` directly (not via Result). They need the most work.
 
 The inference passes are the most critical to handle correctly because they produce side effects (populating effects on instructions, computing mutable ranges) that downstream passes depend on. They must continue producing valid (even if imprecise) output when errors are encountered.
 
-- [ ] **5.1 `inferMutationAliasingEffects`** (`src/Inference/InferMutationAliasingEffects.ts`)
+- [x] **5.1 `inferMutationAliasingEffects`** (`src/Inference/InferMutationAliasingEffects.ts`)
   - Currently returns `Result<void, CompilerError>` — errors are about mutation of frozen/global values
   - Change to record errors on `fn.env` instead of accumulating internally
   - **Key recovery strategy**: When a mutation of a frozen value is detected, record the error but treat the operation as a non-mutating read. This way downstream passes see a consistent (if conservative) view
   - When a mutation of a global is detected, record the error but continue with the global unchanged
   - Update Pipeline.ts (lines 233-239): remove the conditional `.isErr()` / throw pattern
 
-- [ ] **5.2 `inferMutationAliasingRanges`** (`src/Inference/InferMutationAliasingRanges.ts`)
+- [x] **5.2 `inferMutationAliasingRanges`** (`src/Inference/InferMutationAliasingRanges.ts`)
   - Currently returns `Result<Array<AliasingEffect>, CompilerError>`
   - This pass has a meaningful success value (the function's external aliasing effects)
   - Change to: always produce a best-effort effects array, record errors on env
@@ -235,7 +235,7 @@ The inference passes are the most critical to handle correctly because they prod
 
 ### Phase 6: Update Codegen
 
-- [ ] **6.1 `codegenFunction`** (`src/ReactiveScopes/CodegenReactiveFunction.ts`)
+- [x] **6.1 `codegenFunction`** (`src/ReactiveScopes/CodegenReactiveFunction.ts`)
   - Currently returns `Result<CodegenFunction, CompilerError>`
   - Change to: always produce a `CodegenFunction`, record errors on env
   - If codegen encounters an error (e.g., an instruction it can't generate code for), it should:

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/AnalyseFunctions.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/AnalyseFunctions.ts
@@ -54,7 +54,7 @@ function lowerWithMutationAliasing(fn: HIRFunction): void {
   deadCodeElimination(fn);
   const functionEffects = inferMutationAliasingRanges(fn, {
     isFunctionExpression: true,
-  }).unwrap();
+  });
   rewriteInstructionKindsBasedOnReassignment(fn);
   inferReactiveScopeVariables(fn);
   fn.aliasingEffects = functionEffects;

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
@@ -45,7 +45,7 @@ import {
   eachTerminalOperand,
   eachTerminalSuccessor,
 } from '../HIR/visitors';
-import {Ok, Result} from '../Utils/Result';
+
 import {
   assertExhaustive,
   getOrInsertDefault,
@@ -100,7 +100,7 @@ export function inferMutationAliasingEffects(
   {isFunctionExpression}: {isFunctionExpression: boolean} = {
     isFunctionExpression: false,
   },
-): Result<void, CompilerError> {
+): void {
   const initialState = InferenceState.empty(fn.env, isFunctionExpression);
 
   // Map of blocks to the last (merged) incoming state that was processed
@@ -220,7 +220,7 @@ export function inferMutationAliasingEffects(
       }
     }
   }
-  return Ok(undefined);
+  return;
 }
 
 function findHoistedContextDeclarations(

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingRanges.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingRanges.ts
@@ -26,7 +26,7 @@ import {
   eachTerminalOperand,
 } from '../HIR/visitors';
 import {assertExhaustive, getOrInsertWith} from '../Utils/utils';
-import {Err, Ok, Result} from '../Utils/Result';
+
 import {AliasingEffect, MutationReason} from './AliasingEffects';
 
 /**
@@ -74,7 +74,7 @@ import {AliasingEffect, MutationReason} from './AliasingEffects';
 export function inferMutationAliasingRanges(
   fn: HIRFunction,
   {isFunctionExpression}: {isFunctionExpression: boolean},
-): Result<Array<AliasingEffect>, CompilerError> {
+): Array<AliasingEffect> {
   // The set of externally-visible effects
   const functionEffects: Array<AliasingEffect> = [];
 
@@ -547,10 +547,14 @@ export function inferMutationAliasingRanges(
     }
   }
 
-  if (errors.hasAnyErrors() && !isFunctionExpression) {
-    return Err(errors);
+  if (
+    errors.hasAnyErrors() &&
+    !isFunctionExpression &&
+    fn.env.enableValidations
+  ) {
+    fn.env.recordErrors(errors);
   }
-  return Ok(functionEffects);
+  return functionEffects;
 }
 
 function appendFunctionErrors(errors: CompilerError, fn: HIRFunction): void {

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoDerivedComputationsInEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoDerivedComputationsInEffects.ts
@@ -97,8 +97,8 @@ export function validateNoDerivedComputationsInEffects(fn: HIRFunction): void {
       }
     }
   }
-  if (errors.hasAnyErrors()) {
-    throw errors;
+  for (const detail of errors.details) {
+    fn.env.recordError(detail);
   }
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
@@ -37,7 +37,6 @@ import {
   ReactiveFunctionVisitor,
   visitReactiveFunction,
 } from '../ReactiveScopes/visitors';
-import {Result} from '../Utils/Result';
 import {getOrInsertDefault} from '../Utils/utils';
 
 /**
@@ -47,15 +46,15 @@ import {getOrInsertDefault} from '../Utils/utils';
  * This can occur if a value's mutable range somehow extended to include a hook and
  * was pruned.
  */
-export function validatePreservedManualMemoization(
-  fn: ReactiveFunction,
-): Result<void, CompilerError> {
+export function validatePreservedManualMemoization(fn: ReactiveFunction): void {
   const state = {
     errors: new CompilerError(),
     manualMemoState: null,
   };
   visitReactiveFunction(fn, new Visitor(), state);
-  return state.errors.asResult();
+  for (const detail of state.errors.details) {
+    fn.env.recordError(detail);
+  }
 }
 
 const DEBUG = false;

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateSourceLocations.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateSourceLocations.ts
@@ -9,7 +9,7 @@ import {NodePath} from '@babel/traverse';
 import * as t from '@babel/types';
 import {CompilerDiagnostic, CompilerError, ErrorCategory} from '..';
 import {CodegenFunction} from '../ReactiveScopes';
-import {Result} from '../Utils/Result';
+import {Environment} from '../HIR/Environment';
 
 /**
  * IMPORTANT: This validation is only intended for use in unit tests.
@@ -123,7 +123,8 @@ export function validateSourceLocations(
     t.FunctionDeclaration | t.ArrowFunctionExpression | t.FunctionExpression
   >,
   generatedAst: CodegenFunction,
-): Result<void, CompilerError> {
+  env: Environment,
+): void {
   const errors = new CompilerError();
 
   /*
@@ -309,5 +310,7 @@ export function validateSourceLocations(
     }
   }
 
-  return errors.asResult();
+  for (const detail of errors.details) {
+    env.recordError(detail);
+  }
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-reassign-const.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-reassign-const.expect.md
@@ -21,7 +21,7 @@ function Component({foo}) {
 ## Error
 
 ```
-Found 2 errors:
+Found 3 errors:
 
 Todo: Support destructuring of context variables
 
@@ -29,7 +29,18 @@ error.todo-reassign-const.ts:3:20
   1 | import {Stringify} from 'shared-runtime';
   2 |
 > 3 | function Component({foo}) {
-    |                     ^^^ Support destructuring of context variables
+    |                     ^^^
+  4 |   let bar = foo.bar;
+  5 |   return (
+  6 |     <Stringify
+
+Todo: Support destructuring of context variables
+
+error.todo-reassign-const.ts:3:20
+  1 | import {Stringify} from 'shared-runtime';
+  2 |
+> 3 | function Component({foo}) {
+    |                     ^^^
   4 |   let bar = foo.bar;
   5 |   return (
   6 |     <Stringify


### PR DESCRIPTION

Update remaining validation passes to record errors on env:
- validateMemoizedEffectDependencies
- validatePreservedManualMemoization
- validateSourceLocations (added env parameter)
- validateContextVariableLValues (changed throwTodo to recordError)
- validateLocalsNotReassignedAfterRender (changed throw to recordError)
- validateNoDerivedComputationsInEffects (changed throw to recordError)

Update inference passes:
- inferMutationAliasingEffects: return void, errors on env
- inferMutationAliasingRanges: return Array<AliasingEffect> directly, errors on env

Update codegen:
- codegenFunction: return CodegenFunction directly, errors on env
- codegenReactiveFunction: same pattern

Update Pipeline.ts to call all passes directly without tryRecord/unwrap.
Also update AnalyseFunctions.ts which called inferMutationAliasingRanges.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/react/pull/35876).
* #35888
* #35884
* #35883
* #35882
* #35881
* #35880
* #35879
* #35878
* #35877
* __->__ #35876