### PR TITLE
[compiler] Fix TypeError from hoisting nullable closure property deps

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/CollectHoistablePropertyLoads.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/CollectHoistablePropertyLoads.ts
@@ -449,7 +449,19 @@ function collectNonNullsInBlocks(
             innerHoistableMap.get(innerFn.func.body.entry),
           );
           for (const entry of innerHoistables.assumedNonNullObjects) {
-            assumedNonNullObjects.add(entry);
+            /**
+             * Inner functions (e.g. JSX attribute callbacks) prove
+             * non-nullness at invocation time, but NOT at the outer
+             * render scope where cache keys are evaluated. Only
+             * promote an inner hoistable when its root identifier
+             * is already proven non-null in the outer scope.
+             */
+            const rootNode = context.registry.roots.get(
+              entry.fullPath.identifier.id,
+            );
+            if (rootNode != null && assumedNonNullObjects.has(rootNode)) {
+              assumedNonNullObjects.add(entry);
+            }
           }
         }
       } else if (

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-function-member-expr-call.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-function-member-expr-call.expect.md
@@ -35,11 +35,11 @@ function component(t0) {
   }
   const poke = t1;
   let t2;
-  if ($[2] !== mutator.user) {
+  if ($[2] !== mutator) {
     t2 = () => {
       mutator.user.hide();
     };
-    $[2] = mutator.user;
+    $[2] = mutator;
     $[3] = t2;
   } else {
     t2 = $[3];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-member-expr.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-member-expr.expect.md
@@ -23,27 +23,19 @@ export const FIXTURE_ENTRYPOINT = {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function component(a) {
-  const $ = _c(4);
+  const $ = _c(2);
   let t0;
   if ($[0] !== a) {
-    t0 = { a };
+    const z = { a };
+    t0 = function () {
+      console.log(z.a);
+    };
     $[0] = a;
     $[1] = t0;
   } else {
     t0 = $[1];
   }
-  const z = t0;
-  let t1;
-  if ($[2] !== z.a) {
-    t1 = function () {
-      console.log(z.a);
-    };
-    $[2] = z.a;
-    $[3] = t1;
-  } else {
-    t1 = $[3];
-  }
-  const x = t1;
+  const x = t0;
 
   return x;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-nested-member-expr-in-nested-func.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-nested-member-expr-in-nested-func.expect.md
@@ -25,29 +25,21 @@ export const FIXTURE_ENTRYPOINT = {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function component(a) {
-  const $ = _c(4);
+  const $ = _c(2);
   let t0;
   if ($[0] !== a) {
-    t0 = { a: { a } };
+    const z = { a: { a } };
+    t0 = function () {
+      (function () {
+        console.log(z.a.a);
+      })();
+    };
     $[0] = a;
     $[1] = t0;
   } else {
     t0 = $[1];
   }
-  const z = t0;
-  let t1;
-  if ($[2] !== z.a.a) {
-    t1 = function () {
-      (function () {
-        console.log(z.a.a);
-      })();
-    };
-    $[2] = z.a.a;
-    $[3] = t1;
-  } else {
-    t1 = $[3];
-  }
-  const x = t1;
+  const x = t0;
 
   return x;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-nested-member-expr.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/capturing-nested-member-expr.expect.md
@@ -23,27 +23,19 @@ export const FIXTURE_ENTRYPOINT = {
 ```javascript
 import { c as _c } from "react/compiler-runtime";
 function component(a) {
-  const $ = _c(4);
+  const $ = _c(2);
   let t0;
   if ($[0] !== a) {
-    t0 = { a: { a } };
+    const z = { a: { a } };
+    t0 = function () {
+      console.log(z.a.a);
+    };
     $[0] = a;
     $[1] = t0;
   } else {
     t0 = $[1];
   }
-  const z = t0;
-  let t1;
-  if ($[2] !== z.a.a) {
-    t1 = function () {
-      console.log(z.a.a);
-    };
-    $[2] = z.a.a;
-    $[3] = t1;
-  } else {
-    t1 = $[3];
-  }
-  const x = t1;
+  const x = t0;
 
   return x;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructuring-mixed-scope-and-local-variables-with-default.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructuring-mixed-scope-and-local-variables-with-default.expect.md
@@ -96,14 +96,14 @@ function Component(props) {
     }
     const urls = t5;
     let t6;
-    if ($[6] !== comments.length) {
+    if ($[6] !== comments) {
       t6 = (e) => {
         if (!comments.length) {
           return;
         }
         console.log(comments.length);
       };
-      $[6] = comments.length;
+      $[6] = comments;
       $[7] = t6;
     } else {
       t6 = $[7];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructuring-mixed-scope-declarations-and-locals.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructuring-mixed-scope-declarations-and-locals.expect.md
@@ -55,14 +55,14 @@ function Component(props) {
     const allUrls = [];
     const { media, comments, urls } = post;
     let t1;
-    if ($[2] !== comments.length) {
+    if ($[2] !== comments) {
       t1 = (e) => {
         if (!comments.length) {
           return;
         }
         console.log(comments.length);
       };
-      $[2] = comments.length;
+      $[2] = comments;
       $[3] = t1;
     } else {
       t1 = $[3];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-like-name-not-Ref.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-like-name-not-Ref.expect.md
@@ -35,7 +35,7 @@ Found 1 error:
 
 Compilation Skipped: Existing memoization could not be preserved
 
-React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected. The inferred dependency was `Ref.current`, but the source dependencies were []. Inferred dependency not present in source.
+React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected. The inferred dependency was `Ref`, but the source dependencies were []. Inferred dependency not present in source.
 
 error.ref-like-name-not-Ref.ts:11:30
    9 |   const Ref = useCustomRef();

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-like-name-not-a-ref.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.ref-like-name-not-a-ref.expect.md
@@ -35,7 +35,7 @@ Found 1 error:
 
 Compilation Skipped: Existing memoization could not be preserved
 
-React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected. The inferred dependency was `notaref.current`, but the source dependencies were []. Inferred dependency not present in source.
+React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected. The inferred dependency was `notaref`, but the source dependencies were []. Inferred dependency not present in source.
 
 error.ref-like-name-not-a-ref.ts:11:30
    9 |   const notaref = useCustomRef();

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/hook-call-freezes-captured-memberexpr.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/hook-call-freezes-captured-memberexpr.expect.md
@@ -45,9 +45,9 @@ function Foo(t0) {
   }
   const x = t1;
   let t2;
-  if ($[2] !== x.inner) {
+  if ($[2] !== x) {
     t2 = () => x.inner;
-    $[2] = x.inner;
+    $[2] = x;
     $[3] = t2;
   } else {
     t2 = $[3];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/array-map-named-callback-cross-context.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/array-map-named-callback-cross-context.expect.md
@@ -60,9 +60,9 @@ function useFoo(t0) {
   const $ = _c(13);
   const { arr1, arr2 } = t0;
   let t1;
-  if ($[0] !== arr1[0]) {
+  if ($[0] !== arr1) {
     t1 = (e) => arr1[0].value + e.value;
-    $[0] = arr1[0];
+    $[0] = arr1;
     $[1] = t1;
   } else {
     t1 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/conditional-call-chain.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/conditional-call-chain.expect.md
@@ -45,22 +45,22 @@ function Component(t0) {
   const $ = _c(7);
   const { a, b } = t0;
   let t1;
-  if ($[0] !== a.value) {
+  if ($[0] !== a) {
     t1 = () => {
       console.log(a.value);
     };
-    $[0] = a.value;
+    $[0] = a;
     $[1] = t1;
   } else {
     t1 = $[1];
   }
   const logA = t1;
   let t2;
-  if ($[2] !== b.value) {
+  if ($[2] !== b) {
     t2 = () => {
       console.log(b.value);
     };
-    $[2] = b.value;
+    $[2] = b;
     $[3] = t2;
   } else {
     t2 = $[3];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/conditional-call.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/conditional-call.expect.md
@@ -44,13 +44,13 @@ function useMakeCallback(t0) {
   const { obj } = t0;
   const [state, setState] = useState(0);
   let t1;
-  if ($[0] !== obj.value) {
+  if ($[0] !== obj) {
     t1 = () => {
       if (obj.value !== 0) {
         setState(obj.value);
       }
     };
-    $[0] = obj.value;
+    $[0] = obj;
     $[1] = t1;
   } else {
     t1 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/conditionally-return-fn.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/conditionally-return-fn.expect.md
@@ -51,9 +51,9 @@ function useMakeCallback(t0) {
   const $ = _c(3);
   const { obj, shouldMakeCb, setState } = t0;
   let t1;
-  if ($[0] !== obj.value || $[1] !== setState) {
+  if ($[0] !== obj || $[1] !== setState) {
     t1 = () => setState(obj.value);
-    $[0] = obj.value;
+    $[0] = obj;
     $[1] = setState;
     $[2] = t1;
   } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/direct-call.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/direct-call.expect.md
@@ -34,13 +34,13 @@ function useMakeCallback(t0) {
   const { obj } = t0;
   const [state, setState] = useState(0);
   let t1;
-  if ($[0] !== obj.value || $[1] !== state) {
+  if ($[0] !== obj || $[1] !== state) {
     t1 = () => {
       if (obj.value !== state) {
         setState(obj.value);
       }
     };
-    $[0] = obj.value;
+    $[0] = obj;
     $[1] = state;
     $[2] = t1;
   } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/function-with-conditional-callsite-in-another-function.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/function-with-conditional-callsite-in-another-function.expect.md
@@ -89,9 +89,9 @@ function useMakeCallback(t0) {
   const $ = _c(6);
   const { obj, cond, setState } = t0;
   let t1;
-  if ($[0] !== obj.value || $[1] !== setState) {
+  if ($[0] !== obj || $[1] !== setState) {
     t1 = () => setState(obj.value);
-    $[0] = obj.value;
+    $[0] = obj;
     $[1] = setState;
     $[2] = t1;
   } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/hook-call.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/hook-call.expect.md
@@ -48,9 +48,9 @@ function useMakeCallback(t0) {
   const $ = _c(3);
   const { obj, setState } = t0;
   let t1;
-  if ($[0] !== obj.value || $[1] !== setState) {
+  if ($[0] !== obj || $[1] !== setState) {
     t1 = () => setState(obj.value);
-    $[0] = obj.value;
+    $[0] = obj;
     $[1] = setState;
     $[2] = t1;
   } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/jsx-function.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/jsx-function.expect.md
@@ -44,9 +44,9 @@ function useMakeCallback(t0) {
   const $ = _c(3);
   const { obj, setState } = t0;
   let t1;
-  if ($[0] !== obj.value || $[1] !== setState) {
+  if ($[0] !== obj || $[1] !== setState) {
     t1 = <Stringify cb={() => setState(obj.value)} shouldInvokeFns={true} />;
-    $[0] = obj.value;
+    $[0] = obj;
     $[1] = setState;
     $[2] = t1;
   } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/return-function.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/assume-invoked/return-function.expect.md
@@ -47,9 +47,9 @@ function useMakeCallback(t0) {
   const $ = _c(3);
   const { obj, setState } = t0;
   let t1;
-  if ($[0] !== obj.value || $[1] !== setState) {
+  if ($[0] !== obj || $[1] !== setState) {
     t1 = () => setState(obj.value);
-    $[0] = obj.value;
+    $[0] = obj;
     $[1] = setState;
     $[2] = t1;
   } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/bug-invalid-array-map-manual.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/inner-function/nullable-objects/bug-invalid-array-map-manual.expect.md
@@ -31,9 +31,9 @@ function useFoo(t0) {
   const $ = _c(5);
   const { arr1, arr2 } = t0;
   let t1;
-  if ($[0] !== arr2[0].value) {
+  if ($[0] !== arr2) {
     t1 = (e) => arr2[0].value + e.value;
-    $[0] = arr2[0].value;
+    $[0] = arr2;
     $[1] = t1;
   } else {
     t1 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/array-map-named-callback-cross-context.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/array-map-named-callback-cross-context.expect.md
@@ -61,9 +61,9 @@ function useFoo(t0) {
   const $ = _c(13);
   const { arr1, arr2 } = t0;
   let t1;
-  if ($[0] !== arr1[0]) {
+  if ($[0] !== arr1) {
     t1 = (e) => arr1[0].value + e.value;
-    $[0] = arr1[0];
+    $[0] = arr1;
     $[1] = t1;
   } else {
     t1 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/nullable-objects-assume-invoked-direct-call.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/nullable-objects-assume-invoked-direct-call.expect.md
@@ -35,13 +35,13 @@ function useMakeCallback(t0) {
   const { obj } = t0;
   const [state, setState] = useState(0);
   let t1;
-  if ($[0] !== obj.value || $[1] !== state) {
+  if ($[0] !== obj || $[1] !== state) {
     t1 = () => {
       if (obj.value !== state) {
         setState(obj.value);
       }
     };
-    $[0] = obj.value;
+    $[0] = obj;
     $[1] = state;
     $[2] = t1;
   } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nullable-closure-property-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nullable-closure-property-dep.expect.md
@@ -1,0 +1,58 @@
+
+## Input
+
+```javascript
+// Closure property accesses on nullable objects should not be eagerly
+// evaluated as cache keys. The compiler must not hoist `user.name` out
+// of the closure when `user` could be null at render time.
+const MyComponent = ({user}) => {
+  const handleClick = () => {
+    console.log(user.name);
+  };
+
+  if (!user) return null;
+
+  return <button onClick={handleClick}>Click</button>;
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // Closure property accesses on nullable objects should not be eagerly
+// evaluated as cache keys. The compiler must not hoist `user.name` out
+// of the closure when `user` could be null at render time.
+const MyComponent = (t0) => {
+  const $ = _c(4);
+  const { user } = t0;
+  let t1;
+  if ($[0] !== user) {
+    t1 = () => {
+      console.log(user.name);
+    };
+    $[0] = user;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const handleClick = t1;
+
+  if (!user) {
+    return null;
+  }
+  let t2;
+  if ($[2] !== handleClick) {
+    t2 = <button onClick={handleClick}>Click</button>;
+    $[2] = handleClick;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  return t2;
+};
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nullable-closure-property-dep.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nullable-closure-property-dep.js
@@ -1,0 +1,12 @@
+// Closure property accesses on nullable objects should not be eagerly
+// evaluated as cache keys. The compiler must not hoist `user.name` out
+// of the closure when `user` could be null at render time.
+const MyComponent = ({user}) => {
+  const handleClick = () => {
+    console.log(user.name);
+  };
+
+  if (!user) return null;
+
+  return <button onClick={handleClick}>Click</button>;
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.useCallback-conditional-access-noAlloc.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.useCallback-conditional-access-noAlloc.expect.md
@@ -29,7 +29,7 @@ Found 1 error:
 
 Compilation Skipped: Existing memoization could not be preserved
 
-React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected. The inferred dependency was `propB?.x.y`, but the source dependencies were [propA, propB.x.y]. Inferred different dependency than source.
+React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected. The inferred dependency was `propB?.x`, but the source dependencies were [propA, propB.x.y]. Inferred different dependency than source.
 
 error.useCallback-conditional-access-noAlloc.ts:5:21
    3 |

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useCallback-infer-more-specific.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useCallback-infer-more-specific.expect.md
@@ -37,9 +37,9 @@ import { useCallback } from "react";
 function useHook(x) {
   const $ = _c(2);
   let t0;
-  if ($[0] !== x.y.z) {
+  if ($[0] !== x) {
     t0 = () => [x.y.z];
-    $[0] = x.y.z;
+    $[0] = x;
     $[1] = t0;
   } else {
     t0 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/reduce-reactive-deps/infer-function-uncond-access-hoisted.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/reduce-reactive-deps/infer-function-uncond-access-hoisted.expect.md
@@ -29,9 +29,9 @@ function useFoo(t0) {
   const $ = _c(2);
   const { a } = t0;
   let t1;
-  if ($[0] !== a.b.c) {
+  if ($[0] !== a) {
     t1 = <Stringify fn={() => a.b.c} shouldInvokeFns={true} />;
-    $[0] = a.b.c;
+    $[0] = a;
     $[1] = t1;
   } else {
     t1 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/reduce-reactive-deps/infer-function-uncond-access-hoists-other-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/reduce-reactive-deps/infer-function-uncond-access-hoists-other-dep.expect.md
@@ -51,12 +51,12 @@ function Foo(t0) {
   const fn = t1;
   useIdentity(null);
   let x;
-  if ($[2] !== a.b.c || $[3] !== cond) {
+  if ($[2] !== a || $[3] !== cond) {
     x = makeArray();
     if (cond) {
       x.push(identity(a.b.c));
     }
-    $[2] = a.b.c;
+    $[2] = a;
     $[3] = cond;
     $[4] = x;
   } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/reduce-reactive-deps/infer-function-uncond-access-local-var.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/reduce-reactive-deps/infer-function-uncond-access-local-var.expect.md
@@ -41,10 +41,10 @@ function useFoo(t0) {
     local = $[1];
   }
   let t1;
-  if ($[2] !== local.b.c) {
+  if ($[2] !== local) {
     const fn = () => local.b.c;
     t1 = <Stringify fn={fn} shouldInvokeFns={true} />;
-    $[2] = local.b.c;
+    $[2] = local;
     $[3] = t1;
   } else {
     t1 = $[3];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/reduce-reactive-deps/infer-function-uncond-optional-hoists-other-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/reduce-reactive-deps/infer-function-uncond-optional-hoists-other-dep.expect.md
@@ -50,12 +50,12 @@ function Foo(t0) {
   const fn = t1;
   useIdentity(null);
   let arr;
-  if ($[2] !== a.b?.c.e || $[3] !== cond) {
+  if ($[2] !== a || $[3] !== cond) {
     arr = makeArray();
     if (cond) {
       arr.push(identity(a.b?.c.e));
     }
-    $[2] = a.b?.c.e;
+    $[2] = a;
     $[3] = cond;
     $[4] = arr;
   } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/reduce-reactive-deps/infer-nested-function-uncond-access.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/reduce-reactive-deps/infer-nested-function-uncond-access.expect.md
@@ -34,10 +34,10 @@ function useFoo(t0) {
   const $ = _c(2);
   const { a } = t0;
   let t1;
-  if ($[0] !== a.b.c) {
+  if ($[0] !== a) {
     const fn = () => () => ({ value: a.b.c });
     t1 = <Stringify fn={fn} shouldInvokeFns={true} />;
-    $[0] = a.b.c;
+    $[0] = a;
     $[1] = t1;
   } else {
     t1 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/reduce-reactive-deps/todo-infer-function-uncond-optionals-hoisted.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/reduce-reactive-deps/todo-infer-function-uncond-optionals-hoisted.expect.md
@@ -34,9 +34,9 @@ function useFoo(t0) {
   const $ = _c(2);
   const { a } = t0;
   let t1;
-  if ($[0] !== a.b?.c.d?.e) {
+  if ($[0] !== a) {
     t1 = <Stringify fn={() => a.b?.c.d?.e} shouldInvokeFns={true} />;
-    $[0] = a.b?.c.d?.e;
+    $[0] = a;
     $[1] = t1;
   } else {
     t1 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/repro-invariant.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/repro-invariant.expect.md
@@ -29,9 +29,9 @@ function Foo(t0) {
   const $ = _c(5);
   const { data } = t0;
   let t1;
-  if ($[0] !== data.a.d) {
+  if ($[0] !== data.a) {
     t1 = () => data.a.d;
-    $[0] = data.a.d;
+    $[0] = data.a;
     $[1] = t1;
   } else {
     t1 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/todo-infer-function-uncond-optionals-hoisted.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reduce-reactive-deps/todo-infer-function-uncond-optionals-hoisted.expect.md
@@ -31,9 +31,9 @@ function useFoo(t0) {
   const $ = _c(2);
   const { a } = t0;
   let t1;
-  if ($[0] !== a.b?.c.d?.e) {
+  if ($[0] !== a) {
     t1 = <Stringify fn={() => a.b?.c.d?.e} shouldInvokeFns={true} />;
-    $[0] = a.b?.c.d?.e;
+    $[0] = a;
     $[1] = t1;
   } else {
     t1 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-context-var-reassign-no-scope.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-context-var-reassign-no-scope.expect.md
@@ -44,7 +44,7 @@ import { useState, useEffect } from "react";
 import { invoke, Stringify } from "shared-runtime";
 
 function Content() {
-  const $ = _c(8);
+  const $ = _c(7);
   const [announcement, setAnnouncement] = useState("");
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
@@ -55,7 +55,8 @@ function Content() {
   }
   const [users, setUsers] = useState(t0);
   let t1;
-  if ($[1] !== users.length) {
+  let t2;
+  if ($[1] !== users) {
     t1 = () => {
       if (users.length === 2) {
         let removedUserName = "";
@@ -65,32 +66,26 @@ function Content() {
           newUsers.pop();
           return newUsers;
         });
-
         setAnnouncement(`Removed user (${removedUserName})`);
       }
     };
-    $[1] = users.length;
+    t2 = [users];
+    $[1] = users;
     $[2] = t1;
+    $[3] = t2;
   } else {
     t1 = $[2];
-  }
-  let t2;
-  if ($[3] !== users) {
-    t2 = [users];
-    $[3] = users;
-    $[4] = t2;
-  } else {
-    t2 = $[4];
+    t2 = $[3];
   }
   useEffect(t1, t2);
   let t3;
-  if ($[5] !== announcement || $[6] !== users) {
+  if ($[4] !== announcement || $[5] !== users) {
     t3 = <Stringify users={users} announcement={announcement} />;
-    $[5] = announcement;
-    $[6] = users;
-    $[7] = t3;
+    $[4] = announcement;
+    $[5] = users;
+    $[6] = t3;
   } else {
-    t3 = $[7];
+    t3 = $[6];
   }
   return t3;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useContext-maybe-mutate-context-in-callback.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useContext-maybe-mutate-context-in-callback.expect.md
@@ -41,11 +41,11 @@ function Component(props) {
   const $ = _c(5);
   const Foo = useContext(FooContext);
   let t0;
-  if ($[0] !== Foo.current) {
+  if ($[0] !== Foo) {
     t0 = () => {
       mutate(Foo.current);
     };
-    $[0] = Foo.current;
+    $[0] = Foo;
     $[1] = t0;
   } else {
     t0 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useContext-read-context-in-callback-if-condition.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useContext-read-context-in-callback-if-condition.expect.md
@@ -42,7 +42,7 @@ function Component(props) {
   const $ = _c(4);
   const foo = useContext(FooContext);
   let t0;
-  if ($[0] !== foo.current) {
+  if ($[0] !== foo) {
     const getValue = () => {
       if (foo.current) {
         return {};
@@ -51,7 +51,7 @@ function Component(props) {
       }
     };
     t0 = getValue();
-    $[0] = foo.current;
+    $[0] = foo;
     $[1] = t0;
   } else {
     t0 = $[1];

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useContext-read-context-in-callback.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/useContext-read-context-in-callback.expect.md
@@ -34,11 +34,11 @@ function Component(props) {
   const $ = _c(5);
   const foo = useContext(FooContext);
   let t0;
-  if ($[0] !== foo.current) {
+  if ($[0] !== foo) {
     t0 = () => {
       console.log(foo.current);
     };
-    $[0] = foo.current;
+    $[0] = foo;
     $[1] = t0;
   } else {
     t0 = $[1];


### PR DESCRIPTION
## Summary

Fixes #35762

The compiler's hoistable property load analysis promotes non-null proofs from inner functions (JSX attribute callbacks, hook callbacks, direct calls, returned functions) to the outer render scope. However, these proofs are only valid at invocation time, not at the point where cache keys are evaluated during render.

When a closure accesses `obj.value` inside an event handler, the inner function proves `obj` is non-null. The compiler incorrectly promotes this proof to the outer scope, allowing `obj.value` to be hoisted as a cache dependency (`$[0] !== obj.value`). If `obj` is null/undefined at render time, this throws a TypeError before the null guard can run.

## Fix

In `collectNonNullsInBlocks` (`CollectHoistablePropertyLoads.ts`), when promoting hoistable entries from assumed-invoked inner functions to the outer scope, only promote entries whose root identifier is already proven non-null in the outer scope. This prevents unsafe property access hoisting while preserving the optimization for cases where the root is known to be non-null (e.g., component props object, variables proven non-null by prior instructions).

The effect is that dependencies are truncated to the root identifier (e.g., `$[0] !== user` instead of `$[0] !== user.name`), which is always safe for reference comparison and still correct for memoization.

## How did you test this change?

- Added a new fixture `nullable-closure-property-dep` that reproduces the issue from #35762
- Updated 35 existing fixture snapshots (all consistent: property access deps in closures truncated to root when root isn't proven non-null)
- All 43 Jest tests pass across 15 test suites
- Prettier and lint pass

### Steps to reproduce the original bug

```jsx
const MyComponent = ({user}) => {
  const handleClick = () => {
    console.log(user.name);
  };

  if (!user) return null;

  return <button onClick={handleClick}>Click</button>;
};

// Calling <MyComponent user={null} /> throws:
// TypeError: Cannot read properties of null (reading 'name')
```

**Before fix:** Compiler generates `$[0] !== user.name` as cache key, which throws when `user` is null.

**After fix:** Compiler generates `$[0] !== user` as cache key, which safely compares references.
