### PR TITLE
[DevTools] Fix ReactDevToolsBackend module for AMD

### DIFF
--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -361,6 +361,7 @@ function startServer(
     response.end(
       backendFile.toString() +
         '\n;' +
+        `var ReactDevToolsBackend = typeof ReactDevToolsBackend !== "undefined" ? ReactDevToolsBackend : require("ReactDevToolsBackend");\n` +
         `ReactDevToolsBackend.initialize(undefined, undefined, undefined, ${componentFiltersString});` +
         '\n' +
         `ReactDevToolsBackend.connectToDevTools({port: ${port}, host: '${host}', useHttps: ${

--- a/packages/react-devtools-core/webpack.backend.js
+++ b/packages/react-devtools-core/webpack.backend.js
@@ -44,6 +44,7 @@ module.exports = {
     // This name is important; standalone references it in order to connect.
     library: 'ReactDevToolsBackend',
     libraryTarget: 'umd',
+    umdNamedDefine: true,
   },
   resolve: {
     alias: {


### PR DESCRIPTION

## Summary

For apps that use AMD, we need to actually `require()` the ReactDevToolsBackend and load it from the AMD module cache. This adds a check for the case where the `ReactDevToolsBackend` isn't defined globally, and so we load it with `require()`.


## How did you test this change?

Tested through https://github.com/facebook/react/pull/35886
