### PR TITLE
Fix typos in comments (becuase/becasue → because, occured → occurred)

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js
@@ -156,7 +156,7 @@ export default class ErrorBoundary extends Component<Props, State> {
           <CaughtErrorView
             callStack={callStack}
             componentStack={componentStack}
-            errorMessage={errorMessage || 'Error occured in inspected element'}
+            errorMessage={errorMessage || 'Error occurred in inspected element'}
             info={
               <>
                 React DevTools encountered an error while trying to inspect the

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -5328,7 +5328,7 @@ export function writeHoistablesForBoundary(
   hoistableState.stylesheets.forEach(hasStylesToHoist);
 
   // We don't actually want to flush any hoistables until the boundary is complete so we omit
-  // any further writing here. This is becuase unlike Resources, Hoistable Elements act more like
+  // any further writing here. This is because unlike Resources, Hoistable Elements act more like
   // regular elements, each rendered element has a unique representation in the DOM. We don't want
   // these elements to appear in the DOM early, before the boundary has actually completed
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -389,7 +389,7 @@ describe('ReactDOMFizzServerBrowser', () => {
     // an exact view boundary. it's not critical to test this edge case but
     // since we are setting up a test in general for larger chunks I contrived it
     // as such for now. I don't think it needs to be maintained if in the future
-    // the view sizes change or become dynamic becasue of the use of byobRequest
+    // the view sizes change or become dynamic because of the use of byobRequest
     let stream;
     stream = await serverAct(() =>
       ReactDOMFizzServer.renderToReadableStream(

--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -1260,7 +1260,7 @@ describe('ReactDOMServerHydration', () => {
         }
 
         // @TODO changes made to sending Fizz errors to client led to the insertion of templates in client rendered
-        // suspense boundaries. This leaks in this test becuase the client rendered suspense boundary appears like
+        // suspense boundaries. This leaks in this test because the client rendered suspense boundary appears like
         // unhydrated tail nodes and this template is the first match. When we add special case handling for client
         // rendered suspense boundaries this test will likely change again
         expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`

--- a/packages/react-dom/src/__tests__/ReactDOMImageLoad-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMImageLoad-test.internal.js
@@ -296,7 +296,7 @@ describe('ReactDOMImageLoad', () => {
       'render start',
       'Img b',
       'Yield',
-      // yield is ignored becasue we are sync rendering
+      // yield is ignored because we are sync rendering
       'last layout',
       'last passive',
     ]);

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -1258,7 +1258,7 @@ function completeWork(
                 markUpdate(workInProgress);
               }
             } else {
-              // We use the updateHostComponent path becuase it produces
+              // We use the updateHostComponent path because it produces
               // the update queue we need for Hoistables.
               updateHostComponent(
                 current,

--- a/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
@@ -1700,7 +1700,7 @@ describe('ReactAsyncActions', () => {
     'regression: updates in an action passed to React.startTransition are batched ' +
       'even if there were no updates before the first await',
     async () => {
-      // Regression for a bug that occured in an older, too-clever-by-half
+      // Regression for a bug that occurred in an older, too-clever-by-half
       // implementation of the isomorphic startTransition API. Now, the
       // isomorphic startTransition is literally the composition of every
       // reconciler instance's startTransition, so the behavior is less likely


### PR DESCRIPTION
## Summary

Fixed spelling mistakes found in inline code comments across 7 files:

- `becuase` → `because` in `ReactFizzConfigDOM.js`
- `becuase` → `because` in `ReactDOMHydrationDiff-test.js`
- `becuase` → `because` in `ReactFiberCompleteWork.js`
- `becasue` → `because` in `ReactDOMFizzServerBrowser-test.js`
- `becasue` → `because` in `ReactDOMImageLoad-test.internal.js`
- `occured` → `occurred` in `ErrorBoundary.js`
- `occured` → `occurred` in `ReactAsyncActions-test.js`

No logic changes — comments only.