### PR TITLE
fix: correct typos in comments and test descriptions

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -2131,7 +2131,7 @@ describe('InspectedElement', () => {
   });
 
   // See github.com/facebook/react/issues/21654
-  it('should support Proxies that dont return an iterator', async () => {
+  it("should support Proxies that don't return an iterator", async () => {
     const Example = () => null;
     const proxy = new Proxy(
       {},

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -4017,7 +4017,7 @@ export function registerSuspenseInstanceRetry(
     instance.data !== SUSPENSE_PENDING_START_DATA ||
     // The boundary is still in pending status but the document has finished loading
     // before we could register the event handler that would have scheduled the retry
-    // on load so we call teh callback now.
+    // on load so we call the callback now.
     ownerDocument.readyState !== DOCUMENT_READY_STATE_LOADING
   ) {
     callback();

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -264,7 +264,7 @@ export type ResumableState = {
   nextFormID: number,
   streamingFormat: StreamingFormat,
 
-  // We carry the bootstrap intializers in resumable state in case we postpone in the shell
+  // We carry the bootstrap initializers in resumable state in case we postpone in the shell
   // of a prerender. On resume we will reinitialize the bootstrap scripts if necessary.
   // If we end up flushing the bootstrap scripts we void these on the resumable state
   bootstrapScriptContent?: string | void,

--- a/packages/react-dom/src/__tests__/ReactLegacyMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyMount-test.js
@@ -145,7 +145,7 @@ describe('ReactMount', () => {
     const iFrame = document.createElement('iframe');
     document.body.appendChild(iFrame);
 
-    // HostSingletons make the warning for document.body unecessary
+    // HostSingletons make the warning for document.body unnecessary
     ReactDOM.render(<div />, iFrame.contentDocument.body);
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
@@ -1700,7 +1700,7 @@ describe('ReactAsyncActions', () => {
     'regression: updates in an action passed to React.startTransition are batched ' +
       'even if there were no updates before the first await',
     async () => {
-      // Regression for a bug that occured in an older, too-clever-by-half
+      // Regression for a bug that occurred in an older, too-clever-by-half
       // implementation of the isomorphic startTransition API. Now, the
       // isomorphic startTransition is literally the composition of every
       // reconciler instance's startTransition, so the behavior is less likely

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -595,7 +595,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     );
 
     // Unblock the low-pri text and finish. Nothing in the UI changes because
-    // the update was overriden
+    // the update was overridden
     await act(() => resolveText('2'));
     assertLog(['2']);
     expect(ReactNoop).toMatchRenderedOutput(

--- a/packages/react-reconciler/src/__tests__/ReactUse-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUse-test.js
@@ -1374,7 +1374,7 @@ describe('ReactUse', () => {
 
   it('async children are recursively unwrapped', async () => {
     // This is a Usable of a Usable. `use` would only unwrap a single level, but
-    // when passed as a child, the reconciler recurisvely unwraps until it
+    // when passed as a child, the reconciler recursively unwraps until it
     // resolves to a non-Usable value.
     const thenable = {
       then() {},

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -2617,7 +2617,7 @@ describe('ReactFlightDOM', () => {
     );
   });
 
-  it('wont serialize thenables that were not already settled by the time an abort happens', async () => {
+  it("won't serialize thenables that were not already settled by the time an abort happens", async () => {
     function App() {
       return (
         <div>


### PR DESCRIPTION
## Summary

Fixes several typos found in comments and test description strings across the codebase:

- `teh` → `the` (`ReactFiberConfigDOM.js`)
- `intializers` → `initializers` (`ReactFizzConfigDOM.js`)
- `unecessary` → `unnecessary` (`ReactLegacyMount-test.js`)
- `overriden` → `overridden` (`ReactSuspenseWithNoopRenderer-test.js`)
- `recurisvely` → `recursively` (`ReactUse-test.js`)
- `occured` → `occurred` (`ReactAsyncActions-test.js`)
- `dont` → `don't` (`inspectedElement-test.js`)
- `wont` → `won't` (`ReactFlightDOM-test.js`)

No logic changes — comments and test description strings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)