### PR TITLE
fix: handle Symbol values in hook dependency size change warning

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -483,8 +483,8 @@ function areHookInputsEqual(
           'Previous: %s\n' +
           'Incoming: %s',
         currentHookNameInDev,
-        `[${prevDeps.join(', ')}]`,
-        `[${nextDeps.join(', ')}]`,
+        `[${prevDeps.map(String).join(', ')}]`,
+        `[${nextDeps.map(String).join(', ')}]`,
       );
     }
   }

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -591,6 +591,33 @@ describe('ReactHooks', () => {
     ]);
   });
 
+  it('warns about variable number of dependencies when deps contain Symbols', async () => {
+    const {useLayoutEffect} = React;
+    const sym = Symbol('testSymbol');
+    function App(props) {
+      useLayoutEffect(() => {}, props.dependencies);
+      return null;
+    }
+    let root;
+    await act(() => {
+      root = ReactTestRenderer.create(<App dependencies={[sym]} />, {
+        unstable_isConcurrent: true,
+      });
+    });
+    await act(() => {
+      root.update(<App dependencies={[sym, 'extra']} />);
+    });
+    assertConsoleErrorDev([
+      'The final argument passed to useLayoutEffect changed size ' +
+        'between renders. The order and size of this array must remain ' +
+        'constant.\n' +
+        '\n' +
+        'Previous: [Symbol(testSymbol)]\n' +
+        'Incoming: [Symbol(testSymbol), extra]\n' +
+        '    in App (at **)',
+    ]);
+  });
+
   it('warns if switching from dependencies to no dependencies', async () => {
     const {useMemo} = React;
     function App({text, hasDeps}) {

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -151,8 +151,8 @@ function areHookInputsEqual(
           'Previous: %s\n' +
           'Incoming: %s',
         currentHookNameInDev,
-        `[${nextDeps.join(', ')}]`,
-        `[${prevDeps.join(', ')}]`,
+        `[${nextDeps.map(String).join(', ')}]`,
+        `[${prevDeps.map(String).join(', ')}]`,
       );
     }
   }


### PR DESCRIPTION
## Summary

Fixes a crash where React's dev-mode warning about hook dependency array size changes would itself throw a `TypeError: Cannot convert a Symbol value to a string` when any dep was a Symbol.

**Root cause:** `Array.prototype.join()` implicitly calls `.toString()` on each element, which throws for Symbol values. The warning code in `areHookInputsEqual` used `.join()` directly:

```js
// Before (crashes with Symbol deps)
`[${prevDeps.join(', ')}]`
```

**Fix:** Use `String()` (which handles Symbols correctly) before joining:

```js
// After (works with any dep type)
`[${prevDeps.map(String).join(', ')}]`
```

Fixed in both `ReactFiberHooks.js` (client reconciler) and `ReactFizzHooks.js` (server/Fizz renderer) since both had the same issue.

Closes #19848

## Test plan

- Added a new test case `warns about variable number of dependencies when deps contain Symbols` to `ReactHooks-test.internal.js` that:
  - Uses a Symbol as a dep
  - Changes the dep array size between renders
  - Verifies the warning message renders correctly with `Symbol(testSymbol)` instead of crashing
- Existing test `warns about variable number of dependencies` continues to pass unchanged