### PR TITLE
[RN] Fix timeStamp property of SyntheticEvent in React Native

### DIFF
--- a/packages/react-native-renderer/src/legacy-events/SyntheticEvent.js
+++ b/packages/react-native-renderer/src/legacy-events/SyntheticEvent.js
@@ -11,6 +11,21 @@ import assign from 'shared/assign';
 
 const EVENT_POOL_SIZE = 10;
 
+let currentTimeStamp = () => {
+  // Lazily define the function based on the existence of performance.now()
+  if (
+    typeof performance === 'object' &&
+    performance !== null &&
+    typeof performance.now === 'function'
+  ) {
+    currentTimeStamp = () => performance.now();
+  } else {
+    currentTimeStamp = () => Date.now();
+  }
+
+  return currentTimeStamp();
+};
+
 /**
  * @interface Event
  * @see http://www.w3.org/TR/DOM-Level-3-Events/
@@ -26,7 +41,7 @@ const EventInterface = {
   bubbles: null,
   cancelable: null,
   timeStamp: function (event) {
-    return event.timeStamp || Date.now();
+    return event.timeStamp || event.timestamp || currentTimeStamp();
   },
   defaultPrevented: null,
   isTrusted: null,


### PR DESCRIPTION
## Summary

This fixes the semantics of the `timeStamp` property of events in React Native.

Currently, most events just assign `Date.now()` (at the time of creating the event object in JavaScript) as the `timeStamp` property. This is a divergence with Web and most native platforms, that use a monotonic timestamp for the value (on Web, the same timestamp provided by `performance.now()`).

Additionally, many native events specify a timestamp in the event data object as `timestamp` and gets ignored by the logic in JS as it only looks at properties named `timeStamp` specifically (camel case).

This PR fixes both issues by:
1. Using `performance.now()` instead of `Date.now()` by default (if available).
2. Checking for a `timestamp` property before falling back to the default (apart from `timeStamp`).

## How did you test this change?

Added unit tests for verify the new behavior.