### PR TITLE
[RN] Expose event as a global variable during dispatch

### DIFF
--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -1099,6 +1099,8 @@ describe('ReactFabric', () => {
               // Check for referential equality
               expect(ref1.current).toBe(event.target);
               expect(ref1.current).toBe(event.currentTarget);
+
+              expect(global.event).toBe(event);
             }}
             onStartShouldSetResponder={() => true}
           />
@@ -1110,6 +1112,8 @@ describe('ReactFabric', () => {
               // Check for referential equality
               expect(ref2.current).toBe(event.target);
               expect(ref2.current).toBe(event.currentTarget);
+
+              expect(global.event).toBe(event);
             }}
             onStartShouldSetResponder={() => true}
           />
@@ -1122,6 +1126,9 @@ describe('ReactFabric', () => {
 
     const [dispatchEvent] =
       nativeFabricUIManager.registerEventHandler.mock.calls[0];
+
+    const preexistingEvent = {};
+    global.event = preexistingEvent;
 
     dispatchEvent(getViewById('one').instanceHandle, 'topTouchStart', {
       target: getViewById('one').reactTag,
@@ -1150,7 +1157,9 @@ describe('ReactFabric', () => {
       changedTouches: [],
     });
 
-    expect.assertions(6);
+    expect(global.event).toBe(preexistingEvent);
+
+    expect.assertions(9);
   });
 
   it('findHostInstance_DEPRECATED should warn if used to find a host component inside StrictMode', async () => {

--- a/packages/react-native-renderer/src/legacy-events/EventPluginUtils.js
+++ b/packages/react-native-renderer/src/legacy-events/EventPluginUtils.js
@@ -67,6 +67,9 @@ function validateEventDispatches(event) {
  */
 export function executeDispatch(event, listener, inst) {
   event.currentTarget = getNodeFromInstance(inst);
+  const currentEvent = global.event;
+  global.event = event;
+
   try {
     listener(event);
   } catch (error) {
@@ -77,6 +80,8 @@ export function executeDispatch(event, listener, inst) {
       // TODO: Make sure this error gets logged somehow.
     }
   }
+
+  global.event = currentEvent;
   event.currentTarget = null;
 }
 


### PR DESCRIPTION
## Summary

This PR updates the event dispatching logic in React Native to expose the dispatched event in the global scope as done on Web (https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke) and in the new implementation of `EventTarget` in React Native (https://github.com/facebook/react-native/blob/d1b2ddc9cb4f7b4cb795fed197347173ed5c4bfb/packages/react-native/src/private/webapis/dom/events/EventTarget.js#L372).

## How did you test this change?

Added unit tests