### PR TITLE
[react-dom] Support `maskType` SVG prop

### DIFF
--- a/packages/react-dom-bindings/src/shared/getAttributeAlias.js
+++ b/packages/react-dom-bindings/src/shared/getAttributeAlias.js
@@ -50,6 +50,7 @@ const aliases = new Map([
   ['markerEnd', 'marker-end'],
   ['markerMid', 'marker-mid'],
   ['markerStart', 'marker-start'],
+  ['maskType', 'mask-type'],
   ['overlinePosition', 'overline-position'],
   ['overlineThickness', 'overline-thickness'],
   ['paintOrder', 'paint-order'],

--- a/packages/react-dom-bindings/src/shared/possibleStandardNames.js
+++ b/packages/react-dom-bindings/src/shared/possibleStandardNames.js
@@ -314,6 +314,7 @@ const possibleStandardNames = {
   markerwidth: 'markerWidth',
   mask: 'mask',
   maskcontentunits: 'maskContentUnits',
+  masktype: 'maskType',
   maskunits: 'maskUnits',
   mathematical: 'mathematical',
   mode: 'mode',


### PR DESCRIPTION
## Summary

React currently does not recognize the `maskType` prop on SVG elements, causing:
1. The attribute to be rendered as-is (`maskType="luminance"`) rather than the correct `mask-type="luminance"`
2. A React warning: *"React does not recognize the `maskType` prop on a DOM element"*

The SVG `mask-type` attribute is [valid per MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/mask-type) and specifies whether a mask is used as a luminance or alpha mask.

## Changes

- **`getAttributeAlias.js`**: Add `['maskType', 'mask-type']` to the SVG attribute alias map (alphabetically between `markerStart` and `overlinePosition`)
- **`possibleStandardNames.js`**: Add `masktype: 'maskType'` entry so the dev-mode warning correctly suggests the camelCase spelling

## Test

```jsx
// Before: renders as <mask maskType="luminance"> + React warning
// After: renders as <mask mask-type="luminance"> correctly
<svg>
  <mask id="m" maskType="luminance">...</mask>
</svg>
```

Fixes #35920