### PR TITLE
eslint-plugin-react-hooks: fix refs rule overtainting for object property loads

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
@@ -150,16 +150,9 @@ function collectTemporariesSidemap(fn: HIRFunction, env: Env): void {
           break;
         }
         case 'PropertyLoad': {
-          if (
-            isUseRefType(value.object.identifier) &&
-            value.property === 'current'
-          ) {
-            continue;
-          }
-          const temp = env.lookup(value.object);
-          if (temp != null) {
-            env.define(lvalue, temp);
-          }
+          // Property loads are not aliases of the base object. If we alias them
+          // to the base place, marking one ref-like property can overtaint the
+          // whole object and unrelated properties.
           break;
         }
       }

--- a/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleRefs-test.ts
+++ b/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleRefs-test.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {RuleTester} from 'eslint';
+import {allRules} from '../src/shared/ReactCompiler';
+
+const ESLintTesterV8 = require('eslint-v8').RuleTester;
+
+type CompilerTestCases = {
+  valid: RuleTester.ValidTestCase[];
+  invalid: RuleTester.InvalidTestCase[];
+};
+
+const tests: CompilerTestCases = {
+  valid: [
+    {
+      name: 'does not mark entire props object as ref when using ref prop',
+      filename: 'test.js',
+      code: `
+        function Test(props) {
+          return (
+            <div>
+              <button ref={props.buttonRef}>{props.text}</button>
+            </div>
+          );
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'disallows direct ref access during render',
+      filename: 'test.js',
+      code: `
+        import {useRef} from 'react';
+        function Test() {
+          const ref = useRef(null);
+          return <div>{ref.current}</div>;
+        }
+      `,
+      errors: [{message: /Cannot access refs during render/}],
+    },
+  ],
+};
+
+const eslintTester = new ESLintTesterV8({
+  parser: require.resolve('hermes-eslint'),
+  parserOptions: {
+    sourceType: 'module',
+  },
+});
+
+eslintTester.run('react-compiler refs', allRules['refs'].rule, tests);


### PR DESCRIPTION
## Summary

Fixes a false positive in `react-hooks/refs` where accessing a ref-like prop (for example `props.buttonRef`) could over-taint the whole `props` object and incorrectly flag unrelated properties like `props.text`.

Root cause:
- In `ValidateNoRefAccessInRender`, `PropertyLoad` values were being aliased to their base object in `collectTemporariesSidemap()`.
- That aliasing caused ref-related taint from one property path to leak to other property paths on the same object.

Changes:
- `compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts`
  - Stop aliasing `PropertyLoad` lvalues to the base object.
  - Add explanation comment for why property loads should not alias the base object.
- `packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleRefs-test.ts`
  - Add regression test ensuring `<button ref={props.buttonRef}>{props.text}</button>` is valid.
  - Keep sanity invalid case for direct `ref.current` access during render.

Fixes: #35575

## How did you test this change?

I ran:

- `corepack yarn prettier compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleRefs-test.ts`
- `corepack yarn linc`
- `corepack yarn test ReactCompilerRuleRefs-test` (from `packages/eslint-plugin-react-hooks`)  
  - Result: **PASS** (2/2 tests)

I also ran full suites:

- `corepack yarn test`  
  - Result: 329 passed, 1 failed  
  - Failing suite: `packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackDOMEdge-test.js`  
  - Failure: JSON parse error for `{"time":NaN}`

- `corepack yarn test --prod`  
  - Result: 329 passed, 1 failed  
  - Failing suite: `packages/scheduler/src/__tests__/SchedulerSetTimeout-test.js`  
  - Failure: callback ordering/assertion mismatch

The two full-suite failures are outside the files changed in this PR.
