### PR TITLE
[Fiber] Don't warn when rendering data block scripts

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -183,6 +183,7 @@ export type Props = {
   checked?: boolean,
   defaultChecked?: boolean,
   multiple?: boolean,
+  type?: string,
   src?: string | Blob | MediaSource | MediaStream, // TODO: Response
   srcSet?: string,
   loading?: 'eager' | 'lazy',
@@ -469,6 +470,44 @@ export function createHoistableInstance(
 }
 
 let didWarnScriptTags = false;
+function isScriptDataBlock(props: Props): boolean {
+  const scriptType = props.type;
+  if (typeof scriptType !== 'string' || scriptType === '') {
+    return false;
+  }
+  const lower = scriptType.toLowerCase();
+  // Special non-MIME keywords recognized by the HTML spec
+  // TODO: May be fine to also not warn about having these types be parsed as "parser-inserted"
+  if (
+    lower === 'module' ||
+    lower === 'importmap' ||
+    lower === 'speculationrules'
+  ) {
+    return false;
+  }
+  // JavaScript MIME types per https://mimesniff.spec.whatwg.org/#javascript-mime-type
+  switch (lower) {
+    case 'application/ecmascript':
+    case 'application/javascript':
+    case 'application/x-ecmascript':
+    case 'application/x-javascript':
+    case 'text/ecmascript':
+    case 'text/javascript':
+    case 'text/javascript1.0':
+    case 'text/javascript1.1':
+    case 'text/javascript1.2':
+    case 'text/javascript1.3':
+    case 'text/javascript1.4':
+    case 'text/javascript1.5':
+    case 'text/jscript':
+    case 'text/livescript':
+    case 'text/x-ecmascript':
+    case 'text/x-javascript':
+      return false;
+  }
+  // Any other non-empty type value means this is a data block
+  return true;
+}
 const warnedUnknownTags: {
   [key: string]: boolean,
 } = {
@@ -526,7 +565,13 @@ export function createInstance(
           // set to true and it does not execute
           const div = ownerDocument.createElement('div');
           if (__DEV__) {
-            if (enableTrustedTypesIntegration && !didWarnScriptTags) {
+            if (
+              enableTrustedTypesIntegration &&
+              !didWarnScriptTags &&
+              // Data block scripts are not executed by UAs anyway so
+              // we don't need to warn: https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type
+              !isScriptDataBlock(props)
+            ) {
               console.error(
                 'Encountered a script tag while rendering React component. ' +
                   'Scripts inside React components are never executed when rendering ' +

--- a/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
+++ b/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
@@ -249,7 +249,6 @@ describe('when Trusted Types are available in global object', () => {
     });
   });
 
-  // @gate enableTrustedTypesIntegration
   it('should not warn when rendering a data block script tag', async () => {
     const root = ReactDOMClient.createRoot(container);
     await act(() => {
@@ -257,17 +256,8 @@ describe('when Trusted Types are available in global object', () => {
         <script type="application/json">{'{"key": "value"}'}</script>,
       );
     });
-
-    assertConsoleErrorDev([
-      'Encountered a script tag while rendering React component. ' +
-        'Scripts inside React components are never executed when rendering ' +
-        'on the client. Consider using template tag instead ' +
-        '(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).' +
-        '\n    in script (at **)',
-    ]);
   });
 
-  // @gate enableTrustedTypesIntegration
   it('should not warn when rendering a ld+json script tag', async () => {
     const root = ReactDOMClient.createRoot(container);
     await act(() => {
@@ -277,13 +267,5 @@ describe('when Trusted Types are available in global object', () => {
         </script>,
       );
     });
-
-    assertConsoleErrorDev([
-      'Encountered a script tag while rendering React component. ' +
-        'Scripts inside React components are never executed when rendering ' +
-        'on the client. Consider using template tag instead ' +
-        '(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).' +
-        '\n    in script (at **)',
-    ]);
   });
 });


### PR DESCRIPTION


## Summary

React will commit `<script>` tags client-side in a way to blocks them from execution. When that happens we issue a warning when trusted types integration is enabled (introduced in https://github.com/facebook/react/pull/16157).

However, scripts that contain data blocks (e.g. `application/ld+json`) are not executed by user agents anyway. In those cases React will no longer warn with this change. Especially because you couldn't follow the warning and put the `<script>`'s content in a `<template>` instead and have it work the same way.

## How did you test this change?

- [x] Added test (see first commit for current behavior)
