### PR TITLE
[Fiber] Double invoke Effects in StrictMode after Fast Refresh

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -88,6 +88,7 @@ import {
   NoFlags,
   PerformedWork,
   Placement,
+  PlacementDEV,
   Hydrating,
   Callback,
   ContentReset,
@@ -3862,7 +3863,7 @@ function remountFiber(
       deletions.push(current);
     }
 
-    newWorkInProgress.flags |= Placement;
+    newWorkInProgress.flags |= Placement | PlacementDEV;
 
     // Restart work from the new fiber.
     return newWorkInProgress;

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -2371,7 +2371,7 @@ describe('ReactFresh', () => {
       });
 
       expect(container.firstChild.style.color).toBe('red');
-      expect(log).toEqual(['unmount v1', 'mount v2']);
+      expect(log).toEqual(['unmount v1', 'mount v2', 'unmount v2', 'mount v2']);
     }
   });
 
@@ -2414,7 +2414,7 @@ describe('ReactFresh', () => {
       });
 
       expect(container.firstChild.style.color).toBe('red');
-      expect(log).toEqual(['mount v2']);
+      expect(log).toEqual(['mount v2', 'unmount v2', 'mount v2']);
     }
   });
 


### PR DESCRIPTION

## Summary

Fixes https://github.com/facebook/react/issues/29915

Ensures Effects are also double invoked when a Component newly mounts due to Fast Refresh. Looks to have been an oversight in the `remountFiber` path.

## How did you test this change?

- Added test (see first commit for previous behavior)
