### PR TITLE
Fix typo: occured -> occurred

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js
@@ -156,7 +156,7 @@ export default class ErrorBoundary extends Component<Props, State> {
           <CaughtErrorView
             callStack={callStack}
             componentStack={componentStack}
-            errorMessage={errorMessage || 'Error occured in inspected element'}
+            errorMessage={errorMessage || 'Error occurred in inspected element'}
             info={
               <>
                 React DevTools encountered an error while trying to inspect the


### PR DESCRIPTION
## Summary

Fixes a typo in a string in `packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js`: "occured" -> "occurred"

## How did you test this change?

This is a single-character typo fix in a string. No code behavior changes.

## Related issue

N/A - trivial typo fix