### PR TITLE
Fix typo: occured -> occurred (test comment)

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js
@@ -1700,7 +1700,7 @@ describe('ReactAsyncActions', () => {
     'regression: updates in an action passed to React.startTransition are batched ' +
       'even if there were no updates before the first await',
     async () => {
-      // Regression for a bug that occured in an older, too-clever-by-half
+      // Regression for a bug that occurred in an older, too-clever-by-half
       // implementation of the isomorphic startTransition API. Now, the
       // isomorphic startTransition is literally the composition of every
       // reconciler instance's startTransition, so the behavior is less likely


### PR DESCRIPTION
## Summary

Fixes a typo in a comment in `packages/react-reconciler/src/__tests__/ReactAsyncActions-test.js`: "occured" -> "occurred"

## How did you test this change?

This is a single-character typo fix in a comment. No code behavior changes.

## Related issue

N/A - trivial typo fix