### PR TITLE
[compiler] Fix false negative: independently memoize values used as method call receivers

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -46,6 +46,7 @@ import {
   makeScopeId,
 } from './HIR';
 import {
+  BuiltInArrayId,
   BuiltInMixedReadonlyId,
   DefaultMutatingHook,
   DefaultNonmutatingHook,
@@ -1000,6 +1001,24 @@ export class Environment {
       }
     } else if (typeof property === 'string' && isHookName(property)) {
       return this.#getCustomHookType();
+    } else if (receiver.kind === 'Type' && typeof property === 'string') {
+      /*
+       * For unknown receiver types, try to resolve from the BuiltInArray shape
+       * but only for methods also present in MixedReadonly (the safe subset).
+       * If .map() is called on an unknown type, the value must be array-like.
+       * We use the Array shape (not MixedReadonly) because it has aliasing
+       * signatures that correctly model data flow without over-extending
+       * mutable ranges. See ObjectShape.ts BuiltInMixedReadonlyId for details.
+       */
+      const mixedShape = this.#shapes.get(BuiltInMixedReadonlyId);
+      const arrayShape = this.#shapes.get(BuiltInArrayId);
+      if (
+        mixedShape !== undefined &&
+        arrayShape !== undefined &&
+        mixedShape.properties.has(property)
+      ) {
+        return arrayShape.properties.get(property) ?? null;
+      }
     }
     return null;
   }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-independent-memoization-for-unknown-receiver-method-call.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-independent-memoization-for-unknown-receiver-method-call.expect.md
@@ -1,0 +1,52 @@
+
+## Input
+
+```javascript
+function ExpensiveComponent({data, onClick}) {
+  const processedData = expensiveProcessing(data);
+  return (
+    <ul>
+      {processedData.map((item) => (
+        <li key={item.id} onClick={() => onClick(item)}>
+          {item.name}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function ExpensiveComponent(t0) {
+  const $ = _c(5);
+  const {
+    data,
+    onClick
+  } = t0;
+  let t1;
+  if ($[0] !== data) {
+    t1 = expensiveProcessing(data);
+    $[0] = data;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const processedData = t1;
+  let t2;
+  if ($[2] !== onClick || $[3] !== processedData) {
+    t2 = <ul>{processedData.map(item => <li key={item.id} onClick={() => onClick(item)}>{item.name}</li>)}</ul>;
+    $[2] = onClick;
+    $[3] = processedData;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  return t2;
+}
+
+```
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-independent-memoization-for-unknown-receiver-method-call.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-independent-memoization-for-unknown-receiver-method-call.js
@@ -1,0 +1,12 @@
+function ExpensiveComponent({data, onClick}) {
+  const processedData = expensiveProcessing(data);
+  return (
+    <ul>
+      {processedData.map((item) => (
+        <li key={item.id} onClick={() => onClick(item)}>
+          {item.name}
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #35902

When a method like `.map()` is called on a value with an unknown type (e.g. the return value of an unknown function like `expensiveProcessing(data)`), the compiler had no function signature available. This caused the fallback in `InferMutationAliasingEffects` to apply `MutateTransitiveConditionally` on the receiver, over-extending its mutable range and merging it into the same reactive scope as the method call result.

**Before (bug):** `expensiveProcessing(data)` re-executes when `onClick` changes:
```js
if ($[0] !== data || $[1] !== onClick) {
  const processedData = expensiveProcessing(data); // unnecessary!
  t1 = processedData.map(t2);
}
```

**After (fix):** `expensiveProcessing(data)` has its own scope depending only on `data`:
```js
if ($[0] !== data) {
  t1 = expensiveProcessing(data);
}
const processedData = t1;
if ($[2] !== onClick || $[3] !== processedData) {
  t2 = <ul>{processedData.map(...)}</ul>;
}
```

### Root cause

In `getPropertyType()`, when the receiver has an unresolved type (`Type` kind), property lookups returned `null` — meaning no function signature was available for the method call. Without a signature, `InferMutationAliasingEffects` falls back to `MutateTransitiveConditionally` on all operands including the receiver, which extends its mutable range through the method call. This causes `InferReactiveScopeVariables` (union-find) to group the receiver's creation and the method call into the same reactive scope.

### Fix

Added a fallback in `getPropertyType`: when the receiver has an unresolved type, try to resolve the property from the `BuiltInArray` shape — but **only if** the method also exists in `BuiltInMixedReadonly` (the safe, non-mutating subset). This follows the same reasoning already documented in `ObjectShape.ts` for `BuiltInMixedReadonlyId`:

> *"if `.map()` is called on an unknown type, the value must be array-like"*

We use the `BuiltInArray` shape (not `BuiltInMixedReadonly`) because it has `aliasing` signatures that correctly model data flow without over-extending mutable ranges. The `MixedReadonly` guard ensures that mutating methods like `.push()` and `.pop()` — which only exist in `BuiltInArray` — are NOT resolved through this fallback, preserving the conservative behavior for those cases.

## Test plan

- Added fixture `bug-independent-memoization-for-unknown-receiver-method-call` demonstrating the fix
- Verified 1090 existing fixtures produce identical output (zero regressions)
- Manually tested: `.push()` (mutating, not in MixedReadonly) still uses conservative fallback
- Manually tested: `.filter()`, `.map()` on unknown types now correctly separate scopes
- Manually tested: custom methods (not in any shape) still use conservative fallback