### PR TITLE
[react-dom] Normalize attribute whitespace during hydration comparison

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -230,6 +230,16 @@ function warnForPropDifference(
     if (normalizedServerValue === normalizedClientValue) {
       return;
     }
+    // Also check with attribute whitespace normalization: browsers
+    // normalize \t, \n, \r to spaces in HTML attribute values.
+    if (
+      typeof normalizedServerValue === 'string' &&
+      typeof normalizedClientValue === 'string' &&
+      normalizeAttributeValueForComparison(normalizedServerValue) ===
+        normalizeAttributeValueForComparison(normalizedClientValue)
+    ) {
+      return;
+    }
 
     serverDifferences[propName] = serverValue;
   }
@@ -343,6 +353,12 @@ function normalizeHTML(parent: Element, html: string) {
 const NORMALIZE_NEWLINES_REGEX = /\r\n?/g;
 const NORMALIZE_NULL_AND_REPLACEMENT_REGEX = /\u0000|\uFFFD/g;
 
+// Browsers normalize tab, newline, and carriage return characters to spaces
+// when parsing HTML attribute values. We normalize these before comparing
+// attribute values during hydration to avoid false mismatches.
+// See: https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(double-quoted)-state
+const NORMALIZE_ATTRIBUTE_WHITESPACE_REGEX = /[\t\n\r]/g;
+
 function normalizeMarkupForTextOrAttribute(markup: mixed): string {
   if (__DEV__) {
     checkHtmlStringCoercion(markup);
@@ -351,6 +367,10 @@ function normalizeMarkupForTextOrAttribute(markup: mixed): string {
   return markupString
     .replace(NORMALIZE_NEWLINES_REGEX, '\n')
     .replace(NORMALIZE_NULL_AND_REPLACEMENT_REGEX, '');
+}
+
+function normalizeAttributeValueForComparison(value: string): string {
+  return value.replace(NORMALIZE_ATTRIBUTE_WHITESPACE_REGEX, ' ');
 }
 
 function checkForUnmatchedText(
@@ -2119,7 +2139,17 @@ function hydrateAttribute(
           if (__DEV__) {
             checkAttributeStringCoercion(value, propKey);
           }
-          if (serverValue === '' + value) {
+          const coercedValue = '' + value;
+          if (serverValue === coercedValue) {
+            return;
+          }
+          // Browsers may normalize whitespace characters (tab, newline,
+          // carriage return) to spaces in attribute values. If the only
+          // difference is this normalization, treat it as a match.
+          if (
+            normalizeAttributeValueForComparison(serverValue) ===
+            normalizeAttributeValueForComparison(coercedValue)
+          ) {
             return;
           }
         }

--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -527,6 +527,50 @@ describe('ReactDOMServerHydration', () => {
     });
   });
 
+  describe('attribute whitespace normalization', () => {
+    // @gate __DEV__
+    it('does not warn when attribute values differ only by whitespace normalization', () => {
+      function Mismatch({isClient}) {
+        return (
+          <div className="parent">
+            <main
+              className={isClient ? 'foo bar baz' : 'foo\nbar\nbaz'}
+            />
+          </div>
+        );
+      }
+      expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`[]`);
+    });
+
+    // @gate __DEV__
+    it('does not warn for tab and carriage return normalization', () => {
+      function Mismatch({isClient}) {
+        return (
+          <div className="parent">
+            <main
+              className={isClient ? 'foo bar baz' : 'foo\tbar\r\nbaz'}
+            />
+          </div>
+        );
+      }
+      expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`[]`);
+    });
+
+    // @gate __DEV__
+    it('does not warn for title attribute whitespace normalization', () => {
+      function Mismatch({isClient}) {
+        return (
+          <div>
+            <span
+              title={isClient ? 'line1 line2' : 'line1\nline2'}
+            />
+          </div>
+        );
+      }
+      expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`[]`);
+    });
+  });
+
   describe('extra nodes on the client', () => {
     describe('extra elements on the client', () => {
       // @gate __DEV__


### PR DESCRIPTION
## Summary

Related to #35481 — companion to #35978

Browsers normalize tab (`\t`), newline (`\n`), and carriage return (`\r`) characters to spaces when parsing HTML attribute values ([HTML spec](https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(double-quoted)-state)). React's hydration attribute comparison uses strict string equality, which can produce false mismatch warnings when server and client attribute values differ only by this whitespace normalization.

This change adds a fallback comparison in the hydration path that normalizes `\t`, `\n`, and `\r` to spaces before comparing, matching browser behavior.

### What changed

In `ReactDOMComponent.js`:

- Added `NORMALIZE_ATTRIBUTE_WHITESPACE_REGEX` and `normalizeAttributeValueForComparison()` helper
- Modified `hydrateAttribute()`: after strict equality fails, performs a normalized comparison before reporting a mismatch
- Modified `warnForPropDifference()`: adds whitespace normalization as an additional comparison step

### Context

- **This fix targets the DEV warning path** — in production, React does not compare individual attributes during hydration (only text content)
- **Defensive fix** — even if source transforms normalize whitespace (see #35978), this ensures React's hydration comparison is resilient to `\t\n\r` ↔ space differences from any source
- **Preserves existing behavior** — strict equality is checked first (fast path), normalization is only a fallback

### Relationship to #35978

| PR | Layer | What it fixes |
|----|-------|---------------|
| #35978 | React Compiler codegen | Normalizes whitespace in compiled JSX attribute output |
| This PR | React DOM hydration | Prevents false mismatch warnings for whitespace-only differences |

Either fix independently resolves the reported issue. Together they provide defense in depth.

## How did you test this change?

Added 3 test cases to `ReactDOMHydrationDiff-test.js`:

| Test | Scenario |
|------|----------|
| `does not warn when attribute values differ only by whitespace normalization` | `className` with `\n` vs space |
| `does not warn for tab and carriage return normalization` | `className` with `\t` and `\r\n` vs spaces |
| `does not warn for title attribute whitespace normalization` | `title` with `\n` vs space |

```bash
yarn test packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
# Test Suites: 1 passed, 1 total
# Tests:       40 passed, 40 total (37 existing + 3 new)
```