### PR TITLE
Clarify purity for null-guarded ref initialization

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/docs/passes/49-validateNoRefAccessInRender.md
+++ b/compiler/packages/babel-plugin-react-compiler/docs/passes/49-validateNoRefAccessInRender.md
@@ -29,6 +29,12 @@ if (ref.current == null) {
 }
 ```
 
+This exception only applies to the ref access pattern itself. Other validations
+still apply to the initializer expression. In particular, the initializer must
+still be predictable during render. Impure calls such as `Date.now()` or
+`Math.random()` continue to fail the `purity` rule even when they appear inside
+an allowed null-guarded ref initialization.
+
 Error messages produced:
 - Category: `Refs`
 - Reason: "Cannot access refs during render"

--- a/compiler/packages/eslint-plugin-react-compiler/__tests__/ImpureFunctionCallsRule-test.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/__tests__/ImpureFunctionCallsRule-test.ts
@@ -34,6 +34,19 @@ testRule(
           makeTestCaseError('Cannot call impure function during render'),
         ],
       },
+      {
+        name: 'Impure ref initialization still fails purity under a null guard',
+        code: normalizeIndent`
+      function Component() {
+        const ref = useRef(null);
+        if (ref.current === null) {
+          ref.current = Date.now();
+        }
+        return <div>{ref.current}</div>;
+      }
+    `,
+        errors: [makeTestCaseError('Cannot call impure function during render')],
+      },
     ],
   },
 );

--- a/compiler/packages/eslint-plugin-react-compiler/__tests__/NoRefAccessInRender-tests.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/__tests__/NoRefAccessInRender-tests.ts
@@ -16,7 +16,20 @@ testRule(
   'no ref access in render rule',
   allRules[getRuleForCategory(ErrorCategory.Refs).name].rule,
   {
-    valid: [],
+    valid: [
+      {
+        name: 'allow null-guarded ref initialization',
+        code: normalizeIndent`
+      function Component() {
+        const ref = useRef(null);
+        if (ref.current === null) {
+          ref.current = "stable";
+        }
+        return <div />;
+      }
+    `,
+      },
+    ],
     invalid: [
       {
         name: 'validate against simple ref access in render',


### PR DESCRIPTION
## Summary

Clarifies the interaction between the `refs` and `purity` lints for null-guarded ref initialization.

The null-guard pattern:

```
if (ref.current == null) {
  ref.current = ...
}
```

is allowed by the refs rule, but purity still applies to the initializer on the right-hand side. This change adds regression coverage for that behavior and updates the ref-validation docs to make the distinction explicit.

## Changes
Add a purity regression test showing Date.now() still fails inside a null-guarded ref initialization.
Add a refs regression test showing the null-guarded stable assignment pattern remains allowed.
Clarify docs for validateNoRefAccessInRender to note that the exception only applies to ref access, not to impure initializer expressions.

## Test Plan

```
yarn test ImpureFunctionCallsRule-test --runInBand
yarn test NoRefAccessInRender-tests --runInBand
```

## Issue
Closes #35973