### PR TITLE
React hooks/set state in effect lint hir order fix

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoSetStateInEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoSetStateInEffects.ts
@@ -50,85 +50,79 @@ export function validateNoSetStateInEffects(
   const errors = new CompilerError();
 
   // In order to ensure that all HIR components that could contain setState have been iterated,
-  // we run the reconnaissance logic until a stable number of state functions has been achieved.
-  // this makes setState HIR analysis order independent.
-  // We will then handle error on a separate pass.
-  let iterationSize = Number.MAX_SAFE_INTEGER;
-  while (iterationSize !== setStateFunctions.size) {
-    iterationSize = setStateFunctions.size;
-    for (const [, block] of fn.body.blocks) {
-      for (const instr of block.instructions) {
-        switch (instr.value.kind) {
-          case 'LoadLocal': {
-            if (setStateFunctions.has(instr.value.place.identifier.id)) {
-              setStateFunctions.set(
-                instr.lvalue.identifier.id,
-                instr.value.place,
-              );
-            }
-            break;
+  // we fully run the reconnaissance logic, then handle error finding on a separate pass.
+  // This makes setState HIR error analysis order independent.
+  for (const [, block] of fn.body.blocks) {
+    for (const instr of block.instructions) {
+      switch (instr.value.kind) {
+        case 'LoadLocal': {
+          if (setStateFunctions.has(instr.value.place.identifier.id)) {
+            setStateFunctions.set(
+              instr.lvalue.identifier.id,
+              instr.value.place,
+            );
           }
-          case 'StoreLocal': {
-            if (setStateFunctions.has(instr.value.value.identifier.id)) {
-              setStateFunctions.set(
-                instr.value.lvalue.place.identifier.id,
-                instr.value.value,
-              );
-              setStateFunctions.set(
-                instr.lvalue.identifier.id,
-                instr.value.value,
-              );
-            }
-            break;
+          break;
+        }
+        case 'StoreLocal': {
+          if (setStateFunctions.has(instr.value.value.identifier.id)) {
+            setStateFunctions.set(
+              instr.value.lvalue.place.identifier.id,
+              instr.value.value,
+            );
+            setStateFunctions.set(
+              instr.lvalue.identifier.id,
+              instr.value.value,
+            );
           }
-          case 'FunctionExpression': {
-            if (
-              // faster-path to check if the function expression references a setState
-              [...eachInstructionValueOperand(instr.value)].some(
-                operand =>
-                  isSetStateType(operand.identifier) ||
-                  setStateFunctions.has(operand.identifier.id),
-              )
-            ) {
-              const callee = getSetStateCall(
-                instr.value.loweredFunc.func,
-                setStateFunctions,
-                env,
-              );
-              if (callee !== null) {
-                setStateFunctions.set(instr.lvalue.identifier.id, callee);
-              }
+          break;
+        }
+        case 'FunctionExpression': {
+          if (
+            // faster-path to check if the function expression references a setState
+            [...eachInstructionValueOperand(instr.value)].some(
+              operand =>
+                isSetStateType(operand.identifier) ||
+                setStateFunctions.has(operand.identifier.id),
+            )
+          ) {
+            const callee = getSetStateCall(
+              instr.value.loweredFunc.func,
+              setStateFunctions,
+              env,
+            );
+            if (callee !== null) {
+              setStateFunctions.set(instr.lvalue.identifier.id, callee);
             }
-            break;
           }
-          case 'MethodCall':
-          case 'CallExpression': {
-            const callee =
-              instr.value.kind === 'MethodCall'
-                ? instr.value.property
-                : instr.value.callee;
+          break;
+        }
+        case 'MethodCall':
+        case 'CallExpression': {
+          const callee =
+            instr.value.kind === 'MethodCall'
+              ? instr.value.property
+              : instr.value.callee;
 
-            if (isUseEffectEventType(callee.identifier)) {
-              const arg = instr.value.args[0];
-              if (arg !== undefined && arg.kind === 'Identifier') {
-                const setState = setStateFunctions.get(arg.identifier.id);
-                if (setState !== undefined) {
-                  /**
-                   * This effect event function calls setState synchonously,
-                   * treat it as a setState function for transitive tracking
-                   */
-                  setStateFunctions.set(instr.lvalue.identifier.id, setState);
-                }
+          if (isUseEffectEventType(callee.identifier)) {
+            const arg = instr.value.args[0];
+            if (arg !== undefined && arg.kind === 'Identifier') {
+              const setState = setStateFunctions.get(arg.identifier.id);
+              if (setState !== undefined) {
+                /**
+                 * This effect event function calls setState synchonously,
+                 * treat it as a setState function for transitive tracking
+                 */
+                setStateFunctions.set(instr.lvalue.identifier.id, setState);
               }
             }
-            break;
           }
+          break;
         }
       }
     }
   }
 
-  // Report errors in second pass to ensure HIR has been fully evaluated at error reporting time.
   for (const [, block] of fn.body.blocks) {
     for (const instr of block.instructions) {
       if (

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoSetStateInEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoSetStateInEffects.ts
@@ -48,135 +48,161 @@ export function validateNoSetStateInEffects(
 ): Result<void, CompilerError> {
   const setStateFunctions: Map<IdentifierId, Place> = new Map();
   const errors = new CompilerError();
-  for (const [, block] of fn.body.blocks) {
-    for (const instr of block.instructions) {
-      switch (instr.value.kind) {
-        case 'LoadLocal': {
-          if (setStateFunctions.has(instr.value.place.identifier.id)) {
-            setStateFunctions.set(
-              instr.lvalue.identifier.id,
-              instr.value.place,
-            );
-          }
-          break;
-        }
-        case 'StoreLocal': {
-          if (setStateFunctions.has(instr.value.value.identifier.id)) {
-            setStateFunctions.set(
-              instr.value.lvalue.place.identifier.id,
-              instr.value.value,
-            );
-            setStateFunctions.set(
-              instr.lvalue.identifier.id,
-              instr.value.value,
-            );
-          }
-          break;
-        }
-        case 'FunctionExpression': {
-          if (
-            // faster-path to check if the function expression references a setState
-            [...eachInstructionValueOperand(instr.value)].some(
-              operand =>
-                isSetStateType(operand.identifier) ||
-                setStateFunctions.has(operand.identifier.id),
-            )
-          ) {
-            const callee = getSetStateCall(
-              instr.value.loweredFunc.func,
-              setStateFunctions,
-              env,
-            );
-            if (callee !== null) {
-              setStateFunctions.set(instr.lvalue.identifier.id, callee);
-            }
-          }
-          break;
-        }
-        case 'MethodCall':
-        case 'CallExpression': {
-          const callee =
-            instr.value.kind === 'MethodCall'
-              ? instr.value.property
-              : instr.value.callee;
 
-          if (isUseEffectEventType(callee.identifier)) {
-            const arg = instr.value.args[0];
-            if (arg !== undefined && arg.kind === 'Identifier') {
-              const setState = setStateFunctions.get(arg.identifier.id);
-              if (setState !== undefined) {
-                /**
-                 * This effect event function calls setState synchonously,
-                 * treat it as a setState function for transitive tracking
-                 */
-                setStateFunctions.set(instr.lvalue.identifier.id, setState);
+  // In order to ensure that all HIR components that could contain setState have been iterated,
+  // we run the reconnaissance logic until a stable number of state functions has been achieved.
+  // this makes setState HIR analysis order independent.
+  // We will then handle error on a separate pass.
+  let iterationSize = Number.MAX_SAFE_INTEGER;
+  while (iterationSize !== setStateFunctions.size) {
+    iterationSize = setStateFunctions.size;
+    for (const [, block] of fn.body.blocks) {
+      for (const instr of block.instructions) {
+        switch (instr.value.kind) {
+          case 'LoadLocal': {
+            if (setStateFunctions.has(instr.value.place.identifier.id)) {
+              setStateFunctions.set(
+                instr.lvalue.identifier.id,
+                instr.value.place,
+              );
+            }
+            break;
+          }
+          case 'StoreLocal': {
+            if (setStateFunctions.has(instr.value.value.identifier.id)) {
+              setStateFunctions.set(
+                instr.value.lvalue.place.identifier.id,
+                instr.value.value,
+              );
+              setStateFunctions.set(
+                instr.lvalue.identifier.id,
+                instr.value.value,
+              );
+            }
+            break;
+          }
+          case 'FunctionExpression': {
+            if (
+              // faster-path to check if the function expression references a setState
+              [...eachInstructionValueOperand(instr.value)].some(
+                operand =>
+                  isSetStateType(operand.identifier) ||
+                  setStateFunctions.has(operand.identifier.id),
+              )
+            ) {
+              const callee = getSetStateCall(
+                instr.value.loweredFunc.func,
+                setStateFunctions,
+                env,
+              );
+              if (callee !== null) {
+                setStateFunctions.set(instr.lvalue.identifier.id, callee);
               }
             }
-          } else if (
-            isUseEffectHookType(callee.identifier) ||
-            isUseLayoutEffectHookType(callee.identifier) ||
-            isUseInsertionEffectHookType(callee.identifier)
-          ) {
-            const arg = instr.value.args[0];
-            if (arg !== undefined && arg.kind === 'Identifier') {
-              const setState = setStateFunctions.get(arg.identifier.id);
-              if (setState !== undefined) {
-                const enableVerbose =
-                  env.config.enableVerboseNoSetStateInEffect;
-                if (enableVerbose) {
-                  errors.pushDiagnostic(
-                    CompilerDiagnostic.create({
-                      category: ErrorCategory.EffectSetState,
-                      reason:
-                        'Calling setState synchronously within an effect can trigger cascading renders',
-                      description:
-                        'Effects are intended to synchronize state between React and external systems. ' +
-                        'Calling setState synchronously causes cascading renders that hurt performance.\n\n' +
-                        'This pattern may indicate one of several issues:\n\n' +
-                        '**1. Non-local derived data**: If the value being set could be computed from props/state ' +
-                        'but requires data from a parent component, consider restructuring state ownership so the ' +
-                        'derivation can happen during render in the component that owns the relevant state.\n\n' +
-                        "**2. Derived event pattern**: If you're detecting when a prop changes (e.g., `isPlaying` " +
-                        'transitioning from false to true), this often indicates the parent should provide an event ' +
-                        'callback (like `onPlay`) instead of just the current state. Request access to the original event.\n\n' +
-                        "**3. Force update / external sync**: If you're forcing a re-render to sync with an external " +
-                        'data source (mutable values outside React), use `useSyncExternalStore` to properly subscribe ' +
-                        'to external state changes.\n\n' +
-                        'See: https://react.dev/learn/you-might-not-need-an-effect',
-                      suggestions: null,
-                    }).withDetails({
-                      kind: 'error',
-                      loc: setState.loc,
-                      message:
-                        'Avoid calling setState() directly within an effect',
-                    }),
-                  );
-                } else {
-                  errors.pushDiagnostic(
-                    CompilerDiagnostic.create({
-                      category: ErrorCategory.EffectSetState,
-                      reason:
-                        'Calling setState synchronously within an effect can trigger cascading renders',
-                      description:
-                        'Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. ' +
-                        'In general, the body of an effect should do one or both of the following:\n' +
-                        '* Update external systems with the latest state from React.\n' +
-                        '* Subscribe for updates from some external system, calling setState in a callback function when external state changes.\n\n' +
-                        'Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. ' +
-                        '(https://react.dev/learn/you-might-not-need-an-effect)',
-                      suggestions: null,
-                    }).withDetails({
-                      kind: 'error',
-                      loc: setState.loc,
-                      message:
-                        'Avoid calling setState() directly within an effect',
-                    }),
-                  );
+            break;
+          }
+          case 'MethodCall':
+          case 'CallExpression': {
+            const callee =
+              instr.value.kind === 'MethodCall'
+                ? instr.value.property
+                : instr.value.callee;
+
+            if (isUseEffectEventType(callee.identifier)) {
+              const arg = instr.value.args[0];
+              if (arg !== undefined && arg.kind === 'Identifier') {
+                const setState = setStateFunctions.get(arg.identifier.id);
+                if (setState !== undefined) {
+                  /**
+                   * This effect event function calls setState synchonously,
+                   * treat it as a setState function for transitive tracking
+                   */
+                  setStateFunctions.set(instr.lvalue.identifier.id, setState);
                 }
               }
             }
+            break;
           }
-          break;
+        }
+      }
+    }
+  }
+
+  // Report errors in second pass to ensure HIR has been fully evaluated at error reporting time.
+  for (const [, block] of fn.body.blocks) {
+    for (const instr of block.instructions) {
+      if (
+        instr.value.kind !== 'CallExpression' &&
+        instr.value.kind !== 'MethodCall'
+      ) {
+        continue;
+      }
+      const callee =
+        instr.value.kind === 'MethodCall'
+          ? instr.value.property
+          : instr.value.callee;
+      if (
+        isUseEffectHookType(callee.identifier) ||
+        isUseLayoutEffectHookType(callee.identifier) ||
+        isUseInsertionEffectHookType(callee.identifier)
+      ) {
+        const arg = instr.value.args[0];
+        if (arg !== undefined && arg.kind === 'Identifier') {
+          const setState = setStateFunctions.get(arg.identifier.id);
+          if (setState !== undefined) {
+            const enableVerbose =
+              env.config.enableVerboseNoSetStateInEffect;
+            if (enableVerbose) {
+              errors.pushDiagnostic(
+                CompilerDiagnostic.create({
+                  category: ErrorCategory.EffectSetState,
+                  reason:
+                    'Calling setState synchronously within an effect can trigger cascading renders',
+                  description:
+                    'Effects are intended to synchronize state between React and external systems. ' +
+                    'Calling setState synchronously causes cascading renders that hurt performance.\n\n' +
+                    'This pattern may indicate one of several issues:\n\n' +
+                    '**1. Non-local derived data**: If the value being set could be computed from props/state ' +
+                    'but requires data from a parent component, consider restructuring state ownership so the ' +
+                    'derivation can happen during render in the component that owns the relevant state.\n\n' +
+                    "**2. Derived event pattern**: If you're detecting when a prop changes (e.g., `isPlaying` " +
+                    'transitioning from false to true), this often indicates the parent should provide an event ' +
+                    'callback (like `onPlay`) instead of just the current state. Request access to the original event.\n\n' +
+                    "**3. Force update / external sync**: If you're forcing a re-render to sync with an external " +
+                    'data source (mutable values outside React), use `useSyncExternalStore` to properly subscribe ' +
+                    'to external state changes.\n\n' +
+                    'See: https://react.dev/learn/you-might-not-need-an-effect',
+                  suggestions: null,
+                }).withDetails({
+                  kind: 'error',
+                  loc: setState.loc,
+                  message:
+                    'Avoid calling setState() directly within an effect',
+                }),
+              );
+            } else {
+              errors.pushDiagnostic(
+                CompilerDiagnostic.create({
+                  category: ErrorCategory.EffectSetState,
+                  reason:
+                    'Calling setState synchronously within an effect can trigger cascading renders',
+                  description:
+                    'Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. ' +
+                    'In general, the body of an effect should do one or both of the following:\n' +
+                    '* Update external systems with the latest state from React.\n' +
+                    '* Subscribe for updates from some external system, calling setState in a callback function when external state changes.\n\n' +
+                    'Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. ' +
+                    '(https://react.dev/learn/you-might-not-need-an-effect)',
+                  suggestions: null,
+                }).withDetails({
+                  kind: 'error',
+                  loc: setState.loc,
+                  message:
+                    'Avoid calling setState() directly within an effect',
+                }),
+              );
+            }
+          }
         }
       }
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/Logger-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/Logger-test.ts
@@ -7,6 +7,7 @@
 
 import * as t from '@babel/types';
 import invariant from 'invariant';
+import {ErrorCategory} from '../CompilerError';
 import {runBabelPluginReactCompiler} from '../Babel/RunReactCompilerBabelPlugin';
 import type {Logger, LoggerEvent} from '../Entrypoint';
 
@@ -67,4 +68,40 @@ it('logs failed compilation', () => {
   // Make sure event.fnLoc is different from event.detail.loc
   expect(event.fnLoc?.start).toEqual({column: 0, index: 0, line: 1});
   expect(event.fnLoc?.end).toEqual({column: 70, index: 70, line: 1});
+});
+
+it('reports set-state-in-effect error when setState is called inside useEffect via useEffectEvent', () => {
+  const logs: [string | null, LoggerEvent][] = [];
+  const logger: Logger = {
+    logEvent(filename, event) {
+      logs.push([filename, event]);
+    },
+  };
+
+  runBabelPluginReactCompiler(
+    `import {useEffect, useEffectEvent, useState} from 'react';
+    function Component() {
+      const [, setState] = useState('');
+      const onSetState = useEffectEvent(() => {
+        setState('test');
+      });
+      useEffect(() => {
+        onSetState();
+      }, []);
+      return null;
+    }`,
+    'test.js',
+    'flow',
+    {
+      logger,
+      panicThreshold: 'none',
+      outputMode: 'lint',
+      environment: {validateNoSetStateInEffects: true},
+    },
+  );
+
+  const [, event] = logs.at(0)!;
+  expect(event).toBeDefined();
+  expect(event.kind).toBe('CompileError');
+  expect(event.detail.category).toBe(ErrorCategory.EffectSetState);
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
PR references [ this issue](https://github.com/facebook/react/issues/35390)
The HIR evaluation in [ValidateNoSetStateInEffect.ts](https://github.com/facebook/react/blob/main/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoSetStateInEffects.ts) suffers from evaluation order dependence. The validator has to:
1. Recognize that the function passed to useEffectEvent contains setState and record that.
2. When it sees useEffectEvent(callback), treat the return value of useEffectEvent as a function that calls setState and add it to setStateFunctions.
3. When it sees useEffect(onSetState), see that onSetState is in setStateFunctions and report.

This means that if the callback for onSetState (which is a useEffectEvent function) is not evaluated by the time the useEffect hook is being evaluated, it will erroneously not throw "EffectSetState". 

In order to solve this we can split the node discovery and the error reporting into 2 separate passes which ensures that by the time we are evaluating the errors we have a complete view of the HIR function, as opposed to reporting as we traverse it.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
Test: 
```
it('reports set-state-in-effect error when setState is called inside useEffect via useEffectEvent', () => {
  const logs: [string | null, LoggerEvent][] = [];
  const logger: Logger = {
    logEvent(filename, event) {
      logs.push([filename, event]);
    },
  };

  runBabelPluginReactCompiler(
    `import {useEffect, useEffectEvent, useState} from 'react';
    function Component() {
      const [, setState] = useState('');
      const onSetState = useEffectEvent(() => {
        setState('test');
      });
      useEffect(() => {
        onSetState();
      }, []);
      return null;
    }`,
    'test.js',
    'flow',
    {
      logger,
      panicThreshold: 'none',
      outputMode: 'lint',
      environment: {validateNoSetStateInEffects: true},
    },
  );

  const [, event] = logs.at(0)!;
  expect(event).toBeDefined();
  expect(event.kind).toBe('CompileError');
  expect(event.detail.category).toBe(ErrorCategory.EffectSetState);
});
```
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
