### PR TITLE
[flow] Migrate type param bounds to extends syntax in ReactNativeTypes

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -83,7 +83,7 @@ type InspectorDataProps = $ReadOnly<{
 }>;
 
 type InspectorDataGetter = (
-  <TElementType: React.ElementType>(
+  <TElementType extends React.ElementType>(
     componentOrHandle: React.ElementRef<TElementType> | number,
   ) => ?number,
 ) => $ReadOnly<{
@@ -142,10 +142,10 @@ export type RenderRootOptions = {
  * Provide minimal Flow typing for the high-level RN API and call it a day.
  */
 export type ReactNativeType = {
-  findHostInstance_DEPRECATED<TElementType: React.ElementType>(
+  findHostInstance_DEPRECATED<TElementType extends React.ElementType>(
     componentOrHandle: ?(React.ElementRef<TElementType> | number),
   ): ?PublicInstance,
-  findNodeHandle<TElementType: React.ElementType>(
+  findNodeHandle<TElementType extends React.ElementType>(
     componentOrHandle: ?(React.ElementRef<TElementType> | number),
   ): ?number,
   isChildPublicInstance(parent: PublicInstance, child: PublicInstance): boolean,
@@ -171,10 +171,10 @@ export opaque type Node = mixed;
 export opaque type InternalInstanceHandle = mixed;
 
 export type ReactFabricType = {
-  findHostInstance_DEPRECATED<TElementType: React.ElementType>(
+  findHostInstance_DEPRECATED<TElementType extends React.ElementType>(
     componentOrHandle: ?(React.ElementRef<TElementType> | number),
   ): ?PublicInstance,
-  findNodeHandle<TElementType: React.ElementType>(
+  findNodeHandle<TElementType extends React.ElementType>(
     componentOrHandle: ?(React.ElementRef<TElementType> | number),
   ): ?number,
   dispatchCommand(


### PR DESCRIPTION
## Summary

- Migrates deprecated Flow type parameter bound syntax `<T: Type>` to `<T extends Type>` in `ReactNativeTypes.js`
- This is the **source file** that gets synced to `react-native-github/Libraries/Renderer/shims/ReactNativeTypes.js` via the build pipeline
- Fixes the source-of-truth so the downstream sync in D95907848 picks up the change automatically

## Context

D95907848 codemodded the synced copy in fbsource, but reviewer noted this file is synced from the React repo and must be changed here first (see [PR #35989 comment](https://github.com/facebook/react/pull/35989)).

## Test plan

- [x] Verified all 5 occurrences updated (`InspectorDataGetter`, `ReactNativeType.findHostInstance_DEPRECATED`, `ReactNativeType.findNodeHandle`, `ReactFabricType.findHostInstance_DEPRECATED`, `ReactFabricType.findNodeHandle`)
- [x] Confirmed file parses correctly with `flow-remove-types`
- [ ] CI Flow type check