### PR TITLE
Fix clearTimeout using wrong property name in attribute-behavior fixture

### DIFF
--- a/fixtures/attribute-behavior/src/App.js
+++ b/fixtures/attribute-behavior/src/App.js
@@ -602,7 +602,7 @@ class Result extends React.Component {
 
   componentWillUnmount() {
     if (this.timeout) {
-      clearTimeout(this.interval);
+      clearTimeout(this.timeout);
     }
   }
 


### PR DESCRIPTION
The componentWillUnmount method in fixtures/attribute-behavior/src/App.js calls clearTimeout(this.interval), but the timeout ID is stored as this.timeout (set in onMouseEnter). Since this.interval is always undefined, the timer never actually gets cleared when the component unmounts.

Fixes #35814

What changed: one-line fix in fixtures/attribute-behavior/src/App.js, changed clearTimeout(this.interval) to clearTimeout(this.timeout).