### PR TITLE
[DevTools] fix: don't show empty suspended by section

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
@@ -584,6 +584,9 @@ export default function InspectedElementSuspendedBy({
       break;
   }
 
+  if (groups.length === 0) {
+    return null;
+  }
   return (
     <div>
       <div className={styles.HeaderRow}>


### PR DESCRIPTION
The potential paddings and margins for the empty block are already handled via CSS selectors.