### PR TITLE
Add enableViewTransitionForPersistenceMode dynamic feature flag

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -34,6 +34,7 @@ import {
   hasInstanceAffectedParent,
   wasInstanceInViewport,
 } from './ReactFiberConfig';
+import {enableViewTransitionForPersistenceMode} from 'shared/ReactFeatureFlags';
 import {
   scheduleViewTransitionEvent,
   scheduleGestureTransitionEvent,
@@ -139,93 +140,168 @@ function applyViewTransitionToHostInstancesRecursive(
   collectMeasurements: null | Array<InstanceMeasurement>,
   stopAtNestedViewTransitions: boolean,
 ): boolean {
-  if (!supportsMutation) {
-    return false;
-  }
-  let inViewport = false;
-  while (child !== null) {
-    if (child.tag === HostComponent) {
-      const instance: Instance = child.stateNode;
-      if (collectMeasurements !== null) {
-        const measurement = measureInstance(instance);
-        collectMeasurements.push(measurement);
-        if (wasInstanceInViewport(measurement)) {
-          inViewport = true;
+  if (supportsMutation) {
+    let inViewport = false;
+    while (child !== null) {
+      if (child.tag === HostComponent) {
+        const instance: Instance = child.stateNode;
+        if (collectMeasurements !== null) {
+          const measurement = measureInstance(instance);
+          collectMeasurements.push(measurement);
+          if (wasInstanceInViewport(measurement)) {
+            inViewport = true;
+          }
+        } else if (!inViewport) {
+          if (wasInstanceInViewport(measureInstance(instance))) {
+            inViewport = true;
+          }
         }
-      } else if (!inViewport) {
-        if (wasInstanceInViewport(measureInstance(instance))) {
-          inViewport = true;
-        }
-      }
-      shouldStartViewTransition = true;
-      applyViewTransitionName(
-        instance,
-        viewTransitionHostInstanceIdx === 0
-          ? name
-          : // If we have multiple Host Instances below, we add a suffix to the name to give
-            // each one a unique name.
-            name + '_' + viewTransitionHostInstanceIdx,
-        className,
-      );
-      viewTransitionHostInstanceIdx++;
-    } else if (
-      child.tag === OffscreenComponent &&
-      child.memoizedState !== null
-    ) {
-      // Skip any hidden subtrees. They were or are effectively not there.
-    } else if (
-      child.tag === ViewTransitionComponent &&
-      stopAtNestedViewTransitions
-    ) {
-      // Skip any nested view transitions for updates since in that case the
-      // inner most one is the one that handles the update.
-    } else {
-      if (
-        applyViewTransitionToHostInstancesRecursive(
-          child.child,
-          name,
+        shouldStartViewTransition = true;
+        applyViewTransitionName(
+          instance,
+          viewTransitionHostInstanceIdx === 0
+            ? name
+            : // If we have multiple Host Instances below, we add a suffix to the name to give
+              // each one a unique name.
+              name + '_' + viewTransitionHostInstanceIdx,
           className,
-          collectMeasurements,
-          stopAtNestedViewTransitions,
-        )
+        );
+        viewTransitionHostInstanceIdx++;
+      } else if (
+        child.tag === OffscreenComponent &&
+        child.memoizedState !== null
       ) {
-        inViewport = true;
+        // Skip any hidden subtrees. They were or are effectively not there.
+      } else if (
+        child.tag === ViewTransitionComponent &&
+        stopAtNestedViewTransitions
+      ) {
+        // Skip any nested view transitions for updates since in that case the
+        // inner most one is the one that handles the update.
+      } else {
+        if (
+          applyViewTransitionToHostInstancesRecursive(
+            child.child,
+            name,
+            className,
+            collectMeasurements,
+            stopAtNestedViewTransitions,
+          )
+        ) {
+          inViewport = true;
+        }
       }
+      child = child.sibling;
     }
-    child = child.sibling;
+    return inViewport;
+  } else if (enableViewTransitionForPersistenceMode) {
+    let inViewport = false;
+    while (child !== null) {
+      if (child.tag === HostComponent) {
+        const instance: Instance = child.stateNode;
+        if (collectMeasurements !== null) {
+          const measurement = measureInstance(instance);
+          collectMeasurements.push(measurement);
+          if (wasInstanceInViewport(measurement)) {
+            inViewport = true;
+          }
+        } else if (!inViewport) {
+          if (wasInstanceInViewport(measureInstance(instance))) {
+            inViewport = true;
+          }
+        }
+        shouldStartViewTransition = true;
+        applyViewTransitionName(
+          instance,
+          viewTransitionHostInstanceIdx === 0
+            ? name
+            : name + '_' + viewTransitionHostInstanceIdx,
+          className,
+        );
+        viewTransitionHostInstanceIdx++;
+      } else if (
+        child.tag === OffscreenComponent &&
+        child.memoizedState !== null
+      ) {
+        // Skip any hidden subtrees. They were or are effectively not there.
+      } else if (
+        child.tag === ViewTransitionComponent &&
+        stopAtNestedViewTransitions
+      ) {
+        // Skip any nested view transitions for updates since in that case the
+        // inner most one is the one that handles the update.
+      } else {
+        if (
+          applyViewTransitionToHostInstancesRecursive(
+            child.child,
+            name,
+            className,
+            collectMeasurements,
+            stopAtNestedViewTransitions,
+          )
+        ) {
+          inViewport = true;
+        }
+      }
+      child = child.sibling;
+    }
+    return inViewport;
   }
-  return inViewport;
+  return false;
 }
 
 function restoreViewTransitionOnHostInstances(
   child: null | Fiber,
   stopAtNestedViewTransitions: boolean,
 ): void {
-  if (!supportsMutation) {
-    return;
-  }
-  while (child !== null) {
-    if (child.tag === HostComponent) {
-      const instance: Instance = child.stateNode;
-      restoreViewTransitionName(instance, child.memoizedProps);
-    } else if (
-      child.tag === OffscreenComponent &&
-      child.memoizedState !== null
-    ) {
-      // Skip any hidden subtrees. They were or are effectively not there.
-    } else if (
-      child.tag === ViewTransitionComponent &&
-      stopAtNestedViewTransitions
-    ) {
-      // Skip any nested view transitions for updates since in that case the
-      // inner most one is the one that handles the update.
-    } else {
-      restoreViewTransitionOnHostInstances(
-        child.child,
-        stopAtNestedViewTransitions,
-      );
+  if (supportsMutation) {
+    while (child !== null) {
+      if (child.tag === HostComponent) {
+        const instance: Instance = child.stateNode;
+        restoreViewTransitionName(instance, child.memoizedProps);
+      } else if (
+        child.tag === OffscreenComponent &&
+        child.memoizedState !== null
+      ) {
+        // Skip any hidden subtrees. They were or are effectively not there.
+      } else if (
+        child.tag === ViewTransitionComponent &&
+        stopAtNestedViewTransitions
+      ) {
+        // Skip any nested view transitions for updates since in that case the
+        // inner most one is the one that handles the update.
+      } else {
+        restoreViewTransitionOnHostInstances(
+          child.child,
+          stopAtNestedViewTransitions,
+        );
+      }
+      child = child.sibling;
     }
-    child = child.sibling;
+  } else if (enableViewTransitionForPersistenceMode) {
+    while (child !== null) {
+      if (child.tag === HostComponent) {
+        const instance: Instance = child.stateNode;
+        restoreViewTransitionName(instance, child.memoizedProps);
+      } else if (
+        child.tag === OffscreenComponent &&
+        child.memoizedState !== null
+      ) {
+        // Skip any hidden subtrees. They were or are effectively not there.
+      } else if (
+        child.tag === ViewTransitionComponent &&
+        stopAtNestedViewTransitions
+      ) {
+        // Skip any nested view transitions for updates since in that case the
+        // inner most one is the one that handles the update.
+      } else {
+        restoreViewTransitionOnHostInstances(
+          child.child,
+          stopAtNestedViewTransitions,
+        );
+      }
+      child = child.sibling;
+    }
   }
 }
 
@@ -648,112 +724,196 @@ function measureViewTransitionHostInstancesRecursive(
   previousMeasurements: null | Array<InstanceMeasurement>,
   stopAtNestedViewTransitions: boolean,
 ): boolean {
-  if (!supportsMutation) {
-    return true;
-  }
-  let inViewport = false;
-  while (child !== null) {
-    if (child.tag === HostComponent) {
-      const instance: Instance = child.stateNode;
-      if (
-        previousMeasurements !== null &&
-        viewTransitionHostInstanceIdx < previousMeasurements.length
-      ) {
-        // The previous measurement of the Instance in this location within the ViewTransition.
-        // Note that this might not be the same exact Instance if the Instances within the
-        // ViewTransition changed.
-        const previousMeasurement =
-          previousMeasurements[viewTransitionHostInstanceIdx];
-        const nextMeasurement = measureInstance(instance);
+  if (supportsMutation) {
+    let inViewport = false;
+    while (child !== null) {
+      if (child.tag === HostComponent) {
+        const instance: Instance = child.stateNode;
         if (
-          wasInstanceInViewport(previousMeasurement) ||
-          wasInstanceInViewport(nextMeasurement)
+          previousMeasurements !== null &&
+          viewTransitionHostInstanceIdx < previousMeasurements.length
         ) {
-          // If either the old or new state was within the viewport we have to animate this.
-          // But if it turns out that none of them were we'll be able to skip it.
-          inViewport = true;
-        }
-        if (
-          (parentViewTransition.flags & Update) === NoFlags &&
-          hasInstanceChanged(previousMeasurement, nextMeasurement)
-        ) {
-          parentViewTransition.flags |= Update;
-        }
-        if (hasInstanceAffectedParent(previousMeasurement, nextMeasurement)) {
-          // If this instance size within its parent has changed it might have caused the
-          // parent to relayout which needs a cross fade.
+          // The previous measurement of the Instance in this location within the ViewTransition.
+          // Note that this might not be the same exact Instance if the Instances within the
+          // ViewTransition changed.
+          const previousMeasurement =
+            previousMeasurements[viewTransitionHostInstanceIdx];
+          const nextMeasurement = measureInstance(instance);
+          if (
+            wasInstanceInViewport(previousMeasurement) ||
+            wasInstanceInViewport(nextMeasurement)
+          ) {
+            // If either the old or new state was within the viewport we have to animate this.
+            // But if it turns out that none of them were we'll be able to skip it.
+            inViewport = true;
+          }
+          if (
+            (parentViewTransition.flags & Update) === NoFlags &&
+            hasInstanceChanged(previousMeasurement, nextMeasurement)
+          ) {
+            parentViewTransition.flags |= Update;
+          }
+          if (
+            hasInstanceAffectedParent(previousMeasurement, nextMeasurement)
+          ) {
+            // If this instance size within its parent has changed it might have caused the
+            // parent to relayout which needs a cross fade.
+            parentViewTransition.flags |= AffectedParentLayout;
+          }
+        } else {
+          // If there was an insertion of extra nodes, we have to assume they affected the parent.
+          // It should have already been marked as an Update due to the mutation.
           parentViewTransition.flags |= AffectedParentLayout;
         }
-      } else {
-        // If there was an insertion of extra nodes, we have to assume they affected the parent.
-        // It should have already been marked as an Update due to the mutation.
-        parentViewTransition.flags |= AffectedParentLayout;
-      }
-      if ((parentViewTransition.flags & Update) !== NoFlags) {
-        // We might update this node so we need to apply its new name for the new state.
-        // Additionally in the ApplyGesture case we also need to do this because the clone
-        // will have the name but this one won't.
-        applyViewTransitionName(
-          instance,
-          viewTransitionHostInstanceIdx === 0
-            ? newName
-            : // If we have multiple Host Instances below, we add a suffix to the name to give
-              // each one a unique name.
-              newName + '_' + viewTransitionHostInstanceIdx,
-          className,
-        );
-      }
-      if (!inViewport || (parentViewTransition.flags & Update) === NoFlags) {
-        // It turns out that we had no other deeper mutations, the child transitions didn't
-        // affect the parent layout and this instance hasn't changed size. So we can skip
-        // animating it. However, in the current model this only works if the parent also
-        // doesn't animate. So we have to queue these and wait until we complete the parent
-        // to cancel them.
-        if (viewTransitionCancelableChildren === null) {
-          viewTransitionCancelableChildren = [];
+        if ((parentViewTransition.flags & Update) !== NoFlags) {
+          // We might update this node so we need to apply its new name for the new state.
+          // Additionally in the ApplyGesture case we also need to do this because the clone
+          // will have the name but this one won't.
+          applyViewTransitionName(
+            instance,
+            viewTransitionHostInstanceIdx === 0
+              ? newName
+              : // If we have multiple Host Instances below, we add a suffix to the name to give
+                // each one a unique name.
+                newName + '_' + viewTransitionHostInstanceIdx,
+            className,
+          );
         }
-        viewTransitionCancelableChildren.push(
-          instance,
-          viewTransitionHostInstanceIdx === 0
-            ? oldName
-            : // If we have multiple Host Instances below, we add a suffix to the name to give
-              // each one a unique name.
-              oldName + '_' + viewTransitionHostInstanceIdx,
-          child.memoizedProps,
-        );
-      }
-      viewTransitionHostInstanceIdx++;
-    } else if (
-      child.tag === OffscreenComponent &&
-      child.memoizedState !== null
-    ) {
-      // Skip any hidden subtrees. They were or are effectively not there.
-    } else if (
-      child.tag === ViewTransitionComponent &&
-      stopAtNestedViewTransitions
-    ) {
-      // Skip any nested view transitions for updates since in that case the
-      // inner most one is the one that handles the update.
-      // If this inner boundary resized we need to bubble that information up.
-      parentViewTransition.flags |= child.flags & AffectedParentLayout;
-    } else {
-      if (
-        measureViewTransitionHostInstancesRecursive(
-          parentViewTransition,
-          child.child,
-          newName,
-          oldName,
-          className,
-          previousMeasurements,
-          stopAtNestedViewTransitions,
-        )
+        if (!inViewport || (parentViewTransition.flags & Update) === NoFlags) {
+          // It turns out that we had no other deeper mutations, the child transitions didn't
+          // affect the parent layout and this instance hasn't changed size. So we can skip
+          // animating it. However, in the current model this only works if the parent also
+          // doesn't animate. So we have to queue these and wait until we complete the parent
+          // to cancel them.
+          if (viewTransitionCancelableChildren === null) {
+            viewTransitionCancelableChildren = [];
+          }
+          viewTransitionCancelableChildren.push(
+            instance,
+            viewTransitionHostInstanceIdx === 0
+              ? oldName
+              : // If we have multiple Host Instances below, we add a suffix to the name to give
+                // each one a unique name.
+                oldName + '_' + viewTransitionHostInstanceIdx,
+            child.memoizedProps,
+          );
+        }
+        viewTransitionHostInstanceIdx++;
+      } else if (
+        child.tag === OffscreenComponent &&
+        child.memoizedState !== null
       ) {
-        inViewport = true;
+        // Skip any hidden subtrees. They were or are effectively not there.
+      } else if (
+        child.tag === ViewTransitionComponent &&
+        stopAtNestedViewTransitions
+      ) {
+        // Skip any nested view transitions for updates since in that case the
+        // inner most one is the one that handles the update.
+        // If this inner boundary resized we need to bubble that information up.
+        parentViewTransition.flags |= child.flags & AffectedParentLayout;
+      } else {
+        if (
+          measureViewTransitionHostInstancesRecursive(
+            parentViewTransition,
+            child.child,
+            newName,
+            oldName,
+            className,
+            previousMeasurements,
+            stopAtNestedViewTransitions,
+          )
+        ) {
+          inViewport = true;
+        }
       }
+      child = child.sibling;
     }
-    child = child.sibling;
+    return inViewport;
+  } else if (enableViewTransitionForPersistenceMode) {
+    let inViewport = false;
+    while (child !== null) {
+      if (child.tag === HostComponent) {
+        const instance: Instance = child.stateNode;
+        if (
+          previousMeasurements !== null &&
+          viewTransitionHostInstanceIdx < previousMeasurements.length
+        ) {
+          const previousMeasurement =
+            previousMeasurements[viewTransitionHostInstanceIdx];
+          const nextMeasurement = measureInstance(instance);
+          if (
+            wasInstanceInViewport(previousMeasurement) ||
+            wasInstanceInViewport(nextMeasurement)
+          ) {
+            inViewport = true;
+          }
+          if (
+            (parentViewTransition.flags & Update) === NoFlags &&
+            hasInstanceChanged(previousMeasurement, nextMeasurement)
+          ) {
+            parentViewTransition.flags |= Update;
+          }
+          if (
+            hasInstanceAffectedParent(previousMeasurement, nextMeasurement)
+          ) {
+            parentViewTransition.flags |= AffectedParentLayout;
+          }
+        } else {
+          parentViewTransition.flags |= AffectedParentLayout;
+        }
+        if ((parentViewTransition.flags & Update) !== NoFlags) {
+          applyViewTransitionName(
+            instance,
+            viewTransitionHostInstanceIdx === 0
+              ? newName
+              : newName + '_' + viewTransitionHostInstanceIdx,
+            className,
+          );
+        }
+        if (!inViewport || (parentViewTransition.flags & Update) === NoFlags) {
+          if (viewTransitionCancelableChildren === null) {
+            viewTransitionCancelableChildren = [];
+          }
+          viewTransitionCancelableChildren.push(
+            instance,
+            viewTransitionHostInstanceIdx === 0
+              ? oldName
+              : oldName + '_' + viewTransitionHostInstanceIdx,
+            child.memoizedProps,
+          );
+        }
+        viewTransitionHostInstanceIdx++;
+      } else if (
+        child.tag === OffscreenComponent &&
+        child.memoizedState !== null
+      ) {
+        // Skip any hidden subtrees. They were or are effectively not there.
+      } else if (
+        child.tag === ViewTransitionComponent &&
+        stopAtNestedViewTransitions
+      ) {
+        parentViewTransition.flags |= child.flags & AffectedParentLayout;
+      } else {
+        if (
+          measureViewTransitionHostInstancesRecursive(
+            parentViewTransition,
+            child.child,
+            newName,
+            oldName,
+            className,
+            previousMeasurements,
+            stopAtNestedViewTransitions,
+          )
+        ) {
+          inViewport = true;
+        }
+      }
+      child = child.sibling;
+    }
+    return inViewport;
   }
-  return inViewport;
+  return true;
 }
 
 export function measureUpdateViewTransition(

--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -34,7 +34,6 @@ import {
   hasInstanceAffectedParent,
   wasInstanceInViewport,
 } from './ReactFiberConfig';
-import {enableViewTransitionForPersistenceMode} from 'shared/ReactFeatureFlags';
 import {
   scheduleViewTransitionEvent,
   scheduleGestureTransitionEvent,
@@ -47,6 +46,7 @@ import {trackAnimatingTask} from './ReactProfilerTimer';
 import {
   enableComponentPerformanceTrack,
   enableProfilerTimer,
+  enableViewTransitionForPersistenceMode,
 } from 'shared/ReactFeatureFlags';
 
 export let shouldStartViewTransition: boolean = false;
@@ -195,21 +195,10 @@ function applyViewTransitionToHostInstancesRecursive(
     }
     return inViewport;
   } else if (enableViewTransitionForPersistenceMode) {
-    let inViewport = false;
     while (child !== null) {
       if (child.tag === HostComponent) {
         const instance: Instance = child.stateNode;
-        if (collectMeasurements !== null) {
-          const measurement = measureInstance(instance);
-          collectMeasurements.push(measurement);
-          if (wasInstanceInViewport(measurement)) {
-            inViewport = true;
-          }
-        } else if (!inViewport) {
-          if (wasInstanceInViewport(measureInstance(instance))) {
-            inViewport = true;
-          }
-        }
+        // TODO: calculate whether component is in viewport
         shouldStartViewTransition = true;
         applyViewTransitionName(
           instance,
@@ -231,21 +220,17 @@ function applyViewTransitionToHostInstancesRecursive(
         // Skip any nested view transitions for updates since in that case the
         // inner most one is the one that handles the update.
       } else {
-        if (
-          applyViewTransitionToHostInstancesRecursive(
-            child.child,
-            name,
-            className,
-            collectMeasurements,
-            stopAtNestedViewTransitions,
-          )
-        ) {
-          inViewport = true;
-        }
+        applyViewTransitionToHostInstancesRecursive(
+          child.child,
+          name,
+          className,
+          collectMeasurements,
+          stopAtNestedViewTransitions,
+        );
       }
       child = child.sibling;
     }
-    return inViewport;
+    return true;
   }
   return false;
 }
@@ -255,30 +240,6 @@ function restoreViewTransitionOnHostInstances(
   stopAtNestedViewTransitions: boolean,
 ): void {
   if (supportsMutation) {
-    while (child !== null) {
-      if (child.tag === HostComponent) {
-        const instance: Instance = child.stateNode;
-        restoreViewTransitionName(instance, child.memoizedProps);
-      } else if (
-        child.tag === OffscreenComponent &&
-        child.memoizedState !== null
-      ) {
-        // Skip any hidden subtrees. They were or are effectively not there.
-      } else if (
-        child.tag === ViewTransitionComponent &&
-        stopAtNestedViewTransitions
-      ) {
-        // Skip any nested view transitions for updates since in that case the
-        // inner most one is the one that handles the update.
-      } else {
-        restoreViewTransitionOnHostInstances(
-          child.child,
-          stopAtNestedViewTransitions,
-        );
-      }
-      child = child.sibling;
-    }
-  } else if (enableViewTransitionForPersistenceMode) {
     while (child !== null) {
       if (child.tag === HostComponent) {
         const instance: Instance = child.stateNode;
@@ -831,7 +792,6 @@ function measureViewTransitionHostInstancesRecursive(
     }
     return inViewport;
   } else if (enableViewTransitionForPersistenceMode) {
-    let inViewport = false;
     while (child !== null) {
       if (child.tag === HostComponent) {
         const instance: Instance = child.stateNode;
@@ -842,23 +802,6 @@ function measureViewTransitionHostInstancesRecursive(
           const previousMeasurement =
             previousMeasurements[viewTransitionHostInstanceIdx];
           const nextMeasurement = measureInstance(instance);
-          if (
-            wasInstanceInViewport(previousMeasurement) ||
-            wasInstanceInViewport(nextMeasurement)
-          ) {
-            inViewport = true;
-          }
-          if (
-            (parentViewTransition.flags & Update) === NoFlags &&
-            hasInstanceChanged(previousMeasurement, nextMeasurement)
-          ) {
-            parentViewTransition.flags |= Update;
-          }
-          if (
-            hasInstanceAffectedParent(previousMeasurement, nextMeasurement)
-          ) {
-            parentViewTransition.flags |= AffectedParentLayout;
-          }
         } else {
           parentViewTransition.flags |= AffectedParentLayout;
         }
@@ -869,18 +812,6 @@ function measureViewTransitionHostInstancesRecursive(
               ? newName
               : newName + '_' + viewTransitionHostInstanceIdx,
             className,
-          );
-        }
-        if (!inViewport || (parentViewTransition.flags & Update) === NoFlags) {
-          if (viewTransitionCancelableChildren === null) {
-            viewTransitionCancelableChildren = [];
-          }
-          viewTransitionCancelableChildren.push(
-            instance,
-            viewTransitionHostInstanceIdx === 0
-              ? oldName
-              : oldName + '_' + viewTransitionHostInstanceIdx,
-            child.memoizedProps,
           );
         }
         viewTransitionHostInstanceIdx++;
@@ -895,23 +826,19 @@ function measureViewTransitionHostInstancesRecursive(
       ) {
         parentViewTransition.flags |= child.flags & AffectedParentLayout;
       } else {
-        if (
-          measureViewTransitionHostInstancesRecursive(
-            parentViewTransition,
-            child.child,
-            newName,
-            oldName,
-            className,
-            previousMeasurements,
-            stopAtNestedViewTransitions,
-          )
-        ) {
-          inViewport = true;
-        }
+        measureViewTransitionHostInstancesRecursive(
+          parentViewTransition,
+          child.child,
+          newName,
+          oldName,
+          className,
+          previousMeasurements,
+          stopAtNestedViewTransitions,
+        );
       }
       child = child.sibling;
     }
-    return inViewport;
+    return true;
   }
   return true;
 }

--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -684,7 +684,45 @@ function measureViewTransitionHostInstancesRecursive(
   previousMeasurements: null | Array<InstanceMeasurement>,
   stopAtNestedViewTransitions: boolean,
 ): boolean {
-  if (supportsMutation) {
+  if (!supportsMutation && enableViewTransitionForPersistenceMode) {
+    while (child !== null) {
+      if (child.tag === HostComponent) {
+        const instance: Instance = child.stateNode;
+        if ((parentViewTransition.flags & Update) !== NoFlags) {
+          applyViewTransitionName(
+            instance,
+            viewTransitionHostInstanceIdx === 0
+              ? newName
+              : newName + '_' + viewTransitionHostInstanceIdx,
+            className,
+          );
+        }
+        viewTransitionHostInstanceIdx++;
+      } else if (
+        child.tag === OffscreenComponent &&
+        child.memoizedState !== null
+      ) {
+        // Skip any hidden subtrees. They were or are effectively not there.
+      } else if (
+        child.tag === ViewTransitionComponent &&
+        stopAtNestedViewTransitions
+      ) {
+        parentViewTransition.flags |= child.flags & AffectedParentLayout;
+      } else {
+        measureViewTransitionHostInstancesRecursive(
+          parentViewTransition,
+          child.child,
+          newName,
+          oldName,
+          className,
+          previousMeasurements,
+          stopAtNestedViewTransitions,
+        );
+      }
+      child = child.sibling;
+    }
+    return true;
+  }
     let inViewport = false;
     while (child !== null) {
       if (child.tag === HostComponent) {
@@ -790,56 +828,6 @@ function measureViewTransitionHostInstancesRecursive(
       child = child.sibling;
     }
     return inViewport;
-  } else if (enableViewTransitionForPersistenceMode) {
-    while (child !== null) {
-      if (child.tag === HostComponent) {
-        const instance: Instance = child.stateNode;
-        if (
-          previousMeasurements !== null &&
-          viewTransitionHostInstanceIdx < previousMeasurements.length
-        ) {
-          const previousMeasurement =
-            previousMeasurements[viewTransitionHostInstanceIdx];
-          const nextMeasurement = measureInstance(instance);
-        } else {
-          parentViewTransition.flags |= AffectedParentLayout;
-        }
-        if ((parentViewTransition.flags & Update) !== NoFlags) {
-          applyViewTransitionName(
-            instance,
-            viewTransitionHostInstanceIdx === 0
-              ? newName
-              : newName + '_' + viewTransitionHostInstanceIdx,
-            className,
-          );
-        }
-        viewTransitionHostInstanceIdx++;
-      } else if (
-        child.tag === OffscreenComponent &&
-        child.memoizedState !== null
-      ) {
-        // Skip any hidden subtrees. They were or are effectively not there.
-      } else if (
-        child.tag === ViewTransitionComponent &&
-        stopAtNestedViewTransitions
-      ) {
-        parentViewTransition.flags |= child.flags & AffectedParentLayout;
-      } else {
-        measureViewTransitionHostInstancesRecursive(
-          parentViewTransition,
-          child.child,
-          newName,
-          oldName,
-          className,
-          previousMeasurements,
-          stopAtNestedViewTransitions,
-        );
-      }
-      child = child.sibling;
-    }
-    return true;
-  }
-  return true;
 }
 
 export function measureUpdateViewTransition(

--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -693,6 +693,15 @@ function measureViewTransitionHostInstancesRecursive(
       while (child !== null) {
         if (child.tag === HostComponent) {
           const instance: Instance = child.stateNode;
+          if (
+            previousMeasurements == null ||
+            viewTransitionHostInstanceIdx >= previousMeasurements.length
+          ) {
+            // If there was an insertion of extra nodes, we have to assume they affected the parent.
+            // It should have already been marked as an Update due to the mutation.
+            parentViewTransition.flags |= AffectedParentLayout;
+          }
+          // TODO: check if instance is out of viewport
           if ((parentViewTransition.flags & Update) !== NoFlags) {
             applyViewTransitionName(
               instance,
@@ -702,6 +711,7 @@ function measureViewTransitionHostInstancesRecursive(
               className,
             );
           }
+          // TODO: cancel transition by pushing into viewTransitionCancelableChildren
           viewTransitionHostInstanceIdx++;
         } else if (
           child.tag === OffscreenComponent &&
@@ -712,6 +722,9 @@ function measureViewTransitionHostInstancesRecursive(
           child.tag === ViewTransitionComponent &&
           stopAtNestedViewTransitions
         ) {
+          // Skip any nested view transitions for updates since in that case the
+          // inner most one is the one that handles the update.
+          // If this inner boundary resized we need to bubble that information up.
           parentViewTransition.flags |= child.flags & AffectedParentLayout;
         } else {
           measureViewTransitionHostInstancesRecursive(

--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -140,61 +140,7 @@ function applyViewTransitionToHostInstancesRecursive(
   collectMeasurements: null | Array<InstanceMeasurement>,
   stopAtNestedViewTransitions: boolean,
 ): boolean {
-  if (supportsMutation) {
-    let inViewport = false;
-    while (child !== null) {
-      if (child.tag === HostComponent) {
-        const instance: Instance = child.stateNode;
-        if (collectMeasurements !== null) {
-          const measurement = measureInstance(instance);
-          collectMeasurements.push(measurement);
-          if (wasInstanceInViewport(measurement)) {
-            inViewport = true;
-          }
-        } else if (!inViewport) {
-          if (wasInstanceInViewport(measureInstance(instance))) {
-            inViewport = true;
-          }
-        }
-        shouldStartViewTransition = true;
-        applyViewTransitionName(
-          instance,
-          viewTransitionHostInstanceIdx === 0
-            ? name
-            : // If we have multiple Host Instances below, we add a suffix to the name to give
-              // each one a unique name.
-              name + '_' + viewTransitionHostInstanceIdx,
-          className,
-        );
-        viewTransitionHostInstanceIdx++;
-      } else if (
-        child.tag === OffscreenComponent &&
-        child.memoizedState !== null
-      ) {
-        // Skip any hidden subtrees. They were or are effectively not there.
-      } else if (
-        child.tag === ViewTransitionComponent &&
-        stopAtNestedViewTransitions
-      ) {
-        // Skip any nested view transitions for updates since in that case the
-        // inner most one is the one that handles the update.
-      } else {
-        if (
-          applyViewTransitionToHostInstancesRecursive(
-            child.child,
-            name,
-            className,
-            collectMeasurements,
-            stopAtNestedViewTransitions,
-          )
-        ) {
-          inViewport = true;
-        }
-      }
-      child = child.sibling;
-    }
-    return inViewport;
-  } else if (enableViewTransitionForPersistenceMode) {
+  if (!supportsMutation && enableViewTransitionForPersistenceMode) {
     while (child !== null) {
       if (child.tag === HostComponent) {
         const instance: Instance = child.stateNode;
@@ -232,7 +178,59 @@ function applyViewTransitionToHostInstancesRecursive(
     }
     return true;
   }
-  return false;
+  let inViewport = false;
+  while (child !== null) {
+    if (child.tag === HostComponent) {
+      const instance: Instance = child.stateNode;
+      if (collectMeasurements !== null) {
+        const measurement = measureInstance(instance);
+        collectMeasurements.push(measurement);
+        if (wasInstanceInViewport(measurement)) {
+          inViewport = true;
+        }
+      } else if (!inViewport) {
+        if (wasInstanceInViewport(measureInstance(instance))) {
+          inViewport = true;
+        }
+      }
+      shouldStartViewTransition = true;
+      applyViewTransitionName(
+        instance,
+        viewTransitionHostInstanceIdx === 0
+          ? name
+          : // If we have multiple Host Instances below, we add a suffix to the name to give
+            // each one a unique name.
+            name + '_' + viewTransitionHostInstanceIdx,
+        className,
+      );
+      viewTransitionHostInstanceIdx++;
+    } else if (
+      child.tag === OffscreenComponent &&
+      child.memoizedState !== null
+    ) {
+      // Skip any hidden subtrees. They were or are effectively not there.
+    } else if (
+      child.tag === ViewTransitionComponent &&
+      stopAtNestedViewTransitions
+    ) {
+      // Skip any nested view transitions for updates since in that case the
+      // inner most one is the one that handles the update.
+    } else {
+      if (
+        applyViewTransitionToHostInstancesRecursive(
+          child.child,
+          name,
+          className,
+          collectMeasurements,
+          stopAtNestedViewTransitions,
+        )
+      ) {
+        inViewport = true;
+      }
+    }
+    child = child.sibling;
+  }
+  return inViewport;
 }
 
 function restoreViewTransitionOnHostInstances(

--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -140,43 +140,47 @@ function applyViewTransitionToHostInstancesRecursive(
   collectMeasurements: null | Array<InstanceMeasurement>,
   stopAtNestedViewTransitions: boolean,
 ): boolean {
-  if (!supportsMutation && enableViewTransitionForPersistenceMode) {
-    while (child !== null) {
-      if (child.tag === HostComponent) {
-        const instance: Instance = child.stateNode;
-        // TODO: calculate whether component is in viewport
-        shouldStartViewTransition = true;
-        applyViewTransitionName(
-          instance,
-          viewTransitionHostInstanceIdx === 0
-            ? name
-            : name + '_' + viewTransitionHostInstanceIdx,
-          className,
-        );
-        viewTransitionHostInstanceIdx++;
-      } else if (
-        child.tag === OffscreenComponent &&
-        child.memoizedState !== null
-      ) {
-        // Skip any hidden subtrees. They were or are effectively not there.
-      } else if (
-        child.tag === ViewTransitionComponent &&
-        stopAtNestedViewTransitions
-      ) {
-        // Skip any nested view transitions for updates since in that case the
-        // inner most one is the one that handles the update.
-      } else {
-        applyViewTransitionToHostInstancesRecursive(
-          child.child,
-          name,
-          className,
-          collectMeasurements,
-          stopAtNestedViewTransitions,
-        );
+  if (!supportsMutation) {
+    if (enableViewTransitionForPersistenceMode) {
+      while (child !== null) {
+        if (child.tag === HostComponent) {
+          const instance: Instance = child.stateNode;
+          // TODO: calculate whether component is in viewport
+          shouldStartViewTransition = true;
+          applyViewTransitionName(
+            instance,
+            viewTransitionHostInstanceIdx === 0
+              ? name
+              : name + '_' + viewTransitionHostInstanceIdx,
+            className,
+          );
+          viewTransitionHostInstanceIdx++;
+        } else if (
+          child.tag === OffscreenComponent &&
+          child.memoizedState !== null
+        ) {
+          // Skip any hidden subtrees. They were or are effectively not there.
+        } else if (
+          child.tag === ViewTransitionComponent &&
+          stopAtNestedViewTransitions
+        ) {
+          // Skip any nested view transitions for updates since in that case the
+          // inner most one is the one that handles the update.
+        } else {
+          applyViewTransitionToHostInstancesRecursive(
+            child.child,
+            name,
+            className,
+            collectMeasurements,
+            stopAtNestedViewTransitions,
+          );
+        }
+        child = child.sibling;
       }
-      child = child.sibling;
+      return true;
+    } else {
+      return false;
     }
-    return true;
   }
   let inViewport = false;
   while (child !== null) {
@@ -684,134 +688,32 @@ function measureViewTransitionHostInstancesRecursive(
   previousMeasurements: null | Array<InstanceMeasurement>,
   stopAtNestedViewTransitions: boolean,
 ): boolean {
-  if (!supportsMutation && enableViewTransitionForPersistenceMode) {
-    while (child !== null) {
-      if (child.tag === HostComponent) {
-        const instance: Instance = child.stateNode;
-        if ((parentViewTransition.flags & Update) !== NoFlags) {
-          applyViewTransitionName(
-            instance,
-            viewTransitionHostInstanceIdx === 0
-              ? newName
-              : newName + '_' + viewTransitionHostInstanceIdx,
-            className,
-          );
-        }
-        viewTransitionHostInstanceIdx++;
-      } else if (
-        child.tag === OffscreenComponent &&
-        child.memoizedState !== null
-      ) {
-        // Skip any hidden subtrees. They were or are effectively not there.
-      } else if (
-        child.tag === ViewTransitionComponent &&
-        stopAtNestedViewTransitions
-      ) {
-        parentViewTransition.flags |= child.flags & AffectedParentLayout;
-      } else {
-        measureViewTransitionHostInstancesRecursive(
-          parentViewTransition,
-          child.child,
-          newName,
-          oldName,
-          className,
-          previousMeasurements,
-          stopAtNestedViewTransitions,
-        );
-      }
-      child = child.sibling;
-    }
-    return true;
-  }
-    let inViewport = false;
-    while (child !== null) {
-      if (child.tag === HostComponent) {
-        const instance: Instance = child.stateNode;
-        if (
-          previousMeasurements !== null &&
-          viewTransitionHostInstanceIdx < previousMeasurements.length
+  if (!supportsMutation) {
+    if (enableViewTransitionForPersistenceMode) {
+      while (child !== null) {
+        if (child.tag === HostComponent) {
+          const instance: Instance = child.stateNode;
+          if ((parentViewTransition.flags & Update) !== NoFlags) {
+            applyViewTransitionName(
+              instance,
+              viewTransitionHostInstanceIdx === 0
+                ? newName
+                : newName + '_' + viewTransitionHostInstanceIdx,
+              className,
+            );
+          }
+          viewTransitionHostInstanceIdx++;
+        } else if (
+          child.tag === OffscreenComponent &&
+          child.memoizedState !== null
         ) {
-          // The previous measurement of the Instance in this location within the ViewTransition.
-          // Note that this might not be the same exact Instance if the Instances within the
-          // ViewTransition changed.
-          const previousMeasurement =
-            previousMeasurements[viewTransitionHostInstanceIdx];
-          const nextMeasurement = measureInstance(instance);
-          if (
-            wasInstanceInViewport(previousMeasurement) ||
-            wasInstanceInViewport(nextMeasurement)
-          ) {
-            // If either the old or new state was within the viewport we have to animate this.
-            // But if it turns out that none of them were we'll be able to skip it.
-            inViewport = true;
-          }
-          if (
-            (parentViewTransition.flags & Update) === NoFlags &&
-            hasInstanceChanged(previousMeasurement, nextMeasurement)
-          ) {
-            parentViewTransition.flags |= Update;
-          }
-          if (
-            hasInstanceAffectedParent(previousMeasurement, nextMeasurement)
-          ) {
-            // If this instance size within its parent has changed it might have caused the
-            // parent to relayout which needs a cross fade.
-            parentViewTransition.flags |= AffectedParentLayout;
-          }
+          // Skip any hidden subtrees. They were or are effectively not there.
+        } else if (
+          child.tag === ViewTransitionComponent &&
+          stopAtNestedViewTransitions
+        ) {
+          parentViewTransition.flags |= child.flags & AffectedParentLayout;
         } else {
-          // If there was an insertion of extra nodes, we have to assume they affected the parent.
-          // It should have already been marked as an Update due to the mutation.
-          parentViewTransition.flags |= AffectedParentLayout;
-        }
-        if ((parentViewTransition.flags & Update) !== NoFlags) {
-          // We might update this node so we need to apply its new name for the new state.
-          // Additionally in the ApplyGesture case we also need to do this because the clone
-          // will have the name but this one won't.
-          applyViewTransitionName(
-            instance,
-            viewTransitionHostInstanceIdx === 0
-              ? newName
-              : // If we have multiple Host Instances below, we add a suffix to the name to give
-                // each one a unique name.
-                newName + '_' + viewTransitionHostInstanceIdx,
-            className,
-          );
-        }
-        if (!inViewport || (parentViewTransition.flags & Update) === NoFlags) {
-          // It turns out that we had no other deeper mutations, the child transitions didn't
-          // affect the parent layout and this instance hasn't changed size. So we can skip
-          // animating it. However, in the current model this only works if the parent also
-          // doesn't animate. So we have to queue these and wait until we complete the parent
-          // to cancel them.
-          if (viewTransitionCancelableChildren === null) {
-            viewTransitionCancelableChildren = [];
-          }
-          viewTransitionCancelableChildren.push(
-            instance,
-            viewTransitionHostInstanceIdx === 0
-              ? oldName
-              : // If we have multiple Host Instances below, we add a suffix to the name to give
-                // each one a unique name.
-                oldName + '_' + viewTransitionHostInstanceIdx,
-            child.memoizedProps,
-          );
-        }
-        viewTransitionHostInstanceIdx++;
-      } else if (
-        child.tag === OffscreenComponent &&
-        child.memoizedState !== null
-      ) {
-        // Skip any hidden subtrees. They were or are effectively not there.
-      } else if (
-        child.tag === ViewTransitionComponent &&
-        stopAtNestedViewTransitions
-      ) {
-        // Skip any nested view transitions for updates since in that case the
-        // inner most one is the one that handles the update.
-        // If this inner boundary resized we need to bubble that information up.
-        parentViewTransition.flags |= child.flags & AffectedParentLayout;
-      } else {
-        if (
           measureViewTransitionHostInstancesRecursive(
             parentViewTransition,
             child.child,
@@ -820,14 +722,118 @@ function measureViewTransitionHostInstancesRecursive(
             className,
             previousMeasurements,
             stopAtNestedViewTransitions,
-          )
+          );
+        }
+        child = child.sibling;
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+  let inViewport = false;
+  while (child !== null) {
+    if (child.tag === HostComponent) {
+      const instance: Instance = child.stateNode;
+      if (
+        previousMeasurements !== null &&
+        viewTransitionHostInstanceIdx < previousMeasurements.length
+      ) {
+        // The previous measurement of the Instance in this location within the ViewTransition.
+        // Note that this might not be the same exact Instance if the Instances within the
+        // ViewTransition changed.
+        const previousMeasurement =
+          previousMeasurements[viewTransitionHostInstanceIdx];
+        const nextMeasurement = measureInstance(instance);
+        if (
+          wasInstanceInViewport(previousMeasurement) ||
+          wasInstanceInViewport(nextMeasurement)
         ) {
+          // If either the old or new state was within the viewport we have to animate this.
+          // But if it turns out that none of them were we'll be able to skip it.
           inViewport = true;
         }
+        if (
+          (parentViewTransition.flags & Update) === NoFlags &&
+          hasInstanceChanged(previousMeasurement, nextMeasurement)
+        ) {
+          parentViewTransition.flags |= Update;
+        }
+        if (hasInstanceAffectedParent(previousMeasurement, nextMeasurement)) {
+          // If this instance size within its parent has changed it might have caused the
+          // parent to relayout which needs a cross fade.
+          parentViewTransition.flags |= AffectedParentLayout;
+        }
+      } else {
+        // If there was an insertion of extra nodes, we have to assume they affected the parent.
+        // It should have already been marked as an Update due to the mutation.
+        parentViewTransition.flags |= AffectedParentLayout;
       }
-      child = child.sibling;
+      if ((parentViewTransition.flags & Update) !== NoFlags) {
+        // We might update this node so we need to apply its new name for the new state.
+        // Additionally in the ApplyGesture case we also need to do this because the clone
+        // will have the name but this one won't.
+        applyViewTransitionName(
+          instance,
+          viewTransitionHostInstanceIdx === 0
+            ? newName
+            : // If we have multiple Host Instances below, we add a suffix to the name to give
+              // each one a unique name.
+              newName + '_' + viewTransitionHostInstanceIdx,
+          className,
+        );
+      }
+      if (!inViewport || (parentViewTransition.flags & Update) === NoFlags) {
+        // It turns out that we had no other deeper mutations, the child transitions didn't
+        // affect the parent layout and this instance hasn't changed size. So we can skip
+        // animating it. However, in the current model this only works if the parent also
+        // doesn't animate. So we have to queue these and wait until we complete the parent
+        // to cancel them.
+        if (viewTransitionCancelableChildren === null) {
+          viewTransitionCancelableChildren = [];
+        }
+        viewTransitionCancelableChildren.push(
+          instance,
+          viewTransitionHostInstanceIdx === 0
+            ? oldName
+            : // If we have multiple Host Instances below, we add a suffix to the name to give
+              // each one a unique name.
+              oldName + '_' + viewTransitionHostInstanceIdx,
+          child.memoizedProps,
+        );
+      }
+      viewTransitionHostInstanceIdx++;
+    } else if (
+      child.tag === OffscreenComponent &&
+      child.memoizedState !== null
+    ) {
+      // Skip any hidden subtrees. They were or are effectively not there.
+    } else if (
+      child.tag === ViewTransitionComponent &&
+      stopAtNestedViewTransitions
+    ) {
+      // Skip any nested view transitions for updates since in that case the
+      // inner most one is the one that handles the update.
+      // If this inner boundary resized we need to bubble that information up.
+      parentViewTransition.flags |= child.flags & AffectedParentLayout;
+    } else {
+      if (
+        measureViewTransitionHostInstancesRecursive(
+          parentViewTransition,
+          child.child,
+          newName,
+          oldName,
+          className,
+          previousMeasurements,
+          stopAtNestedViewTransitions,
+        )
+      ) {
+        inViewport = true;
+      }
     }
-    return inViewport;
+    child = child.sibling;
+  }
+  return inViewport;
 }
 
 export function measureUpdateViewTransition(

--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -239,30 +239,31 @@ function restoreViewTransitionOnHostInstances(
   child: null | Fiber,
   stopAtNestedViewTransitions: boolean,
 ): void {
-  if (supportsMutation) {
-    while (child !== null) {
-      if (child.tag === HostComponent) {
-        const instance: Instance = child.stateNode;
-        restoreViewTransitionName(instance, child.memoizedProps);
-      } else if (
-        child.tag === OffscreenComponent &&
-        child.memoizedState !== null
-      ) {
-        // Skip any hidden subtrees. They were or are effectively not there.
-      } else if (
-        child.tag === ViewTransitionComponent &&
-        stopAtNestedViewTransitions
-      ) {
-        // Skip any nested view transitions for updates since in that case the
-        // inner most one is the one that handles the update.
-      } else {
-        restoreViewTransitionOnHostInstances(
-          child.child,
-          stopAtNestedViewTransitions,
-        );
-      }
-      child = child.sibling;
+  if (!supportsMutation) {
+    return;
+  }
+  while (child !== null) {
+    if (child.tag === HostComponent) {
+      const instance: Instance = child.stateNode;
+      restoreViewTransitionName(instance, child.memoizedProps);
+    } else if (
+      child.tag === OffscreenComponent &&
+      child.memoizedState !== null
+    ) {
+      // Skip any hidden subtrees. They were or are effectively not there.
+    } else if (
+      child.tag === ViewTransitionComponent &&
+      stopAtNestedViewTransitions
+    ) {
+      // Skip any nested view transitions for updates since in that case the
+      // inner most one is the one that handles the update.
+    } else {
+      restoreViewTransitionOnHostInstances(
+        child.child,
+        stopAtNestedViewTransitions,
+      );
     }
+    child = child.sibling;
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -58,7 +58,6 @@ import {
   disableLegacyMode,
   enableComponentPerformanceTrack,
   enableViewTransition,
-  enableViewTransitionForPersistenceMode,
   enableFragmentRefs,
   enableEagerAlternateStateNodeCleanup,
   enableDefaultTransitionIndicator,
@@ -3714,11 +3713,6 @@ function commitPassiveMountOnFiber(
 
       if (isViewTransitionEligible) {
         if (supportsMutation && rootViewTransitionNameCanceled) {
-          restoreRootViewTransitionName(finishedRoot.containerInfo);
-        } else if (
-          enableViewTransitionForPersistenceMode &&
-          rootViewTransitionNameCanceled
-        ) {
           restoreRootViewTransitionName(finishedRoot.containerInfo);
         }
       }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -58,6 +58,7 @@ import {
   disableLegacyMode,
   enableComponentPerformanceTrack,
   enableViewTransition,
+  enableViewTransitionForPersistenceMode,
   enableFragmentRefs,
   enableEagerAlternateStateNodeCleanup,
   enableDefaultTransitionIndicator,
@@ -3713,6 +3714,11 @@ function commitPassiveMountOnFiber(
 
       if (isViewTransitionEligible) {
         if (supportsMutation && rootViewTransitionNameCanceled) {
+          restoreRootViewTransitionName(finishedRoot.containerInfo);
+        } else if (
+          enableViewTransitionForPersistenceMode &&
+          rootViewTransitionNameCanceled
+        ) {
           restoreRootViewTransitionName(finishedRoot.containerInfo);
         }
       }

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -80,6 +80,8 @@ export const enableTaint = __EXPERIMENTAL__;
 
 export const enableViewTransition: boolean = true;
 
+export const enableViewTransitionForPersistenceMode: boolean = false;
+
 export const enableGestureTransition = __EXPERIMENTAL__;
 
 export const enableScrollEndPolyfill = __EXPERIMENTAL__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -26,3 +26,4 @@ export const enableFragmentRefsScrollIntoView = __VARIANT__;
 export const enableFragmentRefsInstanceHandles = __VARIANT__;
 export const enableEffectEventMutationPhase = __VARIANT__;
 export const enableFragmentRefsTextNodes = __VARIANT__;
+export const enableViewTransitionForPersistenceMode = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -28,6 +28,7 @@ export const {
   enableFragmentRefsScrollIntoView,
   enableFragmentRefsInstanceHandles,
   enableFragmentRefsTextNodes,
+  enableViewTransitionForPersistenceMode,
 } = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.
@@ -69,7 +70,6 @@ export const transitionLaneExpirationMs = 5000;
 export const enableYieldingBeforePassive: boolean = false;
 export const enableThrottledScheduling: boolean = false;
 export const enableViewTransition: boolean = true;
-export const enableViewTransitionForPersistenceMode: boolean = false;
 export const enableGestureTransition: boolean = false;
 export const enableScrollEndPolyfill: boolean = true;
 export const enableSuspenseyImages: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -69,6 +69,7 @@ export const transitionLaneExpirationMs = 5000;
 export const enableYieldingBeforePassive: boolean = false;
 export const enableThrottledScheduling: boolean = false;
 export const enableViewTransition: boolean = true;
+export const enableViewTransitionForPersistenceMode: boolean = false;
 export const enableGestureTransition: boolean = false;
 export const enableScrollEndPolyfill: boolean = true;
 export const enableSuspenseyImages: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -59,6 +59,7 @@ export const enableYieldingBeforePassive: boolean = false;
 
 export const enableThrottledScheduling: boolean = false;
 export const enableViewTransition: boolean = true;
+export const enableViewTransitionForPersistenceMode: boolean = false;
 export const enableGestureTransition: boolean = false;
 export const enableScrollEndPolyfill: boolean = true;
 export const enableSuspenseyImages: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -60,6 +60,7 @@ export const enableYieldingBeforePassive: boolean = true;
 
 export const enableThrottledScheduling: boolean = false;
 export const enableViewTransition: boolean = true;
+export const enableViewTransitionForPersistenceMode: boolean = false;
 export const enableGestureTransition: boolean = false;
 export const enableScrollEndPolyfill: boolean = true;
 export const enableSuspenseyImages: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -55,6 +55,7 @@ export const transitionLaneExpirationMs = 5000;
 export const enableYieldingBeforePassive = false;
 export const enableThrottledScheduling = false;
 export const enableViewTransition = true;
+export const enableViewTransitionForPersistenceMode = false;
 export const enableGestureTransition = false;
 export const enableScrollEndPolyfill = true;
 export const enableSuspenseyImages = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -66,6 +66,7 @@ export const enableYieldingBeforePassive: boolean = false;
 
 export const enableThrottledScheduling: boolean = false;
 export const enableViewTransition: boolean = true;
+export const enableViewTransitionForPersistenceMode: boolean = false;
 export const enableGestureTransition: boolean = false;
 export const enableScrollEndPolyfill: boolean = true;
 export const enableSuspenseyImages: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -98,6 +98,8 @@ export const disableLegacyMode: boolean = true;
 
 export const enableEagerAlternateStateNodeCleanup: boolean = true;
 
+export const enableViewTransitionForPersistenceMode: boolean = false;
+
 export const enableGestureTransition: boolean = false;
 
 export const enableSuspenseyImages: boolean = false;


### PR DESCRIPTION
## Summary
- Adds `enableViewTransitionForPersistenceMode` dynamic feature flag (defaults to `false` in all channels)
- In `applyViewTransitionToHostInstancesRecursive` and `measureViewTransitionHostInstancesRecursive`, when it's persistence mode and enableViewTransitionForPersistenceMode==true, run `applyViewTransitionName` recursively
   - will build on top and add `measureInstance` related logic when it makes sense (see the TODOs inline)

## Test plan
- [x] Existing view transition tests pass (flag is `false` by default, so no behavior change)
- [x] `yarn flow` for dom-node, fabric, native renderers
- [x] Check before vs after for ReactFabric-dev.fb.js and React-dev.js with the viewtransition featureflags default - nothing changes