### PR TITLE
Fix TypeScript typing for flat config in eslint-plugin-react-hooks

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Linter, Rule} from 'eslint';
+import type { Linter, Rule } from 'eslint';
 
 import ExhaustiveDeps from './rules/ExhaustiveDeps';
 import {
@@ -50,15 +50,18 @@ const recommendedRuleConfigs: Linter.RulesRecord = {
   ...basicRuleConfigs,
   ...recommendedCompilerRuleConfigs,
 };
+
 const recommendedLatestRuleConfigs: Linter.RulesRecord = {
   ...basicRuleConfigs,
   ...recommendedLatestCompilerRuleConfigs,
 };
 
-const plugins = ['react-hooks'];
+const plugins = ['react-hooks'] as const;
 
 type ReactHooksFlatConfig = {
-  plugins: {react: any};
+  plugins: {
+    'react-hooks': unknown;
+  };
   rules: Linter.RulesRecord;
 };
 
@@ -88,11 +91,11 @@ const plugin = {
 
 Object.assign(configs.flat, {
   'recommended-latest': {
-    plugins: {'react-hooks': plugin},
+    plugins: { 'react-hooks': plugin },
     rules: configs['recommended-latest'].rules,
   },
   recommended: {
-    plugins: {'react-hooks': plugin},
+    plugins: { 'react-hooks': plugin },
     rules: configs.recommended.rules,
   },
 });


### PR DESCRIPTION
Fixes #36016

The `ReactHooksFlatConfig` type defined the `plugins` property as `{ react: any }`, 
while the actual runtime configuration uses the key `'react-hooks'`.

This mismatch causes incorrect TypeScript inference when using
`configs.flat.recommended` in ESLint flat configuration with TypeScript strict mode.

This change updates the `ReactHooksFlatConfig` type so that the `plugins`
property correctly reflects the plugin key `'react-hooks'`.

No runtime behaviour is changed.
This is a type-only correction to align
the TypeScript definition with the actual configuration object.
