### PR TITLE
fix(DevTools): handle race condition when adding fibers during page reload

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitTreeBuilder.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitTreeBuilder.js
@@ -201,10 +201,11 @@ function updateTree(
 
         i += 3;
 
+        // If the node already exists, it may be a race condition when the page
+        // reloads during profiling. In this case, remove the old node first
+        // before adding the new one.
         if (nodes.has(id)) {
-          throw new Error(
-            `Commit tree already contains fiber "${id}". This is a bug in React DevTools.`,
-          );
+          nodes.delete(id);
         }
 
         if (type === ElementTypeRoot) {


### PR DESCRIPTION
## Summary

Fixes #36006

When a page reloads during profiling, DevTools may receive operations from both the old and new renderer. This can cause the same fiber ID to be added twice, which previously threw an error:

`Commit tree already contains fiber "21". This is a bug in React DevTools.`

## How did you test this change?

The fix removes the existing node before adding a new one when a duplicate ID is detected, allowing the profiling to continue gracefully during page reloads.

This is a defensive fix that handles the race condition gracefully rather than crashing.

## Notes

- This fix relates to the DevTools Profiler CommitTreeBuilder
- The issue occurs when a user presses F5 (refresh) while the profiler is recording