### PR TITLE
[compiler] Fix gating export misplaced on _unoptimized variant with TypeScript overload signatures

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -1258,6 +1258,13 @@ function getFunctionReferencedBeforeDeclarationAtTopLevel(
     TSTypeAliasDeclaration(path) {
       path.skip();
     },
+    TSDeclareFunction(path) {
+      // Skip TypeScript overload signatures (function declarations without a body)
+      // to avoid false positives in reference-before-declaration detection.
+      // TSDeclareFunction.id is treated as isReferencedIdentifier() by Babel,
+      // but these are not actual runtime references.
+      path.skip();
+    },
     Identifier(id) {
       const fn = fnNames.get(id.node.name);
       // We're not tracking this identifier.

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -1259,10 +1259,12 @@ function getFunctionReferencedBeforeDeclarationAtTopLevel(
       path.skip();
     },
     TSDeclareFunction(path) {
-      // Skip TypeScript overload signatures (function declarations without a body)
-      // to avoid false positives in reference-before-declaration detection.
-      // TSDeclareFunction.id is treated as isReferencedIdentifier() by Babel,
-      // but these are not actual runtime references.
+      /*
+       * Skip TypeScript overload signatures (function declarations without a body)
+       * to avoid false positives in reference-before-declaration detection.
+       * TSDeclareFunction.id is treated as isReferencedIdentifier() by Babel,
+       * but these are not actual runtime references.
+       */
       path.skip();
     },
     Identifier(id) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-ts-overload-export.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-ts-overload-export.expect.md
@@ -1,0 +1,86 @@
+
+## Input
+
+```javascript
+// @gating @compilationMode:"annotation"
+import {useStore} from 'shared-runtime';
+
+interface Session {
+  user: string;
+}
+
+// Overload signatures
+export function useSession(): Session | null;
+export function useSession<T>(selector: (session: Session) => T): T | null;
+// Implementation
+export function useSession<T>(
+  selector?: (session: Session) => T,
+): Session | T | null {
+  'use forget';
+  return useStore((s: {session: Session | null}) => {
+    const session = s.session;
+    if (!session) return null;
+    return selector ? selector(session) : session;
+  });
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: eval('useSession'),
+  params: [[]],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag"; // @gating @compilationMode:"annotation"
+import { useStore } from "shared-runtime";
+
+interface Session {
+  user: string;
+}
+
+// Overload signatures
+export function useSession(): Session | null;
+export function useSession<T>(selector: (session: Session) => T): T | null;
+// Implementation
+export const useSession = isForgetEnabled_Fixtures()
+  ? function useSession(selector) {
+      "use forget";
+      const $ = _c(2);
+      let t0;
+      if ($[0] !== selector) {
+        t0 = (s) => {
+          const session = s.session;
+          if (!session) {
+            return null;
+          }
+          return selector ? selector(session) : session;
+        };
+        $[0] = selector;
+        $[1] = t0;
+      } else {
+        t0 = $[1];
+      }
+      return useStore(t0);
+    }
+  : function useSession(selector?: (session: Session) => T) {
+      "use forget";
+      return useStore((s: { session: Session | null }) => {
+        const session = s.session;
+        if (!session) return null;
+        return selector ? selector(session) : session;
+      });
+    };
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: eval("useSession"),
+  params: [[]],
+};
+
+```
+      
+### Eval output
+(kind: exception) (0 , _sharedRuntime.useStore) is not a function

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-ts-overload-export.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-ts-overload-export.tsx
@@ -1,0 +1,26 @@
+// @gating @compilationMode:"annotation"
+import {useStore} from 'shared-runtime';
+
+interface Session {
+  user: string;
+}
+
+// Overload signatures
+export function useSession(): Session | null;
+export function useSession<T>(selector: (session: Session) => T): T | null;
+// Implementation
+export function useSession<T>(
+  selector?: (session: Session) => T,
+): Session | T | null {
+  'use forget';
+  return useStore((s: {session: Session | null}) => {
+    const session = s.session;
+    if (!session) return null;
+    return selector ? selector(session) : session;
+  });
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: eval('useSession'),
+  params: [[]],
+};


### PR DESCRIPTION
## Summary

When a function has TypeScript overload signatures (`TSDeclareFunction` nodes), the overload identifier names were treated as runtime references by Babel's `isReferencedIdentifier()`. This caused `getFunctionReferencedBeforeDeclarationAtTopLevel` to incorrectly mark the implementation as *referenced before declaration*, triggering the `insertAdditionalFunctionDeclaration` path in `insertGatedFunctionDeclaration`.

In that path, the original function is renamed to `<fn>_unoptimized` in-place, keeping any parent `ExportNamedDeclaration` wrapper — so the `export` ended up on the wrong (unoptimized) function. The new dispatcher function was inserted without `export`, breaking the exported binding at runtime.

**Before:**
```ts
// Wrong: export lands on unoptimized variant
export function useSession_unoptimized<T>(...) { ... }
// Wrong: dispatcher has no export
function useSession(arg0) { if (gate()) ... }
```

**After:**
```ts
// Correct: export is on the dispatcher
export const useSession = isForgetEnabled_Fixtures()
  ? function useSession(selector) { /* optimized */ }
  : function useSession(selector) { /* original */ };
```

## Fix

Skip `TSDeclareFunction` nodes in the top-level reference traversal (the same way `TSTypeAliasDeclaration` is already skipped). Overload signatures are not runtime references and should not influence the reference-before-declaration detection.

Fixes #35991

## Test Plan

Added compiler fixture `gating-ts-overload-export.tsx` covering the exported function with TypeScript overload signatures + gating + annotation mode.