### PR TITLE
fix(compiler): recognize 'use' as a hook for hook detection

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -895,7 +895,7 @@ function hasMemoCacheFunctionImport(
 }
 
 function isHookName(s: string): boolean {
-  return /^use[A-Z0-9]/.test(s);
+  return s === 'use' || /^use[A-Z0-9]/.test(s);
 }
 
 /*


### PR DESCRIPTION
## Summary

React's \use()\ API is a hook for reading context and promises, but the compiler's \isHookName()\ function only matched the \use[A-Z0-9]\ pattern, causing custom hooks that only call \use()\ to be silently skipped during compilation.

## Problem

When a custom hook only contains a \use()\ call:

\\\js
function useMyContext() {
  return use(MyContext);
}
\\\

The compiler would skip this function because \use\ does not match \/^use[A-Z0-9]/\. This resulted in no memoization being applied.

## Solution

Add \'use'\ to the hook name recognition in \isHookName()\ so that \use()\ is correctly identified as a hook call.

## Test Plan

Verified by checking that:
1. \isHookName('use')\ now returns \	rue\
2. \isHookName('useContext')\, \isHookName('useState')\ still work correctly
3. Functions calling only \use()\ will now be compiled with memoization

Fixes #35960