### PR TITLE
fix(devtools): correct private field type in react-devtools-fusebox package.json

### DIFF
--- a/packages/react-devtools-fusebox/package.json
+++ b/packages/react-devtools-fusebox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-devtools-fusebox",
   "version": "0.0.0",
-  "private": "true",
+  "private": true,
   "license": "MIT",
   "files": ["dist"],
   "scripts": {


### PR DESCRIPTION
## Summary

The `private` field in `packages/react-devtools-fusebox/package.json` was incorrectly set as a string `"true"` instead of a boolean `true`.

According to the [npm package.json specification](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#private), the `private` field must be a boolean value.

## Fix

Changed:
```json
"private": "true"
```

To:
```json
"private": true
```

## Test Plan

- Verify the package.json is valid JSON
- No functional changes, only metadata correction

Fixes #35793