### PR TITLE
fix(fixture): correct variable name in componentWillUnmount

### DIFF
--- a/fixtures/attribute-behavior/src/App.js
+++ b/fixtures/attribute-behavior/src/App.js
@@ -602,7 +602,7 @@ class Result extends React.Component {
 
   componentWillUnmount() {
     if (this.timeout) {
-      clearTimeout(this.interval);
+      clearTimeout(this.timeout);
     }
   }
 


### PR DESCRIPTION
## Summary

In \ixtures/attribute-behavior/src/App.js\, the \componentWillUnmount\ method had a bug where it checked for \	his.timeout\ but cleared \	his.interval\ (which doesn't exist).

This caused a memory leak where timeouts were never properly cleaned up on component unmount.

## Fix

Changed:
\\\js
clearTimeout(this.interval);
\\\

To:
\\\js
clearTimeout(this.timeout);
\\\

## Test Plan
- No functional changes, only a bug fix in fixture code
- Verify the correct variable is now being cleared

Fixes #35814