### PR TITLE
fix: properly type flat config to avoid TypeScript errors

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -71,9 +71,9 @@ const configs = {
     plugins,
     rules: recommendedLatestRuleConfigs,
   },
-  flat: {} as {
-    recommended: ReactHooksFlatConfig;
-    'recommended-latest': ReactHooksFlatConfig;
+  flat: {
+    recommended: null as unknown as ReactHooksFlatConfig,
+    'recommended-latest': null as unknown as ReactHooksFlatConfig,
   },
 };
 


### PR DESCRIPTION
## Bug

When using eslint-plugin-react-hooks with TypeScript strict mode, the following error occurs:

```
Type 'ReactFlatConfig | undefined' is not assignable to type 'InfiniteArray<ConfigWithExtends>'.
Type 'undefined' is not assignable to type 'InfiniteArray<ConfigWithExtends>'.
```

## Root Cause

The flat config was typed as an empty object `{}` which caused TypeScript errors when users tried to access `pluginReact.configs.flat.recommended`.

## Fix

This fix properly initializes the flat config type to avoid TypeScript errors.

## Test

The change has been tested locally with TypeScript strict mode enabled.