### PR TITLE
Remove disableClientCache feature flag

### DIFF
--- a/packages/react-markup/src/__tests__/ReactMarkupClient-test.js
+++ b/packages/react-markup/src/__tests__/ReactMarkupClient-test.js
@@ -165,7 +165,6 @@ if (!__EXPERIMENTAL__) {
       );
     });
 
-    // @gate disableClientCache
     it('does NOT support cache yet because it is a client component', async () => {
       let counter = 0;
       const getCount = React.cache(() => {

--- a/packages/react/src/ReactCacheClient.js
+++ b/packages/react/src/ReactCacheClient.js
@@ -7,12 +7,6 @@
  * @flow
  */
 
-import {disableClientCache} from 'shared/ReactFeatureFlags';
-import {
-  cache as cacheImpl,
-  cacheSignal as cacheSignalImpl,
-} from './ReactCacheImpl';
-
 function noopCache<A: Iterable<mixed>, T>(fn: (...A) => T): (...A) => T {
   // On the client (i.e. not a Server Components environment) `cache` has
   // no caching behavior. We just return the function as-is.
@@ -32,14 +26,10 @@ function noopCache<A: Iterable<mixed>, T>(fn: (...A) => T): (...A) => T {
   };
 }
 
-export const cache: typeof noopCache = disableClientCache
-  ? noopCache
-  : cacheImpl;
+export const cache: typeof noopCache = noopCache;
 
 function noopCacheSignal(): null | AbortSignal {
   return null;
 }
 
-export const cacheSignal: () => null | AbortSignal = disableClientCache
-  ? noopCacheSignal
-  : cacheSignalImpl;
+export const cacheSignal: () => null | AbortSignal = noopCacheSignal;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -174,9 +174,6 @@ export const disableLegacyContextForFunctionComponents: boolean = true;
 // Enable the moveBefore() alternative to insertBefore(). This preserves states of moves.
 export const enableMoveBefore: boolean = false;
 
-// Disabled caching behavior of `react/cache` in client runtimes.
-export const disableClientCache: boolean = true;
-
 // Warn on any usage of ReactTestRenderer
 export const enableReactTestRendererWarning: boolean = true;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -31,7 +31,6 @@ export const {
 } = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.
-export const disableClientCache: boolean = true;
 export const disableCommentsAsDOMContainers: boolean = true;
 export const disableInputAttributeSyncing: boolean = false;
 export const disableLegacyContext: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -16,7 +16,6 @@ import typeof * as ExportsType from './ReactFeatureFlags.native-oss';
 // All flags
 // -----------------------------------------------------------------------------
 export const alwaysThrottleRetries: boolean = false;
-export const disableClientCache: boolean = true;
 export const disableCommentsAsDOMContainers: boolean = true;
 export const disableInputAttributeSyncing: boolean = false;
 export const disableLegacyContext: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -49,7 +49,6 @@ export const enableFizzExternalRuntime: boolean = true;
 export const alwaysThrottleRetries: boolean = true;
 
 export const passChildrenWhenCloningPersistedNodes: boolean = false;
-export const disableClientCache: boolean = true;
 
 export const enableInfiniteRenderLoopDetection: boolean = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -11,7 +11,6 @@ import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as ExportsType from './ReactFeatureFlags.test-renderer';
 
 export const alwaysThrottleRetries = false;
-export const disableClientCache = true;
 export const disableCommentsAsDOMContainers = true;
 export const disableInputAttributeSyncing = false;
 export const disableLegacyContext = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -51,7 +51,6 @@ export const enableFizzExternalRuntime: boolean = false;
 export const alwaysThrottleRetries: boolean = true;
 
 export const passChildrenWhenCloningPersistedNodes: boolean = false;
-export const disableClientCache: boolean = true;
 
 export const enableInfiniteRenderLoopDetection: boolean = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -90,8 +90,6 @@ export const enableFizzExternalRuntime: boolean = true;
 
 export const passChildrenWhenCloningPersistedNodes: boolean = false;
 
-export const disableClientCache: boolean = true;
-
 export const enableReactTestRendererWarning: boolean = false;
 
 export const disableLegacyMode: boolean = true;

--- a/scripts/jest/setupTests.www.js
+++ b/scripts/jest/setupTests.www.js
@@ -12,11 +12,6 @@ jest.mock('shared/ReactFeatureFlags', () => {
   // code live.
   actual.disableInputAttributeSyncing = __VARIANT__;
 
-  // These are hardcoded to true for the next release,
-  // but still run the tests against both variants until
-  // we remove the flag.
-  actual.disableClientCache = __VARIANT__;
-
   // Some value that doesn't impact existing tests
   actual.ownerStackLimit = __VARIANT__ ? 500 : 1e4;
 


### PR DESCRIPTION
## Summary

The `disableClientCache` feature flag is set to `true` in all environments (main flags file, www, native-fb, native-oss, test-renderer, test-renderer.www, test-renderer.native-fb). This PR removes the flag and the dead code path it guarded.

When `disableClientCache` was `true`, `ReactCacheClient.js` exported `noopCache` and `noopCacheSignal` (no-ops that pass through or return null). With the flag hardcoded to `true` everywhere, the conditional branch that imported the real cache implementation from `ReactCacheImpl.js` was unreachable dead code.

This PR:
- Removes the `disableClientCache` flag from `ReactFeatureFlags.js` and all 6 fork files
- Simplifies `ReactCacheClient.js` to unconditionally export the no-op implementations
- Removes the `__VARIANT__` test override in `setupTests.www.js`
- Removes the `@gate disableClientCache` annotation from a test in `ReactMarkupClient-test.js`

Note: `ReactCacheServer.js` is unaffected -- it imports directly from `ReactCacheImpl.js` without any flag check.

## How did you test this change?

- `yarn linc` (lint on changed files): passed
- `yarn test` (dev mode, experimental): all cache and markup tests passed (23/23)
- `yarn test --prod` (production mode, experimental): all tests passed (23/23)
- `yarn test -r www-modern` (www variant): all tests passed (6/6)
- `yarn flow` (Flow type checks): 0 errors
- Verified zero remaining references to `disableClientCache` across the codebase