### PR TITLE
[infra] Add Volta config for Node and Yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,5 +161,9 @@
     "react-is": "npm:react-is",
     "jsdom": "22.1.0"
   },
-  "packageManager": "yarn@1.22.22"
+  "packageManager": "yarn@1.22.22",
+  "volta": {
+    "node": "20.19.0",
+    "yarn": "1.22.22"
+  }
 }


### PR DESCRIPTION
## Summary

Add a `volta` field to `package.json` so contributors using Volta automatically get the repo's expected Node.js and Yarn versions.

## Why

This repo already declares:

- Node.js via `.nvmrc`
- Yarn via `packageManager`

This PR does not change the existing workflow. It only adds optional metadata for contributors who use Volta.

## Notes

This is intended only as a small DX improvement for Volta users. If adding tool-specific metadata is not desirable for this repo, I’m happy to close this PR.