### PR TITLE
[Flight] Pack deferred children into continuation rows

### DIFF
--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -657,6 +657,38 @@ describe('ReactFlight', () => {
     expect(readValue).toEqual(date);
   });
 
+  it('should warn in DEV if an object with toJSON is passed as a top-level value', async () => {
+    const obj = {
+      toJSON() {
+        return 123;
+      },
+    };
+
+    const transport = ReactNoopFlightServer.render(obj);
+    assertConsoleErrorDev([
+      'Only plain objects can be passed to Client Components from Server Components. ' +
+        'Objects with toJSON methods are not supported. ' +
+        'Convert it manually to a simple value before passing it to props.\n' +
+        '  {: {toJSON: ...}}\n' +
+        '     ^^^^^^^^^^^^^',
+    ]);
+
+    let readValue;
+    await act(async () => {
+      readValue = await ReactNoopFlightClient.read(transport);
+    });
+
+    expect(readValue).toBe(123);
+    assertConsoleErrorDev([
+      'Only plain objects can be passed to Client Components from Server Components. ' +
+        'Objects with toJSON methods are not supported. ' +
+        'Convert it manually to a simple value before passing it to props.\n' +
+        '  {: {toJSON: ...}}\n' +
+        '     ^^^^^^^^^^^^^\n' +
+        '    at  (<anonymous>)',
+    ]);
+  });
+
   it('can transport Error objects as values', async () => {
     class CustomError extends Error {
       constructor(message) {
@@ -670,7 +702,10 @@ describe('ReactFlight', () => {
         is error: ${prop instanceof Error}
         name: ${prop.name}
         message: ${prop.message}
-        stack: ${normalizeCodeLocInfo(prop.stack).split('\n').slice(0, 2).join('\n')}
+        stack: ${normalizeCodeLocInfo(prop.stack)
+          .split('\n')
+          .slice(0, 2)
+          .join('\n')}
         environmentName: ${prop.environmentName}
       `;
     }
@@ -716,7 +751,10 @@ describe('ReactFlight', () => {
         is error: ${error instanceof Error}
         name: ${error.name}
         message: ${error.message}
-        stack: ${normalizeCodeLocInfo(error.stack).split('\n').slice(0, 2).join('\n')}
+        stack: ${normalizeCodeLocInfo(error.stack)
+          .split('\n')
+          .slice(0, 2)
+          .join('\n')}
         environmentName: ${error.environmentName}
         cause: ${'cause' in error ? renderError(error.cause) : 'no cause'}`;
     }
@@ -782,7 +820,10 @@ describe('ReactFlight', () => {
         is error: true
         name: ${error.name}
         message: ${error.message}
-        stack: ${normalizeCodeLocInfo(error.stack).split('\n').slice(0, 2).join('\n')}
+        stack: ${normalizeCodeLocInfo(error.stack)
+          .split('\n')
+          .slice(0, 2)
+          .join('\n')}
         environmentName: ${error.environmentName}
         cause: ${'cause' in error ? renderError(error.cause) : 'no cause'}`;
     }

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1412,6 +1412,68 @@ describe('ReactFlightDOMEdge', () => {
     }
   });
 
+  it('does not leak packed child continuations into client component array props', async () => {
+    const ClientComp = clientExports(function ClientComp({items}) {
+      const flatItems =
+        items.length === 500 && items.every(item => !Array.isArray(item));
+
+      return (
+        <section
+          data-length={items.length}
+          data-flat={flatItems ? 'yes' : 'no'}>
+          {items[0]}
+          {items[items.length - 1]}
+        </section>
+      );
+    });
+
+    function ServerComp() {
+      const flatItems = Array.from({length: 500}, (_, i) => (
+        <div key={i}>{'Item ' + i}</div>
+      ));
+      const nestedItems = Array.from({length: 500}, (_, i) => [
+        <div key={i}>{'Group ' + i}</div>,
+      ]);
+      return (
+        <>
+          <ClientComp items={flatItems} />
+          <ClientComp items={nestedItems} />
+        </>
+      );
+    }
+
+    const clientMetadata = webpackMap[ClientComp.$$id];
+    const translationMap = {
+      [clientMetadata.id]: {
+        '*': clientMetadata,
+      },
+    };
+
+    const stream = await serverAct(() =>
+      passThrough(
+        ReactServerDOMServer.renderToReadableStream(<ServerComp />, webpackMap),
+      ),
+    );
+    const response = ReactServerDOMClient.createFromReadableStream(stream, {
+      serverConsumerManifest: {
+        moduleMap: translationMap,
+        moduleLoading: webpackModuleLoading,
+      },
+    });
+
+    function ClientRoot() {
+      return use(response);
+    }
+
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(<ClientRoot />),
+    );
+
+    expect(await readResult(ssrStream)).toBe(
+      '<section data-length="500" data-flat="yes"><div>Item 0</div><div>Item 499</div></section><section data-length="500" data-flat="no"><div>Group 0</div><div>Group 499</div></section>',
+    );
+  });
+
   it('regression: should not leak serialized size', async () => {
     const MAX_ROW_SIZE = 3200;
     // This test case is a bit convoluted and may no longer trigger the original bug.

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -43,6 +43,38 @@ function normalizeSerializedContent(str) {
   return str.replaceAll(__REACT_ROOT_PATH_TEST__, '**');
 }
 
+function getSerializedModelRows(serializedContent) {
+  return Object.fromEntries(
+    serializedContent
+      .trim()
+      .split('\n')
+      .map(line => {
+        const colonIndex = line.indexOf(':');
+        if (colonIndex < 0 || colonIndex === line.length - 1) {
+          return null;
+        }
+        const tag = line[colonIndex + 1];
+        if (tag === 'D' || tag === 'T' || tag === 'N') {
+          return null;
+        }
+        return [
+          line.slice(0, colonIndex),
+          JSON.parse(line.slice(colonIndex + 1)),
+        ];
+      })
+      .filter(Boolean),
+  );
+}
+
+function createFromStream(stream) {
+  return ReactServerDOMClient.createFromReadableStream(stream, {
+    serverConsumerManifest: {
+      moduleMap: null,
+      moduleLoading: null,
+    },
+  });
+}
+
 describe('ReactFlightDOMEdge', () => {
   beforeEach(() => {
     // Mock performance.now for timing tests
@@ -782,9 +814,9 @@ describe('ReactFlightDOMEdge', () => {
       },
     );
 
-    // We should have resolved enough to be able to get the array even though some
-    // of the items inside are still lazy.
-    expect(result.length).toBe(20);
+    // We should have some of the elements, but not all of them yet
+    expect(result.length).toBeGreaterThan(4);
+    expect(result.length).toBeLessThan(20);
 
     // Unblock the rest
     drip(Infinity);
@@ -803,6 +835,583 @@ describe('ReactFlightDOMEdge', () => {
     expect(html).toBe(html2);
   });
 
+  it('packs trailing children into continuation rows', async () => {
+    const largeText = 'x'.repeat(1000);
+    const elements = [
+      <p
+        key={0}
+        data-a={largeText + '0a'}
+        data-b={largeText + '0b'}
+        data-c={largeText + '0c'}
+        data-d={largeText + '0d'}>
+        w
+      </p>,
+      <p
+        key={1}
+        data-a={largeText + '1a'}
+        data-b={largeText + '1b'}
+        data-c={largeText + '1c'}
+        data-d={largeText + '1d'}>
+        x
+      </p>,
+      <p key={2} data-a={largeText + '2a'}>
+        y
+      </p>,
+      <p key={3} data-a={largeText + '3a'}>
+        z
+      </p>,
+    ];
+
+    // Elements 0 and 1 each exceed MAX_ROW_SIZE alone (4×1000 chars), so
+    // each triggers its own continuation split. Element 3 is small enough to
+    // share a row with element 2 (~1000 chars each), verifying that a continuation can
+    // pack multiple elements when they fit.
+
+    // Without array continuations:
+    // Row 0: [elem0, $L1, $L2, $L3] — all three remaining elements deferred individually
+    // Row 1: [elem1] (the resolved lazy for $L1)
+    // Row 2: [elem2] (the resolved lazy for $L2)
+    // Row 3: [elem3] (the resolved lazy for $L3)
+
+    // With array continuations:
+    // Row 0: [elem0, $L1] — split after elem0 (assertion 1: continuation on first row)
+    // Row 1: [elem1, $L2] — split again after elem1 (assertion 2: continuation itself splits)
+    // Row 2: [elem2, elem3] — both small elements fit together (assertion 3: multiple elements per continuation row)
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(elements),
+    );
+    const serializedContent = normalizeSerializedContent(
+      await readResult(stream),
+    );
+    const modelRows = Object.values(getSerializedModelRows(serializedContent));
+
+    // There should be two rows that have lazy refs
+    expect(
+      modelRows.filter(
+        row =>
+          Array.isArray(row) &&
+          row.some(item => typeof item === 'string' && /^\$L/.test(item)),
+      ).length,
+    ).toBe(2);
+
+    // The last continuation row (for elements 2 and 3) should contain both
+    // elements without a further lazy ref, confirming they share a single row.
+    const lastContinuationRow = modelRows.find(
+      row =>
+        Array.isArray(row) &&
+        !row.some(item => typeof item === 'string' && /^\$L/.test(item)) &&
+        row.length === 2 &&
+        Array.isArray(row[0]) &&
+        row[0].some(prop => prop?.children === 'y') &&
+        Array.isArray(row[1]) &&
+        row[1].some(prop => prop?.children === 'z'),
+    );
+    expect(lastContinuationRow).toBeDefined();
+
+    const result = await createFromStream(
+      passThrough(
+        await serverAct(() =>
+          ReactServerDOMServer.renderToReadableStream(elements),
+        ),
+      ),
+    );
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(result),
+    );
+    const html = await readResult(ssrStream);
+    const ssrStream2 = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(elements),
+    );
+    const html2 = await readResult(ssrStream2);
+    expect(html).toBe(html2);
+  });
+
+  it('does not truncate a packed children array reused by another prop', async () => {
+    const items = Array.from({length: 100}, (_, i) => (
+      <p key={i}>{'text '.repeat(50) + i}</p>
+    ));
+
+    const stream = await serverAct(() =>
+      passThrough(
+        ReactServerDOMServer.renderToReadableStream(
+          React.createElement('div', {children: items, list: items}),
+        ),
+      ),
+    );
+    const serializedContent = normalizeSerializedContent(
+      await readResult(stream),
+    );
+    const rootRow = getSerializedModelRows(serializedContent)['0'];
+
+    // This one intentionally stays at the row level because the regression is
+    // about reusing the packed children encoding rather than the final output.
+    expect(rootRow[3].children.length).toBeLessThan(100);
+    expect(rootRow[3].children[0][3].children).toBe('text '.repeat(50) + 0);
+    expect(rootRow[3].children[rootRow[3].children.length - 1]).toMatch(/^\$L/);
+    expect(rootRow[3].list).toBe('$0:props:children');
+  });
+
+  it('preserves deduped shared props across packed child rows', async () => {
+    const shared = {value: 'deduped'};
+    const items = Array.from({length: 100}, (_, i) => (
+      <div key={i} extra={i > 40 ? shared : null}>
+        {'x'.repeat(80)}
+      </div>
+    ));
+
+    const stream = await serverAct(() =>
+      passThrough(
+        ReactServerDOMServer.renderToReadableStream(<section>{items}</section>),
+      ),
+    );
+    const serializedContent = normalizeSerializedContent(
+      await readResult(stream),
+    );
+    const modelRows = Object.values(getSerializedModelRows(serializedContent));
+    let sharedObjectCount = 0;
+    let sharedReferenceCount = 0;
+
+    function visit(value) {
+      if (Array.isArray(value)) {
+        for (let i = 0; i < value.length; i++) {
+          visit(value[i]);
+        }
+      } else if (value !== null && typeof value === 'object') {
+        if (value.value === 'deduped') {
+          sharedObjectCount++;
+        }
+        for (const key in value) {
+          if (Object.prototype.hasOwnProperty.call(value, key)) {
+            visit(value[key]);
+          }
+        }
+      } else if (typeof value === 'string' && value.endsWith(':props:extra')) {
+        sharedReferenceCount++;
+      }
+    }
+
+    for (let i = 0; i < modelRows.length; i++) {
+      visit(modelRows[i]);
+    }
+
+    expect(sharedObjectCount).toBe(1);
+    expect(sharedReferenceCount).toBeGreaterThan(0);
+  });
+
+  it('preserves deduped nested props across packed child rows', async () => {
+    const shared = {value: 'nested-deduped'};
+    const items = Array.from({length: 100}, (_, i) => (
+      <div key={i} extra={{nested: i > 40 ? shared : null}}>
+        {'x'.repeat(80)}
+      </div>
+    ));
+
+    const stream = await serverAct(() =>
+      passThrough(
+        ReactServerDOMServer.renderToReadableStream(<section>{items}</section>),
+      ),
+    );
+    const serializedContent = normalizeSerializedContent(
+      await readResult(stream),
+    );
+    const modelRows = Object.values(getSerializedModelRows(serializedContent));
+    let sharedObjectCount = 0;
+    let sharedReferenceCount = 0;
+
+    function visit(value) {
+      if (Array.isArray(value)) {
+        for (let i = 0; i < value.length; i++) {
+          visit(value[i]);
+        }
+      } else if (value !== null && typeof value === 'object') {
+        if (value.value === 'nested-deduped') {
+          sharedObjectCount++;
+        }
+        for (const key in value) {
+          if (Object.prototype.hasOwnProperty.call(value, key)) {
+            visit(value[key]);
+          }
+        }
+      } else if (
+        typeof value === 'string' &&
+        value.endsWith(':props:extra:nested')
+      ) {
+        sharedReferenceCount++;
+      }
+    }
+
+    for (let i = 0; i < modelRows.length; i++) {
+      visit(modelRows[i]);
+    }
+
+    expect(sharedObjectCount).toBe(1);
+    expect(sharedReferenceCount).toBeGreaterThan(0);
+  });
+
+  it('preserves promise identity across packed child rows', async () => {
+    const foo = {};
+    const bar = {
+      foo,
+    };
+    foo.bar = bar;
+    const promisedFoo = Promise.resolve(foo);
+    const promisedBar = Promise.resolve(bar);
+
+    const items = Array.from({length: 100}, (_, i) =>
+      i === 70
+        ? promisedFoo
+        : i === 71
+          ? promisedBar
+          : Promise.resolve('x'.repeat(80) + i),
+    );
+
+    const stream = await serverAct(() =>
+      passThrough(ReactServerDOMServer.renderToReadableStream(items)),
+    );
+    const result = await createFromStream(stream);
+
+    const resolvedFoo = await result[70];
+    const resolvedBar = await result[71];
+
+    expect(resolvedFoo.bar).toBe(resolvedBar);
+    expect(resolvedBar.foo).toBe(resolvedFoo);
+  });
+
+  it('preserves outlined promise identity across packed child rows', async () => {
+    const foo = {};
+    const bar = new Set([foo]);
+    foo.bar = bar;
+    const promisedFoo = Promise.resolve(foo);
+    const promisedBar = Promise.resolve(bar);
+
+    const items = Array.from({length: 100}, (_, i) =>
+      i === 70
+        ? promisedFoo
+        : i === 71
+          ? promisedBar
+          : Promise.resolve('y'.repeat(80) + i),
+    );
+
+    const stream = await serverAct(() =>
+      passThrough(ReactServerDOMServer.renderToReadableStream(items)),
+    );
+    const result = await createFromStream(stream);
+
+    const resolvedFoo = await result[70];
+    const resolvedBar = await result[71];
+
+    expect(resolvedFoo.bar).toBe(resolvedBar);
+    expect(Array.from(resolvedBar)[0]).toBe(resolvedFoo);
+  });
+
+  it('preserves map value identity across packed child rows', async () => {
+    const shared = {id: 42};
+    const map = new Map([[42, shared]]);
+    const items = Array.from({length: 100}, (_, i) =>
+      i === 70 ? {shared, map} : Promise.resolve('z'.repeat(80) + i),
+    );
+
+    const stream = await serverAct(() =>
+      passThrough(ReactServerDOMServer.renderToReadableStream(items)),
+    );
+    const result = await createFromStream(stream);
+
+    const target = result[70];
+    expect(target.map.get(42)).toBe(target.shared);
+  });
+
+  it('preserves deduped client props across packed child rows', async () => {
+    const Client = clientExports(function Client({value}) {
+      return JSON.stringify(value);
+    });
+
+    const shared = [1, 2, 3];
+    const items = Array.from({length: 100}, (_, i) =>
+      i === 70 ? (
+        <Client key={i} value={[shared, shared]} />
+      ) : (
+        <span key={i}>{'b'.repeat(80) + i}</span>
+      ),
+    );
+
+    const stream = await serverAct(() =>
+      passThrough(
+        ReactServerDOMServer.renderToReadableStream(items, webpackMap),
+      ),
+    );
+    const serializedContent = normalizeSerializedContent(
+      await readResult(stream),
+    );
+    const modelRows = serializedContent
+      .trim()
+      .split('\n')
+      .map(line => {
+        const colonIndex = line.indexOf(':');
+        if (colonIndex < 0 || colonIndex === line.length - 1) {
+          return null;
+        }
+        const payload = line.slice(colonIndex + 1);
+        if (payload[0] !== '[' && payload[0] !== '{') {
+          return null;
+        }
+        return JSON.parse(payload);
+      })
+      .filter(Boolean);
+    let sharedArrayCount = 0;
+    let sharedReferenceCount = 0;
+
+    function visit(value) {
+      if (Array.isArray(value)) {
+        if (
+          value.length === 3 &&
+          value[0] === 1 &&
+          value[1] === 2 &&
+          value[2] === 3
+        ) {
+          sharedArrayCount++;
+        }
+        for (let i = 0; i < value.length; i++) {
+          visit(value[i]);
+        }
+      } else if (value !== null && typeof value === 'object') {
+        for (const key in value) {
+          if (Object.prototype.hasOwnProperty.call(value, key)) {
+            visit(value[key]);
+          }
+        }
+      } else if (
+        typeof value === 'string' &&
+        value.endsWith(':props:value:0')
+      ) {
+        sharedReferenceCount++;
+      }
+    }
+
+    for (let i = 0; i < modelRows.length; i++) {
+      visit(modelRows[i]);
+    }
+
+    expect(sharedArrayCount).toBe(1);
+    expect(sharedReferenceCount).toBeGreaterThan(0);
+  });
+
+  it('preserves cross-boundary deduped element props across packed child rows', async () => {
+    function PassthroughServerComponent({children}) {
+      return children;
+    }
+
+    const Client = clientExports(function Client({children, track}) {
+      return children;
+    });
+
+    const shared = <div data-shared="yes" />;
+    const items = Array.from({length: 100}, (_, i) =>
+      i === 70 ? (
+        <Client key={i} track={shared}>
+          <PassthroughServerComponent>{shared}</PassthroughServerComponent>
+        </Client>
+      ) : (
+        <span key={i}>{'c'.repeat(80) + i}</span>
+      ),
+    );
+
+    const stream = await serverAct(() =>
+      passThrough(
+        ReactServerDOMServer.renderToReadableStream(items, webpackMap),
+      ),
+    );
+    const serializedContent = normalizeSerializedContent(
+      await readResult(stream),
+    );
+    const modelRows = serializedContent
+      .trim()
+      .split('\n')
+      .map(line => {
+        const colonIndex = line.indexOf(':');
+        if (colonIndex < 0 || colonIndex === line.length - 1) {
+          return null;
+        }
+        const payload = line.slice(colonIndex + 1);
+        if (payload[0] !== '[' && payload[0] !== '{') {
+          return null;
+        }
+        return JSON.parse(payload);
+      })
+      .filter(Boolean);
+    let sharedElementCount = 0;
+    let sharedReferenceCount = 0;
+
+    function visit(value) {
+      if (Array.isArray(value)) {
+        if (
+          value[0] === '$' &&
+          value[1] === 'div' &&
+          value[3] !== null &&
+          typeof value[3] === 'object' &&
+          value[3]['data-shared'] === 'yes'
+        ) {
+          sharedElementCount++;
+        }
+        for (let i = 0; i < value.length; i++) {
+          visit(value[i]);
+        }
+      } else if (value !== null && typeof value === 'object') {
+        for (const key in value) {
+          if (Object.prototype.hasOwnProperty.call(value, key)) {
+            visit(value[key]);
+          }
+        }
+      } else if (typeof value === 'string' && value.endsWith(':props:track')) {
+        sharedReferenceCount++;
+      }
+    }
+
+    for (let i = 0; i < modelRows.length; i++) {
+      visit(modelRows[i]);
+    }
+
+    expect(sharedElementCount).toBe(1);
+    expect(sharedReferenceCount).toBeGreaterThan(0);
+  });
+
+  it('resolves shared children arrays referenced from continuation rows', async () => {
+    // The same children array is reused by two parents while the outer children
+    // array is also split into continuation rows. Before the fix, the server could
+    // emit a property-path reference based on the original unsplit index, which
+    // the client could not resolve after packing.
+    const sharedItems0 = Array.from({length: 8}, (_, i) => (
+      <span key={i} data-item={'x'.repeat(500) + i}>
+        {String(i)}
+      </span>
+    ));
+    const sharedItems1 = Array.from({length: 8}, (_, i) => (
+      <em key={i} data-item={'y'.repeat(500) + i}>
+        {String(i)}
+      </em>
+    ));
+
+    const element = (
+      <div>
+        <section data-parent="first-0">{sharedItems0}</section>
+        <span data-sep={'s'.repeat(400)} />
+        <section data-parent="second-0">{sharedItems0}</section>
+        <section data-parent="first-1">{sharedItems1}</section>
+        <span data-sep={'t'.repeat(400)} />
+        <section data-parent="second-1">{sharedItems1}</section>
+      </div>
+    );
+
+    const rscStream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(element),
+    );
+    const result = await createFromStream(passThrough(rscStream));
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(result),
+    );
+    const rscHtml = await readResult(ssrStream);
+
+    const directStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(element),
+    );
+    const directHtml = await readResult(directStream);
+
+    expect(rscHtml).toBe(directHtml);
+  });
+
+  it('does not pack nested child arrays reused by sibling props', async () => {
+    const items = Array.from({length: 100}, (_, i) => (
+      <p key={i}>{'text '.repeat(50) + i}</p>
+    ));
+
+    const stream = await serverAct(() =>
+      passThrough(
+        ReactServerDOMServer.renderToReadableStream(
+          <div>
+            {items}
+            <span list={items} />
+          </div>,
+        ),
+      ),
+    );
+    const serializedContent = normalizeSerializedContent(
+      await readResult(stream),
+    );
+    const rows = getSerializedModelRows(serializedContent);
+    const rootRow = rows['0'];
+
+    expect(rootRow[3].children[0].length).toBe(100);
+    expect(rootRow[3].children[1]).toMatch(/^\$L/);
+    expect(rows[rootRow[3].children[1].slice(2)][3].list).toBe(
+      '$0:props:children:0',
+    );
+  });
+
+  it('should not treat plain prop arrays as renderable children', async () => {
+    const groups = [];
+    for (let groupIndex = 0; groupIndex < 20; groupIndex++) {
+      const tuples = [];
+      for (let tupleIndex = 0; tupleIndex < 20; tupleIndex++) {
+        tuples.push([
+          'key-' + groupIndex + '-' + tupleIndex,
+          'value-' + groupIndex + '-' + tupleIndex + '-' + 'x'.repeat(40),
+        ]);
+      }
+      groups.push(
+        <div key={groupIndex} data-items={tuples}>
+          <h2>{'Group ' + groupIndex}</h2>
+          <span>{tuples.length + ' items'}</span>
+        </div>,
+      );
+    }
+
+    const stream = await serverAct(() =>
+      passThrough(
+        ReactServerDOMServer.renderToReadableStream(
+          <section>{groups}</section>,
+        ),
+      ),
+    );
+
+    const serializedContent = normalizeSerializedContent(
+      await readResult(stream),
+    );
+    const modelRows = Object.values(getSerializedModelRows(serializedContent));
+    const dataItemArrays = [];
+
+    function visit(value) {
+      if (Array.isArray(value)) {
+        for (let i = 0; i < value.length; i++) {
+          visit(value[i]);
+        }
+      } else if (value !== null && typeof value === 'object') {
+        if (Array.isArray(value['data-items'])) {
+          dataItemArrays.push(value['data-items']);
+        }
+        for (const key in value) {
+          if (Object.prototype.hasOwnProperty.call(value, key)) {
+            visit(value[key]);
+          }
+        }
+      }
+    }
+
+    for (let i = 0; i < modelRows.length; i++) {
+      visit(modelRows[i]);
+    }
+
+    expect(dataItemArrays.length).toBeGreaterThan(0);
+    for (let i = 0; i < dataItemArrays.length; i++) {
+      const tuples = dataItemArrays[i];
+      expect(
+        tuples.some(item => typeof item === 'string' && /^\$L/.test(item)),
+      ).toBe(false);
+      for (let j = 0; j < tuples.length; j++) {
+        expect(Array.isArray(tuples[j])).toBe(true);
+      }
+    }
+  });
+
   it('regression: should not leak serialized size', async () => {
     const MAX_ROW_SIZE = 3200;
     // This test case is a bit convoluted and may no longer trigger the original bug.
@@ -817,26 +1426,13 @@ describe('ReactFlightDOMEdge', () => {
       ReactServerDOMServer.renderToReadableStream(model),
     );
 
-    const result = await ReactServerDOMClient.createFromReadableStream(stream, {
-      serverConsumerManifest: {
-        moduleMap: null,
-        moduleLoading: null,
-      },
-    });
+    const result = await createFromStream(stream);
 
     const stream2 = await serverAct(() =>
       ReactServerDOMServer.renderToReadableStream(model),
     );
 
-    const result2 = await ReactServerDOMClient.createFromReadableStream(
-      stream2,
-      {
-        serverConsumerManifest: {
-          moduleMap: null,
-          moduleLoading: null,
-        },
-      },
-    );
+    const result2 = await createFromStream(stream2);
 
     expect(result2.syncText).toEqual(result.syncText);
   });

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -526,6 +526,8 @@ type Task = {
   id: number,
   status: 0 | 1 | 3 | 4 | 5,
   model: ReactClientValue,
+  continuationSource: null | Array<ReactClientValue>,
+  continuationIndex: number,
   ping: () => void,
   keyPath: ReactKey, // parent server component keys
   implicitSlot: boolean, // true if the root server component of this sequence had a null key
@@ -2711,10 +2713,11 @@ function createTask(
   debugOwner: null | ReactComponentInfo, // DEV-only
   debugStack: null | Error, // DEV-only
   debugTask: null | ConsoleTask, // DEV-only
+  registerModelReference: boolean = true,
 ): Task {
   request.pendingChunks++;
   const id = request.nextChunkId++;
-  if (typeof model === 'object' && model !== null) {
+  if (registerModelReference && typeof model === 'object' && model !== null) {
     // If we're about to write this into a new task we can assign it an ID early so that
     // any other references can refer to the value we're about to write.
     if (keyPath !== null || implicitSlot) {
@@ -2728,6 +2731,8 @@ function createTask(
     id,
     status: PENDING,
     model,
+    continuationSource: null,
+    continuationIndex: 0,
     keyPath,
     implicitSlot,
     formatContext: formatContext,
@@ -3413,13 +3418,14 @@ function renderModel(
 function createArrayContinuationTask(
   request: Request,
   task: Task,
-  model: Array<ReactClientValue>,
+  continuationSource: Array<ReactClientValue>,
+  continuationIndex: number,
 ): Task {
-  // Continuation tasks own a sliced tail, which keeps their bookkeeping and
-  // written-object references independent from the original array.
+  // Continuation tasks resume the same source array from a later index.
+  // This task resumes an existing array instead of outlining a new one.
   const newTask = createTask(
     request,
-    model,
+    continuationSource,
     task.keyPath,
     task.implicitSlot,
     task.formatContext,
@@ -3431,7 +3437,10 @@ function createArrayContinuationTask(
     __DEV__ ? task.debugOwner : null,
     __DEV__ ? task.debugStack : null,
     __DEV__ ? task.debugTask : null,
+    false,
   );
+  newTask.continuationSource = continuationSource;
+  newTask.continuationIndex = continuationIndex;
   return newTask;
 }
 
@@ -3468,19 +3477,25 @@ function resolveModelArray(
   request: Request,
   task: Task,
   sourceArray: Array<ReactJSONValue>,
+  startIndex: number,
   mayBeChildrenArray: boolean,
 ): Array<ReactJSONValue> {
-  const resolvedArray = new Array<ReactJSONValue>(sourceArray.length);
-  let isChildrenArray = false;
-  let didCheckChildrenArray = !mayBeChildrenArray;
-  for (let i = 0; i < sourceArray.length; i++) {
-    resolvedArray[i] = resolveModelNode(
+  const totalLength = sourceArray.length - startIndex;
+  const resolvedArray = new Array<ReactJSONValue>(totalLength);
+  // Continuation tasks are only created for rendered children arrays.
+  let isChildrenArray = startIndex > 0;
+  let didCheckChildrenArray = startIndex > 0 || !mayBeChildrenArray;
+  for (let i = startIndex; i < sourceArray.length; i++) {
+    const targetIndex = i - startIndex;
+    const item = sourceArray[i];
+    const resolvedItem = resolveModelNode(
       request,
       task,
       sourceArray,
       '' + i,
-      sourceArray[i],
+      item,
     );
+    resolvedArray[targetIndex] = resolvedItem;
 
     if (serializedSize > MAX_ROW_SIZE && i + 1 < sourceArray.length) {
       // Most arrays never cross the split threshold, so defer the children-array
@@ -3493,20 +3508,64 @@ function resolveModelArray(
       if (!isChildrenArray) {
         continue;
       }
-      const remaining = sourceArray.slice(i + 1);
       const continuationTask = createArrayContinuationTask(
         request,
         task,
-        ((remaining: any): Array<ReactClientValue>),
+        ((sourceArray: any): Array<ReactClientValue>),
+        i + 1,
       );
       pingTask(request, continuationTask);
 
-      resolvedArray[i + 1] = serializeLazyID(continuationTask.id);
-      resolvedArray.length = i + 2;
+      resolvedArray.length = targetIndex + 2;
+      resolvedArray[targetIndex + 1] = serializeLazyID(continuationTask.id);
       break;
     }
   }
   return resolvedArray;
+}
+
+function getReferenceInParent(
+  request: Request,
+  task: Task,
+  parent:
+    | {+[key: string | number]: ReactClientValue}
+    | $ReadOnlyArray<ReactClientValue>,
+  parentPropertyName: string,
+): void | string {
+  let parentReference;
+  let propertyName = parentPropertyName;
+  if (
+    task.continuationSource !== null &&
+    parent === task.continuationSource &&
+    isArray(parent)
+  ) {
+    parentReference = serializeByValueID(task.id);
+    propertyName = '' + (+parentPropertyName - task.continuationIndex);
+  } else {
+    parentReference = request.writtenObjects.get(parent);
+    if (parentReference === undefined) {
+      return undefined;
+    }
+  }
+
+  if (isArray(parent) && parent[0] === REACT_ELEMENT_TYPE) {
+    switch (propertyName) {
+      case '1':
+        propertyName = 'type';
+        break;
+      case '2':
+        propertyName = 'key';
+        break;
+      case '3':
+        propertyName = 'props';
+        break;
+      case '4':
+        propertyName = '_owner';
+        break;
+    }
+  }
+
+  return parentReference + ':' + propertyName;
 }
 
 function resolveModelNode(
@@ -3585,6 +3644,7 @@ function resolveModelNode(
       request,
       task,
       ((rendered: any): Array<ReactJSONValue>),
+      0,
       parentPropertyName === '' || parentPropertyName === 'children',
     );
   }
@@ -3665,11 +3725,16 @@ function renderModelDestructive(
             }
           } else if (parentPropertyName.indexOf(':') === -1) {
             // TODO: If the property name contains a colon, we don't dedupe. Escape instead.
-            const parentReference = writtenObjects.get(parent);
-            if (parentReference !== undefined) {
+            const reference = getReferenceInParent(
+              request,
+              task,
+              parent,
+              parentPropertyName,
+            );
+            if (reference !== undefined) {
               // If the parent has a reference, we can refer to this object indirectly
               // through the property name inside that parent.
-              elementReference = parentReference + ':' + parentPropertyName;
+              elementReference = reference;
               writtenObjects.set(value, elementReference);
             }
           }
@@ -3890,31 +3955,16 @@ function renderModelDestructive(
       }
     } else if (parentPropertyName.indexOf(':') === -1) {
       // TODO: If the property name contains a colon, we don't dedupe. Escape instead.
-      const parentReference = writtenObjects.get(parent);
-      if (parentReference !== undefined) {
+      const reference = getReferenceInParent(
+        request,
+        task,
+        parent,
+        parentPropertyName,
+      );
+      if (reference !== undefined) {
         // If the parent has a reference, we can refer to this object indirectly
         // through the property name inside that parent.
-        let propertyName = parentPropertyName;
-        if (isArray(parent) && parent[0] === REACT_ELEMENT_TYPE) {
-          // For elements, we've converted it to an array but we'll have converted
-          // it back to an element before we read the references so the property
-          // needs to be aliased.
-          switch (parentPropertyName) {
-            case '1':
-              propertyName = 'type';
-              break;
-            case '2':
-              propertyName = 'key';
-              break;
-            case '3':
-              propertyName = 'props';
-              break;
-            case '4':
-              propertyName = '_owner';
-              break;
-          }
-        }
-        writtenObjects.set(value, parentReference + ':' + propertyName);
+        writtenObjects.set(value, reference);
       }
     }
 
@@ -5913,15 +5963,21 @@ function retryTask(request: Request, task: Task): void {
       canEmitDebugInfo = true;
     }
 
+    const isContinuationRow =
+      task.continuationSource !== null &&
+      task.model === task.continuationSource;
+
     // We call the destructive form that mutates this task. That way if something
     // suspends again, we can reuse the same task instead of spawning a new one.
-    const resolvedModel = renderModelDestructive(
-      request,
-      task,
-      emptyRoot,
-      '',
-      task.model,
-    );
+    const resolvedModel = isContinuationRow
+      ? resolveModelArray(
+          request,
+          task,
+          ((task.continuationSource: any): Array<ReactJSONValue>),
+          task.continuationIndex,
+          true,
+        )
+      : renderModelDestructive(request, task, emptyRoot, '', task.model);
 
     if (__DEV__) {
       // We're now past rendering this task and future renders will spawn new tasks for their
@@ -5962,7 +6018,14 @@ function retryTask(request: Request, task: Task): void {
 
       // Object might contain unresolved values like additional elements.
       // This is simulating what the JSON loop would do if this was part of it.
-      emitChunk(request, task, resolvedModel);
+      if (isContinuationRow && isArray(resolvedModel)) {
+        // This continuation row is already resolved.
+        // $FlowFixMe[incompatible-type] stringify can return null for undefined but we never do
+        const json: string = stringify(resolvedModel);
+        emitModelChunk(request, task.id, json);
+      } else {
+        emitChunk(request, task, resolvedModel);
+      }
     } else {
       // If the value is a string, it means it's a terminal value and we already escaped it
       // We don't need to escape it again.

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -3540,7 +3540,7 @@ function getReferenceInParent(
     isArray(parent)
   ) {
     parentReference = serializeByValueID(task.id);
-    propertyName = '' + (+parentPropertyName - task.continuationIndex);
+    propertyName = (+parentPropertyName - task.continuationIndex).toString(10);
   } else {
     parentReference = request.writtenObjects.get(parent);
     if (parentReference === undefined) {

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -527,7 +527,6 @@ type Task = {
   status: 0 | 1 | 3 | 4 | 5,
   model: ReactClientValue,
   ping: () => void,
-  toJSON: (key: string, value: ReactClientValue) => ReactJSONValue,
   keyPath: ReactKey, // parent server component keys
   implicitSlot: boolean, // true if the root server component of this sequence had a null key
   formatContext: FormatContext, // an approximate parent context from host components
@@ -2733,55 +2732,6 @@ function createTask(
     implicitSlot,
     formatContext: formatContext,
     ping: () => pingTask(request, task),
-    toJSON: function (
-      this:
-        | {+[key: string | number]: ReactClientValue}
-        | $ReadOnlyArray<ReactClientValue>,
-      parentPropertyName: string,
-      value: ReactClientValue,
-    ): ReactJSONValue {
-      const parent = this;
-      // Make sure that `parent[parentPropertyName]` wasn't JSONified before `value` was passed to us
-      if (__DEV__) {
-        // $FlowFixMe[incompatible-use]
-        const originalValue = parent[parentPropertyName];
-        if (
-          typeof originalValue === 'object' &&
-          originalValue !== value &&
-          !(originalValue instanceof Date)
-        ) {
-          // Call with the server component as the currently rendering component
-          // for context.
-          callWithDebugContextInDEV(request, task, () => {
-            if (objectName(originalValue) !== 'Object') {
-              const jsxParentType = jsxChildrenParents.get(parent);
-              if (typeof jsxParentType === 'string') {
-                console.error(
-                  '%s objects cannot be rendered as text children. Try formatting it using toString().%s',
-                  objectName(originalValue),
-                  describeObjectForErrorMessage(parent, parentPropertyName),
-                );
-              } else {
-                console.error(
-                  'Only plain objects can be passed to Client Components from Server Components. ' +
-                    '%s objects are not supported.%s',
-                  objectName(originalValue),
-                  describeObjectForErrorMessage(parent, parentPropertyName),
-                );
-              }
-            } else {
-              console.error(
-                'Only plain objects can be passed to Client Components from Server Components. ' +
-                  'Objects with toJSON methods are not supported. Convert it manually ' +
-                  'to a simple value before passing it to props.%s',
-                describeObjectForErrorMessage(parent, parentPropertyName),
-              );
-            }
-          });
-        }
-      }
-      return renderModel(request, task, parent, parentPropertyName, value);
-    },
     thenableState: null,
   }: Omit<
     Task,
@@ -3458,6 +3408,201 @@ function renderModel(
     // the client deal with it.
     return serializeByValueID(errorId);
   }
+}
+
+function createArrayContinuationTask(
+  request: Request,
+  task: Task,
+  model: Array<ReactClientValue>,
+): Task {
+  // Continuation tasks own a sliced tail, which keeps their bookkeeping and
+  // written-object references independent from the original array.
+  const newTask = createTask(
+    request,
+    model,
+    task.keyPath,
+    task.implicitSlot,
+    task.formatContext,
+    request.abortableTasks,
+    enableProfilerTimer &&
+      (enableComponentPerformanceTrack || enableAsyncDebugInfo)
+      ? task.time
+      : 0,
+    __DEV__ ? task.debugOwner : null,
+    __DEV__ ? task.debugStack : null,
+    __DEV__ ? task.debugTask : null,
+  );
+  return newTask;
+}
+
+function looksLikeRenderableChildrenArray(
+  sourceArray: Array<ReactJSONValue>,
+): boolean {
+  // Only arrays that look like rendered children should use the row-packing
+  // continuation path. Plain data arrays (Map entries, tuple props, etc.) stay
+  // on the normal serialization path.
+  if (sourceArray.length === 0) {
+    return false;
+  }
+  const firstItem = sourceArray[0];
+  if (firstItem === '$' || firstItem === REACT_ELEMENT_TYPE) {
+    return false;
+  }
+  if (typeof firstItem === 'string') {
+    return firstItem[0] === '$';
+  }
+  if (typeof firstItem === 'object' && firstItem !== null) {
+    if (isArray(firstItem)) {
+      return firstItem[0] === '$' || firstItem[0] === REACT_ELEMENT_TYPE;
+    }
+    return (
+      firstItem.$$typeof === REACT_ELEMENT_TYPE ||
+      firstItem.$$typeof === REACT_LAZY_TYPE ||
+      typeof firstItem.then === 'function'
+    );
+  }
+  return false;
+}
+
+function resolveModelArray(
+  request: Request,
+  task: Task,
+  sourceArray: Array<ReactJSONValue>,
+  mayBeChildrenArray: boolean,
+): Array<ReactJSONValue> {
+  const resolvedArray = new Array<ReactJSONValue>(sourceArray.length);
+  let isChildrenArray = false;
+  let didCheckChildrenArray = !mayBeChildrenArray;
+  for (let i = 0; i < sourceArray.length; i++) {
+    resolvedArray[i] = resolveModelNode(
+      request,
+      task,
+      sourceArray,
+      '' + i,
+      sourceArray[i],
+    );
+
+    if (serializedSize > MAX_ROW_SIZE && i + 1 < sourceArray.length) {
+      // Most arrays never cross the split threshold, so defer the children-array
+      // heuristic until we actually need to decide whether this array should be
+      // packed into continuation rows.
+      if (!didCheckChildrenArray) {
+        isChildrenArray = looksLikeRenderableChildrenArray(sourceArray);
+        didCheckChildrenArray = true;
+      }
+      if (!isChildrenArray) {
+        continue;
+      }
+      const remaining = sourceArray.slice(i + 1);
+      const continuationTask = createArrayContinuationTask(
+        request,
+        task,
+        ((remaining: any): Array<ReactClientValue>),
+      );
+      pingTask(request, continuationTask);
+
+      resolvedArray[i + 1] = serializeLazyID(continuationTask.id);
+      resolvedArray.length = i + 2;
+      break;
+    }
+  }
+  return resolvedArray;
+}
+
+function resolveModelNode(
+  request: Request,
+  task: Task,
+  parent:
+    | {+[key: string | number]: ReactClientValue}
+    | $ReadOnlyArray<ReactClientValue>,
+  parentPropertyName: string,
+  value: ReactClientValue,
+): ReactJSONValue {
+  // Mirror JSON.stringify replacer semantics so custom toJSON methods still run
+  // before we recurse, but do the traversal explicitly so we can row-pack arrays
+  // and avoid mutating frozen inputs in place.
+  let jsonValue: ReactClientValue = value;
+  if (
+    value !== null &&
+    typeof value === 'object' &&
+    // $FlowFixMe[method-unbinding]
+    typeof value.toJSON === 'function'
+  ) {
+    // $FlowFixMe[incompatible-use]
+    jsonValue = value.toJSON(parentPropertyName);
+  }
+
+  if (__DEV__) {
+    // $FlowFixMe[incompatible-use]
+    const originalValue = parent[parentPropertyName];
+    if (
+      typeof originalValue === 'object' &&
+      originalValue !== jsonValue &&
+      !(originalValue instanceof Date)
+    ) {
+      callWithDebugContextInDEV(request, task, () => {
+        if (objectName(originalValue) !== 'Object') {
+          const jsxParentType = jsxChildrenParents.get(parent);
+          if (typeof jsxParentType === 'string') {
+            console.error(
+              '%s objects cannot be rendered as text children. Try formatting it using toString().%s',
+              objectName(originalValue),
+              describeObjectForErrorMessage(parent, parentPropertyName),
+            );
+          } else {
+            console.error(
+              'Only plain objects can be passed to Client Components from Server Components. ' +
+                '%s objects are not supported.%s',
+              objectName(originalValue),
+              describeObjectForErrorMessage(parent, parentPropertyName),
+            );
+          }
+        } else {
+          console.error(
+            'Only plain objects can be passed to Client Components from Server Components. ' +
+              'Objects with toJSON methods are not supported. Convert it manually ' +
+              'to a simple value before passing it to props.%s',
+            describeObjectForErrorMessage(parent, parentPropertyName),
+          );
+        }
+      });
+    }
+  }
+  const rendered = renderModel(
+    request,
+    task,
+    parent,
+    parentPropertyName,
+    jsonValue,
+  );
+  if (rendered === null || typeof rendered !== 'object') {
+    return rendered;
+  }
+  if (isArray(rendered)) {
+    // Arrays need special handling so we can split large renderable child lists
+    // into lazy continuation rows.
+    return resolveModelArray(
+      request,
+      task,
+      ((rendered: any): Array<ReactJSONValue>),
+      parentPropertyName === '' || parentPropertyName === 'children',
+    );
+  }
+  const resolvedObject: {[key: string]: ReactJSONValue} = (Object.create(
+    null,
+  ): any);
+  for (const propertyName in rendered) {
+    if (hasOwnProperty.call(rendered, propertyName)) {
+      resolvedObject[propertyName] = resolveModelNode(
+        request,
+        task,
+        rendered,
+        propertyName,
+        rendered[propertyName],
+      );
+    }
+  }
+  return resolvedObject;
 }
 
 function renderModelDestructive(
@@ -5712,8 +5857,9 @@ function emitChunk(
     return;
   }
   // For anything else we need to try to serialize it using JSON.
+  const resolvedModel = resolveModelNode(request, task, {'': value}, '', value);
   // $FlowFixMe[incompatible-type] stringify can return null for undefined but we never do
-  const json: string = stringify(value, task.toJSON);
+  const json: string = stringify(resolvedModel);
   emitModelChunk(request, task.id, json);
 }
 
@@ -5759,7 +5905,7 @@ function retryTask(request: Request, task: Task): void {
   try {
     // Track the root so we know that we have to emit this object even though it
     // already has an ID. This is needed because we might see this object twice
-    // in the same toJSON if it is cyclic.
+    // in the same serialization pass if it is cyclic.
     modelRoot = task.model;
 
     if (__DEV__) {
@@ -5819,7 +5965,7 @@ function retryTask(request: Request, task: Task): void {
       emitChunk(request, task, resolvedModel);
     } else {
       // If the value is a string, it means it's a terminal value and we already escaped it
-      // We don't need to escape it again so it's not passed the toJSON replacer.
+      // We don't need to escape it again.
       // $FlowFixMe[incompatible-type] stringify can return null for undefined but we never do
       const json: string = stringify(resolvedModel);
       emitModelChunk(request, task.id, json);


### PR DESCRIPTION
## Summary

This changes Flight's large-array splitting behavior so rendered children arrays can be packed into continuation rows instead of deferring every remaining child one-by-one once `MAX_ROW_SIZE` is exceeded.

In pages with many children (eg, paragraphs, tables) it leads to a 1.45x performance improvement in req/sec on RSC serialization/deserialization in local benchmarks as well as [deployed canary Next.js code on Vercel](https://github.com/mhart/rsc-array-continuations) (160ms -> 110ms P95). This is due to the per-row overhead in RSC and the reduced number of rows (3674 rows -> 240 rows).

<img width="600" height="219" alt="Screenshot 2026-03-16 at 4 52 33 pm" src="https://github.com/user-attachments/assets/d2522129-7ea1-4878-821d-8c6946281d69" />

Before this change, if a rendered children array crossed the row-size threshold, Flight would often emit one lazy row per remaining child. That creates many tiny rows and adds a lot of per-row overhead. With this change, `MAX_ROW_SIZE` is still respected, but Flight can hand the remaining tail of the children array to a continuation task, so later rows can still pack multiple children together when they fit.

To support this we move the `toJSON` handling out of the `JSON.stringify` replacer path and into an explicit recursive resolution step that uses v8's optimized single-arg `JSON.stringify` call. This allows us to control resolution, including splitting large rendered children arrays before stringifying.

Fixes #35125.

## Why this is safe

This is intended to be a serialization strategy change, not a semantic change.

- It does not introduce a new wire format. The server still emits normal model rows plus existing lazy row references (`$L...`).
- It only changes how large rendered children arrays are chunked after they cross the size threshold.
- It keeps plain data arrays on the existing path, so tuple-like props, map entries, and similar arrays are not treated as renderable children.
- On the client, these continuation rows are resolved through the existing lazy/array model path, and the final rendered output remains the same.
- Shared references and deduped values continue to round-trip correctly across packed rows.

In other words, this should only reduce unnecessary row fragmentation for large children lists while preserving the same decoded model.

## How did you test this change?

Added coverage for:
- packing trailing children into continuation rows,
- preserving reused children-array references,
- preserving deduped shared props across packed child rows,
- preserving promise/map/client prop identity across packed child rows,
- resolving shared children arrays referenced from continuation rows,
- ensuring plain prop arrays are not treated as renderable children,
- preserving the existing DEV warning behavior for top-level `toJSON` values.

## Testing

- `volta run yarn test --silent --no-watchman ReactFlightDOMEdge-test`
- `volta run yarn test --silent --no-watchman ReactFlight-test`