### PR TITLE
fix(eslint-plugin-react-hooks): sync version with package.json

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -6,6 +6,8 @@
  */
 import type {Linter, Rule} from 'eslint';
 
+import {createRequire} from 'module';
+
 import ExhaustiveDeps from './rules/ExhaustiveDeps';
 import {
   allRules,
@@ -14,6 +16,11 @@ import {
   recommendedLatestRules,
 } from './shared/ReactCompiler';
 import RulesOfHooks from './rules/RulesOfHooks';
+
+// Use createRequire to load package.json version at runtime
+// This ensures the version is always in sync with package.json
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json');
 
 const rules = {
   'exhaustive-deps': ExhaustiveDeps,
@@ -80,7 +87,7 @@ const configs = {
 const plugin = {
   meta: {
     name: 'eslint-plugin-react-hooks',
-    version: '7.0.0',
+    version: pkg.version,
   },
   rules,
   configs,

--- a/packages/eslint-plugin-react-hooks/tsconfig.json
+++ b/packages/eslint-plugin-react-hooks/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "extends": "@tsconfig/strictest/tsconfig.json",
   "compilerOptions": {
-    "module": "ES2015",
-    "target": "ES2015",
+    "module": "ES2020",
+    "target": "ES2020",
     "moduleResolution": "Bundler",
     "lib": ["ES2020", "dom"],
     "sourceMap": false,
     "types": ["estree-jsx", "node"],
+    "resolveJsonModule": true,
     "downlevelIteration": true,
     "paths": {
       "babel-plugin-react-compiler": ["../../compiler/packages/babel-plugin-react-compiler/src"]


### PR DESCRIPTION
## Summary

The version in \packages/eslint-plugin-react-hooks/src/index.ts\ was hardcoded as a string (\'7.0.0'\), violating the Single Source of Truth (SSOT) principle for version management.

While \scripts/shared/ReactVersions.js\ manages package versions during the release process and updates \package.json\, it does not update this hardcoded string in the source file. Since this package is published without a bundling step that injects the version, it relies on manual updates, which are prone to human error and version mismatches.

## Changes

- Uses \createRequire\ to dynamically load the version from \package.json\ at runtime
- Updates \	sconfig.json\ to support ES2020 features (\import.meta\)
- Adds \esolveJsonModule\ for future JSON import support

## Why this approach?

Since ESLint plugins run in a Node.js environment, the version can be dynamically retrieved from \package.json\. This ensures that the runtime version always matches the published package metadata without requiring manual synchronization or complex build injections.

## Testing

- TypeScript type checking passes
- The change follows the idiomatic approach for ES modules with \createRequire\

Fixes #35722