### PR TITLE
docs(eslint-plugin-react-hooks): fix misleading additionalHooks regex example

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -135,11 +135,13 @@ This option accepts a regex to match the names of custom Hooks that have depende
   rules: {
     // ...
     "react-hooks/exhaustive-deps": ["warn", {
-      additionalHooks: "(useMyCustomHook|useMyOtherCustomHook)"
+      additionalHooks: "^(useMyCustomHook|useMyOtherCustomHook)$"
     }]
   }
 }
 ```
+
+**Note:** The regex should use anchors (`^` and `$`) to ensure exact matching. Without anchors, the pattern `(useMyCustomHook|useMyOtherCustomHook)` would also match `useMyCustomHook2` or `useMyOtherCustomHookTest`.
 
 We suggest to use this option **very sparingly, if at all**. Generally saying, we recommend most custom Hooks to not use the dependencies argument, and instead provide a higher-level API that is more focused around a specific use case.
 


### PR DESCRIPTION
## Summary

The `additionalHooks` regex example in the README was misleading because it would match unintended hook names.

### Problem

The previous regex:
```js
additionalHooks: "(useMyCustomHook|useMyOtherCustomHook)"
```

Would also match:
- `useMyCustomHook2`
- `useMyOtherCustomHookTest`

This caused issues for projects like WordPress Gutenberg (see #61598).

### Solution

Updated the example to use anchors for exact matching:
```js
additionalHooks: "^(useMyCustomHook|useMyOtherCustomHook)$"
```

Also added a note explaining the importance of using anchors.

## Testing

- Documentation-only change
- No code changes required

Fixes #29045
