### PR TITLE
fix(eslint-plugin-react-hooks): improve TypeScript types for flat configs

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -58,9 +58,19 @@ const recommendedLatestRuleConfigs: Linter.RulesRecord = {
 const plugins = ['react-hooks'];
 
 type ReactHooksFlatConfig = {
-  plugins: {react: any};
+  plugins: {'react-hooks': typeof plugin};
   rules: Linter.RulesRecord;
 };
+
+type FlatConfigs = {
+  recommended: ReactHooksFlatConfig;
+  'recommended-latest': ReactHooksFlatConfig;
+};
+
+// We need to declare the type explicitly because `flat` is populated after
+// `plugin` is defined (due to the circular reference: plugin.configs.flat
+// needs to reference plugin itself).
+let flatConfigs: FlatConfigs;
 
 const configs = {
   recommended: {
@@ -71,9 +81,8 @@ const configs = {
     plugins,
     rules: recommendedLatestRuleConfigs,
   },
-  flat: {} as {
-    recommended: ReactHooksFlatConfig;
-    'recommended-latest': ReactHooksFlatConfig;
+  get flat(): FlatConfigs {
+    return flatConfigs;
   },
 };
 
@@ -86,7 +95,8 @@ const plugin = {
   configs,
 };
 
-Object.assign(configs.flat, {
+// Initialize flat configs after plugin is defined to allow self-reference
+flatConfigs = {
   'recommended-latest': {
     plugins: {'react-hooks': plugin},
     rules: configs['recommended-latest'].rules,
@@ -95,6 +105,6 @@ Object.assign(configs.flat, {
     plugins: {'react-hooks': plugin},
     rules: configs.recommended.rules,
   },
-});
+};
 
 export default plugin;


### PR DESCRIPTION
## Summary

The previous implementation initialized `flat` as an empty object and used `Object.assign` to add properties, causing TypeScript to infer the type as potentially undefined.

### Problem

When using `eslint.config.ts` with strict mode, TypeScript would report:
```
Type 'ReactFlatConfig | undefined' is not assignable to type 'InfiniteArray<ConfigWithExtends>'.
Type 'undefined' is not assignable to type 'InfiniteArray<ConfigWithExtends>'.
```

### Solution

This change:
- Uses a getter function to provide proper type inference
- Explicitly types the flat configs with `FlatConfigs` type
- Removes the need for `Object.assign` with proper initialization
- Fixes the `ReactFlatConfig.plugins` type to correctly reference the plugin

### Testing

- TypeScript type checking passes (only pre-existing unrelated errors remain)
- The `flat.recommended` and `flat['recommended-latest']` are now properly typed

Fixes #36016
