### PR TITLE
fix(devtools): update profiling links to react.dev

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/NoProfilingData.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/NoProfilingData.js
@@ -23,7 +23,7 @@ export default function NoProfilingData(): React.Node {
         Click{' '}
         <a
           className={styles.LearnMoreLink}
-          href="https://fb.me/react-devtools-profiling"
+          href="https://react.dev/reference/profiler"
           rel="noopener noreferrer"
           target="_blank">
           here

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilingNotSupported.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilingNotSupported.js
@@ -23,10 +23,10 @@ export default function ProfilingNotSupported(): React.Node {
         Learn more at{' '}
         <a
           className={styles.Link}
-          href="https://fb.me/react-devtools-profiling"
+          href="https://react.dev/reference/profiler"
           rel="noopener noreferrer"
           target="_blank">
-          reactjs.org/link/profiling
+          react.dev/reference/profiler
         </a>
         .
       </p>

--- a/packages/react-devtools-timeline/src/TimelineNotSupported.js
+++ b/packages/react-devtools-timeline/src/TimelineNotSupported.js
@@ -58,7 +58,7 @@ function UnknownUnsupportedReason() {
         Click{' '}
         <a
           className={styles.Link}
-          href="https://fb.me/react-devtools-profiling"
+          href="https://react.dev/reference/profiler"
           rel="noopener noreferrer"
           target="_blank">
           here


### PR DESCRIPTION
## Summary

This PR updates the profiling documentation links in React DevTools to point to the current react.dev domain instead of the legacy reactjs.org links.

## Problem

The profiling error messages in DevTools displayed links pointing to `fb.me/react-devtools-profiling` which redirects to the old reactjs.org site. This site now shows a banner stating "This site is no longer updated. Go to react.dev".

This creates a poor user experience for developers trying to learn about React profiling.

**Issue**: Fixes #31878

## Solution

Updated all profiling-related links in DevTools to point to `https://react.dev/reference/profiler`:

1. **ProfilingNotSupported.js** - Error message when profiling is not supported
2. **NoProfilingData.js** - "Learn more" link in profiling UI  
3. **TimelineNotSupported.js** - Timeline profiler error message

## Testing

- ✅ Verified the new URL points to valid React Profiler documentation
- ✅ No code changes, only documentation link updates
- ✅ Follows existing link pattern used in TimelineNotSupported.js (already uses react.dev links)

## Before

```jsx
href="https://fb.me/react-devtools-profiling"
```

## After

```jsx
href="https://react.dev/reference/profiler"
```

---

This is a documentation-only change with no functional impact on the codebase.
