### PR TITLE
fix(react-devtools-fusebox): correct 'private' field type in package.json

### DIFF
--- a/packages/react-devtools-fusebox/package.json
+++ b/packages/react-devtools-fusebox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-devtools-fusebox",
   "version": "0.0.0",
-  "private": "true",
+  "private": true,
   "license": "MIT",
   "files": ["dist"],
   "scripts": {


### PR DESCRIPTION
The 'private' field should be a boolean value (true), not a string ("true").
This fixes a malformed package.json that could cause issues with npm/yarn.

Fixes #35793
