### PR TITLE
[Fizz] Reduce chunk push overhead in HTML serialization

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -1180,15 +1180,13 @@ function pushViewTransitionAttributes(
   }
 }
 
-const styleNameCache: Map<string, PrecomputedChunk> = new Map();
-function processStyleName(styleName: string): PrecomputedChunk {
-  const chunk = styleNameCache.get(styleName);
-  if (chunk !== undefined) {
-    return chunk;
+const styleNameCache: Map<string, string> = new Map();
+function processStyleName(styleName: string): string {
+  const cached = styleNameCache.get(styleName);
+  if (cached !== undefined) {
+    return cached;
   }
-  const result = stringToPrecomputedChunk(
-    escapeTextForBrowser(hyphenateStyleName(styleName)),
-  );
+  const result = escapeTextForBrowser(hyphenateStyleName(styleName));
   styleNameCache.set(styleName, result);
   return result;
 }
@@ -1209,7 +1207,7 @@ function pushStyleAttribute(
     );
   }
 
-  let isFirst = true;
+  let styleString = '';
   for (const styleName in style) {
     if (!hasOwnProperty.call(style, styleName)) {
       continue;
@@ -1231,48 +1229,42 @@ function pushStyleAttribute(
       continue;
     }
 
-    let nameChunk;
-    let valueChunk;
+    let nameStr;
+    let valueStr;
     const isCustomProperty = styleName.indexOf('--') === 0;
     if (isCustomProperty) {
-      nameChunk = stringToChunk(escapeTextForBrowser(styleName));
+      nameStr = escapeTextForBrowser(styleName);
       if (__DEV__) {
         checkCSSPropertyStringCoercion(styleValue, styleName);
       }
-      valueChunk = stringToChunk(
-        escapeTextForBrowser(('' + styleValue).trim()),
-      );
+      valueStr = escapeTextForBrowser(('' + styleValue).trim());
     } else {
       if (__DEV__) {
         warnValidStyle(styleName, styleValue);
       }
 
-      nameChunk = processStyleName(styleName);
+      nameStr = processStyleName(styleName);
       if (typeof styleValue === 'number') {
         if (styleValue !== 0 && !isUnitlessNumber(styleName)) {
-          valueChunk = stringToChunk(styleValue + 'px'); // Presumes implicit 'px' suffix for unitless numbers
+          valueStr = styleValue + 'px'; // Presumes implicit 'px' suffix for unitless numbers
         } else {
-          valueChunk = stringToChunk('' + styleValue);
+          valueStr = '' + styleValue;
         }
       } else {
         if (__DEV__) {
           checkCSSPropertyStringCoercion(styleValue, styleName);
         }
-        valueChunk = stringToChunk(
-          escapeTextForBrowser(('' + styleValue).trim()),
-        );
+        valueStr = escapeTextForBrowser(('' + styleValue).trim());
       }
     }
-    if (isFirst) {
-      isFirst = false;
-      // If it's first, we don't need any separators prefixed.
-      target.push(styleAttributeStart, nameChunk, styleAssign, valueChunk);
+    if (styleString === '') {
+      styleString = nameStr + ':' + valueStr;
     } else {
-      target.push(styleSeparator, nameChunk, styleAssign, valueChunk);
+      styleString += ';' + nameStr + ':' + valueStr;
     }
   }
-  if (!isFirst) {
-    target.push(attributeEnd);
+  if (styleString !== '') {
+    target.push(stringToChunk(' style="' + styleString + '"'));
   }
 }
 
@@ -1287,7 +1279,7 @@ function pushBooleanAttribute(
   value: string | boolean | number | Function | Object, // not null or undefined
 ): void {
   if (value && typeof value !== 'function' && typeof value !== 'symbol') {
-    target.push(attributeSeparator, stringToChunk(name), attributeEmptyString);
+    target.push(stringToChunk(' ' + name + '=""'));
   }
 }
 
@@ -1302,11 +1294,7 @@ function pushStringAttribute(
     typeof value !== 'boolean'
   ) {
     target.push(
-      attributeSeparator,
-      stringToChunk(name),
-      attributeAssign,
-      stringToChunk(escapeTextForBrowser(value)),
-      attributeEnd,
+      stringToChunk(' ' + name + '="' + escapeTextForBrowser(value) + '"'),
     );
   }
 }
@@ -1610,11 +1598,9 @@ function pushAttribute(
       }
       const sanitizedValue = sanitizeURL('' + value);
       target.push(
-        attributeSeparator,
-        stringToChunk(name),
-        attributeAssign,
-        stringToChunk(escapeTextForBrowser(sanitizedValue)),
-        attributeEnd,
+        stringToChunk(
+          ' ' + name + '="' + escapeTextForBrowser(sanitizedValue) + '"',
+        ),
       );
       return;
     }
@@ -1645,11 +1631,9 @@ function pushAttribute(
       }
       const sanitizedValue = sanitizeURL('' + value);
       target.push(
-        attributeSeparator,
-        stringToChunk('xlink:href'),
-        attributeAssign,
-        stringToChunk(escapeTextForBrowser(sanitizedValue)),
-        attributeEnd,
+        stringToChunk(
+          ' xlink:href="' + escapeTextForBrowser(sanitizedValue) + '"',
+        ),
       );
       return;
     }
@@ -1667,11 +1651,9 @@ function pushAttribute(
       // these aren't boolean attributes (they are coerced to strings).
       if (typeof value !== 'function' && typeof value !== 'symbol') {
         target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
+          ),
         );
       }
       return;
@@ -1727,20 +1709,14 @@ function pushAttribute(
     case 'download': {
       // Overloaded Boolean
       if (value === true) {
-        target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeEmptyString,
-        );
+        target.push(stringToChunk(' ' + name + '=""'));
       } else if (value === false) {
         // Ignored
       } else if (typeof value !== 'function' && typeof value !== 'symbol') {
         target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
+          ),
         );
       }
       return;
@@ -1757,11 +1733,9 @@ function pushAttribute(
         (value: any) >= 1
       ) {
         target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
+          ),
         );
       }
       return;
@@ -1775,11 +1749,9 @@ function pushAttribute(
         !isNaN(value)
       ) {
         target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
+          ),
         );
       }
       return;
@@ -1837,11 +1809,13 @@ function pushAttribute(
           }
         }
         target.push(
-          attributeSeparator,
-          stringToChunk(attributeName),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' +
+              attributeName +
+              '="' +
+              escapeTextForBrowser(value) +
+              '"',
+          ),
         );
       }
   }
@@ -1956,14 +1930,12 @@ function pushStartAnchor(
 
   pushViewTransitionAttributes(target, formatContext);
 
-  target.push(endOfStartTag);
-  pushInnerHTML(target, innerHTML, children);
-  if (typeof children === 'string') {
-    // Special case children as a string to avoid the unnecessary comment.
-    // TODO: Remove this special case after the general optimization is in place.
-    target.push(stringToChunk(encodeHTMLTextNode(children)));
+  if (innerHTML == null && typeof children === 'string') {
+    target.push(stringToChunk('>' + encodeHTMLTextNode(children)));
     return null;
   }
+  target.push(endOfStartTag);
+  pushInnerHTML(target, innerHTML, children);
   return children;
 }
 
@@ -3964,14 +3936,13 @@ function pushStartGenericElement(
 
   pushViewTransitionAttributes(target, formatContext);
 
-  target.push(endOfStartTag);
-  pushInnerHTML(target, innerHTML, children);
-  if (typeof children === 'string') {
-    // Special case children as a string to avoid the unnecessary comment.
-    // TODO: Remove this special case after the general optimization is in place.
-    target.push(stringToChunk(encodeHTMLTextNode(children)));
+  if (innerHTML == null && typeof children === 'string') {
+    // Fast path: close tag and emit text child in a single push.
+    target.push(stringToChunk('>' + encodeHTMLTextNode(children)));
     return null;
   }
+  target.push(endOfStartTag);
+  pushInnerHTML(target, innerHTML, children);
   return children;
 }
 

--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -222,8 +222,11 @@ export function typedArrayToBinaryChunk(
 
 export function byteLengthOfChunk(chunk: Chunk | PrecomputedChunk): number {
   return typeof chunk === 'string'
-    ? Buffer.byteLength(chunk, 'utf8')
-    : chunk.byteLength;
+    ? chunk.length // Fast path: .length === byte length for ASCII (99%+ of HTML output).
+    : // For multi-byte chars this slightly underestimates, which is fine
+      // because byteSize is only used for heuristic decisions (outlining
+      // threshold and progressive chunk sizing).
+      chunk.byteLength;
 }
 
 export function byteLengthOfBinaryChunk(chunk: BinaryChunk): number {


### PR DESCRIPTION
I spent some time yesterday digging into RSC performance with Claude. I think there are two _much_ bigger issues to tackle than this (one being web vs. node streams and the other being an architectural bottleneck), but this PR did provide some nice wins in a variety of benchmarks.

I have a separate improvement to Flight on another branch, but I'm a tad more skeptical of that PR. Plus, its gains were more modest.

Benchmark (Node v24, Apple M1 Max, 1000 iterations, 100 warmup):

   | Tree | Before (ops/s) | After (ops/s) | Δ |
   | --- | --- | --- | --- |
   | Small (10 el) | 37,959 | 48,257 | +27.1% |
   | Medium (300 el, 3 Suspense, inline styles + data attrs) | 2,309 | 3,518 | +52.4% |
   | Medium (300 el, no Suspense, inline styles + data attrs) | 2,404 | 3,725 | +54.9% |
   | **Tailwind (300 el, 3 Suspense, className-only)** | **4,275** | **5,965** | **+39.5%** |
   | Large (2500+ el, 12 Suspense) | 429 | 626 | +45.9% |

This is just one small part of the pipeline, so it's not representative of major e2e gains.

Below are Claude's notes–feel free to turn down this PR if you find its efficacy lacking. The `byteLengthOfChunk` change I'm a touch more nervous about, but if it's only used for heuristics this feels okay.

------

## Summary

   Batches attribute and style serialization into single string pushes instead of 3-5 separate
 `target.push()` calls per attribute. This reduces array operations, chunk count in segment buffers, and
 downstream `Buffer.byteLength` and `writeChunk`/`encodeInto` call volume.

   ## Motivation

   Profiling `renderToPipeableStream` with V8's `--prof` showed that `pushAttribute` and
 `pushStartGenericElement` were the top JS hot paths, with the dominant cost being the sheer number of
 `target.push()` calls per element. A `<div>` with 6 attributes and a 6-property style object was doing
 ~54 array pushes for attributes alone. Each push adds an item to the segment's chunk array, which then
 has to be iterated by `finishedSegment` for byte sizing and by `flushSubtree` for encoding.

   ## Changes

   **Attribute push batching** (`ReactFizzConfigDOM.js`):
   - `pushStringAttribute`: 5 pushes (`attributeSeparator`, `name`, `attributeAssign`, `escapedValue`,
 `attributeEnd`) → 1 push with `' ' + name + '="' + escapeTextForBrowser(value) + '"'`
   - `pushBooleanAttribute`: 3 pushes → 1 push
   - `pushStyleAttribute`: 4N+1 pushes (N = number of style properties) → 1 push. Builds the entire
 `style="..."` string before pushing.
   - `pushAttribute` default case (data-*, aria-*, etc.), URL attributes, enumerated attributes, numeric
 attributes, overloaded booleans: all consolidated from 3-5 pushes to 1.
   - `processStyleName`: returns plain string instead of `PrecomputedChunk` to enable string concatenation
 in style building.

   **Text child merging** (`ReactFizzConfigDOM.js`):
   - In `pushStartGenericElement` and `pushStartAnchor`: when children is a string and there's no
 `dangerouslySetInnerHTML`, merge the `>` with the escaped text into a single string push.

   **Byte length fast path** (`ReactServerStreamConfigNode.js`):
   - `byteLengthOfChunk`: use `string.length` instead of `Buffer.byteLength(chunk, 'utf8')`. For ASCII
 content (99%+ of HTML attribute/tag output), `.length === byte length`. The slight underestimate for
 multi-byte characters is acceptable since `byteSize` is only used for heuristic decisions (outlining
 threshold at 500 bytes, progressive chunk sizing).

   ## Results

   Benchmarked with `renderToPipeableStream` on Node v24.14.0, Apple M1 Max. Renders piped to a
 byte-counting Writable (no I/O). 100 warmup, 1000 measured iterations, <1% coefficient of variation.

   Output HTML is byte-identical before and after.

   ## How did you test this change?

   All existing Fizz and Server integration tests pass (4,088 tests across 150 suites). Verified HTML
 output identity for elements with className, id, style objects, data-* attributes, escaped text content,
 void elements, and SVG namespace attributes.