### PR TITLE
Include ViewTransitionNamedStatic in subtreeFlags check for enter/exit walks

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -364,7 +364,7 @@ export function commitEnterViewTransitions(
     } else {
       commitAppearingPairViewTransitions(placement);
     }
-  } else if ((placement.subtreeFlags & ViewTransitionStatic) !== NoFlags) {
+  } else if ((placement.subtreeFlags & (ViewTransitionStatic | ViewTransitionNamedStatic)) !== NoFlags) {
     let child = placement.child;
     while (child !== null) {
       commitEnterViewTransitions(child, gesture);
@@ -493,7 +493,7 @@ export function commitExitViewTransitions(deletion: Fiber): void {
       // Look for more pairs deeper in the tree.
       commitDeletedPairViewTransitions(deletion);
     }
-  } else if ((deletion.subtreeFlags & ViewTransitionStatic) !== NoFlags) {
+  } else if ((deletion.subtreeFlags & (ViewTransitionStatic | ViewTransitionNamedStatic)) !== NoFlags) {
     let child = deletion.child;
     while (child !== null) {
       commitExitViewTransitions(child);


### PR DESCRIPTION
## Summary

- `commitEnterViewTransitions` and `commitExitViewTransitions` only checked for `ViewTransitionStatic` in `subtreeFlags`, causing them to skip subtrees that only contained `ViewTransitionNamedStatic` children
- This meant named view transitions nested under non-ViewTransition parents would not fire their enter/exit animations
- Adds `ViewTransitionNamedStatic` to the bitwise flag check in both walks

## Test Plan

- Verified with the view-transition fixture that nested named view transitions now correctly animate on enter and exit