### PR TITLE
fix: pin 10 unpinned action(s),extract 6 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/compiler_discord_notify.yml
+++ b/.github/workflows/compiler_discord_notify.yml
@@ -25,7 +25,7 @@ jobs:
   check_maintainer:
     if: ${{ needs.check_access.outputs.is_member_or_collaborator == 'true' || needs.check_access.outputs.is_member_or_collaborator == true }}
     needs: [check_access]
-    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@3cb2c42013eda273ac449126ab9fcc115a09d39d # main
     permissions:
       # Used by check_maintainer
       contents: read

--- a/.github/workflows/compiler_prereleases_manual.yml
+++ b/.github/workflows/compiler_prereleases_manual.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   publish_prerelease_experimental:
     name: Publish to Experimental channel
-    uses: facebook/react/.github/workflows/compiler_prereleases.yml@main
+    uses: facebook/react/.github/workflows/compiler_prereleases.yml@3cb2c42013eda273ac449126ab9fcc115a09d39d # main
     with:
       commit_sha: ${{ inputs.prerelease_commit_sha || github.sha }}
       release_channel: ${{ inputs.release_channel }}

--- a/.github/workflows/compiler_prereleases_nightly.yml
+++ b/.github/workflows/compiler_prereleases_nightly.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   publish_prerelease_experimental:
     name: Publish to Experimental channel
-    uses: facebook/react/.github/workflows/compiler_prereleases.yml@main
+    uses: facebook/react/.github/workflows/compiler_prereleases.yml@3cb2c42013eda273ac449126ab9fcc115a09d39d # main
     with:
       commit_sha: ${{ github.sha }}
       release_channel: experimental

--- a/.github/workflows/devtools_discord_notify.yml
+++ b/.github/workflows/devtools_discord_notify.yml
@@ -25,7 +25,7 @@ jobs:
   check_maintainer:
     if: ${{ needs.check_access.outputs.is_member_or_collaborator == 'true' || needs.check_access.outputs.is_member_or_collaborator == true }}
     needs: [check_access]
-    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@3cb2c42013eda273ac449126ab9fcc115a09d39d # main
     permissions:
       # Used by check_maintainer
       contents: read

--- a/.github/workflows/devtools_regression_tests.yml
+++ b/.github/workflows/devtools_regression_tests.yml
@@ -46,7 +46,9 @@ jobs:
       - name: Download react-devtools artifacts for base revision
         run: |
           git fetch origin main
-          GH_TOKEN=${{ github.token }} scripts/release/download-experimental-build.js --commit=${{ inputs.commit_sha || '$(git rev-parse origin/main)' }}
+          GH_TOKEN=${GITHUB_TOKEN} scripts/release/download-experimental-build.js --commit=${{ inputs.commit_sha || '$(git rev-parse origin/main)' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Display structure of build
         run: ls -R build
       - name: Archive build

--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -531,7 +531,9 @@ jobs:
           merge-multiple: true
       - name: Display structure of build
         run: ls -R build
-      - run: echo ${{ github.event.inputs.commit_sha != '' && github.event.inputs.commit_sha || github.event.pull_request.head.sha || github.sha }} >> build/COMMIT_SHA
+      - run: echo ${INPUT_COMMIT_SHA} >> build/COMMIT_SHA
+        env:
+          INPUT_COMMIT_SHA: ${{ github.event.inputs.commit_sha != '' && github.event.inputs.commit_sha || github.event.pull_request.head.sha || github.sha }}
       - name: Scrape warning messages
         run: |
           mkdir -p ./build/__test_utils__
@@ -899,8 +901,10 @@ jobs:
         # unverified artifact is not used. Additionally this workflow runs in the pull_request
         # trigger so only restricted permissions are available.
         run: |
-          GH_TOKEN=${{ github.token }} scripts/release/download-experimental-build.js --commit=$(git rev-parse ${{ github.event.pull_request.base.sha }}) ${{ (github.event.pull_request.head.repo.full_name != github.repository && '--noVerify') || ''}}
+          GH_TOKEN=${GITHUB_TOKEN} scripts/release/download-experimental-build.js --commit=$(git rev-parse ${{ github.event.pull_request.base.sha }}) ${{ (github.event.pull_request.head.repo.full_name != github.repository && '--noVerify') || ''}}
           mv ./build ./base-build
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Delete extraneous files
         # TODO: The `download-experimental-build` script copies the npm
         # packages into the `node_modules` directory. This is a historical
@@ -923,7 +927,9 @@ jobs:
           node ./scripts/print-warnings/print-warnings.js > build/__test_utils__/ReactAllWarnings.js
       - name: Display structure of build for PR
         run: ls -R build
-      - run: echo ${{ github.event.inputs.commit_sha != '' && github.event.inputs.commit_sha || github.event.pull_request.head.sha || github.sha }} >> build/COMMIT_SHA
+      - run: echo ${INPUT_COMMIT_SHA} >> build/COMMIT_SHA
+        env:
+          INPUT_COMMIT_SHA: ${{ github.event.inputs.commit_sha != '' && github.event.inputs.commit_sha || github.event.pull_request.head.sha || github.sha }}
       - run: node ./scripts/tasks/danger
       - name: Archive sizebot results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/runtime_commit_artifacts.yml
+++ b/.github/workflows/runtime_commit_artifacts.yml
@@ -52,7 +52,9 @@ jobs:
         if: steps.node_modules.outputs.cache-hit != 'true'
       - name: Download artifacts for base revision
         run: |
-          GH_TOKEN=${{ github.token }} scripts/release/download-experimental-build.js --commit=${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha }}
+          GH_TOKEN=${GITHUB_TOKEN} scripts/release/download-experimental-build.js --commit=${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Display structure of build
         run: ls -R build
       - name: Archive build

--- a/.github/workflows/runtime_discord_notify.yml
+++ b/.github/workflows/runtime_discord_notify.yml
@@ -27,7 +27,7 @@ jobs:
   check_maintainer:
     if: ${{ needs.check_access.outputs.is_member_or_collaborator == 'true' || needs.check_access.outputs.is_member_or_collaborator == true }}
     needs: [check_access]
-    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@3cb2c42013eda273ac449126ab9fcc115a09d39d # main
     permissions:
       # Used by check_maintainer
       contents: read

--- a/.github/workflows/runtime_prereleases.yml
+++ b/.github/workflows/runtime_prereleases.yml
@@ -74,7 +74,9 @@ jobs:
         if: steps.node_modules.outputs.cache-hit != 'true'
       - run: cp ./scripts/release/ci-npmrc ~/.npmrc
       - run: |
-          GH_TOKEN=${{ secrets.GH_TOKEN }} scripts/release/prepare-release-from-ci.js --skipTests -r ${{ inputs.release_channel }} --commit=${{ inputs.commit_sha }}
+          GH_TOKEN=${GH_TOKEN} scripts/release/prepare-release-from-ci.js --skipTests -r ${{ inputs.release_channel }} --commit=${{ inputs.commit_sha }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: Check prepared files
         run: ls -R build/node_modules
       - if: '${{ inputs.only_packages }}'

--- a/.github/workflows/runtime_prereleases_manual.yml
+++ b/.github/workflows/runtime_prereleases_manual.yml
@@ -52,7 +52,7 @@ jobs:
   publish_prerelease_canary:
     if: ${{ !inputs.experimental_only }}
     name: Publish to Canary channel
-    uses: facebook/react/.github/workflows/runtime_prereleases.yml@main
+    uses: facebook/react/.github/workflows/runtime_prereleases.yml@3cb2c42013eda273ac449126ab9fcc115a09d39d # main
     permissions:
       # We use github.token to download the build artifact from a previous runtime_build_and_test.yml run
       actions: read
@@ -79,7 +79,7 @@ jobs:
 
   publish_prerelease_experimental:
     name: Publish to Experimental channel
-    uses: facebook/react/.github/workflows/runtime_prereleases.yml@main
+    uses: facebook/react/.github/workflows/runtime_prereleases.yml@3cb2c42013eda273ac449126ab9fcc115a09d39d # main
     permissions:
       # We use github.token to download the build artifact from a previous runtime_build_and_test.yml run
       actions: read

--- a/.github/workflows/runtime_prereleases_nightly.yml
+++ b/.github/workflows/runtime_prereleases_nightly.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   publish_prerelease_canary:
     name: Publish to Canary channel
-    uses: facebook/react/.github/workflows/runtime_prereleases.yml@main
+    uses: facebook/react/.github/workflows/runtime_prereleases.yml@3cb2c42013eda273ac449126ab9fcc115a09d39d # main
     permissions:
       # We use github.token to download the build artifact from a previous runtime_build_and_test.yml run
       actions: read
@@ -30,7 +30,7 @@ jobs:
 
   publish_prerelease_experimental:
     name: Publish to Experimental channel
-    uses: facebook/react/.github/workflows/runtime_prereleases.yml@main
+    uses: facebook/react/.github/workflows/runtime_prereleases.yml@3cb2c42013eda273ac449126ab9fcc115a09d39d # main
     permissions:
       # We use github.token to download the build artifact from a previous runtime_build_and_test.yml run
       actions: read

--- a/.github/workflows/shared_label_core_team_prs.yml
+++ b/.github/workflows/shared_label_core_team_prs.yml
@@ -26,7 +26,7 @@ jobs:
   check_maintainer:
     if: ${{ needs.check_access.outputs.is_member_or_collaborator == 'true' || needs.check_access.outputs.is_member_or_collaborator == true }}
     needs: [check_access]
-    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@3cb2c42013eda273ac449126ab9fcc115a09d39d # main
     permissions:
       # Used by check_maintainer
       contents: read


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/compiler_discord_notify.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/compiler_prereleases_manual.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/compiler_prereleases_nightly.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/devtools_discord_notify.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/devtools_regression_tests.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/runtime_build_and_test.yml` | Extracted 3 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/runtime_commit_artifacts.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/runtime_discord_notify.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/runtime_prereleases.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/runtime_prereleases_manual.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/runtime_prereleases_nightly.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/shared_label_core_team_prs.yml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-005 | medium | `.github/workflows/shared_label_core_team_prs.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.