### PR TITLE
Add credentialless as a recognized boolean attribute for iframes

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -756,6 +756,7 @@ function setProp(
     case 'async':
     case 'autoPlay':
     case 'controls':
+    case 'credentialless':
     case 'default':
     case 'defer':
     case 'disabled':

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -2850,6 +2850,7 @@ function diffHydratedGenericElement(
       case 'async':
       case 'autoPlay':
       case 'controls':
+      case 'credentialless':
       case 'default':
       case 'defer':
       case 'disabled':

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -1695,6 +1695,7 @@ function pushAttribute(
     case 'async':
     case 'autoPlay':
     case 'controls':
+    case 'credentialless':
     case 'default':
     case 'defer':
     case 'disabled':

--- a/packages/react-dom-bindings/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMUnknownPropertyHook.js
@@ -208,6 +208,7 @@ function validateProperty(tagName, name, value, eventRegistry) {
           case 'async':
           case 'autoPlay':
           case 'controls':
+          case 'credentialless':
           case 'default':
           case 'defer':
           case 'disabled':
@@ -287,6 +288,7 @@ function validateProperty(tagName, name, value, eventRegistry) {
             case 'async':
             case 'autoPlay':
             case 'controls':
+            case 'credentialless':
             case 'default':
             case 'defer':
             case 'disabled':

--- a/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
@@ -160,6 +160,34 @@ describe('DOMPropertyOperations', () => {
       expect(container.firstChild.hasAttribute('allowFullScreen')).toBe(false);
     });
 
+    it('should set credentialless boolean attribute on iframes', async () => {
+      const container = document.createElement('div');
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => {
+        root.render(<iframe credentialless={true} />);
+      });
+      expect(container.firstChild.getAttribute('credentialless')).toBe('');
+      await act(() => {
+        root.render(<iframe credentialless={false} />);
+      });
+      expect(container.firstChild.hasAttribute('credentialless')).toBe(false);
+    });
+
+    it('should set credentialless attribute when passed a string and warn', async () => {
+      const container = document.createElement('div');
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => {
+        root.render(<iframe credentialless="true" />);
+      });
+      assertConsoleErrorDev([
+        'Received the string `true` for the boolean attribute `credentialless`. ' +
+          'Although this works, it will not work as expected if you pass the string "false". ' +
+          'Did you mean credentialless={true}?\n' +
+          '    in iframe (at **)',
+      ]);
+      expect(container.firstChild.getAttribute('credentialless')).toBe('');
+    });
+
     it('should remove when setting custom attr to null', async () => {
       const container = document.createElement('div');
       const root = ReactDOMClient.createRoot(container);

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -187,6 +187,18 @@ describe('ReactDOMServerIntegration', () => {
       });
     });
 
+    describe('credentialless property', function () {
+      itRenders('credentialless prop with true value', async render => {
+        const e = await render(<iframe credentialless={true} />);
+        expect(e.getAttribute('credentialless')).toBe('');
+      });
+
+      itRenders('credentialless prop with false value', async render => {
+        const e = await render(<iframe credentialless={false} />);
+        expect(e.hasAttribute('credentialless')).toBe(false);
+      });
+    });
+
     describe('download property (combined boolean/string attribute)', function () {
       itRenders('download prop with true value', async render => {
         const e = await render(<a download={true} />);


### PR DESCRIPTION
## Summary

The `credentialless` attribute is a boolean HTML attribute for `<iframe>` elements that loads the iframe in a new, ephemeral context without access to the parent's credentials (cookies, client certificates, etc.). This change adds it to all boolean attribute switch/case lists in React DOM so it is properly handled as a boolean (set when true, removed when false) rather than being treated as an unknown string attribute.

Per the [Anonymous iframe spec (WICG)](https://wicg.github.io/anonymous-iframe/):

> The credentialless attribute enables loading documents hosted by the iframe with a new and ephemeral storage partition. It is a boolean value. The default is false.

```
partial interface HTMLIFrameElement {
  attribute boolean credentialless; 
};
```

Changes:
- ReactDOMComponent.js: Added to both `setProp` and `diffHydratedGenericElement`
- ReactFizzConfigDOM.js: Added to `pushAttribute` for server-side rendering
- ReactDOMUnknownPropertyHook.js: Added to both validation switch/case lists

## Test plan

- Added unit test in DOMPropertyOperations-test.js verifying `credentialless={true}` sets the attribute to `''` and `credentialless={false}` removes it
- All tests pass in source and www channels (590 tests each)
- Flow type checking passes (dom-node renderer)
- Prettier and lint pass