### PR TITLE
[compiler] Fix use hook resolution for aliased React imports

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -903,8 +903,14 @@ export class Environment {
       case 'ImportNamespace': {
         if (this.#isKnownReactModule(binding.module)) {
           // only resolve imports to modules we know about
+          // For default imports from 'react', always resolve to the React global type
+          // regardless of the local binding name (e.g., import ReactAlias from 'react')
+          const globalType =
+            binding.kind === 'ImportDefault' && binding.module.toLowerCase() === 'react'
+              ? this.#globals.get('React')
+              : this.#globals.get(binding.name);
           return (
-            this.#globals.get(binding.name) ??
+            globalType ??
             (isHookName(binding.name) ? this.#getCustomHookType() : null)
           );
         } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-hook-aliased-import.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-hook-aliased-import.expect.md
@@ -1,0 +1,34 @@
+
+## Input
+
+```javascript
+import ReactAlias from 'react'
+
+function App3() {
+  const v = ReactAlias.use();
+  return <div>{v}</div>
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import ReactAlias from "react";
+
+function App3() {
+  const $ = _c(2);
+  const v = ReactAlias.use();
+  let t0;
+  if ($[0] !== v) {
+    t0 = <div>{v}</div>;
+    $[0] = v;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+
+```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-hook-aliased-import.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-hook-aliased-import.js
@@ -1,0 +1,6 @@
+import ReactAlias from 'react'
+
+function App3() {
+  const v = ReactAlias.use();
+  return <div>{v}</div>
+}


### PR DESCRIPTION
## Summary

When importing React with an alias (e.g., `import ReactAlias from 'react'`), the compiler was not correctly resolving the 'use' hook type. This caused the compiled output to place the hook call inside a conditional cache block, violating the Rules of Hooks.

## Problem

The issue was in the Environment.ts file where imports from known React modules are resolved. When a user imports React with a different name like:



The compiler looked up `ReactAlias` in the globals map, but the React object type is stored under the key `'React'`. This meant that when the compiler encountered `ReactAlias.use()`, it didn't recognize `use` as the special built-in `use` operator.

## Solution

The fix ensures that default imports from 'react' always resolve to the React global type, regardless of the local binding name.

## Test Plan

Added a test fixture that verifies the correct behavior when using `ReactAlias.use()`.

Fixes #36137