### PR TITLE
fix: potential null dereference in react compiler configuration (#32571)

### DIFF
--- a/babel.config-react-compiler.js
+++ b/babel.config-react-compiler.js
@@ -15,5 +15,5 @@
 const baseConfig = require('./babel.config-ts');
 
 module.exports = {
-  plugins: baseConfig.plugins,
+  plugins: Array.isArray(baseConfig.plugins) ? baseConfig.plugins : [],
 };


### PR DESCRIPTION
Fixes #32571

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Fix potential null dereference in React Compiler configuration by adding a null check for the plugins array.

The babel.config-react-compiler.js file contains a hack comment about Zod spreading values in React Compiler's build artifact. If the baseConfig.plugins array is null or undefined, the assignment `plugins: baseConfig.plugins` will cause a runtime TypeError when the compiler tries to process the configuration. This could crash the build process or cause incorrect transpilation.

## How did you test this change?

- Modified the babel.config-react-compiler.js file to add a null check before assigning plugins
- Verified the change prevents TypeError when baseConfig.plugins is null or undefined
- Confirmed the build process continues to work correctly with valid plugin arrays

```