### PR TITLE
fix(devtools): clear highlight when mouse leaves DevTools panel

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
@@ -384,6 +384,23 @@ export default function Tree(): React.Node {
 
   const handleMouseLeave = clearHighlightHostInstance;
 
+  // The synthetic onMouseLeave on the tree div only fires within the document,
+  // so we need a native listener on the document itself.
+  useEffect(() => {
+    const container = focusTargetRef.current;
+    if (container == null) {
+      return;
+    }
+    const ownerDocument = container.ownerDocument;
+    ownerDocument.addEventListener('mouseleave', clearHighlightHostInstance);
+    return () => {
+      ownerDocument.removeEventListener(
+        'mouseleave',
+        clearHighlightHostInstance,
+      );
+    };
+  }, [clearHighlightHostInstance]);
+
   // Let react-window know to re-render any time the underlying tree data changes.
   // This includes the owner context, since it controls a filtered view of the tree.
   const itemData = useMemo<ItemData>(


### PR DESCRIPTION
  Fixes #17855

When hovering a component in the DevTools Components inspector, a highlight overlay appears on the inspected page. The highlight is cleared via `onMouseLeave` on the tree container `div`. But this React synthetic event only fires when the pointer transitions between elements _within the same document_. When the user moves their mouse out of the DevTools panel window entirely (e.g. to the browser viewport), no element in the React tree receives `mouseleave`, so `clearHostInstanceHighlight` is never sent over the bridge and the overlay persists on the page.

The fix adds a native `mouseleave` listener on the DevTools panel's `ownerDocument` in `Tree.js`. When the pointer exits the panel viewport, it fires `clearHighlightHostInstance` and removes the overlay. Using `ownerDocument` (rather than document) is consistent with the existing pattern in `Tree.js` for browser extension compatibility.

How did you test this change?

Tested manually using the Chrome extension:

1. Opened React DevTools → Components tab on a React app
2. Hovered a component in the tree — highlight appeared on the page ✓
3. Moved the mouse out of the DevTools panel into the browser viewport — highlight cleared immediately ✓ (previously it persisted)
4. Moved the mouse back into the panel and hovered a component — highlighting still works normally ✓
5. Unhovered within the panel — highlight still clears correctly ✓

Ran the DevTools test suite: yarn test --no-watchman ReactDevTools — all tests pass.