### PR TITLE
fix: outlining worklet functions

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineFunctions.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineFunctions.ts
@@ -19,15 +19,15 @@ export function outlineFunctions(
         value.kind === 'FunctionExpression' ||
         value.kind === 'ObjectMethod'
       ) {
-        // Skip functions with 'worklet' directive and all their inner functions as it's not safe to outline them.
-        if (
-          value.loweredFunc.func.directives &&
-          value.loweredFunc.func.directives.includes('worklet')
-        ) {
-          continue;
+        // Don't outline inner functions from parents with 'worklet' directive as it might break multi-threading assumptions.
+        const canOutlineInnerFunctions = value.loweredFunc.func.directives
+          ? !value.loweredFunc.func.directives.includes('worklet')
+          : true;
+        if (canOutlineInnerFunctions) {
+         {
+          // Recurse in case there are inner functions which can be outlined
+          outlineFunctions(value.loweredFunc.func, fbtOperands);
         }
-        // Recurse in case there are inner functions which can be outlined
-        outlineFunctions(value.loweredFunc.func, fbtOperands);
       }
       if (
         value.kind === 'FunctionExpression' &&

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineFunctions.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineFunctions.ts
@@ -19,6 +19,13 @@ export function outlineFunctions(
         value.kind === 'FunctionExpression' ||
         value.kind === 'ObjectMethod'
       ) {
+        // Skip functions with 'worklet' directive and all their inner functions as it's not safe to outline them.
+        if (
+          value.loweredFunc.func.directives &&
+          value.loweredFunc.func.directives.includes('worklet')
+        ) {
+          continue;
+        }
         // Recurse in case there are inner functions which can be outlined
         outlineFunctions(value.loweredFunc.func, fbtOperands);
       }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/arrow-expr-directive.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/arrow-expr-directive.expect.md
@@ -28,7 +28,7 @@ function Component() {
     t0 = () => {
       "worklet";
 
-      setCount(_temp);
+      setCount((count_0) => count_0 + 1);
     };
     $[0] = t0;
   } else {
@@ -44,9 +44,6 @@ function Component() {
     t1 = $[2];
   }
   return t1;
-}
-function _temp(count_0) {
-  return count_0 + 1;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-expr-directive.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/function-expr-directive.expect.md
@@ -34,7 +34,7 @@ function Component() {
     t0 = function update() {
       "worklet";
 
-      setCount(_temp);
+      setCount((count_0) => count_0 + 1);
     };
     $[0] = t0;
   } else {
@@ -50,9 +50,6 @@ function Component() {
     t1 = $[2];
   }
   return t1;
-}
-function _temp(count_0) {
-  return count_0 + 1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/worklet-directive-skips-outlining.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/worklet-directive-skips-outlining.expect.md
@@ -1,0 +1,48 @@
+
+## Input
+
+```javascript
+const useSomeHook = () => {};
+
+const Component = () => {
+  useSomeHook(() => {
+    'worklet';
+    return [1, 2, 3].map(() => null);
+  });
+
+  return null;
+};
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+  isComponent: true,
+};
+
+```
+
+## Code
+
+```javascript
+const useSomeHook = () => {};
+
+const Component = () => {
+  useSomeHook(_temp);
+
+  return null;
+};
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+  isComponent: true,
+};
+function _temp() {
+  "worklet";
+  return [1, 2, 3].map(() => null);
+}
+
+```
+      
+### Eval output
+(kind: ok) null

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/worklet-directive-skips-outlining.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/worklet-directive-skips-outlining.js
@@ -1,0 +1,16 @@
+const useSomeHook = () => {};
+
+const Component = () => {
+  useSomeHook(() => {
+    'worklet';
+    return [1, 2, 3].map(() => null);
+  });
+
+  return null;
+};
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+  isComponent: true,
+};


### PR DESCRIPTION
## Summary

Fixes #32580 

Inner functions of functions marked with the `'worklet'` directive (worklets) can't be safely outlined as it might break the multi-threading in `react-native-worklets`.

I made it so recursion for outlining is skipped when the parent has `'worklet'` directive.

## How did you test this change?

I added a new test case and updated snapshot of previous ones - the code they emitted previously would fail at runtime.
