### PR TITLE
Fix: <select size> list box should not select first option when value does not match

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMSelect.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMSelect.js
@@ -101,7 +101,7 @@ function updateOptions(
         defaultSelected = options[i];
       }
     }
-    if (defaultSelected !== null) {
+    if (defaultSelected !== null && node.size <= 1) {
       defaultSelected.selected = true;
     }
   }

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -486,6 +486,83 @@ describe('ReactDOMSelect', () => {
     expect(select.selectedIndex).toBe(-1);
   });
 
+  it('does not select the first option when size > 1 and value does not match', async () => {
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(() => {
+      root.render(
+        <select size="2" value="does-not-exist" onChange={noop}>
+          <option value="monkey">A monkey!</option>
+          <option value="giraffe">A giraffe!</option>
+          <option value="gorilla">A gorilla!</option>
+        </select>,
+      );
+    });
+
+    const select = container.firstChild;
+
+    // updateOptions runs on both mount (initSelect) and re-render; list box (size > 1) must not auto-select.
+    await act(() => {
+      root.render(
+        <select size="2" value="does-not-exist" onChange={noop}>
+          <option value="monkey">A monkey!</option>
+          <option value="giraffe">A giraffe!</option>
+          <option value="gorilla">A gorilla!</option>
+        </select>,
+      );
+    });
+
+    expect(select.options[0].selected).toBe(false);
+    expect(select.options[1].selected).toBe(false);
+    expect(select.options[2].selected).toBe(false);
+    expect(select.selectedIndex).toBe(-1);
+  });
+
+  it('selects the matching option when size > 1 and value matches', async () => {
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(() => {
+      root.render(
+        <select size="2" value="giraffe" onChange={noop}>
+          <option value="monkey">A monkey!</option>
+          <option value="giraffe">A giraffe!</option>
+          <option value="gorilla">A gorilla!</option>
+        </select>,
+      );
+    });
+
+    const select = container.firstChild;
+
+    expect(select.options[0].selected).toBe(false);
+    expect(select.options[1].selected).toBe(true);
+    expect(select.options[2].selected).toBe(false);
+    expect(select.value).toBe('giraffe');
+  });
+
+  it('does not select the first option when size > 1 and defaultValue does not match', async () => {
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(() => {
+      root.render(
+        <select size="2" defaultValue="does-not-exist">
+          <option value="monkey">A monkey!</option>
+          <option value="giraffe">A giraffe!</option>
+          <option value="gorilla">A gorilla!</option>
+        </select>,
+      );
+    });
+
+    const select = container.firstChild;
+
+    expect(select.options[0].selected).toBe(false);
+    expect(select.options[1].selected).toBe(false);
+    expect(select.options[2].selected).toBe(false);
+    expect(select.selectedIndex).toBe(-1);
+  });
+
   it('should remember value when switching to uncontrolled', async () => {
     const stub = (
       <select value={'giraffe'} onChange={noop}>


### PR DESCRIPTION
## Summary

When `size > 1`, a `<select>` renders as a list box. List boxes don't require a selection, so the browser leaves nothing highlighted when no option carries the `selected` attribute. Dropdowns (`size=1` or no `size`) always show something, so the browser picks the first option automatically.

`updateOptions` in `ReactDOMSelect.js` has a fallback that selects the first non-disabled option when the controlled `value` doesn't match anything. That's fine for dropdowns, where it matches what the browser does anyway. For list boxes, it's wrong: on every re-render, `updateOptions` fires against the live options, finds no match, and silently marks the first option as selected.

The fix skips the fallback when `node.size > 1`.

Fixes #24469

## How did you test this change?

Added three tests to `ReactDOMSelect-test.js`:
- A list box with `size="2"` and a non-matching `value` prop stays deselected after re-render. This was the broken case.
- A list box with `size="2"` and a matching `value` still selects the right option.
- A list box with `size="2"` and a non-matching `defaultValue` stays deselected on mount (covers the uncontrolled path through `initSelect`).

All existing tests in `ReactDOMSelect-test.js` and `ReactDOMServerIntegrationSelect-test.js` pass.