### PR TITLE
[compiler] avoid outer-scope identifier conflicts in synthesizeName

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -462,7 +462,10 @@ class Context {
     }
     let validated = makeIdentifierName(name).value;
     let index = 0;
-    while (this.uniqueIdentifiers.has(validated)) {
+    while (
+      this.uniqueIdentifiers.has(validated) ||
+      this.env.programContext.hasReference(validated)
+    ) {
       validated = makeIdentifierName(`${name}${index++}`).value;
     }
     this.uniqueIdentifiers.add(validated);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-dollar-sign-component-imported.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-dollar-sign-component-imported.expect.md
@@ -1,0 +1,56 @@
+
+## Input
+
+```javascript
+import {Stringify as $} from 'shared-runtime';
+
+// Regression test: when $ is imported as a binding, the compiler should not
+// use $ as the name for its synthesized memo cache variable — that would
+// shadow the import. The memo cache should be renamed to $0 (or similar).
+// See https://github.com/facebook/react/issues/36167
+
+function Component({x}: {x: number}) {
+  return <$ value={x} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{x: 1}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { Stringify as $ } from "shared-runtime";
+
+// Regression test: when $ is imported as a binding, the compiler should not
+// use $ as the name for its synthesized memo cache variable — that would
+// shadow the import. The memo cache should be renamed to $0 (or similar).
+// See https://github.com/facebook/react/issues/36167
+
+function Component(t0) {
+  const $0 = _c(2);
+  const { x } = t0;
+  let t1;
+  if ($0[0] !== x) {
+    t1 = <$ value={x} />;
+    $0[0] = x;
+    $0[1] = t1;
+  } else {
+    t1 = $0[1];
+  }
+  return t1;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ x: 1 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"value":1}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-dollar-sign-component-imported.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-dollar-sign-component-imported.tsx
@@ -1,0 +1,15 @@
+import {Stringify as $} from 'shared-runtime';
+
+// Regression test: when $ is imported as a binding, the compiler should not
+// use $ as the name for its synthesized memo cache variable — that would
+// shadow the import. The memo cache should be renamed to $0 (or similar).
+// See https://github.com/facebook/react/issues/36167
+
+function Component({x}: {x: number}) {
+  return <$ value={x} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{x: 1}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-dollar-sign-component.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-dollar-sign-component.expect.md
@@ -1,0 +1,67 @@
+
+## Input
+
+```javascript
+// Regression test: when a function is named `$`, the compiler should not
+// use `$` as the name for its synthesized memo cache variable — that would
+// shadow the function name. The memo cache should be renamed to $0 (or similar).
+// See https://github.com/facebook/react/issues/36167
+
+function $(n: number) {
+  return n * 2;
+}
+
+function Component({x}: {x: number}) {
+  return <div>{$(x)}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{x: 5}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // Regression test: when a function is named `$`, the compiler should not
+// use `$` as the name for its synthesized memo cache variable — that would
+// shadow the function name. The memo cache should be renamed to $0 (or similar).
+// See https://github.com/facebook/react/issues/36167
+
+function $(n) {
+  return n * 2;
+}
+
+function Component(t0) {
+  const $0 = _c(4);
+  const { x } = t0;
+  let t1;
+  if ($0[0] !== x) {
+    t1 = $(x);
+    $0[0] = x;
+    $0[1] = t1;
+  } else {
+    t1 = $0[1];
+  }
+  let t2;
+  if ($0[2] !== t1) {
+    t2 = <div>{t1}</div>;
+    $0[2] = t1;
+    $0[3] = t2;
+  } else {
+    t2 = $0[3];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ x: 5 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>10</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-dollar-sign-component.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-dollar-sign-component.tsx
@@ -1,0 +1,17 @@
+// Regression test: when a function is named `$`, the compiler should not
+// use `$` as the name for its synthesized memo cache variable — that would
+// shadow the function name. The memo cache should be renamed to $0 (or similar).
+// See https://github.com/facebook/react/issues/36167
+
+function $(n: number) {
+  return n * 2;
+}
+
+function Component({x}: {x: number}) {
+  return <div>{$(x)}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{x: 5}],
+};


### PR DESCRIPTION
## Summary

When a component uses an outer-scope binding named `$` (e.g. a utility helper function or an imported component alias), the compiler's `synthesizeName('$')` would not detect the conflict and would generate a memo cache variable also named `$`, overwriting the outer-scope binding at runtime inside Client Components.

### Root cause

`Context.synthesizeName` checks `uniqueIdentifiers` (local variable names + referenced globals inside the compiled function) but does **not** check the Babel program scope for outer-scope bindings. A function or import named `$` that is used inside a component but not recursively referenced inside the same function body is invisible to the collision check.

### Fix

Extend the collision-avoidance loop in `Context.synthesizeName` to also call `env.programContext.hasReference(validated)`, which queries the Babel scope for existing bindings (imports, outer declarations). If a conflict is found, the synthesized name is incremented (`$0`, `$1`, …) until a unique name is found.

Before fix:
```js
// $ is overwritten — broken in Client Components
import { Stringify as $ } from 'shared-runtime';
function Component({x}) {
  const $ = _c(2); // ← collision!
  ...
}
```

After fix:
```js
import { Stringify as $ } from 'shared-runtime';
function Component({x}) {
  const $0 = _c(2); // ← no conflict
  ...
}
```

## How did you test this change?

Added two regression test fixtures in `compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/`:

1. `jsx-dollar-sign-component.tsx` — outer helper function named `$`
2. `jsx-dollar-sign-component-imported.tsx` — `$` imported from an external module

All 1721 compiler tests pass (`yarn workspace babel-plugin-react-compiler test`).

Fixes #36167