### PR TITLE
Add missing GestureLane case to getLabelForLane

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -144,6 +144,9 @@ export function getLabelForLane(lane: Lane): string | void {
     if (lane & DefaultLane) {
       return 'Default';
     }
+    if (lane & GestureLane) {
+      return 'Gesture';
+    }
     if (lane & TransitionHydrationLane) {
       return 'TransitionHydration';
     }


### PR DESCRIPTION
## Summary

`GestureLane` was added in #34546 but `getLabelForLane` was not updated to handle it. The comment on line 38 of `ReactFiberLane.js` states:

> Lane values below should be kept in sync with `getLabelForLane()`, used by react-devtools-timeline.

Without this case, `getLaneLabelMap` in `ReactFiberReconciler.js:862` casts the `undefined` return value to `string`, resulting in the literal `"undefined"` appearing as the lane label in DevTools timeline.

`getGroupNameOfHighestPriorityLane` was correctly updated in the same PR (#34546) to return `'Gesture'` for `GestureLane`, but `getLabelForLane` was missed.

## How did you test this change?

Verified by code inspection:
- `GestureLane` is defined on line 59 but has no matching case in `getLabelForLane` (lines 127-175)
- `getGroupNameOfHighestPriorityLane` (line 1290) already handles `GestureLane` correctly
- The new case is placed between `DefaultLane` and `TransitionHydrationLane`, matching the lane bit order