### PR TITLE
Call stopTracking() on host component unmount to prevent input memory leak

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
@@ -40,6 +40,8 @@ import {enableScopeAPI} from 'shared/ReactFeatureFlags';
 
 import {enableInternalInstanceMap} from 'shared/ReactFeatureFlags';
 
+import {stopTracking} from './inputValueTracking';
+
 const randomKey = Math.random().toString(36).slice(2);
 const internalInstanceKey = '__reactFiber$' + randomKey;
 const internalPropsKey = '__reactProps$' + randomKey;
@@ -68,6 +70,7 @@ const internalPropsMap:
   | Map<InstanceUnion, Props> = new PossiblyWeakMap();
 
 export function detachDeletedInstance(node: Instance): void {
+  stopTracking((node: any));
   if (enableInternalInstanceMap) {
     internalInstanceMap.delete(node);
     internalPropsMap.delete(node);


### PR DESCRIPTION
## Summary

Hi folks I work on an extremely large SPA and have been hunting a memory leak with <input> elements retaining detached DOM trees on modal unmount. 

From my understanding of the code this has existed for a long time. stopTracking() has been exported from inputValueTracking.js since it was written, but it is never called at any point in unmount. It seems like nothing more than an oversight.

Due to the fact that this property on the input does not show a JS retainer in heapsnapshots, it seems to have evaded detection this long. If we had captured scope, we'd see the scope. But since its just an element that is being retained for no obvious JS reason, it shows as connected to C++ Persisent Roots - this is where most of the time you stop looking as a JS dev as it seems like a dead end. 

On 18.3.1, _wrapperState also needs to be deleted. I notice it has been removed from most recent versions of React.

Note that we are never calling either of these methods at runtime.
https://github.com/search?q=repo%3Afacebook%2Freact%20detachTracker&type=code
https://github.com/search?q=repo%3Afacebook%2Freact+stopTracking&type=code

Heap:
<img width="2058" height="1396" alt="image" src="https://github.com/user-attachments/assets/e6b52ccf-cc3f-46a8-abd5-8d9d3881b6e8" />

Before patch, stopTracking() is never called for an conditionally rendered <input>:
<img width="1802" height="1284" alt="image" src="https://github.com/user-attachments/assets/2fd89443-a94f-4a80-abc1-962f780201b7" />


Verified after this patch that stopTracking() is called:
<img width="1792" height="1242" alt="image" src="https://github.com/user-attachments/assets/f86148c5-58a4-4bdc-a939-d77aa6c5da1c" />

Verified that deleting all exotic props in detach leaves the element 'clean' and able to be GC'd
<img width="2334" height="1298" alt="image" src="https://github.com/user-attachments/assets/eefafb4c-fd19-45fb-a87d-b7e03060e38b" />




AI Summary of the fix, and the analysis I did of the heapsnapshot that found persistent roots only as retainers rather than JS callbacks:

====

`inputValueTracking.js` exports a `stopTracking()` function that restores the native `value` property descriptor on controlled `<input>`, `<textarea>`, and `<select>` elements. However, it is never called — it has been dead code since it was introduced in React 15.6 (2017).

During mount, `track()` calls `Object.defineProperty(node, 'value', { get, set })` to intercept value changes. On unmount, `detachDeletedInstance()` cleans up `__reactFiber$`, `__reactProps$`, and event handler references — but never restores the native `value` descriptor.

The custom property descriptor keeps the element's V8 wrapper permanently reachable to Chromium's unified garbage collector (cppgc). The overridden accessor makes the wrapper "interesting" to Blink's tracing, which creates a `cppgc::Persistent` handle that pins the detached element — and through DOM parent/child references, its entire subtree — indefinitely.

This is the root cause behind several long-standing memory leak reports:
- #17581 — Input nodes leaked by the browser retain React fibers
- #20088 — Input leaks fiber nodes in recent versions of chromium
- #14962 — Password input type causes memory leak
- #26069 — Memory leak in react while focusing input elements
- #16087 — [Umbrella] Memory Leaks (listed under "Unresolved")

## How it was found

While investigating a command bar memory leak in a production app, heap snapshot analysis showed that detached `<input>` elements had a direct `cppgc::Persistent` handle under "C++ Persistent roots" — the only DOM element with such a handle. All JavaScript-level retention paths were weak. Tracing through V8's `cpp-snapshot.cc` and Chromium's `ReactDOMComponentTree` led to the `Object.defineProperty` override as the only difference between input elements and other DOM nodes.

## The fix

Add `stopTracking(node)` to `detachDeletedInstance()`. For non-input elements, `stopTracking` is a no-op (returns early when `_valueTracker` is absent). For tracked inputs, it:
1. Sets `node._valueTracker = null`
2. Deletes the overridden `value` property, restoring the native descriptor from the prototype

## Test plan

- Render a controlled `<input>` inside a conditionally mounted component (e.g. a modal)
- Mount/unmount 10 times, force GC, take heap snapshot
- Before fix: 10 detached `<input>` elements with `_valueTracker` still set
- After fix: 0 detached input elements retained
