### PR TITLE
Wire up startViewTransitionReadyFinished in Fabric

### DIFF
--- a/packages/react-native-renderer/src/ReactFiberConfigFabricWithViewTransition.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabricWithViewTransition.js
@@ -19,6 +19,7 @@ import type {
 const {
   applyViewTransitionName: fabricApplyViewTransitionName,
   startViewTransition: fabricStartViewTransition,
+  startViewTransitionReadyFinished: fabricStartViewTransitionReadyFinished,
 } = nativeFabricUIManager;
 
 export type InstanceMeasurement = {
@@ -251,6 +252,7 @@ export function startViewTransition(
 
   transition.ready.then(() => {
     spawnedWorkCallback();
+    fabricStartViewTransitionReadyFinished();
   });
 
   transition.finished.finally(() => {

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -310,5 +310,6 @@ declare const nativeFabricUIManager: {
     finished: Promise<void>,
     ready: Promise<void>,
   },
+  startViewTransitionReadyFinished: () => void,
   ...
 };


### PR DESCRIPTION
## Summary
- Imports `startViewTransitionReadyFinished` from `nativeFabricUIManager` in `ReactFiberConfigFabricWithViewTransition`
- Calls `fabricStartViewTransitionReadyFinished()` when the view transition `ready` promise resolves

This is not a config function, but it's helpful to have it notify fabric ViewTransition runtime when ready callback is done. Right now we're testing animation kicked off from view transition event handlers, this is signal to know when animations that belong to a transition have all started.

## Test plan
- Existing Fabric renderer tests should continue to pass
- View transition ready callback now notifies the native module when finished