### PR TITLE
Fix 'Should not already be working' error after debugger pause in Firefox

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1125,7 +1125,22 @@ export function performWorkOnRoot(
   forceSync: boolean,
 ): void {
   if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
-    throw new Error('Should not already be working.');
+    // This can happen if the browser paused execution mid-render (e.g. a
+    // debugger breakpoint or alert() call in Firefox). The scheduler may fire
+    // a new callback while React thinks it's still inside a render or commit.
+    // Since JavaScript is single-threaded, this isn't true concurrency — the
+    // previous work was interrupted by a browser-level pause. Reset the
+    // execution context so we can continue safely.
+    if (__DEV__) {
+      console.error(
+        'Warning: React detected that work was scheduled while an existing ' +
+          'render or commit was in progress. This is likely caused by a ' +
+          'browser debugger breakpoint or alert() call. React will try to ' +
+          'recover, but this may indicate a bug in your application if you ' +
+          'are not using a debugger.',
+      );
+    }
+    executionContext = NoContext;
   }
 
   if (enableProfilerTimer && enableComponentPerformanceTrack) {
@@ -3517,7 +3532,19 @@ function completeRoot(
   flushRenderPhaseStrictModeWarningsInDEV();
 
   if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
-    throw new Error('Should not already be working.');
+    // Same as above: a browser-level pause (debugger breakpoint, alert()) can
+    // cause the scheduler to fire a callback while React's execution context
+    // still looks like it's mid-work. Reset it so the commit can proceed.
+    if (__DEV__) {
+      console.error(
+        'Warning: React detected that work was scheduled while an existing ' +
+          'render or commit was in progress. This is likely caused by a ' +
+          'browser debugger breakpoint or alert() call. React will try to ' +
+          'recover, but this may indicate a bug in your application if you ' +
+          'are not using a debugger.',
+      );
+    }
+    executionContext = NoContext;
   }
 
   if (enableProfilerTimer && enableComponentPerformanceTrack) {


### PR DESCRIPTION
This fixes the long-standing issue where React throws \"Should not already be working\" in Firefox (and sometimes Chrome) when you hit a breakpoint or call alert() during a render.

When a debugger breakpoint or alert() pauses JavaScript mid-render, the browser's event loop can still fire scheduled callbacks. React's scheduler picks up one of those callbacks and tries to start new work, but executionContext still has RenderContext or CommitContext set from the paused render. The guard sees this and throws, even though there's no actual concurrent work — JS is single-threaded, the old work is just frozen.

The fix changes both guard locations (performWorkOnRoot and completeRoot) to reset executionContext instead of throwing. In DEV mode we log a console.error so it's still visible if this ever fires outside of a debugging session, which would point to a real bug worth investigating.

Fixes #17355