### PR TITLE
fix: update eslint-plugin-react-hooks version to 7.0.1

### DIFF
--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-react-hooks",
   "description": "ESLint rules for React Hooks",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/react.git",


### PR DESCRIPTION
Fixes #36247 - Update eslint-plugin-react-hooks version from 7.0.0 to 7.0.1 to match npm release.

The npm package `eslint-plugin-react-hooks` has already been released as version 7.0.1, but the source code still shows 7.0.0.