### PR TITLE
Fix typo: 'Recieved' -> 'Received' in test helpers

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -234,7 +234,7 @@ describe('ReactDOMFizzServer', () => {
         bufferedContent.startsWith('<html ')
       ) {
         throw new Error(
-          'Recieved <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
+          'Received <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
         );
       }
 

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -154,7 +154,7 @@ describe('ReactDOMFloat', () => {
         bufferedContent.startsWith('<html ')
       ) {
         throw new Error(
-          'Recieved <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
+          'Received <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
         );
       }
 


### PR DESCRIPTION
Minor typo fix in error messages thrown by test helpers in two `react-dom` test files.

```
- 'Recieved <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
+ 'Received <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
```

- `packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js`
- `packages/react-dom/src/__tests__/ReactDOMFloat-test.js`

Comment/test-only change, no runtime impact.