### PR TITLE
[test] Make `enableSuspenseyImages` dynamic

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -29,6 +29,7 @@ export const enableSchedulingProfiler: boolean = __VARIANT__;
 export const enableInfiniteRenderLoopDetection: boolean = __VARIANT__;
 
 export const enableFastAddPropertiesInDiffing: boolean = __VARIANT__;
+export const enableSuspenseyImages: boolean = __VARIANT__;
 export const enableViewTransition: boolean = __VARIANT__;
 export const enableScrollEndPolyfill: boolean = __VARIANT__;
 export const enableFragmentRefs: boolean = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -27,6 +27,7 @@ export const {
   retryLaneExpirationMs,
   syncLaneExpirationMs,
   transitionLaneExpirationMs,
+  enableSuspenseyImages,
   enableViewTransition,
   enableScrollEndPolyfill,
   enableFragmentRefs,
@@ -102,7 +103,6 @@ export const enableViewTransitionForPersistenceMode: boolean = false;
 
 export const enableGestureTransition: boolean = false;
 
-export const enableSuspenseyImages: boolean = false;
 export const enableFizzBlockingRender: boolean = true;
 export const enableSrcObject: boolean = false;
 export const enableHydrationChangeEvent: boolean = false;


### PR DESCRIPTION
This flag was off everywhere which meant we didn't test the Suspensey commit phase anymore.

As an alternative, we could've converted the [SuspenseyCommit test]((https://github.com/facebook/react/blob/bb428a13994abbea5a9c8c3d025b5ef78c398998/packages/react-reconciler/src/__tests__/ReactSuspenseyCommitPhase-test.js)) to using resources but that requires implementing a lot more host config options ([`packages/react-noop-renderer/src/ReactFiberConfigNoopResources.js`](https://github.com/facebook/react/blob/bb428a13994abbea5a9c8c3d025b5ef78c398998/packages/react-noop-renderer/src/ReactFiberConfigNoopResources.js)).
