### PR TITLE
fix: devtools build-and-test script fixes

### DIFF
--- a/scripts/devtools/build-and-test.js
+++ b/scripts/devtools/build-and-test.js
@@ -94,7 +94,7 @@ async function buildAndTestExtensions() {
   );
 
   console.log('');
-  console.log(`Extensions have been build for Chrome, Edge, and Firefox.`);
+  console.log(`Extensions have been built for Chrome, Edge, and Firefox.`);
   console.log('');
   console.log('Smoke test each extension before continuing:');
   console.log(`  ${chalk.bold.green('cd ' + extensionsPackagePath)}`);
@@ -105,7 +105,7 @@ async function buildAndTestExtensions() {
   console.log(`  ${chalk.dim('# Test Edge extension')}`);
   console.log(`  ${chalk.bold.green('yarn test:edge')}`);
   console.log('');
-  console.log(`  ${chalk.dim('# Firefox Chrome extension')}`);
+  console.log(`  ${chalk.dim('# Test Firefox extension')}`);
   console.log(`  ${chalk.bold.green('yarn test:firefox')}`);
 
   await confirmContinue();
@@ -236,4 +236,7 @@ function printFinalInstructions() {
   console.log(chalk.bold.green('  ' + pathToPrint));
 }
 
-main();
+main().catch(err => {
+  console.error(chalk.red('Release failed:'), err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
1. Fixed a grammatical error: "Extensions have been build" -> "Extensions have been built"
2. Fixed an incorrect comment label: "# Firefox Chrome extension" -> "# Test Firefox extension"
3. Added an error handler to `main()` so that unhandled rejections exit with a clear error message instead of crashing silently

## How did you test this change?

These are non-functional changes (typo/grammar fixes and error handling). 
The first two have no runtime impact.
The third one adds a `.catch()` handler to the `main()` call, which is a standard Node.js practice for async entry points.