### PR TITLE
Fix: change private field from string to boolean in react-devtools-fusebox

### DIFF
--- a/packages/react-devtools-fusebox/package.json
+++ b/packages/react-devtools-fusebox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-devtools-fusebox",
   "version": "0.0.0",
-  "private": "true",
+  "private": true,
   "license": "MIT",
   "files": ["dist"],
   "scripts": {


### PR DESCRIPTION
Good day

## Summary
Changed the `private` field in `packages/react-devtools-fusebox/package.json` from string `"true"` to boolean `true`, fixing a malformed package.json that violates npm specification.

## Changes
- File: `packages/react-devtools-fusebox/package.json`
- Changed: `"private": "true"` → `"private": true`

## Why this fix is correct
Per the [npm package.json specification](https://docs.npmjs.com/cli/v11/configuring-npm/package.json#private), the `private` field must be a boolean. The string value caused validation failures in package scanning tools like ScanCode.io.

This follows the fix in [aboutcode-org/scancode-toolkit#4635](https://github.com/aboutcode-org/scancode-toolkit/pull/4635) which added downstream workarounds — the source data should comply with the specification.

## Testing
- Verified no other packages in the monorepo have the same issue
- The JSON is valid and parses correctly

Fixes #35793.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof