### PR TITLE
[compiler] Fix false positive refs-rule errors when forwarding props.ref

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
@@ -156,6 +156,20 @@ function collectTemporariesSidemap(fn: HIRFunction, env: Env): void {
           ) {
             continue;
           }
+          /*
+           * Skip the temporary alias when the loaded property is itself a ref
+           * (e.g. `props.ref`). The loaded value is a new ref value with its
+           * own env classification; widening env[object] through the alias
+           * would incorrectly make the object appear to be a ref and cause
+           * false positive ref-access errors on unrelated sibling property
+           * reads.
+           */
+          if (
+            isUseRefType(lvalue.identifier) ||
+            isRefValueType(lvalue.identifier)
+          ) {
+            break;
+          }
           const temp = env.lookup(value.object);
           if (temp != null) {
             env.define(lvalue, temp);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-accessing-non-ref-prop-alongside-props-ref.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-accessing-non-ref-prop-alongside-props-ref.expect.md
@@ -1,0 +1,57 @@
+
+## Input
+
+```javascript
+// @validateRefAccessDuringRender
+
+/**
+ * Regression test for https://github.com/facebook/react/issues/34342
+ * Accessing both `props.ref` and a non-ref sibling property (here
+ * `props.value`) on the same props object should not raise a ref
+ * validation error on the sibling read.
+ */
+function Component(props) {
+  return <div ref={props.ref}>{props.value}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 'hello'}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRender
+
+/**
+ * Regression test for https://github.com/facebook/react/issues/34342
+ * Accessing both `props.ref` and a non-ref sibling property (here
+ * `props.value`) on the same props object should not raise a ref
+ * validation error on the sibling read.
+ */
+function Component(props) {
+  const $ = _c(3);
+  let t0;
+  if ($[0] !== props.ref || $[1] !== props.value) {
+    t0 = <div ref={props.ref}>{props.value}</div>;
+    $[0] = props.ref;
+    $[1] = props.value;
+    $[2] = t0;
+  } else {
+    t0 = $[2];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ value: "hello" }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>hello</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-accessing-non-ref-prop-alongside-props-ref.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-accessing-non-ref-prop-alongside-props-ref.js
@@ -1,0 +1,16 @@
+// @validateRefAccessDuringRender
+
+/**
+ * Regression test for https://github.com/facebook/react/issues/34342
+ * Accessing both `props.ref` and a non-ref sibling property (here
+ * `props.value`) on the same props object should not raise a ref
+ * validation error on the sibling read.
+ */
+function Component(props) {
+  return <div ref={props.ref}>{props.value}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 'hello'}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-forwarding-props-ref-does-not-taint-sibling-props.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-forwarding-props-ref-does-not-taint-sibling-props.expect.md
@@ -1,0 +1,72 @@
+
+## Input
+
+```javascript
+// @validateRefAccessDuringRender
+
+/**
+ * Regression test for https://github.com/facebook/react/issues/34775
+ * Forwarding `props.ref` to a child component should not cause sibling
+ * property reads from the same `props` object to be flagged as ref accesses.
+ */
+function Field(props) {
+  return (
+    <Control
+      ref={props.ref}
+      placeholder={props.placeholder}
+      disabled={props.disabled}
+    />
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Field,
+  params: [{placeholder: 'hello', disabled: false}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRender
+
+/**
+ * Regression test for https://github.com/facebook/react/issues/34775
+ * Forwarding `props.ref` to a child component should not cause sibling
+ * property reads from the same `props` object to be flagged as ref accesses.
+ */
+function Field(props) {
+  const $ = _c(4);
+  let t0;
+  if (
+    $[0] !== props.disabled ||
+    $[1] !== props.placeholder ||
+    $[2] !== props.ref
+  ) {
+    t0 = (
+      <Control
+        ref={props.ref}
+        placeholder={props.placeholder}
+        disabled={props.disabled}
+      />
+    );
+    $[0] = props.disabled;
+    $[1] = props.placeholder;
+    $[2] = props.ref;
+    $[3] = t0;
+  } else {
+    t0 = $[3];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Field,
+  params: [{ placeholder: "hello", disabled: false }],
+};
+
+```
+      
+### Eval output
+(kind: exception) Control is not defined

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-forwarding-props-ref-does-not-taint-sibling-props.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-forwarding-props-ref-does-not-taint-sibling-props.js
@@ -1,0 +1,21 @@
+// @validateRefAccessDuringRender
+
+/**
+ * Regression test for https://github.com/facebook/react/issues/34775
+ * Forwarding `props.ref` to a child component should not cause sibling
+ * property reads from the same `props` object to be flagged as ref accesses.
+ */
+function Field(props) {
+  return (
+    <Control
+      ref={props.ref}
+      placeholder={props.placeholder}
+      disabled={props.disabled}
+    />
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Field,
+  params: [{placeholder: 'hello', disabled: false}],
+};


### PR DESCRIPTION
## Summary

Fixes #34775. Also fixes #34342 (same root cause, verified by the added regression fixture).

`ValidateNoRefAccessInRender`'s `collectTemporariesSidemap` aliased every PropertyLoad lvalue back to its object (except `ref.current`). Because `Env.set` widens via the sidemap's canonical id, setting `env[$propsRef] = Ref` (from `refTypeOfType` on the `BuiltInUseRefId`-typed lvalue) also widened `env[props]` to `Ref`. Every subsequent `props.<sibling>` load then inherited that `Ref` classification and the JSX operand check flagged them with "Cannot access ref value during render".

The fix: skip the sidemap alias when the loaded property is itself typed as a ref (`UseRef` or `RefValue`). Generic property loads still alias (so the existing `Structure`/`readRefEffect` propagation used for patterns like `object.foo = () => ref.current; object.foo()` is preserved).

## Repro (#34775)

```tsx
// @validateRefAccessDuringRender
function Field(props) {
  return (
    <Control
      ref={props.ref}
      placeholder={props.placeholder}
      disabled={props.disabled}
    />
  );
}
```

Before: 3 errors (`props.ref`, `props.placeholder`, `props.disabled` all flagged).
After: 0 errors.

## Repro (#34342)

```tsx
// @validateRefAccessDuringRender
function Component(props) {
  return <div ref={props.ref}>{props.value}</div>;
}
```

Before: 2 errors (both `props.ref` and `props.value` flagged).
After: 0 errors.

`props.ref.current` (actual ref-value access during render) still correctly errors.

## How did you test this change?

- `yarn snap` — **1721 passed / 1721** (1719 existing + 2 new regression fixtures: `allow-forwarding-props-ref-does-not-taint-sibling-props` and `allow-accessing-non-ref-prop-alongside-props-ref`).
- `yarn workspace babel-plugin-react-compiler lint` — clean.
- `yarn flow dom-node` — clean.
- `yarn linc` / `yarn prettier` — clean.
- Existing fixtures that depend on the PropertyLoad sidemap (e.g. `error.invalid-access-ref-in-render-mutate-object-with-ref-function`, `error.invalid-use-ref-added-to-dep-without-type-info`, `allow-assigning-ref-accessing-function-to-object-property-if-not-mutated`) continue to pass unchanged — the sidemap is only skipped for ref-typed lvalues.

## Files changed

| File | Change |
|------|--------|
| `ValidateNoRefAccessInRender.ts` | Skip PropertyLoad sidemap alias when the loaded value is itself ref-typed |
| `allow-forwarding-props-ref-does-not-taint-sibling-props.{js,expect.md}` | Regression fixture for #34775 |
| `allow-accessing-non-ref-prop-alongside-props-ref.{js,expect.md}` | Regression fixture for #34342 |

🤖 Generated with [Ora Studio](https://studio.oratelecom.net)

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
