### PR TITLE
fix(eslint-plugin-react-hooks): bump version from 7.0.0 to 7.0.1

### DIFF
--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-react-hooks",
   "description": "ESLint rules for React Hooks",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/react.git",


### PR DESCRIPTION
Good day

This PR bumps the version in \`packages/eslint-plugin-react-hooks/package.json\` from \`7.0.0\` to \`7.0.1\` to match the version already published on npm (\`eslint-plugin-react-hooks@7.0.1\`).

**Issue:** #36247

### Changes
- \`packages/eslint-plugin-react-hooks/package.json\`: Updated \`"version"\` field from \`"7.0.0"\` to \`"7.0.1"\`

This is a one-line fix that aligns the source version with the already-released npm package.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof