### PR TITLE
Add null check before calling fabricSuspendOnActiveViewTransition

### DIFF
--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -657,7 +657,9 @@ export function suspendOnActiveViewTransition(
   state: SuspendedState,
   container: Container,
 ): void {
-  fabricSuspendOnActiveViewTransition();
+  if (fabricSuspendOnActiveViewTransition != null) {
+    fabricSuspendOnActiveViewTransition();
+  }
 }
 
 export function waitForCommitToBeReady(


### PR DESCRIPTION
## Summary
- Adds a null check before calling `fabricSuspendOnActiveViewTransition()` in the Fabric renderer's `suspendOnActiveViewTransition` export
- Prevents crashes on hosts where `nativeFabricUIManager` does not yet implement `suspendOnActiveViewTransition`

## Test plan
- Verified the change compiles correctly
- Hosts with `suspendOnActiveViewTransition` implemented continue to work as before
- Hosts without `suspendOnActiveViewTransition` no longer crash when view transitions are active