### PR TITLE
(react-dom): dynamic In HTML/In SVG labels for DOM nesting warnings

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -48,7 +48,10 @@ import {
   restoreControlledTextareaState,
 } from './ReactDOMTextarea';
 import {setSrcObject} from './ReactDOMSrcObject';
-import {validateTextNesting} from './validateDOMNesting';
+import {
+  validateTextNesting,
+  getHostContextNamespaceForDomNamespace,
+} from './validateDOMNesting';
 import setTextContent from './setTextContent';
 import {
   createDangerousStringForStyles,
@@ -393,7 +396,12 @@ function setProp(
     case 'children': {
       if (typeof value === 'string') {
         if (__DEV__) {
-          validateTextNesting(value, tag, false);
+          validateTextNesting(
+            value,
+            tag,
+            false,
+            getHostContextNamespaceForDomNamespace(domElement.namespaceURI),
+          );
         }
         // Avoid setting initial textContent when the text is empty. In IE11 setting
         // textContent on a <textarea> will cause the placeholder to not
@@ -407,7 +415,12 @@ function setProp(
       } else if (typeof value === 'number' || typeof value === 'bigint') {
         if (__DEV__) {
           // $FlowFixMe[unsafe-addition] Flow doesn't want us to use `+` operator with string and bigint
-          validateTextNesting('' + value, tag, false);
+          validateTextNesting(
+            '' + value,
+            tag,
+            false,
+            getHostContextNamespaceForDomNamespace(domElement.namespaceURI),
+          );
         }
         const canSetTextContent = tag !== 'body';
         if (canSetTextContent) {

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -532,7 +532,7 @@ export function createInstance(
   if (__DEV__) {
     // TODO: take namespace into account when validating.
     const hostContextDev: HostContextDev = (hostContext: any);
-    validateDOMNesting(type, hostContextDev.ancestorInfo);
+    validateDOMNesting(type, hostContextDev.ancestorInfo, hostContextDev.context);
     hostContextProd = hostContextDev.context;
   } else {
     hostContextProd = (hostContext: any);
@@ -758,6 +758,7 @@ export function createTextInstance(
         text,
         ancestor.tag,
         hostContextDev.ancestorInfo.implicitRootScope,
+        hostContextDev.context,
       );
     }
   }
@@ -4249,7 +4250,7 @@ export function validateHydratableInstance(
   if (__DEV__) {
     // TODO: take namespace into account when validating.
     const hostContextDev: HostContextDev = (hostContext: any);
-    return validateDOMNesting(type, hostContextDev.ancestorInfo);
+    return validateDOMNesting(type, hostContextDev.ancestorInfo, hostContextDev.context);
   }
   return true;
 }
@@ -4291,6 +4292,7 @@ export function validateHydratableTextInstance(
         text,
         ancestor.tag,
         hostContextDev.ancestorInfo.implicitRootScope,
+        hostContextDev.context,
       );
     }
   }
@@ -4635,7 +4637,7 @@ export function resolveSingletonInstance(
   if (__DEV__) {
     const hostContextDev = ((hostContext: any): HostContextDev);
     if (validateDOMNestingDev) {
-      validateDOMNesting(type, hostContextDev.ancestorInfo);
+      validateDOMNesting(type, hostContextDev.ancestorInfo, hostContextDev.context);
     }
   }
   const ownerDocument = getOwnerDocumentFromRootContainer(

--- a/packages/react-dom-bindings/src/client/validateDOMNesting.js
+++ b/packages/react-dom-bindings/src/client/validateDOMNesting.js
@@ -23,6 +23,31 @@ import {
 
 import {describeDiff} from 'react-reconciler/src/ReactFiberHydrationDiffs';
 
+import {MATH_NAMESPACE, SVG_NAMESPACE} from './DOMNamespaces';
+
+/**
+ * Mirrors HostContextNamespace in ReactFiberConfigDOM.js (None / Svg / Math).
+ * Used only for dev-only nesting warning prefixes.
+ */
+export type HostContextNamespace = 0 | 1 | 2;
+
+export function getHostContextNamespaceForDomNamespace(
+  namespaceURI: string | null,
+): HostContextNamespace {
+  if (namespaceURI === SVG_NAMESPACE) {
+    return 1;
+  }
+  if (namespaceURI === MATH_NAMESPACE) {
+    return 2;
+  }
+  return 0;
+}
+
+function getContextLabel(hostContextNamespace: HostContextNamespace): string {
+  // "In SVG" only in the SVG namespace; foreignObject switches to HTML (integration point).
+  return hostContextNamespace === 1 ? 'In SVG' : 'In HTML';
+}
+
 function describeAncestors(
   ancestor: Fiber,
   child: Fiber,
@@ -549,6 +574,7 @@ function findAncestor(parent: null | Fiber, tagName: string): null | Fiber {
 function validateDOMNesting(
   childTag: string,
   ancestorInfo: AncestorInfoDev,
+  hostContextNamespace: HostContextNamespace,
 ): boolean {
   if (__DEV__) {
     ancestorInfo = ancestorInfo || emptyAncestorInfoDev;
@@ -589,6 +615,7 @@ function validateDOMNesting(
         : '';
 
     const tagDisplayName = '<' + childTag + '>';
+    const contextLabel = getContextLabel(hostContextNamespace);
     if (invalidParent) {
       let info = '';
       if (ancestorTag === 'table' && childTag === 'tr') {
@@ -597,8 +624,9 @@ function validateDOMNesting(
           'the browser.';
       }
       console.error(
-        'In HTML, %s cannot be a child of <%s>.%s\n' +
+        '%s, %s cannot be a child of <%s>.%s\n' +
           'This will cause a hydration error.%s',
+        contextLabel,
         tagDisplayName,
         ancestorTag,
         info,
@@ -606,8 +634,9 @@ function validateDOMNesting(
       );
     } else {
       console.error(
-        'In HTML, %s cannot be a descendant of <%s>.\n' +
+        '%s, %s cannot be a descendant of <%s>.\n' +
           'This will cause a hydration error.%s',
+        contextLabel,
         tagDisplayName,
         ancestorTag,
         ancestorDescription,
@@ -644,6 +673,7 @@ function validateTextNesting(
   childText: string,
   parentTag: string,
   implicitRootScope: boolean,
+  hostContextNamespace: HostContextNamespace,
 ): boolean {
   if (__DEV__) {
     if (implicitRootScope || isTagValidWithParent('#text', parentTag, false)) {
@@ -668,19 +698,22 @@ function validateTextNesting(
           )
         : '';
 
+    const contextLabel = getContextLabel(hostContextNamespace);
     if (/\S/.test(childText)) {
       console.error(
-        'In HTML, text nodes cannot be a child of <%s>.\n' +
+        '%s, text nodes cannot be a child of <%s>.\n' +
           'This will cause a hydration error.%s',
+        contextLabel,
         parentTag,
         ancestorDescription,
       );
     } else {
       console.error(
-        'In HTML, whitespace text nodes cannot be a child of <%s>. ' +
+        '%s, whitespace text nodes cannot be a child of <%s>. ' +
           "Make sure you don't have any extra whitespace between tags on " +
           'each line of your source code.\n' +
           'This will cause a hydration error.%s',
+        contextLabel,
         parentTag,
         ancestorDescription,
       );

--- a/packages/react-dom/src/__tests__/validateDOMNesting-test.js
+++ b/packages/react-dom/src/__tests__/validateDOMNesting-test.js
@@ -192,7 +192,7 @@ describe('validateDOMNesting', () => {
     expectWarnings(
       ['svg', 'foreignObject', 'body', 'p'],
       [
-        // TODO, this should say "In SVG",
+        // foreignObject is an HTML integration point: nested HTML uses the HTML namespace.
         'In HTML, <body> cannot be a child of <foreignObject>.\n' +
           'This will cause a hydration error.\n' +
           '\n' +


### PR DESCRIPTION
Use HostContextNamespace when emitting validateDOMNesting and validateTextNesting dev errors so SVG subtree warnings say In SVG; foreignObject keeps In HTML as an HTML integration point.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
