### PR TITLE
Fix typos in react-dom dev warnings ("Recieved", "ocurred", "ecountered")

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -3113,7 +3113,7 @@ function pushStyle(
   if (__DEV__) {
     if (href.includes(' ')) {
       console.error(
-        'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but ecountered spaces instead. using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this ocurred is "%s".',
+        'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but encountered spaces instead. using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this occurred is "%s".',
         href,
       );
     }

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -234,7 +234,7 @@ describe('ReactDOMFizzServer', () => {
         bufferedContent.startsWith('<html ')
       ) {
         throw new Error(
-          'Recieved <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
+          'Received <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
         );
       }
 

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -154,7 +154,7 @@ describe('ReactDOMFloat', () => {
         bufferedContent.startsWith('<html ')
       ) {
         throw new Error(
-          'Recieved <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
+          'Received <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
         );
       }
 
@@ -8613,9 +8613,9 @@ background-color: green;
       });
       assertConsoleErrorDev([
         'React expected the `href` prop for a <style> tag opting into hoisting semantics ' +
-          'using the `precedence` prop to not have any spaces but ecountered spaces instead. ' +
+          'using the `precedence` prop to not have any spaces but encountered spaces instead. ' +
           'using spaces in this prop will cause hydration of this style to fail on the client. ' +
-          'The href for the <style> where this ocurred is "foo bar".\n' +
+          'The href for the <style> where this occurred is "foo bar".\n' +
           '    in style (at **)',
       ]);
     });


### PR DESCRIPTION

**Repo:** facebook/react (⭐ 225000)
**Type:** bugfix
**Files changed:** 3
**Lines:** +5/-5

## What
Corrects three misspellings in a `react-dom-bindings` server-side dev warning
emitted when a `<style>` tag using the `precedence` prop has a space in its
`href`: "ecountered" → "encountered" and "ocurred" → "occurred". Also fixes
the matching expected-message strings in `ReactDOMFloat-test.js`, plus a
separate "Recieved" → "Received" typo in two Fizz/Float test harness error
messages thrown when buffered SSR output starts with `<html>` and no doctype.

## Why
These messages are user-facing in development builds (and in test failure
output). Misspellings make warnings look unprofessional, complicate searching
for the warning text in issue trackers, and propagate into downstream
documentation. The fix is text-only inside dev-only branches and the test
harness — no behavior change.

## Testing
- `git diff --stat` shows only the three files above.
- The test files already had the misspelled string as the expected error
  message; updating both source and tests in lockstep keeps the assertions
  passing. No other occurrences of the misspelled strings remain in
  `packages/` (verified via ripgrep).

## Risk
Low — DEV-only warning text and matching test expectations; no runtime logic changed.
