### PR TITLE
Fix false hydration mismatch when client renders portal that returned null on server

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -10,6 +10,7 @@
 'use strict';
 
 let React;
+let ReactDOM;
 let ReactDOMClient;
 let ReactDOMServer;
 let act;
@@ -28,6 +29,7 @@ describe('ReactDOMServerHydration', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
+    ReactDOM = require('react-dom');
     ReactDOMClient = require('react-dom/client');
     ReactDOMServer = require('react-dom/server');
     act = React.act;
@@ -1642,6 +1644,48 @@ describe('ReactDOMServerHydration', () => {
             in Mismatch (at **)",
         ]
       `);
+    });
+  });
+
+  describe('portal', () => {
+    // @gate __DEV__
+    it('does not produce a false mismatch warning when a component renders null on server but a portal on client', () => {
+      const portalContainer = document.createElement('div');
+      document.body.appendChild(portalContainer);
+      try {
+        function HoverMenu({isClient}) {
+          if (!isClient) return null;
+          return ReactDOM.createPortal(<div>Hello World</div>, portalContainer);
+        }
+        function Mismatch({isClient}) {
+          return (
+            <span>
+              Some Text
+              <HoverMenu isClient={isClient} />
+            </span>
+          );
+        }
+        expect(testMismatch(Mismatch)).toEqual([]);
+      } finally {
+        document.body.removeChild(portalContainer);
+      }
+    });
+
+    // @gate __DEV__
+    it('does not produce a false mismatch warning when the portal target is the hydration root', () => {
+      function HoverMenu({isClient}) {
+        if (!isClient) return null;
+        return ReactDOM.createPortal(<div>Hello World</div>, container);
+      }
+      function Mismatch({isClient}) {
+        return (
+          <span>
+            Some Text
+            <HoverMenu isClient={isClient} />
+          </span>
+        );
+      }
+      expect(testMismatch(Mismatch)).toEqual([]);
     });
   });
 });

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -250,6 +250,7 @@ import {
   claimNextHydratableSuspenseInstance,
   warnIfHydrating,
   queueHydrationError,
+  prepareToHydrateHostPortal,
 } from './ReactFiberHydrationContext';
 import {
   constructClassInstance,
@@ -3638,6 +3639,7 @@ function updatePortalComponent(
   renderLanes: Lanes,
 ) {
   pushHostContainer(workInProgress, workInProgress.stateNode.containerInfo);
+  prepareToHydrateHostPortal(workInProgress);
   const nextChildren = workInProgress.pendingProps;
   if (current === null) {
     // Portals are special because we don't append the children during mount

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -162,6 +162,7 @@ import {
   getIsHydrating,
   upgradeHydrationErrorsToRecoverable,
   emitPendingHydrationWarnings,
+  popHydrationStateAfterPortal,
 } from './ReactFiberHydrationContext';
 import {
   renderHasNotSuspendedYet,
@@ -1661,6 +1662,7 @@ function completeWork(
       return null;
     }
     case HostPortal:
+      popHydrationStateAfterPortal(workInProgress);
       popHostContainer(workInProgress);
       updateHostContainer(current, workInProgress);
       if (current === null) {

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -93,6 +93,17 @@ let hydrationErrors: Array<CapturedValue<mixed>> | null = null;
 
 let rootOrSingletonContext = false;
 
+// Stack to save hydration state when traversing into a portal. Portals render
+// into a separate container that was not server-rendered, so hydration must be
+// suspended for the portal's subtree and resumed afterward.
+type PortalHydrationState = {
+  hydrationParentFiber: null | Fiber,
+  nextHydratableInstance: null | HydratableInstance,
+  isHydrating: boolean,
+  rootOrSingletonContext: boolean,
+};
+const hydrationPortalStateStack: Array<PortalHydrationState> = [];
+
 // Builds a common ancestor tree from the root down for collecting diffs.
 function buildHydrationDiffNode(
   fiber: Fiber,
@@ -824,6 +835,38 @@ function warnIfUnhydratedTailNodes(fiber: Fiber) {
   }
 }
 
+export function prepareToHydrateHostPortal(fiber: Fiber): void {
+  if (!supportsHydration) {
+    return;
+  }
+  // Save the current hydration state so we can restore it after the portal.
+  hydrationPortalStateStack.push({
+    hydrationParentFiber,
+    nextHydratableInstance,
+    isHydrating,
+    rootOrSingletonContext,
+  });
+  // Portals render into a separate container that is never server-rendered.
+  // Disable hydration for the portal's children so they are inserted fresh.
+  hydrationParentFiber = null;
+  nextHydratableInstance = null;
+  isHydrating = false;
+  rootOrSingletonContext = false;
+}
+
+export function popHydrationStateAfterPortal(fiber: Fiber): void {
+  if (!supportsHydration) {
+    return;
+  }
+  const savedState = hydrationPortalStateStack.pop();
+  if (savedState !== undefined) {
+    hydrationParentFiber = savedState.hydrationParentFiber;
+    nextHydratableInstance = savedState.nextHydratableInstance;
+    isHydrating = savedState.isHydrating;
+    rootOrSingletonContext = savedState.rootOrSingletonContext;
+  }
+}
+
 function resetHydrationState(): void {
   if (!supportsHydration) {
     return;
@@ -833,6 +876,7 @@ function resetHydrationState(): void {
   nextHydratableInstance = null;
   isHydrating = false;
   didSuspendOrErrorDEV = false;
+  hydrationPortalStateStack.length = 0;
 }
 
 // Restore the hydration cursor when unwinding a HostComponent that already
@@ -954,4 +998,6 @@ export {
   prepareToHydrateHostActivityInstance,
   prepareToHydrateHostSuspenseInstance,
   popHydrationState,
+  prepareToHydrateHostPortal,
+  popHydrationStateAfterPortal,
 };

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -998,6 +998,4 @@ export {
   prepareToHydrateHostActivityInstance,
   prepareToHydrateHostSuspenseInstance,
   popHydrationState,
-  prepareToHydrateHostPortal,
-  popHydrationStateAfterPortal,
 };


### PR DESCRIPTION
## Summary

Fixes #12615

When a component returns `null` on the server but renders a `ReactDOM.createPortal()` on the client, React was incorrectly emitting a hydration mismatch error:

```
Hydration failed because the server rendered HTML didn't match the client.
  <span>
    <HoverMenu>
+     <div>   ← false positive: this is portal content, not a span child
```

This is a false positive — the portal's `<div>` renders into a **separate container**, not into the parent `<span>`. It should not be compared against the parent's server HTML.

## Root Cause

When `updatePortalComponent` calls `pushHostContainer` to switch to the portal's container, the hydration state variables (`isHydrating`, `nextHydratableInstance`, `hydrationParentFiber`) were not reset. The portal's children then tried to claim hydration instances from the **parent container's** server nodes, which failed and triggered a mismatch error.

## Fix

Added two functions to `ReactFiberHydrationContext`:

- **`prepareToHydrateHostPortal`** — called in `updatePortalComponent` (begin work). Saves the current hydration state onto a stack and resets it, so portal children are inserted fresh rather than matched against server HTML.
- **`popHydrationStateAfterPortal`** — called in the `HostPortal` case of complete work. Restores the saved hydration state so the parent resumes hydrating correctly after the portal.

This correctly handles nested portals (via the stack) and cleans up on `resetHydrationState` (work loop interruption).

## Test Plan

- Added two new tests in `ReactDOMHydrationDiff-test.js`:
  - Portal renders to a separate container → no mismatch warning
  - Portal renders to the hydration root container → no mismatch warning
- All 39 hydration diff tests pass
- All 183 tests across `ReactServerRenderingHydration`, `ReactDOMServerPartialHydration`, and `ReactDOMFiber` suites pass