### PR TITLE
Add regression tests for StrictMode transition unmount cleanup

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
@@ -638,6 +638,61 @@ describe('ReactDOMFiberAsync', () => {
     });
   });
 
+  it('calls effect cleanup when unmounting in a transition inside StrictMode', async () => {
+    let handlerCalls = 0;
+    let cleanupCalls = 0;
+    let setShow;
+
+    function Child() {
+      React.useEffect(() => {
+        const onResize = () => {
+          handlerCalls++;
+        };
+        window.addEventListener('resize', onResize);
+        return () => {
+          cleanupCalls++;
+          window.removeEventListener('resize', onResize);
+        };
+      }, []);
+
+      return <div>Child</div>;
+    }
+
+    function App() {
+      const [show, _setShow] = React.useState(true);
+      setShow = _setShow;
+      return <>{show ? <Child /> : null}</>;
+    }
+
+    const root = ReactDOMClient.createRoot(container);
+    await act(async () => {
+      root.render(
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>,
+      );
+    });
+
+    await act(async () => {
+      React.startTransition(() => {
+        setShow(false);
+      });
+    });
+
+    // Cleanup should remove the listener before any post-unmount event.
+    window.dispatchEvent(new Event('resize'));
+    expect(handlerCalls).toBe(0);
+    if (__DEV__) {
+      expect(cleanupCalls).toBe(2);
+    } else {
+      expect(cleanupCalls).toBe(1);
+    }
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it('Should not flush transition lanes if there is no transition scheduled in popState', async () => {
     let setHasNavigated;
     function App() {

--- a/packages/react-reconciler/src/__tests__/ActivityStrictMode-test.js
+++ b/packages/react-reconciler/src/__tests__/ActivityStrictMode-test.js
@@ -127,6 +127,35 @@ describe('Activity StrictMode', () => {
     ]);
   });
 
+  // @gate __DEV__
+  it('calls passive cleanup when unmounting in a transition', async () => {
+    const root = ReactNoop.createRoot();
+
+    await act(() => {
+      root.render(
+        <React.StrictMode>
+          <Activity mode="visible">
+            <Component label="A" />
+          </Activity>
+        </React.StrictMode>,
+      );
+    });
+
+    log = [];
+
+    await act(() => {
+      React.startTransition(() => {
+        root.render(
+          <React.StrictMode>
+            <Activity mode="visible" />
+          </React.StrictMode>,
+        );
+      });
+    });
+
+    expect(log).toContain('A: useEffect unmount');
+  });
+
   it('should not cause infinite render loop when StrictMode is used with Suspense and synchronous set states', async () => {
     // This is a regression test, see https://github.com/facebook/react/pull/25179 for more details.
     function App() {


### PR DESCRIPTION
Summary
This pull request adds regression coverage for issue #36284 about useEffect cleanup behavior when a component is unmounted during a transition under StrictMode with concurrent rendering.

Motivation:
The issue report describes an edge case where effect cleanup may be skipped, potentially causing leaked event listeners and duplicate subscriptions. Even though current behavior in the tested scenarios appears correct, this path did not have explicit focused regression protection for the exact StrictMode + transition unmount pattern.

What this PR changes:

Adds a StrictMode transition-unmount regression test at the reconciler level.
Adds a DOM-level regression test that mirrors the real-world pattern from the issue:
Effect registers a window event listener.
Component is unmounted using startTransition.
Test verifies listener is removed and cleanup is called.
No production runtime logic was changed in this PR.
This is a test-only hardening change to prevent future regressions.
Why this is valuable:

It codifies expected cleanup behavior in the exact scenario raised by the issue.
It protects both internal reconciler behavior and public DOM renderer behavior.
It improves confidence around StrictMode and concurrent transition unmount semantics.
How did you test this change?
I validated the change with focused targeted tests for the added regression coverage.

Commands run:

corepack yarn install --ignore-engines --force
corepack yarn test packages/react-reconciler/src/tests/ActivityStrictMode-test.js -t "calls passive cleanup when unmounting in a transition"
corepack yarn test packages/react-dom/src/tests/ReactDOMFiberAsync-test.js -t "calls effect cleanup when unmounting in a transition inside StrictMode"
Observed results:

Reconciler targeted test: PASS
React DOM targeted test: PASS
Both tests confirm cleanup executes and no post-unmount listener is left active in the tested StrictMode transition unmount scenarios.
Verification approach:

Assert cleanup is invoked on transition-driven unmount.
Assert a post-unmount event does not trigger the removed listener.
Account for StrictMode development double-invocation behavior in assertions.
Scope note:
I ran focused tests directly related to this fix. I did not run the full repository test suite, lint, Flow, or production test matrix in this local iteration.