### PR TITLE
[eslint-plugin-react-hooks] Include cycle-entry segment in cyclic set

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -1168,6 +1168,30 @@ const allTests = {
       code: normalizeIndent`
         // Invalid because it's dangerous and might not warn otherwise.
         // This *must* be invalid.
+        function ComponentWithHookInLoopCondition() {
+          while (useHookInsideLoop()) {
+            foo();
+          }
+        }
+      `,
+      errors: [loopError('useHookInsideLoop')],
+    },
+    {
+      code: normalizeIndent`
+        // Invalid because it's dangerous and might not warn otherwise.
+        // This *must* be invalid.
+        function ComponentWithHookInForCondition() {
+          for (; useHookInsideLoop(); ) {
+            foo();
+          }
+        }
+      `,
+      errors: [loopError('useHookInsideLoop')],
+    },
+    {
+      code: normalizeIndent`
+        // Invalid because it's dangerous and might not warn otherwise.
+        // This *must* be invalid.
         function renderItem() {
           useState();
         }

--- a/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
@@ -348,7 +348,7 @@ const rule = {
           if (pathList.has(segment.id)) {
             const pathArray = [...pathList];
             const cyclicSegments = pathArray.slice(
-              pathArray.indexOf(segment.id) + 1,
+              pathArray.indexOf(segment.id),
             );
             for (const cyclicSegment of cyclicSegments) {
               cyclic.add(cyclicSegment);
@@ -422,7 +422,7 @@ const rule = {
           if (pathList.has(segment.id)) {
             const pathArray = Array.from(pathList);
             const cyclicSegments = pathArray.slice(
-              pathArray.indexOf(segment.id) + 1,
+              pathArray.indexOf(segment.id),
             );
             for (const cyclicSegment of cyclicSegments) {
               cyclic.add(cyclicSegment);


### PR DESCRIPTION
`countPathsFromStart` / `countPathsToEnd` in `RulesOfHooks` populate a `cyclic` set of code-path segments so that hooks inside loops can be reported as "may be executed more than once". When a cycle is detected, the code slices the `pathList` starting at `indexOf(segment.id) + 1` — which excludes the repeated segment itself (the cycle-entry / loop-header segment) from the `cyclic` set.

As a result, a hook that lives directly in the test expression of a `while` or `for` loop is not reported, even though it is called on every iteration:

```js
function Component() {
  while (useHook()) { /* ... */ }   // previously not reported
}

function Component() {
  for (; useHook(); ) { /* ... */ } // previously not reported
}
```

The `do { … } while (useHook())` case happened to be reported, but only because of a separate `isInsideDoWhileLoop` fallback check on the hook node — there was no equivalent for plain `while` / `for`, so the bug was invisible there.

The fix slices from the repeated segment itself (`indexOf(segment.id)` instead of `+ 1`), so every segment participating in the cycle — including the cycle head — is recorded. The change is applied symmetrically to both `countPathsFromStart` and `countPathsToEnd`.

## How did you test this change?

- Added two new invalid cases to ESLintRulesOfHooks-test.js asserting `loopError('useHookInsideLoop')` for:
  - `while (useHookInsideLoop()) { foo(); }`
  - `for (; useHookInsideLoop(); ) { foo(); }`

  Both cases fail on `main` (no error reported) and pass with the fix.

- Reproduced the underlying off-by-one with a standalone simulation of the cycle-detection logic over the CFG shape ESLint produces for `while (useHook()) { … }` (segments: `start → test → body → test`, `test → end`):

  ```
  OLD slice(indexOf + 1):  cyclic = [ 'body' ]
  NEW slice(indexOf):      cyclic = [ 'test', 'body' ]
  ```

  The old behavior drops the `test` segment, which is exactly where the hook in the condition lives — matching the observed false negative.

- Existing tests (including the `do { … } while (useHook())` case, and loop-body cases like `while (a) { useHook1(); … }`) are unaffected: their reported hooks sit in non-header segments that were already captured by the old slice.