### PR TITLE
Fix typos in warning messages, comments, and DevTools function names

### DIFF
--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -330,7 +330,7 @@ const hostResourceToDevToolsInstanceMap: Map<
   Set<DevToolsInstance>,
 > = new Map();
 
-function aquireHostInstance(
+function acquireHostInstance(
   nearestInstance: DevToolsInstance,
   hostInstance: HostInstance,
 ): void {
@@ -350,7 +350,7 @@ function releaseHostInstance(
   }
 }
 
-function aquireHostResource(
+function acquireHostResource(
   nearestInstance: DevToolsInstance,
   resource: ?{instance?: HostInstance},
 ): void {
@@ -3486,7 +3486,7 @@ export function attach(
         if (nearestInstance === null) {
           throw new Error('Did not expect a host hoistable to be the root');
         }
-        aquireHostResource(nearestInstance, fiber.memoizedState);
+        acquireHostResource(nearestInstance, fiber.memoizedState);
         trackDebugInfoFromHostResource(nearestInstance, fiber);
       } else if (
         fiber.tag === HostComponent ||
@@ -3497,7 +3497,7 @@ export function attach(
         if (nearestInstance === null) {
           throw new Error('Did not expect a host hoistable to be the root');
         }
-        aquireHostInstance(nearestInstance, fiber.stateNode);
+        acquireHostInstance(nearestInstance, fiber.stateNode);
         trackDebugInfoFromHostComponent(nearestInstance, fiber);
       }
 
@@ -4468,7 +4468,7 @@ export function attach(
         }
         if (prevFiber.memoizedState !== nextFiber.memoizedState) {
           releaseHostResource(nearestInstance, prevFiber.memoizedState);
-          aquireHostResource(nearestInstance, nextFiber.memoizedState);
+          acquireHostResource(nearestInstance, nextFiber.memoizedState);
         }
         trackDebugInfoFromHostResource(nearestInstance, nextFiber);
       } else if (
@@ -4482,10 +4482,10 @@ export function attach(
         }
         if (prevFiber.stateNode !== nextFiber.stateNode) {
           // In persistent mode, it's possible for the stateNode to update with
-          // a new clone. In that case we need to release the old one and aquire
+          // a new clone. In that case we need to release the old one and acquire
           // new one instead.
           releaseHostInstance(nearestInstance, prevFiber.stateNode);
-          aquireHostInstance(nearestInstance, nextFiber.stateNode);
+          acquireHostInstance(nearestInstance, nextFiber.stateNode);
         }
         trackDebugInfoFromHostComponent(nearestInstance, nextFiber);
       }

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -2874,7 +2874,7 @@ function pushLink(
       if (rel === 'stylesheet' && typeof props.precedence === 'string') {
         if (typeof href !== 'string' || !href) {
           console.error(
-            'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and expected the `href` prop to be a non-empty string but ecountered %s instead. If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` prop ensure there is a non-empty string `href` prop as well, otherwise remove the `precedence` prop.',
+            'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and expected the `href` prop to be a non-empty string but encountered %s instead. If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` prop ensure there is a non-empty string `href` prop as well, otherwise remove the `precedence` prop.',
             getValueDescriptorExpectingObjectForWarning(href),
           );
         }
@@ -2900,7 +2900,7 @@ function pushLink(
         if (typeof precedence === 'string') {
           if (props.disabled != null) {
             console.error(
-              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and a `disabled` prop. The presence of the `disabled` prop indicates an intent to manage the stylesheet active state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` prop remove the `disabled` prop, otherwise remove the `precedence` prop.',
+              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and a `disabled` prop. The presence of the `disabled` prop indicates an intent to manage the stylesheet active state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` prop remove the `disabled` prop, otherwise remove the `precedence` prop.',
             );
           } else if (props.onLoad || props.onError) {
             const propDescription =
@@ -2910,7 +2910,7 @@ function pushLink(
                   ? '`onLoad` prop'
                   : '`onError` prop';
             console.error(
-              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and %s. The presence of loading and error handlers indicates an intent to manage the stylesheet loading state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` prop remove the %s, otherwise remove the `precedence` prop.',
+              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and %s. The presence of loading and error handlers indicates an intent to manage the stylesheet loading state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` prop remove the %s, otherwise remove the `precedence` prop.',
               propDescription,
               propDescription,
             );
@@ -3114,7 +3114,7 @@ function pushStyle(
   if (__DEV__) {
     if (href.includes(' ')) {
       console.error(
-        'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but ecountered spaces instead. using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this ocurred is "%s".',
+        'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but encountered spaces instead. using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this occurred is "%s".',
         href,
       );
     }

--- a/packages/react-dom-bindings/src/shared/ReactDOMResourceValidation.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMResourceValidation.js
@@ -28,7 +28,7 @@ export function validateLinkPropsForStyleResource(props: any): boolean {
         'React encountered a <link rel="stylesheet" href="%s" ... /> with a `precedence` prop that' +
           ' also included %s. The presence of loading and error handlers indicates an intent to manage' +
           ' the stylesheet loading state from your from your Component code and React will not hoist or' +
-          ' deduplicate this stylesheet. If your intent was to have React hoist and deduplciate this stylesheet' +
+          ' deduplicate this stylesheet. If your intent was to have React hoist and deduplicate this stylesheet' +
           ' using the `precedence` prop remove the %s, otherwise remove the `precedence` prop.',
         href,
         withArticlePhrase,

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -81,7 +81,7 @@ let hydrationParentFiber: null | Fiber = null;
 let nextHydratableInstance: null | HydratableInstance = null;
 let isHydrating: boolean = false;
 
-// This flag allows for warning supression when we expect there to be mismatches
+// This flag allows for warning suppression when we expect there to be mismatches
 // due to earlier mismatches or a suspended fiber.
 let didSuspendOrErrorDEV: boolean = false;
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1345,7 +1345,7 @@ function recoverFromConcurrentError(
       // During the synchronous render, we attached additional ping listeners.
       // This is highly suggestive of an uncached promise (though it's not the
       // only reason this would happen). If it was an uncached promise, then
-      // it may have masked a downstream error from ocurring without actually
+      // it may have masked a downstream error from occurring without actually
       // fixing it. Example:
       //
       //    use(Promise.resolve('uncached'))


### PR DESCRIPTION
## Summary

Fixes several typos found across the codebase:

**Warning messages (`ReactFizzConfigDOM.js`, `ReactDOMResourceValidation.js`)**
- `ecountered` → `encountered`
- `deduplciate` → `deduplicate` (3 occurrences)
- `ocurred` → `occurred`

**Comments (`ReactFiberWorkLoop.js`, `ReactFiberHydrationContext.js`)**
- `ocurring` → `occurring`
- `supression` → `suppression`

**DevTools internal function names (`renderer.js`)**
- `aquireHostInstance` → `acquireHostInstance`
- `aquireHostResource` → `acquireHostResource`
- Inline comment: `aquire` → `acquire`

These are purely textual fixes — no logic changes.

Closes #36320