### PR TITLE
Warn when NaN is passed as an aria-* attribute value

### DIFF
--- a/packages/react-dom-bindings/src/shared/ReactDOMInvalidARIAHook.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMInvalidARIAHook.js
@@ -13,7 +13,7 @@ const warnedProperties = {};
 const rARIA = new RegExp('^(aria)-[' + ATTRIBUTE_NAME_CHAR + ']*$');
 const rARIACamel = new RegExp('^(aria)[A-Z][' + ATTRIBUTE_NAME_CHAR + ']*$');
 
-function validateProperty(tagName, name) {
+function validateProperty(tagName, name, value) {
   if (__DEV__) {
     if (hasOwnProperty.call(warnedProperties, name) && warnedProperties[name]) {
       return true;
@@ -69,6 +69,17 @@ function validateProperty(tagName, name) {
         warnedProperties[name] = true;
         return true;
       }
+      // NaN is never a valid aria attribute value. The DOM will stringify it
+      // to "NaN" which violates the ARIA spec for every attribute type.
+      if (typeof value === 'number' && isNaN(value)) {
+        console.error(
+          'Received NaN for the `%s` attribute. If this is expected, cast ' +
+            'the value to a string.',
+          name,
+        );
+        warnedProperties[name] = true;
+        return true;
+      }
     }
   }
 
@@ -80,7 +91,7 @@ export function validateProperties(type, props) {
     const invalidProps = [];
 
     for (const key in props) {
-      const isValid = validateProperty(type, key);
+      const isValid = validateProperty(type, key, props[key]);
       if (!isValid) {
         invalidProps.push(key);
       }

--- a/packages/react-dom-bindings/src/shared/ReactDOMInvalidARIAHook.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMInvalidARIAHook.js
@@ -69,12 +69,14 @@ function validateProperty(tagName, name, value) {
         warnedProperties[name] = true;
         return true;
       }
-      // NaN is never a valid aria attribute value. The DOM will stringify it
-      // to "NaN" which violates the ARIA spec for every attribute type.
-      if (typeof value === 'number' && isNaN(value)) {
+      // NaN and Infinity are never valid aria attribute values. The DOM will
+      // stringify them (e.g. "NaN", "Infinity") which violates the ARIA spec
+      // for every attribute type.
+      if (typeof value === 'number' && !isFinite(value)) {
         console.error(
-          'Received NaN for the `%s` attribute. If this is expected, cast ' +
+          'Received `%s` for the `%s` attribute. If this is expected, cast ' +
             'the value to a string.',
+          value,
           name,
         );
         warnedProperties[name] = true;

--- a/packages/react-dom/src/__tests__/ReactDOMInvalidARIAHook-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInvalidARIAHook-test.js
@@ -106,5 +106,29 @@ describe('ReactDOMInvalidARIAHook', () => {
           '    in div (at **)',
       ]);
     });
+
+    it('should warn when a valid aria-* attribute receives a NaN value', async () => {
+      await mountComponent({'aria-valuenow': NaN});
+      assertConsoleErrorDev([
+        'Received NaN for the `aria-valuenow` attribute. If this is expected, cast ' +
+          'the value to a string.\n' +
+          '    in div (at **)',
+      ]);
+    });
+
+    it('should warn when a string-type aria-* attribute receives a NaN value', async () => {
+      await mountComponent({'aria-label': NaN});
+      assertConsoleErrorDev([
+        'Received NaN for the `aria-label` attribute. If this is expected, cast ' +
+          'the value to a string.\n' +
+          '    in div (at **)',
+      ]);
+    });
+
+    it('should not warn for valid numeric values in aria-* attributes', async () => {
+      await mountComponent({'aria-valuenow': 42});
+      await mountComponent({'aria-level': 3});
+      await mountComponent({'aria-colcount': -1});
+    });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMInvalidARIAHook-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInvalidARIAHook-test.js
@@ -110,7 +110,7 @@ describe('ReactDOMInvalidARIAHook', () => {
     it('should warn when a valid aria-* attribute receives a NaN value', async () => {
       await mountComponent({'aria-valuenow': NaN});
       assertConsoleErrorDev([
-        'Received NaN for the `aria-valuenow` attribute. If this is expected, cast ' +
+        'Received `NaN` for the `aria-valuenow` attribute. If this is expected, cast ' +
           'the value to a string.\n' +
           '    in div (at **)',
       ]);
@@ -119,7 +119,25 @@ describe('ReactDOMInvalidARIAHook', () => {
     it('should warn when a string-type aria-* attribute receives a NaN value', async () => {
       await mountComponent({'aria-label': NaN});
       assertConsoleErrorDev([
-        'Received NaN for the `aria-label` attribute. If this is expected, cast ' +
+        'Received `NaN` for the `aria-label` attribute. If this is expected, cast ' +
+          'the value to a string.\n' +
+          '    in div (at **)',
+      ]);
+    });
+
+    it('should warn when a valid aria-* attribute receives an Infinity value', async () => {
+      await mountComponent({'aria-valuenow': Infinity});
+      assertConsoleErrorDev([
+        'Received `Infinity` for the `aria-valuenow` attribute. If this is expected, cast ' +
+          'the value to a string.\n' +
+          '    in div (at **)',
+      ]);
+    });
+
+    it('should warn when a valid aria-* attribute receives a -Infinity value', async () => {
+      await mountComponent({'aria-valuemin': -Infinity});
+      assertConsoleErrorDev([
+        'Received `-Infinity` for the `aria-valuemin` attribute. If this is expected, cast ' +
           'the value to a string.\n' +
           '    in div (at **)',
       ]);


### PR DESCRIPTION
## Summary

aria-* attributes currently bypass the NaN check in `ReactDOMUnknownPropertyHook` because they return early (line 97-99 of that file) before the check is reached. When a `NaN` number flows through, the DOM stringifies it to the literal string `"NaN"`, which is invalid for **every** ARIA attribute type and silently breaks accessibility.

This is a common pitfall when a computed numeric value is derived from user data or state that can be undefined/null:

```jsx
// e.g. items.findIndex(...) returns -1 → some derived math → NaN
<div aria-valuenow={computedValue} />  // renders aria-valuenow="NaN" — silent bug
```

**Changes:**

- `ReactDOMInvalidARIAHook.js` — extend `validateProperty` to accept the prop `value` and add a `NaN` check for valid, correctly-cased aria-* attributes. Mirrors the warning message already used by `ReactDOMUnknownPropertyHook` for non-aria attributes.
- `ReactDOMInvalidARIAHook-test.js` — three new test cases: NaN on a numeric aria attribute (`aria-valuenow`), NaN on a string-type aria attribute (`aria-label`), and no false-positive for valid integers.

## Test plan

- [x] `yarn test ReactDOMInvalidARIAHook` — all tests pass (new + existing)
- [x] Existing tests unaffected — only the `validateProperty` signature changes (internal)