### PR TITLE
[shared] shallowEqual: avoid Object.keys(objB) allocation

### DIFF
--- a/packages/shared/__tests__/shallowEqual-test.js
+++ b/packages/shared/__tests__/shallowEqual-test.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+'use strict';
+
+describe('shallowEqual', () => {
+  let shallowEqual;
+
+  beforeEach(() => {
+    jest.resetModules();
+    shallowEqual = require('shared/shallowEqual').default;
+  });
+
+  it('returns true for the same reference', () => {
+    const obj = {a: 1};
+    expect(shallowEqual(obj, obj)).toBe(true);
+  });
+
+  it('treats +0 and -0 as different (Object.is semantics)', () => {
+    expect(shallowEqual(+0, -0)).toBe(false);
+    expect(shallowEqual({a: +0}, {a: -0})).toBe(false);
+  });
+
+  it('treats NaN as equal to NaN (Object.is semantics)', () => {
+    expect(shallowEqual(NaN, NaN)).toBe(true);
+    expect(shallowEqual({a: NaN}, {a: NaN})).toBe(true);
+  });
+
+  it('returns false when either argument is null or a non-object', () => {
+    expect(shallowEqual(null, {})).toBe(false);
+    expect(shallowEqual({}, null)).toBe(false);
+    expect(shallowEqual(null, null)).toBe(true);
+    expect(shallowEqual({}, 'a')).toBe(false);
+    expect(shallowEqual(1, {})).toBe(false);
+  });
+
+  it('returns true for two objects with the same keys and values', () => {
+    expect(shallowEqual({a: 1, b: 2}, {a: 1, b: 2})).toBe(true);
+  });
+
+  it('returns false when key counts differ', () => {
+    expect(shallowEqual({a: 1}, {a: 1, b: 2})).toBe(false);
+    expect(shallowEqual({a: 1, b: 2}, {a: 1})).toBe(false);
+  });
+
+  it('returns false when values differ for the same key', () => {
+    expect(shallowEqual({a: 1}, {a: 2})).toBe(false);
+  });
+
+  it('returns false when keys differ but counts match', () => {
+    expect(shallowEqual({a: 1, b: 2}, {a: 1, c: 2})).toBe(false);
+  });
+
+  it('only inspects own enumerable string keys, not the prototype chain', () => {
+    const proto = {inherited: 'should-be-ignored'};
+    const a = Object.create(proto);
+    a.own = 1;
+    const b = Object.create(proto);
+    b.own = 1;
+    expect(shallowEqual(a, b)).toBe(true);
+
+    // A prototype-only property must not satisfy a missing own property on B.
+    const aWithExtra = Object.create(proto);
+    aWithExtra.own = 1;
+    aWithExtra.extra = 2;
+    const bMissingExtra = Object.create({...proto, extra: 2});
+    bMissingExtra.own = 1;
+    expect(shallowEqual(aWithExtra, bMissingExtra)).toBe(false);
+  });
+
+  it('handles null-prototype objects', () => {
+    const a = Object.create(null);
+    a.x = 1;
+    const b = Object.create(null);
+    b.x = 1;
+    expect(shallowEqual(a, b)).toBe(true);
+
+    b.y = 2;
+    expect(shallowEqual(a, b)).toBe(false);
+  });
+
+  it('treats two empty objects as equal', () => {
+    expect(shallowEqual({}, {})).toBe(true);
+    expect(shallowEqual(Object.create(null), Object.create(null))).toBe(true);
+  });
+});

--- a/packages/shared/shallowEqual.js
+++ b/packages/shared/shallowEqual.js
@@ -30,9 +30,20 @@ function shallowEqual(objA: mixed, objB: mixed): boolean {
   }
 
   const keysA = Object.keys(objA);
-  const keysB = Object.keys(objB);
 
-  if (keysA.length !== keysB.length) {
+  // Count B's own enumerable string keys without allocating an array. Bail
+  // as soon as B's count exceeds A's so we don't enumerate further than
+  // needed when the sizes differ.
+  let keysBCount = 0;
+  for (const key in objB) {
+    if (hasOwnProperty.call(objB, key)) {
+      keysBCount++;
+      if (keysBCount > keysA.length) {
+        return false;
+      }
+    }
+  }
+  if (keysBCount !== keysA.length) {
     return false;
   }
 
@@ -40,6 +51,7 @@ function shallowEqual(objA: mixed, objB: mixed): boolean {
   for (let i = 0; i < keysA.length; i++) {
     const currentKey = keysA[i];
     if (
+      // $FlowFixMe[incompatible-use] lost refinement of `objB`
       !hasOwnProperty.call(objB, currentKey) ||
       // $FlowFixMe[incompatible-use] lost refinement of `objB`
       !is(objA[currentKey], objB[currentKey])


### PR DESCRIPTION
## Summary

`shallowEqual` is on the hot path for `React.memo` and `PureComponent.shouldComponentUpdate`. The current implementation calls `Object.keys(objB)` only to read `.length` from the resulting array and then discards it:

```js
const keysA = Object.keys(objA);
const keysB = Object.keys(objB); // ← throwaway array
if (keysA.length !== keysB.length) { … }
```

Replace `Object.keys(objB)` with an inline `for…in` + `hasOwnProperty` counter that:

1. avoids the heap allocation of `keysB`, and
2. bails as soon as B's own-key count exceeds A's, so we don't keep enumerating when sizes already differ.

The set of keys iterated is unchanged: `Object.keys` returns own enumerable string-keyed properties, and `for…in` filtered through `hasOwnProperty.call(objB, key)` returns the same set (excluding the prototype chain, symbols, and non-enumerable keys). The post-loop check `keysBCount !== keysA.length` plus the existing key-by-key compare still catches the case where the counts match but the keys differ.

## Tests

New file: `packages/shared/__tests__/shallowEqual-test.js`. Covers:

- reference equality
- `Object.is` semantics (NaN === NaN, +0 ≠ -0)
- null and non-object inputs on either side
- equal/different keys with same and different counts
- prototype-chain isolation (own-only)
- null-prototype objects (`Object.create(null)`)
- empty objects

## Test plan

- [x] `yarn prettier`, `yarn linc`
- [x] `yarn flow dom-node` — no errors
- [x] `yarn test --no-watchman shallowEqual-test` — 11/11 pass
- [x] `yarn test --no-watchman ReactMemo-test` — 28/28 pass (memo bailout uses shallowEqual)
- [x] `yarn test --no-watchman ReactPureComponent` — 4/4 pass
- [x] `yarn test-www --no-watchman ReactMemo ReactPureComponent shallowEqual-test` — pass on www-modern channel

Fixes #36283