### PR TITLE
Fix typos in react-dom dev warning messages (ecountered, ocurred, deduplciate, Recieved)

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -2874,7 +2874,7 @@ function pushLink(
       if (rel === 'stylesheet' && typeof props.precedence === 'string') {
         if (typeof href !== 'string' || !href) {
           console.error(
-            'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and expected the `href` prop to be a non-empty string but ecountered %s instead. If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` prop ensure there is a non-empty string `href` prop as well, otherwise remove the `precedence` prop.',
+            'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and expected the `href` prop to be a non-empty string but encountered %s instead. If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` prop ensure there is a non-empty string `href` prop as well, otherwise remove the `precedence` prop.',
             getValueDescriptorExpectingObjectForWarning(href),
           );
         }
@@ -2900,7 +2900,7 @@ function pushLink(
         if (typeof precedence === 'string') {
           if (props.disabled != null) {
             console.error(
-              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and a `disabled` prop. The presence of the `disabled` prop indicates an intent to manage the stylesheet active state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` prop remove the `disabled` prop, otherwise remove the `precedence` prop.',
+              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and a `disabled` prop. The presence of the `disabled` prop indicates an intent to manage the stylesheet active state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` prop remove the `disabled` prop, otherwise remove the `precedence` prop.',
             );
           } else if (props.onLoad || props.onError) {
             const propDescription =
@@ -2910,7 +2910,7 @@ function pushLink(
                   ? '`onLoad` prop'
                   : '`onError` prop';
             console.error(
-              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and %s. The presence of loading and error handlers indicates an intent to manage the stylesheet loading state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` prop remove the %s, otherwise remove the `precedence` prop.',
+              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and %s. The presence of loading and error handlers indicates an intent to manage the stylesheet loading state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` prop remove the %s, otherwise remove the `precedence` prop.',
               propDescription,
               propDescription,
             );
@@ -3114,7 +3114,7 @@ function pushStyle(
   if (__DEV__) {
     if (href.includes(' ')) {
       console.error(
-        'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but ecountered spaces instead. using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this ocurred is "%s".',
+        'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but encountered spaces instead. using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this occurred is "%s".',
         href,
       );
     }

--- a/packages/react-dom-bindings/src/shared/ReactDOMResourceValidation.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMResourceValidation.js
@@ -28,7 +28,7 @@ export function validateLinkPropsForStyleResource(props: any): boolean {
         'React encountered a <link rel="stylesheet" href="%s" ... /> with a `precedence` prop that' +
           ' also included %s. The presence of loading and error handlers indicates an intent to manage' +
           ' the stylesheet loading state from your from your Component code and React will not hoist or' +
-          ' deduplicate this stylesheet. If your intent was to have React hoist and deduplciate this stylesheet' +
+          ' deduplicate this stylesheet. If your intent was to have React hoist and deduplicate this stylesheet' +
           ' using the `precedence` prop remove the %s, otherwise remove the `precedence` prop.',
         href,
         withArticlePhrase,

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -234,7 +234,7 @@ describe('ReactDOMFizzServer', () => {
         bufferedContent.startsWith('<html ')
       ) {
         throw new Error(
-          'Recieved <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
+          'Received <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
         );
       }
 

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -154,7 +154,7 @@ describe('ReactDOMFloat', () => {
         bufferedContent.startsWith('<html ')
       ) {
         throw new Error(
-          'Recieved <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
+          'Received <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
         );
       }
 
@@ -7958,14 +7958,14 @@ body {
       assertConsoleErrorDev(
         [
           'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and ' +
-            'expected the `href` prop to be a non-empty string but ecountered `undefined` instead. ' +
-            'If your intent was to have React hoist and deduplciate this stylesheet using the ' +
+            'expected the `href` prop to be a non-empty string but encountered `undefined` instead. ' +
+            'If your intent was to have React hoist and deduplicate this stylesheet using the ' +
             '`precedence` prop ensure there is a non-empty string `href` prop as well, ' +
             'otherwise remove the `precedence` prop.\n' +
             '    in link (at **)',
           'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and ' +
-            'expected the `href` prop to be a non-empty string but ecountered an empty string instead. ' +
-            'If your intent was to have React hoist and deduplciate this stylesheet using the ' +
+            'expected the `href` prop to be a non-empty string but encountered an empty string instead. ' +
+            'If your intent was to have React hoist and deduplicate this stylesheet using the ' +
             '`precedence` prop ensure there is a non-empty string `href` prop as well, ' +
             'otherwise remove the `precedence` prop.\n' +
             '    in link (at **)',
@@ -7977,26 +7977,26 @@ body {
             '`onLoad` and `onError` props. The presence of loading and error handlers indicates ' +
             'an intent to manage the stylesheet loading state from your from your Component code ' +
             'and React will not hoist or deduplicate this stylesheet. ' +
-            'If your intent was to have React hoist and deduplciate this stylesheet using the ' +
+            'If your intent was to have React hoist and deduplicate this stylesheet using the ' +
             '`precedence` prop remove the `onLoad` and `onError` props, otherwise remove the `precedence` prop.\n' +
             '    in link (at **)',
           'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and ' +
             '`onLoad` prop. The presence of loading and error handlers indicates an intent to ' +
             'manage the stylesheet loading state from your from your Component code and ' +
             'React will not hoist or deduplicate this stylesheet. ' +
-            'If your intent was to have React hoist and deduplciate this stylesheet using the ' +
+            'If your intent was to have React hoist and deduplicate this stylesheet using the ' +
             '`precedence` prop remove the `onLoad` prop, otherwise remove the `precedence` prop.\n' +
             '    in link (at **)',
           'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and `onError` prop. ' +
             'The presence of loading and error handlers indicates an intent to manage the stylesheet loading state ' +
             'from your from your Component code and React will not hoist or deduplicate this stylesheet. ' +
-            'If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` ' +
+            'If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` ' +
             'prop remove the `onError` prop, otherwise remove the `precedence` prop.\n' +
             '    in link (at **)',
           'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and a `disabled` prop. ' +
             'The presence of the `disabled` prop indicates an intent to manage the stylesheet active state from ' +
             'your from your Component code and React will not hoist or deduplicate this stylesheet. ' +
-            'If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` ' +
+            'If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` ' +
             'prop remove the `disabled` prop, otherwise remove the `precedence` prop.\n' +
             '    in link (at **)',
         ].filter(Boolean),
@@ -8022,7 +8022,7 @@ body {
           'prop that also included the `onLoad` and `onError` props. ' +
           'The presence of loading and error handlers indicates an intent to manage the stylesheet ' +
           'loading state from your from your Component code and React will not hoist or deduplicate this stylesheet. ' +
-          'If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` ' +
+          'If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` ' +
           'prop remove the `onLoad` and `onError` props, otherwise remove the `precedence` prop.\n' +
           '    in body (at **)',
       ]);
@@ -8613,9 +8613,9 @@ background-color: green;
       });
       assertConsoleErrorDev([
         'React expected the `href` prop for a <style> tag opting into hoisting semantics ' +
-          'using the `precedence` prop to not have any spaces but ecountered spaces instead. ' +
+          'using the `precedence` prop to not have any spaces but encountered spaces instead. ' +
           'using spaces in this prop will cause hydration of this style to fail on the client. ' +
-          'The href for the <style> where this ocurred is "foo bar".\n' +
+          'The href for the <style> where this occurred is "foo bar".\n' +
           '    in style (at **)',
       ]);
     });


### PR DESCRIPTION
## Summary

Fixes #36320

PR has been raised with the help of Claude Code

Corrects four misspellings in DEV-only warning strings emitted by `react-dom-bindings`, along with their matching test expectations:

| Wrong | Correct | Location |
|-------|---------|----------|
| `ecountered` | `encountered` | `ReactFizzConfigDOM.js`, `ReactDOMResourceValidation.js`, tests |
| `ocurred` | `occurred` | `ReactFizzConfigDOM.js`, tests |
| `deduplciate` | `deduplicate` | `ReactFizzConfigDOM.js`, `ReactDOMResourceValidation.js`, tests |
| `Recieved` | `Received` | `ReactDOMFloat-test.js`, `ReactDOMFizzServer-test.js` |

**Files changed:**
- `packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js`
- `packages/react-dom-bindings/src/shared/ReactDOMResourceValidation.js`
- `packages/react-dom/src/__tests__/ReactDOMFloat-test.js`
- `packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js`

No behavior change — DEV-only warning text and matching test expectations only.

## How did you test this change?

- Verified all occurrences of each misspelling with `grep -rn` across `packages/` — none remain after the fix.
- Ran `yarn prettier` on changed files — no formatting changes needed.
- Ran `yarn linc` — **Lint passed for changed files.**
- Source warning strings and test assertion strings are updated in lockstep so existing tests continue to pass.