### PR TITLE
docs: standardize contribution guide URL in CONTRIBUTING.md to match README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Want to contribute to React? There are a few things you need to know.  
 
-We wrote a **[contribution guide](https://reactjs.org/docs/how-to-contribute.html)** to help you get started.
+We wrote a **[contribution guide](https://legacy.reactjs.org/docs/how-to-contribute.html)** to help you get started.


### PR DESCRIPTION
## Summary

Fixes #36341

PR has been raised with the help of Claude Code

`CONTRIBUTING.md` linked to `https://reactjs.org/docs/how-to-contribute.html` while `README.md` already used `https://legacy.reactjs.org/docs/how-to-contribute.html` in all four of its occurrences. The two different URLs both resolve to the same page (the former redirects to the latter), but having them differ is unnecessarily inconsistent and can cause confusion.

This PR updates the single link in `CONTRIBUTING.md` to use `https://legacy.reactjs.org/docs/how-to-contribute.html`, making all five contribution guide references across both files consistent.

**Files changed:**
- `CONTRIBUTING.md` — 1 URL updated

## How did you test this change?

- Verified with `grep -n "reactjs.org" CONTRIBUTING.md README.md` that all five contribution guide links now point to the same `legacy.reactjs.org` URL.
- Ran `yarn prettier` — no formatting changes needed.
- Ran `yarn linc` — **Lint passed for changed files.**
- Documentation-only change; no code or test logic affected.