### PR TITLE
fix: support autoFocus on anchor (<a>) elements

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -698,6 +698,7 @@ export function finalizeInitialChildren(
 ): boolean {
   setInitialProperties(domElement, type, props);
   switch (type) {
+    case 'a':
     case 'button':
     case 'input':
     case 'select':
@@ -891,12 +892,14 @@ export function commitMount(
   // there are also other cases when this might happen (such as patching
   // up text content during hydration mismatch). So we'll check this again.
   switch (type) {
+    case 'a':
     case 'button':
     case 'input':
     case 'select':
     case 'textarea':
       if (newProps.autoFocus) {
         ((domElement: any):
+          | HTMLAnchorElement
           | HTMLButtonElement
           | HTMLInputElement
           | HTMLSelectElement


### PR DESCRIPTION
## Summary

Fixes #35656

PR has been raised with the help of Claude Code

The `autofocus` attribute is a [global HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus) applicable to any focusable element per the HTML spec. React's `autoFocus` prop was only handled for `button`, `input`, `select`, and `textarea` elements. Anchor tags (`<a>`) were silently ignored.

This PR adds `case 'a':` to the two switch statements in `ReactFiberConfigDOM.js` that control `autoFocus` behaviour:

1. **`finalizeInitialChildren`** (line ~701) — tells React whether `commitMount` needs to be called for this element. Adding `'a'` here ensures the mount phase is scheduled when `autoFocus` is set.
2. **`commitMount`** (line ~894) — calls `.focus()` on the DOM node. Adding `'a'` here (with `HTMLAnchorElement` in the Flow cast) performs the actual focus.

**File changed:** `packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js`

**Before:**
```jsx
<a href="#main-content" autoFocus>Skip to main content</a>
// ↑ never focused on mount
```

**After:**
```jsx
<a href="#main-content" autoFocus>Skip to main content</a>
// ↑ correctly focused on mount, consistent with <button autoFocus>
```

## How did you test this change?

- Verified the two switch statement locations match the patch described in the issue.
- Confirmed `<a href="..." autoFocus>` now falls through to the `autoFocus` check in both `finalizeInitialChildren` and `commitMount`, matching the behaviour of `<button autoFocus>`.
- Ran `yarn prettier` — no formatting changes needed.
- Ran `yarn linc` — **Lint passed for changed files.**