### PR TITLE
fix: keep eslint-plugin-react-hooks meta.version in sync during releases

### DIFF
--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -252,6 +252,18 @@ const updateVersionsForNext = async (cwd, reactVersion, version) => {
     }
 
     await writeJson(packageJSONPath, packageJSON, {spaces: 2});
+
+    // eslint-plugin-react-hooks hardcodes its version in src/index.ts because
+    // the rollup build does not inject it. Keep that string in sync with
+    // package.json so plugin.meta.version is never stale after a release.
+    if (packageName === 'eslint-plugin-react-hooks') {
+      const pluginSrcPath = join(packagePath, 'src', 'index.ts');
+      const pluginSrc = readFileSync(pluginSrcPath, 'utf8');
+      writeFileSync(
+        pluginSrcPath,
+        pluginSrc.replace(/version: '[^']+'/, `version: '${version}'`)
+      );
+    }
   }
 };
 


### PR DESCRIPTION
## Summary

Fixes #35722

PR has been created with the help of Claude Code

`packages/eslint-plugin-react-hooks/src/index.ts` has a hardcoded `version: '7.0.0'` in `plugin.meta`. The rollup build for this package does **not** inject the package version at bundle time (unlike `__DEV__` / `__EXPERIMENTAL__`), so `plugin.meta.version` can become stale after a release if `src/index.ts` is not updated alongside `package.json`.

The root cause is in `scripts/release/utils.js`: `updateVersionsForNext` updates every `package.json` but never touches `src/index.ts`.

**Fix:** in `updateVersionsForNext`, after writing `package.json` for `eslint-plugin-react-hooks`, also patch the `version: '...'` literal in `src/index.ts` using the same `readFileSync` / `writeFileSync` / regex-replace pattern already used to keep `packages/shared/ReactVersion.js` in sync.

```js
// after: await writeJson(packageJSONPath, packageJSON, {spaces: 2});
if (packageName === 'eslint-plugin-react-hooks') {
  const pluginSrcPath = join(packagePath, 'src', 'index.ts');
  const pluginSrc = readFileSync(pluginSrcPath, 'utf8');
  writeFileSync(
    pluginSrcPath,
    pluginSrc.replace(/version: '[^']+'/, `version: '${version}'`),
  );
}
```

This keeps `plugin.meta.version` permanently in sync with the published package version without requiring any build system changes or a JSON import.

**File changed:** `scripts/release/utils.js` (+12 lines)

## How did you test this change?

- Verified that `readFileSync` and `writeFileSync` are already imported in `utils.js` (line 6) — no new imports needed.
- Verified the regex `/version: '[^']+'/ ` correctly matches and replaces the single `version: '7.0.0'` in `src/index.ts` without touching unrelated strings.
- Ran `yarn prettier` on the changed file — no formatting changes needed.
- Ran `yarn linc` — **Lint passed for changed files.**