### PR TITLE
Enable ViewTransition onUpdate for persistence mode (Fabric)

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
@@ -144,6 +144,13 @@ export function commitHostUpdate(
   }
 }
 
+export function commitHostCloned(): void {
+  // In persistence mode, host updates are performed as clones during the render
+  // phase (completeWork) rather than as mutations during commit. We only need to
+  // track that a mutation occurred so the parent ViewTransition can detect it.
+  trackHostMutation();
+}
+
 export function commitHostTextUpdate(
   finishedWork: Fiber,
   newText: string,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -62,6 +62,7 @@ import {
   enableEagerAlternateStateNodeCleanup,
   enableDefaultTransitionIndicator,
   enableFragmentRefsTextNodes,
+  enableViewTransitionForPersistenceMode,
 } from 'shared/ReactFeatureFlags';
 import {
   FunctionComponent,
@@ -239,6 +240,7 @@ import {
 import {
   commitHostMount,
   commitHostHydratedInstance,
+  commitHostCloned,
   commitHostUpdate,
   commitHostTextUpdate,
   commitHostResetTextContent,
@@ -2249,8 +2251,11 @@ function commitMutationEffectsOnFiber(
           }
         }
       } else {
-        if (enableEagerAlternateStateNodeCleanup) {
-          if (supportsPersistence) {
+        if (supportsPersistence) {
+          if (enableViewTransitionForPersistenceMode && (flags & Cloned)) {
+            commitHostCloned();
+          }
+          if (enableEagerAlternateStateNodeCleanup) {
             if (finishedWork.alternate !== null) {
               // `finishedWork.alternate.stateNode` is pointing to a stale shadow
               // node at this point, retaining it and its subtree. To reclaim
@@ -2287,6 +2292,9 @@ function commitMutationEffectsOnFiber(
 
           commitHostTextUpdate(finishedWork, newText, oldText);
         }
+      }
+      if (supportsPersistence && enableViewTransitionForPersistenceMode && (flags & Cloned)) {
+        commitHostCloned();
       }
       break;
     }

--- a/packages/react-reconciler/src/ReactFiberFlags.js
+++ b/packages/react-reconciler/src/ReactFiberFlags.js
@@ -10,6 +10,7 @@
 import {
   enableCreateEventHandleAPI,
   enableEffectEventMutationPhase,
+  enableViewTransitionForPersistenceMode,
 } from 'shared/ReactFeatureFlags';
 
 export type Flags = number;
@@ -111,7 +112,13 @@ export const BeforeMutationMask: number =
 // For View Transition support we use the snapshot phase to scan the tree for potentially
 // affected ViewTransition components.
 export const BeforeAndAfterMutationTransitionMask: number =
-  Snapshot | Update | Placement | ChildDeletion | Visibility | ContentReset;
+  Snapshot |
+  Update |
+  Placement |
+  ChildDeletion |
+  Visibility |
+  ContentReset |
+  (enableViewTransitionForPersistenceMode ? Cloned : 0);
 
 export const MutationMask =
   Placement |


### PR DESCRIPTION
## Summary

- Added `Cloned` to `BeforeAndAfterMutationTransitionMask` (gated behind `enableViewTransitionForPersistenceMode`) so the before-mutation phase traverses into subtrees where persistence-mode clones occurred, allowing `shouldStartViewTransition` to be set and `flushAfterMutationEffects` to run
- Introduced `commitHostCloned()` in `ReactFiberCommitHostEffects` to call `trackHostMutation()` for persistence-mode clones, so `viewTransitionMutationContext` is set and the `Update` flag gets applied to parent `ViewTransition` fibers during commit

## Root Cause

In persistence mode (Fabric), host component updates happen via `cloneInstance` during the render phase (`completeWork`), not via `commitUpdate` during commit. The view transition system relied on two mutation-mode-only mechanisms:

1. `BeforeAndAfterMutationTransitionMask` didn't include `Cloned`, so the before-mutation traversal skipped subtrees with only persistence-mode changes — `startViewTransition` was never called and `flushAfterMutationEffects` never ran
2. `trackHostMutation()` was only called from mutation-mode commit paths (`commitHostUpdate`, `commitHostTextUpdate`), so `viewTransitionMutationContext` stayed `false` and the `Update` flag was never set on `ViewTransition` fibers

## Test plan

- [ ] Verify `onUpdate` fires on `ViewTransition` components in React Native Fabric when child host components update
- [ ] Verify no impact on DOM renderer (changes are gated behind `enableViewTransitionForPersistenceMode` and `supportsPersistence`)
- [ ] Verify enter/exit (share) transitions continue to work in Fabric