### PR TITLE
Add writingsuggestions as a recognized booleanish attribute

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -708,6 +708,7 @@ function setProp(
     case 'contentEditable':
     case 'spellCheck':
     case 'draggable':
+    case 'writingsuggestions':
     case 'value':
     case 'autoReverse':
     case 'externalResourcesRequired':
@@ -2831,6 +2832,7 @@ function diffHydratedGenericElement(
         continue;
       }
       case 'draggable':
+      case 'writingsuggestions':
       case 'autoReverse':
       case 'externalResourcesRequired':
       case 'focusable':

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -1656,6 +1656,7 @@ function pushAttribute(
     case 'contentEditable':
     case 'spellCheck':
     case 'draggable':
+    case 'writingsuggestions':
     case 'value':
     case 'autoReverse':
     case 'externalResourcesRequired':

--- a/packages/react-dom-bindings/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMUnknownPropertyHook.js
@@ -199,6 +199,7 @@ function validateProperty(tagName, name, value, eventRegistry) {
           case 'contentEditable':
           case 'spellCheck':
           case 'draggable':
+          case 'writingsuggestions':
           case 'value':
           case 'autoReverse':
           case 'externalResourcesRequired':

--- a/packages/react-dom-bindings/src/shared/possibleStandardNames.js
+++ b/packages/react-dom-bindings/src/shared/possibleStandardNames.js
@@ -162,6 +162,7 @@ const possibleStandardNames = {
   width: 'width',
   wmode: 'wmode',
   wrap: 'wrap',
+  writingsuggestions: 'writingsuggestions',
 
   // SVG
   about: 'about',

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -2688,6 +2688,16 @@ describe('ReactDOMComponent', () => {
       ]);
     });
 
+    it('should warn about incorrect casing on the writingsuggestions property (ssr)', () => {
+      ReactDOMServer.renderToString(
+        React.createElement('div', {WritingSuggestions: 'false'}),
+      );
+      assertConsoleErrorDev([
+        'Invalid DOM property `WritingSuggestions`. Did you mean `writingsuggestions`?\n' +
+          '    in div (at **)',
+      ]);
+    });
+
     it('should warn about incorrect casing on event handlers (ssr)', () => {
       ReactDOMServer.renderToString(
         React.createElement('input', {type: 'text', oninput: '1'}),
@@ -3614,6 +3624,32 @@ describe('ReactDOMComponent', () => {
       const el = container.firstChild;
 
       expect(el.getAttribute('spellCheck')).toBe('true');
+    });
+
+    it('stringifies the boolean true for writingsuggestions', async function () {
+      const container = document.createElement('div');
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(<div writingsuggestions={true} />);
+      });
+
+      const el = container.firstChild;
+
+      expect(el.getAttribute('writingsuggestions')).toBe('true');
+    });
+
+    it('stringifies the boolean false for writingsuggestions', async function () {
+      const container = document.createElement('div');
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(<div writingsuggestions={false} />);
+      });
+
+      const el = container.firstChild;
+
+      expect(el.getAttribute('writingsuggestions')).toBe('false');
     });
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -199,6 +199,18 @@ describe('ReactDOMServerIntegration', () => {
       });
     });
 
+    describe('writingsuggestions property', function () {
+      itRenders('writingsuggestions prop with true value', async render => {
+        const e = await render(<div writingsuggestions={true} />);
+        expect(e.getAttribute('writingsuggestions')).toBe('true');
+      });
+
+      itRenders('writingsuggestions prop with false value', async render => {
+        const e = await render(<div writingsuggestions={false} />);
+        expect(e.getAttribute('writingsuggestions')).toBe('false');
+      });
+    });
+
     describe('download property (combined boolean/string attribute)', function () {
       itRenders('download prop with true value', async render => {
         const e = await render(<a download={true} />);


### PR DESCRIPTION
Add `writingsuggestions` as a recognized booleanish attribute

`writingsuggestions` is a global HTML attribute that controls whether
the browser offers writing suggestions (autocorrect, autocomplete, etc.).
It is an enumerated attribute accepting "true" and "false", similar to
`draggable` and `spellCheck`.

Previously, passing `writingsuggestions={false}` would silently remove
the attribute from the DOM. Now it correctly sets the attribute to the
string "false".

## Summary

`writingsuggestions` is a [global HTML attribute](https://html.spec.whatwg.org/multipage/interaction.html#writing-suggestions) introduced in the HTML Living Standard. It accepts `"true"` (default) or `"false"` as values, making it a booleanish/enumerated attribute — similar to `draggable` and `spellCheck`, not a pure boolean like `credentialless`.

Before this change:
- `<div writingsuggestions={false} />` would **remove** the attribute entirely (React's default behavior for unknown attributes receiving `false`)
- `<div WritingSuggestions="false" />` would produce no casing suggestion

After this change:
- `writingsuggestions={true}` renders as `writingsuggestions="true"`
- `writingsuggestions={false}` renders as `writingsuggestions="false"`
- Incorrect casing like `WritingSuggestions` triggers: _"Invalid DOM property `WritingSuggestions`. Did you mean `writingsuggestions`?"_
- Behavior is consistent across client rendering, SSR (`ReactDOMServer`), and hydration.

## How did you test this change?

Added tests covering:

- **Casing suggestion (SSR):** `WritingSuggestions` triggers the correct warning pointing to `writingsuggestions`
- **Booleanish rendering:** `{true}` → `"true"`, `{false}` → `"false"` on the DOM attribute
- **Server integration:** both values render correctly via `renderToString` and hydrate without mismatch

```bash
yarn test --no-watchman ReactDOMComponent-test
yarn test --no-watchman ReactDOMServerIntegrationAttributes-test
yarn test --no-watchman DOMPropertyOperations-test