### PR TITLE
fix: typos in ReactFizzConfigDOM.js error messages

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -2874,7 +2874,7 @@ function pushLink(
       if (rel === 'stylesheet' && typeof props.precedence === 'string') {
         if (typeof href !== 'string' || !href) {
           console.error(
-            'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and expected the `href` prop to be a non-empty string but ecountered %s instead. If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` prop ensure there is a non-empty string `href` prop as well, otherwise remove the `precedence` prop.',
+            'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and expected the `href` prop to be a non-empty string but encountered %s instead. If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` prop ensure there is a non-empty string `href` prop as well, otherwise remove the `precedence` prop.',
             getValueDescriptorExpectingObjectForWarning(href),
           );
         }
@@ -2900,7 +2900,7 @@ function pushLink(
         if (typeof precedence === 'string') {
           if (props.disabled != null) {
             console.error(
-              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and a `disabled` prop. The presence of the `disabled` prop indicates an intent to manage the stylesheet active state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` prop remove the `disabled` prop, otherwise remove the `precedence` prop.',
+              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and a `disabled` prop. The presence of the `disabled` prop indicates an intent to manage the stylesheet active state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` prop remove the `disabled` prop, otherwise remove the `precedence` prop.',
             );
           } else if (props.onLoad || props.onError) {
             const propDescription =
@@ -2910,7 +2910,7 @@ function pushLink(
                   ? '`onLoad` prop'
                   : '`onError` prop';
             console.error(
-              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and %s. The presence of loading and error handlers indicates an intent to manage the stylesheet loading state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` prop remove the %s, otherwise remove the `precedence` prop.',
+              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and %s. The presence of loading and error handlers indicates an intent to manage the stylesheet loading state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` prop remove the %s, otherwise remove the `precedence` prop.',
               propDescription,
               propDescription,
             );
@@ -3114,7 +3114,7 @@ function pushStyle(
   if (__DEV__) {
     if (href.includes(' ')) {
       console.error(
-        'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but ecountered spaces instead. using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this ocurred is "%s".',
+        'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but encountered spaces instead. using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this occurred is "%s".',
         href,
       );
     }


### PR DESCRIPTION
## Summary

Fix typos in error messages in `packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js`:

- 'ecountered' → 'encountered' (4 occurrences in error messages)
- 'ocurred' → 'occurred' (1 occurrence)
- 'deduplciate' → 'deduplicate' (3 occurrences)

Fixes https://github.com/facebook/react/issues/36320

## Changes

Only changes string literals in console.error() calls - no runtime behavior change.

## Test plan

N/A - only string corrections