### PR TITLE
[Reconciler] Fix: "Should not already be working" in Firefox after a breakpoint/alert #17355

### DIFF
--- a/packages/react-reconciler/src/ReactFiberRootScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberRootScheduler.js
@@ -193,6 +193,11 @@ function flushSyncWorkAcrossRoots_impl(
     return;
   }
 
+  const executionContext = getExecutionContext();
+  if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
+    return;
+  }
+
   if (!mightHavePendingSyncWork) {
     // Fast path. There's no sync work to do.
     return;
@@ -527,9 +532,10 @@ function performWorkOnRootViaSchedulerTask(
     trackSchedulerEvent();
   }
 
-  if (hasPendingCommitEffects()) {
-    // We are currently in the middle of an async committing (such as a View Transition).
-    // We could force these to flush eagerly but it's better to defer any work until
+  const executionContext = getExecutionContext();
+  if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
+    // We are currently in the middle of a render or commit. We could force
+    // these to flush eagerly but it's better to defer any work until
     // it finishes. This may not be the same root as we're waiting on.
     // TODO: This relies on the commit eventually calling ensureRootIsScheduled which
     // always calls processRootScheduleInMicrotask which in turn always loops through


### PR DESCRIPTION
## Summary

This PR addresses the "Should not already be working" invariant error that occurs in Firefox when an alert() or debugger breakpoint is triggered. In these scenarios, the browser flushes the task queue while a React render/commit is already in progress. By adding getExecutionContext() guards to the scheduler's entry points, we ensure that re-entrant work is correctly deferred until the current work loop completes.

Fixes #17355

## How did you test this change?

I verified the change by analyzing the execution context flow and ensuring the guards correctly identify the RenderContext and CommitContext during re-entrant calls. This pattern is consistent with existing fixes for Safari's microtask flushing behavior in ReactFiberRootScheduler.js.
I also manually verified that the getExecutionContext() bitmask correctly identifies active work phases, preventing the performWorkOnRoot from throwing when called re-entrantly.

