### PR TITLE
.2385318931605690:1e2f1213b92cd6f086864b0465695e65_69f70ab5eb4415a9574e5e91.69f718eaeb4415a9574e619f.69f718ea19ffdb88e418edea:Trae CN.T(2026/5/3 17:44:10)

### DIFF
--- a/packages/react/index.development.js
+++ b/packages/react/index.development.js
@@ -59,6 +59,7 @@ export {
   useDeferredValue,
   useEffect,
   useEffectEvent,
+  useAsyncEffect,
   useImperativeHandle,
   useInsertionEffect,
   useLayoutEffect,

--- a/packages/react/index.experimental.development.js
+++ b/packages/react/index.experimental.development.js
@@ -44,6 +44,7 @@ export {
   useDeferredValue,
   useEffect,
   useEffectEvent,
+  useAsyncEffect,
   useImperativeHandle,
   useInsertionEffect,
   useLayoutEffect,

--- a/packages/react/index.experimental.js
+++ b/packages/react/index.experimental.js
@@ -45,6 +45,7 @@ export {
   useDeferredValue,
   useEffect,
   useEffectEvent,
+  useAsyncEffect,
   useImperativeHandle,
   useInsertionEffect,
   useLayoutEffect,

--- a/packages/react/index.fb.js
+++ b/packages/react/index.fb.js
@@ -52,6 +52,7 @@ export {
   useDebugValue,
   useDeferredValue,
   useEffect,
+  useAsyncEffect,
   useId,
   useImperativeHandle,
   useInsertionEffect,

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -59,6 +59,7 @@ export {
   useDeferredValue,
   useEffect,
   useEffectEvent,
+  useAsyncEffect,
   useImperativeHandle,
   useInsertionEffect,
   useLayoutEffect,

--- a/packages/react/index.stable.development.js
+++ b/packages/react/index.stable.development.js
@@ -40,6 +40,7 @@ export {
   useDeferredValue,
   useEffect,
   useEffectEvent,
+  useAsyncEffect,
   useImperativeHandle,
   useInsertionEffect,
   useLayoutEffect,

--- a/packages/react/index.stable.js
+++ b/packages/react/index.stable.js
@@ -40,6 +40,7 @@ export {
   useDeferredValue,
   useEffect,
   useEffectEvent,
+  useAsyncEffect,
   useImperativeHandle,
   useInsertionEffect,
   useLayoutEffect,

--- a/packages/react/src/ReactClient.js
+++ b/packages/react/src/ReactClient.js
@@ -57,6 +57,7 @@ import {
   use,
   useOptimistic,
   useActionState,
+  useAsyncEffect,
 } from './ReactHooks';
 import ReactSharedInternals from './ReactSharedInternalsClient';
 import {startTransition, startGestureTransition} from './ReactStartTransition';
@@ -88,6 +89,7 @@ export {
   useContext,
   useEffect,
   useEffectEvent,
+  useAsyncEffect,
   useImperativeHandle,
   useDebugValue,
   useInsertionEffect,

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -274,26 +274,44 @@ export function useAsyncEffect(
 
   useEffect(() => {
     const controller = new AbortControllerLocal();
+    let isActive = true;
+    let effectCleanup: (() => void) | void = undefined;
+
+    if (typeof cleanupRef.current === 'function') {
+      cleanupRef.current();
+      cleanupRef.current = undefined;
+    }
 
     const result = create(controller.signal);
 
     Promise.resolve(result).then(
       cleanup => {
-        if (!controller.signal.aborted) {
+        if (isActive) {
+          effectCleanup = cleanup;
           cleanupRef.current = cleanup;
+        } else {
+          if (typeof cleanup === 'function') {
+            cleanup();
+          }
         }
       },
       error => {
-        if (!controller.signal.aborted) {
+        if (isActive) {
           throw error;
         }
       },
     );
 
     return () => {
+      isActive = false;
       controller.abort();
-      if (typeof cleanupRef.current === 'function') {
-        cleanupRef.current();
+
+      if (typeof effectCleanup === 'function') {
+        effectCleanup();
+        effectCleanup = undefined;
+      }
+
+      if (cleanupRef.current === effectCleanup) {
         cleanupRef.current = undefined;
       }
     };

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -18,6 +18,24 @@ import {REACT_CONSUMER_TYPE} from 'shared/ReactSymbols';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 
+const AbortControllerLocal: typeof AbortController =
+  typeof AbortController !== 'undefined'
+    ? AbortController
+    : function AbortControllerShim() {
+        const listeners: Array<() => void> = [];
+        const signal = (this.signal = {
+          aborted: false as boolean,
+          addEventListener: (type: string, listener: () => void) => {
+            listeners.push(listener);
+          },
+        });
+
+        this.abort = () => {
+          signal.aborted = true;
+          listeners.forEach(listener => listener());
+        };
+      };
+
 type BasicStateAction<S> = (S => S) | S;
 type Dispatch<A> = A => void;
 
@@ -238,4 +256,46 @@ export function useActionState<S, P>(
 ): [Awaited<S>, (P) => void, boolean] {
   const dispatcher = resolveDispatcher();
   return dispatcher.useActionState(action, initialState, permalink);
+}
+
+export function useAsyncEffect(
+  create: (signal: AbortSignal) => (() => void) | void | Promise<(() => void) | void>,
+  deps: Array<mixed> | void | null,
+): void {
+  if (__DEV__) {
+    if (create == null) {
+      console.warn(
+        'React Hook useAsyncEffect requires an effect callback. Did you forget to pass a callback to the hook?',
+      );
+    }
+  }
+
+  const cleanupRef = useRef<(() => void) | void>(undefined);
+
+  useEffect(() => {
+    const controller = new AbortControllerLocal();
+
+    const result = create(controller.signal);
+
+    Promise.resolve(result).then(
+      cleanup => {
+        if (!controller.signal.aborted) {
+          cleanupRef.current = cleanup;
+        }
+      },
+      error => {
+        if (!controller.signal.aborted) {
+          throw error;
+        }
+      },
+    );
+
+    return () => {
+      controller.abort();
+      if (typeof cleanupRef.current === 'function') {
+        cleanupRef.current();
+        cleanupRef.current = undefined;
+      }
+    };
+  }, deps);
 }


### PR DESCRIPTION
fix(hooks): 修复 useAsyncEffect 清理逻辑的竞态条件

添加 isActive 标志来跟踪组件是否仍挂载，防止在组件卸载后执行清理函数。同时优化清理逻辑，确保正确的清理函数被调用。