### PR TITLE
[Devtools]Fixed incorrect highlights components when filtered parent re-mounts …

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/traceUpdatesHighlight-test.js
+++ b/packages/react-devtools-shared/src/__tests__/traceUpdatesHighlight-test.js
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type Store from 'react-devtools-shared/src/devtools/store';
+
+import {getVersionedRenderImplementation} from './utils';
+
+describe('Trace updates highlighting (backend)', () => {
+  let React;
+  let store: Store;
+  let utils;
+  let actAsync;
+  let hook;
+  let unsubscribe;
+
+  // textContent of every host node the backend reports for highlighting since
+  // the last reset.
+  let highlighted: Array<string>;
+
+  beforeEach(() => {
+    store = global.store;
+    store.collapseNodesByDefault = false;
+    store.componentFilters = [];
+
+    React = require('react');
+    utils = require('./utils');
+    actAsync = utils.actAsync;
+
+    hook = global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    highlighted = [];
+    // Listen to the backend's trace-updates event directly on the hook. We
+    // deliberately do NOT enable trace updates through the Agent: that would
+    // also enable the frontend canvas overlay (TraceUpdates view), which JSDOM
+    // can't draw. Enabling on the renderer interface keeps the overlay disabled
+    // (it early-returns on `!isEnabled`) so we observe exactly which nodes the
+    // backend chooses without rendering anything.
+    unsubscribe = hook.sub('traceUpdates', (nodes: Set<HTMLElement>) => {
+      nodes.forEach(node => highlighted.push((node.textContent || '').trim()));
+    });
+  });
+
+  afterEach(() => {
+    if (unsubscribe != null) {
+      unsubscribe();
+      unsubscribe = null;
+    }
+  });
+
+  const {render} = getVersionedRenderImplementation();
+
+  // Renderers attach (and appear in hook.rendererInterfaces) only once React
+  // has injected, i.e. after the first render — so call this after rendering.
+  function enableTraceUpdates() {
+    for (const rendererInterface of hook.rendererInterfaces.values()) {
+      rendererInterface.setTraceUpdatesEnabled(true);
+    }
+  }
+
+  // @reactVersion >= 18.0
+  it('does not highlight a component when its filtered ancestor re-mounts', async () => {
+    let bumpKey;
+
+    function FilteredParent({children}: {children: React$Node}) {
+      return children;
+    }
+
+    function StableChild() {
+      return <span>stable child</span>;
+    }
+
+    function App() {
+      const [key, setKey] = React.useState(0);
+      bumpKey = () => setKey(k => k + 1);
+      return (
+        <FilteredParent key={key}>
+          <StableChild />
+        </FilteredParent>
+      );
+    }
+
+    // Hide FilteredParent from the tree via a display-name filter.
+    await actAsync(
+      async () =>
+        (store.componentFilters = [
+          utils.createDisplayNameFilter('FilteredParent'),
+        ]),
+    );
+
+    await actAsync(async () => render(<App />));
+    enableTraceUpdates();
+
+    // FilteredParent is filtered out, so StableChild hangs directly under App.
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <App>
+          ▾ <StableChild>
+              <span>
+    `);
+
+    highlighted = [];
+
+    // Bump the key. This re-mounts FilteredParent (and therefore StableChild),
+    // but StableChild's own output did not change — it was re-created, not
+    // re-rendered, so it must not be highlighted.
+    await actAsync(async () => bumpKey());
+
+    expect(highlighted).toEqual([]);
+  });
+
+  // @reactVersion >= 18.0
+  it('still highlights a component that genuinely re-renders', async () => {
+    let bump;
+
+    function Rerendering() {
+      const [count, setCount] = React.useState(0);
+      bump = () => setCount(c => c + 1);
+      return <span>count: {count}</span>;
+    }
+
+    await actAsync(async () => render(<Rerendering />));
+    enableTraceUpdates();
+
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <Rerendering>
+            <span>
+    `);
+
+    highlighted = [];
+
+    // A real state update: the same Fiber re-renders, so its host should flash.
+    await actAsync(async () => bump());
+
+    expect(highlighted).toEqual(['count: 1']);
+  });
+
+  // @reactVersion >= 18.0
+  it('still highlights genuinely new content mounted by an updating parent', async () => {
+    let reveal;
+
+    function NewThing() {
+      return <span>fresh content</span>;
+    }
+
+    function App() {
+      const [visible, setVisible] = React.useState(false);
+      reveal = () => setVisible(true);
+      return visible ? <NewThing /> : null;
+    }
+
+    await actAsync(async () => render(<App />));
+    enableTraceUpdates();
+
+    highlighted = [];
+
+    // App re-renders and NewThing appears for the first time. This is genuinely
+    // new content (nothing occupied this slot before), not a re-mount, so it
+    // should still flash — only re-mounts are suppressed.
+    await actAsync(async () => reveal());
+
+    expect(highlighted).toEqual(['fresh content']);
+  });
+});

--- a/packages/react-devtools-shared/src/__tests__/traceUpdatesHighlight-test.js
+++ b/packages/react-devtools-shared/src/__tests__/traceUpdatesHighlight-test.js
@@ -57,9 +57,9 @@ describe('Trace updates highlighting (backend)', () => {
   // Renderers attach (and appear in hook.rendererInterfaces) only once React
   // has injected, i.e. after the first render — so call this after rendering.
   function enableTraceUpdates() {
-    for (const rendererInterface of hook.rendererInterfaces.values()) {
+    hook.rendererInterfaces.forEach(rendererInterface => {
       rendererInterface.setTraceUpdatesEnabled(true);
-    }
+    });
   }
 
   // @reactVersion >= 18.0

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -4247,7 +4247,19 @@ export function attach(
           // We let the previous instance remain in the "remaining queue" it is
           // in to be deleted at the end since it'll have no match.
 
-          mountFiberRecursively(nextChild, traceNearestHostComponentUpdate);
+          // Distinguish a *re-mount* from genuinely *new* content for trace
+          // updates ("highlight updates when components render"). A re-mount
+          // replaces a Fiber that previously occupied this slot (e.g. a `key`
+          // change, or a filtered ancestor re-mounting its children): the old
+          // instance is being deleted and a fresh one created. That subtree did
+          // not re-render, so an updating ancestor's highlight flag must not
+          // flash it. When no previous child occupied this slot the content is
+          // genuinely new, and we keep flashing it as before.
+          const isRemount = prevChildAtSameIndex !== null;
+          mountFiberRecursively(
+            nextChild,
+            isRemount ? false : traceNearestHostComponentUpdate,
+          );
           // Need to mark the parent set to remount the new instance.
           updateFlags |= ShouldResetChildren | ShouldResetSuspenseChildren;
         }

--- a/packages/react-devtools-shared/src/backend/fiber/shared/DevToolsFiberChangeDetection.js
+++ b/packages/react-devtools-shared/src/backend/fiber/shared/DevToolsFiberChangeDetection.js
@@ -135,7 +135,12 @@ export function didFiberRender(
       // releasing DevTools in lockstep with React, we should import a
       // function from the reconciler instead.
       const PerformedWork = 0b000000000000000000000000001;
-      return (getFiberFlags(nextFiber) & PerformedWork) === PerformedWork;
+      const hasPerformedWork =
+        (getFiberFlags(nextFiber) & PerformedWork) === PerformedWork;
+      if (nextFiber.alternate === null) {
+        return false;
+      }
+      return hasPerformedWork;
     // Note: ContextConsumer only gets PerformedWork effect in 16.3.3+
     // so it won't get highlighted with React 16.3.0 to 16.3.2.
     default:

--- a/packages/react-devtools-shared/src/backend/fiber/shared/DevToolsFiberChangeDetection.js
+++ b/packages/react-devtools-shared/src/backend/fiber/shared/DevToolsFiberChangeDetection.js
@@ -135,12 +135,7 @@ export function didFiberRender(
       // releasing DevTools in lockstep with React, we should import a
       // function from the reconciler instead.
       const PerformedWork = 0b000000000000000000000000001;
-      const hasPerformedWork =
-        (getFiberFlags(nextFiber) & PerformedWork) === PerformedWork;
-      if (nextFiber.alternate === null) {
-        return false;
-      }
-      return hasPerformedWork;
+      return (getFiberFlags(nextFiber) & PerformedWork) === PerformedWork;
     // Note: ContextConsumer only gets PerformedWork effect in 16.3.3+
     // so it won't get highlighted with React 16.3.0 to 16.3.2.
     default:


### PR DESCRIPTION

## Summary

Fixes incorrect highlight outlines drawn on components when one of their
ancestors is hidden via component filters and that ancestor re-mounts.

When a filtered parent re-mounts (for example, due to a `key` change or a
conditional render), React creates fresh fibers for its children — those
children have `alternate === null` because they are being mounted, not
updated. From DevTools' perspective the parent is invisible, so the user
sees the children flash a highlight box as if they re-rendered for no
reason.

`didFiberRender` previously returned `true` for any class / function /
forwardRef / memo fiber whose `PerformedWork` flag was set, which is true
on first mount. This change short-circuits to `false` when the fiber has
no alternate, so initial mounts are no longer reported as "rendered" by
the highlight overlay or the Profiler change-tracking path.

## How did you test this change?

Tested using devtools

**Before**

https://github.com/user-attachments/assets/b8d70166-9f02-4014-bdf2-50e2fd348d8d

**After**


https://github.com/user-attachments/assets/7cf2a5d5-5993-4615-8f0c-c80d0e26ff6d


