### PR TITLE
fix[eslint-plugin-react-hooks]: detect memo/forwardRef-wrapped components in mayContainReactCode heuristic

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleFlow-test.ts
+++ b/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleFlow-test.ts
@@ -53,6 +53,18 @@ const tests: CompilerTestCases = {
         };
       `,
     },
+    {
+      name: '[Heuristic/Flow] Skips lowercase variable initialized with call expression wrapping a function',
+      filename: 'utils.js',
+      // Lowercase name means the heuristic skips this file entirely,
+      // even though the init is a call expression wrapping a function.
+      code: normalizeIndent`
+        const helper = someWrapper(function(obj) {
+          obj.key = 'value';
+          return obj;
+        });
+      `,
+    },
   ],
   invalid: [
     // ===========================================
@@ -131,6 +143,87 @@ const tests: CompilerTestCases = {
       errors: [
         {
           message: /Modifying component props or hook arguments/,
+        },
+      ],
+    },
+    // ===========================================
+    // Tests for HOC-wrapped components (memo, forwardRef, etc.) with Flow parser
+    // The heuristic must unwrap one level of CallExpression to detect these.
+    // Regression tests for: const Comp = memo(function Comp() {...}) being
+    // silently skipped while an equivalent plain function declaration was compiled.
+    // ===========================================
+    {
+      name: '[Heuristic/Flow] Compiles memo-wrapped named function expression - detects prop mutation',
+      filename: 'component.js',
+      code: normalizeIndent`
+        const MyComponent = memo(function MyComponent({a}) {
+          a.key = 'value';
+          return <div />;
+        });
+      `,
+      errors: [
+        {
+          message: /Modifying component props/,
+        },
+      ],
+    },
+    {
+      name: '[Heuristic/Flow] Compiles memo-wrapped arrow function - detects prop mutation',
+      filename: 'component.js',
+      code: normalizeIndent`
+        const MyComponent = memo(({a}) => {
+          a.key = 'value';
+          return <div />;
+        });
+      `,
+      errors: [
+        {
+          message: /Modifying component props/,
+        },
+      ],
+    },
+    {
+      name: '[Heuristic/Flow] Compiles React.memo-wrapped function expression - detects prop mutation',
+      filename: 'component.js',
+      code: normalizeIndent`
+        const MyComponent = React.memo(function MyComponent({a}) {
+          a.key = 'value';
+          return <div />;
+        });
+      `,
+      errors: [
+        {
+          message: /Modifying component props/,
+        },
+      ],
+    },
+    {
+      name: '[Heuristic/Flow] Compiles forwardRef-wrapped function expression - detects prop mutation',
+      filename: 'component.js',
+      code: normalizeIndent`
+        const MyComponent = forwardRef(function MyComponent({a}, ref) {
+          a.key = 'value';
+          return <div ref={ref} />;
+        });
+      `,
+      errors: [
+        {
+          message: /Modifying component props/,
+        },
+      ],
+    },
+    {
+      name: '[Heuristic/Flow] Compiles exported memo-wrapped component - detects prop mutation',
+      filename: 'component.js',
+      code: normalizeIndent`
+        export const MyComponent = memo(function MyComponent({a}) {
+          a.key = 'value';
+          return <div />;
+        });
+      `,
+      errors: [
+        {
+          message: /Modifying component props/,
         },
       ],
     },

--- a/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleTypescript-test.ts
+++ b/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleTypescript-test.ts
@@ -75,6 +75,18 @@ const tests: CompilerTestCases = {
         };
       `,
     },
+    {
+      name: '[Heuristic] Skips lowercase variable initialized with call expression wrapping a function',
+      filename: 'utils.ts',
+      // Lowercase name means the heuristic skips this file entirely,
+      // even though the init is a call expression wrapping a function.
+      code: normalizeIndent`
+        const helper = someWrapper(function(obj) {
+          obj.key = 'value';
+          return obj;
+        });
+      `,
+    },
   ],
   invalid: [
     {
@@ -185,6 +197,87 @@ const tests: CompilerTestCases = {
           a.key = 'value';
           return <div />;
         }
+      `,
+      errors: [
+        {
+          message: /Modifying component props/,
+        },
+      ],
+    },
+    // ===========================================
+    // Tests for HOC-wrapped components (memo, forwardRef, etc.)
+    // The heuristic must unwrap one level of CallExpression to detect these.
+    // Regression tests for: const Comp = memo(function Comp() {...}) being
+    // silently skipped while an equivalent plain function declaration was compiled.
+    // ===========================================
+    {
+      name: '[Heuristic] Compiles memo-wrapped named function expression - detects prop mutation',
+      filename: 'component.tsx',
+      code: normalizeIndent`
+        const MyComponent = memo(function MyComponent({a}) {
+          a.key = 'value';
+          return <div />;
+        });
+      `,
+      errors: [
+        {
+          message: /Modifying component props/,
+        },
+      ],
+    },
+    {
+      name: '[Heuristic] Compiles memo-wrapped arrow function - detects prop mutation',
+      filename: 'component.tsx',
+      code: normalizeIndent`
+        const MyComponent = memo(({a}) => {
+          a.key = 'value';
+          return <div />;
+        });
+      `,
+      errors: [
+        {
+          message: /Modifying component props/,
+        },
+      ],
+    },
+    {
+      name: '[Heuristic] Compiles React.memo-wrapped function expression - detects prop mutation',
+      filename: 'component.tsx',
+      code: normalizeIndent`
+        const MyComponent = React.memo(function MyComponent({a}) {
+          a.key = 'value';
+          return <div />;
+        });
+      `,
+      errors: [
+        {
+          message: /Modifying component props/,
+        },
+      ],
+    },
+    {
+      name: '[Heuristic] Compiles forwardRef-wrapped function expression - detects prop mutation',
+      filename: 'component.tsx',
+      code: normalizeIndent`
+        const MyComponent = forwardRef(function MyComponent({a}, ref) {
+          a.key = 'value';
+          return <div ref={ref} />;
+        });
+      `,
+      errors: [
+        {
+          message: /Modifying component props/,
+        },
+      ],
+    },
+    {
+      name: '[Heuristic] Compiles exported memo-wrapped component - detects prop mutation',
+      filename: 'component.tsx',
+      code: normalizeIndent`
+        export const MyComponent = memo(function MyComponent({a}) {
+          a.key = 'value';
+          return <div />;
+        });
       `,
       errors: [
         {

--- a/packages/eslint-plugin-react-hooks/src/shared/RunReactCompiler.ts
+++ b/packages/eslint-plugin-react-hooks/src/shared/RunReactCompiler.ts
@@ -99,21 +99,40 @@ function checkTopLevelNode(node: ESTree.Node): boolean {
   }
 
   // Handle: const MyComponent = () => {} or const useHook = function() {}
+  // Also handles: const MyComponent = memo(function MyComponent() {}) or
+  //               const MyComponent = React.memo(() => {})
   if (node.type === 'VariableDeclaration') {
     for (const decl of (node as ESTree.VariableDeclaration).declarations) {
       if (decl.id.type === 'Identifier') {
-        const init = decl.init;
+        const name = decl.id.name;
         if (
-          init != null &&
-          (init.type === 'ArrowFunctionExpression' ||
-            init.type === 'FunctionExpression')
+          !COMPONENT_NAME_PATTERN.test(name) &&
+          !HOOK_NAME_PATTERN.test(name)
         ) {
-          const name = decl.id.name;
-          if (
-            COMPONENT_NAME_PATTERN.test(name) ||
-            HOOK_NAME_PATTERN.test(name)
-          ) {
-            return true;
+          continue;
+        }
+        const init = decl.init;
+        if (init == null) {
+          continue;
+        }
+        if (
+          init.type === 'ArrowFunctionExpression' ||
+          init.type === 'FunctionExpression'
+        ) {
+          return true;
+        }
+        // Unwrap one level of call expression to catch patterns like:
+        //   const Comp = memo(function Comp() {...})
+        //   const Comp = React.memo(() => {...})
+        //   const Comp = forwardRef(function Comp() {...})
+        if (init.type === 'CallExpression') {
+          for (const arg of (init as ESTree.CallExpression).arguments) {
+            if (
+              arg.type === 'ArrowFunctionExpression' ||
+              arg.type === 'FunctionExpression'
+            ) {
+              return true;
+            }
           }
         }
       }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

This PR seeks to resolve https://github.com/facebook/react/issues/36432 by updating `packages/eslint-plugin-react-hooks/src/shared/RunReactCompiler.ts` to support `const MyComponent = memo(function MyComponent() {})`, `const MyComponent = React.memo(() => {})`, and  `const MyComponent = forwardRef(function MyComponent() {})` syntaxes.

`eslint-plugin-react-hooks@7.1.0` introduced some logic to improve performance by skipping linting for files that do not return `true` for `mayContainReactCode`. This PR contains some extension of that logic to make sure we are linting files with the above syntax.

The scope specifically only concerns `memo` and `forwardRef`. This PR could be extended to include other `react` exports, but is specifically considering custom higher-order components out of scope.

## How did you test this change?

Manually, by changing the source code of `packages/eslint-plugin-react-hooks/src/shared/RunReactCompiler.ts` directly to raise lint errors in a repo that was not reporting existing `// eslint-disable-next-line `directives, after upgrading `eslint-plugin-react-hooks` from `7.0.1` to `7.1.1`. I double-checked that the compiler itself reports all such instances are errors ([Compiler Playground link](https://playground.react.dev/#N4Igzg9grgTgxgUxALhASwLYAcIwC4AEASggIZx4A0BwBGCGE1UYCAynqXgs6yQGa8EAUX78EFAgF8C-GBAwEA5DDIUlAbgA6AO10B6fQQAKXbjB0EAQsllQdFNBEsATBPzQ6EL2WhhgqOgYIAlIsLAAbNG8CZwIEAA8cfAA6A310gmEkiW4XWzBSegIAIwQAC1IANycYULACAEkdKK8AWWCUgCswBIJAFAICPHKEVlDVOwc8Jx1SCIiATwI0Nx1puDmCOAUcLzWwNJ1DAgBBCig52wJ4sFa8AFpIqABzT3vVcgfyiAgAazAAAIAdhSAEYwQQACIAeWEbAIqmShBqEAiXBmDRGqmQ6Uy1w+FHu3z+YH0qn4YFsAGFSDodBBCOREGAGuSGi5YJ5ngiEDo3DBDsd8Wovj9-vpWA8AlwEPc3u5xBRqXNWtzJRwZQQwAsHOV5PSWIsCAB3NDDTyhSwK3J4652+0Ox1Op0bSx4GBoZ7PBB1DZgDYuLk8vk+g66fj2RxxNgILCkGAyjqMKk7Zy8vAACloVTmUAQ0gAlDRdNdtjoAltnJxPD6BAQALwEFgIAQZnRQeYF7SWSvlwgAbRGnvKgUlAAkEMO8ABdBtN1ga7gZgAMXd0JYIxwJopJZPcDQ8qkxPvzGda+f4aK9MRKSzuPoLG7LFbgsFUawAchA3HOy9WvDAAgpK+MDvng3Ybs2oiKpmGZFvWAB8xY9tcaD8AQGY5hEeZFsAG72luIpEmKpKSvc0rcHKOj3NakiHqMBBYqe56yFe3o+LeBD3jAj4oXa46Ts8I6YbmCBrnxUgblI1D9lhebTuJG6qHgsCWBm+EEAAPIGVQ8vw9bAH+pA1oB7gyAECwRAgBm0EOQmEFIUgIRp1yGW+6Zfj+AD8BByfmtjtvMkl8Zp+g6c5PbicFuiJEiBBuPwpAdoQ9CMBmMZxgm3BJhAKbYGmayKUcRipSExoJlgDTDBekbTHECWeGaMzLC0NaChkxVZDkFDeLY27EbuZEUbK8piLklo+P1xLimyWrfB2Pj0e1pznJcdqjHcjzYa81FTSRwJghCiK4HgDQftCvlOGidXloxJ6HM+hDNOeOV5bs6ZzqVGYRlMzXPTWr2pnsmbZqJhbIaWzgvlWxkAXWjbNq2gUROJkN9gQg6CSO1ACVOs4IwunBLquEE9oRnwDTN+62EyoxgEG5LAe5azxZyOjcu+-JPlDhAgWBnn5o2RkmUBfPpqT1xQWNFAZnBDZIXhfFoRhfm4S5m5GHtg0IFKRMjdRtF4AUOpwHqzjQA06p6y19M-rS8TS3g6u4-ZInYWJ3b2sF1zSRjfkKRLPIqRYGEadpaC6eSBnC3DZlanglnWcAtlYw5Tnq25oEed++Y+X5BABR2ETe3aoXhRuUVFbFJ3xe4SURE9rXtMEb0FeB66dSQnwpKVJoVVVIyTFGrjuI1N0tee7WZNkWC5L1PIU9NpE6+RetUTRjsTQvhJL3uFJzdAESLX4CDLWcKlrdcG2eA8Tw7e8RFLwd4KgjySJnRdKLXRid2qA9PNNCbi2EUgN8rAznF3CgPdgjfVqn9IBkC8CgPemsLMvkwZSDVj2R6vZ-y1ncHORG7g2xF1Rr2CsmMpw4x1hOPGhDCYyhXEVa45Md4kT3pSUIcBmT03ZnpJmWcWYcg9HwzmPpubozFp+HOv4YYi3cAIsCgcpYwVlvBBWGllZuxwhDB0rCdziiGmvUaMFja6n1BbLUOtFz5k8LbfM9tDbOxoanbRHsNIl19rJUSAcO7CmDmpMOOk9LRzkbHfg5kE5WRsndKc0h058VclIvAAsCB5zBoXIKYcwoRwitcSupNq74FrolZKgDzyIOQW3Umxx+C4GNPGFwdZyphAHjVX69VR46CanETwk9cSdRnnPfI28DHL11jKdehst5aypvvMA80j6+D-pkc+FwIhXBuJtO+bxZmAhBC-N+J0P6XVROiKGv9T66Bwf9LwAAxepjSBCt3AY2OpMAGkwCacQn6w9yk1geR8p57gXnpjQfnTBuicEx3wehAmwD+AkM7J7chA47LYysXgWh9l8bznYHrJhgd9GU1JGyGm3C6YMwUck1mIiOa8i5tggByTUlCzCbCxR4s-F4ugrkNR8tdGoXQm4rBjpiW7yMZMkxuQzGmwsSwTFNibYrAcVaR2zisWuNViin2UkZL+2YUHVSocQrBKjoZdlpkInx0TjE9Fac8kOkzvzGR6T3YFwIMjEu1wy65Irt2TBhSkg1wSvXRu55AWfO+fwUFaxuwgEoCAMsHhngoBAIrFh+htjYDQN-ZwbQc62C0CAFUxbdBSATeAb4xpmjmFmBEMAKBEoNoQFIIAA)) and so this is specifically an `eslint-plugin-react-hooks` regression.

Per the PR template and https://legacy.reactjs.org/docs/how-to-contribute.html, I also manually ran the related `yarn` scripts to double-check these changes passed prior to opening a PR and running CI.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
