### PR TITLE
Fix custom module preload resource tracking

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -6552,7 +6552,7 @@ function preloadModule(
           resumableState.moduleUnknownResources.hasOwnProperty(as);
         let resources;
         if (hasAsType) {
-          resources = resumableState.unknownResources[as];
+          resources = resumableState.moduleUnknownResources[as];
           if (resources.hasOwnProperty(key)) {
             // we can return if we already have this resource
             return;

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -6532,6 +6532,26 @@ body {
       );
     });
 
+    it('preloads multiple modules with the same custom as value', async () => {
+      function App() {
+        ReactDOM.preloadModule('worker-a', {as: 'serviceworker'});
+        ReactDOM.preloadModule('worker-b', {as: 'serviceworker'});
+        return <div>hello</div>;
+      }
+
+      await act(() => {
+        renderToPipeableStream(<App />).pipe(writable);
+      });
+
+      expect(getMeaningfulChildren(document.body)).toEqual(
+        <div id="container">
+          <link rel="modulepreload" href="worker-a" as="serviceworker" />
+          <link rel="modulepreload" href="worker-b" as="serviceworker" />
+          <div>hello</div>
+        </div>,
+      );
+    });
+
     it('warns if you provide invalid arguments', async () => {
       function App() {
         ReactDOM.preloadModule();


### PR DESCRIPTION
## Summary

Fixes #36440.

`ReactDOM.preloadModule()` stores non-default `as` values in `moduleUnknownResources`, but the repeated custom-`as` path read the bucket from `unknownResources`. That made the second server render call with the same custom `as` value dereference `undefined` and crash.

This updates the lookup to use `moduleUnknownResources` consistently and adds a regression test for multiple `serviceworker` module preloads.

## How did you test this change?

- `yarn test ReactDOMFloat-test --runInBand`
- `yarn test ReactDOMFloat-test --prod --runInBand`
- `yarn linc`
- `yarn prettier-check check-changed`

Also reproduced the failure before the fix with the new regression test:

```text
TypeError: Cannot read properties of undefined (reading 'hasOwnProperty')
```

`yarn prettier-check` without `check-changed` was attempted, but it exhausted the Node heap while scanning the full repository under Node 22.22.0. The changed-file formatter check passed for this diff.
