### PR TITLE
fix(shared): wrap addObjectToProperties in try-catch to handle cross-origin SecurityError

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactPerformanceTrack-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactPerformanceTrack-test.js
@@ -629,4 +629,97 @@ describe('ReactPerformanceTracks', () => {
       ],
     ]);
   });
+
+  // @gate __DEV__ && enableComponentPerformanceTrack
+  it('does not throw SecurityError when a cross-origin Window is passed as a prop', async () => {
+    // Simulate a cross-origin Window whose property enumeration throws SecurityError,
+    // as happens in browsers when a component receives an iframe.contentWindow
+    // from an iframe with a null/cross origin (e.g. srcdoc="").
+    const createCrossOriginWindow = () => {
+      return new Proxy(
+        {},
+        {
+          ownKeys() {
+            // In browsers, `for...in` on a cross-origin Window throws SecurityError.
+            // We simulate that here so the test can run in JSDOM.
+            throw new Error(
+              "Failed to enumerate the properties of 'Window': " +
+                'cross-origin access blocked.',
+            );
+          },
+          getOwnPropertyDescriptor(target, prop) {
+            throw new Error(
+              `Failed to read a named property '${String(prop)}' from 'Window': ` +
+                'cross-origin access blocked.',
+            );
+          },
+          get(target, prop) {
+            if (prop === Symbol.toStringTag) {
+              return 'Window';
+            }
+            throw new Error(
+              `Failed to read a named property '${String(prop)}' from 'Window': ` +
+                'cross-origin access blocked.',
+            );
+          },
+        },
+      );
+    };
+
+    const crossOriginWin = createCrossOriginWindow();
+
+    const App = function App({win}) {
+      Scheduler.unstable_advanceTime(10);
+      return null;
+    };
+
+    // This should not throw SecurityError and must not corrupt the fiber tree.
+    await act(() => {
+      ReactNoop.render(<App win={crossOriginWin} />);
+    });
+
+    // First render: mount measure should be recorded.
+    expect(performanceMeasureCalls).toEqual([
+      [
+        'Mount',
+        {
+          detail: {
+            devtools: {
+              color: 'warning',
+              properties: null,
+              tooltipText: 'Mount',
+              track: 'Components ⚛',
+            },
+          },
+          end: 10,
+          start: 0,
+        },
+      ],
+    ]);
+    performanceMeasureCalls.length = 0;
+
+    // Verify the UI remains responsive by re-rendering with a new cross-origin
+    // Window instance (different reference forces React to diff the win prop).
+    const crossOriginWin2 = createCrossOriginWindow();
+    Scheduler.unstable_advanceTime(10);
+    await act(() => {
+      ReactNoop.render(<App win={crossOriginWin2} />);
+    });
+
+    // Second render: App measure should be recorded. The cross-origin Window
+    // props should appear as '[CrossOriginObject]' placeholders — not throw
+    // SecurityError or corrupt the fiber tree.
+    expect(performanceMeasureCalls).toHaveLength(1);
+    const [measureName, measureOptions] = performanceMeasureCalls[0];
+    // Component-update measures are prefixed with a zero-width space (\u200b).
+    expect(measureName).toBe('\u200bApp');
+    expect(measureOptions.detail.devtools.tooltipText).toBe('App');
+    // The cross-origin Window must degrade to '[CrossOriginObject]', not throw.
+    const properties = measureOptions.detail.devtools.properties;
+    expect(properties).not.toBeNull();
+    const hasCrossOriginPlaceholder = properties.some(([key]) =>
+      key.includes('[CrossOriginObject]'),
+    );
+    expect(hasCrossOriginPlaceholder).toBe(true);
+  });
 });

--- a/packages/shared/ReactPerformanceTrackProperties.js
+++ b/packages/shared/ReactPerformanceTrackProperties.js
@@ -62,31 +62,49 @@ export function addObjectToProperties(
   prefix: string,
 ): void {
   let addedProperties = 0;
-  for (const key in object) {
-    if (hasOwnProperty.call(object, key) && key[0] !== '_') {
-      addedProperties++;
-      const value = object[key];
-      addValueToProperties(key, value, properties, indent, prefix);
-      if (addedProperties >= OBJECT_WIDTH_LIMIT) {
-        properties.push([
-          prefix +
-            '\xa0\xa0'.repeat(indent) +
-            'Only ' +
-            OBJECT_WIDTH_LIMIT +
-            ' properties are shown. React will not log more properties of this object.',
-          '',
-        ]);
-        break;
+  try {
+    for (const key in object) {
+      if (hasOwnProperty.call(object, key) && key[0] !== '_') {
+        addedProperties++;
+        const value = object[key];
+        addValueToProperties(key, value, properties, indent, prefix);
+        if (addedProperties >= OBJECT_WIDTH_LIMIT) {
+          properties.push([
+            prefix +
+              '\xa0\xa0'.repeat(indent) +
+              'Only ' +
+              OBJECT_WIDTH_LIMIT +
+              ' properties are shown. React will not log more properties of this object.',
+            '',
+          ]);
+          break;
+        }
       }
+    }
+  } catch (e) {
+    // Cross-origin objects (e.g. a Window from a cross-origin iframe) throw
+    // SecurityError when their properties are enumerated. Treat the object as
+    // opaque so the render-logger never corrupts the fiber tree.
+    if (addedProperties === 0) {
+      properties.push([
+        prefix + '\xa0\xa0'.repeat(indent) + '[CrossOriginObject]',
+        '',
+      ]);
     }
   }
 }
 
 function readReactElementTypeof(value: Object): mixed {
-  // Prevents dotting into $$typeof in opaque origin windows.
-  return '$$typeof' in value && hasOwnProperty.call(value, '$$typeof')
-    ? value.$$typeof
-    : undefined;
+  try {
+    // Prevents dotting into $$typeof in opaque origin windows.
+    return '$$typeof' in value && hasOwnProperty.call(value, '$$typeof')
+      ? value.$$typeof
+      : undefined;
+  } catch (e) {
+    // Cross-origin objects (e.g. a Window from a cross-origin iframe) throw
+    // SecurityError on any property access. Treat as non-React-element.
+    return undefined;
+  }
 }
 
 export function addValueToProperties(


### PR DESCRIPTION
## Summary

In React 19.2 DEV builds, `logComponentRender` (called from `commitPassiveMountOnFiber`) calls `addObjectToProperties` which performs an unguarded `for...in` over every prop value. When a component receives a cross-origin `Window` object (e.g. `iframe.contentWindow` with `srcdoc=""` / null origin) as a prop, the enumeration throws `SecurityError` in browsers that enforce the same-origin policy.

This `SecurityError` propagates out of the commit phase and leaves the work-in-progress fiber broken, causing all subsequent renders to throw `Should not already be working.` and making the UI completely unresponsive.

## Root Cause

`addObjectToProperties` in `packages/shared/ReactPerformanceTrackProperties.js` runs `for (const key in object)` without any error guard. For a cross-origin `Window` (null origin iframe), browsers block property enumeration and throw `SecurityError`. Since this error is not caught, it escapes the commit phase and corrupts the fiber tree.

Similarly, `readReactElementTypeof` accesses `'2796107typeof' in value` without a guard, which can also throw for cross-origin objects.

## Fix

- Wrap the `for...in` loop in `addObjectToProperties` with try-catch. On SecurityError, show `[CrossOriginObject]` as a placeholder so the render-logger degrades gracefully without corrupting the fiber.
- Wrap the `in` / hasOwnProperty checks in `readReactElementTypeof` with try-catch so `$$typeof` access never escapes either.

Both are DEV-only diagnostic paths and must not affect production builds or corrupt fiber state when iterating untrusted props.

## Test

Added a new test in `ReactPerformanceTrack-test.js` that simulates a cross-origin `Window` via a Proxy whose `ownKeys` and `getOwnPropertyDescriptor` traps throw, verifying that:
1. The render completes without throwing
2. Subsequent renders succeed (fiber tree not corrupted)

Fixes #36430