### PR TITLE
[compiler] Fix refs lint false positive for props.ref forwarding

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
@@ -150,9 +150,15 @@ function collectTemporariesSidemap(fn: HIRFunction, env: Env): void {
           break;
         }
         case 'PropertyLoad': {
+          /*
+           * Ref-typed property loads (for example props.ref) should keep their
+           * declared ref type instead of aliasing the containing object.
+           */
           if (
-            isUseRefType(value.object.identifier) &&
-            value.property === 'current'
+            (isUseRefType(value.object.identifier) &&
+              value.property === 'current') ||
+            isUseRefType(lvalue.identifier) ||
+            isRefValueType(lvalue.identifier)
           ) {
             continue;
           }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-props-property-access-after-ref-prop.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-props-property-access-after-ref-prop.expect.md
@@ -1,0 +1,56 @@
+
+## Input
+
+```javascript
+// @validateRefAccessDuringRender @compilationMode:"infer"
+
+function Component(props) {
+  return (
+    <Field
+      name={props.name}
+      ref={props.ref}
+      placeholder={props.placeholder}
+      disabled={props.disabled}
+    />
+  );
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRender @compilationMode:"infer"
+
+function Component(props) {
+  const $ = _c(5);
+  let t0;
+  if (
+    $[0] !== props.disabled ||
+    $[1] !== props.name ||
+    $[2] !== props.placeholder ||
+    $[3] !== props.ref
+  ) {
+    t0 = (
+      <Field
+        name={props.name}
+        ref={props.ref}
+        placeholder={props.placeholder}
+        disabled={props.disabled}
+      />
+    );
+    $[0] = props.disabled;
+    $[1] = props.name;
+    $[2] = props.placeholder;
+    $[3] = props.ref;
+    $[4] = t0;
+  } else {
+    t0 = $[4];
+  }
+  return t0;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-props-property-access-after-ref-prop.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-props-property-access-after-ref-prop.tsx
@@ -1,0 +1,12 @@
+// @validateRefAccessDuringRender @compilationMode:"infer"
+
+function Component(props) {
+  return (
+    <Field
+      name={props.name}
+      ref={props.ref}
+      placeholder={props.placeholder}
+      disabled={props.disabled}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Fixes a false positive in the refs validation used by `eslint-plugin-react-hooks` where forwarding `props.ref` through JSX could cause sibling `props.*` reads to be treated as ref accesses.

The ref validation temporary sidemap now keeps ref-typed property loads such as `props.ref` as their declared ref type instead of aliasing them back to the containing object. This preserves diagnostics for direct `props.ref.current` updates while allowing ordinary sibling prop reads in JSX.

Adds a compiler fixture covering JSX forwarding of `props.ref` alongside sibling props.

Fixes #34775

Related: #36416 appears to address the same class of issue; this PR keeps the narrower regression case isolated.

## How did you test this change?

- `corepack yarn prettier --check packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-props-property-access-after-ref-prop.tsx`
- `node ../snap/dist/main.js test --worker-threads false --pattern allow-props-property-access-after-ref-prop` showed `1 Tests, 1 Passed, 0 Failed` before the local snap runner shutdown error `Farm is ended, no more calls can be done to it`
- `node ../snap/dist/main.js test --worker-threads false --pattern error.invalid-write-ref-prop-in-render` showed `1 Tests, 1 Passed, 0 Failed` before the same local snap runner shutdown error