### PR TITLE
perf(react-dom): bound server style name cache

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -1181,6 +1181,10 @@ function pushViewTransitionAttributes(
 }
 
 const styleNameCache: Map<string, PrecomputedChunk> = new Map();
+// Keep this cache bounded for long-running server processes. Style property
+// names are normally a small fixed set, so clearing on pathological growth
+// preserves the fast path without retaining unbounded user-generated keys.
+const MAX_STYLE_NAME_CACHE_SIZE = 1024;
 function processStyleName(styleName: string): PrecomputedChunk {
   const chunk = styleNameCache.get(styleName);
   if (chunk !== undefined) {
@@ -1189,6 +1193,9 @@ function processStyleName(styleName: string): PrecomputedChunk {
   const result = stringToPrecomputedChunk(
     escapeTextForBrowser(hyphenateStyleName(styleName)),
   );
+  if (styleNameCache.size >= MAX_STYLE_NAME_CACHE_SIZE) {
+    styleNameCache.clear();
+  }
   styleNameCache.set(styleName, result);
   return result;
 }


### PR DESCRIPTION
## Summary

This bounds the module-level `styleNameCache` used by `processStyleName` in the React DOM server renderer.

The cache normally contains a small fixed set of style property names, but it is currently unbounded for the lifetime of a long-running SSR process. This change clears the cache if it grows beyond 1024 unique keys, preserving the existing fast path for normal cases while avoiding pathological retention of unbounded user-generated style names.

## Test Plan

- Not run locally yet; opening as draft for initial feedback.
- Intended checks before marking ready:
  - `yarn test packages/react-dom`
  - relevant React DOM server/Fizz tests
  - microbenchmark if maintainers want data for the cache cap tradeoff

## Notes

I chose a simple clear-on-limit strategy instead of LRU to avoid adding per-access overhead to the hot path.
