### PR TITLE
fix(devtools): preserve compiler badge for nested Forget names

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -11,7 +11,9 @@ import {
   getDisplayName,
   getDisplayNameForReactElement,
   isPlainObject,
+  parseElementDisplayNameFromBackend,
 } from 'react-devtools-shared/src/utils';
+import {ElementTypeMemo} from 'react-devtools-shared/src/frontend/types';
 import {stackToComponentLocations} from 'react-devtools-shared/src/devtools/utils';
 import {
   formatConsoleArguments,
@@ -79,6 +81,21 @@ describe('utils', () => {
         ['div', null],
         ['App', null],
       ]);
+    });
+  });
+
+  describe('parseElementDisplayNameFromBackend', () => {
+    it('should identify Forget inside HOC wrappers', () => {
+      expect(
+        parseElementDisplayNameFromBackend(
+          'Memo(Forget(Example))',
+          ElementTypeMemo,
+        ),
+      ).toEqual({
+        formattedDisplayName: 'Example',
+        hocDisplayNames: ['Memo'],
+        compiledWithForget: true,
+      });
     });
   });
 

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -596,11 +596,25 @@ export function parseElementDisplayNameFromBackend(
       break;
   }
 
+  let compiledWithForget = false;
+  if (hocDisplayNames !== null) {
+    const forgetIndex = hocDisplayNames.indexOf('Forget');
+    if (forgetIndex >= 0) {
+      compiledWithForget = true;
+      hocDisplayNames = hocDisplayNames.filter(
+        hocDisplayName => hocDisplayName !== 'Forget',
+      );
+      if (hocDisplayNames.length === 0) {
+        hocDisplayNames = null;
+      }
+    }
+  }
+
   return {
     // $FlowFixMe[incompatible-return]
     formattedDisplayName: displayName,
     hocDisplayNames,
-    compiledWithForget: false,
+    compiledWithForget,
   };
 }
 


### PR DESCRIPTION
## Summary
- detect the DevTools Forget marker when it appears inside parsed HOC wrappers, e.g. `Memo(Forget(Component))`
- remove the synthetic `Forget` wrapper from `hocDisplayNames` so the existing compiler badge renders instead
- add a focused parser regression test for memo/Forget display names

Fixes #32485.

## Test Plan
- Not run locally; API-only patch prepared without a full React checkout.
- Added `parseElementDisplayNameFromBackend` unit coverage in `packages/react-devtools-shared/src/__tests__/utils-test.js`.
