### PR TITLE
[rust-compiler] Dedup async-reassignment immutability diagnostic

### DIFF
--- a/compiler/crates/react_compiler_validation/src/validate_locals_not_reassigned_after_render.rs
+++ b/compiler/crates/react_compiler_validation/src/validate_locals_not_reassigned_after_render.rs
@@ -158,6 +158,7 @@ fn get_context_reassignment(
                                 }),
                             );
                             // Return null (don't propagate further) — matches TS behavior
+                            return None;
                         } else {
                             // Propagate reassignment info on the lvalue
                             reassigning_functions

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-reassign-local-variable-in-multiple-async-callbacks.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-reassign-local-variable-in-multiple-async-callbacks.expect.md
@@ -1,0 +1,51 @@
+
+## Input
+
+```javascript
+function Component() {
+	let value: number | undefined;
+	const a = async () => {
+		value = 1;
+	};
+	const b = async () => {
+		value = 2;
+	};
+	return <div>{[a, b]}</div>;
+}
+
+```
+
+
+## Error
+
+```
+Found 2 errors:
+
+Error: Cannot reassign variable in async function
+
+Reassigning a variable in an async function can cause inconsistent behavior on subsequent renders. Consider using state instead.
+
+error.invalid-reassign-local-variable-in-multiple-async-callbacks.ts:4:2
+  2 | 	let value: number | undefined;
+  3 | 	const a = async () => {
+> 4 | 		value = 1;
+    | 		^^^^^ Cannot reassign `value`
+  5 | 	};
+  6 | 	const b = async () => {
+  7 | 		value = 2;
+
+Error: Cannot reassign variable in async function
+
+Reassigning a variable in an async function can cause inconsistent behavior on subsequent renders. Consider using state instead.
+
+error.invalid-reassign-local-variable-in-multiple-async-callbacks.ts:7:2
+   5 | 	};
+   6 | 	const b = async () => {
+>  7 | 		value = 2;
+     | 		^^^^^ Cannot reassign `value`
+   8 | 	};
+   9 | 	return <div>{[a, b]}</div>;
+  10 | }
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-reassign-local-variable-in-multiple-async-callbacks.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-reassign-local-variable-in-multiple-async-callbacks.expect.md
@@ -19,7 +19,7 @@ function Component() {
 ## Error
 
 ```
-Found 2 errors:
+Found 1 error:
 
 Error: Cannot reassign variable in async function
 
@@ -33,19 +33,6 @@ error.invalid-reassign-local-variable-in-multiple-async-callbacks.ts:4:2
   5 | 	};
   6 | 	const b = async () => {
   7 | 		value = 2;
-
-Error: Cannot reassign variable in async function
-
-Reassigning a variable in an async function can cause inconsistent behavior on subsequent renders. Consider using state instead.
-
-error.invalid-reassign-local-variable-in-multiple-async-callbacks.ts:7:2
-   5 | 	};
-   6 | 	const b = async () => {
->  7 | 		value = 2;
-     | 		^^^^^ Cannot reassign `value`
-   8 | 	};
-   9 | 	return <div>{[a, b]}</div>;
-  10 | }
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-reassign-local-variable-in-multiple-async-callbacks.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-reassign-local-variable-in-multiple-async-callbacks.tsx
@@ -1,0 +1,10 @@
+function Component() {
+	let value: number | undefined;
+	const a = async () => {
+		value = 1;
+	};
+	const b = async () => {
+		value = 2;
+	};
+	return <div>{[a, b]}</div>;
+}


### PR DESCRIPTION
## Bug
`validate_locals_not_reassigned_after_render` emitted the same
`Cannot reassign variable in async function` diagnostic once per
async function body that reassigned the same outer `let`. The TS
reference emits it exactly once per offending variable.

Reproducer (both compilers, `panicThreshold: 'none'`):

```tsx
function Component() {
	let value: number | undefined;
	const a = async () => { value = 1; };
	const b = async () => { value = 2; };
	return <div>{[a, b]}</div>;
}
```

Before: TS emits 1 error, Rust emits 2.
After: both emit 1.

## Root cause
`crates/react_compiler_validation/src/validate_locals_not_reassigned_after_render.rs` is a faithful port of the TS pass, except the inner-function async-reassignment branch is missing the early return. The TS reference does `env.recordError(...); return null;`. The Rust code recorded the diagnostic then fell through into the next loop iteration, so the next async function body got the same emit path.

There was even a `// Return null (don't propagate further) — matches TS behavior` comment in place of the missing return.

## Fix
Replace the comment with the actual `return None;`. One-line change.

## How I found it
TS-vs-Rust differential sweep over a large real-world TSX corpus (~59k files), comparing the in-repo TS compiler vs the Rust port. Among 14k+ error events, this duplicate emission was the most concentrated divergence cluster.

## Verification
- New fixture `error.invalid-reassign-local-variable-in-multiple-async-callbacks.tsx`: `yarn snap` and `yarn snap --rust` both pass (1 error each).
- The existing `error.invalid-reassign-local-variable-in-async-callback.js` fixture still passes.
- Full `yarn snap --rust`: 1782/1794 (+1 vs main, no regression in the 12 known frontier failures).

## Commit order
1. Adds the fixture with the broken-Rust baseline (`Found 2 errors`). `yarn snap --rust` passes against it, `yarn snap` fails — captures the bug.
2. Applies the one-line fix and flips the baseline to `Found 1 error`. Both `yarn snap` and `yarn snap --rust` pass.