### PR TITLE
[rust-compiler] Fix non-exhaustive PatternLike match in scope_resolution test

### DIFF
--- a/compiler/crates/react_compiler_ast/tests/scope_resolution.rs
+++ b/compiler/crates/react_compiler_ast/tests/scope_resolution.rs
@@ -746,6 +746,21 @@ fn visit_pat(pat: &mut PatternLike, si: &ScopeInfo) {
             visit_expr(&mut e.object, si);
             visit_expr(&mut e.property, si);
         }
+        PatternLike::TSAsExpression(e) => {
+            visit_expr(&mut e.expression, si);
+            visit_json(&mut e.type_annotation, si);
+        }
+        PatternLike::TSSatisfiesExpression(e) => {
+            visit_expr(&mut e.expression, si);
+            visit_json(&mut e.type_annotation, si);
+        }
+        PatternLike::TSNonNullExpression(e) => {
+            visit_expr(&mut e.expression, si);
+        }
+        PatternLike::TSTypeAssertion(e) => {
+            visit_expr(&mut e.expression, si);
+            visit_json(&mut e.type_annotation, si);
+        }
     }
 }
 


### PR DESCRIPTION
## What

`cargo test --workspace` (and `cargo test -p react_compiler_ast`) currently fails to compile on `pr-36173`:

```
error[E0004]: non-exhaustive patterns: `&mut PatternLike::TSAsExpression(_)`,
  `&mut PatternLike::TSSatisfiesExpression(_)`, `&mut PatternLike::TSNonNullExpression(_)`
  and 1 more not covered
   --> crates/react_compiler_ast/tests/scope_resolution.rs:711:11
```

The `visit_pat` helper in the `scope_resolution` integration test was not updated when #36492 added four TS cast-wrapper variants to `PatternLike` (`TSAsExpression`, `TSSatisfiesExpression`, `TSNonNullExpression`, `TSTypeAssertion`) to support TS cast wrappers as assignment targets.

This PR adds those four arms to the test helper, mirroring exactly how `visit_expr` in the same file already handles these same wrapper types: descend into the inner `Expression` with `visit_expr`, and visit the type annotation JSON (where present) with `visit_json`.

## Why

The Rust unit-test suite is currently zero-signal — `cargo test --workspace` cannot even compile, let alone run. This change restores it.

## Test plan

- [x] `cargo test --workspace` compiles cleanly
- [x] `cargo test --workspace` → 56 passed, 0 failed, 0 ignored
- [x] No changes to non-test code; isolated to one test helper