### PR TITLE
[rust-compiler] Fix off-by-one in SWC source-location conversion

### DIFF
--- a/compiler/crates/react_compiler_swc/src/convert_ast.rs
+++ b/compiler/crates/react_compiler_swc/src/convert_ast.rs
@@ -196,16 +196,19 @@ impl<'a> ConvertCtx<'a> {
         }
     }
 
+    /// `BytePos` is 1-based; emit 0-based `loc` to match Babel.
+    /// (`BaseNode.start`/`end` stays 1-based: `convert_scope` keys on it.)
     fn position(&self, offset: u32) -> Position {
-        let line_idx = match self.line_offsets.binary_search(&offset) {
+        let zero_based = offset.saturating_sub(1);
+        let line_idx = match self.line_offsets.binary_search(&zero_based) {
             Ok(idx) => idx,
             Err(idx) => idx.saturating_sub(1),
         };
         let line_start = self.line_offsets[line_idx];
         Position {
             line: (line_idx as u32) + 1,
-            column: offset - line_start,
-            index: Some(offset),
+            column: zero_based - line_start,
+            index: Some(zero_based),
         }
     }
 

--- a/compiler/scripts/test-e2e.ts
+++ b/compiler/scripts/test-e2e.ts
@@ -484,11 +484,9 @@ async function runVariant(
   for (let i = 0; i < fixtureInfos.length; i++) {
     const {fixturePath, relPath, source, firstLine, isFlow} = fixtureInfos[i];
     const tsCode = tsBaselines.get(fixturePath)!;
-    // TS baseline uses Babel (0-based columns), no adjustment needed
+    // All variants emit 0-based columns/indices.
     oneBasedColumns = false;
     const tsEvents = normalizeEvents(tsRawEvents.get(fixturePath)!);
-    // SWC uses 1-based columns/indices (BytePos); OXC is 0-based like Babel
-    oneBasedColumns = variant === 'swc';
 
     writeProgress(
       `  ${variant}: ${i + 1}/${fixtureInfos.length} (${s.passed} passed, ${s.failed} failed)`,


### PR DESCRIPTION
## What

`position()` in the SWC `convert_ast` was binary-searching SWC's 1-based `BytePos` against the 0-based `line_offsets` table, producing `loc.{start,end}.{line,column,index}` values that were off by 1 in events. When the referenced byte happened to fall just before a `\n`, the result flipped to "next line, column 0", e.g. TS reports `line: 3, column: 18` and SWC reported `line: 4, column: 0` for the same source position.

## Fix

Shift the offset down by 1 (saturating, to keep DUMMY spans at 0) before the line lookup. `BaseNode.start`/`end` keeps the SWC-native 1-based value because `convert_scope` keys its `node_to_scope` map on `span.lo.0` and the HIR builder looks it up via `base.start`; changing those would require updating both `convert_scope` and the reverse converter together. Doing the focused fix on `loc` clears the bulk of the divergence with minimal blast radius.

Also drop the e2e harness's `oneBasedColumns = variant === 'swc'` workaround that was attempting to compensate post-hoc by subtracting 1 from `column`/`index` but couldn't handle the cases where the off-by-one had pushed the position onto a different line.

## Test plan

| Variant | Before | After | Delta |
| --- | --- | --- | --- |
| `swc` | 1682/1795 (113 failures) | 1742/1795 (53 failures) | **+60 fixed** |
| `babel` | 1788/1795 | 1788/1795 | unchanged |
| `oxc` | 1702/1795 | 1702/1795 | unchanged |

- `cargo test --workspace`: 56 passed, 0 failed (unchanged)
- The dominant remaining SWC cluster (10 source-location diffs) appears to be different bugs, not residue of this one.