### PR TITLE
[rust-compiler] Preserve TS type on SWC cast-wrapper expressions

### DIFF
--- a/compiler/crates/react_compiler_swc/src/convert_ast.rs
+++ b/compiler/crates/react_compiler_swc/src/convert_ast.rs
@@ -2073,6 +2073,39 @@ impl<'a> ConvertCtx<'a> {
         }
     }
 
+    // ===== TS type JSON (binding ident annotations) =====
+
+    fn convert_ts_type_to_json(&self, ty: &swc::TsType) -> Option<serde_json::Value> {
+        match ty {
+            swc::TsType::TsKeywordType(k)
+                if k.kind == swc::TsKeywordTypeKind::TsNumberKeyword =>
+            {
+                Some(serde_json::json!({ "type": "TSNumberKeyword" }))
+            }
+            // Skip generics: `convert_ts_type_annotation_from_json` ignores
+            // type params, so silently emitting `Foo` for `Foo<T>` loses
+            // information. Fall back to `Null` instead.
+            swc::TsType::TsTypeRef(r) if r.type_params.is_none() => match &r.type_name {
+                swc::TsEntityName::Ident(id) => Some(serde_json::json!({
+                    "type": "TSTypeReference",
+                    "typeName": {
+                        "type": "Identifier",
+                        "name": id.sym.to_string()
+                    }
+                })),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn convert_ts_type_ann_to_json(&self, ann: &swc::TsTypeAnn) -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "type": "TSTypeAnnotation",
+            "typeAnnotation": self.convert_ts_type_to_json(&ann.type_ann)?,
+        }))
+    }
+
     // ===== Identifiers =====
 
     fn convert_ident_to_identifier(&self, id: &swc::Ident) -> Identifier {
@@ -2089,10 +2122,12 @@ impl<'a> ConvertCtx<'a> {
         Identifier {
             base: self.make_base_node(id.id.span),
             name: id.id.sym.to_string(),
-            type_annotation: id
-                .type_ann
-                .as_ref()
-                .map(|_| Box::new(serde_json::Value::Null)),
+            type_annotation: id.type_ann.as_ref().map(|ann| {
+                Box::new(
+                    self.convert_ts_type_ann_to_json(ann)
+                        .unwrap_or(serde_json::Value::Null),
+                )
+            }),
             optional: if id.id.optional { Some(true) } else { None },
             decorators: None,
         }

--- a/compiler/crates/react_compiler_swc/src/convert_ast.rs
+++ b/compiler/crates/react_compiler_swc/src/convert_ast.rs
@@ -717,17 +717,26 @@ impl<'a> ConvertCtx<'a> {
             swc::Expr::TsAs(e) => Expression::TSAsExpression(TSAsExpression {
                 base: self.make_base_node(e.span),
                 expression: Box::new(self.convert_expression(&e.expr)),
-                type_annotation: Box::new(serde_json::Value::Null),
+                type_annotation: Box::new(
+                    self.convert_ts_type_to_json(&e.type_ann)
+                        .unwrap_or(serde_json::Value::Null),
+                ),
             }),
             swc::Expr::TsSatisfies(e) => Expression::TSSatisfiesExpression(TSSatisfiesExpression {
                 base: self.make_base_node(e.span),
                 expression: Box::new(self.convert_expression(&e.expr)),
-                type_annotation: Box::new(serde_json::Value::Null),
+                type_annotation: Box::new(
+                    self.convert_ts_type_to_json(&e.type_ann)
+                        .unwrap_or(serde_json::Value::Null),
+                ),
             }),
             swc::Expr::TsTypeAssertion(e) => Expression::TSTypeAssertion(TSTypeAssertion {
                 base: self.make_base_node(e.span),
                 expression: Box::new(self.convert_expression(&e.expr)),
-                type_annotation: Box::new(serde_json::Value::Null),
+                type_annotation: Box::new(
+                    self.convert_ts_type_to_json(&e.type_ann)
+                        .unwrap_or(serde_json::Value::Null),
+                ),
             }),
             swc::Expr::TsNonNull(e) => Expression::TSNonNullExpression(TSNonNullExpression {
                 base: self.make_base_node(e.span),

--- a/compiler/crates/react_compiler_swc/src/convert_ast.rs
+++ b/compiler/crates/react_compiler_swc/src/convert_ast.rs
@@ -196,16 +196,19 @@ impl<'a> ConvertCtx<'a> {
         }
     }
 
+    /// `BytePos` is 1-based; emit 0-based `loc` to match Babel.
+    /// (`BaseNode.start`/`end` stays 1-based: `convert_scope` keys on it.)
     fn position(&self, offset: u32) -> Position {
-        let line_idx = match self.line_offsets.binary_search(&offset) {
+        let zero_based = offset.saturating_sub(1);
+        let line_idx = match self.line_offsets.binary_search(&zero_based) {
             Ok(idx) => idx,
             Err(idx) => idx.saturating_sub(1),
         };
         let line_start = self.line_offsets[line_idx];
         Position {
             line: (line_idx as u32) + 1,
-            column: offset - line_start,
-            index: Some(offset),
+            column: zero_based - line_start,
+            index: Some(zero_based),
         }
     }
 

--- a/compiler/crates/react_compiler_swc/src/convert_ast.rs
+++ b/compiler/crates/react_compiler_swc/src/convert_ast.rs
@@ -82,6 +82,30 @@ fn extract_comments_from_source(source: &str) -> Vec<react_compiler_ast::common:
     let bytes = source.as_bytes();
     let len = bytes.len();
     let mut i = 0;
+    let mut line_offsets = vec![0u32];
+    for (i, ch) in source.char_indices() {
+        if ch == '\n' {
+            line_offsets.push((i + 1) as u32);
+        }
+    }
+    let position = |offset: u32| {
+        let line_idx = match line_offsets.binary_search(&offset) {
+            Ok(idx) => idx,
+            Err(idx) => idx.saturating_sub(1),
+        };
+        let line_start = line_offsets[line_idx];
+        Position {
+            line: (line_idx as u32) + 1,
+            column: offset - line_start,
+            index: Some(offset),
+        }
+    };
+    let source_location = |start: u32, end: u32| SourceLocation {
+        start: position(start),
+        end: position(end),
+        filename: None,
+        identifier_name: None,
+    };
 
     while i < len {
         if bytes[i] == b'/' && i + 1 < len {
@@ -94,11 +118,12 @@ fn extract_comments_from_source(source: &str) -> Vec<react_compiler_ast::common:
                     end += 1;
                 }
                 let value = String::from_utf8_lossy(&bytes[content_start..end]).to_string();
+                let end_u32 = end as u32;
                 comments.push(Comment::CommentLine(CommentData {
                     value: value.trim().to_string(),
                     start: Some(start),
-                    end: Some(end as u32),
-                    loc: None,
+                    end: Some(end_u32),
+                    loc: Some(source_location(start, end_u32)),
                 }));
                 i = end;
                 continue;
@@ -115,11 +140,12 @@ fn extract_comments_from_source(source: &str) -> Vec<react_compiler_ast::common:
                 }
                 let value = String::from_utf8_lossy(&bytes[content_start..end]).to_string();
                 let comment_end = if end + 1 < len { end + 2 } else { end };
+                let comment_end_u32 = comment_end as u32;
                 comments.push(Comment::CommentBlock(CommentData {
                     value: value.trim().to_string(),
                     start: Some(start),
-                    end: Some(comment_end as u32),
-                    loc: None,
+                    end: Some(comment_end_u32),
+                    loc: Some(source_location(start, comment_end_u32)),
                 }));
                 i = comment_end;
                 continue;

--- a/compiler/crates/react_compiler_swc/src/lib.rs
+++ b/compiler/crates/react_compiler_swc/src/lib.rs
@@ -127,22 +127,22 @@ pub fn transform(
 
         // Fix up dummy spans on compiler-generated items: SWC codegen skips
         // comments at BytePos(0) (DUMMY), so we give generated items a real
-        // span derived from the original module's first item.
-        let has_source_items = !module.body.is_empty();
-        if has_source_items {
-            // Use a synthetic span at position 1 (minimal non-dummy position)
-            // This ensures comments can be attached to the first item.
-            let synthetic_span = swc_common::Span::new(
-                swc_common::BytePos(1),
-                swc_common::BytePos(1),
-            );
+        // span before the original module's first item.
+        let first_source_lo = module.body.first().map(|item| item.span().lo);
+        let mut top_level_comment_target = None;
+        if first_source_lo.is_some() {
+            let mut next_synthetic_pos = swc_common::BytePos(1);
             for item in &mut swc_mod.body {
                 if item.span().lo.is_dummy() {
+                    let synthetic_span =
+                        swc_common::Span::new(next_synthetic_pos, next_synthetic_pos);
+                    next_synthetic_pos = next_synthetic_pos + swc_common::BytePos(1);
                     match item {
                         swc_ecma_ast::ModuleItem::ModuleDecl(
                             swc_ecma_ast::ModuleDecl::Import(import),
                         ) => {
                             import.span = synthetic_span;
+                            top_level_comment_target = Some(import.span.hi);
                         }
                         swc_ecma_ast::ModuleItem::Stmt(
                             swc_ecma_ast::Stmt::Decl(swc_ecma_ast::Decl::Var(var)),
@@ -155,16 +155,44 @@ pub fn transform(
             }
         }
 
-        let source_comments = extract_source_comments(source_text);
-        if !source_comments.is_empty() {
+        let (source_leading_comments, source_trailing_comments) =
+            extract_source_comments(source_text);
+        if !source_leading_comments.is_empty() || !source_trailing_comments.is_empty() {
             let merged = comments.unwrap_or_default();
 
-            for (orig_pos, comment_list) in source_comments {
-                // Keep comments at their original positions. Comments
-                // attached to the first source statement will appear before
-                // the corresponding statement in the compiled output
-                // (which preserves the original import's span).
+            let source_bytes = source_text.as_bytes();
+            for (orig_pos, comment_list) in source_leading_comments {
+                // Pragma comments (e.g. `// @gating`) before the first source
+                // item need to attach AFTER any compiler-inserted imports so
+                // the gated output preserves the directive. Other leading
+                // comments (copyright, JSDoc, etc.) stay at their original
+                // position so SWC emits them before the original item.
+                let is_pragma = Some(orig_pos) == first_source_lo
+                    && comment_list
+                        .iter()
+                        .all(|c| c.text.trim_start().starts_with('@'));
+                if is_pragma {
+                    if let Some(pos) = top_level_comment_target {
+                        merged.add_trailing_comments(pos, comment_list);
+                        continue;
+                    }
+                }
                 merged.add_leading_comments(orig_pos, comment_list);
+            }
+            // Trailing comments after a `,` separator are stored by the SWC
+            // parser at the position past the comma, but codegen looks them
+            // up at the previous element's `span.hi`, which is before the
+            // comma. Shift those back by one. Trailing comments after other
+            // tokens (e.g. `;`) are already at the matching `span.hi`, so
+            // pass them through unchanged.
+            for (orig_pos, comment_list) in source_trailing_comments {
+                let idx = orig_pos.0 as usize;
+                let pos = if idx >= 2 && source_bytes.get(idx - 2) == Some(&b',') {
+                    swc_common::BytePos(orig_pos.0 - 1)
+                } else {
+                    orig_pos
+                };
+                merged.add_trailing_comments(pos, comment_list);
             }
             comments = Some(merged);
         }
@@ -861,7 +889,10 @@ fn get_first_code_line(item: &swc_ecma_ast::ModuleItem) -> String {
 /// position of the token following the comment(s).
 fn extract_source_comments(
     source_text: &str,
-) -> Vec<(swc_common::BytePos, Vec<swc_common::comments::Comment>)> {
+) -> (
+    Vec<(swc_common::BytePos, Vec<swc_common::comments::Comment>)>,
+    Vec<(swc_common::BytePos, Vec<swc_common::comments::Comment>)>,
+) {
     let cm = swc_common::sync::Lrc::new(swc_common::SourceMap::default());
     let fm = cm.new_source_file(
         swc_common::sync::Lrc::new(swc_common::FileName::Anon),
@@ -882,16 +913,21 @@ fn extract_source_comments(
         &mut errors,
     );
 
-    // Collect all leading comments
-    let mut result = Vec::new();
-    let (leading, _trailing) = comments.borrow_all();
+    let mut leading_result = Vec::new();
+    let mut trailing_result = Vec::new();
+    let (leading, trailing) = comments.borrow_all();
     for (pos, cmts) in leading.iter() {
         if !cmts.is_empty() {
-            result.push((*pos, cmts.clone()));
+            leading_result.push((*pos, cmts.clone()));
+        }
+    }
+    for (pos, cmts) in trailing.iter() {
+        if !cmts.is_empty() {
+            trailing_result.push((*pos, cmts.clone()));
         }
     }
 
-    result
+    (leading_result, trailing_result)
 }
 
 /// Normalize source code formatting to match Babel's codegen behavior.

--- a/compiler/scripts/test-e2e.ts
+++ b/compiler/scripts/test-e2e.ts
@@ -484,11 +484,9 @@ async function runVariant(
   for (let i = 0; i < fixtureInfos.length; i++) {
     const {fixturePath, relPath, source, firstLine, isFlow} = fixtureInfos[i];
     const tsCode = tsBaselines.get(fixturePath)!;
-    // TS baseline uses Babel (0-based columns), no adjustment needed
+    // All variants emit 0-based columns/indices.
     oneBasedColumns = false;
     const tsEvents = normalizeEvents(tsRawEvents.get(fixturePath)!);
-    // SWC uses 1-based columns/indices (BytePos); OXC is 0-based like Babel
-    oneBasedColumns = variant === 'swc';
 
     writeProgress(
       `  ${variant}: ${i + 1}/${fixtureInfos.length} (${s.passed} passed, ${s.failed} failed)`,


### PR DESCRIPTION
`convert_expression` had the same stub pattern for `TsAs`, `TsSatisfies`,
and `TsTypeAssertion` as `convert_binding_ident`: each set
`type_annotation: Box::new(Null)`, dropping the actual type so the
reverse converter emitted `as any` instead of `as Status`.

Apply the existing `convert_ts_type_to_json` helper at those three
call sites, with the same `unwrap_or(Null)` fallback for unhandled
shapes.

Fixes 2 e2e parity fixtures:
- ts-as-expression-default-value.tsx (`"pending" as Status`)
- ts-instantiation-default-param.tsx (`"hi" as T`)

`ts-non-null-expression-default-value.tsx` is still blocked: it uses
`ReadonlyMap<string, string>` as a binding-type annotation, which my
prior commit (cc1ba1e1) rejects via the `type_params.is_none()` guard
because the reverse converter doesn't deserialize type params either.
Supporting generics in both directions is a separate, larger change.

Test plan:
- bash compiler/scripts/test-e2e.sh --variant swc:
    Before: Total 1768/1795
    After:  Total 1770/1795 (2 fixed)
- bash compiler/scripts/test-e2e.sh --variant babel: 1788/1795 (unchanged)
- bash compiler/scripts/test-e2e.sh --variant oxc:   1702/1795 (unchanged)
- cargo test --workspace: 56 passed, 0 failed

