### PR TITLE
[rust-compiler] Treat redeclared functions as one binding in SWC scope info

### DIFF
--- a/compiler/crates/react_compiler_swc/src/convert_ast.rs
+++ b/compiler/crates/react_compiler_swc/src/convert_ast.rs
@@ -191,19 +191,27 @@ struct ConvertCtx<'a> {
     #[allow(dead_code)]
     source_text: &'a str,
     line_offsets: Vec<u32>,
+    utf16_offsets: Vec<u32>,
 }
 
 impl<'a> ConvertCtx<'a> {
     fn new(source_text: &'a str) -> Self {
         let mut line_offsets = vec![0u32];
+        let mut utf16_offsets = vec![0u32; source_text.len() + 1];
+        let mut utf16_offset = 0u32;
         for (i, ch) in source_text.char_indices() {
+            let next = i + ch.len_utf8();
+            utf16_offsets[i..next].fill(utf16_offset);
+            utf16_offset += ch.len_utf16() as u32;
             if ch == '\n' {
-                line_offsets.push((i + 1) as u32);
+                line_offsets.push(next as u32);
             }
         }
+        utf16_offsets[source_text.len()] = utf16_offset;
         Self {
             source_text,
             line_offsets,
+            utf16_offsets,
         }
     }
 
@@ -222,7 +230,7 @@ impl<'a> ConvertCtx<'a> {
         }
     }
 
-    /// `BytePos` is 1-based; emit 0-based `loc` to match Babel.
+    /// `BytePos` is 1-based; emit 0-based UTF-16 `loc` to match Babel.
     /// (`BaseNode.start`/`end` stays 1-based: `convert_scope` keys on it.)
     fn position(&self, offset: u32) -> Position {
         let zero_based = offset.saturating_sub(1);
@@ -231,10 +239,14 @@ impl<'a> ConvertCtx<'a> {
             Err(idx) => idx.saturating_sub(1),
         };
         let line_start = self.line_offsets[line_idx];
+        // Synthetic spans can point past EOF; clamp to the sentinel.
+        let byte_idx = (zero_based as usize).min(self.utf16_offsets.len() - 1);
+        let utf16_offset = self.utf16_offsets[byte_idx];
+        let line_start_utf16 = self.utf16_offsets[line_start as usize];
         Position {
             line: (line_idx as u32) + 1,
-            column: zero_based - line_start,
-            index: Some(zero_based),
+            column: utf16_offset - line_start_utf16,
+            index: Some(utf16_offset),
         }
     }
 

--- a/compiler/crates/react_compiler_swc/src/convert_scope.rs
+++ b/compiler/crates/react_compiler_swc/src/convert_scope.rs
@@ -45,6 +45,12 @@ pub fn build_scope_info(module: &Module) -> ScopeInfo {
             }
         }
 
+        // Function redeclarations: resolve the second `function x()`'s ident
+        // to the first declaration's binding (overwrites any earlier entry).
+        for (start, binding_id) in &collector.redeclaration_refs {
+            resolver.reference_to_binding.insert(*start, *binding_id);
+        }
+
         resolver.reference_to_binding
     };
 
@@ -72,6 +78,11 @@ struct ScopeCollector {
     /// Set of span starts for block statements that are direct function/catch bodies.
     /// These should NOT create a separate Block scope.
     function_body_spans: HashSet<u32>,
+    /// Function declarations that redeclare an existing hoisted name resolve to
+    /// the first binding's `BindingId` (like babel's `constantViolations`), so
+    /// the compiler treats the redeclaration as a reassignment rather than a
+    /// new binding.
+    redeclaration_refs: HashMap<u32, BindingId>,
 }
 
 impl ScopeCollector {
@@ -83,6 +94,7 @@ impl ScopeCollector {
             node_to_scope_end: HashMap::new(),
             scope_stack: Vec::new(),
             function_body_spans: HashSet::new(),
+            redeclaration_refs: HashMap::new(),
         }
     }
 
@@ -344,14 +356,20 @@ impl Visit for ScopeCollector {
         let hoist_scope = self.enclosing_function_scope();
         let name = fn_decl.ident.sym.to_string();
         let start = fn_decl.ident.span.lo.0;
-        self.add_binding(
-            name,
-            BindingKind::Hoisted,
-            hoist_scope,
-            "FunctionDeclaration".to_string(),
-            Some(start),
-            None,
-        );
+        if let Some(&existing_id) =
+            self.scopes[hoist_scope.0 as usize].bindings.get(&name)
+        {
+            self.redeclaration_refs.insert(start, existing_id);
+        } else {
+            self.add_binding(
+                name,
+                BindingKind::Hoisted,
+                hoist_scope,
+                "FunctionDeclaration".to_string(),
+                Some(start),
+                None,
+            );
+        }
 
         self.visit_function_inner(&fn_decl.function);
     }


### PR DESCRIPTION
`convert_scope.rs::visit_fn_decl` allocated a fresh `BindingId` for
every `function x()` declaration. Babel and OXC collapse same-named
function declarations in the same hoist scope into one binding, with
the second declaration registered as a `constantViolations` reference
(reassignment) rather than a new binding.

For `function-declaration-redeclare.js` the SWC variant emitted
`const x_0 = t0; return x_0;` because the compiler saw two distinct
bindings and renamed one. Babel's output is `let x; ... x = t0;
return x;` because there is one binding that gets reassigned.

In `visit_fn_decl`, check whether the hoist scope already has a
binding for the name. If yes, record the redeclaration's ident
position in a new `redeclaration_refs` map and skip adding a fresh
binding. `build_scope_info` overlays this map onto
`reference_to_binding` so the second function's ident resolves to the
first binding's `BindingId`.

Fixes 1 e2e parity fixture:
- function-declaration-redeclare.js

`valid-setState-in-effect-from-ref-function-call.js` and its sibling
`valid-setState-in-useEffect-controlled-by-ref-value.js` still fail.
Those have a distinct root cause: the SWC frontend discards the
compiler's `renames` output (`lib.rs:91-98`) instead of applying it
to the emitted SWC AST the way the babel adapter does via
`applyRenames`. That fix is its own commit.

Test plan:
- bash compiler/scripts/test-e2e.sh --variant swc:
    Before: Total 1774/1795
    After:  Total 1775/1795 (1 fixed)
- bash compiler/scripts/test-e2e.sh --variant babel: 1788/1795 (unchanged)
- bash compiler/scripts/test-e2e.sh --variant oxc:   1702/1795 (unchanged)
- cargo test --workspace: 56 passed, 0 failed

