### PR TITLE
Fix typos in source code comments

### DIFF
--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -1079,7 +1079,7 @@ export default class Agent extends EventEmitter<{
 
       // Due to the component filters changing, we might be able
       // to select a closer match for the currently selected host element.
-      // The store will already select a suitable parent if the the current
+      // The store will already select a suitable parent if the current
       // selection is now filtered out in which cases this will be a no-op.
       const target = window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0;
       if (target != null) {

--- a/packages/react-devtools-shared/src/backend/fiber/DevToolsFiberComponentStack.js
+++ b/packages/react-devtools-shared/src/backend/fiber/DevToolsFiberComponentStack.js
@@ -204,7 +204,7 @@ export function getOwnerStackByFiberInDev(
         // In a real app it's typically not useful since the root app is always controlled
         // by the framework. These also tend to have noisy stacks because they're not rooted
         // in a React render but in some imperative bootstrapping code. It could be useful
-        // if the element was created in module scope. E.g. hoisted. We could add a a single
+        // if the element was created in module scope. E.g. hoisted. We could add a single
         // stack frame for context for example but it doesn't say much if that's a wrapper.
         if (owner && debugStack) {
           if (typeof debugStack !== 'string') {

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -3686,7 +3686,7 @@ function pushStartHead(
     );
   } else {
     // This <head> is deep and is likely just an error. we emit it inline though.
-    // Validation should warn that this tag is the the wrong spot.
+    // Validation should warn that this tag is in the wrong spot.
     return pushStartGenericElement(target, props, 'head', formatContext);
   }
 }
@@ -3720,7 +3720,7 @@ function pushStartBody(
     );
   } else {
     // This <head> is deep and is likely just an error. we emit it inline though.
-    // Validation should warn that this tag is the the wrong spot.
+    // Validation should warn that this tag is in the wrong spot.
     return pushStartGenericElement(target, props, 'body', formatContext);
   }
 }
@@ -3754,7 +3754,7 @@ function pushStartHtml(
     );
   } else {
     // This <html> is deep and is likely just an error. we emit it inline though.
-    // Validation should warn that this tag is the the wrong spot.
+    // Validation should warn that this tag is in the wrong spot.
     return pushStartGenericElement(target, props, 'html', formatContext);
   }
 }

--- a/packages/react-reconciler/src/ReactFiberAsyncAction.js
+++ b/packages/react-reconciler/src/ReactFiberAsyncAction.js
@@ -143,7 +143,7 @@ export function chainThenableValue<T>(
   result: T,
 ): Thenable<T> {
   // Equivalent to: Promise.resolve(thenable).then(() => result), except we can
-  // cheat a bit since we know that that this thenable is only ever consumed
+  // cheat a bit since we know that this thenable is only ever consumed
   // by React.
   //
   // We don't technically require promise support on the client yet, hence this

--- a/packages/react-reconciler/src/ReactFiberComponentStack.js
+++ b/packages/react-reconciler/src/ReactFiberComponentStack.js
@@ -182,7 +182,7 @@ export function getOwnerStackByFiberInDev(workInProgress: Fiber): string {
         // In a real app it's typically not useful since the root app is always controlled
         // by the framework. These also tend to have noisy stacks because they're not rooted
         // in a React render but in some imperative bootstrapping code. It could be useful
-        // if the element was created in module scope. E.g. hoisted. We could add a a single
+        // if the element was created in module scope. E.g. hoisted. We could add a single
         // stack frame for context for example but it doesn't say much if that's a wrapper.
         if (owner && debugStack) {
           const formattedStack = formatOwnerStack(debugStack);

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -2014,7 +2014,7 @@ function rerenderOptimistic<S, A>(
   // the passthrough value changed.
   //
   // So instead of a forked re-render implementation that knows how to handle
-  // render phase udpates, we can use the same implementation as during a
+  // render phase updates, we can use the same implementation as during a
   // regular mount or update.
   const hook = updateWorkInProgressHook();
 
@@ -2527,7 +2527,7 @@ function rerenderActionState<S, P>(
   // the passthrough value changed.
   //
   // So instead of a forked re-render implementation that knows how to handle
-  // render phase udpates, we can use the same implementation as during a
+  // render phase updates, we can use the same implementation as during a
   // regular mount or update.
   const stateHook = updateWorkInProgressHook();
   const currentStateHook = currentHook;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1923,7 +1923,7 @@ export function flushSyncFromReconciler<R>(fn: (() => R) | void): R | void {
 }
 
 // If called outside of a render or commit will flush all sync work on all roots
-// Returns whether the the call was during a render or not
+// Returns whether the call was during a render or not
 export function flushSyncWork(): boolean {
   if ((executionContext & (RenderContext | CommitContext)) === NoContext) {
     flushSyncWorkOnAllRoots();

--- a/packages/react-server/src/ReactFizzComponentStack.js
+++ b/packages/react-server/src/ReactFizzComponentStack.js
@@ -187,7 +187,7 @@ export function getOwnerStackByComponentStackNodeInDev(
       // In a real app it's typically not useful since the root app is always controlled
       // by the framework. These also tend to have noisy stacks because they're not rooted
       // in a React render but in some imperative bootstrapping code. It could be useful
-      // if the element was created in module scope. E.g. hoisted. We could add a a single
+      // if the element was created in module scope. E.g. hoisted. We could add a single
       // stack frame for context for example but it doesn't say much if that's a wrapper.
       if (owner && ownerStack) {
         info += '\n' + ownerStack;


### PR DESCRIPTION
## Summary

Fix duplicate words and misspellings in comments across multiple packages. All changes are in comments only — no logic changes.

## Changes

| File | Fix |
|------|-----|
| `ReactFiberHooks.js` | `udpates` → `updates` (2 occurrences) |
| `ReactFiberAsyncAction.js` | `that that this` → `that this` |
| `ReactFiberComponentStack.js` | `a a single` → `a single` |
| `ReactFiberWorkLoop.js` | `the the call` → `the call` |
| `ReactFizzConfigDOM.js` | `is the the wrong` → `is in the wrong` (3 occurrences) |
| `ReactFizzComponentStack.js` | `a a single` → `a single` |
| `agent.js` (devtools) | `the the current` → `the current` |
| `DevToolsFiberComponentStack.js` | `a a single` → `a single` |

## How did you test this change?

These are comment-only changes. No functional impact. Verified with `git diff` that only comments were modified.