### PR TITLE
Fix typos: duplicate words and misspellings in comments

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -2367,7 +2367,7 @@ function parseModelString(
     if (value === '$') {
       // A very common symbol.
       if (initializingHandler !== null && key === '0') {
-        // We we already have an initializing handler and we're abound to enter
+        // We already have an initializing handler and we're abound to enter
         // a new element, we need to shadow it because we're now in a new scope.
         // This is effectively the "begin" or "push" phase of Element parsing.
         // We'll pop later when we parse the array itself.

--- a/packages/react-devtools-timeline/src/import-worker/preprocessData.js
+++ b/packages/react-devtools-timeline/src/import-worker/preprocessData.js
@@ -285,7 +285,7 @@ function processEventDispatch(
 
     profilerData.nativeEvents.push(nativeEvent);
 
-    // Keep track of curent event in case future ones overlap.
+    // Keep track of current event in case future ones overlap.
     // We separate them into different vertical lanes in this case.
     state.nativeEventStack.push(nativeEvent);
   }

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -4699,7 +4699,7 @@ export function acquireSingletonInstance(
       // aligned with the actual fix you need to make so we omit the warning in this case
       !isContainerMarkedAsRoot(instance) &&
       // If this instance isn't the root but is currently owned by a different HostSingleton instance then
-      // we we need to warn that you are rendering more than one singleton at a time.
+      // we need to warn that you are rendering more than one singleton at a time.
       getInstanceFromNodeDOMTree(instance)
     ) {
       const tagName = instance.tagName.toLowerCase();

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -1097,7 +1097,7 @@ export function getBumpedLaneForHydration(
     (renderLane & SyncUpdateLanes) !== NoLane
       ? // Unify sync lanes. We don't do this inside getBumpedLaneForHydrationByLane
         // because that causes things to flush synchronously when they shouldn't.
-        // TODO: This is not coherent but that's beacuse the unification is not coherent.
+        // TODO: This is not coherent but that's because the unification is not coherent.
         // We need to get merge these into an actual single lane.
         SyncHydrationLane
       : getBumpedLaneForHydrationByLane(renderLane);

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -332,7 +332,7 @@ export function createHydrationContainer(
   root.context = getContextForSubtree(null);
 
   // Schedule the initial render. In a hydration root, this is different from
-  // a regular update because the initial render must match was was rendered
+  // a regular update because the initial render must match what was rendered
   // on the server.
   // NOTE: This update intentionally doesn't have a payload. We're only using
   // the update to schedule work on the root fiber (and, for legacy roots, to

--- a/packages/react-reconciler/src/ReactFiberSuspenseContext.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseContext.js
@@ -112,7 +112,7 @@ export function pushDehydratedActivitySuspenseHandler(fiber: Fiber): void {
   // dehydrated if it suspends.
   // A SuspenseList context is only pushed here to avoid a push/pop mismatch.
   // Reuse the current value on the stack.
-  // TODO: We can avoid needing to push here by by forking popSuspenseHandler
+  // TODO: We can avoid needing to push here by forking popSuspenseHandler
   // into separate functions for Activity, Suspense and Offscreen.
   push(suspenseStackCursor, suspenseStackCursor.current, fiber);
   push(suspenseHandlerStackCursor, fiber, fiber);
@@ -126,7 +126,7 @@ export function pushOffscreenSuspenseHandler(fiber: Fiber): void {
   if (fiber.tag === OffscreenComponent) {
     // A SuspenseList context is only pushed here to avoid a push/pop mismatch.
     // Reuse the current value on the stack.
-    // TODO: We can avoid needing to push here by by forking popSuspenseHandler
+    // TODO: We can avoid needing to push here by forking popSuspenseHandler
     // into separate functions for Activity, Suspense and Offscreen.
     push(suspenseStackCursor, suspenseStackCursor.current, fiber);
     push(suspenseHandlerStackCursor, fiber, fiber);


### PR DESCRIPTION
## Summary

Fix duplicate words and misspellings in source code comments across multiple packages.

## Changes

| File | Fix |
|------|-----|
| `ReactFiberSuspenseContext.js` | `by by` → `by` (2 occurrences) |
| `ReactFlightClient.js` | `We we` → `We` |
| `ReactFiberConfigDOM.js` | `we we` → `we` |
| `ReactFiberLane.js` | `beacuse` → `because` |
| `ReactFiberReconciler.js` | `was was` → `what was` |
| `preprocessData.js` | `curent` → `current` |

## How did you test this change?

These are comment-only changes with no functional impact.