### PR TITLE
[Flight] Fix stranded row content under Node stream backpressure

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -2092,4 +2092,157 @@ describe('ReactFlightDOMNode', () => {
       globalThis.eval = previousEval;
     }
   });
+
+  // Shared scenario for the two regression tests below. Both guard against
+  // the same destination-backpressure bug — emitTextChunk and
+  // emitTypedArrayChunk each push a [headerChunk, contentChunk] pair into
+  // completedRegularChunks. Before the fix, a flush that broke between the
+  // two writes left the content chunk stranded at the head of the queue,
+  // and the next flush emitted any newly-arrived Import rows ahead of it —
+  // splicing Import bytes into the position the Flight Client expects to
+  // read as the row's content.
+  //
+  // The scenario embeds `payload` in the model under the key `payload` and
+  // returns the deserialized model. Each test asserts that result.payload
+  // round-trips identically to what the Flight Server emitted.
+  async function runScenarioWithBackpressureBetweenHeaderAndContent(payload) {
+    function Client1() {
+      return <span>client1</span>;
+    }
+    // Client1's Import row must exceed VIEW_SIZE (4096) so writeStringChunk
+    // takes its BIG path and calls destination.write directly. That write
+    // returning false is what triggers the backpressure we want to test.
+    const Client1Reference = clientExports(
+      Client1,
+      1,
+      '/' + 'a'.repeat(5000),
+      Promise.resolve(),
+    );
+
+    function Client2() {
+      return <span>client2</span>;
+    }
+    const Client2Reference = clientExports(
+      Client2,
+      2,
+      '/client2.js',
+      Promise.resolve(),
+    );
+
+    let resolveAsync;
+    const asyncPromise = new Promise(resolve => {
+      resolveAsync = resolve;
+    });
+
+    async function AsyncWrapper() {
+      await asyncPromise;
+      return <Client2Reference />;
+    }
+
+    const model = {
+      client: <Client1Reference />,
+      payload,
+      async: <AsyncWrapper />,
+    };
+
+    const heldCallbacks = [];
+    const collectedChunks = [];
+
+    // A destination that returns false from every write (highWaterMark: 1 in
+    // byte mode) and never completes any of them until the test releases the
+    // stored callback. This gives us deterministic control over when each write
+    // finishes and when 'drain' fires.
+    const destination = new Stream.Writable({
+      highWaterMark: 1,
+      write(chunk, encoding, callback) {
+        collectedChunks.push(
+          Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding),
+        );
+        heldCallbacks.push(callback);
+      },
+    });
+
+    const finished = new Promise((resolve, reject) => {
+      destination.on('finish', resolve);
+      destination.on('error', reject);
+    });
+
+    // First flush: Client1's huge Import row hits backpressure, so the flush
+    // loop reaches the payload row's [headerChunk, contentChunk] pair while
+    // destinationHasCapacity is already false. Before the fix, this would
+    // have encoded just the header into currentView, broken the loop, and
+    // let completeWriting flush the header as its own write — stranding
+    // the content chunk at the front of completedRegularChunks.
+    const {pipe} = await serverAct(() =>
+      ReactServerDOMServer.renderToPipeableStream(model, webpackMap),
+    );
+    await serverAct(() => {
+      pipe(destination);
+    });
+
+    // While the destination is still paused, push Client2's Import row into
+    // completedImportChunks. No flush runs (request.destination is null after
+    // the first flush's backpressure break).
+    await serverAct(() => {
+      resolveAsync();
+    });
+
+    // Release callbacks one at a time. The drain that empties the writable
+    // buffer triggers flushCompletedChunks; before the fix, this is where
+    // Client2's newly-queued Import row would have been emitted ahead of
+    // the still-orphaned payload content chunk.
+    while (heldCallbacks.length > 0) {
+      await serverAct(() => {
+        const cb = heldCallbacks.shift();
+        cb();
+      });
+    }
+
+    await finished;
+
+    const readable = new Stream.Readable({read() {}});
+    for (let i = 0; i < collectedChunks.length; i++) {
+      readable.push(collectedChunks[i]);
+    }
+    readable.push(null);
+
+    const response = ReactServerDOMClient.createFromNodeStream(readable, {
+      moduleMap: null,
+      moduleLoading: null,
+    });
+    return await response;
+  }
+
+  it("keeps a Text row's header and content chunks adjacent when a flush hits backpressure between them", async () => {
+    // length >= 1024 makes the Flight Server outline this as a Text row via
+    // serializeLargeTextString, which is where emitTextChunk pushes its
+    // [headerChunk, textChunk] pair.
+    const largeText = 'x'.repeat(2048);
+
+    const result =
+      await runScenarioWithBackpressureBetweenHeaderAndContent(largeText);
+
+    // Before the fix, the Flight Client would have framed Client2's Import
+    // row bytes as text-row content, making result.payload `<id>:I[...]...`
+    // garbage rather than the x's the Flight Server emitted.
+    expect(result.payload).toBe(largeText);
+  });
+
+  it("keeps a TypedArray row's header and content chunks adjacent when a flush hits backpressure between them", async () => {
+    // emitTypedArrayChunk pushes the same [headerChunk, contentChunk] pair as
+    // emitTextChunk. Before the fix, a flush break after the header would have
+    // stranded the content chunk in exactly the same way.
+    const binaryData = new Uint8Array(1024);
+    for (let i = 0; i < binaryData.length; i++) {
+      binaryData[i] = i % 256;
+    }
+
+    const result =
+      await runScenarioWithBackpressureBetweenHeaderAndContent(binaryData);
+
+    // Before the fix, the typed array's bytes would have been replaced by
+    // Client2's Import row bytes followed by whatever happened to land in
+    // the next 1024-byte window.
+    expect(result.payload).toEqual(binaryData);
+  });
 });

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -6059,12 +6059,18 @@ function flushCompletedChunks(request: Request): void {
             );
           }
           request.pendingDebugChunks -= 2;
-          writeChunk(debugDestination, debugChunks[i + 1]);
-          writeChunk(debugDestination, debugChunks[i + 2]);
+          writeChunk(
+            debugDestination,
+            ((debugChunks[i + 1]: any): Chunk | BinaryChunk),
+          );
+          writeChunk(
+            debugDestination,
+            ((debugChunks[i + 2]: any): Chunk | BinaryChunk),
+          );
           i += 2;
         } else {
           request.pendingDebugChunks--;
-          writeChunk(debugDestination, item);
+          writeChunk(debugDestination, ((item: any): Chunk | BinaryChunk));
         }
       }
       debugChunks.splice(0, i);
@@ -6122,12 +6128,21 @@ function flushCompletedChunks(request: Request): void {
               );
             }
             request.pendingDebugChunks -= 2;
-            writeChunk(destination, debugChunks[i + 1]);
-            keepWriting = writeChunkAndReturn(destination, debugChunks[i + 2]);
+            writeChunk(
+              destination,
+              ((debugChunks[i + 1]: any): Chunk | BinaryChunk),
+            );
+            keepWriting = writeChunkAndReturn(
+              destination,
+              ((debugChunks[i + 2]: any): Chunk | BinaryChunk),
+            );
             i += 2;
           } else {
             request.pendingDebugChunks--;
-            keepWriting = writeChunkAndReturn(destination, item);
+            keepWriting = writeChunkAndReturn(
+              destination,
+              ((item: any): Chunk | BinaryChunk),
+            );
           }
           if (!keepWriting) {
             request.destination = null;
@@ -6151,12 +6166,21 @@ function flushCompletedChunks(request: Request): void {
             );
           }
           request.pendingChunks -= 2;
-          writeChunk(destination, regularChunks[i + 1]);
-          keepWriting = writeChunkAndReturn(destination, regularChunks[i + 2]);
+          writeChunk(
+            destination,
+            ((regularChunks[i + 1]: any): Chunk | BinaryChunk),
+          );
+          keepWriting = writeChunkAndReturn(
+            destination,
+            ((regularChunks[i + 2]: any): Chunk | BinaryChunk),
+          );
           i += 2;
         } else {
           request.pendingChunks--;
-          keepWriting = writeChunkAndReturn(destination, item);
+          keepWriting = writeChunkAndReturn(
+            destination,
+            ((item: any): Chunk | BinaryChunk),
+          );
         }
         if (!keepWriting) {
           request.destination = null;

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -587,7 +587,9 @@ export type Request = {
   // sentinel followed by their [headerChunk, contentChunk] pair, so that
   // flushCompletedChunks can write the pair atomically and never strand the
   // content chunk on a backpressure break.
-  completedRegularChunks: Array<Chunk | BinaryChunk | symbol>,
+  completedRegularChunks: Array<
+    Chunk | BinaryChunk | typeof NEXT_TWO_CHUNKS_ARE_ATOMIC,
+  >,
   completedErrorChunks: Array<Chunk>,
   writtenSymbols: Map<symbol, number>,
   writtenClientReferences: Map<ClientReferenceKey, number>,
@@ -607,7 +609,9 @@ export type Request = {
   pendingDebugChunks: number,
   // See completedRegularChunks for why some entries are preceded by the
   // NEXT_TWO_CHUNKS_ARE_ATOMIC sentinel.
-  completedDebugChunks: Array<Chunk | BinaryChunk | symbol>,
+  completedDebugChunks: Array<
+    Chunk | BinaryChunk | typeof NEXT_TWO_CHUNKS_ARE_ATOMIC,
+  >,
   debugDestination: null | Destination,
   environmentName: () => string,
   filterStackFrame: (
@@ -708,7 +712,9 @@ function RequestInstance(
   this.pingedTasks = pingedTasks;
   this.completedImportChunks = ([]: Array<Chunk>);
   this.completedHintChunks = ([]: Array<Chunk>);
-  this.completedRegularChunks = ([]: Array<Chunk | BinaryChunk | symbol>);
+  this.completedRegularChunks = ([]: Array<
+    Chunk | BinaryChunk | typeof NEXT_TWO_CHUNKS_ARE_ATOMIC,
+  >);
   this.completedErrorChunks = ([]: Array<Chunk>);
   this.writtenSymbols = new Map();
   this.writtenClientReferences = new Map();
@@ -724,7 +730,9 @@ function RequestInstance(
 
   if (__DEV__) {
     this.pendingDebugChunks = 0;
-    this.completedDebugChunks = ([]: Array<Chunk | BinaryChunk | symbol>);
+    this.completedDebugChunks = ([]: Array<
+      Chunk | BinaryChunk | typeof NEXT_TWO_CHUNKS_ARE_ATOMIC,
+    >);
     this.debugDestination = null;
     this.environmentName =
       environmentName === undefined

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -576,7 +576,12 @@ export type Request = {
   pingedTasks: Array<Task>,
   completedImportChunks: Array<Chunk>,
   completedHintChunks: Array<Chunk>,
-  completedRegularChunks: Array<Chunk | BinaryChunk>,
+  // Some rows (Text, TypedArray) are pushed as a [headerChunk, contentChunk]
+  // tuple so flushCompletedChunks can write the pair atomically and never
+  // strand the content chunk on a backpressure break.
+  completedRegularChunks: Array<
+    Chunk | BinaryChunk | Array<Chunk | BinaryChunk>,
+  >,
   completedErrorChunks: Array<Chunk>,
   writtenSymbols: Map<symbol, number>,
   writtenClientReferences: Map<ClientReferenceKey, number>,
@@ -594,7 +599,8 @@ export type Request = {
   abortTime: number,
   // DEV-only
   pendingDebugChunks: number,
-  completedDebugChunks: Array<Chunk | BinaryChunk>,
+  // See completedRegularChunks for why some entries are tuples.
+  completedDebugChunks: Array<Chunk | BinaryChunk | Array<Chunk | BinaryChunk>>,
   debugDestination: null | Destination,
   environmentName: () => string,
   filterStackFrame: (
@@ -695,7 +701,9 @@ function RequestInstance(
   this.pingedTasks = pingedTasks;
   this.completedImportChunks = ([]: Array<Chunk>);
   this.completedHintChunks = ([]: Array<Chunk>);
-  this.completedRegularChunks = ([]: Array<Chunk | BinaryChunk>);
+  this.completedRegularChunks = ([]: Array<
+    Chunk | BinaryChunk | Array<Chunk | BinaryChunk>,
+  >);
   this.completedErrorChunks = ([]: Array<Chunk>);
   this.writtenSymbols = new Map();
   this.writtenClientReferences = new Map();
@@ -711,7 +719,9 @@ function RequestInstance(
 
   if (__DEV__) {
     this.pendingDebugChunks = 0;
-    this.completedDebugChunks = ([]: Array<Chunk>);
+    this.completedDebugChunks = ([]: Array<
+      Chunk | BinaryChunk | Array<Chunk | BinaryChunk>,
+    >);
     this.debugDestination = null;
     this.environmentName =
       environmentName === undefined
@@ -4691,10 +4701,16 @@ function emitTypedArrayChunk(
   const binaryLength = byteLengthOfBinaryChunk(binaryChunk);
   const row = id.toString(16) + ':' + tag + binaryLength.toString(16) + ',';
   const headerChunk = stringToChunk(row);
+  // Push the header and binary as a single tuple so flushCompletedChunks can
+  // write them atomically. Otherwise, if the destination's backpressure flips
+  // between the two writes, the content chunk would be stranded at the front of
+  // the queue and the next drain would emit Import or Hint chunks between the
+  // header and the content — and the Flight Client would frame those
+  // intervening bytes as this row's content.
   if (__DEV__ && debug) {
-    request.completedDebugChunks.push(headerChunk, binaryChunk);
+    request.completedDebugChunks.push([headerChunk, binaryChunk]);
   } else {
-    request.completedRegularChunks.push(headerChunk, binaryChunk);
+    request.completedRegularChunks.push([headerChunk, binaryChunk]);
   }
 }
 
@@ -4719,10 +4735,11 @@ function emitTextChunk(
   const binaryLength = byteLengthOfChunk(textChunk);
   const row = id.toString(16) + ':T' + binaryLength.toString(16) + ',';
   const headerChunk = stringToChunk(row);
+  // See emitTypedArrayChunk for why the pair is pushed as a tuple.
   if (__DEV__ && debug) {
-    request.completedDebugChunks.push(headerChunk, textChunk);
+    request.completedDebugChunks.push([headerChunk, textChunk]);
   } else {
-    request.completedRegularChunks.push(headerChunk, textChunk);
+    request.completedRegularChunks.push([headerChunk, textChunk]);
   }
 }
 
@@ -6014,9 +6031,16 @@ function flushCompletedChunks(request: Request): void {
       const debugChunks = request.completedDebugChunks;
       let i = 0;
       for (; i < debugChunks.length; i++) {
-        request.pendingDebugChunks--;
-        const chunk = debugChunks[i];
-        writeChunkAndReturn(debugDestination, chunk);
+        const item = debugChunks[i];
+        if (isArray(item)) {
+          request.pendingDebugChunks -= item.length;
+          for (let j = 0; j < item.length; j++) {
+            writeChunkAndReturn(debugDestination, item[j]);
+          }
+        } else {
+          request.pendingDebugChunks--;
+          writeChunkAndReturn(debugDestination, item);
+        }
       }
       debugChunks.splice(0, i);
     } finally {
@@ -6064,9 +6088,18 @@ function flushCompletedChunks(request: Request): void {
         const debugChunks = request.completedDebugChunks;
         i = 0;
         for (; i < debugChunks.length; i++) {
-          request.pendingDebugChunks--;
-          const chunk = debugChunks[i];
-          const keepWriting: boolean = writeChunkAndReturn(destination, chunk);
+          const item = debugChunks[i];
+          let keepWriting: boolean;
+          if (isArray(item)) {
+            request.pendingDebugChunks -= item.length;
+            keepWriting = true;
+            for (let j = 0; j < item.length; j++) {
+              keepWriting = writeChunkAndReturn(destination, item[j]);
+            }
+          } else {
+            request.pendingDebugChunks--;
+            keepWriting = writeChunkAndReturn(destination, item);
+          }
           if (!keepWriting) {
             request.destination = null;
             i++;
@@ -6080,9 +6113,18 @@ function flushCompletedChunks(request: Request): void {
       const regularChunks = request.completedRegularChunks;
       i = 0;
       for (; i < regularChunks.length; i++) {
-        request.pendingChunks--;
-        const chunk = regularChunks[i];
-        const keepWriting: boolean = writeChunkAndReturn(destination, chunk);
+        const item = regularChunks[i];
+        let keepWriting: boolean;
+        if (isArray(item)) {
+          request.pendingChunks -= item.length;
+          keepWriting = true;
+          for (let j = 0; j < item.length; j++) {
+            keepWriting = writeChunkAndReturn(destination, item[j]);
+          }
+        } else {
+          request.pendingChunks--;
+          keepWriting = writeChunkAndReturn(destination, item);
+        }
         if (!keepWriting) {
           request.destination = null;
           i++;

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -23,6 +23,7 @@ import {
   scheduleMicrotask,
   flushBuffered,
   beginWriting,
+  writeChunk,
   writeChunkAndReturn,
   stringToChunk,
   typedArrayToBinaryChunk,
@@ -560,6 +561,12 @@ const CLOSED = 14;
 const RENDER = 20;
 const PRERENDER = 21;
 
+// Marker pushed before a [headerChunk, contentChunk] pair in
+// completedRegularChunks / completedDebugChunks to signal that the next two
+// entries must be written atomically — see emitTextChunk and
+// emitTypedArrayChunk for why, and flushCompletedChunks for how it's read.
+const NEXT_TWO_CHUNKS_ARE_ATOMIC: symbol = Symbol();
+
 export type Request = {
   status: 10 | 11 | 12 | 13 | 14,
   type: 20 | 21,
@@ -576,12 +583,11 @@ export type Request = {
   pingedTasks: Array<Task>,
   completedImportChunks: Array<Chunk>,
   completedHintChunks: Array<Chunk>,
-  // Some rows (Text, TypedArray) are pushed as a [headerChunk, contentChunk]
-  // tuple so flushCompletedChunks can write the pair atomically and never
-  // strand the content chunk on a backpressure break.
-  completedRegularChunks: Array<
-    Chunk | BinaryChunk | Array<Chunk | BinaryChunk>,
-  >,
+  // Text and TypedArray rows are pushed as a NEXT_TWO_CHUNKS_ARE_ATOMIC
+  // sentinel followed by their [headerChunk, contentChunk] pair, so that
+  // flushCompletedChunks can write the pair atomically and never strand the
+  // content chunk on a backpressure break.
+  completedRegularChunks: Array<Chunk | BinaryChunk | symbol>,
   completedErrorChunks: Array<Chunk>,
   writtenSymbols: Map<symbol, number>,
   writtenClientReferences: Map<ClientReferenceKey, number>,
@@ -599,8 +605,9 @@ export type Request = {
   abortTime: number,
   // DEV-only
   pendingDebugChunks: number,
-  // See completedRegularChunks for why some entries are tuples.
-  completedDebugChunks: Array<Chunk | BinaryChunk | Array<Chunk | BinaryChunk>>,
+  // See completedRegularChunks for why some entries are preceded by the
+  // NEXT_TWO_CHUNKS_ARE_ATOMIC sentinel.
+  completedDebugChunks: Array<Chunk | BinaryChunk | symbol>,
   debugDestination: null | Destination,
   environmentName: () => string,
   filterStackFrame: (
@@ -701,9 +708,7 @@ function RequestInstance(
   this.pingedTasks = pingedTasks;
   this.completedImportChunks = ([]: Array<Chunk>);
   this.completedHintChunks = ([]: Array<Chunk>);
-  this.completedRegularChunks = ([]: Array<
-    Chunk | BinaryChunk | Array<Chunk | BinaryChunk>,
-  >);
+  this.completedRegularChunks = ([]: Array<Chunk | BinaryChunk | symbol>);
   this.completedErrorChunks = ([]: Array<Chunk>);
   this.writtenSymbols = new Map();
   this.writtenClientReferences = new Map();
@@ -719,9 +724,7 @@ function RequestInstance(
 
   if (__DEV__) {
     this.pendingDebugChunks = 0;
-    this.completedDebugChunks = ([]: Array<
-      Chunk | BinaryChunk | Array<Chunk | BinaryChunk>,
-    >);
+    this.completedDebugChunks = ([]: Array<Chunk | BinaryChunk | symbol>);
     this.debugDestination = null;
     this.environmentName =
       environmentName === undefined
@@ -4701,16 +4704,25 @@ function emitTypedArrayChunk(
   const binaryLength = byteLengthOfBinaryChunk(binaryChunk);
   const row = id.toString(16) + ':' + tag + binaryLength.toString(16) + ',';
   const headerChunk = stringToChunk(row);
-  // Push the header and binary as a single tuple so flushCompletedChunks can
-  // write them atomically. Otherwise, if the destination's backpressure flips
-  // between the two writes, the content chunk would be stranded at the front of
-  // the queue and the next drain would emit Import or Hint chunks between the
-  // header and the content — and the Flight Client would frame those
-  // intervening bytes as this row's content.
+  // Push a NEXT_TWO_CHUNKS_ARE_ATOMIC sentinel before the header so that
+  // flushCompletedChunks can write the header and binary chunks atomically.
+  // Otherwise, if the destination's backpressure flips between the two writes,
+  // the content chunk would be stranded at the front of the queue and the next
+  // drain would emit Import or Hint chunks between the header and the content —
+  // and the Flight Client would frame those intervening bytes as this row's
+  // content.
   if (__DEV__ && debug) {
-    request.completedDebugChunks.push([headerChunk, binaryChunk]);
+    request.completedDebugChunks.push(
+      NEXT_TWO_CHUNKS_ARE_ATOMIC,
+      headerChunk,
+      binaryChunk,
+    );
   } else {
-    request.completedRegularChunks.push([headerChunk, binaryChunk]);
+    request.completedRegularChunks.push(
+      NEXT_TWO_CHUNKS_ARE_ATOMIC,
+      headerChunk,
+      binaryChunk,
+    );
   }
 }
 
@@ -4735,11 +4747,19 @@ function emitTextChunk(
   const binaryLength = byteLengthOfChunk(textChunk);
   const row = id.toString(16) + ':T' + binaryLength.toString(16) + ',';
   const headerChunk = stringToChunk(row);
-  // See emitTypedArrayChunk for why the pair is pushed as a tuple.
+  // See emitTypedArrayChunk for why the pair is preceded by a sentinel.
   if (__DEV__ && debug) {
-    request.completedDebugChunks.push([headerChunk, textChunk]);
+    request.completedDebugChunks.push(
+      NEXT_TWO_CHUNKS_ARE_ATOMIC,
+      headerChunk,
+      textChunk,
+    );
   } else {
-    request.completedRegularChunks.push([headerChunk, textChunk]);
+    request.completedRegularChunks.push(
+      NEXT_TWO_CHUNKS_ARE_ATOMIC,
+      headerChunk,
+      textChunk,
+    );
   }
 }
 
@@ -6032,14 +6052,19 @@ function flushCompletedChunks(request: Request): void {
       let i = 0;
       for (; i < debugChunks.length; i++) {
         const item = debugChunks[i];
-        if (isArray(item)) {
-          request.pendingDebugChunks -= item.length;
-          for (let j = 0; j < item.length; j++) {
-            writeChunkAndReturn(debugDestination, item[j]);
+        if (item === NEXT_TWO_CHUNKS_ARE_ATOMIC) {
+          if (i + 2 >= debugChunks.length) {
+            throw new Error(
+              'A chunk pair is incomplete. This is a bug in React.',
+            );
           }
+          request.pendingDebugChunks -= 2;
+          writeChunk(debugDestination, debugChunks[i + 1]);
+          writeChunk(debugDestination, debugChunks[i + 2]);
+          i += 2;
         } else {
           request.pendingDebugChunks--;
-          writeChunkAndReturn(debugDestination, item);
+          writeChunk(debugDestination, item);
         }
       }
       debugChunks.splice(0, i);
@@ -6090,12 +6115,16 @@ function flushCompletedChunks(request: Request): void {
         for (; i < debugChunks.length; i++) {
           const item = debugChunks[i];
           let keepWriting: boolean;
-          if (isArray(item)) {
-            request.pendingDebugChunks -= item.length;
-            keepWriting = true;
-            for (let j = 0; j < item.length; j++) {
-              keepWriting = writeChunkAndReturn(destination, item[j]);
+          if (item === NEXT_TWO_CHUNKS_ARE_ATOMIC) {
+            if (i + 2 >= debugChunks.length) {
+              throw new Error(
+                'A chunk pair is incomplete. This is a bug in React.',
+              );
             }
+            request.pendingDebugChunks -= 2;
+            writeChunk(destination, debugChunks[i + 1]);
+            keepWriting = writeChunkAndReturn(destination, debugChunks[i + 2]);
+            i += 2;
           } else {
             request.pendingDebugChunks--;
             keepWriting = writeChunkAndReturn(destination, item);
@@ -6115,12 +6144,16 @@ function flushCompletedChunks(request: Request): void {
       for (; i < regularChunks.length; i++) {
         const item = regularChunks[i];
         let keepWriting: boolean;
-        if (isArray(item)) {
-          request.pendingChunks -= item.length;
-          keepWriting = true;
-          for (let j = 0; j < item.length; j++) {
-            keepWriting = writeChunkAndReturn(destination, item[j]);
+        if (item === NEXT_TWO_CHUNKS_ARE_ATOMIC) {
+          if (i + 2 >= regularChunks.length) {
+            throw new Error(
+              'A chunk pair is incomplete. This is a bug in React.',
+            );
           }
+          request.pendingChunks -= 2;
+          writeChunk(destination, regularChunks[i + 1]);
+          keepWriting = writeChunkAndReturn(destination, regularChunks[i + 2]);
+          i += 2;
         } else {
           request.pendingChunks--;
           keepWriting = writeChunkAndReturn(destination, item);

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -585,5 +585,6 @@
   "597": "The module \"%s\" is marked as an async ESM module but was loaded as a CJS proxy. This is probably a bug in the React Server Components bundler.",
   "598": "Maximum update depth exceeded. This could be an infinite loop. This can happen when a component repeatedly calls setState during render phase or inside useLayoutEffect, causing infinite render loop. React limits the number of nested updates to prevent infinite loops.",
   "599": "Expected an initialized chunk but got an initialized stream chunk instead. This payload may have been submitted by an older version of React.",
-  "600": "A rejected Promise was passed to React without a `reason` property. React threw a generic error from where the Promise was used to assist in identifying the problematic Promise. Make sure that instrumented Promises correctly set the `reason` property when setting `status` to `'rejected'`."
+  "600": "A rejected Promise was passed to React without a `reason` property. React threw a generic error from where the Promise was used to assist in identifying the problematic Promise. Make sure that instrumented Promises correctly set the `reason` property when setting `status` to `'rejected'`.",
+  "601": "A chunk pair is incomplete. This is a bug in React."
 }


### PR DESCRIPTION
The Flight Server emits Text and TypedArray rows as two chunks: a header that gives the row's id, type, and content length, followed by the content itself. These two chunks were pushed into `completedRegularChunks` (and `completedDebugChunks` in DEV) as separate items, so when the destination signaled backpressure between them, the flush would write the header and then break out before reaching the content. The content chunk was left stranded at the head of the queue. Async work running while the destination was paused appended new rows to `completedImportChunks` / `completedHintChunks`, and the next drain flushed those queues first — splicing the newly-arrived bytes into the position the Flight Client expects to read as the original row's content. From there the Flight Client read rows from the wrong byte offsets and the model failed to deserialize.

This only surfaced on the Node stream path. `createFakeWritableFromReadableStreamController`, used by `renderToReadableStream`, always returns `true` from `write()`, so the flush loop never saw backpressure.

The fix pushes a `NEXT_TWO_CHUNKS_ARE_ATOMIC` sentinel ahead of each `headerChunk` / `contentChunk` pair in `completedRegularChunks` and `completedDebugChunks`. The flush loops detect the sentinel and write the two chunks that follow it together before re-checking backpressure, so backpressure can still break between rows but never within one.

### Alternatives considered

- **Pushing the pair as a `[headerChunk, contentChunk]` tuple.** Simpler but allocates an array per row. The required `isArray` branch in the flush hot path is likely comparable with the symbol check. This also violates the opaque `Chunk` type boundary.
- **Concatenating header and content into one chunk.** Bad for memory — typed-array content can be large.
- **Storing atomic groups in a separate queue.** Conceptually wrong and risks breaking reference-ordering assumptions between rows.
- **Ignoring backpressure until the regulars queue is empty.** Defeats the point of backpressure.
- **Wrapping the tuple behind a host-config API** (`writeAdjacentChunks` / `isAdjacentChunks` / `chunksToAdjacentChunks` / `getAdjacentChunksLength`). Keeps the implementation opaque but adds four exports per host config. Also has the tuple overhead.
- **Begin/end sentinels for variable-length atomic groups.** Not needed — only Text and TypedArray rows use this pattern, and both are pairs.