### PR TITLE
[rust-compiler] Document test-babel-ast.sh status in TODO

### DIFF
--- a/compiler/crates/TODO.md
+++ b/compiler/crates/TODO.md
@@ -145,6 +145,26 @@ Expect significant overlap with the SWC Group C bugs (cast wrappers,
 type annotations, UTF-16/WTF-8 handling) since both frontends share the
 post-conversion pipeline.
 
+## test-babel-ast.sh status
+
+Separate from the e2e variants above, `compiler/scripts/test-babel-ast.sh`
+runs three `react_compiler_ast` integration tests against the same fixture
+set. All three are green end-to-end:
+
+| Sub-test                  | Score        |
+| ------------------------- | ------------ |
+| `round_trip_all_fixtures` | 1779 / 1779  |
+| `scope_info_round_trip`   | 1780 / 1780  |
+| `scope_resolution_rename` | 1779 / 1779  |
+
+One fixture is excluded from the two round-trip tests pending the WTF-8
+work documented under [SWC Group C](#group-c-real-swc-frontend-bugs)
+above: `lone-surrogate-string-values.js`. Babel's `JSON.stringify` emits
+lone surrogate escapes like `"\uD83E"` which `serde_json` cannot
+materialize into Rust `String`. The skip keeps the rest of the suite
+green; the proper fix lives with the SWC Group C entry (same root
+cause, broader impact).
+
 ## How this stack got here
 
 - `compiler/scripts/test-e2e.sh --variant swc` baseline was 1742 / 1795


### PR DESCRIPTION
This stack closed out the three `react_compiler_ast` integration
tests in `compiler/scripts/test-babel-ast.sh`. Add a brief status
section to the e2e parity TODO so future readers know:

1. Where the round-trip / scope tests live and that they're green.
2. Exactly one fixture (`lone-surrogate-string-values.js`) is
   excluded from the two round-trip tests, deferred to the SWC
   Group C WTF-8 work that already covers the same root cause.

E2e numbers (Babel 1788/1795, SWC 1780/1795, OXC 1704/1795)
re-measured at this branch and unchanged from the snapshot at the
top of TODO.md, so the existing status table stays as-is.

Test plan:
- Documentation-only change; cargo build untouched.
- `bash compiler/scripts/test-babel-ast.sh`: green (1779/1779 +
  1780/1780 + 1779/1779, exit 0).

