### PR TITLE
[rust-compiler] Skip empty optional ScopeInfo maps on serialize

### DIFF
--- a/compiler/crates/react_compiler_ast/src/scope.rs
+++ b/compiler/crates/react_compiler_ast/src/scope.rs
@@ -117,7 +117,7 @@ pub struct ScopeInfo {
 
     /// Maps an AST node's start offset to the node's end offset.
     /// Parallel to `node_to_scope` — used for position-range containment checks.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub node_to_scope_end: HashMap<u32, u32>,
 
     /// **DEPRECATED** — retained only for Babel bridge JSON deserialization.
@@ -129,11 +129,19 @@ pub struct ScopeInfo {
     /// Maps an identifier reference's node-ID to the binding it resolves to.
     /// Only present for identifiers that resolve to a binding (not globals).
     /// Uses IndexMap to preserve insertion order.
-    #[serde(default, rename = "refNodeIdToBinding")]
+    #[serde(
+        default,
+        rename = "refNodeIdToBinding",
+        skip_serializing_if = "IndexMap::is_empty"
+    )]
     pub ref_node_id_to_binding: IndexMap<u32, BindingId>,
 
     /// Maps a scope-creating AST node's node-ID to the scope it creates.
-    #[serde(default, rename = "nodeIdToScope")]
+    #[serde(
+        default,
+        rename = "nodeIdToScope",
+        skip_serializing_if = "HashMap::is_empty"
+    )]
     pub node_id_to_scope: HashMap<u32, ScopeId>,
 
     /// The program-level (module) scope. Always scopes[0].


### PR DESCRIPTION
`bash compiler/scripts/test-babel-ast.sh` runs three sub-tests in
order: `round_trip_all_fixtures`, `scope_info_round_trip`, and
`scope_resolution_rename`. The first and third are green after the
earlier slices in this stack, but the middle one fails 1780/1780
with diffs of the shape:

    --- compiler/<fixture>.json ---
    Round-trip mismatch:
    +   "nodeIdToScope": {},

This was previously masked because the round-trip failure earlier in
the script tripped `set -e` and the scope-info test never ran. With
round-trip green, it now surfaces a pre-existing serialization
mismatch in `ScopeInfo`.

Root cause: the Babel-side fixture producer in
`compiler/scripts/babel-ast-to-json.mjs::collectScopeInfo` emits only
five keys per `.scope.json` file — `scopes`, `bindings`,
`nodeToScope`, `referenceToBinding`, and `programScope`. It never
writes `nodeIdToScope`, `refNodeIdToBinding`, or `nodeToScopeEnd`.

The Rust `ScopeInfo` struct declares those three fields with
`#[serde(default)]`, so deserialization happily produces empty
`HashMap` / `IndexMap` values when the keys are missing. Serialization
was then emitting them as `"nodeIdToScope": {}` (etc.), which the
round-trip diff treats as a mismatch.

Add `skip_serializing_if = "<Map>::is_empty"` to all three fields so
a fixture that came in without the key goes back out without the
key. Required fields (no `#[serde(default)]`: `scopes`, `bindings`,
`node_to_scope`, `reference_to_binding`, `program_scope`) are
deliberately untouched — they are present in every fixture by
design.

Alternatives considered:

- Remove `#[serde(default)]` from the three fields. Rejected: would
  break deserialization of legacy fixtures that legitimately omit
  these supplemental maps.
- Wrap the maps in `Option<...>`. Rejected: changes field types and
  forces every reader to unwrap, with no behavior win over the
  existing default + skip-on-empty combination.
- Custom skip function. Rejected: `HashMap::is_empty` and
  `IndexMap::is_empty` express intent directly and are already in
  scope via the existing imports.
- Add a `Default` impl for `ScopeInfo`. Rejected: the issue is on
  the serialize side, not deserialize; `serde(default)` already
  supplies empty maps on deserialize correctly.

Test plan:
- bash compiler/scripts/test-babel-ast.sh:
    Before: round_trip 1779/1780, scope_info_round_trip 0/1780 (every
            fixture fails on the empty-map mismatch), rename 1779/1780
    After:  round_trip 1779/1780, scope_info_round_trip 1780/1780,
            rename 1779/1780
  (Corpus: 1780 parseable of 1795 fixtures. The single remaining
  round_trip/rename failure is lone-surrogate-string-values.js, WTF-8
  string representation, tracked separately; the script exits non-zero
  on it before and after this change.)
- cargo build: clean across the workspace.


