### PR TITLE
Fix boolean representation of aria-* and data-* properties on web components 

### DIFF
--- a/packages/react-dom-bindings/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom-bindings/src/client/DOMPropertyOperations.js
@@ -234,10 +234,13 @@ export function setValueForPropertyOnCustomComponent(
   }
 
   if (value === true) {
-    node.setAttribute(name, '');
-    return;
+    const prefix = name.toLowerCase().slice(0, 5);
+    if (prefix !== 'data-' && prefix !== 'aria-') {
+      // for non aria and data attributes, set the attribute to an empty string (just the value on the DOM)
+      node.setAttribute(name, '');
+      return;
+    }
   }
 
-  // From here, it's the same as any attribute
   setValueForAttribute(node, name, value);
 }

--- a/packages/react-dom-bindings/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom-bindings/src/client/DOMPropertyOperations.js
@@ -76,10 +76,18 @@ export function getValueForAttributeOnCustomComponent(
           return expected;
         case 'function':
           return expected;
-        case 'boolean':
-          if (expected === false) {
-            return expected;
+        case 'boolean': {
+          const prefix = name.toLowerCase().slice(0, 5);
+          if (prefix !== 'data-' && prefix !== 'aria-') {
+            // Custom elements emit true as an empty attribute and omit false.
+            // Only false may match a missing attribute.
+            if (expected === false) {
+              return expected;
+            }
           }
+          // Missing aria-/data- never matches a boolean expected value:
+          // false/"false" are distinct from attribute absence.
+        }
       }
       return expected === undefined ? undefined : null;
     }
@@ -90,7 +98,10 @@ export function getValueForAttributeOnCustomComponent(
     const value = isNonce ? (node as any).nonce : node.getAttribute(name);
 
     if (value === '' && expected === true) {
-      return true;
+      const prefix = name.toLowerCase().slice(0, 5);
+      if (prefix !== 'data-' && prefix !== 'aria-') {
+        return true;
+      }
     }
 
     if (__DEV__) {
@@ -236,7 +247,8 @@ export function setValueForPropertyOnCustomComponent(
   if (value === true) {
     const prefix = name.toLowerCase().slice(0, 5);
     if (prefix !== 'data-' && prefix !== 'aria-') {
-      // for non aria and data attributes, set the attribute to an empty string (just the value on the DOM)
+      // Boolean attribute presence: true → empty string value.
+      // aria-/data- fall through to setValueForAttribute and stringify.
       node.setAttribute(name, '');
       return;
     }

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -4087,22 +4087,17 @@ function pushStartCustomElement(
             typeof propValue !== 'function' &&
             typeof propValue !== 'symbol'
           ) {
-            const prefix = attributeName.toLowerCase().slice(0, 5);
-            const propValueNeedsStringification =
-              prefix === 'data-' || prefix === 'aria-';
-            if (
-              propValueNeedsStringification &&
-              typeof propValue === 'boolean'
-            ) {
-              // aria and data attributes are stringified as 'true' if they have the boolean value `true`
-              // this is because data-foo="true" is the same as data-foo on the DOM
-              propValue = propValue ? 'true' : 'false';
-              // $FlowFixMe[invalid-compare]
-            } else if (propValue === false) {
-              continue;
-              // $FlowFixMe[invalid-compare]
-            } else if (propValue === true) {
-              propValue = '';
+            // Match pushAttribute / setValueForAttribute: aria-* and data-* booleans
+            // stringify ("true"/"false"). Other booleans use empty-string presence.
+            if (typeof propValue === 'boolean') {
+              const prefix = attributeName.toLowerCase().slice(0, 5);
+              if (prefix !== 'data-' && prefix !== 'aria-') {
+                // $FlowFixMe[invalid-compare]
+                if (propValue === false) {
+                  continue;
+                }
+                propValue = '';
+              }
             } else if (typeof propValue === 'object') {
               continue;
             }

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -4087,8 +4087,18 @@ function pushStartCustomElement(
             typeof propValue !== 'function' &&
             typeof propValue !== 'symbol'
           ) {
-            // $FlowFixMe[invalid-compare]
-            if (propValue === false) {
+            const prefix = attributeName.toLowerCase().slice(0, 5);
+            const propValueNeedsStringification =
+              prefix === 'data-' || prefix === 'aria-';
+            if (
+              propValueNeedsStringification &&
+              typeof propValue === 'boolean'
+            ) {
+              // aria and data attributes are stringified as 'true' if they have the boolean value `true`
+              // this is because data-foo="true" is the same as data-foo on the DOM
+              propValue = propValue ? 'true' : 'false';
+              // $FlowFixMe[invalid-compare]
+            } else if (propValue === false) {
               continue;
               // $FlowFixMe[invalid-compare]
             } else if (propValue === true) {

--- a/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
@@ -1151,6 +1151,59 @@ describe('DOMPropertyOperations', () => {
       expect(customElement.getAttribute('foo')).toBe(null);
     });
 
+    it('aria attributes should have proper representation', async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => {
+        root.render(
+          <my-custom-element
+            aria-disabled={true}
+            aria-label={'label test'}
+            aria-hidden={false}
+            aria-required={undefined}
+            aria-colindex={1}
+            aria-rowindex={0}
+          />,
+        );
+      });
+      const customElement = container.querySelector('my-custom-element');
+
+      expect(customElement.getAttribute('aria-disabled')).toBe('true');
+      expect(customElement.getAttribute('aria-label')).toBe('label test');
+      expect(customElement.getAttribute('aria-hidden')).toBe('false');
+      expect(customElement.getAttribute('aria-required')).toBe(null);
+      expect(customElement.getAttribute('aria-colindex')).toBe('1');
+      expect(customElement.getAttribute('aria-rowindex')).toBe('0');
+    });
+
+    it('data attributes should have proper representation', async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => {
+        root.render(
+          <my-custom-element
+            data-false={false}
+            data-true={true}
+            data-undefined={undefined}
+            data-null={null}
+            data-label={'label test'}
+            data-index={1}
+            data-index-0={0}
+          />,
+        );
+      });
+      const customElement = container.querySelector('my-custom-element');
+      expect(customElement.getAttribute('data-false')).toBe('false');
+      expect(customElement.getAttribute('data-true')).toBe('true');
+      expect(customElement.getAttribute('data-undefined')).toBe(null);
+      expect(customElement.getAttribute('data-null')).toBe(null);
+      expect(customElement.getAttribute('data-label')).toBe('label test');
+      expect(customElement.getAttribute('data-index')).toBe('1');
+      expect(customElement.getAttribute('data-index-0')).toBe('0');
+    });
+
     it('custom element custom event handlers assign multiple types', async () => {
       const container = document.createElement('div');
       document.body.appendChild(container);

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -806,5 +806,123 @@ describe('ReactDOMServerIntegration', () => {
         expect(e.hasAttribute('foo')).toBe(false);
       },
     );
+
+    describe('aria attributes', function () {
+      itRenders('simple strings on custom elements', async render => {
+        const e = await render(<custom-element aria-label="hello" />);
+        expect(e.getAttribute('aria-label')).toBe('hello');
+      });
+
+      itRenders(
+        'aria string prop with false value on custom elements',
+        async render => {
+          const e = await render(<custom-element aria-hidden={false} />);
+          expect(e.getAttribute('aria-hidden')).toBe('false');
+        },
+      );
+
+      itRenders(
+        'aria string prop with true value on custom elements',
+        async render => {
+          const e = await render(<custom-element aria-hidden={true} />);
+          expect(e.getAttribute('aria-hidden')).toBe('true');
+        },
+      );
+
+      itRenders(
+        'aria string prop with number value on custom elements',
+        async render => {
+          const e = await render(<custom-element aria-label={1} />);
+          expect(e.getAttribute('aria-label')).toBe('1');
+        },
+      );
+
+      itRenders(
+        'aria string prop with string value on custom elements',
+        async render => {
+          const e = await render(<custom-element aria-label="hello" />);
+          expect(e.getAttribute('aria-label')).toBe('hello');
+        },
+      );
+
+      itRenders(
+        'no aria prop with null value on custom elements',
+        async render => {
+          const e = await render(<custom-element aria-label={null} />);
+          expect(e.hasAttribute('aria-label')).toBe(false);
+        },
+      );
+
+      itRenders(
+        'no aria prop with undefined value on custom elements',
+        async render => {
+          const e = await render(<custom-element aria-label={undefined} />);
+          expect(e.hasAttribute('aria-label')).toBe(false);
+        },
+      );
+    });
+  });
+
+  describe('data attributes', function () {
+    itRenders('simple strings on custom elements', async render => {
+      const e = await render(<custom-element data-foo="hello" />);
+      expect(e.getAttribute('data-foo')).toBe('hello');
+    });
+
+    itRenders(
+      'data string prop with false value on custom elements',
+      async render => {
+        const e = await render(<custom-element data-foo={false} />);
+        expect(e.getAttribute('data-foo')).toBe('false');
+      },
+    );
+
+    itRenders(
+      'data string prop with true value on custom elements',
+      async render => {
+        const e = await render(<custom-element data-foo={true} />);
+        expect(e.getAttribute('data-foo')).toBe('true');
+      },
+    );
+
+    itRenders(
+      'no data prop with null value on custom elements',
+      async render => {
+        const e = await render(<custom-element data-foo={null} />);
+        expect(e.hasAttribute('data-foo')).toBe(false);
+      },
+    );
+
+    itRenders(
+      'no data prop with undefined value on custom elements',
+      async render => {
+        const e = await render(<custom-element data-foo={undefined} />);
+        expect(e.hasAttribute('data-foo')).toBe(false);
+      },
+    );
+
+    itRenders(
+      'no data prop with function value on custom elements',
+      async render => {
+        const e = await render(<custom-element data-foo={function () {}} />);
+        expect(e.hasAttribute('data-foo')).toBe(false);
+      },
+    );
+
+    itRenders(
+      'data string prop for number value on custom elements',
+      async render => {
+        const e = await render(<custom-element data-foo={1} />);
+        expect(e.getAttribute('data-foo')).toBe('1');
+      },
+    );
+
+    itRenders(
+      'data string prop for string value on custom elements',
+      async render => {
+        const e = await render(<custom-element data-foo="hello" />);
+        expect(e.getAttribute('data-foo')).toBe('hello');
+      },
+    );
   });
 });

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -707,6 +707,101 @@ describe('ReactDOMServerHydration', () => {
     expect(customElement.obj).toBe(undefined);
   });
 
+  it('should hydrate aria and data boolean attributes on custom elements', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const jsx = (
+      <my-custom-element
+        aria-hidden={true}
+        aria-disabled={false}
+        data-active={true}
+        data-enabled={false}
+      />
+    );
+
+    container.innerHTML = ReactDOMServer.renderToString(jsx);
+    const customElement = container.querySelector('my-custom-element');
+    expect(customElement.getAttribute('aria-hidden')).toBe('true');
+    expect(customElement.getAttribute('aria-disabled')).toBe('false');
+    expect(customElement.getAttribute('data-active')).toBe('true');
+    expect(customElement.getAttribute('data-enabled')).toBe('false');
+
+    await act(() => {
+      ReactDOMClient.hydrateRoot(container, jsx);
+    });
+
+    expect(customElement.getAttribute('aria-hidden')).toBe('true');
+    expect(customElement.getAttribute('aria-disabled')).toBe('false');
+    expect(customElement.getAttribute('data-active')).toBe('true');
+    expect(customElement.getAttribute('data-enabled')).toBe('false');
+  });
+
+  it('warns when custom element aria boolean mismatches empty attribute', async () => {
+    const container = document.createElement('div');
+    // Legacy boolean-attribute serialization: presence with empty value.
+    container.innerHTML = '<my-custom-element aria-hidden=""></my-custom-element>';
+
+    await act(() => {
+      ReactDOMClient.hydrateRoot(
+        container,
+        <my-custom-element aria-hidden={true} />,
+      );
+    });
+
+    assertConsoleErrorDev([
+      "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. " +
+        "This won't be patched up. This can happen if a SSR-ed Client Component used:\n" +
+        '\n' +
+        "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
+        "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
+        "- Date formatting in a user's locale which doesn't match the server.\n" +
+        '- External changing data without sending a snapshot of it along with the HTML.\n' +
+        '- Invalid HTML tag nesting.\n\nIt can also happen if the client has a browser extension ' +
+        'installed which messes with the HTML before React loaded.\n' +
+        '\n' +
+        'https://react.dev/link/hydration-mismatch\n' +
+        '\n' +
+        '  <my-custom-element\n' +
+        '+   aria-hidden={true}\n' +
+        '-   aria-hidden=""\n' +
+        '  >\n' +
+        '\n    in my-custom-element (at **)',
+    ]);
+  });
+
+  it('warns when custom element aria false mismatches missing attribute', async () => {
+    const container = document.createElement('div');
+    container.innerHTML = '<my-custom-element></my-custom-element>';
+
+    await act(() => {
+      ReactDOMClient.hydrateRoot(
+        container,
+        <my-custom-element aria-hidden={false} />,
+      );
+    });
+
+    assertConsoleErrorDev([
+      "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. " +
+        "This won't be patched up. This can happen if a SSR-ed Client Component used:\n" +
+        '\n' +
+        "- A server/client branch `if (typeof window !== 'undefined')`.\n" +
+        "- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n" +
+        "- Date formatting in a user's locale which doesn't match the server.\n" +
+        '- External changing data without sending a snapshot of it along with the HTML.\n' +
+        '- Invalid HTML tag nesting.\n\nIt can also happen if the client has a browser extension ' +
+        'installed which messes with the HTML before React loaded.\n' +
+        '\n' +
+        'https://react.dev/link/hydration-mismatch\n' +
+        '\n' +
+        '  <my-custom-element\n' +
+        '+   aria-hidden={false}\n' +
+        '-   aria-hidden={null}\n' +
+        '  >\n' +
+        '\n    in my-custom-element (at **)',
+    ]);
+  });
+
   it('refers users to apis that support Suspense when something suspends', async () => {
     const theInfinitePromise = new Promise(() => {});
     function InfiniteSuspend() {


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.  Please provide enough information so that others can review your pull request.  The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2.  Run `yarn` in the repository root.
  3.  If you've fixed a bug or added code that should be tested, add tests!
  4.  Ensure the test suite passes (`yarn test`).  Tip: `yarn test --watch TestName` is helpful in development.
  5.  Run `yarn test --prod` to test in the production environment.  It supports the same options as `yarn test`.
  6.  If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8.  Make sure your code lints (`yarn lint`).  Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10.  If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
HTML treats `aria-*`/ `aria-*="true"` and `data-*`/`data-*="true"` attributes differently; for example, `<my-el aria-hidden />` is visible to screen readers accessibility tree, whereas `<my-el aria-hidden="true" />` is hidden from screen readers accessibility tree.  Issue #32251 reported unexpected behavior where boolean values were not being stringified, and this PR fixes it by stringifying boolean values for aria and data attributes.  This leverages the solution approach and thinking from the following PRs: #24541 and #26546, by copying Preact behavior for aria and data attributes.  I did not touch the behavior of other properties/attributes, because I think React's choice to use shorthand notation for booleans is a better approach than Preact's. 

- Updated DOMPropertyOperations.js and ReactFizzConfigDOM.js to handle stringification of boolean values for aria and data attributes.
- Added tests for aria attributes in DOMPropertyOperations-test.js
- Added tests for data attributes in ReactDOMServerIntegrationAttributes-test.js

fixes: #32251 and #34663


<!--
 Explain the **motivation** for making this change.  What existing problem does the pull request solve?
-->

## How did you test this change?
- Created unit tests to cover the scenarios and ran tests to ensure that they all pass.
- here is the [before](https://codesandbox.io/p/sandbox/eager-golick-9qg7ss) sandbox and [after](https://codesandbox.io/p/sandbox/web-components-booleans-before-forked-c6n5jf) sandbox

## Other considerations 
- This could be considered a breaking change, so it might be part of a major release, if accepted.
- I am currently duplicating the strification check for aria-* and data-*, and it has been duplicated about 6 times in the code base. This could be moved to a helper function (if/when requested), but I did not because I wanted to limit changes to production code.
  

I used Composer 2.5 llm to create this PR, but reviewed every line.
  

<!--
  Demonstrate the code is solid.  Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
