### PR TITLE
[compiler] Fix incorrect closure outlining for factory-function components

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineFunctions.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineFunctions.ts
@@ -27,7 +27,8 @@ export function outlineFunctions(
         value.loweredFunc.func.context.length === 0 &&
         // TODO: handle outlining named functions
         value.loweredFunc.func.id === null &&
-        !fbtOperands.has(lvalue.identifier.id)
+        !fbtOperands.has(lvalue.identifier.id) &&
+        !accessesOuterScopeBinding(value.loweredFunc.func)
       ) {
         const loweredFunc = value.loweredFunc.func;
 
@@ -48,4 +49,29 @@ export function outlineFunctions(
       }
     }
   }
+}
+
+/**
+ * Returns true if the function expression accesses a variable that was
+ * classified as ModuleLocal but is not actually defined at the program/module
+ * scope. This happens when a component is defined inside a factory function:
+ * the factory function's locals are resolved as `scope.parent` bindings and
+ * tagged as ModuleLocal, but they only exist within the factory closure and
+ * would be undefined if the function were outlined to module scope.
+ */
+function accessesOuterScopeBinding(fn: HIRFunction): boolean {
+  const programScope = fn.env.parentFunction.scope.getProgramParent();
+  for (const [, block] of fn.body.blocks) {
+    for (const instr of block.instructions) {
+      const {value} = instr;
+      if (
+        value.kind === 'LoadGlobal' &&
+        value.binding.kind === 'ModuleLocal' &&
+        programScope.getBinding(value.binding.name) == null
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-factory-function-arrow-component-captures-outer-variable.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-factory-function-arrow-component-captures-outer-variable.expect.md
@@ -1,0 +1,101 @@
+
+## Input
+
+```javascript
+// @compilationMode:"infer"
+/**
+ * Regression test for https://github.com/facebook/react/issues/34901
+ *
+ * When an arrow-function component is defined inside a factory function,
+ * inner callbacks that capture variables from the factory function scope
+ * must NOT be outlined to module scope.
+ *
+ * Bug: in `infer` mode, the compiler compiled `Counter` as a standalone
+ * component. Variables from the factory function scope (e.g. `counter`)
+ * were misclassified as `ModuleLocal` and emitted as `LoadGlobal`
+ * instructions with an empty context array on inner functions like
+ * `getCount`. The `outlineFunctions` pass saw `context.length === 0` and
+ * incorrectly outlined `getCount` to a top-level `_temp` helper where
+ * `counter` was undefined at runtime.
+ *
+ * Fix: `outlineFunctions` now checks whether the function body contains
+ * a `LoadGlobal(ModuleLocal)` reference to a name that does not exist at
+ * the true program/module scope. If so, the function is not outlined.
+ */
+function makeCounter(initialValue) {
+  const counter = {value: initialValue};
+
+  // `getCount` captures `counter` from the factory scope.
+  // It must stay inline — outlined as a top-level function it would break.
+  const Counter = () => {
+    const getCount = () => counter.value;
+    return <div>{getCount()}</div>;
+  };
+
+  return Counter;
+}
+
+const Counter = makeCounter(42);
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Counter,
+  params: [],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @compilationMode:"infer"
+/**
+ * Regression test for https://github.com/facebook/react/issues/34901
+ *
+ * When an arrow-function component is defined inside a factory function,
+ * inner callbacks that capture variables from the factory function scope
+ * must NOT be outlined to module scope.
+ *
+ * Bug: in `infer` mode, the compiler compiled `Counter` as a standalone
+ * component. Variables from the factory function scope (e.g. `counter`)
+ * were misclassified as `ModuleLocal` and emitted as `LoadGlobal`
+ * instructions with an empty context array on inner functions like
+ * `getCount`. The `outlineFunctions` pass saw `context.length === 0` and
+ * incorrectly outlined `getCount` to a top-level `_temp` helper where
+ * `counter` was undefined at runtime.
+ *
+ * Fix: `outlineFunctions` now checks whether the function body contains
+ * a `LoadGlobal(ModuleLocal)` reference to a name that does not exist at
+ * the true program/module scope. If so, the function is not outlined.
+ */
+function makeCounter(initialValue) {
+  const counter = { value: initialValue };
+
+  // `getCount` captures `counter` from the factory scope.
+  // It must stay inline — outlined as a top-level function it would break.
+  const Counter = () => {
+    const $ = _c(1);
+    let t0;
+    if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+      const getCount = () => counter.value;
+      t0 = <div>{getCount()}</div>;
+      $[0] = t0;
+    } else {
+      t0 = $[0];
+    }
+    return t0;
+  };
+
+  return Counter;
+}
+
+const Counter = makeCounter(42);
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Counter,
+  params: [],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>42</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-factory-function-arrow-component-captures-outer-variable.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-factory-function-arrow-component-captures-outer-variable.js
@@ -1,0 +1,39 @@
+// @compilationMode:"infer"
+/**
+ * Regression test for https://github.com/facebook/react/issues/34901
+ *
+ * When an arrow-function component is defined inside a factory function,
+ * inner callbacks that capture variables from the factory function scope
+ * must NOT be outlined to module scope.
+ *
+ * Bug: in `infer` mode, the compiler compiled `Counter` as a standalone
+ * component. Variables from the factory function scope (e.g. `counter`)
+ * were misclassified as `ModuleLocal` and emitted as `LoadGlobal`
+ * instructions with an empty context array on inner functions like
+ * `getCount`. The `outlineFunctions` pass saw `context.length === 0` and
+ * incorrectly outlined `getCount` to a top-level `_temp` helper where
+ * `counter` was undefined at runtime.
+ *
+ * Fix: `outlineFunctions` now checks whether the function body contains
+ * a `LoadGlobal(ModuleLocal)` reference to a name that does not exist at
+ * the true program/module scope. If so, the function is not outlined.
+ */
+function makeCounter(initialValue) {
+  const counter = {value: initialValue};
+
+  // `getCount` captures `counter` from the factory scope.
+  // It must stay inline — outlined as a top-level function it would break.
+  const Counter = () => {
+    const getCount = () => counter.value;
+    return <div>{getCount()}</div>;
+  };
+
+  return Counter;
+}
+
+const Counter = makeCounter(42);
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Counter,
+  params: [],
+};


### PR DESCRIPTION
## Summary

When the outermost function being compiled is nested inside another function (factory/HOC, `infer` mode), `HIRBuilder` resolves identifiers against `parentFunction.scope.parent` — the enclosing function's scope, not the program scope. The enclosing scope's locals are mis-tagged as `ModuleLocal`, and `outlineFunctions` sees `context.length === 0` and hoists the inner closure to module scope, where the captured name is undefined at runtime.

This PR adds a guard in `outlineFunctions`: a function is not outlined if its body contains a `LoadGlobal(ModuleLocal)` whose name does not resolve at the program scope.

Fixes #34901

## Alternative considered

A more principled fix is to correct the misclassification in `HIRBuilder.resolveIdentifier` / `isContextIdentifier` by using `scope.getProgramParent()` instead of `scope.parent`. That change alone is semantically correct but exposes a deeper structural gap: the compiler's capture machinery (`gatherCapturedContext`, `captureScopes`) only walks scopes up to `parentFunction.scope`, so factory-scope variables get no value-kind initialization and `InferMutationAliasingEffects` invariant-fails. Closing that gap requires extending capture collection up to (but excluding) the program scope and gathering captures for the outermost function as well — a substantially larger change with wide effects on how nested functions are lowered. Worth doing in a follow-up; out of scope for this fix.

## Test plan

- Added regression fixture `factory-function-component-captures-outer-scope.js`. Eval output renders `<div>42</div>`, confirming `getCount` stays inline.
- Full snap suite: 1720/1720 pass.
- `yarn workspace babel-plugin-react-compiler lint` clean.