### PR TITLE
Stop transpiling computed property names

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -16,7 +16,6 @@ module.exports = {
     '@babel/plugin-transform-block-scoped-functions',
     '@babel/plugin-transform-object-super',
     '@babel/plugin-transform-shorthand-properties',
-    '@babel/plugin-transform-computed-properties',
     '@babel/plugin-transform-for-of',
     ['@babel/plugin-transform-spread', {loose: true, useBuiltIns: true}],
     '@babel/plugin-transform-parameters',

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@babel/plugin-transform-block-scoping": "^7.11.1",
     "@babel/plugin-transform-class-properties": "^7.25.9",
     "@babel/plugin-transform-classes": "^7.10.4",
-    "@babel/plugin-transform-computed-properties": "^7.10.4",
     "@babel/plugin-transform-destructuring": "^7.10.4",
     "@babel/plugin-transform-for-of": "^7.10.4",
     "@babel/plugin-transform-literals": "^7.10.4",

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -136,7 +136,6 @@ const babelToES5Plugins = [
   '@babel/plugin-transform-arrow-functions',
   '@babel/plugin-transform-block-scoped-functions',
   '@babel/plugin-transform-shorthand-properties',
-  '@babel/plugin-transform-computed-properties',
   ['@babel/plugin-transform-block-scoping', {throwIfClosureRequired: true}],
 ];
 


### PR DESCRIPTION
Support for these has landed 10 years ago in popular browsers and Node.js. Hermes also supports these.

Only affects `react-server-dom-*` packages in development. Google Closure Compiler still downlevels these. We're applying GCC to prod and dev nowadays so this PR just normalizes the final code between dev and prod.

For React 20, we should consider revisiting our target matrix to something more modern.