### PR TITLE
Only allow releases from protected environment

### DIFF
--- a/.github/workflows/runtime_releases_from_npm_manual.yml
+++ b/.github/workflows/runtime_releases_from_npm_manual.yml
@@ -61,6 +61,7 @@ jobs:
   publish:
     name: Publish releases
     runs-on: ubuntu-latest
+    environment: npm
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
The environment will have additional restriction that reduces blast radius of a single compromised account.