### PR TITLE
[ci] Allow CI on backport branches

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -2,11 +2,7 @@ name: (Runtime) Build and Test
 
 on:
   push:
-    branches: [main]
-    tags:
-      # To get CI for backport releases.
-      # This will duplicate CI for releases from main which is acceptable
-      - "v*"
+    branches: [main, releases/**]
   pull_request:
     paths-ignore:
       - compiler/**


### PR DESCRIPTION
Instead of running on tags, we run CI on the branches that are allowed to be released from. Rules and protected environments are already based on these branches so this just unifies these restrictions. 