### PR TITLE
[ci] Create artifact attestations for builds on backport branches

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -2,7 +2,10 @@ name: (Runtime) Build and Test
 
 on:
   push:
-    branches: [main, releases/**]
+    branches:
+      # release branches (keep in sync with branches that receive artifact attestations)
+      - main
+      - releases/**
   pull_request:
     paths-ignore:
       - compiler/**
@@ -486,12 +489,12 @@ jobs:
           if-no-files-found: error
       - uses: actions/attest-build-provenance@v2
         # We don't verify builds generated from pull requests not originating from facebook/react.
-        # However, if the PR lands, the run on `main` will generate the attestation which can then
+        # However, if the PR lands, the run on release branches will generate the attestation which can then
         # be used to download a build via scripts/release/download-experimental-build.js.
         #
         # Note that this means that scripts/release/download-experimental-build.js must be run with
         # --no-verify when downloading a build from a fork.
-        if: github.event_name == 'push' && github.ref_name == 'main' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'push' && (github.ref_name == 'main' || startsWith(github.ref_name, 'releases/')) || github.event.pull_request.head.repo.full_name == github.repository
         with:
           subject-name: artifacts_combined.zip
           subject-digest: sha256:${{ steps.upload_artifacts_combined.outputs.artifact-digest }}


### PR DESCRIPTION
We verify GitHub artifact attestations before doing a release. However, only builds on `main` received attestations. Now we attest builds on all release branches (`main` or `releases/**`) to enable releases for older versions. 