### PR TITLE
Fix referrerPolicy in Fizz image preload headers

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -3404,7 +3404,7 @@ function pushImg(
           nonce: props.nonce,
           type: props.type,
           fetchPriority: props.fetchPriority,
-          referrerPolicy: props.refererPolicy,
+          referrerPolicy: props.referrerPolicy,
         })),
         // We always consume the header length since once we find one header that doesn't fit
         // we assume all the rest won't as well. This is to avoid getting into a situation

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -3811,6 +3811,39 @@ describe('ReactDOMFizzServer', () => {
     });
   });
 
+  it('includes referrerPolicy in rendered image preload headers', async () => {
+    let headers = null;
+    function onHeaders(x) {
+      headers = x;
+    }
+
+    function App() {
+      return (
+        <html>
+          <body>
+            <img
+              src="referrer-policy-img"
+              fetchPriority="high"
+              referrerPolicy="no-referrer"
+            />
+          </body>
+        </html>
+      );
+    }
+
+    await act(() => {
+      renderToPipeableStream(<App />, {onHeaders});
+    });
+
+    expect(headers).toEqual({
+      Link: `
+<referrer-policy-img>; rel=preload; as="image"; fetchpriority="high"; referrerpolicy="no-referrer"
+`
+        .replaceAll('\n', '')
+        .trim(),
+    });
+  });
+
   it('emits nothing for headers if you pipe before work begins', async () => {
     let headers = null;
     function onHeaders(x) {


### PR DESCRIPTION
## Summary

This fixes a typo in the Fizz image preload header path.

When a rendered `<img>` preload is emitted as an HTTP `Link` header, this code was reading `props.refererPolicy` instead of `props.referrerPolicy`, so `referrerpolicy` would get dropped from the header.

The fallback `<link rel="preload">` path already used the correct prop, so the behavior depended on whether the preload was emitted as a header or as a DOM node.

## Changes

- use `props.referrerPolicy` when building rendered image preload headers
- add a regression test for the `onHeaders` path covering a rendered `<img>` with `referrerPolicy`

## Testing

- `ASDF_NODEJS_VERSION=20.10.0 asdf exec corepack yarn test ReactDOMFizzServer-test --runInBand -t "includes referrerPolicy in rendered image preload headers"`
