### PR TITLE
[Fizz] Fix non-script modulepreload tracking

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -6552,7 +6552,7 @@ function preloadModule(
           resumableState.moduleUnknownResources.hasOwnProperty(as);
         let resources;
         if (hasAsType) {
-          resources = resumableState.unknownResources[as];
+          resources = resumableState.moduleUnknownResources[as];
           if (resources.hasOwnProperty(key)) {
             // we can return if we already have this resource
             return;

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -6532,6 +6532,34 @@ body {
       );
     });
 
+    it('preloads multiple non-script modules with the same as type', async () => {
+      function App() {
+        ReactDOM.preloadModule('serviceworker one', {as: 'serviceworker'});
+        ReactDOM.preloadModule('serviceworker two', {as: 'serviceworker'});
+        return <div>hello</div>;
+      }
+
+      await act(() => {
+        renderToPipeableStream(<App />).pipe(writable);
+      });
+
+      expect(getMeaningfulChildren(document.body)).toEqual(
+        <div id="container">
+          <link
+            rel="modulepreload"
+            href="serviceworker one"
+            as="serviceworker"
+          />
+          <link
+            rel="modulepreload"
+            href="serviceworker two"
+            as="serviceworker"
+          />
+          <div>hello</div>
+        </div>,
+      );
+    });
+
     it('warns if you provide invalid arguments', async () => {
       function App() {
         ReactDOM.preloadModule();


### PR DESCRIPTION
## Summary

This fixes a bad resource-table lookup in the Fizz `preloadModule()` path for non-script modulepreloads.

When `as` is something other than `script`, the code checks and writes `moduleUnknownResources`, but on the second call it was reading from `unknownResources` instead. That means repeated calls like `preloadModule(..., {as: 'serviceworker'})` could blow up once the `serviceworker` bucket already existed.

## Changes

- read repeated non-script modulepreloads from `moduleUnknownResources`
- add a regression test that calls `preloadModule()` twice with `as: 'serviceworker'`

## Testing

- `ASDF_NODEJS_VERSION=20.10.0 asdf exec corepack yarn test ReactDOMFloat-test --runInBand -t "preloads multiple non-script modules with the same as type"`

Fixes #36440.