### PR TITLE
docs: fix broken links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -781,7 +781,7 @@ Today, we are releasing React 17!
 * Adjust `SuspenseList` CPU bound heuristic ([@sebmarkbage](https://github.com/sebmarkbage) in [#17455](https://github.com/facebook/react/pull/17455))
 * Add missing event plugin priorities ([@trueadm](https://github.com/trueadm) in [#17914](https://github.com/facebook/react/pull/17914))
 * Fix `isPending` only being true when transitioning from inside an input event ([@acdlite](https://github.com/acdlite) in [#17382](https://github.com/facebook/react/pull/17382))
-* Fix `React.memo` components dropping updates when interrupted by a higher priority update ([@acdlite]((https://github.com/acdlite)) in [#18091](https://github.com/facebook/react/pull/18091))
+* Fix `React.memo` components dropping updates when interrupted by a higher priority update ([@acdlite](https://github.com/acdlite) in [#18091](https://github.com/facebook/react/pull/18091))
 * Don't warn when suspending at the wrong priority ([@gaearon](https://github.com/gaearon) in [#17971](https://github.com/facebook/react/pull/17971))
 * Fix a bug with rebasing updates ([@acdlite](https://github.com/acdlite) and [@sebmarkbage](https://github.com/sebmarkbage) in [#17560](https://github.com/facebook/react/pull/17560), [#17510](https://github.com/facebook/react/pull/17510), [#17483](https://github.com/facebook/react/pull/17483), [#17480](https://github.com/facebook/react/pull/17480))
 

--- a/compiler/packages/snap/src/sprout/README.md
+++ b/compiler/packages/snap/src/sprout/README.md
@@ -4,7 +4,7 @@ React Forget test framework that executes compiler fixtures.
 Currently, Sprout runs each fixture with a known set of inputs and annotations. Sprout compares execution outputs (i.e. return values and console logs) of original source code and the corresponding Forget-transformed version.
 We hope to add fuzzing capabilities to Sprout, synthesizing sets of program inputs based on type and/or effect annotations.
 
-Sprout is now enabled for all fixtures! If Sprout cannot execute your fixture due to some technical limitations, add your fixture to [`SproutTodoFilter.ts`](./src/SproutTodoFilter.ts) with a comment explaining why.
+Sprout is now enabled for all fixtures! If Sprout cannot execute your fixture due to some technical limitations, add your fixture to [`SproutTodoFilter.ts`](../SproutTodoFilter.ts) with a comment explaining why.
 
 ### Sprout CLI
 Sprout is now run as a part of snap, except when in filter mode.
@@ -68,7 +68,7 @@ function customHelper(val1, val2) {
 
 - Sprout currently runs each fixture in an iife to prevent variable collisions, but it does not run fixtures in isolation. Please do not mutate any external state in fixtures.
 
-- Sprout does not run fixtures listed in [`SproutTodoFilter.ts`](./src/SproutTodoFilter.ts), even in filter mode.
+- Sprout does not run fixtures listed in [`SproutTodoFilter.ts`](../SproutTodoFilter.ts), even in filter mode.
 
 ### Milestones:
 - [✅] Render fixtures with React runtime / `testing-library/react`.

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -54,7 +54,7 @@ Before promoting, make sure the versions have been bumped:
 1. `package.json` files for each package
 1. [packages/shared/ReactVersion.js](../../packages/shared/ReactVersion.js)
 
-Once the "canary" release has been tested and verified, you can promote it to stable by running the [Publish release](./actions/workflows/runtime_release_from_ci.yml) GitHub Action workflow. This workflow will prepare the release artifacts and publish them to NPM as either `stable-latest` (e.g. for `react@latest`) or `stable-backport` for an older release line that shouldn't move `@latest` (published under the `@backport` dist-tag instead).
+Once the "canary" release has been tested and verified, you can promote it to stable by running the [Publish release](https://github.com/facebook/react/actions/workflows/runtime_release_from_ci.yml) GitHub Action workflow. This workflow will prepare the release artifacts and publish them to NPM as either `stable-latest` (e.g. for `react@latest`) or `stable-backport` for an older release line that shouldn't move `@latest` (published under the `@backport` dist-tag instead).
 
 > [!IMPORTANT]
 > The designated commit must be able to build in CI. If runtime_build_and_test.yml fails for that commit, the release workflow will also fail.
@@ -67,7 +67,7 @@ Once the "canary" release has been tested and verified, you can promote it to st
 1. Make sure versions (`ReactVersions.js`, `ReactVersion.js`, `package.json`) are set to an unreleased version 
 1. Cherry-pick desired commits
 1. Push to branch
-1. [Publish release](./actions/workflows/runtime_release_from_ci.yml)
+1. [Publish release](https://github.com/facebook/react/actions/workflows/runtime_release_from_ci.yml)
    - `workflow_from` is the newly pushed commit containing cherry-picked changes,
    - `type` is either `stable-latest` (e.g. for `react@latest`) or `stable-backport` for an older release line that shouldn't move `@latest` (published under the `@backport` dist-tag instead).
 1. For stable releases the workflow will prepare everything for an automated publish. However, the final publish step will require manual approval in the GitHub Actions UI.


### PR DESCRIPTION
## Summary

- fix Sprout README links to `SproutTodoFilter.ts`
- point release workflow references to the GitHub Actions workflow page
- fix a malformed changelog link for `@acdlite`

## Verification

- `test -f compiler/packages/snap/src/SproutTodoFilter.ts && test -f .github/workflows/runtime_release_from_ci.yml && ! git grep -n -E '\./src/SproutTodoFilter\.ts|\./actions/workflows/runtime_release_from_ci\.yml|\[@acdlite]\(\(https://github\.com/acdlite\)\)' -- compiler/packages/snap/src/sprout/README.md scripts/release/README.md CHANGELOG.md`
- `git diff --check`
