### PR TITLE
[Fizz] Allow Pending Work to Specialize Abort Reasons

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -3603,6 +3603,88 @@ describe('ReactDOMFizzServer', () => {
     expect(errors).toEqual(['abort reason', 'abort reason', 'abort reason']);
   });
 
+  it('uses a rejection reason from a lazy component before the abort finishes', async () => {
+    let reject;
+    const Lazy = React.lazy(
+      () =>
+        new Promise((resolve, rejectPromise) => {
+          reject = rejectPromise;
+        }),
+    );
+    const haltedPromise = new Promise(() => {});
+    function HaltedWait() {
+      use(haltedPromise);
+      return null;
+    }
+
+    const errors = [];
+    let abort;
+    await act(() => {
+      const controls = renderToPipeableStream(
+        <>
+          <Suspense fallback="Loading lazy">
+            <Lazy />
+          </Suspense>
+          <Suspense fallback="Loading halted">
+            <HaltedWait />
+          </Suspense>
+        </>,
+        {
+          onError(error) {
+            errors.push(error.message);
+          },
+        },
+      );
+      abort = controls.abort;
+      controls.pipe(writable);
+    });
+
+    await act(() => {
+      abort(new Error('abort reason'));
+      reject(new Error('rejected during abort'));
+    });
+
+    expect(errors).toEqual(['rejected during abort', 'abort reason']);
+  });
+
+  it('does not report a rejection reason after abort has finished', async () => {
+    let reject;
+    const promise = new Promise((resolve, rejectPromise) => {
+      reject = rejectPromise;
+    });
+    function Wait() {
+      use(promise);
+      return null;
+    }
+
+    const errors = [];
+    let abort;
+    await act(() => {
+      const controls = renderToPipeableStream(
+        <Suspense fallback="Loading">
+          <Wait />
+        </Suspense>,
+        {
+          onError(error) {
+            errors.push(error.message);
+          },
+        },
+      );
+      abort = controls.abort;
+      controls.pipe(writable);
+    });
+
+    await act(() => {
+      abort(new Error('abort reason'));
+    });
+
+    await act(() => {
+      reject(new Error('rejected after abort'));
+    });
+
+    expect(errors).toEqual(['abort reason']);
+  });
+
   it('warns in dev if you access digest from errorInfo in onRecoverableError', async () => {
     await act(() => {
       const {pipe} = renderToPipeableStream(

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
@@ -527,7 +527,7 @@ describe('ReactDOMFizzStaticBrowser', () => {
     expect(errors).toEqual(['uh oh', 'uh oh']);
   });
 
-  it('currently uses the abort reason when an abort listener synchronously rejects pending work', async () => {
+  it('uses a rejection reason when an abort listener rejects pending work before the abort finishes', async () => {
     let reject;
     const rejectedPromise = new Promise((resolve, rejectPromise) => {
       reject = rejectPromise;
@@ -572,7 +572,7 @@ describe('ReactDOMFizzStaticBrowser', () => {
     });
     await resultPromise;
 
-    expect(errors).toEqual(['abort reason', 'abort reason']);
+    expect(errors).toEqual(['rejected during abort', 'abort reason']);
   });
 
   it('logs an error if onHeaders throws but continues the prerender', async () => {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticNode-test.js
@@ -464,7 +464,7 @@ describe('ReactDOMFizzStaticNode', () => {
     expect(errors).toEqual(['uh oh', 'uh oh']);
   });
 
-  it('currently uses the abort reason when an abort listener synchronously rejects pending work', async () => {
+  it('uses a rejection reason when an abort listener rejects pending work before the abort finishes', async () => {
     let reject;
     const rejectedPromise = new Promise((resolve, rejectPromise) => {
       reject = rejectPromise;
@@ -505,10 +505,11 @@ describe('ReactDOMFizzStaticNode', () => {
     });
     controller.abort(new Error('abort reason'));
 
+    await Promise.resolve();
     await jest.runAllTimers();
     await resultPromise;
 
-    expect(errors).toEqual(['abort reason', 'abort reason']);
+    expect(errors).toEqual(['rejected during abort', 'abort reason']);
   });
 
   describe('with real timers', () => {

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -276,11 +276,16 @@ type SuspenseBoundary = {
   errorComponentStack?: null | string, // the error component stack if it errors
 };
 
+type Ping = {
+  resolve: () => void,
+  reject: (error: mixed) => void,
+};
+
 type RenderTask = {
   replay: null,
   node: ReactNodeList,
   childIndex: number,
-  ping: () => void,
+  ping: Ping,
   blockedBoundary: Root | SuspenseBoundary,
   blockedSegment: Segment, // the segment we'll write to
   blockedPreamble: null | PreambleState,
@@ -311,7 +316,7 @@ type ReplayTask = {
   replay: ReplaySet,
   node: ReactNodeList,
   childIndex: number,
-  ping: () => void,
+  ping: Ping,
   blockedBoundary: Root | SuspenseBoundary,
   blockedSegment: null, // we don't write to anything when we replay
   blockedPreamble: null,
@@ -810,6 +815,27 @@ function pingTask(request: Request, task: Task): void {
   }
 }
 
+function pingRejectedTask(request: Request, task: Task, error: mixed): void {
+  if (!request.aborted) {
+    // Replaying the task is what gives ordinary render errors their complete
+    // component stack.
+    pingTask(request, task);
+    return;
+  }
+  if (!task.abortSet.delete(task)) {
+    // finishAbort already completed this task with the request's abort reason.
+    return;
+  }
+  // abortTask synchronously claimed this task before abort listeners could
+  // reject its wakeable. Finish it with the more specific reason before the
+  // scheduled final abort uses the reason for the whole request.
+  if (__DEV__) {
+    finishAbortedTaskDEV(task, request, error);
+  } else {
+    finishAbortedTask(task, request, error);
+  }
+}
+
 function createSuspenseBoundary(
   request: Request,
   row: null | SuspenseListRow,
@@ -889,7 +915,10 @@ function createRenderTask(
     replay: null,
     node,
     childIndex,
-    ping: () => pingTask(request, task),
+    ping: {
+      resolve: () => pingTask(request, task),
+      reject: error => pingRejectedTask(request, task, error),
+    },
     blockedBoundary,
     blockedSegment,
     blockedPreamble,
@@ -945,7 +974,10 @@ function createReplayTask(
     replay,
     node,
     childIndex,
-    ping: () => pingTask(request, task),
+    ping: {
+      resolve: () => pingTask(request, task),
+      reject: error => pingRejectedTask(request, task, error),
+    },
     blockedBoundary,
     blockedSegment: null,
     blockedPreamble: null,
@@ -4204,7 +4236,7 @@ function renderNode(
             thenableState,
           );
           const ping = newTask.ping;
-          wakeable.then(ping, ping);
+          wakeable.then(ping.resolve, ping.reject);
 
           // Restore the context. We assume that this will be restored by the inner
           // functions in case nothing throws so we don't use "finally" here.
@@ -4305,7 +4337,7 @@ function renderNode(
             thenableState,
           );
           const ping = newTask.ping;
-          wakeable.then(ping, ping);
+          wakeable.then(ping.resolve, ping.reject);
 
           // Restore the context. We assume that this will be restored by the inner
           // functions in case nothing throws so we don't use "finally" here.
@@ -5216,7 +5248,7 @@ function retryRenderTask(
             : null;
         const ping = task.ping;
         // We've asserted that x is a thenable above
-        (x: any).then(ping, ping);
+        (x: any).then(ping.resolve, ping.reject);
         return;
       }
     }
@@ -5316,7 +5348,7 @@ function retryReplayTask(request: Request, task: ReplayTask): void {
       if (typeof x.then === 'function') {
         // Something suspended again, let's pick it back up later.
         const ping = task.ping;
-        x.then(ping, ping);
+        x.then(ping.resolve, ping.reject);
         task.thenableState =
           thrownValue === SuspenseException
             ? getThenableStateAfterSuspending()


### PR DESCRIPTION
# Allow Pending Work to Specialize Abort Reasons

## Summary

Fizz currently reports every unfinished task using the same request-wide abort reason. This makes it possible to observe that a render did not finish, but not to understand why any individual suspended slot remained incomplete.

This change allows suspended tasks to report a more specific rejection reason when the wakeable they are blocked on rejects after abort begins and before Fizz finalizes that task. Tasks that do not reject during this window continue to report the general abort reason.

This is primarily motivated by partial prerendering, where aborting is not merely an exceptional termination mechanism. It is the API used to intentionally finish a prerender while leaving some work unresolved.

## Motivation

For an ordinary server render, a request abort generally means that the result is no longer needed. Reporting the same abort reason for every unfinished task is usually sufficient.

For a partial prerender, the meaning is different. The caller intentionally aborts in order to produce a partial result. The unfinished work is then useful information: it identifies which parts of the tree prevented the prerender from completing.

Today, all of those tasks receive the same abort reason:

```text
slot A -> prerender aborted
slot B -> prerender aborted
slot C -> prerender aborted
```

That says which work was incomplete, but not whether different slots should be interpreted differently.

For example, an application may have:

- A slow API that is permitted to miss the prerender deadline and should not produce actionable logging.
- Other work that is expected to finish during prerendering and should be reported when it does not.
- A data source that can provide additional telemetry about why it did not finish once it learns that the prerender has been aborted.

With a single request-wide abort reason, `onError` cannot distinguish these cases.

## Proposed Behavior

When abort begins, Fizz still associates a general abort reason with the request. That reason remains the fallback for every unfinished task.

However, if a task is suspended on a wakeable and that wakeable rejects during the interval between:

1. The request beginning to abort.
2. Fizz finalizing that task as aborted.

then Fizz reports the wakeable's rejection reason for that task instead of the general abort reason.

Conceptually:

```text
slot A -> rejected during abort with TimeoutError("optional recommendations timed out")
slot B -> still pending when abort finishes -> Error("prerender deadline reached")
slot C -> rejected during abort with QueryError("inventory lookup canceled")
```

A rejection that arrives after its task has already been finalized is ignored.

## Intended Usage

The canonical usage is for the caller to use the same `AbortSignal` both to terminate the prerender and to notify data sources that may still be blocking suspended work. A data source can reject with a more specific error whose `cause` preserves its relationship to the overall abort.

```js
const controller = new AbortController();
const abortReason = new Error('prerender deadline reached');

const result = prerender(<App signal={controller.signal} />, {
  signal: controller.signal,
  onError(error) {
    if (error === abortReason) {
      // This task was unfinished but did not provide a more specific reason.
      return;
    }

    if (error instanceof Error && error.cause === abortReason) {
      // This task reported a specialized failure caused by the prerender abort.
      // For example, suppress an expected optional timeout or record telemetry.
      return;
    }

    // Interpret an ordinary rendering error.
  },
});

controller.abort(abortReason);
```

An interested data source can observe that signal and reject pending work with an operation-specific reason that records the abort as its cause:

```js
signal.addEventListener(
  'abort',
  () => {
    reject(
      new Error('optional recommendations timed out', {
        cause: signal.reason,
      }),
    );
  },
  {once: true},
);
```

If this rejection arrives before Fizz finishes aborting the suspended task, `onError` receives the operation-specific error instead of the general abort reason. Work that does not provide a specialized rejection continues to report `abortReason` directly.

This allows applications to:

- Suppress logging for intentionally optional or deadline-limited work.
- Surface unfinished work that should be investigated.
- Include operation-specific telemetry or context in aborted-slot reporting.
- Retain an explicit causal relationship between a specialized error and the request-wide abort.

## Causality And Scope

Fizz does not attempt to prove that a wakeable rejected because of the abort signal.

The precise behavior is temporal:

- If a suspended wakeable rejects after abort begins and before its task is finalized, its rejection specializes that task's abort reason.
- If it does not reject during that interval, the task receives the general abort reason.
- If it rejects after finalization, the rejection is ignored for Fizz error reporting.

Using the same `AbortSignal` to notify data sources is the intended protocol, but Fizz cannot distinguish a rejection caused by that signal from any unrelated rejection that happens to occur during the abort window.

Likewise, `signal.aborted` in `onError` lets callers distinguish errors observed before abort initiation from errors observed after it began. It does not independently prove causality for an arbitrary rejection.

## Implementation

Previously, a suspended task attached the same ping callback for both fulfillment and rejection:

```js
wakeable.then(ping, ping);
```

That is correct during ordinary rendering because retrying the task allows a rejected wakeable to throw through the normal render path, preserving regular error handling and stack construction.

During abort, however, retrying general work is intentionally suppressed. To preserve a rejection that arrives during the abort window, the task now stores distinct fulfillment and rejection ping callbacks:

```js
wakeable.then(ping.resolve, ping.reject);
```

Before abort begins, `ping.reject` retains existing behavior by scheduling the task for retry.

After abort begins, `ping.reject` attempts to claim the still-pending aborted task from its owning abort set. If successful, Fizz finalizes that task immediately using the rejection reason. The later scheduled abort finish processes only tasks that remain in their abort sets, using the general abort reason.

This avoids adding another top-level property to `Task`, whose production shape is already at the current field-count threshold, while also covering suspension mechanisms such as `React.lazy` that cannot be handled by inspecting `use()` thenable state.

## Tests

The tests cover:

- A rejected suspended task reporting a specialized reason while unrelated pending work still reports the general abort reason.
- Specialization for `React.lazy`, ensuring this is not limited to `use()` suspension.
- A rejection arriving after abort finalization being ignored.
- The prerender scheduling window in both static Browser and Node APIs, where abort listeners can reject pending work before abort completion.