### PR TITLE
Version 19.2.7

### DIFF
--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -7,18 +7,18 @@
 //
 // The @latest channel uses the version as-is, e.g.:
 //
-//   19.2.6
+//   19.2.7
 //
 // The @canary channel appends additional information, with the scheme
 // <version>-<label>-<commit_sha>, e.g.:
 //
-//   19.2.6-canary-a1c2d3e4
+//   19.2.7-canary-a1c2d3e4
 //
 // The @experimental channel doesn't include a version, only a date and a sha, e.g.:
 //
 //   0.0.0-experimental-241c4467e-20200129
 
-const ReactVersion = '19.2.6';
+const ReactVersion = '19.2.7';
 
 // The label used by the @canary channel. Represents the upcoming release's
 // stability. Most of the time, this will be "canary", but we may temporarily

--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-art",
   "description": "React ART is a JavaScript library for drawing vector graphics using React. It provides declarative and reactive bindings to the ART library. Using the same declarative API you can render the output to either Canvas, SVG or VML (IE8).",
-  "version": "19.2.6",
+  "version": "19.2.7",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -27,7 +27,7 @@
     "scheduler": "^0.27.0"
   },
   "peerDependencies": {
-    "react": "^19.2.6"
+    "react": "^19.2.7"
   },
   "files": [
     "LICENSE",

--- a/packages/react-dom-bindings/package.json
+++ b/packages/react-dom-bindings/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-dom-bindings",
   "description": "React implementation details for react-dom.",
-  "version": "19.2.6",
+  "version": "19.2.7",
   "private": true,
   "main": "index.js",
   "repository": {

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dom",
-  "version": "19.2.6",
+  "version": "19.2.7",
   "description": "React package for working with the DOM.",
   "main": "index.js",
   "repository": {
@@ -20,7 +20,7 @@
     "scheduler": "^0.27.0"
   },
   "peerDependencies": {
-    "react": "^19.2.6"
+    "react": "^19.2.7"
   },
   "files": [
     "LICENSE",

--- a/packages/react-is/package.json
+++ b/packages/react-is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-is",
-  "version": "19.2.6",
+  "version": "19.2.7",
   "description": "Brand checking of React Elements.",
   "main": "index.js",
   "sideEffects": false,

--- a/packages/react-markup/package.json
+++ b/packages/react-markup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-markup",
-  "version": "19.2.6",
+  "version": "19.2.7",
   "description": "React package generating embedded markup such as e-mails with support for Server Components.",
   "main": "index.js",
   "repository": {

--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -26,7 +26,7 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^19.2.6"
+    "react": "^19.2.7"
   },
   "dependencies": {
     "scheduler": "^0.27.0"

--- a/packages/react-server-dom-esm/package.json
+++ b/packages/react-server-dom-esm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-server-dom-esm",
   "description": "React Server Components bindings for DOM using ESM. This is intended to be integrated into meta-frameworks. It is not intended to be imported directly.",
-  "version": "19.2.6",
+  "version": "19.2.7",
   "keywords": [
     "react"
   ],

--- a/packages/react-server-dom-parcel/package.json
+++ b/packages/react-server-dom-parcel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-server-dom-parcel",
   "description": "React Server Components bindings for DOM using Parcel. This is intended to be integrated into meta-frameworks. It is not intended to be imported directly.",
-  "version": "19.2.6",
+  "version": "19.2.7",
   "keywords": [
     "react"
   ],
@@ -79,7 +79,7 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   }
 }

--- a/packages/react-server-dom-turbopack/package.json
+++ b/packages/react-server-dom-turbopack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-server-dom-turbopack",
   "description": "React Server Components bindings for DOM using Turbopack. This is intended to be integrated into meta-frameworks. It is not intended to be imported directly.",
-  "version": "19.2.6",
+  "version": "19.2.7",
   "keywords": [
     "react"
   ],
@@ -79,8 +79,8 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "dependencies": {
     "acorn-loose": "^8.3.0",

--- a/packages/react-server-dom-webpack/package.json
+++ b/packages/react-server-dom-webpack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-server-dom-webpack",
   "description": "React Server Components bindings for DOM using Webpack. This is intended to be integrated into meta-frameworks. It is not intended to be imported directly.",
-  "version": "19.2.6",
+  "version": "19.2.7",
   "keywords": [
     "react"
   ],
@@ -85,8 +85,8 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "webpack": "^5.59.0"
   },
   "dependencies": {

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-test-renderer",
-  "version": "19.2.6",
+  "version": "19.2.7",
   "description": "React package for snapshot testing.",
   "main": "index.js",
   "repository": {
@@ -19,11 +19,11 @@
   },
   "homepage": "https://react.dev/",
   "dependencies": {
-    "react-is": "^19.2.6",
+    "react-is": "^19.2.7",
     "scheduler": "^0.27.0"
   },
   "peerDependencies": {
-    "react": "^19.2.6"
+    "react": "^19.2.7"
   },
   "files": [
     "LICENSE",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "react"
   ],
-  "version": "19.2.6",
+  "version": "19.2.7",
   "homepage": "https://react.dev/",
   "bugs": "https://github.com/facebook/react/issues",
   "license": "MIT",

--- a/packages/shared/ReactVersion.js
+++ b/packages/shared/ReactVersion.js
@@ -12,4 +12,4 @@
 // TODO: This module is used both by the release scripts and to expose a version
 // at runtime. We should instead inject the version number as part of the build
 // process, and use the ReactVersions.js module as the single source of truth.
-export default '19.2.6';
+export default '19.2.7';


### PR DESCRIPTION
Releasing with
```console
gh workflow run runtime_release_from_ci.yml \
  --ref releases/19.2.x \
  --raw-field="type=stable-latest"\
  --raw-field="only_packages=react react-art react-dom react-server-dom-webpack react-server-dom-turbopack react-server-dom-parcel react-is react-test-renderer" \
  --raw-field="dry=true"
```