### PR TITLE
[react-devtools-facade] 2/ implement component tree tools

### DIFF
--- a/packages/react-devtools-facade/src/DevToolsFacade.js
+++ b/packages/react-devtools-facade/src/DevToolsFacade.js
@@ -20,6 +20,11 @@ import type {
 
 import {getInternalReactConstants} from 'react-devtools-shared/src/backend/fiber/shared/DevToolsFiberInternalReactConstants';
 
+// Re-export the tools assembler so the full building-block API is available
+// from the package entry point (index.js re-exports this module).
+export {createTools} from './DevToolsFacadeTools';
+export type {Tools} from './DevToolsFacadeTools';
+
 // Per-renderer internal constants, initialized at inject() time. Building
 // blocks read these to translate fibers into human-readable output.
 export type RendererInternals = {

--- a/packages/react-devtools-facade/src/DevToolsFacadeTools.js
+++ b/packages/react-devtools-facade/src/DevToolsFacadeTools.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Facade} from './DevToolsFacade';
+import type {
+  TreeNode,
+  NodeInfo,
+  ComponentSource,
+  OwnersStack,
+  OwnerEntry,
+  FindComponentsResult,
+  ToolError,
+} from './DevToolsFacadeTreeTools';
+
+import {createTreeTools} from './DevToolsFacadeTreeTools';
+
+export type {
+  TreeNode,
+  NodeInfo,
+  HookNode,
+  ComponentSource,
+  SourceLocation,
+  OwnersStack,
+  OwnerEntry,
+  FindComponentsResult,
+  ToolError,
+} from './DevToolsFacadeTreeTools';
+
+// The set of tools assembled from a Facade. Each tool returns a plain
+// JavaScript value (see the types in ./DevToolsFacadeTreeTools); serialization is the
+// integrator's responsibility. Integrators decide whether to expose these on
+// globals or call them directly.
+export type Tools = {
+  getComponentTree: (
+    depth?: number,
+    rootUid?: string,
+  ) => Array<TreeNode> | ToolError,
+  getComponentByUid: (uid: string) => NodeInfo | ToolError,
+  findComponents: (
+    name: string,
+    rootUid?: string,
+    page?: number,
+    pageSize?: number,
+  ) => FindComponentsResult | ToolError,
+  getComponentSource: (uid: string) => ComponentSource | ToolError,
+  getOwnersStack: (uid: string) => OwnersStack | ToolError,
+  getOwnersBranch: (uid: string) => Array<OwnerEntry> | ToolError,
+};
+
+/**
+ * Assemble the set of tools from a Facade. The tools read the facade's tracked
+ * runtime state (fiber roots, per-renderer internals) lazily on each call and
+ * never touch globals, so the integrator fully owns both the facade and the
+ * returned tools.
+ *
+ * @param facade - A Facade returned by installFacade().
+ */
+export function createTools(facade: Facade): Tools {
+  const tree = createTreeTools(facade.fiberRoots, facade.rendererInternals);
+
+  return {
+    getComponentTree: tree.getComponentTree,
+    getComponentByUid: tree.getComponentByUid,
+    findComponents: tree.findComponents,
+    getComponentSource: tree.getComponentSource,
+    getOwnersStack: tree.getOwnersStack,
+    getOwnersBranch: tree.getOwnersBranch,
+  };
+}

--- a/packages/react-devtools-facade/src/DevToolsFacadeTreeTools.js
+++ b/packages/react-devtools-facade/src/DevToolsFacadeTreeTools.js
@@ -1,0 +1,670 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {extractLocationFromComponentStack} from 'react-devtools-shared/src/backend/utils/parseStackTrace';
+import {
+  getOwnerStackByFiberInDev,
+  getSourceLocationByFiber,
+} from 'react-devtools-shared/src/backend/fiber/DevToolsFiberComponentStack';
+import {getDispatcherRef} from 'react-devtools-shared/src/backend/shared/DevToolsReactDispatcher';
+import {inspectHooksOfFiberWithoutDefaultDispatcher} from 'react-debug-tools';
+
+import type {Fiber, FiberRoot} from 'react-reconciler/src/ReactInternalTypes';
+import type {WorkTagMap} from 'react-devtools-shared/src/backend/types';
+import type {HooksTree, HooksNode} from 'react-debug-tools/src/ReactDebugHooks';
+import type {RendererInternals} from './DevToolsFacade';
+
+// Tools return plain JavaScript values with the types below. Serialization
+// (to TOON, JSON, etc.) is the integrator's responsibility.
+
+// Returned by any tool when the requested component/root cannot be resolved.
+export type ToolError = {error: string};
+
+// A single component in a tree snapshot. firstChild/nextSibling reference other
+// nodes by their uid, forming an adjacency list the integrator can rebuild.
+export type TreeNode = {
+  uid: string,
+  type: string,
+  name: string,
+  key: string | null,
+  firstChild: string | null,
+  nextSibling: string | null,
+};
+
+// One inspected hook. value is normalized (serialization-safe); subHooks holds
+// the hooks called by a custom hook, recursively.
+export type HookNode = {
+  id: number | null,
+  name: string,
+  value: mixed,
+  subHooks: Array<HookNode>,
+};
+
+export type NodeInfo = {
+  uid: string,
+  type: string,
+  name: string,
+  key?: string,
+  props?: {[string]: mixed},
+  hooks?: Array<HookNode>,
+};
+
+export type SourceLocation = {
+  name: string,
+  fileName: string,
+  line: number,
+  column: number,
+};
+
+export type ComponentSource = {source: SourceLocation | null};
+
+export type OwnersStack = {stack: string};
+
+export type OwnerEntry = {uid: string, name: string, type: string};
+
+export type FindComponentsResult = {
+  page: number,
+  pageSize: number,
+  totalCount: number,
+  totalPages: number,
+  results: Array<TreeNode>,
+};
+
+export type TreeTools = {
+  getComponentTree: (
+    depth?: number,
+    rootUid?: string,
+  ) => Array<TreeNode> | ToolError,
+  getComponentByUid: (uid: string) => NodeInfo | ToolError,
+  findComponents: (
+    name: string,
+    rootUid?: string,
+    page?: number,
+    pageSize?: number,
+  ) => FindComponentsResult | ToolError,
+  getComponentSource: (uid: string) => ComponentSource | ToolError,
+  getOwnersStack: (uid: string) => OwnersStack | ToolError,
+  getOwnersBranch: (uid: string) => Array<OwnerEntry> | ToolError,
+};
+
+/**
+ * Map a fiber work tag number to a human-readable type string.
+ * Every tag maps to a descriptive string; unknown tags return 'unknown'.
+ */
+export function getTypeTag(workTagMap: WorkTagMap, tag: number): string {
+  const {
+    FunctionComponent,
+    IncompleteFunctionComponent,
+    ClassComponent,
+    IncompleteClassComponent,
+    HostComponent,
+    HostHoistable,
+    HostSingleton,
+    HostRoot,
+    ForwardRef,
+    MemoComponent,
+    SimpleMemoComponent,
+    ContextConsumer,
+    ContextProvider,
+    SuspenseComponent,
+    SuspenseListComponent,
+    LazyComponent,
+    Profiler,
+    HostPortal,
+    ActivityComponent,
+    ViewTransitionComponent,
+    CacheComponent,
+    ScopeComponent,
+    OffscreenComponent,
+    LegacyHiddenComponent,
+    Throw,
+    HostText,
+    Fragment,
+    DehydratedSuspenseComponent,
+    Mode,
+  } = workTagMap;
+
+  switch (tag) {
+    case FunctionComponent:
+    case IncompleteFunctionComponent:
+      return 'function';
+    case ClassComponent:
+    case IncompleteClassComponent:
+      return 'class';
+    case HostComponent:
+    case HostHoistable:
+    case HostSingleton:
+      return 'host';
+    case HostRoot:
+      return 'root';
+    case ForwardRef:
+      return 'forwardRef';
+    case MemoComponent:
+    case SimpleMemoComponent:
+      return 'memo';
+    case ContextConsumer:
+    case ContextProvider:
+      return 'context';
+    case SuspenseComponent:
+      return 'suspense';
+    case SuspenseListComponent:
+      return 'suspenseList';
+    case LazyComponent:
+      return 'lazy';
+    case Profiler:
+      return 'profiler';
+    case HostPortal:
+      return 'portal';
+    case ActivityComponent:
+      return 'activity';
+    case ViewTransitionComponent:
+      return 'viewTransition';
+    case CacheComponent:
+      return 'cache';
+    case ScopeComponent:
+      return 'scope';
+    case OffscreenComponent:
+    case LegacyHiddenComponent:
+      return 'offscreen';
+    case Throw:
+      return 'throw';
+    case HostText:
+      return 'text';
+    case Fragment:
+      return 'fragment';
+    case Mode:
+      return 'mode';
+    case DehydratedSuspenseComponent:
+      return 'dehydrated';
+    default:
+      return 'unknown';
+  }
+}
+
+const MAX_NORMALIZE_DEPTH = 3;
+
+// Normalize a value to a plain, serialization-safe shape. Tracks seen objects
+// to break circular references and limits depth to avoid stack overflow on
+// deeply nested structures. Functions/symbols/elements become descriptive
+// strings so the result can be safely serialized downstream.
+function normalizeValue(val: mixed, seen?: Set<mixed>, depth?: number): mixed {
+  if (val === undefined) return null;
+  if (typeof val === 'function')
+    return val.name ? '[fn ' + val.name + ']' : '[fn]';
+  if (typeof val === 'symbol') return '[symbol]';
+  if (typeof val === 'object' && val !== null) {
+    if ((val as any).$$typeof != null) return '[React element]';
+    const currentDepth = depth || 0;
+    if (currentDepth >= MAX_NORMALIZE_DEPTH) return '[max depth]';
+    const currentSeen = seen || new Set();
+    if (currentSeen.has(val)) return '[circular]';
+    currentSeen.add(val);
+    if (Array.isArray(val)) {
+      const mapped = val.map((v: mixed) =>
+        normalizeValue(v, currentSeen, currentDepth + 1),
+      );
+      currentSeen.delete(val);
+      return mapped;
+    }
+    const result: {[string]: mixed} = {};
+    const keys = Object.keys(val);
+    for (let i = 0; i < keys.length; i++) {
+      result[keys[i]] = normalizeValue(
+        (val as any)[keys[i]],
+        currentSeen,
+        currentDepth + 1,
+      );
+    }
+    currentSeen.delete(val);
+    return result;
+  }
+  return val;
+}
+
+// Normalize props for output: skip children, normalize values.
+function normalizeProps(props: mixed): {[string]: mixed} | null {
+  if (props == null || typeof props !== 'object') return null;
+  const result: {[string]: mixed} = {};
+  const keys = Object.keys(props);
+  let hasProps = false;
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    if (key === 'children') continue;
+    result[key] = normalizeValue((props as any)[key]);
+    hasProps = true;
+  }
+  return hasProps ? result : null;
+}
+
+// Normalize an inspected hooks tree into a serialization-safe shape.
+function normalizeHooks(hooks: HooksTree): Array<HookNode> {
+  return hooks.map((hook: HooksNode) => ({
+    id: hook.id,
+    name: hook.name,
+    value: normalizeValue(hook.value),
+    subHooks: normalizeHooks(hook.subHooks),
+  }));
+}
+
+export function createTreeTools(
+  fiberRoots: Map<number, Set<FiberRoot>>,
+  rendererInternals: Map<number, RendererInternals>,
+): TreeTools {
+  function getTypeTagForFiber(
+    internals: RendererInternals,
+    fiber: Fiber,
+  ): string {
+    return getTypeTag(internals.ReactTypeOfWork, fiber.tag);
+  }
+
+  function getDisplayName(internals: RendererInternals, fiber: Fiber): string {
+    return internals.getDisplayNameForFiber(fiber) || 'Unknown';
+  }
+
+  // Persistent uid state — survives across calls so the same fiber
+  // always maps to the same uid, even after React re-renders (which
+  // swap fiber objects via double-buffering / alternates).
+  const fiberToUid: WeakMap<Fiber, string> = new WeakMap();
+  let nextId: number = 0;
+
+  function getUid(fiber: Fiber): string {
+    let uid = fiberToUid.get(fiber);
+    if (uid != null) return uid;
+    const alt = fiber.alternate;
+    if (alt != null) {
+      uid = fiberToUid.get(alt);
+      if (uid != null) {
+        fiberToUid.set(fiber, uid);
+        return uid;
+      }
+    }
+    uid = 'r' + nextId++;
+    fiberToUid.set(fiber, uid);
+    return uid;
+  }
+
+  // Collect direct children of a fiber via the child/sibling linked list.
+  function collectChildren(fiber: Fiber): Array<Fiber> {
+    const result: Array<Fiber> = [];
+    let child = fiber.child;
+    while (child !== null) {
+      result.push(child);
+      child = child.sibling;
+    }
+    return result;
+  }
+
+  function collectNodes(
+    internals: RendererInternals,
+    fiber: Fiber,
+    maxDepth: number,
+    currentDepth: number,
+    nodes: Array<TreeNode>,
+  ): void {
+    const children = currentDepth < maxDepth ? collectChildren(fiber) : [];
+    const firstChild = children.length > 0 ? getUid(children[0]) : null;
+    nodes.push({
+      uid: getUid(fiber),
+      type: getTypeTagForFiber(internals, fiber),
+      name: getDisplayName(internals, fiber),
+      key: fiber.key != null ? String(fiber.key) : null,
+      firstChild,
+      nextSibling: null,
+    });
+    for (let i = 0; i < children.length; i++) {
+      collectNodes(internals, children[i], maxDepth, currentDepth + 1, nodes);
+      if (i < children.length - 1) {
+        const childUid = getUid(children[i]);
+        for (let j = nodes.length - 1; j >= 0; j--) {
+          if (nodes[j].uid === childUid) {
+            nodes[j].nextSibling = getUid(children[i + 1]);
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  function findByUid(fiber: Fiber, targetUid: string): Fiber | null {
+    if (getUid(fiber) === targetUid) return fiber;
+    const children = collectChildren(fiber);
+    for (let i = 0; i < children.length; i++) {
+      const found = findByUid(children[i], targetUid);
+      if (found != null) return found;
+    }
+    return null;
+  }
+
+  // Find a fiber by uid across all mounted roots.
+  // Returns the fiber and its renderer's internals, or an error.
+  function findFiberByUid(
+    uid: string,
+  ):
+    | {fiber: Fiber, internals: RendererInternals, error: null}
+    | {fiber: null, internals: null, error: string} {
+    // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+    for (const [rendererID, roots] of fiberRoots) {
+      const internals = rendererInternals.get(rendererID);
+      if (internals == null) {
+        return {
+          fiber: null,
+          internals: null,
+          error: 'Missing internals for renderer ' + rendererID,
+        };
+      }
+      // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+      for (const root of roots) {
+        const fiber = findByUid(root.current, uid);
+        if (fiber != null) return {fiber, internals, error: null};
+      }
+    }
+    return {
+      fiber: null,
+      internals: null,
+      error: 'Component not found: "' + uid + '"',
+    };
+  }
+
+  /**
+   * Returns a snapshot of the component tree as an array of nodes. Each node
+   * includes: uid, type, name, key, firstChild, nextSibling (the last two
+   * reference other nodes by uid).
+   *
+   * @param depth - Maximum tree depth to traverse (default 20).
+   * @param rootUid - If provided, snapshot starts from this component.
+   */
+  function getComponentTree(
+    depth?: number = 20,
+    rootUid?: string,
+  ): Array<TreeNode> | ToolError {
+    if (rootUid != null) {
+      const result = findFiberByUid(rootUid);
+      if (result.error != null) {
+        return {error: result.error};
+      }
+      const nodes: Array<TreeNode> = [];
+      collectNodes(result.internals, result.fiber, depth, 0, nodes);
+      return nodes;
+    }
+
+    const nodes: Array<TreeNode> = [];
+    // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+    for (const [rendererID, roots] of fiberRoots) {
+      const internals = rendererInternals.get(rendererID);
+      if (internals == null) {
+        return {error: 'Missing internals for renderer ' + rendererID};
+      }
+      roots.forEach(root => {
+        collectNodes(internals, root.current, depth, 0, nodes);
+      });
+    }
+    if (nodes.length === 0) {
+      return {error: 'No mounted React roots found'};
+    }
+    return nodes;
+  }
+
+  /**
+   * Returns detailed info about a single component by its uid: type, name,
+   * key, props (excluding children), and — for function components — the
+   * inspected hooks tree. Values are normalized to a serialization-safe shape.
+   *
+   * Inspecting hooks re-renders the component's render function (effects are
+   * not run); failures are tolerated and simply omit `hooks`.
+   *
+   * @param uid - The component uid (e.g. "r5").
+   */
+  function getComponentByUid(uid: string): NodeInfo | ToolError {
+    const result = findFiberByUid(uid);
+    if (result.error != null) {
+      return {error: result.error};
+    }
+    const {fiber, internals} = result;
+    const info: NodeInfo = {
+      uid: getUid(fiber),
+      type: getTypeTagForFiber(internals, fiber),
+      name: getDisplayName(internals, fiber),
+    };
+    if (fiber.key != null) {
+      info.key = String(fiber.key);
+    }
+    const props = normalizeProps(fiber.memoizedProps);
+    if (props != null) {
+      info.props = props;
+    }
+    // Hooks are only inspectable for function components, forwardRef, and
+    // simple-memo components. inspectHooksOfFiberWithoutDefaultDispatcher
+    // re-renders the component (using the renderer's injected dispatcher, never
+    // React's shared internals), so guard by tag and tolerate failures (e.g. a
+    // component that throws).
+    const {FunctionComponent, SimpleMemoComponent, ForwardRef} =
+      internals.ReactTypeOfWork;
+    if (
+      fiber.tag === FunctionComponent ||
+      fiber.tag === SimpleMemoComponent ||
+      fiber.tag === ForwardRef
+    ) {
+      try {
+        const hooksTree = inspectHooksOfFiberWithoutDefaultDispatcher(
+          fiber,
+          getDispatcherRef(internals),
+        );
+        info.hooks = normalizeHooks(hooksTree);
+      } catch {
+        // Hook inspection failed; omit hooks rather than failing the call.
+      }
+    }
+    return info;
+  }
+
+  function collectMatches(
+    internals: RendererInternals,
+    fiber: Fiber,
+    query: string,
+    matches: Array<Fiber>,
+  ): void {
+    const displayName = internals.getDisplayNameForFiber(fiber);
+    if (
+      displayName != null &&
+      displayName.toLowerCase().indexOf(query) !== -1
+    ) {
+      matches.push(fiber);
+    }
+    let child = fiber.child;
+    while (child !== null) {
+      collectMatches(internals, child, query, matches);
+      child = child.sibling;
+    }
+  }
+
+  type FiberMatch = {fiber: Fiber, internals: RendererInternals};
+
+  /**
+   * Searches for components by name (case-insensitive substring match).
+   * Returns a paginated result with matching components.
+   *
+   * @param name - Search query to match against component display names.
+   * @param rootUid - If provided, limits search to this component's subtree.
+   * @param page - Page number (default 1, clamped to valid range).
+   * @param pageSize - Results per page (default 10).
+   */
+  function findComponents(
+    name: string,
+    rootUid?: string,
+    page?: number = 1,
+    pageSize?: number = 10,
+  ): FindComponentsResult | ToolError {
+    const query = name.toLowerCase();
+    const allMatches: Array<FiberMatch> = [];
+
+    if (rootUid != null) {
+      const found = findFiberByUid(rootUid);
+      if (found.error != null) {
+        return {error: found.error};
+      }
+      const fibers: Array<Fiber> = [];
+      collectMatches(found.internals, found.fiber, query, fibers);
+      for (let i = 0; i < fibers.length; i++) {
+        allMatches.push({fiber: fibers[i], internals: found.internals});
+      }
+    } else {
+      // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+      for (const [rendererID, roots] of fiberRoots) {
+        const internals = rendererInternals.get(rendererID);
+        if (internals == null) {
+          return {error: 'Missing internals for renderer ' + rendererID};
+        }
+        roots.forEach(root => {
+          const fibers: Array<Fiber> = [];
+          collectMatches(internals, root.current, query, fibers);
+          for (let i = 0; i < fibers.length; i++) {
+            allMatches.push({fiber: fibers[i], internals});
+          }
+        });
+      }
+    }
+
+    const totalCount = allMatches.length;
+    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+    const clampedPage = Math.max(1, Math.min(page, totalPages));
+    const startIdx = (clampedPage - 1) * pageSize;
+    const pageMatches = allMatches.slice(startIdx, startIdx + pageSize);
+
+    const rows: Array<TreeNode> = [];
+    for (let i = 0; i < pageMatches.length; i++) {
+      const {fiber, internals} = pageMatches[i];
+      const children = collectChildren(fiber);
+      rows.push({
+        uid: getUid(fiber),
+        type: getTypeTagForFiber(internals, fiber),
+        name: getDisplayName(internals, fiber),
+        key: fiber.key != null ? String(fiber.key) : null,
+        firstChild: children.length > 0 ? getUid(children[0]) : null,
+        nextSibling: null,
+      });
+    }
+
+    return {
+      page: clampedPage,
+      pageSize,
+      totalCount,
+      totalPages,
+      results: rows,
+    };
+  }
+
+  /**
+   * Returns the definition location of a component — where the component
+   * function or class is defined in source code. Uses the same "throwing
+   * trick" as React DevTools to capture a stack frame from within the
+   * component's function body.
+   *
+   * Returns {source: {name, fileName, line, column}} or {source: null} if the
+   * location cannot be determined (e.g. host components, production builds).
+   *
+   * @param uid - The component uid (e.g. "r5").
+   */
+  function getComponentSource(uid: string): ComponentSource | ToolError {
+    const result = findFiberByUid(uid);
+    if (result.error != null) {
+      return {error: result.error};
+    }
+    const {fiber, internals} = result;
+    const stackFrame = getSourceLocationByFiber(
+      internals.ReactTypeOfWork,
+      fiber,
+      internals.currentDispatcherRef,
+    );
+    if (stackFrame == null) {
+      return {source: null};
+    }
+    const location = extractLocationFromComponentStack(stackFrame);
+    if (location == null) {
+      return {source: null};
+    }
+    const [name, fileName, line, column] = location;
+    return {source: {name, fileName, line, column}};
+  }
+
+  /**
+   * Returns the raw owner stack trace string — the chain of JSX creation
+   * locations from this component up to the root. Each line is a stack frame
+   * showing where <Component /> was written in the owner's code. The stack can
+   * be passed to source map tools for symbolication.
+   *
+   * Returns {stack: string}. DEV-only — in production, the stack will be empty.
+   *
+   * @param uid - The component uid (e.g. "r5").
+   */
+  function getOwnersStack(uid: string): OwnersStack | ToolError {
+    const result = findFiberByUid(uid);
+    if (result.error != null) {
+      return {error: result.error};
+    }
+    const {fiber, internals} = result;
+    const stackString = getOwnerStackByFiberInDev(
+      internals.ReactTypeOfWork,
+      fiber,
+      internals.currentDispatcherRef,
+    );
+    return {stack: stackString};
+  }
+
+  /**
+   * Returns the structured list of owner components — which components rendered
+   * this component, ordered from immediate owner to root ancestor. Each entry
+   * includes a uid for cross-referencing with other tools (e.g.
+   * getComponentByUid, getComponentSource, getComponentTree).
+   *
+   * Returns an array of {uid, name, type}, or an empty array if the component
+   * has no owner (root component). DEV-only — in production, _debugOwner is not
+   * available.
+   *
+   * @param uid - The component uid (e.g. "r5").
+   */
+  function getOwnersBranch(uid: string): Array<OwnerEntry> | ToolError {
+    const result = findFiberByUid(uid);
+    if (result.error != null) {
+      return {error: result.error};
+    }
+    const {fiber, internals} = result;
+
+    const owners: Array<OwnerEntry> = [];
+    // Walk the JSX-creation owner chain from this component up to the root,
+    // collecting only Fiber owners (client components). A Fiber's _debugOwner
+    // points to the next owner — itself a Fiber (client) or a
+    // ReactComponentInfo (server component); the latter continues the chain
+    // via its .owner field.
+    let owner: mixed = fiber._debugOwner;
+    while (owner != null) {
+      const node: any = owner;
+      if (typeof node.tag === 'number') {
+        owners.push({
+          uid: getUid(node),
+          name: getDisplayName(internals, node),
+          type: getTypeTagForFiber(internals, node),
+        });
+        owner = node._debugOwner;
+      } else {
+        // Server component (ReactComponentInfo): continue via its .owner.
+        owner = node.owner;
+      }
+    }
+    return owners;
+  }
+
+  return {
+    getComponentTree,
+    getComponentByUid,
+    findComponents,
+    getComponentSource,
+    getOwnersStack,
+    getOwnersBranch,
+  };
+}

--- a/packages/react-devtools-facade/src/__tests__/DevToolsFacade-test.js
+++ b/packages/react-devtools-facade/src/__tests__/DevToolsFacade-test.js
@@ -8,6 +8,7 @@
 'use strict';
 
 let installFacade;
+let createTools;
 let facade;
 let React;
 let ReactDOMClient;
@@ -27,7 +28,9 @@ describe('react-devtools-facade', () => {
 
     // Install the facade BEFORE React so the hook captures the first commit.
     // Import through the package entry point to exercise the public surface.
-    installFacade = require('../../index').installFacade;
+    const facadeAPI = require('../../index');
+    installFacade = facadeAPI.installFacade;
+    createTools = facadeAPI.createTools;
     facade = installFacade();
 
     React = require('react');
@@ -121,5 +124,1414 @@ describe('react-devtools-facade', () => {
     });
 
     expect(facade.hook.getFiberRoots(rendererID).size).toBe(0);
+  });
+
+  describe('getComponentTree', () => {
+    let getComponentTree;
+
+    beforeEach(() => {
+      getComponentTree = createTools(facade).getComponentTree;
+    });
+
+    it('returns error when nothing is rendered', () => {
+      const result = getComponentTree();
+      expect(result.error).toMatch(/No mounted React roots found/);
+    });
+
+    it('returns an array of component nodes', () => {
+      function App() {
+        return <div>hello</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const result = getComponentTree();
+      expect(Array.isArray(result)).toBe(true);
+      const app = result.find(n => n.name === 'App');
+      const div = result.find(n => n.name === 'div');
+      // App is the root's only child; its child is the host div.
+      expect(app).toEqual({
+        uid: 'r0',
+        type: 'function',
+        name: 'App',
+        key: null,
+        firstChild: div.uid,
+        nextSibling: null,
+      });
+      // A single string child ('hello') is stored as a prop, not a child fiber,
+      // so the div is a leaf in the tree.
+      expect(div).toEqual({
+        uid: 'r2',
+        type: 'host',
+        name: 'div',
+        key: null,
+        firstChild: null,
+        nextSibling: null,
+      });
+    });
+
+    it('encodes firstChild and nextSibling relationships', () => {
+      function Header() {
+        return <h1>title</h1>;
+      }
+      function Footer() {
+        return <footer>foot</footer>;
+      }
+      function App() {
+        return (
+          <div>
+            <Header />
+            <Footer />
+          </div>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const nodes = getComponentTree();
+      const app = nodes.find(n => n.name === 'App');
+      const div = nodes.find(n => n.name === 'div');
+      const header = nodes.find(n => n.name === 'Header');
+      const footer = nodes.find(n => n.name === 'Footer');
+
+      // App's firstChild is div
+      expect(app.firstChild).toBe(div.uid);
+      // div's firstChild is Header
+      expect(div.firstChild).toBe(header.uid);
+      // Header's nextSibling is Footer
+      expect(header.nextSibling).toBe(footer.uid);
+      // Footer has no nextSibling
+      expect(footer.nextSibling).toBe(null);
+    });
+
+    it('shows keys in the output', () => {
+      function Item() {
+        return <li>item</li>;
+      }
+      function List() {
+        return (
+          <ul>
+            <Item key="a" />
+            <Item key="b" />
+          </ul>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<List />);
+      });
+
+      const items = getComponentTree().filter(n => n.name === 'Item');
+      expect(items.map(i => i.key)).toEqual(['a', 'b']);
+    });
+
+    it('limits depth with the depth parameter', () => {
+      function Child() {
+        return <span>leaf</span>;
+      }
+      function Parent() {
+        return <Child />;
+      }
+      function App() {
+        return <Parent />;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const names = snapshot => snapshot.map(n => n.name);
+
+      // depth=0: only the root node (HostRoot)
+      const shallow = getComponentTree(0);
+      expect(shallow).toHaveLength(1);
+      expect(shallow[0].type).toBe('root');
+
+      // depth=1: root + App
+      const d1 = getComponentTree(1);
+      expect(names(d1)).toContain('App');
+      expect(names(d1)).not.toContain('Parent');
+
+      // depth=2: root + App + Parent
+      const d2 = getComponentTree(2);
+      expect(names(d2)).toContain('App');
+      expect(names(d2)).toContain('Parent');
+      expect(names(d2)).not.toContain('Child');
+
+      const deep = getComponentTree(20);
+      expect(names(deep)).toEqual(
+        expect.arrayContaining(['App', 'Parent', 'Child']),
+      );
+    });
+
+    it('starts from a specific node when rootUid is provided', () => {
+      function Nav() {
+        return <nav>nav</nav>;
+      }
+      function Header() {
+        return <Nav />;
+      }
+      function Footer() {
+        return <footer>foot</footer>;
+      }
+      function App() {
+        return (
+          <div>
+            <Header />
+            <Footer />
+          </div>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      // First, get the full tree to find Header's uid
+      const header = getComponentTree().find(n => n.name === 'Header');
+      expect(header).toBeDefined();
+
+      // Snapshot from Header
+      const sub = getComponentTree(20, header.uid);
+      const names = sub.map(n => n.name);
+      expect(names).toContain('Header');
+      expect(names).toContain('Nav');
+      // Should NOT contain App or Footer
+      expect(names).not.toContain('App');
+      expect(names).not.toContain('Footer');
+    });
+
+    it('returns error for non-existent rootUid', () => {
+      function App() {
+        return <div>hello</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const result = getComponentTree(20, 'r9999');
+      expect(result.error).toMatch(/Component not found/);
+    });
+
+    it('assigns stable uids across calls', () => {
+      function App() {
+        return <div>hello</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const first = getComponentTree();
+      const second = getComponentTree();
+      expect(first).toEqual(second);
+    });
+
+    it('shows class components with class type', () => {
+      class MyComponent extends React.Component {
+        render() {
+          return <div>class</div>;
+        }
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<MyComponent />);
+      });
+
+      const node = getComponentTree().find(n => n.name === 'MyComponent');
+      expect(node.type).toBe('class');
+    });
+
+    it('shows host components with host type', () => {
+      function App() {
+        return <div>hello</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const node = getComponentTree().find(n => n.name === 'div');
+      expect(node.type).toBe('host');
+    });
+
+    it('shows Memo components with memo type', () => {
+      function Inner() {
+        return <span>inner</span>;
+      }
+      const Memoized = React.memo(Inner);
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<Memoized />);
+      });
+
+      const node = getComponentTree().find(n => n.name === 'Memo(Inner)');
+      expect(node).toBeDefined();
+      expect(node.type).toBe('memo');
+    });
+
+    it('shows ForwardRef components with forwardRef type', () => {
+      const FancyButton = React.forwardRef(function FancyButton(props, ref) {
+        return <button ref={ref}>{props.children}</button>;
+      });
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(
+          <FancyButton>click</FancyButton>,
+        );
+      });
+
+      const node = getComponentTree().find(
+        n => n.name === 'ForwardRef(FancyButton)',
+      );
+      expect(node).toBeDefined();
+      expect(node.type).toBe('forwardRef');
+    });
+
+    it('includes Fragment in the tree', () => {
+      function A() {
+        return <span>a</span>;
+      }
+      function B() {
+        return <span>b</span>;
+      }
+      function App() {
+        // Keyed Fragment creates a Fragment fiber
+        return (
+          <div>
+            <React.Fragment key="group">
+              <A />
+              <B />
+            </React.Fragment>
+          </div>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const nodes = getComponentTree();
+      const fragment = nodes.find(n => n.type === 'fragment');
+      const a = nodes.find(n => n.name === 'A');
+      const b = nodes.find(n => n.name === 'B');
+      // The keyed Fragment is the div's child and parents A then B.
+      expect(fragment).toEqual({
+        uid: 'r3',
+        type: 'fragment',
+        name: 'Fragment',
+        key: 'group',
+        firstChild: a.uid,
+        nextSibling: null,
+      });
+      expect(a).toEqual({
+        uid: 'r4',
+        type: 'function',
+        name: 'A',
+        key: null,
+        firstChild: 'r5',
+        nextSibling: b.uid,
+      });
+      expect(b).toEqual({
+        uid: 'r6',
+        type: 'function',
+        name: 'B',
+        key: null,
+        firstChild: 'r7',
+        nextSibling: null,
+      });
+    });
+
+    it('includes HostRoot with type root', () => {
+      function App() {
+        return <div>hello</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const nodes = getComponentTree();
+      const root = nodes.find(n => n.type === 'root');
+      const app = nodes.find(n => n.name === 'App');
+      // The HostRoot is the tree's entry; its only child is App.
+      expect(root).toEqual({
+        uid: 'r1',
+        type: 'root',
+        name: 'createRoot()',
+        key: null,
+        firstChild: app.uid,
+        nextSibling: null,
+      });
+    });
+
+    it('includes Suspense in the tree', () => {
+      function App() {
+        return (
+          <React.Suspense fallback={<div>loading</div>}>
+            <div>content</div>
+          </React.Suspense>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const suspense = getComponentTree().find(n => n.type === 'suspense');
+      // Suspense wraps its content via an internal primary/Offscreen child, so
+      // firstChild is a valid uid but its exact identity is an internal detail.
+      expect(suspense).toEqual({
+        uid: 'r2',
+        type: 'suspense',
+        name: 'Suspense',
+        key: null,
+        firstChild: 'r3',
+        nextSibling: null,
+      });
+    });
+
+    it('includes Context Provider in the tree', () => {
+      const MyContext = React.createContext('default');
+      function App() {
+        return (
+          <MyContext value="test">
+            <div>child</div>
+          </MyContext>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const provider = getComponentTree().find(n => n.type === 'context');
+      expect(provider).toEqual({
+        uid: 'r2',
+        type: 'context',
+        name: 'Context.Provider',
+        key: null,
+        firstChild: 'r3',
+        nextSibling: null,
+      });
+    });
+
+    it('uids survive re-renders via alternate fiber handling', () => {
+      function Counter({count}) {
+        return <div>{'Count: ' + count}</div>;
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      act(() => {
+        root.render(<Counter count={0} />);
+      });
+
+      const counter1 = getComponentTree().find(n => n.name === 'Counter');
+      expect(counter1).toBeDefined();
+
+      act(() => {
+        root.render(<Counter count={1} />);
+      });
+
+      const counter2 = getComponentTree().find(n => n.name === 'Counter');
+      expect(counter2).toBeDefined();
+      // Same uid after re-render
+      expect(counter2.uid).toBe(counter1.uid);
+    });
+
+    it('removes unmounted roots from the tree', () => {
+      function App() {
+        return <div>hello</div>;
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      act(() => {
+        root.render(<App />);
+      });
+
+      const before = getComponentTree();
+      expect(before.find(n => n.name === 'App')).toBeDefined();
+
+      act(() => {
+        root.unmount();
+      });
+
+      const after = getComponentTree();
+      expect(after.error).toMatch(/No mounted React roots found/);
+    });
+  });
+
+  describe('findComponents', () => {
+    let findComponents;
+    let getComponentTree;
+
+    beforeEach(() => {
+      const tools = createTools(facade);
+      findComponents = tools.findComponents;
+      getComponentTree = tools.getComponentTree;
+    });
+
+    it('finds components by name (case-insensitive substring match)', () => {
+      function Header() {
+        return <h1>title</h1>;
+      }
+      function Footer() {
+        return <footer>foot</footer>;
+      }
+      function App() {
+        return (
+          <div>
+            <Header />
+            <Footer />
+          </div>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const result = findComponents('header');
+      expect(result.totalCount).toBe(1);
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].name).toBe('Header');
+      expect(result.results[0].type).toBe('function');
+      expect(result.results[0].uid).toBe('r0');
+    });
+
+    it('returns all matches when multiple components match', () => {
+      function Card() {
+        return <div>card</div>;
+      }
+      function App() {
+        return (
+          <div>
+            <Card key="a" />
+            <Card key="b" />
+            <Card key="c" />
+          </div>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const result = findComponents('Card');
+      expect(result.totalCount).toBe(3);
+      expect(result.results.map(r => r.key)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('returns empty results when no components match', () => {
+      function App() {
+        return <div>hello</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const result = findComponents('NonExistent');
+      expect(result.totalCount).toBe(0);
+      expect(result.results).toEqual([]);
+      expect(result.page).toBe(1);
+      expect(result.totalPages).toBe(1);
+    });
+
+    it('scopes search to subtree when rootUid is provided', () => {
+      function Badge() {
+        return <span>badge</span>;
+      }
+      function Sidebar() {
+        return <Badge />;
+      }
+      function Main() {
+        return <Badge />;
+      }
+      function App() {
+        return (
+          <div>
+            <Sidebar />
+            <Main />
+          </div>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      // Find Sidebar's uid
+      const sidebar = getComponentTree().find(n => n.name === 'Sidebar');
+      expect(sidebar).toBeDefined();
+
+      // Search for Badge only under Sidebar
+      const result = findComponents('Badge', sidebar.uid);
+      expect(result.totalCount).toBe(1);
+      expect(result.results[0].name).toBe('Badge');
+
+      // Without rootUid, should find both Badges
+      const allResult = findComponents('Badge');
+      expect(allResult.totalCount).toBe(2);
+    });
+
+    it('paginates results with default page size of 10', () => {
+      function Item() {
+        return <li>item</li>;
+      }
+      function App() {
+        const items = [];
+        for (let i = 0; i < 15; i++) {
+          items.push(<Item key={String(i)} />);
+        }
+        return <ul>{items}</ul>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const page1 = findComponents('Item');
+      expect(page1.totalCount).toBe(15);
+      expect(page1.page).toBe(1);
+      expect(page1.pageSize).toBe(10);
+      expect(page1.totalPages).toBe(2);
+      expect(page1.results).toHaveLength(10);
+
+      const page2 = findComponents('Item', undefined, 2);
+      expect(page2.page).toBe(2);
+      expect(page2.results).toHaveLength(5);
+    });
+
+    it('supports custom page size', () => {
+      function Item() {
+        return <li>item</li>;
+      }
+      function App() {
+        return (
+          <ul>
+            <Item key="0" />
+            <Item key="1" />
+            <Item key="2" />
+            <Item key="3" />
+            <Item key="4" />
+          </ul>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const result = findComponents('Item', undefined, 1, 2);
+      expect(result.totalCount).toBe(5);
+      expect(result.pageSize).toBe(2);
+      expect(result.totalPages).toBe(3);
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0].key).toBe('0');
+      expect(result.results[1].key).toBe('1');
+
+      const page3 = findComponents('Item', undefined, 3, 2);
+      expect(page3.results).toHaveLength(1);
+      expect(page3.results[0].key).toBe('4');
+    });
+
+    it('clamps page number to valid range', () => {
+      function App() {
+        return <div>hello</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      // Page 0 should clamp to 1
+      const low = findComponents('div', undefined, 0);
+      expect(low.page).toBe(1);
+
+      // Page beyond total should clamp to last page
+      const high = findComponents('div', undefined, 999);
+      expect(high.page).toBe(1);
+    });
+
+    it('results have same shape as tree snapshot nodes', () => {
+      function Widget() {
+        return <span>w</span>;
+      }
+      function App() {
+        return <Widget />;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const result = findComponents('Widget');
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]).toEqual({
+        uid: 'r0',
+        type: 'function',
+        name: 'Widget',
+        key: null,
+        firstChild: 'r1',
+        nextSibling: null,
+      });
+    });
+
+    it('uids are consistent with getComponentTree', () => {
+      function Target() {
+        return <div>target</div>;
+      }
+      function App() {
+        return <Target />;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      // Get uid from tree snapshot
+      const target = getComponentTree().find(n => n.name === 'Target');
+      expect(target).toBeDefined();
+
+      // findComponents should return the same uid
+      const result = findComponents('Target');
+      expect(result.results[0].uid).toBe(target.uid);
+    });
+
+    it('matches host components by tag name', () => {
+      function App() {
+        return (
+          <div>
+            <span>a</span>
+            <span>b</span>
+          </div>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const result = findComponents('span');
+      expect(result.totalCount).toBe(2);
+      expect(result.results[0].type).toBe('host');
+      expect(result.results[0].name).toBe('span');
+    });
+
+    it('does not match internal nodes with null displayName', () => {
+      function App() {
+        return (
+          <React.Fragment>
+            <div>hello</div>
+          </React.Fragment>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      // Fragment has null displayName in getDisplayNameForFiber,
+      // so it should not appear in search results
+      const fragmentResult = findComponents('Fragment');
+      expect(fragmentResult.totalCount).toBe(0);
+    });
+
+    it('finds Memo components by wrapped display name', () => {
+      function Inner() {
+        return <span>inner</span>;
+      }
+      const Memoized = React.memo(Inner);
+      function App() {
+        return <Memoized />;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      // memo(Inner) renders Inner inline (no separate FunctionComponent fiber),
+      // so the only match for "Inner" is the memo wrapper "Memo(Inner)".
+      const result = findComponents('Inner');
+      expect(result.totalCount).toBe(1);
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]).toEqual({
+        uid: 'r0',
+        type: 'memo',
+        name: 'Memo(Inner)',
+        key: null,
+        firstChild: 'r1',
+        nextSibling: null,
+      });
+    });
+
+    it('returns error for non-existent rootUid in scoped search', () => {
+      function App() {
+        return <div>hello</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const result = findComponents('App', 'r9999');
+      expect(result.error).toMatch(/Component not found/);
+    });
+  });
+
+  describe('getComponentSource', () => {
+    let getComponentSource;
+    let getComponentTree;
+
+    beforeEach(() => {
+      const tools = createTools(facade);
+      getComponentSource = tools.getComponentSource;
+      getComponentTree = tools.getComponentTree;
+    });
+
+    it('returns {source: null} for a function component when the location is unavailable', () => {
+      // The throwing trick that resolves a component's definition location does
+      // not produce file positions under jsdom, so source is null here. In a
+      // real browser this returns {name, fileName, line, column}.
+      function Greeting() {
+        return <div>Hello</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<Greeting />);
+      });
+
+      const greeting = getComponentTree().find(n => n.name === 'Greeting');
+      expect(greeting).toBeDefined();
+      expect(getComponentSource(greeting.uid)).toEqual({source: null});
+    });
+
+    it('returns {source: null} for host components', () => {
+      function App() {
+        return <div>hello</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const div = getComponentTree().find(n => n.name === 'div');
+      expect(div).toBeDefined();
+      // Host components like div have no source location.
+      expect(getComponentSource(div.uid)).toEqual({source: null});
+    });
+
+    it('returns error for non-existent uid', () => {
+      const result = getComponentSource('r9999');
+      expect(result.error).toMatch(/Component not found/);
+    });
+  });
+
+  describe('getOwnersStack', () => {
+    let getOwnersStack;
+    let getComponentTree;
+
+    beforeEach(() => {
+      const tools = createTools(facade);
+      getOwnersStack = tools.getOwnersStack;
+      getComponentTree = tools.getComponentTree;
+    });
+
+    it('returns a stack string for a nested component', () => {
+      function Child() {
+        return <span>leaf</span>;
+      }
+      function Parent() {
+        return <Child />;
+      }
+      function App() {
+        return <Parent />;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const child = getComponentTree().find(n => n.name === 'Child');
+      expect(child).toBeDefined();
+
+      const result = getOwnersStack(child.uid);
+      expect(typeof result.stack).toBe('string');
+      // The stack should mention the owner components
+      expect(result.stack).toContain('Parent');
+      expect(result.stack).toContain('App');
+    });
+
+    it('returns a stack string for the root component', () => {
+      function App() {
+        return <div>hello</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const app = getComponentTree().find(n => n.name === 'App');
+      const result = getOwnersStack(app.uid);
+      expect(typeof result.stack).toBe('string');
+    });
+
+    it('returns error for non-existent uid', () => {
+      const result = getOwnersStack('r9999');
+      expect(result.error).toMatch(/Component not found/);
+    });
+  });
+
+  describe('getOwnersBranch', () => {
+    let getOwnersBranch;
+    let getComponentTree;
+
+    beforeEach(() => {
+      const tools = createTools(facade);
+      getOwnersBranch = tools.getOwnersBranch;
+      getComponentTree = tools.getComponentTree;
+    });
+
+    it('returns owner list for a nested component', () => {
+      function Child() {
+        return <span>leaf</span>;
+      }
+      function Parent() {
+        return <Child />;
+      }
+      function App() {
+        return <Parent />;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const child = getComponentTree().find(n => n.name === 'Child');
+      expect(child).toBeDefined();
+
+      const owners = getOwnersBranch(child.uid);
+      expect(owners).toEqual([
+        {
+          uid: 'r2',
+          name: 'Parent',
+          type: 'function',
+        },
+        {
+          uid: 'r0',
+          name: 'App',
+          type: 'function',
+        },
+      ]);
+    });
+
+    it('each entry has uid, name, and type', () => {
+      function Child() {
+        return <span>leaf</span>;
+      }
+      function App() {
+        return <Child />;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const child = getComponentTree().find(n => n.name === 'Child');
+      const owners = getOwnersBranch(child.uid);
+
+      expect(owners).toHaveLength(1);
+      expect(owners[0].uid).toBe('r0');
+      expect(owners[0].name).toBe('App');
+      expect(owners[0].type).toBe('function');
+    });
+
+    it('owner uids are consistent with getComponentTree', () => {
+      function Child() {
+        return <span>leaf</span>;
+      }
+      function App() {
+        return <Child />;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const tree = getComponentTree();
+      const child = tree.find(n => n.name === 'Child');
+      const app = tree.find(n => n.name === 'App');
+
+      const owners = getOwnersBranch(child.uid);
+      expect(owners[0].uid).toBe(app.uid);
+    });
+
+    it('returns empty array for root component with no owner', () => {
+      function App() {
+        return <div>hello</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const app = getComponentTree().find(n => n.name === 'App');
+      const owners = getOwnersBranch(app.uid);
+      expect(owners).toEqual([]);
+    });
+
+    it('returns error for non-existent uid', () => {
+      const result = getOwnersBranch('r9999');
+      expect(result.error).toMatch(/Component not found/);
+    });
+
+    it('is ordered from immediate owner to root ancestor', () => {
+      function GrandChild() {
+        return <span>gc</span>;
+      }
+      function Child() {
+        return <GrandChild />;
+      }
+      function Parent() {
+        return <Child />;
+      }
+      function App() {
+        return <Parent />;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const gc = getComponentTree().find(n => n.name === 'GrandChild');
+      const owners = getOwnersBranch(gc.uid);
+      expect(owners).toEqual([
+        {
+          uid: 'r3',
+          name: 'Child',
+          type: 'function',
+        },
+        {
+          uid: 'r2',
+          name: 'Parent',
+          type: 'function',
+        },
+        {
+          uid: 'r0',
+          name: 'App',
+          type: 'function',
+        },
+      ]);
+    });
+  });
+
+  describe('getComponentByUid', () => {
+    let getComponentTree;
+    let getComponentByUid;
+
+    beforeEach(() => {
+      const tools = createTools(facade);
+      getComponentTree = tools.getComponentTree;
+      getComponentByUid = tools.getComponentByUid;
+    });
+
+    it('returns error for non-existent uid', () => {
+      const result = getComponentByUid('r9999');
+      expect(result.error).toMatch(/Component not found/);
+    });
+
+    it('returns info for a function component', () => {
+      function Greeting() {
+        return <div>Hello</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<Greeting />);
+      });
+
+      const greeting = getComponentTree().find(n => n.name === 'Greeting');
+      expect(greeting).toBeDefined();
+      const info = getComponentByUid(greeting.uid);
+
+      expect(info.uid).toBe(greeting.uid);
+      expect(info.type).toBe('function');
+      expect(info.name).toBe('Greeting');
+    });
+
+    it('returns props (excluding children)', () => {
+      function Button() {
+        return <button>click</button>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(
+          <Button text="Click me" disabled={true} />,
+        );
+      });
+
+      const button = getComponentTree().find(n => n.name === 'Button');
+      const info = getComponentByUid(button.uid);
+
+      expect(info.props.text).toBe('Click me');
+      expect(info.props.disabled).toBe(true);
+      expect(info.props).not.toHaveProperty('children');
+    });
+
+    it('serializes function props as descriptive strings', () => {
+      function Button() {
+        return <button>click</button>;
+      }
+
+      function handleClick() {}
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(
+          <Button onClick={handleClick} />,
+        );
+      });
+
+      const button = getComponentTree().find(n => n.name === 'Button');
+      const info = getComponentByUid(button.uid);
+
+      expect(info.props.onClick).toBe('[fn handleClick]');
+    });
+
+    it('returns key when present', () => {
+      function Item() {
+        return <li>item</li>;
+      }
+      function List() {
+        return (
+          <ul>
+            <Item key="first" />
+          </ul>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<List />);
+      });
+
+      const item = getComponentTree().find(n => n.name === 'Item');
+      const info = getComponentByUid(item.uid);
+
+      expect(info.key).toBe('first');
+    });
+
+    it('returns correct type for class components', () => {
+      class MyClass extends React.Component {
+        render() {
+          return <div>class</div>;
+        }
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<MyClass />);
+      });
+
+      const myClass = getComponentTree().find(n => n.name === 'MyClass');
+      expect(myClass).toBeDefined();
+      const info = getComponentByUid(myClass.uid);
+
+      expect(info.type).toBe('class');
+      expect(info.name).toBe('MyClass');
+    });
+
+    it('returns correct type for host components', () => {
+      function App() {
+        return <div className="app" id="root" />;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const div = getComponentTree().find(n => n.name === 'div');
+      const info = getComponentByUid(div.uid);
+
+      expect(info.type).toBe('host');
+      expect(info.name).toBe('div');
+      expect(info.props.className).toBe('app');
+      expect(info.props.id).toBe('root');
+    });
+
+    it('uses uids consistent with getComponentTree', () => {
+      function Header() {
+        return <h1>title</h1>;
+      }
+      function Footer() {
+        return <footer>foot</footer>;
+      }
+      function App() {
+        return (
+          <div>
+            <Header />
+            <Footer />
+          </div>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const nodes = getComponentTree();
+      nodes.forEach(node => {
+        const info = getComponentByUid(node.uid);
+        expect(info.uid).toBe(node.uid);
+      });
+    });
+
+    it('normalizes nested objects and arrays in props', () => {
+      function Config() {
+        return <div>config</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(
+          <Config style={{color: 'red', fontSize: 14}} items={[1, 2, 3]} />,
+        );
+      });
+
+      const config = getComponentTree().find(n => n.name === 'Config');
+      const info = getComponentByUid(config.uid);
+      expect(info.props.style).toEqual({color: 'red', fontSize: 14});
+      expect(info.props.items).toEqual([1, 2, 3]);
+    });
+
+    it('normalizes symbol and undefined props', () => {
+      function Widget() {
+        return <div>w</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(
+          <Widget sym={Symbol('test')} undef={undefined} />,
+        );
+      });
+
+      const widget = getComponentTree().find(n => n.name === 'Widget');
+      const info = getComponentByUid(widget.uid);
+      expect(info.props.sym).toBe('[symbol]');
+      expect(info.props.undef).toBe(null);
+    });
+
+    it('returns info for Memo component with correct type', () => {
+      function Inner() {
+        return <span>inner</span>;
+      }
+      const Memoized = React.memo(Inner);
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<Memoized value={42} />);
+      });
+
+      const memo = getComponentTree().find(n => n.type === 'memo');
+      expect(memo).toBeDefined();
+      const info = getComponentByUid(memo.uid);
+      expect(info.type).toBe('memo');
+    });
+
+    it('returns info for ForwardRef component with correct type', () => {
+      const FancyInput = React.forwardRef(function FancyInput(props, ref) {
+        return <input ref={ref} />;
+      });
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<FancyInput />);
+      });
+
+      const fwd = getComponentTree().find(n => n.type === 'forwardRef');
+      expect(fwd).toBeDefined();
+      const info = getComponentByUid(fwd.uid);
+      expect(info.type).toBe('forwardRef');
+    });
+
+    it('returns no props when component has only children', () => {
+      function Wrapper() {
+        return <div>child</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<Wrapper />);
+      });
+
+      const wrapper = getComponentTree().find(n => n.name === 'Wrapper');
+      const info = getComponentByUid(wrapper.uid);
+      // No props key at all (children are excluded)
+      expect(info.props).toBeUndefined();
+    });
+
+    it('handles circular references in props without stack overflow', () => {
+      function Widget() {
+        return <div>widget</div>;
+      }
+
+      const circular = {a: 1};
+      circular.self = circular;
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<Widget data={circular} />);
+      });
+
+      const widget = getComponentTree().find(n => n.name === 'Widget');
+      // Should not throw or stack overflow
+      const info = getComponentByUid(widget.uid);
+      expect(info.props.data.a).toBe(1);
+      expect(info.props.data.self).toBe('[circular]');
+    });
+
+    it('handles deeply nested objects in props without stack overflow', () => {
+      function Widget() {
+        return <div>widget</div>;
+      }
+
+      // Create a very deeply nested object
+      let deep = {value: 'leaf'};
+      for (let i = 0; i < 200; i++) {
+        deep = {nested: deep};
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<Widget data={deep} />);
+      });
+
+      const widget = getComponentTree().find(n => n.name === 'Widget');
+      // Should not throw or stack overflow
+      const info = getComponentByUid(widget.uid);
+      expect(info.props.data).toBeDefined();
+    });
+
+    it('returns the full hooks tree for a function component', () => {
+      function useCounter() {
+        const [c] = React.useState(0);
+        return c;
+      }
+      function Widget() {
+        const [count] = React.useState(7);
+        React.useEffect(() => {}, []);
+        const [obj] = React.useState({color: 'red'});
+        useCounter();
+        const ref = React.useRef(1);
+        const memo = React.useMemo(() => 5, []);
+        return (
+          <div>
+            {count}
+            {obj.color}
+            {ref.current}
+            {memo}
+          </div>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<Widget />);
+      });
+
+      const widget = getComponentTree().find(n => n.name === 'Widget');
+      const info = getComponentByUid(widget.uid);
+
+      // Full structural assertion: every hook node, in order, with its id
+      // (sequential per primitive hook; custom hooks are null), name, normalized
+      // value (the Effect's create fn becomes '[fn]'), and subHooks.
+      expect(info.hooks).toEqual([
+        {id: 0, name: 'State', value: 7, subHooks: []},
+        {id: 1, name: 'Effect', value: '[fn]', subHooks: []},
+        {id: 2, name: 'State', value: {color: 'red'}, subHooks: []},
+        {
+          id: null,
+          name: 'Counter',
+          value: null,
+          subHooks: [{id: 3, name: 'State', value: 0, subHooks: []}],
+        },
+        {id: 4, name: 'Ref', value: 1, subHooks: []},
+        {id: 5, name: 'Memo', value: 5, subHooks: []},
+      ]);
+    });
+
+    it('captures the useContext hook with its provided value', () => {
+      const ThemeContext = React.createContext('light');
+      function Themed() {
+        const theme = React.useContext(ThemeContext);
+        const [count] = React.useState(0);
+        return (
+          <div>
+            {theme}
+            {count}
+          </div>
+        );
+      }
+      function App() {
+        return (
+          <ThemeContext value="dark">
+            <Themed />
+          </ThemeContext>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const themed = getComponentTree().find(n => n.name === 'Themed');
+      const info = getComponentByUid(themed.uid);
+      // useContext is captured as a "Context" hook holding the provider's value.
+      // It does not consume a primitive hook slot, so its id is null; the
+      // following useState is the first primitive hook (id 0).
+      expect(info.hooks).toEqual([
+        {id: null, name: 'Context', value: 'dark', subHooks: []},
+        {id: 0, name: 'State', value: 0, subHooks: []},
+      ]);
+    });
+
+    it('returns an empty hooks array for a function component with no hooks', () => {
+      function Plain() {
+        return <div>plain</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<Plain />);
+      });
+
+      const plain = getComponentTree().find(n => n.name === 'Plain');
+      const info = getComponentByUid(plain.uid);
+      expect(info.hooks).toEqual([]);
+    });
+
+    it('does not include hooks for class components', () => {
+      class MyClass extends React.Component {
+        render() {
+          return <div>class</div>;
+        }
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<MyClass />);
+      });
+
+      const myClass = getComponentTree().find(n => n.name === 'MyClass');
+      const info = getComponentByUid(myClass.uid);
+      expect(info.hooks).toBeUndefined();
+    });
+
+    it('does not include hooks for host components', () => {
+      function App() {
+        return <div>hello</div>;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const div = getComponentTree().find(n => n.name === 'div');
+      const info = getComponentByUid(div.uid);
+      expect(info.hooks).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
Adds the component-tree building blocks and the `createTools(facade)` assembler — the first tools layered on top of the `installFacade` hook from commit 1.

### `createTools(facade): Tools`

Reads the facade's tracked state (fiber roots + per-renderer internals) and returns a plain `Tools` object — no globals; the integrator decides what to do with it. Tools return **typed, plain JavaScript values** (or `{error}`); serialization (to an integration package's wire format) is left to the caller.

### Tools

- **`getComponentTree(depth?, rootUid?)`** — the component tree as a flat array of `{uid, type, name, key, firstChild, nextSibling}` nodes (an adjacency list referencing other nodes by label).
- **`getComponentByUid(uid)`** — one component's `{type, name, key?, props?, hooks?}`. For function components, `hooks` is the inspected hooks tree (nested `subHooks`), obtained via `react-debug-tools'` `inspectHooksOfFiberWithoutDefaultDispatcher` with the renderer's injected dispatcher (normalized by `getDispatcherRef`) — so hooks introspection never falls back to, or bundles, React's shared internals.
- **`findComponents(name, rootUid?, page?, pageSize?)`** — paginated, case-insensitive name search.
- **`getComponentSource(uid)`** — the component's definition location `{name, fileName, line, column}` (or `null`).
- **`getOwnersStack(uid)`** — the raw JSX owner-stack string (DEV only).
- **`getOwnersBranch(uid)`** — the structured owner chain `[{uid, name, type}]`, ordered immediate owner → root (DEV only).

### UIDs

Components are addressed by stable `rN` uids, assigned lazily and memoized per fiber (and its alternate), so a component keeps the same uid across re-renders and across every tool. These uids don't survive page reloads.

