### PR TITLE
[react-devtools-facade] 3/ implement profiler tools 

### DIFF
--- a/packages/react-devtools-facade/src/DevToolsFacadeProfilerTools.js
+++ b/packages/react-devtools-facade/src/DevToolsFacadeProfilerTools.js
@@ -1,0 +1,327 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {didFiberRender} from 'react-devtools-shared/src/backend/fiber/shared/DevToolsFiberChangeDetection';
+
+import type {Fiber, FiberRoot} from 'react-reconciler/src/ReactInternalTypes';
+import type {RendererInternals, ProfilingState} from './DevToolsFacade';
+import type {ToolError} from './DevToolsFacadeTreeTools';
+
+import {getTypeTag} from './DevToolsFacadeTreeTools';
+
+// Per-component render timing within a single commit. Durations are null when
+// the build does not collect profiler timing.
+export type CommitComponent = {
+  uid: string,
+  name: string,
+  type: string,
+  actualDuration: number | null,
+  selfDuration: number | null,
+};
+
+// One row of a trace overview — a per-commit timing summary.
+export type TraceOverviewRow = {
+  commit: number,
+  committedAt: number,
+  renderDuration: number | null,
+  layoutDuration: number | null,
+  passiveDuration: number | null,
+  componentsChanged: number,
+};
+
+// A detailed report for a single commit.
+export type CommitReport = {
+  committedAt: number,
+  priority: string,
+  renderDuration: number | null,
+  layoutDuration: number | null,
+  passiveDuration: number | null,
+  components: Array<CommitComponent>,
+};
+
+export type StartProfilingResult = {status: 'started', traceName: string};
+export type StopProfilingResult = {
+  status: 'stopped',
+  traceName: string,
+  commits: number,
+};
+
+export type ProfilerTools = {
+  startProfiling: (traceName?: string) => StartProfilingResult | ToolError,
+  stopProfiling: () => StopProfilingResult | ToolError,
+  getTraceOverview: (traceName: string) => Array<TraceOverviewRow> | ToolError,
+  getCommitReport: (
+    traceName: string,
+    commitIndex: number,
+  ) => CommitReport | ToolError,
+};
+
+// Internal per-commit record (durations captured at commit time).
+type CommitRecord = {
+  timestamp: number,
+  priority: string,
+  renderDuration: number | null,
+  layoutDuration: number | null,
+  passiveDuration: number | null,
+  durations: Array<CommitComponent>,
+};
+
+type TraceData = {
+  startTime: number,
+  commits: Array<CommitRecord>,
+};
+
+function priorityToString(
+  internals: RendererInternals,
+  schedulerPriority: number | void,
+): string {
+  const {
+    ImmediatePriority,
+    UserBlockingPriority,
+    NormalPriority,
+    IdlePriority,
+  } = internals.ReactPriorityLevels;
+  switch (schedulerPriority) {
+    case ImmediatePriority:
+      return 'Sync';
+    case UserBlockingPriority:
+      return 'UserBlocking';
+    case NormalPriority:
+      return 'Normal';
+    case IdlePriority:
+      return 'Idle';
+    default:
+      return 'Normal';
+  }
+}
+
+/**
+ * Build the profiler tools from a renderer-internals map, the shared profiling
+ * state, and the tree tools' getUid (so component uids are consistent with
+ * getComponentTree/getComponentByUid). The hook installed by installFacade
+ * invokes profilingState.onCommit/onPostCommit while a session is active.
+ */
+export function createProfilerTools(
+  rendererInternals: Map<number, RendererInternals>,
+  profilingState: ProfilingState,
+  getUid: (fiber: Fiber) => string,
+): ProfilerTools {
+  // Walk the fiber tree collecting timing for fibers that actually rendered.
+  // Matches the same didFiberRender check and display-name filtering as the
+  // DevTools Profiler — only fibers with a non-null display name are recorded,
+  // which filters out internal types (HostRoot, Fragment, Mode, HostText, etc.).
+  function collectDurations(
+    internals: RendererInternals,
+    fiber: Fiber,
+    durations: Array<CommitComponent>,
+  ): void {
+    const {ReactTypeOfWork, getDisplayNameForFiber} = internals;
+    const displayName = getDisplayNameForFiber(fiber);
+    if (displayName != null) {
+      const prevFiber = fiber.alternate;
+      if (
+        prevFiber == null ||
+        didFiberRender(ReactTypeOfWork, prevFiber, fiber)
+      ) {
+        const actual =
+          fiber.actualDuration != null ? fiber.actualDuration : null;
+        let self: number | null = actual;
+        if (actual != null) {
+          let selfDuration: number = actual;
+          let child = fiber.child;
+          while (child !== null) {
+            selfDuration -= child.actualDuration || 0;
+            child = child.sibling;
+          }
+          self = selfDuration;
+        }
+        durations.push({
+          uid: getUid(fiber),
+          name: displayName,
+          type: getTypeTag(ReactTypeOfWork, fiber.tag),
+          actualDuration: actual,
+          selfDuration: self,
+        });
+      }
+    }
+    // Recurse into children regardless of whether this node rendered.
+    let child = fiber.child;
+    while (child !== null) {
+      collectDurations(internals, child, durations);
+      child = child.sibling;
+    }
+  }
+
+  // Commits awaiting their passive-effect pass, keyed by root so that a late
+  // onPostCommit attributes passiveDuration to the right commit even when
+  // multiple roots commit before their passive passes run.
+  const pendingPassive: Map<FiberRoot, CommitRecord> = new Map();
+
+  /**
+   * Start a named profiling session that captures per-commit render timing.
+   * While active, every React commit records timing for components that
+   * rendered. Errors if a session is already active.
+   *
+   * @param traceName - Optional trace name (auto-generated if omitted).
+   */
+  function startProfiling(
+    traceName?: string,
+  ): StartProfilingResult | ToolError {
+    if (profilingState.isActive) {
+      return {
+        error:
+          'Already profiling trace "' +
+          (profilingState.currentTraceName || '') +
+          '"',
+      };
+    }
+    const resolvedTraceName = traceName || 'trace-' + Date.now();
+    const trace: TraceData = {startTime: Date.now(), commits: []};
+    profilingState.traces.set(resolvedTraceName, trace);
+    profilingState.isActive = true;
+    profilingState.currentTraceName = resolvedTraceName;
+
+    profilingState.onCommit = function onCommit(
+      rendererID: number,
+      root: FiberRoot,
+      schedulerPriority: number | void,
+    ) {
+      const internals = rendererInternals.get(rendererID);
+      if (internals == null) {
+        console.error(
+          'react-devtools-facade: Missing internals for renderer %s, commit not recorded.',
+          rendererID,
+        );
+        return;
+      }
+      const durations: Array<CommitComponent> = [];
+      collectDurations(internals, root.current, durations);
+      const rootFiber = root.current;
+      const record: CommitRecord = {
+        timestamp: Date.now(),
+        priority: priorityToString(internals, schedulerPriority),
+        renderDuration:
+          rootFiber.actualDuration != null ? rootFiber.actualDuration : null,
+        layoutDuration:
+          root.effectDuration != null ? root.effectDuration : null,
+        passiveDuration: null,
+        durations,
+      };
+      trace.commits.push(record);
+      pendingPassive.set(root, record);
+    };
+
+    profilingState.onPostCommit = function onPostCommit(root: FiberRoot) {
+      const record = pendingPassive.get(root);
+      if (record != null) {
+        record.passiveDuration =
+          root.passiveEffectDuration != null
+            ? root.passiveEffectDuration
+            : null;
+        pendingPassive.delete(root);
+      }
+    };
+
+    return {status: 'started', traceName: resolvedTraceName};
+  }
+
+  /**
+   * Stop the active profiling session. Errors if no session is active.
+   */
+  function stopProfiling(): StopProfilingResult | ToolError {
+    if (!profilingState.isActive) {
+      return {error: 'Not currently profiling'};
+    }
+    const traceName = profilingState.currentTraceName;
+    if (traceName == null) {
+      return {error: 'No active trace'};
+    }
+    const trace = profilingState.traces.get(traceName);
+    const commitCount = trace ? trace.commits.length : 0;
+    profilingState.isActive = false;
+    profilingState.currentTraceName = null;
+    profilingState.onCommit = null;
+    profilingState.onPostCommit = null;
+    pendingPassive.clear();
+    return {status: 'stopped', traceName, commits: commitCount};
+  }
+
+  function getTrace(traceName: string): TraceData | null {
+    return profilingState.traces.get(traceName) || null;
+  }
+
+  /**
+   * Return an overview of a trace — one row per commit with a timing breakdown
+   * (render, layout effects, passive effects) and the number of components that
+   * changed.
+   *
+   * @param traceName - The name of the trace to query.
+   */
+  function getTraceOverview(
+    traceName: string,
+  ): Array<TraceOverviewRow> | ToolError {
+    const trace = getTrace(traceName);
+    if (trace == null) {
+      return {error: 'Unknown trace "' + traceName + '"'};
+    }
+    const rows: Array<TraceOverviewRow> = [];
+    for (let i = 0; i < trace.commits.length; i++) {
+      const commit = trace.commits[i];
+      rows.push({
+        commit: i,
+        committedAt: commit.timestamp - trace.startTime,
+        renderDuration: commit.renderDuration,
+        layoutDuration: commit.layoutDuration,
+        passiveDuration: commit.passiveDuration,
+        componentsChanged: commit.durations.length,
+      });
+    }
+    return rows;
+  }
+
+  /**
+   * Return a detailed report for a single commit — timing metadata
+   * (committedAt, priority, duration breakdown) and per-component render
+   * durations sorted by actualDuration descending.
+   *
+   * @param traceName - The name of the trace.
+   * @param commitIndex - Zero-based index of the commit within the trace.
+   */
+  function getCommitReport(
+    traceName: string,
+    commitIndex: number,
+  ): CommitReport | ToolError {
+    const trace = getTrace(traceName);
+    if (trace == null) {
+      return {error: 'Unknown trace "' + traceName + '"'};
+    }
+    if (commitIndex < 0 || commitIndex >= trace.commits.length) {
+      return {error: 'Commit index out of range'};
+    }
+    const commit = trace.commits[commitIndex];
+    const components = commit.durations
+      .slice()
+      .sort((a, b) => (b.actualDuration || 0) - (a.actualDuration || 0));
+    return {
+      committedAt: commit.timestamp - trace.startTime,
+      priority: commit.priority,
+      renderDuration: commit.renderDuration,
+      layoutDuration: commit.layoutDuration,
+      passiveDuration: commit.passiveDuration,
+      components,
+    };
+  }
+
+  return {
+    startProfiling,
+    stopProfiling,
+    getTraceOverview,
+    getCommitReport,
+  };
+}

--- a/packages/react-devtools-facade/src/DevToolsFacadeTools.js
+++ b/packages/react-devtools-facade/src/DevToolsFacadeTools.js
@@ -17,8 +17,15 @@ import type {
   FindComponentsResult,
   ToolError,
 } from './DevToolsFacadeTreeTools';
+import type {
+  StartProfilingResult,
+  StopProfilingResult,
+  TraceOverviewRow,
+  CommitReport,
+} from './DevToolsFacadeProfilerTools';
 
 import {createTreeTools} from './DevToolsFacadeTreeTools';
+import {createProfilerTools} from './DevToolsFacadeProfilerTools';
 
 export type {
   TreeNode,
@@ -31,11 +38,18 @@ export type {
   FindComponentsResult,
   ToolError,
 } from './DevToolsFacadeTreeTools';
+export type {
+  CommitComponent,
+  TraceOverviewRow,
+  CommitReport,
+  StartProfilingResult,
+  StopProfilingResult,
+} from './DevToolsFacadeProfilerTools';
 
 // The set of tools assembled from a Facade. Each tool returns a plain
-// JavaScript value (see the types in ./DevToolsFacadeTreeTools); serialization is the
-// integrator's responsibility. Integrators decide whether to expose these on
-// globals or call them directly.
+// JavaScript value (see the types in ./DevToolsFacadeTreeTools and
+// ./DevToolsFacadeProfilerTools); serialization is the integrator's responsibility.
+// Integrators decide whether to expose these on globals or call them directly.
 export type Tools = {
   getComponentTree: (
     depth?: number,
@@ -51,18 +65,31 @@ export type Tools = {
   getComponentSource: (uid: string) => ComponentSource | ToolError,
   getOwnersStack: (uid: string) => OwnersStack | ToolError,
   getOwnersBranch: (uid: string) => Array<OwnerEntry> | ToolError,
+  startProfiling: (traceName?: string) => StartProfilingResult | ToolError,
+  stopProfiling: () => StopProfilingResult | ToolError,
+  getTraceOverview: (traceName: string) => Array<TraceOverviewRow> | ToolError,
+  getCommitReport: (
+    traceName: string,
+    commitIndex: number,
+  ) => CommitReport | ToolError,
 };
 
 /**
  * Assemble the set of tools from a Facade. The tools read the facade's tracked
- * runtime state (fiber roots, per-renderer internals) lazily on each call and
- * never touch globals, so the integrator fully owns both the facade and the
- * returned tools.
+ * runtime state (fiber roots, per-renderer internals, profiling state) lazily
+ * on each call and never touch globals, so the integrator fully owns both the
+ * facade and the returned tools. Profiler tools share the tree tools' getUid
+ * so component labels are consistent across all tools.
  *
  * @param facade - A Facade returned by installFacade().
  */
 export function createTools(facade: Facade): Tools {
   const tree = createTreeTools(facade.fiberRoots, facade.rendererInternals);
+  const profiler = createProfilerTools(
+    facade.rendererInternals,
+    facade.profilingState,
+    tree.getUid,
+  );
 
   return {
     getComponentTree: tree.getComponentTree,
@@ -71,5 +98,9 @@ export function createTools(facade: Facade): Tools {
     getComponentSource: tree.getComponentSource,
     getOwnersStack: tree.getOwnersStack,
     getOwnersBranch: tree.getOwnersBranch,
+    startProfiling: profiler.startProfiling,
+    stopProfiling: profiler.stopProfiling,
+    getTraceOverview: profiler.getTraceOverview,
+    getCommitReport: profiler.getCommitReport,
   };
 }

--- a/packages/react-devtools-facade/src/DevToolsFacadeTreeTools.js
+++ b/packages/react-devtools-facade/src/DevToolsFacadeTreeTools.js
@@ -91,6 +91,9 @@ export type TreeTools = {
   getComponentSource: (uid: string) => ComponentSource | ToolError,
   getOwnersStack: (uid: string) => OwnersStack | ToolError,
   getOwnersBranch: (uid: string) => Array<OwnerEntry> | ToolError,
+  // Shared with the profiler tools so component uids are consistent across all
+  // tools. Maps a fiber to its stable uid (assigning one on first encounter).
+  getUid: (fiber: Fiber) => string,
 };
 
 /**
@@ -666,5 +669,6 @@ export function createTreeTools(
     getComponentSource,
     getOwnersStack,
     getOwnersBranch,
+    getUid,
   };
 }

--- a/packages/react-devtools-facade/src/__tests__/DevToolsFacade-test.js
+++ b/packages/react-devtools-facade/src/__tests__/DevToolsFacade-test.js
@@ -15,6 +15,12 @@ let ReactDOMClient;
 let act;
 let container;
 
+// Profiler durations are timing-dependent: null when the build does not collect
+// them, otherwise a non-negative number.
+function isDuration(value) {
+  return value === null || (typeof value === 'number' && value >= 0);
+}
+
 describe('react-devtools-facade', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -1532,6 +1538,357 @@ describe('react-devtools-facade', () => {
       const div = getComponentTree().find(n => n.name === 'div');
       const info = getComponentByUid(div.uid);
       expect(info.hooks).toBeUndefined();
+    });
+  });
+
+  describe('profiler', () => {
+    let startProfiling;
+    let stopProfiling;
+    let getTraceOverview;
+    let getCommitReport;
+    let getComponentTree;
+    let getComponentByUid;
+
+    beforeEach(() => {
+      const tools = createTools(facade);
+      startProfiling = tools.startProfiling;
+      stopProfiling = tools.stopProfiling;
+      getTraceOverview = tools.getTraceOverview;
+      getCommitReport = tools.getCommitReport;
+      getComponentTree = tools.getComponentTree;
+      getComponentByUid = tools.getComponentByUid;
+    });
+
+    it('startProfiling returns the started status and trace name', () => {
+      expect(startProfiling('my-trace')).toEqual({
+        status: 'started',
+        traceName: 'my-trace',
+      });
+      stopProfiling();
+    });
+
+    it('startProfiling auto-generates a trace name when none is provided', () => {
+      const result = startProfiling();
+      expect(result.status).toBe('started');
+      expect(result.traceName).toMatch(/^trace-\d+$/);
+      stopProfiling();
+    });
+
+    it('stopProfiling reports the trace name and commit count', () => {
+      startProfiling('test-trace');
+      expect(stopProfiling()).toEqual({
+        status: 'stopped',
+        traceName: 'test-trace',
+        commits: 0,
+      });
+    });
+
+    it('cannot start profiling twice', () => {
+      startProfiling('first');
+      expect(startProfiling('second')).toEqual({
+        error: 'Already profiling trace "first"',
+      });
+      stopProfiling();
+    });
+
+    it('cannot stop when not profiling', () => {
+      expect(stopProfiling()).toEqual({error: 'Not currently profiling'});
+    });
+
+    it('records one commit per render and reports the count on stop', () => {
+      function Counter({count}) {
+        return <div>{'Count: ' + count}</div>;
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      act(() => {
+        root.render(<Counter count={0} />);
+      });
+
+      startProfiling('render-trace');
+      act(() => {
+        root.render(<Counter count={1} />);
+      });
+      act(() => {
+        root.render(<Counter count={2} />);
+      });
+
+      expect(stopProfiling()).toEqual({
+        status: 'stopped',
+        traceName: 'render-trace',
+        commits: 2,
+      });
+    });
+
+    it('getTraceOverview returns one row per commit', () => {
+      function Child() {
+        return <span>child</span>;
+      }
+      function Counter({count}) {
+        return (
+          <div>
+            <Child />
+            {count}
+          </div>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      act(() => {
+        root.render(<Counter count={0} />);
+      });
+
+      startProfiling('overview-trace');
+      act(() => {
+        root.render(<Counter count={1} />);
+      });
+      act(() => {
+        root.render(<Counter count={2} />);
+      });
+      stopProfiling();
+
+      const overview = getTraceOverview('overview-trace');
+      expect(overview).toHaveLength(2);
+      let previousCommittedAt = 0;
+      overview.forEach((row, i) => {
+        expect(row.commit).toBe(i);
+        // committedAt is relative to trace start: non-negative and monotonic.
+        expect(row.committedAt).toBeGreaterThanOrEqual(previousCommittedAt);
+        previousCommittedAt = row.committedAt;
+        // componentsChanged matches the commit report's component count.
+        expect(row.componentsChanged).toBe(
+          getCommitReport('overview-trace', i).components.length,
+        );
+        expect(isDuration(row.renderDuration)).toBe(true);
+        expect(isDuration(row.layoutDuration)).toBe(true);
+        expect(isDuration(row.passiveDuration)).toBe(true);
+      });
+    });
+
+    it('getTraceOverview returns an error for an unknown trace', () => {
+      expect(getTraceOverview('nope')).toEqual({error: 'Unknown trace "nope"'});
+    });
+
+    it('getTraceOverview returns an empty array for a trace with no commits', () => {
+      startProfiling('empty-trace');
+      stopProfiling();
+      expect(getTraceOverview('empty-trace')).toEqual([]);
+    });
+
+    it('getCommitReport returns commit metadata and the full component set', () => {
+      function Child() {
+        return <span>child</span>;
+      }
+      function Counter({count}) {
+        return (
+          <div>
+            <Child />
+            {count}
+          </div>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      act(() => {
+        root.render(<Counter count={0} />);
+      });
+
+      startProfiling('detail-trace');
+      act(() => {
+        root.render(<Counter count={1} />);
+      });
+      stopProfiling();
+
+      const report = getCommitReport('detail-trace', 0);
+      expect(report.priority).toBe('Normal');
+      expect(report.committedAt).toBeGreaterThanOrEqual(0);
+      expect(isDuration(report.renderDuration)).toBe(true);
+      expect(isDuration(report.layoutDuration)).toBe(true);
+      expect(isDuration(report.passiveDuration)).toBe(true);
+
+      // The exact set of components that rendered. Order is duration-dependent
+      // (sorted descending), so compare sorted by name.
+      const byName = report.components
+        .map(c => ({name: c.name, type: c.type}))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      expect(byName).toEqual([
+        {name: 'Child', type: 'function'},
+        {name: 'Counter', type: 'function'},
+        {name: 'createRoot()', type: 'root'},
+        {name: 'div', type: 'host'},
+        {name: 'span', type: 'host'},
+      ]);
+      report.components.forEach(c => {
+        expect(c.uid).toMatch(/^r\d+$/);
+        expect(isDuration(c.actualDuration)).toBe(true);
+        expect(isDuration(c.selfDuration)).toBe(true);
+      });
+    });
+
+    it('getCommitReport sorts components by actualDuration descending', () => {
+      function Child() {
+        return <span>child</span>;
+      }
+      function Counter({count}) {
+        return (
+          <div>
+            <Child />
+            {count}
+          </div>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      act(() => {
+        root.render(<Counter count={0} />);
+      });
+      startProfiling('sort-trace');
+      act(() => {
+        root.render(<Counter count={1} />);
+      });
+      stopProfiling();
+
+      const durations = getCommitReport('sort-trace', 0).components.map(
+        c => c.actualDuration || 0,
+      );
+      for (let i = 1; i < durations.length; i++) {
+        expect(durations[i]).toBeLessThanOrEqual(durations[i - 1]);
+      }
+    });
+
+    it('getCommitReport committedAt matches getTraceOverview', () => {
+      function Counter({count}) {
+        return <div>{'Count: ' + count}</div>;
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      act(() => {
+        root.render(<Counter count={0} />);
+      });
+      startProfiling('match-trace');
+      act(() => {
+        root.render(<Counter count={1} />);
+      });
+      stopProfiling();
+
+      const overview = getTraceOverview('match-trace');
+      const report = getCommitReport('match-trace', 0);
+      expect(report.committedAt).toBe(overview[0].committedAt);
+    });
+
+    it('getCommitReport returns an error for an unknown trace', () => {
+      expect(getCommitReport('nope', 0)).toEqual({
+        error: 'Unknown trace "nope"',
+      });
+    });
+
+    it('getCommitReport returns an error for an out-of-range commit index', () => {
+      startProfiling('range-trace');
+      stopProfiling();
+      expect(getCommitReport('range-trace', 5)).toEqual({
+        error: 'Commit index out of range',
+      });
+      expect(getCommitReport('range-trace', -1)).toEqual({
+        error: 'Commit index out of range',
+      });
+    });
+
+    it('does not record internal nodes like Fragment, Mode, or text', () => {
+      function Child() {
+        return <span>child</span>;
+      }
+      function App() {
+        return (
+          <React.StrictMode>
+            <React.Fragment>
+              <Child />
+            </React.Fragment>
+          </React.StrictMode>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      act(() => {
+        root.render(<App />);
+      });
+      startProfiling('internal-trace');
+      act(() => {
+        root.render(<App />);
+      });
+      stopProfiling();
+
+      const names = getCommitReport('internal-trace', 0).components.map(
+        c => c.name,
+      );
+      expect(names).not.toContain('Fragment');
+      expect(names).not.toContain('StrictMode');
+      // Only named components are recorded; no Unknown/internal entries.
+      names.forEach(name => {
+        expect(typeof name).toBe('string');
+        expect(name).not.toBe('Unknown');
+      });
+    });
+
+    it('uses uids consistent with the tree tools', () => {
+      function Widget() {
+        return <div>widget</div>;
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      act(() => {
+        root.render(<Widget />);
+      });
+      const widget = getComponentTree().find(n => n.name === 'Widget');
+
+      startProfiling('uid-trace');
+      act(() => {
+        root.render(<Widget />);
+      });
+      stopProfiling();
+
+      const report = getCommitReport('uid-trace', 0);
+      const widgetEntry = report.components.find(c => c.name === 'Widget');
+      expect(widgetEntry).toBeDefined();
+      expect(widgetEntry.uid).toBe(widget.uid);
+      // ...and the same uid resolves back through getComponentByUid.
+      expect(getComponentByUid(widget.uid).name).toBe('Widget');
+    });
+
+    it('records commits across multiple independent traces', () => {
+      function Counter({count}) {
+        return <div>{'Count: ' + count}</div>;
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      act(() => {
+        root.render(<Counter count={0} />);
+      });
+
+      startProfiling('trace-a');
+      act(() => {
+        root.render(<Counter count={1} />);
+      });
+      stopProfiling();
+
+      startProfiling('trace-b');
+      act(() => {
+        root.render(<Counter count={2} />);
+      });
+      act(() => {
+        root.render(<Counter count={3} />);
+      });
+      stopProfiling();
+
+      expect(getTraceOverview('trace-a')).toHaveLength(1);
+      expect(getTraceOverview('trace-b')).toHaveLength(2);
+    });
+
+    it('the hook onPostCommitFiberRoot is a no-op when not profiling', () => {
+      const hook = facade.hook;
+      expect(typeof hook.onPostCommitFiberRoot).toBe('function');
+      expect(() => {
+        hook.onPostCommitFiberRoot(0, {passiveEffectDuration: 0});
+      }).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
Adds the profiler building blocks to `createTools` — per-commit render timing on top of the component-tree tools from commit 2.

### Tools

- **`startProfiling(traceName?)`** → `{status: 'started', trace}`. Begins a session that records timing on every commit. Errors if a session is already active.
- **`stopProfiling()`** → `{status: 'stopped', traceName, commits}` (commit count). Errors if no session is active.
- **`getTraceOverview(traceName)`** → one row per commit: `{commit, committedAt, renderDuration, layoutDuration, passiveDuration, componentsChanged}`.
- **`getCommitReport(traceName, commitIndex)`** → one commit's detail:
  `{committedAt, priority, renderDuration, layoutDuration, passiveDuration,
  components}`, where `components` is `{label, name, type, actualDuration,
  selfDuration}` sorted by `actualDuration` descending.

Durations are in milliseconds, or `null` when the build does not collect profiler
timing. `passiveDuration` is attributed per root via the hook's post-commit pass.