### PR TITLE
[flags] Cleanup `enableActivity`

### DIFF
--- a/packages/react-reconciler/src/__tests__/Activity-test.js
+++ b/packages/react-reconciler/src/__tests__/Activity-test.js
@@ -1527,7 +1527,6 @@ describe('Activity', () => {
     expect(root).toMatchRenderedOutput(<span prop={2} />);
   });
 
-  // @gate enableActivity
   it('getSnapshotBeforeUpdate does not run in hidden trees', async () => {
     let setState;
 
@@ -1607,7 +1606,6 @@ describe('Activity', () => {
     ]);
   });
 
-  // @gate enableActivity
   it('warns if you pass a hidden prop', async () => {
     function App() {
       return (

--- a/packages/react-reconciler/src/__tests__/useEffectEvent-test.js
+++ b/packages/react-reconciler/src/__tests__/useEffectEvent-test.js
@@ -1266,7 +1266,6 @@ describe('useEffectEvent', () => {
     assertLog(['ContextReader (Effect event): second']);
   });
 
-  // @gate enableActivity
   it('effect events are fresh inside Activity', async () => {
     function Child({value}) {
       const getValue = useEffectEvent(() => {

--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -82,7 +82,6 @@ function getTestFlags() {
 
       // These aren't flags, just a useful aliases for tests.
       // TODO: Clean this up.
-      enableActivity: true,
       enableSuspenseList: releaseChannel === 'experimental' || www || xplat,
       enableLegacyHidden: www,
       // TODO: Suspending the work loop during the render phase is currently

--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -81,7 +81,6 @@ function getTestFlags() {
       fb: www || xplat,
 
       // These aren't flags, just a useful aliases for tests.
-      // TODO: Clean this up.
       enableSuspenseList: releaseChannel === 'experimental' || www || xplat,
       enableLegacyHidden: www,
       // TODO: Suspending the work loop during the render phase is currently


### PR DESCRIPTION
Leftover test-only flag that has been hardcoded to true. `<Activity>` has been live for a while now so this can be cleaned up.