### PR TITLE
[Fiber] Don't disappear Layout Effects when hydrating `<Activity mode="hidden">`

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1146,6 +1146,13 @@ function updateActivityComponent(
           renderLanes,
         );
         workInProgress.lanes = laneToLanes(OffscreenLane);
+        // memoizedState on Offscreen is used to indicate whether it is hidden.
+        const nextState: OffscreenState = {
+          baseLanes: NoLanes,
+          cachePool: null,
+        };
+        primaryChildFragment.memoizedState = nextState;
+
         return bailoutOffscreenComponent(null, primaryChildFragment);
       } else {
         // We must push the suspense handler context *before* attempting to


### PR DESCRIPTION
We use `fiber.memoizedState === null` for to determine if the Offscreen Fiber is hidden. That state was initialized for hidden Offscreen everywhere except when hydrating hidden Offscreen when we bail out.

This lead to attempting to disappear Layout Effects. This works just fine now since there are no destroy functions registered just yet. So this is mostly for correctness. Perf concerns are negligible since the hidden Offscreen in Activity wouldn't have any child Fibers.

I only noticed this when trying to use `offscreenSubtreeWasHidden` in https://github.com/facebook/react/pull/34983. When hydrating `<Activity mode="hidden">`, we entered `recursivelyTraverseDisappearLayoutEffects` in https://github.com/facebook/react/blob/7b22afdf172cf8ed9c666c9c8300fc16e80ac67f/packages/react-reconciler/src/ReactFiberCommitWork.js#L2543-L2559