### PR TITLE
Add parentEnter/parentExit props to ViewTransition

### DIFF
--- a/fixtures/view-transition/src/components/NestedParentExit.css
+++ b/fixtures/view-transition/src/components/NestedParentExit.css
@@ -79,6 +79,68 @@
   animation: nested-enter-from-left 450ms ease-out 650ms both;
 }
 
+/* Title relays the parent activation but exits/enters vertically. */
+@keyframes nested-title-exit-up {
+  from {
+    opacity: 1;
+    translate: 0 0;
+  }
+  to {
+    opacity: 0;
+    translate: 0 -80%;
+  }
+}
+
+::view-transition-old(.nested-title-exit-up) {
+  animation: nested-title-exit-up 450ms ease-out forwards;
+}
+
+@keyframes nested-title-enter-from-up {
+  from {
+    opacity: 0;
+    translate: 0 -80%;
+  }
+  to {
+    opacity: 1;
+    translate: 0 0;
+  }
+}
+
+::view-transition-new(.nested-title-enter-from-up) {
+  animation: nested-title-enter-from-up 450ms ease-out 650ms both;
+}
+
+/* Body relays the same parent activation but exits/enters to the right. */
+@keyframes nested-body-exit-right {
+  from {
+    opacity: 1;
+    translate: 0 0;
+  }
+  to {
+    opacity: 0;
+    translate: 120% 0;
+  }
+}
+
+::view-transition-old(.nested-body-exit-right) {
+  animation: nested-body-exit-right 450ms ease-in forwards;
+}
+
+@keyframes nested-body-enter-from-right {
+  from {
+    opacity: 0;
+    translate: 120% 0;
+  }
+  to {
+    opacity: 1;
+    translate: 0 0;
+  }
+}
+
+::view-transition-new(.nested-body-enter-from-right) {
+  animation: nested-body-enter-from-right 450ms ease-out 650ms both;
+}
+
 ::view-transition-group(.nested-shared-post-forward) {
   animation-duration: 600ms;
   animation-delay: 300ms;

--- a/fixtures/view-transition/src/components/NestedParentExit.css
+++ b/fixtures/view-transition/src/components/NestedParentExit.css
@@ -1,0 +1,150 @@
+.nested-parent-exit {
+  width: 280px;
+  min-height: 280px;
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid #ccc;
+}
+
+.nested-parent-exit-swipe {
+  min-height: 200px;
+}
+
+.nested-parent-exit-label {
+  margin: 0 0 0.75rem;
+  font-size: 13px;
+  color: #666;
+}
+
+.nested-parent-exit-panel {
+  min-height: 240px;
+}
+
+.nested-parent-exit .feed-item {
+  margin-bottom: 0.75rem;
+  cursor: pointer;
+}
+
+.nested-parent-exit .feed-item-title {
+  margin: 0 0 0.15rem;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.nested-parent-exit .feed-item p,
+.nested-parent-exit .detail-view p {
+  margin: 0;
+  font-size: 13px;
+  color: #666;
+}
+
+.nested-parent-exit .back-button {
+  margin-bottom: 0.75rem;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  text-decoration: underline;
+}
+
+@keyframes nested-exit-left {
+  from {
+    opacity: 1;
+    translate: 0 0;
+  }
+  to {
+    opacity: 0;
+    translate: -120% 0;
+  }
+}
+
+::view-transition-old(.nested-exit-left) {
+  animation: nested-exit-left 450ms ease-out forwards;
+}
+
+@keyframes nested-enter-from-left {
+  from {
+    opacity: 0;
+    translate: -120% 0;
+  }
+  to {
+    opacity: 1;
+    translate: 0 0;
+  }
+}
+
+::view-transition-new(.nested-enter-from-left) {
+  animation: nested-enter-from-left 450ms ease-out 650ms both;
+}
+
+::view-transition-group(.nested-shared-post-forward) {
+  animation-duration: 600ms;
+  animation-delay: 300ms;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: both;
+}
+
+::view-transition-old(.nested-shared-post-forward),
+::view-transition-new(.nested-shared-post-forward) {
+  animation-delay: 300ms;
+  animation-duration: 600ms;
+  animation-fill-mode: both;
+}
+
+::view-transition-group(.nested-shared-post-back) {
+  animation-duration: 600ms;
+  animation-timing-function: ease-in-out;
+}
+
+::view-transition-group(.nested-shared-inner-forward) {
+  animation-duration: 500ms;
+  animation-delay: 400ms;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: both;
+}
+
+::view-transition-old(.nested-shared-inner-forward),
+::view-transition-new(.nested-shared-inner-forward) {
+  animation-delay: 400ms;
+  animation-duration: 500ms;
+  animation-fill-mode: both;
+}
+
+::view-transition-group(.nested-shared-inner-back) {
+  animation-duration: 500ms;
+  animation-delay: 100ms;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: both;
+}
+
+@keyframes nested-back-btn-enter {
+  from {
+    opacity: 0;
+    translate: -20px 0;
+  }
+  to {
+    opacity: 1;
+    translate: 0 0;
+  }
+}
+
+@keyframes nested-back-btn-exit {
+  from {
+    opacity: 1;
+    translate: 0 0;
+  }
+  to {
+    opacity: 0;
+    translate: -20px 0;
+  }
+}
+
+::view-transition-new(.nested-back-btn-enter):only-child {
+  animation: nested-back-btn-enter 300ms ease-out 650ms both;
+}
+
+::view-transition-old(.nested-back-btn-exit):only-child {
+  animation: nested-back-btn-exit 200ms ease-in forwards;
+}

--- a/fixtures/view-transition/src/components/NestedParentExit.js
+++ b/fixtures/view-transition/src/components/NestedParentExit.js
@@ -43,10 +43,16 @@ function FeedItem({item, index, activeIndex, onSelect}) {
           share={{
             'nav-forward': 'nested-shared-inner-forward',
             'nav-back': 'nested-shared-inner-back',
-          }}>
+          }}
+          parentExit={isActive ? undefined : 'nested-title-exit-up'}
+          parentEnter={isActive ? undefined : 'nested-title-enter-from-up'}>
           <div className="feed-item-title">{item.title}</div>
         </ViewTransition>
-        <p>{item.body}</p>
+        <ViewTransition
+          parentExit={isActive ? undefined : 'nested-body-exit-right'}
+          parentEnter={isActive ? undefined : 'nested-body-enter-from-right'}>
+          <p>{item.body}</p>
+        </ViewTransition>
       </div>
     </ViewTransition>
   );
@@ -107,9 +113,9 @@ export default function NestedParentExit() {
   const {selected, activeIndex} = optimisticNav;
 
   function goToDetail(item, index) {
-    setNav({selected: item, activeIndex: index});
     startTransition(() => {
       addTransitionType('nav-forward');
+      setNav({selected: item, activeIndex: index});
     });
   }
 
@@ -119,9 +125,9 @@ export default function NestedParentExit() {
       return;
     }
     const backIndex = items.findIndex(i => i.id === current.id);
-    setNav({selected: null, activeIndex: backIndex});
     startTransition(() => {
       addTransitionType('nav-back');
+      setNav({selected: null, activeIndex: backIndex});
     });
   }
 

--- a/fixtures/view-transition/src/components/NestedParentExit.js
+++ b/fixtures/view-transition/src/components/NestedParentExit.js
@@ -1,0 +1,174 @@
+import React, {
+  ViewTransition,
+  useState,
+  useOptimistic,
+  startTransition,
+  addTransitionType,
+} from 'react';
+import SwipeRecognizer from './SwipeRecognizer.js';
+import './NestedParentExit.css';
+
+const items = [
+  {id: 1, title: 'First Post', body: 'Hello from the first post.'},
+  {id: 2, title: 'Second Post', body: 'Hello from the second post.'},
+  {id: 3, title: 'Third Post', body: 'Hello from the third post.'},
+];
+
+function logGestureParent(kind, title, _timeline, _options, _instance, types) {
+  // eslint-disable-next-line no-console
+  console.log(`[NestedParentExit] onGestureParent${kind}`, title, types);
+}
+
+function FeedItem({item, index, activeIndex, onSelect}) {
+  const isActive = activeIndex === index;
+
+  return (
+    <ViewTransition
+      name={'nested-post-' + item.id}
+      share={{
+        'nav-forward': 'nested-shared-post-forward',
+        'nav-back': 'nested-shared-post-back',
+      }}
+      parentExit={isActive ? undefined : 'nested-exit-left'}
+      parentEnter={isActive ? undefined : 'nested-enter-from-left'}
+      onGestureParentExit={(...args) =>
+        logGestureParent('Exit', item.title, ...args)
+      }
+      onGestureParentEnter={(...args) =>
+        logGestureParent('Enter', item.title, ...args)
+      }>
+      <div className="feed-item" onClick={() => onSelect(item, index)}>
+        <ViewTransition
+          name={'nested-title-' + item.id}
+          share={{
+            'nav-forward': 'nested-shared-inner-forward',
+            'nav-back': 'nested-shared-inner-back',
+          }}>
+          <div className="feed-item-title">{item.title}</div>
+        </ViewTransition>
+        <p>{item.body}</p>
+      </div>
+    </ViewTransition>
+  );
+}
+
+function Detail({item, onBack}) {
+  return (
+    <ViewTransition
+      name={'nested-post-' + item.id}
+      share={{
+        'nav-forward': 'nested-shared-post-forward',
+        'nav-back': 'nested-shared-post-back',
+      }}>
+      <div className="detail-view">
+        <ViewTransition
+          enter="nested-back-btn-enter"
+          exit="nested-back-btn-exit">
+          <button className="back-button" onClick={onBack}>
+            ← Back
+          </button>
+        </ViewTransition>
+        <ViewTransition
+          name={'nested-title-' + item.id}
+          share={{
+            'nav-forward': 'nested-shared-inner-forward',
+            'nav-back': 'nested-shared-inner-back',
+          }}>
+          <div className="feed-item-title">{item.title}</div>
+        </ViewTransition>
+        <p>{item.body}</p>
+      </div>
+    </ViewTransition>
+  );
+}
+
+const initialNav = {selected: null, activeIndex: null};
+
+export default function NestedParentExit() {
+  const [nav, setNav] = useState(initialNav);
+  const [optimisticNav, navigateByGesture] = useOptimistic(
+    nav,
+    (state, direction) => {
+      if (direction === 'left' && state.selected === null) {
+        return {selected: items[0], activeIndex: 0};
+      }
+      if (direction === 'right' && state.selected !== null) {
+        return {
+          selected: null,
+          activeIndex:
+            state.activeIndex ??
+            items.findIndex(i => i.id === state.selected.id),
+        };
+      }
+      return state;
+    }
+  );
+
+  const {selected, activeIndex} = optimisticNav;
+
+  function goToDetail(item, index) {
+    setNav({selected: item, activeIndex: index});
+    startTransition(() => {
+      addTransitionType('nav-forward');
+    });
+  }
+
+  function goBack() {
+    const current = selected;
+    if (current == null) {
+      return;
+    }
+    const backIndex = items.findIndex(i => i.id === current.id);
+    setNav({selected: null, activeIndex: backIndex});
+    startTransition(() => {
+      addTransitionType('nav-back');
+    });
+  }
+
+  function swipeAction() {
+    if (nav.selected === null) {
+      goToDetail(items[0], 0);
+    } else {
+      goBack();
+    }
+  }
+
+  return (
+    <div className="nested-parent-exit">
+      <p className="nested-parent-exit-label">
+        Parent Exit/Enter — click a post or swipe (scroll the strip below)
+      </p>
+      <div className="nested-parent-exit-swipe swipe-recognizer">
+        <SwipeRecognizer
+          action={swipeAction}
+          gesture={direction => {
+            addTransitionType(
+              direction === 'left' ? 'nav-forward' : 'nav-back'
+            );
+            navigateByGesture(direction);
+          }}
+          direction={selected ? 'right' : 'left'}>
+          <ViewTransition key={selected ? 'detail' : 'feed'} update="none">
+            <div className="nested-parent-exit-panel">
+              {selected ? (
+                <Detail item={selected} onBack={goBack} />
+              ) : (
+                <>
+                  {items.map((item, index) => (
+                    <FeedItem
+                      key={item.id}
+                      item={item}
+                      index={index}
+                      activeIndex={activeIndex}
+                      onSelect={goToDetail}
+                    />
+                  ))}
+                </>
+              )}
+            </div>
+          </ViewTransition>
+        </SwipeRecognizer>
+      </div>
+    </div>
+  );
+}

--- a/fixtures/view-transition/src/components/Page.js
+++ b/fixtures/view-transition/src/components/Page.js
@@ -20,6 +20,7 @@ import './Page.css';
 
 import transitions from './Transitions.module.css';
 import NestedReveal from './NestedReveal.js';
+import NestedParentExit from './NestedParentExit.js';
 
 async function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -322,6 +323,7 @@ export default function Page({url, navigate}) {
         </ViewTransition>
       </SwipeRecognizer>
       <NestedReveal />
+      <NestedParentExit />
     </div>
   );
 }

--- a/packages/react-dom/src/__tests__/ReactDOMViewTransition-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMViewTransition-test.js
@@ -462,7 +462,7 @@ describe('ReactDOMViewTransition', () => {
       ).toBeGreaterThanOrEqual(1);
     });
 
-    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    // @gate enableViewTransition
     it('does not fire onExit/onEnter on nested ViewTransition when the subtree is removed as one unit', async () => {
       const onParentExit = jest.fn();
       const onParentEnter = jest.fn();
@@ -677,7 +677,7 @@ describe('ReactDOMViewTransition', () => {
       expect(onParentExit2).toHaveBeenCalledTimes(1);
     });
 
-    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    // @gate enableViewTransition
     it('does not fire onParentEnter when ancestor exits', async () => {
       const onParentEnter = jest.fn();
 
@@ -719,7 +719,7 @@ describe('ReactDOMViewTransition', () => {
       expect(onParentEnter).not.toHaveBeenCalled();
     });
 
-    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    // @gate enableViewTransition
     it('does not fire onParentExit when ancestor shares instead of exiting', async () => {
       const onShare = jest.fn();
       const onParentExit = jest.fn();
@@ -768,7 +768,7 @@ describe('ReactDOMViewTransition', () => {
       expect(onParentExit).not.toHaveBeenCalled();
     });
 
-    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    // @gate enableViewTransition
     it('does not fire onParentEnter when ancestor shares instead of entering', async () => {
       const onShare = jest.fn();
       const onParentEnter = jest.fn();
@@ -817,7 +817,7 @@ describe('ReactDOMViewTransition', () => {
       expect(onParentEnter).not.toHaveBeenCalled();
     });
 
-    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    // @gate enableViewTransition
     it('does not fire onParentExit when ancestor exit is none', async () => {
       const onParentExit = jest.fn();
 
@@ -855,7 +855,7 @@ describe('ReactDOMViewTransition', () => {
       expect(onParentExit).not.toHaveBeenCalled();
     });
 
-    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    // @gate enableViewTransition
     it('does not fire onParentEnter when ancestor enter is none', async () => {
       const onParentEnter = jest.fn();
 
@@ -933,6 +933,319 @@ describe('ReactDOMViewTransition', () => {
       });
 
       expect(onParentExit).toHaveBeenCalledTimes(1);
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('fires onParentExit when ancestor ViewTransition exits with handler only', async () => {
+      const onParentExit = jest.fn();
+      const onRelayParentExit = jest.fn();
+      const onParentExitDeep = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition onExit={onParentExit}>
+            <div>
+              <ViewTransition onParentExit={onRelayParentExit}>
+                <ViewTransition onParentExit={onParentExitDeep}>
+                  <div>Item</div>
+                </ViewTransition>
+              </ViewTransition>
+            </div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      onParentExit.mockClear();
+      onRelayParentExit.mockClear();
+      onParentExitDeep.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      expect(onParentExit).toHaveBeenCalledTimes(1);
+      expect(onRelayParentExit).toHaveBeenCalledTimes(1);
+      expect(onParentExitDeep).toHaveBeenCalledTimes(1);
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('fires onParentEnter when ancestor ViewTransition enters with handler only', async () => {
+      const onParentEnter = jest.fn();
+      const onRelayParentEnter = jest.fn();
+      const onParentEnterDeep = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition onEnter={onParentEnter}>
+            <div>
+              <ViewTransition onParentEnter={onRelayParentEnter}>
+                <ViewTransition onParentEnter={onParentEnterDeep}>
+                  <div>Item</div>
+                </ViewTransition>
+              </ViewTransition>
+            </div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      onParentEnter.mockClear();
+      onRelayParentEnter.mockClear();
+      onParentEnterDeep.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      expect(onParentEnter).toHaveBeenCalledTimes(1);
+      expect(onRelayParentEnter).toHaveBeenCalledTimes(1);
+      expect(onParentEnterDeep).toHaveBeenCalledTimes(1);
+    });
+
+    // @gate enableViewTransition
+    it('does not fire onParentEnter when ancestor enter is none with handler only', async () => {
+      const onParentEnter = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition enter="none">
+            <ViewTransition onParentEnter={onParentEnter}>
+              <div>Item</div>
+            </ViewTransition>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      onParentEnter.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      expect(onParentEnter).not.toHaveBeenCalled();
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('relays parentEnter chain to handler-only child through intermediate divs', async () => {
+      const onParentEnter = jest.fn();
+      const onParentEnterNested = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition onEnter={onParentEnter}>
+            <div>
+              <div>
+                <ViewTransition onParentEnter={onParentEnterNested}>
+                  <div>Item</div>
+                </ViewTransition>
+              </div>
+            </div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      onParentEnter.mockClear();
+      onParentEnterNested.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      expect(onParentEnter).toHaveBeenCalledTimes(1);
+      expect(onParentEnterNested).toHaveBeenCalledTimes(1);
+    });
+
+    // @gate enableViewTransition
+    it('enters without props and does not fire handlers', async () => {
+      const startViewTransitionSpy = jest.fn(document.startViewTransition);
+      document.startViewTransition = startViewTransitionSpy;
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition>
+            <div>Hello</div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(<App show={false} />);
+      });
+      expect(startViewTransitionSpy).not.toHaveBeenCalled();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      expect(startViewTransitionSpy).toHaveBeenCalled();
+    });
+
+    // @gate enableViewTransition
+    it('exits without props and does not fire handlers', async () => {
+      const startViewTransitionSpy = jest.fn(document.startViewTransition);
+      document.startViewTransition = startViewTransitionSpy;
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition>
+            <div>Goodbye</div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+      startViewTransitionSpy.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      expect(startViewTransitionSpy).toHaveBeenCalled();
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('fires onParentEnter when ancestor ViewTransition has no props', async () => {
+      const onParentEnterNested = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition>
+            <div>
+              <ViewTransition onParentEnter={onParentEnterNested}>
+                <div>Item</div>
+              </ViewTransition>
+            </div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      onParentEnterNested.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      expect(onParentEnterNested).toHaveBeenCalledTimes(1);
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('fires onParentExit when ancestor ViewTransition has no props', async () => {
+      const onParentExitNested = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition>
+            <div>
+              <ViewTransition onParentExit={onParentExitNested}>
+                <div>Item</div>
+              </ViewTransition>
+            </div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      onParentExitNested.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      expect(onParentExitNested).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMViewTransition-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMViewTransition-test.js
@@ -461,5 +461,478 @@ describe('ReactDOMViewTransition', () => {
         onEnter.mock.calls.length + enterCallsAfterFallback,
       ).toBeGreaterThanOrEqual(1);
     });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('does not fire onExit/onEnter on nested ViewTransition when the subtree is removed as one unit', async () => {
+      const onParentExit = jest.fn();
+      const onParentEnter = jest.fn();
+      const onNestedExit = jest.fn();
+      const onNestedEnter = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition
+            exit="page-exit"
+            enter="page-enter"
+            onExit={onParentExit}
+            onEnter={onParentEnter}>
+            <div>
+              <ViewTransition
+                exit="nested-exit"
+                enter="nested-enter"
+                onExit={onNestedExit}
+                onEnter={onNestedEnter}>
+                <div>Item</div>
+              </ViewTransition>
+            </div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      onParentEnter.mockClear();
+      onNestedEnter.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      expect(onParentEnter).toHaveBeenCalledTimes(1);
+      expect(onNestedEnter).not.toHaveBeenCalled();
+
+      onParentExit.mockClear();
+      onNestedExit.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      expect(onParentExit).toHaveBeenCalledTimes(1);
+      expect(onNestedExit).not.toHaveBeenCalled();
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('fires onParentExit when ancestor ViewTransition exits', async () => {
+      const onParentExit = jest.fn();
+      const onNestedExit = jest.fn();
+      const onParentExitNested = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition exit="page-exit" onExit={onParentExit}>
+            <div>
+              <ViewTransition
+                exit="nested-exit"
+                onExit={onNestedExit}
+                parentExit="nested-parent-exit"
+                onParentExit={onParentExitNested}>
+                <div>Item</div>
+              </ViewTransition>
+            </div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      onParentExit.mockClear();
+      onNestedExit.mockClear();
+      onParentExitNested.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      expect(onParentExit).toHaveBeenCalledTimes(1);
+      expect(onNestedExit).not.toHaveBeenCalled();
+      expect(onParentExitNested).toHaveBeenCalledTimes(1);
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('fires onParentEnter when ancestor ViewTransition enters', async () => {
+      const onParentEnter = jest.fn();
+      const onNestedEnter = jest.fn();
+      const onParentEnterNested = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition enter="page-enter" onEnter={onParentEnter}>
+            <div>
+              <ViewTransition
+                enter="nested-enter"
+                onEnter={onNestedEnter}
+                parentEnter="nested-parent-enter"
+                onParentEnter={onParentEnterNested}>
+                <div>Item</div>
+              </ViewTransition>
+            </div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      onParentEnter.mockClear();
+      onNestedEnter.mockClear();
+      onParentEnterNested.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      expect(onParentEnter).toHaveBeenCalledTimes(1);
+      expect(onNestedEnter).not.toHaveBeenCalled();
+      expect(onParentEnterNested).toHaveBeenCalledTimes(1);
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('breaks parentExit chain when intermediate ViewTransition lacks parentExit', async () => {
+      const onParentExit1 = jest.fn();
+      const onParentExit2 = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition exit="page-exit">
+            <div>
+              <ViewTransition parentExit="relay-exit">
+                <div>
+                  <ViewTransition>
+                    <div>
+                      <ViewTransition
+                        parentExit="nested-exit"
+                        onParentExit={onParentExit1}>
+                        <div>Deep</div>
+                      </ViewTransition>
+                    </div>
+                  </ViewTransition>
+                </div>
+              </ViewTransition>
+              <ViewTransition
+                parentExit="nested-exit"
+                onParentExit={onParentExit2}>
+                <div>Shallow</div>
+              </ViewTransition>
+            </div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      onParentExit1.mockClear();
+      onParentExit2.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      expect(onParentExit1).not.toHaveBeenCalled();
+      expect(onParentExit2).toHaveBeenCalledTimes(1);
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('does not fire onParentEnter when ancestor exits', async () => {
+      const onParentEnter = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition exit="page-exit">
+            <div>
+              <ViewTransition parentExit="relay-exit">
+                <ViewTransition
+                  parentEnter="nested-enter"
+                  onParentEnter={onParentEnter}>
+                  <div>Item</div>
+                </ViewTransition>
+              </ViewTransition>
+            </div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      onParentEnter.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      expect(onParentEnter).not.toHaveBeenCalled();
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('does not fire onParentExit when ancestor shares instead of exiting', async () => {
+      const onShare = jest.fn();
+      const onParentExit = jest.fn();
+
+      function App({page}) {
+        if (page === 'a') {
+          return (
+            <ViewTransition key="a" name="hero" onShare={onShare}>
+              <ViewTransition
+                parentExit="child-parent-exit"
+                onParentExit={onParentExit}>
+                <div>Page A</div>
+              </ViewTransition>
+            </ViewTransition>
+          );
+        }
+        return (
+          <ViewTransition key="b" name="hero">
+            <ViewTransition
+              parentExit="child-parent-exit"
+              onParentExit={onParentExit}>
+              <div>Page B</div>
+            </ViewTransition>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App page="a" />);
+        });
+      });
+
+      onShare.mockClear();
+      onParentExit.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App page="b" />);
+        });
+      });
+
+      expect(onShare).toHaveBeenCalledTimes(1);
+      expect(onParentExit).not.toHaveBeenCalled();
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('does not fire onParentEnter when ancestor shares instead of entering', async () => {
+      const onShare = jest.fn();
+      const onParentEnter = jest.fn();
+
+      function App({page}) {
+        if (page === 'a') {
+          return (
+            <ViewTransition key="a" name="hero" onShare={onShare}>
+              <ViewTransition
+                parentEnter="child-parent-enter"
+                onParentEnter={onParentEnter}>
+                <div>Page A</div>
+              </ViewTransition>
+            </ViewTransition>
+          );
+        }
+        return (
+          <ViewTransition key="b" name="hero">
+            <ViewTransition
+              parentEnter="child-parent-enter"
+              onParentEnter={onParentEnter}>
+              <div>Page B</div>
+            </ViewTransition>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App page="a" />);
+        });
+      });
+
+      onShare.mockClear();
+      onParentEnter.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App page="b" />);
+        });
+      });
+
+      expect(onShare).toHaveBeenCalledTimes(1);
+      expect(onParentEnter).not.toHaveBeenCalled();
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('does not fire onParentExit when ancestor exit is none', async () => {
+      const onParentExit = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition exit="none">
+            <ViewTransition
+              parentExit="nested-parent-exit"
+              onParentExit={onParentExit}>
+              <div>Item</div>
+            </ViewTransition>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      onParentExit.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      expect(onParentExit).not.toHaveBeenCalled();
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('does not fire onParentEnter when ancestor enter is none', async () => {
+      const onParentEnter = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition enter="none">
+            <ViewTransition
+              parentEnter="nested-parent-enter"
+              onParentEnter={onParentEnter}>
+              <div>Item</div>
+            </ViewTransition>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      onParentEnter.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      expect(onParentEnter).not.toHaveBeenCalled();
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('relays parentExit chain through unstyled parentExit', async () => {
+      const onParentExit = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition exit="page-exit">
+            <div>
+              <ViewTransition parentExit="auto">
+                <ViewTransition
+                  parentExit="nested-exit"
+                  onParentExit={onParentExit}>
+                  <div>Item</div>
+                </ViewTransition>
+              </ViewTransition>
+            </div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      onParentExit.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      expect(onParentExit).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMViewTransition-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMViewTransition-test.js
@@ -677,7 +677,111 @@ describe('ReactDOMViewTransition', () => {
       expect(onParentExit2).toHaveBeenCalledTimes(1);
     });
 
-    // @gate enableViewTransition
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('stops the parentExit relay when an intermediate class is "none"', async () => {
+      const onParentExitDeep = jest.fn();
+      const onParentExitSibling = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition exit="page-exit">
+            <div>
+              <ViewTransition parentExit="none">
+                <div>
+                  <ViewTransition
+                    parentExit="nested-exit"
+                    onParentExit={onParentExitDeep}>
+                    <div>Deep</div>
+                  </ViewTransition>
+                </div>
+              </ViewTransition>
+              <ViewTransition
+                parentExit="nested-exit"
+                onParentExit={onParentExitSibling}>
+                <div>Shallow</div>
+              </ViewTransition>
+            </div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      onParentExitDeep.mockClear();
+      onParentExitSibling.mockClear();
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      // The "none" class stops the relay so nested activations below it never fire.
+      expect(onParentExitDeep).not.toHaveBeenCalled();
+      // A sibling that is not behind a "none" boundary still relays.
+      expect(onParentExitSibling).toHaveBeenCalledTimes(1);
+    });
+
+    // @gate enableViewTransition && enableViewTransitionParentEnterExit
+    it('stops the parentEnter relay when an intermediate class is "none"', async () => {
+      const onParentEnterDeep = jest.fn();
+      const onParentEnterSibling = jest.fn();
+
+      function App({show}) {
+        if (!show) {
+          return null;
+        }
+        return (
+          <ViewTransition enter="page-enter">
+            <div>
+              <ViewTransition parentEnter="none">
+                <div>
+                  <ViewTransition
+                    parentEnter="nested-enter"
+                    onParentEnter={onParentEnterDeep}>
+                    <div>Deep</div>
+                  </ViewTransition>
+                </div>
+              </ViewTransition>
+              <ViewTransition
+                parentEnter="nested-enter"
+                onParentEnter={onParentEnterSibling}>
+                <div>Shallow</div>
+              </ViewTransition>
+            </div>
+          </ViewTransition>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={false} />);
+        });
+      });
+
+      await act(() => {
+        startTransition(() => {
+          root.render(<App show={true} />);
+        });
+      });
+
+      // The "none" class stops the relay so nested activations below it never fire.
+      expect(onParentEnterDeep).not.toHaveBeenCalled();
+      // A sibling that is not behind a "none" boundary still relays.
+      expect(onParentEnterSibling).toHaveBeenCalledTimes(1);
+    });
+
     it('does not fire onParentEnter when ancestor exits', async () => {
       const onParentEnter = jest.fn();
 
@@ -817,7 +921,6 @@ describe('ReactDOMViewTransition', () => {
       expect(onParentEnter).not.toHaveBeenCalled();
     });
 
-    // @gate enableViewTransition
     it('does not fire onParentExit when ancestor exit is none', async () => {
       const onParentExit = jest.fn();
 
@@ -855,7 +958,6 @@ describe('ReactDOMViewTransition', () => {
       expect(onParentExit).not.toHaveBeenCalled();
     });
 
-    // @gate enableViewTransition
     it('does not fire onParentEnter when ancestor enter is none', async () => {
       const onParentEnter = jest.fn();
 
@@ -1027,7 +1129,6 @@ describe('ReactDOMViewTransition', () => {
       expect(onParentEnterDeep).toHaveBeenCalledTimes(1);
     });
 
-    // @gate enableViewTransition
     it('does not fire onParentEnter when ancestor enter is none with handler only', async () => {
       const onParentEnter = jest.fn();
 

--- a/packages/react-reconciler/src/ReactFiberApplyGesture.js
+++ b/packages/react-reconciler/src/ReactFiberApplyGesture.js
@@ -75,6 +75,7 @@ import {
   restoreUpdateViewTransitionForGesture,
   appearingViewTransitions,
   commitEnterViewTransitions,
+  commitParentExitViewTransitions,
   measureNestedViewTransitions,
   measureUpdateViewTransition,
   viewTransitionCancelableChildren,
@@ -93,6 +94,7 @@ import {
 import {
   enableProfilerTimer,
   enableComponentPerformanceTrack,
+  enableViewTransitionParentEnterExit,
 } from 'shared/ReactFeatureFlags';
 import {trackAnimatingTask} from './ReactProfilerTimer';
 import {scheduleGestureTransitionEvent} from './ReactFiberWorkLoop';
@@ -327,6 +329,9 @@ function applyExitViewTransition(placement: Fiber): void {
       scheduleGestureTransitionEvent(placement, props.onGestureShare);
     } else {
       scheduleGestureTransitionEvent(placement, props.onGestureExit);
+      if (enableViewTransitionParentEnterExit) {
+        commitParentExitViewTransitions(placement, true);
+      }
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -338,21 +338,38 @@ export function commitParentEnterViewTransitions(
       // Skip hidden subtrees.
     } else if (child.tag === ViewTransitionComponent) {
       const props: ViewTransitionProps = child.memoizedProps;
-      if (props.parentEnter !== undefined) {
-        const state: ViewTransitionState = child.stateNode;
-        const name = getViewTransitionName(props, state);
-        const className: ?string = getViewTransitionClassName(
-          props.default,
-          props.parentEnter,
-        );
-        if (className !== 'none') {
-          applyViewTransitionToHostInstances(
-            child,
-            name,
-            className,
-            null,
-            false,
+      const hasParentClass = props.parentEnter !== undefined;
+      const hasParentHandler = gesture
+        ? props.onGestureParentEnter != null
+        : props.onParentEnter != null;
+      if (hasParentClass || hasParentHandler) {
+        if (hasParentClass) {
+          const state: ViewTransitionState = child.stateNode;
+          const name = getViewTransitionName(props, state);
+          const className: ?string = getViewTransitionClassName(
+            props.default,
+            props.parentEnter,
           );
+          if (className !== 'none') {
+            applyViewTransitionToHostInstances(
+              child,
+              name,
+              className,
+              null,
+              false,
+            );
+            if (hasParentHandler) {
+              if (gesture) {
+                scheduleGestureTransitionEvent(
+                  child,
+                  props.onGestureParentEnter,
+                );
+              } else {
+                scheduleViewTransitionEvent(child, props.onParentEnter);
+              }
+            }
+          }
+        } else {
           if (gesture) {
             scheduleGestureTransitionEvent(child, props.onGestureParentEnter);
           } else {
@@ -378,21 +395,38 @@ export function commitParentExitViewTransitions(
       // Skip hidden subtrees.
     } else if (child.tag === ViewTransitionComponent) {
       const props: ViewTransitionProps = child.memoizedProps;
-      if (props.parentExit !== undefined) {
-        const state: ViewTransitionState = child.stateNode;
-        const name = getViewTransitionName(props, state);
-        const className: ?string = getViewTransitionClassName(
-          props.default,
-          props.parentExit,
-        );
-        if (className !== 'none') {
-          applyViewTransitionToHostInstances(
-            child,
-            name,
-            className,
-            null,
-            false,
+      const hasParentClass = props.parentExit !== undefined;
+      const hasParentHandler = gesture
+        ? props.onGestureParentExit != null
+        : props.onParentExit != null;
+      if (hasParentClass || hasParentHandler) {
+        if (hasParentClass) {
+          const state: ViewTransitionState = child.stateNode;
+          const name = getViewTransitionName(props, state);
+          const className: ?string = getViewTransitionClassName(
+            props.default,
+            props.parentExit,
           );
+          if (className !== 'none') {
+            applyViewTransitionToHostInstances(
+              child,
+              name,
+              className,
+              null,
+              false,
+            );
+            if (hasParentHandler) {
+              if (gesture) {
+                scheduleGestureTransitionEvent(
+                  child,
+                  props.onGestureParentExit,
+                );
+              } else {
+                scheduleViewTransitionEvent(child, props.onParentExit);
+              }
+            }
+          }
+        } else {
           if (gesture) {
             scheduleGestureTransitionEvent(child, props.onGestureParentExit);
           } else {
@@ -415,8 +449,17 @@ function restoreParentEnterOrExitViewTransitions(parent: Fiber): void {
       // Skip hidden subtrees.
     } else if (child.tag === ViewTransitionComponent) {
       const props: ViewTransitionProps = child.memoizedProps;
-      if (props.parentEnter !== undefined || props.parentExit !== undefined) {
+      const hasParentClass =
+        props.parentEnter !== undefined || props.parentExit !== undefined;
+      const hasParentHandler =
+        props.onParentEnter != null ||
+        props.onParentExit != null ||
+        props.onGestureParentEnter != null ||
+        props.onGestureParentExit != null;
+      if (hasParentClass) {
         restoreViewTransitionOnHostInstances(child.child, false);
+      }
+      if (hasParentClass || hasParentHandler) {
         restoreParentEnterOrExitViewTransitions(child);
       }
     } else if ((child.subtreeFlags & ViewTransitionStaticParent) !== NoFlags) {

--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -21,6 +21,7 @@ import {
   NoFlags,
   Update,
   ViewTransitionStatic,
+  ViewTransitionStaticParent,
   AffectedParentLayout,
   ViewTransitionNamedStatic,
 } from './ReactFiberFlags';
@@ -47,6 +48,7 @@ import {
   enableComponentPerformanceTrack,
   enableProfilerTimer,
   enableViewTransitionForPersistenceMode,
+  enableViewTransitionParentEnterExit,
 } from 'shared/ReactFeatureFlags';
 
 export let shouldStartViewTransition: boolean = false;
@@ -326,6 +328,104 @@ function commitAppearingPairViewTransitions(placement: Fiber): void {
   }
 }
 
+export function commitParentEnterViewTransitions(
+  parent: Fiber,
+  gesture: boolean,
+): void {
+  let child = parent.child;
+  while (child !== null) {
+    if (child.tag === OffscreenComponent && child.memoizedState !== null) {
+      // Skip hidden subtrees.
+    } else if (child.tag === ViewTransitionComponent) {
+      const props: ViewTransitionProps = child.memoizedProps;
+      if (props.parentEnter !== undefined) {
+        const state: ViewTransitionState = child.stateNode;
+        const name = getViewTransitionName(props, state);
+        const className: ?string = getViewTransitionClassName(
+          props.default,
+          props.parentEnter,
+        );
+        if (className !== 'none') {
+          applyViewTransitionToHostInstances(
+            child,
+            name,
+            className,
+            null,
+            false,
+          );
+          if (gesture) {
+            scheduleGestureTransitionEvent(child, props.onGestureParentEnter);
+          } else {
+            scheduleViewTransitionEvent(child, props.onParentEnter);
+          }
+        }
+        commitParentEnterViewTransitions(child, gesture);
+      }
+    } else if ((child.subtreeFlags & ViewTransitionStaticParent) !== NoFlags) {
+      commitParentEnterViewTransitions(child, gesture);
+    }
+    child = child.sibling;
+  }
+}
+
+export function commitParentExitViewTransitions(
+  parent: Fiber,
+  gesture: boolean,
+): void {
+  let child = parent.child;
+  while (child !== null) {
+    if (child.tag === OffscreenComponent && child.memoizedState !== null) {
+      // Skip hidden subtrees.
+    } else if (child.tag === ViewTransitionComponent) {
+      const props: ViewTransitionProps = child.memoizedProps;
+      if (props.parentExit !== undefined) {
+        const state: ViewTransitionState = child.stateNode;
+        const name = getViewTransitionName(props, state);
+        const className: ?string = getViewTransitionClassName(
+          props.default,
+          props.parentExit,
+        );
+        if (className !== 'none') {
+          applyViewTransitionToHostInstances(
+            child,
+            name,
+            className,
+            null,
+            false,
+          );
+          if (gesture) {
+            scheduleGestureTransitionEvent(child, props.onGestureParentExit);
+          } else {
+            scheduleViewTransitionEvent(child, props.onParentExit);
+          }
+        }
+        commitParentExitViewTransitions(child, gesture);
+      }
+    } else if ((child.subtreeFlags & ViewTransitionStaticParent) !== NoFlags) {
+      commitParentExitViewTransitions(child, gesture);
+    }
+    child = child.sibling;
+  }
+}
+
+function restoreParentEnterOrExitViewTransitions(parent: Fiber): void {
+  let child = parent.child;
+  while (child !== null) {
+    if (child.tag === OffscreenComponent && child.memoizedState !== null) {
+      // Skip hidden subtrees.
+    } else if (child.tag === ViewTransitionComponent) {
+      const props: ViewTransitionProps = child.memoizedProps;
+      if (props.parentEnter !== undefined || props.parentExit !== undefined) {
+        restoreViewTransitionOnHostInstances(child.child, false);
+        restoreParentEnterOrExitViewTransitions(child);
+      }
+    } else if ((child.subtreeFlags & ViewTransitionStaticParent) !== NoFlags) {
+      restoreParentEnterOrExitViewTransitions(child);
+    }
+    child = child.sibling;
+  }
+}
+
 export function commitEnterViewTransitions(
   placement: Fiber,
   gesture: boolean,
@@ -360,6 +460,9 @@ export function commitEnterViewTransitions(
             scheduleGestureTransitionEvent(placement, props.onGestureEnter);
           } else {
             scheduleViewTransitionEvent(placement, props.onEnter);
+          }
+          if (enableViewTransitionParentEnterExit) {
+            commitParentEnterViewTransitions(placement, gesture);
           }
         }
       }
@@ -489,6 +592,9 @@ export function commitExitViewTransitions(deletion: Fiber): void {
         scheduleViewTransitionEvent(deletion, props.onShare);
       } else {
         scheduleViewTransitionEvent(deletion, props.onExit);
+        if (enableViewTransitionParentEnterExit) {
+          commitParentExitViewTransitions(deletion, false);
+        }
       }
     }
     if (appearingViewTransitions !== null) {
@@ -619,6 +725,9 @@ export function restoreEnterOrExitViewTransitions(fiber: Fiber): void {
     const instance: ViewTransitionState = fiber.stateNode;
     instance.paired = null;
     restoreViewTransitionOnHostInstances(fiber.child, false);
+    if (enableViewTransitionParentEnterExit) {
+      restoreParentEnterOrExitViewTransitions(fiber);
+    }
     restorePairedViewTransitions(fiber);
   } else if ((fiber.subtreeFlags & ViewTransitionStatic) !== NoFlags) {
     let child = fiber.child;

--- a/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
+++ b/packages/react-reconciler/src/ReactFiberCommitViewTransitions.js
@@ -343,6 +343,7 @@ export function commitParentEnterViewTransitions(
         ? props.onGestureParentEnter != null
         : props.onParentEnter != null;
       if (hasParentClass || hasParentHandler) {
+        let relay = true;
         if (hasParentClass) {
           const state: ViewTransitionState = child.stateNode;
           const name = getViewTransitionName(props, state);
@@ -350,7 +351,9 @@ export function commitParentEnterViewTransitions(
             props.default,
             props.parentEnter,
           );
-          if (className !== 'none') {
+          if (className === 'none') {
+            relay = false;
+          } else {
             applyViewTransitionToHostInstances(
               child,
               name,
@@ -376,7 +379,9 @@ export function commitParentEnterViewTransitions(
             scheduleViewTransitionEvent(child, props.onParentEnter);
           }
         }
-        commitParentEnterViewTransitions(child, gesture);
+        if (relay) {
+          commitParentEnterViewTransitions(child, gesture);
+        }
       }
     } else if ((child.subtreeFlags & ViewTransitionStaticParent) !== NoFlags) {
       commitParentEnterViewTransitions(child, gesture);
@@ -400,6 +405,7 @@ export function commitParentExitViewTransitions(
         ? props.onGestureParentExit != null
         : props.onParentExit != null;
       if (hasParentClass || hasParentHandler) {
+        let relay = true;
         if (hasParentClass) {
           const state: ViewTransitionState = child.stateNode;
           const name = getViewTransitionName(props, state);
@@ -407,7 +413,9 @@ export function commitParentExitViewTransitions(
             props.default,
             props.parentExit,
           );
-          if (className !== 'none') {
+          if (className === 'none') {
+            relay = false;
+          } else {
             applyViewTransitionToHostInstances(
               child,
               name,
@@ -433,7 +441,9 @@ export function commitParentExitViewTransitions(
             scheduleViewTransitionEvent(child, props.onParentExit);
           }
         }
-        commitParentExitViewTransitions(child, gesture);
+        if (relay) {
+          commitParentExitViewTransitions(child, gesture);
+        }
       }
     } else if ((child.subtreeFlags & ViewTransitionStaticParent) !== NoFlags) {
       commitParentExitViewTransitions(child, gesture);

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -40,6 +40,7 @@ import {
   passChildrenWhenCloningPersistedNodes,
   disableLegacyMode,
   enableViewTransition,
+  enableViewTransitionParentEnterExit,
   enableSuspenseyImages,
 } from 'shared/ReactFeatureFlags';
 
@@ -98,6 +99,7 @@ import {
   ShouldSuspendCommit,
   Cloned,
   ViewTransitionStatic,
+  ViewTransitionStaticParent,
   Hydrate,
   PortalStatic,
 } from './ReactFiberFlags';
@@ -2076,6 +2078,17 @@ function completeWork(
         // bubble up to the parent tree to indicate that there's a child that
         // might need an exit View Transition upon unmount.
         workInProgress.flags |= ViewTransitionStatic;
+        if (enableViewTransitionParentEnterExit) {
+          const props = workInProgress.pendingProps;
+          if (
+            props.parentEnter !== undefined ||
+            props.parentExit !== undefined
+          ) {
+            workInProgress.flags |= ViewTransitionStaticParent;
+          } else {
+            workInProgress.flags &= ~ViewTransitionStaticParent;
+          }
+        }
         bubbleProperties(workInProgress);
       }
       return null;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -2082,7 +2082,11 @@ function completeWork(
           const props = workInProgress.pendingProps;
           if (
             props.parentEnter !== undefined ||
-            props.parentExit !== undefined
+            props.parentExit !== undefined ||
+            props.onParentEnter != null ||
+            props.onParentExit != null ||
+            props.onGestureParentEnter != null ||
+            props.onGestureParentExit != null
           ) {
             workInProgress.flags |= ViewTransitionStaticParent;
           } else {

--- a/packages/react-reconciler/src/ReactFiberFlags.js
+++ b/packages/react-reconciler/src/ReactFiberFlags.js
@@ -83,6 +83,10 @@ export const ViewTransitionNamedStatic =
 // ViewTransitionStatic tracks whether there are an ViewTransition components from
 // the nearest HostComponent down. It resets at every HostComponent level.
 export const ViewTransitionStatic = /*         */ 0b0000010000000000000000000000000;
+// ViewTransitionStaticParent tracks whether there are ViewTransition components
+// with parentEnter/parentExit props. Unlike ViewTransitionStatic, this is NOT
+// cleared by HostComponents so it can be used to skip subtrees in parent walks.
+export const ViewTransitionStaticParent = /*   */ 0b1000000000000000000000000000000;
 // Tracks whether a HostPortal is present in the tree.
 export const PortalStatic = /*                 */ 0b0000100000000000000000000000000;
 
@@ -140,6 +144,7 @@ export const StaticMask =
   RefStatic |
   MaySuspendCommit |
   ViewTransitionStatic |
+  ViewTransitionStaticParent |
   ViewTransitionNamedStatic |
   PortalStatic |
   Forked;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -80,6 +80,8 @@ export const enableTaint = __EXPERIMENTAL__;
 
 export const enableViewTransition: boolean = true;
 
+export const enableViewTransitionParentEnterExit = __EXPERIMENTAL__;
+
 export const enableViewTransitionForPersistenceMode: boolean = false;
 
 export const enableGestureTransition = __EXPERIMENTAL__;

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -313,11 +313,21 @@ export type ViewTransitionProps = {
   exit?: ViewTransitionClass,
   share?: ViewTransitionClass,
   update?: ViewTransitionClass,
+  parentEnter?: ViewTransitionClass,
+  parentExit?: ViewTransitionClass,
   onEnter?: (
     instance: ViewTransitionInstance,
     types: Array<string>,
   ) => void | (() => void),
   onExit?: (
+    instance: ViewTransitionInstance,
+    types: Array<string>,
+  ) => void | (() => void),
+  onParentEnter?: (
+    instance: ViewTransitionInstance,
+    types: Array<string>,
+  ) => void | (() => void),
+  onParentExit?: (
     instance: ViewTransitionInstance,
     types: Array<string>,
   ) => void | (() => void),
@@ -336,6 +346,18 @@ export type ViewTransitionProps = {
     types: Array<string>,
   ) => void | (() => void),
   onGestureExit?: (
+    timeline: GestureProvider,
+    options: GestureOptionsRequired,
+    instance: ViewTransitionInstance,
+    types: Array<string>,
+  ) => void | (() => void),
+  onGestureParentEnter?: (
+    timeline: GestureProvider,
+    options: GestureOptionsRequired,
+    instance: ViewTransitionInstance,
+    types: Array<string>,
+  ) => void | (() => void),
+  onGestureParentExit?: (
     timeline: GestureProvider,
     options: GestureOptionsRequired,
     instance: ViewTransitionInstance,

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -70,6 +70,7 @@ export const transitionLaneExpirationMs = 5000;
 export const enableYieldingBeforePassive: boolean = false;
 export const enableThrottledScheduling: boolean = false;
 export const enableViewTransition: boolean = true;
+export const enableViewTransitionParentEnterExit: boolean = true;
 export const enableGestureTransition: boolean = false;
 export const enableScrollEndPolyfill: boolean = true;
 export const enableSuspenseyImages: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -59,6 +59,7 @@ export const enableYieldingBeforePassive: boolean = false;
 
 export const enableThrottledScheduling: boolean = false;
 export const enableViewTransition: boolean = true;
+export const enableViewTransitionParentEnterExit: boolean = false;
 export const enableViewTransitionForPersistenceMode: boolean = false;
 export const enableGestureTransition: boolean = false;
 export const enableScrollEndPolyfill: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -60,6 +60,7 @@ export const enableYieldingBeforePassive: boolean = true;
 
 export const enableThrottledScheduling: boolean = false;
 export const enableViewTransition: boolean = true;
+export const enableViewTransitionParentEnterExit = __EXPERIMENTAL__;
 export const enableViewTransitionForPersistenceMode: boolean = false;
 export const enableGestureTransition: boolean = false;
 export const enableScrollEndPolyfill: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -55,6 +55,7 @@ export const transitionLaneExpirationMs = 5000;
 export const enableYieldingBeforePassive = false;
 export const enableThrottledScheduling = false;
 export const enableViewTransition = true;
+export const enableViewTransitionParentEnterExit = false;
 export const enableViewTransitionForPersistenceMode = false;
 export const enableGestureTransition = false;
 export const enableScrollEndPolyfill = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -66,6 +66,7 @@ export const enableYieldingBeforePassive: boolean = false;
 
 export const enableThrottledScheduling: boolean = false;
 export const enableViewTransition: boolean = true;
+export const enableViewTransitionParentEnterExit = __EXPERIMENTAL__;
 export const enableViewTransitionForPersistenceMode: boolean = false;
 export const enableGestureTransition: boolean = false;
 export const enableScrollEndPolyfill: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -32,6 +32,7 @@ export const enableInfiniteRenderLoopDetectionForceThrow: boolean = __VARIANT__;
 export const enableFastAddPropertiesInDiffing: boolean = __VARIANT__;
 export const enableSuspenseyImages: boolean = __VARIANT__;
 export const enableViewTransition: boolean = __VARIANT__;
+export const enableViewTransitionParentEnterExit: boolean = __VARIANT__;
 export const enableScrollEndPolyfill: boolean = __VARIANT__;
 export const enableFragmentRefs: boolean = __VARIANT__;
 export const enableFragmentRefsScrollIntoView: boolean = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -36,6 +36,7 @@ export const {
   enableFragmentRefsTextNodes,
   enableInternalInstanceMap,
   enableParallelTransitions,
+  enableViewTransitionParentEnterExit,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.


### PR DESCRIPTION
An alternative to https://github.com/facebook/react/pull/36135

___

Adds experimental support for `parentEnter` and `parentExit` on nested `<ViewTransition>` components, so descendants can animate when an ancestor boundary enters or exits.

This is gated behind the `enableViewTransitionParentEnterExit` feature flag.

Addresses the use case of animating individual items in a list (such as sliding inactive feed posts off-screen) when a parent `<ViewTransition>` is the one being added or removed during the update.

Today, `exit`/ `enter` only fire on the `<ViewTransition>` that was directly mounted or unmounted. Nested boundaries in the same subtree are not visited for their own `exit`/`enter` when the whole tree goes away as one unit, which is usually what you want. But some cases need an explicit opt-in to nested animations.

This PR adds `parentEnter`/`parentExit`, and their handlers `onParentEnter`/`onParentExit`. When an ancestor runs a real `enter` or `exit`, React walks descendants and activates boundaries that define the nested props. This only continues through `<ViewTransition>` nodes that define `parentEnter` / `parentExit` / `onParentEnter` / `onParentExit` / `onGestureParentEnter` / `onGestureParentExit`, otherwise the chaining stops. A boundary’s own `enter`/`exit` still do not run when only an ancestor animates. So it is possible to have different animations on the same `<ViewTransition>` for `enter` vs `parentEnter`.

```jsx
function ExampleOnAncestorExit() {
  return (
    // This boundary exits — starts the parentExit walk
    <ViewTransition exit="panel-exit">
      <div>
        {/* ✓ Activates: parentExit set. Walk continues inside */}
        <ViewTransition parentExit="slide-out">
          <div>
            {/* ✗ parentEnter is not consulted on an exit walk */}
            <ViewTransition parentEnter="slide-in">
              ...
            </ViewTransition>
            {/* ✗ Chain broken: no parentExit or onParentExit */}
            <ViewTransition>
              <div>
                {/* ✗ Never reached on this path, blocked by parent above */}
                <ViewTransition parentExit="slide-out">
                  ...
                </ViewTransition>
              </div>
            </ViewTransition>
            {/* ✓ Handler-only chain: onParentExit continues the walk */}
            <ViewTransition onParentExit={() => animateOut()}>
              <ViewTransition onParentExit={() => animateDeepOut()}>
                ...
              </ViewTransition>
            </ViewTransition>
            {/* ✓ Activates: sibling under the chain */}
            <ViewTransition parentExit="slide-out">
              ...
            </ViewTransition>
          </div>
        </ViewTransition>
      </div>
    </ViewTransition>
  );
}
```