### PR TITLE
docs: update react-server request examples

### DIFF
--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -44,8 +44,10 @@ function render(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.temporaryReferences : undefined,
+    options ? options.startTime : undefined,
     __DEV__ && options ? options.environmentName : undefined,
     __DEV__ && options ? options.filterStackFrame : undefined,
+    __DEV__ && options ? options.keepDebugAlive : false,
   );
   const stream = new ReadableStream(
     {
@@ -214,8 +216,10 @@ function prerender(
       options ? options.onError : undefined,
       options ? options.identifierPrefix : undefined,
       options ? options.temporaryReferences : undefined,
+      options ? options.startTime : undefined,
       __DEV__ && options ? options.environmentName : undefined,
       __DEV__ && options ? options.filterStackFrame : undefined,
+      __DEV__ && options ? options.keepDebugAlive : false,
     );
     startWork(request);
   });


### PR DESCRIPTION
## Summary

Update the react-server README Flight examples so the createRequest and createPrerenderRequest calls include the newer debugStartTime/startTime and keepDebugAlive arguments.

This keeps the examples aligned with the current ReactFlightServer signatures.

Part of #36549.

## How did you test this change?

Docs-only change; verified the README examples against packages/react-server/src/ReactFlightServer.js.