### PR TITLE
fix: support ctrl f devtools search shortcut

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/SearchInput.js
+++ b/packages/react-devtools-shared/src/devtools/views/SearchInput.js
@@ -57,13 +57,18 @@ export default function SearchInput({
 
   // Auto-focus search input
   useEffect(() => {
+    const isMac =
+      typeof navigator !== 'undefined' &&
+      navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+
     if (inputRef.current === null) {
       return () => {};
     }
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      const {key, metaKey} = event;
-      if (key === 'f' && metaKey) {
+      const {key} = event;
+      const correctModifier = isMac ? event.metaKey : event.ctrlKey;
+      if (key === 'f' && correctModifier) {
         const inputElement = inputRef.current;
         if (inputElement !== null) {
           inputElement.focus();


### PR DESCRIPTION
## Summary

Update the shared DevTools SearchInput shortcut handling so Mac keeps using Cmd+F while Windows/Linux use Ctrl+F.

This matches the platform-specific modifier handling already used by the Profiler keyboard shortcuts and fixes #26052.

## How did you test this change?

- `git diff --check`

I also attempted `yarn prettier-check packages/react-devtools-shared/src/devtools/views/SearchInput.js`, but this sparse checkout has no local node_modules and Node resolved an incompatible parent chalk ESM package, so that command could not run locally.