### PR TITLE
fix: update react-devtools runtime dependencies

### DIFF
--- a/packages/react-devtools/bin.js
+++ b/packages/react-devtools/bin.js
@@ -13,24 +13,31 @@ const electron = require('electron');
 const spawn = require('cross-spawn');
 const argv = process.argv.slice(2);
 const pkg = require('./package.json');
-const updateNotifier = require('update-notifier');
 
-// Notify if there's an update in 7 days' interval
-const notifier = updateNotifier({
-  pkg,
-  updateCheckInterval: 1000 * 60 * 60 * 24 * 7,
-});
+async function notifyIfUpdateIsAvailable() {
+  const updateNotifier = (await import('update-notifier')).default;
 
-if (notifier.update) {
-  const updateMsg =
-    `Update available ${notifier.update.current} -> ${notifier.update.latest}` +
-    '\nTo update:' +
-    '\n"npm i [-g] react-devtools" or "yarn add react-devtools"';
-  notifier.notify({defer: false, message: updateMsg});
+  // Notify if there's an update in 7 days' interval
+  const notifier = updateNotifier({
+    pkg,
+    updateCheckInterval: 1000 * 60 * 60 * 24 * 7,
+  });
+
+  if (notifier.update) {
+    const updateMsg =
+      `Update available ${notifier.update.current} -> ${notifier.update.latest}` +
+      '\nTo update:' +
+      '\n"npm i [-g] react-devtools" or "yarn add react-devtools"';
+    notifier.notify({defer: false, message: updateMsg});
+  }
 }
 
-const result = spawn.sync(electron, [require.resolve('./app')].concat(argv), {
-  stdio: 'ignore',
-});
+function startDevTools() {
+  const result = spawn.sync(electron, [require.resolve('./app')].concat(argv), {
+    stdio: 'ignore',
+  });
 
-process.exit(result.status);
+  process.exit(result.status);
+}
+
+notifyIfUpdateIsAvailable().then(startDevTools, startDevTools);

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -23,10 +23,10 @@
   },
   "dependencies": {
     "cross-spawn": "^5.0.1",
-    "electron": "^23.1.2",
+    "electron": "^28.3.3",
     "internal-ip": "^6.2.0",
     "minimist": "^1.2.3",
     "react-devtools-core": "7.0.1",
-    "update-notifier": "^5.0.0"
+    "update-notifier": "^6.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4074,6 +4074,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.14.tgz#5465ce598486a703caddbefe8603f8a2cffa3461"
   integrity sha512-wvzClDGQXOCVNU4APPopC2KtMYukaF1MN/W3xAmslx22Z4/IF1/izDMekuyoUlwfnDHYCIZGaj7jMwnJKBTxKw==
 
+"@types/node@^18.11.18":
+  version "18.19.130"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.130.tgz#da4c6324793a79defb7a62cba3947ec5add00d59"
+  integrity sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==
+  dependencies:
+    undici-types "~5.26.4"
+
 "@types/node@^20.2.5":
   version "20.17.16"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.16.tgz#b33b0edc1bf925b27349e494b871ca4451fabab4"
@@ -7815,13 +7822,13 @@ electron-to-chromium@^1.5.73:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.114.tgz#f2bb4fda80a7db4ea273565e75b0ebbe19af0ac3"
   integrity sha512-DFptFef3iktoKlFQK/afbo274/XNWD00Am0xa7M8FZUepHlHT8PEuiNBoRfFHbH1okqN58AlhbJ4QTkcnXorjA==
 
-electron@^23.1.2:
-  version "23.1.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-23.1.2.tgz#f03e361c94f8dd2407963b5461d19aadea335316"
-  integrity sha512-ajE6xzIwH7swf8TlTU5WklDqpI3mPj4Am6690YrpCXzcp+E+dmMBXIajUUNt4joDrFhJC/lC6ZqDS2Q1BApKgQ==
+electron@^28.3.3:
+  version "28.3.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-28.3.3.tgz#2df898f653c4f77b66b4cf3eeba79d8bea6d03c0"
+  integrity sha512-ObKMLSPNhomtCOBAxFS8P2DW/4umkh72ouZUlUKzXGtYuPzgr1SYhskhFWgzAsPtUzhL2CzyV2sfbHcEW4CXqw==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^16.11.26"
+    "@types/node" "^18.11.18"
     extract-zip "^2.0.1"
 
 emittery@^0.13.1:
@@ -17232,7 +17239,7 @@ update-notifier@4.1.0:
     semver-diff "^3.1.1"
     xdg-basedir "^4.0.0"
 
-update-notifier@6.0.2:
+update-notifier@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-6.0.2.tgz#a6990253dfe6d5a02bd04fbb6a61543f55026b60"
   integrity sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==
@@ -17251,26 +17258,6 @@ update-notifier@6.0.2:
     semver "^7.3.7"
     semver-diff "^4.0.0"
     xdg-basedir "^5.1.0"
-
-update-notifier@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-5.1.0.tgz#4ab0d7c7f36a231dd7316cf7729313f0214d9ad9"
-  integrity sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==
-  dependencies:
-    boxen "^5.0.0"
-    chalk "^4.1.0"
-    configstore "^5.0.1"
-    has-yarn "^2.1.0"
-    import-lazy "^2.1.0"
-    is-ci "^2.0.0"
-    is-installed-globally "^0.4.0"
-    is-npm "^5.0.0"
-    is-yarn-global "^0.3.0"
-    latest-version "^5.1.0"
-    pupa "^2.1.1"
-    semver "^7.3.4"
-    semver-diff "^3.1.1"
-    xdg-basedir "^4.0.0"
 
 uri-js@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
## Summary

Update react-devtools runtime dependencies to avoid vulnerable Electron 23 and the old update-notifier/got dependency chain.

- Upgrade electron from ^23.1.2 to ^28.3.3
- Upgrade update-notifier from ^5.0.0 to ^6.0.2
- Load update-notifier with dynamic import because v6 is ESM-only while bin.js remains CommonJS
- Update yarn.lock accordingly

Fixes #28058.

## How did you test this change?

- `git diff --check`
- `node --check packages/react-devtools/bin.js`

I did not run the full DevTools build locally because this sparse checkout does not have installed dependencies. The issue validation steps should be run in a full checkout with dependencies installed.