### PR TITLE
fix(compiler): treat underscore-prefixed JSX tags as components

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -3409,19 +3409,19 @@ function lowerJsxElementName(
   const exprLoc = exprNode.loc ?? GeneratedSource;
   if (exprPath.isJSXIdentifier()) {
     const tag: string = exprPath.node.name;
-    if (tag.match(/^[A-Z]/)) {
+    if (tag.match(/^[a-z]/)) {
+      return {
+        kind: 'BuiltinTag',
+        name: tag,
+        loc: exprLoc,
+      };
+    } else {
       const kind = getLoadKind(builder, exprPath);
       return lowerValueToTemporary(builder, {
         kind: kind,
         place: lowerIdentifier(builder, exprPath),
         loc: exprLoc,
       });
-    } else {
-      return {
-        kind: 'BuiltinTag',
-        name: tag,
-        loc: exprLoc,
-      };
     }
   } else if (exprPath.isJSXMemberExpression()) {
     return lowerJsxMemberExpression(builder, exprPath);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-underscore-prefixed-tag-is-component.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-underscore-prefixed-tag-is-component.expect.md
@@ -1,0 +1,58 @@
+
+## Input
+
+```javascript
+import {Stringify} from 'shared-runtime';
+
+// Repro for #36601: an underscore-prefixed JSX tag (`<_Bar>`) is a component
+// reference, not a host/builtin element. Before the fix, `lowerJsxElementName`
+// used `/^[A-Z]/` to detect components, so `_Bar` (which is not A-Z) was lowered
+// as a BuiltinTag — emitting the literal string tag "_Bar" instead of loading
+// the `_Bar` binding. The compiled output below must reference the `_Bar`
+// identifier (component), not a string tag.
+function Foo({_Bar}: {_Bar: React.ComponentType<{children: React.ReactNode}>}) {
+  return <_Bar>ok</_Bar>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [{_Bar: Stringify}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { Stringify } from "shared-runtime";
+
+// Repro for #36601: an underscore-prefixed JSX tag (`<_Bar>`) is a component
+// reference, not a host/builtin element. Before the fix, `lowerJsxElementName`
+// used `/^[A-Z]/` to detect components, so `_Bar` (which is not A-Z) was lowered
+// as a BuiltinTag — emitting the literal string tag "_Bar" instead of loading
+// the `_Bar` binding. The compiled output below must reference the `_Bar`
+// identifier (component), not a string tag.
+function Foo(t0) {
+  const $ = _c(2);
+  const { _Bar } = t0;
+  let t1;
+  if ($[0] !== _Bar) {
+    t1 = <_Bar>ok</_Bar>;
+    $[0] = _Bar;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  return t1;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [{ _Bar: Stringify }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"children":"ok"}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-underscore-prefixed-tag-is-component.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/jsx-underscore-prefixed-tag-is-component.tsx
@@ -1,0 +1,16 @@
+import {Stringify} from 'shared-runtime';
+
+// Repro for #36601: an underscore-prefixed JSX tag (`<_Bar>`) is a component
+// reference, not a host/builtin element. Before the fix, `lowerJsxElementName`
+// used `/^[A-Z]/` to detect components, so `_Bar` (which is not A-Z) was lowered
+// as a BuiltinTag — emitting the literal string tag "_Bar" instead of loading
+// the `_Bar` binding. The compiled output below must reference the `_Bar`
+// identifier (component), not a string tag.
+function Foo({_Bar}: {_Bar: React.ComponentType<{children: React.ReactNode}>}) {
+  return <_Bar>ok</_Bar>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Foo,
+  params: [{_Bar: Stringify}],
+};


### PR DESCRIPTION
## Summary

Fixes #36601

The React Compiler was using a regex check `/^[A-Z]/` to determine whether a JSX tag is a component or a builtin (host) element. This meant that tags prefixed with underscore (e.g., `<_Bar>`) were incorrectly treated as builtin elements.

Per the JSX specification, only tags starting with a **lowercase** letter (`a-z`) should be treated as host/builtin elements. Tags starting with anything else (uppercase letters, underscore, dollar sign, etc.) should be treated as component references.

## The Bug

Given this input:

```tsx
function Foo({ _Bar }: { _Bar: React.ComponentType }) {
    return (
      <_Bar>
        {() => <div />}
      </_Bar>
    );
}
```

The compiler was incorrectly treating `<_Bar>` as a builtin tag, which caused the children `{() => <div />}` to be incorrectly extracted into a separate `_temp` function — silently changing the runtime behavior from what worked fine before React Compiler.

## The Fix

Changed the condition in `lowerJsxElementName()` in `BuildHIR.ts` from:

```
if (tag.match(/^[A-Z]/)) {
  // component
} else {
  // builtin tag
}
```

To:

```
if (tag.match(/^[a-z]/)) {
  // builtin tag
} else {
  // component
}
```

This matches the React JSX transform convention where a JSX tag is a host element only if its name starts with a lowercase ASCII letter.

## Testing

Existing test fixtures (`builtin-jsx-tag-lowered-between-mutations`, `global-jsx-tag-lowered-between-mutations`) continue to work correctly since:
- `<div>` (lowercase) → still treated as builtin ✓
- `<View>` (uppercase) → still treated as component ✓

---

## Test verification (RED → GREEN)

Added fixture `compiler/.../fixtures/compiler/jsx-underscore-prefixed-tag-is-component.tsx` (+ generated `.expect.md`).

Command: `yarn snap -p '*underscore*'`

**GREEN — with the fix (`/^[a-z]/`):** `_Bar` is lowered as a component (reactive dependency), sprout eval matches.
```
1 Tests, 1 Passed, 0 Failed
```

**RED — fix reverted to `/^[A-Z]/`:**
```
FAIL: jsx-underscore-prefixed-tag-is-component
Found differences in evaluator results
Non-forget (expected): (kind: ok) <div>{"children":"ok"}</div>
Forget:                (kind: exception) _Bar is not defined
1 Tests, 0 Passed, 1 Failed
```
Without the patch, `<_Bar>` is lowered as a BuiltinTag (host string), so the compiled output references an undefined `_Bar` and throws at runtime — diverging from the non-compiled reference. The fixture catches exactly this regression.
