### PR TITLE
[rust-compiler] Tolerate unknown statement kinds at the AST boundary

### DIFF
--- a/compiler/crates/TODO.md
+++ b/compiler/crates/TODO.md
@@ -134,9 +134,13 @@ the broken symptom today via three different root causes:
 	is also unmodeled but unreachable from Babel-parsed fixtures, which
 	represent `declare global` as `TSModuleDeclaration`). Deferred.
 
-Known-red until the fixes land: the three fixtures fail Babel and SWC
-e2e and `test-babel-ast.sh`, and the e2e totals elsewhere in this doc
-are stale by +3 fixtures.
+Known-red until the fixes land: the three fixtures fail SWC e2e (Babel
+e2e and the `round_trip` half of `test-babel-ast.sh` are green as of
+the unknown-statement tolerance slice; the scope-resolution half stays
+red corpus-wide on the pr-36173 tip because `babel-ast-to-json.mjs`
+still emits offset-based scope JSON without `_nodeId` after the node-ID
+migration, a pre-existing gap needing its own fix). The e2e totals
+elsewhere in this doc are stale by +3 fixtures plus tip drift.
 
 Planned fixes: (1) Babel path: unknown-statement tolerance in
 `react_compiler_ast` (untagged catch-all carrying the raw node,

--- a/compiler/crates/react_compiler/src/entrypoint/program.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/program.rs
@@ -459,6 +459,9 @@ fn returns_non_node_in_stmt(stmt: &Statement, result: &mut bool) {
         Statement::WithStatement(with) => returns_non_node_in_stmt(&with.body, result),
         // Skip nested function/class declarations -- they have their own returns
         Statement::FunctionDeclaration(_) | Statement::ClassDeclaration(_) => {}
+        // Unmodeled statements are opaque to return analysis; functions
+        // containing them bail out in lowering before this matters.
+        Statement::Unknown(_) => {}
         _ => {}
     }
 }
@@ -607,6 +610,9 @@ fn calls_hooks_or_creates_jsx_in_stmt(stmt: &Statement) -> bool {
         // where Babel's traverse enters class bodies, only skipping nested functions)
         Statement::FunctionDeclaration(_) => false,
         Statement::ClassDeclaration(class) => calls_hooks_or_creates_jsx_in_class_body(&class.body),
+        // Unmodeled statements are preserved verbatim and never compiled, so
+        // hook/JSX content inside them cannot affect compilation decisions.
+        Statement::Unknown(_) => false,
         _ => false,
     }
 }
@@ -2164,6 +2170,29 @@ fn stmt_references_identifier_at_top_level(stmt: &Statement, name: &str) -> bool
             .argument
             .as_ref()
             .map_or(false, |e| expr_references_identifier_at_top_level(e, name)),
+        // Unmodeled statements (e.g. `export = X`) can reference top-level
+        // bindings; scan the raw node for a matching Identifier so the
+        // gating reference-before-declaration analysis does not miss them.
+        Statement::Unknown(unknown) => raw_node_references_identifier(unknown.raw(), name),
+        _ => false,
+    }
+}
+
+/// Conservatively detect an `Identifier` node with the given name anywhere in
+/// a raw unmodeled subtree.
+fn raw_node_references_identifier(value: &serde_json::Value, name: &str) -> bool {
+    match value {
+        serde_json::Value::Object(map) => {
+            if map.get("type").and_then(serde_json::Value::as_str) == Some("Identifier")
+                && map.get("name").and_then(serde_json::Value::as_str) == Some(name)
+            {
+                return true;
+            }
+            map.values().any(|v| raw_node_references_identifier(v, name))
+        }
+        serde_json::Value::Array(items) => {
+            items.iter().any(|v| raw_node_references_identifier(v, name))
+        }
         _ => false,
     }
 }

--- a/compiler/crates/react_compiler/src/entrypoint/validate_source_locations.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/validate_source_locations.rs
@@ -802,6 +802,7 @@ fn statement_loc(stmt: &Statement) -> &Option<AstSourceLocation> {
         Statement::DeclareTypeAlias(n) => &n.base.loc,
         Statement::DeclareOpaqueType(n) => &n.base.loc,
         Statement::EnumDeclaration(n) => &n.base.loc,
+        Statement::Unknown(n) => &n.base().loc,
     }
 }
 
@@ -1297,6 +1298,9 @@ fn statement_type_name(stmt: &Statement) -> &'static str {
         Statement::DeclareTypeAlias(_) => "DeclareTypeAlias",
         Statement::DeclareOpaqueType(_) => "DeclareOpaqueType",
         Statement::EnumDeclaration(_) => "EnumDeclaration",
+        // The real Babel `type` lives in the raw node, but this function
+        // returns &'static str; "Unknown" is the static stand-in.
+        Statement::Unknown(_) => "Unknown",
     }
 }
 

--- a/compiler/crates/react_compiler_ast/src/statements.rs
+++ b/compiler/crates/react_compiler_ast/src/statements.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::common::BaseNode;
 
@@ -9,7 +10,7 @@ fn is_false(v: &bool) -> bool {
     !v
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type")]
 pub enum Statement {
     // Statements
@@ -61,6 +62,206 @@ pub enum Statement {
     DeclareTypeAlias(crate::declarations::DeclareTypeAlias),
     DeclareOpaqueType(crate::declarations::DeclareOpaqueType),
     EnumDeclaration(crate::declarations::EnumDeclaration),
+    /// Catch-all for statement `type`s the typed AST does not model, e.g. the
+    /// TypeScript module-interop statements `import x = require(...)`,
+    /// `export = x`, and `export as namespace X`. Carries the complete raw
+    /// Babel node so the Babel path can preserve unmodeled top-level
+    /// statements verbatim instead of failing the whole file.
+    ///
+    /// Deserialization dispatches through [`KnownStatement`]: a modeled `type`
+    /// whose body is malformed errors with the typed variant's precise message
+    /// rather than degrading to `Unknown`. Adding a variant to this enum
+    /// requires adding it to the `known_statements!` list below, which is the
+    /// single source for the dispatch enum, its `From` mapping, and
+    /// [`KNOWN_STATEMENT_TYPES`]. A variant added here but not there degrades
+    /// to `Unknown` silently; that is the one drift case structure cannot
+    /// catch.
+    #[serde(untagged)]
+    Unknown(UnknownStatement),
+}
+
+// NOTE: `Deserialize` for `Statement` is hand-written below; the
+// `#[serde(tag = "type")]` and `#[serde(untagged)]` attributes on the enum
+// configure only the derived `Serialize`.
+
+#[derive(Debug, Clone)]
+pub struct UnknownStatement {
+    raw: serde_json::Value,
+    base: BaseNode,
+}
+
+impl UnknownStatement {
+    pub fn from_raw(raw: serde_json::Value) -> Result<Self, String> {
+        match raw.get("type").and_then(serde_json::Value::as_str) {
+            Some(_) => {
+                // By-ref deserialization clones only the fields BaseNode
+                // reads, not the whole (arbitrarily large) unknown subtree.
+                let base = BaseNode::deserialize(&raw)
+                    .map_err(|err| format!("failed to read unknown statement base: {err}"))?;
+                Ok(Self { raw, base })
+            }
+            None => Err("unknown statement is missing a string `type` field".to_string()),
+        }
+    }
+
+    /// The node's `type` discriminant, read from the captured [`BaseNode`].
+    /// Falls back to `"Unknown"` rather than panicking if the raw node was
+    /// mutated out from under it.
+    pub fn node_type(&self) -> &str {
+        self.base.node_type.as_deref().unwrap_or("Unknown")
+    }
+
+    pub fn raw(&self) -> &serde_json::Value {
+        &self.raw
+    }
+
+    /// Mutate the raw node, then refresh the cached [`BaseNode`] so `base()`
+    /// and `node_type()` cannot drift from `raw`. Mutations that remove the
+    /// string `type` field are rejected and rolled back.
+    pub fn with_raw_mut<R>(
+        &mut self,
+        f: impl FnOnce(&mut serde_json::Value) -> R,
+    ) -> Result<R, String> {
+        let saved = self.raw.clone();
+        let result = f(&mut self.raw);
+        if self.raw.get("type").and_then(serde_json::Value::as_str).is_none() {
+            self.raw = saved;
+            return Err("unknown statement mutation removed the string `type` field".to_string());
+        }
+        match BaseNode::deserialize(&self.raw) {
+            Ok(base) => {
+                self.base = base;
+                Ok(result)
+            }
+            Err(err) => {
+                self.raw = saved;
+                Err(format!("failed to refresh unknown statement base: {err}"))
+            }
+        }
+    }
+
+    pub fn base(&self) -> &BaseNode {
+        &self.base
+    }
+}
+
+impl Serialize for UnknownStatement {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.raw.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for UnknownStatement {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = serde_json::Value::deserialize(deserializer)?;
+        Self::from_raw(raw).map_err(D::Error::custom)
+    }
+}
+
+impl<'de> Deserialize<'de> for Statement {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = serde_json::Value::deserialize(deserializer)?;
+        let node_type = raw
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| D::Error::custom("statement is missing a string `type` field"))?
+            .to_string();
+
+        if is_known_statement_type(&node_type) {
+            let known: KnownStatement = serde_json::from_value(raw).map_err(D::Error::custom)?;
+            Ok(known.into())
+        } else {
+            UnknownStatement::from_raw(raw)
+                .map(Statement::Unknown)
+                .map_err(D::Error::custom)
+        }
+    }
+}
+
+/// Single source of truth for the statement `type` tags [`Statement`] models.
+/// Generates the [`KnownStatement`] dispatch enum, its `From` mapping, and
+/// [`KNOWN_STATEMENT_TYPES`] from one list, so the three cannot drift from
+/// each other. A variant added to [`Statement`] but not listed here still
+/// degrades to [`Statement::Unknown`] silently; that residual gap is
+/// documented on the variant.
+macro_rules! known_statements {
+    ($($variant:ident => $ty:ty),+ $(,)?) => {
+        const KNOWN_STATEMENT_TYPES: &[&str] = &[$(stringify!($variant)),+];
+
+        fn is_known_statement_type(node_type: &str) -> bool {
+            KNOWN_STATEMENT_TYPES.contains(&node_type)
+        }
+
+        #[derive(Debug, Deserialize)]
+        #[serde(tag = "type")]
+        enum KnownStatement {
+            $($variant($ty),)+
+        }
+
+        impl From<KnownStatement> for Statement {
+            fn from(value: KnownStatement) -> Self {
+                match value {
+                    $(KnownStatement::$variant(s) => Statement::$variant(s),)+
+                }
+            }
+        }
+    };
+}
+
+known_statements! {
+    BlockStatement => BlockStatement,
+    ReturnStatement => ReturnStatement,
+    IfStatement => IfStatement,
+    ForStatement => ForStatement,
+    WhileStatement => WhileStatement,
+    DoWhileStatement => DoWhileStatement,
+    ForInStatement => ForInStatement,
+    ForOfStatement => ForOfStatement,
+    SwitchStatement => SwitchStatement,
+    ThrowStatement => ThrowStatement,
+    TryStatement => TryStatement,
+    BreakStatement => BreakStatement,
+    ContinueStatement => ContinueStatement,
+    LabeledStatement => LabeledStatement,
+    ExpressionStatement => ExpressionStatement,
+    EmptyStatement => EmptyStatement,
+    DebuggerStatement => DebuggerStatement,
+    WithStatement => WithStatement,
+    VariableDeclaration => VariableDeclaration,
+    FunctionDeclaration => FunctionDeclaration,
+    ClassDeclaration => ClassDeclaration,
+    ImportDeclaration => crate::declarations::ImportDeclaration,
+    ExportNamedDeclaration => crate::declarations::ExportNamedDeclaration,
+    ExportDefaultDeclaration => crate::declarations::ExportDefaultDeclaration,
+    ExportAllDeclaration => crate::declarations::ExportAllDeclaration,
+    TSTypeAliasDeclaration => crate::declarations::TSTypeAliasDeclaration,
+    TSInterfaceDeclaration => crate::declarations::TSInterfaceDeclaration,
+    TSEnumDeclaration => crate::declarations::TSEnumDeclaration,
+    TSModuleDeclaration => crate::declarations::TSModuleDeclaration,
+    TSDeclareFunction => crate::declarations::TSDeclareFunction,
+    TypeAlias => crate::declarations::TypeAlias,
+    OpaqueType => crate::declarations::OpaqueType,
+    InterfaceDeclaration => crate::declarations::InterfaceDeclaration,
+    DeclareVariable => crate::declarations::DeclareVariable,
+    DeclareFunction => crate::declarations::DeclareFunction,
+    DeclareClass => crate::declarations::DeclareClass,
+    DeclareModule => crate::declarations::DeclareModule,
+    DeclareModuleExports => crate::declarations::DeclareModuleExports,
+    DeclareExportDeclaration => crate::declarations::DeclareExportDeclaration,
+    DeclareExportAllDeclaration => crate::declarations::DeclareExportAllDeclaration,
+    DeclareInterface => crate::declarations::DeclareInterface,
+    DeclareTypeAlias => crate::declarations::DeclareTypeAlias,
+    DeclareOpaqueType => crate::declarations::DeclareOpaqueType,
+    EnumDeclaration => crate::declarations::EnumDeclaration,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -364,4 +565,164 @@ pub struct ClassDeclaration {
     pub type_parameters: Option<Box<serde_json::Value>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mixins: Option<Vec<serde_json::Value>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::Statement;
+
+    #[test]
+    fn unknown_statement_round_trips_at_program_level() {
+        let input = json!({
+            "type": "File",
+            "comments": [],
+            "errors": [],
+            "program": {
+                "type": "Program",
+                "sourceType": "module",
+                "interpreter": null,
+                "body": [
+                    {
+                        "type": "TSImportEqualsDeclaration",
+                        "start": 0,
+                        "end": 39,
+                        "importKind": "value",
+                        "isExport": false,
+                        "id": { "type": "Identifier", "name": "lib" },
+                        "moduleReference": {
+                            "type": "TSExternalModuleReference",
+                            "expression": { "type": "StringLiteral", "value": "shared-runtime" }
+                        }
+                    }
+                ],
+                "directives": []
+            }
+        });
+
+        let file: crate::File = serde_json::from_value(input.clone()).unwrap();
+
+        match &file.program.body[0] {
+            Statement::Unknown(unknown) => {
+                assert_eq!(unknown.node_type(), "TSImportEqualsDeclaration");
+            }
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+        assert_eq!(serde_json::to_value(&file).unwrap(), input);
+    }
+
+    #[test]
+    fn unknown_statement_round_trips_inside_function_block() {
+        let input = json!({
+            "type": "FunctionDeclaration",
+            "id": null,
+            "generator": false,
+            "async": false,
+            "params": [],
+            "body": {
+                "type": "BlockStatement",
+                "body": [
+                    {
+                        "type": "TSExportAssignment",
+                        "expression": { "type": "Identifier", "name": "x" }
+                    }
+                ],
+                "directives": []
+            }
+        });
+
+        let stmt: Statement = serde_json::from_value(input.clone()).unwrap();
+        let Statement::FunctionDeclaration(function) = &stmt else {
+            panic!("expected function declaration, got {stmt:?}");
+        };
+        assert!(matches!(function.body.body[0], Statement::Unknown(_)));
+        assert_eq!(serde_json::to_value(&stmt).unwrap(), input);
+    }
+
+    #[test]
+    fn known_statement_type_uses_typed_variant() {
+        let stmt: Statement = serde_json::from_value(json!({
+            "type": "EmptyStatement"
+        }))
+        .unwrap();
+
+        assert!(matches!(stmt, Statement::EmptyStatement(_)));
+    }
+
+    #[test]
+    fn malformed_known_statement_type_errors() {
+        let err = serde_json::from_value::<Statement>(json!({
+            "type": "IfStatement",
+            "consequent": {
+                "type": "EmptyStatement"
+            }
+        }))
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("missing field `test`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn statement_without_type_field_errors() {
+        let err = serde_json::from_value::<Statement>(json!({
+            "start": 0,
+            "end": 1
+        }))
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("`type`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn non_object_statement_errors() {
+        let err = serde_json::from_value::<Statement>(json!([1, 2])).unwrap_err();
+        assert!(
+            err.to_string().contains("`type`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn non_string_type_field_errors() {
+        let err = serde_json::from_value::<Statement>(json!({ "type": 7 })).unwrap_err();
+        assert!(
+            err.to_string().contains("`type`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// Mutating the raw node through the scoped mutator refreshes the cached
+    /// base, and mutations that strip `type` are rejected.
+    #[test]
+    fn with_raw_mut_refreshes_base_and_guards_type() {
+        let raw = json!({
+            "type": "TSExportAssignment",
+            "start": 5,
+            "expression": { "type": "Identifier", "name": "x" }
+        });
+        let Statement::Unknown(mut unknown) = serde_json::from_value(raw).unwrap() else {
+            panic!("expected Unknown");
+        };
+
+        unknown
+            .with_raw_mut(|v| {
+                v["start"] = json!(9);
+                v["expression"]["name"] = json!("y");
+            })
+            .unwrap();
+        assert_eq!(unknown.base().start, Some(9));
+        assert_eq!(unknown.raw()["expression"]["name"], json!("y"));
+
+        let err = unknown.with_raw_mut(|v| {
+            v.as_object_mut().unwrap().remove("type");
+        });
+        assert!(err.is_err(), "type removal must be rejected");
+    }
 }

--- a/compiler/crates/react_compiler_ast/src/visitor.rs
+++ b/compiler/crates/react_compiler_ast/src/visitor.rs
@@ -368,7 +368,9 @@ impl<'a> AstWalker<'a> {
             | Statement::DeclareInterface(_)
             | Statement::DeclareTypeAlias(_)
             | Statement::DeclareOpaqueType(_)
-            | Statement::EnumDeclaration(_) => {}
+            | Statement::EnumDeclaration(_)
+            // Unmodeled raw node: opaque, no compilable children to traverse.
+            | Statement::Unknown(_) => {}
         }
     }
 
@@ -1069,7 +1071,9 @@ pub fn walk_statement_mut(v: &mut impl MutVisitor, stmt: &mut Statement) -> Visi
         | Statement::DeclareInterface(_)
         | Statement::DeclareTypeAlias(_)
         | Statement::DeclareOpaqueType(_)
-        | Statement::EnumDeclaration(_) => {}
+        | Statement::EnumDeclaration(_)
+        // Unmodeled raw node: opaque, no compilable children to traverse.
+        | Statement::Unknown(_) => {}
     }
     VisitResult::Continue
 }

--- a/compiler/crates/react_compiler_ast/tests/scope_resolution.rs
+++ b/compiler/crates/react_compiler_ast/tests/scope_resolution.rs
@@ -528,6 +528,10 @@ fn visit_stmt(stmt: &mut Statement, si: &ScopeInfo) {
             rename_id(&mut d.id, si);
             visit_json(&mut d.body, si);
         }
+        Statement::Unknown(d) => {
+            d.with_raw_mut(|raw| visit_json(raw, si))
+                .expect("identifier rename preserves the node `type`");
+        }
         Statement::BreakStatement(_)
         | Statement::ContinueStatement(_)
         | Statement::EmptyStatement(_)

--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -2408,6 +2408,7 @@ fn statement_start(stmt: &react_compiler_ast::statements::Statement) -> Option<u
         Statement::DeclareTypeAlias(s) => s.base.start,
         Statement::DeclareOpaqueType(s) => s.base.start,
         Statement::EnumDeclaration(s) => s.base.start,
+        Statement::Unknown(s) => s.base().start,
     }
 }
 
@@ -2458,6 +2459,7 @@ fn statement_end(stmt: &react_compiler_ast::statements::Statement) -> Option<u32
         Statement::DeclareTypeAlias(s) => s.base.end,
         Statement::DeclareOpaqueType(s) => s.base.end,
         Statement::EnumDeclaration(s) => s.base.end,
+        Statement::Unknown(s) => s.base().end,
     }
 }
 
@@ -2509,6 +2511,7 @@ fn statement_loc(stmt: &react_compiler_ast::statements::Statement) -> Option<Sou
         Statement::DeclareTypeAlias(s) => s.base.loc.clone(),
         Statement::DeclareOpaqueType(s) => s.base.loc.clone(),
         Statement::EnumDeclaration(s) => s.base.loc.clone(),
+        Statement::Unknown(s) => s.base().loc.clone(),
     };
     convert_opt_loc(&loc)
 }
@@ -4196,6 +4199,29 @@ fn lower_statement(
         | Statement::DeclareInterface(_)
         | Statement::DeclareTypeAlias(_)
         | Statement::DeclareOpaqueType(_) => {}
+        // The TS reference can only reach its equivalent default case via
+        // assertExhaustive (Babel's closed Statement type), so it crashes;
+        // here unmodeled syntax is reachable by construction and degrades
+        // like the other unsupported-statement arms instead.
+        Statement::Unknown(unknown) => {
+            let loc = convert_opt_loc(&unknown.base().loc);
+            let node_type = unknown.node_type().to_string();
+            builder.record_error(CompilerErrorDetail {
+                category: ErrorCategory::UnsupportedSyntax,
+                reason: format!("Unsupported statement kind '{node_type}'"),
+                description: None,
+                loc: loc.clone(),
+                suggestions: None,
+            })?;
+            lower_value_to_temporary(
+                builder,
+                InstructionValue::UnsupportedNode {
+                    node_type: Some(node_type),
+                    original_node: Some(unknown.raw().clone()),
+                    loc,
+                },
+            )?;
+        }
     }
     Ok(())
 }

--- a/compiler/crates/react_compiler_lowering/tests/unknown_statement_lowering.rs
+++ b/compiler/crates/react_compiler_lowering/tests/unknown_statement_lowering.rs
@@ -1,0 +1,91 @@
+use react_compiler_ast::scope::ScopeInfo;
+use react_compiler_ast::statements::FunctionDeclaration;
+use react_compiler_hir::environment::Environment;
+use react_compiler_hir::InstructionValue;
+use react_compiler_lowering::{lower, FunctionNode};
+use serde_json::json;
+
+/// An unknown statement inside a function body degrades like the other
+/// unsupported-statement arms: an UnsupportedSyntax error is recorded and an
+/// UnsupportedNode instruction carries the raw node verbatim.
+#[test]
+fn unknown_statement_in_function_body_records_bailout() {
+	let unknown_node = json!({
+		"type": "TSFutureStatement",
+		"start": 40,
+		"end": 52,
+		"payload": { "type": "Identifier", "name": "x" }
+	});
+	let func: FunctionDeclaration = serde_json::from_value(json!({
+		"type": "FunctionDeclaration",
+		"start": 0,
+		"end": 60,
+		"id": { "type": "Identifier", "name": "useValue", "start": 9, "end": 17 },
+		"generator": false,
+		"async": false,
+		"params": [],
+		"body": {
+			"type": "BlockStatement",
+			"start": 20,
+			"end": 60,
+			"body": [unknown_node.clone()],
+			"directives": []
+		}
+	}))
+	.unwrap();
+
+	let scope_info: ScopeInfo = serde_json::from_value(json!({
+		"scopes": [
+			{ "id": 0, "parent": null, "kind": "program", "bindings": { "useValue": 0 } },
+			{ "id": 1, "parent": 0, "kind": "function", "bindings": {} }
+		],
+		"bindings": [
+			{
+				"id": 0,
+				"name": "useValue",
+				"kind": "hoisted",
+				"scope": 0,
+				"declarationType": "FunctionDeclaration"
+			}
+		],
+		"nodeToScope": { "0": 1 },
+		"referenceToBinding": {},
+		"programScope": 0
+	}))
+	.unwrap();
+
+	let mut env = Environment::new();
+	let result = lower(
+		&FunctionNode::FunctionDeclaration(&func),
+		None,
+		&scope_info,
+		&mut env,
+	);
+
+	assert!(
+		env.has_errors(),
+		"expected a recorded error, got result {result:?}"
+	);
+	let rendered = format!("{:?}", env.errors());
+	assert!(
+		rendered.contains("Unsupported statement kind 'TSFutureStatement'"),
+		"unexpected error payload: {rendered}"
+	);
+
+	let hir = result.expect("lowering degrades, it does not fail outright");
+	let unsupported = hir
+		.instructions
+		.iter()
+		.find_map(|instr| match &instr.value {
+			InstructionValue::UnsupportedNode {
+				node_type,
+				original_node,
+				..
+			} => Some((node_type.clone(), original_node.clone())),
+			_ => None,
+		})
+		.expect("expected an UnsupportedNode instruction");
+
+	assert_eq!(unsupported.0.as_deref(), Some("TSFutureStatement"));
+	assert_eq!(unsupported.1, Some(unknown_node));
+}

--- a/compiler/crates/react_compiler_oxc/src/convert_ast_reverse.rs
+++ b/compiler/crates/react_compiler_oxc/src/convert_ast_reverse.rs
@@ -387,6 +387,20 @@ impl<'a> ReverseCtx<'a> {
             | Statement::DeclareInterface(_)
             | Statement::DeclareTypeAlias(_)
             | Statement::DeclareOpaqueType(_) => self.builder.statement_empty(SPAN),
+            // The OXC forward converter never produces `Unknown` today.
+            // Degrading to an empty statement would silently drop the node,
+            // so emit a deliberate runtime tripwire (a `throw` in generated
+            // code) if this arm is ever reached.
+            Statement::Unknown(unknown) => {
+                let message = format!(
+                    "[react-compiler] internal error: unmodeled statement `{}` reached the OXC reverse converter",
+                    unknown.node_type()
+                );
+                let arg = self
+                    .builder
+                    .expression_string_literal(SPAN, self.atom(&message), None);
+                self.builder.statement_throw(SPAN, arg)
+            }
         }
     }
 

--- a/compiler/crates/react_compiler_swc/src/convert_ast_reverse.rs
+++ b/compiler/crates/react_compiler_swc/src/convert_ast_reverse.rs
@@ -545,6 +545,26 @@ impl ReverseCtx {
             | BabelStmt::DeclareInterface(_)
             | BabelStmt::DeclareTypeAlias(_)
             | BabelStmt::DeclareOpaqueType(_) => Stmt::Empty(EmptyStmt { span: DUMMY_SP }),
+            // Unreachable from the SWC path in this slice: the SWC forward
+            // converter rewrites unmodeled TS statements to EmptyStatement, so
+            // an `Unknown` never reaches here. Degrading it to EmptyStatement
+            // would silently drop the node, so emit a deliberate runtime
+            // tripwire (a `throw` in generated code) if this arm is ever
+            // reached without a matching forward-conversion policy.
+            BabelStmt::Unknown(unknown) => {
+                let message = format!(
+                    "[react-compiler] internal error: unmodeled statement `{}` reached the SWC reverse converter",
+                    unknown.node_type()
+                );
+                Stmt::Throw(ThrowStmt {
+                    span: DUMMY_SP,
+                    arg: Box::new(Expr::Lit(Lit::Str(Str {
+                        span: DUMMY_SP,
+                        value: self.wtf8(&message),
+                        raw: None,
+                    }))),
+                })
+            }
         }
     }
 

--- a/compiler/docs/rust-port/rust-port-0001-babel-ast.md
+++ b/compiler/docs/rust-port/rust-port-0001-babel-ast.md
@@ -223,10 +223,15 @@ TypeScript and Flow type annotation bodies (e.g., `TSTypeAnnotation`, type param
 
 `File`, `Program`, `SourceType`, `InterpreterDirective`
 
-### No catch-all / Unknown variants
+### Catch-all / Unknown variants: statements only
 
-Enums do **not** have catch-all `Unknown(serde_json::Value)` variants. If a fixture contains a node type that isn't modeled, deserialization fails — this is intentional. It surfaces unsupported node types immediately so the representation can be updated, rather than silently passing data through an opaque blob. 
-This is distinct from unknown *fields*, which are silently dropped (see design decision #6 on `deny_unknown_fields`). An unknown field on a known node is harmless — an unknown node type is a gap in the model that should be fixed. All enums now use this strict approach — no `Unknown` catch-all variants remain.
+Most enums do **not** have catch-all `Unknown(serde_json::Value)` variants: an unmodeled node type fails deserialization so the gap gets fixed rather than silently passing through an opaque blob.
+
+`Statement` is the one deliberate exception. Real TS module-interop syntax (`import x = require(...)`, `export = x`, `export as namespace X`) is legal Babel output that the model does not cover, and failing deserialization there failed entire files the TS reference compiles fine. `Statement::Unknown(UnknownStatement)` carries the complete raw node: top-level unknowns are preserved verbatim in output, function-body unknowns degrade to the standard `UnsupportedNode` bailout. Deserialization still dispatches modeled `type` tags through a typed helper, so a malformed modeled node errors with its precise message instead of degrading to `Unknown`; only genuinely unmodeled tags take the catch-all. The `known_statements!` macro in `statements.rs` is the single source for that dispatch.
+
+Expression/declaration/pattern enums keep the strict no-catch-all rule.
+
+This is distinct from unknown *fields*, which are silently dropped (see design decision #6 on `deny_unknown_fields`). An unknown field on a known node is harmless.
 
 ### Union types as enums
 


### PR DESCRIPTION
## Summary

Babel can emit statement kinds the typed AST does not model; #36704 pins three TS module-interop forms. Deserialization previously failed the whole file on the first such node, while the TS reference compiles the file and leaves the statement alone.

- `Statement` gains a final `#[serde(untagged)] Unknown(UnknownStatement)` variant carrying the complete raw Babel node. Deserialization is hand-written and dispatches modeled `type` tags through a `KnownStatement` helper enum, so a malformed modeled node still errors with its precise field-level message instead of degrading to `Unknown`; only genuinely unmodeled tags take the catch-all. A `known_statements!` macro is the single source for the dispatch enum, its `From` mapping, and the tag list, so the three cannot drift from each other.
- Top-level unknown statements are preserved verbatim through re-serialization. Function-body occurrences record the standard `UnsupportedSyntax` bailout with an `UnsupportedNode` instruction carrying the raw node. The TS reference reaches its equivalent default case only via `assertExhaustive`, which Babel's closed types make unreachable; in Rust unmodeled syntax is reachable by construction, so it degrades per the fault-tolerance model instead of crashing.
- Program-level analyses handle `Unknown` explicitly: the gating reference-before-declaration scan walks the raw node for identifier references (an `export = X` does reference `X`), and the prefilter and return-analysis arms are deliberately inert.
- The SWC/OXC reverse converters get loud tripwire arms (a deliberate `throw` in generated code) instead of silently dropping unknown nodes. The SWC forward path is fixed in the next PR of this stack.
- `rust-port-0001-babel-ast.md`'s no-catch-all policy is amended to document `Statement` as the single deliberate exception.

Perf note: deserialization now materializes a `serde_json::Value` per statement before typed parsing. The marginal cost is a move-based tree rebuild at a one-time boundary; the previous derive also buffered every node through serde's internal `Content` to read the tag, so the delta is allocation shape, not asymptotics.

## Test plan

- [x] `cargo test --workspace` green; unit tests cover program-level and nested-in-function round trips with reserialize equality, known-tag non-shadowing, precise malformed-node errors, missing/non-string/non-object `type`, scoped raw mutation, and a lowering integration test pinning the function-body bailout shape
- [x] All three fixtures pass scoped Babel e2e including events parity (`import lib = require("shared-runtime")` is preserved verbatim next to real memoization)
- [x] Full Babel e2e 1791/1798; the only failures are the 7 documented pre-existing ones
- [x] `test-babel-ast.sh` (round-trip and scope-resolution tests) fully green on this stack

## Stack

| PR | Slice | Base |
|---|---|---|
| #36517 → #36518 → #36522 | SWC parity stack (open) | `pr-36173` |
| #36704 | TDD fixtures (red) | #36522's branch |
| #36705 | Unknown-statement tolerance (Babel green) | #36704's branch |
| #36706 | SWC preservation + renames (SWC green) | #36705's branch |

Merge order: bottom up.