### PR TITLE
[compiler] Treat TS overload-signature ids as non-references in BlockStatement hoist

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -418,6 +418,23 @@ function lowerStatement(
             ) {
               return;
             }
+            /*
+             * TypeScript function overload signatures (TSDeclareFunction) share
+             * a name with their implementation FunctionDeclaration. Babel's
+             * `isReferencedIdentifier()` returns true for the overload-signature
+             * id because the binding's path resolves to the implementation, but
+             * the signature itself is type-only and erased. Treating it as a
+             * reference incorrectly forces the implementation to be hoisted into
+             * a context variable, which then escapes its reactive memo block as
+             * a block-scoped function declaration that never assigns the outer
+             * `let` binding (issue #34378).
+             */
+            if (
+              id.parent.type === 'TSDeclareFunction' &&
+              (id.parent as t.TSDeclareFunction).id === id.node
+            ) {
+              return;
+            }
             const binding = id.scope.getBinding(id.node.name);
             /**
              * We can only hoist an identifier decl if

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ts-function-overloads-in-hook.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ts-function-overloads-in-hook.expect.md
@@ -1,0 +1,92 @@
+
+## Input
+
+```javascript
+function useTranslatedResource(translations: {[key: string]: string}) {
+  function formatValue(key: string): string;
+  function formatValue(key: string | null | undefined): string | null;
+  function formatValue(key: string | null | undefined) {
+    if (!key) return null;
+    if (!translations[key]) return key;
+    return translations[key];
+  }
+
+  return {formatValue};
+}
+
+function Component() {
+  const {formatValue} = useTranslatedResource({hello: 'Hello'});
+  return <div>{formatValue('hello')}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function useTranslatedResource(translations) {
+  const $ = _c(2);
+  let t0;
+  if ($[0] !== translations) {
+    const formatValue = function formatValue(key) {
+      if (!key) {
+        return null;
+      }
+      if (!translations[key]) {
+        return key;
+      }
+      return translations[key];
+    };
+    t0 = { formatValue };
+    $[0] = translations;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+
+function Component() {
+  const $ = _c(5);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = { hello: "Hello" };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const { formatValue } = useTranslatedResource(t0);
+  let t1;
+  if ($[1] !== formatValue) {
+    t1 = formatValue("hello");
+    $[1] = formatValue;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  let t2;
+  if ($[3] !== t1) {
+    t2 = <div>{t1}</div>;
+    $[3] = t1;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>Hello</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ts-function-overloads-in-hook.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ts-function-overloads-in-hook.tsx
@@ -1,0 +1,21 @@
+function useTranslatedResource(translations: {[key: string]: string}) {
+  function formatValue(key: string): string;
+  function formatValue(key: string | null | undefined): string | null;
+  function formatValue(key: string | null | undefined) {
+    if (!key) return null;
+    if (!translations[key]) return key;
+    return translations[key];
+  }
+
+  return {formatValue};
+}
+
+function Component() {
+  const {formatValue} = useTranslatedResource({hello: 'Hello'});
+  return <div>{formatValue('hello')}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};


### PR DESCRIPTION
## Summary

Fixes #34378.

When a TypeScript function overload signature shares a name with its
implementation `FunctionDeclaration`, babel's `isReferencedIdentifier()`
returns `true` for the overload-signature id (the binding's path resolves
to the impl, so the signature is seen as a reference to it). The
BlockStatement hoist analysis in `BuildHIR.ts` then treats the impl as
needing hoisting and lowers it to `DeclareContext HoistedFunction`
plus `StoreContext Function`.

Inside a reactive memo block the codegen emits:

```js
let formatValue;
if ($[0] !== translations) {
  function formatValue(key) { /* ... */ }  // block-scoped in strict mode
  $[0] = translations;
  $[1] = formatValue;
}
return { formatValue };  // undefined — outer let was never assigned
```

In strict mode (which the compiler output targets, being ESM) the bare
`function formatValue(...)` declaration is block-scoped to the `if`, so the
outer `let` is never assigned and the returned object captures
`formatValue = undefined`. Consumers then call the destructured `formatValue`
and crash with `formatValue is not a function`.

The fix: skip overload-signature ids (`TSDeclareFunction.id`) in the hoist
visitor. They are type-only and erased at runtime, so they should not
influence the lowering of the impl.

With the fix, the compiled output for the same input keeps `formatValue`
inside the memo block as a local `const`:

```js
let t0;
if ($[0] !== translations) {
  const formatValue = function formatValue(key) { /* ... */ };
  t0 = { formatValue };
  /* ... */
}
return t0;
```

## How did you test this change?

- Added a fixture
  `compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ts-function-overloads-in-hook.tsx`
  reproducing the bug pattern (two TS overload signatures + an impl
  `FunctionDeclaration` returned via a hook object).
- `yarn snap -p ts-function-overloads-in-hook` → passes.
- Full compiler suite: `yarn snap` → **1720 Tests, 1720 Passed, 0 Failed**.
- `yarn workspace babel-plugin-react-compiler lint` → clean.
- `prettier --check` on touched files → clean.

### Test verification (RED → GREEN)

RED — fixture with the prod fix reverted (the new test fails as expected,
since the compiled output crashes at runtime):

```
FAIL: ts-function-overloads-in-hook
 >> Unexpected error during test:

Found differences in evaluator results
Non-forget (expected):
(kind: ok) <div>Hello</div>
Forget:
(kind: exception) formatValue is not a function

1 Tests, 0 Passed, 1 Failed
```

GREEN — with the prod fix applied:

```
1 Tests, 1 Passed, 0 Failed
```
