### PR TITLE
fix: preserve non-null assertion dependencies in compiler

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -2764,8 +2764,16 @@ function lowerExpression(
         loc: expr.node.loc ?? GeneratedSource,
       };
     }
-    case 'TSInstantiationExpression':
     case 'TSNonNullExpression': {
+      let expr = exprPath as NodePath<t.TSNonNullExpression>;
+      const value = lowerExpressionToTemporary(builder, expr.get('expression'));
+      return {
+        kind: 'NonNullExpression',
+        value,
+        loc: exprLoc,
+      };
+    }
+    case 'TSInstantiationExpression': {
       let expr = exprPath as NodePath<t.TSNonNullExpression>;
       return lowerExpression(builder, expr.get('expression'));
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -978,6 +978,11 @@ export type InstructionValue =
           typeAnnotationKind: 'as' | 'satisfies';
         }
     ))
+  | {
+      kind: 'NonNullExpression';
+      value: Place;
+      loc: SourceLocation;
+    }
   | JsxExpression
   | {
       kind: 'ObjectExpression';

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -708,6 +708,10 @@ export function printInstructionValue(instrValue: ReactiveValue): string {
       value = `FinishMemoize decl=${printPlace(instrValue.decl)}${instrValue.pruned ? ' pruned' : ''}`;
       break;
     }
+    case 'NonNullExpression': {
+      value = `NonNullExpression ${printPlace(instrValue.value)}`;
+      break;
+    }
     default: {
       assertExhaustive(
         instrValue,

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/visitors.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/visitors.ts
@@ -227,6 +227,7 @@ export function* eachInstructionValueOperand(
       yield instrValue.tag;
       break;
     }
+    case 'NonNullExpression':
     case 'TypeCastExpression': {
       yield instrValue.value;
       break;
@@ -598,6 +599,7 @@ export function mapInstructionValueOperands(
       instrValue.tag = fn(instrValue.tag);
       break;
     }
+    case 'NonNullExpression':
     case 'TypeCastExpression': {
       instrValue.value = fn(instrValue.value);
       break;

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
@@ -2248,6 +2248,7 @@ function computeSignatureForInstruction(
       effects.push({kind: 'Assign', from: value.value, into: lvalue});
       break;
     }
+    case 'NonNullExpression':
     case 'TypeCastExpression': {
       effects.push({kind: 'Assign', from: value.value, into: lvalue});
       break;

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/DeadCodeElimination.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/DeadCodeElimination.ts
@@ -393,6 +393,7 @@ function pruneableValue(value: InstructionValue, state: State): boolean {
     case 'Primitive':
     case 'PropertyLoad':
     case 'TemplateLiteral':
+    case 'NonNullExpression':
     case 'TypeCastExpression':
     case 'UnaryExpression': {
       // Definitely safe to prune since they are read-only

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineJsx.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineJsx.ts
@@ -147,6 +147,7 @@ function outlineJsxImpl(
         case 'StoreLocal':
         case 'TaggedTemplateExpression':
         case 'TemplateLiteral':
+        case 'NonNullExpression':
         case 'TypeCastExpression':
         case 'UnsupportedNode':
         case 'UnaryExpression': {

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -2081,6 +2081,12 @@ function codegenInstructionValue(
       );
       break;
     }
+    case 'NonNullExpression': {
+      value = t.tsNonNullExpression(
+        codegenPlaceToExpression(cx, instrValue.value),
+      );
+      break;
+    }
     case 'StartMemoize':
     case 'FinishMemoize':
     case 'Debugger':

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/InferReactiveScopeVariables.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/InferReactiveScopeVariables.ts
@@ -220,6 +220,7 @@ function mayAllocate(_env: Environment, instruction: Instruction): boolean {
     case 'StoreLocal':
     case 'LoadGlobal':
     case 'MetaProperty':
+    case 'NonNullExpression':
     case 'TypeCastExpression':
     case 'LoadLocal':
     case 'LoadContext':

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonEscapingScopes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonEscapingScopes.ts
@@ -556,6 +556,7 @@ class CollectDependenciesVisitor extends ReactiveFunctionVisitor<
         };
       }
       case 'Await':
+      case 'NonNullExpression':
       case 'TypeCastExpression': {
         return {
           // Indirection for the inner value, memoized if the value is

--- a/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
@@ -408,6 +408,11 @@ function* generateInstructionTypes(
       break;
     }
 
+    case 'NonNullExpression': {
+      yield equation(left, value.value.identifier.type);
+      break;
+    }
+
     case 'TypeCastExpression': {
       yield equation(left, value.value.identifier.type);
       break;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/non-null-assertion-event-handler.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/non-null-assertion-event-handler.expect.md
@@ -1,0 +1,112 @@
+
+## Input
+
+```javascript
+import {useState} from 'react';
+
+type TestState = {
+  test: string;
+};
+
+function Component() {
+  const [test, setTest] = useState<TestState | null>(null);
+
+  return (
+    <>
+      <button
+        onClick={() =>
+          test == null ? setTest({test: 'test'}) : setTest(null)
+        }>
+        Toggle
+      </button>
+      <button disabled={!test} onClick={() => console.log(test!.test)}>
+        Print
+      </button>
+    </>
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { useState } from "react";
+
+type TestState = {
+  test: string;
+};
+
+function Component() {
+  const $ = _c(10);
+  const [test, setTest] = useState(null);
+  let t0;
+  if ($[0] !== test) {
+    t0 = (
+      <button
+        onClick={() =>
+          test == null ? setTest({ test: "test" }) : setTest(null)
+        }
+      >
+        Toggle
+      </button>
+    );
+    $[0] = test;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  const t1 = !test;
+  let t2;
+  if ($[2] !== test) {
+    t2 = () => console.log(test!.test);
+    $[2] = test;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  let t3;
+  if ($[4] !== t1 || $[5] !== t2) {
+    t3 = (
+      <button disabled={t1} onClick={t2}>
+        Print
+      </button>
+    );
+    $[4] = t1;
+    $[5] = t2;
+    $[6] = t3;
+  } else {
+    t3 = $[6];
+  }
+  let t4;
+  if ($[7] !== t0 || $[8] !== t3) {
+    t4 = (
+      <>
+        {t0}
+        {t3}
+      </>
+    );
+    $[7] = t0;
+    $[8] = t3;
+    $[9] = t4;
+  } else {
+    t4 = $[9];
+  }
+  return t4;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+      
+### Eval output
+(kind: ok) <button>Toggle</button><button disabled="">Print</button>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/non-null-assertion-event-handler.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/non-null-assertion-event-handler.tsx
@@ -1,0 +1,28 @@
+import {useState} from 'react';
+
+type TestState = {
+  test: string;
+};
+
+function Component() {
+  const [test, setTest] = useState<TestState | null>(null);
+
+  return (
+    <>
+      <button
+        onClick={() =>
+          test == null ? setTest({test: 'test'}) : setTest(null)
+        }>
+        Toggle
+      </button>
+      <button disabled={!test} onClick={() => console.log(test!.test)}>
+        Print
+      </button>
+    </>
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/non-null-assertion.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/non-null-assertion.expect.md
@@ -27,15 +27,16 @@ interface ComponentProps {
 
 function Component(props) {
   const $ = _c(2);
-  let t0;
-  if ($[0] !== props.name) {
-    t0 = props.name.toUpperCase();
-    $[0] = props.name;
-    $[1] = t0;
+  const t0 = props.name!;
+  let t1;
+  if ($[0] !== t0) {
+    t1 = t0.toUpperCase();
+    $[0] = t0;
+    $[1] = t1;
   } else {
-    t0 = $[1];
+    t1 = $[1];
   }
-  return t0;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/non-null-expression.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/non-null-expression.expect.md
@@ -1,0 +1,83 @@
+
+## Input
+
+```javascript
+import {useState} from 'react';
+
+function Component() {
+  const [value, setValue] = useState(null);
+  const createValue = () => {
+    setValue({value: 42});
+  };
+  const logValue = () => {
+    console.log(value!.value);
+  };
+  return (
+    <>
+      <button onClick={createValue} />
+      <button disabled={value == null} onClick={logValue} />
+    </>
+  );
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { useState } from "react";
+
+function Component() {
+  const $ = _c(7);
+  const [value, setValue] = useState(null);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = () => {
+      setValue({ value: 42 });
+    };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const createValue = t0;
+  let t1;
+  if ($[1] !== value) {
+    t1 = () => {
+      console.log(value!.value);
+    };
+    $[1] = value;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  const logValue = t1;
+  let t2;
+  if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
+    t2 = <button onClick={createValue} />;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  const t3 = value == null;
+  let t4;
+  if ($[4] !== logValue || $[5] !== t3) {
+    t4 = (
+      <>
+        {t2}
+        <button disabled={t3} onClick={logValue} />
+      </>
+    );
+    $[4] = logValue;
+    $[5] = t3;
+    $[6] = t4;
+  } else {
+    t4 = $[6];
+  }
+  return t4;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/non-null-expression.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/non-null-expression.tsx
@@ -1,0 +1,17 @@
+import {useState} from 'react';
+
+function Component() {
+  const [value, setValue] = useState(null);
+  const createValue = () => {
+    setValue({value: 42});
+  };
+  const logValue = () => {
+    console.log(value!.value);
+  };
+  return (
+    <>
+      <button onClick={createValue} />
+      <button disabled={value == null} onClick={logValue} />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #33054.

React Compiler preserves TypeScript non-null expressions through HIR/codegen, but non-null assertions still needed dependency/effect handling so property reads inside callbacks are not evaluated during render.

This updates the non-null expression handling so it is treated as an assign-through value for mutation/aliasing effects, and adds regression coverage for a non-null assertion inside an event handler.

## How did you test this change?

- `yarn prettier-check`
- `yarn linc`
- `yarn flow dom-node`
- `cd compiler && yarn snap:build`
- `cd compiler && yarn snap -p non-null-assertion-event-handler`
- `cd compiler && yarn snap -p non-null-expression`
- `cd compiler && yarn snap -p non-null-assertion`
