### PR TITLE
[rust-compiler] Add release profile: fat LTO, one codegen unit, strip

### DIFF
--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -5,3 +5,12 @@ members = [
 ]
 resolver = "3"
 
+# Sizes the shipped napi binary (index.node). Measured on arm64 macOS:
+# default release is 11.2MB; fat LTO + one codegen unit + stripping symbols
+# lands at 7.2MB with no runtime cost. Release builds get slower; debug
+# builds (snap --rust, the e2e harness) are unaffected.
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = true
+

--- a/compiler/scripts/profile-rust-port.ts
+++ b/compiler/scripts/profile-rust-port.ts
@@ -59,8 +59,9 @@ if (!jsonMode) {
   );
 }
 
+// Profiling needs symbol names; override the release profile's strip=true.
 const cargoBuildArgs = releaseMode
-  ? '--release -p react_compiler_napi'
+  ? "--release --config 'profile.release.strip=false' -p react_compiler_napi"
   : '-p react_compiler_napi';
 
 try {


### PR DESCRIPTION
The workspace has no `[profile.release]`, so the shipped napi binary (`index.node`) is built on stock cargo defaults with the symbol table retained: 11.2MB on arm64 macOS. Fat LTO + `codegen-units = 1` + `strip = true` lands at 7.2MB with no runtime cost. Release builds get slower; debug builds (`snap --rust`, the e2e harness) are unaffected.

`profile-rust-port.ts --release` overrides `strip` so profiling runs keep symbol names.

Measured (arm64 macOS, `cargo build --release -p react_compiler_napi`):

| profile | size |
|---|---|
| defaults | 11.2MB |
| this PR | 7.2MB |

`opt-level = "s"` was measured and rejected: it cuts a further 2MB but costs ~50% compile throughput (3.9s to 5.85s median compiling 598 fixtures through the release CLI).