### PR TITLE
[rust-compiler] Drop the regex dependency from the napi binary

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1189,7 +1189,6 @@ dependencies = [
  "react_compiler_ssa",
  "react_compiler_typeinference",
  "react_compiler_validation",
- "regex",
  "serde",
  "serde_json",
 ]

--- a/compiler/crates/react_compiler/Cargo.toml
+++ b/compiler/crates/react_compiler/Cargo.toml
@@ -15,6 +15,5 @@ react_compiler_ssa = { path = "../react_compiler_ssa" }
 react_compiler_typeinference = { path = "../react_compiler_typeinference" }
 react_compiler_validation = { path = "../react_compiler_validation" }
 indexmap = "2"
-regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }

--- a/compiler/crates/react_compiler/src/entrypoint/program.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/program.rs
@@ -43,7 +43,6 @@ use react_compiler_diagnostics::SourceLocation;
 use react_compiler_hir::ReactFunctionType;
 use react_compiler_hir::environment_config::EnvironmentConfig;
 use react_compiler_lowering::FunctionNode;
-use regex::Regex;
 
 use super::compile_result::BindingRenameInfo;
 use super::compile_result::CodegenFunction;
@@ -175,26 +174,21 @@ fn find_directives_dynamic_gating<'a>(
         None => return Ok(None),
     };
 
-    let pattern = Regex::new(r"^use memo if\(([^\)]*)\)$").expect("Invalid dynamic gating regex");
-
     let mut errors: Vec<CompilerErrorDetail> = Vec::new();
     let mut matches: Vec<(&'a Directive, String)> = Vec::new();
 
     for directive in directives {
-        if let Some(caps) = pattern.captures(&directive.value.value) {
-            if let Some(m) = caps.get(1) {
-                let ident = m.as_str();
-                if is_valid_identifier(ident) {
-                    matches.push((directive, ident.to_string()));
-                } else {
-                    let mut detail = CompilerErrorDetail::new(
-                        ErrorCategory::Gating,
-                        "Dynamic gating directive is not a valid JavaScript identifier",
-                    )
-                    .with_description(format!("Found '{}'", directive.value.value));
-                    detail.loc = directive.base.loc.as_ref().map(convert_loc);
-                    errors.push(detail);
-                }
+        if let Some(ident) = parse_dynamic_gating_directive(&directive.value.value) {
+            if is_valid_identifier(ident) {
+                matches.push((directive, ident.to_string()));
+            } else {
+                let mut detail = CompilerErrorDetail::new(
+                    ErrorCategory::Gating,
+                    "Dynamic gating directive is not a valid JavaScript identifier",
+                )
+                .with_description(format!("Found '{}'", directive.value.value));
+                detail.loc = directive.base.loc.as_ref().map(convert_loc);
+                errors.push(detail);
             }
         }
     }
@@ -234,6 +228,20 @@ fn find_directives_dynamic_gating<'a>(
     } else {
         Ok(None)
     }
+}
+
+/// Parse a `use memo if(<condition>)` directive, returning the condition.
+/// Exact equivalent of the TS DYNAMIC_GATING_DIRECTIVE regex
+/// `^use memo if\(([^\)]*)\)$`: the condition may not contain `)` and the
+/// directive must end at the closing paren.
+fn parse_dynamic_gating_directive(value: &str) -> Option<&str> {
+    let condition = value
+        .strip_prefix("use memo if(")?
+        .strip_suffix(')')?;
+    if condition.contains(')') {
+        return None;
+    }
+    Some(condition)
 }
 
 /// Simple check for valid JavaScript identifier (alphanumeric + underscore + $, starting with letter/$/_ )


### PR DESCRIPTION
The regex crate services exactly one pattern, the dynamic-gating directive `^use memo if\(([^\)]*)\)$`, while costing ~570KB of `.text` (regex + regex_automata + regex_syntax + aho_corasick) in the shipped binary; after LTO the removal saves ~1MB through dead-code cascade.

Replaced with an exact hand parse: strip the `use memo if(` prefix and `)` suffix, reject conditions containing a close paren. Equivalence with the TS `DYNAMIC_GATING_DIRECTIVE` regex verified on the full gating fixture directory: 30/30 byte-identical TS-vs-Rust on the e2e comparison harness, dynamic-gating snap fixtures green.

Independent of #36726; the two compose to take the default release binary from 11.2MB to 6.1MB.