### PR TITLE
[rust-compiler] Return the compiled AST by value instead of JSON

### DIFF
--- a/compiler/crates/react_compiler/src/entrypoint/compile_result.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/compile_result.rs
@@ -1,6 +1,7 @@
 use react_compiler_ast::expressions::Identifier as AstIdentifier;
 use react_compiler_ast::patterns::PatternLike;
 use react_compiler_ast::statements::BlockStatement;
+use react_compiler_ast::File;
 use react_compiler_diagnostics::SourceLocation;
 use react_compiler_hir::ReactFunctionType;
 use serde::Serialize;
@@ -81,10 +82,12 @@ pub struct BindingRenameInfo {
 pub enum CompileResult {
     /// Compilation succeeded (or no functions needed compilation).
     /// `ast` is None if no changes were made to the program.
-    /// The AST is stored as a pre-serialized JSON string (RawValue) to avoid
-    /// double-serialization: File→Value→String becomes File→String directly.
+    /// The compiled Babel AST is returned by value so in-process Rust consumers
+    /// (the oxc/swc frontends) use it directly instead of round-tripping through
+    /// JSON. CompileResult still derives Serialize, so the napi consumer
+    /// serializes the whole result (inlining the File) as before.
     Success {
-        ast: Option<Box<serde_json::value::RawValue>>,
+        ast: Option<File>,
         events: Vec<LoggerEvent>,
         /// Unified ordered log interleaving events and debug entries.
         /// Items appear in the order they were emitted during compilation.

--- a/compiler/crates/react_compiler/src/entrypoint/program.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/program.rs
@@ -4020,27 +4020,12 @@ pub fn compile_program(mut file: File, scope: ScopeInfo, options: PluginOptions)
     // Now we can mutate file.program
     apply_compiled_functions(&replacements, &mut file.program, &mut context);
 
-    // Serialize the modified File AST directly to a JSON string and wrap as RawValue.
-    // This avoids double-serialization (File→Value→String) by going File→String directly.
-    // The RawValue is embedded verbatim when the CompileResult is serialized.
-    let ast = match serde_json::to_string(&file) {
-        Ok(s) => match serde_json::value::RawValue::from_string(s) {
-            Ok(raw) => Some(raw),
-            Err(e) => {
-                eprintln!("RUST COMPILER: Failed to create RawValue: {}", e);
-                None
-            }
-        },
-        Err(e) => {
-            eprintln!("RUST COMPILER: Failed to serialize AST: {}", e);
-            None
-        }
-    };
-
     let timing_entries = context.timing.into_entries();
 
+    // Return the compiled File by value; in-process Rust consumers use it
+    // directly, and the napi consumer serializes the whole result as before.
     CompileResult::Success {
-        ast,
+        ast: Some(file),
         events: context.events,
         ordered_log: context.ordered_log,
         renames: convert_renames(&context.renames),

--- a/compiler/crates/react_compiler_oxc/src/lib.rs
+++ b/compiler/crates/react_compiler_oxc/src/lib.rs
@@ -77,16 +77,8 @@ pub fn transform(
     // This maps source positions to new identifier names for uncompiled code.
     let rename_plan = build_rename_plan(&scope_info, &renames);
 
-    let compiled_file = program_ast.and_then(|raw_json| {
-        // First parse to serde_json::Value which deduplicates "type" fields
-        // (the compiler output can produce duplicate "type" keys due to
-        // BaseNode.node_type + #[serde(tag = "type")] enum tagging)
-        let value: serde_json::Value = serde_json::from_str(raw_json.get()).ok()?;
-        serde_json::from_value(value).ok()
-    });
-
     TransformResult {
-        file: compiled_file,
+        file: program_ast,
         diagnostics,
         events,
         rename_plan,

--- a/compiler/crates/react_compiler_swc/src/lib.rs
+++ b/compiler/crates/react_compiler_swc/src/lib.rs
@@ -91,7 +91,7 @@ pub fn transform(
         react_compiler::entrypoint::program::compile_program(file, scope_info, options);
 
     let diagnostics = compile_result_to_diagnostics(&result);
-    let (program_json, events, renames) = match result {
+    let (program_ast, events, renames) = match result {
         react_compiler::entrypoint::compile_result::CompileResult::Success {
             ast,
             events,
@@ -103,14 +103,8 @@ pub fn transform(
         } => (None, events, Vec::new()),
     };
 
-    let conversion_result = program_json.and_then(|raw_json| {
-        // First parse to serde_json::Value which deduplicates "type" fields
-        // (the compiler output can produce duplicate "type" keys due to
-        // BaseNode.node_type + #[serde(tag = "type")] enum tagging)
-        let value: serde_json::Value = serde_json::from_str(raw_json.get()).ok()?;
-        let file: react_compiler_ast::File = serde_json::from_value(value).ok()?;
-        let result = convert_program_to_swc_with_source(&file, Some(source_text));
-        Some(result)
+    let conversion_result = program_ast.map(|file| {
+        convert_program_to_swc_with_source(&file, Some(source_text))
     });
 
     let (mut swc_module, mut comments) = match conversion_result {


### PR DESCRIPTION
`compile_program` serialized the transformed `File` to a JSON string and every in-process consumer immediately deserialized it back, so each oxc/swc compile paid a full serialize/parse round-trip of the entire program for nothing. `CompileResult::Success.ast` is now `Option<react_compiler_ast::File>`; the napi bridge keeps its JSON boundary by serializing at the edge, while the oxc and swc frontends consume the typed AST directly.

This ports the typed-AST patch the Oxc team carries on their fork (co-authored with Boshen), which also makes their integration patch-free going forward.

Verified: cargo workspace tests, both snap channels 1804/1804, e2e comparison harness at parity baseline (1802 byte-identical, fbt local-require the one known divergence).

First of a stack of three with #36730 and #36731.