### PR TITLE
[rust-compiler] Represent string values as JsString (WTF-16 aware)

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -257,6 +257,7 @@ name = "react_compiler_ast"
 version = "0.1.0"
 dependencies = [
  "indexmap",
+ "react_compiler_diagnostics",
  "serde",
  "serde-transcode",
  "serde_json",

--- a/compiler/crates/react_compiler/src/entrypoint/imports.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/imports.rs
@@ -279,7 +279,12 @@ pub fn validate_restricted_imports(
 
     for stmt in &program.body {
         if let Statement::ImportDeclaration(import) = stmt {
-            if restricted.contains(import.source.value.as_str()) {
+            if import
+                .source
+                .value
+                .as_str()
+                .is_some_and(|v| restricted.contains(v))
+            {
                 let mut detail = CompilerErrorDetail::new(
                     ErrorCategory::Todo,
                     "Bailing out due to blocklisted import",
@@ -328,7 +333,7 @@ pub fn add_imports_to_program(program: &mut Program, context: &ProgramContext) {
         .filter_map(|(idx, stmt)| {
             if let Statement::ImportDeclaration(import) = stmt {
                 if is_non_namespaced_import(import) {
-                    return Some((import.source.value.clone(), idx));
+                    return Some((import.source.value.to_marker_string(), idx));
                 }
             }
             None
@@ -363,7 +368,7 @@ pub fn add_imports_to_program(program: &mut Program, context: &ProgramContext) {
                 specifiers: import_specifiers,
                 source: StringLiteral {
                     base: BaseNode::typed("StringLiteral"),
-                    value: module_name.clone(),
+                    value: module_name.clone().into(),
                 },
                 import_kind: None,
                 assertions: None,
@@ -420,7 +425,7 @@ pub fn add_imports_to_program(program: &mut Program, context: &ProgramContext) {
                         })),
                         arguments: vec![Expression::StringLiteral(StringLiteral {
                             base: BaseNode::typed("StringLiteral"),
-                            value: module_name.clone(),
+                            value: module_name.clone().into(),
                         })],
                         type_parameters: None,
                         type_arguments: None,

--- a/compiler/crates/react_compiler/src/entrypoint/program.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/program.rs
@@ -1651,10 +1651,10 @@ fn has_memo_cache_function_import(program: &Program, module_name: &str) -> bool 
                 for specifier in &import.specifiers {
                     if let ImportSpecifier::ImportSpecifier(data) = specifier {
                         let imported_name = match &data.imported {
-                            ModuleExportName::Identifier(id) => &id.name,
-                            ModuleExportName::StringLiteral(s) => &s.value,
+                            ModuleExportName::Identifier(id) => Some(id.name.as_str()),
+                            ModuleExportName::StringLiteral(s) => s.value.as_str(),
                         };
-                        if imported_name == "c" {
+                        if imported_name == Some("c") {
                             return true;
                         }
                     }

--- a/compiler/crates/react_compiler_ast/Cargo.toml
+++ b/compiler/crates/react_compiler_ast/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+react_compiler_diagnostics = { path = "../react_compiler_diagnostics" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value", "unbounded_depth"] }
 serde-transcode = "1"

--- a/compiler/crates/react_compiler_ast/src/literals.rs
+++ b/compiler/crates/react_compiler_ast/src/literals.rs
@@ -1,3 +1,4 @@
+use react_compiler_diagnostics::JsString;
 use serde::{Deserialize, Serialize};
 
 use crate::common::BaseNode;
@@ -6,7 +7,8 @@ use crate::common::BaseNode;
 pub struct StringLiteral {
     #[serde(flatten)]
     pub base: BaseNode,
-    pub value: String,
+    /// JS string values may contain unpaired surrogates; see [`JsString`].
+    pub value: JsString,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/compiler/crates/react_compiler_diagnostics/src/js_string.rs
+++ b/compiler/crates/react_compiler_diagnostics/src/js_string.rs
@@ -1,0 +1,245 @@
+//! A JavaScript string value. JS strings are sequences of UTF-16 code units
+//! with no validity requirement, so a value can contain unpaired surrogate
+//! halves that Rust's `String` cannot represent. `JsString` keeps the common
+//! valid case as UTF-8 and falls back to code units only when the value is
+//! ill-formed, so the compiler computes on true program values instead of
+//! replacement characters or escape hatches.
+//!
+//! Wire format: the babel bridge transports lone surrogates as
+//! `__SURROGATE_XXXX__` markers (see `sanitizeJsonSurrogates` in bridge.ts),
+//! because serde_json can neither parse nor emit a lone `\uXXXX` escape.
+//! Serde for `JsString` decodes and re-emits that marker form, which keeps the
+//! JS side of the bridge unchanged.
+
+use std::fmt;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum JsString {
+    /// A well-formed string (no unpaired surrogates), stored as UTF-8.
+    Utf8(String),
+    /// An ill-formed string, stored as UTF-16 code units.
+    Wtf16(Vec<u16>),
+}
+
+impl JsString {
+    /// Build from UTF-16 code units, normalizing to `Utf8` when well-formed.
+    pub fn from_code_units(units: Vec<u16>) -> Self {
+        match String::from_utf16(&units) {
+            Ok(s) => JsString::Utf8(s),
+            Err(_) => JsString::Wtf16(units),
+        }
+    }
+
+    /// The UTF-8 view, when the value is well-formed.
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            JsString::Utf8(s) => Some(s),
+            JsString::Wtf16(_) => None,
+        }
+    }
+
+    pub fn code_units(&self) -> Vec<u16> {
+        match self {
+            JsString::Utf8(s) => s.encode_utf16().collect(),
+            JsString::Wtf16(units) => units.clone(),
+        }
+    }
+
+    /// Length in UTF-16 code units (JS `String.prototype.length`).
+    pub fn len_utf16(&self) -> usize {
+        match self {
+            JsString::Utf8(s) => s.encode_utf16().count(),
+            JsString::Wtf16(units) => units.len(),
+        }
+    }
+
+    /// The value with unpaired surrogates replaced by U+FFFD, for consumers
+    /// whose string type cannot represent ill-formed values.
+    pub fn to_string_lossy(&self) -> String {
+        match self {
+            JsString::Utf8(s) => s.clone(),
+            JsString::Wtf16(units) => String::from_utf16_lossy(units),
+        }
+    }
+
+    /// Decode the bridge wire form: a UTF-8 string in which lone surrogates
+    /// appear as `__SURROGATE_XXXX__` markers.
+    pub fn from_marker_string(s: &str) -> Self {
+        if !s.contains("__SURROGATE_") {
+            return JsString::Utf8(s.to_string());
+        }
+        let mut units: Vec<u16> = Vec::with_capacity(s.len());
+        let mut rest = s;
+        while let Some(idx) = rest.find("__SURROGATE_") {
+            units.extend(rest[..idx].encode_utf16());
+            let tail = &rest[idx..];
+            // Marker shape: __SURROGATE_ + 4 hex digits + __
+            if tail.len() >= 18 && &tail[16..18] == "__" {
+                if let Ok(unit) = u16::from_str_radix(&tail[12..16], 16) {
+                    units.push(unit);
+                    rest = &tail[18..];
+                    continue;
+                }
+            }
+            // Not a well-formed marker: keep the literal text and move on.
+            units.extend("__SURROGATE_".encode_utf16());
+            rest = &tail["__SURROGATE_".len()..];
+        }
+        units.extend(rest.encode_utf16());
+        JsString::from_code_units(units)
+    }
+
+    /// Encode to the bridge wire form (markers for unpaired surrogates).
+    pub fn to_marker_string(&self) -> String {
+        match self {
+            JsString::Utf8(s) => s.clone(),
+            JsString::Wtf16(units) => {
+                let mut out = String::with_capacity(units.len() * 2);
+                let mut iter = units.iter().copied().peekable();
+                while let Some(unit) = iter.next() {
+                    match unit {
+                        0xD800..=0xDBFF => {
+                            if let Some(&next) = iter.peek() {
+                                if (0xDC00..=0xDFFF).contains(&next) {
+                                    iter.next();
+                                    let cp = 0x10000
+                                        + ((unit as u32 - 0xD800) << 10)
+                                        + (next as u32 - 0xDC00);
+                                    out.push(char::from_u32(cp).expect("valid supplementary"));
+                                    continue;
+                                }
+                            }
+                            out.push_str(&format!("__SURROGATE_{unit:04X}__"));
+                        }
+                        0xDC00..=0xDFFF => {
+                            out.push_str(&format!("__SURROGATE_{unit:04X}__"));
+                        }
+                        _ => {
+                            out.push(
+                                char::from_u32(unit as u32).expect("BMP non-surrogate is a char"),
+                            );
+                        }
+                    }
+                }
+                out
+            }
+        }
+    }
+
+    /// Render as JS-source-style escaped text, matching the form TS's debug
+    /// printer produces via JSON.stringify: unpaired surrogates print as
+    /// lowercase `\udXXX` escapes inside the otherwise UTF-8 text.
+    pub fn to_escaped_string(&self) -> String {
+        match self {
+            JsString::Utf8(s) => s.clone(),
+            JsString::Wtf16(units) => {
+                let mut out = String::with_capacity(units.len() * 2);
+                let mut iter = units.iter().copied().peekable();
+                while let Some(unit) = iter.next() {
+                    match unit {
+                        0xD800..=0xDBFF => {
+                            if let Some(&next) = iter.peek() {
+                                if (0xDC00..=0xDFFF).contains(&next) {
+                                    iter.next();
+                                    let cp = 0x10000
+                                        + ((unit as u32 - 0xD800) << 10)
+                                        + (next as u32 - 0xDC00);
+                                    out.push(char::from_u32(cp).expect("valid supplementary"));
+                                    continue;
+                                }
+                            }
+                            out.push_str(&format!("\\u{unit:04x}"));
+                        }
+                        0xDC00..=0xDFFF => {
+                            out.push_str(&format!("\\u{unit:04x}"));
+                        }
+                        _ => {
+                            out.push(
+                                char::from_u32(unit as u32).expect("BMP non-surrogate is a char"),
+                            );
+                        }
+                    }
+                }
+                out
+            }
+        }
+    }
+}
+
+impl From<String> for JsString {
+    fn from(s: String) -> Self {
+        JsString::Utf8(s)
+    }
+}
+
+impl From<&str> for JsString {
+    fn from(s: &str) -> Self {
+        JsString::Utf8(s.to_string())
+    }
+}
+
+impl PartialEq<str> for JsString {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == Some(other)
+    }
+}
+
+impl PartialEq<&str> for JsString {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == Some(*other)
+    }
+}
+
+impl fmt::Display for JsString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_escaped_string())
+    }
+}
+
+impl Serialize for JsString {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_marker_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for JsString {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(JsString::from_marker_string(&s))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JsString;
+
+    #[test]
+    fn marker_round_trip_preserves_lone_surrogates() {
+        let js = JsString::from_marker_string("__SURROGATE_D83E__");
+        assert_eq!(js.code_units(), vec![0xD83E]);
+        assert_eq!(js.to_marker_string(), "__SURROGATE_D83E__");
+        assert_eq!(js.to_escaped_string(), "\\ud83e");
+    }
+
+    #[test]
+    fn paired_halves_render_as_the_supplementary_character() {
+        let js = JsString::from_code_units(vec![0xD83E, 0xDD21]);
+        assert_eq!(js.as_str(), Some("\u{1F921}"));
+    }
+
+    #[test]
+    fn plain_strings_stay_utf8_and_compare_with_str() {
+        let js = JsString::from("use memo");
+        assert!(js == "use memo");
+        assert_eq!(js.to_marker_string(), "use memo");
+    }
+
+    #[test]
+    fn malformed_marker_text_is_kept_literally() {
+        let js = JsString::from_marker_string("__SURROGATE_XYZ__");
+        assert_eq!(js.as_str(), Some("__SURROGATE_XYZ__"));
+    }
+}

--- a/compiler/crates/react_compiler_diagnostics/src/js_string.rs
+++ b/compiler/crates/react_compiler_diagnostics/src/js_string.rs
@@ -66,29 +66,45 @@ impl JsString {
     }
 
     /// Decode the bridge wire form: a UTF-8 string in which lone surrogates
-    /// appear as `__SURROGATE_XXXX__` markers.
+    /// appear as `__SURROGATE_XXXX__` markers (uppercase hex, mirroring what
+    /// `sanitizeJsonSurrogates` emits and `restoreJsonSurrogates` accepts).
+    ///
+    /// All scanning is byte-wise: a marker is 18 ASCII bytes, so byte-slice
+    /// comparisons cannot land on a UTF-8 char boundary the way `str` range
+    /// indexing can when multibyte text follows the prefix.
     pub fn from_marker_string(s: &str) -> Self {
+        const PREFIX: &[u8] = b"__SURROGATE_";
+        const MARKER_LEN: usize = 18;
         if !s.contains("__SURROGATE_") {
             return JsString::Utf8(s.to_string());
         }
+        let bytes = s.as_bytes();
         let mut units: Vec<u16> = Vec::with_capacity(s.len());
-        let mut rest = s;
-        while let Some(idx) = rest.find("__SURROGATE_") {
-            units.extend(rest[..idx].encode_utf16());
-            let tail = &rest[idx..];
-            // Marker shape: __SURROGATE_ + 4 hex digits + __
-            if tail.len() >= 18 && &tail[16..18] == "__" {
-                if let Ok(unit) = u16::from_str_radix(&tail[12..16], 16) {
-                    units.push(unit);
-                    rest = &tail[18..];
-                    continue;
-                }
+        let mut pos = 0;
+        let mut segment_start = 0;
+        while let Some(found) = s[pos..].find("__SURROGATE_") {
+            let idx = pos + found;
+            let tail = &bytes[idx..];
+            let well_formed = tail.len() >= MARKER_LEN
+                && &tail[MARKER_LEN - 2..MARKER_LEN] == b"__"
+                && tail[PREFIX.len()..PREFIX.len() + 4]
+                    .iter()
+                    .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_lowercase());
+            if well_formed {
+                let hex = std::str::from_utf8(&tail[PREFIX.len()..PREFIX.len() + 4])
+                    .expect("ascii hex is valid utf8");
+                let unit = u16::from_str_radix(hex, 16).expect("validated hex digits");
+                units.extend(s[segment_start..idx].encode_utf16());
+                units.push(unit);
+                pos = idx + MARKER_LEN;
+                segment_start = pos;
+            } else {
+                // Not a well-formed marker: keep the literal text and continue
+                // scanning after the prefix.
+                pos = idx + PREFIX.len();
             }
-            // Not a well-formed marker: keep the literal text and move on.
-            units.extend("__SURROGATE_".encode_utf16());
-            rest = &tail["__SURROGATE_".len()..];
         }
-        units.extend(rest.encode_utf16());
+        units.extend(s[segment_start..].encode_utf16());
         JsString::from_code_units(units)
     }
 
@@ -241,5 +257,33 @@ mod tests {
     fn malformed_marker_text_is_kept_literally() {
         let js = JsString::from_marker_string("__SURROGATE_XYZ__");
         assert_eq!(js.as_str(), Some("__SURROGATE_XYZ__"));
+    }
+
+    #[test]
+    fn multibyte_text_after_marker_prefix_does_not_panic() {
+        let input = "__SURROGATE_\u{20AC}\u{20AC}";
+        let js = JsString::from_marker_string(input);
+        assert_eq!(js.as_str(), Some(input));
+
+        let truncated = "__SURROGATE_D8";
+        assert_eq!(
+            JsString::from_marker_string(truncated).as_str(),
+            Some(truncated)
+        );
+
+        let mixed = "a\u{20AC}__SURROGATE_D83E__b\u{20AC}";
+        let js = JsString::from_marker_string(mixed);
+        let mut expected: Vec<u16> = "a\u{20AC}".encode_utf16().collect();
+        expected.push(0xD83E);
+        expected.extend("b\u{20AC}".encode_utf16());
+        assert_eq!(js.code_units(), expected);
+    }
+
+    #[test]
+    fn lowercase_hex_markers_are_not_decoded() {
+        // The bridge emits uppercase hex only; lowercase marker-shaped text is
+        // user text and must survive verbatim.
+        let input = "__SURROGATE_d83e__";
+        assert_eq!(JsString::from_marker_string(input).as_str(), Some(input));
     }
 }

--- a/compiler/crates/react_compiler_diagnostics/src/js_string.rs
+++ b/compiler/crates/react_compiler_diagnostics/src/js_string.rs
@@ -16,52 +16,76 @@ use std::fmt;
 use serde::Deserialize;
 use serde::Serialize;
 
+/// Invariant: `Repr::Utf8` holds every well-formed value and `Repr::Wtf16`
+/// only ill-formed ones (at least one unpaired surrogate). The derived
+/// `PartialEq`/`Hash` are only sound under this invariant: a well-formed
+/// value smuggled into `Wtf16` would compare unequal to its `Utf8` twin. The
+/// representation is private so the invariant holds by construction; match on
+/// [`JsString::as_ref`] to branch on well-formedness.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum JsString {
+pub struct JsString(Repr);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Repr {
     /// A well-formed string (no unpaired surrogates), stored as UTF-8.
     Utf8(String),
     /// An ill-formed string, stored as UTF-16 code units.
     Wtf16(Vec<u16>),
 }
 
+/// Borrowed view of a [`JsString`] for callers that need to branch on
+/// well-formedness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JsStringRef<'a> {
+    Utf8(&'a str),
+    Wtf16(&'a [u16]),
+}
+
 impl JsString {
-    /// Build from UTF-16 code units, normalizing to `Utf8` when well-formed.
+    /// Build from UTF-16 code units, normalizing to UTF-8 when well-formed.
     pub fn from_code_units(units: Vec<u16>) -> Self {
         match String::from_utf16(&units) {
-            Ok(s) => JsString::Utf8(s),
-            Err(_) => JsString::Wtf16(units),
+            Ok(s) => JsString(Repr::Utf8(s)),
+            Err(_) => JsString(Repr::Wtf16(units)),
+        }
+    }
+
+    pub fn as_ref(&self) -> JsStringRef<'_> {
+        match &self.0 {
+            Repr::Utf8(s) => JsStringRef::Utf8(s),
+            Repr::Wtf16(units) => JsStringRef::Wtf16(units),
         }
     }
 
     /// The UTF-8 view, when the value is well-formed.
     pub fn as_str(&self) -> Option<&str> {
-        match self {
-            JsString::Utf8(s) => Some(s),
-            JsString::Wtf16(_) => None,
+        match &self.0 {
+            Repr::Utf8(s) => Some(s),
+            Repr::Wtf16(_) => None,
         }
     }
 
     pub fn code_units(&self) -> Vec<u16> {
-        match self {
-            JsString::Utf8(s) => s.encode_utf16().collect(),
-            JsString::Wtf16(units) => units.clone(),
+        match &self.0 {
+            Repr::Utf8(s) => s.encode_utf16().collect(),
+            Repr::Wtf16(units) => units.clone(),
         }
     }
 
     /// Length in UTF-16 code units (JS `String.prototype.length`).
     pub fn len_utf16(&self) -> usize {
-        match self {
-            JsString::Utf8(s) => s.encode_utf16().count(),
-            JsString::Wtf16(units) => units.len(),
+        match &self.0 {
+            Repr::Utf8(s) => s.encode_utf16().count(),
+            Repr::Wtf16(units) => units.len(),
         }
     }
 
     /// The value with unpaired surrogates replaced by U+FFFD, for consumers
     /// whose string type cannot represent ill-formed values.
     pub fn to_string_lossy(&self) -> String {
-        match self {
-            JsString::Utf8(s) => s.clone(),
-            JsString::Wtf16(units) => String::from_utf16_lossy(units),
+        match &self.0 {
+            Repr::Utf8(s) => s.clone(),
+            Repr::Wtf16(units) => String::from_utf16_lossy(units),
         }
     }
 
@@ -76,7 +100,7 @@ impl JsString {
         const PREFIX: &[u8] = b"__SURROGATE_";
         const MARKER_LEN: usize = 18;
         if !s.contains("__SURROGATE_") {
-            return JsString::Utf8(s.to_string());
+            return JsString(Repr::Utf8(s.to_string()));
         }
         let bytes = s.as_bytes();
         let mut units: Vec<u16> = Vec::with_capacity(s.len());
@@ -110,9 +134,9 @@ impl JsString {
 
     /// Encode to the bridge wire form (markers for unpaired surrogates).
     pub fn to_marker_string(&self) -> String {
-        match self {
-            JsString::Utf8(s) => s.clone(),
-            JsString::Wtf16(units) => {
+        match &self.0 {
+            Repr::Utf8(s) => s.clone(),
+            Repr::Wtf16(units) => {
                 let mut out = String::with_capacity(units.len() * 2);
                 let mut iter = units.iter().copied().peekable();
                 while let Some(unit) = iter.next() {
@@ -149,9 +173,9 @@ impl JsString {
     /// printer produces via JSON.stringify: unpaired surrogates print as
     /// lowercase `\udXXX` escapes inside the otherwise UTF-8 text.
     pub fn to_escaped_string(&self) -> String {
-        match self {
-            JsString::Utf8(s) => s.clone(),
-            JsString::Wtf16(units) => {
+        match &self.0 {
+            Repr::Utf8(s) => s.clone(),
+            Repr::Wtf16(units) => {
                 let mut out = String::with_capacity(units.len() * 2);
                 let mut iter = units.iter().copied().peekable();
                 while let Some(unit) = iter.next() {
@@ -187,13 +211,15 @@ impl JsString {
 
 impl From<String> for JsString {
     fn from(s: String) -> Self {
-        JsString::Utf8(s)
+        // A Rust String is valid UTF-8 and so cannot contain an unpaired
+        // surrogate; constructing Utf8 directly preserves the invariant.
+        JsString(Repr::Utf8(s))
     }
 }
 
 impl From<&str> for JsString {
     fn from(s: &str) -> Self {
-        JsString::Utf8(s.to_string())
+        JsString(Repr::Utf8(s.to_string()))
     }
 }
 
@@ -231,6 +257,26 @@ impl<'de> Deserialize<'de> for JsString {
 #[cfg(test)]
 mod tests {
     use super::JsString;
+    use super::JsStringRef;
+
+    #[test]
+    fn as_ref_views_match_well_formedness() {
+        assert!(matches!(
+            JsString::from("plain").as_ref(),
+            JsStringRef::Utf8("plain")
+        ));
+        assert!(matches!(
+            JsString::from_code_units(vec![0xD83E]).as_ref(),
+            JsStringRef::Wtf16(&[0xD83E])
+        ));
+        // Well-formed code units normalize to the Utf8 representation, so
+        // equal logical strings are equal values regardless of how they
+        // were constructed.
+        assert_eq!(
+            JsString::from_code_units("plain".encode_utf16().collect()),
+            JsString::from("plain")
+        );
+    }
 
     #[test]
     fn marker_round_trip_preserves_lone_surrogates() {

--- a/compiler/crates/react_compiler_diagnostics/src/lib.rs
+++ b/compiler/crates/react_compiler_diagnostics/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod code_frame;
+pub mod js_string;
+
+pub use js_string::JsString;
 
 use serde::{Deserialize, Serialize};
 

--- a/compiler/crates/react_compiler_hir/src/lib.rs
+++ b/compiler/crates/react_compiler_hir/src/lib.rs
@@ -845,7 +845,7 @@ pub enum PrimitiveValue {
     Undefined,
     Boolean(bool),
     Number(FloatValue),
-    String(String),
+    String(react_compiler_diagnostics::JsString),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/compiler/crates/react_compiler_hir/src/print.rs
+++ b/compiler/crates/react_compiler_hir/src/print.rs
@@ -80,7 +80,53 @@ pub fn format_primitive(prim: &crate::PrimitiveValue) -> String {
         crate::PrimitiveValue::Undefined => "undefined".to_string(),
         crate::PrimitiveValue::Boolean(b) => format!("{}", b),
         crate::PrimitiveValue::Number(n) => crate::format_js_number(n.value()),
-        crate::PrimitiveValue::String(s) => format_js_string(s),
+        crate::PrimitiveValue::String(s) => match s.as_str() {
+            Some(utf8) => format_js_string(utf8),
+            // Ill-formed strings: escape the well-formed segments exactly like
+            // format_js_string and render each unpaired surrogate as \uXXXX,
+            // matching what TS's JSON.stringify-based printer emits.
+            None => {
+                let mut result = String::new();
+                result.push('"');
+                let mut units = s.code_units().into_iter().peekable();
+                while let Some(unit) = units.next() {
+                    let is_lead = (0xD800..=0xDBFF).contains(&unit);
+                    let is_trail = (0xDC00..=0xDFFF).contains(&unit);
+                    if is_lead {
+                        if let Some(&next) = units.peek() {
+                            if (0xDC00..=0xDFFF).contains(&next) {
+                                units.next();
+                                let cp = 0x10000
+                                    + ((unit as u32 - 0xD800) << 10)
+                                    + (next as u32 - 0xDC00);
+                                result.push(char::from_u32(cp).expect("valid supplementary"));
+                                continue;
+                            }
+                        }
+                    }
+                    if is_lead || is_trail {
+                        result.push_str(&format!("\\u{unit:04x}"));
+                        continue;
+                    }
+                    let c = char::from_u32(unit as u32).expect("BMP non-surrogate is a char");
+                    match c {
+                        '"' => result.push_str("\\\""),
+                        '\\' => result.push_str("\\\\"),
+                        '\n' => result.push_str("\\n"),
+                        '\r' => result.push_str("\\r"),
+                        '\t' => result.push_str("\\t"),
+                        '\u{0008}' => result.push_str("\\b"),
+                        '\u{000c}' => result.push_str("\\f"),
+                        c if (c as u32) <= 0x1F => {
+                            result.push_str(&format!("\\u{:04x}", c as u32));
+                        }
+                        c => result.push(c),
+                    }
+                }
+                result.push('"');
+                result
+            }
+        },
     }
 }
 

--- a/compiler/crates/react_compiler_inference/src/memoize_fbt_and_macro_operands_in_same_scope.rs
+++ b/compiler/crates/react_compiler_inference/src/memoize_fbt_and_macro_operands_in_same_scope.rs
@@ -134,7 +134,9 @@ fn populate_macro_tags(
                     value: PrimitiveValue::String(s),
                     ..
                 } => {
-                    if let Some(macro_def) = macro_kinds.get(s.as_str()) {
+                    if let Some(macro_def) =
+                        s.as_str().and_then(|utf8| macro_kinds.get(utf8))
+                    {
                         // We don't distinguish between tag names and strings, so record
                         // all `fbt` string literals in case they are used as a jsx tag.
                         macro_tags.insert(lvalue_id, macro_def.clone());

--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -6289,7 +6289,7 @@ fn lower_jsx_element_name(
             let place = lower_value_to_temporary(
                 builder,
                 InstructionValue::Primitive {
-                    value: PrimitiveValue::String(tag),
+                    value: PrimitiveValue::String(tag.into()),
                     loc: loc.clone(),
                 },
             )?;
@@ -6518,8 +6518,10 @@ fn lower_object_property_key(
 ) -> Result<Option<ObjectPropertyKey>, CompilerError> {
     use react_compiler_ast::expressions::Expression;
     match key {
+        // Property keys stay String-typed; the marker wire form preserves the
+        // pre-JsString behavior for pathological surrogate keys end to end.
         Expression::StringLiteral(lit) => Ok(Some(ObjectPropertyKey::String {
-            name: lit.value.clone(),
+            name: lit.value.to_marker_string(),
         })),
         Expression::Identifier(ident) if !computed => Ok(Some(ObjectPropertyKey::Identifier {
             name: ident.name.clone(),

--- a/compiler/crates/react_compiler_optimization/src/constant_propagation.rs
+++ b/compiler/crates/react_compiler_optimization/src/constant_propagation.rs
@@ -26,6 +26,7 @@
 
 use std::collections::HashMap;
 
+use react_compiler_diagnostics::JsString;
 use react_compiler_hir::environment::Environment;
 use react_compiler_hir::{
     BinaryOperator, BlockKind, FloatValue, FunctionId, GotoVariant, HirFunction, IdentifierId,
@@ -303,10 +304,11 @@ fn evaluate_instruction(
             }) = prop_value
             {
                 match prim {
-                    PrimitiveValue::String(s) if is_valid_identifier(s) => {
+                    PrimitiveValue::String(s) if s.as_str().is_some_and(is_valid_identifier) => {
                         let object = object.clone();
                         let loc = *loc;
-                        let new_property = PropertyLiteral::String(s.clone());
+                        let new_property =
+                            PropertyLiteral::String(s.as_str().expect("guarded utf8").to_string());
                         func.instructions[instr_id.0 as usize].value =
                             InstructionValue::PropertyLoad {
                                 object,
@@ -345,11 +347,12 @@ fn evaluate_instruction(
             }) = prop_value
             {
                 match prim {
-                    PrimitiveValue::String(s) if is_valid_identifier(s) => {
+                    PrimitiveValue::String(s) if s.as_str().is_some_and(is_valid_identifier) => {
                         let object = object.clone();
                         let store_value = value.clone();
                         let loc = *loc;
-                        let new_property = PropertyLiteral::String(s.clone());
+                        let new_property =
+                            PropertyLiteral::String(s.as_str().expect("guarded utf8").to_string());
                         func.instructions[instr_id.0 as usize].value =
                             InstructionValue::PropertyStore {
                                 object,
@@ -534,7 +537,7 @@ fn evaluate_instruction(
                 if let PropertyLiteral::String(prop_name) = property {
                     if prop_name == "length" {
                         // Use UTF-16 code unit count to match JS .length semantics
-                        let len = s.encode_utf16().count() as f64;
+                        let len = s.len_utf16() as f64;
                         let loc = *loc;
                         let result = Constant::Primitive {
                             value: PrimitiveValue::Number(FloatValue::new(len)),
@@ -567,11 +570,11 @@ fn evaluate_instruction(
                 }
                 let loc = *loc;
                 let result = Constant::Primitive {
-                    value: PrimitiveValue::String(result_string.clone()),
+                    value: PrimitiveValue::String(JsString::from_marker_string(&result_string)),
                     loc,
                 };
                 func.instructions[instr_id.0 as usize].value = InstructionValue::Primitive {
-                    value: PrimitiveValue::String(result_string),
+                    value: PrimitiveValue::String(JsString::from_marker_string(&result_string)),
                     loc,
                 };
                 return Some(result);
@@ -600,7 +603,7 @@ fn evaluate_instruction(
                     PrimitiveValue::Null => "null".to_string(),
                     PrimitiveValue::Boolean(b) => b.to_string(),
                     PrimitiveValue::Number(n) => format_js_number(n.value()),
-                    PrimitiveValue::String(s) => s.clone(),
+                    PrimitiveValue::String(s) => s.to_marker_string(),
                     // TS rejects undefined subexpression values
                     PrimitiveValue::Undefined => return None,
                 };
@@ -617,11 +620,11 @@ fn evaluate_instruction(
 
             let loc = *loc;
             let result = Constant::Primitive {
-                value: PrimitiveValue::String(result_string.clone()),
+                value: PrimitiveValue::String(JsString::from_marker_string(&result_string)),
                 loc,
             };
             func.instructions[instr_id.0 as usize].value = InstructionValue::Primitive {
-                value: PrimitiveValue::String(result_string),
+                value: PrimitiveValue::String(JsString::from_marker_string(&result_string)),
                 loc,
             };
             Some(result)
@@ -847,7 +850,7 @@ fn is_truthy(value: &PrimitiveValue) -> bool {
             let v = n.value();
             v != 0.0 && !v.is_nan()
         }
-        PrimitiveValue::String(s) => !s.is_empty(),
+        PrimitiveValue::String(s) => s.len_utf16() != 0,
     }
 }
 
@@ -866,9 +869,13 @@ fn evaluate_binary_op(
                 FloatValue::new(l.value() + r.value()),
             )),
             (PrimitiveValue::String(l), PrimitiveValue::String(r)) => {
-                let mut s = l.clone();
-                s.push_str(r);
-                Some(PrimitiveValue::String(s))
+                // Concatenate as code units: JS `+` can pair up surrogate
+                // halves split across the operands.
+                let mut units = l.code_units();
+                units.extend(r.code_units());
+                Some(PrimitiveValue::String(
+                    react_compiler_diagnostics::JsString::from_code_units(units),
+                ))
             }
             _ => None,
         },
@@ -1056,8 +1063,12 @@ fn js_abstract_equal(lhs: &PrimitiveValue, rhs: &PrimitiveValue) -> bool {
         // Cross-type coercions for primitives
         (PrimitiveValue::Number(n), PrimitiveValue::String(s))
         | (PrimitiveValue::String(s), PrimitiveValue::Number(n)) => {
-            // String is coerced to number using JS ToNumber semantics
-            let sv = js_to_number(s);
+            // String is coerced to number using JS ToNumber semantics.
+            // Ill-formed strings coerce to NaN, like any non-numeric text.
+            let sv = match s.as_str() {
+                Some(utf8) => js_to_number(utf8),
+                None => f64::NAN,
+            };
             let nv = n.value();
             if nv.is_nan() || sv.is_nan() {
                 false

--- a/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
@@ -282,7 +282,7 @@ pub fn codegen_function(
                     })),
                     right: Box::new(Expression::StringLiteral(StringLiteral {
                         base: BaseNode::typed("StringLiteral"),
-                        value: hash.clone(),
+                        value: hash.clone().into(),
                     })),
                 })),
                 consequent: Box::new(Statement::BlockStatement(BlockStatement {
@@ -382,7 +382,7 @@ pub fn codegen_function(
                                                     arguments: vec![Expression::StringLiteral(
                                                         StringLiteral {
                                                             base: BaseNode::typed("StringLiteral"),
-                                                            value: MEMO_CACHE_SENTINEL.to_string(),
+                                                            value: MEMO_CACHE_SENTINEL.to_string().into(),
                                                         },
                                                     )],
                                                     type_parameters: None,
@@ -421,7 +421,7 @@ pub fn codegen_function(
                                     )),
                                     right: Box::new(Expression::StringLiteral(StringLiteral {
                                         base: BaseNode::typed("StringLiteral"),
-                                        value: hash.clone(),
+                                        value: hash.clone().into(),
                                     })),
                                 },
                             )),
@@ -493,11 +493,11 @@ pub fn codegen_function(
                         arguments: vec![
                             Expression::StringLiteral(StringLiteral {
                                 base: BaseNode::typed("StringLiteral"),
-                                value: fn_name_str.to_string(),
+                                value: fn_name_str.to_string().into(),
                             }),
                             Expression::StringLiteral(StringLiteral {
                                 base: BaseNode::typed("StringLiteral"),
-                                value: filename_str.to_string(),
+                                value: filename_str.to_string().into(),
                             }),
                         ],
                         type_parameters: None,
@@ -2010,7 +2010,7 @@ fn codegen_instruction_value(
                         })?;
                         expressions.push(Expression::StringLiteral(StringLiteral {
                             base: BaseNode::typed("StringLiteral"),
-                            value: format!("TODO handle declaration"),
+                            value: format!("TODO handle declaration").into(),
                         }));
                     }
                     _ => {
@@ -2025,7 +2025,7 @@ fn codegen_instruction_value(
                         })?;
                         expressions.push(Expression::StringLiteral(StringLiteral {
                             base: BaseNode::typed("StringLiteral"),
-                            value: format!("TODO handle statement"),
+                            value: format!("TODO handle statement").into(),
                         }));
                     }
                 }
@@ -2714,7 +2714,7 @@ fn codegen_function_expression(
                         base: BaseNode::typed("ObjectProperty"),
                         key: Box::new(Expression::StringLiteral(StringLiteral {
                             base: BaseNode::typed("StringLiteral"),
-                            value: hint.clone(),
+                            value: hint.clone().into(),
                         })),
                         value: Box::new(value),
                         computed: false,
@@ -2726,7 +2726,7 @@ fn codegen_function_expression(
             })),
             property: Box::new(Expression::StringLiteral(StringLiteral {
                 base: BaseNode::typed("StringLiteral"),
-                value: hint.clone(),
+                value: hint.clone().into(),
             })),
             computed: true,
         });
@@ -2848,7 +2848,7 @@ fn codegen_object_property_key(
     match key {
         ObjectPropertyKey::String { name } => Ok(Expression::StringLiteral(StringLiteral {
             base: BaseNode::typed("StringLiteral"),
-            value: name.clone(),
+            value: name.clone().into(),
         })),
         ObjectPropertyKey::Identifier { name } => Ok(Expression::Identifier(make_identifier(name))),
         ObjectPropertyKey::Computed { name } => {
@@ -2892,7 +2892,7 @@ fn codegen_jsx_expression(
         JsxTag::Builtin(builtin) => (
             Expression::StringLiteral(StringLiteral {
                 base: BaseNode::typed("StringLiteral"),
-                value: builtin.name.clone(),
+                value: builtin.name.clone().into(),
             }),
             None,
         ),
@@ -2901,7 +2901,9 @@ fn codegen_jsx_expression(
     let jsx_tag = expression_to_jsx_tag(&tag_value, jsx_tag_loc(tag))?;
 
     let is_fbt_tag = if let Expression::StringLiteral(ref s) = tag_value {
-        SINGLE_CHILD_FBT_TAGS.contains(&s.value.as_str())
+        s.value
+            .as_str()
+            .is_some_and(|v| SINGLE_CHILD_FBT_TAGS.contains(&v))
     } else {
         false
     };
@@ -3002,7 +3004,7 @@ fn codegen_jsx_attribute(
             let inner_value = codegen_place_to_expression(cx, place)?;
             let attr_value = match &inner_value {
                 Expression::StringLiteral(s) => {
-                    if string_requires_expr_container(&s.value)
+                    if string_requires_expr_container(&s.value.to_marker_string())
                         && !cx.fbt_operands.contains(&place.identifier)
                     {
                         Some(JSXAttributeValue::JSXExpressionContainer(
@@ -3065,7 +3067,7 @@ fn codegen_jsx_element(cx: &mut Context, place: &Place) -> Result<JSXChild, Comp
                     expression: JSXExpressionContainerExpr::Expression(Box::new(
                         Expression::StringLiteral(StringLiteral {
                             base: base_node_with_loc("StringLiteral", loc),
-                            value: text.value.clone(),
+                            value: text.value.clone().into(),
                         }),
                     )),
                 }))
@@ -3121,8 +3123,11 @@ fn expression_to_jsx_tag(
             convert_member_expression_to_jsx(me)?,
         )),
         Expression::StringLiteral(s) => {
-            if s.value.contains(':') {
-                let parts: Vec<&str> = s.value.splitn(2, ':').collect();
+            // JSX tag names are identifier-shaped; the marker form preserves
+            // the pre-JsString behavior for pathological values.
+            let tag_text = s.value.to_marker_string();
+            if tag_text.contains(':') {
+                let parts: Vec<&str> = tag_text.splitn(2, ':').collect();
                 Ok(JSXElementName::JSXNamespacedName(JSXNamespacedName {
                     base: base_node_with_loc("JSXNamespacedName", loc),
                     namespace: JSXIdentifier {
@@ -3137,7 +3142,7 @@ fn expression_to_jsx_tag(
             } else {
                 Ok(JSXElementName::JSXIdentifier(JSXIdentifier {
                     base: base_node_with_loc("JSXIdentifier", loc),
-                    name: s.value.clone(),
+                    name: tag_text,
                 }))
             }
         }
@@ -3746,7 +3751,7 @@ fn symbol_for(name: &str) -> Expression {
         })),
         arguments: vec![Expression::StringLiteral(StringLiteral {
             base: BaseNode::typed("StringLiteral"),
-            value: name.to_string(),
+            value: name.to_string().into(),
         })],
         type_parameters: None,
         type_arguments: None,
@@ -3824,7 +3829,7 @@ fn convert_value_to_expression(value: ExpressionOrJsxText) -> Expression {
         ExpressionOrJsxText::Expression(e) => e,
         ExpressionOrJsxText::JsxText(text) => Expression::StringLiteral(StringLiteral {
             base: BaseNode::typed("StringLiteral"),
-            value: text.value,
+            value: text.value.into(),
         }),
     }
 }

--- a/compiler/crates/react_compiler_reactive_scopes/src/propagate_early_returns.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/propagate_early_returns.rs
@@ -264,7 +264,7 @@ fn apply_early_return_to_scope(
                 loc: None, // GeneratedSource
             }),
             value: ReactiveValue::Instruction(InstructionValue::Primitive {
-                value: PrimitiveValue::String(EARLY_RETURN_SENTINEL.to_string()),
+                value: PrimitiveValue::String(EARLY_RETURN_SENTINEL.into()),
                 loc,
             }),
             effects: None,


### PR DESCRIPTION
Last of the boundary trilogy, after #36729 and #36730 (both merged); rebased onto main as a standalone 3-commit change.

JS strings are WTF-16: a lone surrogate in source (`"\uD83E"`) is a legal string value, but Rust `String` is UTF-8 and cannot hold it. The compiler previously leaned on the napi bridge's `__SURROGATE_XXXX__` marker encoding end to end, so the core compiler compared, concatenated, and constant-folded marker text as if it were the actual string value.

`JsString` (in `react_compiler_diagnostics`, our lowest layer) holds the common well-formed case as a plain UTF-8 `String` with zero overhead and falls back to UTF-16 code units only for ill-formed values. `StringLiteral.value` and `PrimitiveValue::String` carry it through the pipeline; constant folding concatenates via code units so split surrogate halves re-pair exactly as they do in JS; markers are emitted only at the napi edge, where the babel bridge requires them (serde_json can neither parse nor emit a lone `\uXXXX` escape).

The representation is encapsulated behind an opaque struct (private `Repr` enum, borrowed `JsStringRef` view via `as_ref`) so the "well-formed values are always UTF-8" invariant that makes the derived `PartialEq`/`Hash` sound holds by construction, per review feedback.

The marker decoder scans byte-wise (an earlier draft range-sliced at fixed offsets and panicked on multibyte UTF-8 following `__SURROGATE_`), validates hex digits, and accepts uppercase only, exactly mirroring what the bridge emits; lowercase marker-shaped user text survives verbatim. The HIR debug printer renders unpaired surrogates as `\uXXXX` escapes byte-identical to the TS printer.

This closes the lone-surrogate divergence on the e2e harness. Verified on the rebased branch: cargo workspace tests, Rust snap channel 1804/1804, and HIR + Code parity on the lone-surrogate fixture through the comparison harness.