### PR TITLE
[compiler] Treat non-null assertions as dependency boundaries

### DIFF
--- a/compiler/crates/react_compiler_hir/src/lib.rs
+++ b/compiler/crates/react_compiler_hir/src/lib.rs
@@ -640,6 +640,14 @@ pub enum InstructionValue {
         type_annotation: Option<Box<serde_json::Value>>,
         loc: Option<SourceLocation>,
     },
+    /// TSNonNullExpression (`expr!`). Lowered as its own instruction rather
+    /// than a transparent unwrap so dependency collection stops at the
+    /// asserted value instead of hoisting member accesses past a `!` that
+    /// only holds inside guarded callbacks (react/react#34752).
+    NonNullExpression {
+        value: Place,
+        loc: Option<SourceLocation>,
+    },
     JsxExpression {
         tag: JsxTag,
         props: Vec<JsxAttribute>,
@@ -803,6 +811,7 @@ impl InstructionValue {
             | InstructionValue::MethodCall { loc, .. }
             | InstructionValue::UnaryExpression { loc, .. }
             | InstructionValue::TypeCastExpression { loc, .. }
+            | InstructionValue::NonNullExpression { loc, .. }
             | InstructionValue::JsxExpression { loc, .. }
             | InstructionValue::ObjectExpression { loc, .. }
             | InstructionValue::ObjectMethod { loc, .. }

--- a/compiler/crates/react_compiler_hir/src/print.rs
+++ b/compiler/crates/react_compiler_hir/src/print.rs
@@ -904,6 +904,14 @@ impl<'a> PrintFormatter<'a> {
                     format_loc(loc)
                 ));
             }
+            InstructionValue::NonNullExpression { value: val, loc } => {
+                self.line("NonNullExpression {");
+                self.indent();
+                self.format_place_field("value", val);
+                self.line(&format!("loc: {}", format_loc(loc)));
+                self.dedent();
+                self.line("}");
+            }
             InstructionValue::TypeCastExpression {
                 value: val,
                 type_,

--- a/compiler/crates/react_compiler_hir/src/visitors.rs
+++ b/compiler/crates/react_compiler_hir/src/visitors.rs
@@ -55,6 +55,7 @@ pub fn each_instruction_value_lvalue(value: &InstructionValue) -> Vec<Place> {
         | InstructionValue::MethodCall { .. }
         | InstructionValue::UnaryExpression { .. }
         | InstructionValue::TypeCastExpression { .. }
+        | InstructionValue::NonNullExpression { .. }
         | InstructionValue::JsxExpression { .. }
         | InstructionValue::ObjectExpression { .. }
         | InstructionValue::ObjectMethod { .. }
@@ -119,6 +120,7 @@ pub fn each_instruction_lvalue_with_kind(
         | InstructionValue::MethodCall { .. }
         | InstructionValue::UnaryExpression { .. }
         | InstructionValue::TypeCastExpression { .. }
+        | InstructionValue::NonNullExpression { .. }
         | InstructionValue::JsxExpression { .. }
         | InstructionValue::ObjectExpression { .. }
         | InstructionValue::ObjectMethod { .. }
@@ -323,7 +325,8 @@ pub fn each_instruction_value_operand_with_functions(
         InstructionValue::TaggedTemplateExpression { tag, .. } => {
             result.push(tag.clone());
         }
-        InstructionValue::TypeCastExpression { value: val, .. } => {
+        InstructionValue::TypeCastExpression { value: val, .. }
+        | InstructionValue::NonNullExpression { value: val, .. } => {
             result.push(val.clone());
         }
         InstructionValue::TemplateLiteral { subexprs, .. } => {
@@ -763,7 +766,8 @@ pub fn map_instruction_value_operands(
         InstructionValue::TaggedTemplateExpression { tag, .. } => {
             *tag = f(tag.clone());
         }
-        InstructionValue::TypeCastExpression { value: val, .. } => {
+        InstructionValue::TypeCastExpression { value: val, .. }
+        | InstructionValue::NonNullExpression { value: val, .. } => {
             *val = f(val.clone());
         }
         InstructionValue::TemplateLiteral { subexprs, .. } => {
@@ -1600,7 +1604,8 @@ pub fn for_each_instruction_value_operand_mut(
         InstructionValue::TaggedTemplateExpression { tag, .. } => {
             f(tag);
         }
-        InstructionValue::TypeCastExpression { value: val, .. } => {
+        InstructionValue::TypeCastExpression { value: val, .. }
+        | InstructionValue::NonNullExpression { value: val, .. } => {
             f(val);
         }
         InstructionValue::TemplateLiteral { subexprs, .. } => {

--- a/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
@@ -2523,6 +2523,9 @@ fn compute_signature_for_instruction(
         }
         InstructionValue::TypeCastExpression {
             value: tc_value, ..
+        }
+        | InstructionValue::NonNullExpression {
+            value: tc_value, ..
         } => {
             effects.push(AliasingEffect::Assign {
                 from: tc_value.clone(),

--- a/compiler/crates/react_compiler_inference/src/infer_reactive_scope_variables.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_reactive_scope_variables.rs
@@ -192,6 +192,7 @@ fn may_allocate(value: &InstructionValue, lvalue_type_is_primitive: bool) -> boo
         | InstructionValue::LoadGlobal { .. }
         | InstructionValue::MetaProperty { .. }
         | InstructionValue::TypeCastExpression { .. }
+        | InstructionValue::NonNullExpression { .. }
         | InstructionValue::LoadLocal { .. }
         | InstructionValue::LoadContext { .. }
         | InstructionValue::StoreContext { .. }

--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -2231,7 +2231,11 @@ fn lower_expression(
                 loc,
             })
         }
-        Expression::TSNonNullExpression(ts) => Ok(lower_expression(builder, &ts.expression)?),
+        Expression::TSNonNullExpression(ts) => {
+            let loc = convert_opt_loc(&ts.base.loc);
+            let value = lower_expression_to_temporary(builder, &ts.expression)?;
+            Ok(InstructionValue::NonNullExpression { value, loc })
+        }
         Expression::TSTypeAssertion(ts) => {
             let loc = convert_opt_loc(&ts.base.loc);
             let value = lower_expression_to_temporary(builder, &ts.expression)?;

--- a/compiler/crates/react_compiler_optimization/src/constant_propagation.rs
+++ b/compiler/crates/react_compiler_optimization/src/constant_propagation.rs
@@ -705,6 +705,7 @@ fn evaluate_instruction(
         | InstructionValue::CallExpression { .. }
         | InstructionValue::MethodCall { .. }
         | InstructionValue::TypeCastExpression { .. }
+        | InstructionValue::NonNullExpression { .. }
         | InstructionValue::JsxExpression { .. }
         | InstructionValue::ObjectExpression { .. }
         | InstructionValue::ArrayExpression { .. }

--- a/compiler/crates/react_compiler_optimization/src/dead_code_elimination.rs
+++ b/compiler/crates/react_compiler_optimization/src/dead_code_elimination.rs
@@ -400,6 +400,7 @@ fn pruneable_value(value: &InstructionValue, state: &State, env: &Environment) -
         | InstructionValue::PropertyLoad { .. }
         | InstructionValue::TemplateLiteral { .. }
         | InstructionValue::TypeCastExpression { .. }
+        | InstructionValue::NonNullExpression { .. }
         | InstructionValue::UnaryExpression { .. } => {
             // Definitely safe to prune since they are read-only
             true

--- a/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
@@ -2517,6 +2517,15 @@ fn codegen_base_instruction_value(
                 }),
             ))
         }
+        InstructionValue::NonNullExpression { value, .. } => {
+            let expr = codegen_place_to_expression(cx, value)?;
+            Ok(ExpressionOrJsxText::Expression(
+                Expression::TSNonNullExpression(ast_expr::TSNonNullExpression {
+                    base: BaseNode::typed("TSNonNullExpression"),
+                    expression: Box::new(expr),
+                }),
+            ))
+        }
         InstructionValue::TypeCastExpression {
             value,
             type_annotation_kind,

--- a/compiler/crates/react_compiler_reactive_scopes/src/prune_non_escaping_scopes.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/prune_non_escaping_scopes.rs
@@ -508,7 +508,8 @@ impl<'a> CollectDependenciesVisitor<'a> {
                 }
             }
             InstructionValue::Await { value: inner, .. }
-            | InstructionValue::TypeCastExpression { value: inner, .. } => {
+            | InstructionValue::TypeCastExpression { value: inner, .. }
+            | InstructionValue::NonNullExpression { value: inner, .. } => {
                 let lvalues = if let Some(lv) = lvalue {
                     vec![LValueMemoization {
                         place_identifier: lv,

--- a/compiler/crates/react_compiler_typeinference/src/infer_types.rs
+++ b/compiler/crates/react_compiler_typeinference/src/infer_types.rs
@@ -786,7 +786,8 @@ fn generate_instruction_types(
             }
         },
 
-        InstructionValue::TypeCastExpression { value, .. } => {
+        InstructionValue::TypeCastExpression { value, .. }
+        | InstructionValue::NonNullExpression { value, .. } => {
             let value_type = get_type(value.identifier, identifiers);
             unifier.unify(left, value_type, shapes)?;
         }
@@ -1093,7 +1094,8 @@ fn apply_instruction_operands(
         InstructionValue::UnaryExpression { value: val, .. } => {
             resolve_identifier(val.identifier, identifiers, types, unifier);
         }
-        InstructionValue::TypeCastExpression { value: val, .. } => {
+        InstructionValue::TypeCastExpression { value: val, .. }
+        | InstructionValue::NonNullExpression { value: val, .. } => {
             resolve_identifier(val.identifier, identifiers, types, unifier);
         }
         InstructionValue::CallExpression { callee, args, .. } => {

--- a/compiler/crates/react_compiler_validation/src/validate_no_ref_access_in_render.rs
+++ b/compiler/crates/react_compiler_validation/src/validate_no_ref_access_in_render.rs
@@ -728,7 +728,8 @@ fn validate_no_ref_access_in_render_impl(
                             }),
                         );
                     }
-                    InstructionValue::TypeCastExpression { value, .. } => {
+                    InstructionValue::TypeCastExpression { value, .. }
+                    | InstructionValue::NonNullExpression { value, .. } => {
                         ref_env.set(
                             instr.lvalue.identifier,
                             ref_env.get(value.identifier).cloned().unwrap_or_else(|| {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -2771,8 +2771,16 @@ function lowerExpression(
         loc: expr.node.loc ?? GeneratedSource,
       };
     }
-    case 'TSInstantiationExpression':
     case 'TSNonNullExpression': {
+      let expr = exprPath as NodePath<t.TSNonNullExpression>;
+      const value = lowerExpressionToTemporary(builder, expr.get('expression'));
+      return {
+        kind: 'NonNullExpression',
+        value,
+        loc: exprLoc,
+      };
+    }
+    case 'TSInstantiationExpression': {
       let expr = exprPath as NodePath<t.TSNonNullExpression>;
       return lowerExpression(builder, expr.get('expression'));
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/DebugPrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/DebugPrintHIR.ts
@@ -363,6 +363,15 @@ export class DebugPrinter {
         this.line('}');
         break;
       }
+      case 'NonNullExpression': {
+        this.line('NonNullExpression {');
+        this.indent();
+        this.formatPlaceField('value', instrValue.value);
+        this.line(`loc: ${this.formatLoc(instrValue.loc)}`);
+        this.dedent();
+        this.line('}');
+        break;
+      }
       case 'JsxExpression': {
         this.line('JsxExpression {');
         this.indent();

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -978,6 +978,11 @@ export type InstructionValue =
           typeAnnotationKind: 'as' | 'satisfies';
         }
     ))
+  | {
+      kind: 'NonNullExpression';
+      value: Place;
+      loc: SourceLocation;
+    }
   | JsxExpression
   | {
       kind: 'ObjectExpression';

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -708,6 +708,10 @@ export function printInstructionValue(instrValue: ReactiveValue): string {
       value = `FinishMemoize decl=${printPlace(instrValue.decl)}${instrValue.pruned ? ' pruned' : ''}`;
       break;
     }
+    case 'NonNullExpression': {
+      value = `NonNullExpression ${printPlace(instrValue.value)}`;
+      break;
+    }
     default: {
       assertExhaustive(
         instrValue,

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/visitors.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/visitors.ts
@@ -227,6 +227,7 @@ export function* eachInstructionValueOperand(
       yield instrValue.tag;
       break;
     }
+    case 'NonNullExpression':
     case 'TypeCastExpression': {
       yield instrValue.value;
       break;
@@ -598,6 +599,7 @@ export function mapInstructionValueOperands(
       instrValue.tag = fn(instrValue.tag);
       break;
     }
+    case 'NonNullExpression':
     case 'TypeCastExpression': {
       instrValue.value = fn(instrValue.value);
       break;

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
@@ -2248,6 +2248,7 @@ function computeSignatureForInstruction(
       effects.push({kind: 'Assign', from: value.value, into: lvalue});
       break;
     }
+    case 'NonNullExpression':
     case 'TypeCastExpression': {
       effects.push({kind: 'Assign', from: value.value, into: lvalue});
       break;

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/DeadCodeElimination.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/DeadCodeElimination.ts
@@ -393,6 +393,7 @@ function pruneableValue(value: InstructionValue, state: State): boolean {
     case 'Primitive':
     case 'PropertyLoad':
     case 'TemplateLiteral':
+    case 'NonNullExpression':
     case 'TypeCastExpression':
     case 'UnaryExpression': {
       // Definitely safe to prune since they are read-only

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineJsx.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineJsx.ts
@@ -147,6 +147,7 @@ function outlineJsxImpl(
         case 'StoreLocal':
         case 'TaggedTemplateExpression':
         case 'TemplateLiteral':
+        case 'NonNullExpression':
         case 'TypeCastExpression':
         case 'UnsupportedNode':
         case 'UnaryExpression': {

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -2081,6 +2081,12 @@ function codegenInstructionValue(
       );
       break;
     }
+    case 'NonNullExpression': {
+      value = t.tsNonNullExpression(
+        codegenPlaceToExpression(cx, instrValue.value),
+      );
+      break;
+    }
     case 'StartMemoize':
     case 'FinishMemoize':
     case 'Debugger':

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/InferReactiveScopeVariables.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/InferReactiveScopeVariables.ts
@@ -220,6 +220,7 @@ function mayAllocate(_env: Environment, instruction: Instruction): boolean {
     case 'StoreLocal':
     case 'LoadGlobal':
     case 'MetaProperty':
+    case 'NonNullExpression':
     case 'TypeCastExpression':
     case 'LoadLocal':
     case 'LoadContext':

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonEscapingScopes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonEscapingScopes.ts
@@ -556,6 +556,7 @@ class CollectDependenciesVisitor extends ReactiveFunctionVisitor<
         };
       }
       case 'Await':
+      case 'NonNullExpression':
       case 'TypeCastExpression': {
         return {
           // Indirection for the inner value, memoized if the value is

--- a/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
@@ -408,6 +408,11 @@ function* generateInstructionTypes(
       break;
     }
 
+    case 'NonNullExpression': {
+      yield equation(left, value.value.identifier.type);
+      break;
+    }
+
     case 'TypeCastExpression': {
       yield equation(left, value.value.identifier.type);
       break;

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
@@ -383,7 +383,8 @@ function validateNoRefAccessInRenderImpl(
             );
             break;
           }
-          case 'TypeCastExpression': {
+          case 'TypeCastExpression':
+          case 'NonNullExpression': {
             env.set(
               instr.lvalue.identifier.id,
               env.get(instr.value.value.identifier.id) ??

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-nonnull-assertion-hoisted-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-nonnull-assertion-hoisted-dep.expect.md
@@ -1,0 +1,71 @@
+
+## Input
+
+```javascript
+import {Stringify} from 'shared-runtime';
+
+function Component({data}: {data: {id: number} | null}) {
+  const handleClick = () => {
+    console.log(data!.id);
+  };
+  return (
+    <div>{data ? <Stringify onClick={handleClick} /> : 'empty'}</div>
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{data: null}],
+  sequentialRenders: [{data: null}, {data: {id: 1}}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { Stringify } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(7);
+  const { data } = t0;
+  let t1;
+  if ($[0] !== data.id) {
+    t1 = () => {
+      console.log(data.id);
+    };
+    $[0] = data.id;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const handleClick = t1;
+  let t2;
+  if ($[2] !== data || $[3] !== handleClick) {
+    t2 = data ? <Stringify onClick={handleClick} /> : "empty";
+    $[2] = data;
+    $[3] = handleClick;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  let t3;
+  if ($[5] !== t2) {
+    t3 = <div>{t2}</div>;
+    $[5] = t2;
+    $[6] = t3;
+  } else {
+    t3 = $[6];
+  }
+  return t3;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ data: null }],
+  sequentialRenders: [{ data: null }, { data: { id: 1 } }],
+};
+
+```
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-nonnull-assertion-hoisted-dep.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-nonnull-assertion-hoisted-dep.tsx
@@ -1,0 +1,16 @@
+import {Stringify} from 'shared-runtime';
+
+function Component({data}: {data: {id: number} | null}) {
+  const handleClick = () => {
+    console.log(data!.id);
+  };
+  return (
+    <div>{data ? <Stringify onClick={handleClick} /> : 'empty'}</div>
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{data: null}],
+  sequentialRenders: [{data: null}, {data: {id: 1}}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/non-null-assertion.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/non-null-assertion.expect.md
@@ -27,15 +27,16 @@ interface ComponentProps {
 
 function Component(props) {
   const $ = _c(2);
-  let t0;
-  if ($[0] !== props.name) {
-    t0 = props.name.toUpperCase();
-    $[0] = props.name;
-    $[1] = t0;
+  const t0 = props.name!;
+  let t1;
+  if ($[0] !== t0) {
+    t1 = t0.toUpperCase();
+    $[0] = t0;
+    $[1] = t1;
   } else {
-    t0 = $[1];
+    t1 = $[1];
   }
-  return t0;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nonnull-assertion-mixed-optional-chain.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nonnull-assertion-mixed-optional-chain.expect.md
@@ -1,0 +1,81 @@
+
+## Input
+
+```javascript
+import {Stringify} from 'shared-runtime';
+
+function Component({data}: {data: {nested: {id: number} | null} | null}) {
+  const onClick = () => {
+    console.log(data!.nested?.id);
+  };
+  return <div>{data ? <Stringify onClick={onClick} /> : 'empty'}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{data: null}],
+  sequentialRenders: [
+    {data: null},
+    {data: {nested: null}},
+    {data: {nested: {id: 1}}},
+  ],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { Stringify } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(7);
+  const { data } = t0;
+  let t1;
+  if ($[0] !== data) {
+    t1 = () => {
+      console.log(data!.nested?.id);
+    };
+    $[0] = data;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const onClick = t1;
+  let t2;
+  if ($[2] !== data || $[3] !== onClick) {
+    t2 = data ? <Stringify onClick={onClick} /> : "empty";
+    $[2] = data;
+    $[3] = onClick;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  let t3;
+  if ($[5] !== t2) {
+    t3 = <div>{t2}</div>;
+    $[5] = t2;
+    $[6] = t3;
+  } else {
+    t3 = $[6];
+  }
+  return t3;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ data: null }],
+  sequentialRenders: [
+    { data: null },
+    { data: { nested: null } },
+    { data: { nested: { id: 1 } } },
+  ],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>empty</div>
+<div><div>{"onClick":"[[ function params=0 ]]"}</div></div>
+<div><div>{"onClick":"[[ function params=0 ]]"}</div></div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nonnull-assertion-mixed-optional-chain.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nonnull-assertion-mixed-optional-chain.tsx
@@ -1,0 +1,18 @@
+import {Stringify} from 'shared-runtime';
+
+function Component({data}: {data: {nested: {id: number} | null} | null}) {
+  const onClick = () => {
+    console.log(data!.nested?.id);
+  };
+  return <div>{data ? <Stringify onClick={onClick} /> : 'empty'}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{data: null}],
+  sequentialRenders: [
+    {data: null},
+    {data: {nested: null}},
+    {data: {nested: {id: 1}}},
+  ],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nonnull-assertion-optional-dep.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nonnull-assertion-optional-dep.expect.md
@@ -8,9 +8,7 @@ function Component({data}: {data: {id: number} | null}) {
   const handleClick = () => {
     console.log(data!.id);
   };
-  return (
-    <div>{data ? <Stringify onClick={handleClick} /> : 'empty'}</div>
-  );
+  return <div>{data ? <Stringify onClick={handleClick} /> : 'empty'}</div>;
 }
 
 export const FIXTURE_ENTRYPOINT = {
@@ -31,11 +29,11 @@ function Component(t0) {
   const $ = _c(7);
   const { data } = t0;
   let t1;
-  if ($[0] !== data.id) {
+  if ($[0] !== data) {
     t1 = () => {
-      console.log(data.id);
+      console.log(data!.id);
     };
-    $[0] = data.id;
+    $[0] = data;
     $[1] = t1;
   } else {
     t1 = $[1];
@@ -69,3 +67,6 @@ export const FIXTURE_ENTRYPOINT = {
 
 ```
       
+### Eval output
+(kind: ok) <div>empty</div>
+<div><div>{"onClick":"[[ function params=0 ]]"}</div></div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nonnull-assertion-optional-dep.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nonnull-assertion-optional-dep.tsx
@@ -4,9 +4,7 @@ function Component({data}: {data: {id: number} | null}) {
   const handleClick = () => {
     console.log(data!.id);
   };
-  return (
-    <div>{data ? <Stringify onClick={handleClick} /> : 'empty'}</div>
-  );
+  return <div>{data ? <Stringify onClick={handleClick} /> : 'empty'}</div>;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nonnull-assertion-render-scope.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nonnull-assertion-render-scope.expect.md
@@ -1,0 +1,60 @@
+
+## Input
+
+```javascript
+import {identity, Stringify} from 'shared-runtime';
+
+function Component({data}: {data: {id: number} | null}) {
+  const id = identity(data!.id);
+  return <Stringify id={id} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{data: {id: 1}}],
+  sequentialRenders: [{data: {id: 1}}, {data: {id: 2}}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { identity, Stringify } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(4);
+  const { data } = t0;
+  const t1 = data!;
+  let t2;
+  if ($[0] !== t1.id) {
+    t2 = identity(t1.id);
+    $[0] = t1.id;
+    $[1] = t2;
+  } else {
+    t2 = $[1];
+  }
+  const id = t2;
+  let t3;
+  if ($[2] !== id) {
+    t3 = <Stringify id={id} />;
+    $[2] = id;
+    $[3] = t3;
+  } else {
+    t3 = $[3];
+  }
+  return t3;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ data: { id: 1 } }],
+  sequentialRenders: [{ data: { id: 1 } }, { data: { id: 2 } }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"id":1}</div>
+<div>{"id":2}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nonnull-assertion-render-scope.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/nonnull-assertion-render-scope.tsx
@@ -1,0 +1,12 @@
+import {identity, Stringify} from 'shared-runtime';
+
+function Component({data}: {data: {id: number} | null}) {
+  const id = identity(data!.id);
+  return <Stringify id={id} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{data: {id: 1}}],
+  sequentialRenders: [{data: {id: 1}}, {data: {id: 2}}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ts-non-null-expression-default-value.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ts-non-null-expression-default-value.expect.md
@@ -31,7 +31,7 @@ const THEME_MAP: ReadonlyMap<string, string> = new Map([
 export const Component = (t0) => {
   const $ = _c(2);
   const { theme: t1 } = t0;
-  const theme = t1 === undefined ? THEME_MAP.get("default") : t1;
+  const theme = t1 === undefined ? THEME_MAP.get("default")! : t1;
   const t2 = `theme-${theme}`;
   let t3;
   if ($[0] !== t2) {

--- a/compiler/packages/snap/src/SproutTodoFilter.ts
+++ b/compiler/packages/snap/src/SproutTodoFilter.ts
@@ -7,12 +7,6 @@
 
 const skipFilter = new Set([
   /**
-   * Known-bug fixture documenting wrong runtime behavior; removed when the
-   * fix lands.
-   */
-  'bug-nonnull-assertion-hoisted-dep',
-
-  /**
    * Fixtures using external modules (jest, Lexical, etc.) that can't be evaluated
    * in the test harness. These were previously error.todo-* but now compile in both TS and Rust.
    */

--- a/compiler/packages/snap/src/SproutTodoFilter.ts
+++ b/compiler/packages/snap/src/SproutTodoFilter.ts
@@ -7,6 +7,12 @@
 
 const skipFilter = new Set([
   /**
+   * Known-bug fixture documenting wrong runtime behavior; removed when the
+   * fix lands.
+   */
+  'bug-nonnull-assertion-hoisted-dep',
+
+  /**
    * Fixtures using external modules (jest, Lexical, etc.) that can't be evaluated
    * in the test harness. These were previously error.todo-* but now compile in both TS and Rust.
    */


### PR DESCRIPTION
`data!.id` inside a callback contributed an unconditional hoisted dependency: the memo compare chain read `data.id` without a null guard. When `data` is legitimately null on a render and the assertion only holds inside a guarded callback, the compiled component crashes (`TypeError: Cannot read properties of null`) where the uncompiled source renders fine. This is the planned direction from #34752/#34194 discussion: treat `!` as a source of nullability when computing deps.

TSNonNullExpression previously lowered as a transparent unwrap, indistinguishable from a plain member access by dependency collection. It now lowers to a `NonNullExpression` HIR instruction with the same shape as TypeCastExpression: dependency collection stops at the asserted value (the callback dep becomes the null-safe `data`), the assertion is preserved in output, and render-scope assertions keep property granularity through the materialized temporary, matching how `as`-casts behave today.

Builds on #36709 by Scarab Systems, extended with the two match sites that PR missed (the HIR debug printer and the ref-state passthrough in ValidateNoRefAccessInRender, where dropping ref-ness through `ref!` would change ref validation) and the full Rust port mirror (every TypeCastExpression match arm, driven by exhaustiveness checking).

Fixtures: the crash repro (null-first sequential renders now pass sprout), a mixed chain (`data!.nested?.id`), and a render-scope assertion. Corpus delta is two fixtures, both reviewed: `non-null-assertion` materializes `props.name!` as a temporary (granularity preserved, assertion kept in output); `ts-non-null-expression-default-value` keeps the `!` in output.

Verification: TS snap 1807/1807, Rust snap 1807/1807, cargo workspace green, TS-vs-Rust HIR debug parity on the new instruction via the e2e harness.

Closes #34752
Closes #34194