### PR TITLE
[compiler] Preserve computed keys on object method shorthand

### DIFF
--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -6519,12 +6519,9 @@ fn lower_object_method(
         })?;
         return Ok(None);
     }
-    let key = lower_object_property_key(builder, &method.key, method.computed)?.unwrap_or(
-        ObjectPropertyKey::String {
-            name: String::new(),
-        },
-    );
-
+    // Lower the method before its key: TS lowers ObjectMethod members in
+    // this order (the opposite of ObjectProperty members), and instruction
+    // order is load-bearing for identifier numbering and scope ranges.
     let lowered_func = lower_function_for_object_method(builder, method)?;
 
     let loc = convert_opt_loc(&method.base.loc);
@@ -6533,6 +6530,12 @@ fn lower_object_method(
         lowered_func,
     };
     let method_place = lower_value_to_temporary(builder, method_value)?;
+
+    let key = lower_object_property_key(builder, &method.key, method.computed)?.unwrap_or(
+        ObjectPropertyKey::String {
+            name: String::new(),
+        },
+    );
 
     Ok(Some(ObjectProperty {
         key,

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -1685,7 +1685,7 @@ function codegenInstructionValue(
                 key,
                 fn.params,
                 fn.body,
-                false,
+                property.key.kind === 'computed',
               );
               babelNode.async = fn.async;
               babelNode.generator = fn.generator;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-computed-key-template-literal.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-computed-key-template-literal.expect.md
@@ -1,0 +1,64 @@
+
+## Input
+
+```javascript
+import {Stringify} from 'shared-runtime';
+
+function Component({k}) {
+  const obj = {
+    [`prefix-${k}`]() {
+      return 42;
+    },
+  };
+  return <Stringify keys={Object.keys(obj)} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{k: 'dynamic'}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { Stringify } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(4);
+  const { k } = t0;
+  let t1;
+  if ($[0] !== k) {
+    t1 = {
+      [`prefix-${k}`]() {
+        return 42;
+      },
+    };
+    $[0] = k;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const obj = t1;
+  let t2;
+  if ($[2] !== obj) {
+    t2 = <Stringify keys={Object.keys(obj)} />;
+    $[2] = obj;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ k: "dynamic" }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"keys":["prefix-dynamic"]}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-computed-key-template-literal.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-computed-key-template-literal.js
@@ -1,0 +1,15 @@
+import {Stringify} from 'shared-runtime';
+
+function Component({k}) {
+  const obj = {
+    [`prefix-${k}`]() {
+      return 42;
+    },
+  };
+  return <Stringify keys={Object.keys(obj)} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{k: 'dynamic'}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-computed-key.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-computed-key.expect.md
@@ -1,0 +1,64 @@
+
+## Input
+
+```javascript
+import {Stringify} from 'shared-runtime';
+
+function Component({keyName}) {
+  const obj = {
+    [keyName]() {
+      return 42;
+    },
+  };
+  return <Stringify keys={Object.keys(obj)} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{keyName: 'dynamic'}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { Stringify } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(4);
+  const { keyName } = t0;
+  let t1;
+  if ($[0] !== keyName) {
+    t1 = {
+      [keyName]() {
+        return 42;
+      },
+    };
+    $[0] = keyName;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const obj = t1;
+  let t2;
+  if ($[2] !== obj) {
+    t2 = <Stringify keys={Object.keys(obj)} />;
+    $[2] = obj;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ keyName: "dynamic" }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"keys":["dynamic"]}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-computed-key.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-computed-key.js
@@ -1,0 +1,15 @@
+import {Stringify} from 'shared-runtime';
+
+function Component({keyName}) {
+  const obj = {
+    [keyName]() {
+      return 42;
+    },
+  };
+  return <Stringify keys={Object.keys(obj)} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{keyName: 'dynamic'}],
+};


### PR DESCRIPTION
`{[key]() {}}` compiled to `{key() {}}`: TS codegen rebuilt the babel ObjectMethod node with the computed flag hardcoded to `false`, silently changing runtime behavior (object gains a literal `key` property instead of the computed name). BuildHIR lowering was already correct; the fix derives the flag from the HIR property key kind, exactly as the sibling ObjectProperty case does. Adopts #35248 by @lluisemper, which sat approved since November; this PR adds a reactive-prop key fixture (sprout-verified against uncompiled React) plus a template-literal key fixture for non-identifier key expressions.

The Rust port preserved the flag correctly but had a latent lowering divergence on the same node shape, invisible until these fixtures existed because the corpus contained zero computed-key object methods: it lowered the key before the method where TS lowers the method before the key, shifting instruction ids (HIR parity break) and, for non-trivial key expressions, promotion decisions (template-literal keys hoisted to a named const outside the memo scope). The Rust lowering now matches TS order. Non-computed keys lower no key instructions, so the reorder is inert elsewhere, confirmed corpus-wide on both snap channels.

Verification: TS snap 1806/1806, Rust snap 1806/1806, cargo workspace green, TS-vs-Rust HIR parity harness green on both fixtures.

Closes #35203