### PR TITLE
[rust-compiler] Skip TypeScript `this` pseudo-params in scope collector

### DIFF
--- a/compiler/crates/react_compiler_swc/src/convert_scope.rs
+++ b/compiler/crates/react_compiler_swc/src/convert_scope.rs
@@ -175,6 +175,11 @@ impl ScopeCollector {
         match pat {
             Pat::Ident(binding_ident) => {
                 let name = binding_ident.id.sym.to_string();
+                // TypeScript `this` pseudo-parameters are type annotations only.
+                // They are erased before emit and must not be registered as bindings.
+                if name == "this" {
+                    return;
+                }
                 let start = binding_ident.id.span.lo.0;
                 self.add_binding(
                     name,

--- a/compiler/crates/react_compiler_swc/tests/integration.rs
+++ b/compiler/crates/react_compiler_swc/tests/integration.rs
@@ -13,6 +13,7 @@ use react_compiler_swc::convert_ast_reverse::convert_program_to_swc;
 use react_compiler_swc::convert_scope::build_scope_info;
 use react_compiler_swc::lint_source;
 use react_compiler_swc::prefilter::has_react_like_functions;
+use react_compiler_swc::transform;
 use react_compiler_swc::transform_source;
 use swc_common::FileName;
 use swc_common::SourceMap;
@@ -755,5 +756,40 @@ fn ts_import_equals_export_round_trips() {
     assert!(
         code.contains("export import x = require(\"shared-runtime\");"),
         "missing exported import-equals in output: {code}"
+    );
+}
+
+/// A TypeScript `this` parameter in a function expression (used to declare the
+/// type of `this` inside the function) should not trigger the
+/// "Expected a non-reserved identifier name" error. TypeScript erases `this`
+/// params before emitting JavaScript; the React Compiler processes TypeScript
+/// source and must not treat these type-only params as real identifiers.
+///
+/// Otherwise, we get "[ReactCompiler] Unexpected error: `this` is a reserved word in JavaScript"
+#[test]
+fn ts_this_param_in_function_expression_is_not_a_reserved_identifier_error() {
+    let source = r#"
+        'use client';
+
+        import * as React from 'react';
+
+        function useClickHandler() {
+            const [count, setCount] = React.useState(0);
+            function handleClick(this: HTMLElement) {
+                setCount(c => c + 1);
+            }
+            return handleClick;
+        }
+    "#;
+
+    let module = parse_ts_module(source);
+    let result = transform(&module, source, default_options());
+
+    // TypeScript `this` params are type annotations, not real JS identifiers.
+    // The compiler must not emit a "reserved word" diagnostic for them.
+    let diagnostics: Vec<_> = result.diagnostics;
+    assert!(
+        diagnostics.is_empty(),
+        "got unexpected diagnostic for TS `this` param: {diagnostics:#?}"
     );
 }


### PR DESCRIPTION
TypeScript allows functions to declare the type of `this` via a fake first parameter (`function foo(this: T, ...)`). The parameter is erased before JS emit and is not a real binding.

The SWC scope collector was treating `this` as a regular param, causing the compiler to emit `Unexpected error: \`this\` is a reserved word in JavaScript` when processing such functions.

Fix: skip params whose pattern is `this` in the scope collector.

## Test plan
- Added `ts_this_param_in_function_expression_is_not_a_reserved_identifier_error` in `integration.rs` — parses a component with a `this: HTMLElement` typed param and asserts no reserved-identifier diagnostics are emitted.
- `cargo test -p react_compiler_swc`