### PR TITLE
Update required references to GitHub repo

### DIFF
--- a/.github/workflows/compiler_discord_notify.yml
+++ b/.github/workflows/compiler_discord_notify.yml
@@ -25,7 +25,7 @@ jobs:
   check_maintainer:
     if: ${{ needs.check_access.outputs.is_member_or_collaborator == 'true' || needs.check_access.outputs.is_member_or_collaborator == true }}
     needs: [check_access]
-    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    uses: react/react/.github/workflows/shared_check_maintainer.yml@main
     permissions:
       # Used by check_maintainer
       contents: read

--- a/.github/workflows/compiler_prereleases_manual.yml
+++ b/.github/workflows/compiler_prereleases_manual.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   publish_prerelease_experimental:
     name: Publish to Experimental channel
-    uses: facebook/react/.github/workflows/compiler_prereleases.yml@main
+    uses: react/react/.github/workflows/compiler_prereleases.yml@main
     with:
       commit_sha: ${{ inputs.prerelease_commit_sha || github.sha }}
       release_channel: ${{ inputs.release_channel }}

--- a/.github/workflows/compiler_prereleases_nightly.yml
+++ b/.github/workflows/compiler_prereleases_nightly.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   publish_prerelease_experimental:
     name: Publish to Experimental channel
-    uses: facebook/react/.github/workflows/compiler_prereleases.yml@main
+    uses: react/react/.github/workflows/compiler_prereleases.yml@main
     with:
       commit_sha: ${{ github.sha }}
       release_channel: experimental

--- a/.github/workflows/devtools_discord_notify.yml
+++ b/.github/workflows/devtools_discord_notify.yml
@@ -25,7 +25,7 @@ jobs:
   check_maintainer:
     if: ${{ needs.check_access.outputs.is_member_or_collaborator == 'true' || needs.check_access.outputs.is_member_or_collaborator == true }}
     needs: [check_access]
-    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    uses: react/react/.github/workflows/shared_check_maintainer.yml@main
     permissions:
       # Used by check_maintainer
       contents: read

--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -488,7 +488,7 @@ jobs:
             ./build2.tgz
           if-no-files-found: error
       - uses: actions/attest-build-provenance@v2
-        # We don't verify builds generated from pull requests not originating from facebook/react.
+        # We don't verify builds generated from pull requests not originating from react/react.
         # However, if the PR lands, the run on release branches will generate the attestation which can then
         # be used to download a build via scripts/release/download-experimental-build.js.
         #

--- a/.github/workflows/runtime_commit_artifacts.yml
+++ b/.github/workflows/runtime_commit_artifacts.yml
@@ -292,7 +292,7 @@ jobs:
           git config --global user.name "${{ github.triggering_actor }}"
 
           git fetch origin --quiet
-          git commit -m "$(git show ${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha }} --no-patch --pretty=format:'%B%n%nDiffTrain build for [${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha }}](https://github.com/facebook/react/commit/${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha}})')" || echo "No changes to commit"
+          git commit -m "$(git show ${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha }} --no-patch --pretty=format:'%B%n%nDiffTrain build for [${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha }}](https://github.com/react/react/commit/${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha}})')" || echo "No changes to commit"
       - name: Push changes to branch
         if: inputs.dry_run == false && (inputs.force == true || steps.check_should_commit.outputs.should_commit == 'true')
         run: git push
@@ -466,7 +466,7 @@ jobs:
           git config --global user.name "${{ github.triggering_actor }}"
 
           git fetch origin --quiet
-          git commit -m "$(git show ${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha }} --no-patch --pretty=format:'%B%n%nDiffTrain build for [${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha }}](https://github.com/facebook/react/commit/${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha}})')" || echo "No changes to commit"
+          git commit -m "$(git show ${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha }} --no-patch --pretty=format:'%B%n%nDiffTrain build for [${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha }}](https://github.com/react/react/commit/${{ inputs.commit_sha || github.event.workflow_run.head_sha || github.sha}})')" || echo "No changes to commit"
       - name: Push changes to branch
         if: inputs.dry_run == false && (inputs.force == true || steps.check_should_commit.outputs.should_commit == 'true')
         run: git push

--- a/.github/workflows/runtime_discord_notify.yml
+++ b/.github/workflows/runtime_discord_notify.yml
@@ -27,7 +27,7 @@ jobs:
   check_maintainer:
     if: ${{ needs.check_access.outputs.is_member_or_collaborator == 'true' || needs.check_access.outputs.is_member_or_collaborator == true }}
     needs: [check_access]
-    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    uses: react/react/.github/workflows/shared_check_maintainer.yml@main
     permissions:
       # Used by check_maintainer
       contents: read

--- a/.github/workflows/shared_label_core_team_prs.yml
+++ b/.github/workflows/shared_label_core_team_prs.yml
@@ -26,7 +26,7 @@ jobs:
   check_maintainer:
     if: ${{ needs.check_access.outputs.is_member_or_collaborator == 'true' || needs.check_access.outputs.is_member_or_collaborator == true }}
     needs: [check_access]
-    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    uses: react/react/.github/workflows/shared_check_maintainer.yml@main
     permissions:
       # Used by check_maintainer
       contents: read

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -7,7 +7,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react.git"
+    "url": "git+https://github.com/react/react.git"
   },
   "scripts": {
     "copyright": "node scripts/copyright.js",

--- a/compiler/packages/babel-plugin-react-compiler-rust/package.json
+++ b/compiler/packages/babel-plugin-react-compiler-rust/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react.git",
+    "url": "git+https://github.com/react/react.git",
     "directory": "compiler/packages/babel-plugin-react-compiler-rust"
   }
 }

--- a/compiler/packages/babel-plugin-react-compiler/package.json
+++ b/compiler/packages/babel-plugin-react-compiler/package.json
@@ -65,7 +65,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react.git",
+    "url": "git+https://github.com/react/react.git",
     "directory": "compiler/packages/babel-plugin-react-compiler"
   }
 }

--- a/compiler/packages/eslint-plugin-react-compiler/package.json
+++ b/compiler/packages/eslint-plugin-react-compiler/package.json
@@ -45,7 +45,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react.git",
+    "url": "git+https://github.com/react/react.git",
     "directory": "compiler/packages/eslint-plugin-react-compiler"
   },
   "license": "MIT"

--- a/compiler/packages/make-read-only-util/package.json
+++ b/compiler/packages/make-read-only-util/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react.git",
+    "url": "git+https://github.com/react/react.git",
     "directory": "compiler/packages/make-read-only-util"
   }
 }

--- a/compiler/packages/react-compiler-healthcheck/package.json
+++ b/compiler/packages/react-compiler-healthcheck/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react.git",
+    "url": "git+https://github.com/react/react.git",
     "directory": "compiler/packages/react-compiler-healthcheck"
   }
 }

--- a/compiler/packages/react-compiler-runtime/package.json
+++ b/compiler/packages/react-compiler-runtime/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react.git",
+    "url": "git+https://github.com/react/react.git",
     "directory": "compiler/packages/react-compiler-runtime"
   }
 }

--- a/compiler/packages/react-forgive/client/package.json
+++ b/compiler/packages/react-forgive/client/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react.git",
+    "url": "git+https://github.com/react/react.git",
     "directory": "compiler/packages/react-forgive"
   },
   "dependencies": {

--- a/compiler/packages/react-forgive/package.json
+++ b/compiler/packages/react-forgive/package.json
@@ -6,7 +6,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react.git",
+    "url": "git+https://github.com/react/react.git",
     "directory": "compiler/packages/react-forgive"
   },
   "categories": [

--- a/compiler/packages/react-forgive/server/package.json
+++ b/compiler/packages/react-forgive/server/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react.git",
+    "url": "git+https://github.com/react/react.git",
     "directory": "compiler/packages/react-forgive"
   },
   "dependencies": {

--- a/compiler/packages/react-mcp-server/package.json
+++ b/compiler/packages/react-mcp-server/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react.git",
+    "url": "git+https://github.com/react/react.git",
     "directory": "compiler/packages/react-mcp-server"
   }
 }

--- a/compiler/packages/snap/package.json
+++ b/compiler/packages/snap/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/react.git",
+    "url": "git+https://github.com/react/react.git",
     "directory": "compiler/packages/snap"
   },
   "dependencies": {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -105,7 +105,7 @@ function row(result, baseSha, headSha) {
   // where the branches differ
 
   const upstreamRepo = danger.github.pr.base.repo.full_name;
-  if (upstreamRepo !== 'facebook/react') {
+  if (upstreamRepo !== 'react/react') {
     // Exit unless we're running in the main repo
     return;
   }

--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -4,7 +4,7 @@
   "version": "7.0.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/eslint-plugin-react-hooks"
   },
   "files": [
@@ -27,7 +27,7 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/facebook/react/issues"
+    "url": "https://github.com/react/react/issues"
   },
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/packages/jest-react/package.json
+++ b/packages/jest-react/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/jest-react"
   },
   "keywords": [
@@ -15,7 +15,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/facebook/react/issues"
+    "url": "https://github.com/react/react/issues"
   },
   "homepage": "https://react.dev/",
   "peerDependencies": {

--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-art"
   },
   "keywords": [
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/facebook/react/issues"
+    "url": "https://github.com/react/react/issues"
   },
   "homepage": "https://react.dev/",
   "dependencies": {

--- a/packages/react-cache/package.json
+++ b/packages/react-cache/package.json
@@ -5,7 +5,7 @@
   "version": "2.0.0-alpha.0",
   "repository": {
     "type" : "git",
-    "url" : "https://github.com/facebook/react.git",
+    "url" : "https://github.com/react/react.git",
     "directory": "packages/react-cache"
   },
   "files": [

--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -7,7 +7,7 @@
     "react"
   ],
   "homepage": "https://react.dev/",
-  "bugs": "https://github.com/facebook/react/issues",
+  "bugs": "https://github.com/react/react/issues",
   "license": "MIT",
   "files": [
     "LICENSE",
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type" : "git",
-    "url" : "https://github.com/facebook/react.git",
+    "url" : "https://github.com/react/react.git",
     "directory": "packages/react-client"
   },
   "engines": {

--- a/packages/react-debug-tools/package.json
+++ b/packages/react-debug-tools/package.json
@@ -7,7 +7,7 @@
     "react"
   ],
   "homepage": "https://react.dev/",
-  "bugs": "https://github.com/facebook/react/issues",
+  "bugs": "https://github.com/react/react/issues",
   "license": "MIT",
   "files": [
     "LICENSE",
@@ -18,7 +18,7 @@
   "main": "index.js",
   "repository": {
     "type" : "git",
-    "url" : "https://github.com/facebook/react.git",
+    "url" : "https://github.com/react/react.git",
     "directory": "packages/react-debug-tools"
   },
   "engines": {

--- a/packages/react-devtools-core/package.json
+++ b/packages/react-devtools-core/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/backend.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-devtools-core"
   },
   "files": [

--- a/packages/react-devtools-inline/package.json
+++ b/packages/react-devtools-inline/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/backend.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-devtools-inline"
   },
   "files": [

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-devtools"
   },
   "bin": {

--- a/packages/react-dom-bindings/package.json
+++ b/packages/react-dom-bindings/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-dom-bindings"
   },
   "keywords": [
@@ -14,7 +14,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/facebook/react/issues"
+    "url": "https://github.com/react/react/issues"
   },
   "homepage": "https://react.dev/",
   "peerDependencies": {

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-dom"
   },
   "keywords": [
@@ -13,7 +13,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/facebook/react/issues"
+    "url": "https://github.com/react/react/issues"
   },
   "homepage": "https://react.dev/",
   "dependencies": {

--- a/packages/react-flight-server-fb/package.json
+++ b/packages/react-flight-server-fb/package.json
@@ -6,7 +6,7 @@
     "react"
   ],
   "homepage": "https://react.dev/",
-  "bugs": "https://github.com/facebook/react/issues",
+  "bugs": "https://github.com/react/react/issues",
   "license": "MIT",
   "files": [
     "LICENSE",
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type" : "git",
-    "url" : "https://github.com/facebook/react.git",
+    "url" : "https://github.com/react/react.git",
     "directory": "packages/react-flight-server-fb"
   },
   "engines": {

--- a/packages/react-is/package.json
+++ b/packages/react-is/package.json
@@ -6,7 +6,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-is"
   },
   "keywords": [
@@ -14,7 +14,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/facebook/react/issues"
+    "url": "https://github.com/react/react/issues"
   },
   "homepage": "https://react.dev/",
   "files": [

--- a/packages/react-markup/package.json
+++ b/packages/react-markup/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-markup"
   },
   "keywords": [
@@ -13,7 +13,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/facebook/react/issues"
+    "url": "https://github.com/react/react/issues"
   },
   "homepage": "https://react.dev/",
   "peerDependencies": {

--- a/packages/react-native-renderer/package.json
+++ b/packages/react-native-renderer/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-native-renderer"
   },
   "dependencies": {

--- a/packages/react-noop-renderer/package.json
+++ b/packages/react-noop-renderer/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "repository": {
     "type" : "git",
-    "url" : "https://github.com/facebook/react.git",
+    "url" : "https://github.com/react/react.git",
     "directory": "packages/react-noop-renderer"
   },
   "license": "MIT",

--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -6,7 +6,7 @@
     "react"
   ],
   "homepage": "https://react.dev/",
-  "bugs": "https://github.com/facebook/react/issues",
+  "bugs": "https://github.com/react/react/issues",
   "license": "MIT",
   "files": [
     "LICENSE",
@@ -19,7 +19,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-reconciler"
   },
   "engines": {

--- a/packages/react-refresh/package.json
+++ b/packages/react-refresh/package.json
@@ -6,7 +6,7 @@
   ],
   "version": "0.19.0",
   "homepage": "https://react.dev/",
-  "bugs": "https://github.com/facebook/react/issues",
+  "bugs": "https://github.com/react/react/issues",
   "license": "MIT",
   "files": [
     "LICENSE",
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react"
   },
   "engines": {

--- a/packages/react-server-dom-esm/package.json
+++ b/packages/react-server-dom-esm/package.json
@@ -6,7 +6,7 @@
     "react"
   ],
   "homepage": "https://react.dev/",
-  "bugs": "https://github.com/facebook/react/issues",
+  "bugs": "https://github.com/react/react/issues",
   "license": "MIT",
   "files": [
     "LICENSE",
@@ -47,7 +47,7 @@
   "main": "index.js",
   "repository": {
     "type" : "git",
-    "url" : "https://github.com/facebook/react.git",
+    "url" : "https://github.com/react/react.git",
     "directory": "packages/react-server-dom-esm"
   },
   "engines": {

--- a/packages/react-server-dom-fb/package.json
+++ b/packages/react-server-dom-fb/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-server-dom-fb"
   },
   "dependencies": {

--- a/packages/react-server-dom-parcel/package.json
+++ b/packages/react-server-dom-parcel/package.json
@@ -6,7 +6,7 @@
     "react"
   ],
   "homepage": "https://reactjs.org/",
-  "bugs": "https://github.com/facebook/react/issues",
+  "bugs": "https://github.com/react/react/issues",
   "license": "MIT",
   "files": [
     "LICENSE",
@@ -72,7 +72,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-server-dom-parcel"
   },
   "engines": {

--- a/packages/react-server-dom-turbopack/package.json
+++ b/packages/react-server-dom-turbopack/package.json
@@ -6,7 +6,7 @@
     "react"
   ],
   "homepage": "https://react.dev/",
-  "bugs": "https://github.com/facebook/react/issues",
+  "bugs": "https://github.com/react/react/issues",
   "license": "MIT",
   "files": [
     "LICENSE",
@@ -72,7 +72,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-server-dom-turbopack"
   },
   "engines": {

--- a/packages/react-server-dom-webpack/package.json
+++ b/packages/react-server-dom-webpack/package.json
@@ -6,7 +6,7 @@
     "react"
   ],
   "homepage": "https://react.dev/",
-  "bugs": "https://github.com/facebook/react/issues",
+  "bugs": "https://github.com/react/react/issues",
   "license": "MIT",
   "files": [
     "LICENSE",
@@ -78,7 +78,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-server-dom-webpack"
   },
   "engines": {

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -7,7 +7,7 @@
     "react"
   ],
   "homepage": "https://react.dev/",
-  "bugs": "https://github.com/facebook/react/issues",
+  "bugs": "https://github.com/react/react/issues",
   "license": "MIT",
   "files": [
     "LICENSE",
@@ -19,7 +19,7 @@
   "main": "index.js",
   "repository": {
     "type" : "git",
-    "url" : "https://github.com/facebook/react.git",
+    "url" : "https://github.com/react/react.git",
     "directory": "packages/react-server"
   },
   "engines": {

--- a/packages/react-suspense-test-utils/package.json
+++ b/packages/react-suspense-test-utils/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type" : "git",
-    "url" : "https://github.com/facebook/react.git",
+    "url" : "https://github.com/react/react.git",
     "directory": "packages/react-suspense-test-utils"
   },
   "license": "MIT",

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-test-renderer"
   },
   "keywords": [
@@ -15,7 +15,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/facebook/react/issues"
+    "url": "https://github.com/react/react/issues"
   },
   "homepage": "https://react.dev/",
   "dependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -6,7 +6,7 @@
   ],
   "version": "19.3.0",
   "homepage": "https://react.dev/",
-  "bugs": "https://github.com/facebook/react/issues",
+  "bugs": "https://github.com/react/react/issues",
   "license": "MIT",
   "files": [
     "LICENSE",
@@ -43,7 +43,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react"
   },
   "engines": {

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -4,7 +4,7 @@
   "description": "Cooperative scheduler for the browser environment.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/scheduler"
   },
   "license": "MIT",
@@ -12,7 +12,7 @@
     "react"
   ],
   "bugs": {
-    "url": "https://github.com/facebook/react/issues"
+    "url": "https://github.com/react/react/issues"
   },
   "homepage": "https://react.dev/",
   "files": [

--- a/packages/use-subscription/package.json
+++ b/packages/use-subscription/package.json
@@ -4,7 +4,7 @@
   "version": "1.13.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/use-subscription"
   },
   "files": [

--- a/packages/use-sync-external-store/package.json
+++ b/packages/use-sync-external-store/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/use-sync-external-store"
   },
   "files": [


### PR DESCRIPTION
The `repository` fields in the `package.json` needs to match the actual repo for Trusted Publishing.

Action references to facebook/react can't be resolved in GitHub workflows (see https://github.com/react/react/actions/runs/27368469865?pr=36752)

There are more references to `facebook/react` all of which continue to work due to the redirect. I want to keep this diff as minimal as possible to ease backporting.

