### PR TITLE
fix(react-dom): safely remove abort event listeners on stream success…

### DIFF
--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -12,14 +12,14 @@ import type {
   PostponedState,
   ErrorInfo,
 } from 'react-server/src/ReactFizzServer';
-import type {ReactNodeList, ReactFormState} from 'shared/ReactTypes';
-import type {Writable} from 'stream';
+import type { ReactNodeList, ReactFormState } from 'shared/ReactTypes';
+import type { Writable } from 'stream';
 import type {
   BootstrapScriptDescriptor,
   HeadersDescriptor,
 } from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
-import type {Destination} from 'react-server/src/ReactServerStreamConfigNode';
-import type {ImportMap} from '../shared/ReactDOMTypes';
+import type { Destination } from 'react-server/src/ReactServerStreamConfigNode';
+import type { ImportMap } from '../shared/ReactDOMTypes';
 
 import ReactVersion from 'shared/ReactVersion';
 
@@ -40,9 +40,9 @@ import {
   createRootFormatContext,
 } from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 
-import {textEncoder} from 'react-server/src/ReactServerStreamConfigNode';
+import { textEncoder } from 'react-server/src/ReactServerStreamConfigNode';
 
-import {ensureCorrectIsomorphicReactVersion} from '../shared/ensureCorrectIsomorphicReactVersion';
+import { ensureCorrectIsomorphicReactVersion } from '../shared/ensureCorrectIsomorphicReactVersion';
 ensureCorrectIsomorphicReactVersion();
 
 function createDrainHandler(destination: Destination, request: Request) {
@@ -60,9 +60,9 @@ function createCancelHandler(request: Request, reason: string) {
 type NonceOption =
   | string
   | {
-      script?: string,
-      style?: string,
-    };
+    script?: string,
+    style?: string,
+  };
 
 type Options = {
   identifierPrefix?: string,
@@ -168,24 +168,19 @@ function renderToPipeableStream(
 function createFakeWritableFromReadableStreamController(
   controller: ReadableStreamController,
 ): Writable {
-  // The current host config expects a Writable so we create
-  // a fake writable for now to push into the Readable.
   return {
     write(chunk: string | Uint8Array) {
       if (typeof chunk === 'string') {
         chunk = textEncoder.encode(chunk);
       }
       controller.enqueue(chunk);
-      // in web streams there is no backpressure so we can alwas write more
       return true;
     },
     end() {
       controller.close();
     },
     destroy(error) {
-      // $FlowFixMe[method-unbinding]
       if (typeof controller.error === 'function') {
-        // $FlowFixMe[incompatible-call]: This is an Error object or the destination accepts other types.
         controller.error(error);
       } else {
         controller.close();
@@ -194,7 +189,6 @@ function createFakeWritableFromReadableStreamController(
   } as any;
 }
 
-// TODO: Move to sub-classing ReadableStream.
 type ReactDOMServerReadableStream = ReadableStream & {
   allReady: Promise<void>,
 };
@@ -202,15 +196,18 @@ type ReactDOMServerReadableStream = ReadableStream & {
 type WebStreamsOptions = Omit<
   Options,
   'onShellReady' | 'onShellError' | 'onAllReady' | 'onHeaders',
-> & {signal: AbortSignal, onHeaders?: (headers: Headers) => void};
+> & { signal: AbortSignal, onHeaders?: (headers: Headers) => void };
 
-function renderToReadableStream(
+// FIXED: Added missing identifier 'renderToReadableStream'
+export function renderToReadableStream(
   children: ReactNodeList,
   options?: WebStreamsOptions,
 ): Promise<ReactDOMServerReadableStream> {
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    let abortListener = null;
+
     const allReady = new Promise<void>((res, rej) => {
       onAllReady = res;
       onFatalError = rej;
@@ -233,21 +230,33 @@ function renderToReadableStream(
             abort(request, reason);
           },
         },
-        // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
-        // $FlowFixMe[incompatible-type]
-        {highWaterMark: 0},
+        { highWaterMark: 0 },
       ) as any;
-      // TODO: Move to sub-classing ReadableStream.
       stream.allReady = allReady;
       resolve(stream);
     }
+    
     function onShellError(error: mixed) {
-      // If the shell errors the caller of `renderToReadableStream` won't have access to `allReady`.
-      // However, `allReady` will be rejected by `onFatalError` as well.
-      // So we need to catch the duplicate, uncatchable fatal error in `allReady` to prevent a `UnhandledPromiseRejection`.
-      allReady.catch(() => {});
+      if (options && options.signal && abortListener) {
+        options.signal.removeEventListener('abort', abortListener);
+      }
+      allReady.catch(() => { });
       reject(error);
     }
+
+    const wrappedOnAllReady = () => {
+      if (options && options.signal && abortListener) {
+        options.signal.removeEventListener('abort', abortListener);
+      }
+      if (typeof onAllReady === 'function') onAllReady();
+    };
+
+    const wrappedOnFatalError = (error: mixed) => {
+      if (options && options.signal && abortListener) {
+        options.signal.removeEventListener('abort', abortListener);
+      }
+      if (typeof onFatalError === 'function') onFatalError(error);
+    };
 
     const onHeaders = options ? options.onHeaders : undefined;
     let onHeadersImpl;
@@ -278,10 +287,10 @@ function renderToReadableStream(
       createRootFormatContext(options ? options.namespaceURI : undefined),
       options ? options.progressiveChunkSize : undefined,
       options ? options.onError : undefined,
-      onAllReady,
+      wrappedOnAllReady,
       onShellReady,
       onShellError,
-      onFatalError,
+      wrappedOnFatalError,
       options ? options.formState : undefined,
     );
     if (options && options.signal) {
@@ -289,11 +298,11 @@ function renderToReadableStream(
       if (signal.aborted) {
         abort(request, (signal as any).reason);
       } else {
-        const listener = () => {
+        abortListener = () => {
           abort(request, (signal as any).reason);
-          signal.removeEventListener('abort', listener);
+          if (abortListener) signal.removeEventListener('abort', abortListener);
         };
-        signal.addEventListener('abort', listener);
+        signal.addEventListener('abort', abortListener);
       }
     }
     startWork(request);
@@ -360,9 +369,10 @@ function resumeToPipeableStream(
 type WebStreamsResumeOptions = Omit<
   Options,
   'onShellReady' | 'onShellError' | 'onAllReady',
-> & {signal: AbortSignal};
+> & { signal: AbortSignal };
 
-function resume(
+// FIXED: Implemented fixed resume function with memory leak protection
+export function resume(
   children: ReactNodeList,
   postponedState: PostponedState,
   options?: WebStreamsResumeOptions,
@@ -370,6 +380,8 @@ function resume(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    let abortListener = null;
+
     const allReady = new Promise<void>((res, rej) => {
       onAllReady = res;
       onFatalError = rej;
@@ -392,21 +404,34 @@ function resume(
             abort(request, reason);
           },
         },
-        // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
-        // $FlowFixMe[incompatible-type]
-        {highWaterMark: 0},
+        { highWaterMark: 0 },
       ) as any;
-      // TODO: Move to sub-classing ReadableStream.
       stream.allReady = allReady;
       resolve(stream);
     }
-    function onShellError(error: mixed) {
-      // If the shell errors the caller of `renderToReadableStream` won't have access to `allReady`.
-      // However, `allReady` will be rejected by `onFatalError` as well.
-      // So we need to catch the duplicate, uncatchable fatal error in `allReady` to prevent a `UnhandledPromiseRejection`.
-      allReady.catch(() => {});
+
+    function onShellError(error: any) {
+      if (options && options.signal && abortListener) {
+        options.signal.removeEventListener('abort', abortListener);
+      }
+      allReady.catch(() => { });
       reject(error);
     }
+
+    const wrappedOnAllReady = () => {
+      if (options && options.signal && abortListener) {
+        options.signal.removeEventListener('abort', abortListener);
+      }
+      if (typeof onAllReady === 'function') onAllReady();
+    };
+
+    const wrappedOnFatalError = (error: mixed) => {
+      if (options && options.signal && abortListener) {
+        options.signal.removeEventListener('abort', abortListener);
+      }
+      if (typeof onFatalError === 'function') onFatalError(error);
+    };
+
     const request = resumeRequest(
       children,
       postponedState,
@@ -415,31 +440,31 @@ function resume(
         options ? options.nonce : undefined,
       ),
       options ? options.onError : undefined,
-      onAllReady,
+      wrappedOnAllReady,
       onShellReady,
       onShellError,
-      onFatalError,
+      wrappedOnFatalError,
     );
+
     if (options && options.signal) {
       const signal = options.signal;
       if (signal.aborted) {
         abort(request, (signal as any).reason);
       } else {
-        const listener = () => {
+        abortListener = () => {
           abort(request, (signal as any).reason);
-          signal.removeEventListener('abort', listener);
+          if (abortListener) signal.removeEventListener('abort', abortListener);
         };
-        signal.addEventListener('abort', listener);
+        signal.addEventListener('abort', abortListener);
       }
     }
+
     startWork(request);
   });
 }
 
 export {
   renderToPipeableStream,
-  renderToReadableStream,
   resumeToPipeableStream,
-  resume,
   ReactVersion as version,
 };

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -12,14 +12,14 @@ import type {
   PostponedState,
   ErrorInfo,
 } from 'react-server/src/ReactFizzServer';
-import type { ReactNodeList, ReactFormState } from 'shared/ReactTypes';
-import type { Writable } from 'stream';
+import type {ReactNodeList, ReactFormState} from 'shared/ReactTypes';
+import type {Writable} from 'stream';
 import type {
   BootstrapScriptDescriptor,
   HeadersDescriptor,
 } from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
-import type { Destination } from 'react-server/src/ReactServerStreamConfigNode';
-import type { ImportMap } from '../shared/ReactDOMTypes';
+import type {Destination} from 'react-server/src/ReactServerStreamConfigNode';
+import type {ImportMap} from '../shared/ReactDOMTypes';
 
 import ReactVersion from 'shared/ReactVersion';
 
@@ -40,9 +40,9 @@ import {
   createRootFormatContext,
 } from 'react-dom-bindings/src/server/ReactFizzConfigDOM';
 
-import { textEncoder } from 'react-server/src/ReactServerStreamConfigNode';
+import {textEncoder} from 'react-server/src/ReactServerStreamConfigNode';
 
-import { ensureCorrectIsomorphicReactVersion } from '../shared/ensureCorrectIsomorphicReactVersion';
+import {ensureCorrectIsomorphicReactVersion} from '../shared/ensureCorrectIsomorphicReactVersion';
 ensureCorrectIsomorphicReactVersion();
 
 function createDrainHandler(destination: Destination, request: Request) {
@@ -60,9 +60,9 @@ function createCancelHandler(request: Request, reason: string) {
 type NonceOption =
   | string
   | {
-    script?: string,
-    style?: string,
-  };
+      script?: string,
+      style?: string,
+    };
 
 type Options = {
   identifierPrefix?: string,
@@ -168,19 +168,24 @@ function renderToPipeableStream(
 function createFakeWritableFromReadableStreamController(
   controller: ReadableStreamController,
 ): Writable {
+  // The current host config expects a Writable so we create
+  // a fake writable for now to push into the Readable.
   return {
     write(chunk: string | Uint8Array) {
       if (typeof chunk === 'string') {
         chunk = textEncoder.encode(chunk);
       }
       controller.enqueue(chunk);
+      // in web streams there is no backpressure so we can alwas write more
       return true;
     },
     end() {
       controller.close();
     },
     destroy(error) {
+      // $FlowFixMe[method-unbinding]
       if (typeof controller.error === 'function') {
+        // $FlowFixMe[incompatible-call]: This is an Error object or the destination accepts other types.
         controller.error(error);
       } else {
         controller.close();
@@ -189,6 +194,7 @@ function createFakeWritableFromReadableStreamController(
   } as any;
 }
 
+// TODO: Move to sub-classing ReadableStream.
 type ReactDOMServerReadableStream = ReadableStream & {
   allReady: Promise<void>,
 };
@@ -196,21 +202,35 @@ type ReactDOMServerReadableStream = ReadableStream & {
 type WebStreamsOptions = Omit<
   Options,
   'onShellReady' | 'onShellError' | 'onAllReady' | 'onHeaders',
-> & { signal: AbortSignal, onHeaders?: (headers: Headers) => void };
+> & {signal: AbortSignal, onHeaders?: (headers: Headers) => void};
 
-// FIXED: Added missing identifier 'renderToReadableStream'
-export function renderToReadableStream(
+function renderToReadableStream(
   children: ReactNodeList,
   options?: WebStreamsOptions,
 ): Promise<ReactDOMServerReadableStream> {
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
-    let abortListener = null;
+
+    let abortListener: ?() => void = null;
+    const signal = options ? options.signal : null;
+
+    function cleanupAbortListener() {
+      if (signal && abortListener) {
+        signal.removeEventListener('abort', abortListener);
+        abortListener = null;
+      }
+    }
 
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupAbortListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupAbortListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -230,33 +250,22 @@ export function renderToReadableStream(
             abort(request, reason);
           },
         },
-        { highWaterMark: 0 },
+        // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
+        // $FlowFixMe[incompatible-type]
+        {highWaterMark: 0},
       ) as any;
+      // TODO: Move to sub-classing ReadableStream.
       stream.allReady = allReady;
       resolve(stream);
     }
-    
     function onShellError(error: mixed) {
-      if (options && options.signal && abortListener) {
-        options.signal.removeEventListener('abort', abortListener);
-      }
-      allReady.catch(() => { });
+      cleanupAbortListener();
+      // If the shell errors the caller of `renderToReadableStream` won't have access to `allReady`.
+      // However, `allReady` will be rejected by `onFatalError` as well.
+      // So we need to catch the duplicate, uncatchable fatal error in `allReady` to prevent a `UnhandledPromiseRejection`.
+      allReady.catch(() => {});
       reject(error);
     }
-
-    const wrappedOnAllReady = () => {
-      if (options && options.signal && abortListener) {
-        options.signal.removeEventListener('abort', abortListener);
-      }
-      if (typeof onAllReady === 'function') onAllReady();
-    };
-
-    const wrappedOnFatalError = (error: mixed) => {
-      if (options && options.signal && abortListener) {
-        options.signal.removeEventListener('abort', abortListener);
-      }
-      if (typeof onFatalError === 'function') onFatalError(error);
-    };
 
     const onHeaders = options ? options.onHeaders : undefined;
     let onHeadersImpl;
@@ -287,20 +296,19 @@ export function renderToReadableStream(
       createRootFormatContext(options ? options.namespaceURI : undefined),
       options ? options.progressiveChunkSize : undefined,
       options ? options.onError : undefined,
-      wrappedOnAllReady,
+      onAllReady,
       onShellReady,
       onShellError,
-      wrappedOnFatalError,
+      onFatalError,
       options ? options.formState : undefined,
     );
     if (options && options.signal) {
-      const signal = options.signal;
-      if (signal.aborted) {
+      if (signal && signal.aborted) {
         abort(request, (signal as any).reason);
-      } else {
+      } else if (signal) {
         abortListener = () => {
           abort(request, (signal as any).reason);
-          if (abortListener) signal.removeEventListener('abort', abortListener);
+          cleanupAbortListener();
         };
         signal.addEventListener('abort', abortListener);
       }
@@ -369,10 +377,9 @@ function resumeToPipeableStream(
 type WebStreamsResumeOptions = Omit<
   Options,
   'onShellReady' | 'onShellError' | 'onAllReady',
-> & { signal: AbortSignal };
+> & {signal: AbortSignal};
 
-// FIXED: Implemented fixed resume function with memory leak protection
-export function resume(
+function resume(
   children: ReactNodeList,
   postponedState: PostponedState,
   options?: WebStreamsResumeOptions,
@@ -380,11 +387,26 @@ export function resume(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
-    let abortListener = null;
+
+    let abortListener: ?() => void = null;
+    const signal = options ? options.signal : null;
+
+    function cleanupAbortListener() {
+      if (signal && abortListener) {
+        signal.removeEventListener('abort', abortListener);
+        abortListener = null;
+      }
+    }
 
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupAbortListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupAbortListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -404,34 +426,22 @@ export function resume(
             abort(request, reason);
           },
         },
-        { highWaterMark: 0 },
+        // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
+        // $FlowFixMe[incompatible-type]
+        {highWaterMark: 0},
       ) as any;
+      // TODO: Move to sub-classing ReadableStream.
       stream.allReady = allReady;
       resolve(stream);
     }
-
-    function onShellError(error: any) {
-      if (options && options.signal && abortListener) {
-        options.signal.removeEventListener('abort', abortListener);
-      }
-      allReady.catch(() => { });
+    function onShellError(error: mixed) {
+      cleanupAbortListener();
+      // If the shell errors the caller of `renderToReadableStream` won't have access to `allReady`.
+      // However, `allReady` will be rejected by `onFatalError` as well.
+      // So we need to catch the duplicate, uncatchable fatal error in `allReady` to prevent a `UnhandledPromiseRejection`.
+      allReady.catch(() => {});
       reject(error);
     }
-
-    const wrappedOnAllReady = () => {
-      if (options && options.signal && abortListener) {
-        options.signal.removeEventListener('abort', abortListener);
-      }
-      if (typeof onAllReady === 'function') onAllReady();
-    };
-
-    const wrappedOnFatalError = (error: mixed) => {
-      if (options && options.signal && abortListener) {
-        options.signal.removeEventListener('abort', abortListener);
-      }
-      if (typeof onFatalError === 'function') onFatalError(error);
-    };
-
     const request = resumeRequest(
       children,
       postponedState,
@@ -440,31 +450,30 @@ export function resume(
         options ? options.nonce : undefined,
       ),
       options ? options.onError : undefined,
-      wrappedOnAllReady,
+      onAllReady,
       onShellReady,
       onShellError,
-      wrappedOnFatalError,
+      onFatalError,
     );
-
     if (options && options.signal) {
-      const signal = options.signal;
-      if (signal.aborted) {
+      if (signal && signal.aborted) {
         abort(request, (signal as any).reason);
-      } else {
+      } else if (signal) {
         abortListener = () => {
           abort(request, (signal as any).reason);
-          if (abortListener) signal.removeEventListener('abort', abortListener);
+          cleanupAbortListener();
         };
         signal.addEventListener('abort', abortListener);
       }
     }
-
     startWork(request);
   });
 }
 
 export {
   renderToPipeableStream,
+  renderToReadableStream,
   resumeToPipeableStream,
+  resume,
   ReactVersion as version,
 };


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork the repository and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with prettier (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the Flow type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

This pull request resolves a memory leak vulnerability in the React DOM Fizz Server (`ReactDOMFizzServerNode.js`) when utilizing `renderToReadableStream` and `resume` for web streams (Fixes #36763).

### Motivation
Currently, when an `AbortSignal` is provided via stream options, an event listener is attached to handle timely stream aborts. However, when the stream reaches its terminal lifecycle state—either completing successfully (`onAllReady`) or failing early due to shell or fatal errors (`onShellError`, `onFatalError`)—the `abortListener` remains permanently attached to the `AbortSignal`.

If a long-lived or shared `AbortSignal` is reused across multiple incoming SSR requests, this leads to a continuous, critical leak of request contexts, stream configurations, and event handlers in Node.js/Edge environments under sustained traffic.

### Solution
- Extracted `abortListener` to the outer closure scope of the stream initialization promise.
- Wrapped the `onAllReady` and `onFatalError` callbacks to cleanly invoke `signal.removeEventListener('abort', abortListener)` when the stream lifecycle terminates.
- Added explicit listener cleanup inside `onShellError` to ensure graceful disposal during premature shell failures.

## How did you test this change?

To ensure the changes are completely stable and backwards-compatible, the following verifications were performed inside the local development workspace environment:

1. **Unit Test Suite Execution:** Ran the core React DOM test suites using Jest to confirm all streaming and async hydration behaviors remain unaffected:
```bash
   yarn test react-dom