### PR TITLE
[Scheduler] Unref MessageChannel ports to avoid hanging Node/Jest

### DIFF
--- a/packages/scheduler/src/__tests__/SchedulerMessageChannelUnref-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerMessageChannelUnref-test.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+ */
+
+'use strict';
+
+// Regression test for https://github.com/facebook/react/issues/26608
+// When Scheduler falls through to the MessageChannel path (no setImmediate),
+// the ports should be unref'd so they don't keep Node/Jest alive.
+describe('SchedulerMessageChannelUnref', () => {
+  afterEach(() => {
+    jest.resetModules();
+    delete global.MessageChannel;
+  });
+
+  it('calls unref on MessageChannel ports when available', () => {
+    // Remove setImmediate to force the MessageChannel branch.
+    const originalSetImmediate = global.setImmediate;
+    delete global.setImmediate;
+
+    const port1UnrefMock = jest.fn();
+    const port2UnrefMock = jest.fn();
+
+    const port1 = {unref: port1UnrefMock};
+    const port2 = {
+      postMessage: jest.fn(),
+      unref: port2UnrefMock,
+    };
+
+    global.MessageChannel = function MessageChannel() {
+      this.port1 = port1;
+      this.port2 = port2;
+    };
+
+    jest.resetModules();
+    jest.unmock('scheduler');
+    require('scheduler');
+
+    expect(port1UnrefMock).toHaveBeenCalledTimes(1);
+    expect(port2UnrefMock).toHaveBeenCalledTimes(1);
+
+    // Restore setImmediate.
+    global.setImmediate = originalSetImmediate;
+  });
+
+  it('does not throw when unref is not available', () => {
+    const originalSetImmediate = global.setImmediate;
+    delete global.setImmediate;
+
+    const port1 = {};
+    const port2 = {
+      postMessage: jest.fn(),
+    };
+
+    global.MessageChannel = function MessageChannel() {
+      this.port1 = port1;
+      this.port2 = port2;
+    };
+
+    jest.resetModules();
+    jest.unmock('scheduler');
+
+    expect(() => {
+      require('scheduler');
+    }).not.toThrow();
+
+    global.setImmediate = originalSetImmediate;
+  });
+});

--- a/packages/scheduler/src/forks/Scheduler.js
+++ b/packages/scheduler/src/forks/Scheduler.js
@@ -549,6 +549,14 @@ if (typeof localSetImmediate === 'function') {
   const channel = new MessageChannel();
   const port = channel.port2;
   channel.port1.onmessage = performWorkUntilDeadline;
+  // In environments where MessagePort supports unref (e.g. Node.js with
+  // worker_threads), call it so the port does not keep the process alive.
+  if (typeof channel.port1.unref === 'function') {
+    channel.port1.unref();
+  }
+  if (typeof port.unref === 'function') {
+    port.unref();
+  }
   schedulePerformWorkUntilDeadline = () => {
     port.postMessage(null);
   };


### PR DESCRIPTION
Fixes #26608

## Summary

When `setImmediate` is unavailable but `MessageChannel` is available, like for example in Node.js 15+ with jsdom, Scheduler falls back to creating a `MessageChannel` and wiring `port1.onmessage`.

In Node `worker_threads.MessageChannel` treats both ports as active handles that keep the event loop alive which can prevent Jest from exiting cleanly and leave an open `MESSAGEPORT` handle. The existing code already prefers `setImmediate` because it does not prevent a Node.js process from exiting but the `MessageChannel` fallback did not apply the same mitigation.

This change calls `unref()` on both `port1` and `port2` when available so the ports no longer keep Node or Jest alive. In browser environments, `unref` does not exist so the guarded check is a no-op.

## How did you test this change?

Added `SchedulerMessageChannelUnref-test.js` with coverage for both supported cases.

* Mocks `MessageChannel` with ports that expose `unref` deletes `setImmediate` to force the `MessageChannel` path and asserts `unref()` is called on both ports.
* Mocks `MessageChannel` with ports that do not expose `unref` and asserts Scheduler loads without throwing.

Ran the Scheduler test suite in development mode:

```bash
yarn test --testPathPattern="packages/scheduler/src/__tests__/Scheduler"
```

```text
PASS packages/scheduler/src/__tests__/SchedulerMessageChannelUnref-test.js
PASS packages/scheduler/src/__tests__/SchedulerSetTimeout-test.js
PASS packages/scheduler/src/__tests__/SchedulerSetImmediate-test.js
PASS packages/scheduler/src/__tests__/Scheduler-test.js
PASS packages/scheduler/src/__tests__/SchedulerPostTask-test.js
PASS packages/scheduler/src/__tests__/SchedulerProfiling-test.js
PASS packages/scheduler/src/__tests__/SchedulerMock-test.js

Test Suites: 7 passed, 7 total
Tests:       65 passed, 65 total
```

Ran the Scheduler test suite in production mode:

```bash
yarn test --prod --testPathPattern="packages/scheduler/src/__tests__/Scheduler"
```

```text
Test Suites: 7 passed, 7 total
Tests:       65 passed, 65 total
```