### PR TITLE
[Fizz] Finalize postponed nextSegmentId after the prelude flush

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
@@ -1105,32 +1105,35 @@ describe('ReactDOMFizzStaticBrowser', () => {
     );
   });
 
-  it('resumes segment ids past boundaries that were outlined into the shell', async () => {
-    // Regression test: getPostponedState snapshots request.nextSegmentId before
-    // the pull-driven prelude flush. Flushing the shell outlines large completed
-    // boundaries, advancing nextSegmentId past that snapshot. If the snapshot
-    // isn't finalized post-flush, the resume seeds from the stale value and
-    // re-allocates segment ids the shell already emitted, so the concatenated
-    // shell+resume document carries duplicate B:/S: ids that cross-wire $RC.
+  it('reveals a resumed boundary even when the shell outlined a completed boundary', async () => {
+    // Regression test for a segment-id collision between the prerendered shell
+    // and the resume. The prelude flush outlines a large *completed* boundary
+    // into the shell, advancing request.nextSegmentId past the value
+    // getPostponedState snapshotted before the flush. If that snapshot isn't
+    // finalized after the flush, the resume re-allocates ids the shell already
+    // used; in the served document $RC (getElementById, first match) then
+    // reveals the wrong element and the resumed boundary stays on its fallback.
+    // Asserts on the rendered output rather than the segment ids.
     let prerendering = true;
-    const bigText = 'x'.repeat(800); // > 500 bytes => eligible for outlining
+    const shellText = 'a'.repeat(800); // > 500 bytes => eligible for outlining
+    const resumeText = 'b'.repeat(800);
 
     // Completes during the prerender; large enough that the prelude flush
-    // outlines it into the shell (consuming an id >= the snapshot).
+    // outlines it into the shell.
     function ShellBoundary() {
-      return <div>{bigText}</div>;
+      return <div>{shellText}</div>;
     }
 
     // Suspends during the prerender so its boundary becomes a hole the resume
-    // fills. On resume it renders a nested large boundary that is itself
-    // outlined, so the resume allocates fresh segment ids from the seed.
+    // fills. On resume it renders a nested large boundary that itself outlines,
+    // so the resume allocates fresh segment ids from the postponed seed.
     function Hole() {
       if (prerendering) {
         return React.use(theInfinitePromise);
       }
       return (
         <Suspense fallback="LoadingC">
-          <div>{bigText}</div>
+          <div>{resumeText}</div>
         </Suspense>
       );
     }
@@ -1163,19 +1166,6 @@ describe('ReactDOMFizzStaticBrowser', () => {
 
     const shellHTML = await readContent(prerendered.prelude);
 
-    // Highest segment id React actually emitted into the shell.
-    let maxShellId = -1;
-    Array.from(shellHTML.matchAll(/id="[BS]:([0-9a-f]+)"/g)).forEach(m => {
-      maxShellId = Math.max(maxShellId, parseInt(m[1], 16));
-    });
-    // The shell must contain at least one outlined boundary for this test to be
-    // meaningful.
-    expect(maxShellId).toBeGreaterThanOrEqual(0);
-
-    // The fix: the resume must start strictly above every id the shell emitted.
-    expect(prerendered.postponed.nextSegmentId).toBeGreaterThan(maxShellId);
-
-    // End-to-end: the stitched shell+resume document must have no duplicate ids.
     prerendering = false;
     const resumed = await serverAct(() =>
       ReactDOMFizzServer.resume(
@@ -1186,18 +1176,22 @@ describe('ReactDOMFizzStaticBrowser', () => {
     );
     const resumeHTML = await readContent(resumed);
 
-    const seen = new Set();
-    const dupes = new Set();
-    Array.from(
-      (shellHTML + resumeHTML).matchAll(/id="([BS]:[0-9a-f]+)"/g),
-    ).forEach(m => {
-      const id = m[1];
-      if (seen.has(id)) {
-        dupes.add(id);
-      }
-      seen.add(id);
-    });
-    expect(Array.from(dupes)).toEqual([]);
+    // Run the shell and the resume as one served document so the completion
+    // instructions ($RC) execute against both together, the way a browser does.
+    const temp = document.createElement('div');
+    temp.innerHTML = shellHTML + resumeHTML;
+    await insertNodesAndExecuteScripts(temp, container, null);
+    jest.runAllTimers();
+
+    // Both boundaries reveal their own content. Without the fix the resumed
+    // boundary reuses the shell's ids, so its $RC resolves to the shell's
+    // element and it stays on its "LoadingC" fallback.
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <div>{shellText}</div>
+        <div>{resumeText}</div>
+      </div>,
+    );
   });
 
   it('can omit a preamble with an empty shell if no preamble is ready when prerendering finishes', async () => {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
@@ -1165,9 +1165,9 @@ describe('ReactDOMFizzStaticBrowser', () => {
 
     // Highest segment id React actually emitted into the shell.
     let maxShellId = -1;
-    for (const m of shellHTML.matchAll(/id="[BS]:([0-9a-f]+)"/g)) {
+    Array.from(shellHTML.matchAll(/id="[BS]:([0-9a-f]+)"/g)).forEach(m => {
       maxShellId = Math.max(maxShellId, parseInt(m[1], 16));
-    }
+    });
     // The shell must contain at least one outlined boundary for this test to be
     // meaningful.
     expect(maxShellId).toBeGreaterThanOrEqual(0);
@@ -1188,15 +1188,15 @@ describe('ReactDOMFizzStaticBrowser', () => {
 
     const seen = new Set();
     const dupes = new Set();
-    for (const m of (shellHTML + resumeHTML).matchAll(
-      /id="([BS]:[0-9a-f]+)"/g,
-    )) {
+    Array.from(
+      (shellHTML + resumeHTML).matchAll(/id="([BS]:[0-9a-f]+)"/g),
+    ).forEach(m => {
       const id = m[1];
       if (seen.has(id)) {
         dupes.add(id);
       }
       seen.add(id);
-    }
+    });
     expect(Array.from(dupes)).toEqual([]);
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
@@ -1105,6 +1105,101 @@ describe('ReactDOMFizzStaticBrowser', () => {
     );
   });
 
+  it('resumes segment ids past boundaries that were outlined into the shell', async () => {
+    // Regression test: getPostponedState snapshots request.nextSegmentId before
+    // the pull-driven prelude flush. Flushing the shell outlines large completed
+    // boundaries, advancing nextSegmentId past that snapshot. If the snapshot
+    // isn't finalized post-flush, the resume seeds from the stale value and
+    // re-allocates segment ids the shell already emitted, so the concatenated
+    // shell+resume document carries duplicate B:/S: ids that cross-wire $RC.
+    let prerendering = true;
+    const bigText = 'x'.repeat(800); // > 500 bytes => eligible for outlining
+
+    // Completes during the prerender; large enough that the prelude flush
+    // outlines it into the shell (consuming an id >= the snapshot).
+    function ShellBoundary() {
+      return <div>{bigText}</div>;
+    }
+
+    // Suspends during the prerender so its boundary becomes a hole the resume
+    // fills. On resume it renders a nested large boundary that is itself
+    // outlined, so the resume allocates fresh segment ids from the seed.
+    function Hole() {
+      if (prerendering) {
+        return React.use(theInfinitePromise);
+      }
+      return (
+        <Suspense fallback="LoadingC">
+          <div>{bigText}</div>
+        </Suspense>
+      );
+    }
+
+    function App() {
+      return (
+        <div>
+          <Suspense fallback="LoadingA">
+            <ShellBoundary />
+          </Suspense>
+          <Suspense fallback="LoadingB">
+            <Hole />
+          </Suspense>
+        </div>
+      );
+    }
+
+    const controller = new AbortController();
+    let pendingResult;
+    await serverAct(() => {
+      pendingResult = ReactDOMFizzStatic.prerender(<App />, {
+        signal: controller.signal,
+        progressiveChunkSize: 100, // force the completed boundary to outline
+        onError() {},
+      });
+    });
+    await serverAct(() => controller.abort());
+    const prerendered = await pendingResult;
+    expect(prerendered.postponed).not.toBe(null);
+
+    const shellHTML = await readContent(prerendered.prelude);
+
+    // Highest segment id React actually emitted into the shell.
+    let maxShellId = -1;
+    for (const m of shellHTML.matchAll(/id="[BS]:([0-9a-f]+)"/g)) {
+      maxShellId = Math.max(maxShellId, parseInt(m[1], 16));
+    }
+    // The shell must contain at least one outlined boundary for this test to be
+    // meaningful.
+    expect(maxShellId).toBeGreaterThanOrEqual(0);
+
+    // The fix: the resume must start strictly above every id the shell emitted.
+    expect(prerendered.postponed.nextSegmentId).toBeGreaterThan(maxShellId);
+
+    // End-to-end: the stitched shell+resume document must have no duplicate ids.
+    prerendering = false;
+    const resumed = await serverAct(() =>
+      ReactDOMFizzServer.resume(
+        <App />,
+        JSON.parse(JSON.stringify(prerendered.postponed)),
+        {onError() {}},
+      ),
+    );
+    const resumeHTML = await readContent(resumed);
+
+    const seen = new Set();
+    const dupes = new Set();
+    for (const m of (shellHTML + resumeHTML).matchAll(
+      /id="([BS]:[0-9a-f]+)"/g,
+    )) {
+      const id = m[1];
+      if (seen.has(id)) {
+        dupes.add(id);
+      }
+      seen.add(id);
+    }
+    expect(Array.from(dupes)).toEqual([]);
+  });
+
   it('can omit a preamble with an empty shell if no preamble is ready when prerendering finishes', async () => {
     const errors = [];
 

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -6164,6 +6164,9 @@ function flushCompletedQueues(
       // the resume allocates segment ids strictly above the shell's and can't
       // emit duplicate B:/S: ids. nextSegmentId only increases, so later flush
       // passes refine this monotonically.
+      // TODO: Could be too late if the postponed state was already serialized
+      // by API consumers. Accessing postponed state before the prelude has flushed
+      // should be forbidden in the API.
       postponedState.nextSegmentId = request.nextSegmentId;
     }
     if (
@@ -6446,14 +6449,13 @@ export function getPostponedState(request: Request): null | PostponedState {
   // True only when we postponed with a real shell (as opposed to postponing the
   // root itself). Only in that case does the prelude flush outline completed
   // boundaries and advance nextSegmentId past the value we capture here.
-  let hasFlushableShell = false;
-  if (
-    request.completedRootSegment !== null &&
-    // The Root postponed
-    (request.completedRootSegment.status === POSTPONED ||
-      // Or the Preamble was not available
-      request.completedPreambleSegments === null)
-  ) {
+  const hasFlushableShell =
+    request.completedRootSegment === null ||
+    // The Root did not postpone
+    (request.completedRootSegment.status !== POSTPONED &&
+      // the Preamble was available
+      request.completedPreambleSegments !== null);
+  if (!hasFlushableShell) {
     nextSegmentId = 0;
     // We need to ensure that on resume we retry the root. We use a number
     // type for the replaySlots to signify this (see resumeRequest).
@@ -6466,7 +6468,6 @@ export function getPostponedState(request: Request): null | PostponedState {
     nextSegmentId = request.nextSegmentId;
     replaySlots = trackedPostpones.rootSlots;
     completeResumableState(request.resumableState);
-    hasFlushableShell = true;
   }
   const postponedState: PostponedState = {
     nextSegmentId,

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -394,6 +394,15 @@ export opaque type Request = {
   completedBoundaries: Array<SuspenseBoundary>, // Completed but not yet fully flushed boundaries to show.
   partialBoundaries: Array<SuspenseBoundary>, // Partially completed boundaries that can flush its segments early.
   trackedPostpones: null | PostponedHoles, // Gets set to non-null while we want to track postponed holes. I.e. during a prerender.
+  // While prerendering a postponed request that produced a real shell, this
+  // holds the PostponedState returned by getPostponedState. getPostponedState
+  // snapshots nextSegmentId before the (pull-driven) prelude flush runs, but the
+  // flush outlines completed boundaries and advances nextSegmentId past that
+  // snapshot. We finalize the snapshot from flushCompletedQueues so the resumed
+  // render allocates segment ids strictly above the shell's; otherwise the shell
+  // and resume emit duplicate B:/S: ids once concatenated. Stays null for live
+  // renders and resumes.
+  postponedState: null | PostponedState,
   // onError is called when an error happens anywhere in the tree. It might recover.
   // The return string is used in production  primarily to avoid leaking internals, secondarily to save bytes.
   // Returning null/undefined will cause a default error message in production
@@ -553,6 +562,7 @@ function RequestInstance(
   this.completedBoundaries = [] as Array<SuspenseBoundary>;
   this.partialBoundaries = [] as Array<SuspenseBoundary>;
   this.trackedPostpones = null;
+  this.postponedState = null;
   this.onError = onError === undefined ? defaultErrorHandler : onError;
   this.onAllReady = onAllReady === undefined ? noop : onAllReady;
   this.onShellReady = onShellReady === undefined ? noop : onShellReady;
@@ -6146,6 +6156,16 @@ function flushCompletedQueues(
     largeBoundaries.splice(0, i);
   } finally {
     flushingPartialBoundaries = false;
+    const postponedState = request.postponedState;
+    if (postponedState !== null) {
+      // The shell flush above may have outlined completed boundaries, advancing
+      // nextSegmentId past the value getPostponedState snapshotted before the
+      // flush. Re-sync the postponed state to the post-flush high-water mark so
+      // the resume allocates segment ids strictly above the shell's and can't
+      // emit duplicate B:/S: ids. nextSegmentId only increases, so later flush
+      // passes refine this monotonically.
+      postponedState.nextSegmentId = request.nextSegmentId;
+    }
     if (
       request.allPendingTasks === 0 &&
       request.clientRenderedBoundaries.length === 0 &&
@@ -6423,6 +6443,10 @@ export function getPostponedState(request: Request): null | PostponedState {
   }
   let replaySlots: ResumeSlots;
   let nextSegmentId: number;
+  // True only when we postponed with a real shell (as opposed to postponing the
+  // root itself). Only in that case does the prelude flush outline completed
+  // boundaries and advance nextSegmentId past the value we capture here.
+  let hasFlushableShell = false;
   if (
     request.completedRootSegment !== null &&
     // The Root postponed
@@ -6442,8 +6466,9 @@ export function getPostponedState(request: Request): null | PostponedState {
     nextSegmentId = request.nextSegmentId;
     replaySlots = trackedPostpones.rootSlots;
     completeResumableState(request.resumableState);
+    hasFlushableShell = true;
   }
-  return {
+  const postponedState: PostponedState = {
     nextSegmentId,
     rootFormatContext: request.rootFormatContext,
     progressiveChunkSize: request.progressiveChunkSize,
@@ -6451,4 +6476,15 @@ export function getPostponedState(request: Request): null | PostponedState {
     replayNodes: trackedPostpones.rootNodes,
     replaySlots,
   };
+  if (hasFlushableShell) {
+    // The prelude hasn't flushed yet — it's pull-driven and runs after this
+    // (see completeAll -> onAllReady). Flushing the shell outlines completed
+    // boundaries, bumping request.nextSegmentId beyond the snapshot above. Hold
+    // a reference so flushCompletedQueues can finalize nextSegmentId to the
+    // post-flush high-water mark. Otherwise the resume reuses the shell's
+    // segment ids and the concatenated document has duplicate B:/S: ids, which
+    // cross-wires React's boundary-completion scripts ($RC).
+    request.postponedState = postponedState;
+  }
+  return postponedState;
 }


### PR DESCRIPTION
`getPostponedState` snapshots `request.nextSegmentId` at `onAllReady`, before the Fizz stream is flowing. At this point we have visited all Suspense boundaries and know which ones suspended by user code or not. However, only when the stream is flowing are we counting the size of each boundary. When we detect large boundaries, we suspend them i.e. we outline them instead of keeping them inline. This results in more segments being written while the postponed state holds a stale count.

We now keep a reference to the returned postponed state and mutate the segment IDs when we outline. That way serializing `postponed` after the `prelude` has flushed writes the latest postponed state.

The current API design means that you can potentially serialize stale postponed state. We're considering a redesign to make these issues impossible (e.g. https://github.com/react/react/pull/36815).

For now, the postponed state should only be serialized or passed onto a `resume` once the `prelude` has flushed e.g.:

```js
const { createWriteStream, writeFileSync } = require('node:fs');
const { createWriteStream } = require('node:stream');

const { prelude, postponed } = prenderToNodeStream(...)
// serializing `postponed` now would write a stale state.
// serialize prelude
const destination = createWriteStream('prelude.html')

prelude.pipe(destination)

await finished(prelude)
// now we can serialize postponed
writeFileSync('postponed.json', JSON.stringify(postponed))
```

