### PR TITLE
[Fizz] Preserve task position during DEV diagnostic replay 

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticNode-test.js
@@ -255,6 +255,47 @@ describe('ReactDOMFizzStaticNode', () => {
     expect(errors).toEqual(['This operation was aborted']);
   });
 
+  it('does not lose a sibling task slot when replaying a suspended call site during abort', async () => {
+    const promise = new Promise(() => {});
+    const controller = new AbortController();
+    let shouldSuspend = true;
+
+    function ConditionalSuspend() {
+      if (shouldSuspend) {
+        React.use(promise);
+      }
+      return <div>resolved</div>;
+    }
+
+    // Keep a second task suspended at child index 1.
+    const LazyPending = React.lazy(() => promise);
+
+    const resultPromise = ReactDOMFizzStatic.prerenderToNodeStream(
+      <div>
+        <Suspense fallback={<div>Loading</div>}>
+          <ConditionalSuspend />
+          <LazyPending />
+        </Suspense>
+      </div>,
+      {
+        signal: controller.signal,
+        onError() {},
+      },
+    );
+
+    await jest.runAllTimers();
+
+    // The DEV abort replay can now complete the task at child index 0.
+    shouldSuspend = false;
+    controller.abort();
+    await jest.runAllTimers();
+
+    const {prelude} = await resultPromise;
+    const content = await readContent(prelude);
+    expect(content).toContain('Loading');
+    expect(content).not.toContain('resolved');
+  });
+
   it('should resolve an empty shell if aborting before the shell is complete', async () => {
     const errors = [];
     const controller = new AbortController();

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -1079,6 +1079,12 @@ function pushHaltedAwaitOnComponentStack(
 function rerenderStalledTask(request: Request, task: Task): void {
   const prevStatus = request.status;
   const prevAborted = request.aborted;
+  // The diagnostic replay may continue past the original suspension and
+  // destructively update these fields. They identify the task's resumable
+  // slot, so leaking those updates can make trackPostpone confuse an element
+  // root with one of its child slots.
+  const prevNode = task.node;
+  const prevChildIndex = task.childIndex;
   request.status = STALLED_DEV;
   // This diagnostic replay must reach the suspended call site instead of
   // taking the abort path.
@@ -1127,6 +1133,8 @@ function rerenderStalledTask(request: Request, task: Task): void {
     currentRequest = prevRequest;
     request.status = prevStatus;
     request.aborted = prevAborted;
+    task.node = prevNode;
+    task.childIndex = prevChildIndex;
   }
 }
 


### PR DESCRIPTION
A DEV abort replay can continue past the original suspension and mutate the task's node and child index. Restore these fields afterward so postponed sibling slots are tracked correctly.