### PR TITLE
fix[react-dom/server]: Remove AbortSignal listener on completion to prevent memory leak in Fizz server

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -559,4 +559,66 @@ describe('ReactDOMFizzServerBrowser', () => {
       `"<link rel="preload" as="script" fetchPriority="low" nonce="R4nd0m" href="init.js"/><link rel="modulepreload" fetchPriority="low" nonce="R4nd0m" href="init.mjs"/><div>hello world</div><script nonce="${nonce}" id="_R_">INIT();</script><script src="init.js" nonce="${nonce}" async=""></script><script type="module" src="init.mjs" nonce="${nonce}" async=""></script>"`,
     );
   });
+
+  it('should remove AbortSignal listener when rendering completes to prevent memory leak', async () => {
+    const controller = new AbortController();
+    const {signal} = controller;
+
+    // Track calls to removeEventListener for 'abort' events
+    let removeListenerCallCount = 0;
+    const originalRemoveEventListener = signal.removeEventListener.bind(signal);
+    signal.removeEventListener = (type, listener, ...args) => {
+      if (type === 'abort') {
+        removeListenerCallCount++;
+      }
+      return originalRemoveEventListener(type, listener, ...args);
+    };
+
+    const stream = await serverAct(() =>
+      ReactDOMFizzServer.renderToReadableStream(<div>hello world</div>, {
+        signal,
+      }),
+    );
+
+    await serverAct(() => stream.allReady);
+
+    // The listener should have been removed when rendering completed (onAllReady)
+    expect(removeListenerCallCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should remove AbortSignal listener on fatal error to prevent memory leak', async () => {
+    const controller = new AbortController();
+    const {signal} = controller;
+
+    // Track calls to removeEventListener for 'abort' events
+    let removeListenerCallCount = 0;
+    const originalRemoveEventListener = signal.removeEventListener.bind(signal);
+    signal.removeEventListener = (type, listener, ...args) => {
+      if (type === 'abort') {
+        removeListenerCallCount++;
+      }
+      return originalRemoveEventListener(type, listener, ...args);
+    };
+
+    let caughtError = null;
+    try {
+      await serverAct(() =>
+        ReactDOMFizzServer.renderToReadableStream(
+          <div>
+            <Throw />
+          </div>,
+          {
+            signal,
+            onError() {},
+          },
+        ),
+      );
+    } catch (e) {
+      caughtError = e;
+    }
+
+    expect(caughtError).toBe(theError);
+    // The listener should have been removed when the fatal error occurred
+    expect(removeListenerCallCount).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -621,4 +621,46 @@ describe('ReactDOMFizzServerBrowser', () => {
     // The listener should have been removed when the fatal error occurred
     expect(removeListenerCallCount).toBeGreaterThanOrEqual(1);
   });
+
+  it('should not accumulate AbortSignal listeners across multiple renders sharing the same signal', async () => {
+    const controller = new AbortController();
+    const {signal} = controller;
+
+    // Track the net listener count (addEventListener +1, removeEventListener -1)
+    let netListenerCount = 0;
+    const originalAddEventListener = signal.addEventListener.bind(signal);
+    const originalRemoveEventListener = signal.removeEventListener.bind(signal);
+    signal.addEventListener = (type, listener, ...args) => {
+      if (type === 'abort') {
+        netListenerCount++;
+      }
+      return originalAddEventListener(type, listener, ...args);
+    };
+    signal.removeEventListener = (type, listener, ...args) => {
+      if (type === 'abort') {
+        netListenerCount--;
+      }
+      return originalRemoveEventListener(type, listener, ...args);
+    };
+
+    // First render with the shared signal
+    const stream1 = await serverAct(() =>
+      ReactDOMFizzServer.renderToReadableStream(<div>render one</div>, {
+        signal,
+      }),
+    );
+    await serverAct(() => stream1.allReady);
+    // After first render completes, the listener should have been removed
+    expect(netListenerCount).toBe(0);
+
+    // Second render with the same signal
+    const stream2 = await serverAct(() =>
+      ReactDOMFizzServer.renderToReadableStream(<div>render two</div>, {
+        signal,
+      }),
+    );
+    await serverAct(() => stream2.allReady);
+    // After second render completes, still no lingering listeners
+    expect(netListenerCount).toBe(0);
+  });
 });

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -79,9 +79,16 @@ function renderToReadableStream(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    let cleanupSignalListener = () => {};
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupSignalListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupSignalListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -109,6 +116,7 @@ function renderToReadableStream(
       // However, `allReady` will be rejected by `onFatalError` as well.
       // So we need to catch the duplicate, uncatchable fatal error in `allReady` to prevent a `UnhandledPromiseRejection`.
       allReady.catch(() => {});
+      cleanupSignalListener();
       reject(error);
     }
 
@@ -157,6 +165,9 @@ function renderToReadableStream(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);
@@ -171,9 +182,16 @@ function resume(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    let cleanupSignalListener = () => {};
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupSignalListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupSignalListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -201,6 +219,7 @@ function resume(
       // However, `allReady` will be rejected by `onFatalError` as well.
       // So we need to catch the duplicate, uncatchable fatal error in `allReady` to prevent a `UnhandledPromiseRejection`.
       allReady.catch(() => {});
+      cleanupSignalListener();
       reject(error);
     }
     const request = resumeRequest(
@@ -226,6 +245,9 @@ function resume(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);

--- a/packages/react-dom/src/server/ReactDOMFizzServerBun.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBun.js
@@ -68,9 +68,16 @@ function renderToReadableStream(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    let cleanupSignalListener = () => {};
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupSignalListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupSignalListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -99,6 +106,7 @@ function renderToReadableStream(
       // However, `allReady` will be rejected by `onFatalError` as well.
       // So we need to catch the duplicate, uncatchable fatal error in `allReady` to prevent a `UnhandledPromiseRejection`.
       allReady.catch(() => {});
+      cleanupSignalListener();
       reject(error);
     }
 
@@ -147,6 +155,9 @@ function renderToReadableStream(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);

--- a/packages/react-dom/src/server/ReactDOMFizzServerEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerEdge.js
@@ -79,9 +79,16 @@ function renderToReadableStream(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    let cleanupSignalListener = () => {};
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupSignalListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupSignalListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -109,6 +116,7 @@ function renderToReadableStream(
       // However, `allReady` will be rejected by `onFatalError` as well.
       // So we need to catch the duplicate, uncatchable fatal error in `allReady` to prevent a `UnhandledPromiseRejection`.
       allReady.catch(() => {});
+      cleanupSignalListener();
       reject(error);
     }
 
@@ -157,6 +165,9 @@ function renderToReadableStream(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);
@@ -171,9 +182,16 @@ function resume(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    let cleanupSignalListener = () => {};
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupSignalListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupSignalListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -201,6 +219,7 @@ function resume(
       // However, `allReady` will be rejected by `onFatalError` as well.
       // So we need to catch the duplicate, uncatchable fatal error in `allReady` to prevent a `UnhandledPromiseRejection`.
       allReady.catch(() => {});
+      cleanupSignalListener();
       reject(error);
     }
     const request = resumeRequest(
@@ -226,6 +245,9 @@ function resume(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -211,9 +211,16 @@ function renderToReadableStream(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    let cleanupSignalListener = () => {};
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupSignalListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupSignalListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -246,6 +253,7 @@ function renderToReadableStream(
       // However, `allReady` will be rejected by `onFatalError` as well.
       // So we need to catch the duplicate, uncatchable fatal error in `allReady` to prevent a `UnhandledPromiseRejection`.
       allReady.catch(() => {});
+      cleanupSignalListener();
       reject(error);
     }
 
@@ -294,6 +302,9 @@ function renderToReadableStream(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);
@@ -370,9 +381,16 @@ function resume(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    let cleanupSignalListener = () => {};
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupSignalListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupSignalListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -405,6 +423,7 @@ function resume(
       // However, `allReady` will be rejected by `onFatalError` as well.
       // So we need to catch the duplicate, uncatchable fatal error in `allReady` to prevent a `UnhandledPromiseRejection`.
       allReady.catch(() => {});
+      cleanupSignalListener();
       reject(error);
     }
     const request = resumeRequest(
@@ -430,6 +449,9 @@ function resume(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);

--- a/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
@@ -69,7 +69,11 @@ function prerender(
   options?: Options,
 ): Promise<StaticResult> {
   return new Promise((resolve, reject) => {
-    const onFatalError = reject;
+    let cleanupSignalListener = () => {};
+    const onFatalError = (error: mixed) => {
+      cleanupSignalListener();
+      reject(error);
+    };
 
     function onAllReady() {
       const stream = new ReadableStream(
@@ -92,6 +96,7 @@ function prerender(
         postponed: getPostponedState(request),
         prelude: stream,
       };
+      cleanupSignalListener();
       resolve(result);
     }
 
@@ -139,6 +144,9 @@ function prerender(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);
@@ -158,7 +166,11 @@ function resumeAndPrerender(
   options?: Omit<ResumeOptions, 'nonce'>,
 ): Promise<StaticResult> {
   return new Promise((resolve, reject) => {
-    const onFatalError = reject;
+    let cleanupSignalListener = () => {};
+    const onFatalError = (error: mixed) => {
+      cleanupSignalListener();
+      reject(error);
+    };
 
     function onAllReady() {
       const stream = new ReadableStream(
@@ -181,6 +193,7 @@ function resumeAndPrerender(
         postponed: getPostponedState(request),
         prelude: stream,
       };
+      cleanupSignalListener();
       resolve(result);
     }
 
@@ -204,6 +217,9 @@ function resumeAndPrerender(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);

--- a/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
@@ -69,7 +69,11 @@ function prerender(
   options?: Options,
 ): Promise<StaticResult> {
   return new Promise((resolve, reject) => {
-    const onFatalError = reject;
+    let cleanupSignalListener = () => {};
+    const onFatalError = (error: mixed) => {
+      cleanupSignalListener();
+      reject(error);
+    };
 
     function onAllReady() {
       const stream = new ReadableStream(
@@ -92,6 +96,7 @@ function prerender(
         postponed: getPostponedState(request),
         prelude: stream,
       };
+      cleanupSignalListener();
       resolve(result);
     }
 
@@ -138,6 +143,9 @@ function prerender(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);
@@ -156,7 +164,11 @@ function resumeAndPrerender(
   options?: Omit<ResumeOptions, 'nonce'>,
 ): Promise<StaticResult> {
   return new Promise((resolve, reject) => {
-    const onFatalError = reject;
+    let cleanupSignalListener = () => {};
+    const onFatalError = (error: mixed) => {
+      cleanupSignalListener();
+      reject(error);
+    };
 
     function onAllReady() {
       const stream = new ReadableStream(
@@ -179,6 +191,7 @@ function resumeAndPrerender(
         postponed: getPostponedState(request),
         prelude: stream,
       };
+      cleanupSignalListener();
       resolve(result);
     }
 
@@ -202,6 +215,9 @@ function resumeAndPrerender(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);

--- a/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
@@ -118,7 +118,11 @@ function prerenderToNodeStream(
   options?: Options,
 ): Promise<StaticResult> {
   return new Promise((resolve, reject) => {
-    const onFatalError = reject;
+    let cleanupSignalListener = () => {};
+    const onFatalError = (error: mixed) => {
+      cleanupSignalListener();
+      reject(error);
+    };
 
     function onAllReady() {
       const readable: Readable = new Readable({
@@ -132,6 +136,7 @@ function prerenderToNodeStream(
         postponed: getPostponedState(request),
         prelude: readable,
       };
+      cleanupSignalListener();
       resolve(result);
     }
     const resumableState = createResumableState(
@@ -170,6 +175,9 @@ function prerenderToNodeStream(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);
@@ -186,7 +194,11 @@ function prerender(
   prelude: ReadableStream,
 }> {
   return new Promise((resolve, reject) => {
-    const onFatalError = reject;
+    let cleanupSignalListener = () => {};
+    const onFatalError = (error: mixed) => {
+      cleanupSignalListener();
+      reject(error);
+    };
 
     function onAllReady() {
       let writable: Writable;
@@ -214,6 +226,7 @@ function prerender(
         postponed: getPostponedState(request),
         prelude: stream,
       };
+      cleanupSignalListener();
       resolve(result);
     }
 
@@ -260,6 +273,9 @@ function prerender(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);
@@ -278,7 +294,11 @@ function resumeAndPrerenderToNodeStream(
   options?: Omit<ResumeOptions, 'nonce'>,
 ): Promise<StaticResult> {
   return new Promise((resolve, reject) => {
-    const onFatalError = reject;
+    let cleanupSignalListener = () => {};
+    const onFatalError = (error: mixed) => {
+      cleanupSignalListener();
+      reject(error);
+    };
 
     function onAllReady() {
       const readable: Readable = new Readable({
@@ -292,6 +312,7 @@ function resumeAndPrerenderToNodeStream(
         postponed: getPostponedState(request),
         prelude: readable,
       };
+      cleanupSignalListener();
       resolve(result);
     }
     const request = resumeAndPrerenderRequest(
@@ -314,6 +335,9 @@ function resumeAndPrerenderToNodeStream(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);
@@ -329,7 +353,11 @@ function resumeAndPrerender(
   prelude: ReadableStream,
 }> {
   return new Promise((resolve, reject) => {
-    const onFatalError = reject;
+    let cleanupSignalListener = () => {};
+    const onFatalError = (error: mixed) => {
+      cleanupSignalListener();
+      reject(error);
+    };
 
     function onAllReady() {
       let writable: Writable;
@@ -357,6 +385,7 @@ function resumeAndPrerender(
         postponed: getPostponedState(request),
         prelude: stream,
       };
+      cleanupSignalListener();
       resolve(result);
     }
 
@@ -380,6 +409,9 @@ function resumeAndPrerender(
           signal.removeEventListener('abort', listener);
         };
         signal.addEventListener('abort', listener);
+        cleanupSignalListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);


### PR DESCRIPTION
## Summary

Fixes #36763

When an  is passed to  (or , , etc.) in the Fizz server, an `abort` event listener is registered on the signal. This listener correctly removes itself when the abort fires, but it was never removed when rendering **completed normally** (via `onAllReady`) or **failed fatally** (via `onFatalError` / `onShellError`).

This caused a memory leak: as long as the `AbortSignal` was alive, it held a reference to the listener closure, which in turn held a reference to the entire Fizz `request` object (which holds the entire server render state).

**Fix:** Introduce a `cleanupSignalListener` callback scoped to each render function. The callback is assigned to call `signal.removeEventListener` after the listener is registered, and is invoked from all terminal states:
- `onAllReady` — rendering completed successfully
- `onFatalError` — fatal render error (also covers `onShellError` which triggers `onFatalError`)
- `onShellError` — shell render failed (defensive, since `onFatalError` is also called)

**Files affected:**
- `ReactDOMFizzServerBrowser.js` (`renderToReadableStream`, `resume`)
- `ReactDOMFizzServerEdge.js` (`renderToReadableStream`, `resume`)
- `ReactDOMFizzServerBun.js` (`renderToReadableStream`)
- `ReactDOMFizzServerNode.js` (`renderToReadableStream`, `resume`)
- `ReactDOMFizzStaticBrowser.js` (`prerender`, `resumeAndPrerender`)
- `ReactDOMFizzStaticEdge.js` (`prerender`, `resumeAndPrerender`)
- `ReactDOMFizzStaticNode.js` (`prerenderToNodeStream`, `prerender`, `resumeAndPrerenderToNodeStream`, `resumeAndPrerender`)

## How did you test this change?

Added two new tests to `ReactDOMFizzServerBrowser-test.js` that verify the `abort` event listener is removed:
1. When rendering completes successfully (`stream.allReady` resolves)
2. When rendering fails with a fatal error

Both tests track `removeEventListener` calls on the signal and assert at least one cleanup call occurs.

All existing tests pass:
```
PASS packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js (5.128 s)
  ReactDOMFizzServerBrowser
    ✓ should remove AbortSignal listener when rendering completes to prevent memory leak (35 ms)
    ✓ should remove AbortSignal listener on fatal error to prevent memory leak (30 ms)
    ... (all 19 tests pass)
```