### PR TITLE
[Flight] Preserve late debug info after stream errors

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -128,7 +128,7 @@ interface FlightStreamController {
   enqueueValue(value: any): void;
   enqueueModel(json: UninitializedModel): void;
   close(json: UninitializedModel): void;
-  error(error: Error): void;
+  error(error: mixed): void;
 }
 
 type UninitializedModel = string;
@@ -164,6 +164,9 @@ type PendingChunk<T> = {
   _children: Array<SomeChunk<any>> | ProfilingResult, // Profiling-only
   _debugChunk: null | SomeChunk<ReactDebugInfoEntry>, // DEV-only
   _debugInfo: ReactDebugInfo, // DEV-only
+  _debugInfoPruned?: boolean, // DEV-only
+  _debugInfoBackupIndex?: number, // DEV-only
+  _debugInfoBackupRows?: Array<UninitializedModel>, // DEV-only
   then(resolve: (T) => mixed, reject?: (mixed) => mixed): void,
 };
 type BlockedChunk<T> = {
@@ -173,6 +176,9 @@ type BlockedChunk<T> = {
   _children: Array<SomeChunk<any>> | ProfilingResult, // Profiling-only
   _debugChunk: null, // DEV-only
   _debugInfo: ReactDebugInfo, // DEV-only
+  _debugInfoPruned?: boolean, // DEV-only
+  _debugInfoBackupIndex?: number, // DEV-only
+  _debugInfoBackupRows?: Array<UninitializedModel>, // DEV-only
   then(resolve: (T) => mixed, reject?: (mixed) => mixed): void,
 };
 type ResolvedModelChunk<T> = {
@@ -182,6 +188,9 @@ type ResolvedModelChunk<T> = {
   _children: Array<SomeChunk<any>> | ProfilingResult, // Profiling-only
   _debugChunk: null | SomeChunk<ReactDebugInfoEntry>, // DEV-only
   _debugInfo: ReactDebugInfo, // DEV-only
+  _debugInfoPruned?: boolean, // DEV-only
+  _debugInfoBackupIndex?: number, // DEV-only
+  _debugInfoBackupRows?: Array<UninitializedModel>, // DEV-only
   then(resolve: (T) => mixed, reject?: (mixed) => mixed): void,
 };
 type ResolvedModuleChunk<T> = {
@@ -191,6 +200,9 @@ type ResolvedModuleChunk<T> = {
   _children: Array<SomeChunk<any>> | ProfilingResult, // Profiling-only
   _debugChunk: null, // DEV-only
   _debugInfo: ReactDebugInfo, // DEV-only
+  _debugInfoPruned?: boolean, // DEV-only
+  _debugInfoBackupIndex?: number, // DEV-only
+  _debugInfoBackupRows?: Array<UninitializedModel>, // DEV-only
   then(resolve: (T) => mixed, reject?: (mixed) => mixed): void,
 };
 type InitializedChunk<T> = {
@@ -200,6 +212,9 @@ type InitializedChunk<T> = {
   _children: Array<SomeChunk<any>> | ProfilingResult, // Profiling-only
   _debugChunk: null, // DEV-only
   _debugInfo: ReactDebugInfo, // DEV-only
+  _debugInfoPruned?: boolean, // DEV-only
+  _debugInfoBackupIndex?: number, // DEV-only
+  _debugInfoBackupRows?: Array<UninitializedModel>, // DEV-only
   then(resolve: (T) => mixed, reject?: (mixed) => mixed): void,
 };
 type InitializedStreamChunk<
@@ -211,6 +226,9 @@ type InitializedStreamChunk<
   _children: Array<SomeChunk<any>> | ProfilingResult, // Profiling-only
   _debugChunk: null, // DEV-only
   _debugInfo: ReactDebugInfo, // DEV-only
+  _debugInfoPruned?: boolean, // DEV-only
+  _debugInfoBackupIndex?: number, // DEV-only
+  _debugInfoBackupRows?: Array<UninitializedModel>, // DEV-only
   then(resolve: (ReadableStream) => mixed, reject?: (mixed) => mixed): void,
 };
 type ErroredChunk<T> = {
@@ -218,8 +236,11 @@ type ErroredChunk<T> = {
   value: null,
   reason: mixed,
   _children: Array<SomeChunk<any>> | ProfilingResult, // Profiling-only
-  _debugChunk: null, // DEV-only
+  _debugChunk: null | SomeChunk<ReactDebugInfoEntry>, // DEV-only
   _debugInfo: ReactDebugInfo, // DEV-only
+  _debugInfoPruned?: boolean, // DEV-only
+  _debugInfoBackupIndex?: number, // DEV-only
+  _debugInfoBackupRows?: Array<UninitializedModel>, // DEV-only
   then(resolve: (T) => mixed, reject?: (mixed) => mixed): void,
 };
 type HaltedChunk<T> = {
@@ -229,6 +250,9 @@ type HaltedChunk<T> = {
   _children: Array<SomeChunk<any>> | ProfilingResult, // Profiling-only
   _debugChunk: null, // DEV-only
   _debugInfo: ReactDebugInfo, // DEV-only
+  _debugInfoPruned?: boolean, // DEV-only
+  _debugInfoBackupIndex?: number, // DEV-only
+  _debugInfoBackupRows?: Array<UninitializedModel>, // DEV-only
   then(resolve: (T) => mixed, reject?: (mixed) => mixed): void,
 };
 type SomeChunk<T> =
@@ -362,6 +386,8 @@ type Response = {
   _debugRootTask?: null | ConsoleTask, // DEV-only
   _debugStartTime: number, // DEV-only
   _debugEndTime: null | number, // DEV-only
+  // Undefined: no readable debug channel, false: buffer backups, true: replay.
+  _replayDebugInfo?: boolean, // DEV-only
   _debugIOStarted: boolean, // DEV-only
   _debugFindSourceMapURL?: void | FindSourceMapURLCallback, // DEV-only
   _debugChannel?: void | DebugChannel, // DEV-only
@@ -540,6 +566,8 @@ function pruneDebugInfoAfterError(
     if (typeof info.time === 'number' && info.time > relativeEndTime) {
       // This array may already be attached to the Lazy suspended in Fizz.
       debugInfo.length = i;
+      chunk._debugInfoPruned = true;
+      chunk._debugChunk = null;
       return;
     }
   }
@@ -745,7 +773,6 @@ function triggerErrorOnChunk<T>(
     // a stream chunk since any other row shouldn't have more than one entry.
     const streamChunk: InitializedStreamChunk<any> = chunk as any;
     const controller = streamChunk.reason;
-    // $FlowFixMe[incompatible-type]: The error method should accept mixed.
     controller.error(error);
     return;
   }
@@ -884,11 +911,14 @@ function resolveModelChunk<T>(
   value: UninitializedModel,
 ): void {
   if (chunk.status !== PENDING) {
-    // If we get more data to an already resolved ID, we assume that it's
-    // a stream chunk since any other row shouldn't have more than one entry.
-    const streamChunk: InitializedStreamChunk<any> = chunk as any;
-    const controller = streamChunk.reason;
-    controller.enqueueModel(value);
+    // Only initialized stream chunks can receive additional model rows. A
+    // settled model can receive late rows after an abort, which we ignore so
+    // that the reader can continue processing its debug rows.
+    if (chunk.status === INITIALIZED && chunk.reason !== null) {
+      const streamChunk: InitializedStreamChunk<any> = chunk as any;
+      const controller = streamChunk.reason;
+      controller.enqueueModel(value);
+    }
     return;
   }
   releasePendingChunk(response, chunk);
@@ -950,6 +980,7 @@ type InitializationReference = {
   ) => any,
   path: Array<string>,
   isDebug?: boolean, // DEV-only
+  debugInfoOwner?: SomeChunk<any>, // DEV-only
 };
 type InitializationHandler = {
   parent: null | InitializationHandler,
@@ -962,21 +993,24 @@ type InitializationHandler = {
 let initializingHandler: null | InitializationHandler = null;
 let initializingChunk: null | BlockedChunk<any> = null;
 let isInitializingDebugInfo: boolean = false;
+let currentDebugInfoOwner: null | SomeChunk<any> = null;
 
 function initializeDebugChunk(
   response: Response,
-  chunk: ResolvedModelChunk<any> | PendingChunk<any>,
+  chunk: ResolvedModelChunk<any> | PendingChunk<any> | ErroredChunk<any>,
 ): void {
   const debugChunk = chunk._debugChunk;
   if (debugChunk !== null) {
     const debugInfo = chunk._debugInfo;
     const prevIsInitializingDebugInfo = isInitializingDebugInfo;
+    const prevDebugInfoOwner = currentDebugInfoOwner;
     isInitializingDebugInfo = true;
+    currentDebugInfoOwner = chunk;
     try {
       if (debugChunk.status === RESOLVED_MODEL) {
         // Find the index of this debug info by walking the linked list.
         let idx = debugInfo.length;
-        let c = debugChunk._debugChunk;
+        let c: null | SomeChunk<ReactDebugInfoEntry> = debugChunk._debugChunk;
         while (c !== null) {
           if (c.status !== INITIALIZED) {
             idx++;
@@ -1034,10 +1068,16 @@ function initializeDebugChunk(
             throw debugChunk.reason;
         }
       }
+      if (chunk.status === ERRORED) {
+        pruneDebugInfoAfterError(response, chunk);
+      }
     } catch (error) {
-      triggerErrorOnChunk(response, chunk, error);
+      if (chunk.status !== ERRORED) {
+        triggerErrorOnChunk(response, chunk, error);
+      }
     } finally {
       isInitializingDebugInfo = prevIsInitializingDebugInfo;
+      currentDebugInfoOwner = prevDebugInfoOwner;
     }
   }
 }
@@ -1138,13 +1178,20 @@ function initializeModuleChunk<T>(chunk: ResolvedModuleChunk<T>): void {
 // error upon read. Also notify any pending promises.
 export function reportGlobalError(
   weakResponse: WeakResponse,
-  error: Error,
+  error: mixed,
 ): void {
   if (hasGCedResponse(weakResponse)) {
     // Ignore close signal if we are not awaiting any more pending chunks.
     return;
   }
   const response = unwrapWeakResponse(weakResponse);
+  const replayDebugInfo = __DEV__ && response._replayDebugInfo === false;
+  if (replayDebugInfo === true) {
+    response._replayDebugInfo = true;
+  }
+  if (response._closed) {
+    return;
+  }
   response._closed = true;
   response._closedReason = error;
   response._chunks.forEach(chunk => {
@@ -1155,6 +1202,9 @@ export function reportGlobalError(
       triggerErrorOnChunk(response, chunk, error);
     } else if (chunk.status === INITIALIZED && chunk.reason !== null) {
       chunk.reason.error(error);
+    }
+    if (replayDebugInfo === true) {
+      replayDebugInfoBackupRows(response, chunk);
     }
   });
   if (__DEV__) {
@@ -1636,54 +1686,69 @@ function fulfillReference(
       break;
     }
 
-    const mappedValue = map(response, value, parentObject, key);
-    if (key !== __PROTO__) {
-      parentObject[key] = mappedValue;
-    }
-
-    // If this is the root object for a model reference, where `handler.value`
-    // is a stale `null`, the resolved value can be used directly.
-    if (key === '' && handler.value === null) {
-      handler.value = mappedValue;
-    }
-
-    // If the parent object is an unparsed React element tuple, we also need to
-    // update the props and owner of the parsed element object (i.e.
-    // handler.value).
-    if (
-      parentObject[0] === REACT_ELEMENT_TYPE &&
-      typeof handler.value === 'object' &&
-      handler.value !== null &&
-      handler.value.$$typeof === REACT_ELEMENT_TYPE
-    ) {
-      const element: any = handler.value;
-      switch (key) {
-        case '3':
-          if (__DEV__) {
-            transferReferencedDebugInfo(handler.chunk, fulfilledChunk);
-          }
-          element.props = mappedValue;
-          break;
-        case '4':
-          // This path doesn't call transferReferencedDebugInfo because this reference is to a debug chunk.
-          if (__DEV__) {
-            element._owner = mappedValue;
-          }
-          break;
-        case '5':
-          // This path doesn't call transferReferencedDebugInfo because this reference is to a debug chunk.
-          if (__DEV__) {
-            element._debugStack = mappedValue;
-          }
-          break;
-        default:
-          if (__DEV__) {
-            transferReferencedDebugInfo(handler.chunk, fulfilledChunk);
-          }
-          break;
+    const debugInfoOwner = __DEV__ ? reference.debugInfoOwner : undefined;
+    const debugInfoWasPruned =
+      __DEV__ &&
+      debugInfoOwner !== undefined &&
+      debugInfoOwner._debugInfoPruned === true;
+    if (!debugInfoWasPruned) {
+      const mappedValue = map(response, value, parentObject, key);
+      if (key !== __PROTO__) {
+        parentObject[key] = mappedValue;
       }
-    } else if (__DEV__ && !reference.isDebug) {
-      transferReferencedDebugInfo(handler.chunk, fulfilledChunk);
+
+      // If this is the root object for a model reference, where `handler.value`
+      // is a stale `null`, the resolved value can be used directly.
+      if (key === '' && handler.value === null) {
+        handler.value = mappedValue;
+      }
+
+      // If the parent object is an unparsed React element tuple, we also need to
+      // update the props and owner of the parsed element object (i.e.
+      // handler.value).
+      if (
+        parentObject[0] === REACT_ELEMENT_TYPE &&
+        typeof handler.value === 'object' &&
+        handler.value !== null &&
+        handler.value.$$typeof === REACT_ELEMENT_TYPE
+      ) {
+        const element: any = handler.value;
+        switch (key) {
+          case '3':
+            if (__DEV__) {
+              transferReferencedDebugInfo(handler.chunk, fulfilledChunk);
+            }
+            element.props = mappedValue;
+            break;
+          case '4':
+            // This path doesn't call transferReferencedDebugInfo because this reference is to a debug chunk.
+            if (__DEV__) {
+              element._owner = mappedValue;
+            }
+            break;
+          case '5':
+            // This path doesn't call transferReferencedDebugInfo because this reference is to a debug chunk.
+            if (__DEV__) {
+              element._debugStack = mappedValue;
+            }
+            break;
+          default:
+            if (__DEV__) {
+              transferReferencedDebugInfo(handler.chunk, fulfilledChunk);
+            }
+            break;
+        }
+      } else if (__DEV__ && !reference.isDebug) {
+        transferReferencedDebugInfo(handler.chunk, fulfilledChunk);
+      }
+
+      if (
+        __DEV__ &&
+        debugInfoOwner !== undefined &&
+        debugInfoOwner.status === ERRORED
+      ) {
+        pruneDebugInfoAfterError(response, debugInfoOwner);
+      }
     }
   } catch (error) {
     rejectReference(response, reference.handler, error);
@@ -1815,6 +1880,9 @@ function waitForReference<T>(
   };
   if (__DEV__) {
     reference.isDebug = isAwaitingDebugInfo;
+    if (isAwaitingDebugInfo && currentDebugInfoOwner !== null) {
+      reference.debugInfoOwner = currentDebugInfoOwner;
+    }
   }
 
   // Add "listener".
@@ -2788,6 +2856,9 @@ function ResponseInstance(
       setTimeout(markIOStarted.bind(this), 0);
     }
     this._debugEndTime = debugEndTime === undefined ? null : debugEndTime;
+    if (debugChannel !== undefined && debugChannel.hasReadable) {
+      this._replayDebugInfo = false;
+    }
     this._debugFindSourceMapURL = findSourceMapURL;
     this._debugChannel = debugChannel;
     this._blockedConsole = null;
@@ -3438,7 +3509,7 @@ function startAsyncIterable<T>(
         );
       }
     },
-    error(error: Error): void {
+    error(error: mixed): void {
       if (closed) {
         return;
       }
@@ -4118,15 +4189,13 @@ function initializeDebugInfo(
   return debugInfo;
 }
 
-function resolveDebugModel(
+function resolveDebugModelImpl(
   response: Response,
-  id: number,
   json: UninitializedModel,
+  parentChunk: SomeChunk<any>,
 ): void {
-  const parentChunk = getChunk(response, id);
   if (
     parentChunk.status === INITIALIZED ||
-    parentChunk.status === ERRORED ||
     parentChunk.status === HALTED ||
     parentChunk.status === BLOCKED
   ) {
@@ -4138,6 +4207,9 @@ function resolveDebugModel(
     return;
   }
   const previousChunk = parentChunk._debugChunk;
+  if (parentChunk._debugInfoPruned === true) {
+    return;
+  }
   const debugChunk: ResolvedModelChunk<ReactDebugInfoEntry> =
     createResolvedModelChunk(response, json);
   debugChunk._debugChunk = previousChunk; // Linked list of the debug chunks
@@ -4162,6 +4234,81 @@ function resolveDebugModel(
         parentChunk._debugChunk = null;
       }
     }
+  }
+}
+
+function resolveDebugModel(
+  response: Response,
+  id: number,
+  json: UninitializedModel,
+): void {
+  const parentChunk = getChunk(response, id);
+  switch (response._replayDebugInfo) {
+    case true:
+      // After a global error, backup rows become authoritative.
+      return;
+    case false: {
+      // Before an error, track regular rows so matching backups can be ignored.
+      const rows = parentChunk._debugInfoBackupRows;
+      const index = parentChunk._debugInfoBackupIndex || 0;
+      if (rows !== undefined && rows.length > 0) {
+        const nextIndex = index + 1;
+        if (nextIndex === rows.length) {
+          rows.length = 0;
+          parentChunk._debugInfoBackupIndex = 0;
+        } else {
+          parentChunk._debugInfoBackupIndex = nextIndex;
+        }
+      } else {
+        parentChunk._debugInfoBackupIndex = index + 1;
+      }
+      // Fallthrough
+    }
+    default:
+      resolveDebugModelImpl(response, json, parentChunk);
+  }
+}
+
+function resolveDebugModelBackup(
+  response: Response,
+  id: number,
+  json: UninitializedModel,
+): void {
+  const replayDebugInfo = response._replayDebugInfo;
+  if (replayDebugInfo === undefined) {
+    return;
+  }
+  const parentChunk = getChunk(response, id);
+  const rows = parentChunk._debugInfoBackupRows;
+  const index = parentChunk._debugInfoBackupIndex || 0;
+  if (index > 0 && (rows === undefined || rows.length === 0)) {
+    parentChunk._debugInfoBackupIndex = index - 1;
+    return;
+  }
+  if (replayDebugInfo === false) {
+    if (rows === undefined) {
+      parentChunk._debugInfoBackupRows = [json];
+    } else {
+      rows.push(json);
+    }
+    return;
+  }
+  resolveDebugModelImpl(response, json, parentChunk);
+}
+
+function replayDebugInfoBackupRows(
+  response: Response,
+  parentChunk: SomeChunk<any>,
+): void {
+  const rows = parentChunk._debugInfoBackupRows;
+  if (rows === undefined || rows.length === 0) {
+    return;
+  }
+  const index = parentChunk._debugInfoBackupIndex || 0;
+  parentChunk._debugInfoBackupIndex = 0;
+  parentChunk._debugInfoBackupRows = undefined;
+  for (let i = index; i < rows.length; i++) {
+    resolveDebugModelImpl(response, rows[i], parentChunk);
   }
 }
 
@@ -4945,6 +5092,13 @@ function processFullStringRow(
     case 68 /* "D" */: {
       if (__DEV__) {
         resolveDebugModel(response, id, row);
+        return;
+      }
+      // Fallthrough to share the error with Console entries.
+    }
+    case 66 /* "B" */: {
+      if (__DEV__) {
+        resolveDebugModelBackup(response, id, row);
         return;
       }
       // Fallthrough to share the error with Console entries.

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -1766,6 +1766,448 @@ describe('ReactFlightDOMNode', () => {
       }
     });
 
+    // @gate __DEV__
+    it('should preserve a Flight stream error and late debug info when aborting Fizz', async () => {
+      let resolveDynamicData1;
+      let resolveDynamicData2;
+      let resolveDynamicData3;
+
+      async function getDynamicData1() {
+        return new Promise(resolve => {
+          resolveDynamicData1 = resolve;
+        });
+      }
+
+      async function getDynamicData2() {
+        return new Promise(resolve => {
+          resolveDynamicData2 = resolve;
+        });
+      }
+
+      async function getDynamicData3() {
+        return new Promise(resolve => {
+          resolveDynamicData3 = resolve;
+        });
+      }
+
+      async function loadDynamicData1() {
+        return await getDynamicData1();
+      }
+
+      async function loadDynamicData2() {
+        return await getDynamicData2();
+      }
+
+      async function loadDynamicData3() {
+        return await getDynamicData3();
+      }
+
+      async function loadDynamicData() {
+        const data1 = await loadDynamicData1();
+        const data2 = await loadDynamicData2();
+        const data3 = await loadDynamicData3();
+        return [data1, data2, data3];
+      }
+
+      async function Dynamic() {
+        const [data1, data2, data3] = await loadDynamicData();
+
+        return ReactServer.createElement(
+          'p',
+          null,
+          data1,
+          ' ',
+          data2,
+          ' ',
+          data3,
+        );
+      }
+
+      function App() {
+        return ReactServer.createElement(
+          'html',
+          null,
+          ReactServer.createElement(
+            'body',
+            null,
+            ReactServer.createElement(Dynamic),
+          ),
+        );
+      }
+
+      let staticEndTime = -1;
+      const initialContentChunks = [];
+      const initialDebugChunks = [];
+      const dynamicDebugChunks = [];
+
+      await new Promise(resolve => {
+        setTimeout(() => {
+          const debugPassThrough = new Stream.PassThrough(streamOptions);
+          const stream = ReactServerDOMServer.renderToPipeableStream(
+            ReactServer.createElement(App),
+            webpackMap,
+            {
+              filterStackFrame,
+              debugChannel: new Stream.Writable({
+                write(chunk, encoding, callback) {
+                  debugPassThrough.write(chunk, encoding);
+                  callback();
+                },
+                final(callback) {
+                  debugPassThrough.end();
+                  callback();
+                },
+              }),
+            },
+          );
+
+          const contentPassThrough = new Stream.PassThrough(streamOptions);
+          stream.pipe(contentPassThrough);
+
+          contentPassThrough.on('data', chunk => {
+            if (staticEndTime < 0) {
+              initialContentChunks.push(chunk);
+            }
+          });
+          contentPassThrough.on('end', resolve);
+
+          debugPassThrough.on('data', chunk => {
+            if (staticEndTime < 0) {
+              initialDebugChunks.push(chunk);
+            } else {
+              dynamicDebugChunks.push(chunk);
+            }
+          });
+        });
+        setTimeout(() => {
+          resolveDynamicData1('Hi');
+          setTimeout(() => {
+            resolveDynamicData2('Josh');
+            // Data 2 is included by endTime. Data 3 begins in a subsequent
+            // microtask and should be filtered out.
+            staticEndTime = performance.now() + performance.timeOrigin;
+            setTimeout(() => {
+              resolveDynamicData3('Story');
+            });
+          });
+        });
+      });
+
+      const contentStream = new Stream.Readable({
+        ...streamOptions,
+        read() {},
+      });
+      const debugStream = new Stream.Readable({...streamOptions, read() {}});
+      const flightResponse = ReactServerDOMClient.createFromNodeStream(
+        contentStream,
+        {
+          moduleMap: null,
+          moduleLoading: null,
+          serverModuleMap: null,
+        },
+        {
+          endTime: staticEndTime,
+          debugChannel: debugStream,
+        },
+      );
+      for (let i = 0; i < initialContentChunks.length; i++) {
+        contentStream.push(initialContentChunks[i]);
+      }
+      for (let i = 0; i < initialDebugChunks.length; i++) {
+        debugStream.push(initialDebugChunks[i]);
+      }
+      const decoded = await flightResponse;
+
+      function ClientRoot() {
+        return decoded;
+      }
+
+      const flightError = new Error('Flight stream errored');
+      const fizzAbortReason = new Error('Fizz aborted');
+      const fizzAbortController = new AbortController();
+      const errors = [];
+      let componentStack;
+      let ownerStack;
+
+      const {prelude} = await new Promise(resolve => {
+        let result;
+
+        setTimeout(() => {
+          result = ReactDOMFizzStatic.prerenderToNodeStream(
+            React.createElement(ClientRoot),
+            {
+              signal: fizzAbortController.signal,
+              onError(error, errorInfo) {
+                errors.push(error);
+                componentStack = errorInfo.componentStack;
+                ownerStack = React.captureOwnerStack
+                  ? React.captureOwnerStack()
+                  : null;
+              },
+            },
+          );
+        });
+
+        setTimeout(() => {
+          // Error the content transport, deliver the delayed debug rows, and
+          // then synchronously begin the Fizz abort.
+          contentStream.emit('error', flightError);
+          for (let i = 0; i < dynamicDebugChunks.length; i++) {
+            debugStream.push(dynamicDebugChunks[i]);
+          }
+          contentStream.push(null);
+          debugStream.push(null);
+          fizzAbortController.abort(fizzAbortReason);
+          resolve(result);
+        });
+      });
+
+      const prerenderHTML = await readResult(prelude);
+
+      expect(prerenderHTML).toBe('');
+      expect(errors).toEqual([flightError]);
+      expect(normalizeCodeLocInfo(componentStack)).toBe(
+        '\n' +
+          gate(flags =>
+            flags.enableAsyncDebugInfo ? '    in Dynamic (at **)\n' : '',
+          ) +
+          '    in body\n' +
+          '    in html\n' +
+          '    in App (at **)\n' +
+          '    in ClientRoot',
+      );
+      expect(normalizeCodeLocInfo(ownerStack)).toBe(
+        '\n' +
+          gate(flags =>
+            flags.enableAsyncDebugInfo
+              ? '    in loadDynamicData2 (at **)\n' +
+                '    in loadDynamicData (at **)\n' +
+                '    in Dynamic (at **)\n'
+              : '',
+          ) +
+          '    in App (at **)',
+      );
+    });
+
+    // @gate __DEV__
+    it('filters debug info when a backup row resolves after the Flight stream errors', async () => {
+      const clientModuleId = 'sync-client-module';
+      const clientModuleListeners = [];
+      const asyncClientModule = {
+        status: 'pending',
+        value: null,
+        then(resolve) {
+          if (this.status === 'fulfilled') {
+            resolve(this.value);
+          } else {
+            clientModuleListeners.push(resolve);
+          }
+        },
+      };
+      function resolveClientModule() {
+        asyncClientModule.status = 'fulfilled';
+        asyncClientModule.value = {
+          default: function ClientComponent() {
+            return null;
+          },
+        };
+        for (let i = 0; i < clientModuleListeners.length; i++) {
+          clientModuleListeners[i](asyncClientModule.value);
+        }
+      }
+      webpackMap[clientModuleId] = {
+        id: clientModuleId,
+        chunks: [],
+        name: '*',
+        async: true,
+      };
+      webpackModules[clientModuleId] = asyncClientModule;
+      const ClientReference = ReactServerDOMServer.registerClientReference(
+        function ClientComponent() {
+          return null;
+        },
+        clientModuleId,
+        '*',
+      );
+
+      let resolveDataBeforeCutoff;
+      let resolveLaterData;
+
+      async function getLaterData() {
+        return new Promise(resolve => {
+          resolveLaterData = resolve;
+        });
+      }
+
+      async function getDataBeforeCutoff() {
+        return new Promise(resolve => {
+          resolveDataBeforeCutoff = resolve;
+        });
+      }
+
+      async function loadLaterData() {
+        return await getLaterData();
+      }
+
+      async function loadDataBeforeCutoff() {
+        return await getDataBeforeCutoff();
+      }
+
+      async function Late({unusedClientReference}) {
+        const dataBeforeCutoff = await loadDataBeforeCutoff();
+        staticEndTime = performance.now() + performance.timeOrigin;
+        const laterData = await loadLaterData();
+        return ReactServer.createElement(
+          'p',
+          null,
+          dataBeforeCutoff,
+          laterData,
+        );
+      }
+
+      function Dynamic() {
+        return ReactServer.createElement(Late, {
+          unusedClientReference: ClientReference,
+        });
+      }
+
+      function App() {
+        return ReactServer.createElement(
+          'html',
+          null,
+          ReactServer.createElement(
+            'body',
+            null,
+            ReactServer.createElement(Dynamic),
+          ),
+        );
+      }
+
+      let staticEndTime = -1;
+      const initialContentChunks = [];
+      const initialDebugChunks = [];
+      const lateDebugChunks = [];
+
+      await new Promise(resolve => {
+        setTimeout(() => {
+          const stream = ReactServerDOMServer.renderToPipeableStream(
+            ReactServer.createElement(App),
+            webpackMap,
+            {
+              filterStackFrame,
+              debugChannel: new Stream.Writable({
+                ...streamOptions,
+                write(chunk, encoding, callback) {
+                  const copy = Buffer.from(chunk);
+                  if (staticEndTime < 0) {
+                    initialDebugChunks.push(copy);
+                  } else {
+                    lateDebugChunks.push(copy);
+                  }
+                  callback();
+                },
+              }),
+            },
+          );
+
+          const contentPassThrough = new Stream.PassThrough(streamOptions);
+          stream.pipe(contentPassThrough);
+          contentPassThrough.on('data', chunk => {
+            if (staticEndTime < 0) {
+              initialContentChunks.push(chunk);
+            }
+          });
+          contentPassThrough.on('end', resolve);
+        });
+
+        setTimeout(() => {
+          resolveDataBeforeCutoff('Hi');
+          setTimeout(() => {
+            resolveLaterData('Story');
+          });
+        });
+      });
+
+      const contentStream = new Stream.Readable({
+        ...streamOptions,
+        read() {},
+      });
+      const debugStream = new Stream.Readable({...streamOptions, read() {}});
+      const flightResponse = ReactServerDOMClient.createFromNodeStream(
+        contentStream,
+        {
+          moduleMap: null,
+          moduleLoading: webpackModuleLoading,
+          serverModuleMap: null,
+        },
+        {
+          endTime: staticEndTime,
+          debugChannel: debugStream,
+        },
+      );
+      for (let i = 0; i < initialContentChunks.length; i++) {
+        contentStream.push(initialContentChunks[i]);
+      }
+      for (let i = 0; i < initialDebugChunks.length; i++) {
+        debugStream.push(initialDebugChunks[i]);
+      }
+      const decoded = await flightResponse;
+
+      function ClientRoot() {
+        return decoded;
+      }
+
+      const flightError = new Error('Flight stream errored');
+      const fizzAbortController = new AbortController();
+      const errors = [];
+      let ownerStack;
+
+      const {prelude} = await new Promise(resolve => {
+        let result;
+
+        setTimeout(() => {
+          result = ReactDOMFizzStatic.prerenderToNodeStream(
+            React.createElement(ClientRoot),
+            {
+              signal: fizzAbortController.signal,
+              onError(error) {
+                errors.push(error);
+                ownerStack = React.captureOwnerStack
+                  ? React.captureOwnerStack()
+                  : null;
+              },
+            },
+          );
+        });
+
+        setTimeout(() => {
+          contentStream.emit('error', flightError);
+          for (let i = 0; i < lateDebugChunks.length; i++) {
+            debugStream.push(lateDebugChunks[i]);
+          }
+          resolveClientModule();
+          contentStream.push(null);
+          debugStream.push(null);
+          fizzAbortController.abort(flightError);
+          resolve(result);
+        });
+      });
+
+      expect(await readResult(prelude)).toBe('');
+      expect(errors).toEqual([flightError]);
+      expect(normalizeCodeLocInfo(ownerStack)).toBe(
+        '\n' +
+          gate(flags =>
+            flags.enableAsyncDebugInfo
+              ? '    in loadDataBeforeCutoff (at **)\n' +
+                '    in Late (at **)\n' +
+                '    in Dynamic (at **)\n'
+              : '',
+          ) +
+          '    in App (at **)',
+      );
+    });
+
     function createReadableWithLateRelease(initialChunks, lateChunks, signal) {
       // Create a new Readable and push all initial chunks immediately.
       const readable = new Stream.Readable({...streamOptions, read() {}});
@@ -2393,5 +2835,205 @@ describe('ReactFlightDOMNode', () => {
     // Client2's Import row bytes followed by whatever happened to land in
     // the next 1024-byte window.
     expect(result.payload).toEqual(binaryData);
+  });
+
+  // @gate __DEV__
+  it('replays buffered debug info for every errored Flight chunk', async () => {
+    let resolveDynamicDataA1;
+    let resolveDynamicDataA2;
+    let resolveDynamicDataB;
+
+    async function getDynamicDataA1() {
+      return new Promise(resolve => {
+        resolveDynamicDataA1 = resolve;
+      });
+    }
+
+    async function getDynamicDataA2() {
+      return new Promise(resolve => {
+        resolveDynamicDataA2 = resolve;
+      });
+    }
+
+    async function getDynamicDataB() {
+      return new Promise(resolve => {
+        resolveDynamicDataB = resolve;
+      });
+    }
+
+    async function loadDynamicDataA1() {
+      return await getDynamicDataA1();
+    }
+
+    async function loadDynamicDataA2() {
+      return await getDynamicDataA2();
+    }
+
+    async function loadDynamicDataB() {
+      return await getDynamicDataB();
+    }
+
+    async function DynamicA() {
+      const data1 = await loadDynamicDataA1();
+      const data2 = await loadDynamicDataA2();
+      return ReactServer.createElement('p', null, data1, ' ', data2);
+    }
+
+    async function DynamicB() {
+      const data = await loadDynamicDataB();
+      return ReactServer.createElement('p', null, data);
+    }
+
+    function App() {
+      return ReactServer.createElement(
+        'html',
+        null,
+        ReactServer.createElement(
+          'body',
+          null,
+          ReactServer.createElement(DynamicA),
+          ReactServer.createElement(DynamicB),
+        ),
+      );
+    }
+
+    let isInitialRender = true;
+    const initialContentChunks = [];
+    const initialDebugChunks = [];
+    const lateDebugChunks = [];
+
+    const debugDestination = new Stream.Writable({
+      ...streamOptions,
+      write(chunk, encoding, callback) {
+        const copy = Buffer.from(chunk);
+        if (isInitialRender) {
+          initialDebugChunks.push(copy);
+        } else {
+          lateDebugChunks.push(copy);
+        }
+        callback();
+      },
+    });
+    const contentDestination = new Stream.PassThrough(streamOptions);
+    contentDestination.on('data', chunk => {
+      if (isInitialRender) {
+        initialContentChunks.push(Buffer.from(chunk));
+      }
+    });
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToPipeableStream(
+        ReactServer.createElement(App),
+        webpackMap,
+        {
+          filterStackFrame,
+          debugChannel: debugDestination,
+        },
+      ),
+    );
+    stream.pipe(contentDestination);
+
+    await serverAct(async () => {});
+    isInitialRender = false;
+
+    resolveDynamicDataA1('Hi');
+    await serverAct(async () => {});
+    resolveDynamicDataB('B');
+    await serverAct(async () => {});
+    resolveDynamicDataA2('A');
+    await serverAct(async () => {});
+
+    const contentStream = new Stream.Readable({
+      ...streamOptions,
+      read() {},
+    });
+    const debugStream = new Stream.Readable({...streamOptions, read() {}});
+    const flightResponse = ReactServerDOMClient.createFromNodeStream(
+      contentStream,
+      {
+        moduleMap: null,
+        moduleLoading: null,
+        serverModuleMap: null,
+      },
+      {
+        debugChannel: debugStream,
+      },
+    );
+
+    // Let backup rows arrive first so the matching regular rows consume them.
+    for (let i = 0; i < initialDebugChunks.length; i++) {
+      debugStream.push(initialDebugChunks[i]);
+    }
+    for (let i = 0; i < initialContentChunks.length; i++) {
+      contentStream.push(initialContentChunks[i]);
+    }
+    const decoded = await flightResponse;
+
+    // These backups have no matching content rows. They should remain buffered
+    // until the content stream errors.
+    for (let i = 0; i < lateDebugChunks.length; i++) {
+      debugStream.push(lateDebugChunks[i]);
+    }
+
+    function ClientRoot() {
+      return decoded;
+    }
+
+    const flightError = new Error('Flight stream errored');
+    const fizzAbortController = new AbortController();
+    const errors = [];
+    const ownerStacks = [];
+
+    const pendingResult = ReactDOMFizzStatic.prerenderToNodeStream(
+      React.createElement(ClientRoot),
+      {
+        signal: fizzAbortController.signal,
+        onError(error) {
+          errors.push(error);
+          ownerStacks.push(
+            React.captureOwnerStack ? React.captureOwnerStack() : null,
+          );
+        },
+      },
+    );
+
+    await serverAct(
+      async () =>
+        new Promise(resolve => {
+          setImmediate(() => {
+            contentStream.emit('error', flightError);
+            contentStream.push(null);
+            debugStream.push(null);
+            fizzAbortController.abort(new Error('Fizz aborted'));
+            resolve();
+          });
+        }),
+    );
+
+    const {prelude} = await pendingResult;
+    expect(await readResult(prelude)).toBe('');
+    expect(errors).toEqual([flightError, flightError]);
+    expect(
+      ownerStacks.map(stack =>
+        normalizeCodeLocInfo(stack, {preserveLocation: true}),
+      ),
+    ).toEqual([
+      '\n' +
+        gate(flags =>
+          flags.enableAsyncDebugInfo
+            ? '    in loadDynamicDataA2 (file://ReactFlightDOMNode-test.js:2869:20)\n' +
+              '    in DynamicA (file://ReactFlightDOMNode-test.js:2878:25)\n'
+            : '',
+        ) +
+        '    in App (file://ReactFlightDOMNode-test.js:2894:23)',
+      '\n' +
+        gate(flags =>
+          flags.enableAsyncDebugInfo
+            ? '    in loadDynamicDataB (file://ReactFlightDOMNode-test.js:2873:20)\n' +
+              '    in DynamicB (file://ReactFlightDOMNode-test.js:2883:24)\n'
+            : '',
+        ) +
+        '    in App (file://ReactFlightDOMNode-test.js:2895:23)',
+    ]);
   });
 });

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -4471,6 +4471,19 @@ function emitDebugHaltChunk(request: Request, id: number): void {
   request.completedDebugChunks.push(processedChunk);
 }
 
+function emitDebugInfoRow(request: Request, id: number, json: string): void {
+  const row = serializeRowHeader('D', id) + json + '\n';
+  request.completedRegularChunks.push(stringToChunk(row));
+  if (request.debugDestination !== null) {
+    // The regular row preserves ordering on a healthy content stream. The
+    // backup lets a surviving debug stream attach this information after the
+    // content stream has errored.
+    const backupRow = serializeRowHeader('B', id) + json + '\n';
+    request.pendingDebugChunks++;
+    request.completedDebugChunks.push(stringToChunk(backupRow));
+  }
+}
+
 function emitDebugChunk(
   request: Request,
   id: number,
@@ -4489,21 +4502,17 @@ function emitDebugChunk(
     if (json[0] === '"' && json[1] === '$') {
       // This is already an outlined reference so we can just emit it directly,
       // without an unnecessary indirection.
-      const row = serializeRowHeader('D', id) + json + '\n';
-      request.completedRegularChunks.push(stringToChunk(row));
+      emitDebugInfoRow(request, id, json);
     } else {
       // Outline the debug information to the debug channel.
       const outlinedId = request.nextChunkId++;
       const debugRow = outlinedId.toString(16) + ':' + json + '\n';
       request.pendingDebugChunks++;
       request.completedDebugChunks.push(stringToChunk(debugRow));
-      const row =
-        serializeRowHeader('D', id) + '"$' + outlinedId.toString(16) + '"\n';
-      request.completedRegularChunks.push(stringToChunk(row));
+      emitDebugInfoRow(request, id, '"$' + outlinedId.toString(16) + '"');
     }
   } else {
-    const row = serializeRowHeader('D', id) + json + '\n';
-    request.completedRegularChunks.push(stringToChunk(row));
+    emitDebugInfoRow(request, id, json);
   }
 }
 
@@ -5740,12 +5749,9 @@ function emitTimingChunk(
     const debugRow = outlinedId.toString(16) + ':' + json + '\n';
     request.pendingDebugChunks++;
     request.completedDebugChunks.push(stringToChunk(debugRow));
-    const row =
-      serializeRowHeader('D', id) + '"$' + outlinedId.toString(16) + '"\n';
-    request.completedRegularChunks.push(stringToChunk(row));
+    emitDebugInfoRow(request, id, '"$' + outlinedId.toString(16) + '"');
   } else {
-    const row = serializeRowHeader('D', id) + json + '\n';
-    request.completedRegularChunks.push(stringToChunk(row));
+    emitDebugInfoRow(request, id, json);
   }
 }
 


### PR DESCRIPTION
Stacked on #36782

## Motivation

During a Fizz prerender, tasks blocked on RSC models should be able to report a Flight-specific abort reason without giving up the high-quality component and owner stacks associated with the model. Today those stacks are recovered by allowing the Flight models and their debug information to resolve, then carefully timing the Fizz abort so the newly available models enrich the aborted tasks without being rendered. Fizz now supports specializing the abort reason for each blocked task, which lets a slot identify that it was blocked on Flight rather than only receiving the request-wide Fizz abort reason. However, triggering that specialization requires erroring the Flight stream, and the error previously rejected the models before their remaining debug information could resolve, losing the improved stacks.

## Implementation

To resolve this conflict, take advantage of the separate debug stream. When one is present, the content stream can be errored with a Flight-specific reason before the Fizz abort while additional debug information continues to be processed through the alternate stream.

Today debug rows are linked to content models by D attachment rows emitted on the content stream. This placement has semantic implications because models block on their debug information, so simply moving those rows to the debug stream would change ordering and would no longer match the behavior of a response without a separate debug stream. Instead, also emit backup attachment rows on the debug stream. During normal rendering these backups are ignored after matching them against the authoritative D rows, with unmatched backups buffered if they arrive first. When the content stream errors, switch to treating the remaining and subsequently arriving backup rows as authoritative for associating additional debug information with each errored chunk.

Preserve the original Flight error and ignore model rows targeting already settled non-stream chunks so a surviving transport can continue processing debug information. Apply the consumer end-time cutoff both when a chunk transitions to errored and whenever pending or late debug models resolve. Truncate shared debug-info arrays in place because Fizz may already hold them through a suspended Lazy, and prevent later rows or pending references from repopulating an array after it has been pruned. This lets every Flight-blocked Fizz task report the specialized Flight error with debug information from before the cutoff.

This currently requires synchronously flushing the relevant Node debug-stream chunks before calling the Fizz abort because Fizz enriches aborted task stacks synchronously during that call. A future change can make this enrichment asynchronous so debug information delivered in microtasks can participate, enabling the same behavior for Web Streams that cannot be flushed synchronously.

## Alternatives Considered

This enrichment is enabled only when a separate readable debug stream is present. With a single stream, an error cannot both signal that pending content should be abandoned and leave a transport through which additional debug information can arrive. We explored adding a Flight client abort API to separate those signals, but its practical purpose here would be DEV-only debug enrichment and it would add a second way to indicate that the client may abandon the response, so the additional API surface did not seem justified.

## Testing

Add Node coverage for real-timer scheduling, debug rows arriving before and after the content error, parsed and pending end-time pruning, replay across multiple errored chunks, preservation of the Flight transport error, distinct Fizz owner stacks, and exact source locations.