### PR TITLE
test: verify core hooks and component exports

### DIFF
--- a/packages/react/src/__tests__/ReactVersion-test.js
+++ b/packages/react/src/__tests__/ReactVersion-test.js
@@ -24,3 +24,16 @@ test('ReactVersion matches package.json', () => {
     expect(React.version).toBe(packageJSON.version);
   }
 });
+
+// Added to verify build stability by ensuring standard core React hooks and APIs are properly exported
+test('React object has expected core exports', () => {
+  if (gate(flags => flags.build)) {
+    const React = require('react');
+
+    expect(typeof React.useState).toBe('function');
+    expect(typeof React.useEffect).toBe('function');
+    expect(typeof React.useTransition).toBe('function');
+    expect(typeof React.Component).toBe('function');
+    expect(typeof React.createElement).toBe('function');
+  }
+});


### PR DESCRIPTION
## Summary

Adds a basic sanity test to `ReactVersion-test.js` verifying that core exports (`useState`, `useEffect`, `useTransition`, `Component`, `createElement`) exist on the `React` object, preventing accidental bundle omissions during build pipeline updates.

## How did you test this change?

Verified locally by building and running the test suite.

1. **Passing run:** Running `yarn test ReactVersion` passes successfully after running the Node rollup build script.
2. **Failure run:** Temporarily added a fake API check (`React.useMagicPowers`), which successfully threw a red `Expected: "function", Received: "undefined"` error, proving the test catches missing exports.