### PR TITLE
[reconciler] warn uncached use() promise before ping-loop crash

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1107,6 +1107,7 @@ function useThenable<T>(thenable: Thenable<T>): T {
     thenable,
     index,
     __DEV__ ? currentlyRenderingFiber : null,
+    true,
   );
 
   // When something suspends with `use`, we replay the component with the

--- a/packages/react-reconciler/src/ReactFiberThenable.js
+++ b/packages/react-reconciler/src/ReactFiberThenable.js
@@ -257,10 +257,15 @@ export function trackUsedThenable<T>(
         // Detect infinite ping loops caused by uncached promises.
         const root = getWorkInProgressRoot();
         if (root !== null && root.shellSuspendCounter > 100) {
-          if (__DEV__) {
-            if (fromUseHook === true) {
+          if (fromUseHook === true) {
+            if (__DEV__) {
               warnAboutUncachedPromise(thenableState);
             }
+            throw new Error(
+              'A component was suspended by an uncached promise. Creating ' +
+                'promises inside a Client Component or hook is not yet ' +
+                'supported, except via a Suspense-compatible library or framework.',
+            );
           }
           // This root has suspended repeatedly in the shell without making any
           // progress (i.e. committing something). This is highly suggestive of

--- a/packages/react-reconciler/src/ReactFiberThenable.js
+++ b/packages/react-reconciler/src/ReactFiberThenable.js
@@ -52,6 +52,36 @@ function getThenablesFromState(state: ThenableState): Array<Thenable<any>> {
   }
 }
 
+function warnAboutUncachedPromise(thenableState: ThenableState): void {
+  if (__DEV__) {
+    const thenableStateDev: ThenableStateDev = thenableState as any;
+    if (!thenableStateDev.didWarnAboutUncachedPromise) {
+      // We should only warn the first time an uncached thenable is discovered
+      // per component, because if there are multiple, the subsequent ones are
+      // likely derived from the first.
+      //
+      // We track this on the thenableState instead of deduping using the
+      // component name like we usually do, because in the case of a
+      // promise-as-React-node, the owner component is likely different from the
+      // parent that's currently being reconciled. We'd have to track the owner
+      // using state, which we're trying to move away from. Though since this is
+      // dev-only, maybe that'd be OK.
+      //
+      // However, another benefit of doing it this way is we might eventually
+      // have a thenableState per memo/Forget boundary instead of per component,
+      // so this would allow us to have more granular warnings.
+      thenableStateDev.didWarnAboutUncachedPromise = true;
+
+      // TODO: This warning should link to a corresponding docs page.
+      console.error(
+        'A component was suspended by an uncached promise. Creating ' +
+          'promises inside a Client Component or hook is not yet ' +
+          'supported, except via a Suspense-compatible library or framework.',
+      );
+    }
+  }
+}
+
 // An error that is thrown (e.g. by `use`) to trigger Suspense. If we
 // detect this is caught by userspace, we'll log a warning in development.
 export const SuspenseException: mixed = new Error(
@@ -142,32 +172,7 @@ export function trackUsedThenable<T>(
       // they represent the same value, because components are idempotent.
 
       if (__DEV__) {
-        const thenableStateDev: ThenableStateDev = thenableState as any;
-        if (!thenableStateDev.didWarnAboutUncachedPromise) {
-          // We should only warn the first time an uncached thenable is
-          // discovered per component, because if there are multiple, the
-          // subsequent ones are likely derived from the first.
-          //
-          // We track this on the thenableState instead of deduping using the
-          // component name like we usually do, because in the case of a
-          // promise-as-React-node, the owner component is likely different from
-          // the parent that's currently being reconciled. We'd have to track
-          // the owner using state, which we're trying to move away from. Though
-          // since this is dev-only, maybe that'd be OK.
-          //
-          // However, another benefit of doing it this way is we might
-          // eventually have a thenableState per memo/Forget boundary instead
-          // of per component, so this would allow us to have more
-          // granular warnings.
-          thenableStateDev.didWarnAboutUncachedPromise = true;
-
-          // TODO: This warning should link to a corresponding docs page.
-          console.error(
-            'A component was suspended by an uncached promise. Creating ' +
-              'promises inside a Client Component or hook is not yet ' +
-              'supported, except via a Suspense-compatible library or framework.',
-          );
-        }
+        warnAboutUncachedPromise(thenableState);
       }
 
       // Avoid an unhandled rejection errors for the Promises that we'll
@@ -253,17 +258,8 @@ export function trackUsedThenable<T>(
         const root = getWorkInProgressRoot();
         if (root !== null && root.shellSuspendCounter > 100) {
           if (__DEV__) {
-            const thenableStateDev: ThenableStateDev = thenableState as any;
-            if (
-              fromUseHook === true &&
-              !thenableStateDev.didWarnAboutUncachedPromise
-            ) {
-              thenableStateDev.didWarnAboutUncachedPromise = true;
-              console.error(
-                'A component was suspended by an uncached promise. Creating ' +
-                  'promises inside a Client Component or hook is not yet ' +
-                  'supported, except via a Suspense-compatible library or framework.',
-              );
+            if (fromUseHook === true) {
+              warnAboutUncachedPromise(thenableState);
             }
           }
           // This root has suspended repeatedly in the shell without making any

--- a/packages/react-reconciler/src/ReactFiberThenable.js
+++ b/packages/react-reconciler/src/ReactFiberThenable.js
@@ -127,6 +127,7 @@ export function trackUsedThenable<T>(
   thenable: Thenable<T>,
   index: number,
   fiber: null | Fiber, // DEV-only
+  fromUseHook?: boolean,
 ): T {
   if (__DEV__ && ReactSharedInternals.actQueue !== null) {
     ReactSharedInternals.didUsePromise = true;
@@ -251,6 +252,20 @@ export function trackUsedThenable<T>(
         // Detect infinite ping loops caused by uncached promises.
         const root = getWorkInProgressRoot();
         if (root !== null && root.shellSuspendCounter > 100) {
+          if (__DEV__) {
+            const thenableStateDev: ThenableStateDev = thenableState as any;
+            if (
+              fromUseHook === true &&
+              !thenableStateDev.didWarnAboutUncachedPromise
+            ) {
+              thenableStateDev.didWarnAboutUncachedPromise = true;
+              console.error(
+                'A component was suspended by an uncached promise. Creating ' +
+                  'promises inside a Client Component or hook is not yet ' +
+                  'supported, except via a Suspense-compatible library or framework.',
+              );
+            }
+          }
           // This root has suspended repeatedly in the shell without making any
           // progress (i.e. committing something). This is highly suggestive of
           // an infinite ping loop, often caused by an accidental Async Client

--- a/packages/react-reconciler/src/__tests__/ReactUse-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUse-test.js
@@ -287,6 +287,84 @@ describe('ReactUse', () => {
     expect(root).toMatchRenderedOutput('ABC');
   });
 
+  it('warns for an uncached use() promise that resolves in a later task', async () => {
+    spyOnDev(console, 'error').mockImplementation(() => {});
+
+    class ErrorBoundary extends React.Component {
+      state = {error: null};
+      static getDerivedStateFromError(error) {
+        return {error};
+      }
+      render() {
+        if (this.state.error) {
+          return <Text text={this.state.error.message} />;
+        }
+        return this.props.children;
+      }
+    }
+
+    function Async() {
+      return <Text text={use(getAsyncText('Async'))} />;
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(() => {
+      root.render(
+        <ErrorBoundary>
+          <Async />
+        </ErrorBoundary>,
+      );
+    });
+    assertLog(['Async text requested [Async]', 'Async text requested [Async]']);
+
+    let finalLog;
+    // Keep resolving each uncached request until the existing shell ping-loop
+    // guard trips. This is the path that used to throw without first logging
+    // the uncached-promise warning.
+    for (let i = 0; i < 100; i++) {
+      await act(() => {
+        resolveTextRequests('Async');
+      });
+      const log = Scheduler.unstable_clearLog();
+      if (
+        log.some(entry =>
+          entry.startsWith('An unknown Component is an async Client Component.'),
+        )
+      ) {
+        finalLog = log;
+        break;
+      }
+      expect(log).toEqual([
+        'Async text requested [Async]',
+        'Async text requested [Async]',
+      ]);
+    }
+    expect(finalLog).toContain(
+      'An unknown Component is an async Client Component. ' +
+        'Only Server Components can be async at the moment. ' +
+        'This error is often caused by accidentally adding ' +
+        "`'use client'` to a module that was originally written for " +
+        'the server.',
+    );
+    expect(root).toMatchRenderedOutput(
+      'An unknown Component is an async Client Component. ' +
+        'Only Server Components can be async at the moment. ' +
+        'This error is often caused by accidentally adding ' +
+        "`'use client'` to a module that was originally written for " +
+        'the server.',
+    );
+
+    if (__DEV__) {
+      const loggedMessages = console.error.mock.calls.map(call => call[0]);
+      expect(loggedMessages).toContain(
+        'A component was suspended by an uncached promise. Creating ' +
+          'promises inside a Client Component or hook is not yet ' +
+          'supported, except via a Suspense-compatible library or framework.',
+      );
+      console.error.mockRestore();
+    }
+  });
+
   it('using a rejected promise will throw', async () => {
     class ErrorBoundary extends React.Component {
       state = {error: null};

--- a/packages/react-reconciler/src/__tests__/ReactUse-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUse-test.js
@@ -288,7 +288,10 @@ describe('ReactUse', () => {
   });
 
   it('warns for an uncached use() promise that resolves in a later task', async () => {
-    spyOnDev(console, 'error').mockImplementation(() => {});
+    const uncachedPromiseErrorMessage =
+      'A component was suspended by an uncached promise. Creating ' +
+      'promises inside a Client Component or hook is not yet ' +
+      'supported, except via a Suspense-compatible library or framework.';
 
     class ErrorBoundary extends React.Component {
       state = {error: null};
@@ -319,18 +322,14 @@ describe('ReactUse', () => {
 
     let finalLog;
     // Keep resolving each uncached request until the existing shell ping-loop
-    // guard trips. This is the path that used to throw without first logging
-    // the uncached-promise warning.
+    // guard trips. This is the path that used to misdiagnose the uncached
+    // use() promise as an async Client Component.
     for (let i = 0; i < 100; i++) {
       await act(() => {
         resolveTextRequests('Async');
       });
       const log = Scheduler.unstable_clearLog();
-      if (
-        log.some(entry =>
-          entry.startsWith('An unknown Component is an async Client Component.'),
-        )
-      ) {
+      if (log.includes(uncachedPromiseErrorMessage)) {
         finalLog = log;
         break;
       }
@@ -339,30 +338,12 @@ describe('ReactUse', () => {
         'Async text requested [Async]',
       ]);
     }
-    expect(finalLog).toContain(
-      'An unknown Component is an async Client Component. ' +
-        'Only Server Components can be async at the moment. ' +
-        'This error is often caused by accidentally adding ' +
-        "`'use client'` to a module that was originally written for " +
-        'the server.',
-    );
-    expect(root).toMatchRenderedOutput(
-      'An unknown Component is an async Client Component. ' +
-        'Only Server Components can be async at the moment. ' +
-        'This error is often caused by accidentally adding ' +
-        "`'use client'` to a module that was originally written for " +
-        'the server.',
-    );
-
-    if (__DEV__) {
-      const loggedMessages = console.error.mock.calls.map(call => call[0]);
-      expect(loggedMessages).toContain(
-        'A component was suspended by an uncached promise. Creating ' +
-          'promises inside a Client Component or hook is not yet ' +
-          'supported, except via a Suspense-compatible library or framework.',
-      );
-      console.error.mockRestore();
-    }
+    expect(finalLog).toContain(uncachedPromiseErrorMessage);
+    assertConsoleErrorDev([
+      uncachedPromiseErrorMessage + '\n' + '    in Async (at **)',
+      uncachedPromiseErrorMessage + '\n' + '    in Async (at **)',
+    ]);
+    expect(root).toMatchRenderedOutput(uncachedPromiseErrorMessage);
   });
 
   it('using a rejected promise will throw', async () => {

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -592,5 +592,6 @@
   "604": "The server render could not complete because client rendering was requested outside a Suspense boundary. See this error's cause for additional details.",
   "605": "Recoverable Exception: This is not a real error! It's an implementation detail of `use` to interrupt the current render so a downstream renderer can recover it. You must either rethrow it immediately, or move the `use` call outside of the `try/catch` block. Capturing without rethrowing will lead to unexpected behavior.",
   "606": "Expected a suspended recoverable. This is a bug in React. Please file an issue.",
-  "607": "This library called use() to suspend in a previous render but did not call use() when it finished. This indicates an incorrect use of use(). Learn more: https://react.dev/warnings/conditional-use-of-use"
+  "607": "This library called use() to suspend in a previous render but did not call use() when it finished. This indicates an incorrect use of use(). Learn more: https://react.dev/warnings/conditional-use-of-use",
+  "608": "A component was suspended by an uncached promise. Creating promises inside a Client Component or hook is not yet supported, except via a Suspense-compatible library or framework."
 }


### PR DESCRIPTION
## Summary

When an uncached promise from React.use() repeatedly suspends in the shell, React can eventually hit the sync ping-loop guard.

Before this change, that path was diagnosed as an async Client Component, which was misleading for React.use() callsites and could also happen without the more specific uncached-promise warning.

This patch improves the diagnosis for that path:

- trackUsedThenable accepts an optional fromUseHook flag.
- useThenable passes fromUseHook: true.
- In the ping-loop guard path, React.use() callsites now report the uncached-promise diagnosis instead of the async Client Component diagnosis.
- The async Client Component diagnosis is preserved for non-use() callsites.
- The uncached-promise warning emission is shared through a helper so both warning paths stay consistent.
- A regression test covers an uncached React.use() promise that resolves in a later task.

Closes #31790

## How did you test this change?

- yarn test ReactUse-test --runInBand --testNamePattern "warns for an uncached use\(\) promise that resolves in a later task"
- yarn test --prod ReactUse-test --runInBand --testNamePattern "warns for an uncached use\(\) promise that resolves in a later task"
- yarn test ReactUse-test --runInBand
- yarn test --prod ReactUse-test --runInBand
- yarn linc

All passed locally.