### PR TITLE
[Fizz] Preserve referrerPolicy in image preload headers

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -3405,7 +3405,7 @@ function pushImg(
           nonce: props.nonce,
           type: props.type,
           fetchPriority: props.fetchPriority,
-          referrerPolicy: props.refererPolicy,
+          referrerPolicy: props.referrerPolicy,
         })),
         // We always consume the header length since once we find one header that doesn't fit
         // we assume all the rest won't as well. This is to avoid getting into a situation

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -3934,6 +3934,35 @@ describe('ReactDOMFizzServer', () => {
     });
   });
 
+  it('preserves referrerPolicy for image preload headers', async () => {
+    let headers = null;
+    function onHeaders(x) {
+      headers = x;
+    }
+
+    function App() {
+      return (
+        <html>
+          <body>
+            <img
+              src="image-with-referrer-policy"
+              fetchPriority="high"
+              referrerPolicy="no-referrer"
+            />
+          </body>
+        </html>
+      );
+    }
+
+    await act(() => {
+      renderToPipeableStream(<App />, {onHeaders});
+    });
+
+    expect(headers).toEqual({
+      Link: `<image-with-referrer-policy>; rel=preload; as="image"; fetchpriority="high"; referrerpolicy="no-referrer"`,
+    });
+  });
+
   it('emits nothing for headers if you pipe before work begins', async () => {
     let headers = null;
     function onHeaders(x) {


### PR DESCRIPTION
## Summary
- fix a typo in Fizz image preload header generation (refererPolicy -> referrerPolicy)
- add a regression test that verifies referrerPolicy is preserved in emitted preload Link headers

## Test plan
- yarn test ReactDOMFizzServer-test --runInBand --testNamePattern "referrerPolicy for image preload headers"
- yarn test --prod ReactDOMFizzServer-test --runInBand --testNamePattern "referrerPolicy for image preload headers"
- yarn test ReactDOMFizzServer-test --runInBand
- yarn linc

Closes #36563