### PR TITLE
[Fizz] Prevent accessing postponed state before prelude has flushed

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
@@ -1162,7 +1162,9 @@ describe('ReactDOMFizzStaticBrowser', () => {
     });
     await serverAct(() => controller.abort());
     const prerendered = await pendingResult;
-    expect(prerendered.postponed).not.toBe(null);
+    expect(() => prerendered.postponed).toThrow(
+      'Postponed state is not finalized. Flush the prelude stream to finalize the state.',
+    );
 
     const shellHTML = await readContent(prerendered.prelude);
 

--- a/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
@@ -25,6 +25,7 @@ import {
   stopFlowing,
   abort,
   getPostponedState,
+  getFinalizedPostponedState,
 } from 'react-server/src/ReactFizzServer';
 
 import {
@@ -89,9 +90,17 @@ function prerender(
       );
 
       const result: StaticResult = {
-        postponed: getPostponedState(request),
+        postponed: null,
         prelude: stream,
       };
+
+      const postponed = getPostponedState(request);
+      if (postponed !== null) {
+        Object.defineProperty(result, 'postponed', {
+          get: getFinalizedPostponedState.bind(null, request, postponed),
+        });
+      }
+
       resolve(result);
     }
 

--- a/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticEdge.js
@@ -25,6 +25,7 @@ import {
   stopFlowing,
   abort,
   getPostponedState,
+  getFinalizedPostponedState,
 } from 'react-server/src/ReactFizzServer';
 
 import {
@@ -89,9 +90,17 @@ function prerender(
       );
 
       const result: StaticResult = {
-        postponed: getPostponedState(request),
+        postponed: null,
         prelude: stream,
       };
+
+      const postponed = getPostponedState(request);
+      if (postponed !== null) {
+        Object.defineProperty(result, 'postponed', {
+          get: getFinalizedPostponedState.bind(null, request, postponed),
+        });
+      }
+
       resolve(result);
     }
 
@@ -175,10 +184,18 @@ function resumeAndPrerender(
         {highWaterMark: 0},
       );
 
-      const result = {
-        postponed: getPostponedState(request),
+      const result: StaticResult = {
+        postponed: null,
         prelude: stream,
       };
+
+      const postponed = getPostponedState(request);
+      if (postponed !== null) {
+        Object.defineProperty(result, 'postponed', {
+          get: getFinalizedPostponedState.bind(null, request, postponed),
+        });
+      }
+
       resolve(result);
     }
 

--- a/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
@@ -27,6 +27,7 @@ import {
   stopFlowing,
   abort,
   getPostponedState,
+  getFinalizedPostponedState,
 } from 'react-server/src/ReactFizzServer';
 
 import {
@@ -63,9 +64,14 @@ type Options = {
   maxHeadersLength?: number,
 };
 
-type StaticResult = {
+type StaticResultNode = {
   postponed: null | PostponedState,
   prelude: Readable,
+};
+
+type StaticResultWeb = {
+  postponed: null | PostponedState,
+  prelude: ReadableStream,
 };
 
 function createFakeWritableFromReadableStreamController(
@@ -116,7 +122,7 @@ function createFakeWritableFromReadable(readable: any): Writable {
 function prerenderToNodeStream(
   children: ReactNodeList,
   options?: Options,
-): Promise<StaticResult> {
+): Promise<StaticResultNode> {
   return new Promise((resolve, reject) => {
     const onFatalError = reject;
 
@@ -128,10 +134,18 @@ function prerenderToNodeStream(
       });
       const writable = createFakeWritableFromReadable(readable);
 
-      const result: StaticResult = {
-        postponed: getPostponedState(request),
+      const result: StaticResultNode = {
+        postponed: null,
         prelude: readable,
       };
+
+      const postponed = getPostponedState(request);
+      if (postponed !== null) {
+        Object.defineProperty(result, 'postponed', {
+          get: getFinalizedPostponedState.bind(null, request, postponed),
+        });
+      }
+
       resolve(result);
     }
     const resumableState = createResumableState(
@@ -181,10 +195,7 @@ function prerender(
   options?: Omit<Options, 'onHeaders'> & {
     onHeaders?: (headers: Headers) => void,
   },
-): Promise<{
-  postponed: null | PostponedState,
-  prelude: ReadableStream,
-}> {
+): Promise<StaticResultWeb> {
   return new Promise((resolve, reject) => {
     const onFatalError = reject;
 
@@ -205,15 +216,22 @@ function prerender(
             abort(request, reason);
           },
         },
-        // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
         // $FlowFixMe[incompatible-type]
         {highWaterMark: 0},
       );
 
-      const result = {
-        postponed: getPostponedState(request),
+      const result: StaticResultWeb = {
+        postponed: null,
         prelude: stream,
       };
+
+      const postponed = getPostponedState(request);
+      if (postponed !== null) {
+        Object.defineProperty(result, 'postponed', {
+          get: getFinalizedPostponedState.bind(null, request, postponed),
+        });
+      }
+
       resolve(result);
     }
 
@@ -276,7 +294,7 @@ function resumeAndPrerenderToNodeStream(
   children: ReactNodeList,
   postponedState: PostponedState,
   options?: Omit<ResumeOptions, 'nonce'>,
-): Promise<StaticResult> {
+): Promise<StaticResultNode> {
   return new Promise((resolve, reject) => {
     const onFatalError = reject;
 
@@ -288,10 +306,18 @@ function resumeAndPrerenderToNodeStream(
       });
       const writable = createFakeWritableFromReadable(readable);
 
-      const result = {
-        postponed: getPostponedState(request),
+      const result: StaticResultNode = {
+        postponed: null,
         prelude: readable,
       };
+
+      const postponed = getPostponedState(request);
+      if (postponed !== null) {
+        Object.defineProperty(result, 'postponed', {
+          get: getFinalizedPostponedState.bind(null, request, postponed),
+        });
+      }
+
       resolve(result);
     }
     const request = resumeAndPrerenderRequest(
@@ -324,10 +350,7 @@ function resumeAndPrerender(
   children: ReactNodeList,
   postponedState: PostponedState,
   options?: Omit<ResumeOptions, 'nonce'>,
-): Promise<{
-  postponed: null | PostponedState,
-  prelude: ReadableStream,
-}> {
+): Promise<StaticResultWeb> {
   return new Promise((resolve, reject) => {
     const onFatalError = reject;
 
@@ -348,15 +371,22 @@ function resumeAndPrerender(
             abort(request, reason);
           },
         },
-        // $FlowFixMe[prop-missing] size() methods are not allowed on byte streams.
-        // $FlowFixMe[incompatible-type]
+        // $FlowFixMe[incompatible-type] size() methods are not allowed on byte streams.
         {highWaterMark: 0},
       );
 
-      const result = {
-        postponed: getPostponedState(request),
+      const result: StaticResultWeb = {
+        postponed: null,
         prelude: stream,
       };
+
+      const postponed = getPostponedState(request);
+      if (postponed !== null) {
+        Object.defineProperty(result, 'postponed', {
+          get: getFinalizedPostponedState.bind(null, request, postponed),
+        });
+      }
+
       resolve(result);
     }
 

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -6458,7 +6458,7 @@ export function getPostponedState(request: Request): null | PostponedState {
   if (!hasFlushableShell) {
     nextSegmentId = 0;
     // We need to ensure that on resume we retry the root. We use a number
-    // type for the replaySlots to signify this (see resumeRequest).
+    // type for the replaySlots to signify this (see resuhasFlushableShellmeRequest).
     // The value -1 represents an unassigned ID but is not functionally meaningful
     // for resuming at the root.
     replaySlots = -1;

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -394,15 +394,6 @@ export opaque type Request = {
   completedBoundaries: Array<SuspenseBoundary>, // Completed but not yet fully flushed boundaries to show.
   partialBoundaries: Array<SuspenseBoundary>, // Partially completed boundaries that can flush its segments early.
   trackedPostpones: null | PostponedHoles, // Gets set to non-null while we want to track postponed holes. I.e. during a prerender.
-  // While prerendering a postponed request that produced a real shell, this
-  // holds the PostponedState returned by getPostponedState. getPostponedState
-  // snapshots nextSegmentId before the (pull-driven) prelude flush runs, but the
-  // flush outlines completed boundaries and advances nextSegmentId past that
-  // snapshot. We finalize the snapshot from flushCompletedQueues so the resumed
-  // render allocates segment ids strictly above the shell's; otherwise the shell
-  // and resume emit duplicate B:/S: ids once concatenated. Stays null for live
-  // renders and resumes.
-  postponedState: null | PostponedState,
   // onError is called when an error happens anywhere in the tree. It might recover.
   // The return string is used in production  primarily to avoid leaking internals, secondarily to save bytes.
   // Returning null/undefined will cause a default error message in production
@@ -562,7 +553,6 @@ function RequestInstance(
   this.completedBoundaries = [] as Array<SuspenseBoundary>;
   this.partialBoundaries = [] as Array<SuspenseBoundary>;
   this.trackedPostpones = null;
-  this.postponedState = null;
   this.onError = onError === undefined ? defaultErrorHandler : onError;
   this.onAllReady = onAllReady === undefined ? noop : onAllReady;
   this.onShellReady = onShellReady === undefined ? noop : onShellReady;
@@ -6156,19 +6146,6 @@ function flushCompletedQueues(
     largeBoundaries.splice(0, i);
   } finally {
     flushingPartialBoundaries = false;
-    const postponedState = request.postponedState;
-    if (postponedState !== null) {
-      // The shell flush above may have outlined completed boundaries, advancing
-      // nextSegmentId past the value getPostponedState snapshotted before the
-      // flush. Re-sync the postponed state to the post-flush high-water mark so
-      // the resume allocates segment ids strictly above the shell's and can't
-      // emit duplicate B:/S: ids. nextSegmentId only increases, so later flush
-      // passes refine this monotonically.
-      // TODO: Could be too late if the postponed state was already serialized
-      // by API consumers. Accessing postponed state before the prelude has flushed
-      // should be forbidden in the API.
-      postponedState.nextSegmentId = request.nextSegmentId;
-    }
     if (
       request.allPendingTasks === 0 &&
       request.clientRenderedBoundaries.length === 0 &&
@@ -6432,7 +6409,24 @@ export type PostponedState = {
   replaySlots: ResumeSlots,
 };
 
+export function getFinalizedPostponedState(
+  request: Request,
+  postponed: PostponedState,
+): PostponedState {
+  if (request.status !== CLOSED) {
+    throw new Error(
+      'Postponed state is not finalized. Flush the prelude stream to finalize the state.',
+    );
+  }
+
+  // The shell flush may have outlined completed boundaries.
+  // Advancing nextSegmentId past the value getPostponedState snapshotted before the flush. Re-sync the postponed state to the post-flush high-water mark so the resume allocates segment ids strictly above the shell's and can't emit duplicate B:/S: ids. nextSegmentId only increases, so later flush passes refine this monotonically.
+  postponed.nextSegmentId = request.nextSegmentId;
+  return postponed;
+}
+
 // Returns the state of a postponed request or null if nothing was postponed.
+// If we did postpone, only getFinalizePostponedState should be consumed.
 export function getPostponedState(request: Request): null | PostponedState {
   const trackedPostpones = request.trackedPostpones;
   if (
@@ -6449,16 +6443,16 @@ export function getPostponedState(request: Request): null | PostponedState {
   // True only when we postponed with a real shell (as opposed to postponing the
   // root itself). Only in that case does the prelude flush outline completed
   // boundaries and advance nextSegmentId past the value we capture here.
-  const hasFlushableShell =
-    request.completedRootSegment === null ||
-    // The Root did not postpone
-    (request.completedRootSegment.status !== POSTPONED &&
-      // the Preamble was available
-      request.completedPreambleSegments !== null);
-  if (!hasFlushableShell) {
+  if (
+    request.completedRootSegment !== null &&
+    // The Root postponed
+    (request.completedRootSegment.status === POSTPONED ||
+      // Or the Preamble was not available
+      request.completedPreambleSegments === null)
+  ) {
     nextSegmentId = 0;
     // We need to ensure that on resume we retry the root. We use a number
-    // type for the replaySlots to signify this (see resuhasFlushableShellmeRequest).
+    // type for the replaySlots to signify this (see resumeRequest).
     // The value -1 represents an unassigned ID but is not functionally meaningful
     // for resuming at the root.
     replaySlots = -1;
@@ -6469,7 +6463,7 @@ export function getPostponedState(request: Request): null | PostponedState {
     replaySlots = trackedPostpones.rootSlots;
     completeResumableState(request.resumableState);
   }
-  const postponedState: PostponedState = {
+  return {
     nextSegmentId,
     rootFormatContext: request.rootFormatContext,
     progressiveChunkSize: request.progressiveChunkSize,
@@ -6477,15 +6471,4 @@ export function getPostponedState(request: Request): null | PostponedState {
     replayNodes: trackedPostpones.rootNodes,
     replaySlots,
   };
-  if (hasFlushableShell) {
-    // The prelude hasn't flushed yet — it's pull-driven and runs after this
-    // (see completeAll -> onAllReady). Flushing the shell outlines completed
-    // boundaries, bumping request.nextSegmentId beyond the snapshot above. Hold
-    // a reference so flushCompletedQueues can finalize nextSegmentId to the
-    // post-flush high-water mark. Otherwise the resume reuses the shell's
-    // segment ids and the concatenated document has duplicate B:/S: ids, which
-    // cross-wires React's boundary-completion scripts ($RC).
-    request.postponedState = postponedState;
-  }
-  return postponedState;
 }


### PR DESCRIPTION
Follow-up to https://github.com/react/react/pull/36779

API change is not final and will be discussed internally before landing.

Alternatives to consider:
- explicit sync getter e.g. `getPostponedState` ("more" breakage)
- explicit async getter that rejects if the requests isn't flowing and resolves once the request closed
- `postponed` as a Promises (could lead to deadlock if you `await postponed` before `prelude` is piped)
- start flowing on abort (even more buffering we do ignoring backpressure)