### PR TITLE
[react-devtools-facade] add host instance component lookup

### DIFF
--- a/packages/react-devtools-facade/src/DevToolsFacadeTools.js
+++ b/packages/react-devtools-facade/src/DevToolsFacadeTools.js
@@ -59,6 +59,7 @@ export type Tools = {
     uid: string,
     includeHooks?: boolean,
   ) => NodeInfo | ToolError,
+  getComponentByHostInstance: (hostInstance: mixed) => NodeInfo | ToolError,
   findComponents: (
     name: string,
     rootUid?: string,
@@ -97,6 +98,7 @@ export function createTools(facade: Facade): Tools {
   return {
     getComponentTree: tree.getComponentTree,
     getComponentByUid: tree.getComponentByUid,
+    getComponentByHostInstance: tree.getComponentByHostInstance,
     findComponents: tree.findComponents,
     getComponentSource: tree.getComponentSource,
     getOwnerStackTrace: tree.getOwnerStackTrace,

--- a/packages/react-devtools-facade/src/DevToolsFacadeTreeTools.js
+++ b/packages/react-devtools-facade/src/DevToolsFacadeTreeTools.js
@@ -85,6 +85,7 @@ export type TreeTools = {
     uid: string,
     includeHooks?: boolean,
   ) => NodeInfo | ToolError,
+  getComponentByHostInstance: (hostInstance: mixed) => NodeInfo | ToolError,
   findComponents: (
     name: string,
     rootUid?: string,
@@ -377,6 +378,108 @@ export function createTreeTools(
     };
   }
 
+  function getHostInstanceForFiber(
+    internals: RendererInternals,
+    fiber: Fiber,
+  ): mixed {
+    const {HostComponent, HostText, HostSingleton, HostHoistable} =
+      internals.ReactTypeOfWork;
+
+    if (
+      fiber.tag === HostComponent ||
+      fiber.tag === HostText ||
+      fiber.tag === HostSingleton
+    ) {
+      return fiber.stateNode;
+    }
+
+    if (fiber.tag === HostHoistable) {
+      const resource = fiber.memoizedState;
+      if (
+        resource != null &&
+        typeof resource === 'object' &&
+        (resource as any).instance != null
+      ) {
+        return (resource as any).instance;
+      }
+    }
+
+    return null;
+  }
+
+  function findByHostInstance(
+    internals: RendererInternals,
+    root: Fiber,
+    hostInstance: mixed,
+  ): Fiber | null {
+    let current: Fiber | null = root;
+    while (current !== null) {
+      if (getHostInstanceForFiber(internals, current) === hostInstance) {
+        return current;
+      }
+
+      if (current.child !== null) {
+        current = current.child;
+        continue;
+      }
+
+      while (current !== null && current !== root && current.sibling === null) {
+        current = current.return;
+      }
+      if (current === null || current === root) {
+        return null;
+      }
+      current = current.sibling;
+    }
+    return null;
+  }
+
+  function buildNodeInfo(
+    fiber: Fiber,
+    internals: RendererInternals,
+    includeHooks?: boolean = false,
+  ): NodeInfo | ToolError {
+    const info: NodeInfo = {
+      uid: getUid(fiber),
+      type: getTypeTagForFiber(internals, fiber),
+      name: getDisplayName(internals, fiber),
+    };
+    if (fiber.key != null) {
+      info.key = String(fiber.key);
+    }
+    const props = normalizeProps(fiber.memoizedProps);
+    if (props != null) {
+      info.props = props;
+    }
+    if (includeHooks) {
+      // Hooks are only inspectable for function components, forwardRef, and
+      // simple-memo components. inspectHooksOfFiberWithoutDefaultDispatcher
+      // re-renders the component (using the renderer's injected dispatcher,
+      // never React's shared internals), so guard by tag and tolerate failures
+      // (e.g. a component that throws).
+      const {FunctionComponent, SimpleMemoComponent, ForwardRef} =
+        internals.ReactTypeOfWork;
+      if (
+        fiber.tag === FunctionComponent ||
+        fiber.tag === SimpleMemoComponent ||
+        fiber.tag === ForwardRef
+      ) {
+        try {
+          const hooksTree = inspectHooksOfFiberWithoutDefaultDispatcher(
+            fiber,
+            getDispatcherRef(internals),
+          );
+          info.hooks = normalizeHooks(hooksTree);
+        } catch (error) {
+          return {
+            error: new Error('Failed to inspect hooks.', {cause: error}),
+          };
+        }
+      }
+    }
+    return info;
+  }
+
   /**
    * Returns a snapshot of the component tree as an array of nodes. Each node
    * includes: uid, type, name, key, firstChild, nextSibling (the last two
@@ -436,46 +539,49 @@ export function createTreeTools(
     if (result.error != null) {
       return {error: result.error};
     }
-    const {fiber, internals} = result;
-    const info: NodeInfo = {
-      uid: getUid(fiber),
-      type: getTypeTagForFiber(internals, fiber),
-      name: getDisplayName(internals, fiber),
-    };
-    if (fiber.key != null) {
-      info.key = String(fiber.key);
+    return buildNodeInfo(result.fiber, result.internals, includeHooks);
+  }
+
+  /**
+   * Returns detailed info about the React host component for a host instance
+   * reference. The reference is opaque: for react-dom it may be a DOM
+   * Element/Text, but the facade only compares it by identity with host fiber
+   * state. It does not read platform-specific fields or walk host parents.
+   *
+   * @param hostInstance - A renderer host instance reference.
+   */
+  function getComponentByHostInstance(
+    hostInstance: mixed,
+  ): NodeInfo | ToolError {
+    if (hostInstance == null) {
+      return {error: 'Host instance is required'};
     }
-    const props = normalizeProps(fiber.memoizedProps);
-    if (props != null) {
-      info.props = props;
-    }
-    if (includeHooks) {
-      // Hooks are only inspectable for function components, forwardRef, and
-      // simple-memo components. inspectHooksOfFiberWithoutDefaultDispatcher
-      // re-renders the component (using the renderer's injected dispatcher,
-      // never React's shared internals), so guard by tag and tolerate failures
-      // (e.g. a component that throws).
-      const {FunctionComponent, SimpleMemoComponent, ForwardRef} =
-        internals.ReactTypeOfWork;
-      if (
-        fiber.tag === FunctionComponent ||
-        fiber.tag === SimpleMemoComponent ||
-        fiber.tag === ForwardRef
-      ) {
-        try {
-          const hooksTree = inspectHooksOfFiberWithoutDefaultDispatcher(
-            fiber,
-            getDispatcherRef(internals),
-          );
-          info.hooks = normalizeHooks(hooksTree);
-        } catch (error) {
-          return {
-            error: new Error('Failed to inspect hooks.', {cause: error}),
-          };
+
+    let sawRoot = false;
+    // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+    for (const [rendererID, roots] of fiberRoots) {
+      const internals = rendererInternals.get(rendererID);
+      if (internals == null) {
+        return {error: 'Missing internals for renderer ' + rendererID};
+      }
+      // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+      for (const root of roots) {
+        sawRoot = true;
+        const hostFiber = findByHostInstance(
+          internals,
+          root.current,
+          hostInstance,
+        );
+        if (hostFiber !== null) {
+          return buildNodeInfo(hostFiber, internals);
         }
       }
     }
-    return info;
+
+    if (!sawRoot) {
+      return {error: 'No mounted React roots found'};
+    }
+    return {error: 'Host instance is not managed by React'};
   }
 
   function collectMatches(
@@ -677,6 +783,7 @@ export function createTreeTools(
   return {
     getComponentTree,
     getComponentByUid,
+    getComponentByHostInstance,
     findComponents,
     getComponentSource,
     getOwnerStackTrace,

--- a/packages/react-devtools-facade/src/__tests__/DevToolsFacade-test.js
+++ b/packages/react-devtools-facade/src/__tests__/DevToolsFacade-test.js
@@ -1634,6 +1634,138 @@ describe('react-devtools-facade', () => {
     });
   });
 
+  describe('getComponentByHostInstance', () => {
+    let getComponentTree;
+    let getComponentByUid;
+    let getComponentByHostInstance;
+
+    beforeEach(() => {
+      const tools = createTools(facade);
+      getComponentTree = tools.getComponentTree;
+      getComponentByUid = tools.getComponentByUid;
+      getComponentByHostInstance = tools.getComponentByHostInstance;
+    });
+
+    it('returns the host component for a DOM host element', () => {
+      function Child({label}) {
+        return <span className="leaf">{label}</span>;
+      }
+      function App() {
+        return (
+          <div>
+            <Child label="leaf" />
+          </div>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const span = container.querySelector('span.leaf');
+      const host = getComponentTree().find(n => n.name === 'span');
+      const result = getComponentByHostInstance(span);
+
+      expect(result).toEqual(getComponentByUid(host.uid));
+      expect(result).toMatchObject({
+        uid: host.uid,
+        type: 'host',
+        name: 'span',
+        props: {className: 'leaf'},
+      });
+    });
+
+    it('returns the host component rather than the tree owner', () => {
+      function Wrapper({children}) {
+        return <section className="wrap">{children}</section>;
+      }
+      function App() {
+        return (
+          <Wrapper>
+            <button className="action">Run</button>
+          </Wrapper>
+        );
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const button = container.querySelector('button.action');
+      const tree = getComponentTree();
+      const host = tree.find(n => n.name === 'button');
+      const wrapper = tree.find(n => n.name === 'Wrapper');
+      const app = tree.find(n => n.name === 'App');
+      const result = getComponentByHostInstance(button);
+
+      expect(result.uid).toBe(host.uid);
+      expect(result.uid).not.toBe(wrapper.uid);
+      expect(result.uid).not.toBe(app.uid);
+      expect(result).toMatchObject({
+        type: 'host',
+        name: 'button',
+        props: {className: 'action'},
+      });
+    });
+
+    it('keeps uids stable across re-renders via alternate fibers', () => {
+      function Counter({count}) {
+        return <div className="counter">{'Count: ' + count}</div>;
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      act(() => {
+        root.render(<Counter count={0} />);
+      });
+
+      const div = container.querySelector('div.counter');
+      const first = getComponentByHostInstance(div);
+
+      act(() => {
+        root.render(<Counter count={1} />);
+      });
+
+      const second = getComponentByHostInstance(div);
+      expect(second.uid).toBe(first.uid);
+      expect(second.name).toBe('div');
+      expect(second.type).toBe('host');
+      expect(second.props.className).toBe('counter');
+    });
+
+    it('does not walk platform parent pointers for unmanaged nested nodes', () => {
+      function App() {
+        return <div className="host" />;
+      }
+
+      act(() => {
+        ReactDOMClient.createRoot(container).render(<App />);
+      });
+
+      const host = container.querySelector('div.host');
+      const unmanagedChild = document.createElement('i');
+      host.appendChild(unmanagedChild);
+
+      expect(getComponentByHostInstance(unmanagedChild)).toEqual({
+        error: 'Host instance is not managed by React',
+      });
+    });
+
+    it('returns an error when no roots are mounted', () => {
+      expect(getComponentByHostInstance({})).toEqual({
+        error: 'No mounted React roots found',
+      });
+    });
+
+    it('returns an error for null or undefined references', () => {
+      expect(getComponentByHostInstance(null)).toEqual({
+        error: 'Host instance is required',
+      });
+      expect(getComponentByHostInstance(undefined)).toEqual({
+        error: 'Host instance is required',
+      });
+    });
+  });
+
   describe('profiler', () => {
     let startProfiling;
     let stopProfiling;


### PR DESCRIPTION
Adds a new tool to the Facade, where the input is the `HostInstance` and the output is the corresponding component payload for the `HostFiber` of this `HostInstance`. Supports multiple Host objects from Fiber: `HostComponent`, `HostText`, `HostSingleton`, `HostHoistable`.

> [!NOTE]
> This doesn't bring much value now, because this returns the payload for the corresponding HostFiber, not the closest user-defined Fiber. This will be improved by adding a parentUid reference to the element payload, so the agent can crawl up through the component tree.