### PR TITLE
[react-devtools-cdt-mcp] add DOM element component lookup

### DIFF
--- a/packages/react-devtools-cdt-mcp/README.md
+++ b/packages/react-devtools-cdt-mcp/README.md
@@ -55,6 +55,15 @@ Detailed info for a single component.
   is true, `hooks` (function, forwardRef, and memo components) is an array of
   `{id, name, value, subHooks}`.
 
+### `react_get_component_by_dom_element`
+
+Detailed info for the React DOM component corresponding to a DOM element.
+
+- **Input:** `element` (object, required). This is an opaque page-side DOM
+  element reference. Chrome DevTools MCP clients pass this as
+  `{uid: string}`, using an element uid from the page snapshot.
+- **Output:** `{uid, type, name, key?, props?, hooks?}`.
+
 ### `react_find_components`
 
 Find components by case-insensitive name substring.

--- a/packages/react-devtools-cdt-mcp/src/DevToolsCdtMcp.js
+++ b/packages/react-devtools-cdt-mcp/src/DevToolsCdtMcp.js
@@ -46,6 +46,24 @@ function normalizeToolResult(result: mixed): mixed {
   return result;
 }
 
+function getComponentForDomElement(tools: Tools, element: mixed): mixed {
+  const result = tools.getComponentByHostInstance(element);
+  if (
+    result != null &&
+    typeof result === 'object' &&
+    typeof (result as any).error === 'string'
+  ) {
+    const error = (result as any).error;
+    if (error === 'Host instance is required') {
+      return {error: 'DOM element is required'};
+    }
+    if (error === 'Host instance is not managed by React') {
+      return {error: 'DOM element is not managed by React'};
+    }
+  }
+  return result;
+}
+
 const TOOL_DEFINITIONS: Array<ToolDefinition> = [
   {
     name: 'react_get_component_tree',
@@ -96,6 +114,27 @@ const TOOL_DEFINITIONS: Array<ToolDefinition> = [
     },
     call: (tools, args) =>
       tools.getComponentByUid(args.uid, args.includeHooks === true),
+  },
+  {
+    name: 'react_get_component_by_dom_element',
+    description:
+      'Detailed info for one React DOM component by DOM element reference: ' +
+      '{uid, type, name, key?, props?, hooks?}. The element is an opaque ' +
+      'page-side reference, such as the currently selected Chrome DevTools ' +
+      'element.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        element: {
+          type: 'object',
+          'x-mcp-type': 'HTMLElement',
+          description:
+            'DOM element reference from the Chrome DevTools MCP page snapshot.',
+        },
+      },
+      required: ['element'],
+    },
+    call: (tools, args) => getComponentForDomElement(tools, args.element),
   },
   {
     name: 'react_find_components',

--- a/packages/react-devtools-cdt-mcp/src/__tests__/DevToolsCdtMcp-test.js
+++ b/packages/react-devtools-cdt-mcp/src/__tests__/DevToolsCdtMcp-test.js
@@ -10,6 +10,7 @@
 const TOOL_NAMES = [
   'react_get_component_tree',
   'react_get_component_by_uid',
+  'react_get_component_by_dom_element',
   'react_find_components',
   'react_get_component_source',
   'react_get_owner_stack_trace',
@@ -121,6 +122,17 @@ describe('react-devtools-cdt-mcp', () => {
         includeHooks: {type: 'boolean', description: expect.any(String)},
       },
       required: ['uid'],
+    });
+    expect(getTool('react_get_component_by_dom_element').inputSchema).toEqual({
+      type: 'object',
+      properties: {
+        element: {
+          type: 'object',
+          'x-mcp-type': 'HTMLElement',
+          description: expect.any(String),
+        },
+      },
+      required: ['element'],
     });
     expect(getTool('react_find_components').inputSchema).toEqual({
       type: 'object',
@@ -306,6 +318,56 @@ describe('react-devtools-cdt-mcp', () => {
       name: 'Counter',
       props: {title: 'hi'},
     });
+  });
+
+  it('react_get_component_by_dom_element returns the DOM element component', () => {
+    function Wrapper({children}) {
+      return <section className="wrap">{children}</section>;
+    }
+    function App() {
+      return (
+        <Wrapper>
+          <button className="action">Run</button>
+        </Wrapper>
+      );
+    }
+
+    act(() => {
+      ReactDOMClient.createRoot(container).render(<App />);
+    });
+
+    const button = container.querySelector('button.action');
+    const tree = getTool('react_get_component_tree').execute({}).nodes;
+    const host = tree.find(n => n.name === 'button');
+    const wrapper = tree.find(n => n.name === 'Wrapper');
+    const result = getTool('react_get_component_by_dom_element').execute({
+      element: button,
+    });
+
+    expect(result.uid).toBe(host.uid);
+    expect(result.uid).not.toBe(wrapper.uid);
+    expect(result).toMatchObject({
+      type: 'host',
+      name: 'button',
+      props: {className: 'action'},
+    });
+  });
+
+  it('react_get_component_by_dom_element returns DOM-oriented errors', () => {
+    expect(getTool('react_get_component_by_dom_element').execute({})).toEqual({
+      error: 'DOM element is required',
+    });
+
+    act(() => {
+      ReactDOMClient.createRoot(container).render(<div className="host" />);
+    });
+
+    const unmanaged = document.createElement('span');
+    expect(
+      getTool('react_get_component_by_dom_element').execute({
+        element: unmanaged,
+      }),
+    ).toEqual({error: 'DOM element is not managed by React'});
   });
 
   it('returns tool errors as a raw payload', () => {


### PR DESCRIPTION
Integrates newly added `getComponentByHostInstance` tool from `react-devtools-facade` into `react-devtools-cdt-mcp`.

The API uses `uid` of the element from CDT MCP tree snapshot, but under the hood it gets converted to the DOM Element reference, which is exactly what we pass to `getComponentByHostInstance`.
