### PR TITLE
[DevTools] Add ignore-listed stack frame disclosure

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSharedStyles.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSharedStyles.css
@@ -143,3 +143,8 @@
   padding-left: 1.25rem;
   margin-top: 0.25rem;
 }
+
+.SuspendedBySkeleton {
+  padding: 0.25rem;
+  padding-left: 1.25rem;
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
@@ -17,10 +17,7 @@ import {serializeDataForCopy, pluralize} from '../utils';
 import Store from '../../store';
 import styles from './InspectedElementSharedStyles.css';
 import {withPermissionsCheck} from 'react-devtools-shared/src/frontend/utils/withPermissionsCheck';
-import StackTraceView, {
-  IgnoredCallSitesToggle,
-  useIgnoredCallSites,
-} from './StackTraceView';
+import StackTraceView from './StackTraceView';
 import OwnerView from './OwnerView';
 import {meta} from '../../../hydration';
 import useInferredName from '../useInferredName';
@@ -110,7 +107,6 @@ function SuspendedByRow({
 }: RowProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [openIsPending, startOpenTransition] = useTransition();
-  const ignoredCallSites = useIgnoredCallSites();
   const ioInfo = asyncInfo.awaited;
   const name = useInferredName(asyncInfo);
   const description = ioInfo.description;
@@ -207,12 +203,6 @@ function SuspendedByRow({
       </Button>
       {isOpen && (
         <div className={styles.CollapsableContent}>
-          {ignoredCallSites.hasIgnoredCallSites && (
-            <IgnoredCallSitesToggle
-              showIgnoredCallSites={ignoredCallSites.showIgnoredCallSites}
-              onClick={ignoredCallSites.toggle}
-            />
-          )}
           {showIOStack && (
             <StackTraceView
               stack={ioInfo.stack}
@@ -221,7 +211,6 @@ function SuspendedByRow({
                   ? null
                   : ioInfo.env
               }
-              ignoredCallSites={ignoredCallSites}
             />
           )}
           {ioOwner !== null &&
@@ -257,7 +246,6 @@ function SuspendedByRow({
                       ? null
                       : asyncInfo.env
                   }
-                  ignoredCallSites={ignoredCallSites}
                 />
               )}
               {asyncOwner !== null && asyncOwner.id !== inspectedElement.id ? (

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
@@ -20,6 +20,7 @@ import {withPermissionsCheck} from 'react-devtools-shared/src/frontend/utils/wit
 import StackTraceView from './StackTraceView';
 import OwnerView from './OwnerView';
 import {meta} from '../../../hydration';
+import Skeleton from './Skeleton';
 import useInferredName from '../useInferredName';
 
 import {getClassNameForEnvironment} from '../SuspenseTab/SuspenseEnvironmentColors.js';
@@ -203,102 +204,109 @@ function SuspendedByRow({
       </Button>
       {isOpen && (
         <div className={styles.CollapsableContent}>
-          {showIOStack && (
-            <StackTraceView
-              stack={ioInfo.stack}
-              environmentName={
-                ioOwner !== null && ioOwner.env === ioInfo.env
-                  ? null
-                  : ioInfo.env
-              }
-            />
-          )}
-          {ioOwner !== null &&
-          ioOwner.id !== inspectedElement.id &&
-          (showIOStack ||
-            !showAwaitStack ||
-            asyncOwner === null ||
-            ioOwner.id !== asyncOwner.id) ? (
-            <OwnerView
-              key={ioOwner.id}
-              displayName={ioOwner.displayName || 'Anonymous'}
-              environmentName={
-                ioOwner.env === inspectedElement.env &&
-                ioOwner.env === ioInfo.env
-                  ? null
-                  : ioOwner.env
-              }
-              hocDisplayNames={ioOwner.hocDisplayNames}
-              compiledWithForget={ioOwner.compiledWithForget}
-              id={ioOwner.id}
-              isInStore={store.containsElement(ioOwner.id)}
-              type={ioOwner.type}
-            />
-          ) : null}
-          {showAwaitStack ? (
-            <>
-              <div className={styles.SmallHeader}>awaited at:</div>
-              {asyncInfo.stack !== null && asyncInfo.stack.length > 0 && (
-                <StackTraceView
-                  stack={asyncInfo.stack}
-                  environmentName={
-                    asyncOwner !== null && asyncOwner.env === asyncInfo.env
-                      ? null
-                      : asyncInfo.env
-                  }
-                />
-              )}
-              {asyncOwner !== null && asyncOwner.id !== inspectedElement.id ? (
-                <OwnerView
-                  key={asyncOwner.id}
-                  displayName={asyncOwner.displayName || 'Anonymous'}
-                  environmentName={
-                    asyncOwner.env === inspectedElement.env &&
-                    asyncOwner.env === asyncInfo.env
-                      ? null
-                      : asyncOwner.env
-                  }
-                  hocDisplayNames={asyncOwner.hocDisplayNames}
-                  compiledWithForget={asyncOwner.compiledWithForget}
-                  id={asyncOwner.id}
-                  isInStore={store.containsElement(asyncOwner.id)}
-                  type={asyncOwner.type}
-                />
-              ) : null}
-            </>
-          ) : null}
-          <div className={styles.PreviewContainer}>
-            <KeyValue
-              alphaSort={true}
-              bridge={bridge}
-              canDeletePaths={false}
-              canEditValues={false}
-              canRenamePaths={false}
-              depth={1}
-              element={element}
-              hidden={false}
-              inspectedElement={inspectedElement}
-              name={
-                isFulfilled
-                  ? 'awaited value'
-                  : isRejected
-                    ? 'rejected with'
-                    : 'pending value'
-              }
-              path={
-                isFulfilled
-                  ? [index, 'awaited', 'value', 'value']
-                  : isRejected
-                    ? [index, 'awaited', 'value', 'reason']
-                    : [index, 'awaited', 'value']
-              }
-              pathRoot="suspendedBy"
-              store={store}
-              value={
-                isFulfilled ? value.value : isRejected ? value.reason : value
-              }
-            />
-          </div>
+          <React.Suspense
+            fallback={
+              <div className={styles.SuspendedBySkeleton}>
+                <Skeleton height={16} width="40%" />
+              </div>
+            }>
+            {showIOStack && (
+              <StackTraceView
+                stack={ioInfo.stack}
+                environmentName={
+                  ioOwner !== null && ioOwner.env === ioInfo.env
+                    ? null
+                    : ioInfo.env
+                }
+              />
+            )}
+            {ioOwner !== null &&
+            ioOwner.id !== inspectedElement.id &&
+            (showIOStack ||
+              !showAwaitStack ||
+              asyncOwner === null ||
+              ioOwner.id !== asyncOwner.id) ? (
+              <OwnerView
+                key={ioOwner.id}
+                displayName={ioOwner.displayName || 'Anonymous'}
+                environmentName={
+                  ioOwner.env === inspectedElement.env &&
+                  ioOwner.env === ioInfo.env
+                    ? null
+                    : ioOwner.env
+                }
+                hocDisplayNames={ioOwner.hocDisplayNames}
+                compiledWithForget={ioOwner.compiledWithForget}
+                id={ioOwner.id}
+                isInStore={store.containsElement(ioOwner.id)}
+                type={ioOwner.type}
+              />
+            ) : null}
+            {showAwaitStack ? (
+              <>
+                <div className={styles.SmallHeader}>awaited at:</div>
+                {asyncInfo.stack !== null && asyncInfo.stack.length > 0 && (
+                  <StackTraceView
+                    stack={asyncInfo.stack}
+                    environmentName={
+                      asyncOwner !== null && asyncOwner.env === asyncInfo.env
+                        ? null
+                        : asyncInfo.env
+                    }
+                  />
+                )}
+                {asyncOwner !== null && asyncOwner.id !== inspectedElement.id ? (
+                  <OwnerView
+                    key={asyncOwner.id}
+                    displayName={asyncOwner.displayName || 'Anonymous'}
+                    environmentName={
+                      asyncOwner.env === inspectedElement.env &&
+                      asyncOwner.env === asyncInfo.env
+                        ? null
+                        : asyncOwner.env
+                    }
+                    hocDisplayNames={asyncOwner.hocDisplayNames}
+                    compiledWithForget={asyncOwner.compiledWithForget}
+                    id={asyncOwner.id}
+                    isInStore={store.containsElement(asyncOwner.id)}
+                    type={asyncOwner.type}
+                  />
+                ) : null}
+              </>
+            ) : null}
+            <div className={styles.PreviewContainer}>
+              <KeyValue
+                alphaSort={true}
+                bridge={bridge}
+                canDeletePaths={false}
+                canEditValues={false}
+                canRenamePaths={false}
+                depth={1}
+                element={element}
+                hidden={false}
+                inspectedElement={inspectedElement}
+                name={
+                  isFulfilled
+                    ? 'awaited value'
+                    : isRejected
+                      ? 'rejected with'
+                      : 'pending value'
+                }
+                path={
+                  isFulfilled
+                    ? [index, 'awaited', 'value', 'value']
+                    : isRejected
+                      ? [index, 'awaited', 'value', 'reason']
+                      : [index, 'awaited', 'value']
+                }
+                pathRoot="suspendedBy"
+                store={store}
+                value={
+                  isFulfilled ? value.value : isRejected ? value.reason : value
+                }
+              />
+            </div>
+          </React.Suspense>
         </div>
       )}
     </div>

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
@@ -17,7 +17,10 @@ import {serializeDataForCopy, pluralize} from '../utils';
 import Store from '../../store';
 import styles from './InspectedElementSharedStyles.css';
 import {withPermissionsCheck} from 'react-devtools-shared/src/frontend/utils/withPermissionsCheck';
-import StackTraceView from './StackTraceView';
+import StackTraceView, {
+  IgnoredCallSitesToggle,
+  useIgnoredCallSites,
+} from './StackTraceView';
 import OwnerView from './OwnerView';
 import {meta} from '../../../hydration';
 import useInferredName from '../useInferredName';
@@ -107,6 +110,7 @@ function SuspendedByRow({
 }: RowProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [openIsPending, startOpenTransition] = useTransition();
+  const ignoredCallSites = useIgnoredCallSites();
   const ioInfo = asyncInfo.awaited;
   const name = useInferredName(asyncInfo);
   const description = ioInfo.description;
@@ -203,6 +207,12 @@ function SuspendedByRow({
       </Button>
       {isOpen && (
         <div className={styles.CollapsableContent}>
+          {ignoredCallSites.hasIgnoredCallSites && (
+            <IgnoredCallSitesToggle
+              showIgnoredCallSites={ignoredCallSites.showIgnoredCallSites}
+              onClick={ignoredCallSites.toggle}
+            />
+          )}
           {showIOStack && (
             <StackTraceView
               stack={ioInfo.stack}
@@ -211,6 +221,7 @@ function SuspendedByRow({
                   ? null
                   : ioInfo.env
               }
+              ignoredCallSites={ignoredCallSites}
             />
           )}
           {ioOwner !== null &&
@@ -246,6 +257,7 @@ function SuspendedByRow({
                       ? null
                       : asyncInfo.env
                   }
+                  ignoredCallSites={ignoredCallSites}
                 />
               )}
               {asyncOwner !== null && asyncOwner.id !== inspectedElement.id ? (

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
@@ -9,7 +9,7 @@
 
 import {copy} from 'clipboard-js';
 import * as React from 'react';
-import {useState, useTransition} from 'react';
+import {use, useContext, useState, useTransition} from 'react';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import KeyValue from './KeyValue';
@@ -17,11 +17,13 @@ import {serializeDataForCopy, pluralize} from '../utils';
 import Store from '../../store';
 import styles from './InspectedElementSharedStyles.css';
 import {withPermissionsCheck} from 'react-devtools-shared/src/frontend/utils/withPermissionsCheck';
-import StackTraceView from './StackTraceView';
+import FetchFileWithCachingContext from './FetchFileWithCachingContext';
+import StackTraceView, {IgnoreListToggleButton} from './StackTraceView';
 import OwnerView from './OwnerView';
 import {meta} from '../../../hydration';
 import Skeleton from './Skeleton';
 import useInferredName from '../useInferredName';
+import {symbolicateSourceWithCache} from 'react-devtools-shared/src/symbolicateSource';
 
 import {getClassNameForEnvironment} from '../SuspenseTab/SuspenseEnvironmentColors.js';
 
@@ -30,6 +32,8 @@ import type {
   SerializedAsyncInfo,
 } from 'react-devtools-shared/src/frontend/types';
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
+import type {ReactStackTrace} from 'shared/ReactTypes';
+import type {SourceMappedLocation} from 'react-devtools-shared/src/symbolicateSource';
 
 import {
   UNKNOWN_SUSPENDERS_NONE,
@@ -93,6 +97,54 @@ function formatBytes(bytes: number) {
     return (bytes / 1_000_000).toFixed(1) + ' mB';
   }
   return (bytes / 1_000_000_000).toFixed(1) + ' gB';
+}
+
+type StackTraceGroupProps = {
+  children: (showIgnoreList: boolean) => React.Node,
+  ioStack: null | ReactStackTrace,
+};
+
+function StackTraceGroup({
+  children,
+  ioStack,
+}: StackTraceGroupProps): React.Node {
+  const [showIgnoreList, setShowIgnoreList] = useState(false);
+  const fetchFileWithCaching = useContext(FetchFileWithCachingContext);
+
+  const ioStackHasIgnoredFrames =
+    ioStack !== null &&
+    ioStack.some(callSite => {
+      const [, virtualURL, virtualLine, virtualColumn] = callSite;
+
+      // symbolicated output is cached
+      const symbolicatedCallSite: null | SourceMappedLocation =
+        fetchFileWithCaching !== null
+          ? use(
+              symbolicateSourceWithCache(
+                fetchFileWithCaching,
+                virtualURL,
+                virtualLine,
+                virtualColumn,
+              ),
+            )
+          : null;
+
+      return symbolicatedCallSite !== null && symbolicatedCallSite.ignored;
+    });
+
+  const hasIgnoredFrames = ioStackHasIgnoredFrames;
+
+  return (
+    <>
+      {children(showIgnoreList)}
+      {hasIgnoredFrames && (
+        <IgnoreListToggleButton
+          onClick={() => setShowIgnoreList(prev => !prev)}
+          showIgnoreList={showIgnoreList}
+        />
+      )}
+    </>
+  );
 }
 
 function SuspendedByRow({
@@ -210,102 +262,116 @@ function SuspendedByRow({
                 <Skeleton height={16} width="40%" />
               </div>
             }>
-            {showIOStack && (
-              <StackTraceView
-                stack={ioInfo.stack}
-                environmentName={
-                  ioOwner !== null && ioOwner.env === ioInfo.env
-                    ? null
-                    : ioInfo.env
-                }
-              />
-            )}
-            {ioOwner !== null &&
-            ioOwner.id !== inspectedElement.id &&
-            (showIOStack ||
-              !showAwaitStack ||
-              asyncOwner === null ||
-              ioOwner.id !== asyncOwner.id) ? (
-              <OwnerView
-                key={ioOwner.id}
-                displayName={ioOwner.displayName || 'Anonymous'}
-                environmentName={
-                  ioOwner.env === inspectedElement.env &&
-                  ioOwner.env === ioInfo.env
-                    ? null
-                    : ioOwner.env
-                }
-                hocDisplayNames={ioOwner.hocDisplayNames}
-                compiledWithForget={ioOwner.compiledWithForget}
-                id={ioOwner.id}
-                isInStore={store.containsElement(ioOwner.id)}
-                type={ioOwner.type}
-              />
-            ) : null}
-            {showAwaitStack ? (
-              <>
-                <div className={styles.SmallHeader}>awaited at:</div>
-                {asyncInfo.stack !== null && asyncInfo.stack.length > 0 && (
-                  <StackTraceView
-                    stack={asyncInfo.stack}
-                    environmentName={
-                      asyncOwner !== null && asyncOwner.env === asyncInfo.env
-                        ? null
-                        : asyncInfo.env
-                    }
-                  />
-                )}
-                {asyncOwner !== null && asyncOwner.id !== inspectedElement.id ? (
-                  <OwnerView
-                    key={asyncOwner.id}
-                    displayName={asyncOwner.displayName || 'Anonymous'}
-                    environmentName={
-                      asyncOwner.env === inspectedElement.env &&
-                      asyncOwner.env === asyncInfo.env
-                        ? null
-                        : asyncOwner.env
-                    }
-                    hocDisplayNames={asyncOwner.hocDisplayNames}
-                    compiledWithForget={asyncOwner.compiledWithForget}
-                    id={asyncOwner.id}
-                    isInStore={store.containsElement(asyncOwner.id)}
-                    type={asyncOwner.type}
-                  />
-                ) : null}
-              </>
-            ) : null}
-            <div className={styles.PreviewContainer}>
-              <KeyValue
-                alphaSort={true}
-                bridge={bridge}
-                canDeletePaths={false}
-                canEditValues={false}
-                canRenamePaths={false}
-                depth={1}
-                element={element}
-                hidden={false}
-                inspectedElement={inspectedElement}
-                name={
-                  isFulfilled
-                    ? 'awaited value'
-                    : isRejected
-                      ? 'rejected with'
-                      : 'pending value'
-                }
-                path={
-                  isFulfilled
-                    ? [index, 'awaited', 'value', 'value']
-                    : isRejected
-                      ? [index, 'awaited', 'value', 'reason']
-                      : [index, 'awaited', 'value']
-                }
-                pathRoot="suspendedBy"
-                store={store}
-                value={
-                  isFulfilled ? value.value : isRejected ? value.reason : value
-                }
-              />
-            </div>
+            <StackTraceGroup ioStack={showIOStack ? ioInfo.stack : null}>
+              {(showIgnoreList: boolean) => (
+                <>
+                  {showIOStack && (
+                    <StackTraceView
+                      stack={ioInfo.stack}
+                      environmentName={
+                        ioOwner !== null && ioOwner.env === ioInfo.env
+                          ? null
+                          : ioInfo.env
+                      }
+                      showIgnoreList={showIgnoreList}
+                    />
+                  )}
+                  {ioOwner !== null &&
+                  ioOwner.id !== inspectedElement.id &&
+                  (showIOStack ||
+                    !showAwaitStack ||
+                    asyncOwner === null ||
+                    ioOwner.id !== asyncOwner.id) ? (
+                    <OwnerView
+                      key={ioOwner.id}
+                      displayName={ioOwner.displayName || 'Anonymous'}
+                      environmentName={
+                        ioOwner.env === inspectedElement.env &&
+                        ioOwner.env === ioInfo.env
+                          ? null
+                          : ioOwner.env
+                      }
+                      hocDisplayNames={ioOwner.hocDisplayNames}
+                      compiledWithForget={ioOwner.compiledWithForget}
+                      id={ioOwner.id}
+                      isInStore={store.containsElement(ioOwner.id)}
+                      type={ioOwner.type}
+                    />
+                  ) : null}
+                  {showAwaitStack ? (
+                    <>
+                      <div className={styles.SmallHeader}>awaited at:</div>
+                      {asyncInfo.stack !== null &&
+                        asyncInfo.stack.length > 0 && (
+                          <StackTraceView
+                            stack={asyncInfo.stack}
+                            environmentName={
+                              asyncOwner !== null &&
+                              asyncOwner.env === asyncInfo.env
+                                ? null
+                                : asyncInfo.env
+                            }
+                          />
+                        )}
+                      {asyncOwner !== null &&
+                      asyncOwner.id !== inspectedElement.id ? (
+                        <OwnerView
+                          key={asyncOwner.id}
+                          displayName={asyncOwner.displayName || 'Anonymous'}
+                          environmentName={
+                            asyncOwner.env === inspectedElement.env &&
+                            asyncOwner.env === asyncInfo.env
+                              ? null
+                              : asyncOwner.env
+                          }
+                          hocDisplayNames={asyncOwner.hocDisplayNames}
+                          compiledWithForget={asyncOwner.compiledWithForget}
+                          id={asyncOwner.id}
+                          isInStore={store.containsElement(asyncOwner.id)}
+                          type={asyncOwner.type}
+                        />
+                      ) : null}
+                    </>
+                  ) : null}
+                  <div className={styles.PreviewContainer}>
+                    <KeyValue
+                      alphaSort={true}
+                      bridge={bridge}
+                      canDeletePaths={false}
+                      canEditValues={false}
+                      canRenamePaths={false}
+                      depth={1}
+                      element={element}
+                      hidden={false}
+                      inspectedElement={inspectedElement}
+                      name={
+                        isFulfilled
+                          ? 'awaited value'
+                          : isRejected
+                            ? 'rejected with'
+                            : 'pending value'
+                      }
+                      path={
+                        isFulfilled
+                          ? [index, 'awaited', 'value', 'value']
+                          : isRejected
+                            ? [index, 'awaited', 'value', 'reason']
+                            : [index, 'awaited', 'value']
+                      }
+                      pathRoot="suspendedBy"
+                      store={store}
+                      value={
+                        isFulfilled
+                          ? value.value
+                          : isRejected
+                            ? value.reason
+                            : value
+                      }
+                    />
+                  </div>
+                </>
+              )}
+            </StackTraceGroup>
           </React.Suspense>
         </div>
       )}

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspendedBy.js
@@ -102,11 +102,13 @@ function formatBytes(bytes: number) {
 type StackTraceGroupProps = {
   children: (showIgnoreList: boolean) => React.Node,
   ioStack: null | ReactStackTrace,
+  asyncInfoStack: null | ReactStackTrace,
 };
 
 function StackTraceGroup({
   children,
   ioStack,
+  asyncInfoStack,
 }: StackTraceGroupProps): React.Node {
   const [showIgnoreList, setShowIgnoreList] = useState(false);
   const fetchFileWithCaching = useContext(FetchFileWithCachingContext);
@@ -132,7 +134,29 @@ function StackTraceGroup({
       return symbolicatedCallSite !== null && symbolicatedCallSite.ignored;
     });
 
-  const hasIgnoredFrames = ioStackHasIgnoredFrames;
+  const asyncInfoStackHasIgnoredFrames =
+    asyncInfoStack !== null &&
+    asyncInfoStack.some(callSite => {
+      const [, virtualURL, virtualLine, virtualColumn] = callSite;
+
+      // symbolicated output is cached
+      const symbolicatedCallSite: null | SourceMappedLocation =
+        fetchFileWithCaching !== null
+          ? use(
+              symbolicateSourceWithCache(
+                fetchFileWithCaching,
+                virtualURL,
+                virtualLine,
+                virtualColumn,
+              ),
+            )
+          : null;
+
+      return symbolicatedCallSite !== null && symbolicatedCallSite.ignored;
+    });
+
+  const hasIgnoredFrames =
+    ioStackHasIgnoredFrames || asyncInfoStackHasIgnoredFrames;
 
   return (
     <>
@@ -262,7 +286,9 @@ function SuspendedByRow({
                 <Skeleton height={16} width="40%" />
               </div>
             }>
-            <StackTraceGroup ioStack={showIOStack ? ioInfo.stack : null}>
+            <StackTraceGroup
+              ioStack={showIOStack ? ioInfo.stack : null}
+              asyncInfoStack={showAwaitStack ? asyncInfo.stack : null}>
               {(showIgnoreList: boolean) => (
                 <>
                   {showIOStack && (
@@ -311,6 +337,7 @@ function SuspendedByRow({
                                 ? null
                                 : asyncInfo.env
                             }
+                            showIgnoreList={showIgnoreList}
                           />
                         )}
                       {asyncOwner !== null &&

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
@@ -8,7 +8,7 @@
  */
 
 import * as React from 'react';
-import {Fragment, useContext} from 'react';
+import {Fragment, useContext, useState, use} from 'react';
 import {BridgeContext, StoreContext} from '../context';
 import InspectedElementBadges from './InspectedElementBadges';
 import InspectedElementContextTree from './InspectedElementContextTree';
@@ -19,15 +19,17 @@ import InspectedElementStateTree from './InspectedElementStateTree';
 import InspectedElementStyleXPlugin from './InspectedElementStyleXPlugin';
 import InspectedElementSuspendedBy from './InspectedElementSuspendedBy';
 import NativeStyleEditor from './NativeStyleEditor';
+import FetchFileWithCachingContext from './FetchFileWithCachingContext';
 import {enableStyleXFeatures} from 'react-devtools-feature-flags';
 import InspectedElementSourcePanel from './InspectedElementSourcePanel';
-import StackTraceView from './StackTraceView';
+import StackTraceView, {IgnoreListToggleButton} from './StackTraceView';
 import OwnerView from './OwnerView';
 import Skeleton from './Skeleton';
 import {
   ElementTypeSuspense,
   ElementTypeActivity,
 } from 'react-devtools-shared/src/frontend/types';
+import {symbolicateSourceWithCache} from 'react-devtools-shared/src/symbolicateSource';
 
 import styles from './InspectedElementView.css';
 
@@ -38,6 +40,52 @@ import type {
 import type {HookNames} from 'react-devtools-shared/src/frontend/types';
 import type {ToggleParseHookNames} from './InspectedElementContext';
 import type {SourceMappedLocation} from 'react-devtools-shared/src/symbolicateSource';
+
+type StackTraceGroupProps = {
+  children: (showIgnoreList: boolean) => React.Node,
+  componentStack: InspectedElement['stack'],
+};
+
+function StackTraceGroup({
+  children,
+  componentStack,
+}: StackTraceGroupProps): React.Node {
+  const [showIgnoreList, setShowIgnoreList] = useState(false);
+  const fetchFileWithCaching = useContext(FetchFileWithCachingContext);
+
+  const hasIgnoredFrames =
+    componentStack !== null &&
+    componentStack.some(callSite => {
+      const [, virtualURL, virtualLine, virtualColumn] = callSite;
+
+      // symbolicated output is cached
+      const symbolicatedCallSite: null | SourceMappedLocation =
+        fetchFileWithCaching !== null
+          ? use(
+              symbolicateSourceWithCache(
+                fetchFileWithCaching,
+                virtualURL,
+                virtualLine,
+                virtualColumn,
+              ),
+            )
+          : null;
+
+      return symbolicatedCallSite !== null && symbolicatedCallSite.ignored;
+    });
+
+  return (
+    <>
+      {children(showIgnoreList)}
+      {hasIgnoredFrames && (
+        <IgnoreListToggleButton
+          onClick={() => setShowIgnoreList(prev => !prev)}
+          showIgnoreList={showIgnoreList}
+        />
+      )}
+    </>
+  );
+}
 
 type Props = {
   element: Element,
@@ -189,33 +237,48 @@ export default function InspectedElementView({
                   <Skeleton height={16} width="40%" />
                 </div>
               }>
-              {showStack ? <StackTraceView stack={stack} /> : null}
-              {showOwnersList &&
-                owners?.map(owner => (
-                  <Fragment key={owner.id}>
-                    <OwnerView
-                      displayName={owner.displayName || 'Anonymous'}
-                      hocDisplayNames={owner.hocDisplayNames}
-                      environmentName={
-                        inspectedElement.env === owner.env ? null : owner.env
-                      }
-                      compiledWithForget={owner.compiledWithForget}
-                      id={owner.id}
-                      isInStore={store.containsElement(owner.id)}
-                      type={owner.type}
-                    />
-                    {owner.stack != null && owner.stack.length > 0 ? (
-                      <StackTraceView stack={owner.stack} />
+              <StackTraceGroup componentStack={stack}>
+                {(showIgnoreList: boolean) => (
+                  <>
+                    {showStack ? (
+                      <StackTraceView
+                        stack={stack}
+                        showIgnoreList={showIgnoreList}
+                      />
                     ) : null}
-                  </Fragment>
-                ))}
+                    {showOwnersList &&
+                      owners?.map(owner => (
+                        <Fragment key={owner.id}>
+                          <OwnerView
+                            displayName={owner.displayName || 'Anonymous'}
+                            hocDisplayNames={owner.hocDisplayNames}
+                            environmentName={
+                              inspectedElement.env === owner.env
+                                ? null
+                                : owner.env
+                            }
+                            compiledWithForget={owner.compiledWithForget}
+                            id={owner.id}
+                            isInStore={store.containsElement(owner.id)}
+                            type={owner.type}
+                          />
+                          {owner.stack != null && owner.stack.length > 0 ? (
+                            <StackTraceView stack={owner.stack} />
+                          ) : null}
+                        </Fragment>
+                      ))}
 
-              {rootType !== null && (
-                <div className={styles.OwnersMetaField}>{rootType}</div>
-              )}
-              {rendererLabel !== null && (
-                <div className={styles.OwnersMetaField}>{rendererLabel}</div>
-              )}
+                    {rootType !== null && (
+                      <div className={styles.OwnersMetaField}>{rootType}</div>
+                    )}
+                    {rendererLabel !== null && (
+                      <div className={styles.OwnersMetaField}>
+                        {rendererLabel}
+                      </div>
+                    )}
+                  </>
+                )}
+              </StackTraceGroup>
             </React.Suspense>
           </div>
         )}

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
@@ -21,7 +21,10 @@ import InspectedElementSuspendedBy from './InspectedElementSuspendedBy';
 import NativeStyleEditor from './NativeStyleEditor';
 import {enableStyleXFeatures} from 'react-devtools-feature-flags';
 import InspectedElementSourcePanel from './InspectedElementSourcePanel';
-import StackTraceView from './StackTraceView';
+import StackTraceView, {
+  IgnoredCallSitesToggle,
+  useIgnoredCallSites,
+} from './StackTraceView';
 import OwnerView from './OwnerView';
 import Skeleton from './Skeleton';
 import {
@@ -69,6 +72,7 @@ export default function InspectedElementView({
 
   const bridge = useContext(BridgeContext);
   const store = useContext(StoreContext);
+  const ignoredCallSites = useIgnoredCallSites();
 
   const rendererLabel =
     rendererPackageName !== null && rendererVersion !== null
@@ -189,7 +193,19 @@ export default function InspectedElementView({
                   <Skeleton height={16} width="40%" />
                 </div>
               }>
-              {showStack ? <StackTraceView stack={stack} /> : null}
+              {ignoredCallSites.hasIgnoredCallSites && (
+                <IgnoredCallSitesToggle
+                  showIgnoredCallSites={ignoredCallSites.showIgnoredCallSites}
+                  onClick={ignoredCallSites.toggle}
+                />
+              )}
+              {showStack ? (
+                <StackTraceView
+                  stack={stack}
+                  environmentName={null}
+                  ignoredCallSites={ignoredCallSites}
+                />
+              ) : null}
               {showOwnersList &&
                 owners?.map(owner => (
                   <Fragment key={owner.id}>
@@ -205,7 +221,11 @@ export default function InspectedElementView({
                       type={owner.type}
                     />
                     {owner.stack != null && owner.stack.length > 0 ? (
-                      <StackTraceView stack={owner.stack} />
+                      <StackTraceView
+                        stack={owner.stack}
+                        environmentName={null}
+                        ignoredCallSites={ignoredCallSites}
+                      />
                     ) : null}
                   </Fragment>
                 ))}

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
@@ -21,10 +21,7 @@ import InspectedElementSuspendedBy from './InspectedElementSuspendedBy';
 import NativeStyleEditor from './NativeStyleEditor';
 import {enableStyleXFeatures} from 'react-devtools-feature-flags';
 import InspectedElementSourcePanel from './InspectedElementSourcePanel';
-import StackTraceView, {
-  IgnoredCallSitesToggle,
-  useIgnoredCallSites,
-} from './StackTraceView';
+import StackTraceView from './StackTraceView';
 import OwnerView from './OwnerView';
 import Skeleton from './Skeleton';
 import {
@@ -72,7 +69,6 @@ export default function InspectedElementView({
 
   const bridge = useContext(BridgeContext);
   const store = useContext(StoreContext);
-  const ignoredCallSites = useIgnoredCallSites();
 
   const rendererLabel =
     rendererPackageName !== null && rendererVersion !== null
@@ -193,19 +189,7 @@ export default function InspectedElementView({
                   <Skeleton height={16} width="40%" />
                 </div>
               }>
-              {ignoredCallSites.hasIgnoredCallSites && (
-                <IgnoredCallSitesToggle
-                  showIgnoredCallSites={ignoredCallSites.showIgnoredCallSites}
-                  onClick={ignoredCallSites.toggle}
-                />
-              )}
-              {showStack ? (
-                <StackTraceView
-                  stack={stack}
-                  environmentName={null}
-                  ignoredCallSites={ignoredCallSites}
-                />
-              ) : null}
+              {showStack ? <StackTraceView stack={stack} /> : null}
               {showOwnersList &&
                 owners?.map(owner => (
                   <Fragment key={owner.id}>
@@ -221,11 +205,7 @@ export default function InspectedElementView({
                       type={owner.type}
                     />
                     {owner.stack != null && owner.stack.length > 0 ? (
-                      <StackTraceView
-                        stack={owner.stack}
-                        environmentName={null}
-                        ignoredCallSites={ignoredCallSites}
-                      />
+                      <StackTraceView stack={owner.stack} />
                     ) : null}
                   </Fragment>
                 ))}

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
@@ -44,16 +44,18 @@ import type {SourceMappedLocation} from 'react-devtools-shared/src/symbolicateSo
 type StackTraceGroupProps = {
   children: (showIgnoreList: boolean) => React.Node,
   componentStack: InspectedElement['stack'],
+  owners: InspectedElement['owners'],
 };
 
 function StackTraceGroup({
   children,
   componentStack,
+  owners,
 }: StackTraceGroupProps): React.Node {
   const [showIgnoreList, setShowIgnoreList] = useState(false);
   const fetchFileWithCaching = useContext(FetchFileWithCachingContext);
 
-  const hasIgnoredFrames =
+  const componentStackHasIgnoredFrames =
     componentStack !== null &&
     componentStack.some(callSite => {
       const [, virtualURL, virtualLine, virtualColumn] = callSite;
@@ -73,6 +75,35 @@ function StackTraceGroup({
 
       return symbolicatedCallSite !== null && symbolicatedCallSite.ignored;
     });
+
+  const ownerStacksHaveIgnoredFrames =
+    owners !== null &&
+    owners.some(owner => {
+      return (
+        owner.stack !== null &&
+        owner.stack.some(callSite => {
+          const [, virtualURL, virtualLine, virtualColumn] = callSite;
+
+          // symbolicated output is cached
+          const symbolicatedCallSite: null | SourceMappedLocation =
+            fetchFileWithCaching !== null
+              ? use(
+                  symbolicateSourceWithCache(
+                    fetchFileWithCaching,
+                    virtualURL,
+                    virtualLine,
+                    virtualColumn,
+                  ),
+                )
+              : null;
+
+          return symbolicatedCallSite !== null && symbolicatedCallSite.ignored;
+        })
+      );
+    });
+
+  const hasIgnoredFrames =
+    componentStackHasIgnoredFrames || ownerStacksHaveIgnoredFrames;
 
   return (
     <>
@@ -237,7 +268,7 @@ export default function InspectedElementView({
                   <Skeleton height={16} width="40%" />
                 </div>
               }>
-              <StackTraceGroup componentStack={stack}>
+              <StackTraceGroup componentStack={stack} owners={owners}>
                 {(showIgnoreList: boolean) => (
                   <>
                     {showStack ? (
@@ -263,7 +294,10 @@ export default function InspectedElementView({
                             type={owner.type}
                           />
                           {owner.stack != null && owner.stack.length > 0 ? (
-                            <StackTraceView stack={owner.stack} />
+                            <StackTraceView
+                              stack={owner.stack}
+                              showIgnoreList={showIgnoreList}
+                            />
                           ) : null}
                         </Fragment>
                       ))}

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
@@ -33,3 +33,13 @@
   margin-left: 0.25rem;
 }
 
+.IgnoreListToggleContainer {
+  padding-left: 1rem;
+}
+
+.IgnoreListToggleButton {
+  background: none;
+  color: var(--color-link);
+  font: inherit;
+  text-decoration: underline;
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
@@ -8,8 +8,16 @@
   white-space-collapse: preserve;
 }
 
+.IgnoredCallSite {
+  opacity: 0.5;
+}
+
 .IgnoredCallSite, .BuiltInCallSite {
   display: none;
+}
+
+.IgnoredCallSite.CallSite {
+  display: flex;
 }
 
 .CallSite + .BuiltInCallSite {

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
@@ -2,7 +2,7 @@
   padding: 0.25rem;
 }
 
-.CallSite, .BuiltInCallSite {
+.CallSite, .IgnoredCallSite, .BuiltInCallSite {
   display: flex;
   padding-left: 1rem;
   white-space-collapse: preserve;
@@ -12,8 +12,38 @@
   display: none;
 }
 
+.ShowIgnoredCallSites .IgnoredCallSite {
+  display: flex;
+  opacity: 0.65;
+}
+
 .CallSite + .BuiltInCallSite {
   display: block;
+}
+
+.IgnoredCallSitesToggle {
+  display: inline-flex;
+  align-items: center;
+  margin: 0.25rem 0.25rem 0;
+  padding: 0;
+  text-align: left;
+}
+
+.StackTraceView .IgnoredCallSitesToggle {
+  margin: 0;
+}
+
+.IgnoredCallSitesToggleIcon {
+  flex: 0 0 1rem;
+  color: var(--color-expand-collapse-toggle);
+}
+
+.IgnoredCallSitesToggleLabel {
+  margin-left: 0.25rem;
+  color: var(--color-attribute-name-not-editable);
+  font-family: var(--font-family-monospace);
+  font-size: var(--font-size-monospace-normal);
+  white-space: nowrap;
 }
 
 .Link {
@@ -32,4 +62,3 @@
 .ElementBadges {
   margin-left: 0.25rem;
 }
-

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
@@ -2,7 +2,7 @@
   padding: 0.25rem;
 }
 
-.CallSite, .IgnoredCallSite, .BuiltInCallSite {
+.CallSite, .BuiltInCallSite {
   display: flex;
   padding-left: 1rem;
   white-space-collapse: preserve;
@@ -12,38 +12,8 @@
   display: none;
 }
 
-.ShowIgnoredCallSites .IgnoredCallSite {
-  display: flex;
-  opacity: 0.65;
-}
-
 .CallSite + .BuiltInCallSite {
   display: block;
-}
-
-.IgnoredCallSitesToggle {
-  display: inline-flex;
-  align-items: center;
-  margin: 0.25rem 0.25rem 0;
-  padding: 0;
-  text-align: left;
-}
-
-.StackTraceView .IgnoredCallSitesToggle {
-  margin: 0;
-}
-
-.IgnoredCallSitesToggleIcon {
-  flex: 0 0 1rem;
-  color: var(--color-expand-collapse-toggle);
-}
-
-.IgnoredCallSitesToggleLabel {
-  margin-left: 0.25rem;
-  color: var(--color-attribute-name-not-editable);
-  font-family: var(--font-family-monospace);
-  font-size: var(--font-size-monospace-normal);
-  white-space: nowrap;
 }
 
 .Link {
@@ -62,3 +32,4 @@
 .ElementBadges {
   margin-left: 0.25rem;
 }
+

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.css
@@ -49,5 +49,6 @@
   background: none;
   color: var(--color-link);
   font: inherit;
+  font-style: italic;
   text-decoration: underline;
 }

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
@@ -111,7 +111,6 @@ export function IgnoreListToggleButton({
   return (
     <div className={styles.IgnoreListToggleContainer}>
       <Button
-        aria-expanded={showIgnoreList}
         className={styles.IgnoreListToggleButton}
         onClick={onClick}
         title={label}>
@@ -124,13 +123,17 @@ export function IgnoreListToggleButton({
 type Props = {
   stack: ReactStackTrace,
   environmentName: null | string,
+  // TODO: Un-optional when removing showIgnoreListLocal
+  showIgnoreList?: boolean,
 };
 
 export default function StackTraceView({
   stack,
   environmentName,
+  showIgnoreList,
 }: Props): React.Node {
-  const [showIgnoreList, setShowIgnoreList] = useState(false);
+  // TODO: Remove this local state and use the prop directly.
+  const [showIgnoreListLocal, setShowIgnoreListLocal] = useState(false);
   const fetchFileWithCaching = useContext(FetchFileWithCachingContext);
 
   const hasIgnoredFrames = stack.some(callSite => {
@@ -164,15 +167,17 @@ export default function StackTraceView({
             // non-ignored row.
             index === stack.length - 1 ? environmentName : null
           }
-          showIgnoreList={showIgnoreList}
+          showIgnoreList={
+            showIgnoreList === undefined ? showIgnoreListLocal : showIgnoreList
+          }
         />
       ))}
       {/* TODO: Ideally this UI should be higher than a single Stack Trace so that there's not
         multiple buttons in a single inspection taking up space. */}
-      {hasIgnoredFrames && (
+      {showIgnoreList === undefined && hasIgnoredFrames && (
         <IgnoreListToggleButton
-          onClick={() => setShowIgnoreList(prev => !prev)}
-          showIgnoreList={showIgnoreList}
+          onClick={() => setShowIgnoreListLocal(prev => !prev)}
+          showIgnoreList={showIgnoreListLocal}
         />
       )}
     </div>

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
@@ -8,7 +8,7 @@
  */
 
 import * as React from 'react';
-import {use, useContext, useState} from 'react';
+import {use, useContext} from 'react';
 
 import Button from '../Button';
 import useOpenResource from '../useOpenResource';
@@ -123,8 +123,7 @@ export function IgnoreListToggleButton({
 type Props = {
   stack: ReactStackTrace,
   environmentName: null | string,
-  // TODO: Un-optional when removing showIgnoreListLocal
-  showIgnoreList?: boolean,
+  showIgnoreList: boolean,
 };
 
 export default function StackTraceView({
@@ -132,28 +131,6 @@ export default function StackTraceView({
   environmentName,
   showIgnoreList,
 }: Props): React.Node {
-  // TODO: Remove this local state and use the prop directly.
-  const [showIgnoreListLocal, setShowIgnoreListLocal] = useState(false);
-  const fetchFileWithCaching = useContext(FetchFileWithCachingContext);
-
-  const hasIgnoredFrames = stack.some(callSite => {
-    const [, virtualURL, virtualLine, virtualColumn] = callSite;
-
-    // symbolicated output is cached
-    const symbolicatedCallSite: null | SourceMappedLocation =
-      fetchFileWithCaching !== null
-        ? use(
-            symbolicateSourceWithCache(
-              fetchFileWithCaching,
-              virtualURL,
-              virtualLine,
-              virtualColumn,
-            ),
-          )
-        : null;
-
-    return symbolicatedCallSite !== null && symbolicatedCallSite.ignored;
-  });
 
   return (
     <div className={styles.StackTraceView}>
@@ -167,19 +144,9 @@ export default function StackTraceView({
             // non-ignored row.
             index === stack.length - 1 ? environmentName : null
           }
-          showIgnoreList={
-            showIgnoreList === undefined ? showIgnoreListLocal : showIgnoreList
-          }
+          showIgnoreList={showIgnoreList}
         />
       ))}
-      {/* TODO: Ideally this UI should be higher than a single Stack Trace so that there's not
-        multiple buttons in a single inspection taking up space. */}
-      {showIgnoreList === undefined && hasIgnoredFrames && (
-        <IgnoreListToggleButton
-          onClick={() => setShowIgnoreListLocal(prev => !prev)}
-          showIgnoreList={showIgnoreListLocal}
-        />
-      )}
     </div>
   );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
@@ -8,8 +8,9 @@
  */
 
 import * as React from 'react';
-import {use, useContext} from 'react';
+import {use, useContext, useState} from 'react';
 
+import Button from '../Button';
 import useOpenResource from '../useOpenResource';
 
 import ElementBadges from './ElementBadges';
@@ -94,6 +95,32 @@ export function CallSiteView({
   );
 }
 
+type IgnoreListToggleButtonProps = {
+  onClick: () => void,
+  showIgnoreList: boolean,
+};
+
+export function IgnoreListToggleButton({
+  onClick,
+  showIgnoreList,
+}: IgnoreListToggleButtonProps): React.Node {
+  const label = showIgnoreList
+    ? 'Hide ignore-listed frames'
+    : 'Show ignore-listed frames';
+
+  return (
+    <div className={styles.IgnoreListToggleContainer}>
+      <Button
+        aria-expanded={showIgnoreList}
+        className={styles.IgnoreListToggleButton}
+        onClick={onClick}
+        title={label}>
+        {label}
+      </Button>
+    </div>
+  );
+}
+
 type Props = {
   stack: ReactStackTrace,
   environmentName: null | string,
@@ -103,6 +130,8 @@ export default function StackTraceView({
   stack,
   environmentName,
 }: Props): React.Node {
+  const [showIgnoreList, setShowIgnoreList] = useState(false);
+
   return (
     <div className={styles.StackTraceView}>
       {stack.map((callSite, index) => (
@@ -117,6 +146,10 @@ export default function StackTraceView({
           }
         />
       ))}
+      <IgnoreListToggleButton
+        onClick={() => setShowIgnoreList(prev => !prev)}
+        showIgnoreList={showIgnoreList}
+      />
     </div>
   );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
@@ -8,10 +8,8 @@
  */
 
 import * as React from 'react';
-import {use, useCallback, useContext, useEffect, useId, useState} from 'react';
+import {use, useContext} from 'react';
 
-import Button from '../Button';
-import ButtonIcon from '../ButtonIcon';
 import useOpenResource from '../useOpenResource';
 
 import ElementBadges from './ElementBadges';
@@ -28,33 +26,45 @@ import {symbolicateSourceWithCache} from 'react-devtools-shared/src/symbolicateS
 
 import formatLocationForDisplay from './formatLocationForDisplay';
 
-type ResolvedCallSite = {
-  callSite: ReactCallSite,
-  ignored: boolean,
-  isBuiltIn: boolean,
-  location: ReactCallSite,
-  symbolicatedLocation: null | ReactCallSite,
-};
-
 type CallSiteViewProps = {
+  callSite: ReactCallSite,
   environmentName: null | string,
-  resolvedCallSite: ResolvedCallSite,
 };
 
 export function CallSiteView({
-  resolvedCallSite,
+  callSite,
   environmentName,
 }: CallSiteViewProps): React.Node {
-  const {callSite, ignored, isBuiltIn, location, symbolicatedLocation} =
-    resolvedCallSite;
-  const [virtualFunctionName] = callSite;
-  const [functionName, url, line, column] = location;
+  const fetchFileWithCaching = useContext(FetchFileWithCachingContext);
+
+  const [virtualFunctionName, virtualURL, virtualLine, virtualColumn] =
+    callSite;
+
+  const symbolicatedCallSite: null | SourceMappedLocation =
+    fetchFileWithCaching !== null
+      ? use(
+          symbolicateSourceWithCache(
+            fetchFileWithCaching,
+            virtualURL,
+            virtualLine,
+            virtualColumn,
+          ),
+        )
+      : null;
 
   const [linkIsEnabled, viewSource] = useOpenResource(
     callSite,
-    symbolicatedLocation,
+    symbolicatedCallSite == null ? null : symbolicatedCallSite.location,
   );
+  const [functionName, url, line, column] =
+    symbolicatedCallSite !== null ? symbolicatedCallSite.location : callSite;
+  const ignored =
+    symbolicatedCallSite !== null ? symbolicatedCallSite.ignored : false;
+  // TODO: Make an option to be able to toggle the display of ignore listed rows.
+  // Ideally this UI should be higher than a single Stack Trace so that there's not
+  // multiple buttons in a single inspection taking up space.
 
+  const isBuiltIn = url === '' || url.startsWith('<anonymous>'); // This looks like a fake anonymous through eval.
   return (
     <div
       className={
@@ -87,190 +97,23 @@ export function CallSiteView({
 type Props = {
   stack: ReactStackTrace,
   environmentName: null | string,
-  ignoredCallSites: IgnoredCallSitesState,
 };
-
-type IgnoredCallSitesToggleProps = {
-  showIgnoredCallSites: boolean,
-  onClick: () => void,
-};
-
-export function IgnoredCallSitesToggle({
-  showIgnoredCallSites,
-  onClick,
-}: IgnoredCallSitesToggleProps): React.Node {
-  const label = showIgnoredCallSites
-    ? 'Hide ignore-listed frames'
-    : 'Show ignore-listed frames';
-
-  return (
-    <Button
-      aria-expanded={showIgnoredCallSites}
-      className={styles.IgnoredCallSitesToggle}
-      onClick={onClick}
-      testName="ToggleIgnoreListedFrames"
-      title={label}>
-      <ButtonIcon
-        className={styles.IgnoredCallSitesToggleIcon}
-        type={showIgnoredCallSites ? 'expanded' : 'collapsed'}
-      />
-      <span className={styles.IgnoredCallSitesToggleLabel}>{label}</span>
-    </Button>
-  );
-}
-
-type IgnoredCallSitesState = {
-  hasIgnoredCallSites: boolean,
-  showIgnoredCallSites: boolean,
-  onHasIgnoredCallSitesChange: (
-    stackID: string,
-    hasIgnoredCallSites: boolean,
-  ) => void,
-  onStackUnmount: (stackID: string) => void,
-  toggle: () => void,
-};
-
-export function useIgnoredCallSites(): IgnoredCallSitesState {
-  const [showIgnoredCallSites, setShowIgnoredCallSites] = useState(false);
-  const [ignoredCallSiteStackIDs, setIgnoredCallSiteStackIDs] = useState<
-    Set<string>,
-  >(() => new Set());
-
-  const onHasIgnoredCallSitesChange = useCallback(
-    (stackID: string, hasIgnoredCallSites: boolean) => {
-      setIgnoredCallSiteStackIDs(previous => {
-        if (previous.has(stackID) === hasIgnoredCallSites) {
-          return previous;
-        }
-        const next = new Set(previous);
-        if (hasIgnoredCallSites) {
-          next.add(stackID);
-        } else {
-          next.delete(stackID);
-        }
-        return next;
-      });
-    },
-    [],
-  );
-  const onStackUnmount = useCallback((stackID: string) => {
-    setIgnoredCallSiteStackIDs(previous => {
-      if (!previous.has(stackID)) {
-        return previous;
-      }
-      const next = new Set(previous);
-      next.delete(stackID);
-      return next;
-    });
-  }, []);
-
-  const hasIgnoredCallSites = ignoredCallSiteStackIDs.size > 0;
-  const toggle = useCallback(() => {
-    setShowIgnoredCallSites(
-      prevShowIgnoredCallSites => !prevShowIgnoredCallSites,
-    );
-  }, []);
-
-  return {
-    hasIgnoredCallSites,
-    showIgnoredCallSites,
-    onHasIgnoredCallSitesChange,
-    onStackUnmount,
-    toggle,
-  };
-}
 
 export default function StackTraceView({
   stack,
   environmentName,
-  ignoredCallSites,
 }: Props): React.Node {
-  const stackID = useId();
-  const {onHasIgnoredCallSitesChange, onStackUnmount, showIgnoredCallSites} =
-    ignoredCallSites;
-  const fetchFileWithCaching = useContext(FetchFileWithCachingContext);
-
-  const resolvedCallSites: Array<ResolvedCallSite> = [];
-  let hasIgnoredCallSites = false;
-  let lastVisibleCallSiteIndex = -1;
-
-  for (let index = 0; index < stack.length; index++) {
-    const callSite = stack[index];
-    const [, virtualURL, virtualLine, virtualColumn] = callSite;
-
-    const symbolicatedCallSite: null | SourceMappedLocation =
-      fetchFileWithCaching !== null
-        ? use(
-            symbolicateSourceWithCache(
-              fetchFileWithCaching,
-              virtualURL,
-              virtualLine,
-              virtualColumn,
-            ),
-          )
-        : null;
-
-    const symbolicatedLocation =
-      symbolicatedCallSite !== null ? symbolicatedCallSite.location : null;
-    const location =
-      symbolicatedLocation !== null ? symbolicatedLocation : callSite;
-    const [, url] = location;
-
-    const resolvedCallSite = {
-      callSite,
-      ignored:
-        symbolicatedCallSite !== null ? symbolicatedCallSite.ignored : false,
-      // This looks like a fake anonymous through eval.
-      isBuiltIn: url === '' || url.startsWith('<anonymous>'),
-      location,
-      symbolicatedLocation,
-    };
-    resolvedCallSites.push(resolvedCallSite);
-
-    if (resolvedCallSite.ignored) {
-      hasIgnoredCallSites = true;
-      continue;
-    }
-
-    if (!resolvedCallSite.isBuiltIn) {
-      lastVisibleCallSiteIndex = index;
-      continue;
-    }
-
-    const previousCallSite = resolvedCallSites[index - 1];
-    if (
-      previousCallSite !== undefined &&
-      !previousCallSite.ignored &&
-      !previousCallSite.isBuiltIn
-    ) {
-      lastVisibleCallSiteIndex = index;
-    }
-  }
-
-  useEffect(() => {
-    onHasIgnoredCallSitesChange(stackID, hasIgnoredCallSites);
-  }, [hasIgnoredCallSites, onHasIgnoredCallSitesChange, stackID]);
-
-  useEffect(() => {
-    return () => {
-      onStackUnmount(stackID);
-    };
-  }, [onStackUnmount, stackID]);
-
   return (
-    <div
-      className={
-        showIgnoredCallSites
-          ? `${styles.StackTraceView} ${styles.ShowIgnoredCallSites}`
-          : styles.StackTraceView
-      }>
-      {resolvedCallSites.map((resolvedCallSite, index) => (
+    <div className={styles.StackTraceView}>
+      {stack.map((callSite, index) => (
         <CallSiteView
           key={index}
-          resolvedCallSite={resolvedCallSite}
+          callSite={callSite}
           environmentName={
-            // Badge the last visible row.
-            index === lastVisibleCallSiteIndex ? environmentName : null
+            // Badge last row
+            // TODO: If we start ignore listing the last row, we should badge the last
+            // non-ignored row.
+            index === stack.length - 1 ? environmentName : null
           }
         />
       ))}

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
@@ -30,11 +30,13 @@ import formatLocationForDisplay from './formatLocationForDisplay';
 type CallSiteViewProps = {
   callSite: ReactCallSite,
   environmentName: null | string,
+  showIgnoreList: boolean,
 };
 
 export function CallSiteView({
   callSite,
   environmentName,
+  showIgnoreList,
 }: CallSiteViewProps): React.Node {
   const fetchFileWithCaching = useContext(FetchFileWithCachingContext);
 
@@ -70,7 +72,8 @@ export function CallSiteView({
     <div
       className={
         ignored
-          ? styles.IgnoredCallSite
+          ? styles.IgnoredCallSite +
+            (showIgnoreList ? ' ' + styles.CallSite : '')
           : isBuiltIn
             ? styles.BuiltInCallSite
             : styles.CallSite
@@ -144,6 +147,7 @@ export default function StackTraceView({
             // non-ignored row.
             index === stack.length - 1 ? environmentName : null
           }
+          showIgnoreList={showIgnoreList}
         />
       ))}
       <IgnoreListToggleButton

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
@@ -8,8 +8,10 @@
  */
 
 import * as React from 'react';
-import {use, useContext} from 'react';
+import {use, useCallback, useContext, useEffect, useId, useState} from 'react';
 
+import Button from '../Button';
+import ButtonIcon from '../ButtonIcon';
 import useOpenResource from '../useOpenResource';
 
 import ElementBadges from './ElementBadges';
@@ -26,45 +28,33 @@ import {symbolicateSourceWithCache} from 'react-devtools-shared/src/symbolicateS
 
 import formatLocationForDisplay from './formatLocationForDisplay';
 
-type CallSiteViewProps = {
+type ResolvedCallSite = {
   callSite: ReactCallSite,
+  ignored: boolean,
+  isBuiltIn: boolean,
+  location: ReactCallSite,
+  symbolicatedLocation: null | ReactCallSite,
+};
+
+type CallSiteViewProps = {
   environmentName: null | string,
+  resolvedCallSite: ResolvedCallSite,
 };
 
 export function CallSiteView({
-  callSite,
+  resolvedCallSite,
   environmentName,
 }: CallSiteViewProps): React.Node {
-  const fetchFileWithCaching = useContext(FetchFileWithCachingContext);
-
-  const [virtualFunctionName, virtualURL, virtualLine, virtualColumn] =
-    callSite;
-
-  const symbolicatedCallSite: null | SourceMappedLocation =
-    fetchFileWithCaching !== null
-      ? use(
-          symbolicateSourceWithCache(
-            fetchFileWithCaching,
-            virtualURL,
-            virtualLine,
-            virtualColumn,
-          ),
-        )
-      : null;
+  const {callSite, ignored, isBuiltIn, location, symbolicatedLocation} =
+    resolvedCallSite;
+  const [virtualFunctionName] = callSite;
+  const [functionName, url, line, column] = location;
 
   const [linkIsEnabled, viewSource] = useOpenResource(
     callSite,
-    symbolicatedCallSite == null ? null : symbolicatedCallSite.location,
+    symbolicatedLocation,
   );
-  const [functionName, url, line, column] =
-    symbolicatedCallSite !== null ? symbolicatedCallSite.location : callSite;
-  const ignored =
-    symbolicatedCallSite !== null ? symbolicatedCallSite.ignored : false;
-  // TODO: Make an option to be able to toggle the display of ignore listed rows.
-  // Ideally this UI should be higher than a single Stack Trace so that there's not
-  // multiple buttons in a single inspection taking up space.
 
-  const isBuiltIn = url === '' || url.startsWith('<anonymous>'); // This looks like a fake anonymous through eval.
   return (
     <div
       className={
@@ -97,23 +87,190 @@ export function CallSiteView({
 type Props = {
   stack: ReactStackTrace,
   environmentName: null | string,
+  ignoredCallSites: IgnoredCallSitesState,
 };
+
+type IgnoredCallSitesToggleProps = {
+  showIgnoredCallSites: boolean,
+  onClick: () => void,
+};
+
+export function IgnoredCallSitesToggle({
+  showIgnoredCallSites,
+  onClick,
+}: IgnoredCallSitesToggleProps): React.Node {
+  const label = showIgnoredCallSites
+    ? 'Hide ignore-listed frames'
+    : 'Show ignore-listed frames';
+
+  return (
+    <Button
+      aria-expanded={showIgnoredCallSites}
+      className={styles.IgnoredCallSitesToggle}
+      onClick={onClick}
+      testName="ToggleIgnoreListedFrames"
+      title={label}>
+      <ButtonIcon
+        className={styles.IgnoredCallSitesToggleIcon}
+        type={showIgnoredCallSites ? 'expanded' : 'collapsed'}
+      />
+      <span className={styles.IgnoredCallSitesToggleLabel}>{label}</span>
+    </Button>
+  );
+}
+
+type IgnoredCallSitesState = {
+  hasIgnoredCallSites: boolean,
+  showIgnoredCallSites: boolean,
+  onHasIgnoredCallSitesChange: (
+    stackID: string,
+    hasIgnoredCallSites: boolean,
+  ) => void,
+  onStackUnmount: (stackID: string) => void,
+  toggle: () => void,
+};
+
+export function useIgnoredCallSites(): IgnoredCallSitesState {
+  const [showIgnoredCallSites, setShowIgnoredCallSites] = useState(false);
+  const [ignoredCallSiteStackIDs, setIgnoredCallSiteStackIDs] = useState<
+    Set<string>,
+  >(() => new Set());
+
+  const onHasIgnoredCallSitesChange = useCallback(
+    (stackID: string, hasIgnoredCallSites: boolean) => {
+      setIgnoredCallSiteStackIDs(previous => {
+        if (previous.has(stackID) === hasIgnoredCallSites) {
+          return previous;
+        }
+        const next = new Set(previous);
+        if (hasIgnoredCallSites) {
+          next.add(stackID);
+        } else {
+          next.delete(stackID);
+        }
+        return next;
+      });
+    },
+    [],
+  );
+  const onStackUnmount = useCallback((stackID: string) => {
+    setIgnoredCallSiteStackIDs(previous => {
+      if (!previous.has(stackID)) {
+        return previous;
+      }
+      const next = new Set(previous);
+      next.delete(stackID);
+      return next;
+    });
+  }, []);
+
+  const hasIgnoredCallSites = ignoredCallSiteStackIDs.size > 0;
+  const toggle = useCallback(() => {
+    setShowIgnoredCallSites(
+      prevShowIgnoredCallSites => !prevShowIgnoredCallSites,
+    );
+  }, []);
+
+  return {
+    hasIgnoredCallSites,
+    showIgnoredCallSites,
+    onHasIgnoredCallSitesChange,
+    onStackUnmount,
+    toggle,
+  };
+}
 
 export default function StackTraceView({
   stack,
   environmentName,
+  ignoredCallSites,
 }: Props): React.Node {
+  const stackID = useId();
+  const {onHasIgnoredCallSitesChange, onStackUnmount, showIgnoredCallSites} =
+    ignoredCallSites;
+  const fetchFileWithCaching = useContext(FetchFileWithCachingContext);
+
+  const resolvedCallSites: Array<ResolvedCallSite> = [];
+  let hasIgnoredCallSites = false;
+  let lastVisibleCallSiteIndex = -1;
+
+  for (let index = 0; index < stack.length; index++) {
+    const callSite = stack[index];
+    const [, virtualURL, virtualLine, virtualColumn] = callSite;
+
+    const symbolicatedCallSite: null | SourceMappedLocation =
+      fetchFileWithCaching !== null
+        ? use(
+            symbolicateSourceWithCache(
+              fetchFileWithCaching,
+              virtualURL,
+              virtualLine,
+              virtualColumn,
+            ),
+          )
+        : null;
+
+    const symbolicatedLocation =
+      symbolicatedCallSite !== null ? symbolicatedCallSite.location : null;
+    const location =
+      symbolicatedLocation !== null ? symbolicatedLocation : callSite;
+    const [, url] = location;
+
+    const resolvedCallSite = {
+      callSite,
+      ignored:
+        symbolicatedCallSite !== null ? symbolicatedCallSite.ignored : false,
+      // This looks like a fake anonymous through eval.
+      isBuiltIn: url === '' || url.startsWith('<anonymous>'),
+      location,
+      symbolicatedLocation,
+    };
+    resolvedCallSites.push(resolvedCallSite);
+
+    if (resolvedCallSite.ignored) {
+      hasIgnoredCallSites = true;
+      continue;
+    }
+
+    if (!resolvedCallSite.isBuiltIn) {
+      lastVisibleCallSiteIndex = index;
+      continue;
+    }
+
+    const previousCallSite = resolvedCallSites[index - 1];
+    if (
+      previousCallSite !== undefined &&
+      !previousCallSite.ignored &&
+      !previousCallSite.isBuiltIn
+    ) {
+      lastVisibleCallSiteIndex = index;
+    }
+  }
+
+  useEffect(() => {
+    onHasIgnoredCallSitesChange(stackID, hasIgnoredCallSites);
+  }, [hasIgnoredCallSites, onHasIgnoredCallSitesChange, stackID]);
+
+  useEffect(() => {
+    return () => {
+      onStackUnmount(stackID);
+    };
+  }, [onStackUnmount, stackID]);
+
   return (
-    <div className={styles.StackTraceView}>
-      {stack.map((callSite, index) => (
+    <div
+      className={
+        showIgnoredCallSites
+          ? `${styles.StackTraceView} ${styles.ShowIgnoredCallSites}`
+          : styles.StackTraceView
+      }>
+      {resolvedCallSites.map((resolvedCallSite, index) => (
         <CallSiteView
           key={index}
-          callSite={callSite}
+          resolvedCallSite={resolvedCallSite}
           environmentName={
-            // Badge last row
-            // TODO: If we start ignore listing the last row, we should badge the last
-            // non-ignored row.
-            index === stack.length - 1 ? environmentName : null
+            // Badge the last visible row.
+            index === lastVisibleCallSiteIndex ? environmentName : null
           }
         />
       ))}

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
@@ -63,9 +63,6 @@ export function CallSiteView({
     symbolicatedCallSite !== null ? symbolicatedCallSite.location : callSite;
   const ignored =
     symbolicatedCallSite !== null ? symbolicatedCallSite.ignored : false;
-  // TODO: Make an option to be able to toggle the display of ignore listed rows.
-  // Ideally this UI should be higher than a single Stack Trace so that there's not
-  // multiple buttons in a single inspection taking up space.
 
   const isBuiltIn = url === '' || url.startsWith('<anonymous>'); // This looks like a fake anonymous through eval.
   return (
@@ -134,6 +131,26 @@ export default function StackTraceView({
   environmentName,
 }: Props): React.Node {
   const [showIgnoreList, setShowIgnoreList] = useState(false);
+  const fetchFileWithCaching = useContext(FetchFileWithCachingContext);
+
+  const hasIgnoredFrames = stack.some(callSite => {
+    const [, virtualURL, virtualLine, virtualColumn] = callSite;
+
+    // symbolicated output is cached
+    const symbolicatedCallSite: null | SourceMappedLocation =
+      fetchFileWithCaching !== null
+        ? use(
+            symbolicateSourceWithCache(
+              fetchFileWithCaching,
+              virtualURL,
+              virtualLine,
+              virtualColumn,
+            ),
+          )
+        : null;
+
+    return symbolicatedCallSite !== null && symbolicatedCallSite.ignored;
+  });
 
   return (
     <div className={styles.StackTraceView}>
@@ -150,10 +167,14 @@ export default function StackTraceView({
           showIgnoreList={showIgnoreList}
         />
       ))}
-      <IgnoreListToggleButton
-        onClick={() => setShowIgnoreList(prev => !prev)}
-        showIgnoreList={showIgnoreList}
-      />
+      {/* TODO: Ideally this UI should be higher than a single Stack Trace so that there's not
+        multiple buttons in a single inspection taking up space. */}
+      {hasIgnoredFrames && (
+        <IgnoreListToggleButton
+          onClick={() => setShowIgnoreList(prev => !prev)}
+          showIgnoreList={showIgnoreList}
+        />
+      )}
     </div>
   );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/StackTraceView.js
@@ -131,6 +131,38 @@ export default function StackTraceView({
   environmentName,
   showIgnoreList,
 }: Props): React.Node {
+  const fetchFileWithCaching = useContext(FetchFileWithCachingContext);
+
+  let lastMeaningfulFrameIndex = -1;
+  // Reverse loop to find the last non-ignored, non-built-in index
+  for (let index = stack.length - 1; index >= 0; index--) {
+    const callSite = stack[index];
+    const [, virtualURL, virtualLine, virtualColumn] = callSite;
+
+    // symbolicated output is cached
+    const symbolicatedCallSite: null | SourceMappedLocation =
+      fetchFileWithCaching !== null
+        ? use(
+            symbolicateSourceWithCache(
+              fetchFileWithCaching,
+              virtualURL,
+              virtualLine,
+              virtualColumn,
+            ),
+          )
+        : null;
+    const [, url] =
+      symbolicatedCallSite !== null ? symbolicatedCallSite.location : callSite;
+    const ignored =
+      symbolicatedCallSite !== null ? symbolicatedCallSite.ignored : false;
+    // This looks like a fake anonymous through eval.
+    const isBuiltIn = url === '' || url.startsWith('<anonymous>');
+
+    if (!ignored && !isBuiltIn) {
+      lastMeaningfulFrameIndex = index;
+      break;
+    }
+  }
 
   return (
     <div className={styles.StackTraceView}>
@@ -139,10 +171,8 @@ export default function StackTraceView({
           key={index}
           callSite={callSite}
           environmentName={
-            // Badge last row
-            // TODO: If we start ignore listing the last row, we should badge the last
-            // non-ignored row.
-            index === stack.length - 1 ? environmentName : null
+            // Badge last meaningful frame (non-ignored, non-built-in)
+            index === lastMeaningfulFrameIndex ? environmentName : null
           }
           showIgnoreList={showIgnoreList}
         />


### PR DESCRIPTION
> [!TIP]
> Best reviewed commit by commit, hide whitespace

### Why?

Ignore-listed stack frames are hidden today with no way to inspect them. For most cases users wouldn't have to care about it, but there are some cases that you need to dig deep in order to find the cause.

For example, a third party library had incorrect usage of `use()`, which caused flicker during hydration in my app, but it was hard for me to spot without support of Suspense DevTools as that library was ignore listed.

### How?

- Add an inline show/hide disclosure that appears when a stack has ignore-listed frames.
- Keep frames hidden by default, retain the disclosure state while mounted, and group related rendered-by and suspended-by/awaited-at stacks behind one control.

### Screenshots

| Area | Hidden/default state | Shown state |
| --- | --- | --- |
| Suspense tab, suspended by | <img width="360" alt="Suspense tab with ignore-listed frames hidden" src="https://github.com/user-attachments/assets/8ff64704-841d-44f8-bd28-1a9b440e2a48" /> | <img width="360" alt="Suspense tab with ignore-listed frames shown" src="https://github.com/user-attachments/assets/cc380823-f3e5-4737-b8ee-509f94e0aeae" /> |
| Components tab, rendered by | <img width="360" alt="Components rendered-by stack with ignore-listed frames hidden" src="https://github.com/user-attachments/assets/a90c8fa9-b941-4545-9969-d7d759f51f2e" /> | <img width="360" alt="Components rendered-by stack with ignore-listed frames shown" src="https://github.com/user-attachments/assets/7b608bc4-3994-4cb6-bd9a-15dccb72806d" /> |
