### PR TITLE
[Fizz] Remove the AbortSignal listener when the stream finishes

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -132,6 +132,48 @@ describe('ReactDOMFizzServerBrowser', () => {
     );
   });
 
+  it('removes the abort listener from a shared signal once the stream finishes', async () => {
+    // A long-lived / shared AbortSignal must not accumulate one 'abort'
+    // listener per request after each request reaches a terminal state.
+    // Regression test for facebook/react#36763.
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    let added = 0;
+    let removed = 0;
+    const realAdd = signal.addEventListener.bind(signal);
+    const realRemove = signal.removeEventListener.bind(signal);
+    signal.addEventListener = function (type, ...rest) {
+      if (type === 'abort') {
+        added++;
+      }
+      return realAdd(type, ...rest);
+    };
+    signal.removeEventListener = function (type, ...rest) {
+      if (type === 'abort') {
+        removed++;
+      }
+      return realRemove(type, ...rest);
+    };
+
+    for (let i = 0; i < 3; i++) {
+      const stream = await serverAct(() =>
+        ReactDOMFizzServer.renderToReadableStream(<div>hello world</div>, {
+          signal,
+        }),
+      );
+      // Read the stream to completion so the request reaches a terminal state.
+      await serverAct(() => readResult(stream));
+      await stream.allReady;
+    }
+
+    // The signal was never aborted, so every listener that was added must have
+    // been removed again (no leak).
+    expect(added).toBe(3);
+    expect(removed).toBe(3);
+    expect(signal.aborted).toBe(false);
+  });
+
   it('should reject the promise when an error is thrown at the root', async () => {
     const reportedErrors = [];
     let caughtError = null;

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -79,9 +79,26 @@ function renderToReadableStream(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    // See facebook/react#36763. Remove the AbortSignal listener (registered
+    // below, if any) once the request reaches a terminal state, so that a
+    // long-lived or shared signal doesn't accumulate listeners for requests
+    // that have already finished.
+    let removeAbortListener: null | (() => void) = null;
+    const cleanupAbortListener = () => {
+      if (removeAbortListener !== null) {
+        removeAbortListener();
+        removeAbortListener = null;
+      }
+    };
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupAbortListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupAbortListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -154,9 +171,12 @@ function renderToReadableStream(
       } else {
         const listener = () => {
           abort(request, (signal as any).reason);
-          signal.removeEventListener('abort', listener);
+          cleanupAbortListener();
         };
         signal.addEventListener('abort', listener);
+        removeAbortListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);
@@ -171,9 +191,26 @@ function resume(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    // See facebook/react#36763. Remove the AbortSignal listener (registered
+    // below, if any) once the request reaches a terminal state, so that a
+    // long-lived or shared signal doesn't accumulate listeners for requests
+    // that have already finished.
+    let removeAbortListener: null | (() => void) = null;
+    const cleanupAbortListener = () => {
+      if (removeAbortListener !== null) {
+        removeAbortListener();
+        removeAbortListener = null;
+      }
+    };
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupAbortListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupAbortListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -223,9 +260,12 @@ function resume(
       } else {
         const listener = () => {
           abort(request, (signal as any).reason);
-          signal.removeEventListener('abort', listener);
+          cleanupAbortListener();
         };
         signal.addEventListener('abort', listener);
+        removeAbortListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);

--- a/packages/react-dom/src/server/ReactDOMFizzServerBun.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBun.js
@@ -68,9 +68,26 @@ function renderToReadableStream(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    // See facebook/react#36763. Remove the AbortSignal listener (registered
+    // below, if any) once the request reaches a terminal state, so that a
+    // long-lived or shared signal doesn't accumulate listeners for requests
+    // that have already finished.
+    let removeAbortListener: null | (() => void) = null;
+    const cleanupAbortListener = () => {
+      if (removeAbortListener !== null) {
+        removeAbortListener();
+        removeAbortListener = null;
+      }
+    };
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupAbortListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupAbortListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -144,9 +161,12 @@ function renderToReadableStream(
       } else {
         const listener = () => {
           abort(request, (signal as any).reason);
-          signal.removeEventListener('abort', listener);
+          cleanupAbortListener();
         };
         signal.addEventListener('abort', listener);
+        removeAbortListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);

--- a/packages/react-dom/src/server/ReactDOMFizzServerEdge.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerEdge.js
@@ -79,9 +79,26 @@ function renderToReadableStream(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    // See facebook/react#36763. Remove the AbortSignal listener (registered
+    // below, if any) once the request reaches a terminal state, so that a
+    // long-lived or shared signal doesn't accumulate listeners for requests
+    // that have already finished.
+    let removeAbortListener: null | (() => void) = null;
+    const cleanupAbortListener = () => {
+      if (removeAbortListener !== null) {
+        removeAbortListener();
+        removeAbortListener = null;
+      }
+    };
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupAbortListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupAbortListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -154,9 +171,12 @@ function renderToReadableStream(
       } else {
         const listener = () => {
           abort(request, (signal as any).reason);
-          signal.removeEventListener('abort', listener);
+          cleanupAbortListener();
         };
         signal.addEventListener('abort', listener);
+        removeAbortListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);
@@ -171,9 +191,26 @@ function resume(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    // See facebook/react#36763. Remove the AbortSignal listener (registered
+    // below, if any) once the request reaches a terminal state, so that a
+    // long-lived or shared signal doesn't accumulate listeners for requests
+    // that have already finished.
+    let removeAbortListener: null | (() => void) = null;
+    const cleanupAbortListener = () => {
+      if (removeAbortListener !== null) {
+        removeAbortListener();
+        removeAbortListener = null;
+      }
+    };
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupAbortListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupAbortListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -223,9 +260,12 @@ function resume(
       } else {
         const listener = () => {
           abort(request, (signal as any).reason);
-          signal.removeEventListener('abort', listener);
+          cleanupAbortListener();
         };
         signal.addEventListener('abort', listener);
+        removeAbortListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -211,9 +211,26 @@ function renderToReadableStream(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    // See facebook/react#36763. Remove the AbortSignal listener (registered
+    // below, if any) once the request reaches a terminal state, so that a
+    // long-lived or shared signal doesn't accumulate listeners for requests
+    // that have already finished.
+    let removeAbortListener: null | (() => void) = null;
+    const cleanupAbortListener = () => {
+      if (removeAbortListener !== null) {
+        removeAbortListener();
+        removeAbortListener = null;
+      }
+    };
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupAbortListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupAbortListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -291,9 +308,12 @@ function renderToReadableStream(
       } else {
         const listener = () => {
           abort(request, (signal as any).reason);
-          signal.removeEventListener('abort', listener);
+          cleanupAbortListener();
         };
         signal.addEventListener('abort', listener);
+        removeAbortListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);
@@ -370,9 +390,26 @@ function resume(
   return new Promise((resolve, reject) => {
     let onFatalError;
     let onAllReady;
+    // See facebook/react#36763. Remove the AbortSignal listener (registered
+    // below, if any) once the request reaches a terminal state, so that a
+    // long-lived or shared signal doesn't accumulate listeners for requests
+    // that have already finished.
+    let removeAbortListener: null | (() => void) = null;
+    const cleanupAbortListener = () => {
+      if (removeAbortListener !== null) {
+        removeAbortListener();
+        removeAbortListener = null;
+      }
+    };
     const allReady = new Promise<void>((res, rej) => {
-      onAllReady = res;
-      onFatalError = rej;
+      onAllReady = () => {
+        cleanupAbortListener();
+        res();
+      };
+      onFatalError = (error: mixed) => {
+        cleanupAbortListener();
+        rej(error);
+      };
     });
 
     function onShellReady() {
@@ -427,9 +464,12 @@ function resume(
       } else {
         const listener = () => {
           abort(request, (signal as any).reason);
-          signal.removeEventListener('abort', listener);
+          cleanupAbortListener();
         };
         signal.addEventListener('abort', listener);
+        removeAbortListener = () => {
+          signal.removeEventListener('abort', listener);
+        };
       }
     }
     startWork(request);


### PR DESCRIPTION
> **Note on existing PRs:** #36763 already has two PRs — #36764 (@SaqibFarhanProgrammer) and #36785 (@sleitor) — both of which remove the listener once the stream reaches a terminal state. I'm opening this as an alternative because I think this approach handles it a bit more cleanly: the cleanup is wired into the `onAllReady` / `onFatalError` resolvers through a single hoisted, idempotent helper (so `stream.allReady`'s rejection / unhandled-rejection behavior is untouched), and the regression test reproduces the actual listener *accumulation* across repeated requests (`added === removed === 3`, and fails with `removed: 0` before the fix). Happy to consolidate into a single PR — deferring to the maintainers on which direction to take.

---

## Summary

Fixes #36763.

When an `AbortSignal` is passed to `renderToReadableStream` / `resume` (the Web
Streams server entry points), an `abort` listener is added to the signal. That
listener only removes itself from inside its own body — i.e. **only if the abort
actually fires**. When the stream instead finishes normally (`onAllReady`) or
errors (`onShellError` / `onFatalError`), the listener is left attached. With a
long-lived or shared signal (e.g. one reused across many SSR requests) the
listeners pile up and keep each request's closure alive, leaking memory.

This removes the listener once the request reaches a terminal state. The cleanup
is wired into the `onAllReady` / `onFatalError` resolvers (via a small hoisted,
idempotent helper) rather than by attaching a handler to the `allReady` promise,
so that the caller-visible `stream.allReady` rejection behavior — including
unhandled-rejection diagnostics — is unchanged. The abort path also runs the same
helper, and it nulls out the stored remover so the cleanup is safe to call more
than once.

Applies to `renderToReadableStream` + `resume` in the Browser, Edge, Node and Bun
server builds. The Static (`prerender`) and Flight servers share the same listener
pattern but don't have an `allReady` promise to hang the cleanup off of, and
aren't part of the APIs this issue reports, so they're intentionally left out of
this change.

## How did you test this change?

- Added a regression test in `ReactDOMFizzServerBrowser-test.js` that wraps a
  shared signal's `addEventListener` / `removeEventListener`, renders three times
  reading each stream to completion, and asserts the listener was removed every
  time (`added === removed === 3`, signal never aborted). It fails before this
  change (`removed: 0`) and passes after.
- `yarn test` for the Browser, Edge, Node fizz server suites and the main
  `ReactDOMFizzServer-test` suite all pass; `yarn test --prod` of the Browser
  suite passes.
- `yarn linc`, `yarn prettier-check`, and `yarn flow dom-node` pass.
</content>

