### PR TITLE
[DevTools] Fix fetch request cleanup

### DIFF
--- a/packages/react-devtools-extensions/src/__tests__/fetchFileWithCaching-test.js
+++ b/packages/react-devtools-extensions/src/__tests__/fetchFileWithCaching-test.js
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+describe('fetchFileWithCaching', () => {
+  let fetchFileWithCaching;
+  let messageListeners;
+  let navigationListener;
+  let unloadListener;
+  let sendMessage;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllTimers();
+
+    messageListeners = new Set();
+    navigationListener = null;
+    unloadListener = null;
+    sendMessage = jest.fn();
+
+    global.__IS_CHROME__ = false;
+    global.__IS_EDGE__ = false;
+    global.__IS_FIREFOX__ = false;
+    global.chrome = {
+      devtools: {
+        inspectedWindow: {
+          tabId: 1,
+        },
+        network: {
+          getHAR: jest.fn(callback => callback({entries: []})),
+          onNavigated: {
+            addListener: jest.fn(listener => {
+              navigationListener = listener;
+            }),
+          },
+        },
+      },
+      runtime: {
+        onMessage: {
+          addListener: jest.fn(listener => messageListeners.add(listener)),
+          removeListener: jest.fn(listener =>
+            messageListeners.delete(listener),
+          ),
+        },
+        sendMessage,
+      },
+    };
+
+    const addEventListener = jest
+      .spyOn(window, 'addEventListener')
+      .mockImplementation((type, listener) => {
+        if (type === 'beforeunload') {
+          unloadListener = listener;
+        }
+      });
+
+    fetchFileWithCaching = require('../main/fetchFileWithCaching').default;
+    addEventListener.mockRestore();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    delete global.chrome;
+  });
+
+  function dispatchMessage(type, url, value) {
+    messageListeners.forEach(listener => {
+      listener({
+        source: 'react-devtools-background',
+        payload: {type, url, value},
+      });
+    });
+  }
+
+  it('reuses one pending request and removes its listener after success', async () => {
+    const first = fetchFileWithCaching('https://example.com/source.js');
+    const second = fetchFileWithCaching('https://example.com/source.js');
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(messageListeners.size).toBe(1);
+
+    dispatchMessage(
+      'fetch-file-with-cache-complete',
+      'https://example.com/source.js',
+      'source',
+    );
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      'source',
+      'source',
+    ]);
+    expect(messageListeners.size).toBe(0);
+    expect(chrome.runtime.onMessage.removeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles only the request matching a response URL', async () => {
+    const first = fetchFileWithCaching('https://example.com/first.js');
+    const second = fetchFileWithCaching('https://example.com/second.js');
+    let secondStatus = 'pending';
+    const secondResult = second.then(
+      value => {
+        secondStatus = 'resolved';
+        return value;
+      },
+      error => {
+        secondStatus = 'rejected';
+        throw error;
+      },
+    );
+
+    dispatchMessage(
+      'fetch-file-with-cache-complete',
+      'https://example.com/first.js',
+      'first source',
+    );
+
+    await expect(first).resolves.toBe('first source');
+    expect(secondStatus).toBe('pending');
+    expect(messageListeners.size).toBe(1);
+
+    const error = new Error('second failed');
+    dispatchMessage(
+      'fetch-file-with-cache-error',
+      'https://example.com/second.js',
+      error,
+    );
+
+    await expect(secondResult).rejects.toBe(error);
+    expect(messageListeners.size).toBe(0);
+  });
+
+  it('rejects every request on navigation and permits later requests', async () => {
+    const first = fetchFileWithCaching('https://example.com/first.js');
+    const second = fetchFileWithCaching('https://example.com/second.js');
+    const firstResult = first.catch(error => error);
+    const secondResult = second.catch(error => error);
+
+    navigationListener();
+
+    await expect(firstResult).resolves.toEqual(
+      expect.objectContaining({message: expect.stringContaining('navigated')}),
+    );
+    await expect(secondResult).resolves.toEqual(
+      expect.objectContaining({message: expect.stringContaining('navigated')}),
+    );
+    expect(messageListeners.size).toBe(0);
+
+    const retry = fetchFileWithCaching('https://example.com/first.js');
+    expect(sendMessage).toHaveBeenCalledTimes(3);
+    dispatchMessage(
+      'fetch-file-with-cache-complete',
+      'https://example.com/first.js',
+      'retry source',
+    );
+    await expect(retry).resolves.toBe('retry source');
+  });
+
+  it('rejects pending requests when DevTools unloads', async () => {
+    const request = fetchFileWithCaching('https://example.com/source.js');
+    const result = request.catch(error => error);
+
+    unloadListener();
+
+    await expect(result).resolves.toEqual(
+      expect.objectContaining({message: expect.stringContaining('Aborted')}),
+    );
+    expect(messageListeners.size).toBe(0);
+  });
+
+  it('times out, removes its listener, and permits a retry', async () => {
+    const request = fetchFileWithCaching('https://example.com/source.js');
+    const result = request.catch(error => error);
+
+    jest.advanceTimersByTime(60_000);
+
+    await expect(result).resolves.toEqual(
+      expect.objectContaining({message: expect.stringContaining('Timed out')}),
+    );
+    expect(messageListeners.size).toBe(0);
+
+    dispatchMessage(
+      'fetch-file-with-cache-complete',
+      'https://example.com/source.js',
+      'late source',
+    );
+
+    const retry = fetchFileWithCaching('https://example.com/source.js');
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    dispatchMessage(
+      'fetch-file-with-cache-complete',
+      'https://example.com/source.js',
+      'retry source',
+    );
+    await expect(retry).resolves.toBe('retry source');
+  });
+
+  it('cleans up immediately if sending the request throws', async () => {
+    const error = new Error('Extension context invalidated');
+    sendMessage.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    await expect(
+      fetchFileWithCaching('https://example.com/source.js'),
+    ).rejects.toBe(error);
+    expect(messageListeners.size).toBe(0);
+
+    const retry = fetchFileWithCaching('https://example.com/source.js');
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    dispatchMessage(
+      'fetch-file-with-cache-complete',
+      'https://example.com/source.js',
+      'retry source',
+    );
+    await expect(retry).resolves.toBe('retry source');
+  });
+});

--- a/packages/react-devtools-extensions/src/main/fetchFileWithCaching.js
+++ b/packages/react-devtools-extensions/src/main/fetchFileWithCaching.js
@@ -4,11 +4,19 @@ import {normalizeUrlIfValid} from 'react-devtools-shared/src/utils';
 import {__DEBUG__} from 'react-devtools-shared/src/constants';
 
 let debugIDCounter = 0;
+const FETCH_FROM_PAGE_TIMEOUT = 60000;
 
 const debugLog = (...args) => {
   if (__DEBUG__) {
     console.log(...args);
   }
+};
+
+type PendingFetchRequest = {
+  promise: Promise<string>,
+  onMessage: (message: any) => void,
+  reject: (reason: mixed) => void,
+  timeoutID: TimeoutID,
 };
 
 const fetchFromNetworkCache = (url, resolve, reject) => {
@@ -67,6 +75,8 @@ const fetchFromNetworkCache = (url, resolve, reject) => {
           fetchFromPage(url, resolve, reject);
         }
       }
+
+      return;
     }
 
     debugLog(
@@ -78,42 +88,95 @@ const fetchFromNetworkCache = (url, resolve, reject) => {
   });
 };
 
-const pendingFetchRequests = new Set();
-function pendingFetchRequestsCleanup({payload, source}) {
-  if (source === 'react-devtools-background') {
-    switch (payload?.type) {
-      case 'fetch-file-with-cache-complete':
-      case 'fetch-file-with-cache-error':
-        pendingFetchRequests.delete(payload.url);
-    }
-  }
-}
-chrome.runtime.onMessage.addListener(pendingFetchRequestsCleanup);
+const pendingFetchRequests: Map<string, PendingFetchRequest> = new Map();
 
-const fetchFromPage = async (url, resolve, reject) => {
+function clearPendingFetchRequest(url: string) {
+  const pendingFetchRequest = pendingFetchRequests.get(url);
+  if (pendingFetchRequest == null) {
+    return;
+  }
+
+  chrome.runtime.onMessage.removeListener(pendingFetchRequest.onMessage);
+  clearTimeout(pendingFetchRequest.timeoutID);
+  pendingFetchRequests.delete(url);
+}
+
+function rejectPendingFetchRequests(reason: Error) {
+  pendingFetchRequests.forEach((pendingFetchRequest, url) => {
+    clearPendingFetchRequest(url);
+    pendingFetchRequest.reject(reason);
+  });
+}
+
+chrome.devtools.network.onNavigated.addListener(() => {
+  rejectPendingFetchRequests(
+    new Error(
+      'Aborted fetching source from the inspected page because the page navigated.',
+    ),
+  );
+});
+
+const abortPendingFetchRequestsOnUnload = () => {
+  rejectPendingFetchRequests(
+    new Error('Aborted fetching source from the inspected page.'),
+  );
+};
+
+if (__IS_FIREFOX__) {
+  window.addEventListener('unload', abortPendingFetchRequestsOnUnload);
+} else {
+  window.addEventListener('beforeunload', abortPendingFetchRequestsOnUnload);
+}
+
+const fetchFromPage = (url, resolve, reject) => {
   debugLog('[main] fetchFromPage()', url);
+
+  const pendingFetchRequest = pendingFetchRequests.get(url);
+  if (pendingFetchRequest != null) {
+    pendingFetchRequest.promise.then(resolve, reject);
+    return;
+  }
+
+  let resolveFetchRequest: string => void = (null: any);
+  let rejectFetchRequest: mixed => void = (null: any);
+  const promise: Promise<string> = new Promise(
+    (resolveRequest, rejectRequest) => {
+      resolveFetchRequest = resolveRequest;
+      rejectFetchRequest = rejectRequest;
+    },
+  );
 
   function onPortMessage({payload, source}) {
     if (source === 'react-devtools-background' && payload?.url === url) {
       switch (payload?.type) {
         case 'fetch-file-with-cache-complete':
-          chrome.runtime.onMessage.removeListener(onPortMessage);
-          resolve(payload.value);
+          clearPendingFetchRequest(url);
+          resolveFetchRequest(payload.value);
           break;
         case 'fetch-file-with-cache-error':
-          chrome.runtime.onMessage.removeListener(onPortMessage);
-          reject(payload.value);
+          clearPendingFetchRequest(url);
+          rejectFetchRequest(payload.value);
           break;
       }
     }
   }
 
-  chrome.runtime.onMessage.addListener(onPortMessage);
-  if (pendingFetchRequests.has(url)) {
-    return;
-  }
+  const timeoutID = setTimeout(() => {
+    clearPendingFetchRequest(url);
+    const error = new Error(
+      `Timed out fetching source from the inspected page: ${url}`,
+    );
+    rejectFetchRequest(error);
+  }, FETCH_FROM_PAGE_TIMEOUT);
 
-  pendingFetchRequests.add(url);
+  pendingFetchRequests.set(url, {
+    promise,
+    onMessage: onPortMessage,
+    reject: rejectFetchRequest,
+    timeoutID,
+  });
+  chrome.runtime.onMessage.addListener(onPortMessage);
+  promise.then(resolve, reject);
   chrome.runtime.sendMessage({
     source: 'devtools-page',
     payload: {

--- a/packages/react-devtools-extensions/src/main/fetchFileWithCaching.js
+++ b/packages/react-devtools-extensions/src/main/fetchFileWithCaching.js
@@ -175,14 +175,19 @@ const fetchFromPage = (url, resolve, reject) => {
   });
   chrome.runtime.onMessage.addListener(onPortMessage);
   promise.then(resolve, reject);
-  chrome.runtime.sendMessage({
-    source: 'devtools-page',
-    payload: {
-      type: 'fetch-file-with-cache',
-      tabId: chrome.devtools.inspectedWindow.tabId,
-      url,
-    },
-  });
+  try {
+    chrome.runtime.sendMessage({
+      source: 'devtools-page',
+      payload: {
+        type: 'fetch-file-with-cache',
+        tabId: chrome.devtools.inspectedWindow.tabId,
+        url,
+      },
+    });
+  } catch (error) {
+    clearPendingFetchRequest(url);
+    rejectFetchRequest(error);
+  }
 };
 
 // 1. Check if resource is available via chrome.devtools.inspectedWindow.getResources

--- a/packages/react-devtools-extensions/src/main/fetchFileWithCaching.js
+++ b/packages/react-devtools-extensions/src/main/fetchFileWithCaching.js
@@ -75,8 +75,6 @@ const fetchFromNetworkCache = (url, resolve, reject) => {
           fetchFromPage(url, resolve, reject);
         }
       }
-
-      return;
     }
 
     debugLog(


### PR DESCRIPTION
## Summary

- Track page fetches by URL with a single pending promise/listener and reuse it for duplicate callers.
- Clean up pending fetch listeners on completion, error, timeout, navigation, and DevTools unload.
- Reject and clean up immediately if sending through an invalidated extension context throws.
- Add focused tests for deduplication, response routing, cleanup, navigation, unload, timeout, and retry behavior.

## How did you test this?

- `NODE_ENV=development RELEASE_CHANNEL=experimental ./node_modules/.bin/jest --config scripts/jest/config.base.js --runInBand --runTestsByPath packages/react-devtools-extensions/src/__tests__/fetchFileWithCaching-test.js`
- `corepack yarn lint packages/react-devtools-extensions/src/main/fetchFileWithCaching.js packages/react-devtools-extensions/src/__tests__/fetchFileWithCaching-test.js`
- `node scripts/prettier/index.js check packages/react-devtools-extensions/src/main/fetchFileWithCaching.js packages/react-devtools-extensions/src/__tests__/fetchFileWithCaching-test.js`