### PR TITLE
[DevTools] Avoid fallback fetch after HAR hit

### DIFF
--- a/packages/react-devtools-extensions/src/main/fetchFileWithCaching.js
+++ b/packages/react-devtools-extensions/src/main/fetchFileWithCaching.js
@@ -67,6 +67,8 @@ const fetchFromNetworkCache = (url, resolve, reject) => {
           fetchFromPage(url, resolve, reject);
         }
       }
+
+      return;
     }
 
     debugLog(


### PR DESCRIPTION
## Summary
- Stop searching the HAR once a matching request has been handled.
- Avoid logging that no cached request was found and starting a fallback page fetch after a HAR match.

## How did you test this?
- `corepack yarn prettier`
- `corepack yarn lint packages/react-devtools-extensions/src/main/fetchFileWithCaching.js`