### PR TITLE
[react-dom] Support fetchPriority in ReactDOM.preloadModule()

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -6532,6 +6532,35 @@ body {
       );
     });
 
+    it('supports fetchPriority', async () => {
+      function App({ssr}) {
+        const prefix = ssr ? 'ssr ' : 'browser ';
+        ReactDOM.preloadModule(prefix + 'high', {fetchPriority: 'high'});
+        ReactDOM.preloadModule(prefix + 'low', {fetchPriority: 'low'});
+        ReactDOM.preloadModule(prefix + 'auto', {fetchPriority: 'auto'});
+        return <div>hello</div>;
+      }
+      await act(() => {
+        renderToPipeableStream(<App ssr={true} />).pipe(writable);
+      });
+      expect(getMeaningfulChildren(document.body)).toEqual(
+        <div id="container">
+          <link rel="modulepreload" href="ssr high" fetchpriority="high" />
+          <link rel="modulepreload" href="ssr low" fetchpriority="low" />
+          <link rel="modulepreload" href="ssr auto" fetchpriority="auto" />
+          <div>hello</div>
+        </div>,
+      );
+
+      ReactDOMClient.hydrateRoot(container, <App />);
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document.head)).toEqual([
+        <link rel="modulepreload" href="browser high" fetchpriority="high" />,
+        <link rel="modulepreload" href="browser low" fetchpriority="low" />,
+        <link rel="modulepreload" href="browser auto" fetchpriority="auto" />,
+      ]);
+    });
+
     it('warns if you provide invalid arguments', async () => {
       function App() {
         ReactDOM.preloadModule();

--- a/packages/react-dom/src/shared/ReactDOMFloat.js
+++ b/packages/react-dom/src/shared/ReactDOMFloat.js
@@ -192,6 +192,10 @@ export function preloadModule(href: string, options?: ?PreloadModuleOptions) {
             typeof options.integrity === 'string'
               ? options.integrity
               : undefined,
+          fetchPriority:
+            typeof options.fetchPriority === 'string'
+              ? options.fetchPriority
+              : undefined,
         });
     } else {
       ReactDOMSharedInternals.d /* ReactDOMCurrentDispatcher */

--- a/packages/react-dom/src/shared/ReactDOMTypes.js
+++ b/packages/react-dom/src/shared/ReactDOMTypes.js
@@ -28,6 +28,7 @@ export type PreloadModuleOptions = {
   crossOrigin?: string,
   integrity?: string,
   nonce?: string,
+  fetchPriority?: FetchPriorityEnum,
 };
 export type PreinitOptions = {
   as: string,
@@ -63,6 +64,7 @@ export type PreloadModuleImplOptions = {
   crossOrigin?: ?CrossOriginEnum,
   integrity?: ?string,
   nonce?: ?string,
+  fetchPriority?: ?string,
 };
 export type PreinitStyleOptions = {
   crossOrigin?: ?CrossOriginEnum,


### PR DESCRIPTION
## Summary

`ReactDOM.preload()` and `ReactDOM.preinit()` accept a `fetchPriority` option, but `ReactDOM.preloadModule()` silently ignored it. This left no way to influence the priority of the `<link rel="modulepreload">` hints emitted for native-ESM apps, so module preloads (which browsers default to **high** priority) can compete with render-critical resources when a page emits many of them.

This is exactly the case frameworks hit when forwarding `fetchPriority: 'low'` to module preloads (e.g. `@vitejs/plugin-rsc`). React itself already relies on this for bootstrap modules — it emits `fetchPriority="low"` on their `modulepreload` links — so the attribute is fully supported on these links. The only gap was that the public `preloadModule` API never forwarded the user-supplied option to the host dispatcher.

This PR:

- Adds `fetchPriority` to `PreloadModuleOptions` and `PreloadModuleImplOptions`.
- Forwards `fetchPriority` from `preloadModule` to the dispatcher (`.m`).

No further plumbing was needed: the client (`ReactFiberConfigDOM`), Fizz (`ReactFizzConfigDOM`), and Flight (`ReactDOMFlightServerHostDispatcher`) paths already spread the impl options onto the generated link / hint, so the value flows through to the emitted `modulepreload` once forwarded.

`preinitModule()` could plausibly gain the same option for symmetry with `preinit()`, but I kept this PR scoped to the reported `preloadModule()` case.

Fixes #36834

## How did you test this change?

Added a `supports fetchPriority` test to the `ReactDOM.preloadModule(href, options)` suite in `ReactDOMFloat-test.js` that asserts `fetchpriority` is emitted on the `modulepreload` link both during SSR (Fizz) and after client hydration, for `high`/`low`/`auto`.

```
$ yarn test ReactDOMFloat -t "preloadModule"
Tests:       125 skipped, 3 passed, 128 total

$ yarn test --prod ReactDOMFloat -t "preloadModule"
Tests:       125 skipped, 3 passed, 128 total
```

Also ran the full `ReactDOMFloat` suite (127 passed) and `ReactFlightDOM` (49 passed) for regressions, plus `yarn prettier`, `yarn linc`, and `yarn flow dom-node` (no errors).