### PR TITLE
feat: add fetchPriority support to ReactDOM.preloadModule() and ReactDOM.preinitModule()

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -6630,6 +6630,104 @@ body {
           '    in App (at **)',
       ]);
     });
+
+    it('supports fetchPriority', async () => {
+      function Component({isServer}) {
+        ReactDOM.preloadModule(
+          isServer ? 'highserver' : 'highclient',
+          {fetchPriority: 'high'},
+        );
+        ReactDOM.preloadModule(
+          isServer ? 'lowserver' : 'lowclient',
+          {fetchPriority: 'low'},
+        );
+        ReactDOM.preloadModule(
+          isServer ? 'autoserver' : 'autoclient',
+          {fetchPriority: 'auto'},
+        );
+        return 'hello';
+      }
+
+      await act(() => {
+        renderToPipeableStream(
+          <html>
+            <body>
+              <Component isServer={true} />
+            </body>
+          </html>,
+        ).pipe(writable);
+      });
+
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <link
+              rel="modulepreload"
+              href="highserver"
+              fetchpriority="high"
+            />
+            <link
+              rel="modulepreload"
+              href="lowserver"
+              fetchpriority="low"
+            />
+            <link
+              rel="modulepreload"
+              href="autoserver"
+              fetchpriority="auto"
+            />
+          </head>
+          <body>hello</body>
+        </html>,
+      );
+
+      ReactDOMClient.hydrateRoot(
+        document,
+        <html>
+          <body>
+            <Component />
+          </body>
+        </html>,
+      );
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <link
+              rel="modulepreload"
+              href="highserver"
+              fetchpriority="high"
+            />
+            <link
+              rel="modulepreload"
+              href="lowserver"
+              fetchpriority="low"
+            />
+            <link
+              rel="modulepreload"
+              href="autoserver"
+              fetchpriority="auto"
+            />
+            <link
+              rel="modulepreload"
+              href="highclient"
+              fetchpriority="high"
+            />
+            <link
+              rel="modulepreload"
+              href="lowclient"
+              fetchpriority="low"
+            />
+            <link
+              rel="modulepreload"
+              href="autoclient"
+              fetchpriority="auto"
+            />
+          </head>
+          <body>hello</body>
+        </html>,
+      );
+    });
   });
 
   describe('ReactDOM.preinit(href, { as: ... })', () => {
@@ -7333,6 +7431,91 @@ body {
           'The `as` option encountered was something with type "boolean".\n' +
           '    in App (at **)',
       ]);
+    });
+
+    it('supports fetchPriority', async () => {
+      function Component({isServer}) {
+        ReactDOM.preinitModule(
+          isServer ? 'highserver' : 'highclient',
+          {fetchPriority: 'high'},
+        );
+        ReactDOM.preinitModule(
+          isServer ? 'lowserver' : 'lowclient',
+          {fetchPriority: 'low'},
+        );
+        return 'hello';
+      }
+
+      await act(() => {
+        renderToPipeableStream(
+          <html>
+            <body>
+              <Component isServer={true} />
+            </body>
+          </html>,
+        ).pipe(writable);
+      });
+
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <script
+              type="module"
+              src="highserver"
+              async=""
+              fetchpriority="high"
+            />
+            <script
+              type="module"
+              src="lowserver"
+              async=""
+              fetchpriority="low"
+            />
+          </head>
+          <body>hello</body>
+        </html>,
+      );
+
+      ReactDOMClient.hydrateRoot(
+        document,
+        <html>
+          <body>
+            <Component />
+          </body>
+        </html>,
+      );
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <script
+              type="module"
+              src="highserver"
+              async=""
+              fetchpriority="high"
+            />
+            <script
+              type="module"
+              src="lowserver"
+              async=""
+              fetchpriority="low"
+            />
+            <script
+              type="module"
+              src="highclient"
+              async=""
+              fetchpriority="high"
+            />
+            <script
+              type="module"
+              src="lowclient"
+              async=""
+              fetchpriority="low"
+            />
+          </head>
+          <body>hello</body>
+        </html>,
+      );
     });
   });
 

--- a/packages/react-dom/src/shared/ReactDOMFloat.js
+++ b/packages/react-dom/src/shared/ReactDOMFloat.js
@@ -192,6 +192,12 @@ export function preloadModule(href: string, options?: ?PreloadModuleOptions) {
             typeof options.integrity === 'string'
               ? options.integrity
               : undefined,
+          nonce:
+            typeof options.nonce === 'string' ? options.nonce : undefined,
+          fetchPriority:
+            typeof options.fetchPriority === 'string'
+              ? options.fetchPriority
+              : undefined,
         });
     } else {
       ReactDOMSharedInternals.d /* ReactDOMCurrentDispatcher */
@@ -321,6 +327,10 @@ export function preinitModule(href: string, options?: ?PreinitModuleOptions) {
                 : undefined,
             nonce:
               typeof options.nonce === 'string' ? options.nonce : undefined,
+            fetchPriority:
+              typeof options.fetchPriority === 'string'
+                ? options.fetchPriority
+                : undefined,
           });
       }
     } else if (options == null) {

--- a/packages/react-dom/src/shared/ReactDOMTypes.js
+++ b/packages/react-dom/src/shared/ReactDOMTypes.js
@@ -28,6 +28,7 @@ export type PreloadModuleOptions = {
   crossOrigin?: string,
   integrity?: string,
   nonce?: string,
+  fetchPriority?: FetchPriorityEnum,
 };
 export type PreinitOptions = {
   as: string,
@@ -42,6 +43,7 @@ export type PreinitModuleOptions = {
   crossOrigin?: string,
   integrity?: string,
   nonce?: string,
+  fetchPriority?: FetchPriorityEnum,
 };
 
 export type CrossOriginEnum = '' | 'use-credentials' | CrossOriginString;
@@ -63,6 +65,7 @@ export type PreloadModuleImplOptions = {
   crossOrigin?: ?CrossOriginEnum,
   integrity?: ?string,
   nonce?: ?string,
+  fetchPriority?: ?string,
 };
 export type PreinitStyleOptions = {
   crossOrigin?: ?CrossOriginEnum,
@@ -79,6 +82,7 @@ export type PreinitModuleScriptOptions = {
   crossOrigin?: ?CrossOriginEnum,
   integrity?: ?string,
   nonce?: ?string,
+  fetchPriority?: ?string,
 };
 
 export type HostDispatcher = {


### PR DESCRIPTION
## Summary

`ReactDOM.preload()` and `ReactDOM.preinit()` already accept a `fetchPriority` option, but the module variants — `ReactDOM.preloadModule()` and `ReactDOM.preinitModule()` — were missing it. This causes frameworks like `@vitejs/plugin-rsc` that need to pass `fetchPriority: 'low'` for modulepreload links to be unable to do so.

This PR adds `fetchPriority` support to both functions, mirroring exactly how the non-module `preload()`/`preinit()` paths already handle it.

Closes #36834

## Changes

- **`packages/react-dom/src/shared/ReactDOMTypes.js`**: Added `fetchPriority?: FetchPriorityEnum` to `PreloadModuleOptions` and `PreinitModuleOptions` (public API types). Added `fetchPriority?: ?string` to `PreloadModuleImplOptions` and `PreinitModuleScriptOptions` (internal/dispatcher types).

- **`packages/react-dom/src/shared/ReactDOMFloat.js`**: Forward `fetchPriority` through the `.m()` dispatcher call in `preloadModule()` and through the `.M()` call in `preinitModule()`, matching the existing pattern in `preload()`/`preinit()`.

No changes are needed in the server (`ReactFizzConfigDOM.js`) or client (`ReactFiberConfigDOM.js`) implementations because they already use `Object.assign({...defaults}, options)` to build element props, so `fetchPriority` in the options automatically flows through to the emitted `fetchpriority` attribute on the `<link rel="modulepreload">` or `<script type="module">` element.

## Test Plan

Added two new `it('supports fetchPriority', ...)` tests inside the existing `describe('ReactDOM.preloadModule(href, options)')` and `describe('ReactDOM.preinitModule(href, options)')` blocks in `ReactDOMFloat-test.js`, mirroring the existing fetchPriority tests for `preload()`/`preinit()`. Tests cover SSR (server-rendered HTML with `fetchpriority` attribute) and client hydration.

Full test suite: `yarn test packages/react-dom/src/__tests__/ReactDOMFloat-test.js` — **129 passed, 1 skipped, 0 failed**.