### PR TITLE
[scripts] Fix release channel artifact cleanup for local builds 

### DIFF
--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -383,7 +383,10 @@ function processExperimental(buildDir, version) {
       pathName !== 'facebook-www' &&
       pathName !== 'sizes-experimental'
     ) {
-      spawnSync('rm', ['-rm', buildDir + '/' + pathName]);
+      fs.rmSync(path.join(buildDir, pathName), {
+        recursive: true,
+        force: true,
+      });
     }
   }
 }

--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -372,6 +372,12 @@ function processExperimental(buildDir, version) {
   if (fs.existsSync(buildDir + '/sizes')) {
     fs.renameSync(buildDir + '/sizes', buildDir + '/sizes-experimental');
   }
+  if (fs.existsSync(buildDir + '/bundle-sizes.json')) {
+    fs.renameSync(
+      buildDir + '/bundle-sizes.json',
+      buildDir + '/bundle-sizes-experimental.json'
+    );
+  }
 
   // Delete all other artifacts that weren't handled above. We assume they are
   // duplicates of the corresponding artifacts in the stable channel. Ideally,


### PR DESCRIPTION
## Summary

The experimental release-channel cleanup was shelling out to `rm -rm`, which is rejected by `rm` as an invalid option. Since the `spawnSync` result was ignored, cleanup failures could leave duplicate artifacts behind.

This switches the cleanup to Node's `fs.rmSync` with `recursive` and `force`, avoiding shell option parsing entirely and using `path.join` for the target path.

## Test plan

- `node ./scripts/prettier/index.js check-changed`
- `node ./scripts/tasks/eslint.js scripts/rollup/build-all-release-channels.js`
- `git diff --check`
- Verified locally that `rm -rm` exits with `rm: illegal option -- m`
- Verified `fs.rmSync(..., {recursive: true, force: true})` removes a nested temp directory
