### PR TITLE
[scripts] Fix Linux benchmark xvfb startup

### DIFF
--- a/scripts/bench/benchmark.js
+++ b/scripts/bench/benchmark.js
@@ -90,7 +90,10 @@ async function initChrome() {
   if (platform === 'linux') {
     process.env.XVFBARGS = '-screen 0, 1024x768x16';
     process.env.LIGHTHOUSE_CHROMIUM_PATH = 'chromium-browser';
-    const child = spawn('xvfb start', [{detached: true, stdio: ['ignore']}]);
+    const child = spawn('xvfb', ['start'], {
+      detached: true,
+      stdio: 'ignore',
+    });
     child.unref();
     // wait for chrome to load then continue
     await wait(3000);


### PR DESCRIPTION
## Summary

The Linux benchmark setup was calling `spawn('xvfb start', [{detached: true, stdio: ['ignore']}])`. Node treats the first parameter as the executable name, so it would try to run a binary literally named `xvfb start`. The options object was also being passed as an argv item instead of the third `spawn` parameter.

This keeps the existing benchmark startup flow, but passes `xvfb` as the executable, `start` as an argument, and the detached/stdio settings as spawn options.

## Test plan

- `node --check scripts/bench/benchmark.js`
- `node ./scripts/prettier/index.js check-changed`
- `node ./scripts/tasks/eslint.js scripts/bench/benchmark.js`
- `git diff --check`
