### PR TITLE
[DevTools] Run Firefox extension test without shell

### DIFF
--- a/packages/react-devtools-extensions/firefox/test.js
+++ b/packages/react-devtools-extensions/firefox/test.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const {exec} = require('child-process-promise');
+const {spawn} = require('child_process');
 const {Finder} = require('firefox-profile');
 const {resolve} = require('path');
 const {argv} = require('yargs');
@@ -11,6 +11,23 @@ const EXTENSION_PATH = resolve('./firefox/build/unpacked');
 const START_URL = argv.url || 'https://react.dev/';
 
 const firefoxVersion = process.env.WEB_EXT_FIREFOX;
+
+function runWebExt(options) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn('web-ext', ['run', ...options], {
+      stdio: 'inherit',
+    });
+
+    child.on('error', rejectPromise);
+    child.on('close', code => {
+      if (code === 0) {
+        resolvePromise();
+      } else {
+        rejectPromise(new Error(`web-ext run exited with code ${code}`));
+      }
+    });
+  });
+}
 
 const getFirefoxProfileName = () => {
   // Keys are pulled from https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#--firefox
@@ -52,16 +69,15 @@ const main = async () => {
 
   try {
     const path = await findPathPromise;
-    const trimmedPath = path.replace(' ', '\\ ');
-    options.push(`--firefox-profile=${trimmedPath}`);
+    options.push(`--firefox-profile=${path}`);
   } catch (err) {
     console.warn('Could not find default profile, using temporary profile.');
   }
 
   try {
-    await exec(`web-ext run ${options.join(' ')}`);
+    await runWebExt(options);
   } catch (err) {
-    console.error('`web-ext run` failed', err.stdout, err.stderr);
+    console.error('`web-ext run` failed', err);
   }
 };
 


### PR DESCRIPTION
## Summary

The Firefox extension test script was building a `web-ext run` shell command from an options array. That made `--url` values sensitive to shell parsing, and it required manual escaping for profile paths. The existing profile escaping only handled the first space.

This switches the script to native `spawn` with an argument array. Each `web-ext` option stays as a single argv item, including `--start-url=...` and `--firefox-profile=...`, so paths and URLs no longer need manual shell escaping.

## Test plan

- `node --check packages/react-devtools-extensions/firefox/test.js`
- `node ./scripts/prettier/index.js check-changed`
- `node ./scripts/tasks/eslint.js packages/react-devtools-extensions/firefox/test.js`
- `git diff --check`
- Verified an argv-array spawn preserves a start URL containing spaces and shell syntax as a single argument
