### PR TITLE
[test] Assert aborted Replies reject Promises

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js
@@ -740,9 +740,7 @@ describe('ReactFlightDOMReply', () => {
 
     const result = await ReactServerDOMServer.decodeReply(await bodyPromise);
     expect(result.hello).toBe('world');
-    // TODO: await result.promise should reject at this point because the stream
-    // has closed but that's a bug in both ReactFlightReplyServer and ReactFlightClient.
-    // It just halts in this case.
+    await expect(result.promise).rejects.toThrow('Connection closed.');
   });
 
   it('cannot deserialize a Blob reference backed by a string', async () => {


### PR DESCRIPTION
## Summary

The RSC reply test for aborting an unresolved model still had a TODO saying that awaiting the unresolved promise would halt forever after the stream closed.

That behavior is already fixed: the partial reply still exposes resolved fields, and the unresolved promise rejects with `Connection closed.`. This updates the test to assert that behavior directly so it does not regress.

## Test plan

- `node scripts/jest/jest-cli.js packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js --runInBand`
- `node ./scripts/prettier/index.js check-changed`
- `node ./scripts/tasks/eslint.js packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReply-test.js`
- `git diff --check`
