### PR TITLE
[compiler] Unskip lone surrogate string fixture

### DIFF
--- a/compiler/crates/TODO.md
+++ b/compiler/crates/TODO.md
@@ -67,13 +67,6 @@ Each line names the failure mode and a sketch of where to look.
 	output; the fix is either an SWC codegen flag for quote style or a
 	post-emit pass. Low impact, high effort.
 
-- `lone-surrogate-string-values.js` — TS preserves lone surrogates
-	(`\uD83E`); SWC emits `\uFFFD` because `Wtf8Atom::to_string_lossy()` in
-	`react_compiler_swc/src/convert_ast.rs::wtf8_to_string` replaces invalid
-	UTF-8 sequences. Real WTF-8 handling work that touches every call site
-	using that helper. Probably needs to detect lone surrogates and emit
-	`\uXXXX` escapes before they hit `String`.
-
 - `many-scopes-no-stack-overflow.js` — TS memoizes the function
 	(`const $ = _c(401);` with 401 memo slots); SWC pipeline bails out and
 	returns the uncompiled source. The fixture exists to test that the

--- a/compiler/crates/react_compiler_ast/tests/round_trip.rs
+++ b/compiler/crates/react_compiler_ast/tests/round_trip.rs
@@ -72,10 +72,7 @@ fn round_trip_all_fixtures() {
     let mut total = 0;
     let mut passed = 0;
 
-    // Fixtures with known issues that can't be fixed in the AST crate:
-    // - lone-surrogate-string-values: contains lone Unicode surrogates (\uD800)
-    //   that serde_json rejects during deserialization.
-    let known_failures: &[&str] = &["lone-surrogate-string-values"];
+    let known_failures: &[&str] = &[];
 
     for entry in walkdir::WalkDir::new(&json_dir)
         .into_iter()

--- a/compiler/crates/react_compiler_ast/tests/scope_resolution.rs
+++ b/compiler/crates/react_compiler_ast/tests/scope_resolution.rs
@@ -1019,7 +1019,6 @@ fn scope_resolution_rename() {
     let mut skipped = 0;
 
     let known_failures: &[&str] = &[
-        "lone-surrogate-string-values",
         "component-in-object-method-body.flow",
         "error.todo-hoist-type-alias-before-declaration",
         "error.todo-round2_severity_diff",


### PR DESCRIPTION
## Summary

This unskips the `lone-surrogate-string-values` fixture for AST round-tripping and scope rename coverage.

The old TODO points at an SWC conversion helper that is no longer present in this checkout. The fixture now passes through the existing `JsString` marker/code-unit-preserving path, so it should be covered by the tests instead of staying listed as a known failure.

## How I tested

- `cargo test -p react_compiler_ast round_trip_all_fixtures`
- `cargo test -p react_compiler_ast scope_resolution_rename`
- `cargo test -p react_compiler_diagnostics js_string`
- `cargo fmt --check`
- `git diff --check`
