### PR TITLE
Harden Server Reference resolution in the FB Flight bundler

### DIFF
--- a/packages/react-flight-server-fb/src/client/ReactFlightClientConfigBundlerFB.js
+++ b/packages/react-flight-server-fb/src/client/ReactFlightClientConfigBundlerFB.js
@@ -20,6 +20,10 @@ import type {ModuleLoading} from 'react-client/src/ReactFlightClientConfig';
 
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 
+import hasOwnProperty from 'shared/hasOwnProperty';
+
+import {isServerReference} from '../ReactFlightFBReferences';
+
 export type ServerConsumerModuleMap = null;
 
 export type ServerManifest = null;
@@ -64,11 +68,24 @@ export function resolveServerReference<T>(
   config: ServerManifest,
   id: ServerReferenceId,
 ): ClientReference<T> {
-  return {
+  const reference: ClientReference<T> = {
     $$typeof: Symbol.for('react.client.reference'),
     $$id: id,
     $$hblp: null,
   } as any;
+  if (!canUseDOM) {
+    // On the server the id comes from an untrusted reply and there is no
+    // manifest to validate it against, so require the module and confirm the
+    // export was registered via registerServerReference. This stops an
+    // arbitrary id from resolving to an unrelated module export.
+    const resolvedModule = requireModule<T>(reference);
+    if (resolvedModule == null || !isServerReference(resolvedModule as any)) {
+      throw new Error(
+        'Could not resolve "' + id + '" to a registered Server Reference.',
+      );
+    }
+  }
+  return reference;
 }
 
 const asyncModuleCache: Map<string, Thenable<any>> = new Map();
@@ -125,7 +142,10 @@ export function requireModule<T>(metadata: ClientReference<T>): T {
       if (exportName === '' || exportName === 'default') {
         return mod.__esModule ? mod.default : mod;
       }
-      return mod[exportName];
+      if (hasOwnProperty.call(mod, exportName)) {
+        return mod[exportName];
+      }
+      return undefined as any;
     }
     // Use .call to prevent bundlers from statically resolving this require.
     return require.call(null, id); // eslint-disable-line no-useless-call


### PR DESCRIPTION
## Summary

`ReactFlightClientConfigBundlerFB.js` was missing the Server Reference resolution guards the other bundlers received in #35277, so when a reply is decoded on the server a request-controlled reference id could resolve to an arbitrary module export.

Although Meta currently runs the Flight server on Hermes (where these ids can't reach Node built-ins), this hardens the bundler for environments that use a Node-style `require`, and brings it in line with the others:

- `resolveServerReference` is the only place Server References are resolved (client references go through `resolveClientReference`). On the server it now requires the module and rejects any id whose resolved export was not registered via `registerServerReference`. This bundler has no manifest to allowlist against, so the registration tag is the equivalent check.
- `requireModule` reads only the module's own exports via `hasOwnProperty`, preventing ids like `x#constructor` from reaching prototype-chain properties.

## How did you test this?

- Built the FB bundles (`yarn build react-flight-server-fb`) and confirmed both guards are present in the output.

