### PR TITLE
Forward fetchPriority option in ReactDOM.preloadModule

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -6560,6 +6560,35 @@ body {
       );
     });
 
+    it('forwards fetchPriority to the modulepreload link', async () => {
+      function App({ssr}) {
+        const prefix = ssr ? 'ssr ' : 'browser ';
+        ReactDOM.preloadModule(prefix + 'low', {fetchPriority: 'low'});
+        ReactDOM.preloadModule(prefix + 'high', {fetchPriority: 'high'});
+        ReactDOM.preloadModule(prefix + 'auto', {fetchPriority: 'auto'});
+        return <div>hello</div>;
+      }
+      await act(() => {
+        renderToPipeableStream(<App ssr={true} />).pipe(writable);
+      });
+      expect(getMeaningfulChildren(document.body)).toEqual(
+        <div id="container">
+          <link rel="modulepreload" href="ssr low" fetchpriority="low" />
+          <link rel="modulepreload" href="ssr high" fetchpriority="high" />
+          <link rel="modulepreload" href="ssr auto" fetchpriority="auto" />
+          <div>hello</div>
+        </div>,
+      );
+
+      ReactDOMClient.hydrateRoot(container, <App />);
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document.head)).toEqual([
+        <link rel="modulepreload" href="browser low" fetchpriority="low" />,
+        <link rel="modulepreload" href="browser high" fetchpriority="high" />,
+        <link rel="modulepreload" href="browser auto" fetchpriority="auto" />,
+      ]);
+    });
+
     it('warns if you provide invalid arguments', async () => {
       function App() {
         ReactDOM.preloadModule();

--- a/packages/react-dom/src/shared/ReactDOMFloat.js
+++ b/packages/react-dom/src/shared/ReactDOMFloat.js
@@ -192,6 +192,10 @@ export function preloadModule(href: string, options?: ?PreloadModuleOptions) {
             typeof options.integrity === 'string'
               ? options.integrity
               : undefined,
+          fetchPriority:
+            typeof options.fetchPriority === 'string'
+              ? options.fetchPriority
+              : undefined,
         });
     } else {
       ReactDOMSharedInternals.d /* ReactDOMCurrentDispatcher */

--- a/packages/react-dom/src/shared/ReactDOMTypes.js
+++ b/packages/react-dom/src/shared/ReactDOMTypes.js
@@ -28,6 +28,7 @@ export type PreloadModuleOptions = {
   crossOrigin?: string,
   integrity?: string,
   nonce?: string,
+  fetchPriority?: FetchPriorityEnum,
 };
 export type PreinitOptions = {
   as: string,
@@ -63,6 +64,7 @@ export type PreloadModuleImplOptions = {
   crossOrigin?: ?CrossOriginEnum,
   integrity?: ?string,
   nonce?: ?string,
+  fetchPriority?: ?string,
 };
 export type PreinitStyleOptions = {
   crossOrigin?: ?CrossOriginEnum,


### PR DESCRIPTION
## Summary

\`ReactDOM.preload()\` already accepts a \`fetchPriority\` option and forwards it to the emitted \`<link rel=\"preload\">\` tag, but \`ReactDOM.preloadModule()\` silently dropped it. That ruled out granular priority hints for ESM apps using \`modulepreload\` (e.g. letting \`@vitejs/plugin-rsc\` mark non-critical client modules as \`fetchPriority=\"low\"\`).

This PR adds \`fetchPriority\` to \`PreloadModuleOptions\` and forwards it through to the dispatcher so it lands on the \`<link rel=\"modulepreload\">\` tag.

Fixes #36834.

## How did you test this change?

- New test in \`ReactDOMFloat-test.js\` covering \`high\`, \`low\`, and \`auto\` on both the SSR-emitted markup and the client-emitted \`<head>\` tags.
- \`yarn test ReactDOMFloat\` — all 128 tests pass.
- \`yarn linc\`, \`yarn prettier\`, \`yarn flow dom-node\` — clean.