### PR TITLE
[compiler] Add explain-compiler-diagnostic MCP tool

### DIFF
--- a/compiler/packages/react-mcp-server/README.md
+++ b/compiler/packages/react-mcp-server/README.md
@@ -20,3 +20,19 @@ First, add this file if you're using Claude Desktop: `code ~/Library/Application
 ```
 
 Next, run `yarn workspace react-mcp-server watch` from the `react/compiler` directory and make changes as needed. You will need to restart Claude everytime you want to try your changes.
+
+## Testing
+
+Run `yarn workspace react-mcp-server test` to execute the Jest unit tests in `src/**/__tests__/`. The package uses `ts-jest` and `jest.config.js` to transpile TypeScript on the fly.
+
+## Tools
+
+The server exposes the following tools to MCP clients:
+
+- **`query-react-dev-docs`** — Search react.dev docs via Algolia. Use to look up APIs (`useTransition`, `<ViewTransition>`, etc.) before making recommendations.
+- **`compile`** — Compile a snippet with React Compiler. Returns the compiled output and, on failure, diagnostic messages. Use to verify a change before suggesting it.
+- **`explain-compiler-diagnostic`** — Explain a diagnostic message returned by `compile` in plain English. Returns a structured object with `title`, `summary`, `why_it_happens`, `how_to_fix`, an optional `code_example`, `severity`, and `related_links`. Falls back to a generic guidance string when no curated explanation matches.
+- **`review-react-runtime`** — Measure render time, Web Vitals (LCP/INP/CLS), and React Profiler metrics for a snippet. Use to verify a performance change actually helps.
+- **`parse-react-component-tree`** — Connect to a running Chrome instance (debug port 9222) and return the React component tree at a given URL.
+
+It also exposes a single prompt, **`review-react-code`**, which embeds the React + React Compiler guidelines a model should follow when reviewing a snippet.

--- a/compiler/packages/react-mcp-server/jest.config.js
+++ b/compiler/packages/react-mcp-server/jest.config.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  rootDir: '.',
+  testMatch: ['<rootDir>/src/**/__tests__/**/*-test.ts'],
+  // The package tsconfig sets `noEmit: true` and `module: Node16`. Both
+  // prevent ts-jest from emitting code that jest's runtime can load, so
+  // we override them here. `commonjs` + `esModuleInterop` matches the
+  // tsup CJS output that the MCP server ships to users.
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          noEmit: false,
+          module: 'commonjs',
+          moduleResolution: 'node',
+          target: 'es2022',
+          rootDir: '.',
+          esModuleInterop: true,
+          jsx: 'react-jsxdev',
+          lib: ['ES2022'],
+          strict: true,
+        },
+      },
+    ],
+  },
+  transformIgnorePatterns: ['/node_modules/'],
+};

--- a/compiler/packages/react-mcp-server/package.json
+++ b/compiler/packages/react-mcp-server/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "rimraf dist && tsup",
-    "test": "echo 'no tests'",
+    "test": "jest",
     "dev": "concurrently --kill-others -n build,inspect \"yarn run watch\" \"wait-on dist/index.js && yarn run inspect\"",
     "inspect": "npx @modelcontextprotocol/inspector node dist/index.js",
     "watch": "yarn build --watch"

--- a/compiler/packages/react-mcp-server/src/diagnostics/catalog.ts
+++ b/compiler/packages/react-mcp-server/src/diagnostics/catalog.ts
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A hand-curated, plain-English explanation of a React Compiler diagnostic.
+ *
+ * The catalog is keyed by the stable rule name from
+ * babel-plugin-react-compiler's `ErrorCategory` enum (see
+ * `compiler/packages/babel-plugin-react-compiler/src/CompilerError.ts`). The
+ * rule name is the most stable identifier the compiler exposes — it survives
+ * diagnostic message text changes across versions, so the catalog should be
+ * keyed on it, not on message text.
+ *
+ * The `messagePatterns` field is used by the tool to identify which catalog
+ * entry applies to a given formatted compile error. Each pattern is a
+ * JavaScript RegExp source string (e.g. `"setState.*render"`); the tool
+ * compiles them with the `i` flag. Patterns are best-effort — they are
+ * intentionally broad to survive small wording changes in compiler messages.
+ * When a pattern is missing or fails to match, the tool returns the fallback
+ * object instead of a specific explanation.
+ */
+export type DiagnosticSeverity = 'error' | 'warning' | 'info';
+
+export type DiagnosticCodeExample = {
+  problem: string;
+  solution: string;
+};
+
+export type DiagnosticExplanation = {
+  /**
+   * The rule name from `ErrorCategory`. Acts as the catalog key.
+   */
+  rule: string;
+  /**
+   * Short human-readable title for the diagnostic (e.g. "Setting state
+   * during render").
+   */
+  title: string;
+  /**
+   * One-sentence summary. Plain text — the LLM composes from this directly.
+   */
+  summary: string;
+  /**
+   * High-level category (e.g. "render-purity", "hook-usage").
+   */
+  category: string;
+  /**
+   * Why this diagnostic is reported — what the compiler is concerned about.
+   * Plain text, one or two short paragraphs.
+   */
+  why_it_happens: string;
+  /**
+   * Concrete fix suggestion. Plain text.
+   */
+  how_to_fix: string;
+  /**
+   * Optional before/after example. Omit if the fix is hard to illustrate in a
+   * short snippet.
+   */
+  code_example: DiagnosticCodeExample | null;
+  /**
+   * Diagnostic severity as exposed by the compiler.
+   */
+  severity: DiagnosticSeverity;
+  /**
+   * Links to relevant React docs, blog posts, or compiler documentation.
+   * Empty array if no helpful links exist yet.
+   */
+  related_links: Array<string>;
+  /**
+   * RegExp source strings (no flags) used to match this rule from the
+   * formatted compile error text. The tool compiles each with the `i` flag
+   * and tests against the LLM-supplied message. Empty array means the rule
+   * is only reachable by direct key lookup.
+   */
+  messagePatterns: Array<string>;
+};
+
+const setStateInRender: DiagnosticExplanation = {
+  rule: 'set-state-in-render',
+  title: 'Setting state during render',
+  summary:
+    'A component is calling a state setter (e.g. setState, setX) directly in its render body, which will trigger an extra render and can produce infinite loops.',
+  category: 'render-purity',
+  why_it_happens:
+    'React renders a component to compute its output. If that render call updates state, the same component will re-render before the original render finishes. In most cases the second render will set state again, producing an infinite render loop. Even when the loop terminates, the extra renders waste work and make component behavior hard to reason about.',
+  how_to_fix:
+    'Move the state update into an event handler (e.g. onClick, onChange) or a useEffect if you are synchronizing with an external system. If you are deriving a value from props or state, compute it during render and store it in a const — no state setter is needed. To reset state when a prop changes, use a `key` on the component, not a setState call.',
+  code_example: {
+    problem: `function Counter({step}) {
+  const [count, setCount] = useState(0);
+  if (step > 0) {
+    setCount(count + step); // ❌ setState during render
+  }
+  return <div>{count}</div>;
+}`,
+    solution: `function Counter({step}) {
+  const [count, setCount] = useState(0);
+  // Derive values from props/state without calling setState.
+  const next = step > 0 ? count + step : count;
+  return <div>{next}</div>;
+}`,
+  },
+  severity: 'error',
+  related_links: [
+    'https://react.dev/reference/rules/components-and-hooks-must-be-pure',
+  ],
+  messagePatterns: [
+    'setState.*render',
+    'setting state.*render',
+    'cannot update.*while rendering',
+    'render.*state.*update',
+  ],
+};
+
+const preserveManualMemoization: DiagnosticExplanation = {
+  rule: 'preserve-manual-memoization',
+  title: 'Manual memoization could not be preserved',
+  summary:
+    'The component uses useMemo, useCallback, or React.memo, but the compiler cannot guarantee the same memoization guarantee from its automatic analysis, so the component was skipped.',
+  category: 'memoization',
+  why_it_happens:
+    'React Compiler adds automatic memoization around components and hooks. The compiler will only rewrite a function if its automatic memoization is at least as tight as the manual memoization a developer wrote. When the compiler cannot match or exceed the existing guarantee — for example, because the existing memo depends on referential identity the compiler cannot prove stable — the component is skipped to avoid silently changing behavior.',
+  how_to_fix:
+    'Remove the manual useMemo/useCallback/React.memo and let the compiler handle memoization automatically. If the manual memo was placed there for a specific reason (e.g. object identity stability for a downstream consumer), restructure the code so the compiler can see the dependency, or split the function so the memoized piece is independent of the rest.',
+  code_example: {
+    problem: `function List({items}) {
+  const sorted = useMemo(
+    () => [...items].sort((a, b) => a.id - b.id),
+    [items],
+  );
+  return <ul>{sorted.map(...)}</ul>;
+}`,
+    solution: `function List({items}) {
+  // The compiler memoizes this sort automatically.
+  const sorted = [...items].sort((a, b) => a.id - b.id);
+  return <ul>{sorted.map(...)}</ul>;
+}`,
+  },
+  severity: 'error',
+  related_links: [
+    'https://react.dev/learn/react-compiler/introduction#what-should-i-do-about-usememo-usecallback-and-reactmemo',
+  ],
+  messagePatterns: [
+    'manual memoization',
+    'useMemo.*could not.*preserved',
+    'useCallback.*could not.*preserved',
+    'skipping optimization.*memoization',
+    'skipped optimizing.*manual memo',
+  ],
+};
+
+const immutability: DiagnosticExplanation = {
+  rule: 'immutability',
+  title: 'Mutating a value that should be immutable',
+  summary:
+    'The component is mutating a prop, a hook return value, or another value that the compiler has identified as immutable, which would silently break reactivity.',
+  category: 'immutability',
+  why_it_happens:
+    'React expects props, state, and hook return values to be treated as immutable. The compiler memoizes reads of these values; if a function mutates them in place, later renders will see the mutated value even when the inputs have not changed. This breaks the assumption that React renders are pure functions of their inputs and can produce subtle, hard-to-reproduce bugs.',
+  how_to_fix:
+    'Replace the mutation with a non-mutating update: spread the value into a new object/array (`{...obj, key: value}` or `[...arr, newItem]`), use `Array.prototype.map`/`filter`/`slice` instead of push/splice/sort, and avoid helper libraries that mutate in place. If the value is genuinely local to the function, declare a fresh `const` and use that.',
+  code_example: {
+    problem: `function AddItem({items}) {
+  items.push({id: 1, name: 'new'}); // ❌ mutates a prop
+  return <List items={items} />;
+}`,
+    solution: `function AddItem({items}) {
+  const next = [...items, {id: 1, name: 'new'}];
+  return <List items={next} />;
+}`,
+  },
+  severity: 'error',
+  related_links: [
+    'https://react.dev/reference/rules/components-and-hooks-must-be-pure#props-and-state-are-immutable',
+  ],
+  messagePatterns: [
+    'mutating',
+    'mutation',
+    'in place',
+    'readonly.*mutated',
+    'immutable.*mutated',
+  ],
+};
+
+const purity: DiagnosticExplanation = {
+  rule: 'purity',
+  title: 'Side effect or impure call during render',
+  summary:
+    'The component is performing a side effect (network request, logging, mutation of an external value, etc.) or calling a known-impure function directly inside the render body.',
+  category: 'purity',
+  why_it_happens:
+    'React may render a component more than once for scheduling reasons, especially in development with Strict Mode. If a render call performs a side effect — fetching data, mutating a global, logging to an external system — the side effect runs on every render, potentially many times per logical render. This produces duplicate requests, corrupted state, and non-deterministic UI.',
+  how_to_fix:
+    'Move side effects into event handlers (for user-initiated actions) or into a useEffect (for synchronization with external systems). If a value must be computed during render, compute it from props and state without calling external functions. If the component is initializing state lazily, use the initializer form of useState: `useState(() => computeInitial())`.',
+  code_example: {
+    problem: `function Profile({userId}) {
+  fetch('/api/users/' + userId).then(...); // ❌ fetch during render
+  return <div>...</div>;
+}`,
+    solution: `function Profile({userId}) {
+  const [user, setUser] = useState(null);
+  useEffect(() => {
+    fetch('/api/users/' + userId)
+      .then(r => r.json())
+      .then(setUser);
+  }, [userId]);
+  return <div>{user?.name ?? 'Loading...'}</div>;
+}`,
+  },
+  severity: 'error',
+  related_links: [
+    'https://react.dev/reference/rules/components-and-hooks-must-be-pure',
+  ],
+  messagePatterns: [
+    'side effect',
+    'impure',
+    'not pure',
+    'render.*pure',
+    'cannot read.*during render',
+  ],
+};
+
+const refs: DiagnosticExplanation = {
+  rule: 'refs',
+  title: 'Reading or writing a ref during render',
+  summary:
+    'The component is reading or writing `ref.current` directly inside its render body, which makes the output depend on mutable state and can produce inconsistent UI.',
+  category: 'refs',
+  why_it_happens:
+    'Refs are mutable escape hatches. Their values persist across renders, but unlike state, reading or writing a ref does not schedule a re-render. If a render reads `ref.current` and uses it to compute its output, the output depends on mutable state the rendering system does not know about, which can produce UI that lags behind the real value. If a render writes to `ref.current`, the write is silently lost on the next commit or duplicated across renders.',
+  how_to_fix:
+    'Read refs in event handlers and useEffects, not during render. To display a ref value, store it in state via useEffect: `useEffect(() => { setX(ref.current); }, [...])`. To write a ref, do it in an event handler or useEffect — never in the render body. Lazy initialization (creating the ref with a value) is the one place where writing to a ref during render is allowed.',
+  code_example: {
+    problem: `function Counter() {
+  const countRef = useRef(0);
+  countRef.current += 1; // ❌ writing a ref during render
+  return <div>Renders: {countRef.current}</div>;
+}`,
+    solution: `function Counter() {
+  const [renderCount, setRenderCount] = useState(0);
+  useEffect(() => {
+    setRenderCount(c => c + 1);
+  }, []);
+  return <div>Renders: {renderCount}</div>;
+}`,
+  },
+  severity: 'error',
+  related_links: [
+    'https://react.dev/reference/react/useRef#caveats',
+  ],
+  messagePatterns: [
+    'ref\\.current',
+    'reading.*ref.*render',
+    'writing.*ref.*render',
+    'ref.*during render',
+    'accessing.*ref',
+  ],
+};
+
+/**
+ * Catalog of hand-curated diagnostic explanations, keyed by rule name.
+ *
+ * Adding a new entry is the only change required to support a new
+ * diagnostic — the tool function in `src/tools/explainCompilerDiagnostic.ts`
+ * looks up by rule name and falls back to a generic response on miss.
+ */
+export const diagnosticCatalog: ReadonlyMap<string, DiagnosticExplanation> =
+  new Map<string, DiagnosticExplanation>([
+    [setStateInRender.rule, setStateInRender],
+    [preserveManualMemoization.rule, preserveManualMemoization],
+    [immutability.rule, immutability],
+    [purity.rule, purity],
+    [refs.rule, refs],
+  ]);

--- a/compiler/packages/react-mcp-server/src/index.ts
+++ b/compiler/packages/react-mcp-server/src/index.ts
@@ -22,6 +22,7 @@ import assertExhaustive from './utils/assertExhaustive';
 import {convert} from 'html-to-text';
 import {measurePerformance} from './tools/runtimePerf';
 import {parseReactComponentTree} from './tools/componentTree';
+import {explainCompilerDiagnostic} from './tools/explainCompilerDiagnostic';
 
 function calculateMean(values: number[]): string {
   return values.length > 0
@@ -287,6 +288,50 @@ server.tool(
         content: [{type: 'text' as const, text: `Error: ${err.stack}`}],
       };
     }
+  },
+);
+
+server.tool(
+  'explain-compiler-diagnostic',
+  `Explain a React Compiler diagnostic in plain English.
+
+  Use this tool whenever the \`compile\` tool returns a diagnostic and you want
+  to understand what the diagnostic means, why it was reported, and how to fix
+  the underlying code. The tool returns a structured explanation with a
+  title, summary, category, why-it-happens, how-to-fix, optional before/after
+  code example, severity, and links to the relevant React docs.
+
+  <input>
+  - \`message\` (required): the diagnostic message exactly as returned by the
+    \`compile\` tool. Used to identify the rule via regex pattern matching.
+  - \`rule\` (optional): the rule name from babel-plugin-react-compiler's
+    \`ErrorCategory\` enum (e.g. "set-state-in-render"). If you know the rule
+    name, this gives an exact lookup without depending on message text.
+  - \`codeContext\` (optional): the source code that produced the diagnostic.
+    Currently unused by the matcher but accepted for completeness.
+  </input>
+
+  <output>
+  A JSON object with one of two shapes:
+  - On match: \`{ "kind": "matched", "explanation": { rule, title, summary, ... } }\`
+  - On miss:  \`{ "kind": "unmatched", "message", "genericGuidance" }\`
+  </output>
+  `,
+  {
+    message: z.string(),
+    codeContext: z.string().optional(),
+    rule: z.string().optional(),
+  },
+  async ({message, codeContext, rule}) => {
+    const result = explainCompilerDiagnostic({message, codeContext, rule});
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+    };
   },
 );
 

--- a/compiler/packages/react-mcp-server/src/tools/__tests__/explainCompilerDiagnostic-test.ts
+++ b/compiler/packages/react-mcp-server/src/tools/__tests__/explainCompilerDiagnostic-test.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {explainCompilerDiagnostic} from '../explainCompilerDiagnostic';
+
+describe('explainCompilerDiagnostic', () => {
+  describe('direct rule lookup', () => {
+    test.each([
+      'set-state-in-render',
+      'preserve-manual-memoization',
+      'immutability',
+      'purity',
+      'refs',
+    ])('returns matched explanation for rule %s', rule => {
+      const result = explainCompilerDiagnostic({message: 'irrelevant', rule});
+      expect(result.kind).toBe('matched');
+      if (result.kind === 'matched') {
+        expect(result.explanation.rule).toBe(rule);
+      }
+    });
+
+    test('falls through to message matching when rule is unknown', () => {
+      const result = explainCompilerDiagnostic({
+        message: 'Cannot update a component while rendering a different component',
+        rule: 'not-a-real-rule',
+      });
+      expect(result.kind).toBe('matched');
+      if (result.kind === 'matched') {
+        expect(result.explanation.rule).toBe('set-state-in-render');
+      }
+    });
+
+    test('treats empty rule string as no rule', () => {
+      const result = explainCompilerDiagnostic({
+        message: 'Cannot update a component while rendering a different component',
+        rule: '',
+      });
+      expect(result.kind).toBe('matched');
+      if (result.kind === 'matched') {
+        expect(result.explanation.rule).toBe('set-state-in-render');
+      }
+    });
+  });
+
+  describe('message pattern matching', () => {
+    test('matches set-state-in-render on "cannot update...while rendering"', () => {
+      const result = explainCompilerDiagnostic({
+        message:
+          'Cannot update a component while rendering a different component',
+      });
+      expect(result.kind).toBe('matched');
+      if (result.kind === 'matched') {
+        expect(result.explanation.rule).toBe('set-state-in-render');
+      }
+    });
+
+    test('matches preserve-manual-memoization on "manual memoization"', () => {
+      const result = explainCompilerDiagnostic({
+        message: 'Existing manual memoization could not be preserved',
+      });
+      expect(result.kind).toBe('matched');
+      if (result.kind === 'matched') {
+        expect(result.explanation.rule).toBe('preserve-manual-memoization');
+      }
+    });
+
+    test('matches immutability on a mutation message', () => {
+      const result = explainCompilerDiagnostic({
+        message: 'Mutating a value that should be immutable',
+      });
+      expect(result.kind).toBe('matched');
+      if (result.kind === 'matched') {
+        expect(result.explanation.rule).toBe('immutability');
+      }
+    });
+
+    test('matches purity on a "side effect" message', () => {
+      const result = explainCompilerDiagnostic({
+        message: 'Functions are not pure: side effect detected',
+      });
+      expect(result.kind).toBe('matched');
+      if (result.kind === 'matched') {
+        expect(result.explanation.rule).toBe('purity');
+      }
+    });
+
+    test('matches refs on a ref.current message', () => {
+      const result = explainCompilerDiagnostic({
+        message: 'Cannot access ref.current during render',
+      });
+      expect(result.kind).toBe('matched');
+      if (result.kind === 'matched') {
+        expect(result.explanation.rule).toBe('refs');
+      }
+    });
+
+    test('matching is case-insensitive', () => {
+      const result = explainCompilerDiagnostic({
+        message: 'CANNOT UPDATE WHILE RENDERING',
+      });
+      expect(result.kind).toBe('matched');
+      if (result.kind === 'matched') {
+        expect(result.explanation.rule).toBe('set-state-in-render');
+      }
+    });
+  });
+
+  describe('unmatched messages', () => {
+    test('returns unmatched with genericGuidance for unrecognized text', () => {
+      const result = explainCompilerDiagnostic({
+        message: 'Something completely unrelated to any rule',
+      });
+      expect(result.kind).toBe('unmatched');
+      if (result.kind === 'unmatched') {
+        expect(result.message).toBe(
+          'Something completely unrelated to any rule',
+        );
+        expect(result.genericGuidance).toMatch(/ErrorCategory/);
+        expect(result.genericGuidance).toMatch(/react\.dev/);
+      }
+    });
+
+    test('returns unmatched for an empty message when no rule is given', () => {
+      const result = explainCompilerDiagnostic({message: ''});
+      expect(result.kind).toBe('unmatched');
+    });
+  });
+
+  describe('explanation shape on match', () => {
+    test('every entry exposes all required fields', () => {
+      const result = explainCompilerDiagnostic({
+        message: 'cannot update while rendering',
+      });
+      if (result.kind !== 'matched') {
+        throw new Error('expected matched result');
+      }
+      const exp = result.explanation;
+      expect(typeof exp.rule).toBe('string');
+      expect(exp.rule.length).toBeGreaterThan(0);
+      expect(typeof exp.title).toBe('string');
+      expect(typeof exp.summary).toBe('string');
+      expect(typeof exp.category).toBe('string');
+      expect(typeof exp.why_it_happens).toBe('string');
+      expect(typeof exp.how_to_fix).toBe('string');
+      expect(['error', 'warning', 'info']).toContainEqual(exp.severity);
+      expect(Array.isArray(exp.related_links)).toBe(true);
+      expect(Array.isArray(exp.messagePatterns)).toBe(true);
+    });
+  });
+
+  describe('input shape', () => {
+    test('codeContext is accepted but does not affect matching', () => {
+      const withContext = explainCompilerDiagnostic({
+        message: 'side effect detected',
+        codeContext: 'function C() { fetch("/x") }',
+      });
+      const withoutContext = explainCompilerDiagnostic({
+        message: 'side effect detected',
+      });
+      expect(withContext.kind).toBe('matched');
+      expect(withoutContext.kind).toBe('matched');
+      if (withContext.kind === 'matched' && withoutContext.kind === 'matched') {
+        expect(withContext.explanation.rule).toBe(
+          withoutContext.explanation.rule,
+        );
+      }
+    });
+  });
+});

--- a/compiler/packages/react-mcp-server/src/tools/explainCompilerDiagnostic.ts
+++ b/compiler/packages/react-mcp-server/src/tools/explainCompilerDiagnostic.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  diagnosticCatalog,
+  type DiagnosticExplanation,
+} from '../diagnostics/catalog';
+
+/**
+ * Input to `explainCompilerDiagnostic`. The LLM either supplies a formatted
+ * message (as returned by the `compile` tool) and the function uses regex
+ * patterns from the catalog to identify the rule, or it supplies the rule
+ * name directly for an exact-key lookup. `codeContext` is optional source
+ * code that produced the diagnostic — it is currently unused by the
+ * matching logic but is accepted so the LLM does not have to drop it.
+ */
+/**
+ * Input to `explainCompilerDiagnostic`. The LLM either supplies a formatted
+ * message (as returned by the `compile` tool) and the function uses regex
+ * patterns from the catalog to identify the rule, or it supplies the rule
+ * name directly for an exact-key lookup. `codeContext` is optional source
+ * code that produced the diagnostic — it is currently unused by the
+ * matching logic but is accepted so the LLM does not have to drop it.
+ */
+export type ExplainCompilerDiagnosticInput = {
+  /** Formatted diagnostic message exactly as returned by the `compile` tool. */
+  message: string;
+  /** Optional source code that produced the diagnostic. Currently informational. */
+  codeContext?: string;
+  /** Optional rule name from babel-plugin-react-compiler's `ErrorCategory` enum. */
+  rule?: string;
+};
+
+/**
+ * Result of `explainCompilerDiagnostic`. A `matched` result carries the full
+ * `DiagnosticExplanation` from the catalog. An `unmatched` result carries the
+ * raw message and a generic guidance string the LLM can use to investigate
+ * further (search docs, look at `ErrorCategory`, etc.).
+ */
+export type ExplainCompilerDiagnosticResult =
+  | {
+      kind: 'matched';
+      explanation: DiagnosticExplanation;
+    }
+  | {
+      kind: 'unmatched';
+      message: string;
+      genericGuidance: string;
+    };
+
+/**
+ * Guidance shown to the LLM when no catalog entry matches. Designed to push
+ * the LLM toward something useful (docs search, source-of-truth pointer)
+ * rather than admitting defeat.
+ */
+const GENERIC_GUIDANCE = `I do not have a curated explanation for this React Compiler diagnostic yet.
+
+To investigate, try:
+1. Search the React docs (https://react.dev) for keywords from the message.
+2. Look up the rule in the React Compiler source:
+   compiler/packages/babel-plugin-react-compiler/src/CompilerError.ts
+   (the \`ErrorCategory\` enum lists every rule name).
+3. If you can identify the rule name, pass it as the \`rule\` parameter
+   to this tool for an exact lookup once it has been added to the catalog.
+
+You can also open an issue at https://github.com/facebook/react/issues
+with a minimal reproduction so the rule can be added to a future version
+of this catalog.`;
+
+/**
+ * Look up a plain-English explanation for a React Compiler diagnostic.
+ *
+ * Matching strategy:
+ *  1. If `rule` is provided and the catalog has an entry with that key,
+ *     return it directly.
+ *  2. Otherwise, iterate the catalog in insertion order and test each
+ *     entry's `messagePatterns` against `message` (case-insensitive). The
+ *     first entry with any matching pattern wins.
+ *  3. If no rule or pattern matches, return the unmatched result.
+ *
+ * The function is pure — it does not import the MCP SDK, do I/O, or depend
+ * on Node APIs — so it can be unit tested in isolation.
+ */
+export function explainCompilerDiagnostic(
+  input: ExplainCompilerDiagnosticInput,
+): ExplainCompilerDiagnosticResult {
+  if (input.rule != null && input.rule.length > 0) {
+    const direct = diagnosticCatalog.get(input.rule);
+    if (direct != null) {
+      return {kind: 'matched', explanation: direct};
+    }
+  }
+
+  for (const explanation of diagnosticCatalog.values()) {
+    for (const patternSource of explanation.messagePatterns) {
+      const re = new RegExp(patternSource, 'i');
+      if (re.test(input.message)) {
+        return {kind: 'matched', explanation};
+      }
+    }
+  }
+
+  return {
+    kind: 'unmatched',
+    message: input.message,
+    genericGuidance: GENERIC_GUIDANCE,
+  };
+}


### PR DESCRIPTION
## Summary

When the existing `compile` tool returns a diagnostic, the LLM receives a cryptic formatted message with no explanation of what the rule means or how to fix it. The LLM has to guess based on the message text alone.

This PR adds a new `explain-compiler-diagnostic` tool to `react-mcp-server` that takes a diagnostic and returns a structured plain-English explanation: title, summary, category, why-it-happens, how-to-fix, an optional before/after code example, severity, and links to the relevant React docs. The tool is registered alongside the existing `compile` tool so a model can chain the two: `compile` -> on failure, `explain-compiler-diagnostic`.

This is the first time the MCP server ships a hand-curated knowledge base alongside its tools. The catalog is keyed by the stable `ErrorCategory` rule name from `babel-plugin-react-compiler`, so it survives compiler message-wording changes across versions. Adding a new entry is a single map-insert.

## What is in the catalog (v1)

5 hand-curated entries covering the most common compiler diagnostics:
- `set-state-in-render`
- `preserve-manual-memoization`
- `immutability`
- `purity`
- `refs`

All five are in the `Recommended` lint preset. The catalog supports incremental growth -- future entries can be added as `Map` inserts without changing the tool code.

## How the matching works

- Input: `{ message, codeContext?, rule? }`.
- If `rule` is supplied, the tool does an exact lookup against the catalog (fast path).
- Otherwise it tests each entry's `messagePatterns: RegExp[]` against `message` (case-insensitive) and returns the first match.
- On miss the tool returns a generic guidance string that points the LLM at docs, the `ErrorCategory` enum source, and how to file an issue.

## Files changed

- `src/diagnostics/catalog.ts` (new, 279 lines) -- the catalog.
- `src/tools/explainCompilerDiagnostic.ts` (new, 112 lines) -- the lookup function.
- `src/index.ts` (+45 lines) -- register the new tool.
- `jest.config.js` (new), `src/tools/__tests__/explainCompilerDiagnostic-test.ts` (new, 173 lines), `package.json` -- bootstrap Jest for the package (the existing test script was `echo "no tests"`).
- `README.md` (+16 lines) -- document the new tool alongside the existing ones.

## How I tested

- `yarn workspace react-mcp-server test` -> **17/17 tests pass** in 4.55s.
- `yarn workspace react-mcp-server build` -> tsup produces a 1.72 MB CJS bundle.
- Manual typecheck of the new files via `tsc --strict` -> clean.

I did not run the MCP inspector manually. The new tool is wired into `server.tool(...)` following the same pattern as the existing `compile` tool.

## Future work (out of scope for this PR)

- The `compile` tool currently only exposes `{message, loc}` to the LLM, no structured `category` field. Today the new tool works around this with regex matching + an optional direct rule-name lookup. A follow-up could expose `category` on the diagnostic so the matcher becomes a simple hash lookup with no regex cost.
- Catalog growth: 5 entries is a useful start. Future entries can be added incrementally.