### PR TITLE
[compiler] Ensure builds use the current checkout's compiler

### DIFF
--- a/scripts/react-compiler/link-compiler.sh
+++ b/scripts/react-compiler/link-compiler.sh
@@ -12,6 +12,11 @@ fi
 
 HERE=$(pwd)
 
-cd compiler/packages/babel-plugin-react-compiler && yarn --silent link && cd "$HERE"
+cd compiler/packages/babel-plugin-react-compiler
+# Free the global link name first — it may be held by another React checkout,
+# and `yarn link` (register) won't overwrite an existing owner.
+yarn --silent unlink 2>/dev/null || true
+yarn --silent link
+cd "$HERE"
 
 yarn --silent link babel-plugin-react-compiler


### PR DESCRIPTION
`yarn link` doesn't overwrite existing links which can be problematic if a different, older checkout is linked already leading to

```console
yarn build eslint-plugin-react-hooks
yarn run v1.22.22
$ ./scripts/react-compiler/link-compiler.sh
warning There's already a package called "babel-plugin-react-compiler" registered. This command has had no effect. If this command was run in another folder with the same name, the other folder is still linked. Please run yarn unlink in the other folder if you want to register this folder.
$ node ./scripts/rollup/build-all-release-channels.js eslint-plugin-react-hooks
Running: mkdir -p ./compiler/packages/babel-plugin-react-compiler/dist && echo "module.exports = require('../src/index.ts');" > ./compiler/packages/babel-plugin-react-compiler/dist/index.js
 BUILDING  eslint-plugin-react-hooks.development.js (node_dev)

@rollup/plugin-typescript TS2451: Cannot redeclare block-scoped variable '__DEV__'.

error Command failed with exit code 1.
```

Enforcing that `yarn link` overwrites fixed it. 

For older checkouts without this change, just run `cd compiler/packages/babel-plugin-react-compiler && yarn unlink`.