### PR TITLE
[rust-compiler] Avoid stack overflow when lowering logical expressions

### DIFF
--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -322,6 +322,204 @@ fn lower_expression_to_temporary(
     Ok(lower_value_to_temporary(builder, value)?)
 }
 
+struct LogicalLoweringFrame<'a> {
+    continuation_block: crate::hir_builder::WipBlock,
+    consequent_block: BlockId,
+    alternate_block: BlockId,
+    place: Place,
+    left_place: Place,
+    operator: LogicalOperator,
+    loc: Option<SourceLocation>,
+    left: &'a react_compiler_ast::expressions::Expression,
+}
+
+enum LogicalLoweringTask<'a> {
+    FinishRight {
+        frame: LogicalLoweringFrame<'a>,
+        test_block: crate::hir_builder::WipBlock,
+        suspended_block: crate::hir_builder::SuspendedBlock,
+    },
+    FinishLeft(LogicalLoweringFrame<'a>),
+}
+
+/// Lower an entire tree of logical expressions without using the Rust call
+/// stack for its shape.
+fn lower_logical_expression(
+    builder: &mut HirBuilder,
+    root: &react_compiler_ast::expressions::LogicalExpression,
+) -> Result<InstructionValue, CompilerError> {
+    use react_compiler_ast::expressions::Expression;
+
+    enum Next<'a> {
+        Logical(&'a react_compiler_ast::expressions::LogicalExpression),
+        Expression(&'a Expression),
+    }
+
+    let mut tasks = Vec::<LogicalLoweringTask<'_>>::new();
+    let mut next = Next::Logical(root);
+
+    'lower: loop {
+        let mut value = loop {
+            match next {
+                Next::Expression(Expression::LogicalExpression(logical))
+                | Next::Logical(logical) => {
+                    let loc = convert_opt_loc(&logical.base.loc);
+                    let continuation_block = builder.reserve(builder.current_block_kind());
+                    let continuation_id = continuation_block.id;
+                    let test_block = builder.reserve(BlockKind::Value);
+                    let place = build_temporary_place(builder, loc.clone());
+                    let left_place = build_temporary_place(builder, expression_loc(&logical.left));
+
+                    let consequent_block =
+                        builder.try_enter(BlockKind::Value, |builder, _block_id| {
+                            lower_value_to_temporary(
+                                builder,
+                                InstructionValue::StoreLocal {
+                                    lvalue: LValue {
+                                        kind: InstructionKind::Const,
+                                        place: place.clone(),
+                                    },
+                                    value: left_place.clone(),
+                                    type_annotation: None,
+                                    loc: left_place.loc.clone(),
+                                },
+                            )?;
+                            Ok(Terminal::Goto {
+                                block: continuation_id,
+                                variant: GotoVariant::Break,
+                                id: EvaluationOrder(0),
+                                loc: left_place.loc.clone(),
+                            })
+                        })?;
+
+                    let alternate = builder.reserve(BlockKind::Value);
+                    let alternate_block = alternate.id;
+                    let suspended_block = builder.suspend_current(alternate);
+                    let operator = match logical.operator {
+                        react_compiler_ast::operators::LogicalOperator::And => LogicalOperator::And,
+                        react_compiler_ast::operators::LogicalOperator::Or => LogicalOperator::Or,
+                        react_compiler_ast::operators::LogicalOperator::NullishCoalescing => {
+                            LogicalOperator::NullishCoalescing
+                        }
+                    };
+                    tasks.push(LogicalLoweringTask::FinishRight {
+                        frame: LogicalLoweringFrame {
+                            continuation_block,
+                            consequent_block,
+                            alternate_block,
+                            place,
+                            left_place,
+                            operator,
+                            loc,
+                            left: &logical.left,
+                        },
+                        test_block,
+                        suspended_block,
+                    });
+                    next = Next::Expression(&logical.right);
+                    continue;
+                }
+                // These wrappers do not emit HIR, so traverse through them here to
+                // keep parenthesized right-nested logical trees iterative as well.
+                Next::Expression(Expression::ParenthesizedExpression(paren)) => {
+                    next = Next::Expression(&paren.expression);
+                    continue;
+                }
+                Next::Expression(Expression::TSNonNullExpression(ts)) => {
+                    next = Next::Expression(&ts.expression);
+                    continue;
+                }
+                Next::Expression(Expression::TSInstantiationExpression(ts)) => {
+                    next = Next::Expression(&ts.expression);
+                    continue;
+                }
+                Next::Expression(expression) => {
+                    break lower_expression_to_temporary(builder, expression)?;
+                }
+            }
+        };
+
+        loop {
+            let Some(task) = tasks.pop() else {
+                return Ok(InstructionValue::LoadLocal {
+                    loc: value.loc.clone(),
+                    place: value,
+                });
+            };
+            match task {
+                LogicalLoweringTask::FinishRight {
+                    frame,
+                    test_block,
+                    suspended_block,
+                } => {
+                    let right = value;
+                    let right_loc = right.loc.clone();
+                    lower_value_to_temporary(
+                        builder,
+                        InstructionValue::StoreLocal {
+                            lvalue: LValue {
+                                kind: InstructionKind::Const,
+                                place: frame.place.clone(),
+                            },
+                            value: right,
+                            type_annotation: None,
+                            loc: right_loc.clone(),
+                        },
+                    )?;
+                    builder.complete_current_and_restore(
+                        suspended_block,
+                        Terminal::Goto {
+                            block: frame.continuation_block.id,
+                            variant: GotoVariant::Break,
+                            id: EvaluationOrder(0),
+                            loc: right_loc,
+                        },
+                    );
+                    builder.terminate_with_continuation(
+                        Terminal::Logical {
+                            operator: frame.operator,
+                            test: test_block.id,
+                            fallthrough: frame.continuation_block.id,
+                            id: EvaluationOrder(0),
+                            loc: frame.loc.clone(),
+                        },
+                        test_block,
+                    );
+                    let left = frame.left;
+                    tasks.push(LogicalLoweringTask::FinishLeft(frame));
+                    next = Next::Expression(left);
+                    continue 'lower;
+                }
+                LogicalLoweringTask::FinishLeft(frame) => {
+                    let left_value = value;
+                    builder.push(Instruction {
+                        id: EvaluationOrder(0),
+                        lvalue: frame.left_place.clone(),
+                        value: InstructionValue::LoadLocal {
+                            place: left_value,
+                            loc: frame.loc.clone(),
+                        },
+                        effects: None,
+                        loc: frame.loc.clone(),
+                    });
+                    builder.terminate_with_continuation(
+                        Terminal::Branch {
+                            test: frame.left_place,
+                            consequent: frame.consequent_block,
+                            alternate: frame.alternate_block,
+                            fallthrough: frame.continuation_block.id,
+                            id: EvaluationOrder(0),
+                            loc: frame.loc,
+                        },
+                        frame.continuation_block,
+                    );
+                    value = frame.place;
+                }
+            }
+        }
+    }
+}
+
 // =============================================================================
 // Operator conversion
 // =============================================================================
@@ -852,111 +1050,7 @@ fn lower_expression(
         Expression::OptionalMemberExpression(opt_member) => {
             Ok(lower_optional_member_expression(builder, opt_member)?)
         }
-        Expression::LogicalExpression(expr) => {
-            let loc = convert_opt_loc(&expr.base.loc);
-            let continuation_block = builder.reserve(builder.current_block_kind());
-            let continuation_id = continuation_block.id;
-            let test_block = builder.reserve(BlockKind::Value);
-            let test_block_id = test_block.id;
-            let place = build_temporary_place(builder, loc.clone());
-            let left_loc = expression_loc(&expr.left);
-            let left_place = build_temporary_place(builder, left_loc);
-
-            // Block for short-circuit case: store left value as result, goto continuation
-            let consequent_block = builder.try_enter(BlockKind::Value, |builder, _block_id| {
-                lower_value_to_temporary(
-                    builder,
-                    InstructionValue::StoreLocal {
-                        lvalue: LValue {
-                            kind: InstructionKind::Const,
-                            place: place.clone(),
-                        },
-                        value: left_place.clone(),
-                        type_annotation: None,
-                        loc: left_place.loc.clone(),
-                    },
-                )?;
-                Ok(Terminal::Goto {
-                    block: continuation_id,
-                    variant: GotoVariant::Break,
-                    id: EvaluationOrder(0),
-                    loc: left_place.loc.clone(),
-                })
-            });
-
-            // Block for evaluating right side
-            let alternate_block = builder.try_enter(BlockKind::Value, |builder, _block_id| {
-                let right = lower_expression_to_temporary(builder, &expr.right)?;
-                let right_loc = right.loc.clone();
-                lower_value_to_temporary(
-                    builder,
-                    InstructionValue::StoreLocal {
-                        lvalue: LValue {
-                            kind: InstructionKind::Const,
-                            place: place.clone(),
-                        },
-                        value: right,
-                        type_annotation: None,
-                        loc: right_loc.clone(),
-                    },
-                )?;
-                Ok(Terminal::Goto {
-                    block: continuation_id,
-                    variant: GotoVariant::Break,
-                    id: EvaluationOrder(0),
-                    loc: right_loc,
-                })
-            });
-
-            let hir_op = match expr.operator {
-                react_compiler_ast::operators::LogicalOperator::And => LogicalOperator::And,
-                react_compiler_ast::operators::LogicalOperator::Or => LogicalOperator::Or,
-                react_compiler_ast::operators::LogicalOperator::NullishCoalescing => {
-                    LogicalOperator::NullishCoalescing
-                }
-            };
-
-            builder.terminate_with_continuation(
-                Terminal::Logical {
-                    operator: hir_op,
-                    test: test_block_id,
-                    fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
-                    loc: loc.clone(),
-                },
-                test_block,
-            );
-
-            // Now in test block: lower left expression, copy to left_place
-            let left_value = lower_expression_to_temporary(builder, &expr.left)?;
-            builder.push(Instruction {
-                id: EvaluationOrder(0),
-                lvalue: left_place.clone(),
-                value: InstructionValue::LoadLocal {
-                    place: left_value,
-                    loc: loc.clone(),
-                },
-                effects: None,
-                loc: loc.clone(),
-            });
-
-            builder.terminate_with_continuation(
-                Terminal::Branch {
-                    test: left_place,
-                    consequent: consequent_block?,
-                    alternate: alternate_block?,
-                    fallthrough: continuation_id,
-                    id: EvaluationOrder(0),
-                    loc: loc.clone(),
-                },
-                continuation_block,
-            );
-
-            Ok(InstructionValue::LoadLocal {
-                place: place.clone(),
-                loc: place.loc.clone(),
-            })
-        }
+        Expression::LogicalExpression(expr) => lower_logical_expression(builder, expr),
         Expression::UpdateExpression(update) => {
             let loc = convert_opt_loc(&update.base.loc);
             match update.argument.as_ref() {

--- a/compiler/crates/react_compiler_lowering/src/hir_builder.rs
+++ b/compiler/crates/react_compiler_lowering/src/hir_builder.rs
@@ -126,6 +126,13 @@ pub struct WipBlock {
     pub kind: BlockKind,
 }
 
+/// Opaque handle to a block suspended while another block is current.
+///
+/// This can only be created by [`HirBuilder::suspend_current`], preventing
+/// callers from accidentally restoring an arbitrary `WipBlock`.
+#[must_use = "a suspended block must be restored"]
+pub(crate) struct SuspendedBlock(WipBlock);
+
 fn new_block(id: BlockId, kind: BlockKind) -> WipBlock {
     WipBlock {
         id,
@@ -461,6 +468,25 @@ impl<'a> HirBuilder<'a> {
                 phis: Vec::new(),
             },
         );
+    }
+
+    /// Make a reserved block current and suspend the block that was current.
+    ///
+    /// This is the non-closure form of `enter_reserved`. It is useful for
+    /// iterative lowering algorithms which need to suspend work on one block
+    /// while an explicit work stack populates another one.
+    pub(crate) fn suspend_current(&mut self, block: WipBlock) -> SuspendedBlock {
+        SuspendedBlock(std::mem::replace(&mut self.current, block))
+    }
+
+    /// Complete the current block and restore a previously suspended block.
+    pub(crate) fn complete_current_and_restore(
+        &mut self,
+        suspended: SuspendedBlock,
+        terminal: Terminal,
+    ) {
+        let completed = std::mem::replace(&mut self.current, suspended.0);
+        self.complete(completed, terminal);
     }
 
     /// Sets the given wip block as current, executes the closure to populate

--- a/compiler/crates/react_compiler_lowering/tests/deep_logical_expression.rs
+++ b/compiler/crates/react_compiler_lowering/tests/deep_logical_expression.rs
@@ -1,0 +1,201 @@
+use serde_json::json;
+
+use react_compiler_ast::common::{BaseNode, Position, SourceLocation};
+use react_compiler_ast::expressions::{Expression, LogicalExpression, ParenthesizedExpression};
+use react_compiler_ast::literals::BooleanLiteral;
+use react_compiler_ast::operators::LogicalOperator as AstLogicalOperator;
+use react_compiler_ast::scope::ScopeInfo;
+use react_compiler_ast::statements::{
+    BlockStatement, FunctionDeclaration, ReturnStatement, Statement,
+};
+use react_compiler_hir::environment::Environment;
+use react_compiler_hir::{LogicalOperator, Terminal};
+use react_compiler_lowering::{FunctionNode, lower};
+
+const OPERAND_COUNT: usize = 96;
+
+fn base(node_type: &str, start: u32, end: u32) -> BaseNode {
+    BaseNode {
+        node_type: Some(node_type.to_string()),
+        start: Some(start),
+        end: Some(end),
+        loc: Some(SourceLocation {
+            start: Position {
+                line: 1,
+                column: start,
+                index: Some(start),
+            },
+            end: Position {
+                line: 1,
+                column: end,
+                index: Some(end),
+            },
+            filename: None,
+            identifier_name: None,
+        }),
+        ..BaseNode::default()
+    }
+}
+
+fn operand(index: usize) -> Expression {
+    let offset = index as u32 * 4;
+    Expression::BooleanLiteral(BooleanLiteral {
+        base: base("BooleanLiteral", offset, offset + 1),
+        value: index % 2 == 0,
+    })
+}
+
+fn operator(index: usize, mixed: bool) -> AstLogicalOperator {
+    if !mixed {
+        AstLogicalOperator::Or
+    } else {
+        match index % 3 {
+            0 => AstLogicalOperator::And,
+            1 => AstLogicalOperator::Or,
+            _ => AstLogicalOperator::NullishCoalescing,
+        }
+    }
+}
+
+fn logical(left: Expression, right: Expression, index: usize, mixed: bool) -> Expression {
+    Expression::LogicalExpression(LogicalExpression {
+        base: base("LogicalExpression", 0, index as u32 * 4 + 1),
+        operator: operator(index, mixed),
+        left: Box::new(left),
+        right: Box::new(right),
+    })
+}
+
+fn left_associated(mixed: bool) -> Expression {
+    (1..OPERAND_COUNT).fold(operand(0), |left, index| {
+        logical(left, operand(index), index, mixed)
+    })
+}
+
+fn right_associated_parenthesized(mixed: bool) -> Expression {
+    (0..OPERAND_COUNT - 1)
+        .rev()
+        .fold(operand(OPERAND_COUNT - 1), |right, index| {
+            let right = Expression::ParenthesizedExpression(ParenthesizedExpression {
+                base: base("ParenthesizedExpression", index as u32 * 4, 400),
+                expression: Box::new(right),
+            });
+            logical(operand(index), right, index, mixed)
+        })
+}
+
+fn scope_info() -> ScopeInfo {
+    serde_json::from_value(json!({
+        "scopes": [
+            { "id": 0, "parent": null, "kind": "program", "bindings": {} },
+            { "id": 1, "parent": 0, "kind": "function", "bindings": {} }
+        ],
+        "bindings": [],
+        "nodeToScope": { "0": 1 },
+        "nodeToScopeEnd": { "0": 400 },
+        "referenceToBinding": {},
+        "refNodeIdToBinding": {},
+        "nodeIdToScope": { "1": 1 },
+        "programScope": 0
+    }))
+    .unwrap()
+}
+
+fn lower_expression(expression: Expression) -> Vec<LogicalOperator> {
+    let function = FunctionDeclaration {
+        base: BaseNode {
+            node_id: Some(1),
+            ..base("FunctionDeclaration", 0, 400)
+        },
+        id: None,
+        params: vec![],
+        body: BlockStatement {
+            base: base("BlockStatement", 0, 400),
+            body: vec![Statement::ReturnStatement(ReturnStatement {
+                base: base("ReturnStatement", 0, 400),
+                argument: Some(Box::new(expression)),
+            })],
+            directives: vec![],
+        },
+        generator: false,
+        is_async: false,
+        declare: None,
+        return_type: None,
+        type_parameters: None,
+        predicate: None,
+        component_declaration: false,
+        hook_declaration: false,
+    };
+    let mut environment = Environment::new();
+    let hir = lower(
+        &FunctionNode::FunctionDeclaration(&function),
+        None,
+        &scope_info(),
+        &mut environment,
+    )
+    .expect("deep logical expression should lower");
+    assert!(!environment.has_errors());
+    let branch_count = hir
+        .body
+        .blocks
+        .values()
+        .filter(|block| matches!(block.terminal, Terminal::Branch { .. }))
+        .count();
+    assert_eq!(branch_count, OPERAND_COUNT - 1);
+
+    hir.body
+        .blocks
+        .values()
+        .filter_map(|block| match block.terminal {
+            Terminal::Logical { operator, loc, .. } => {
+                assert!(
+                    loc.is_some(),
+                    "logical terminal should retain its source location"
+                );
+                Some(operator)
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn deeply_nested_logical_expressions_use_bounded_call_stack() {
+    std::thread::Builder::new()
+        .name("deep-logical-lowering".into())
+        .stack_size(2 * 1024 * 1024)
+        .spawn(|| {
+            let or_operators = lower_expression(left_associated(false));
+            let mixed_operators = lower_expression(left_associated(true));
+            let right_nested_operators = lower_expression(right_associated_parenthesized(true));
+
+            for operators in [&or_operators, &mixed_operators, &right_nested_operators] {
+                assert_eq!(operators.len(), OPERAND_COUNT - 1);
+            }
+
+            assert!(
+                or_operators
+                    .iter()
+                    .all(|operator| matches!(operator, LogicalOperator::Or))
+            );
+
+            assert!(
+                mixed_operators
+                    .iter()
+                    .any(|op| matches!(op, LogicalOperator::And))
+            );
+            assert!(
+                mixed_operators
+                    .iter()
+                    .any(|op| matches!(op, LogicalOperator::Or))
+            );
+            assert!(
+                mixed_operators
+                    .iter()
+                    .any(|op| matches!(op, LogicalOperator::NullishCoalescing))
+            );
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+}


### PR DESCRIPTION
## Summary

I've made this PR to address the crash in oxlint described here https://github.com/oxc-project/oxc/issues/23601

This crash occurs when lowering a deep logical expression chain.

## Implementation of the changes.

Lowering logical expressions currently works via the following recursive call chain:

```
 ╭ lower_expression(LogicalExpression)
 │ ╰ lower_expression_to_temporary(expr.left)
 │     ╰ lower_expression(expr.left)
 ╰───────╯
```

Each `expr.left` is another `LogicalExpression`, so each operand adds frames for both.

As a result, this caused stack overflows when lowering this code.

This PR changes the approach to use an iterative state machine to help keep the stack size usage down,

## How did you test this change?

There are test cases in `compiler/crates/react_compiler_lowering/tests/deep_logical_expression.rs`, this test case fails on the current main, and passes on this branch. I've simulated a smaller stack size via `ThreadBuilder::stack_size`.