### PR TITLE
[Transition] Keep previous UI when a popstate transition suspends

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
@@ -777,6 +777,111 @@ describe('ReactDOMFiberAsync', () => {
     });
   });
 
+  // Regression test for https://github.com/facebook/react/issues/35966
+  it('popstate transition keeps previous UI when an already-revealed boundary re-suspends', async () => {
+    function makeRecord() {
+      let resolve;
+      const promise = new Promise(res => {
+        resolve = () => {
+          promise.status = 'fulfilled';
+          res();
+        };
+      });
+      promise.status = 'pending';
+      return {promise, resolve};
+    }
+
+    const records = {
+      '/a': makeRecord(),
+      '/b': makeRecord(),
+    };
+    // /b is ready immediately.
+    records['/b'].resolve();
+
+    function Page({path}) {
+      const record = records[path];
+      if (record.promise.status !== 'fulfilled') {
+        Scheduler.log(`Suspend! [${path}]`);
+        throw record.promise;
+      }
+      Scheduler.log(`Render [${path}]`);
+      return path;
+    }
+
+    function Fallback() {
+      Scheduler.log('Loading');
+      return 'Loading';
+    }
+
+    let navigate;
+    function App() {
+      const [path, setPath] = React.useState('/a');
+      React.useEffect(() => {
+        navigate = next => React.startTransition(() => setPath(next));
+        function onPopstate() {
+          React.startTransition(() => setPath('/a'));
+        }
+        window.addEventListener('popstate', onPopstate);
+        return () => window.removeEventListener('popstate', onPopstate);
+      });
+      return (
+        <React.Suspense fallback={<Fallback />}>
+          <Page path={path} />
+        </React.Suspense>
+      );
+    }
+
+    const root = ReactDOMClient.createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    // Initial render: /a suspends, the boundary shows its fallback.
+    // (The extra Suspend! is from pre-warming the suspended tree.)
+    assertLog(['Suspend! [/a]', 'Loading', 'Suspend! [/a]']);
+    expect(container.textContent).toBe('Loading');
+    // Resolve /a so the boundary reveals real content.
+    await act(async () => {
+      records['/a'].resolve();
+    });
+    assertLog(['Render [/a]']);
+    expect(container.textContent).toBe('/a');
+
+    // Navigate forward to /b (already resolved).
+    await act(async () => {
+      navigate('/b');
+    });
+    assertLog(['Render [/b]']);
+    expect(container.textContent).toBe('/b');
+
+    // Invalidate /a so it will suspend again on the next render.
+    records['/a'] = makeRecord();
+
+    // Simulate pressing the browser back button.
+    await act(async () => {
+      const popStateEvent = new Event('popstate');
+      window.event = popStateEvent;
+      window.dispatchEvent(popStateEvent);
+      await waitForMicrotasks();
+      window.event = undefined;
+
+      // The transition back to /a suspends. Because /b was already revealed,
+      // the transition should keep the previous UI visible instead of
+      // replacing it with the Suspense fallback.
+      expect(container.textContent).toBe('/b');
+    });
+    // The fallback is re-rendered while prewarming, but it is never committed:
+    // the previous UI (/b) stays on screen.
+    assertLog(['Suspend! [/a]', 'Loading', 'Suspend! [/a]', 'Loading']);
+    expect(container.textContent).toBe('/b');
+
+    // Once /a's data resolves, the navigation completes and /a is shown.
+    await act(async () => {
+      records['/a'].resolve();
+    });
+    assertLog(['Render [/a]']);
+    expect(container.textContent).toBe('/a');
+  });
+
   it('regression: useDeferredValue in popState leads to infinite deferral loop', async () => {
     // At the time this test was written, it simulated a particular crash that
     // was happened due to a combination of very subtle implementation details.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -404,6 +404,7 @@ import {
   flushSyncWorkOnAllRoots,
   flushSyncWorkOnLegacyRootsOnly,
   requestTransitionLane,
+  didCurrentEventScheduleTransition,
 } from './ReactFiberRootScheduler';
 import {getMaskedContext, getUnmaskedContext} from './ReactFiberLegacyContext';
 import {logUncaughtError} from './ReactFiberErrorLogger';
@@ -1414,7 +1415,22 @@ function finishConcurrentRender(
       throw new Error('Root did not complete. This is a bug in React.');
     }
     case RootSuspendedWithDelay: {
-      if (!includesOnlyTransitions(lanes) && !includesOnlyRetries(lanes)) {
+      if (
+        !includesOnlyTransitions(lanes) &&
+        !includesOnlyRetries(lanes) &&
+        // A transition flushed synchronously during a popstate event carries a
+        // synthetic SyncLane that marks the priority of the batch (see
+        // getNextLanesToFlushSync). That extra lane makes the work look like a
+        // non-transition update, which would commit the Suspense fallback. When
+        // the only non-transition lane is that synthetic SyncLane, fall through
+        // instead and delay, so the update is re-rendered concurrently and the
+        // previous UI stays visible (#35966).
+        !(
+          didCurrentEventScheduleTransition() &&
+          includesTransitionLane(lanes) &&
+          includesOnlyTransitions(lanes & ~SyncLane)
+        )
+      ) {
         // Commit the placeholder.
         break;
       }


### PR DESCRIPTION
Fixes #35966.

When a transition is started inside a `popstate` handler, React flushes it synchronously to preserve scroll position. `getNextLanesToFlushSync` adds a synthetic `SyncLane` to that batch to mark its priority. If the transition then suspends inside an already-revealed Suspense boundary, that extra lane makes `finishConcurrentRender` see the work as a non-transition update (`includesOnlyTransitions` returns false), so it commits the fallback and hides the content that was already on screen.

This makes the `RootSuspendedWithDelay` branch ignore the synthetic `SyncLane` when the rest of the work is a popstate transition, so it delays instead of committing — the update re-renders concurrently and the previous UI stays visible, matching the behavior outside of `popstate`. This is the "fall back to regular transition behavior" follow-up noted in #26025.

Added a regression test in `ReactDOMFiberAsync-test.js` (confirmed it fails without the change).
