### PR TITLE
[Fiber] Clarify shell-suspend error for use() of an uncached promise

### DIFF
--- a/packages/react-reconciler/src/ReactFiberThenable.js
+++ b/packages/react-reconciler/src/ReactFiberThenable.js
@@ -234,8 +234,9 @@ export function trackUsedThenable<T>(
         if (root !== null && root.shellSuspendCounter > 100) {
           // This root has suspended repeatedly in the shell without making any
           // progress (i.e. committing something). This is highly suggestive of
-          // an infinite ping loop, often caused by an accidental Async Client
-          // Component.
+          // an infinite ping loop, usually caused either by an accidental async
+          // Client Component or by a promise passed to `use()` that is
+          // re-created on every render.
           //
           // During a transition, we can suspend the work loop until the promise
           // to resolve, but this is a sync render, so that's not an option. We
@@ -246,11 +247,17 @@ export function trackUsedThenable<T>(
           // this case include forcing a concurrent render, or putting the whole
           // root into offscreen mode.
           throw new Error(
-            'An unknown Component is an async Client Component. ' +
-              'Only Server Components can be async at the moment. ' +
-              'This error is often caused by accidentally ' +
+            'A component suspended while rendering, but no Suspense boundary ' +
+              'was found to show a fallback. This usually has one of two ' +
+              'causes:\n\n' +
+              '1) An async Client Component. Only Server Components can be ' +
+              'async at the moment. This is often caused by accidentally ' +
               "adding `'use client'` to a module that was originally written " +
-              'for the server.',
+              'for the server.\n' +
+              '2) A promise passed to `use()` that is re-created on every ' +
+              'render, for example a promise created during render instead of ' +
+              'being cached. Cache the promise so the same instance is reused ' +
+              'across renders, or wrap the component in a Suspense boundary.',
           );
         }
 

--- a/packages/react-reconciler/src/__tests__/ReactUse-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUse-test.js
@@ -1889,23 +1889,41 @@ describe('ReactUse', () => {
         '    in AsyncClientComponent (at **)',
     ]);
     assertLog([
-      'An unknown Component is an async Client Component. ' +
-        'Only Server Components can be async at the moment. ' +
-        'This error is often caused by accidentally adding ' +
-        "`'use client'` to a module that was originally written for " +
-        'the server.',
-      'An unknown Component is an async Client Component. ' +
-        'Only Server Components can be async at the moment. ' +
-        'This error is often caused by accidentally adding ' +
-        "`'use client'` to a module that was originally written for " +
-        'the server.',
+      'A component suspended while rendering, but no Suspense boundary ' +
+        'was found to show a fallback. This usually has one of two ' +
+        'causes:\n\n' +
+        '1) An async Client Component. Only Server Components can be ' +
+        'async at the moment. This is often caused by accidentally ' +
+        "adding `'use client'` to a module that was originally written " +
+        'for the server.\n' +
+        '2) A promise passed to `use()` that is re-created on every ' +
+        'render, for example a promise created during render instead of ' +
+        'being cached. Cache the promise so the same instance is reused ' +
+        'across renders, or wrap the component in a Suspense boundary.',
+      'A component suspended while rendering, but no Suspense boundary ' +
+        'was found to show a fallback. This usually has one of two ' +
+        'causes:\n\n' +
+        '1) An async Client Component. Only Server Components can be ' +
+        'async at the moment. This is often caused by accidentally ' +
+        "adding `'use client'` to a module that was originally written " +
+        'for the server.\n' +
+        '2) A promise passed to `use()` that is re-created on every ' +
+        'render, for example a promise created during render instead of ' +
+        'being cached. Cache the promise so the same instance is reused ' +
+        'across renders, or wrap the component in a Suspense boundary.',
     ]);
     expect(root).toMatchRenderedOutput(
-      'An unknown Component is an async Client Component. ' +
-        'Only Server Components can be async at the moment. ' +
-        'This error is often caused by accidentally adding ' +
-        "`'use client'` to a module that was originally written for " +
-        'the server.',
+      'A component suspended while rendering, but no Suspense boundary ' +
+        'was found to show a fallback. This usually has one of two ' +
+        'causes:\n\n' +
+        '1) An async Client Component. Only Server Components can be ' +
+        'async at the moment. This is often caused by accidentally ' +
+        "adding `'use client'` to a module that was originally written " +
+        'for the server.\n' +
+        '2) A promise passed to `use()` that is re-created on every ' +
+        'render, for example a promise created during render instead of ' +
+        'being cached. Cache the promise so the same instance is reused ' +
+        'across renders, or wrap the component in a Suspense boundary.',
     );
   });
 
@@ -1944,25 +1962,107 @@ describe('ReactUse', () => {
         '    in AsyncClientComponent (at **)',
     ]);
     assertLog([
-      'An unknown Component is an async Client Component. ' +
-        'Only Server Components can be async at the moment. ' +
-        'This error is often caused by accidentally adding ' +
-        "`'use client'` to a module that was originally written for " +
-        'the server.',
-      'An unknown Component is an async Client Component. ' +
-        'Only Server Components can be async at the moment. ' +
-        'This error is often caused by accidentally adding ' +
-        "`'use client'` to a module that was originally written for " +
-        'the server.',
+      'A component suspended while rendering, but no Suspense boundary ' +
+        'was found to show a fallback. This usually has one of two ' +
+        'causes:\n\n' +
+        '1) An async Client Component. Only Server Components can be ' +
+        'async at the moment. This is often caused by accidentally ' +
+        "adding `'use client'` to a module that was originally written " +
+        'for the server.\n' +
+        '2) A promise passed to `use()` that is re-created on every ' +
+        'render, for example a promise created during render instead of ' +
+        'being cached. Cache the promise so the same instance is reused ' +
+        'across renders, or wrap the component in a Suspense boundary.',
+      'A component suspended while rendering, but no Suspense boundary ' +
+        'was found to show a fallback. This usually has one of two ' +
+        'causes:\n\n' +
+        '1) An async Client Component. Only Server Components can be ' +
+        'async at the moment. This is often caused by accidentally ' +
+        "adding `'use client'` to a module that was originally written " +
+        'for the server.\n' +
+        '2) A promise passed to `use()` that is re-created on every ' +
+        'render, for example a promise created during render instead of ' +
+        'being cached. Cache the promise so the same instance is reused ' +
+        'across renders, or wrap the component in a Suspense boundary.',
     ]);
     expect(root).toMatchRenderedOutput(
-      'An unknown Component is an async Client Component. ' +
-        'Only Server Components can be async at the moment. ' +
-        'This error is often caused by accidentally adding ' +
-        "`'use client'` to a module that was originally written for " +
-        'the server.',
+      'A component suspended while rendering, but no Suspense boundary ' +
+        'was found to show a fallback. This usually has one of two ' +
+        'causes:\n\n' +
+        '1) An async Client Component. Only Server Components can be ' +
+        'async at the moment. This is often caused by accidentally ' +
+        "adding `'use client'` to a module that was originally written " +
+        'for the server.\n' +
+        '2) A promise passed to `use()` that is re-created on every ' +
+        'render, for example a promise created during render instead of ' +
+        'being cached. Cache the promise so the same instance is reused ' +
+        'across renders, or wrap the component in a Suspense boundary.',
     );
   });
+
+  // Regression test for https://github.com/facebook/react/issues/30709
+  it(
+    'use(promise) without a Suspense boundary, where the promise is ' +
+      're-created on every render, throws a useful error',
+    async () => {
+      class ErrorBoundary extends React.Component {
+        state = {error: null};
+        static getDerivedStateFromError(error) {
+          return {error};
+        }
+        render() {
+          if (this.state.error) {
+            return <Text text={this.state.error.message} />;
+          }
+          return this.props.children;
+        }
+      }
+
+      function App() {
+        // A promise stored in state, but because there's no Suspense
+        // boundary the shell suspends and discards the in-progress state,
+        // so the initializer re-runs and a new promise is created on every
+        // retry. This is an uncached promise from React's perspective.
+        const [promise] = React.useState(
+          () => new Promise(resolve => Promise.resolve().then(resolve)),
+        );
+        return use(promise);
+      }
+
+      const root = ReactNoop.createRoot();
+      await act(async () => {
+        root.render(
+          <ErrorBoundary>
+            <App />
+          </ErrorBoundary>,
+        );
+      });
+      assertLog([
+        'A component suspended while rendering, but no Suspense boundary ' +
+          'was found to show a fallback. This usually has one of two ' +
+          'causes:\n\n' +
+          '1) An async Client Component. Only Server Components can be ' +
+          'async at the moment. This is often caused by accidentally ' +
+          "adding `'use client'` to a module that was originally written " +
+          'for the server.\n' +
+          '2) A promise passed to `use()` that is re-created on every ' +
+          'render, for example a promise created during render instead of ' +
+          'being cached. Cache the promise so the same instance is reused ' +
+          'across renders, or wrap the component in a Suspense boundary.',
+        'A component suspended while rendering, but no Suspense boundary ' +
+          'was found to show a fallback. This usually has one of two ' +
+          'causes:\n\n' +
+          '1) An async Client Component. Only Server Components can be ' +
+          'async at the moment. This is often caused by accidentally ' +
+          "adding `'use client'` to a module that was originally written " +
+          'for the server.\n' +
+          '2) A promise passed to `use()` that is re-created on every ' +
+          'render, for example a promise created during render instead of ' +
+          'being cached. Cache the promise so the same instance is reused ' +
+          'across renders, or wrap the component in a Suspense boundary.',
+      ]);
+    },
+  );
 
   it(
     'warn if async client component calls a hook (e.g. useState) ' +

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -586,5 +586,6 @@
   "598": "Maximum update depth exceeded. This could be an infinite loop. This can happen when a component repeatedly calls setState during render phase or inside useLayoutEffect, causing infinite render loop. React limits the number of nested updates to prevent infinite loops.",
   "599": "Expected an initialized chunk but got an initialized stream chunk instead. This payload may have been submitted by an older version of React.",
   "600": "A rejected Promise was passed to React without a `reason` property. React threw a generic error from where the Promise was used to assist in identifying the problematic Promise. Make sure that instrumented Promises correctly set the `reason` property when setting `status` to `'rejected'`.",
-  "601": "A chunk pair is incomplete. This is a bug in React."
+  "601": "A chunk pair is incomplete. This is a bug in React.",
+  "602": "A component suspended while rendering, but no Suspense boundary was found to show a fallback. This usually has one of two causes:\n\n1) An async Client Component. Only Server Components can be async at the moment. This is often caused by accidentally adding `'use client'` to a module that was originally written for the server.\n2) A promise passed to `use()` that is re-created on every render, for example a promise created during render instead of being cached. Cache the promise so the same instance is reused across renders, or wrap the component in a Suspense boundary."
 }


### PR DESCRIPTION
Fixes #30709.

When a render suspends in the shell with no Suspense boundary and keeps suspending past the `shellSuspendCounter > 100` guard in `ReactFiberThenable`, React throws an error that always blames an async Client Component. The same path is also hit by `use(promise)` with a promise that's re-created on every render — e.g. created during render, or held in a `useState` initializer that gets discarded each time the shell suspends (the case in the linked issue). There the "async Client Component" wording points in the wrong direction.

This broadens the message to describe both causes and the matching fixes (cache the promise so the same instance is reused, or add a Suspense boundary). Added a new error code for the new message, updated the tests that asserted the old one, and added a regression test for the `use()`-without-boundary case.
