### PR TITLE
[compiler] Fix hoisted gating initialization order

### DIFF
--- a/compiler/crates/react_compiler/src/entrypoint/program.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/program.rs
@@ -2123,6 +2123,26 @@ fn get_functions_referenced_before_declaration(
     referenced_before_decl
 }
 
+/// Find the earliest top-level statement that references a function before its
+/// declaration statement.
+fn get_first_top_level_reference_before_declaration_index(
+    program: &Program,
+    function_name: &str,
+    function_node_id: u32,
+) -> Option<usize> {
+    for (idx, stmt) in program.body.iter().enumerate() {
+        if let Statement::FunctionDeclaration(f) = stmt {
+            if f.base.node_id == Some(function_node_id) {
+                return None;
+            }
+        }
+        if stmt_references_identifier_at_top_level(stmt, function_name) {
+            return Some(idx);
+        }
+    }
+    None
+}
+
 /// Check if a statement references an identifier at the top level (not inside nested functions).
 fn stmt_references_identifier_at_top_level(stmt: &Statement, name: &str) -> bool {
     match stmt {
@@ -3016,6 +3036,9 @@ fn apply_gated_function_hoisted(
         Some(idx) => idx,
         None => return,
     };
+    let gating_insert_idx =
+        get_first_top_level_reference_before_declaration_index(program, &original_fn_name, node_id)
+            .unwrap_or(fn_idx);
 
     // Rename the original function to `_unoptimized`
     if let Statement::FunctionDeclaration(f) = &mut program.body[fn_idx] {
@@ -3221,17 +3244,9 @@ fn apply_gated_function_hoisted(
         hook_declaration: false,
     });
 
-    // Insert nodes. The TS code uses insertBefore for the gating result and optimized fn,
-    // and insertAfter for the dispatcher. The order in the output should be:
-    //   ... (existing statements before fn_idx) ...
-    //   const gating_result = gating();       <- inserted before
-    //   function Foo_optimized() { ... }       <- inserted before
-    //   function Foo_unoptimized() { ... }     <- the original (renamed)
-    //   function Foo(arg0) { ... }             <- inserted after
-    //   ... (existing statements after fn_idx) ...
-    //
-    // insertBefore inserts before the target, and insertAfter inserts after.
-    // We insert in reverse order for insertAfter.
+    // Insert nodes. The gating result must come before the earliest top-level
+    // reference to the hoisted dispatcher to avoid TDZ reads from the wrapper.
+    // The optimized function stays adjacent to the original declaration.
 
     // Insert dispatcher after the original (now renamed) function
     program.body.insert(fn_idx + 1, dispatcher_fn);
@@ -3241,8 +3256,8 @@ fn apply_gated_function_hoisted(
         .body
         .insert(fn_idx, Statement::FunctionDeclaration(compiled_fn_decl));
 
-    // Insert gating result before the optimized function
-    program.body.insert(fn_idx, gating_result_stmt);
+    // Insert gating result before the earliest top-level reference.
+    program.body.insert(gating_insert_idx, gating_result_stmt);
 }
 
 /// Recursively search for a function at `start` position and insert `new_stmt`

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Gating.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Gating.ts
@@ -59,6 +59,18 @@ function insertAdditionalFunctionDeclaration(
       'Expected React Compiler optimized function declarations to have the same number of parameters as source',
     loc: fnPath.node.loc ?? GeneratedSource,
   });
+  const firstReferenceStatementPath =
+    findFirstTopLevelReferenceStatementBeforeDeclaration(
+      fnPath,
+      originalFnName.name,
+    );
+  const declarationStatementPath = fnPath.getStatementParent();
+  CompilerError.invariant(declarationStatementPath != null, {
+    reason: 'Expected function declaration to have a statement parent',
+    loc: fnPath.node.loc ?? GeneratedSource,
+  });
+  const gatingInsertionTargetPath =
+    firstReferenceStatementPath ?? declarationStatementPath;
 
   const gatingCondition = t.identifier(
     programContext.newUid(`${gatingFunctionIdentifierName}_result`),
@@ -114,7 +126,7 @@ function insertAdditionalFunctionDeclaration(
       ]),
     ),
   );
-  fnPath.insertBefore(
+  gatingInsertionTargetPath.insertBefore(
     t.variableDeclaration('const', [
       t.variableDeclarator(
         gatingCondition,
@@ -124,6 +136,74 @@ function insertAdditionalFunctionDeclaration(
   );
   fnPath.insertBefore(compiled);
 }
+
+function findFirstTopLevelReferenceStatementBeforeDeclaration(
+  fnPath: NodePath<t.FunctionDeclaration>,
+  name: string,
+): NodePath<t.Statement> | null {
+  const declarationStatementPath = fnPath.getStatementParent();
+  if (
+    declarationStatementPath == null ||
+    !declarationStatementPath.parentPath.isProgram()
+  ) {
+    return null;
+  }
+
+  for (const stmtPath of declarationStatementPath.parentPath.get('body')) {
+    if (stmtPath.node === declarationStatementPath.node) {
+      break;
+    }
+    if (
+      stmtPath.isStatement() &&
+      statementReferencesIdentifierAtTopLevel(stmtPath, name)
+    ) {
+      return stmtPath;
+    }
+  }
+
+  return null;
+}
+
+function statementReferencesIdentifierAtTopLevel(
+  stmtPath: NodePath<t.Statement>,
+  name: string,
+): boolean {
+  if (stmtPath.isFunctionDeclaration()) {
+    return false;
+  }
+
+  let found = false;
+  stmtPath.traverse({
+    TypeAnnotation(path) {
+      path.skip();
+    },
+    TSTypeAnnotation(path) {
+      path.skip();
+    },
+    TypeAlias(path) {
+      path.skip();
+    },
+    TSTypeAliasDeclaration(path) {
+      path.skip();
+    },
+    Function(path) {
+      path.skip();
+    },
+    Identifier(path) {
+      if (
+        path.node.name === name &&
+        path.scope.getFunctionParent() == null &&
+        path.isReferencedIdentifier()
+      ) {
+        found = true;
+        path.stop();
+      }
+    },
+  });
+
+  return found;
+}
+
 export function insertGatedFunctionDeclaration(
   fnPath: NodePath<
     t.FunctionDeclaration | t.ArrowFunctionExpression | t.FunctionExpression

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/component-syntax-ref-gating.flow.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/component-syntax-ref-gating.flow.expect.md
@@ -24,9 +24,9 @@ import { c as _c } from "react/compiler-runtime";
 import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag";
 import { Stringify } from "shared-runtime";
 import * as React from "react";
+const isForgetEnabled_Fixtures_result = isForgetEnabled_Fixtures();
 
 const Foo = React.forwardRef(Foo_withRef);
-const isForgetEnabled_Fixtures_result = isForgetEnabled_Fixtures();
 function Foo_withRef_optimized(_$$empty_props_placeholder$$, ref) {
   const $ = _c(2);
   let t0;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-eager-call.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-eager-call.expect.md
@@ -1,0 +1,51 @@
+
+## Input
+
+```javascript
+// @gating
+const result = Foo(42);
+function Foo(value) {
+  'use memo';
+  return value;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: () => result,
+  params: [],
+};
+
+```
+
+## Code
+
+```javascript
+import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag";
+const isForgetEnabled_Fixtures_result = isForgetEnabled_Fixtures(); // @gating
+const result = Foo(42);
+function Foo_optimized(value) {
+  "use memo";
+
+  return value;
+}
+function Foo_unoptimized(value) {
+  "use memo";
+  return value;
+}
+function Foo(arg0) {
+  if (isForgetEnabled_Fixtures_result) return Foo_optimized(arg0);
+  else return Foo_unoptimized(arg0);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: isForgetEnabled_Fixtures()
+    ? () => {
+        return result;
+      }
+    : () => result,
+  params: [],
+};
+
+```
+      
+### Eval output
+(kind: ok) 42

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-eager-call.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-eager-call.js
@@ -1,0 +1,11 @@
+// @gating
+const result = Foo(42);
+function Foo(value) {
+  'use memo';
+  return value;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: () => result,
+  params: [],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-ref.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-ref.expect.md
@@ -25,9 +25,9 @@ import { c as _c } from "react/compiler-runtime";
 import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag"; // @gating
 import { createRef, forwardRef } from "react";
 import { Stringify } from "shared-runtime";
+const isForgetEnabled_Fixtures_result = isForgetEnabled_Fixtures();
 
 const Foo = forwardRef(Foo_withRef);
-const isForgetEnabled_Fixtures_result = isForgetEnabled_Fixtures();
 function Foo_withRef_optimized(props, ref) {
   const $ = _c(3);
   let t0;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl.expect.md
@@ -26,9 +26,9 @@ import { c as _c } from "react/compiler-runtime";
 import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag"; // @gating
 import { memo } from "react";
 import { Stringify } from "shared-runtime";
+const isForgetEnabled_Fixtures_result = isForgetEnabled_Fixtures();
 
 export default memo(Foo);
-const isForgetEnabled_Fixtures_result = isForgetEnabled_Fixtures();
 function Foo_optimized(t0) {
   "use memo";
   const $ = _c(3);


### PR DESCRIPTION
## Summary

Move hoisted gating initialization before the first top-level reference to a gated function declaration.

Keep the optimized and unoptimized function declarations next to the original declaration, and add an eager-call regression fixture so the ordering stays covered.

## Why

The hoisted gating rewrite could emit a wrapper that read `gating_result` before the `const` was initialized when a function was used before its declaration.

## Validation

- `cargo test -p react_compiler_ast round_trip --quiet`
- `env -u NO_COLOR corepack yarn snap -p "gating/*"` — 31 passed
- `env -u NO_COLOR corepack yarn snap --rust -p "gating/*"` — 31 passed
- `bash scripts/test-rust-port.sh --no-color --failures`