### PR TITLE
Avoid sync Suspense fallbacks for resolved thenables

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/profilingCache-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilingCache-test.js
@@ -1018,13 +1018,13 @@ describe('ProfilingCache', () => {
       `);
       expect(commitData[1].fiberActualDurations).toMatchInlineSnapshot(`
         Map {
-          5 => 3,
-          3 => 3,
+          5 => 6,
+          3 => 6,
         }
       `);
       expect(commitData[1].fiberSelfDurations).toMatchInlineSnapshot(`
         Map {
-          5 => 3,
+          5 => 6,
           3 => 0,
         }
       `);

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -105,6 +105,7 @@ import {
   requestDeferredLane,
   markSkippedUpdateLanes,
   isInvalidExecutionContextForEventFunction,
+  shouldTrackStoreConsistencyForSyncThenableReplay,
 } from './ReactFiberWorkLoop';
 
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
@@ -1674,6 +1675,9 @@ function mountSyncExternalStore<T>(
       }
     }
     // Unless we're rendering a blocking lane, schedule a consistency check.
+    // Do the same for sync renders that may replay suspended work before
+    // committing a Suspense fallback, because store reads may become stale
+    // before commit.
     // Right before committing, we will walk the tree and check if any of the
     // stores were mutated.
     //
@@ -1689,7 +1693,10 @@ function mountSyncExternalStore<T>(
     }
 
     const rootRenderLanes = getWorkInProgressRootRenderLanes();
-    if (!includesBlockingLane(rootRenderLanes)) {
+    if (
+      !includesBlockingLane(rootRenderLanes) ||
+      shouldTrackStoreConsistencyForSyncThenableReplay()
+    ) {
       pushStoreConsistencyCheck(fiber, getSnapshot, nextSnapshot);
     }
   }
@@ -1791,6 +1798,9 @@ function updateSyncExternalStore<T>(
     );
 
     // Unless we're rendering a blocking lane, schedule a consistency check.
+    // Do the same for sync renders that may replay suspended work before
+    // committing a Suspense fallback, because store reads may become stale
+    // before commit.
     // Right before committing, we will walk the tree and check if any of the
     // stores were mutated.
     const root: FiberRoot | null = getWorkInProgressRoot();
@@ -1801,7 +1811,11 @@ function updateSyncExternalStore<T>(
       );
     }
 
-    if (!isHydrating && !includesBlockingLane(renderLanes)) {
+    if (
+      !isHydrating &&
+      (!includesBlockingLane(renderLanes) ||
+        shouldTrackStoreConsistencyForSyncThenableReplay())
+    ) {
       pushStoreConsistencyCheck(fiber, getSnapshot, nextSnapshot);
     }
   }

--- a/packages/react-reconciler/src/ReactFiberRootScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberRootScheduler.js
@@ -171,20 +171,31 @@ export function ensureScheduleIsScheduled(): void {
 export function flushSyncWorkOnAllRoots() {
   // This is allowed to be called synchronously, but the caller should check
   // the execution context first.
-  flushSyncWorkAcrossRoots_impl(NoLanes, false);
+  flushSyncWorkAcrossRoots_impl(
+    NoLanes,
+    false,
+    // Keep explicit sync flushes on the immediate unwind path.
+    false,
+  );
 }
 
 export function flushSyncWorkOnLegacyRootsOnly() {
   // This is allowed to be called synchronously, but the caller should check
   // the execution context first.
   if (!disableLegacyMode) {
-    flushSyncWorkAcrossRoots_impl(NoLanes, true);
+    flushSyncWorkAcrossRoots_impl(
+      NoLanes,
+      true,
+      // Keep explicit sync flushes on the immediate unwind path.
+      false,
+    );
   }
 }
 
 function flushSyncWorkAcrossRoots_impl(
   syncTransitionLanes: Lanes | Lane,
   onlyLegacy: boolean,
+  shouldPauseForSyncThenableReplay: boolean,
 ) {
   if (isFlushingWork) {
     // Prevent reentrancy.
@@ -213,7 +224,17 @@ function flushSyncWorkAcrossRoots_impl(
           if (nextLanes !== NoLanes) {
             // This root has pending sync work. Flush it now.
             didPerformSomeWork = true;
-            performSyncWorkOnRoot(root, nextLanes);
+            const didPauseForSyncThenableReplay = performSyncWorkOnRoot(
+              root,
+              nextLanes,
+              shouldPauseForSyncThenableReplay,
+            );
+            if (didPauseForSyncThenableReplay) {
+              // Exit the current sync flush so React can replay suspended work
+              // if the thenable settles, or unwind otherwise.
+              isFlushingWork = false;
+              return;
+            }
           }
         } else {
           const workInProgressRoot = getWorkInProgressRoot();
@@ -236,7 +257,17 @@ function flushSyncWorkAcrossRoots_impl(
           ) {
             // This root has pending sync work. Flush it now.
             didPerformSomeWork = true;
-            performSyncWorkOnRoot(root, nextLanes);
+            const didPauseForSyncThenableReplay = performSyncWorkOnRoot(
+              root,
+              nextLanes,
+              shouldPauseForSyncThenableReplay,
+            );
+            if (didPauseForSyncThenableReplay) {
+              // Exit the current sync flush so React can replay suspended work
+              // if the thenable settles, or unwind otherwise.
+              isFlushingWork = false;
+              return;
+            }
           }
         }
       }
@@ -337,7 +368,13 @@ function processRootScheduleInMicrotask() {
   // interrupt that sequence. Instead, we'll flush any remaining work when it
   // completes.
   if (!hasPendingCommitEffects()) {
-    flushSyncWorkAcrossRoots_impl(syncTransitionLanes, false);
+    flushSyncWorkAcrossRoots_impl(
+      syncTransitionLanes,
+      false,
+      // Let scheduled sync work pause before unwinding, so React can replay
+      // suspended work if the thenable settles, or unwind otherwise.
+      true,
+    );
   }
 
   if (currentEventTransitionLane !== NoLane) {
@@ -587,7 +624,23 @@ function performWorkOnRootViaSchedulerTask(
   // bug we're still investigating. Once the bug in Scheduler is fixed,
   // we can remove this, since we track expiration ourselves.
   const forceSync = !disableSchedulerTimeoutInWorkLoop && didTimeout;
-  performWorkOnRoot(root, lanes, forceSync);
+  const didPauseForSyncThenableReplay = performWorkOnRoot(
+    root,
+    lanes,
+    forceSync,
+    // Forced sync work should stay on the immediate unwind path. Otherwise,
+    // pause before unwinding so React can replay suspended work if the
+    // thenable settles, or unwind otherwise.
+    !forceSync,
+  );
+  if (didPauseForSyncThenableReplay) {
+    // Stop this Scheduler task. performWorkOnRoot already scheduled the root,
+    // so React can replay suspended work if the thenable settles, or unwind
+    // otherwise.
+    root.callbackNode = null;
+    root.callbackPriority = NoLane;
+    return null;
+  }
 
   // The work loop yielded, but there may or may not be work left at the current
   // priority. Need to determine whether we need to schedule a continuation.
@@ -605,20 +658,29 @@ function performWorkOnRootViaSchedulerTask(
   return null;
 }
 
-function performSyncWorkOnRoot(root: FiberRoot, lanes: Lanes) {
+function performSyncWorkOnRoot(
+  root: FiberRoot,
+  lanes: Lanes,
+  shouldPauseForSyncThenableReplay: boolean,
+): boolean {
   // This is the entry point for synchronous tasks that don't go
   // through Scheduler.
   const didFlushPassiveEffects = flushPendingEffects();
   if (didFlushPassiveEffects) {
     // If passive effects were flushed, exit to the outer work loop in the root
     // scheduler, so we can recompute the priority.
-    return null;
+    return false;
   }
   if (enableProfilerTimer && enableProfilerNestedUpdatePhase) {
     syncNestedUpdateFlag();
   }
   const forceSync = true;
-  performWorkOnRoot(root, lanes, forceSync);
+  return performWorkOnRoot(
+    root,
+    lanes,
+    forceSync,
+    shouldPauseForSyncThenableReplay,
+  );
 }
 
 const fakeActCallbackNode = {};

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -2598,6 +2598,32 @@ export function renderHasNotSuspendedYet(): boolean {
   return workInProgressRootExitStatus === RootInProgress;
 }
 
+function replayOrUnwindSuspendedUnitOfWork(
+  root: FiberRoot,
+  unitOfWork: Fiber,
+  thrownValue: mixed,
+): boolean {
+  const thenable: Thenable<mixed> = thrownValue as any;
+  if (isThenableResolved(thenable)) {
+    // The data resolved. Try rendering the component again.
+    workInProgressSuspendedReason = NotSuspended;
+    workInProgressThrownValue = null;
+    replaySuspendedUnitOfWork(unitOfWork);
+    return false;
+  } else {
+    // Otherwise, unwind then continue with the normal work loop.
+    workInProgressSuspendedReason = NotSuspended;
+    workInProgressThrownValue = null;
+    throwAndUnwindWorkLoop(
+      root,
+      unitOfWork,
+      thrownValue,
+      SuspendedAndReadyToContinue,
+    );
+    return true;
+  }
+}
+
 // TODO: Over time, this function and renderRootConcurrent have become more
 // and more similar. Not sure it makes sense to maintain forked paths. Consider
 // unifying them again.
@@ -2690,6 +2716,34 @@ function renderRootSync(
               // work loop.
               exitStatus = RootInProgress;
               break outer;
+            }
+            break;
+          }
+          case SuspendedAndReadyToContinue: {
+            // Snapshot the Suspense handler before replaying or unwinding
+            // because unwinding can pop the handler stack.
+            const suspenseHandler = getSuspenseHandler();
+            const didUnwind = replayOrUnwindSuspendedUnitOfWork(
+              root,
+              unitOfWork,
+              thrownValue,
+            );
+            if (didUnwind) {
+              // No Suspense handler means there was no boundary to capture
+              // this suspend, so this suspended in the shell.
+              if (suspenseHandler === null) {
+                didSuspendInShell = true;
+              }
+              if (
+                shouldYieldForPrerendering &&
+                workInProgressRootIsPrerendering
+              ) {
+                // We've switched into prerendering mode. Yield to the main
+                // thread so we can continue prerendering using the concurrent
+                // work loop.
+                exitStatus = RootInProgress;
+                break outer;
+              }
             }
             break;
           }
@@ -2868,23 +2922,7 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes): RootExitStatus {
             break outer;
           }
           case SuspendedAndReadyToContinue: {
-            const thenable: Thenable<mixed> = thrownValue as any;
-            if (isThenableResolved(thenable)) {
-              // The data resolved. Try rendering the component again.
-              workInProgressSuspendedReason = NotSuspended;
-              workInProgressThrownValue = null;
-              replaySuspendedUnitOfWork(unitOfWork);
-            } else {
-              // Otherwise, unwind then continue with the normal work loop.
-              workInProgressSuspendedReason = NotSuspended;
-              workInProgressThrownValue = null;
-              throwAndUnwindWorkLoop(
-                root,
-                unitOfWork,
-                thrownValue,
-                SuspendedAndReadyToContinue,
-              );
-            }
+            replayOrUnwindSuspendedUnitOfWork(root, unitOfWork, thrownValue);
             break;
           }
           case SuspendedOnInstanceAndReadyToContinue: {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -473,6 +473,19 @@ let workInProgressRootIsPrerendering: boolean = false;
 // listeners to a promise we've already seen (per root and lane).
 let workInProgressRootDidAttachPingListener: boolean = false;
 
+// Set before rendering so useSyncExternalStore can record consistency checks
+// when a sync render may pause before unwinding so a settled thenable can
+// replay.
+let workInProgressRootMayPauseForSyncThenableReplay: boolean = false;
+// Set only if this render actually paused before unwinding. If the thenable
+// settles and we replay, store reads from the first attempt may be stale by the
+// time we commit, so verify them first.
+let workInProgressRootDidPauseForSyncThenableReplay: boolean = false;
+
+export function shouldTrackStoreConsistencyForSyncThenableReplay(): boolean {
+  return workInProgressRootMayPauseForSyncThenableReplay;
+}
+
 // A contextual version of workInProgressRootRenderLanes. It is a superset of
 // the lanes that we started working on at the root. When we enter a subtree
 // that is currently hidden, we add the lanes that would have committed if
@@ -1203,14 +1216,16 @@ export function performWorkOnRoot(
 
       // The render completed.
 
-      // Check if this render may have yielded to a concurrent event, and if so,
-      // confirm that any newly rendered stores are consistent.
+      // Check if this render may have yielded to a concurrent event or paused
+      // before unwinding, and if so, confirm that any newly rendered stores are
+      // consistent. Sync renders only enter this path if they actually paused.
       // TODO: It's possible that even a concurrent render may never have yielded
       // to the main thread, if it was fast enough, or if it expired. We could
       // skip the consistency check in that case, too.
       const finishedWork: Fiber = root.current.alternate as any;
       if (
-        renderWasConcurrent &&
+        (renderWasConcurrent ||
+          workInProgressRootDidPauseForSyncThenableReplay) &&
         !isRenderConsistentWithExternalStores(finishedWork)
       ) {
         if (enableProfilerTimer && enableComponentPerformanceTrack) {
@@ -2265,6 +2280,8 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes): Fiber {
   workInProgressRootDidSkipSuspendedSiblings = false;
   workInProgressRootIsPrerendering = checkIfRootIsPrerendering(root, lanes);
   workInProgressRootDidAttachPingListener = false;
+  workInProgressRootMayPauseForSyncThenableReplay = false;
+  workInProgressRootDidPauseForSyncThenableReplay = false;
   workInProgressRootExitStatus = RootInProgress;
   workInProgressRootSkippedLanes = NoLanes;
   workInProgressRootInterleavedUpdatedLanes = NoLanes;
@@ -2638,12 +2655,7 @@ function replayOrUnwindSuspendedUnitOfWork(
     // Otherwise, unwind then continue with the normal work loop.
     workInProgressSuspendedReason = NotSuspended;
     workInProgressThrownValue = null;
-    throwAndUnwindWorkLoop(
-      root,
-      unitOfWork,
-      thrownValue,
-      unwindReason,
-    );
+    throwAndUnwindWorkLoop(root, unitOfWork, thrownValue, unwindReason);
     return true;
   }
 }
@@ -2689,6 +2701,13 @@ function renderRootSync(
     markRenderStarted(lanes);
   }
 
+  // Scheduled sync renders may pause before unwinding so React can replay
+  // suspended work if the thenable settles, or unwind otherwise. Store reads
+  // before that pause need consistency checks in case they become stale before
+  // commit.
+  workInProgressRootMayPauseForSyncThenableReplay =
+    shouldPauseForSyncThenableReplay;
+
   let didSuspendInShell = false;
   let exitStatus = workInProgressRootExitStatus;
   outer: do {
@@ -2732,6 +2751,7 @@ function renderRootSync(
               // Pause this sync render before unwinding to a fallback. When React
               // resumes, SuspendedAndReadyToContinue will check the thenable and
               // replay if the thenable settled, otherwise unwind.
+              workInProgressRootDidPauseForSyncThenableReplay = true;
               workInProgressSuspendedReason = SuspendedAndReadyToContinue;
               exitStatus = RootInProgress;
               break outer;
@@ -2892,6 +2912,9 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes): RootExitStatus {
   if (enableSchedulingProfiler) {
     markRenderStarted(lanes);
   }
+
+  // Concurrent renders already use renderWasConcurrent for store consistency.
+  workInProgressRootMayPauseForSyncThenableReplay = false;
 
   outer: do {
     try {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -2625,6 +2625,7 @@ function replayOrUnwindSuspendedUnitOfWork(
   root: FiberRoot,
   unitOfWork: Fiber,
   thrownValue: mixed,
+  unwindReason: SuspendedReason,
 ): boolean {
   const thenable: Thenable<mixed> = thrownValue as any;
   if (isThenableResolved(thenable)) {
@@ -2641,7 +2642,7 @@ function replayOrUnwindSuspendedUnitOfWork(
       root,
       unitOfWork,
       thrownValue,
-      SuspendedAndReadyToContinue,
+      unwindReason,
     );
     return true;
   }
@@ -2764,6 +2765,9 @@ function renderRootSync(
               root,
               unitOfWork,
               thrownValue,
+              // If it is still pending, unwind as the original immediate
+              // suspend so sync fallback/prewarming behavior stays the same.
+              SuspendedOnImmediate,
             );
             if (didUnwind) {
               // No Suspense handler means there was no boundary to capture
@@ -2959,7 +2963,12 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes): RootExitStatus {
             break outer;
           }
           case SuspendedAndReadyToContinue: {
-            replayOrUnwindSuspendedUnitOfWork(root, unitOfWork, thrownValue);
+            replayOrUnwindSuspendedUnitOfWork(
+              root,
+              unitOfWork,
+              thrownValue,
+              SuspendedAndReadyToContinue,
+            );
             break;
           }
           case SuspendedOnInstanceAndReadyToContinue: {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1120,11 +1120,14 @@ export function isUnsafeClassRenderPhaseUpdate(fiber: Fiber): boolean {
   return (executionContext & RenderContext) !== NoContext;
 }
 
+// Returns whether a sync render paused before unwinding so React can replay
+// suspended work if the thenable settles, or unwind otherwise.
 export function performWorkOnRoot(
   root: FiberRoot,
   lanes: Lanes,
   forceSync: boolean,
-): void {
+  shouldPauseForSyncThenableReplay: boolean,
+): boolean {
   if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
     throw new Error('Should not already be working.');
   }
@@ -1164,7 +1167,7 @@ export function performWorkOnRoot(
 
   let exitStatus: RootExitStatus = shouldTimeSlice
     ? renderRootConcurrent(root, lanes)
-    : renderRootSync(root, lanes, true);
+    : renderRootSync(root, lanes, true, shouldPauseForSyncThenableReplay);
 
   let renderWasConcurrent = shouldTimeSlice;
 
@@ -1221,7 +1224,13 @@ export function performWorkOnRoot(
         }
         // A store was mutated in an interleaved event. Render again,
         // synchronously, to block further mutations.
-        exitStatus = renderRootSync(root, lanes, false);
+        exitStatus = renderRootSync(
+          root,
+          lanes,
+          false,
+          // Keep this external store retry synchronous.
+          false,
+        );
         // We assume the tree is now consistent because we didn't yield to any
         // concurrent events.
         renderWasConcurrent = false;
@@ -1308,6 +1317,14 @@ export function performWorkOnRoot(
   } while (true);
 
   ensureRootIsScheduled(root);
+  // Signal that this render stopped before unwinding so React can check whether
+  // the thenable settled before showing a fallback.
+  return (
+    !shouldTimeSlice &&
+    shouldPauseForSyncThenableReplay &&
+    exitStatus === RootInProgress &&
+    workInProgressSuspendedReason === SuspendedAndReadyToContinue
+  );
 }
 
 function recoverFromConcurrentError(
@@ -1340,7 +1357,13 @@ function recoverFromConcurrentError(
     rootWorkInProgress.flags |= ForceClientRender;
   }
 
-  const exitStatus = renderRootSync(root, errorRetryLanes, false);
+  const exitStatus = renderRootSync(
+    root,
+    errorRetryLanes,
+    false,
+    // This error recovery retry should not yield again.
+    false,
+  );
   if (exitStatus !== RootErrored) {
     // Successfully finished rendering on retry
 
@@ -2631,6 +2654,7 @@ function renderRootSync(
   root: FiberRoot,
   lanes: Lanes,
   shouldYieldForPrerendering: boolean,
+  shouldPauseForSyncThenableReplay: boolean,
 ): RootExitStatus {
   const prevExecutionContext = executionContext;
   executionContext |= RenderContext;
@@ -2672,14 +2696,12 @@ function renderRootSync(
         workInProgressSuspendedReason !== NotSuspended &&
         workInProgress !== null
       ) {
-        // The work loop is suspended. During a synchronous render, we don't
-        // yield to the main thread. Immediately unwind the stack. This will
-        // trigger either a fallback or an error boundary.
-        // TODO: For discrete and "default" updates (anything that's not
-        // flushSync), we want to wait for the microtasks the flush before
-        // unwinding. Will probably implement this using renderRootConcurrent,
-        // or merge renderRootSync and renderRootConcurrent into the same
-        // function and fork the behavior some other way.
+        // The work loop is suspended. During a synchronous render, we usually
+        // unwind immediately to a fallback or error boundary. Scheduled sync
+        // suspends can pause below so React can replay if the thenable
+        // settles, or unwind otherwise.
+        // TODO: Refactor renderRootSync and renderRootConcurrent into a shared
+        // renderRoot path, with this behavior forked by render mode.
         const unitOfWork = workInProgress;
         const thrownValue = workInProgressThrownValue;
         switch (workInProgressSuspendedReason) {
@@ -2698,7 +2720,22 @@ function renderRootSync(
           case SuspendedOnData:
           case SuspendedOnAction:
           case SuspendedOnDeprecatedThrowPromise: {
-            if (getSuspenseHandler() === null) {
+            const suspenseHandler = getSuspenseHandler();
+            if (
+              workInProgressSuspendedReason === SuspendedOnImmediate &&
+              shouldPauseForSyncThenableReplay &&
+              // Only pause when there is a Suspense handler that can capture
+              // this if replay is not possible.
+              suspenseHandler !== null
+            ) {
+              // Pause this sync render before unwinding to a fallback. When React
+              // resumes, SuspendedAndReadyToContinue will check the thenable and
+              // replay if the thenable settled, otherwise unwind.
+              workInProgressSuspendedReason = SuspendedAndReadyToContinue;
+              exitStatus = RootInProgress;
+              break outer;
+            }
+            if (suspenseHandler === null) {
               didSuspendInShell = true;
             }
             const reason = workInProgressSuspendedReason;

--- a/packages/react-reconciler/src/__tests__/ReactMemo-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactMemo-test.js
@@ -43,6 +43,10 @@ describe('memo', () => {
   }
 
   async function fakeImport(result) {
+    // Sync render may replay suspended work for an immediately settled thenable
+    // before showing a Suspense fallback. Resolve in a later macrotask so this
+    // fixture still tests the Suspense fallback path.
+    await new Promise(resolve => setTimeout(resolve, 0));
     return {default: result};
   }
 

--- a/packages/react-reconciler/src/__tests__/ReactUse-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUse-test.js
@@ -17,6 +17,7 @@ let use;
 let useDebugValue;
 let useState;
 let useTransition;
+let useSyncExternalStore;
 let useMemo;
 let useEffect;
 let Suspense;
@@ -41,6 +42,7 @@ describe('ReactUse', () => {
     useDebugValue = React.useDebugValue;
     useState = React.useState;
     useTransition = React.useTransition;
+    useSyncExternalStore = React.useSyncExternalStore;
     useMemo = React.useMemo;
     useEffect = React.useEffect;
     Suspense = React.Suspense;
@@ -332,6 +334,57 @@ describe('ReactUse', () => {
     expect(root).toMatchRenderedOutput('Loading...');
 
     await waitForAll(['Async']);
+  });
+
+  it('rerenders if an external store updates before a sync suspend replay commits', async () => {
+    const listeners = new Set();
+    let storeValue = 0;
+    const store = {
+      set(value) {
+        storeValue = value;
+        listeners.forEach(listener => listener());
+      },
+      subscribe(listener) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+      getState() {
+        return storeValue;
+      },
+    };
+    const promise = Promise.resolve('Async');
+    let didScheduleStoreUpdate = false;
+
+    function StoreReader() {
+      const value = useSyncExternalStore(store.subscribe, store.getState);
+      if (!didScheduleStoreUpdate) {
+        didScheduleStoreUpdate = true;
+        Promise.resolve().then(() => {
+          store.set(1);
+        });
+      }
+      return <Text text={'Store: ' + value} />;
+    }
+
+    function Async() {
+      return <Text text={use(promise)} />;
+    }
+
+    function App() {
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          <StoreReader />
+          <Async />
+        </Suspense>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(() => {
+      root.render(<App />);
+    });
+    assertLog(['Store: 0', 'Async', 'Store: 1', 'Async']);
+    expect(root).toMatchRenderedOutput('Store: 1Async');
   });
 
   it("using a promise that's not cached between attempts", async () => {

--- a/packages/react-reconciler/src/__tests__/ReactUse-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUse-test.js
@@ -254,6 +254,86 @@ describe('ReactUse', () => {
     expect(root).toMatchRenderedOutput('ABC');
   });
 
+  it('does not show a fallback when a sync render uses an immediately resolving promise', async () => {
+    const promise = Promise.resolve('Async');
+
+    function Async() {
+      return <Text text={use(promise)} />;
+    }
+
+    function App() {
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          <Async />
+        </Suspense>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(() => {
+      root.render(<App />);
+    });
+    assertLog(['Async']);
+    expect(root).toMatchRenderedOutput('Async');
+  });
+
+  it('commits a fallback when a sync render promise is still pending after a microtask', async () => {
+    let resolve;
+    const promise = new Promise(r => {
+      resolve = r;
+    });
+
+    function Async() {
+      return <Text text={use(promise)} />;
+    }
+
+    function App() {
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          <Async />
+        </Suspense>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    await act(() => {
+      root.render(<App />);
+    });
+    assertLog(['Loading...']);
+    expect(root).toMatchRenderedOutput('Loading...');
+
+    await act(async () => {
+      resolve('Async');
+    });
+    assertLog(['Async']);
+    expect(root).toMatchRenderedOutput('Async');
+  });
+
+  it('commits a fallback when flushSync uses an immediately resolving promise', async () => {
+    const promise = Promise.resolve('Async');
+
+    function Async() {
+      return <Text text={use(promise)} />;
+    }
+
+    function App() {
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          <Async />
+        </Suspense>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    ReactNoop.flushSync(() => {
+      root.render(<App />);
+    });
+    assertLog(['Loading...']);
+    expect(root).toMatchRenderedOutput('Loading...');
+
+    await waitForAll(['Async']);
+  });
+
   it("using a promise that's not cached between attempts", async () => {
     function Async() {
       const text =


### PR DESCRIPTION
### Why?

Scheduled sync renders can currently unwind to a Suspense fallback as soon as a component suspends, even if the thrown thenable resolves in the next promise microtask. Concurrent render already gets a chance to replay before unwinding, so `use(Promise.resolve(...))` can avoid a fallback there but not in scheduled sync work.

This avoids that fallback flash for scheduled sync renders without changing `flushSync` behavior.

### How?

- Pause the scheduled sync path before unwinding an immediate suspend under a Suspense boundary.
- Resume by replaying the suspended fiber if the thenable resolved, or by continuing the previous sync unwind behavior if it did not.
- Stop the Scheduler task at that pause so promise microtasks can run before React retries.
- Keep external-store reads consistent by checking store snapshots before committing a replayed sync render.
- Cover immediate, pending, `flushSync`, external-store, and lazy fallback behavior in tests.