### PR TITLE
[scripts] Fix missing VERSION_NATIVE_FB in commit artifacts

### DIFF
--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -237,6 +237,12 @@ function processStable(buildDir) {
         buildDir + '/facebook-react-native',
         rnVersionString
       );
+
+      // Also save a file with the version number.
+      fs.writeFileSync(
+        buildDir + '/facebook-react-native/VERSION_NATIVE_FB',
+        rnVersionString
+      );
     }
 
     if (fs.existsSync(buildDir + '/react-native')) {
@@ -347,12 +353,7 @@ function processExperimental(buildDir, version) {
       buildDir + '/facebook-react-native',
       rnVersionString
     );
-
-    // Also save a file with the version number
-    fs.writeFileSync(
-      buildDir + '/facebook-react-native/VERSION_NATIVE_FB',
-      rnVersionString
-    );
+    // NOTE: VERSION_NATIVE_FB is written in processStable
   }
 
   if (fs.existsSync(buildDir + '/react-native')) {


### PR DESCRIPTION
## Summary

The `runtime_commit_artifacts` workflow has been failing in the "move relevant files for react in fbsource into compiled-rn" step with:

```
mv: cannot stat 'build/facebook-react-native/VERSION_NATIVE_FB': No such file or directory
```

`VERSION_NATIVE_FB` was only written in `processExperimental`, *inside* `build/facebook-react-native/`. That directory is not part of the allowlist in the cleanup loop at the end of `processExperimental`, so the experimental workers wrote the version file and then immediately deleted it.

This was masked until #36859. The cleanup loop previously used `rm -rm` (an invalid flag), so `rm` errored out and deleted nothing — the loop was effectively a no-op. Once it was changed to `fs.rmSync`, the deletion actually took effect. After CI merges the per-worker artifacts, `facebook-react-native/*/cjs` still survives (the **stable** workers produce it and `processStable` has no cleanup loop), but `VERSION_NATIVE_FB` is gone because stable never wrote it.

## Fix

The `build/facebook-react-native` artifacts are identical across release channels:
- RN packages resolve to the generic `.fb.js` entry fork (no `.modern.fb.js` / `.classic.fb.js` split).
- The `native-fb` feature-flag forks don't reference `__EXPERIMENTAL__`.
- The version string is identical (`<ReactVersion>-native-fb-<sha>-<date>`).

So this writes `VERSION_NATIVE_FB` from `processStable`, where `facebook-react-native` is preserved, and drops the now-dead write from `processExperimental`.

## Test Plan

Verified locally by building the `react` package through each code path:

- **Stable channel** (`yarn build --r=stable react/index`): `build/facebook-react-native/VERSION_NATIVE_FB` is written with the correct `19.3.0-native-fb-<sha>-<date>` version string. ✅
- **Experimental channel** (`yarn build --r=experimental react/index`): `build/facebook-react-native` is deleted by the cleanup loop, leaving only `oss-experimental` and `facebook-www` — confirming the version file cannot come from this channel. ✅
- **Local merged build** (`yarn build react/index`, builds both channels and merges): the final `build/facebook-react-native/` contains `VERSION_NATIVE_FB`, matching what CI produces after merging per-worker artifacts. ✅