### PR TITLE
[Fizz] Batch attribute and style serialization into single pushes

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -1180,15 +1180,13 @@ function pushViewTransitionAttributes(
   }
 }
 
-const styleNameCache: Map<string, PrecomputedChunk> = new Map();
-function processStyleName(styleName: string): PrecomputedChunk {
-  const chunk = styleNameCache.get(styleName);
-  if (chunk !== undefined) {
-    return chunk;
+const styleNameCache: Map<string, string> = new Map();
+function processStyleName(styleName: string): string {
+  const cached = styleNameCache.get(styleName);
+  if (cached !== undefined) {
+    return cached;
   }
-  const result = stringToPrecomputedChunk(
-    escapeTextForBrowser(hyphenateStyleName(styleName)),
-  );
+  const result = escapeTextForBrowser(hyphenateStyleName(styleName));
   styleNameCache.set(styleName, result);
   return result;
 }
@@ -1209,7 +1207,7 @@ function pushStyleAttribute(
     );
   }
 
-  let isFirst = true;
+  let styleString = '';
   for (const styleName in style) {
     if (!hasOwnProperty.call(style, styleName)) {
       continue;
@@ -1231,48 +1229,42 @@ function pushStyleAttribute(
       continue;
     }
 
-    let nameChunk;
-    let valueChunk;
+    let nameStr;
+    let valueStr;
     const isCustomProperty = styleName.indexOf('--') === 0;
     if (isCustomProperty) {
-      nameChunk = stringToChunk(escapeTextForBrowser(styleName));
+      nameStr = escapeTextForBrowser(styleName);
       if (__DEV__) {
         checkCSSPropertyStringCoercion(styleValue, styleName);
       }
-      valueChunk = stringToChunk(
-        escapeTextForBrowser(('' + styleValue).trim()),
-      );
+      valueStr = escapeTextForBrowser(('' + styleValue).trim());
     } else {
       if (__DEV__) {
         warnValidStyle(styleName, styleValue);
       }
 
-      nameChunk = processStyleName(styleName);
+      nameStr = processStyleName(styleName);
       if (typeof styleValue === 'number') {
         if (styleValue !== 0 && !isUnitlessNumber(styleName)) {
-          valueChunk = stringToChunk(styleValue + 'px'); // Presumes implicit 'px' suffix for unitless numbers
+          valueStr = styleValue + 'px'; // Presumes implicit 'px' suffix for unitless numbers
         } else {
-          valueChunk = stringToChunk('' + styleValue);
+          valueStr = '' + styleValue;
         }
       } else {
         if (__DEV__) {
           checkCSSPropertyStringCoercion(styleValue, styleName);
         }
-        valueChunk = stringToChunk(
-          escapeTextForBrowser(('' + styleValue).trim()),
-        );
+        valueStr = escapeTextForBrowser(('' + styleValue).trim());
       }
     }
-    if (isFirst) {
-      isFirst = false;
-      // If it's first, we don't need any separators prefixed.
-      target.push(styleAttributeStart, nameChunk, styleAssign, valueChunk);
+    if (styleString === '') {
+      styleString = nameStr + ':' + valueStr;
     } else {
-      target.push(styleSeparator, nameChunk, styleAssign, valueChunk);
+      styleString += ';' + nameStr + ':' + valueStr;
     }
   }
-  if (!isFirst) {
-    target.push(attributeEnd);
+  if (styleString !== '') {
+    target.push(stringToChunk(' style="' + styleString + '"'));
   }
 }
 
@@ -1287,7 +1279,7 @@ function pushBooleanAttribute(
   value: string | boolean | number | Function | Object, // not null or undefined
 ): void {
   if (value && typeof value !== 'function' && typeof value !== 'symbol') {
-    target.push(attributeSeparator, stringToChunk(name), attributeEmptyString);
+    target.push(stringToChunk(' ' + name + '=""'));
   }
 }
 
@@ -1302,11 +1294,7 @@ function pushStringAttribute(
     typeof value !== 'boolean'
   ) {
     target.push(
-      attributeSeparator,
-      stringToChunk(name),
-      attributeAssign,
-      stringToChunk(escapeTextForBrowser(value)),
-      attributeEnd,
+      stringToChunk(' ' + name + '="' + escapeTextForBrowser(value) + '"'),
     );
   }
 }
@@ -1610,11 +1598,9 @@ function pushAttribute(
       }
       const sanitizedValue = sanitizeURL('' + value);
       target.push(
-        attributeSeparator,
-        stringToChunk(name),
-        attributeAssign,
-        stringToChunk(escapeTextForBrowser(sanitizedValue)),
-        attributeEnd,
+        stringToChunk(
+          ' ' + name + '="' + escapeTextForBrowser(sanitizedValue) + '"',
+        ),
       );
       return;
     }
@@ -1645,11 +1631,9 @@ function pushAttribute(
       }
       const sanitizedValue = sanitizeURL('' + value);
       target.push(
-        attributeSeparator,
-        stringToChunk('xlink:href'),
-        attributeAssign,
-        stringToChunk(escapeTextForBrowser(sanitizedValue)),
-        attributeEnd,
+        stringToChunk(
+          ' xlink:href="' + escapeTextForBrowser(sanitizedValue) + '"',
+        ),
       );
       return;
     }
@@ -1667,11 +1651,9 @@ function pushAttribute(
       // these aren't boolean attributes (they are coerced to strings).
       if (typeof value !== 'function' && typeof value !== 'symbol') {
         target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
+          ),
         );
       }
       return;
@@ -1727,20 +1709,14 @@ function pushAttribute(
     case 'download': {
       // Overloaded Boolean
       if (value === true) {
-        target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeEmptyString,
-        );
+        target.push(stringToChunk(' ' + name + '=""'));
       } else if (value === false) {
         // Ignored
       } else if (typeof value !== 'function' && typeof value !== 'symbol') {
         target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
+          ),
         );
       }
       return;
@@ -1757,11 +1733,9 @@ function pushAttribute(
         (value: any) >= 1
       ) {
         target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
+          ),
         );
       }
       return;
@@ -1775,11 +1749,9 @@ function pushAttribute(
         !isNaN(value)
       ) {
         target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
+          ),
         );
       }
       return;
@@ -1837,11 +1809,13 @@ function pushAttribute(
           }
         }
         target.push(
-          attributeSeparator,
-          stringToChunk(attributeName),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' +
+              attributeName +
+              '="' +
+              escapeTextForBrowser(value) +
+              '"',
+          ),
         );
       }
   }
@@ -1956,14 +1930,12 @@ function pushStartAnchor(
 
   pushViewTransitionAttributes(target, formatContext);
 
-  target.push(endOfStartTag);
-  pushInnerHTML(target, innerHTML, children);
-  if (typeof children === 'string') {
-    // Special case children as a string to avoid the unnecessary comment.
-    // TODO: Remove this special case after the general optimization is in place.
-    target.push(stringToChunk(encodeHTMLTextNode(children)));
+  if (innerHTML == null && typeof children === 'string') {
+    target.push(stringToChunk('>' + encodeHTMLTextNode(children)));
     return null;
   }
+  target.push(endOfStartTag);
+  pushInnerHTML(target, innerHTML, children);
   return children;
 }
 
@@ -3964,14 +3936,13 @@ function pushStartGenericElement(
 
   pushViewTransitionAttributes(target, formatContext);
 
-  target.push(endOfStartTag);
-  pushInnerHTML(target, innerHTML, children);
-  if (typeof children === 'string') {
-    // Special case children as a string to avoid the unnecessary comment.
-    // TODO: Remove this special case after the general optimization is in place.
-    target.push(stringToChunk(encodeHTMLTextNode(children)));
+  if (innerHTML == null && typeof children === 'string') {
+    // Fast path: close tag and emit text child in a single push.
+    target.push(stringToChunk('>' + encodeHTMLTextNode(children)));
     return null;
   }
+  target.push(endOfStartTag);
+  pushInnerHTML(target, innerHTML, children);
   return children;
 }
 

--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -222,8 +222,11 @@ export function typedArrayToBinaryChunk(
 
 export function byteLengthOfChunk(chunk: Chunk | PrecomputedChunk): number {
   return typeof chunk === 'string'
-    ? Buffer.byteLength(chunk, 'utf8')
-    : chunk.byteLength;
+    ? chunk.length // Fast path: .length === byte length for ASCII (99%+ of HTML output).
+    : // For multi-byte chars this slightly underestimates, which is fine
+      // because byteSize is only used for heuristic decisions (outlining
+      // threshold and progressive chunk sizing).
+      chunk.byteLength;
 }
 
 export function byteLengthOfBinaryChunk(chunk: BinaryChunk): number {

--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -222,11 +222,8 @@ export function typedArrayToBinaryChunk(
 
 export function byteLengthOfChunk(chunk: Chunk | PrecomputedChunk): number {
   return typeof chunk === 'string'
-    ? chunk.length // Fast path: .length === byte length for ASCII (99%+ of HTML output).
-    : // For multi-byte chars this slightly underestimates, which is fine
-      // because byteSize is only used for heuristic decisions (outlining
-      // threshold and progressive chunk sizing).
-      chunk.byteLength;
+    ? Buffer.byteLength(chunk, 'utf8')
+    : chunk.byteLength;
 }
 
 export function byteLengthOfBinaryChunk(chunk: BinaryChunk): number {

--- a/scripts/bench/fizz-attr-bench.js
+++ b/scripts/bench/fizz-attr-bench.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const B = process.env.BUILD || './build/node_modules';
+const React = require(B + '/react/cjs/react.production.js');
+const {renderToPipeableStream} = require(
+  B + '/react-dom/cjs/react-dom-server.node.production.js',
+);
+const {Writable} = require('stream');
+
+function Row({i}) {
+  return React.createElement(
+    'div',
+    {
+      className: 'row item-' + i,
+      id: 'row-' + i,
+      'data-index': i,
+      'aria-label': 'Row ' + i,
+      title: 'Item number ' + i,
+      style: {color: 'red', padding: 4, margin: 2, fontWeight: 600},
+    },
+    'Item content ' + i,
+  );
+}
+
+function App() {
+  const rows = [];
+  for (let i = 0; i < 1000; i++) rows.push(React.createElement(Row, {key: i, i}));
+  return React.createElement('main', {className: 'container'}, rows);
+}
+
+function once() {
+  return new Promise(resolve => {
+    const sink = new Writable({write(c, e, cb) {cb();}});
+    sink.on('finish', resolve);
+    renderToPipeableStream(React.createElement(App)).pipe(sink);
+  });
+}
+
+(async () => {
+  for (let i = 0; i < 50; i++) await once(); // warmup
+  const N = 500;
+  const start = process.hrtime.bigint();
+  for (let i = 0; i < N; i++) await once();
+  const ms = Number(process.hrtime.bigint() - start) / 1e6;
+  console.log((N / (ms / 1000)).toFixed(1) + ' ops/s (' + ms.toFixed(0) + 'ms / ' + N + ')');
+})();


### PR DESCRIPTION
Split out from #36139, keeping only the attribute/style/text-child batching. The `byteLengthOfChunk` fast path from that PR is intentionally excluded (it's unsound for multi-byte content — see companion test PR).


## Test plan

Existing tests.