### PR TITLE
[Fizz] Stop firing `onAllReady` after the shell errored

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -210,6 +210,8 @@ describe('ReactDOMFizzServerNode', () => {
   it('should error the stream when an error is thrown at the root', async () => {
     const reportedErrors = [];
     const reportedShellErrors = [];
+    let shellReadyCalls = 0;
+    let allReadyCalls = 0;
     const {writable, output, completed} = getTestWritable();
     const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
       <div>
@@ -221,6 +223,12 @@ describe('ReactDOMFizzServerNode', () => {
         },
         onShellError(x) {
           reportedShellErrors.push(x);
+        },
+        onShellReady() {
+          shellReadyCalls++;
+        },
+        onAllReady() {
+          allReadyCalls++;
         },
       },
     );
@@ -235,6 +243,10 @@ describe('ReactDOMFizzServerNode', () => {
     // This type of error is reported to the error callback too.
     expect(reportedErrors).toEqual([theError]);
     expect(reportedShellErrors).toEqual([theError]);
+    expect(shellReadyCalls).toBe(0);
+    // onAllReady currently still fires once after a fatal shell error, even
+    // though the render never completed (facebook/react#36890).
+    expect(allReadyCalls).toBe(1);
   });
 
   it('should not report aborts after the shell has fatally errored', async () => {
@@ -301,6 +313,7 @@ describe('ReactDOMFizzServerNode', () => {
   it('should not error the stream when an error is thrown inside suspense boundary', async () => {
     const reportedErrors = [];
     const reportedShellErrors = [];
+    let allReadyCalls = 0;
     const {writable, output, completed} = getTestWritable();
     const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
       <div>
@@ -315,6 +328,9 @@ describe('ReactDOMFizzServerNode', () => {
         onShellError(x) {
           reportedShellErrors.push(x);
         },
+        onAllReady() {
+          allReadyCalls++;
+        },
       },
     );
     pipe(writable);
@@ -326,6 +342,9 @@ describe('ReactDOMFizzServerNode', () => {
     // While no error is reported to the stream, the error is reported to the callback.
     expect(reportedErrors).toEqual([theError]);
     expect(reportedShellErrors).toEqual([]);
+    // The shell stays valid, the boundary client-renders, and the render
+    // completes, so onAllReady fires. This is documented behavior.
+    expect(allReadyCalls).toBe(1);
   });
 
   it('should not attempt to render the fallback if the main content completes first', async () => {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -244,9 +244,7 @@ describe('ReactDOMFizzServerNode', () => {
     expect(reportedErrors).toEqual([theError]);
     expect(reportedShellErrors).toEqual([theError]);
     expect(shellReadyCalls).toBe(0);
-    // onAllReady currently still fires once after a fatal shell error, even
-    // though the render never completed (facebook/react#36890).
-    expect(allReadyCalls).toBe(1);
+    expect(allReadyCalls).toBe(0);
   });
 
   it('should not report aborts after the shell has fatally errored', async () => {

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -1378,6 +1378,10 @@ function fatalError(
   // It's also called if React itself or its host configs errors.
   const onShellError = request.onShellError;
   const onFatalError = request.onFatalError;
+  // The shell has fatally errored, so the render can never complete. Prevent a
+  // later completeAll from invoking onAllReady, which would signal a successful
+  // render to consumers waiting on all content.
+  request.onAllReady = noop;
   if (__DEV__ && debugTask) {
     debugTask.run(onShellError.bind(null, error));
     debugTask.run(onFatalError.bind(null, error));


### PR DESCRIPTION

Fixes #36890

`renderToPipeableStream` (and the other Fizz renderers) still invoke `onAllReady` after a fatal shell error has already been reported through `onShellError`/`onFatalError`. When the shell fatally errors, the request's pending task count can still reach zero and trigger `completeAll`, which calls `onAllReady`, signalling a successful, fully ready render to consumers even though nothing was rendered.

The first commit adds tests against the public `renderToPipeableStream` callbacks documenting the current behavior (both the shell-error and boundary-error cases). The second commit applies the fix and updates the shell-error test to assert that `onAllReady` is not called.

## Test plan

- [x] New test assertion: a root-level throw fires `onShellError` and does not fire `onAllReady`