### PR TITLE
[test] Use awaited `serverAct` to drive task loop

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -2007,25 +2007,33 @@ describe('ReactFlightDOMEdge', () => {
 
     const serverAbortController = new AbortController();
     const errors = [];
-    const prerenderResult = ReactServerDOMStaticServer.prerender(
-      ReactServer.createElement(App, null),
-      webpackMap,
-      {
-        signal: serverAbortController.signal,
-        onError(err) {
-          errors.push(err);
-        },
-      },
-    );
-
-    await new Promise(resolve => {
-      setImmediate(() => {
-        serverAbortController.abort();
-        resolve();
-      });
+    const {pendingResult} = await serverAct(async () => {
+      // destructure trick to avoid the act scope from awaiting the returned value
+      return {
+        pendingResult: ReactServerDOMStaticServer.prerender(
+          ReactServer.createElement(App, null),
+          webpackMap,
+          {
+            signal: serverAbortController.signal,
+            onError(err) {
+              errors.push(err);
+            },
+          },
+        ),
+      };
     });
 
-    const {prelude} = await prerenderResult;
+    await serverAct(
+      () =>
+        new Promise(resolve => {
+          setImmediate(() => {
+            serverAbortController.abort();
+            resolve();
+          });
+        }),
+    );
+
+    const {prelude} = await pendingResult;
 
     expect(errors).toEqual([]);
 
@@ -2061,12 +2069,15 @@ describe('ReactFlightDOMEdge', () => {
       },
     );
 
-    await new Promise(resolve => {
-      setImmediate(() => {
-        clientAbortController.abort();
-        resolve();
-      });
-    });
+    await serverAct(
+      () =>
+        new Promise(resolve => {
+          setImmediate(() => {
+            clientAbortController.abort();
+            resolve();
+          });
+        }),
+    );
 
     const fizzPrerenderStream = await fizzPrerenderStreamResult;
     const prerenderHTML = await readResult(fizzPrerenderStream.prelude);

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1794,23 +1794,33 @@ describe('ReactFlightDOMEdge', () => {
     const expectedError = new Error('Bam!');
     const errors = [];
 
-    const {prelude} = await ReactServerDOMStaticServer.prerender(
-      new ReadableStream({
-        async start(controller) {
-          await serverAct(() => {
-            setTimeout(() => {
-              controller.error(expectedError);
-            });
-          });
-        },
-      }),
-      webpackMap,
-      {
-        onError(err) {
-          errors.push(err);
-        },
+    let streamController;
+    const erroringStream = new ReadableStream({
+      start(controller) {
+        streamController = controller;
       },
-    );
+    });
+
+    const {pendingResult} = await serverAct(async () => {
+      // destructure trick to avoid the act scope from awaiting the returned value
+      return {
+        pendingResult: ReactServerDOMStaticServer.prerender(
+          erroringStream,
+          webpackMap,
+          {
+            onError(err) {
+              errors.push(err);
+            },
+          },
+        ),
+      };
+    });
+
+    await serverAct(() => {
+      streamController.error(expectedError);
+    });
+
+    const {prelude} = await pendingResult;
 
     expect(errors).toEqual([expectedError]);
 


### PR DESCRIPTION
I noticed that `yarn test packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js -t "does not include source locations in component stacks for halted components"` timed out unless you also ran "should be able to handle an erroring readable stream in prerender" in the same test batch.

The first test had an unawaited `serverAct` that leaked across tests and actually drove the task loop for the second test.

The fix was simply using `serverAct` in the second test. We now explicitly await the `serverAct` in the first test to prevent future regressions.