### PR TITLE
Fix: Treat incomplete tree as an error during recovery

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzShellHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzShellHydration-test.js
@@ -101,6 +101,56 @@ describe('ReactDOMFizzShellHydration', () => {
     }
   }
 
+  async function hydrateRootAndCollectErrors(reactNode) {
+    const errors = [];
+    await clientAct(async () => {
+      ReactDOMClient.hydrateRoot(container, reactNode, {
+        onCaughtError(error) {
+          Scheduler.log('onCaughtError: ' + error.message);
+          errors.push('caught: ' + error.message);
+        },
+        onUncaughtError(error) {
+          Scheduler.log('onUncaughtError: ' + error.message);
+          errors.push('uncaught: ' + error.message);
+        },
+        onRecoverableError(error) {
+          Scheduler.log('onRecoverableError: ' + error.message);
+          errors.push('recoverable: ' + error.message);
+        },
+      });
+    });
+    return errors;
+  }
+
+  function createErrorBoundaryAndBomb() {
+    class ErrorBoundary extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {error: null};
+      }
+
+      static getDerivedStateFromError(error) {
+        return {error};
+      }
+
+      componentDidCatch() {}
+
+      render() {
+        if (this.state.error) {
+          return 'Something went wrong: ' + this.state.error.message;
+        }
+
+        return this.props.children;
+      }
+    }
+
+    function Bomb() {
+      throw new Error('boom');
+    }
+
+    return {ErrorBoundary, Bomb};
+  }
+
   function resolveText(text) {
     const record = textCache.get(text);
     if (record === undefined) {
@@ -655,4 +705,134 @@ describe('ReactDOMFizzShellHydration', () => {
       expect(container.innerHTML).toBe('Client');
     },
   );
+
+  it(
+    'does not corrupt hooks during hydration when conditional use suspends ' +
+      'after a cascading update (#33580)',
+    async () => {
+      const {ErrorBoundary, Bomb} = createErrorBoundaryAndBomb();
+
+      function Updater({setPromise}) {
+        const [state, setState] = React.useState(false);
+
+        React.useEffect(() => {
+          setState(true);
+          startTransition(() => {
+            setPromise(Promise.resolve('resolved'));
+          });
+        }, [state]);
+
+        return null;
+      }
+
+      function Page() {
+        const [promise, setPromise] = React.useState(null);
+        const value = promise ? React.use(promise) : promise;
+
+        React.useMemo(() => {}, []);
+
+        return (
+          <>
+            <Updater setPromise={setPromise} />
+            <React.Suspense fallback="Loading...">
+              <ErrorBoundary>
+                <Bomb />
+              </ErrorBoundary>
+            </React.Suspense>
+            {value !== null ? value : 'hello world'}
+          </>
+        );
+      }
+
+      function App() {
+        return <Page />;
+      }
+
+      await serverAct(async () => {
+        const {pipe} = ReactDOMFizzServer.renderToPipeableStream(<App />, {
+          onError(error) {
+            Scheduler.log('onError: ' + error.message);
+          },
+        });
+        pipe(writable);
+      });
+      assertLog(['onError: boom']);
+
+      const errors = await hydrateRootAndCollectErrors(<App />);
+      assertLog(['onCaughtError: boom']);
+
+      expect(
+        errors.find(error => error.includes('Rendered more hooks')),
+      ).toBeUndefined();
+      expect(container.textContent).toBe('Something went wrong: boomresolved');
+    },
+  );
+
+  it('preserves hooks when suspension happens before the first tracked hook', async () => {
+    const {ErrorBoundary, Bomb} = createErrorBoundaryAndBomb();
+    let setReady;
+
+    function Updater({setPromise}) {
+      React.useEffect(() => {
+        setReady(true);
+        startTransition(() => {
+          setPromise(Promise.resolve('resolved'));
+        });
+      }, []);
+
+      return null;
+    }
+
+    function Page({promise}) {
+      const value = promise ? React.use(promise) : promise;
+
+      const [ready, _setReady] = React.useState(false);
+      setReady = _setReady;
+
+      React.useMemo(() => {}, []);
+
+      return (
+        <>
+          <React.Suspense fallback="Loading...">
+            <ErrorBoundary>
+              <Bomb />
+            </ErrorBoundary>
+          </React.Suspense>
+          <span>{ready ? 'ready' : 'not-ready'}</span>
+          <span>{value !== null ? value : 'hello world'}</span>
+        </>
+      );
+    }
+
+    function App() {
+      const [promise, setPromise] = React.useState(null);
+
+      return (
+        <>
+          <Updater setPromise={setPromise} />
+          <Page promise={promise} />
+        </>
+      );
+    }
+
+    await serverAct(async () => {
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(<App />, {
+        onError(error) {
+          Scheduler.log('onError: ' + error.message);
+        },
+      });
+      pipe(writable);
+    });
+    assertLog(['onError: boom']);
+
+    const errors = await hydrateRootAndCollectErrors(<App />);
+    assertLog(['onCaughtError: boom']);
+
+    expect(
+      errors.find(error => error.includes('Rendered more hooks')),
+    ).toBeUndefined();
+    expect(container.textContent).toBe(
+      'Something went wrong: boomreadyresolved',
+    );
+  });
 });

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1341,7 +1341,12 @@ function recoverFromConcurrentError(
   }
 
   const exitStatus = renderRootSync(root, errorRetryLanes, false);
-  if (exitStatus !== RootErrored) {
+  // A status of RootSuspendedAtTheShell means the retry unwound to the root
+  // without completing (e.g. something suspended in the shell), so the tree is
+  // incomplete and must not be treated as recovered — committing it would
+  // corrupt the current tree. Fall through and return the status as-is so the
+  // root stays suspended.
+  if (exitStatus !== RootErrored && exitStatus !== RootSuspendedAtTheShell) {
     // Successfully finished rendering on retry
 
     if (workInProgressRootDidAttachPingListener && !wasRootDehydrated) {

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -732,6 +732,61 @@ describe('ReactHooksWithNoopRenderer', () => {
       });
     });
 
+    it(
+      'preserves pending updates on later hooks that were not processed ' +
+        'before unwind',
+      async () => {
+        const thenable = {then() {}};
+
+        let setLabel;
+        function Foo({suspend}) {
+          return (
+            <Suspense fallback="Loading...">
+              <Bar suspend={suspend} />
+            </Suspense>
+          );
+        }
+
+        function Bar({suspend}) {
+          const [counter, setCounter] = useState(0);
+
+          if (suspend) {
+            setCounter(c => c + 1);
+            Scheduler.log('Suspend!');
+            throw thenable;
+          }
+
+          const [label, _setLabel] = useState('A');
+          setLabel = _setLabel;
+
+          return <Text text={`${label}:${counter}`} />;
+        }
+
+        const root = ReactNoop.createRoot();
+        root.render(<Foo suspend={false} />);
+
+        await waitForAll(['A:0']);
+        expect(root).toMatchRenderedOutput(<span prop="A:0" />);
+
+        await act(async () => {
+          React.startTransition(() => {
+            root.render(<Foo suspend={true} />);
+            setLabel('B');
+          });
+
+          await waitForAll(['Suspend!']);
+          expect(root).toMatchRenderedOutput(<span prop="A:0" />);
+
+          React.startTransition(() => {
+            root.render(<Foo suspend={false} />);
+          });
+
+          await waitForAll(['B:0']);
+          expect(root).toMatchRenderedOutput(<span prop="B:0" />);
+        });
+      },
+    );
+
     it('regression: render phase updates cause lower pri work to be dropped', async () => {
       let setRow;
       function ScrollView() {


### PR DESCRIPTION
In `recoverFromConcurrentError`, there's logic to determine if the latest render attempt resulted in another error or if it completed successfully, by checking whether the exit status matches RootErrored.

The logic was incomplete because RootSuspendedAtTheShell is also considered an errored state in this context. This can cause an incomplete tree (i.e. one that unwinds without entering the complete phase) to be mistaken for a complete one, leading to confusing errors. An incomplete tree can never be committed because it's not guaranteed to represent a coherent state.

An example of how this can manifest as a bug: in #33580, an error caught by an error boundary triggers a synchronous recovery render. During that render a parent component suspends on `use(thenable)` with no Suspense boundary above it, so the tree unwinds to the shell instead of completing. Because the incomplete tree is mistaken for a recovered one and committed, the parent fiber becomes current with a truncated hook list — only the hooks it rendered before suspending. On the next render it calls the rest of its hooks and throws "Rendered more hooks than during the previous render."

Fixes #33580.

Co-authored-by: Arunanshu Biswas <48434243+arunanshub@users.noreply.github.com>
