### PR TITLE
Fix panose1 SVG attribute alias

### DIFF
--- a/packages/react-dom-bindings/src/shared/getAttributeAlias.js
+++ b/packages/react-dom-bindings/src/shared/getAttributeAlias.js
@@ -54,7 +54,7 @@ const aliases = new Map([
   ['overlinePosition', 'overline-position'],
   ['overlineThickness', 'overline-thickness'],
   ['paintOrder', 'paint-order'],
-  ['panose-1', 'panose-1'],
+  ['panose1', 'panose-1'],
   ['pointerEvents', 'pointer-events'],
   ['renderingIntent', 'rendering-intent'],
   ['shapeRendering', 'shape-rendering'],

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -595,6 +595,21 @@ describe('ReactDOMServerIntegration', () => {
           expect(e.firstChild.getAttribute('stroke-dasharray')).toBe('10 10');
         },
       );
+
+      itRenders(
+        'panose1 prop as the hyphenated SVG attribute',
+        async render => {
+          const e = await render(
+            <svg>
+              <text panose1="2 0 5 9 0 0 0 0 0 0" />
+            </svg>,
+          );
+          expect(e.firstChild.getAttribute('panose-1')).toBe(
+            '2 0 5 9 0 0 0 0 0 0',
+          );
+          expect(e.firstChild.hasAttribute('panose1')).toBe(false);
+        },
+      );
     });
 
     describe('unknown attributes', function () {


### PR DESCRIPTION
getAttributeAlias.js maps `panose-1` to itself instead of mapping `panose1` to `panose-1`. possibleStandardNames.js already normalizes the prop to `panose1` (no hyphen), so the alias lookup is keyed on a value that's never actually passed in — the alias silently never fires and the hyphenated `panose-1` attribute never gets set on `<font-face>`.

Swapped the key to `panose1` and added a test alongside the other SVG-attribute-alias cases in the same file, verifying both the correct attribute is set and the unhyphenated one isn't. Confirmed it fails on the four SSR/hydration render paths without the fix and passes with it.