### PR TITLE
[Fizz] Guard the shell-error callbacks instead of nulling them out on the request

### DIFF
--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -1378,15 +1378,19 @@ function fatalError(
   // It's also called if React itself or its host configs errors.
   const onShellError = request.onShellError;
   const onFatalError = request.onFatalError;
-  // The shell has fatally errored, so the render can never complete. Prevent a
-  // later completeAll from invoking onAllReady, which would signal a successful
-  // render to consumers waiting on all content.
-  request.onAllReady = noop;
+  // Once the shell has completed it can't error anymore, so onShellError only
+  // fires while root tasks are still pending. onFatalError always fires because
+  // the error is always fatal to the request.
+  const shellComplete = request.pendingRootTasks === 0;
   if (__DEV__ && debugTask) {
-    debugTask.run(onShellError.bind(null, error));
+    if (!shellComplete) {
+      debugTask.run(onShellError.bind(null, error));
+    }
     debugTask.run(onFatalError.bind(null, error));
   } else {
-    onShellError(error);
+    if (!shellComplete) {
+      onShellError(error);
+    }
     onFatalError(error);
   }
   if (request.destination !== null) {
@@ -4509,6 +4513,11 @@ function erroredTask(
   const errorDigest = logRecoverableError(request, error, errorInfo, debugTask);
   if (boundary === null) {
     fatalError(request, error, errorInfo, debugTask);
+    // The shell fatally errored, so the render can never complete. Return before
+    // the completeAll check below so we don't fire onAllReady for a render that
+    // produced nothing. This mirrors finishAbortedTask, which also returns after
+    // a fatalError on the root.
+    return;
   } else {
     boundary.pendingTasks--;
     if (boundary.status !== CLIENT_RENDERED) {
@@ -4960,8 +4969,6 @@ function completeShell(request: Request) {
     preparePreamble(request);
   }
 
-  // We have completed the shell so the shell can't error anymore.
-  request.onShellError = noop;
   const onShellReady = request.onShellReady;
   onShellReady();
 }


### PR DESCRIPTION
Follow-up to #36903

The previous change stopped `onAllReady` from firing after a fatal shell error by assigning `noop` to `request.onAllReady` inside `fatalError`. This mutated a completion callback on the request as a side channel, mirroring the existing `request.onShellError = noop` in `completeShell`. This refactor removes both noop assignments and instead guards the calls at the point where they would happen, so the callbacks on the request stay the ones the caller passed in.

For `onAllReady`, `erroredTask` now returns right after `fatalError` in the root (`boundary === null`) case, so it no longer falls through to the `allPendingTasks === 0` check that calls `completeAll`. This matches the sibling `finishAbortedTask`, which already returns after a fatal root error. Later task completions cannot reach `completeAll` either, because `performWork` bails out once the request status is past `OPEN`.

For `onShellError`, `fatalError` now decides whether to call it based on the same condition that governed the assignment: the shell is complete exactly when `request.pendingRootTasks === 0`, and `completeShell` only runs at that point, so guarding the call is equivalent to the previous nulling out. `onFatalError` still always fires because the error is always fatal to the request.

This is a behavior-preserving refactor of the fix landed in #36903; the tests added there continue to pass unchanged.
