### PR TITLE
[eslint-plugin-react-hooks] Hoist flat configs to resolve TypeScript error

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/index.ts
+++ b/packages/eslint-plugin-react-hooks/src/index.ts
@@ -75,7 +75,7 @@ const recommendedLatestRuleConfigs: Linter.RulesRecord = {
 const plugins = ['react-hooks'];
 
 type ReactHooksFlatConfig = {
-  plugins: {react: any};
+   plugins: {'react-hooks': any};
   rules: Linter.RulesRecord;
 };
 
@@ -88,10 +88,7 @@ const configs = {
     plugins,
     rules: recommendedLatestRuleConfigs,
   },
-  flat: {} as {
-    recommended: ReactHooksFlatConfig;
-    'recommended-latest': ReactHooksFlatConfig;
-  },
+  'flat/recommended': {} as ReactHooksFlatConfig,  'flat/recommended-latest': {} as ReactHooksFlatConfig,
 };
 
 const plugin = {
@@ -103,15 +100,21 @@ const plugin = {
   configs,
 };
 
-Object.assign(configs.flat, {
-  'recommended-latest': {
+Object.assign(configs, {
+  'flat/recommended-latest': {
     plugins: {'react-hooks': plugin},
     rules: configs['recommended-latest'].rules,
   },
-  recommended: {
+  'flat/recommended': {
     plugins: {'react-hooks': plugin},
     rules: configs.recommended.rules,
   },
 });
+
+(configs as any).flat = {
+  'recommended-latest': configs['flat/recommended-latest'],
+  recommended: configs['flat/recommended'],
+
+};
 
 export default plugin;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Fixes #36907.

**Motivation:**
When developers import `eslint-plugin-react-hooks` in a TypeScript environment using the new ESLint 9 Flat Config, they encounter a `TS2322` error: `Property 'flat' is incompatible with index signature`. This happens because the exported `configs` object includes a nested `flat` object, which strictly violates the `ESLint.Plugin` type definition (`Record<string, Linter.Config>`).

**Changes made:**
1. **Hoisted Flat Configs:** Exposed the flat configs at the top level using standard ecosystem keys (`'flat/recommended'` and `'flat/recommended-latest'`), matching the pattern used by plugins like `typescript-eslint`.
2. **Maintained Backward Compatibility:** Retained the nested `configs.flat` object at runtime using a type override. This ensures that the type definitions are strictly compliant for `tsc` while preventing runtime breaks for developers who have already migrated to referencing `configs.flat.recommended`.

## How did you test this change?

1. **Local Issue Reproduction:**
   - Cloned the issue author's reproduction repository (`typescript-error-project`).
   - Ran `pnpm lint:tsc` and verified the original `TS2322` failure.
   - Manually replaced `node_modules/eslint-plugin-react-hooks/src/index.ts` with the updated code and deleted the cached `index.d.ts`.
   - Ran `pnpm lint:tsc` again. The compiler ran silently and exited with code `0`, confirming the type strictness issue is resolved.

2. **React Monorepo Build:**
   - Ran `yarn tsc` within `packages/eslint-plugin-react-hooks` to ensure the fix complies with the monorepo's internal TypeScript configuration.