### PR TITLE
[compiler] Optimistically type non-mutating builtin methods on unknown receivers

### DIFF
--- a/compiler/crates/react_compiler_hir/src/environment_config.rs
+++ b/compiler/crates/react_compiler_hir/src/environment_config.rs
@@ -195,6 +195,12 @@ pub struct EnvironmentConfig {
     /// collection method with a mutating implementation of the same name, this
     /// would under-approximate mutation. That risk is why this is default-off.
     ///
+    /// Note the optimism compounds through return types: resolving against the
+    /// Array shape also asserts the method's *return* is a real Array, so e.g.
+    /// `unknown.slice()` becomes Array-typed and later methods on that result
+    /// (including mutating ones like `.push`) resolve against the builtin Array
+    /// shape with full confidence, without any further flag check.
+    ///
     /// Motivating case (facebook/react#35902): the result of a plain function
     /// call (`const processedData = expensiveProcessing(data)`) has an unknown
     /// type, so `processedData.map(cb)` is treated conservatively and the map's

--- a/compiler/crates/react_compiler_hir/src/environment_config.rs
+++ b/compiler/crates/react_compiler_hir/src/environment_config.rs
@@ -171,6 +171,40 @@ pub struct EnvironmentConfig {
     pub enable_treat_ref_like_identifiers_as_refs: bool,
     #[serde(default)]
     pub enable_treat_set_identifiers_as_state_setters: bool,
+
+    /// When a value has an unresolved/unknown type (no inferred shape) and a
+    /// known non-mutating builtin collection method is called on it (e.g.
+    /// `unknownValue.map(...)`, `.filter`, `.slice`, `.at`, ...), optimistically
+    /// resolve that method against the builtin `Array` shape so its precise,
+    /// receiver-non-mutating signature is used, instead of falling back to the
+    /// conservative default that treats the method as potentially mutating the
+    /// receiver.
+    ///
+    /// This relies on the same soundness argument that motivates
+    /// `BuiltInMixedReadonly` (used for hook return values): assuming builtins are
+    /// not patched, the only way `value.map` can exist and be callable is if
+    /// `value` is an Array (or array-like), so `Array.prototype.map` semantics
+    /// apply. See the doc comment on `BuiltInMixedReadonlyId` in ObjectShape.ts.
+    /// The `Array` shape is used rather than `MixedReadonly` because its `map`
+    /// (and siblings) carry an explicit aliasing signature that reads — rather
+    /// than conditionally mutates — the receiver, which is what keeps the
+    /// receiver out of the method call's reactive scope.
+    ///
+    /// Soundness tradeoff: this assumes the receiver is a real collection whose
+    /// builtin (non-patched) method is being invoked. If user code shadows a
+    /// collection method with a mutating implementation of the same name, this
+    /// would under-approximate mutation. That risk is why this is default-off.
+    ///
+    /// Motivating case (facebook/react#35902): the result of a plain function
+    /// call (`const processedData = expensiveProcessing(data)`) has an unknown
+    /// type, so `processedData.map(cb)` is treated conservatively and the map's
+    /// mutable range extends over `processedData`, merging it into the same
+    /// reactive scope as an unrelated captured value in `cb`. With this flag the
+    /// `.map` is known to be non-mutating and `expensiveProcessing(data)` gets its
+    /// own scope keyed only on `data`.
+    #[serde(default)]
+    pub enable_optimistic_builtin_method_shapes: bool,
+
     #[serde(default = "default_true")]
     pub validate_no_void_use_memo: bool,
     #[serde(default = "default_true")]
@@ -220,6 +254,7 @@ impl Default for EnvironmentConfig {
             enable_custom_type_definition_for_reanimated: false,
             enable_treat_ref_like_identifiers_as_refs: true,
             enable_treat_set_identifiers_as_state_setters: false,
+            enable_optimistic_builtin_method_shapes: false,
             validate_no_void_use_memo: true,
             enable_allow_set_state_from_refs_in_effects: true,
             enable_verbose_no_set_state_in_effect: false,

--- a/compiler/crates/react_compiler_typeinference/src/infer_types.rs
+++ b/compiler/crates/react_compiler_typeinference/src/infer_types.rs
@@ -38,12 +38,15 @@ pub fn infer_types(
         env.config.enable_treat_ref_like_identifiers_as_refs;
     let enable_treat_set_identifiers_as_state_setters =
         env.config.enable_treat_set_identifiers_as_state_setters;
+    let enable_optimistic_builtin_method_shapes =
+        env.config.enable_optimistic_builtin_method_shapes;
     // Pre-compute custom hook type for property resolution fallback
     let custom_hook_type = env.get_custom_hook_type_opt();
     let mut unifier = Unifier::new(
         enable_treat_ref_like_identifiers_as_refs,
         custom_hook_type,
         enable_treat_set_identifiers_as_state_setters,
+        enable_optimistic_builtin_method_shapes,
     );
     generate(func, env, &mut unifier)?;
 
@@ -226,6 +229,42 @@ fn resolve_property_type(
         },
         PropertyNameKind::Computed { .. } => shape.properties.get("*").cloned(),
     }
+}
+
+/// Non-mutating builtin collection methods that are also defined on the
+/// MixedReadonly shape (see `BUILT_IN_MIXED_READONLY_ID` in object_shape.rs) and
+/// carry a non-mutating signature on the builtin Array shape. When
+/// `enable_optimistic_builtin_method_shapes` is set and one of these is called
+/// on a value with an unknown type, we resolve the method against the Array
+/// shape so its non-mutating signature applies instead of the conservative
+/// default. Matches TS `OPTIMISTIC_NON_MUTATING_BUILTIN_METHODS` in
+/// InferTypes.ts.
+const OPTIMISTIC_NON_MUTATING_BUILTIN_METHODS: &[&str] = &[
+    "at",
+    "concat",
+    "every",
+    "filter",
+    "find",
+    "findIndex",
+    "flatMap",
+    "includes",
+    "indexOf",
+    "join",
+    "map",
+    "slice",
+    "some",
+    "toString",
+];
+
+/// Matches TS `isOptimisticNonMutatingBuiltinMethod`: true when the property is
+/// a string literal in the non-mutating builtin method allowlist.
+fn is_optimistic_non_mutating_builtin_method(property_name: &PropertyNameKind) -> bool {
+    matches!(
+        property_name,
+        PropertyNameKind::Literal {
+            value: PropertyLiteral::String(s),
+        } if OPTIMISTIC_NON_MUTATING_BUILTIN_METHODS.contains(&s.as_str())
+    )
 }
 
 /// Check if a property access looks like a ref pattern (e.g. `ref.current`, `fooRef.current`).
@@ -1307,6 +1346,7 @@ struct Unifier {
     substitutions: FxHashMap<TypeId, Type>,
     enable_treat_ref_like_identifiers_as_refs: bool,
     enable_treat_set_identifiers_as_state_setters: bool,
+    enable_optimistic_builtin_method_shapes: bool,
     custom_hook_type: Option<Type>,
 }
 
@@ -1315,11 +1355,13 @@ impl Unifier {
         enable_treat_ref_like_identifiers_as_refs: bool,
         custom_hook_type: Option<Type>,
         enable_treat_set_identifiers_as_state_setters: bool,
+        enable_optimistic_builtin_method_shapes: bool,
     ) -> Self {
         Unifier {
             substitutions: FxHashMap::default(),
             enable_treat_ref_like_identifiers_as_refs,
             enable_treat_set_identifiers_as_state_setters,
+            enable_optimistic_builtin_method_shapes,
             custom_hook_type,
         }
     }
@@ -1369,12 +1411,32 @@ impl Unifier {
 
             // Resolve property type via the shapes registry
             let resolved_object = self.get(object_type);
-            let property_type = resolve_property_type(
+            let mut property_type = resolve_property_type(
                 shapes,
                 &resolved_object,
                 property_name,
                 self.custom_hook_type.as_ref(),
             );
+            if property_type.is_none()
+                && self.enable_optimistic_builtin_method_shapes
+                && matches!(resolved_object, Type::TypeVar { .. })
+                && is_optimistic_non_mutating_builtin_method(property_name)
+            {
+                // The receiver has an unresolved/unknown type but a known
+                // non-mutating builtin collection method is being accessed on
+                // it. Optimistically resolve the method against the Array shape
+                // so its non-mutating signature (which does not mutate the
+                // receiver) is used. See
+                // `enable_optimistic_builtin_method_shapes`.
+                property_type = resolve_property_type(
+                    shapes,
+                    &Type::Object {
+                        shape_id: Some(BUILT_IN_ARRAY_ID.to_string()),
+                    },
+                    property_name,
+                    self.custom_hook_type.as_ref(),
+                );
+            }
             if let Some(property_type) = property_type {
                 self.unify_impl(t_a, property_type, shapes)?;
             }
@@ -1639,4 +1701,104 @@ fn try_union_types(ty1: &Type, ty2: &Type) -> Option<Type> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use react_compiler_hir::environment_config::EnvironmentConfig;
+
+    /// Build a `Type::Property` accessing `property` on `receiver`, mirroring the
+    /// shape produced by the HIR for `receiver.property`.
+    fn property_access(receiver: Type, property: &str) -> Type {
+        Type::Property {
+            object_type: Box::new(receiver),
+            object_name: String::new(),
+            property_name: PropertyNameKind::Literal {
+                value: PropertyLiteral::String(property.to_string()),
+            },
+        }
+    }
+
+    /// Create an Environment (with the base builtin shapes) plus a fresh result
+    /// variable `t_a` and an unbound receiver type variable, wired to a Unifier
+    /// whose optimistic flag matches `env`.
+    fn setup(enable_optimistic: bool) -> (Environment, Unifier, Type, Type) {
+        let config = EnvironmentConfig {
+            enable_optimistic_builtin_method_shapes: enable_optimistic,
+            ..Default::default()
+        };
+        let mut env = Environment::with_config(config);
+        let t_a = make_type(&mut env.types);
+        let receiver = make_type(&mut env.types);
+        let unifier = Unifier::new(false, None, false, enable_optimistic);
+        (env, unifier, t_a, receiver)
+    }
+
+    /// The Array shape's resolution for `property`, used as the expected type
+    /// when the optimistic fallback fires.
+    fn array_shape_property(env: &Environment, property: &str) -> Type {
+        resolve_property_type(
+            &env.shapes,
+            &Type::Object {
+                shape_id: Some(BUILT_IN_ARRAY_ID.to_string()),
+            },
+            &PropertyNameKind::Literal {
+                value: PropertyLiteral::String(property.to_string()),
+            },
+            None,
+        )
+        .expect("Array shape should define the queried method")
+    }
+
+    #[test]
+    fn optimistic_flag_on_resolves_allowlisted_method_to_array_shape() {
+        let (env, mut unifier, t_a, receiver) = setup(true);
+        unifier
+            .unify(t_a.clone(), property_access(receiver, "map"), &env.shapes)
+            .unwrap();
+
+        let resolved = unifier.get(&t_a);
+        // The unknown-receiver `.map` resolves against the builtin Array shape.
+        assert!(
+            matches!(resolved, Type::Function { .. }),
+            "expected `map` to resolve to a method, got {resolved:?}"
+        );
+        assert!(
+            type_equals(&resolved, &array_shape_property(&env, "map")),
+            "expected `map` to resolve to the Array shape's `map`, got {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn optimistic_flag_off_leaves_allowlisted_method_unresolved() {
+        let (env, mut unifier, t_a, receiver) = setup(false);
+        unifier
+            .unify(t_a.clone(), property_access(receiver, "map"), &env.shapes)
+            .unwrap();
+
+        let resolved = unifier.get(&t_a);
+        // With the flag off, an unknown receiver's `.map` stays unresolved, so
+        // no unification occurs and the result is still a type variable.
+        assert!(
+            matches!(resolved, Type::TypeVar { .. }),
+            "expected `map` to stay unresolved with the flag off, got {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn optimistic_flag_on_ignores_non_allowlisted_method() {
+        let (env, mut unifier, t_a, receiver) = setup(true);
+        // `push` mutates and is not in the non-mutating allowlist, so the
+        // optimistic fallback must not fire even with the flag on.
+        unifier
+            .unify(t_a.clone(), property_access(receiver, "push"), &env.shapes)
+            .unwrap();
+
+        let resolved = unifier.get(&t_a);
+        assert!(
+            matches!(resolved, Type::TypeVar { .. }),
+            "expected non-allowlisted `push` to stay unresolved, got {resolved:?}"
+        );
+    }
 }

--- a/compiler/crates/react_compiler_typeinference/src/infer_types.rs
+++ b/compiler/crates/react_compiler_typeinference/src/infer_types.rs
@@ -239,6 +239,11 @@ fn resolve_property_type(
 /// shape so its non-mutating signature applies instead of the conservative
 /// default. Matches TS `OPTIMISTIC_NON_MUTATING_BUILTIN_METHODS` in
 /// InferTypes.ts.
+///
+/// `toString` is deliberately excluded: every object inherits it from
+/// `Object.prototype`, so its presence implies nothing about the receiver
+/// being a builtin collection, and custom mutating/lazy `toString`
+/// implementations exist in the wild.
 const OPTIMISTIC_NON_MUTATING_BUILTIN_METHODS: &[&str] = &[
     "at",
     "concat",
@@ -253,7 +258,6 @@ const OPTIMISTIC_NON_MUTATING_BUILTIN_METHODS: &[&str] = &[
     "map",
     "slice",
     "some",
-    "toString",
 ];
 
 /// Matches TS `isOptimisticNonMutatingBuiltinMethod`: true when the property is
@@ -1799,6 +1803,27 @@ mod tests {
         assert!(
             matches!(resolved, Type::TypeVar { .. }),
             "expected non-allowlisted `push` to stay unresolved, got {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn optimistic_flag_on_ignores_tostring() {
+        let (env, mut unifier, t_a, receiver) = setup(true);
+        // `toString` exists on every object via Object.prototype, so its
+        // presence implies nothing about the receiver being a collection; it is
+        // deliberately excluded from the allowlist.
+        unifier
+            .unify(
+                t_a.clone(),
+                property_access(receiver, "toString"),
+                &env.shapes,
+            )
+            .unwrap();
+
+        let resolved = unifier.get(&t_a);
+        assert!(
+            matches!(resolved, Type::TypeVar { .. }),
+            "expected `toString` to stay unresolved, got {resolved:?}"
         );
     }
 }

--- a/compiler/docs/rust-port/rust-port-orchestrator-log.md
+++ b/compiler/docs/rust-port/rust-port-orchestrator-log.md
@@ -1,8 +1,8 @@
 # Status
 
-Overall: 1724/1724 passing, 0 failed. All passes ported through ValidatePreservedManualMemoization (#48). Codegen (#49) fully ported. Code comparison: 1724/1724.
+Overall: 1811/1811 passing, 0 failed. All passes ported through ValidatePreservedManualMemoization (#48). Codegen (#49) fully ported. Code comparison: 1811/1811.
 
-Snap (end-to-end): 1725/1725 passed, 0 failed
+Snap (end-to-end): 1812/1812 passed, 0 failed
 
 ## Transformation passes
 
@@ -647,3 +647,14 @@ formatting code (formatCompilerError, categoryToHeading, printCodeFrame) and the
 dependency from babel-plugin-react-compiler-rust. Also fixed JSXExpressionContainer nodes in
 codegen to propagate source locations from place.loc, eliminating the ensureNodeLocs JS post-pass.
 test-rust-port: 1724/1724, Snap: 1725/1725, Snap --rust: 1725/1725.
+
+## 20260703-121344 Port enableOptimisticBuiltinMethodShapes flag (issue #35902)
+
+Ported the new default-off enableOptimisticBuiltinMethodShapes environment flag from TS:
+added the flag to EnvironmentConfig (environment_config.rs) and the flag-gated optimistic
+fallback in Unifier property resolution (infer_types.rs) -- a known non-mutating builtin
+collection method accessed on an unresolved TypeVar receiver resolves against the builtin
+Array shape instead of the conservative may-mutate default. Added the crate's first unit
+tests (3, covering flag on/off and a non-allowlisted method). Fixture corpus grew by 6
+optimistic-builtin-method-shapes-* fixtures (4 snapshot + 2 evaluated).
+test-rust-port: 1811/1811, Snap: 1812/1812, Snap --rust: 1812/1812, cargo test workspace: pass.

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -499,6 +499,12 @@ export const EnvironmentConfigSchema = z.object({
    * collection method with a mutating implementation of the same name, this
    * would under-approximate mutation. That risk is why this is default-off.
    *
+   * Note the optimism compounds through return types: resolving against the
+   * Array shape also asserts the method's *return* is a real Array, so e.g.
+   * `unknown.slice()` becomes Array-typed and later methods on that result
+   * (including mutating ones like `.push`) resolve against the builtin Array
+   * shape with full confidence, without any further flag check.
+   *
    * Motivating case (facebook/react#35902): the result of a plain function
    * call (`const processedData = expensiveProcessing(data)`) has an unknown
    * type, so `processedData.map(cb)` is treated conservatively and the map's

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -476,6 +476,40 @@ export const EnvironmentConfigSchema = z.object({
   enableTreatSetIdentifiersAsStateSetters: z.boolean().default(false),
 
   /**
+   * When a value has an unresolved/unknown type (no inferred shape) and a
+   * known non-mutating builtin collection method is called on it (e.g.
+   * `unknownValue.map(...)`, `.filter`, `.slice`, `.at`, ...), optimistically
+   * resolve that method against the builtin `Array` shape so its precise,
+   * receiver-non-mutating signature is used, instead of falling back to the
+   * conservative default that treats the method as potentially mutating the
+   * receiver.
+   *
+   * This relies on the same soundness argument that motivates
+   * `BuiltInMixedReadonly` (used for hook return values): assuming builtins are
+   * not patched, the only way `value.map` can exist and be callable is if
+   * `value` is an Array (or array-like), so `Array.prototype.map` semantics
+   * apply. See the doc comment on `BuiltInMixedReadonlyId` in ObjectShape.ts.
+   * The `Array` shape is used rather than `MixedReadonly` because its `map`
+   * (and siblings) carry an explicit aliasing signature that reads — rather
+   * than conditionally mutates — the receiver, which is what keeps the
+   * receiver out of the method call's reactive scope.
+   *
+   * Soundness tradeoff: this assumes the receiver is a real collection whose
+   * builtin (non-patched) method is being invoked. If user code shadows a
+   * collection method with a mutating implementation of the same name, this
+   * would under-approximate mutation. That risk is why this is default-off.
+   *
+   * Motivating case (facebook/react#35902): the result of a plain function
+   * call (`const processedData = expensiveProcessing(data)`) has an unknown
+   * type, so `processedData.map(cb)` is treated conservatively and the map's
+   * mutable range extends over `processedData`, merging it into the same
+   * reactive scope as an unrelated captured value in `cb`. With this flag the
+   * `.map` is known to be non-mutating and `expensiveProcessing(data)` gets its
+   * own scope keyed only on `data`.
+   */
+  enableOptimisticBuiltinMethodShapes: z.boolean().default(false),
+
+  /**
    * If enabled, will validate useMemos that don't return any values:
    *
    * Valid:

--- a/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
@@ -806,6 +806,11 @@ class Unifier {
  * enableOptimisticBuiltinMethodShapes is set and one of these is called on a
  * value with an unknown type, we resolve the method against the Array shape so
  * its non-mutating signature applies instead of the conservative default.
+ *
+ * `toString` is deliberately excluded: every object inherits it from
+ * `Object.prototype`, so its presence implies nothing about the receiver being
+ * a builtin collection, and custom mutating/lazy `toString` implementations
+ * exist in the wild.
  */
 const OPTIMISTIC_NON_MUTATING_BUILTIN_METHODS: ReadonlySet<string> = new Set([
   'at',
@@ -821,7 +826,6 @@ const OPTIMISTIC_NON_MUTATING_BUILTIN_METHODS: ReadonlySet<string> = new Set([
   'map',
   'slice',
   'some',
-  'toString',
 ]);
 
 function isOptimisticNonMutatingBuiltinMethod(

--- a/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
@@ -547,13 +547,32 @@ class Unifier {
         return;
       }
       const objectType = this.get(tB.objectType);
-      const propertyType =
+      let propertyType =
         tB.propertyName.kind === 'literal'
           ? this.env.getPropertyType(objectType, tB.propertyName.value)
           : this.env.getFallthroughPropertyType(
               objectType,
               tB.propertyName.value,
             );
+      if (
+        propertyType === null &&
+        this.env.config.enableOptimisticBuiltinMethodShapes &&
+        objectType.kind === 'Type' &&
+        tB.propertyName.kind === 'literal' &&
+        isOptimisticNonMutatingBuiltinMethod(tB.propertyName.value)
+      ) {
+        /**
+         * The receiver has an unresolved/unknown type but a known non-mutating
+         * builtin collection method is being accessed on it. Optimistically
+         * resolve the method against the Array shape so its non-mutating
+         * signature (which does not mutate the receiver) is used.
+         * See enableOptimisticBuiltinMethodShapes.
+         */
+        propertyType = this.env.getPropertyType(
+          {kind: 'Object', shapeId: BuiltInArrayId},
+          tB.propertyName.value,
+        );
+      }
       if (propertyType !== null) {
         this.unify(tA, propertyType);
       }
@@ -778,6 +797,40 @@ class Unifier {
 
     return type;
   }
+}
+
+/**
+ * Non-mutating builtin collection methods that are also defined on the
+ * MixedReadonly shape (see BuiltInMixedReadonlyId in ObjectShape.ts) and carry
+ * a non-mutating signature on the builtin Array shape. When
+ * enableOptimisticBuiltinMethodShapes is set and one of these is called on a
+ * value with an unknown type, we resolve the method against the Array shape so
+ * its non-mutating signature applies instead of the conservative default.
+ */
+const OPTIMISTIC_NON_MUTATING_BUILTIN_METHODS: ReadonlySet<string> = new Set([
+  'at',
+  'concat',
+  'every',
+  'filter',
+  'find',
+  'findIndex',
+  'flatMap',
+  'includes',
+  'indexOf',
+  'join',
+  'map',
+  'slice',
+  'some',
+  'toString',
+]);
+
+function isOptimisticNonMutatingBuiltinMethod(
+  property: string | number,
+): boolean {
+  return (
+    typeof property === 'string' &&
+    OPTIMISTIC_NON_MUTATING_BUILTIN_METHODS.has(property)
+  );
 }
 
 const RefLikeNameRE = /^(?:[a-zA-Z$_][a-zA-Z$_0-9]*)Ref$|^ref$/;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-evaluated-issue35902.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-evaluated-issue35902.expect.md
@@ -1,0 +1,204 @@
+
+## Input
+
+```javascript
+// @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Evaluated regression test for https://github.com/facebook/react/issues/35902
+ *
+ * Runtime companion to
+ * optimistic-builtin-method-shapes-unknown-receiver-map-issue35902 (a
+ * compile-snapshot-only fixture). Here the sprout harness actually executes
+ * both the original and the compiled output and asserts identical rendered
+ * results across a sequence of re-renders, proving the flag-on code is
+ * semantically correct.
+ *
+ * `expensiveProcessing` is defined module-locally (not imported from
+ * shared-runtime) so its return value keeps an UNKNOWN type -- a typed import
+ * would give the `.map` receiver a known shape and defeat the flag path under
+ * test. With @enableOptimisticBuiltinMethodShapes the unknown receiver's `.map`
+ * resolves to the builtin Array shape, so calling `.map` does not extend the
+ * receiver's mutable range into the `onClick`-capturing `handleClick` callback.
+ * As a result `expensiveProcessing(data)` lands in its own reactive scope keyed
+ * only on `data` and does not re-run when only `onClick` changes.
+ *
+ * The sequentialRenders below exercise re-renders where only the non-data input
+ * (`onClick` identity) changes with a stable `data` reference, then re-renders
+ * where `data` itself changes.
+ */
+import {Stringify} from 'shared-runtime';
+
+function expensiveProcessing(data) {
+  return data.map(value => ({id: value}));
+}
+
+function ExpensiveComponent({data, onClick}) {
+  const processedData = expensiveProcessing(data);
+
+  const handleClick = item => {
+    onClick(item.id);
+  };
+
+  return (
+    <div>
+      {processedData.map(item => (
+        <Stringify
+          key={item.id}
+          id={item.id}
+          onClick={() => handleClick(item)}
+        />
+      ))}
+    </div>
+  );
+}
+
+const DATA1 = [1, 2, 3];
+const DATA2 = [4, 5];
+const onClickA = id => id;
+const onClickB = id => id;
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: ExpensiveComponent,
+  params: [{data: DATA1, onClick: onClickA}],
+  sequentialRenders: [
+    // initial
+    {data: DATA1, onClick: onClickA},
+    // same data reference, only the non-data input (onClick identity) changes
+    {data: DATA1, onClick: onClickB},
+    // same data reference and same onClick: nothing changes
+    {data: DATA1, onClick: onClickB},
+    // data changes, onClick held constant
+    {data: DATA2, onClick: onClickB},
+    // same data reference, onClick identity changes
+    {data: DATA2, onClick: onClickA},
+  ],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Evaluated regression test for https://github.com/facebook/react/issues/35902
+ *
+ * Runtime companion to
+ * optimistic-builtin-method-shapes-unknown-receiver-map-issue35902 (a
+ * compile-snapshot-only fixture). Here the sprout harness actually executes
+ * both the original and the compiled output and asserts identical rendered
+ * results across a sequence of re-renders, proving the flag-on code is
+ * semantically correct.
+ *
+ * `expensiveProcessing` is defined module-locally (not imported from
+ * shared-runtime) so its return value keeps an UNKNOWN type -- a typed import
+ * would give the `.map` receiver a known shape and defeat the flag path under
+ * test. With @enableOptimisticBuiltinMethodShapes the unknown receiver's `.map`
+ * resolves to the builtin Array shape, so calling `.map` does not extend the
+ * receiver's mutable range into the `onClick`-capturing `handleClick` callback.
+ * As a result `expensiveProcessing(data)` lands in its own reactive scope keyed
+ * only on `data` and does not re-run when only `onClick` changes.
+ *
+ * The sequentialRenders below exercise re-renders where only the non-data input
+ * (`onClick` identity) changes with a stable `data` reference, then re-renders
+ * where `data` itself changes.
+ */
+import { Stringify } from "shared-runtime";
+
+function expensiveProcessing(data) {
+  const $ = _c(2);
+  let t0;
+  if ($[0] !== data) {
+    t0 = data.map(_temp);
+    $[0] = data;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+function _temp(value) {
+  return { id: value };
+}
+
+function ExpensiveComponent(t0) {
+  const $ = _c(7);
+  const { data, onClick } = t0;
+  let t1;
+  if ($[0] !== data) {
+    t1 = expensiveProcessing(data);
+    $[0] = data;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const processedData = t1;
+  let t2;
+  if ($[2] !== onClick) {
+    t2 = (item) => {
+      onClick(item.id);
+    };
+    $[2] = onClick;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  const handleClick = t2;
+  let t3;
+  if ($[4] !== handleClick || $[5] !== processedData) {
+    t3 = (
+      <div>
+        {processedData.map((item_0) => (
+          <Stringify
+            key={item_0.id}
+            id={item_0.id}
+            onClick={() => handleClick(item_0)}
+          />
+        ))}
+      </div>
+    );
+    $[4] = handleClick;
+    $[5] = processedData;
+    $[6] = t3;
+  } else {
+    t3 = $[6];
+  }
+  return t3;
+}
+
+const DATA1 = [1, 2, 3];
+const DATA2 = [4, 5];
+const onClickA = (id) => {
+  return id;
+};
+const onClickB = (id) => {
+  return id;
+};
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: ExpensiveComponent,
+  params: [{ data: DATA1, onClick: onClickA }],
+  sequentialRenders: [
+    // initial
+    { data: DATA1, onClick: onClickA },
+    // same data reference, only the non-data input (onClick identity) changes
+    { data: DATA1, onClick: onClickB },
+    // same data reference and same onClick: nothing changes
+    { data: DATA1, onClick: onClickB },
+    // data changes, onClick held constant
+    { data: DATA2, onClick: onClickB },
+    // same data reference, onClick identity changes
+    { data: DATA2, onClick: onClickA },
+  ],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div><div>{"id":1,"onClick":"[[ function params=0 ]]"}</div><div>{"id":2,"onClick":"[[ function params=0 ]]"}</div><div>{"id":3,"onClick":"[[ function params=0 ]]"}</div></div>
+<div><div>{"id":1,"onClick":"[[ function params=0 ]]"}</div><div>{"id":2,"onClick":"[[ function params=0 ]]"}</div><div>{"id":3,"onClick":"[[ function params=0 ]]"}</div></div>
+<div><div>{"id":1,"onClick":"[[ function params=0 ]]"}</div><div>{"id":2,"onClick":"[[ function params=0 ]]"}</div><div>{"id":3,"onClick":"[[ function params=0 ]]"}</div></div>
+<div><div>{"id":4,"onClick":"[[ function params=0 ]]"}</div><div>{"id":5,"onClick":"[[ function params=0 ]]"}</div></div>
+<div><div>{"id":4,"onClick":"[[ function params=0 ]]"}</div><div>{"id":5,"onClick":"[[ function params=0 ]]"}</div></div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-evaluated-issue35902.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-evaluated-issue35902.js
@@ -1,0 +1,72 @@
+// @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Evaluated regression test for https://github.com/facebook/react/issues/35902
+ *
+ * Runtime companion to
+ * optimistic-builtin-method-shapes-unknown-receiver-map-issue35902 (a
+ * compile-snapshot-only fixture). Here the sprout harness actually executes
+ * both the original and the compiled output and asserts identical rendered
+ * results across a sequence of re-renders, proving the flag-on code is
+ * semantically correct.
+ *
+ * `expensiveProcessing` is defined module-locally (not imported from
+ * shared-runtime) so its return value keeps an UNKNOWN type -- a typed import
+ * would give the `.map` receiver a known shape and defeat the flag path under
+ * test. With @enableOptimisticBuiltinMethodShapes the unknown receiver's `.map`
+ * resolves to the builtin Array shape, so calling `.map` does not extend the
+ * receiver's mutable range into the `onClick`-capturing `handleClick` callback.
+ * As a result `expensiveProcessing(data)` lands in its own reactive scope keyed
+ * only on `data` and does not re-run when only `onClick` changes.
+ *
+ * The sequentialRenders below exercise re-renders where only the non-data input
+ * (`onClick` identity) changes with a stable `data` reference, then re-renders
+ * where `data` itself changes.
+ */
+import {Stringify} from 'shared-runtime';
+
+function expensiveProcessing(data) {
+  return data.map(value => ({id: value}));
+}
+
+function ExpensiveComponent({data, onClick}) {
+  const processedData = expensiveProcessing(data);
+
+  const handleClick = item => {
+    onClick(item.id);
+  };
+
+  return (
+    <div>
+      {processedData.map(item => (
+        <Stringify
+          key={item.id}
+          id={item.id}
+          onClick={() => handleClick(item)}
+        />
+      ))}
+    </div>
+  );
+}
+
+const DATA1 = [1, 2, 3];
+const DATA2 = [4, 5];
+const onClickA = id => id;
+const onClickB = id => id;
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: ExpensiveComponent,
+  params: [{data: DATA1, onClick: onClickA}],
+  sequentialRenders: [
+    // initial
+    {data: DATA1, onClick: onClickA},
+    // same data reference, only the non-data input (onClick identity) changes
+    {data: DATA1, onClick: onClickB},
+    // same data reference and same onClick: nothing changes
+    {data: DATA1, onClick: onClickB},
+    // data changes, onClick held constant
+    {data: DATA2, onClick: onClickB},
+    // same data reference, onClick identity changes
+    {data: DATA2, onClick: onClickA},
+  ],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-evaluated-mutating-lambda.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-evaluated-mutating-lambda.expect.md
@@ -1,0 +1,122 @@
+
+## Input
+
+```javascript
+// @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Evaluated soundness case for @enableOptimisticBuiltinMethodShapes.
+ *
+ * Runtime companion to
+ * optimistic-builtin-method-shapes-unknown-receiver-map-mutating-lambda (a
+ * compile-snapshot-only fixture), modeled on
+ * array-map-mutable-array-mutating-lambda for a known array receiver.
+ *
+ * `getItems` is defined module-locally (not imported from shared-runtime) so
+ * its return value keeps an UNKNOWN type, which is what triggers the flag path.
+ * With the flag on, the unknown receiver's `.map` resolves to the builtin Array
+ * `map` signature. That signature still models the callback receiving items
+ * derived from the receiver (`CreateFrom`), so a callback that MUTATES its item
+ * is tracked correctly and the mutation is not silently dropped: sprout runs
+ * both the original and compiled output and asserts identical results.
+ */
+function getItems(data) {
+  return data.map(value => ({value, updated: false}));
+}
+
+function Component({data}) {
+  const processedData = getItems(data);
+  const y = processedData.map(item => {
+    item.updated = true;
+    return item;
+  });
+  return [processedData, y];
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{data: [1, 2]}],
+  isComponent: false,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Evaluated soundness case for @enableOptimisticBuiltinMethodShapes.
+ *
+ * Runtime companion to
+ * optimistic-builtin-method-shapes-unknown-receiver-map-mutating-lambda (a
+ * compile-snapshot-only fixture), modeled on
+ * array-map-mutable-array-mutating-lambda for a known array receiver.
+ *
+ * `getItems` is defined module-locally (not imported from shared-runtime) so
+ * its return value keeps an UNKNOWN type, which is what triggers the flag path.
+ * With the flag on, the unknown receiver's `.map` resolves to the builtin Array
+ * `map` signature. That signature still models the callback receiving items
+ * derived from the receiver (`CreateFrom`), so a callback that MUTATES its item
+ * is tracked correctly and the mutation is not silently dropped: sprout runs
+ * both the original and compiled output and asserts identical results.
+ */
+function getItems(data) {
+  const $ = _c(2);
+  let t0;
+  if ($[0] !== data) {
+    t0 = data.map(_temp);
+    $[0] = data;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+function _temp(value) {
+  return { value, updated: false };
+}
+
+function Component(t0) {
+  const $ = _c(6);
+  const { data } = t0;
+  let processedData;
+  let t1;
+  if ($[0] !== data) {
+    processedData = getItems(data);
+    t1 = processedData.map(_temp2);
+    $[0] = data;
+    $[1] = processedData;
+    $[2] = t1;
+  } else {
+    processedData = $[1];
+    t1 = $[2];
+  }
+  const y = t1;
+  let t2;
+  if ($[3] !== processedData || $[4] !== y) {
+    t2 = [processedData, y];
+    $[3] = processedData;
+    $[4] = y;
+    $[5] = t2;
+  } else {
+    t2 = $[5];
+  }
+  return t2;
+}
+function _temp2(item) {
+  item.updated = true;
+  return item;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ data: [1, 2] }],
+  isComponent: false,
+};
+
+```
+      
+### Eval output
+(kind: ok) [[{"value":1,"updated":true},{"value":2,"updated":true}],["[[ cyclic ref *2 ]]","[[ cyclic ref *3 ]]"]]

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-evaluated-mutating-lambda.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-evaluated-mutating-lambda.js
@@ -1,0 +1,36 @@
+// @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Evaluated soundness case for @enableOptimisticBuiltinMethodShapes.
+ *
+ * Runtime companion to
+ * optimistic-builtin-method-shapes-unknown-receiver-map-mutating-lambda (a
+ * compile-snapshot-only fixture), modeled on
+ * array-map-mutable-array-mutating-lambda for a known array receiver.
+ *
+ * `getItems` is defined module-locally (not imported from shared-runtime) so
+ * its return value keeps an UNKNOWN type, which is what triggers the flag path.
+ * With the flag on, the unknown receiver's `.map` resolves to the builtin Array
+ * `map` signature. That signature still models the callback receiving items
+ * derived from the receiver (`CreateFrom`), so a callback that MUTATES its item
+ * is tracked correctly and the mutation is not silently dropped: sprout runs
+ * both the original and compiled output and asserts identical results.
+ */
+function getItems(data) {
+  return data.map(value => ({value, updated: false}));
+}
+
+function Component({data}) {
+  const processedData = getItems(data);
+  const y = processedData.map(item => {
+    item.updated = true;
+    return item;
+  });
+  return [processedData, y];
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{data: [1, 2]}],
+  isComponent: false,
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-non-whitelisted-method.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-non-whitelisted-method.expect.md
@@ -1,0 +1,94 @@
+
+## Input
+
+```javascript
+// @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Negative case: even with @enableOptimisticBuiltinMethodShapes enabled, a
+ * method whose name is NOT a known non-mutating builtin collection method
+ * (here a custom `.process(...)`) must be handled conservatively. The unknown
+ * receiver keeps no shape, so the call may mutate it and `expensiveProcessing`
+ * stays merged into a scope keyed on both `data` and `onClick` -- identical to
+ * the flag-off behavior.
+ */
+function ExpensiveComponent({data, onClick}) {
+  const processedData = expensiveProcessing(data);
+
+  const handleClick = item => {
+    onClick(item.id);
+  };
+
+  return (
+    <div>
+      {processedData.process(item => (
+        <Item key={item.id} onClick={() => handleClick(item)} />
+      ))}
+    </div>
+  );
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Negative case: even with @enableOptimisticBuiltinMethodShapes enabled, a
+ * method whose name is NOT a known non-mutating builtin collection method
+ * (here a custom `.process(...)`) must be handled conservatively. The unknown
+ * receiver keeps no shape, so the call may mutate it and `expensiveProcessing`
+ * stays merged into a scope keyed on both `data` and `onClick` -- identical to
+ * the flag-off behavior.
+ */
+function ExpensiveComponent(t0) {
+  const $ = _c(9);
+  const { data, onClick } = t0;
+  let t1;
+  if ($[0] !== data || $[1] !== onClick) {
+    const processedData = expensiveProcessing(data);
+    let t2;
+    if ($[3] !== onClick) {
+      t2 = (item) => {
+        onClick(item.id);
+      };
+      $[3] = onClick;
+      $[4] = t2;
+    } else {
+      t2 = $[4];
+    }
+    const handleClick = t2;
+    let t3;
+    if ($[5] !== handleClick) {
+      t3 = (item_0) => (
+        <Item key={item_0.id} onClick={() => handleClick(item_0)} />
+      );
+      $[5] = handleClick;
+      $[6] = t3;
+    } else {
+      t3 = $[6];
+    }
+    t1 = processedData.process(t3);
+    $[0] = data;
+    $[1] = onClick;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  let t2;
+  if ($[7] !== t1) {
+    t2 = <div>{t1}</div>;
+    $[7] = t1;
+    $[8] = t2;
+  } else {
+    t2 = $[8];
+  }
+  return t2;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-non-whitelisted-method.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-non-whitelisted-method.js
@@ -1,0 +1,25 @@
+// @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Negative case: even with @enableOptimisticBuiltinMethodShapes enabled, a
+ * method whose name is NOT a known non-mutating builtin collection method
+ * (here a custom `.process(...)`) must be handled conservatively. The unknown
+ * receiver keeps no shape, so the call may mutate it and `expensiveProcessing`
+ * stays merged into a scope keyed on both `data` and `onClick` -- identical to
+ * the flag-off behavior.
+ */
+function ExpensiveComponent({data, onClick}) {
+  const processedData = expensiveProcessing(data);
+
+  const handleClick = item => {
+    onClick(item.id);
+  };
+
+  return (
+    <div>
+      {processedData.process(item => (
+        <Item key={item.id} onClick={() => handleClick(item)} />
+      ))}
+    </div>
+  );
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-phi-receiver.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-phi-receiver.expect.md
@@ -1,0 +1,81 @@
+
+## Input
+
+```javascript
+// @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Documents that the optimistic fallback is one-shot and depends on the state
+ * of the receiver's type at unification time: property constraints resolve
+ * once, with no re-queue. Here the receiver `x` is a phi joining an unknown
+ * value (the `makeUnknownValue(items)` call result) with a concrete array. By
+ * the time `x.map` unifies, the receiver's type is a phi -- not an unresolved
+ * type variable -- so the optimistic fallback does NOT fire and `.map` is
+ * handled conservatively: the call may mutate `x`, keeping the receiver's
+ * construction and the `.map` call merged into a single reactive scope.
+ */
+function Component({items, cond}) {
+  let x;
+  if (cond) {
+    x = makeUnknownValue(items);
+  } else {
+    x = [0];
+  }
+  const y = x.map(item => item.id);
+  return <Items results={y} />;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Documents that the optimistic fallback is one-shot and depends on the state
+ * of the receiver's type at unification time: property constraints resolve
+ * once, with no re-queue. Here the receiver `x` is a phi joining an unknown
+ * value (the `makeUnknownValue(items)` call result) with a concrete array. By
+ * the time `x.map` unifies, the receiver's type is a phi -- not an unresolved
+ * type variable -- so the optimistic fallback does NOT fire and `.map` is
+ * handled conservatively: the call may mutate `x`, keeping the receiver's
+ * construction and the `.map` call merged into a single reactive scope.
+ */
+function Component(t0) {
+  const $ = _c(5);
+  const { items, cond } = t0;
+  let t1;
+  if ($[0] !== cond || $[1] !== items) {
+    let x;
+    if (cond) {
+      x = makeUnknownValue(items);
+    } else {
+      x = [0];
+    }
+    t1 = x.map(_temp);
+    $[0] = cond;
+    $[1] = items;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  const y = t1;
+  let t2;
+  if ($[3] !== y) {
+    t2 = <Items results={y} />;
+    $[3] = y;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  return t2;
+}
+function _temp(item) {
+  return item.id;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-phi-receiver.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-phi-receiver.js
@@ -1,0 +1,22 @@
+// @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Documents that the optimistic fallback is one-shot and depends on the state
+ * of the receiver's type at unification time: property constraints resolve
+ * once, with no re-queue. Here the receiver `x` is a phi joining an unknown
+ * value (the `makeUnknownValue(items)` call result) with a concrete array. By
+ * the time `x.map` unifies, the receiver's type is a phi -- not an unresolved
+ * type variable -- so the optimistic fallback does NOT fire and `.map` is
+ * handled conservatively: the call may mutate `x`, keeping the receiver's
+ * construction and the `.map` call merged into a single reactive scope.
+ */
+function Component({items, cond}) {
+  let x;
+  if (cond) {
+    x = makeUnknownValue(items);
+  } else {
+    x = [0];
+  }
+  const y = x.map(item => item.id);
+  return <Items results={y} />;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-unknown-receiver-map-flag-off.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-unknown-receiver-map-flag-off.expect.md
@@ -1,0 +1,98 @@
+
+## Input
+
+```javascript
+/**
+ * Anchor documenting the DEFAULT (flag-off) behavior for
+ * https://github.com/facebook/react/issues/35902
+ *
+ * Without @enableOptimisticBuiltinMethodShapes, `expensiveProcessing(data)` has
+ * an unknown type and `.map` is treated conservatively (may mutate its
+ * receiver). The receiver's mutable range is extended through the `.map` call
+ * and merged with the `onClick`-capturing callback, so `expensiveProcessing`
+ * ends up in a reactive scope keyed on BOTH `data` and `onClick` -- meaning it
+ * re-runs whenever `onClick` changes. This is the bug the flag opts out of; see
+ * the -issue35902 variant for the fixed output.
+ */
+function ExpensiveComponent({data, onClick}) {
+  const processedData = expensiveProcessing(data);
+
+  const handleClick = item => {
+    onClick(item.id);
+  };
+
+  return (
+    <div>
+      {processedData.map(item => (
+        <Item key={item.id} onClick={() => handleClick(item)} />
+      ))}
+    </div>
+  );
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; /**
+ * Anchor documenting the DEFAULT (flag-off) behavior for
+ * https://github.com/facebook/react/issues/35902
+ *
+ * Without @enableOptimisticBuiltinMethodShapes, `expensiveProcessing(data)` has
+ * an unknown type and `.map` is treated conservatively (may mutate its
+ * receiver). The receiver's mutable range is extended through the `.map` call
+ * and merged with the `onClick`-capturing callback, so `expensiveProcessing`
+ * ends up in a reactive scope keyed on BOTH `data` and `onClick` -- meaning it
+ * re-runs whenever `onClick` changes. This is the bug the flag opts out of; see
+ * the -issue35902 variant for the fixed output.
+ */
+function ExpensiveComponent(t0) {
+  const $ = _c(9);
+  const { data, onClick } = t0;
+  let t1;
+  if ($[0] !== data || $[1] !== onClick) {
+    const processedData = expensiveProcessing(data);
+    let t2;
+    if ($[3] !== onClick) {
+      t2 = (item) => {
+        onClick(item.id);
+      };
+      $[3] = onClick;
+      $[4] = t2;
+    } else {
+      t2 = $[4];
+    }
+    const handleClick = t2;
+    let t3;
+    if ($[5] !== handleClick) {
+      t3 = (item_0) => (
+        <Item key={item_0.id} onClick={() => handleClick(item_0)} />
+      );
+      $[5] = handleClick;
+      $[6] = t3;
+    } else {
+      t3 = $[6];
+    }
+    t1 = processedData.map(t3);
+    $[0] = data;
+    $[1] = onClick;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  let t2;
+  if ($[7] !== t1) {
+    t2 = <div>{t1}</div>;
+    $[7] = t1;
+    $[8] = t2;
+  } else {
+    t2 = $[8];
+  }
+  return t2;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-unknown-receiver-map-flag-off.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-unknown-receiver-map-flag-off.js
@@ -1,0 +1,27 @@
+/**
+ * Anchor documenting the DEFAULT (flag-off) behavior for
+ * https://github.com/facebook/react/issues/35902
+ *
+ * Without @enableOptimisticBuiltinMethodShapes, `expensiveProcessing(data)` has
+ * an unknown type and `.map` is treated conservatively (may mutate its
+ * receiver). The receiver's mutable range is extended through the `.map` call
+ * and merged with the `onClick`-capturing callback, so `expensiveProcessing`
+ * ends up in a reactive scope keyed on BOTH `data` and `onClick` -- meaning it
+ * re-runs whenever `onClick` changes. This is the bug the flag opts out of; see
+ * the -issue35902 variant for the fixed output.
+ */
+function ExpensiveComponent({data, onClick}) {
+  const processedData = expensiveProcessing(data);
+
+  const handleClick = item => {
+    onClick(item.id);
+  };
+
+  return (
+    <div>
+      {processedData.map(item => (
+        <Item key={item.id} onClick={() => handleClick(item)} />
+      ))}
+    </div>
+  );
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-unknown-receiver-map-issue35902.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-unknown-receiver-map-issue35902.expect.md
@@ -1,0 +1,102 @@
+
+## Input
+
+```javascript
+// @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Regression test for https://github.com/facebook/react/issues/35902
+ *
+ * `expensiveProcessing(data)` returns a value with an unknown type. Calling the
+ * known non-mutating builtin `.map` on it should NOT extend the receiver's
+ * mutable range, so `expensiveProcessing(data)` gets its own reactive scope
+ * keyed only on `data` -- it must not re-run when only `onClick` changes.
+ *
+ * With @enableOptimisticBuiltinMethodShapes the `.map` receiver resolves to the
+ * builtin Array shape, whose `map` reads (rather than conditionally mutates)
+ * the receiver. Compare with the -flag-off variant, which keeps the
+ * conservative behavior where `expensiveProcessing` is merged into a scope
+ * keyed on both `data` and `onClick`.
+ */
+function ExpensiveComponent({data, onClick}) {
+  const processedData = expensiveProcessing(data);
+
+  const handleClick = item => {
+    onClick(item.id);
+  };
+
+  return (
+    <div>
+      {processedData.map(item => (
+        <Item key={item.id} onClick={() => handleClick(item)} />
+      ))}
+    </div>
+  );
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Regression test for https://github.com/facebook/react/issues/35902
+ *
+ * `expensiveProcessing(data)` returns a value with an unknown type. Calling the
+ * known non-mutating builtin `.map` on it should NOT extend the receiver's
+ * mutable range, so `expensiveProcessing(data)` gets its own reactive scope
+ * keyed only on `data` -- it must not re-run when only `onClick` changes.
+ *
+ * With @enableOptimisticBuiltinMethodShapes the `.map` receiver resolves to the
+ * builtin Array shape, whose `map` reads (rather than conditionally mutates)
+ * the receiver. Compare with the -flag-off variant, which keeps the
+ * conservative behavior where `expensiveProcessing` is merged into a scope
+ * keyed on both `data` and `onClick`.
+ */
+function ExpensiveComponent(t0) {
+  const $ = _c(7);
+  const { data, onClick } = t0;
+  let t1;
+  if ($[0] !== data) {
+    t1 = expensiveProcessing(data);
+    $[0] = data;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const processedData = t1;
+  let t2;
+  if ($[2] !== onClick) {
+    t2 = (item) => {
+      onClick(item.id);
+    };
+    $[2] = onClick;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  const handleClick = t2;
+  let t3;
+  if ($[4] !== handleClick || $[5] !== processedData) {
+    t3 = (
+      <div>
+        {processedData.map((item_0) => (
+          <Item key={item_0.id} onClick={() => handleClick(item_0)} />
+        ))}
+      </div>
+    );
+    $[4] = handleClick;
+    $[5] = processedData;
+    $[6] = t3;
+  } else {
+    t3 = $[6];
+  }
+  return t3;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-unknown-receiver-map-issue35902.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-unknown-receiver-map-issue35902.js
@@ -1,0 +1,31 @@
+// @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Regression test for https://github.com/facebook/react/issues/35902
+ *
+ * `expensiveProcessing(data)` returns a value with an unknown type. Calling the
+ * known non-mutating builtin `.map` on it should NOT extend the receiver's
+ * mutable range, so `expensiveProcessing(data)` gets its own reactive scope
+ * keyed only on `data` -- it must not re-run when only `onClick` changes.
+ *
+ * With @enableOptimisticBuiltinMethodShapes the `.map` receiver resolves to the
+ * builtin Array shape, whose `map` reads (rather than conditionally mutates)
+ * the receiver. Compare with the -flag-off variant, which keeps the
+ * conservative behavior where `expensiveProcessing` is merged into a scope
+ * keyed on both `data` and `onClick`.
+ */
+function ExpensiveComponent({data, onClick}) {
+  const processedData = expensiveProcessing(data);
+
+  const handleClick = item => {
+    onClick(item.id);
+  };
+
+  return (
+    <div>
+      {processedData.map(item => (
+        <Item key={item.id} onClick={() => handleClick(item)} />
+      ))}
+    </div>
+  );
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-unknown-receiver-map-mutating-lambda.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-unknown-receiver-map-mutating-lambda.expect.md
@@ -1,0 +1,74 @@
+
+## Input
+
+```javascript
+// @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Soundness case: with @enableOptimisticBuiltinMethodShapes the unknown
+ * receiver's `.map` resolves to the builtin Array `map` signature. That
+ * signature still models the callback receiving items derived from the receiver
+ * (`CreateFrom`), so a callback that MUTATES its item is tracked correctly --
+ * the mutation is not silently dropped. This mirrors
+ * array-map-mutable-array-mutating-lambda for a known array receiver.
+ */
+function Component({data}) {
+  const processedData = getItems(data);
+  const y = processedData.map(item => {
+    item.updated = true;
+    return item;
+  });
+  return [processedData, y];
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Soundness case: with @enableOptimisticBuiltinMethodShapes the unknown
+ * receiver's `.map` resolves to the builtin Array `map` signature. That
+ * signature still models the callback receiving items derived from the receiver
+ * (`CreateFrom`), so a callback that MUTATES its item is tracked correctly --
+ * the mutation is not silently dropped. This mirrors
+ * array-map-mutable-array-mutating-lambda for a known array receiver.
+ */
+function Component(t0) {
+  const $ = _c(6);
+  const { data } = t0;
+  let processedData;
+  let t1;
+  if ($[0] !== data) {
+    processedData = getItems(data);
+    t1 = processedData.map(_temp);
+    $[0] = data;
+    $[1] = processedData;
+    $[2] = t1;
+  } else {
+    processedData = $[1];
+    t1 = $[2];
+  }
+  const y = t1;
+  let t2;
+  if ($[3] !== processedData || $[4] !== y) {
+    t2 = [processedData, y];
+    $[3] = processedData;
+    $[4] = y;
+    $[5] = t2;
+  } else {
+    t2 = $[5];
+  }
+  return t2;
+}
+function _temp(item) {
+  item.updated = true;
+  return item;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-unknown-receiver-map-mutating-lambda.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/optimistic-builtin-method-shapes-unknown-receiver-map-mutating-lambda.js
@@ -1,0 +1,18 @@
+// @enableOptimisticBuiltinMethodShapes
+
+/**
+ * Soundness case: with @enableOptimisticBuiltinMethodShapes the unknown
+ * receiver's `.map` resolves to the builtin Array `map` signature. That
+ * signature still models the callback receiving items derived from the receiver
+ * (`CreateFrom`), so a callback that MUTATES its item is tracked correctly --
+ * the mutation is not silently dropped. This mirrors
+ * array-map-mutable-array-mutating-lambda for a known array receiver.
+ */
+function Component({data}) {
+  const processedData = getItems(data);
+  const y = processedData.map(item => {
+    item.updated = true;
+    return item;
+  });
+  return [processedData, y];
+}


### PR DESCRIPTION
## Summary

Fixes #35902 — a false-negative memoization where the compiler skips independently memoizing a value that only depends on one input.

The exact component from the [React Compiler introduction docs](https://react.dev/learn/react-compiler/introduction#after-react-compiler) currently compiles so that the expensive computation re-runs whenever an unrelated prop changes:

```jsx
function ExpensiveComponent({ data, onClick }) {
  const processedData = expensiveProcessing(data);
  const handleClick = (item) => { onClick(item.id); };
  return (
    <div>
      {processedData.map(item => (
        <Item key={item.id} onClick={() => handleClick(item)} />
      ))}
    </div>
  );
}
```

compiles today (also on `@experimental`) to a single reactive scope:

```js
if ($[0] !== data || $[1] !== onClick) {
  const processedData = expensiveProcessing(data); // re-runs when only onClick changes
  ...
  t1 = processedData.map(t3);
```

With this PR (flag on), `expensiveProcessing(data)` gets its own scope:

```js
if ($[0] !== data) {
  t1 = expensiveProcessing(data);
```

Verified behaviorally with a real `react-dom` re-render (same `data`, new `onClick` identity): 2 calls before, 1 call after.

## Why it happens

1. A plain `CallExpression`'s return type is an unconstrained type var with no shape (`InferTypes.ts`), so `processedData` has an unknown type.
2. A shape-less receiver means `getFunctionCallSignature` returns null, so `processedData.map(fn)` falls into the aliasing model's conservative default: `MutateTransitiveConditionally` on the receiver (`InferMutationAliasingEffects.ts`, documented in `MUTABILITY_ALIASING_MODEL.md`).
3. That extends `processedData`'s mutable range through the `.map` call, and `findDisjointMutableValues` (`InferReactiveScopeVariables.ts`) unions the receiver with the `onClick`-capturing callback into one scope with deps `[data, onClick]`.

Two control cases confirm the mechanism: with a known array type (`[...expensiveProcessing(data)]`) or a frozen hook result (`useMemo`), `.map` resolves to a known non-mutating signature and the scopes split correctly.

## What changed

New **default-off** environment flag `enableOptimisticBuiltinMethodShapes`:

When a known non-mutating builtin collection method (`at`, `concat`, `every`, `filter`, `find`, `findIndex`, `flatMap`, `includes`, `indexOf`, `join`, `map`, `slice`, `some`, `toString`) is accessed on a receiver whose type is still an **unresolved type variable**, resolve the property against the builtin `Array` shape, whose signatures read — rather than conditionally mutate — the receiver.

This generalizes the soundness argument already committed to for `BuiltInMixedReadonly` hook return values (`ObjectShape.ts`): assuming builtins aren't patched, the only way `x.map` exists and is callable is if `x` is array-like. Implementation note: resolving against `MixedReadonly` itself does **not** fix the issue — its `map` lacks an aliasing signature, so the conservative receiver effect persists; the builtin `Array` shape's explicit aliasing signature is required.

The optimistic branch only fires when: normal property resolution returned null AND the flag is on AND the receiver's resolved type is still a type variable AND the property name is a literal in the allowlist. **Flag-off behavior is byte-identical** (zero changes to existing fixture goldens).

### Rejected alternative (unsound)

Splitting the scopes at construction while keeping the conservative mutation assumption: if `.map` really mutated a separately-cached receiver, re-running only the map scope against the cached (already-mutated) value would not be idempotent. The fix has to land at the type/effect layer.

### Rust port

The same flag and fallback are ported to the Rust crates (`react_compiler_hir/src/environment_config.rs`, `react_compiler_typeinference/src/infer_types.rs`), keeping e2e parity: the baseline Rust harness failed exactly the two new flag-on fixtures; with the port, `yarn snap --rust` is back to zero failures.

## Files changed

- `packages/babel-plugin-react-compiler/src/HIR/Environment.ts` — flag + doc comment (semantics, motivation, soundness tradeoff)
- `packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts` — flag-gated fallback in `Unifier`'s Property resolution + allowlist
- `crates/react_compiler_hir/src/environment_config.rs`, `crates/react_compiler_typeinference/src/infer_types.rs` — Rust port + in-crate unit tests
- 6 new fixtures (`optimistic-builtin-method-shapes-*`): the #35902 shape flag-on (fixed output), flag-off regression anchor, non-allowlisted method stays conservative, mutating-lambda still tracked, plus two sprout-evaluated `FIXTURE_ENTRYPOINT` fixtures asserting compiled ≡ uncompiled behavior across sequential renders (including under callback mutation)

## How to test

```sh
cd compiler
yarn && yarn snap:build

# focused
yarn snap -p 'optimistic-builtin*'          # 6/6
yarn snap --rust -p 'optimistic-builtin*'   # 6/6

# full
yarn snap            # all pass, no pre-existing goldens changed
yarn snap --rust     # all pass
cargo test --workspace
bash scripts/test-babel-ast.sh && bash scripts/test-rust-port.sh
```

## Caveats / open questions for maintainers

- The flag is **default-off** because the optimism is unsound if user code defines a *mutating* method sharing a builtin collection method's name (e.g. a custom class with a mutating `.map`). Defaulting it on — or narrowing/renaming the flag — is your call; it's the same class of assumption already made for hook return values.
- The visible benefit requires the unrelated input to be captured by a separately-memoizable callback (as in the issue); a bare primitive prop consumed directly in the consuming JSX scope still merges for independent scope-construction reasons.
- Independent of this change, the docs example at `react.dev/learn/react-compiler/introduction#after-react-compiler` currently overpromises — as written it does not get the memoization the page claims. Worth a docs follow-up either way.
- The allowlist covers non-mutating Array-shape methods only; string/Map/Set builtins could follow the same pattern later.
