### PR TITLE
[compiler] Fix enable-feature-flag fixture update counters

### DIFF
--- a/compiler/scripts/__tests__/enable-feature-flag-test.js
+++ b/compiler/scripts/__tests__/enable-feature-flag-test.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const {main} = require('../enable-feature-flag');
+
+describe('enable-feature-flag', () => {
+  let consoleError;
+  let consoleLog;
+  let consoleWarn;
+
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    consoleLog.mockRestore();
+    consoleWarn.mockRestore();
+  });
+
+  it('should count updated fixtures if fixture pragmas are added', async () => {
+    const exit = jest.fn(code => code);
+    const updateSnapshots = jest.fn(() => true);
+    const verifyAllTestsPass = jest.fn(() => true);
+
+    await main({
+      flagName: 'enableFoo',
+      enableFlagInEnvironment: jest.fn(),
+      runTests: jest.fn(() => ({
+        output: 'FAIL: first-fixture\nFAIL: second-fixture',
+      })),
+      findFixtureFile: jest.fn(testName => `/fixtures/${testName}.js`),
+      addPragmaToFixture: jest.fn(() => true),
+      updateSnapshots,
+      verifyAllTestsPass,
+      exit,
+    });
+
+    expect(updateSnapshots).toHaveBeenCalledTimes(1);
+    expect(verifyAllTestsPass).toHaveBeenCalledTimes(1);
+    expect(consoleLog).toHaveBeenCalledWith(
+      '\nSummary: Updated 2 fixtures, 0 not found'
+    );
+    expect(consoleLog).toHaveBeenCalledWith(
+      '  - Updated 2 fixture files with pragma'
+    );
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('should fail before updating snapshots if a fixture file cannot be found', async () => {
+    const exit = jest.fn(code => code);
+    const updateSnapshots = jest.fn(() => true);
+    const verifyAllTestsPass = jest.fn(() => true);
+
+    await main({
+      flagName: 'enableFoo',
+      enableFlagInEnvironment: jest.fn(),
+      runTests: jest.fn(() => ({
+        output: 'FAIL: first-fixture\nFAIL: missing-fixture',
+      })),
+      findFixtureFile: jest.fn(testName =>
+        testName === 'missing-fixture' ? null : `/fixtures/${testName}.js`
+      ),
+      addPragmaToFixture: jest.fn(() => true),
+      updateSnapshots,
+      verifyAllTestsPass,
+      exit,
+    });
+
+    expect(consoleWarn).toHaveBeenCalledWith(
+      'Could not find fixture file for: missing-fixture'
+    );
+    expect(consoleLog).toHaveBeenCalledWith(
+      '\nSummary: Updated 1 fixtures, 1 not found'
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      '\nFailed to update snapshots, could not find:\nmissing-fixture'
+    );
+    expect(updateSnapshots).not.toHaveBeenCalled();
+    expect(verifyAllTestsPass).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/compiler/scripts/enable-feature-flag.js
+++ b/compiler/scripts/enable-feature-flag.js
@@ -11,8 +11,6 @@
 const fs = require('fs');
 const path = require('path');
 const {execSync} = require('child_process');
-const yargs = require('yargs/yargs');
-const {hideBin} = require('yargs/helpers');
 
 // Constants
 const COMPILER_ROOT = path.resolve(__dirname, '..');
@@ -30,6 +28,9 @@ const FIXTURE_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx'];
  * Parse command line arguments
  */
 function parseArgs() {
+  const yargs = require('yargs/yargs');
+  const {hideBin} = require('yargs/helpers');
+
   const argv = yargs(hideBin(process.argv))
     .usage('Usage: $0 <flag-name>')
     .command('$0 <flag-name>', 'Enable a feature flag by default', yargs => {
@@ -264,42 +265,56 @@ function verifyAllTestsPass() {
 /**
  * Main function
  */
-async function main() {
-  const flagName = parseArgs();
+async function main(options = {}) {
+  const flagName =
+    options.flagName != null
+      ? options.flagName
+      : (options.parseArgs || parseArgs)();
+  const enableFlagInEnvironmentImpl =
+    options.enableFlagInEnvironment || enableFlagInEnvironment;
+  const runTestsImpl = options.runTests || runTests;
+  const parseFailingTestsImpl = options.parseFailingTests || parseFailingTests;
+  const findFixtureFileImpl = options.findFixtureFile || findFixtureFile;
+  const addPragmaToFixtureImpl =
+    options.addPragmaToFixture || addPragmaToFixture;
+  const updateSnapshotsImpl = options.updateSnapshots || updateSnapshots;
+  const verifyAllTestsPassImpl =
+    options.verifyAllTestsPass || verifyAllTestsPass;
+  const exit = options.exit || process.exit;
 
   console.log(`\nEnabling flag: '${flagName}'`);
 
   try {
     // Step 1: Enable flag in Environment.ts
-    enableFlagInEnvironment(flagName);
+    enableFlagInEnvironmentImpl(flagName);
 
     // Step 2: Run tests to find failures
-    const {output} = runTests();
-    const failingTests = parseFailingTests(output);
+    const {output} = runTestsImpl();
+    const failingTests = parseFailingTestsImpl(output);
 
     console.log(`\nFound ${failingTests.length} failing tests`);
 
     if (failingTests.length === 0) {
       console.log('No failing tests! Feature flag enabled successfully.');
-      process.exit(0);
+      return exit(0);
     }
 
     // Step 3: Add pragma to each failing fixture
     console.log(`\nAdding '@${flagName}:false' pragma to failing fixtures...`);
 
     const notFound = [];
-    let notFoundCount = 0;
+    let updatedCount = 0;
 
     for (const testName of failingTests) {
-      const fixturePath = findFixtureFile(testName);
+      const fixturePath = findFixtureFileImpl(testName);
 
       if (!fixturePath) {
         console.warn(`Could not find fixture file for: ${testName}`);
-        notFound.push(fixturePath);
+        notFound.push(testName);
         continue;
       }
 
-      const updated = addPragmaToFixture(fixturePath, flagName);
+      const updated = addPragmaToFixtureImpl(fixturePath, flagName);
       if (updated) {
         updatedCount++;
         console.log(`  Updated: ${testName}`);
@@ -307,26 +322,26 @@ async function main() {
     }
 
     console.log(
-      `\nSummary: Updated ${updatedCount} fixtures, ${notFoundCount} not found`
+      `\nSummary: Updated ${updatedCount} fixtures, ${notFound.length} not found`
     );
 
-    if (notFoundCount.length !== 0) {
+    if (notFound.length !== 0) {
       console.error(
         '\nFailed to update snapshots, could not find:\n' + notFound.join('\n')
       );
-      process.exit(1);
+      return exit(1);
     }
 
     // Step 4: Update snapshots
-    if (!updateSnapshots()) {
+    if (!updateSnapshotsImpl()) {
       console.error('\nFailed to update snapshots');
-      process.exit(1);
+      return exit(1);
     }
 
     // Step 5: Verify all tests pass
-    if (!verifyAllTestsPass()) {
+    if (!verifyAllTestsPassImpl()) {
       console.error('\nVerification failed: Some tests are still failing');
-      process.exit(1);
+      return exit(1);
     }
 
     console.log('\nSuccess! Feature flag enabled and all tests passing.');
@@ -335,13 +350,26 @@ async function main() {
     console.log(`  - Updated ${updatedCount} fixture files with pragma`);
     console.log(`  - All tests passing`);
 
-    process.exit(0);
+    return exit(0);
   } catch (error) {
     console.error('\nFatal error:', error.message);
     console.error(error.stack);
-    process.exit(1);
+    return exit(1);
   }
 }
 
 // Run the script
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  addPragmaToFixture,
+  enableFlagInEnvironment,
+  findFixtureFile,
+  main,
+  parseFailingTests,
+  runTests,
+  updateSnapshots,
+  verifyAllTestsPass,
+};

--- a/scripts/jest/config.base.js
+++ b/scripts/jest/config.base.js
@@ -28,7 +28,11 @@ module.exports = {
   testRegex: '/__tests__/[^/]*(\\.js|\\.coffee|[^d]\\.ts)$',
   moduleFileExtensions: ['js', 'json', 'node', 'coffee', 'ts'],
   rootDir: process.cwd(),
-  roots: ['<rootDir>/packages', '<rootDir>/scripts'],
+  roots: [
+    '<rootDir>/packages',
+    '<rootDir>/scripts',
+    '<rootDir>/compiler/scripts',
+  ],
   collectCoverageFrom: ['packages/**/*.js'],
   fakeTimers: {
     enableGlobally: true,


### PR DESCRIPTION
## Summary
- Initialize the fixture update counter before adding feature-flag pragmas.
- Use the missing-fixture list for the not-found summary and error path.
- Make the script import-safe and add focused tests for the update and missing-fixture flows.

## Test plan
- `corepack yarn test compiler/scripts/__tests__/enable-feature-flag-test.js --runInBand`
- `corepack yarn prettier-check`
