### PR TITLE
reconciler docs: fix stale host config method signatures

### DIFF
--- a/packages/react-reconciler/README.md
+++ b/packages/react-reconciler/README.md
@@ -119,7 +119,7 @@ This method should mutate the `parentInstance` and add the child to its list of 
 
 This method happens **in the render phase**. It can mutate `parentInstance` and `child`, but it must not modify any other nodes. It's called while the tree is still being built up and not connected to the actual tree on the screen.
 
-#### `finalizeInitialChildren(instance, type, props, rootContainer, hostContext)`
+#### `finalizeInitialChildren(instance, type, props, hostContext)`
 
 In this method, you can perform some final mutations on the `instance`. Unlike with `createInstance`, by the time `finalizeInitialChildren` is called, all the initial children have already been added to the `instance`, but the instance itself has not yet been connected to the tree on the screen.
 
@@ -147,7 +147,7 @@ If you don't intend to use host context, you can return `null`.
 
 This method happens **in the render phase**. Do not mutate the tree from it.
 
-#### `getChildHostContext(parentHostContext, type, rootContainer)`
+#### `getChildHostContext(parentHostContext, type)`
 
 Host context lets you track some information about where you are in the tree so that it's available inside `createInstance` as the `hostContext` parameter. For example, the DOM renderer uses it to track whether it's inside an HTML or an SVG tree, because `createInstance` implementation needs to be different for them.
 
@@ -322,7 +322,7 @@ This method should mutate the `container` root node and remove all children from
 
 This method is called during render to determine if the Host Component type and props require some kind of loading process to complete before committing an update.
 
-#### `preloadInstance(type, props)`
+#### `preloadInstance(instance, type, props)`
 
 This method may be called during render if the Host Component type and props might suspend a commit. It can be used to initiate any work that might shorten the duration of a suspended commit.
 
@@ -330,11 +330,11 @@ This method may be called during render if the Host Component type and props mig
 
 This method is called just before the commit phase. Use it to set up any necessary state while any Host Components that might suspend this commit are evaluated to determine if the commit must be suspended.
 
-#### `suspendInstance(type, props)`
+#### `suspendInstance(suspendedState, instance, type, props)`
 
 This method is called after `startSuspendingCommit` for each Host Component that indicated it might suspend a commit.
 
-#### `waitForCommitToBeReady()`
+#### `waitForCommitToBeReady(suspendedState, timeoutOffset)`
 
 This method is called after all `suspendInstance` calls are complete.
 


### PR DESCRIPTION

The custom-renderer host config reference in `packages/react-reconciler/README.md`
documents five method signatures whose parameter lists no longer match the actual
API. This updates the headings so they match the real signatures in
`packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js` and the arguments
the reconciler actually passes at each call site.

- `finalizeInitialChildren`: drop the removed `rootContainer` param
  -> `finalizeInitialChildren(instance, type, props, hostContext)`
- `getChildHostContext`: drop the removed `rootContainer` param
  -> `getChildHostContext(parentHostContext, type)`
- `preloadInstance`: add the leading `instance` param
  -> `preloadInstance(instance, type, props)`
- `suspendInstance`: add the leading `suspendedState` and `instance` params
  -> `suspendInstance(suspendedState, instance, type, props)`
- `waitForCommitToBeReady`: document its params
  -> `waitForCommitToBeReady(suspendedState, timeoutOffset)`

Background on the drift:
- The `rootContainer` (internally `rootContainerInstance`) argument was removed
  from `finalizeInitialChildren` and `getChildHostContext` in #25024; the README
  kept the old form.
- The `instance` argument was added to `preloadInstance` in #32819 (Suspensey
  Images); the README kept the old two-argument form.
- `suspendInstance` and `waitForCommitToBeReady` were in the same Suspensey
  cluster and had never had their real parameters documented.

The README uses friendly parameter names by convention rather than the DOM impl's
internal names (for example `instance` for `domElement`, and existing headings
already use `rootContainer`, `internalHandle`, `prevProps`/`nextProps`). This
change keeps that convention: `suspendedState` matches the reconciler's own local
variable name (the value returned by `startSuspendingCommit` and threaded through
`suspendInstance` and `waitForCommitToBeReady`).

This is documentation only; no code changes.

## How did you test this change?

There is no automated test for a Markdown doc, so each corrected signature was
verified by hand against both the definition and the call sites:

| Heading (updated) | Definition | Reconciler call site(s) |
|---|---|---|
| `finalizeInitialChildren(instance, type, props, hostContext)` | `ReactFiberConfigDOM.js` `finalizeInitialChildren` (4 params) | `ReactFiberCompleteWork.js` passes 4 args |
| `getChildHostContext(parentHostContext, type)` | `ReactFiberConfigDOM.js` `getChildHostContext` (2 params) | `ReactFiberHostContext.js` `getChildHostContext(context, fiber.type)` |
| `preloadInstance(instance, type, props)` | `ReactFiberConfigDOM.js` `preloadInstance` (3 params) | `ReactFiberCompleteWork.js` / `ReactFiberWorkLoop.js` pass `stateNode, type, props` |
| `suspendInstance(suspendedState, instance, type, props)` | `ReactFiberConfigDOM.js` `suspendInstance` (4 params) | `ReactFiberCommitWork.js` passes `suspendedState, instance, type, props` |
| `waitForCommitToBeReady(suspendedState, timeoutOffset)` | `ReactFiberConfigDOM.js` `waitForCommitToBeReady` (2 params) | `ReactFiberWorkLoop.js` passes `suspendedState, timeoutOffset` |

I also checked every other method heading in this README against its definition;
no other signature drift remains.

`scripts/prettier/index.js` only formats `js/jsx/ts/tsx`, so Markdown is not
prettier-formatted here; running the changed-file formatter left the README
untouched. `yarn lint` and `yarn flow` do not apply to Markdown.
