### PR TITLE
docs: remove stale parentType param from validateChildKeys JSDoc

### DIFF
--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -860,7 +860,6 @@ export function cloneElement(element, config, children) {
  *
  * @internal
  * @param {ReactNode} node Statically passed child of any type.
- * @param {*} parentType node's parent's type.
  */
 function validateChildKeys(node) {
   if (__DEV__) {


### PR DESCRIPTION


`validateChildKeys` in `packages/react/src/jsx/ReactJSXElement.js` had a signature
of `validateChildKeys(node, parentType)`, but #34174 ("Remove unused arguments from
ReactElement") dropped the second argument, changing the signature to
`validateChildKeys(node)` and updating every call site to pass a single argument.

That change removed several now-unused `@param` lines from the same file, but left
one behind on `validateChildKeys`:

```js
/**
 * ...
 * @internal
 * @param {ReactNode} node Statically passed child of any type.
 * @param {*} parentType node's parent's type.   // <- no such parameter anymore
 */
function validateChildKeys(node) {
```

`parentType` no longer appears anywhere in the function signature or body, so this
`@param` line is stale and misleading to anyone reading the doc comment. This PR
deletes that single line. The remaining `@param {ReactNode} node` already fully and
correctly documents the sole parameter. No code or behavior change.

## How did you test this change?

This is a documentation-only change (a JSDoc comment on an `@internal` helper), so
there is no runtime behavior to test. I verified it as follows:

- Confirmed `parentType` no longer appears anywhere in
  `packages/react/src/jsx/ReactJSXElement.js` (`grep -n parentType` returns no
  matches after the change).
- Confirmed the signature `function validateChildKeys(node)` and all call sites are
  unchanged by this diff.
- `yarn prettier` (via `scripts/prettier/index.js check-changed`) - clean.
- `yarn linc` (ESLint on changed files) - passed.
- `yarn flow dom-node` - No errors.

---

## Diff (for reference)

```diff
diff --git a/packages/react/src/jsx/ReactJSXElement.js b/packages/react/src/jsx/ReactJSXElement.js
@@ -860,7 +860,6 @@ export function cloneElement(element, config, children) {
   *
   * @internal
   * @param {ReactNode} node Statically passed child of any type.
- * @param {*} parentType node's parent's type.
   */
 function validateChildKeys(node) {
```
