### PR TITLE
Fix RangeError in binaryToComparableString for large buffers

### DIFF
--- a/packages/shared/__tests__/binaryToComparableString-test.internal.js
+++ b/packages/shared/__tests__/binaryToComparableString-test.internal.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let binaryToComparableString;
+
+describe('binaryToComparableString', () => {
+  beforeEach(() => {
+    binaryToComparableString = require('shared/binaryToComparableString')
+      .default;
+  });
+
+  it('returns an empty string for an empty view', () => {
+    expect(binaryToComparableString(new Uint8Array(0))).toBe('');
+  });
+
+  it('preserves every byte in the resulting string', () => {
+    const bytes = new Uint8Array(256);
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = i;
+    }
+    const result = binaryToComparableString(bytes);
+    expect(result.length).toBe(bytes.length);
+    for (let i = 0; i < bytes.length; i++) {
+      expect(result.charCodeAt(i)).toBe(bytes[i]);
+    }
+  });
+
+  it('produces equal strings for equal bytes and different strings otherwise', () => {
+    const a = new Uint8Array([1, 2, 3, 4]);
+    const b = new Uint8Array([1, 2, 3, 4]);
+    const c = new Uint8Array([1, 2, 3, 5]);
+    expect(binaryToComparableString(a)).toBe(binaryToComparableString(b));
+    expect(binaryToComparableString(a)).not.toBe(binaryToComparableString(c));
+  });
+
+  it('respects byteOffset and byteLength of the view', () => {
+    const buffer = new Uint8Array([0, 1, 2, 3, 4, 5]).buffer;
+    const view = new Uint8Array(buffer, 2, 3);
+    const result = binaryToComparableString(view);
+    expect(result).toBe(String.fromCharCode(2, 3, 4));
+  });
+
+  it('does not throw for large buffers that exceed the argument limit', () => {
+    // A single String.fromCharCode.apply call with this many arguments throws a
+    // RangeError in most engines. The chunked implementation must not.
+    const bytes = new Uint8Array(300000);
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = i % 256;
+    }
+    let result;
+    expect(() => {
+      result = binaryToComparableString(bytes);
+    }).not.toThrow();
+    expect(result.length).toBe(bytes.length);
+    expect(result.charCodeAt(0)).toBe(0);
+    expect(result.charCodeAt(bytes.length - 1)).toBe((bytes.length - 1) % 256);
+  });
+});

--- a/packages/shared/binaryToComparableString.js
+++ b/packages/shared/binaryToComparableString.js
@@ -12,8 +12,18 @@
 export default function binaryToComparableString(
   view: $ArrayBufferView,
 ): string {
-  return String.fromCharCode.apply(
-    String,
-    new Uint8Array(view.buffer, view.byteOffset, view.byteLength),
-  );
+  const bytes = new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+  // We build the string in chunks. Passing every byte as a separate argument to
+  // String.fromCharCode.apply exceeds the engine's maximum argument count for
+  // large buffers and throws a RangeError, so we cap how many bytes we spread
+  // per call.
+  const chunkSize = 0x8000;
+  let result = '';
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    result += String.fromCharCode.apply(
+      String,
+      bytes.subarray(i, i + chunkSize),
+    );
+  }
+  return result;
 }


### PR DESCRIPTION
﻿## Summary

`binaryToComparableString` turned a TypedArray/DataView into a string by spreading every byte as a separate argument to `String.fromCharCode.apply`. JS engines cap the number of call arguments, so for large buffers this throws `RangeError` ("Maximum call stack size exceeded" / "too many arguments").

This broke two paths behind the experimental `enableTaint` flag:

- `experimental_taintUniqueValue` with a large TypedArray/DataView value throws at registration time (`packages/react/src/ReactTaint.js`).
- `emitTypedArrayChunk` in the Flight server calls it for every serialized typed array whose `byteLength` matches a previously tainted length (`packages/react-server/src/ReactFlightServer.js`), so a large legitimate typed array can crash serialization.

Fixes #36933.

## Fix

Build the comparable string in chunks so no single `String.fromCharCode.apply` call exceeds the engine argument limit. The output is byte-for-byte identical to the previous implementation for inputs the old code could handle, so existing Map lookups remain compatible.

## How did you test this change?

Added `packages/shared/__tests__/binaryToComparableString-test.internal.js` covering:

- empty view
- byte preservation for all 256 byte values
- equal bytes produce equal strings, differing bytes produce different strings
- `byteOffset` / `byteLength` are respected
- large buffers (300k bytes) no longer throw and preserve all bytes

Also verified in a standalone script that the new implementation matches the old one for small inputs and that the old implementation throws `RangeError` on a 300k-byte array while the new one does not.
