### PR TITLE
Use Closure exit code in Rollup plugin

### DIFF
--- a/scripts/rollup/plugins/closure-plugin.js
+++ b/scripts/rollup/plugins/closure-plugin.js
@@ -10,10 +10,13 @@ function compile(flags) {
   return new Promise((resolve, reject) => {
     const closureCompiler = new ClosureCompiler(flags);
     closureCompiler.run(function (exitCode, stdOut, stdErr) {
-      if (!stdErr) {
+      if (exitCode === 0) {
+        if (stdErr) {
+          process.stderr.write(stdErr);
+        }
         resolve(stdOut);
       } else {
-        reject(new Error(stdErr));
+        reject(new Error(stdErr || 'Closure Compiler failed.'));
       }
     });
   });


### PR DESCRIPTION
## Summary

The Rollup Closure plugin currently treats any Closure Compiler stderr output as a build failure, even when Closure exits successfully.

On newer Java versions, Closure can print JVM deprecation warnings to stderr while still returning exit code `0`. This causes otherwise successful bundle builds to fail. I hit this while building the Bun server bundle:

`yarn build react-dom/src/server/react-dom-server.bun --type=BUN_DEV`

This change uses Closure’s exit code as the failure signal. If Closure exits successfully, stderr is still forwarded so warnings remain visible. If Closure exits with a non-zero code, the plugin rejects as before.

## How did you test this change?

- `yarn build react-dom/src/server/react-dom-server.bun --type=BUN_DEV`
  - Before the change: failed because JVM warnings were written to stderr.
  - After the change: passed and completed `react-dom-server.bun.development.js`.
- `yarn lint scripts/rollup/plugins/closure-plugin.js`
  - Passed.
- `yarn prettier`
  - Passed.
- `yarn linc`
  - Passed.
- `git diff --check HEAD`
  - Passed.