### PR TITLE
Design owned host context

### DIFF
--- a/docs/superpowers/plans/2026-07-06-owned-host-context-stage-1.md
+++ b/docs/superpowers/plans/2026-07-06-owned-host-context-stage-1.md
@@ -1,0 +1,781 @@
+# Owned Host Context Stage 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow `useFormStatus()` to observe a single `<form>` directly returned by the same function component, while preserving existing descendant form status behavior.
+
+**Architecture:** Add an internal owned-host-status dependency list to function component update queues. During render, `useHostTransitionStatus()` records a dependency when no parent host transition is active. During host reconciliation, a directly owned `<form>` binds that dependency to the form host fiber, and form status changes schedule the owner fiber.
+
+**Tech Stack:** React Fiber reconciler, React DOM form actions, Flow, Jest source tests, React internal Scheduler test utils.
+
+---
+
+## File Structure
+
+- Modify `packages/react-dom/src/__tests__/ReactDOMForm-test.js`
+  - Adds regression coverage for same-component `useFormStatus`.
+  - Adds ambiguity coverage for multiple directly owned forms.
+- Modify `packages/react-reconciler/src/ReactFiberHooks.js`
+  - Extends `FunctionComponentUpdateQueue`.
+  - Records owned host status requests from `useHostTransitionStatus`.
+  - Exports helpers used by begin work to bind and schedule owner dependencies.
+- Modify `packages/react-reconciler/src/ReactFiberBeginWork.js`
+  - Binds owned form status dependencies while reconciling direct children returned by a function component.
+  - Schedules owner fibers when a bound form status changes.
+This plan intentionally does not add the explicit scope token API. That belongs in Stage 2 after the implicit single-form behavior lands.
+
+---
+
+### Task 1: Add Failing Same-Component Form Status Test
+
+**Files:**
+- Modify: `packages/react-dom/src/__tests__/ReactDOMForm-test.js`
+
+- [x] **Step 1: Add the failing regression test**
+
+Insert this test after the existing `useFormStatus reads the status of a pending form action` test.
+
+```js
+  it('useFormStatus can read the status of a form returned by the same component', async () => {
+    const formRef = React.createRef();
+
+    async function myAction() {
+      Scheduler.log('Async action started');
+      await getText('Wait');
+      Scheduler.log('Async action finished');
+    }
+
+    function App() {
+      const {pending, data, action, method} = useFormStatus();
+      let status;
+      if (!pending) {
+        status = 'No pending action';
+      } else {
+        status = `Pending action ${action.name}: foo is ${data.get(
+          'foo',
+        )}, method is ${method}`;
+      }
+
+      return (
+        <form action={myAction} ref={formRef}>
+          <input type="text" name="foo" defaultValue="bar" />
+          <Text text={status} />
+        </form>
+      );
+    }
+
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => root.render(<App />));
+    assertLog(['No pending action']);
+    expect(container.textContent).toBe('No pending action');
+
+    await submit(formRef.current);
+    assertLog([
+      'Async action started',
+      'Pending action myAction: foo is bar, method is get',
+    ]);
+    expect(container.textContent).toBe(
+      'Pending action myAction: foo is bar, method is get',
+    );
+
+    await act(() => resolveText('Wait'));
+    assertLog(['Async action finished', 'No pending action']);
+    expect(container.textContent).toBe('No pending action');
+  });
+```
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+yarn test ReactDOMForm-test --runInBand
+```
+
+Expected: this new test fails because `useFormStatus()` returns `NotPending` in `App` while the form action is pending.
+
+- [x] **Step 3: Commit the failing test**
+
+```bash
+git add packages/react-dom/src/__tests__/ReactDOMForm-test.js
+git commit -m "test: add same component form status coverage"
+```
+
+---
+
+### Task 2: Add Owned Host Status Dependency Storage
+
+**Files:**
+- Modify: `packages/react-reconciler/src/ReactFiberHooks.js`
+
+- [x] **Step 1: Add dependency types**
+
+Near `FunctionComponentUpdateQueue`, add:
+
+```js
+export type OwnedHostTransitionStatusDependency = {
+  kind: 'form',
+  owner: Fiber,
+  provider: Fiber | null,
+  value: TransitionStatus,
+  ambiguous: boolean,
+};
+```
+
+Then extend `FunctionComponentUpdateQueue`:
+
+```js
+export type FunctionComponentUpdateQueue = {
+  lastEffect: Effect | null,
+  events: Array<EventFunctionPayload<any, any, any>> | null,
+  stores: Array<StoreConsistencyCheck<any>> | null,
+  memoCache: MemoCache | null,
+  ownedHostTransitionStatus:
+    | Array<OwnedHostTransitionStatusDependency>
+    | null,
+};
+```
+
+- [x] **Step 2: Initialize and reset the dependency list**
+
+Update `createFunctionComponentUpdateQueue`:
+
+```js
+function createFunctionComponentUpdateQueue(): FunctionComponentUpdateQueue {
+  return {
+    lastEffect: null,
+    events: null,
+    stores: null,
+    memoCache: null,
+    ownedHostTransitionStatus: null,
+  };
+}
+```
+
+Update `resetFunctionComponentUpdateQueue`:
+
+```js
+function resetFunctionComponentUpdateQueue(
+  updateQueue: FunctionComponentUpdateQueue,
+): void {
+  updateQueue.lastEffect = null;
+  updateQueue.events = null;
+  updateQueue.stores = null;
+  updateQueue.ownedHostTransitionStatus = null;
+  if (updateQueue.memoCache != null) {
+    updateQueue.memoCache.index = 0;
+  }
+}
+```
+
+- [x] **Step 3: Add helper to record a dependency**
+
+Below `resetFunctionComponentUpdateQueue`, add:
+
+```js
+function recordOwnedHostTransitionStatusDependency(): TransitionStatus {
+  let updateQueue: FunctionComponentUpdateQueue | null =
+    currentlyRenderingFiber.updateQueue as any;
+  if (updateQueue === null) {
+    updateQueue = createFunctionComponentUpdateQueue();
+    currentlyRenderingFiber.updateQueue = updateQueue as any;
+  }
+
+  const dependency: OwnedHostTransitionStatusDependency = {
+    kind: 'form',
+    owner: currentlyRenderingFiber,
+    provider: null,
+    value: NoPendingHostTransition,
+    ambiguous: false,
+  };
+
+  if (updateQueue.ownedHostTransitionStatus === null) {
+    updateQueue.ownedHostTransitionStatus = [dependency];
+  } else {
+    updateQueue.ownedHostTransitionStatus.push(dependency);
+  }
+
+  return NoPendingHostTransition;
+}
+```
+
+- [x] **Step 4: Run Flow status for dom-node**
+
+Run:
+
+```bash
+cp scripts/flow/dom-node/.flowconfig .flowconfig
+./node_modules/.bin/flow status
+```
+
+Expected: Flow passes or reports only errors introduced by missing imports in this task.
+
+- [x] **Step 5: Commit storage changes**
+
+```bash
+git add packages/react-reconciler/src/ReactFiberHooks.js
+git commit -m "feat: track owned host status dependencies"
+```
+
+---
+
+### Task 3: Record Dependencies from useHostTransitionStatus
+
+**Files:**
+- Modify: `packages/react-reconciler/src/ReactFiberHooks.js`
+
+- [x] **Step 1: Change the hook implementation**
+
+Replace:
+
+```js
+function useHostTransitionStatus(): TransitionStatus {
+  return readContext(HostTransitionContext);
+}
+```
+
+with:
+
+```js
+function useHostTransitionStatus(): TransitionStatus {
+  const status = readContext(HostTransitionContext);
+  if (status !== NoPendingHostTransition) {
+    return status;
+  }
+  return recordOwnedHostTransitionStatusDependency();
+}
+```
+
+- [x] **Step 2: Verify existing child behavior still passes**
+
+Run:
+
+```bash
+yarn test ReactDOMForm-test --runInBand
+```
+
+Expected: existing child-component form status tests still pass; the new same-component test still fails because dependencies are not bound to forms yet.
+
+- [x] **Step 3: Commit hook dependency recording**
+
+```bash
+git add packages/react-reconciler/src/ReactFiberHooks.js
+git commit -m "feat: record owned form status reads"
+```
+
+---
+
+### Task 4: Bind Dependencies to Directly Owned Forms
+
+**Files:**
+- Modify: `packages/react-reconciler/src/ReactFiberHooks.js`
+- Modify: `packages/react-reconciler/src/ReactFiberBeginWork.js`
+
+- [x] **Step 1: Export binding helpers from ReactFiberHooks**
+
+Add these exports near the owned dependency helper code:
+
+```js
+export function bindOwnedHostTransitionStatusDependencies(
+  owner: Fiber,
+  provider: Fiber,
+): void {
+  const updateQueue: FunctionComponentUpdateQueue | null =
+    owner.updateQueue as any;
+  const dependencies =
+    updateQueue !== null ? updateQueue.ownedHostTransitionStatus : null;
+  if (dependencies === null) {
+    return;
+  }
+
+  for (let i = 0; i < dependencies.length; i++) {
+    const dependency = dependencies[i];
+    if (dependency.kind !== 'form') {
+      continue;
+    }
+    if (dependency.provider === null) {
+      dependency.provider = provider;
+      dependency.value = getTransitionStatusFromHostFiber(provider);
+    } else if (dependency.provider !== provider) {
+      dependency.ambiguous = true;
+      dependency.provider = null;
+      dependency.value = NoPendingHostTransition;
+    }
+  }
+}
+
+function getTransitionStatusFromHostFiber(provider: Fiber): TransitionStatus {
+  const stateHook: Hook | null = provider.memoizedState;
+  if (stateHook === null) {
+    return NoPendingHostTransition;
+  }
+  return stateHook.memoizedState;
+}
+```
+
+- [x] **Step 2: Add DEV warning helper**
+
+In `ReactFiberHooks.js`, add:
+
+```js
+export function warnIfOwnedHostTransitionStatusIsAmbiguous(
+  owner: Fiber,
+): void {
+  if (__DEV__) {
+    const updateQueue: FunctionComponentUpdateQueue | null =
+      owner.updateQueue as any;
+    const dependencies =
+      updateQueue !== null ? updateQueue.ownedHostTransitionStatus : null;
+    if (dependencies === null) {
+      return;
+    }
+    for (let i = 0; i < dependencies.length; i++) {
+      if (dependencies[i].ambiguous) {
+        console.error(
+          'useFormStatus() was called in a component that returns multiple ' +
+            '<form> elements. React cannot infer which form status to read. ' +
+            'Move useFormStatus() into a child of the form, or use an explicit ' +
+            'form scope when that API is available.',
+        );
+        return;
+      }
+    }
+  }
+}
+```
+
+- [x] **Step 3: Import helpers in ReactFiberBeginWork**
+
+In `packages/react-reconciler/src/ReactFiberBeginWork.js`, extend the hooks import:
+
+```js
+import {
+  renderTransitionAwareHostComponentWithHooks,
+  bindOwnedHostTransitionStatusDependencies,
+  warnIfOwnedHostTransitionStatusIsAmbiguous,
+} from './ReactFiberHooks';
+```
+
+Keep existing imported names in that import block.
+
+- [x] **Step 4: Add direct child binding helper in ReactFiberBeginWork**
+
+Add this helper near `updateFunctionComponent` helpers:
+
+```js
+function bindOwnedHostTransitionStatusToDirectForms(
+  owner: Fiber,
+  child: Fiber | null,
+): void {
+  let node = child;
+  while (node !== null) {
+    if (node.tag === HostComponent && node.type === 'form') {
+      bindOwnedHostTransitionStatusDependencies(owner, node);
+    }
+    node = node.sibling;
+  }
+  warnIfOwnedHostTransitionStatusIsAmbiguous(owner);
+}
+```
+
+- [x] **Step 5: Call binding after function children are reconciled**
+
+In `updateFunctionComponent`, immediately after:
+
+```js
+  reconcileChildren(current, workInProgress, nextChildren, renderLanes);
+```
+
+add:
+
+```js
+bindOwnedHostTransitionStatusToDirectForms(workInProgress, workInProgress.child);
+```
+
+Keep the existing `return workInProgress.child;` as the next statement.
+
+- [x] **Step 6: Verify failure narrows to scheduling**
+
+Run:
+
+```bash
+yarn test ReactDOMForm-test --runInBand
+```
+
+Expected: the new test may still fail on the pending update because the owner is not scheduled when the form status changes. Existing tests should continue passing.
+
+- [x] **Step 7: Commit binding changes**
+
+```bash
+git add packages/react-reconciler/src/ReactFiberHooks.js packages/react-reconciler/src/ReactFiberBeginWork.js
+git commit -m "feat: bind owned form status dependencies"
+```
+
+---
+
+### Task 5: Schedule Owners When Form Status Changes
+
+**Files:**
+- Modify: `packages/react-reconciler/src/ReactFiberHooks.js`
+- Modify: `packages/react-reconciler/src/ReactFiberBeginWork.js`
+
+- [x] **Step 1: Export a scheduler helper**
+
+In `ReactFiberHooks.js`, add:
+
+```js
+export function markOwnedHostTransitionStatusChanged(
+  provider: Fiber,
+  newState: TransitionStatus,
+  renderLanes: Lanes,
+): void {
+  let owner = provider.return;
+  while (owner !== null) {
+    const updateQueue: FunctionComponentUpdateQueue | null =
+      owner.updateQueue as any;
+    const dependencies =
+      updateQueue !== null ? updateQueue.ownedHostTransitionStatus : null;
+    if (dependencies !== null) {
+      for (let i = 0; i < dependencies.length; i++) {
+        const dependency = dependencies[i];
+        if (dependency.provider === provider && dependency.value !== newState) {
+          dependency.value = newState;
+          owner.lanes = mergeLanes(owner.lanes, renderLanes);
+          const alternate = owner.alternate;
+          if (alternate !== null) {
+            alternate.lanes = mergeLanes(alternate.lanes, renderLanes);
+          }
+          scheduleOwnedHostTransitionStatusWorkOnParentPath(
+            owner.return,
+            renderLanes,
+          );
+        }
+      }
+    }
+    owner = owner.return;
+  }
+}
+
+function scheduleOwnedHostTransitionStatusWorkOnParentPath(
+  parent: Fiber | null,
+  renderLanes: Lanes,
+): void {
+  let node = parent;
+  while (node !== null) {
+    const alternate = node.alternate;
+    if (!isSubsetOfLanes(node.childLanes, renderLanes)) {
+      node.childLanes = mergeLanes(node.childLanes, renderLanes);
+      if (alternate !== null) {
+        alternate.childLanes = mergeLanes(alternate.childLanes, renderLanes);
+      }
+    } else if (
+      alternate !== null &&
+      !isSubsetOfLanes(alternate.childLanes, renderLanes)
+    ) {
+      alternate.childLanes = mergeLanes(alternate.childLanes, renderLanes);
+    }
+    node = node.return;
+  }
+}
+```
+
+`ReactFiberHooks.js` already imports `mergeLanes` and `isSubsetOfLanes` from `ReactFiberLane`; keep those imports in place.
+
+- [x] **Step 2: Import scheduler helper in ReactFiberBeginWork**
+
+```js
+import {
+  renderTransitionAwareHostComponentWithHooks,
+  bindOwnedHostTransitionStatusDependencies,
+  markOwnedHostTransitionStatusChanged,
+  warnIfOwnedHostTransitionStatusIsAmbiguous,
+} from './ReactFiberHooks';
+```
+
+- [x] **Step 3: Call scheduler helper when host transition state changes**
+
+In `updateHostComponent`, after `newState` is computed and before writing `HostTransitionContext`, add:
+
+```js
+    const oldState =
+      current !== null && current.memoizedState !== null
+        ? current.memoizedState.memoizedState
+        : NotPendingTransition;
+    if (oldState !== newState) {
+      markOwnedHostTransitionStatusChanged(
+        workInProgress,
+        newState,
+        renderLanes,
+      );
+    }
+```
+
+Keep the existing `HostTransitionContext._currentValue = newState` logic unchanged.
+
+- [x] **Step 4: Run same-component test**
+
+Run:
+
+```bash
+yarn test ReactDOMForm-test --runInBand
+```
+
+Expected: the new same-component test passes. Existing tests in `ReactDOMForm-test` pass.
+
+- [x] **Step 5: Commit scheduling changes**
+
+```bash
+git add packages/react-reconciler/src/ReactFiberHooks.js packages/react-reconciler/src/ReactFiberBeginWork.js
+git commit -m "feat: schedule owned form status readers"
+```
+
+---
+
+### Task 6: Add Ambiguity Test
+
+**Files:**
+- Modify: `packages/react-dom/src/__tests__/ReactDOMForm-test.js`
+
+- [x] **Step 1: Add multi-form ambiguity test**
+
+Insert this test near the same-component test:
+
+```js
+  it('useFormStatus returns not pending for ambiguous same-component forms', async () => {
+    const firstFormRef = React.createRef();
+    const secondFormRef = React.createRef();
+
+    async function firstAction() {
+      Scheduler.log('First action started');
+      await getText('First');
+    }
+
+    async function secondAction() {
+      Scheduler.log('Second action started');
+      await getText('Second');
+    }
+
+    function App() {
+      const {pending} = useFormStatus();
+      return (
+        <>
+          <form action={firstAction} ref={firstFormRef}>
+            <Text text={pending ? 'Pending' : 'Not pending'} />
+          </form>
+          <form action={secondAction} ref={secondFormRef} />
+        </>
+      );
+    }
+
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => root.render(<App />));
+    assertLog(['Not pending']);
+    expect(container.textContent).toBe('Not pending');
+
+    await submit(firstFormRef.current);
+    assertLog(['First action started']);
+    expect(container.textContent).toBe('Not pending');
+
+    await act(() => resolveText('First'));
+  });
+```
+
+- [x] **Step 2: Add DEV warning assertion**
+
+`ReactDOMForm-test.js` already initializes `assertConsoleErrorDev` in `beforeEach`. After the initial render, assert the warning:
+
+```js
+    await act(() => root.render(<App />));
+    assertConsoleErrorDev([
+      'useFormStatus() was called in a component that returns multiple <form> elements. ' +
+        'React cannot infer which form status to read. Move useFormStatus() into a child ' +
+        'of the form, or use an explicit form scope when that API is available.\n' +
+        '    in App (at **)',
+    ]);
+```
+
+- [x] **Step 3: Run ambiguity test**
+
+Run:
+
+```bash
+yarn test ReactDOMForm-test --runInBand
+```
+
+Expected: all tests in `ReactDOMForm-test` pass.
+
+- [x] **Step 4: Commit ambiguity coverage**
+
+```bash
+git add packages/react-dom/src/__tests__/ReactDOMForm-test.js
+git commit -m "test: cover ambiguous owned form status"
+```
+
+---
+
+### Task 7: Verify Server Rendering Stays Not Pending
+
+**Files:**
+- Modify: `packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js`
+
+- [x] **Step 1: Add same-component server render assertion**
+
+Near the existing `useFormStatus is not pending during server render` test, add:
+
+```js
+  it('useFormStatus in the same component as a form is not pending during server render', async () => {
+    function App() {
+      const {pending} = useFormStatus();
+      return (
+        <form action={() => {}}>
+          <span>{pending ? 'Pending' : 'Not pending'}</span>
+        </form>
+      );
+    }
+
+    const stream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(<App />),
+    );
+    await readIntoContainer(stream);
+    expect(container.textContent).toBe('Not pending');
+  });
+```
+
+`ReactDOMFizzForm-test.js` already defines `readIntoContainer(stream)` and initializes `serverAct` in `beforeEach`; use both exactly as shown.
+
+- [x] **Step 2: Run server form test**
+
+Run:
+
+```bash
+yarn test ReactDOMFizzForm-test --runInBand
+```
+
+Expected: all tests in `ReactDOMFizzForm-test` pass.
+
+- [x] **Step 3: Commit server coverage**
+
+```bash
+git add packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js
+git commit -m "test: preserve server form status behavior"
+```
+
+---
+
+### Task 8: Full Focused Verification
+
+**Files:**
+- No source changes.
+
+- [x] **Step 1: Run development focused suites**
+
+```bash
+yarn test ReactDOMForm-test ReactDOMFizzForm-test --runInBand
+```
+
+Expected: both suites pass.
+
+- [x] **Step 2: Run production focused suites**
+
+```bash
+yarn test --prod ReactDOMForm-test ReactDOMFizzForm-test --runInBand
+```
+
+Expected: both suites pass in production mode.
+
+- [x] **Step 3: Run changed-file lint**
+
+```bash
+yarn linc
+```
+
+Expected: changed-file lint passes.
+
+- [x] **Step 4: Run formatting**
+
+```bash
+yarn prettier
+```
+
+Expected: command completes and leaves no unexpected formatting diff.
+
+- [x] **Step 5: Run Flow for DOM renderer**
+
+```bash
+cp scripts/flow/dom-node/.flowconfig .flowconfig
+./node_modules/.bin/flow status
+```
+
+Expected: Flow exits with code 0.
+
+- [x] **Step 6: Check whitespace**
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+- [x] **Step 7: Commit verification-only formatting changes**
+
+Run `git status --short`. When `yarn prettier` changed files, commit them:
+
+```bash
+git add packages/react-dom/src/__tests__/ReactDOMForm-test.js packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js packages/react-reconciler/src/ReactFiberHooks.js packages/react-reconciler/src/ReactFiberBeginWork.js
+git commit -m "style: format owned form status changes"
+```
+
+When `git status --short` shows no formatting changes after verification, skip this commit.
+
+---
+
+## Implementation Notes (2026-07-06)
+
+Tasks 1-3 were implemented as planned. Tasks 4-7 landed with the following
+deviations from the plan's sketched code, all discovered through the plan's own
+verification steps:
+
+1. **Owner notification moved from render phase to commit phase.** The plan's
+   `markOwnedHostTransitionStatusChanged` ran during `updateHostComponent` and
+   mutated owner fiber lanes from within a render attempt. Form actions apply
+   pending status as an optimistic update with a `revertLane`, so render
+   attempts at the transition lane compute a reverted (not pending) status and
+   then suspend without committing. Notifying owners from those doomed attempts
+   caused an infinite re-render loop (observed: 1785 re-renders in one test
+   run). The implementation instead:
+   - sets the `Callback` flag on the form fiber during render when the newly
+     computed status differs from the committed status (a flag on the
+     work-in-progress fiber dies with a discarded attempt, so this is safe);
+   - notifies owners from `commitLayoutEffectOnFiber` via a new
+     `commitOwnedHostTransitionStatusChanged`, which schedules the owner with
+     `enqueueConcurrentRenderForLane` + `scheduleUpdateOnFiber` at `SyncLane` -
+     the same mechanism `useSyncExternalStore` uses for store inconsistency.
+   The plan's `scheduleOwnedHostTransitionStatusWorkOnParentPath` was dropped;
+   proper update scheduling handles root/child lanes.
+
+2. **The hook carries the observed status across renders.** The plan's
+   `useHostTransitionStatus` always returned `NotPending` when no parent
+   context was pending, because `renderWithHooks` clears the update queue
+   before hooks run and binding happens after the component returns. The
+   implemented `recordOwnedHostTransitionStatusDependency` reads the previous
+   render's dependency (matched by hook call order index on the alternate's
+   update queue) and returns its carried `value`.
+
+3. **`renderedValue` field + bailout prevention.** Dependencies track both the
+   last observed status (`value`, updated by the commit-phase notifier) and the
+   status the owner actually rendered with (`renderedValue`). When they differ
+   during a re-render the hook calls `markWorkInProgressReceivedUpdate()`,
+   otherwise the owner bails out after rendering and its children never
+   reconcile against the new status.
+
+4. **Alternate-aware provider identity.** Fibers flip between two alternates,
+   so `dependency.provider === provider` checks also accept
+   `provider.alternate`.
+
+5. **Loose null checks on `ownedHostTransitionStatus`.** Non-function fibers
+   reuse `updateQueue` for other data structures where the property is
+   `undefined`; the ancestor walk uses `!= null` to avoid crashing on them.
+
+6. **Fizz test assertion.** The server-render test asserts on the `<span>`'s
+   text instead of `container.textContent`, because Fizz injects the form
+   action replay script whose source otherwise appears in `textContent`.

--- a/docs/superpowers/specs/2026-07-06-owned-host-context-design.md
+++ b/docs/superpowers/specs/2026-07-06-owned-host-context-design.md
@@ -1,0 +1,212 @@
+# Owned Host Context
+
+## Summary
+
+Owned Host Context is a proposed React primitive that lets a function component observe state from a host component it directly owns, without changing normal parent-to-child context flow.
+
+The motivating case is `useFormStatus`. Today, `useFormStatus()` reads the nearest parent form's host transition context. It cannot read a `<form>` returned by the same component because React evaluates hooks before reconciling the returned host children.
+
+This proposal keeps normal context semantics intact and adds a separate, renderer-owned channel for stateful host resources declared by the same component.
+
+## Goals
+
+- Allow the ergonomic form pattern:
+
+  ```js
+  function Form() {
+    const {pending} = useFormStatus();
+    return (
+      <form action={submit}>
+        <button disabled={pending}>Save</button>
+      </form>
+    );
+  }
+  ```
+
+- Preserve existing descendant behavior:
+
+  ```js
+  function Submit() {
+    const {pending} = useFormStatus();
+    return <button disabled={pending}>Save</button>;
+  }
+  ```
+
+- Avoid guessing when one component owns multiple possible providers.
+- Avoid adding overhead to every normal Context read.
+- Keep the mechanism renderer-defined, so React DOM can use it for forms without forcing every renderer to support the same host resources.
+
+## Non-Goals
+
+- Do not make ordinary React Context flow upward or sideways.
+- Do not make hooks inspect JSX directly during hook evaluation.
+- Do not infer status from arbitrary nested forms, portals, or components.
+- Do not change public `useFormStatus` behavior for already-supported child components.
+
+## Current Model
+
+React DOM form status is implemented as a host transition context.
+
+- A form host fiber is upgraded to be stateful when a form action starts.
+- During host context push, React DOM writes the form status into `HostTransitionContext`.
+- Descendants read that context through `useHostTransitionStatus`, which powers `useFormStatus`.
+- The component that returns the `<form>` cannot read that form's status, because hooks run before React has reconciled the returned `<form>` fiber.
+
+This is correct under normal Context semantics: providers affect descendants, not the component that returns them.
+
+## Proposed Concept
+
+Add an internal primitive called Owned Host Context.
+
+An owned host context is a relationship between:
+
+- an owner function fiber,
+- a renderer-recognized host fiber returned by that owner, and
+- a host state value exposed to hooks in the owner.
+
+Unlike normal Context, this is not lexical parent-to-child propagation. It is an owner-to-owned-resource subscription, closer to a render-observable ref, but integrated with scheduling and Fiber identity.
+
+## Implicit Ergonomics
+
+For the common case, `useFormStatus()` can implicitly request an owned form status if no parent form status exists.
+
+Render behavior:
+
+1. `useFormStatus()` reads the current parent `HostTransitionContext`.
+2. If a parent form is pending, return that status exactly as today.
+3. If no parent form is active, record an unresolved owned-host-context dependency on the currently rendering function fiber.
+4. Continue rendering normally.
+5. During reconciliation of the returned children, if React sees exactly one directly owned `<form>` host fiber, bind the dependency to that form fiber.
+6. When the form status changes, schedule the owning function fiber to render.
+
+Directly owned means the `<form>` appears in the returned element tree before crossing another function/class component boundary. This avoids turning owned host context into a general descendant query.
+
+## Ambiguity
+
+If a component calls `useFormStatus()` and directly owns multiple forms, React must not guess.
+
+Development behavior:
+
+- Warn that `useFormStatus()` is ambiguous because the component owns multiple forms.
+- Return `NotPending`.
+- Suggest the explicit scope API.
+
+Production behavior:
+
+- Return `NotPending`.
+- Do not bind implicitly.
+
+If a component calls `useFormStatus()` and owns no form, behavior remains equivalent to today: it reads the parent context if one exists, otherwise returns `NotPending`.
+
+## Explicit Scope API
+
+For ambiguous or advanced cases, add an explicit renderer-owned scope token.
+
+Possible API shape:
+
+```js
+function Form() {
+  const form = useHostContextScope('form');
+  const {pending} = useFormStatus(form);
+
+  return (
+    <form unstable_scope={form} action={submit}>
+      <button disabled={pending}>Save</button>
+    </form>
+  );
+}
+```
+
+The token is opaque. React DOM owns its meaning. React core only tracks the relationship between the token, the owner fiber, and the host fiber that consumes it.
+
+Rules:
+
+- A scope token may be attached to one matching host component per render.
+- Attaching a token to the wrong host type warns in development.
+- Reusing a token for multiple host instances warns in development.
+- `useFormStatus(scope)` reads only that scoped form's status.
+
+This API can remain unstable until a second host use case validates the abstraction.
+
+## Scheduling
+
+When a host resource status changes:
+
+- Existing descendant context propagation continues as today.
+- Any owner fibers subscribed through owned host context are scheduled on the same lane as the host status update.
+- If the owner re-renders and no longer owns the host fiber, the subscription is detached during reconciliation.
+
+This prevents stale status reads while preserving React's render-before-commit model.
+
+## Fiber Data Model
+
+The implementation can be modeled with two internal structures:
+
+- On the owner function fiber: a list of requested owned host context dependencies.
+- On the host fiber: a back-reference set of owner fibers or dependency records that observe its host status.
+
+For `useFormStatus`, the dependency stores:
+
+- host resource kind: `form`,
+- optional explicit scope token,
+- last bound host fiber,
+- last observed status.
+
+The host fiber remains the source of truth for pending form status.
+
+## Server Rendering
+
+During server render, form actions are not pending. `useFormStatus()` already returns `NotPending`.
+
+Owned host context should preserve that behavior:
+
+- No owned host subscriptions are created on the server.
+- Implicit self-form status always resolves to `NotPending`.
+- Markup output is unchanged.
+
+## Error Handling
+
+Development warnings:
+
+- Multiple implicitly owned forms.
+- Explicit scope attached to no host by the end of reconciliation.
+- Explicit scope attached to the wrong host type.
+- Explicit scope reused by multiple host instances.
+
+Runtime errors should be avoided because the current hook returns `NotPending` outside a form rather than throwing.
+
+## Testing Plan
+
+React DOM tests should cover:
+
+- `useFormStatus()` in the same component as a single returned `<form>`.
+- Existing child-component `useFormStatus()` behavior remains unchanged.
+- Parent form context wins over owned form context when nested ownership-like shapes appear through components.
+- Multiple directly owned forms warn in development and return `NotPending`.
+- Explicit scope selects the intended form among multiple forms.
+- Scope warnings for wrong host type and duplicate attachment.
+- Server rendering returns `NotPending` and does not change markup.
+
+## Risks
+
+- This is a new direction for React dataflow. Naming and documentation must avoid implying ordinary Context can flow upward.
+- Implicit binding may be hard to explain if the returned JSX is conditional.
+- Owner subscriptions add a new invalidation edge from host fibers back to function fibers.
+- The explicit API needs careful naming because `scope` may imply CSS or DOM scoping.
+
+## Recommendation
+
+Implement this in two stages.
+
+Stage 1:
+
+- Internal owned-host-context dependency infrastructure.
+- Implicit `useFormStatus()` support for the single directly owned form case.
+- Development warnings for ambiguity.
+
+Stage 2:
+
+- Add the explicit scope token API behind an unstable name.
+- Use it to resolve multiple-form cases.
+- Revisit whether the abstraction should remain form-specific or become a public renderer capability.
+

--- a/packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzForm-test.js
@@ -455,6 +455,25 @@ describe('ReactDOMFizzForm', () => {
     expect(container.textContent).toBe('Pending: false');
   });
 
+  it('useFormStatus in the same component as a form is not pending during server render', async () => {
+    function App() {
+      const {pending} = useFormStatus();
+      return (
+        <form action={() => {}}>
+          <span>{pending ? 'Pending' : 'Not pending'}</span>
+        </form>
+      );
+    }
+
+    const stream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(<App />),
+    );
+    await readIntoContainer(stream);
+    // The container also holds the form action replay script that Fizz
+    // injects for forms with actions, so read only the span's text.
+    expect(container.querySelector('span').textContent).toBe('Not pending');
+  });
+
   it('should replay a form action after hydration', async () => {
     let foo;
     function action(formData) {

--- a/packages/react-dom/src/__tests__/ReactDOMForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMForm-test.js
@@ -992,6 +992,50 @@ describe('ReactDOMForm', () => {
     expect(container.textContent).toBe('No pending action');
   });
 
+  it('useFormStatus returns not pending for ambiguous same-component forms', async () => {
+    const firstFormRef = React.createRef();
+    const secondFormRef = React.createRef();
+
+    async function firstAction() {
+      Scheduler.log('First action started');
+      await getText('First');
+    }
+
+    async function secondAction() {
+      Scheduler.log('Second action started');
+      await getText('Second');
+    }
+
+    function App() {
+      const {pending} = useFormStatus();
+      return (
+        <>
+          <form action={firstAction} ref={firstFormRef}>
+            <Text text={pending ? 'Pending' : 'Not pending'} />
+          </form>
+          <form action={secondAction} ref={secondFormRef} />
+        </>
+      );
+    }
+
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => root.render(<App />));
+    assertConsoleErrorDev([
+      'useFormStatus() was called in a component that returns multiple <form> elements. ' +
+        'React cannot infer which form status to read. Move useFormStatus() into a child ' +
+        'of the form, or use an explicit form scope when that API is available.\n' +
+        '    in App (at **)',
+    ]);
+    assertLog(['Not pending']);
+    expect(container.textContent).toBe('Not pending');
+
+    await submit(firstFormRef.current);
+    assertLog(['First action started']);
+    expect(container.textContent).toBe('Not pending');
+
+    await act(() => resolveText('First'));
+  });
+
   it('should error if submitting a form manually', async () => {
     const ref = React.createRef();
 

--- a/packages/react-dom/src/__tests__/ReactDOMForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMForm-test.js
@@ -945,6 +945,53 @@ describe('ReactDOMForm', () => {
     assertLog(['Async action finished', 'No pending action']);
   });
 
+  it('useFormStatus can read the status of a form returned by the same component', async () => {
+    const formRef = React.createRef();
+
+    async function myAction() {
+      Scheduler.log('Async action started');
+      await getText('Wait');
+      Scheduler.log('Async action finished');
+    }
+
+    function App() {
+      const {pending, data, action, method} = useFormStatus();
+      let status;
+      if (!pending) {
+        status = 'No pending action';
+      } else {
+        status = `Pending action ${action.name}: foo is ${data.get(
+          'foo',
+        )}, method is ${method}`;
+      }
+
+      return (
+        <form action={myAction} ref={formRef}>
+          <input type="text" name="foo" defaultValue="bar" />
+          <Text text={status} />
+        </form>
+      );
+    }
+
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => root.render(<App />));
+    assertLog(['No pending action']);
+    expect(container.textContent).toBe('No pending action');
+
+    await submit(formRef.current);
+    assertLog([
+      'Async action started',
+      'Pending action myAction: foo is bar, method is get',
+    ]);
+    expect(container.textContent).toBe(
+      'Pending action myAction: foo is bar, method is get',
+    );
+
+    await act(() => resolveText('Wait'));
+    assertLog(['Async action finished', 'No pending action']);
+    expect(container.textContent).toBe('No pending action');
+  });
+
   it('should error if submitting a form manually', async () => {
     const ref = React.createRef();
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -226,6 +226,8 @@ import {
   bailoutHooks,
   replaySuspendedComponentWithHooks,
   renderTransitionAwareHostComponentWithHooks,
+  bindOwnedHostTransitionStatusDependencies,
+  warnIfOwnedHostTransitionStatusIsAmbiguous,
 } from './ReactFiberHooks';
 import {stopProfilerTimerIfRunning} from './ReactProfilerTimer';
 import {
@@ -1531,7 +1533,25 @@ function updateFunctionComponent(
   // React DevTools reads this flag.
   workInProgress.flags |= PerformedWork;
   reconcileChildren(current, workInProgress, nextChildren, renderLanes);
+  bindOwnedHostTransitionStatusToDirectForms(
+    workInProgress,
+    workInProgress.child,
+  );
   return workInProgress.child;
+}
+
+function bindOwnedHostTransitionStatusToDirectForms(
+  owner: Fiber,
+  child: Fiber | null,
+): void {
+  let node = child;
+  while (node !== null) {
+    if (node.tag === HostComponent && node.type === 'form') {
+      bindOwnedHostTransitionStatusDependencies(owner, node);
+    }
+    node = node.sibling;
+  }
+  warnIfOwnedHostTransitionStatusIsAmbiguous(owner);
 }
 
 export function replayFunctionComponent(

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -183,6 +183,7 @@ import {
   getResource,
   createHoistableInstance,
   HostTransitionContext,
+  NotPendingTransition,
 } from './ReactFiberConfig';
 import type {ActivityInstance, SuspenseInstance} from './ReactFiberConfig';
 import {shouldError, shouldSuspend} from './ReactFiberReconciler';
@@ -1999,6 +2000,23 @@ function updateHostComponent(
       workInProgress,
       renderLanes,
     );
+
+    // If the transition state changed compared to what was last committed,
+    // schedule a commit-phase notification for function components that
+    // observe this form's status through an owned host status dependency,
+    // i.e. components that returned this form directly. They live above this
+    // fiber, so context propagation doesn't reach them, and they cannot be
+    // notified during render because this render attempt may never commit.
+    // Callback is otherwise unused on host components and is part of the
+    // layout effect mask, which guarantees the commit phase visits this
+    // fiber even when nothing else in the subtree changed.
+    const oldState =
+      current !== null && current.memoizedState !== null
+        ? current.memoizedState.memoizedState
+        : NotPendingTransition;
+    if (oldState !== newState) {
+      workInProgress.flags |= Callback;
+    }
 
     // If the transition state changed, propagate the change to all the
     // descendents. We use Context as an implementation detail for this.

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -29,6 +29,7 @@ import type {ActivityState} from './ReactFiberActivityComponent';
 import type {SuspenseState, RetryQueue} from './ReactFiberSuspenseComponent';
 import type {UpdateQueue} from './ReactFiberClassUpdateQueue';
 import type {FunctionComponentUpdateQueue} from './ReactFiberHooks';
+import {commitOwnedHostTransitionStatusChanged} from './ReactFiberHooks';
 import type {Wakeable, ViewTransitionProps} from 'shared/ReactTypes';
 import type {
   OffscreenState,
@@ -687,6 +688,13 @@ function commitLayoutEffectOnFiber(
         } else if (flags & Hydrate) {
           commitHostHydratedInstance(finishedWork);
         }
+      }
+
+      // A stateful host component (a form with a pending action) committed a
+      // transition status change. Notify function components that observe
+      // this status as a directly owned form so they re-render with it.
+      if (flags & Callback) {
+        commitOwnedHostTransitionStatusChanged(finishedWork);
       }
 
       if (flags & Ref) {

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1129,6 +1129,67 @@ function recordOwnedHostTransitionStatusDependency(): TransitionStatus {
   return NoPendingHostTransition;
 }
 
+export function bindOwnedHostTransitionStatusDependencies(
+  owner: Fiber,
+  provider: Fiber,
+): void {
+  const updateQueue: FunctionComponentUpdateQueue | null =
+    owner.updateQueue as any;
+  const dependencies =
+    updateQueue !== null ? updateQueue.ownedHostTransitionStatus : null;
+  if (dependencies == null) {
+    return;
+  }
+
+  for (let i = 0; i < dependencies.length; i++) {
+    const dependency = dependencies[i];
+    if (dependency.kind !== 'form') {
+      continue;
+    }
+    if (dependency.provider === null) {
+      dependency.provider = provider;
+      dependency.value = getTransitionStatusFromHostFiber(provider);
+    } else if (dependency.provider !== provider) {
+      dependency.ambiguous = true;
+      dependency.provider = null;
+      dependency.value = NoPendingHostTransition;
+    }
+  }
+}
+
+function getTransitionStatusFromHostFiber(provider: Fiber): TransitionStatus {
+  const stateHook: Hook | null = provider.memoizedState;
+  if (stateHook === null) {
+    return NoPendingHostTransition;
+  }
+  return stateHook.memoizedState;
+}
+
+export function warnIfOwnedHostTransitionStatusIsAmbiguous(
+  owner: Fiber,
+): void {
+  if (__DEV__) {
+    const updateQueue: FunctionComponentUpdateQueue | null =
+      owner.updateQueue as any;
+    const dependencies =
+      updateQueue !== null ? updateQueue.ownedHostTransitionStatus : null;
+    if (dependencies == null) {
+      return;
+    }
+    for (let i = 0; i < dependencies.length; i++) {
+      if (dependencies[i].ambiguous) {
+        console.error(
+          'useFormStatus() was called in a component that returns multiple ' +
+            '<form> elements. React cannot infer which form status to read. ' +
+            'Move useFormStatus() into a child of the form, or use an explicit ' +
+            'form scope when that API is available.',
+        );
+        return;
+      }
+    }
+  }
+}
+
 function useThenable<T>(thenable: Thenable<T>): T {
   // Track the position of the thenable within this fiber.
   const index = thenableIndexCounter;

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1117,16 +1117,48 @@ function recordOwnedHostTransitionStatusDependency(): TransitionStatus {
     owner: currentlyRenderingFiber,
     provider: null,
     value: NoPendingHostTransition,
+    renderedValue: NoPendingHostTransition,
     ambiguous: false,
   };
 
+  let index;
   if (updateQueue.ownedHostTransitionStatus === null) {
+    index = 0;
     updateQueue.ownedHostTransitionStatus = [dependency];
   } else {
+    index = updateQueue.ownedHostTransitionStatus.length;
     updateQueue.ownedHostTransitionStatus.push(dependency);
   }
 
-  return NoPendingHostTransition;
+  // The owner's hooks run before its returned children are reconciled, so a
+  // freshly recorded dependency is always unbound. If a previous render
+  // already observed an owned form's status, carry that value forward.
+  // Dependencies are recorded in hook call order, so matching by index pairs
+  // this read with the same read from the previous render.
+  const current = currentlyRenderingFiber.alternate;
+  if (current !== null) {
+    const currentUpdateQueue: FunctionComponentUpdateQueue | null =
+      current.updateQueue as any;
+    const currentDependencies =
+      currentUpdateQueue !== null
+        ? currentUpdateQueue.ownedHostTransitionStatus
+        : null;
+    if (currentDependencies != null && index < currentDependencies.length) {
+      const currentDependency = currentDependencies[index];
+      if (currentDependency.kind === 'form') {
+        dependency.value = currentDependency.value;
+        dependency.renderedValue = currentDependency.value;
+        if (currentDependency.renderedValue !== currentDependency.value) {
+          // The bound form's status changed since the owner last rendered.
+          // The owner must reconcile its children instead of bailing out,
+          // the same way a changed state hook prevents a bailout.
+          markWorkInProgressReceivedUpdate();
+        }
+      }
+    }
+  }
+
+  return dependency.value;
 }
 
 export function bindOwnedHostTransitionStatusDependencies(
@@ -1146,13 +1178,15 @@ export function bindOwnedHostTransitionStatusDependencies(
     if (dependency.kind !== 'form') {
       continue;
     }
-    if (dependency.provider === null) {
+    if (dependency.provider === null && !dependency.ambiguous) {
       dependency.provider = provider;
       dependency.value = getTransitionStatusFromHostFiber(provider);
+      dependency.renderedValue = dependency.value;
     } else if (dependency.provider !== provider) {
       dependency.ambiguous = true;
       dependency.provider = null;
       dependency.value = NoPendingHostTransition;
+      dependency.renderedValue = NoPendingHostTransition;
     }
   }
 }
@@ -1163,6 +1197,55 @@ function getTransitionStatusFromHostFiber(provider: Fiber): TransitionStatus {
     return NoPendingHostTransition;
   }
   return stateHook.memoizedState;
+}
+
+export function commitOwnedHostTransitionStatusChanged(
+  finishedWork: Fiber,
+): void {
+  // Called during the commit phase when a stateful host component committed
+  // a render in which its transition status changed. Owners are notified
+  // from the commit phase rather than during render because render attempts
+  // at the transition lane compute a reverted (not pending) status and then
+  // suspend until the action resolves. Those attempts never commit, so they
+  // must not be observable to owner components.
+  const stateHook: Hook | null = finishedWork.memoizedState;
+  if (stateHook === null) {
+    return;
+  }
+  const newState: TransitionStatus = stateHook.memoizedState;
+  // The provider flips between its two alternates across render passes, so a
+  // dependency bound during an earlier render can point at either one.
+  const alternateProvider = finishedWork.alternate;
+  let owner = finishedWork.return;
+  while (owner !== null) {
+    const updateQueue: FunctionComponentUpdateQueue | null =
+      owner.updateQueue as any;
+    // Non-function fibers reuse the updateQueue field for other data
+    // structures, so this property may be undefined rather than null.
+    const dependencies =
+      updateQueue !== null ? updateQueue.ownedHostTransitionStatus : null;
+    if (dependencies != null) {
+      for (let i = 0; i < dependencies.length; i++) {
+        const dependency = dependencies[i];
+        if (
+          (dependency.provider === finishedWork ||
+            (alternateProvider !== null &&
+              dependency.provider === alternateProvider)) &&
+          dependency.value !== newState
+        ) {
+          dependency.value = newState;
+          // Schedule the owner to re-render with the committed status. This
+          // is the same mechanism useSyncExternalStore uses to recover from
+          // an inconsistent external store read.
+          const root = enqueueConcurrentRenderForLane(owner, SyncLane);
+          if (root !== null) {
+            scheduleUpdateOnFiber(root, owner, SyncLane);
+          }
+        }
+      }
+    }
+    owner = owner.return;
+  }
 }
 
 export function warnIfOwnedHostTransitionStatusIsAmbiguous(

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -243,11 +243,22 @@ type EventFunctionPayload<Args, Return, F: (...Array<Args>) => Return> = {
   nextImpl: F,
 };
 
+export type OwnedHostTransitionStatusDependency = {
+  kind: 'form',
+  owner: Fiber,
+  provider: Fiber | null,
+  value: TransitionStatus,
+  ambiguous: boolean,
+};
+
 export type FunctionComponentUpdateQueue = {
   lastEffect: Effect | null,
   events: Array<EventFunctionPayload<any, any, any>> | null,
   stores: Array<StoreConsistencyCheck<any>> | null,
   memoCache: MemoCache | null,
+  ownedHostTransitionStatus:
+    | Array<OwnedHostTransitionStatusDependency>
+    | null,
 };
 
 type BasicStateAction<S> = (S => S) | S;
@@ -1074,6 +1085,7 @@ function createFunctionComponentUpdateQueue(): FunctionComponentUpdateQueue {
     events: null,
     stores: null,
     memoCache: null,
+    ownedHostTransitionStatus: null,
   };
 }
 
@@ -1083,12 +1095,38 @@ function resetFunctionComponentUpdateQueue(
   updateQueue.lastEffect = null;
   updateQueue.events = null;
   updateQueue.stores = null;
+  updateQueue.ownedHostTransitionStatus = null;
   if (updateQueue.memoCache != null) {
     // NOTE: this function intentionally does not reset memoCache data. We reuse updateQueue for the memo
     // cache to avoid increasing the size of fibers that don't need a cache, but we don't want to reset
     // the cache when other properties are reset.
     updateQueue.memoCache.index = 0;
   }
+}
+
+function recordOwnedHostTransitionStatusDependency(): TransitionStatus {
+  let updateQueue: FunctionComponentUpdateQueue | null =
+    currentlyRenderingFiber.updateQueue as any;
+  if (updateQueue === null) {
+    updateQueue = createFunctionComponentUpdateQueue();
+    currentlyRenderingFiber.updateQueue = updateQueue as any;
+  }
+
+  const dependency: OwnedHostTransitionStatusDependency = {
+    kind: 'form',
+    owner: currentlyRenderingFiber,
+    provider: null,
+    value: NoPendingHostTransition,
+    ambiguous: false,
+  };
+
+  if (updateQueue.ownedHostTransitionStatus === null) {
+    updateQueue.ownedHostTransitionStatus = [dependency];
+  } else {
+    updateQueue.ownedHostTransitionStatus.push(dependency);
+  }
+
+  return NoPendingHostTransition;
 }
 
 function useThenable<T>(thenable: Thenable<T>): T {

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -247,7 +247,12 @@ export type OwnedHostTransitionStatusDependency = {
   kind: 'form',
   owner: Fiber,
   provider: Fiber | null,
+  // The most recently observed status of the bound provider. Updated by
+  // commitOwnedHostTransitionStatusChanged when a status change commits.
   value: TransitionStatus,
+  // The status the owner actually rendered with. When this differs from
+  // `value` on a subsequent render, the owner cannot bail out.
+  renderedValue: TransitionStatus,
   ambiguous: boolean,
 };
 
@@ -256,9 +261,7 @@ export type FunctionComponentUpdateQueue = {
   events: Array<EventFunctionPayload<any, any, any>> | null,
   stores: Array<StoreConsistencyCheck<any>> | null,
   memoCache: MemoCache | null,
-  ownedHostTransitionStatus:
-    | Array<OwnedHostTransitionStatusDependency>
-    | null,
+  ownedHostTransitionStatus: Array<OwnedHostTransitionStatusDependency> | null,
 };
 
 type BasicStateAction<S> = (S => S) | S;
@@ -1248,9 +1251,7 @@ export function commitOwnedHostTransitionStatusChanged(
   }
 }
 
-export function warnIfOwnedHostTransitionStatusIsAmbiguous(
-  owner: Fiber,
-): void {
+export function warnIfOwnedHostTransitionStatusIsAmbiguous(owner: Fiber): void {
   if (__DEV__) {
     const updateQueue: FunctionComponentUpdateQueue | null =
       owner.updateQueue as any;

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -3485,7 +3485,11 @@ function rerenderTransition(): [
 }
 
 function useHostTransitionStatus(): TransitionStatus {
-  return readContext(HostTransitionContext);
+  const status = readContext(HostTransitionContext);
+  if (status !== NoPendingHostTransition) {
+    return status;
+  }
+  return recordOwnedHostTransitionStatusDependency();
 }
 
 function mountId(): string {


### PR DESCRIPTION
# Owned Host Context Stage 1: same-component useFormStatus

## Summary

Implements Stage 1 of the Owned Host Context design (see `docs/superpowers/specs/2026-07-06-owned-host-context-design.md`): `useFormStatus()` can now observe a single `<form>` returned directly by the same function component, while preserving all existing descendant form status behavior.

Today `useFormStatus()` only reads the nearest *parent* form's host transition context, so the ergonomic pattern of calling the hook in the component that renders the form silently returns "not pending". This PR adds an internal owned-host-status dependency channel:

- `useHostTransitionStatus()` records an owned dependency on the rendering fiber's update queue when no parent host transition is active, carrying forward the last observed status across renders (matched by hook call order).
- After a function component's children are reconciled, a directly returned `<form>` host fiber is bound to the dependency. Multiple directly owned forms are ambiguous: DEV warns and the hook returns not-pending.
- When a stateful form commits a transition status change, a `Callback` flag set during render triggers a commit-phase notification (`commitOwnedHostTransitionStatusChanged`) that schedules the owner fiber at `SyncLane` — the same mechanism `useSyncExternalStore` uses for store inconsistencies. Notifying at commit rather than during render is load-bearing: transition-lane render attempts compute a reverted status and suspend without committing, and reacting to those caused an infinite re-render loop.
- Server rendering behavior is unchanged (always not-pending, no owned subscriptions).

The explicit scope token API for disambiguating multiple forms is deferred to Stage 2 per the design doc. Implementation deviations from the original plan are recorded in `docs/superpowers/plans/2026-07-06-owned-host-context-stage-1.md`.

## How did you test this change?

New tests:

- `ReactDOMForm-test`: `useFormStatus can read the status of a form returned by the same component` (full pending → resolved lifecycle), and `useFormStatus returns not pending for ambiguous same-component forms` (multi-form DEV warning).
- `ReactDOMFizzForm-test`: `useFormStatus in the same component as a form is not pending during server render`.

Verification (all passing):

- `yarn test --silent --no-watchman ReactDOMForm-test ReactDOMFizzForm-test`
- `yarn test --prod --silent --no-watchman ReactDOMForm-test ReactDOMFizzForm-test`
- `yarn test-www --silent --no-watchman ReactDOMForm-test ReactDOMFizzForm-test` (both `__VARIANT__` values)
- `yarn test --silent --no-watchman packages/react-reconciler` — only failures are pre-existing Windows path-separator stack-trace mismatches in `ReactUse-test`/`ReactMemo-test`, reproduced identically on `main`.
- `yarn flow` (dom-node config): no errors.
- `yarn linc`, `yarn prettier`, `git diff --check`: clean.