### PR TITLE
[Fast Refresh] Remount correctly when an edit changes the component kind

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -136,6 +136,7 @@ import {
   resolveFunctionForHotReloading,
   resolveForwardRefForHotReloading,
   resolveClassForHotReloading,
+  resolveRemountTypeForHotReloading,
 } from './ReactFiberHotReloading';
 
 import {
@@ -4195,7 +4196,10 @@ function beginWork(
     if (workInProgress._debugNeedsRemount && current !== null) {
       // This will restart the begin phase with a new fiber.
       const copiedFiber = createFiberFromTypeAndProps(
-        workInProgress.type,
+        resolveRemountTypeForHotReloading(
+          workInProgress.elementType,
+          workInProgress.type,
+        ),
         workInProgress.key,
         workInProgress.pendingProps,
         workInProgress._debugOwner || null,

--- a/packages/react-reconciler/src/ReactFiberHotReloading.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.js
@@ -121,6 +121,29 @@ export function resolveForwardRefForHotReloading(type: any): any {
   }
 }
 
+export function resolveRemountTypeForHotReloading(
+  elementType: any,
+  type: any,
+): any {
+  if (__DEV__) {
+    if (resolveFamily === null) {
+      // Hot reloading is disabled.
+      return type;
+    }
+    // The elementType is the fiber's public identity, so its family tracks
+    // the latest implementation even when an edit changed the kind of the
+    // type (e.g. memo to a plain function) and `type` still points at the
+    // old inner implementation.
+    const family = resolveFamily(elementType);
+    if (family === undefined) {
+      return type;
+    }
+    return family.current;
+  } else {
+    return type;
+  }
+}
+
 export function isCompatibleFamilyForHotReloading(
   fiber: Fiber,
   element: ReactElement,
@@ -130,6 +153,7 @@ export function isCompatibleFamilyForHotReloading(
       // Hot reloading is disabled.
       return false;
     }
+    const resolve = resolveFamily;
 
     const prevType = fiber.elementType;
     const nextType = element.type;
@@ -191,9 +215,8 @@ export function isCompatibleFamilyForHotReloading(
       // If we unwrapped and compared the inner types for wrappers instead,
       // then we would risk falsely saying two separate memo(Foo)
       // calls are equivalent because they wrap the same Foo function.
-      const prevFamily = resolveFamily(prevType);
-      // $FlowFixMe[not-a-function] found when upgrading Flow
-      if (prevFamily !== undefined && prevFamily === resolveFamily(nextType)) {
+      const prevFamily = resolve(prevType);
+      if (prevFamily !== undefined && prevFamily === resolve(nextType)) {
         return true;
       }
     }
@@ -262,17 +285,30 @@ function scheduleFibersWithFamiliesRecursively(
 ): void {
   if (__DEV__) {
     do {
-      const {alternate, child, sibling, tag, type} = fiber;
+      const {alternate, child, sibling, tag, type, elementType} = fiber;
 
       let candidateType = null;
+      // Wrapper fibers (memo, forwardRef) resolve their family through the
+      // inner implementation, but an edit that changes the kind of the type
+      // (e.g. memo to a plain function) is only recorded on the family of the
+      // outer type. Check the outer type too so such edits trigger a remount.
+      let outerCandidateType = null;
       switch (tag) {
         case FunctionComponent:
-        case SimpleMemoComponent:
         case ClassComponent:
           candidateType = type;
           break;
+        case SimpleMemoComponent:
+          candidateType = type;
+          outerCandidateType = elementType;
+          break;
+        case MemoComponent:
+          // Edits to the inner implementation are handled by the inner fiber.
+          outerCandidateType = elementType;
+          break;
         case ForwardRef:
           candidateType = type.render;
+          outerCandidateType = elementType;
           break;
         default:
           break;
@@ -281,11 +317,12 @@ function scheduleFibersWithFamiliesRecursively(
       if (resolveFamily === null) {
         throw new Error('Expected resolveFamily to be set during hot reload.');
       }
+      const resolve = resolveFamily;
 
       let needsRender = false;
       let needsRemount = false;
       if (candidateType !== null) {
-        const family = resolveFamily(candidateType);
+        const family = resolve(candidateType);
         if (family !== undefined) {
           if (staleFamilies.has(family)) {
             needsRemount = true;
@@ -296,6 +333,12 @@ function scheduleFibersWithFamiliesRecursively(
               needsRender = true;
             }
           }
+        }
+      }
+      if (!needsRemount && outerCandidateType !== null) {
+        const outerFamily = resolve(outerCandidateType);
+        if (outerFamily !== undefined && staleFamilies.has(outerFamily)) {
+          needsRemount = true;
         }
       }
       if (failedBoundaries !== null) {

--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -146,6 +146,19 @@ function canPreserveStateBetween(prevType: any, nextType: any) {
   if (isReactClass(prevType) || isReactClass(nextType)) {
     return false;
   }
+  // A fiber's tag is derived from the kind of its type (a plain function
+  // vs memo vs forwardRef), and the reconciler can only swap implementations
+  // in place within the same tag. If the kind changed, the tree must remount.
+  if (typeof prevType !== typeof nextType) {
+    return false;
+  }
+  if (typeof prevType === 'object' && prevType !== null && nextType !== null) {
+    if (
+      getProperty(prevType, '$$typeof') !== getProperty(nextType, '$$typeof')
+    ) {
+      return false;
+    }
+  }
   if (haveEqualSignatures(prevType, nextType)) {
     return true;
   }

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -699,6 +699,301 @@ describe('ReactFresh', () => {
     }
   });
 
+  it('can remount when change function to memo', async () => {
+    if (__DEV__) {
+      await act(async () => {
+        await render(() => {
+          function Test() {
+            return <p>hi test</p>;
+          }
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      // Check the initial render
+      const el = container.firstChild;
+      expect(el.textContent).toBe('hi test');
+
+      // Patch to change function to memo
+      await act(async () => {
+        await patch(() => {
+          function Test2() {
+            return <p>hi memo</p>;
+          }
+          const Test = React.memo(Test2);
+          $RefreshReg$(Test2, 'Test2');
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      // Check remount
+      expect(container.firstChild).not.toBe(el);
+      const nextEl = container.firstChild;
+      expect(nextEl.textContent).toBe('hi memo');
+
+      // Patch back to original function
+      await act(async () => {
+        await patch(() => {
+          function Test() {
+            return <p>hi test</p>;
+          }
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      // Check final remount
+      expect(container.firstChild).not.toBe(nextEl);
+      const newEl = container.firstChild;
+      expect(newEl.textContent).toBe('hi test');
+    }
+  });
+
+  it('can remount when change memo to forwardRef', async () => {
+    if (__DEV__) {
+      await act(async () => {
+        await render(() => {
+          function Test2() {
+            return <p>hi memo</p>;
+          }
+          const Test = React.memo(Test2);
+          $RefreshReg$(Test2, 'Test2');
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+      // Check the initial render
+      const el = container.firstChild;
+      expect(el.textContent).toBe('hi memo');
+
+      // Patch to change memo to forwardRef
+      await act(async () => {
+        await patch(() => {
+          function Test2() {
+            return <p>hi forwardRef</p>;
+          }
+          const Test = React.forwardRef(Test2);
+          $RefreshReg$(Test2, 'Test2');
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+      // Check remount
+      expect(container.firstChild).not.toBe(el);
+      const nextEl = container.firstChild;
+      expect(nextEl.textContent).toBe('hi forwardRef');
+
+      // Patch back to memo
+      await act(async () => {
+        await patch(() => {
+          function Test2() {
+            return <p>hi memo</p>;
+          }
+          const Test = React.memo(Test2);
+          $RefreshReg$(Test2, 'Test2');
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+      // Check final remount
+      expect(container.firstChild).not.toBe(nextEl);
+      const newEl = container.firstChild;
+      expect(newEl.textContent).toBe('hi memo');
+    }
+  });
+
+  it('can remount when change function to forwardRef', async () => {
+    if (__DEV__) {
+      await act(async () => {
+        await render(() => {
+          function Test() {
+            return <p>hi test</p>;
+          }
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      // Check the initial render
+      const el = container.firstChild;
+      expect(el.textContent).toBe('hi test');
+
+      // Patch to change function to forwardRef
+      await act(async () => {
+        await patch(() => {
+          function Test2() {
+            return <p>hi forwardRef</p>;
+          }
+          const Test = React.forwardRef(Test2);
+          $RefreshReg$(Test2, 'Test2');
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      // Check remount
+      expect(container.firstChild).not.toBe(el);
+      const nextEl = container.firstChild;
+      expect(nextEl.textContent).toBe('hi forwardRef');
+
+      // Patch back to a new function
+      await act(async () => {
+        await patch(() => {
+          function Test() {
+            return <p>hi test1</p>;
+          }
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      // Check final remount
+      expect(container.firstChild).not.toBe(nextEl);
+      const newEl = container.firstChild;
+      expect(newEl.textContent).toBe('hi test1');
+    }
+  });
+
+  it('can remount when change memo inner type from function to forwardRef', async () => {
+    if (__DEV__) {
+      await act(async () => {
+        await render(() => {
+          function Test2() {
+            return <p>hi memo</p>;
+          }
+          const Test = React.memo(Test2);
+          $RefreshReg$(Test2, 'Test$React.memo');
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      // Check the initial render
+      const el = container.firstChild;
+      expect(el.textContent).toBe('hi memo');
+
+      // Patch to wrap the inner function in forwardRef.
+      // The outer type is still a memo, so only the inner family changes.
+      await act(async () => {
+        await patch(() => {
+          function Test2(props, ref) {
+            return <p>hi memo forwardRef</p>;
+          }
+          const Test2Ref = React.forwardRef(Test2);
+          const Test = React.memo(Test2Ref);
+          $RefreshReg$(Test2, 'Test$React.memo$React.forwardRef');
+          $RefreshReg$(Test2Ref, 'Test$React.memo');
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      // Check remount
+      expect(container.firstChild).not.toBe(el);
+      const nextEl = container.firstChild;
+      expect(nextEl.textContent).toBe('hi memo forwardRef');
+
+      // Patch back to a plain function inside memo
+      await act(async () => {
+        await patch(() => {
+          function Test2() {
+            return <p>hi memo</p>;
+          }
+          const Test = React.memo(Test2);
+          $RefreshReg$(Test2, 'Test$React.memo');
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      // Check final remount
+      expect(container.firstChild).not.toBe(nextEl);
+      const newEl = container.firstChild;
+      expect(newEl.textContent).toBe('hi memo');
+    }
+  });
+
+  it('resets state when switching between different component types', async () => {
+    if (__DEV__) {
+      await act(async () => {
+        await render(() => {
+          function Test() {
+            const [count, setCount] = React.useState(0);
+            return (
+              <div onClick={() => setCount(c => c + 1)}>count: {count}</div>
+            );
+          }
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      expect(container.firstChild.textContent).toBe('count: 0');
+      await act(async () => {
+        container.firstChild.click();
+      });
+      expect(container.firstChild.textContent).toBe('count: 1');
+
+      await act(async () => {
+        await patch(() => {
+          function Test2() {
+            const [count, setCount] = React.useState(0);
+            return (
+              <div onClick={() => setCount(c => c + 1)}>count: {count}</div>
+            );
+          }
+          const Test = React.memo(Test2);
+          $RefreshReg$(Test2, 'Test2');
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      expect(container.firstChild.textContent).toBe('count: 0');
+      await act(async () => {
+        container.firstChild.click();
+      });
+      expect(container.firstChild.textContent).toBe('count: 1');
+
+      await act(async () => {
+        await patch(() => {
+          const Test = React.forwardRef((props, ref) => {
+            const [count, setCount] = React.useState(0);
+            const handleClick = () => setCount(c => c + 1);
+
+            // Ensure ref is extensible
+            const divRef = React.useRef(null);
+            React.useEffect(() => {
+              if (ref) {
+                if (typeof ref === 'function') {
+                  ref(divRef.current);
+                } else if (Object.isExtensible(ref)) {
+                  ref.current = divRef.current;
+                }
+              }
+            }, [ref]);
+
+            return (
+              <div ref={divRef} onClick={handleClick}>
+                count: {count}
+              </div>
+            );
+          });
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      expect(container.firstChild.textContent).toBe('count: 0');
+      await act(async () => {
+        container.firstChild.click();
+      });
+      expect(container.firstChild.textContent).toBe('count: 1');
+    }
+  });
+
   it('can update simple memo function in isolation', async () => {
     if (__DEV__) {
       await render(() => {


### PR DESCRIPTION
Fixes #30659. I'm not confident in this yet but here's what Fable said based on https://github.com/react/react/pull/32214#issuecomment-2734436781:

Editing a component from a plain function to a memo or forwardRef wrapper (or between wrapper kinds) crashed with "Component is not a function", because canPreserveStateBetween only compared hook signatures. The edit was classified as state-preserving, so createWorkInProgress swapped the wrapper object in as the type of a FunctionComponent fiber and renderWithHooks tried to call it.

Two fixes, both DEV-only:

- canPreserveStateBetween returns false when typeof or $$typeof differ. A fiber's tag is derived from the kind of its type, so state can never be preserved across a kind change; these edits must go to staleFamilies (remount). Nested wrappers need no special handling because register() creates a family per nesting level ($type/$render ids), and each level's kind is compared against its own family.

- The reconciler now finds and remounts wrapper fibers whose outer kind changed. scheduleFibersWithFamiliesRecursively previously resolved families only through the inner implementation (type/type.render), but a kind-changing edit is recorded only on the outer type's family, so edits like memo -> function never reached the scanner and were silently dropped. The scanner now also checks the elementType's family, and the _debugNeedsRemount branch in beginWork rebuilds the fiber from family.current (the latest registered type for the fiber's identity) rather than the fiber's possibly-stale inner type. This also fixes stale simple memo remounts recreating as plain functions, dropping the memo wrapper.

Unlike the reverted #30660 (see #32214), this does not fabricate families or guess type shapes: families are still created in exactly one place, and the same ID always resolves to the same family.

Restores the tests from #30660 and adds coverage for changing the inner type of a memo between function and forwardRef.
