### PR TITLE
[compiler] Port JSX tag classification fix to Rust (not-lowercase is a component)

### DIFF
--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -6271,7 +6271,7 @@ fn lower_jsx_element_name(
             let tag = &id.name;
             let loc = convert_opt_loc(&id.base.loc);
             let start = id.base.start.unwrap_or(0);
-            if tag.starts_with(|c: char| c.is_ascii_uppercase()) {
+            if !tag.starts_with(|c: char| c.is_ascii_lowercase()) {
                 // Component tag: resolve as identifier and load
                 let place = lower_identifier(builder, tag, start, loc.clone(), id.base.node_id)?;
                 let load_value = if builder.is_context_identifier(tag, start, id.base.node_id) {


### PR DESCRIPTION
## Summary

facebook/react#36688 fixed JSX tag classification in the TypeScript compiler.
Rust parity CI began failing on `jsx-underscore-prefix-component` when that fixture merged.
The Rust lowering still treated only ASCII uppercase tags as components.
This change mirrors the TypeScript rule: every tag not starting with an ASCII lowercase letter is a component.

## How did you test this change?

- `scripts/test-rust-port.sh`: 1806 passed, 0 failed, with no frontier failure and HIR at 1715/1715.
- The `jsx-underscore-prefix-component` fixture passed HIR parity at 1/1.
- `yarn snap`: 1807 passed, 0 failed.
- `yarn snap --rust`: 1807 passed, 0 failed.
- `cargo test --workspace` passed from `compiler/crates`.
- `bash scripts/test-babel-ast.sh` passed.
- `cargo fmt --all -- --check` passed.


<div><a href="https://cursor.com/agents/bc-f65efae6-4e69-4ee3-9c9a-0152d87d9847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f65efae6-4e69-4ee3-9c9a-0152d87d9847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>