### PR TITLE
[test] Normalize Windows paths in the Jest preprocessor

### DIFF
--- a/scripts/jest/__tests__/preprocessor-test.js
+++ b/scripts/jest/__tests__/preprocessor-test.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const preprocessor = require('../preprocessor');
+
+describe('preprocessor', () => {
+  // Jest hands the transformer an OS-native absolute path, which uses
+  // backslashes on Windows. The path classification below must therefore be
+  // separator-agnostic, otherwise every source file is misclassified on
+  // Windows: third_party files stop being excluded from the JSX transform and
+  // the DevTools version-pragma transform is never applied.
+  const source = 'const element = <div />;\n';
+
+  it('excludes third_party files from the JSX transform (posix path)', () => {
+    const filePath = '/repo/scripts/third_party/foo.js';
+    expect(preprocessor.process(source, filePath).code).toBe(source);
+  });
+
+  it('excludes third_party files from the JSX transform (windows path)', () => {
+    const filePath = 'C:\\repo\\scripts\\third_party\\foo.js';
+    expect(preprocessor.process(source, filePath).code).toBe(source);
+  });
+
+  it('still transforms non-third_party files (windows path)', () => {
+    const filePath = 'C:\\repo\\packages\\react\\src\\React.js';
+    expect(preprocessor.process(source, filePath).code).not.toBe(source);
+  });
+});

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -53,6 +53,10 @@ const babelOptions = {
 
 module.exports = {
   process: function (src, filePath) {
+    // Jest passes the OS-native absolute path, which uses backslashes on
+    // Windows. Normalize to forward slashes so the separator-anchored regexes
+    // below classify files the same way on every platform.
+    const posixPath = filePath.replace(/\\/g, '/');
     if (filePath.match(/\.css$/)) {
       // Don't try to parse CSS modules; they aren't needed for tests anyway.
       return {code: ''};
@@ -66,11 +70,11 @@ module.exports = {
     if (filePath.match(/\.json$/)) {
       return {code: src};
     }
-    if (!filePath.match(/\/third_party\//)) {
+    if (!posixPath.match(/\/third_party\//)) {
       // for test files, we also apply the async-await transform, but we want to
       // make sure we don't accidentally apply that transform to product code.
-      const isTestFile = !!filePath.match(/\/__tests__\//);
-      const isInDevToolsPackages = !!filePath.match(
+      const isTestFile = !!posixPath.match(/\/__tests__\//);
+      const isInDevToolsPackages = !!posixPath.match(
         /\/packages\/react-devtools.*\//
       );
       const plugins = [].concat(babelOptions.plugins);


### PR DESCRIPTION
## Summary

`scripts/jest/preprocessor.js` is the Jest transformer applied to every non-TypeScript source file during `yarn test`. It classifies each file with regexes anchored on the POSIX separator `/`:

- `if (!filePath.match(/\/third_party\//))` to exclude `third_party` files from the JSX/Babel transform,
- `filePath.match(/\/__tests__\//)` to detect test files, and
- `filePath.match(/\/packages\/react-devtools.*\//)` to detect DevTools files,

the last two of which gate the `transform-react-version-pragma` transform (`isTestFile && isInDevToolsPackages`).

Jest hands a transformer the OS-native absolute path, which uses backslashes on Windows (for example `C:\...\packages\react-devtools-shared\src\__tests__\Store-test.js`). None of these `/`-anchored regexes match such a path, so on Windows `third_party` files are no longer excluded from the transform, and `isTestFile` / `isInDevToolsPackages` are always `false`, meaning the DevTools React-version-pragma transform never runs. The sibling transformer `scripts/jest/typescript/preprocessor.js` already normalizes the separator for exactly this reason (it calls `path.normalize` with a comment about backslashes on Windows).

This normalizes backslashes to forward slashes once at the top of `process`, and uses that value for the three separator-anchored matches. The extension checks (`.css` / `.coffee` / `.ts` / `.json`) contain no separator and are left unchanged.

## How did you test this change?

Added `scripts/jest/__tests__/preprocessor-test.js` covering both path styles, and ran it (Node 20):

```
$ yarn test scripts/jest/__tests__/preprocessor-test.js
PASS scripts/jest/__tests__/preprocessor-test.js
  preprocessor
    ✓ excludes third_party files from the JSX transform (posix path)
    ✓ excludes third_party files from the JSX transform (windows path)
    ✓ still transforms non-third_party files (windows path)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
```

The test is red before the fix: reverting only `scripts/jest/preprocessor.js` (keeping the new test) makes the "windows path" `third_party` case fail, because the JSX transform runs and rewrites the source to `jsxDEV(...)` instead of leaving it untouched. With the fix all three pass.

Also ran `yarn prettier-check` (clean) and `yarn linc` (lint passed for changed files).

Note: React CI runs on `ubuntu-latest`, so this is latent on CI but affects any contributor running `yarn test` on Windows.
