### PR TITLE
fix: update stale profiling documentation link in DevTools

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilingNotSupported.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilingNotSupported.js
@@ -23,7 +23,7 @@ export default function ProfilingNotSupported(): React.Node {
         Learn more at{' '}
         <a
           className={styles.Link}
-          href="https://fb.me/react-devtools-profiling"
+          href="https://react.dev/link/profiling"
           rel="noopener noreferrer"
           target="_blank">
           reactjs.org/link/profiling
@@ -33,3 +33,4 @@ export default function ProfilingNotSupported(): React.Node {
     </div>
   );
 }
+


### PR DESCRIPTION
Closes #31878

The DevTools profiling not supported error links to fb.me/react-devtools-profiling, which redirects to deprecated reactjs.org. Updated the URL to react.dev/link/profiling.