### PR TITLE
[compiler] Accept AssignmentPattern as a destructuring target under Babel 8

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -4213,7 +4213,7 @@ function lowerAssignment(
             continue;
           }
           const element = property.get('value');
-          if (!element.isLVal()) {
+          if (!element.isLVal() && !element.isPatternLike()) {
             builder.recordError(
               new CompilerErrorDetail({
                 reason: `(BuildHIR::lowerAssignment) Expected object property value to be an LVal, got: ${element.type}`,

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/FindContextIdentifiers.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/FindContextIdentifiers.ts
@@ -181,7 +181,7 @@ function handleAssignment(
       for (const property of path.get('properties')) {
         if (property.isObjectProperty()) {
           const valuePath = property.get('value');
-          CompilerError.invariant(valuePath.isLVal(), {
+          CompilerError.invariant(valuePath.isLVal() || valuePath.isPatternLike(), {
             reason: `[FindContextIdentifiers] Expected object property value to be an LVal, got: ${valuePath.type}`,
             loc: valuePath.node.loc ?? GeneratedSource,
           });

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/babel8_compat_test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/babel8_compat_test.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {transformSync} from '@babel/core';
+import {createRequire} from 'module';
+import type {NodePath as BabelNodePath} from '@babel/traverse';
+import BabelPluginReactCompiler from '..';
+import type {Logger, LoggerEvent} from '..';
+import {parseConfigPragmaForTests} from '../Utils/TestUtils';
+
+const requireFromBabelCore = createRequire(require.resolve('@babel/core'));
+const babelCoreTraverse: typeof import('@babel/traverse') =
+  requireFromBabelCore('@babel/traverse');
+const {NodePath} = babelCoreTraverse;
+
+const source = `
+export const Badge = ({variant = "primary", ...rest}) => {
+  return <div {...rest} />;
+};
+`;
+
+const sourceAssignment = `
+export function Counter(props) {
+  let value;
+  ({value = 0} = props);
+  const onClick = () => value;
+  return <button onClick={onClick}>{value}</button>;
+}
+`;
+
+describe('Babel 8 compatibility', () => {
+  test('compiles object destructuring parameter default when Babel 8 rejects AssignmentPattern as LVal', () => {
+    const events: Array<LoggerEvent> = [];
+    const logger: Logger = {
+      logEvent(_filename, event) {
+        events.push(event);
+      },
+      debugLogIRs() {},
+    };
+    const originalIsLVal = NodePath.prototype.isLVal;
+    NodePath.prototype.isLVal = function (this: BabelNodePath): boolean {
+      if (this.isAssignmentPattern()) {
+        return false;
+      }
+      return originalIsLVal.call(this);
+    };
+
+    try {
+      expect(() => {
+        transformSync(source, {
+          filename: 'badge.jsx',
+          plugins: [
+            '@babel/plugin-syntax-jsx',
+            [
+              BabelPluginReactCompiler,
+              {
+                ...parseConfigPragmaForTests('', {compilationMode: 'all'}),
+                logger,
+                enableReanimatedCheck: false,
+              },
+            ],
+          ],
+          configFile: false,
+          babelrc: false,
+        });
+      }).not.toThrow(
+        'Expected object property value to be an LVal, got: AssignmentPattern',
+      );
+      const compileErrors = events.flatMap(event => {
+        if (event.kind === 'CompileError') {
+          return [event.detail.reason];
+        }
+        return [];
+      });
+      expect(compileErrors).toEqual([]);
+      expect(events.some(event => event.kind === 'CompileSuccess')).toBe(true);
+    } finally {
+      NodePath.prototype.isLVal = originalIsLVal;
+    }
+  });
+
+  test('compiles object destructuring assignment default when Babel 8 rejects AssignmentPattern as LVal', () => {
+    const events: Array<LoggerEvent> = [];
+    const logger: Logger = {
+      logEvent(_filename, event) {
+        events.push(event);
+      },
+      debugLogIRs() {},
+    };
+    const originalIsLVal = NodePath.prototype.isLVal;
+    NodePath.prototype.isLVal = function (this: BabelNodePath): boolean {
+      if (this.isAssignmentPattern()) {
+        return false;
+      }
+      return originalIsLVal.call(this);
+    };
+
+    try {
+      expect(() => {
+        transformSync(sourceAssignment, {
+          filename: 'counter.jsx',
+          plugins: [
+            '@babel/plugin-syntax-jsx',
+            [
+              BabelPluginReactCompiler,
+              {
+                ...parseConfigPragmaForTests('', {compilationMode: 'all'}),
+                logger,
+                enableReanimatedCheck: false,
+              },
+            ],
+          ],
+          configFile: false,
+          babelrc: false,
+        });
+      }).not.toThrow(
+        'Expected object property value to be an LVal, got: AssignmentPattern',
+      );
+      const compileErrors = events.flatMap(event => {
+        if (event.kind === 'CompileError') {
+          return [event.detail.reason];
+        }
+        return [];
+      });
+      expect(compileErrors).toEqual([]);
+      expect(events.some(event => event.kind === 'CompileSuccess')).toBe(true);
+    } finally {
+      NodePath.prototype.isLVal = originalIsLVal;
+    }
+  });
+});

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/babel8_destructured_default_param.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/babel8_destructured_default_param.expect.md
@@ -1,0 +1,58 @@
+
+## Input
+
+```javascript
+export const Badge = ({variant = "primary", ...rest}) => {
+  const className = `badge badge-${variant}`;
+  return <div className={className} {...rest} />;
+};
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Badge,
+  params: [{variant: undefined, title: "Hello"}],
+  isComponent: true,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+export const Badge = (t0) => {
+  const $ = _c(6);
+  let rest;
+  let t1;
+  if ($[0] !== t0) {
+    ({ variant: t1, ...rest } = t0);
+    $[0] = t0;
+    $[1] = rest;
+    $[2] = t1;
+  } else {
+    rest = $[1];
+    t1 = $[2];
+  }
+  const variant = t1 === undefined ? "primary" : t1;
+  const className = `badge badge-${variant}`;
+  let t2;
+  if ($[3] !== className || $[4] !== rest) {
+    t2 = <div className={className} {...rest} />;
+    $[3] = className;
+    $[4] = rest;
+    $[5] = t2;
+  } else {
+    t2 = $[5];
+  }
+  return t2;
+};
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Badge,
+  params: [{ variant: undefined, title: "Hello" }],
+  isComponent: true,
+};
+
+```
+      
+### Eval output
+(kind: ok) <div class="badge badge-primary" title="Hello"></div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/babel8_destructured_default_param.jsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/babel8_destructured_default_param.jsx
@@ -1,0 +1,10 @@
+export const Badge = ({variant = "primary", ...rest}) => {
+  const className = `badge badge-${variant}`;
+  return <div className={className} {...rest} />;
+};
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Badge,
+  params: [{variant: undefined, title: "Hello"}],
+  isComponent: true,
+};


### PR DESCRIPTION
## Summary

Under Babel 8, babel-plugin-react-compiler crashes on a destructured default parameter such as `({variant = "primary", ...rest}) => ...` with `Expected object property value to be an LVal, got: AssignmentPattern`.

Babel 8 removed AssignmentPattern from the `LVal` alias (it remains in `PatternLike`), so two guards that assert `path.isLVal()` on an object property value now throw for a legal destructuring default:

* `BuildHIR.ts` `lowerAssignment` (parameter and assignment destructuring)
* `FindContextIdentifiers.ts` (object property value in a destructuring assignment, which runs earlier in the pipeline)

Both sites already have a downstream `AssignmentPattern` handler, so the value only needs to pass the guard. This relaxes each guard to accept `isPatternLike()` in addition to `isLVal()`. On Babel 7 this is a no-op because `PatternLike` is a subset of `LVal` there; under Babel 8 the only newly admitted node is AssignmentPattern, which is exactly the intended target.

The `({a = 1} = props)` assignment form reaches `FindContextIdentifiers` first, so both guards must be relaxed; fixing only `BuildHIR` leaves the assignment form crashing.

## Tests

Added a compat test that emulates the Babel 8 change (patching `isLVal` to return false for AssignmentPattern while leaving `isPatternLike` intact) and covers both the parameter path and the destructuring assignment path, plus a fixture. Reverting either guard makes the matching test fail with the corresponding error.

```
yarn jest babel8_compat_test --runInBand   # 2 passed
yarn jest --runInBand                       # 45 passed
yarn workspace snap run snap                # 1808 passed, 0 failed
```

Fixes #36868
