### PR TITLE
[compiler] Fix ConfigEditor toggle typing and button semantics

### DIFF
--- a/compiler/apps/playground/components/Editor/ConfigEditor.tsx
+++ b/compiler/apps/playground/components/Editor/ConfigEditor.tsx
@@ -72,7 +72,7 @@ function ExpandedEditor({
   onToggle,
   formattedAppliedConfig,
 }: {
-  onToggle: (expanded: boolean) => void;
+  onToggle: () => void;
   formattedAppliedConfig: string;
 }): React.ReactElement {
   const store = useStore();
@@ -120,10 +120,12 @@ function ExpandedEditor({
         defaultSize={{width: 350}}
         enable={{right: true, bottom: false}}>
         <div className="bg-blue-10 relative h-full flex flex-col !h-[calc(100vh_-_3.5rem)] border border-gray-300">
-          <div
-            className="absolute w-8 h-16 bg-blue-10 rounded-r-full flex items-center justify-center z-[2] cursor-pointer border border-l-0 border-gray-300"
+          <button
+            type="button"
+            aria-label="Minimize config editor"
+            className="absolute w-8 h-16 bg-blue-10 rounded-r-full flex items-center justify-center z-[2] cursor-pointer border border-l-0 border-gray-300 p-0"
             title="Minimize config editor"
-            onClick={onToggle}
+            onClick={() => onToggle()}
             style={{
               top: '50%',
               marginTop: '-32px',
@@ -132,7 +134,7 @@ function ExpandedEditor({
               borderBottomLeftRadius: 0,
             }}>
             <IconChevron displayDirection="left" className="text-blue-50" />
-          </div>
+          </button>
 
           <div className="flex-1 flex flex-col m-2 mb-2">
             <div className="pb-2">
@@ -188,10 +190,12 @@ function CollapsedEditor({
     <div
       className="w-4 !h-[calc(100vh_-_3.5rem)]"
       style={{position: 'relative'}}>
-      <div
-        className="absolute w-10 h-16 bg-blue-10 hover:translate-x-2 transition-transform rounded-r-full flex items-center justify-center z-[2] cursor-pointer border border-gray-300"
+      <button
+        type="button"
+        aria-label="Expand config editor"
+        className="absolute w-10 h-16 bg-blue-10 hover:translate-x-2 transition-transform rounded-r-full flex items-center justify-center z-[2] cursor-pointer border border-gray-300 p-0"
         title="Expand config editor"
-        onClick={onToggle}
+        onClick={() => onToggle()}
         style={{
           top: '50%',
           marginTop: '-32px',
@@ -200,7 +204,7 @@ function CollapsedEditor({
           borderBottomLeftRadius: 0,
         }}>
         <IconChevron displayDirection="right" className="text-blue-50" />
-      </div>
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- change `ExpandedEditor`'s `onToggle` prop to a zero-argument callback so it matches how the handler is invoked
- wrap both config panel toggle handlers in `() => onToggle()` so click events are not forwarded as phantom boolean arguments
- replace the clickable toggle `div`s with `button` elements and add button semantics for the icon-only controls

## Why
The expanded config toggle was typed as `(expanded: boolean) => void` even though it was wired directly to `onClick`. In practice React passes a mouse event there, so the type was lying even if callers happened to ignore the argument.

## Impact
This keeps the toggle contract honest and makes the config panel controls behave like real buttons instead of clickable `div`s.

## Validation
- `corepack yarn lint --file components/Editor/ConfigEditor.tsx` in `compiler/apps/playground`
