### PR TITLE
[compiler] Track computed member refs before declaration

### DIFF
--- a/compiler/crates/react_compiler/src/entrypoint/program.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/program.rs
@@ -2218,6 +2218,8 @@ fn expr_references_identifier_at_top_level(expr: &Expression, name: &str) -> boo
         }
         Expression::MemberExpression(member) => {
             expr_references_identifier_at_top_level(&member.object, name)
+                || (member.computed
+                    && expr_references_identifier_at_top_level(&member.property, name))
         }
         Expression::ConditionalExpression(cond) => {
             expr_references_identifier_at_top_level(&cond.test, name)

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-computed-member.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-computed-member.expect.md
@@ -1,0 +1,66 @@
+
+## Input
+
+```javascript
+// @gating
+import {Stringify} from 'shared-runtime';
+
+const registry = {};
+
+export default registry[Foo];
+function Foo({prop1, prop2}) {
+  'use memo';
+  return <Stringify prop1={prop1} prop2={prop2} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: eval('Foo'),
+  params: [{prop1: 1, prop2: 2}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag"; // @gating
+import { Stringify } from "shared-runtime";
+
+const registry = {};
+
+export default registry[Foo];
+const isForgetEnabled_Fixtures_result = isForgetEnabled_Fixtures();
+function Foo_optimized(t0) {
+  "use memo";
+  const $ = _c(3);
+  const { prop1, prop2 } = t0;
+  let t1;
+  if ($[0] !== prop1 || $[1] !== prop2) {
+    t1 = <Stringify prop1={prop1} prop2={prop2} />;
+    $[0] = prop1;
+    $[1] = prop2;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  return t1;
+}
+function Foo_unoptimized({ prop1, prop2 }) {
+  "use memo";
+  return <Stringify prop1={prop1} prop2={prop2} />;
+}
+function Foo(arg0) {
+  if (isForgetEnabled_Fixtures_result) return Foo_optimized(arg0);
+  else return Foo_unoptimized(arg0);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: eval("Foo"),
+  params: [{ prop1: 1, prop2: 2 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"prop1":1,"prop2":2}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-computed-member.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-computed-member.js
@@ -1,0 +1,15 @@
+// @gating
+import {Stringify} from 'shared-runtime';
+
+const registry = {};
+
+export default registry[Foo];
+function Foo({prop1, prop2}) {
+  'use memo';
+  return <Stringify prop1={prop1} prop2={prop2} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: eval('Foo'),
+  params: [{prop1: 1, prop2: 2}],
+};


### PR DESCRIPTION
## Summary
- treat computed member properties as top-level identifier references during Rust gating's use-before-declaration scan
- add a focused gating fixture covering `registry[Foo]` before `function Foo()`
- snapshot the hoisted gated rewrite that keeps the pre-declaration computed member access valid

## Why
The Rust entrypoint only checked the object side of a member expression when deciding whether a gated function declaration was referenced before its declaration. For computed access like `registry[Foo]`, that missed the real reference to `Foo` and could pick the conditional gating rewrite instead of the hoisted function-declaration form.

## Impact
This brings the Rust backend back in line with the TypeScript behavior for computed member references and protects gating rewrites that depend on use-before-declaration detection.

## Validation
- `NODE_NO_WARNINGS=1 corepack yarn workspace snap run snap test --update --pattern gating/gating-use-before-decl-computed-member`
- `NODE_NO_WARNINGS=1 corepack yarn workspace snap run snap test --rust --pattern gating/gating-use-before-decl-computed-member`
