### PR TITLE
[compiler] Mark unported assertion logs as unimplemented

### DIFF
--- a/compiler/crates/react_compiler/src/entrypoint/pipeline.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/pipeline.rs
@@ -161,14 +161,14 @@ pub fn compile_fn(
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new(
             "AssertConsistentIdentifiers",
-            "ok".to_string(),
+            "unimplemented".to_string(),
         ));
     }
     // TODO: port assertTerminalSuccessorsExist
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new(
             "AssertTerminalSuccessorsExist",
-            "ok".to_string(),
+            "unimplemented".to_string(),
         ));
     }
 
@@ -212,7 +212,7 @@ pub fn compile_fn(
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new(
             "AssertConsistentIdentifiers",
-            "ok".to_string(),
+            "unimplemented".to_string(),
         ));
     }
 
@@ -694,7 +694,7 @@ pub fn compile_fn(
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new(
             "AssertValidBlockNesting",
-            "ok".to_string(),
+            "unimplemented".to_string(),
         ));
     }
 
@@ -718,7 +718,7 @@ pub fn compile_fn(
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new(
             "AssertValidBlockNesting",
-            "ok".to_string(),
+            "unimplemented".to_string(),
         ));
     }
 
@@ -756,14 +756,14 @@ pub fn compile_fn(
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new(
             "AssertTerminalSuccessorsExist",
-            "ok".to_string(),
+            "unimplemented".to_string(),
         ));
     }
     // TODO: port assertTerminalPredsExist
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new(
             "AssertTerminalPredsExist",
-            "ok".to_string(),
+            "unimplemented".to_string(),
         ));
     }
 


### PR DESCRIPTION
## Summary
- change unported assertion pass debug log entries from `ok` to `unimplemented`
- keep the existing assertion names visible in debug output without implying the checks actually ran

## Why
Several TODO assertion passes in the Rust pipeline still log `ok` even though they have not been ported yet. That makes debug output claim validation succeeded when the assertion was skipped entirely.

## Impact
Debug logs now reflect the real state of the pipeline more accurately, which should make maintainer debugging less misleading.

## Validation
- `cargo check -p react_compiler`
