### PR TITLE
[Fast Refresh] Make edits to a memo comparison function take effect

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -427,6 +427,9 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     switch (workInProgress.tag) {
       case FunctionComponent:
       case SimpleMemoComponent:
+      case MemoComponent:
+        // For MemoComponent, type is the memo object itself, so this picks
+        // up edits to the outer wrapper (e.g. its comparison function).
         workInProgress.type = resolveFunctionForHotReloading(current.type);
         break;
       case ClassComponent:

--- a/packages/react-reconciler/src/ReactFiberHotReloading.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.js
@@ -196,9 +196,12 @@ export function isCompatibleFamilyForHotReloading(
       case MemoComponent:
       case SimpleMemoComponent: {
         if ($$typeofNextType === REACT_MEMO_TYPE) {
-          // TODO: if it was but can no longer be simple,
-          // we shouldn't set this.
-          needsCompareFamilies = true;
+          // A SimpleMemoComponent fiber can only host a memo with the
+          // default shallow comparison. If the next type has a custom
+          // one, the fiber tag has to change, so it isn't compatible.
+          if (fiber.tag !== SimpleMemoComponent || nextType.compare === null) {
+            needsCompareFamilies = true;
+          }
         } else if ($$typeofNextType === REACT_LAZY_TYPE) {
           needsCompareFamilies = true;
         }

--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -158,6 +158,16 @@ function canPreserveStateBetween(prevType: any, nextType: any) {
     ) {
       return false;
     }
+    // Switching from SimpleMemoComponent to MemoComponent requires a remount;
+    // for symmetry, remount for the reverse too.
+    if (getProperty(prevType, '$$typeof') === REACT_MEMO_TYPE) {
+      if (
+        (getProperty(prevType, 'compare') === null) !==
+        (getProperty(nextType, 'compare') === null)
+      ) {
+        return false;
+      }
+    }
   }
   if (haveEqualSignatures(prevType, nextType)) {
     return true;
@@ -187,7 +197,7 @@ function cloneSet<T>(set: Set<T>): Set<T> {
 }
 
 // This is a safety mechanism to protect against rogue getters and Proxies.
-function getProperty(object: any, property: string) {
+function getProperty(object: any, property: string): any {
   try {
     return object[property];
   } catch (err) {

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -915,6 +915,204 @@ describe('ReactFresh', () => {
     }
   });
 
+  it('can remount when adding or removing a memo comparison function', async () => {
+    if (__DEV__) {
+      await act(async () => {
+        await render(() => {
+          function Test2() {
+            return <p>hi memo</p>;
+          }
+          const Test = React.memo(Test2);
+          $RefreshReg$(Test2, 'Test$React.memo');
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      // Check the initial render
+      const el = container.firstChild;
+      expect(el.textContent).toBe('hi memo');
+
+      // Patch to add a custom comparison function.
+      // The fiber can no longer be a SimpleMemoComponent.
+      await act(async () => {
+        await patch(() => {
+          function Test2() {
+            return <p>hi memo with compare</p>;
+          }
+          const Test = React.memo(Test2, (prevProps, nextProps) => false);
+          $RefreshReg$(Test2, 'Test$React.memo');
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      // Check remount
+      expect(container.firstChild).not.toBe(el);
+      const nextEl = container.firstChild;
+      expect(nextEl.textContent).toBe('hi memo with compare');
+
+      // Patch to remove the comparison function again
+      await act(async () => {
+        await patch(() => {
+          function Test2() {
+            return <p>hi memo</p>;
+          }
+          const Test = React.memo(Test2);
+          $RefreshReg$(Test2, 'Test$React.memo');
+          $RefreshReg$(Test, 'Test');
+          return Test;
+        });
+      });
+
+      // Check final remount
+      expect(container.firstChild).not.toBe(nextEl);
+      const newEl = container.firstChild;
+      expect(newEl.textContent).toBe('hi memo');
+    }
+  });
+
+  it('can update a memo comparison function in place', async () => {
+    if (__DEV__) {
+      await act(async () => {
+        await render(() => {
+          function Inner({label}) {
+            return <p>{label}</p>;
+          }
+          const InnerMemo = React.memo(Inner, (prevProps, nextProps) => true);
+          $RefreshReg$(Inner, 'Inner$React.memo');
+          $RefreshReg$(InnerMemo, 'Inner');
+
+          function App() {
+            const [n, setN] = React.useState(1);
+            return (
+              <div onClick={() => setN(c => c + 1)}>
+                <InnerMemo label={'n:' + n} />
+              </div>
+            );
+          }
+          $RefreshReg$(App, 'App');
+          return App;
+        });
+      });
+
+      // Check the initial render
+      const el = container.firstChild;
+      expect(el.textContent).toBe('n:1');
+
+      // The comparison function blocks the update.
+      await act(async () => {
+        el.click();
+      });
+      expect(el.textContent).toBe('n:1');
+
+      // Patch to change only the comparison function implementation.
+      await act(async () => {
+        await patch(() => {
+          function Inner({label}) {
+            return <p>{label}</p>;
+          }
+          const InnerMemo = React.memo(Inner, (prevProps, nextProps) => false);
+          $RefreshReg$(Inner, 'Inner$React.memo');
+          $RefreshReg$(InnerMemo, 'Inner');
+
+          function App() {
+            const [n, setN] = React.useState(1);
+            return (
+              <div onClick={() => setN(c => c + 1)}>
+                <InnerMemo label={'n:' + n} />
+              </div>
+            );
+          }
+          $RefreshReg$(App, 'App');
+          return App;
+        });
+      });
+
+      // No remount, and the previously blocked update shows through
+      // because the new comparison function is used.
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('n:2');
+
+      // The new comparison function applies to future updates too.
+      await act(async () => {
+        el.click();
+      });
+      expect(el.textContent).toBe('n:3');
+    }
+  });
+
+  it('does not reuse a simple memo fiber for a memo with a comparison function', async () => {
+    if (__DEV__) {
+      let oldElement;
+      let newElement;
+      let currentChild = null;
+
+      await act(async () => {
+        await render(() => {
+          function Inner({label}) {
+            return <p>{label}</p>;
+          }
+          const InnerMemo = React.memo(Inner);
+          $RefreshReg$(Inner, 'Inner$React.memo');
+          $RefreshReg$(InnerMemo, 'Inner');
+          oldElement = <InnerMemo label="hi" />;
+
+          function App() {
+            const [, forceUpdate] = React.useState(0);
+            return (
+              <div onClick={() => forceUpdate(n => n + 1)}>{currentChild}</div>
+            );
+          }
+          $RefreshReg$(App, 'App');
+          return App;
+        });
+      });
+
+      // Patch to add a comparison function before the memo has ever mounted,
+      // so the refresh itself has nothing to remount.
+      await act(async () => {
+        await patch(() => {
+          function Inner({label}) {
+            return <p>{label}</p>;
+          }
+          const InnerMemo = React.memo(Inner, (prevProps, nextProps) => true);
+          $RefreshReg$(Inner, 'Inner$React.memo');
+          $RefreshReg$(InnerMemo, 'Inner');
+          newElement = <InnerMemo label="hi" />;
+
+          function App() {
+            const [, forceUpdate] = React.useState(0);
+            return (
+              <div onClick={() => forceUpdate(n => n + 1)}>{currentChild}</div>
+            );
+          }
+          $RefreshReg$(App, 'App');
+          return App;
+        });
+      });
+
+      // Mount the element created before the edit. Its type has no
+      // comparison function, so it mounts as a simple memo.
+      currentChild = oldElement;
+      await act(async () => {
+        container.firstChild.click();
+      });
+      const innerEl = container.firstChild.firstChild;
+      expect(innerEl.textContent).toBe('hi');
+
+      // Switch to the element created after the edit. It belongs to the same
+      // family, but a simple memo fiber cannot honor its comparison function,
+      // so the fiber must be recreated rather than reused.
+      currentChild = newElement;
+      await act(async () => {
+        container.firstChild.click();
+      });
+      expect(container.firstChild.firstChild).not.toBe(innerEl);
+      expect(container.firstChild.firstChild.textContent).toBe('hi');
+    }
+  });
+
   it('resets state when switching between different component types', async () => {
     if (__DEV__) {
       await act(async () => {


### PR DESCRIPTION
Editing the second argument of memo() previously never took effect until something else remounted the tree, for three separate reasons:

- canPreserveStateBetween only compared hook signatures, so adding or removing the compare argument was classified as a state-preserving update, even when the fiber was a SimpleMemoComponent and can no longer be.
- MemoComponent was missing from the hot reload type resolution in createWorkInProgress, so even when the tag did not need to change, the fiber kept reading the old `compare` function forever.
- isCompatibleFamilyForHotReloading would reuse a SimpleMemoComponent fiber for an element whose type has a custom comparison function.

Make the behavior consistent with how other edits are treated: shape changes remount, content changes apply in place.

- Adding or removing the comparison function remounts since adding one requires a fiber type change.
- Editing the comparison function implementation applies in place with state preserved: MemoComponent types now resolve through their family in createWorkInProgress like the other component tags, so the fiber picks up the latest wrapper object.
