### PR TITLE
[Fast Refresh] Unify hot reload type resolution

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -79,11 +79,7 @@ import {
 } from './ReactWorkTags';
 import {getComponentNameFromOwner} from 'react-reconciler/src/getComponentNameFromFiber';
 import {isDevToolsPresent} from './ReactFiberDevToolsHook';
-import {
-  resolveClassForHotReloading,
-  resolveFunctionForHotReloading,
-  resolveForwardRefForHotReloading,
-} from './ReactFiberHotReloading';
+import {resolveTypeForHotReloading} from './ReactFiberHotReloading';
 import {NoLanes} from './ReactFiberLane';
 import {
   NoMode,
@@ -427,13 +423,9 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     switch (workInProgress.tag) {
       case FunctionComponent:
       case SimpleMemoComponent:
-        workInProgress.type = resolveFunctionForHotReloading(current.type);
-        break;
       case ClassComponent:
-        workInProgress.type = resolveClassForHotReloading(current.type);
-        break;
       case ForwardRef:
-        workInProgress.type = resolveForwardRefForHotReloading(current.type);
+        workInProgress.type = resolveTypeForHotReloading(current.type);
         break;
       default:
         break;
@@ -573,11 +565,11 @@ export function createFiberFromTypeAndProps(
     if (shouldConstruct(type)) {
       fiberTag = ClassComponent;
       if (__DEV__) {
-        resolvedType = resolveClassForHotReloading(resolvedType);
+        resolvedType = resolveTypeForHotReloading(resolvedType);
       }
     } else {
       if (__DEV__) {
-        resolvedType = resolveFunctionForHotReloading(resolvedType);
+        resolvedType = resolveTypeForHotReloading(resolvedType);
       }
     }
   } else if (typeof type === 'string') {
@@ -664,9 +656,6 @@ export function createFiberFromTypeAndProps(
             // $FlowFixMe[invalid-compare]
             case REACT_FORWARD_REF_TYPE:
               fiberTag = ForwardRef;
-              if (__DEV__) {
-                resolvedType = resolveForwardRefForHotReloading(resolvedType);
-              }
               break getTag;
             // $FlowFixMe[invalid-compare]
             case REACT_MEMO_TYPE:

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -133,9 +133,7 @@ import {
 } from 'shared/ReactSymbols';
 import {setCurrentFiber} from './ReactCurrentFiber';
 import {
-  resolveFunctionForHotReloading,
-  resolveForwardRefForHotReloading,
-  resolveClassForHotReloading,
+  resolveTypeForHotReloading,
   resolveRemountTypeForHotReloading,
 } from './ReactFiberHotReloading';
 
@@ -414,7 +412,16 @@ function updateForwardRef(
   // TODO: current can be non-null here even if the component
   // hasn't yet mounted. This happens after the first render suspends.
   // We'll need to figure out if this is fine or can cause issues.
-  const render = Component.render;
+  let render = Component.render;
+  if (__DEV__) {
+    const resolvedRender = resolveTypeForHotReloading(render);
+    if (resolvedRender !== render) {
+      render = resolvedRender;
+      if (current !== null) {
+        didReceiveUpdate = true;
+      }
+    }
+  }
   const ref = workInProgress.ref;
 
   let propsWithoutRef;
@@ -482,7 +489,7 @@ function updateMemoComponent(
     if (isSimpleFunctionComponent(type) && Component.compare === null) {
       let resolvedType = type;
       if (__DEV__) {
-        resolvedType = resolveFunctionForHotReloading(type);
+        resolvedType = resolveTypeForHotReloading(type);
       }
       // If this is a plain function component without default props,
       // and with only the default shallow comparison, we upgrade it
@@ -2103,8 +2110,7 @@ function mountLazyComponent(
       const resolvedProps = resolveClassComponentProps(Component, props);
       workInProgress.tag = ClassComponent;
       if (__DEV__) {
-        workInProgress.type = Component =
-          resolveClassForHotReloading(Component);
+        workInProgress.type = Component = resolveTypeForHotReloading(Component);
       }
       return updateClassComponent(
         null,
@@ -2117,8 +2123,7 @@ function mountLazyComponent(
       workInProgress.tag = FunctionComponent;
       if (__DEV__) {
         validateFunctionComponentInDev(workInProgress, Component);
-        workInProgress.type = Component =
-          resolveFunctionForHotReloading(Component);
+        workInProgress.type = Component = resolveTypeForHotReloading(Component);
       }
       return updateFunctionComponent(
         null,
@@ -2135,8 +2140,7 @@ function mountLazyComponent(
     if ($$typeof === REACT_FORWARD_REF_TYPE) {
       workInProgress.tag = ForwardRef;
       if (__DEV__) {
-        workInProgress.type = Component =
-          resolveForwardRefForHotReloading(Component);
+        workInProgress.type = Component = resolveTypeForHotReloading(Component);
       }
       return updateForwardRef(
         null,

--- a/packages/react-reconciler/src/ReactFiberHotReloading.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.js
@@ -61,7 +61,7 @@ export const setRefreshHandler = (handler: RefreshHandler | null): void => {
   }
 };
 
-export function resolveFunctionForHotReloading(type: any): any {
+export function resolveTypeForHotReloading(type: any): any {
   if (__DEV__) {
     if (resolveFamily === null) {
       // Hot reloading is disabled.
@@ -69,49 +69,6 @@ export function resolveFunctionForHotReloading(type: any): any {
     }
     const family = resolveFamily(type);
     if (family === undefined) {
-      return type;
-    }
-    // Use the latest known implementation.
-    return family.current;
-  } else {
-    return type;
-  }
-}
-
-export function resolveClassForHotReloading(type: any): any {
-  // No implementation differences.
-  return resolveFunctionForHotReloading(type);
-}
-
-export function resolveForwardRefForHotReloading(type: any): any {
-  if (__DEV__) {
-    if (resolveFamily === null) {
-      // Hot reloading is disabled.
-      return type;
-    }
-    const family = resolveFamily(type);
-    if (family === undefined) {
-      // Check if we're dealing with a real forwardRef. Don't want to crash early.
-      if (
-        type !== null &&
-        type !== undefined &&
-        typeof type.render === 'function'
-      ) {
-        // ForwardRef is special because its resolved .type is an object,
-        // but it's possible that we only have its inner render function in the map.
-        // If that inner render function is different, we'll build a new forwardRef type.
-        const currentRender = resolveFunctionForHotReloading(type.render);
-        if (type.render !== currentRender) {
-          const syntheticType = {
-            $$typeof: REACT_FORWARD_REF_TYPE,
-            render: currentRender,
-          };
-          if (type.displayName !== undefined) {
-            (syntheticType as any).displayName = type.displayName;
-          }
-          return syntheticType;
-        }
-      }
       return type;
     }
     // Use the latest known implementation.


### PR DESCRIPTION
Previously resolveForwardRefForHotReloading was treated as a special
case. It's simpler to move this logic to updateForwardRef which
mirrors how updateMemoComponent and mountLazyComponent already are,
and it allows us to unify to a single resolveTypeForHotReloading which
we'll use in the next commit.

Since .type is no longer changing we need to set didReceiveUpdate
manually.

This behavior is already tested in "can update forwardRef render
function in isolation".