### PR TITLE
[Fast Refresh] Derive the fiber tag from the resolved type when mounting

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -561,18 +561,14 @@ export function createFiberFromTypeAndProps(
   let fiberTag: WorkTag = FunctionComponent;
   // The resolved type is set if we know what the final type will be. I.e. it's not lazy.
   let resolvedType = type;
-  if (typeof type === 'function') {
-    if (shouldConstruct(type)) {
+  if (__DEV__) {
+    resolvedType = resolveTypeForHotReloading(type);
+  }
+  if (typeof resolvedType === 'function') {
+    if (shouldConstruct(resolvedType)) {
       fiberTag = ClassComponent;
-      if (__DEV__) {
-        resolvedType = resolveTypeForHotReloading(resolvedType);
-      }
-    } else {
-      if (__DEV__) {
-        resolvedType = resolveTypeForHotReloading(resolvedType);
-      }
     }
-  } else if (typeof type === 'string') {
+  } else if (typeof resolvedType === 'string') {
     // $FlowFixMe[constant-condition]
     if (supportsResources && supportsSingletons) {
       const hostContext = getHostContext();
@@ -594,7 +590,7 @@ export function createFiberFromTypeAndProps(
       fiberTag = HostComponent;
     }
   } else {
-    getTag: switch (type) {
+    getTag: switch (resolvedType) {
       // $FlowFixMe[invalid-compare]
       case REACT_ACTIVITY_TYPE:
         return createFiberFromActivity(pendingProps, mode, lanes, key);
@@ -642,8 +638,8 @@ export function createFiberFromTypeAndProps(
       // Fall through
       default: {
         // $FlowFixMe[invalid-compare]
-        if (typeof type === 'object' && type !== null) {
-          switch (type.$$typeof) {
+        if (typeof resolvedType === 'object' && resolvedType !== null) {
+          switch (resolvedType.$$typeof) {
             // $FlowFixMe[invalid-compare]
             case REACT_CONTEXT_TYPE:
               fiberTag = ContextProvider;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -2102,6 +2102,9 @@ function mountLazyComponent(
   const props = workInProgress.pendingProps;
   const lazyComponent: LazyComponentType<any, any> = elementType;
   let Component = resolveLazy(lazyComponent);
+  if (__DEV__) {
+    Component = resolveTypeForHotReloading(Component);
+  }
   // Store the unwrapped component in the type.
   workInProgress.type = Component;
 
@@ -2109,9 +2112,6 @@ function mountLazyComponent(
     if (isFunctionClassComponent(Component)) {
       const resolvedProps = resolveClassComponentProps(Component, props);
       workInProgress.tag = ClassComponent;
-      if (__DEV__) {
-        workInProgress.type = Component = resolveTypeForHotReloading(Component);
-      }
       return updateClassComponent(
         null,
         workInProgress,
@@ -2123,7 +2123,6 @@ function mountLazyComponent(
       workInProgress.tag = FunctionComponent;
       if (__DEV__) {
         validateFunctionComponentInDev(workInProgress, Component);
-        workInProgress.type = Component = resolveTypeForHotReloading(Component);
       }
       return updateFunctionComponent(
         null,
@@ -2139,9 +2138,6 @@ function mountLazyComponent(
     // $FlowFixMe[invalid-compare]
     if ($$typeof === REACT_FORWARD_REF_TYPE) {
       workInProgress.tag = ForwardRef;
-      if (__DEV__) {
-        workInProgress.type = Component = resolveTypeForHotReloading(Component);
-      }
       return updateForwardRef(
         null,
         workInProgress,

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -915,6 +915,61 @@ describe('ReactFresh', () => {
     }
   });
 
+  it('can mount an element created before its type changed kinds', async () => {
+    if (__DEV__) {
+      let oldElement;
+      let currentChild = null;
+
+      await act(async () => {
+        await render(() => {
+          function Test() {
+            return <p>hi test</p>;
+          }
+          $RefreshReg$(Test, 'Test');
+          oldElement = <Test />;
+
+          function App() {
+            const [, forceUpdate] = React.useState(0);
+            return (
+              <div onClick={() => forceUpdate(n => n + 1)}>{currentChild}</div>
+            );
+          }
+          $RefreshReg$(App, 'App');
+          return App;
+        });
+      });
+
+      // Change the component kind before it has ever mounted.
+      await act(async () => {
+        await patch(() => {
+          function Test2() {
+            return <p>hi memo</p>;
+          }
+          const Test = React.memo(Test2);
+          $RefreshReg$(Test2, 'Test$React.memo');
+          $RefreshReg$(Test, 'Test');
+
+          function App() {
+            const [, forceUpdate] = React.useState(0);
+            return (
+              <div onClick={() => forceUpdate(n => n + 1)}>{currentChild}</div>
+            );
+          }
+          $RefreshReg$(App, 'App');
+          return App;
+        });
+      });
+
+      // Mount the element created before the edit. The fiber must be
+      // created from the latest type, with the tag matching its kind.
+      currentChild = oldElement;
+      await act(async () => {
+        container.firstChild.click();
+      });
+      expect(container.firstChild.textContent).toBe('hi memo');
+    }
+  });
+
   it('resets state when switching between different component types', async () => {
     if (__DEV__) {
       await act(async () => {


### PR DESCRIPTION
If an edit changed the kind of the type (e.g. a plain function got
wrapped in memo()), the fiber could get the old kind's tag with the
new kind's type, usually throwing an error.