### PR TITLE
[test] Fix Error Proxy stack assignment in Node.js 21+

### DIFF
--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -140,6 +140,10 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
           if (key === 'message') {
             return ReflectSet(target, key, decodeErrorMessage(value), receiver);
           }
+          if (key === 'stack') {
+            // https://github.com/nodejs/node/issues/60862
+            return ReflectSet(target, key, value);
+          }
           return ReflectSet(target, key, value, receiver);
         },
         get(target, key, receiver) {


### PR DESCRIPTION
Same as #35227, but for `set`.

V8's `stack` setter silently noops when `this` is a Proxy (nodejs/node#60862), so prodstack-stripping assignments like `error.stack = 'Error: ' + message` in `resolveErrorProd` were dropped and reads returned the real stack.

This caused `yarn test --prod` failures on Node 21+.

## Test Plan

`yarn test --prod` passes on both old and new Nodes.