### PR TITLE
[Flight] Recognize Node 22+ V8 frames for Promise statics in debug info

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -204,15 +204,24 @@ function isPromiseCreationInternal(url: string, functionName: string): boolean {
   if (url !== '') {
     return false;
   }
+  // V8 used to name the frames of static methods on the Promise constructor
+  // "Function.x" but newer versions name them "Promise.x". We match both.
   switch (functionName) {
     case 'new Promise':
     case 'Function.withResolvers':
+    case 'Promise.withResolvers':
     case 'Function.reject':
+    case 'Promise.reject':
     case 'Function.resolve':
+    case 'Promise.resolve':
     case 'Function.all':
+    case 'Promise.all':
     case 'Function.allSettled':
+    case 'Promise.allSettled':
     case 'Function.race':
+    case 'Promise.race':
     case 'Function.try':
+    case 'Promise.try':
       return true;
     default:
       return false;
@@ -333,18 +342,28 @@ function isPromiseAwaitInternal(url: string, functionName: string): boolean {
   if (url !== '') {
     return false;
   }
+  // V8 used to name the frames of static methods on the Promise constructor
+  // "Function.x" but newer versions name them "Promise.x". We match both.
   switch (functionName) {
     case 'Promise.then':
     case 'Promise.catch':
     case 'Promise.finally':
     case 'Function.reject':
+    case 'Promise.reject':
     case 'Function.resolve':
+    case 'Promise.resolve':
     case 'Function.all':
+    case 'Promise.all':
     case 'Function.allSettled':
+    case 'Promise.allSettled':
     case 'Function.any':
+    case 'Promise.any':
     case 'Function.race':
+    case 'Promise.race':
     case 'Function.try':
+    case 'Promise.try':
     case 'Function.withResolvers':
+    case 'Promise.withResolvers':
       return true;
     default:
       return false;


### PR DESCRIPTION

## Summary

Newer V8 versions (Node.js ≥ ~22) name the stack frames of static methods on the `Promise` constructor `Promise.all`, `Promise.race`, etc., where older versions named them `Function.all`, `Function.race`, etc. The `isPromiseCreationInternal` and `isPromiseAwaitInternal` allowlists in `ReactFlightServer` only matched the old spellings.

## How did you test this change?

- `yarn test --no-watchman ReactFlightAsyncDebugInfo` — 18/18 pass on both Node 20.19.0 and Node 24.16.0 (previously, "can track async information when awaited" failed on Node 24)
- `yarn test --silent --no-watchman packages/react-server/src/__tests__ packages/react-server-dom-webpack` — 243/243 pass on both Node versions, default and `-r=experimental` channels
- `yarn test-www --silent --no-watchman packages/react-server/src/__tests__` with `__VARIANT__` true and false — pass
- `yarn flow dom-node`, `yarn prettier`, `yarn linc` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)