### PR TITLE
[react-devtools-cdt-mcp] Make registration idempotent

### DIFF
--- a/packages/react-devtools-cdt-mcp/src/DevToolsCdtMcp.js
+++ b/packages/react-devtools-cdt-mcp/src/DevToolsCdtMcp.js
@@ -307,6 +307,17 @@ export type CdtMcpToolGroup = {
   tools: Array<CdtMcpTool>,
 };
 
+type Registration = {
+  facade: Facade,
+  unregister: () => void,
+};
+
+type ToolDiscoveryEvent = {
+  respondWith: (toolGroup: CdtMcpToolGroup) => void,
+};
+
+const registrations: WeakMap<any, Registration> = new WeakMap();
+
 /**
  * Build the chrome-devtools-mcp tool group from an assembled set of facade
  * tools. Each tool returns its facade result directly.
@@ -350,10 +361,15 @@ export function register(target?: any = globalThis): {
   facade: Facade,
   unregister: () => void,
 } {
+  const existingRegistration: Registration | void = registrations.get(target);
+  if (existingRegistration !== undefined) {
+    return existingRegistration;
+  }
+
   const facade = installFacade(target);
 
   let toolGroup: CdtMcpToolGroup | null = null;
-  const listener = (event: any) => {
+  const listener = (event: ToolDiscoveryEvent) => {
     if (toolGroup === null) {
       toolGroup = buildToolGroup(createTools(facade));
     }
@@ -361,10 +377,19 @@ export function register(target?: any = globalThis): {
   };
   target.addEventListener('devtoolstooldiscovery', listener);
 
-  return {
+  let isRegistered = true;
+  const registration: Registration = {
     facade,
     unregister: () => {
+      if (!isRegistered) {
+        return;
+      }
+      isRegistered = false;
       target.removeEventListener('devtoolstooldiscovery', listener);
+      registrations.delete(target);
     },
   };
+
+  registrations.set(target, registration);
+  return registration;
 }

--- a/packages/react-devtools-cdt-mcp/src/__tests__/DevToolsCdtMcp-test.js
+++ b/packages/react-devtools-cdt-mcp/src/__tests__/DevToolsCdtMcp-test.js
@@ -118,6 +118,90 @@ describe('react-devtools-cdt-mcp', () => {
     }
   });
 
+  it('returns the cached registration for repeated calls per target', () => {
+    let listener = null;
+    const target = {
+      addEventListener: jest.fn((type, callback) => {
+        expect(type).toBe('devtoolstooldiscovery');
+        listener = callback;
+      }),
+      removeEventListener: jest.fn(),
+    };
+
+    const first = register(target);
+    const second = register(target);
+
+    expect(target.addEventListener).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+    expect(second.facade).toBe(first.facade);
+
+    let firstGroup = null;
+    let secondGroup = null;
+    listener({
+      respondWith: group => {
+        firstGroup = group;
+      },
+    });
+    listener({
+      respondWith: group => {
+        secondGroup = group;
+      },
+    });
+    expect(secondGroup).toBe(firstGroup);
+
+    first.unregister();
+    expect(target.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(target.removeEventListener).toHaveBeenCalledWith(
+      'devtoolstooldiscovery',
+      listener,
+    );
+
+    second.unregister();
+    expect(target.removeEventListener).toHaveBeenCalledTimes(1);
+
+    const third = register(target);
+    expect(third).not.toBe(first);
+    expect(target.addEventListener).toHaveBeenCalledTimes(2);
+    third.unregister();
+  });
+
+  it('does not write registration state to the target', () => {
+    let listener = null;
+    const existingHook = {
+      inject: jest.fn(() => 0),
+      onCommitFiberRoot: jest.fn(),
+      onPostCommitFiberRoot: jest.fn(),
+      renderers: new Map(),
+    };
+    const target = Object.preventExtensions({
+      __REACT_DEVTOOLS_GLOBAL_HOOK__: existingHook,
+      addEventListener: jest.fn((type, callback) => {
+        expect(type).toBe('devtoolstooldiscovery');
+        listener = callback;
+      }),
+      removeEventListener: jest.fn(),
+    });
+
+    const first = register(target);
+    const second = register(target);
+
+    expect(target.addEventListener).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+    expect(second.facade).toBe(first.facade);
+    expect(Object.keys(target).sort()).toEqual([
+      '__REACT_DEVTOOLS_GLOBAL_HOOK__',
+      'addEventListener',
+      'removeEventListener',
+    ]);
+
+    first.unregister();
+    second.unregister();
+    expect(target.removeEventListener).toHaveBeenCalledWith(
+      'devtoolstooldiscovery',
+      listener,
+    );
+  });
+
   it('builds a "react" tool group exposing every facade tool', () => {
     expect(toolGroup.name).toBe('react');
     expect(typeof toolGroup.description).toBe('string');


### PR DESCRIPTION
Adds support for the scenario, when the package is imported multiple times for the same target.

This will return the same (referentially) facade object with tools, and will only clean up if all invocations were cleaned up.