### PR TITLE
[react-devtools-cdt-mcp] Add explicit register entry

### DIFF
--- a/packages/react-devtools-cdt-mcp/README.md
+++ b/packages/react-devtools-cdt-mcp/README.md
@@ -3,19 +3,27 @@
 Integrates React tools with
 [chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp).
 
-Importing this package **before React** installs the DevTools hook and registers
-a React tool group via chrome-devtools-mcp's `devtoolstooldiscovery` / `__dtmcp`
-third-party-tool protocol. The React tools then become discoverable and callable
-inside a chrome-devtools-mcp session — no separate server.
+Importing `react-devtools-cdt-mcp/register` **before React** installs the
+DevTools hook and registers a React tool group via chrome-devtools-mcp's
+`devtoolstooldiscovery` / `__dtmcp` third-party-tool protocol. The React tools
+then become discoverable and callable inside a chrome-devtools-mcp session — no
+separate server.
 
 ## Usage
 
-Import the package **before** React so the hook is installed before React
-initializes:
+Import the register entry **before** React so the hook is installed before
+React initializes:
 
 ```js
-import 'react-devtools-cdt-mcp';
+import 'react-devtools-cdt-mcp/register';
 import React from 'react';
+```
+
+The package root is side-effect-free and exports the lower-level API for custom
+targets:
+
+```js
+import {register, buildToolGroup} from 'react-devtools-cdt-mcp';
 ```
 
 When the page runs under chrome-devtools-mcp, the React tools are listed by

--- a/packages/react-devtools-cdt-mcp/fixtures/app/index.js
+++ b/packages/react-devtools-cdt-mcp/fixtures/app/index.js
@@ -1,7 +1,7 @@
-// Import the package source first so it installs the DevTools hook and registers
-// the chrome-devtools-mcp tool group BEFORE react-dom evaluates — the hook must
-// be in place when React's renderer injects on the first commit.
-import '../../src/index.js';
+// Import the register entry first so it installs the DevTools hook and
+// registers the chrome-devtools-mcp tool group BEFORE react-dom evaluates — the
+// hook must be in place when React's renderer injects on the first commit.
+import '../../src/register.js';
 
 import * as React from 'react';
 import {createRoot} from 'react-dom/client';

--- a/packages/react-devtools-cdt-mcp/package.json
+++ b/packages/react-devtools-cdt-mcp/package.json
@@ -11,7 +11,8 @@
   },
   "files": [
     "dist",
-    "index.js"
+    "index.js",
+    "register.js"
   ],
   "scripts": {
     "build": "cross-env NODE_ENV=production rollup -c rollup.config.cjs",

--- a/packages/react-devtools-cdt-mcp/register.js
+++ b/packages/react-devtools-cdt-mcp/register.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./dist/register.js');

--- a/packages/react-devtools-cdt-mcp/rollup.config.cjs
+++ b/packages/react-devtools-cdt-mcp/rollup.config.cjs
@@ -9,35 +9,44 @@ if (!NODE_ENV) {
   process.exit(1);
 }
 
-module.exports = {
-  input: 'src/index.js',
-  // CommonJS bundle for the npm package (referenced by the root index.js stub).
-  output: {
-    file: 'dist/index.js',
-    format: 'cjs',
-    exports: 'named',
-  },
-  treeshake: {moduleSideEffects: false},
-  plugins: [
-    nodeResolve({
-      extensions: ['.js', '.mjs'],
-    }),
-    commonjs({
-      include: /node_modules/,
-    }),
-    babel({
-      configFile: __dirname + '/../react-devtools-shared/babel.config.js',
-      babelHelpers: 'bundled',
-    }),
-    replace({
-      preventAssignment: true,
-      values: {
-        __DEV__: String(NODE_ENV === 'development'),
-        __IS_CHROME__: 'false',
-        __IS_FIREFOX__: 'false',
-        __IS_EDGE__: 'false',
-        __IS_NATIVE__: 'false',
-      },
-    }),
-  ],
-};
+const plugins = [
+  nodeResolve({
+    extensions: ['.js', '.mjs'],
+  }),
+  commonjs({
+    include: /node_modules/,
+  }),
+  babel({
+    configFile: __dirname + '/../react-devtools-shared/babel.config.js',
+    babelHelpers: 'bundled',
+  }),
+  replace({
+    preventAssignment: true,
+    values: {
+      __DEV__: String(NODE_ENV === 'development'),
+      __IS_CHROME__: 'false',
+      __IS_FIREFOX__: 'false',
+      __IS_EDGE__: 'false',
+      __IS_NATIVE__: 'false',
+    },
+  }),
+];
+
+function createBundle(input, file) {
+  return {
+    input,
+    // CommonJS bundles for the npm package (referenced by root stubs).
+    output: {
+      file,
+      format: 'cjs',
+      exports: 'named',
+    },
+    treeshake: {moduleSideEffects: false},
+    plugins,
+  };
+}
+
+module.exports = [
+  createBundle('src/index.js', 'dist/index.js'),
+  createBundle('src/register.js', 'dist/register.js'),
+];

--- a/packages/react-devtools-cdt-mcp/src/__tests__/DevToolsCdtMcp-test.js
+++ b/packages/react-devtools-cdt-mcp/src/__tests__/DevToolsCdtMcp-test.js
@@ -94,7 +94,19 @@ describe('react-devtools-cdt-mcp', () => {
     expect(globalThis.__dtmcp).toBeUndefined();
   });
 
-  it('throws when the auto entry is imported outside an event target', () => {
+  it('root entry exports tools without registering', () => {
+    unregister();
+    delete globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    jest.resetModules();
+
+    const api = require('../index');
+
+    expect(typeof api.register).toBe('function');
+    expect(typeof api.buildToolGroup).toBe('function');
+    expect(globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__).toBeUndefined();
+  });
+
+  it('throws when the register entry is imported outside an event target', () => {
     const originalAddEventListener = globalThis.addEventListener;
     const originalRemoveEventListener = globalThis.removeEventListener;
 
@@ -108,11 +120,50 @@ describe('react-devtools-cdt-mcp', () => {
       // $FlowFixMe[cannot-write]
       globalThis.removeEventListener = undefined;
 
-      expect(() => require('../index')).toThrow(
-        'react-devtools-cdt-mcp must be imported in a browser-like environment',
+      expect(() => require('../register')).toThrow(
+        'react-devtools-cdt-mcp/register must be imported in a browser-like environment',
       );
       expect(globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__).toBeUndefined();
     } finally {
+      globalThis.addEventListener = originalAddEventListener;
+      globalThis.removeEventListener = originalRemoveEventListener;
+    }
+  });
+
+  it('register entry installs the DevTools hook', () => {
+    const originalAddEventListener = globalThis.addEventListener;
+    const originalRemoveEventListener = globalThis.removeEventListener;
+    let autoListener = null;
+
+    unregister();
+    delete globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    jest.resetModules();
+
+    try {
+      // $FlowFixMe[cannot-write]
+      globalThis.addEventListener = (type, listener, options) => {
+        if (type === 'devtoolstooldiscovery') {
+          autoListener = listener;
+        }
+        return originalAddEventListener.call(
+          globalThis,
+          type,
+          listener,
+          options,
+        );
+      };
+
+      require('../register');
+
+      expect(globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__).toBeDefined();
+    } finally {
+      if (autoListener !== null) {
+        originalRemoveEventListener.call(
+          globalThis,
+          'devtoolstooldiscovery',
+          autoListener,
+        );
+      }
       globalThis.addEventListener = originalAddEventListener;
       globalThis.removeEventListener = originalRemoveEventListener;
     }

--- a/packages/react-devtools-cdt-mcp/src/index.js
+++ b/packages/react-devtools-cdt-mcp/src/index.js
@@ -7,23 +7,4 @@
  * @flow
  */
 
-import {register} from './DevToolsCdtMcp';
-
-// Side effect: install the facade (before React) and register the React tool
-// group for chrome-devtools-mcp. Import this module before React.
-if (
-  typeof window !== 'undefined' &&
-  typeof window.addEventListener === 'function' &&
-  typeof window.removeEventListener === 'function'
-) {
-  register();
-} else {
-  // eslint-disable-next-line react-internal/prod-error-codes
-  throw new Error(
-    'react-devtools-cdt-mcp must be imported in a browser-like environment ' +
-      'before React initializes. Use a client-only entry point, or the manual ' +
-      'entry point for custom targets.',
-  );
-}
-
 export * from './DevToolsCdtMcp';

--- a/packages/react-devtools-cdt-mcp/src/register.js
+++ b/packages/react-devtools-cdt-mcp/src/register.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {register} from './DevToolsCdtMcp';
+
+// Side effect: install the facade (before React) and register the React tool
+// group for chrome-devtools-mcp. Import this module before React.
+if (
+  typeof window !== 'undefined' &&
+  typeof window.addEventListener === 'function' &&
+  typeof window.removeEventListener === 'function'
+) {
+  register();
+} else {
+  // eslint-disable-next-line react-internal/prod-error-codes
+  throw new Error(
+    'react-devtools-cdt-mcp/register must be imported in a browser-like ' +
+      'environment before React initializes. Use the root entry point for ' +
+      'side-effect-free access to register().',
+  );
+}
+
+export * from './DevToolsCdtMcp';


### PR DESCRIPTION
We should provide a way for consumers to handle the installation on their own, so the index entrypoint will just export the APIs and won't have any side-effects.

The `/register` entrypoint (via `import react-devtools-cdt-mcp/register`), will subscribe an event listener and install the tools.