### PR TITLE
[react-devtools-cdt-mcp] Make it esm-only package

### DIFF
--- a/packages/react-devtools-cdt-mcp/e2e/package.json
+++ b/packages/react-devtools-cdt-mcp/e2e/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/react-devtools-cdt-mcp/index.js
+++ b/packages/react-devtools-cdt-mcp/index.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = require('./dist/index.js');

--- a/packages/react-devtools-cdt-mcp/package.json
+++ b/packages/react-devtools-cdt-mcp/package.json
@@ -3,16 +3,23 @@
   "version": "0.0.0",
   "description": "Integration of React tools with chrome-devtools-mcp",
   "license": "MIT",
-  "main": "index.js",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./register": "./dist/register.js",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": [
+    "./src/register.js",
+    "./dist/register.js"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/react.git",
     "directory": "packages/react-devtools-cdt-mcp"
   },
   "files": [
-    "dist",
-    "index.js",
-    "register.js"
+    "dist"
   ],
   "scripts": {
     "build": "cross-env NODE_ENV=production rollup -c rollup.config.cjs",

--- a/packages/react-devtools-cdt-mcp/register.js
+++ b/packages/react-devtools-cdt-mcp/register.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = require('./dist/register.js');

--- a/packages/react-devtools-cdt-mcp/rollup.config.cjs
+++ b/packages/react-devtools-cdt-mcp/rollup.config.cjs
@@ -32,14 +32,12 @@ const plugins = [
   }),
 ];
 
-function createBundle(input, file) {
+function createBundle(input, name) {
   return {
     input,
-    // CommonJS bundles for the npm package (referenced by root stubs).
     output: {
-      file,
-      format: 'cjs',
-      exports: 'named',
+      file: `dist/${name}.js`,
+      format: 'es',
     },
     treeshake: {moduleSideEffects: false},
     plugins,
@@ -47,6 +45,6 @@ function createBundle(input, file) {
 }
 
 module.exports = [
-  createBundle('src/index.js', 'dist/index.js'),
-  createBundle('src/register.js', 'dist/register.js'),
+  createBundle('src/index.js', 'index'),
+  createBundle('src/register.js', 'register'),
 ];

--- a/packages/react-devtools-cdt-mcp/src/index.js
+++ b/packages/react-devtools-cdt-mcp/src/index.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export * from './DevToolsCdtMcp';
+export * from './DevToolsCdtMcp.js';

--- a/packages/react-devtools-cdt-mcp/src/register.js
+++ b/packages/react-devtools-cdt-mcp/src/register.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import {register} from './DevToolsCdtMcp';
+import {register} from './DevToolsCdtMcp.js';
 
 // Side effect: install the facade (before React) and register the React tool
 // group for chrome-devtools-mcp. Import this module before React.
@@ -26,4 +26,4 @@ if (
   );
 }
 
-export * from './DevToolsCdtMcp';
+export * from './DevToolsCdtMcp.js';


### PR DESCRIPTION
The package was CJS-only, now adding basic ESM package exports to make sure it works there as well.