### PR TITLE
[Fizz] Extend stack overflow recovery to retries

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -7676,13 +7676,14 @@ describe('ReactDOMFizzServer', () => {
       return <span>hi</span>;
     }
 
-    // Recursively render a component tree deep enough to trigger stack overflow.
-    // Don't make this too short to not hit the limit but also not too deep to slow
-    // down the test.
+    // Recursively render a component tree deep enough to trigger stack overflow
+    // more than once. The first overflow is recovered by the renderNode
+    // trampoline; deeper trees must also recover when the retried task
+    // overflows again. Don't make this too deep to slow down the test.
     await act(() => {
       const {pipe} = renderToPipeableStream(
         <div>
-          <Recursive n={1000} />
+          <Recursive n={1200} />
         </div>,
       );
       pipe(writable);

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -7730,6 +7730,94 @@ describe('ReactDOMFizzServer', () => {
     expect(caughtError.message).toBe('Maximum call stack size exceeded');
   });
 
+  it('can recover from very deep trees during resume to avoid stack overflow', async () => {
+    const promise = new Promise(() => {});
+
+    let prerendering = true;
+
+    // Deep wrappers above the postponed boundary. On resume, replaying this
+    // path goes through retryReplayTask → retryNode (no trampoline), so a
+    // tree deep enough to overflow must recover there — not only on the
+    // ordinary render retry path.
+    function Deep({n, children}) {
+      if (n > 0) {
+        return <Deep n={n - 1}>{children}</Deep>;
+      }
+      return children;
+    }
+
+    function Content() {
+      if (prerendering) {
+        return React.use(promise);
+      }
+      return <span>hi</span>;
+    }
+
+    function App() {
+      return (
+        <div>
+          <Deep n={1200}>
+            <Suspense fallback="Loading...">
+              <Content />
+            </Suspense>
+          </Deep>
+        </div>
+      );
+    }
+
+    const controller = new AbortController();
+    const errors = [];
+    let pendingPrerender;
+    await act(() => {
+      pendingPrerender = ReactDOMFizzStatic.prerenderToNodeStream(<App />, {
+        signal: controller.signal,
+        onError(error) {
+          errors.push(error);
+        },
+      });
+    });
+    controller.abort('abort');
+
+    const prerendered = await pendingPrerender;
+    expect(errors).toEqual(['abort']);
+    expect(prerendered.postponed).not.toBe(null);
+
+    const preludeWritable = new Stream.PassThrough();
+    preludeWritable.setEncoding('utf8');
+    preludeWritable.on('data', chunk => {
+      writable.write(chunk);
+    });
+
+    await act(() => {
+      prerendered.prelude.pipe(preludeWritable);
+    });
+    expect(getVisibleChildren(container)).toEqual(<div>Loading...</div>);
+
+    prerendering = false;
+    errors.length = 0;
+
+    const resumed = await ReactDOMFizzServer.resumeToPipeableStream(
+      <App />,
+      JSON.parse(JSON.stringify(prerendered.postponed)),
+      {
+        onError(error) {
+          errors.push(error);
+        },
+      },
+    );
+
+    await act(() => {
+      resumed.pipe(writable);
+    });
+
+    expect(errors).toEqual([]);
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <span>hi</span>
+      </div>,
+    );
+  });
+
   it('client renders incomplete Suspense boundaries when the document is no longer loading when hydration begins', async () => {
     let resolve;
     const promise = new Promise(r => {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzShellHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzShellHydration-test.js
@@ -375,7 +375,7 @@ describe('ReactDOMFizzShellHydration', () => {
     expect(container.textContent).toBe('New screen');
   });
 
-  it('TODO: A large component stack causes SSR to stack overflow', async () => {
+  it('recovers from a large component stack during SSR', async () => {
     spyOnDevAndProd(console, 'error').mockImplementation(() => {});
 
     function NestedComponent({depth}: {depth: number}) {
@@ -385,16 +385,16 @@ describe('ReactDOMFizzShellHydration', () => {
       return <NestedComponent depth={depth - 1} />;
     }
 
-    // Server render
+    await resolveText('Shell');
     await serverAct(async () => {
-      ReactDOMFizzServer.renderToPipeableStream(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <NestedComponent depth={3000} />,
       );
+      pipe(writable);
     });
-    expect(console.error).toHaveBeenCalledTimes(1);
-    expect(console.error.mock.calls[0][0].toString()).toBe(
-      'RangeError: Maximum call stack size exceeded',
-    );
+    expect(console.error).not.toHaveBeenCalled();
+    assertLog(['Shell']);
+    expect(container.textContent).toBe('Shell');
   });
 
   it('client renders when an error is thrown in an error boundary', async () => {

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -5239,6 +5239,11 @@ function retryRenderTask(
 
   const childrenLength = segment.children.length;
   const chunkLength = segment.chunks.length;
+  // Remember which node we were about to render. renderNodeDestructive advances
+  // task.node as it walks down the tree, so we can detect whether we made
+  // forward progress if we hit a stack overflow and need to decide whether it's
+  // safe to reschedule the task versus fatally erroring.
+  const startNode = task.node;
   try {
     // We call the destructive form that mutates this task. That way if something
     // suspends again, we can reuse the same task instead of spawning a new one.
@@ -5301,6 +5306,25 @@ function retryRenderTask(
         const ping = task.ping;
         // We've asserted that x is a thenable above
         (x as any).then(ping.resolve, ping.reject);
+        return;
+      }
+      if (
+        x.message === 'Maximum call stack size exceeded' &&
+        task.node !== startNode
+      ) {
+        // We hit a stack overflow while retrying an extremely deep tree whose
+        // remaining depth still doesn't fit in a single fresh stack. Unlike the
+        // initial render, retryNode isn't wrapped in the renderNode trampoline,
+        // so the overflow surfaces here instead of being caught deeper.
+        // renderNodeDestructive stashes the deepest node we reached on the task;
+        // because task.node advanced past where we started this attempt, we know
+        // we made forward progress, so rescheduling the task lets it continue
+        // from a fresh stack rather than fatally erroring. If task.node had not
+        // advanced (e.g. a component that overflows within its own body) we fall
+        // through and treat it as a genuine, unrecoverable error.
+        segment.status = PENDING;
+        task.thenableState = null;
+        pingTask(request, task);
         return;
       }
     }

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -3213,7 +3213,10 @@ function replayElement(
         if (
           typeof x === 'object' &&
           x !== null &&
-          (x === SuspenseException || typeof x.then === 'function')
+          (x === SuspenseException ||
+            typeof x.then === 'function' ||
+            // Rethrow so retryReplayTask can trampoline on stack overflow.
+            x.message === 'Maximum call stack size exceeded')
         ) {
           // Suspend
           if (task.node === currentNode) {
@@ -5239,10 +5242,7 @@ function retryRenderTask(
 
   const childrenLength = segment.children.length;
   const chunkLength = segment.chunks.length;
-  // Remember which node we were about to render. renderNodeDestructive advances
-  // task.node as it walks down the tree, so we can detect whether we made
-  // forward progress if we hit a stack overflow and need to decide whether it's
-  // safe to reschedule the task versus fatally erroring.
+  // Used to detect forward progress if we hit a stack overflow below.
   const startNode = task.node;
   try {
     // We call the destructive form that mutates this task. That way if something
@@ -5312,19 +5312,12 @@ function retryRenderTask(
         x.message === 'Maximum call stack size exceeded' &&
         task.node !== startNode
       ) {
-        // We hit a stack overflow while retrying an extremely deep tree whose
-        // remaining depth still doesn't fit in a single fresh stack. Unlike the
-        // initial render, retryNode isn't wrapped in the renderNode trampoline,
-        // so the overflow surfaces here instead of being caught deeper.
-        // renderNodeDestructive stashes the deepest node we reached on the task;
-        // because task.node advanced past where we started this attempt, we know
-        // we made forward progress, so rescheduling the task lets it continue
-        // from a fresh stack rather than fatally erroring. If task.node had not
-        // advanced (e.g. a component that overflows within its own body) we fall
-        // through and treat it as a genuine, unrecoverable error.
+        // Stack overflow after making forward progress. Retry from a fresh stack.
+        // No progress (e.g. overflow inside the component itself) falls through.
         segment.status = PENDING;
         task.thenableState = null;
-        pingTask(request, task);
+        // Immediately schedule the task for retrying.
+        request.pingedTasks.push(task);
         return;
       }
     }
@@ -5369,6 +5362,8 @@ function retryReplayTask(request: Request, task: ReplayTask): void {
     setCurrentTaskInDEV(task);
   }
 
+  // Used to detect forward progress if we hit a stack overflow below.
+  const startNode = task.node;
   try {
     // We call the destructive form that mutates this task. That way if something
     // suspends again, we can reuse the same task instead of spawning a new one.
@@ -5430,6 +5425,17 @@ function retryReplayTask(request: Request, task: ReplayTask): void {
           thrownValue === SuspenseException
             ? getThenableStateAfterSuspending()
             : null;
+        return;
+      }
+      if (
+        x.message === 'Maximum call stack size exceeded' &&
+        task.node !== startNode
+      ) {
+        // Stack overflow after making forward progress. Retry from a fresh stack.
+        // No progress (e.g. overflow inside the component itself) falls through.
+        task.thenableState = null;
+        // Immediately schedule the task for retrying.
+        request.pingedTasks.push(task);
         return;
       }
     }


### PR DESCRIPTION
Ran into this test failure as part of https://github.com/react/react/pull/36917 - it seems that the added code was just enough to increase stack size and fail the deep tree recovery test in CI. Looking into that, there appears to be a gap here with retries, including a TODO test case for the scenario.

Fizz recovers from stack overflows in extremely deep trees by catching the first overflow in the `renderNode` trampoline and spawning a continuation task. That continuation is retried via `retryRenderTask → retryNode`, which has no trampoline above it. So if the remaining tree still doesn't fit in one fresh stack, the overflow was treated as a fatal error instead of recovering again.

This fix re-schedules the task when a retried render overflows but `task.node` advanced (proving forward progress was made). If this is a real in-component overflow, `task.node` doesn't advance and we still fail.

The existing test used `n={1000}`, which only required one recovery round and didn't catch this gap in source mode. It's updated to `n={1200}`, which reliably requires multiple recovery rounds.