### PR TITLE
[DevTools] Fix highlight overlay misalignment when page uses CSS zoom

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/backendViewsUtils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/backendViewsUtils-test.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+describe('backend views utils', () => {
+  let getEffectiveZoom;
+
+  beforeEach(() => {
+    getEffectiveZoom =
+      require('react-devtools-shared/src/backend/views/utils').getEffectiveZoom;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  describe('getEffectiveZoom', () => {
+    it('should return 1 when no zoom is applied', () => {
+      const element = document.createElement('div');
+      document.body.appendChild(element);
+
+      expect(getEffectiveZoom(element)).toBe(1);
+    });
+
+    it('should prefer currentCSSZoom when the browser provides it', () => {
+      const element = document.createElement('div');
+      document.body.appendChild(element);
+      Object.defineProperty(element, 'currentCSSZoom', {value: 0.9});
+
+      expect(getEffectiveZoom(element)).toBe(0.9);
+    });
+
+    it('should accumulate zoom from the ancestor chain', () => {
+      const grandparent = document.createElement('div');
+      const parent = document.createElement('div');
+      const element = document.createElement('div');
+      grandparent.appendChild(parent);
+      parent.appendChild(element);
+      document.body.appendChild(grandparent);
+
+      const zooms = new Map([
+        [grandparent, '0.5'],
+        [parent, '2'],
+        [element, '0.9'],
+      ]);
+      jest
+        .spyOn(window, 'getComputedStyle')
+        .mockImplementation(node => ({zoom: zooms.get(node) ?? ''}) as any);
+
+      expect(getEffectiveZoom(element)).toBeCloseTo(0.9);
+      expect(getEffectiveZoom(parent)).toBeCloseTo(1);
+      expect(getEffectiveZoom(grandparent)).toBeCloseTo(0.5);
+    });
+
+    it('should ignore unsupported or invalid computed zoom values', () => {
+      const parent = document.createElement('div');
+      const element = document.createElement('div');
+      parent.appendChild(element);
+      document.body.appendChild(parent);
+
+      const zooms = new Map([
+        [parent, 'normal'],
+        [element, '0'],
+      ]);
+      jest
+        .spyOn(window, 'getComputedStyle')
+        .mockImplementation(node => ({zoom: zooms.get(node) ?? ''}) as any);
+
+      expect(getEffectiveZoom(element)).toBe(1);
+    });
+  });
+});

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
@@ -7,7 +7,11 @@
  * @flow
  */
 
-import {getElementDimensions, getNestedBoundingClientRect} from '../utils';
+import {
+  getEffectiveZoom,
+  getElementDimensions,
+  getNestedBoundingClientRect,
+} from '../utils';
 
 import type {Rect} from '../utils';
 import type Agent from 'react-devtools-shared/src/backend/agent';
@@ -208,6 +212,15 @@ export default class Overlay {
       this.rects.push(new OverlayRect(this.window.document, this.container));
     }
 
+    // CSS zoom inherited from the document scales the overlay's fixed-position
+    // coordinates, while getBoundingClientRect() coordinates are unscaled.
+    // Cancel the inherited zoom out so both coordinate systems match.
+    const inheritedZoom = getEffectiveZoom(this.window.document.body);
+    this.container.style.setProperty(
+      'zoom',
+      inheritedZoom !== 1 ? String(1 / inheritedZoom) : '1',
+    );
+
     const outerBox = {
       top: Number.POSITIVE_INFINITY,
       right: Number.NEGATIVE_INFINITY,
@@ -216,7 +229,13 @@ export default class Overlay {
     };
     elements.forEach((element, index) => {
       const box = getNestedBoundingClientRect(element, this.window);
-      const dims = getElementDimensions(element);
+      // Computed margin/border/padding values are reported unscaled, but the
+      // element renders them multiplied by its effective zoom. Scale them so
+      // the overlay bands match what is actually painted.
+      const dims = scaleElementDimensions(
+        getElementDimensions(element),
+        getEffectiveZoom(element),
+      );
 
       outerBox.top = Math.min(outerBox.top, box.top - dims.marginTop);
       outerBox.right = Math.max(
@@ -308,6 +327,26 @@ function findTipPos(
   left += 'px';
   return {
     style: {top, left},
+  };
+}
+
+function scaleElementDimensions(dims: any, zoom: number) {
+  if (zoom === 1) {
+    return dims;
+  }
+  return {
+    borderLeft: dims.borderLeft * zoom,
+    borderRight: dims.borderRight * zoom,
+    borderTop: dims.borderTop * zoom,
+    borderBottom: dims.borderBottom * zoom,
+    marginLeft: dims.marginLeft * zoom,
+    marginRight: dims.marginRight * zoom,
+    marginTop: dims.marginTop * zoom,
+    marginBottom: dims.marginBottom * zoom,
+    paddingLeft: dims.paddingLeft * zoom,
+    paddingRight: dims.paddingRight * zoom,
+    paddingTop: dims.paddingTop * zoom,
+    paddingBottom: dims.paddingBottom * zoom,
   };
 }
 

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -13,6 +13,7 @@ import type {HostInstance} from '../../types';
 import type Agent from '../../agent';
 
 import {isReactNativeEnvironment} from 'react-devtools-shared/src/backend/utils';
+import {getEffectiveZoom} from '../utils';
 
 // Note these colors are in sync with DevTools Profiler chart colors.
 const COLORS = [
@@ -49,6 +50,18 @@ function drawWeb(nodeToData: Map<HostInstance, Data>) {
 
   const dpr = window.devicePixelRatio || 1;
   const canvasFlow: HTMLCanvasElement = canvas as any as HTMLCanvasElement;
+
+  // CSS zoom inherited from the document scales the canvas' size and drawing
+  // coordinates, while the rects to draw are unscaled viewport coordinates.
+  // Cancel the inherited zoom out so both coordinate systems match.
+  const inheritedZoom = getEffectiveZoom(
+    canvasFlow.parentElement ?? window.document.documentElement,
+  );
+  canvasFlow.style.setProperty(
+    'zoom',
+    inheritedZoom !== 1 ? String(1 / inheritedZoom) : '1',
+  );
+
   canvasFlow.width = window.innerWidth * dpr;
   canvasFlow.height = window.innerHeight * dpr;
   canvasFlow.style.width = `${window.innerWidth}px`;

--- a/packages/react-devtools-shared/src/backend/views/utils.js
+++ b/packages/react-devtools-shared/src/backend/views/utils.js
@@ -112,6 +112,38 @@ export function getNestedBoundingClientRect(
   }
 }
 
+// CSS `zoom` on an ancestor scales the rendered position and size of all
+// descendants — including position: fixed ones — while getBoundingClientRect()
+// keeps returning unscaled viewport coordinates. Overlays injected into a
+// zoomed document need to know the accumulated zoom to stay aligned.
+// See https://github.com/facebook/react/issues/36904
+export function getEffectiveZoom(node: HTMLElement): number {
+  // Modern browsers expose the accumulated zoom directly.
+  const currentCSSZoom = (node as any).currentCSSZoom;
+  if (typeof currentCSSZoom === 'number') {
+    return currentCSSZoom;
+  }
+
+  // Fall back to accumulating `zoom` from the ancestor chain.
+  let zoom = 1;
+  let current: HTMLElement | null = node;
+  while (current != null) {
+    const ownerWindow = getOwnerWindow(current);
+    if (ownerWindow == null) {
+      break;
+    }
+    // Browsers without CSS zoom support report an empty string.
+    const styleZoom = parseFloat(
+      (ownerWindow.getComputedStyle(current) as any).zoom,
+    );
+    if (!isNaN(styleZoom) && styleZoom > 0) {
+      zoom *= styleZoom;
+    }
+    current = current.parentElement;
+  }
+  return zoom;
+}
+
 export function getElementDimensions(domElement: HTMLElement): {
   borderBottom: number,
   borderLeft: number,


### PR DESCRIPTION
## Summary

Fixes #36904

When a page applies CSS `zoom` (e.g. `html { zoom: 0.9 }`), both DevTools
highlight systems render misaligned:

- **Inspect highlight** (`Highlighter/Overlay.js`) — injects `position: fixed`
  nodes into the page. In Chromium, ancestor `zoom` scales the coordinate
  system for fixed descendants, while `getBoundingClientRect()` keeps
  returning unscaled viewport coordinates, so the overlay lands at
  `coordinate × zoom` — off by a factor of `1 - zoom`.
- **Trace updates** (`TraceUpdates/canvas.js`) — the injected canvas is
  scaled the same way, shifting every drawn rect.

## Fix

- Add `getEffectiveZoom()` to `backend/views/utils.js`: returns the
  accumulated zoom for an element, preferring the browser's
  `currentCSSZoom` API and falling back to walking the ancestor chain
  multiplying computed `zoom` values (returns 1 where zoom is unsupported,
  so unaffected browsers are untouched).
- Counter-zoom the overlay container and the trace-updates canvas
  (`zoom: 1/inheritedZoom`) so their rendered coordinate system matches
  `getBoundingClientRect()` again — no coordinate math needs rewriting.
- Scale the overlay's margin/border/padding bands by the target element's
  effective zoom, since computed style values are reported unscaled but
  painted scaled.

This is a targeted fix in the existing code, as discussed in #36904; it
doesn't conflict with the larger unification proposed in #36787.

## How did you test it?

- New unit tests for `getEffectiveZoom` in
  `packages/react-devtools-shared/src/__tests__/backendViewsUtils-test.js`
- `yarn linc`, `yarn prettier`, and Flow (`dom-node`) all pass locally
