### PR TITLE
Outline object methods in function outlining

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineFunctions.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineFunctions.ts
@@ -11,6 +11,8 @@ export function outlineFunctions(
   fn: HIRFunction,
   fbtOperands: Set<IdentifierId>,
 ): void {
+  const outlinedObjectMethods = new Set<IdentifierId>();
+
   for (const [, block] of fn.body.blocks) {
     for (const instr of block.instructions) {
       const {value, lvalue} = instr;
@@ -23,7 +25,8 @@ export function outlineFunctions(
         outlineFunctions(value.loweredFunc.func, fbtOperands);
       }
       if (
-        value.kind === 'FunctionExpression' &&
+        (value.kind === 'FunctionExpression' ||
+          value.kind === 'ObjectMethod') &&
         value.loweredFunc.func.context.length === 0 &&
         // TODO: handle outlining named functions
         value.loweredFunc.func.id === null &&
@@ -37,6 +40,9 @@ export function outlineFunctions(
         loweredFunc.id = id.value;
 
         fn.env.outlineFunction(loweredFunc, null);
+        if (value.kind === 'ObjectMethod') {
+          outlinedObjectMethods.add(lvalue.identifier.id);
+        }
         instr.value = {
           kind: 'LoadGlobal',
           binding: {
@@ -45,6 +51,25 @@ export function outlineFunctions(
           },
           loc: value.loc,
         };
+      }
+    }
+  }
+
+  if (outlinedObjectMethods.size > 0) {
+    for (const [, block] of fn.body.blocks) {
+      for (const instr of block.instructions) {
+        if (instr.value.kind !== 'ObjectExpression') {
+          continue;
+        }
+        for (const property of instr.value.properties) {
+          if (
+            property.kind === 'ObjectProperty' &&
+            property.type === 'method' &&
+            outlinedObjectMethods.has(property.place.identifier.id)
+          ) {
+            property.type = 'property';
+          }
+        }
       }
     }
   }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-prop-across-objectmethod-def.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-prop-across-objectmethod-def.expect.md
@@ -34,12 +34,13 @@ import { identity } from "shared-runtime";
 // inferred as a context variable.
 
 function Component() {
-  const obj = { method() {} };
+  const obj = { method: _temp };
 
   identity(obj);
 
   return 4;
 }
+function _temp() {}
 
 export const FIXTURE_ENTRYPOINT = {
   fn: Component,

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-prop-to-object-method.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-prop-to-object-method.expect.md
@@ -31,17 +31,16 @@ function Foo() {
   const $ = _c(1);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    const x = {
-      foo() {
-        return identity(1);
-      },
-    };
+    const x = { foo: _temp };
     t0 = x.foo();
     $[0] = t0;
   } else {
     t0 = $[0];
   }
   return t0;
+}
+function _temp() {
+  return identity(1);
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-nested-object-method.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/infer-nested-object-method.expect.md
@@ -35,17 +35,16 @@ function Test() {
   const $ = _c(1);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    const context = {
-      testFn() {
-        return _temp;
-      },
-    };
+    const context = { testFn: _temp2 };
     t0 = <Stringify value={context} shouldInvokeFns={true} />;
     $[0] = t0;
   } else {
     t0 = $[0];
   }
   return t0;
+}
+function _temp2() {
+  return _temp;
 }
 function _temp() {
   return "test";

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-maybe-alias.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-maybe-alias.expect.md
@@ -38,11 +38,7 @@ function useHook(props) {
         return props;
       },
     };
-    const y = {
-      getY() {
-        return "y";
-      },
-    };
+    const y = { getY: _temp };
     t0 = setProperty(x, y);
     $[0] = props;
     $[1] = t0;
@@ -50,6 +46,9 @@ function useHook(props) {
     t0 = $[1];
   }
   return t0;
+}
+function _temp() {
+  return "y";
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-shorthand.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/object-method-shorthand.expect.md
@@ -26,17 +26,16 @@ function Component() {
   const $ = _c(1);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    const obj = {
-      method() {
-        return 1;
-      },
-    };
+    const obj = { method: _temp };
     t0 = obj.method();
     $[0] = t0;
   } else {
     t0 = $[0];
   }
   return t0;
+}
+function _temp() {
+  return 1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outline-object-method.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outline-object-method.expect.md
@@ -1,0 +1,58 @@
+
+## Input
+
+```javascript
+// @enableFunctionOutlining
+
+function Component() {
+  const object = {
+    method() {
+      return false;
+    },
+    property: () => {
+      return true;
+    },
+  };
+  return [object.method(), object.property()];
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enableFunctionOutlining
+
+function Component() {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    const object = { method: _temp, property: _temp2 };
+    t0 = [object.method(), object.property()];
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0;
+}
+function _temp2() {
+  return true;
+}
+function _temp() {
+  return false;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};
+
+```
+      
+### Eval output
+(kind: ok) [false,true]

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outline-object-method.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outline-object-method.js
@@ -1,0 +1,18 @@
+// @enableFunctionOutlining
+
+function Component() {
+  const object = {
+    method() {
+      return false;
+    },
+    property: () => {
+      return true;
+    },
+  };
+  return [object.method(), object.property()];
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-within-object-method.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-within-object-method.expect.md
@@ -30,21 +30,20 @@ function Component(props) {
   const $ = _c(1);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    const object = {
-      foo() {
-        try {
-          return [];
-        } catch (t1) {
-          return;
-        }
-      },
-    };
+    const object = { foo: _temp };
     t0 = object.foo();
     $[0] = t0;
   } else {
     t0 = $[0];
   }
   return t0;
+}
+function _temp() {
+  try {
+    return [];
+  } catch (t0) {
+    return;
+  }
 }
 
 export const FIXTURE_ENTRYPOINT = {


### PR DESCRIPTION
## Summary

Closes #32039

This extends function outlining to context-free object methods. When an object method is outlined, the object literal property is emitted as a normal property that points at the outlined helper function, matching how outlined function-valued properties are emitted.

I added a focused fixture covering a shorthand object method next to an arrow-function property, and updated the existing snapshots where context-free object methods are now outlined.

## How did you test this change?

- Reproduced before the change with `yarn snap compile packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outline-object-method.js`; the shorthand method stayed inline while the arrow property was outlined.
- Verified after the change with the same compile command; both helpers are outlined.
- `env -u NO_COLOR yarn snap -p outline-object-method`
- `env -u NO_COLOR yarn snap -p "*object-method*"`
- `env -u NO_COLOR yarn snap -p "*outline*"`
- `env -u NO_COLOR yarn snap`
- `env -u NO_COLOR yarn workspace babel-plugin-react-compiler run test`
- `yarn workspace babel-plugin-react-compiler run build`
- `yarn workspace babel-plugin-react-compiler run lint`
- `yarn prettier-check compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineFunctions.ts compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/outline-object-method.js`
- `git diff --check`