### PR TITLE
[Flight] Dedupe client reference chunk URL lists shared by identity

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -576,6 +576,75 @@ describe('ReactFlightDOMEdge', () => {
     ); // two random items are the same instance
   });
 
+  it('should dedupe a chunk URL list shared by identity across client references', async () => {
+    // Bundlers merge a page's client modules into shared chunk groups, so it's
+    // common for many client references to point at the exact same chunks
+    // array by identity. Each client reference should still get its own "I"
+    // row, but the shared array should only be embedded in the payload once.
+    function ComponentA() {
+      return <span>A</span>;
+    }
+    function ComponentB() {
+      return <span>B</span>;
+    }
+    const ClientComponentA = clientExports(
+      ComponentA,
+      'shared-chunk-id',
+      'shared-chunk-filename.js',
+      Promise.resolve(),
+    );
+    const ClientComponentB = clientExports(
+      ComponentB,
+      'shared-chunk-id',
+      'shared-chunk-filename.js',
+    );
+    // clientExports() always allocates a fresh chunks array per call. Make
+    // the two client references share one array by identity, the way a real
+    // bundler's manifest would for modules in the same chunk group.
+    webpackMap[ClientComponentB.$$id].chunks =
+      webpackMap[ClientComponentA.$$id].chunks;
+
+    function App() {
+      return (
+        <>
+          <ClientComponentA />
+          <ClientComponentB />
+        </>
+      );
+    }
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(<App />, webpackMap),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    // Two client references, each with their own "I" row...
+    expect((serializedContent.match(/:I\[/g) || []).length).toBe(2);
+    // ...but the shared chunk filename text should only appear once.
+    expect(serializedContent.split('shared-chunk-filename.js').length - 1).toBe(
+      1,
+    );
+
+    const response = ReactServerDOMClient.createFromReadableStream(stream2, {
+      serverConsumerManifest: {
+        moduleMap: null,
+        moduleLoading: webpackModuleLoading,
+      },
+    });
+
+    function ClientRoot() {
+      return use(response);
+    }
+
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(<ClientRoot />),
+    );
+    const result = await readResult(ssrStream);
+    expect(result).toContain('<span>A</span>');
+    expect(result).toContain('<span>B</span>');
+  });
+
   it('should execute repeated server components only once', async () => {
     const str = 'this is a long return value';
     let timesRendered = 0;

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -3018,6 +3018,44 @@ function encodeReferenceChunk(
   return stringToChunk(row);
 }
 
+// Bundlers merge a page's client modules into shared chunk groups, so the
+// chunk URL list (the second element of the [id, chunks, name] tuple that
+// resolveClientReferenceMetadata returns) is frequently the exact same
+// array, by identity, across many client references on the same page. If we
+// inline it on every "I" row we pay for it repeatedly even though it's
+// already deduped upstream. Instead, the first time we see a given chunks
+// array we outline it into its own row and remember a reference to it; every
+// later client reference that shares the array just points at that row.
+//
+// The outlined row is queued into completedImportChunks (not
+// completedRegularChunks) specifically so that it is guaranteed to reach the
+// client before any "I" row that references it: import rows are always
+// flushed ahead of regular model rows (see flushCompletedChunks), and
+// resolveModule() on the client resolves client reference metadata
+// synchronously, so a forward reference would break it.
+function dedupeClientReferenceMetadataChunks(
+  request: Request,
+  clientReferenceMetadata: ClientReferenceMetadata,
+): ClientReferenceMetadata {
+  const chunks = (clientReferenceMetadata as $FlowFixMe)[1];
+  if (!isArray(chunks) || chunks.length < 2) {
+    // Not worth outlining a short or malformed chunk list into its own row.
+    return clientReferenceMetadata;
+  }
+  const writtenObjects = request.writtenObjects;
+  let chunksRef = writtenObjects.get(chunks);
+  if (chunksRef === undefined) {
+    request.pendingChunks++;
+    const chunksId = request.nextChunkId++;
+    emitChunkListChunk(request, chunksId, chunks);
+    chunksRef = serializeByValueID(chunksId);
+    writtenObjects.set(chunks, chunksRef);
+  }
+  const deduped = clientReferenceMetadata.slice(0);
+  (deduped as $FlowFixMe)[1] = chunksRef;
+  return deduped as $FlowFixMe as ClientReferenceMetadata;
+}
+
 function serializeClientReference(
   request: Request,
   parent:
@@ -3043,7 +3081,10 @@ function serializeClientReference(
   }
   try {
     const clientReferenceMetadata: ClientReferenceMetadata =
-      resolveClientReferenceMetadata(request.bundlerConfig, clientReference);
+      dedupeClientReferenceMetadataChunks(
+        request,
+        resolveClientReferenceMetadata(request.bundlerConfig, clientReference),
+      );
     request.pendingChunks++;
     const importId = request.nextChunkId++;
     emitImportChunk(request, importId, clientReferenceMetadata, false);
@@ -4461,6 +4502,22 @@ function emitImportChunk(
   } else {
     request.completedImportChunks.push(processedChunk);
   }
+}
+
+function emitChunkListChunk(
+  request: Request,
+  id: number,
+  chunks: $ReadOnlyArray<string>,
+): void {
+  // Encoded exactly like a regular model row (id:json\n) so the client
+  // resolves a "$id" reference to it with no protocol changes required.
+  // Queued into completedImportChunks -- see dedupeClientReferenceMetadataChunks
+  // for why this needs to flush ahead of the "I" rows that reference it.
+  // $FlowFixMe[incompatible-type] stringify can return null
+  const json: string = stringify(chunks);
+  const row = id.toString(16) + ':' + json + '\n';
+  const processedChunk = stringToChunk(row);
+  request.completedImportChunks.push(processedChunk);
 }
 
 function emitHintChunk<Code: HintCode>(


### PR DESCRIPTION
Alternate to https://github.com/react/react/pull/36198

## Summary

Bundlers (webpack, Turbopack) merge a page's client modules into shared chunk groups, so many client references end up pointing at the exact same `chunks: Array<string>` by identity in the manifest. `serializeClientReference`/`emitImportChunk` previously re-inlined that array in full on every `I` row, so the duplication grows as (client references) x (chunk group size). On real pages this can account for ~30% of the whole SSR HTML document.

Originating report with measurements: vercel/next.js#95559 (a minimal repro shows 23x duplication / ~29% of HTML bytes; a real production page shows 43x duplication / ~136 KB of pure repeated chunk-URL text, ~29% of the document).

This PR dedupes the chunk list at the Flight wire-protocol layer: the first time a given `chunks` array is seen (by identity, via `request.writtenObjects`), it's outlined into its own row and a reference to that row is remembered. Every later client reference that shares the same array points at that row (`$<id>`) instead of re-embedding the whole URL list.

The outlined row is queued into `completedImportChunks` rather than `completedRegularChunks`, specifically because import rows are always flushed to the client ahead of regular model rows (see `flushCompletedChunks`), and `resolveModule()` on the client resolves client reference metadata **synchronously** to start preloading -- a forward reference (chunk-list row arriving after the `I` row that points to it) would break that. Routing the outlined row through the same priority queue as `I` rows preserves the ordering guarantee.

The reference itself uses the same `$<id>` back-reference syntax Flight already uses elsewhere in the model graph (e.g. for deduped objects/elements), and `reviveModel`/`parseModelString` on the client already resolve it generically -- so **no client-side changes are required**, this is a pure server-side/wire-format-compatible change.

## How did you test this change?

- Added `should dedupe a chunk URL list shared by identity across client references` in `packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js`: renders two client components whose manifest entries share one `chunks` array by identity (as real bundlers do), asserts the raw serialized payload contains the shared chunk filename exactly once while still emitting two separate `I` rows (one per client reference), and verifies both components still resolve and render correctly end-to-end through `createFromReadableStream` -> SSR.
  - Verified the new test fails without the fix (`git stash` on `ReactFlightServer.js` alone): filename count is 2 instead of 1.
- `yarn flow dom-edge-webpack` and `yarn flow dom-edge-turbopack` -- no errors.
- `yarn lint` -- passes.
- `yarn prettier --check` on touched files -- passes.
- `node ./scripts/jest/jest-cli.js ReactFlight` and `ReactFlightDOM` (dev and `--prod`) -- all pass (one pre-existing, unrelated snapshot failure in `ReactFlightAsyncDebugInfo-test.js` reproduces identically on a clean checkout without this change, confirmed via `git stash`).