### PR TITLE
docs: fix self-referential JSDoc for forEachContext param

### DIFF
--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -410,7 +410,7 @@ type ForEachFunc = (child: ?React$Node) => void;
  *
  * @param {?*} children Children tree container.
  * @param {function(*, int)} forEachFunc
- * @param {*} forEachContext Context for forEachContext.
+ * @param {*} forEachContext Context for forEachFunc.
  */
 function forEachChildren(
   children: ?ReactNodeList,


### PR DESCRIPTION
## Summary

The JSDoc description for the `forEachContext` parameter in `forEachChildren` is self-referential:

\`\`\`js
* @param {*} forEachContext Context for forEachContext.
\`\`\`

The description names the parameter in its own definition, which is meaningless. `forEachContext` is the execution context (`this`) passed to `forEachFunc` when it is called. The sibling `mapChildren` function (line 363) shows the correct pattern:

\`\`\`js
* @param {*} context Context for mapFunction.
\`\`\`

## How did you test this change?

Documentation-only change to a JSDoc comment — no runtime behavior is affected, no tests needed. Verified by:

1. Comparing with the sibling `mapChildren` function's `@param {*} context Context for mapFunction.` description, which uses the same convention (naming the callback the context belongs to, not the parameter itself).
2. Confirming the parameter's purpose: `forEachContext` is passed as the `this` value in `forEachFunc.apply(this, arguments)` (line 424), so "Context for forEachFunc" is factually correct.