### PR TITLE
[compiler] Preserve member update expression semantics

### DIFF
--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -961,72 +961,89 @@ fn lower_expression(
             let loc = convert_opt_loc(&update.base.loc);
             match update.argument.as_ref() {
                 Expression::MemberExpression(member) => {
-                    let binary_op = match &update.operator {
-                        react_compiler_ast::operators::UpdateOperator::Increment => {
-                            BinaryOperator::Add
-                        }
-                        react_compiler_ast::operators::UpdateOperator::Decrement => {
-                            BinaryOperator::Subtract
-                        }
-                    };
-                    // Use the member expression's loc (not the update expression's)
-                    // to match TS behavior where the inner operations use leftExpr.node.loc
                     let member_loc = convert_opt_loc(&member.base.loc);
                     let lowered = lower_member_expression(builder, member)?;
                     let object = lowered.object;
                     let lowered_property = lowered.property;
-                    let prev_value = lower_value_to_temporary(builder, lowered.value)?;
-
-                    let one = lower_value_to_temporary(
+                    let member_value = lower_value_to_temporary(builder, lowered.value)?;
+                    // Preserve native update coercion (including BigInt) and the expression result.
+                    let update_target = build_temporary_place(builder, member_loc.clone());
+                    promote_temporary(builder, update_target.identifier);
+                    lower_value_to_temporary(
                         builder,
-                        InstructionValue::Primitive {
-                            value: PrimitiveValue::Number(FloatValue::new(1.0)),
-                            loc: None,
-                        },
-                    )?;
-                    let updated = lower_value_to_temporary(
-                        builder,
-                        InstructionValue::BinaryExpression {
-                            operator: binary_op,
-                            left: prev_value.clone(),
-                            right: one,
+                        InstructionValue::StoreLocal {
+                            lvalue: LValue {
+                                kind: InstructionKind::Const,
+                                place: update_target.clone(),
+                            },
+                            value: member_value,
+                            type_annotation: None,
                             loc: member_loc.clone(),
                         },
                     )?;
 
-                    // Store back using the property from the lowered member expression.
-                    // For prefix, the result is the PropertyStore/ComputedStore lvalue
-                    // (matching TS which uses newValuePlace). For postfix, it's prev_value.
-                    let new_value_place = match lowered_property {
-                        MemberProperty::Literal(prop_literal) => lower_value_to_temporary(
-                            builder,
-                            InstructionValue::PropertyStore {
-                                object,
-                                property: prop_literal,
-                                value: updated.clone(),
-                                loc: member_loc,
+                    let operation = convert_update_operator(&update.operator);
+                    let update_value = lower_value_to_temporary(
+                        builder,
+                        if update.prefix {
+                            InstructionValue::PrefixUpdate {
+                                lvalue: update_target.clone(),
+                                operation,
+                                value: update_target.clone(),
+                                loc: loc.clone(),
+                            }
+                        } else {
+                            InstructionValue::PostfixUpdate {
+                                lvalue: update_target.clone(),
+                                operation,
+                                value: update_target.clone(),
+                                loc: loc.clone(),
+                            }
+                        },
+                    )?;
+                    let result = build_temporary_place(builder, loc.clone());
+                    promote_temporary(builder, result.identifier);
+                    lower_value_to_temporary(
+                        builder,
+                        InstructionValue::StoreLocal {
+                            lvalue: LValue {
+                                kind: InstructionKind::Const,
+                                place: result.clone(),
                             },
-                        )?,
-                        MemberProperty::Computed(prop_place) => lower_value_to_temporary(
-                            builder,
-                            InstructionValue::ComputedStore {
-                                object,
-                                property: prop_place,
-                                value: updated.clone(),
-                                loc: member_loc,
-                            },
-                        )?,
-                    };
+                            value: update_value,
+                            type_annotation: None,
+                            loc: loc.clone(),
+                        },
+                    )?;
 
-                    // Return previous for postfix, newValuePlace for prefix
-                    let result_place = if update.prefix {
-                        new_value_place
-                    } else {
-                        prev_value
-                    };
+                    match lowered_property {
+                        MemberProperty::Literal(prop_literal) => {
+                            lower_value_to_temporary(
+                                builder,
+                                InstructionValue::PropertyStore {
+                                    object,
+                                    property: prop_literal,
+                                    value: update_target,
+                                    loc: member_loc,
+                                },
+                            )?;
+                        }
+                        MemberProperty::Computed(prop_place) => {
+                            lower_value_to_temporary(
+                                builder,
+                                InstructionValue::ComputedStore {
+                                    object,
+                                    property: prop_place,
+                                    value: update_target,
+                                    loc: member_loc,
+                                },
+                            )?;
+                        }
+                    }
+
                     Ok(InstructionValue::LoadLocal {
-                        place: result_place.clone(),
-                        loc: result_place.loc.clone(),
+                        place: result.clone(),
+                        loc: result.loc,
                     })
                 }
                 Expression::Identifier(ident) => {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -2639,53 +2639,69 @@ function lowerExpression(
       let expr = exprPath as NodePath<t.UpdateExpression>;
       const argument = expr.get('argument');
       if (argument.isMemberExpression()) {
-        const binaryOperator = expr.node.operator === '++' ? '+' : '-';
         const leftExpr = argument as NodePath<t.MemberExpression>;
         const {object, property, value} = lowerMemberExpression(
           builder,
           leftExpr,
         );
 
-        // Store the previous value to a temporary
-        const previousValuePlace = lowerValueToTemporary(builder, value);
-        // Store the new value to a temporary
-        const updatedValue = lowerValueToTemporary(builder, {
-          kind: 'BinaryExpression',
-          operator: binaryOperator,
-          left: {...previousValuePlace},
-          right: lowerValueToTemporary(builder, {
-            kind: 'Primitive',
-            value: 1,
-            loc: GeneratedSource,
-          }),
-          loc: leftExpr.node.loc ?? GeneratedSource,
+        const loc = leftExpr.node.loc ?? GeneratedSource;
+        const memberValue = lowerValueToTemporary(builder, value);
+        // Preserve native update coercion (including BigInt) and the expression result.
+        const updateTarget = buildTemporaryPlace(builder, loc);
+        promoteTemporary(updateTarget.identifier);
+        lowerValueToTemporary(builder, {
+          kind: 'StoreLocal',
+          lvalue: {
+            place: {...updateTarget},
+            kind: InstructionKind.Const,
+          },
+          value: {...memberValue},
+          type: null,
+          loc,
         });
 
-        // Save the result back to the property
-        let newValuePlace;
+        const updateValue = lowerValueToTemporary(builder, {
+          kind: expr.node.prefix ? 'PrefixUpdate' : 'PostfixUpdate',
+          lvalue: {...updateTarget},
+          operation: expr.node.operator,
+          value: {...updateTarget},
+          loc: exprLoc,
+        });
+        const result = buildTemporaryPlace(builder, exprLoc);
+        promoteTemporary(result.identifier);
+        lowerValueToTemporary(builder, {
+          kind: 'StoreLocal',
+          lvalue: {
+            place: {...result},
+            kind: InstructionKind.Const,
+          },
+          value: {...updateValue},
+          type: null,
+          loc: exprLoc,
+        });
+
         if (typeof property === 'string' || typeof property === 'number') {
-          newValuePlace = lowerValueToTemporary(builder, {
+          lowerValueToTemporary(builder, {
             kind: 'PropertyStore',
             object: {...object},
             property: makePropertyLiteral(property),
-            value: {...updatedValue},
-            loc: leftExpr.node.loc ?? GeneratedSource,
+            value: {...updateTarget},
+            loc,
           });
         } else {
-          newValuePlace = lowerValueToTemporary(builder, {
+          lowerValueToTemporary(builder, {
             kind: 'ComputedStore',
             object: {...object},
             property: {...property},
-            value: {...updatedValue},
-            loc: leftExpr.node.loc ?? GeneratedSource,
+            value: {...updateTarget},
+            loc,
           });
         }
 
         return {
           kind: 'LoadLocal',
-          place: expr.node.prefix
-            ? {...newValuePlace}
-            : {...previousValuePlace},
+          place: {...result},
           loc: exprLoc,
         };
       }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-ref-prefix-postfix-operator.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-ref-prefix-postfix-operator.expect.md
@@ -2,46 +2,113 @@
 ## Input
 
 ```javascript
-import {useRef, useEffect} from 'react';
+function testMemberUpdateSemantics() {
+  const plain = {
+    postIncrement: 0,
+    preIncrement: 0,
+    postDecrement: 2,
+    preDecrement: 2,
+  };
+  const plainResults = {
+    postIncrement: plain.postIncrement++,
+    preIncrement: ++plain.preIncrement,
+    postDecrement: plain.postDecrement--,
+    preDecrement: --plain.preDecrement,
+  };
 
-/**
- * The postfix increment operator should return the value before incrementing.
- * ```js
- * const id = count.current; // 0
- * count.current = count.current + 1; // 1
- * return id;
- * ```
- * The bug is that we currently increment the value before the expression is evaluated.
- * This bug does not trigger when the incremented value is a plain primitive.
- *
- * Found differences in evaluator results
- * Non-forget (expected):
- * (kind: ok) {"count":{"current":0},"updateCountPostfix":"[[ function params=0 ]]","updateCountPrefix":"[[ function params=0 ]]"}
- * logs: ['id = 0','count = 1']
- * Forget:
- * (kind: ok) {"count":{"current":0},"updateCountPostfix":"[[ function params=0 ]]","updateCountPrefix":"[[ function params=0 ]]"}
- * logs: ['id = 1','count = 1']
- */
-function useFoo() {
-  const count = useRef(0);
-  const updateCountPostfix = () => {
-    const id = count.current++;
-    return id;
+  const evaluationLog = [];
+  const computed = {value: 5};
+  const getObject = () => {
+    evaluationLog.push('object');
+    return computed;
   };
-  const updateCountPrefix = () => {
-    const id = ++count.current;
-    return id;
+  const getKey = () => {
+    evaluationLog.push('key');
+    return 'value';
   };
-  useEffect(() => {
-    const id = updateCountPostfix();
-    console.log(`id = ${id}`);
-    console.log(`count = ${count.current}`);
-  }, []);
-  return {count, updateCountPostfix, updateCountPrefix};
+  const computedResult = getObject()[getKey()]++;
+
+  const array = [10, 20];
+  let index = 0;
+  const arrayResult = array[index++]++;
+
+  const accessorLog = [];
+  const accessorState = {value: 3};
+  const accessor = {};
+  Object.defineProperty(accessor, 'value', {
+    get: () => {
+      accessorLog.push(`get:${accessorState.value}`);
+      return accessorState.value;
+    },
+    set: value => {
+      accessorLog.push(`set:${value}`);
+      accessorState.value = value;
+    },
+  });
+  const accessorPostfix = accessor.value++;
+  const accessorPrefix = ++accessor.value;
+
+  const proxyLog = [];
+  const proxyTarget = {value: 7};
+  const proxy = new Proxy(proxyTarget, {
+    get(target, property) {
+      proxyLog.push(`get:${String(property)}`);
+      return target[property];
+    },
+    set(target, property, value) {
+      proxyLog.push(`set:${String(property)}:${value}`);
+      target[property] = value;
+      return true;
+    },
+  });
+  const proxyPostfix = proxy.value++;
+  const proxyPrefixDecrement = --proxy.value;
+
+  const bigint = {value: BigInt(1)};
+  const bigintPostfixIncrement = bigint.value++;
+  const bigintPrefixIncrement = ++bigint.value;
+  const bigintPostfixDecrement = bigint.value--;
+  const bigintPrefixDecrement = --bigint.value;
+
+  const numericString = {value: '1'};
+  const numericStringResult = numericString.value++;
+
+  return {
+    plain: {results: plainResults, values: plain},
+    computed: {
+      result: computedResult,
+      value: computed.value,
+      evaluationLog,
+    },
+    array: {result: arrayResult, index, values: array},
+    accessor: {
+      postfix: accessorPostfix,
+      prefix: accessorPrefix,
+      value: accessorState.value,
+      log: accessorLog,
+    },
+    proxy: {
+      postfix: proxyPostfix,
+      prefixDecrement: proxyPrefixDecrement,
+      value: proxyTarget.value,
+      log: proxyLog,
+    },
+    bigint: {
+      postfixIncrement: String(bigintPostfixIncrement),
+      prefixIncrement: String(bigintPrefixIncrement),
+      postfixDecrement: String(bigintPostfixDecrement),
+      prefixDecrement: String(bigintPrefixDecrement),
+      value: String(bigint.value),
+    },
+    numericString: {
+      result: numericStringResult,
+      value: numericString.value,
+    },
+  };
 }
 
 export const FIXTURE_ENTRYPOINT = {
-  fn: useFoo,
+  fn: testMemberUpdateSemantics,
   params: [],
 };
 
@@ -51,82 +118,271 @@ export const FIXTURE_ENTRYPOINT = {
 
 ```javascript
 import { c as _c } from "react/compiler-runtime";
-import { useRef, useEffect } from "react";
-
-/**
- * The postfix increment operator should return the value before incrementing.
- * ```js
- * const id = count.current; // 0
- * count.current = count.current + 1; // 1
- * return id;
- * ```
- * The bug is that we currently increment the value before the expression is evaluated.
- * This bug does not trigger when the incremented value is a plain primitive.
- *
- * Found differences in evaluator results
- * Non-forget (expected):
- * (kind: ok) {"count":{"current":0},"updateCountPostfix":"[[ function params=0 ]]","updateCountPrefix":"[[ function params=0 ]]"}
- * logs: ['id = 0','count = 1']
- * Forget:
- * (kind: ok) {"count":{"current":0},"updateCountPostfix":"[[ function params=0 ]]","updateCountPrefix":"[[ function params=0 ]]"}
- * logs: ['id = 1','count = 1']
- */
-function useFoo() {
-  const $ = _c(5);
-  const count = useRef(0);
+function testMemberUpdateSemantics() {
+  const $ = _c(28);
+  let plain;
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = () => {
-      count.current = count.current + 1;
-      const id = count.current;
-      return id;
+    plain = {
+      postIncrement: 0,
+      preIncrement: 0,
+      postDecrement: 2,
+      preDecrement: 2,
     };
-    $[0] = t0;
+    let t1 = plain.postIncrement;
+    const t2 = t1++;
+    plain.postIncrement = t1;
+    let t3 = plain.preIncrement;
+    const t4 = ++t3;
+    plain.preIncrement = t3;
+    let t5 = plain.postDecrement;
+    const t6 = t5--;
+    plain.postDecrement = t5;
+    let t7 = plain.preDecrement;
+    const t8 = --t7;
+    plain.preDecrement = t7;
+    t0 = {
+      postIncrement: t2,
+      preIncrement: t4,
+      postDecrement: t6,
+      preDecrement: t8,
+    };
+    $[0] = plain;
+    $[1] = t0;
   } else {
-    t0 = $[0];
+    plain = $[0];
+    t0 = $[1];
   }
-  const updateCountPostfix = t0;
+  const plainResults = t0;
+  let computed;
+  let evaluationLog;
   let t1;
-  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = () => {
-      const id_0 = (count.current = count.current + 1);
-      return id_0;
-    };
-    $[1] = t1;
-  } else {
-    t1 = $[1];
-  }
-  const updateCountPrefix = t1;
-  let t2;
-  let t3;
   if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
-    t2 = () => {
-      const id_1 = updateCountPostfix();
-      console.log(`id = ${id_1}`);
-      console.log(`count = ${count.current}`);
+    evaluationLog = [];
+    computed = { value: 5 };
+    const getObject = () => {
+      evaluationLog.push("object");
+      return computed;
     };
-    t3 = [];
-    $[2] = t2;
-    $[3] = t3;
+    const getKey = () => {
+      evaluationLog.push("key");
+      return "value";
+    };
+    const t2 = getObject();
+    const t3 = getKey();
+    let t4 = t2[t3];
+    t1 = t4++;
+    t2[t3] = t4;
+    $[2] = computed;
+    $[3] = evaluationLog;
+    $[4] = t1;
   } else {
-    t2 = $[2];
-    t3 = $[3];
+    computed = $[2];
+    evaluationLog = $[3];
+    t1 = $[4];
   }
-  useEffect(t2, t3);
+  const computedResult = t1;
+  let array;
+  let t2;
+  if ($[5] === Symbol.for("react.memo_cache_sentinel")) {
+    array = [10, 20];
+    let t3 = array[0];
+    t2 = t3++;
+    array[0] = t3;
+    $[5] = array;
+    $[6] = t2;
+  } else {
+    array = $[5];
+    t2 = $[6];
+  }
+  const arrayResult = t2;
+  let accessorLog;
+  let accessorPostfix;
+  let accessorState;
+  let t3;
+  if ($[7] === Symbol.for("react.memo_cache_sentinel")) {
+    accessorLog = [];
+    accessorState = { value: 3 };
+    const accessor = {};
+    Object.defineProperty(accessor, "value", {
+      get: () => {
+        accessorLog.push(`get:${accessorState.value}`);
+        return accessorState.value;
+      },
+      set: (value) => {
+        accessorLog.push(`set:${value}`);
+        accessorState.value = value;
+      },
+    });
+    let t4 = accessor.value;
+    const t5 = t4++;
+    accessor.value = t4;
+    accessorPostfix = t5;
+    let t6 = accessor.value;
+    t3 = ++t6;
+    accessor.value = t6;
+    $[7] = accessorLog;
+    $[8] = accessorPostfix;
+    $[9] = accessorState;
+    $[10] = t3;
+  } else {
+    accessorLog = $[7];
+    accessorPostfix = $[8];
+    accessorState = $[9];
+    t3 = $[10];
+  }
+  const accessorPrefix = t3;
+  let proxyLog;
+  let proxyPostfix;
+  let proxyTarget;
   let t4;
-  if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
-    t4 = { count, updateCountPostfix, updateCountPrefix };
-    $[4] = t4;
+  if ($[11] === Symbol.for("react.memo_cache_sentinel")) {
+    proxyLog = [];
+    proxyTarget = { value: 7 };
+    const proxy = new Proxy(proxyTarget, {
+      get(target, property) {
+        proxyLog.push(`get:${String(property)}`);
+        return target[property];
+      },
+      set(target_0, property_0, value_0) {
+        proxyLog.push(`set:${String(property_0)}:${value_0}`);
+        target_0[property_0] = value_0;
+        return true;
+      },
+    });
+    let t5 = proxy.value;
+    const t6 = t5++;
+    proxy.value = t5;
+    proxyPostfix = t6;
+    let t7 = proxy.value;
+    t4 = --t7;
+    proxy.value = t7;
+    $[11] = proxyLog;
+    $[12] = proxyPostfix;
+    $[13] = proxyTarget;
+    $[14] = t4;
   } else {
-    t4 = $[4];
+    proxyLog = $[11];
+    proxyPostfix = $[12];
+    proxyTarget = $[13];
+    t4 = $[14];
   }
-  return t4;
+  const proxyPrefixDecrement = t4;
+  let bigint;
+  let bigintPostfixDecrement;
+  let bigintPostfixIncrement;
+  let bigintPrefixIncrement;
+  let t5;
+  if ($[15] === Symbol.for("react.memo_cache_sentinel")) {
+    bigint = { value: BigInt(1) };
+    let t6 = bigint.value;
+    const t7 = t6++;
+    bigint.value = t6;
+    bigintPostfixIncrement = t7;
+    let t8 = bigint.value;
+    const t9 = ++t8;
+    bigint.value = t8;
+    bigintPrefixIncrement = t9;
+    let t10 = bigint.value;
+    const t11 = t10--;
+    bigint.value = t10;
+    bigintPostfixDecrement = t11;
+    let t12 = bigint.value;
+    t5 = --t12;
+    bigint.value = t12;
+    $[15] = bigint;
+    $[16] = bigintPostfixDecrement;
+    $[17] = bigintPostfixIncrement;
+    $[18] = bigintPrefixIncrement;
+    $[19] = t5;
+  } else {
+    bigint = $[15];
+    bigintPostfixDecrement = $[16];
+    bigintPostfixIncrement = $[17];
+    bigintPrefixIncrement = $[18];
+    t5 = $[19];
+  }
+  const bigintPrefixDecrement = t5;
+  let numericString;
+  let t6;
+  if ($[20] === Symbol.for("react.memo_cache_sentinel")) {
+    numericString = { value: "1" };
+    let t7 = numericString.value;
+    t6 = t7++;
+    numericString.value = t7;
+    $[20] = numericString;
+    $[21] = t6;
+  } else {
+    numericString = $[20];
+    t6 = $[21];
+  }
+  const numericStringResult = t6;
+  let t10;
+  let t11;
+  let t7;
+  let t8;
+  let t9;
+  if ($[22] === Symbol.for("react.memo_cache_sentinel")) {
+    t7 = { results: plainResults, values: plain };
+    t8 = { result: computedResult, value: computed.value, evaluationLog };
+    t9 = { result: arrayResult, index: 1, values: array };
+    t10 = {
+      postfix: accessorPostfix,
+      prefix: accessorPrefix,
+      value: accessorState.value,
+      log: accessorLog,
+    };
+    t11 = {
+      postfix: proxyPostfix,
+      prefixDecrement: proxyPrefixDecrement,
+      value: proxyTarget.value,
+      log: proxyLog,
+    };
+    $[22] = t10;
+    $[23] = t11;
+    $[24] = t7;
+    $[25] = t8;
+    $[26] = t9;
+  } else {
+    t10 = $[22];
+    t11 = $[23];
+    t7 = $[24];
+    t8 = $[25];
+    t9 = $[26];
+  }
+  let t12;
+  if ($[27] === Symbol.for("react.memo_cache_sentinel")) {
+    t12 = {
+      plain: t7,
+      computed: t8,
+      array: t9,
+      accessor: t10,
+      proxy: t11,
+      bigint: {
+        postfixIncrement: String(bigintPostfixIncrement),
+        prefixIncrement: String(bigintPrefixIncrement),
+        postfixDecrement: String(bigintPostfixDecrement),
+        prefixDecrement: String(bigintPrefixDecrement),
+        value: String(bigint.value),
+      },
+      numericString: {
+        result: numericStringResult,
+        value: numericString.value,
+      },
+    };
+    $[27] = t12;
+  } else {
+    t12 = $[27];
+  }
+  return t12;
 }
 
 export const FIXTURE_ENTRYPOINT = {
-  fn: useFoo,
+  fn: testMemberUpdateSemantics,
   params: [],
 };
 
 ```
       
+### Eval output
+(kind: ok) {"plain":{"results":{"postIncrement":0,"preIncrement":1,"postDecrement":2,"preDecrement":1},"values":{"postIncrement":1,"preIncrement":1,"postDecrement":1,"preDecrement":1}},"computed":{"result":5,"value":6,"evaluationLog":["object","key"]},"array":{"result":10,"index":1,"values":[11,20]},"accessor":{"postfix":3,"prefix":5,"value":5,"log":["get:3","set:4","get:4","set:5"]},"proxy":{"postfix":7,"prefixDecrement":7,"value":7,"log":["get:value","set:value:8","get:value","set:value:7"]},"bigint":{"postfixIncrement":"1","prefixIncrement":"3","postfixDecrement":"3","prefixDecrement":"1","value":"1"},"numericString":{"result":1,"value":2}}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-ref-prefix-postfix-operator.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-ref-prefix-postfix-operator.js
@@ -1,42 +1,109 @@
-import {useRef, useEffect} from 'react';
+function testMemberUpdateSemantics() {
+  const plain = {
+    postIncrement: 0,
+    preIncrement: 0,
+    postDecrement: 2,
+    preDecrement: 2,
+  };
+  const plainResults = {
+    postIncrement: plain.postIncrement++,
+    preIncrement: ++plain.preIncrement,
+    postDecrement: plain.postDecrement--,
+    preDecrement: --plain.preDecrement,
+  };
 
-/**
- * The postfix increment operator should return the value before incrementing.
- * ```js
- * const id = count.current; // 0
- * count.current = count.current + 1; // 1
- * return id;
- * ```
- * The bug is that we currently increment the value before the expression is evaluated.
- * This bug does not trigger when the incremented value is a plain primitive.
- *
- * Found differences in evaluator results
- * Non-forget (expected):
- * (kind: ok) {"count":{"current":0},"updateCountPostfix":"[[ function params=0 ]]","updateCountPrefix":"[[ function params=0 ]]"}
- * logs: ['id = 0','count = 1']
- * Forget:
- * (kind: ok) {"count":{"current":0},"updateCountPostfix":"[[ function params=0 ]]","updateCountPrefix":"[[ function params=0 ]]"}
- * logs: ['id = 1','count = 1']
- */
-function useFoo() {
-  const count = useRef(0);
-  const updateCountPostfix = () => {
-    const id = count.current++;
-    return id;
+  const evaluationLog = [];
+  const computed = {value: 5};
+  const getObject = () => {
+    evaluationLog.push('object');
+    return computed;
   };
-  const updateCountPrefix = () => {
-    const id = ++count.current;
-    return id;
+  const getKey = () => {
+    evaluationLog.push('key');
+    return 'value';
   };
-  useEffect(() => {
-    const id = updateCountPostfix();
-    console.log(`id = ${id}`);
-    console.log(`count = ${count.current}`);
-  }, []);
-  return {count, updateCountPostfix, updateCountPrefix};
+  const computedResult = getObject()[getKey()]++;
+
+  const array = [10, 20];
+  let index = 0;
+  const arrayResult = array[index++]++;
+
+  const accessorLog = [];
+  const accessorState = {value: 3};
+  const accessor = {};
+  Object.defineProperty(accessor, 'value', {
+    get: () => {
+      accessorLog.push(`get:${accessorState.value}`);
+      return accessorState.value;
+    },
+    set: value => {
+      accessorLog.push(`set:${value}`);
+      accessorState.value = value;
+    },
+  });
+  const accessorPostfix = accessor.value++;
+  const accessorPrefix = ++accessor.value;
+
+  const proxyLog = [];
+  const proxyTarget = {value: 7};
+  const proxy = new Proxy(proxyTarget, {
+    get(target, property) {
+      proxyLog.push(`get:${String(property)}`);
+      return target[property];
+    },
+    set(target, property, value) {
+      proxyLog.push(`set:${String(property)}:${value}`);
+      target[property] = value;
+      return true;
+    },
+  });
+  const proxyPostfix = proxy.value++;
+  const proxyPrefixDecrement = --proxy.value;
+
+  const bigint = {value: BigInt(1)};
+  const bigintPostfixIncrement = bigint.value++;
+  const bigintPrefixIncrement = ++bigint.value;
+  const bigintPostfixDecrement = bigint.value--;
+  const bigintPrefixDecrement = --bigint.value;
+
+  const numericString = {value: '1'};
+  const numericStringResult = numericString.value++;
+
+  return {
+    plain: {results: plainResults, values: plain},
+    computed: {
+      result: computedResult,
+      value: computed.value,
+      evaluationLog,
+    },
+    array: {result: arrayResult, index, values: array},
+    accessor: {
+      postfix: accessorPostfix,
+      prefix: accessorPrefix,
+      value: accessorState.value,
+      log: accessorLog,
+    },
+    proxy: {
+      postfix: proxyPostfix,
+      prefixDecrement: proxyPrefixDecrement,
+      value: proxyTarget.value,
+      log: proxyLog,
+    },
+    bigint: {
+      postfixIncrement: String(bigintPostfixIncrement),
+      prefixIncrement: String(bigintPrefixIncrement),
+      postfixDecrement: String(bigintPostfixDecrement),
+      prefixDecrement: String(bigintPrefixDecrement),
+      value: String(bigint.value),
+    },
+    numericString: {
+      result: numericStringResult,
+      value: numericString.value,
+    },
+  };
 }
 
 export const FIXTURE_ENTRYPOINT = {
-  fn: useFoo,
+  fn: testMemberUpdateSemantics,
   params: [],
 };

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/member-inc.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/member-inc.expect.md
@@ -31,24 +31,37 @@ export const FIXTURE_ENTRYPOINT = {
 ```javascript
 function Foo() {
   const x = { a: 1 };
-  x.a = x.a + 1;
-  x.a = x.a - 1;
-  console.log((x.a = x.a + 1));
-  const t0 = x.a;
-  x.a = t0 + 1;
-  console.log(t0);
+  let t0 = x.a;
+  t0++;
+  x.a = t0;
+  let t1 = x.a;
+  t1--;
+  x.a = t1;
+  let t2 = x.a;
+  const t3 = ++t2;
+  x.a = t2;
+  console.log(t3);
+  let t4 = x.a;
+  const t5 = t4++;
+  x.a = t4;
+  console.log(t5);
 
   console.log(x.a);
-  const t1 = x.a;
-  x.a = t1 + 1;
-  const y = t1;
+  let t6 = x.a;
+  const t7 = t6++;
+  x.a = t6;
+  const y = t7;
   console.log(y);
   console.log(x.a);
 
-  const t2 = (x.a = x.a + 1).toString();
-  const t3 = x.a;
-  x.a = t3 + 1;
-  console.log(t2, t3.toString(), x.a);
+  let t8 = x.a;
+  const t9 = ++t8;
+  x.a = t8;
+  const t10 = t9.toString();
+  let t11 = x.a;
+  const t12 = t11++;
+  x.a = t11;
+  console.log(t10, t12.toString(), x.a);
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/snap/src/SproutTodoFilter.ts
+++ b/compiler/packages/snap/src/SproutTodoFilter.ts
@@ -486,8 +486,6 @@ const skipFilter = new Set([
   'fbt/bug-fbt-plural-multiple-function-calls',
   'fbt/bug-fbt-plural-multiple-mixed-call-tag',
   'bug-invalid-phi-as-dependency',
-  'bug-ref-prefix-postfix-operator',
-
   // 'react-compiler-runtime' not yet supported
   'flag-enable-emit-hook-guards',
   'fast-refresh-refresh-on-const-changes-dev',


### PR DESCRIPTION
## Summary

Member update expressions were lowered into a property read, a binary `+ 1` or `- 1`, and a property store. This could return the stored value for postfix updates instead of the previous value, and the binary operation did not preserve JavaScript update coercion for values such as numeric strings and BigInts.

Lower member updates through a generated local that uses the native `++` or `--` operator, then store the updated local back to the member and return the captured update result. The TypeScript and Rust lowerers now stay in sync.

Expand the existing evaluator fixture to cover prefix and postfix increment/decrement, computed object and key evaluation, arrays with side-effecting indices, getters/setters, proxies, BigInts, and numeric-string coercion. The fixture is no longer skipped by the evaluator.

## How did you test this change?

- `yarn snap` — 1,810 passed
- `yarn snap --rust` — 1,810 passed
- `yarn snap --pattern '*update*' --sync` — 20 passed
- `yarn snap --pattern '*update*' --sync --rust` — 20 passed
- `yarn workspace babel-plugin-react-compiler lint`
- `cargo test --workspace`
