### PR TITLE
Fix RangeError in readAsDataURL base64 fallback for large blobs

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactDOMLegacyServerStreamConfig.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMLegacyServerStreamConfig.js
@@ -81,12 +81,28 @@ export function closeWithError(destination: Destination, error: mixed): void {
 
 export {createFastHashJS as createFastHash} from 'react-server/src/createFastHashJS';
 
+function arrayBufferToBase64(arrayBuffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(arrayBuffer);
+  // btoa expects a binary string. Passing every byte as a separate argument to
+  // String.fromCharCode.apply exceeds the engine's maximum argument count for
+  // large buffers and throws a RangeError, so we build the string in chunks.
+  const chunkSize = 0x8000;
+  let binaryString = '';
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binaryString += String.fromCharCode.apply(
+      String,
+      bytes.subarray(i, i + chunkSize),
+    );
+  }
+  return btoa(binaryString);
+}
+
 export function readAsDataURL(blob: Blob): Promise<string> {
   return blob.arrayBuffer().then(arrayBuffer => {
     const encoded =
       typeof Buffer === 'function' && typeof Buffer.from === 'function'
         ? Buffer.from(arrayBuffer).toString('base64')
-        : btoa(String.fromCharCode.apply(String, new Uint8Array(arrayBuffer)));
+        : arrayBufferToBase64(arrayBuffer);
     const mimeType = blob.type || 'application/octet-stream';
     return 'data:' + mimeType + ';base64,' + encoded;
   });

--- a/packages/react-server/src/ReactServerStreamConfigEdge.js
+++ b/packages/react-server/src/ReactServerStreamConfigEdge.js
@@ -181,12 +181,28 @@ export function closeWithError(destination: Destination, error: mixed): void {
 
 export {createFastHashJS as createFastHash} from 'react-server/src/createFastHashJS';
 
+function arrayBufferToBase64(arrayBuffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(arrayBuffer);
+  // btoa expects a binary string. Passing every byte as a separate argument to
+  // String.fromCharCode.apply exceeds the engine's maximum argument count for
+  // large buffers and throws a RangeError, so we build the string in chunks.
+  const chunkSize = 0x8000;
+  let binaryString = '';
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binaryString += String.fromCharCode.apply(
+      String,
+      bytes.subarray(i, i + chunkSize),
+    );
+  }
+  return btoa(binaryString);
+}
+
 export function readAsDataURL(blob: Blob): Promise<string> {
   return blob.arrayBuffer().then(arrayBuffer => {
     const encoded =
       typeof Buffer === 'function' && typeof Buffer.from === 'function'
         ? Buffer.from(arrayBuffer).toString('base64')
-        : btoa(String.fromCharCode.apply(String, new Uint8Array(arrayBuffer)));
+        : arrayBufferToBase64(arrayBuffer);
     const mimeType = blob.type || 'application/octet-stream';
     return 'data:' + mimeType + ';base64,' + encoded;
   });


### PR DESCRIPTION
## Summary

`readAsDataURL` encodes a Blob to a `data:` URL. When `Buffer` is unavailable (Edge runtime and browsers), it falls back to:

```js
btoa(String.fromCharCode.apply(String, new Uint8Array(arrayBuffer)))
```

`String.fromCharCode.apply` spreads every byte as a separate function argument. For large blobs this exceeds the engine''s maximum argument count and throws a `RangeError`, breaking `data:` URL serialization of large binary values in exactly the environments that rely on the fallback.

This affects two host configs:
- `packages/react-server/src/ReactServerStreamConfigEdge.js`
- `packages/react-dom-bindings/src/server/ReactDOMLegacyServerStreamConfig.js`

## Fix

Build the binary string in chunks of `0x8000` bytes using `subarray` before calling `btoa`, capping how many bytes are spread per `String.fromCharCode.apply` call. This mirrors the approach used for the same class of bug in `binaryToComparableString` (#36941). The `Buffer` fast path is unchanged.

## Test plan

Verified independently that:
- The previous approach throws `RangeError` on a 300,000-byte buffer.
- The chunked approach produces base64 output identical to `Buffer.from(arrayBuffer).toString('base64')`.
- Empty and small buffers encode correctly.