### PR TITLE
docs(compiler): refresh Rust HIR reading paths

### DIFF
--- a/compiler/.claude/skills/compiler-port/SKILL.md
+++ b/compiler/.claude/skills/compiler-port/SKILL.md
@@ -46,8 +46,8 @@ Read the following files (all reads happen in main context):
 2. **Pass documentation**: Check `compiler/packages/babel-plugin-react-compiler/docs/passes/` for docs about this pass
 3. **TypeScript source**: All TypeScript source files for the pass + any helpers imported from the same folder
 4. **Rust pipeline**: `compiler/crates/react_compiler/src/entrypoint/pipeline.rs`
-5. **Rust HIR types**: Key type files in `compiler/crates/react_compiler_hir/src/` (especially `hir.rs`, `environment.rs`)
-6. **Rust reactive types**: For reactive passes, also read `compiler/crates/react_compiler_hir/src/reactive_function.rs`
+5. **Rust HIR types**: Key type files in `compiler/crates/react_compiler_hir/src/` (especially `lib.rs`, `environment.rs`)
+6. **Rust reactive types**: For reactive passes, also read `compiler/crates/react_compiler_hir/src/reactive.rs`
 7. **Target crate**: If the target crate already exists, read its `Cargo.toml`, `src/lib.rs`, and existing files to understand the current structure
 
 ## Step 3: Create implementation plan


### PR DESCRIPTION
## Summary

- Replace the removed `hir.rs` reference with the current HIR entry point, `lib.rs`.
- Point reactive-pass readers at `reactive.rs` instead of the removed `reactive_function.rs`.

This keeps the compiler contributor reading list aligned with the current Rust module layout. The docs-only correction was found with the attest static instruction-binding scan.

## How did you test this change?

- Confirmed both replacement paths exist at the submitted base commit.
- Ran the modified instruction file through attest with zero broken bindings.
- Verified the branch is one clean commit on top of the current upstream base.
