### PR TITLE
[DevTools] Don't reconnect proxy port while page is prerendering

### DIFF
--- a/packages/react-devtools-extensions/src/contentScripts/proxy.js
+++ b/packages/react-devtools-extensions/src/contentScripts/proxy.js
@@ -114,7 +114,18 @@ function handleDisconnect() {
   window.removeEventListener('message', handleMessageFromPage);
   port = null;
 
-  connectPort();
+  // Mirrors the guard in handlePageShow(): the background script can evict/
+  // replace a tab's proxy port (see registerProxyPort in background/index.js),
+  // which disconnects us while still prerendering. Reconnecting immediately
+  // in that case causes an unbounded connect/disconnect cycle for as long as
+  // the document stays in the prerendering state (https://crbug.com/478909972).
+  if (document.prerendering) {
+    document.addEventListener('prerenderingchange', connectPort, {
+      once: true,
+    });
+  } else {
+    connectPort();
+  }
 }
 
 // Creates port from application page to the React DevTools' service worker


### PR DESCRIPTION
## Summary

Fixes #37003.

The content script's proxy port `onDisconnect` handler (`handleDisconnect` in `packages/react-devtools-extensions/src/contentScripts/proxy.js`) reconnected unconditionally, unlike the initial connection path in `handlePageShow()`, which already waits for `prerenderingchange`/`pagereveal` before connecting (see #35958 / crbug.com/489633225).

The background service worker (`background/index.js`) evicts and replaces a tab's registered proxy port whenever a new one connects for that tab id (`registerProxyPort`). Because a prerendered page shares its eventual tab id with the page it will activate into, this eviction can disconnect a still-prerendering document's port. Without a guard, `handleDisconnect` would reconnect immediately, which the background script would evict again, and so on — an unbounded connect/disconnect cycle for as long as the document stayed in the prerendering state. This matches the near-100% CPU usage reported by the Chrome team at crbug.com/478909972 for the extension's frame on prerendered pages while DevTools is open.

## Fix

`handleDisconnect()` now checks `document.prerendering` the same way `handlePageShow()` does: if the document is still prerendering, defer reconnection until `prerenderingchange` fires (i.e. until the page is actually activated), instead of reconnecting immediately.

## Test plan

- [x] `yarn lint` passes on the changed file
- [x] `yarn flow dom-node` — full check completes with 0 errors (153 pre-existing warnings elsewhere in the repo, unrelated to this file)
- No existing Jest tests cover the extension's content-script/background layer (it depends on Chrome extension APIs), so none were run/added for this change