### PR TITLE
[DevTools] Ignore stale suspense resize/reorder ops for nodes removed in the same batch

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -97,6 +97,110 @@ describe('Store', () => {
   const {render, unmount, createContainer} = getVersionedRenderImplementation();
 
   // @reactVersion >= 18.0
+  it('should ignore suspense resize and reorder operations for nodes removed earlier in the same bridge update', () => {
+    const {
+      SUSPENSE_TREE_OPERATION_ADD,
+      SUSPENSE_TREE_OPERATION_REMOVE,
+      SUSPENSE_TREE_OPERATION_REORDER_CHILDREN,
+      SUSPENSE_TREE_OPERATION_RESIZE,
+      TREE_OPERATION_ADD,
+    } = require('react-devtools-shared/src/constants');
+    const {
+      ElementTypeFunction,
+      ElementTypeRoot,
+    } = require('react-devtools-shared/src/frontend/types');
+
+    store.onBridgeOperations([
+      1, // renderer ID
+      1, // root ID
+      7, // string table size
+      6, // next string length
+      80, // P
+      97, // a
+      114, // r
+      101, // e
+      110, // n
+      116, // t
+      TREE_OPERATION_ADD,
+      1,
+      ElementTypeRoot,
+      0, // StrictMode compliant?
+      0, // Profiling flags
+      0, // StrictMode supported?
+      0, // Owner metadata?
+      SUSPENSE_TREE_OPERATION_ADD,
+      1, // suspense root mirrors the root element
+      0, // no parent
+      0, // no name
+      0, // not suspended
+      -1, // no rects
+      TREE_OPERATION_ADD,
+      2,
+      ElementTypeFunction,
+      1, // parent
+      0, // owner
+      1, // displayName "Parent"
+      0, // key
+      0, // nameProp
+      SUSPENSE_TREE_OPERATION_ADD,
+      3, // suspense boundary inside the root
+      1, // parent suspense node
+      0, // no name
+      0, // not suspended
+      1, // one rect
+      1000, // x
+      2000, // y
+      3000, // width
+      4000, // height
+    ]);
+
+    expect(store.getSuspenseByID(3)).not.toBeNull();
+
+    // The backend flush layout batches all removals ahead of any other
+    // operations recorded during the same commit, so operations that
+    // reference a suspense node removed earlier in the same batch are
+    // expected stale references and must not throw.
+    expect(() =>
+      store.onBridgeOperations([
+        1, // renderer ID
+        1, // root ID
+        0, // string table size
+        SUSPENSE_TREE_OPERATION_REMOVE,
+        1, // number of removals
+        3,
+        SUSPENSE_TREE_OPERATION_RESIZE,
+        3, // stale reference to the removed node
+        2, // two rects: the payload must be skipped in full
+        1000,
+        2000,
+        3000,
+        4000,
+        5000,
+        6000,
+        7000,
+        8000,
+        SUSPENSE_TREE_OPERATION_REORDER_CHILDREN,
+        3, // stale reference to the removed node
+        1, // one child: the payload must be skipped in full
+        4,
+        // A trailing operation that must still parse correctly, proving the
+        // stale operations were skipped without corrupting the read offset.
+        TREE_OPERATION_ADD,
+        4,
+        ElementTypeFunction,
+        2, // parent
+        0, // owner
+        0, // displayName
+        0, // key
+        0, // nameProp
+      ]),
+    ).not.toThrow();
+
+    expect(store.getSuspenseByID(3)).toBeNull();
+    expect(store.getElementByID(4)).not.toBeNull();
+  });
+
+  // @reactVersion >= 18.0
   it('should not allow a root node to be collapsed', async () => {
     const Component = () => <div>Hi</div>;
 

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -1985,6 +1985,15 @@ export default class Store extends EventEmitter<{
 
           const suspense = this._idToSuspense.get(id);
           if (suspense === undefined) {
+            if (removedSuspenseIDs.has(id)) {
+              // The backend batches all removals ahead of other operations
+              // within a flush, so a reorder that references a suspense node
+              // removed earlier in this same batch is an expected stale
+              // reference. Skip past this operation's payload.
+              i += numChildren;
+              break;
+            }
+
             this._throwAndEmitError(
               Error(
                 `Cannot reorder children for suspense node "${id}" because no matching node was found in the Store.`,
@@ -2036,6 +2045,17 @@ export default class Store extends EventEmitter<{
 
           const suspense = this._idToSuspense.get(id);
           if (suspense === undefined) {
+            if (removedSuspenseIDs.has(id)) {
+              // The backend batches all removals ahead of other operations
+              // within a flush, so a resize that references a suspense node
+              // removed earlier in this same batch is an expected stale
+              // reference. Skip past this operation's rects payload.
+              if (numRects > 0) {
+                i += numRects * 4;
+              }
+              break;
+            }
+
             this._throwAndEmitError(
               Error(
                 `Cannot set rects for suspense node "${id}" because no matching node was found in the Store.`,


### PR DESCRIPTION
## Summary

Fixes #36577 (`Cannot set rects for suspense node "168" because no matching node was found in the Store`, reported as reproducing "every time" on a real production site).

## Root cause mechanism

The backend's `flushPendingEvents` (`react-devtools-shared/src/backend/fiber/renderer.js`) assembles each bridge payload in a fixed layout: all `SUSPENSE_TREE_OPERATION_REMOVE` entries first, then all `TREE_OPERATION_REMOVE` entries, then the chronologically recorded `pendingOperations` (which include `SUSPENSE_TREE_OPERATION_RESIZE` and `SUSPENSE_TREE_OPERATION_REORDER_CHILDREN`).

This means whenever a single flush window both records a resize/reorder for a suspense node **and** unmounts that node, the frontend is guaranteed to process the REMOVE before the trailing operation that references it — and throws.

Notably, the backend already guards the analogous hazard for the suspenders op: `recordSuspenseUnmount` calls `pendingSuspenderChanges.delete(id)` so a suspender update never survives its node's removal. But resize/reorder ops are pushed immediately into the flat `pendingOperations` buffer, so they *can't* be scrubbed retroactively on unmount — the stale reference has to be tolerated on the frontend instead. That's the same conclusion #36472 reached for the elements tree (`removedElementIDs`); this PR extends the identical pattern to the suspense tree using the existing `removedSuspenseIDs` map.

## Fix

In `store.js`, when a `SUSPENSE_TREE_OPERATION_RESIZE` or `SUSPENSE_TREE_OPERATION_REORDER_CHILDREN` references a node missing from `_idToSuspense`, check `removedSuspenseIDs` (populated by removals earlier in the same batch). If present, skip the operation instead of throwing.

One subtlety the skip has to handle that the throwing path never did: at the point of the missing-node check, the operation's *payload* (rects: `numRects * 4` values; reorder: `numChildren` values) has not been consumed yet. Since `_throwAndEmitError` always throws, pointer alignment never mattered before — but a non-throwing skip must advance `i` past the payload, or every subsequent operation in the batch gets misparsed as garbage opcodes.

The `SUSPENDERS` case is intentionally left throwing: the backend actively prevents that scenario (see above), so if it ever fires it indicates a genuine backend bug that should stay loud.

## Test

Added a regression test that:
1. Builds a store with a suspense node (with rects) via bridge operations.
2. Sends a single batch containing: REMOVE for that node → stale RESIZE with a 2-rect payload → stale REORDER with a child payload → a valid trailing `TREE_OPERATION_ADD`.
3. Asserts no throw, the removed node is gone, **and the trailing ADD still parsed correctly** — proving the skips advance past their payloads without corrupting the operation stream.

Verified both guards independently: disabling only the resize guard fails with exactly the issue's reported error; disabling only the reorder guard fails with the reorder variant; with both enabled the test passes.

## Test plan

- [x] New regression test passes; fails with the exact reported errors when either guard is disabled
- [x] Full `store-test.js` suite: 75 passed, 2 failed — confirmed those 2 (`Lazy › unmounted before they finish loading` and `inline errors and warnings › React 18.x`) fail identically on unpatched `main` in this environment, unrelated to this change
- [x] `yarn lint` passes on both changed files
- [x] `yarn prettier` produces no changes