### PR TITLE
[Fizz] Don't discard a queued dehydrated boundary on a concurrent update

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -4022,6 +4022,13 @@ export function isSuspenseInstancePending(instance: SuspenseInstance): boolean {
   );
 }
 
+export function isSuspenseInstanceQueued(instance: SuspenseInstance): boolean {
+  // The Fizz runtime has already streamed in the completed content for this
+  // boundary and queued it for reveal (rAF/throttled). It's no longer
+  // waiting on the server, it's just waiting for the batched DOM swap.
+  return instance.data === SUSPENSE_QUEUED_START_DATA;
+}
+
 export function isSuspenseInstanceFallback(
   instance: SuspenseInstance,
 ): boolean {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -2951,6 +2951,184 @@ describe('ReactDOMFizzServer', () => {
     },
   );
 
+  it(
+    'does not discard a dehydrated boundary that is queued for a throttled ' +
+      'reveal when a concurrent client update races it (#37014)',
+    async () => {
+      // The server and client each get their own independent, manually
+      // resolved promise. This matters: if they shared one (e.g. a single
+      // cached record keyed by the same text), resolving it would ping both
+      // the server's stream and the client's own hydration attempt in the
+      // same synchronous/microtask step, which lets the client "shortcut"
+      // straight to a successful hydration and never actually exercises the
+      // race this test is targeting. Two independent promises is the only
+      // way to accurately model server and client being different machines.
+      //
+      // The `step` prop is intentionally not rendered into the DOM. It only
+      // exists so a client update can change the element identity of the
+      // boundary (forcing didReceiveUpdate on the dehydrated Suspense) while
+      // leaving the streamed markup byte-for-byte identical. That isolates
+      // the behavior under test from any incidental hydration mismatch.
+      function makeApp() {
+        let resolve, resolved;
+        const promise = new Promise(r => {
+          resolve = () => {
+            resolved = true;
+            return r();
+          };
+        });
+        function Child() {
+          if (!resolved) {
+            throw promise;
+          }
+          return 'hello';
+        }
+        function App({step}) {
+          return (
+            <div>
+              <Suspense fallback={<p>Loading...</p>}>
+                <span className="target">
+                  <Child />
+                </span>
+              </Suspense>
+            </div>
+          );
+        }
+        return [App, resolve];
+      }
+
+      // This test file runs with real timers, and the queued reveal's delay
+      // can be as short as a single requestAnimationFrame tick, so we can't
+      // just avoid awaiting long enough for it to fire. Instead we intercept
+      // requestAnimationFrame the same way the original bug report did: hold
+      // its callback captive so we can inspect the DOM in the window between
+      // "content streamed in and queued" and "reveal actually runs", then
+      // release it ourselves once we're done.
+      const realRAF = global.requestAnimationFrame;
+      let pendingRAFs = [];
+      global.requestAnimationFrame = global.window.requestAnimationFrame =
+        cb => {
+          pendingRAFs.push(cb);
+        };
+      function flushRAFs() {
+        const cbs = pendingRAFs;
+        pendingRAFs = [];
+        cbs.forEach(cb => cb());
+      }
+      try {
+        const [ServerApp, serverResolve] = makeApp();
+        await act(() => {
+          const {pipe} = renderToPipeableStream(<ServerApp step={1} />);
+          pipe(writable);
+        });
+        expect(getVisibleChildren(container)).toEqual(
+          <div>
+            <p>Loading...</p>
+          </div>,
+        );
+
+        const [ClientApp, clientResolve] = makeApp();
+        const root = ReactDOMClient.hydrateRoot(
+          container,
+          <ClientApp step={1} />,
+          {
+            onRecoverableError(error) {
+              Scheduler.log(
+                'onRecoverableError: ' + normalizeError(error.message),
+              );
+            },
+          },
+        );
+        await waitForAll([]);
+        expect(getVisibleChildren(container)).toEqual(
+          <div>
+            <p>Loading...</p>
+          </div>,
+        );
+
+        // The server finishes its content and streams it in out-of-band.
+        // This executes a `completeBoundary` instruction that marks the
+        // boundary as "$~" (queued for a throttled reveal) and queues a
+        // requestAnimationFrame callback to actually swap it in. Because we
+        // intercepted requestAnimationFrame above, that callback is now
+        // sitting captive in `pendingRAFs` instead of having run.
+        serverResolve();
+        for (let i = 0; i < 5; i++) {
+          await new Promise(resolve => setImmediate(resolve));
+          if (buffer) {
+            const bufferedContent = buffer;
+            buffer = '';
+            const div = document.createElement('div');
+            div.innerHTML = bufferedContent;
+            await insertNodesAndExecuteScripts(
+              div,
+              streamingContainer,
+              CSPnonce,
+            );
+          }
+        }
+        expect(pendingRAFs.length).toBeGreaterThan(0);
+
+        // The boundary is now marked "$~" (queued) with its streamed content
+        // waiting in a hidden sibling, but the reveal hasn't run yet.
+        expect(container.innerHTML).toContain('<!--$~-->');
+        expect(getVisibleChildren(container)).toEqual(
+          <div>
+            <p>Loading...</p>
+          </div>,
+        );
+
+        // A concurrent client update (e.g. a transition or setState
+        // elsewhere in the tree) re-renders the root while this Suspense
+        // boundary is still dehydrated and queued. This is the race: the
+        // reconciler must NOT discard the already-streamed content and mount
+        // a fresh client render, because that orphans the streamed segment
+        // and races the queued reveal, producing the transient duplicate the
+        // issue describes. Instead it must leave the dehydrated content in
+        // place and let the queued reveal proceed.
+        await clientAct(() => {
+          root.render(<ClientApp step={2} />);
+        });
+        assertLog([]);
+        // The "$~" boundary must still be intact (not discarded/replaced by
+        // a client-rendered fallback), with its streamed content preserved.
+        expect(container.innerHTML).toContain('<!--$~-->');
+        expect(container.querySelectorAll('span').length).toBe(1);
+
+        // Now let the queued reveal run. It swaps the streamed content into
+        // place. Without the fix, the streamed content would have been
+        // orphaned by the discard above and this reveal would instead delete
+        // it, leaving the boundary showing a client fallback (0 spans).
+        await clientAct(() => {
+          while (pendingRAFs.length > 0) {
+            flushRAFs();
+          }
+        });
+        assertLog([]);
+        expect(getVisibleChildren(container)).toEqual(
+          <div>
+            <span class="target">hello</span>
+          </div>,
+        );
+
+        // The client's own data finally resolves and hydration completes
+        // cleanly against the streamed content (no mismatch, no errors).
+        await clientAct(() => {
+          clientResolve();
+        });
+        assertLog([]);
+        expect(getVisibleChildren(container)).toEqual(
+          <div>
+            <span class="target">hello</span>
+          </div>,
+        );
+      } finally {
+        global.requestAnimationFrame = global.window.requestAnimationFrame =
+          realRAF;
+      }
+    },
+  );
+
   // Disabled because of a WWW late mutations regression.
   // We may want to re-enable this if we figure out why.
 

--- a/packages/react-noop-renderer/src/ReactFiberConfigNoopHydration.js
+++ b/packages/react-noop-renderer/src/ReactFiberConfigNoopHydration.js
@@ -23,6 +23,7 @@ export type ActivityInstance = mixed;
 export type SuspenseInstance = mixed;
 export const supportsHydration = false;
 export const isSuspenseInstancePending = shim;
+export const isSuspenseInstanceQueued = shim;
 export const isSuspenseInstanceFallback = shim;
 export const getSuspenseInstanceFallbackErrorDetails = shim;
 export const registerSuspenseInstanceRetry = shim;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -170,6 +170,7 @@ import {
 import {
   shouldSetTextContent,
   isSuspenseInstancePending,
+  isSuspenseInstanceQueued,
   isSuspenseInstanceFallback,
   getSuspenseInstanceFallbackErrorDetails,
   supportsHydration,
@@ -3069,7 +3070,20 @@ function updateDehydratedSuspenseComponent(
       // outside a transition.
       //
       // This path should only happen if the hydration lane already suspended.
-      if (isSuspenseInstancePending(suspenseInstance)) {
+      if (isSuspenseInstanceQueued(suspenseInstance)) {
+        // The Fizz runtime has already streamed in the completed content for
+        // this boundary and queued it for a batched reveal (it's not waiting
+        // on the server anymore, just on the throttled DOM swap). If we
+        // discard the dehydrated content now and mount a fresh client render,
+        // we race that in-flight reveal: both the client-rendered tree and
+        // the still-unrevealed streamed segment would exist in the DOM until
+        // the queued reveal runs and cleans up. Leave the dehydrated content
+        // in place instead and let the queued reveal complete; the retry
+        // callback registered below will give us another chance to hydrate.
+        workInProgress.flags |= DidCapture | Callback;
+        workInProgress.child = current.child;
+        return null;
+      } else if (isSuspenseInstancePending(suspenseInstance)) {
         // This is a dehydrated suspense instance. We don't need to suspend
         // because we're already showing a fallback.
         // TODO: The Fizz runtime might still stream in completed HTML, out-of-

--- a/packages/react-reconciler/src/ReactFiberConfigWithNoHydration.js
+++ b/packages/react-reconciler/src/ReactFiberConfigWithNoHydration.js
@@ -23,6 +23,7 @@ export type ActivityInstance = mixed;
 export type SuspenseInstance = mixed;
 export const supportsHydration = false;
 export const isSuspenseInstancePending = shim;
+export const isSuspenseInstanceQueued = shim;
 export const isSuspenseInstanceFallback = shim;
 export const getSuspenseInstanceFallbackErrorDetails = shim;
 export const registerSuspenseInstanceRetry = shim;

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.custom.js
@@ -194,6 +194,7 @@ export const cloneHiddenTextInstance = $$$config.cloneHiddenTextInstance;
 //     (optional)
 // -------------------
 export const isSuspenseInstancePending = $$$config.isSuspenseInstancePending;
+export const isSuspenseInstanceQueued = $$$config.isSuspenseInstanceQueued;
 export const isSuspenseInstanceFallback = $$$config.isSuspenseInstanceFallback;
 export const getSuspenseInstanceFallbackErrorDetails =
   $$$config.getSuspenseInstanceFallbackErrorDetails;

--- a/packages/react-reconciler/src/forks/ReactFiberConfig.noop.js
+++ b/packages/react-reconciler/src/forks/ReactFiberConfig.noop.js
@@ -189,6 +189,7 @@ export const cloneHiddenTextInstance = $$$config.cloneHiddenTextInstance;
 //     (optional)
 // -------------------
 export const isSuspenseInstancePending = $$$config.isSuspenseInstancePending;
+export const isSuspenseInstanceQueued = $$$config.isSuspenseInstanceQueued;
 export const isSuspenseInstanceFallback = $$$config.isSuspenseInstanceFallback;
 export const getSuspenseInstanceFallbackErrorDetails =
   $$$config.getSuspenseInstanceFallbackErrorDetails;


### PR DESCRIPTION
## Summary

Fixes **path 2** of #37014 — the transient DOM duplication where streamed Suspense content briefly exists twice.

When a concurrent client update (`didReceiveUpdate`) reaches a dehydrated Suspense boundary, `updateDehydratedSuspenseComponent` fell through to `retrySuspenseComponentWithoutHydrating` for **both** the still-pending (`$?`) and already-queued-for-reveal (`$~`) states.

For the `$~` case the completed content has *already streamed in* and been queued for a throttled/rAF reveal (React 19.2 batched reveals). Discarding it to client-render orphans that streamed segment and races the in-flight reveal, so the client-rendered tree and the still-unrevealed streamed segment coexist in the DOM until the queued reveal runs and cleans up — exactly the ~300ms duplication window the issue describes.

This is the second trigger path called out in the issue thread (a concurrent app-level update racing hydration), distinct from the document-load timing of path 1. It corresponds to the long-standing TODO in `updateDehydratedSuspenseComponent`:

> // TODO: The Fizz runtime might still stream in completed HTML, out-of-band. Should we fix this? There's a version of this bug that happens during client rendering, too. Needs more consideration.

## Fix

Split the `$~` case off first and give it the same treatment the existing "still pending" branch already uses: keep the dehydrated child, mark `DidCapture | Callback`, and bail. The `Callback` flag re-registers the `_reactRetry` callback that the Fizz reveal invokes, so hydration resumes cleanly once the reveal swaps the content into place. The `$?` path is unchanged.

Supporting plumbing: a new `isSuspenseInstanceQueued` host-config method, threaded through the DOM config, both reconciler forks (custom/noop), and both no-hydration shims.

## Behavior (verified by instrumenting the DOM)

| Window | Before | After |
|---|---|---|
| After concurrent update | `$~` marker gone — boundary discarded, streamed `<span>` orphaned | `$~` intact, streamed content preserved |
| After reveal | streamed content deleted (0 spans) | revealed in place (1 span) |

## Test

Adds a regression test in `ReactDOMFizzServer-test.js` that reproduces the race with:
- **Independent server/client promises** — a shared promise would let the client "shortcut" straight to a successful hydration via React's internal ping/retry and never exercise the race (this is the false-negative trap noted in the issue discussion).
- **`requestAnimationFrame` interception** — holds the queued reveal captive so the concurrent update lands while the boundary is genuinely `$~`.

The test **fails without the reconciler change and passes with it**.

## Caveat

This is a rigorous React-only reproduction of the mechanism. I was not able to reproduce the reporter's exact Next.js App Router end-to-end scenario locally (that needs the Next runtime), but the reconciler-level race and its fix are demonstrated deterministically.

## Test plan

- `yarn test ReactDOMFizzServer` — 168/168 pass (new test included)
- `yarn test ReactDOMServerPartialHydration` — 65/65 pass (no regression to `$?` behavior)
- `yarn linc` clean, `yarn prettier` applied, Flow reports no errors