### PR TITLE
fix(devtools): handle profile file read errors

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/profilingImportExportButtons-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilingImportExportButtons-test.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+jest.mock('react-devtools-shared/src/devtools/views/Button', () => {
+  return function Button({children, ...props}) {
+    return require('react').createElement('button', props, children);
+  };
+});
+
+jest.mock('react-devtools-shared/src/devtools/views/ButtonIcon', () => {
+  return function ButtonIcon() {
+    return null;
+  };
+});
+
+describe('ProfilingImportExportButtons', () => {
+  let React;
+  let ReactDOMClient;
+  let ProfilingImportExportButtons;
+  let ModalDialogContext;
+  let ProfilerContext;
+  let StoreContext;
+  let TimelineContext;
+  let container;
+  let root;
+  let utils;
+  let originalFileReader;
+
+  beforeEach(() => {
+    utils = require('./utils');
+    utils.beforeEachProfiling();
+
+    React = require('react');
+    ReactDOMClient = require('react-dom/client');
+    ProfilingImportExportButtons =
+      require('react-devtools-shared/src/devtools/views/Profiler/ProfilingImportExportButtons').default;
+    ModalDialogContext =
+      require('react-devtools-shared/src/devtools/views/ModalDialog').ModalDialogContext;
+    ProfilerContext =
+      require('react-devtools-shared/src/devtools/views/Profiler/ProfilerContext').ProfilerContext;
+    StoreContext =
+      require('react-devtools-shared/src/devtools/views/context').StoreContext;
+    TimelineContext =
+      require('react-devtools-timeline/src/TimelineContext').TimelineContext;
+
+    originalFileReader = global.FileReader;
+    container = document.createElement('div');
+    root = ReactDOMClient.createRoot(container);
+  });
+
+  afterEach(() => {
+    utils.act(() => root.unmount());
+    global.FileReader = originalFileReader;
+  });
+
+  it('shows an import error when the selected file cannot be read', () => {
+    let fileReader;
+
+    class MockFileReader {
+      error = new DOMException('The selected file could not be read.');
+      listeners = {};
+
+      constructor() {
+        fileReader = this;
+      }
+
+      addEventListener(type, listener) {
+        this.listeners[type] = listener;
+      }
+
+      readAsText() {}
+
+      triggerError() {
+        const listener = this.listeners.error;
+        if (listener) {
+          listener();
+        }
+      }
+    }
+
+    global.FileReader = MockFileReader;
+
+    const modalDialogDispatch = jest.fn();
+    const setFile = jest.fn();
+
+    utils.act(() => {
+      root.render(
+        <StoreContext.Provider value={global.store}>
+          <ProfilerContext.Provider
+            value={
+              ({isProfiling: false, profilingData: null, rootID: null}: any)
+            }>
+            <TimelineContext.Provider value={({setFile}: any)}>
+              <ModalDialogContext.Provider
+                value={({dialogs: [], dispatch: modalDialogDispatch}: any)}>
+                <ProfilingImportExportButtons />
+              </ModalDialogContext.Provider>
+            </TimelineContext.Provider>
+          </ProfilerContext.Provider>
+        </StoreContext.Provider>,
+      );
+    });
+
+    const input = container.querySelector('input[type="file"]');
+    const file = new File(['profile'], 'profile.json', {
+      type: 'application/json',
+    });
+    Object.defineProperty(input, 'files', {
+      configurable: true,
+      value: [file],
+    });
+
+    utils.act(() => {
+      input.dispatchEvent(new Event('change', {bubbles: true}));
+    });
+    utils.act(() => fileReader.triggerError());
+
+    expect(modalDialogDispatch).toHaveBeenCalledTimes(1);
+    expect(modalDialogDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'ProfilingImportExportButtons',
+        type: 'SHOW',
+        title: 'Import failed',
+      }),
+    );
+  });
+});

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilingImportExportButtons.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilingImportExportButtons.js
@@ -38,6 +38,25 @@ export default function ProfilingImportExportButtons(): React.Node {
 
   const {dispatch: modalDialogDispatch} = useContext(ModalDialogContext);
 
+  const showImportError = useCallback(
+    (error: null | {message: string}) => {
+      modalDialogDispatch({
+        id: 'ProfilingImportExportButtons',
+        type: 'SHOW',
+        title: 'Import failed',
+        content: (
+          <Fragment>
+            <div>The profiling data you selected cannot be imported.</div>
+            {error !== null && (
+              <div className={styles.ErrorMessage}>{error.message}</div>
+            )}
+          </Fragment>
+        ),
+      });
+    },
+    [modalDialogDispatch],
+  );
+
   const doesHaveInMemoryData = profilerStore.didRecordCommits;
 
   const downloadData = useCallback(() => {
@@ -83,8 +102,10 @@ export default function ProfilingImportExportButtons(): React.Node {
     if (input !== null && input.files.length > 0) {
       const file = input.files[0];
 
-      // TODO (profiling) Handle fileReader errors.
       const fileReader = new FileReader();
+      fileReader.addEventListener('error', () => {
+        showImportError(fileReader.error);
+      });
       fileReader.addEventListener('load', () => {
         const raw = fileReader.result as any as string;
         const json = JSON.parse(raw);
@@ -99,19 +120,7 @@ export default function ProfilingImportExportButtons(): React.Node {
             profilerStore.profilingData =
               prepareProfilingDataFrontendFromExport(profilingDataExport);
           } catch (error) {
-            modalDialogDispatch({
-              id: 'ProfilingImportExportButtons',
-              type: 'SHOW',
-              title: 'Import failed',
-              content: (
-                <Fragment>
-                  <div>The profiling data you selected cannot be imported.</div>
-                  {error !== null && (
-                    <div className={styles.ErrorMessage}>{error.message}</div>
-                  )}
-                </Fragment>
-              ),
-            });
+            showImportError(error);
           }
         } else {
           // Otherwise let's assume this is Trace Event data and pass it to the Timeline preprocessor.


### PR DESCRIPTION
## Summary

The Profiler import UI only listened for successful `FileReader` loads. When the browser failed to read a selected profile, DevTools did not show any feedback.

- Handle the `FileReader` error event and show the existing "Import failed" dialog.
- Reuse the same dialog helper for file read and profile conversion failures.
- Add a regression test for the file read error path.

## How did you test this change?

- `node ./scripts/jest/jest-cli.js --build --project devtools --release-channel experimental profilingImportExportButtons --runInBand`
  - 1 suite passed, 1 test passed.
- `node ./scripts/tasks/eslint.js`
  - Lint passed.
- `flow.exe status --strip-root`
  - No errors.
- `node ./scripts/prettier/index.js write-changed`
- Built the React bundles required by the DevTools test configuration with the experimental release channel.

I also ran the complete experimental DevTools suite on both the parent commit and this branch. Both runs had the same 15 failing suites and 103 failing tests in existing tests. This branch increased the passing result from 31 suites / 581 tests to 32 suites / 582 tests by adding the regression coverage above.
