### PR TITLE
[Compiler] Memoize const declarations between hooks

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/FlattenScopesWithHooksOrUseHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/FlattenScopesWithHooksOrUseHIR.ts
@@ -8,12 +8,14 @@
 import {CompilerError} from '..';
 import {
   BlockId,
+  BasicBlock,
   HIRFunction,
   LabelTerminal,
   PrunedScopeTerminal,
   getHookKind,
   isUseOperator,
 } from '../HIR';
+import {eachTerminalSuccessor} from '../HIR/visitors';
 import {retainWhere} from '../Utils/utils';
 
 /**
@@ -40,10 +42,10 @@ import {retainWhere} from '../Utils/utils';
 export function flattenScopesWithHooksOrUseHIR(fn: HIRFunction): void {
   const activeScopes: Array<{block: BlockId; fallthrough: BlockId}> = [];
   const prune: Array<BlockId> = [];
+  const blocksWithHooks = new Set<BlockId>();
 
+  // First pass: identify blocks that contain hooks
   for (const [, block] of fn.body.blocks) {
-    retainWhere(activeScopes, current => current.fallthrough !== block.id);
-
     for (const instr of block.instructions) {
       const {value} = instr;
       switch (value.kind) {
@@ -55,17 +57,65 @@ export function flattenScopesWithHooksOrUseHIR(fn: HIRFunction): void {
             getHookKind(fn.env, callee.identifier) != null ||
             isUseOperator(callee.identifier)
           ) {
-            prune.push(...activeScopes.map(entry => entry.block));
-            activeScopes.length = 0;
+            blocksWithHooks.add(block.id);
           }
         }
       }
     }
+  }
+
+  // Helper to find all blocks reachable within the scope's boundary
+  function getBlocksInScope(
+    blocks: Map<BlockId, BasicBlock>,
+    startBlockId: BlockId,
+    fallthroughBlockId: BlockId,
+  ): Set<BlockId> {
+    const visited = new Set<BlockId>();
+    const queue = [startBlockId];
+    while (queue.length > 0) {
+      const currentId = queue.shift()!;
+      if (currentId === fallthroughBlockId || visited.has(currentId)) {
+        continue;
+      }
+      visited.add(currentId);
+      const block = blocks.get(currentId);
+      if (block != null) {
+        for (const succId of eachTerminalSuccessor(block.terminal)) {
+          queue.push(succId);
+        }
+      }
+    }
+    return visited;
+  }
+
+  // Helper function to check if a scope contains hooks
+  function scopeContainsHook(startBlockId: BlockId, fallthroughBlockId: BlockId): boolean {
+    const scopeBlocks = getBlocksInScope(fn.body.blocks, startBlockId, fallthroughBlockId);
+    for (const blockId of scopeBlocks) {
+      if (blocksWithHooks.has(blockId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Second pass: prune only scopes that contain hooks
+  for (const [, block] of fn.body.blocks) {
+    retainWhere(activeScopes, current => current.fallthrough !== block.id);
+
     if (block.terminal.kind === 'scope') {
-      activeScopes.push({
-        block: block.id,
-        fallthrough: block.terminal.fallthrough,
-      });
+      const scopeBodyBlockId = block.terminal.block;
+      const fallthroughBlockId = block.terminal.fallthrough;
+      // Only prune scopes whose body blocks contain hooks
+      if (scopeContainsHook(scopeBodyBlockId, fallthroughBlockId)) {
+        prune.push(block.id);
+      } else {
+        // Scope doesn't contain hooks, so track it (it can be memoized)
+        activeScopes.push({
+          block: block.id,
+          fallthrough: block.terminal.fallthrough,
+        });
+      }
     }
   }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/memoize-const-between-hooks.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/memoize-const-between-hooks.js
@@ -1,0 +1,16 @@
+import {useState} from 'react';
+
+function Component() {
+  const [state, setState] = useState(0);
+  const someConst = 42;
+  const memoized = someConst * 2;
+  const [anotherState, setAnotherState] = useState(0);
+
+  return (
+    <div>
+      {memoized} {state} {anotherState}
+    </div>
+  );
+}
+
+export default Component;


### PR DESCRIPTION
React Compiler currently prunes all active scopes when encountering any hook/use operator call during `flattenScopesWithHooksOrUseHIR`. While this prevents hooks from being conditionally executed (which is a Rules of Hooks violation), it incorrectly prunes independent scopes (like `const` value declarations) that happen to be defined between React hooks. This prevents these values from being properly memoized, leading to unnecessary re-computations or instability in returned properties.

This change modifies `flattenScopesWithHooksOrUseHIR` to:
1. In a first pass, identify all basic blocks that contain hook or `use` operator calls.
2. Define a helper `getBlocksInScope` to retrieve all blocks enclosed within a scope's start block and fallthrough block.
3. In a second pass, only prune a scope if it encloses a block containing hook/use calls, allowing independent scopes created between hooks to be properly memoized.

## How did you test this change?

Added a compiler test fixture `memoize-const-between-hooks.js` to verify that variables declared between hook calls are properly memoized.