### PR TITLE
Clean up flag to enable microtasks in RN

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -464,7 +464,6 @@ module.exports = {
       files: ['packages/react-native-renderer/**/*.js'],
       globals: {
         nativeFabricUIManager: 'readonly',
-        RN$enableMicrotasksInReact: 'readonly',
         RN$isNativeEventTargetEventDispatchingEnabled: 'readonly',
       },
     },

--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -947,9 +947,7 @@ export function resetFormInstance(form: Instance): void {}
 //     Microtasks
 // -------------------
 
-export const supportsMicrotasks: boolean =
-  typeof RN$enableMicrotasksInReact !== 'undefined' &&
-  !!RN$enableMicrotasksInReact;
+export const supportsMicrotasks: boolean = true;
 
 export const scheduleMicrotask: any =
   typeof queueMicrotask === 'function' ? queueMicrotask : scheduleTimeout;

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -128,9 +128,6 @@ declare module 'react-native' {
 }
 
 // eslint-disable-next-line no-unused-vars
-declare const RN$enableMicrotasksInReact: boolean;
-
-// eslint-disable-next-line no-unused-vars
 declare const RN$isNativeEventTargetEventDispatchingEnabled:
   | (() => boolean)
   | void;

--- a/scripts/rollup/validate/eslintrc.rn.js
+++ b/scripts/rollup/validate/eslintrc.rn.js
@@ -46,8 +46,6 @@ module.exports = {
     // Fabric. See https://github.com/facebook/react/pull/15490
     // for more information
     nativeFabricUIManager: 'readonly',
-    // RN flag to enable microtasks
-    RN$enableMicrotasksInReact: 'readonly',
     RN$isNativeEventTargetEventDispatchingEnabled: 'readonly',
     // Trusted Types
     trustedTypes: 'readonly',


### PR DESCRIPTION
## Summary

Microtasks are enabled by default in RN already, so there's no need to gate their use in Fabric atm. 

## How did you test this change?

Existing tests. Tested e2e at Meta.