### PR TITLE
[DevTools] Ignore stale remove operations instead of throwing

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -97,6 +97,59 @@ describe('Store', () => {
   const {render, unmount, createContainer} = getVersionedRenderImplementation();
 
   // @reactVersion >= 18.0
+  it('should ignore a duplicate or stale remove operation instead of throwing', () => {
+    const {
+      TREE_OPERATION_ADD,
+      TREE_OPERATION_REMOVE,
+    } = require('react-devtools-shared/src/constants');
+    const {
+      ElementTypeFunction,
+      ElementTypeRoot,
+    } = require('react-devtools-shared/src/frontend/types');
+
+    store.onBridgeOperations([
+      1, // renderer ID
+      1, // root ID
+      2, // string table size
+      1, // next string length
+      67, // C
+      TREE_OPERATION_ADD,
+      1,
+      ElementTypeRoot,
+      0, // StrictMode compliant?
+      0, // Profiling flags
+      0, // StrictMode supported?
+      0, // Owner metadata?
+      TREE_OPERATION_ADD,
+      2,
+      ElementTypeFunction,
+      1, // parent
+      0, // owner
+      1, // displayName "C"
+      0, // key
+      0, // nameProp
+    ]);
+
+    expect(store.getElementByID(2)).not.toBeNull();
+
+    // A second, stale REMOVE referencing the same id (e.g. a duplicated or
+    // desynced bridge message) must not crash the whole DevTools panel.
+    expect(() =>
+      store.onBridgeOperations([
+        1, // renderer ID
+        1, // root ID
+        0, // string table size
+        TREE_OPERATION_REMOVE,
+        2, // number of removals
+        2, // first removal
+        2, // duplicate, stale removal of the same id
+      ]),
+    ).not.toThrow();
+
+    expect(store.getElementByID(2)).toBeNull();
+  });
+
+  // @reactVersion >= 18.0
   it('should not allow a root node to be collapsed', async () => {
     const Component = () => <div>Hi</div>;
 

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -1616,17 +1616,14 @@ export default class Store extends EventEmitter<{
             const id = operations[i];
             const element = this._idToElement.get(id);
 
-            if (element === undefined) {
-              this._throwAndEmitError(
-                Error(
-                  `Cannot remove node "${id}" because no matching node was found in the Store.`,
-                ),
-              );
-
-              break;
-            }
-
             i += 1;
+
+            if (element === undefined) {
+              // This node was already removed (e.g. a desynced or duplicate
+              // REMOVE op for the same id). Skip it rather than crashing the
+              // whole DevTools panel; there's nothing left to clean up for it.
+              continue;
+            }
 
             const {children, ownerID, parentID, weight} = element;
             if (children.length > 0) {
@@ -1656,18 +1653,12 @@ export default class Store extends EventEmitter<{
               }
 
               parentElement = this._idToElement.get(parentID);
-              if (parentElement === undefined) {
-                this._throwAndEmitError(
-                  Error(
-                    `Cannot remove node "${id}" from parent "${parentID}" because no matching node was found in the Store.`,
-                  ),
-                );
-
-                break;
+              if (parentElement !== undefined) {
+                const index = parentElement.children.indexOf(id);
+                if (index !== -1) {
+                  parentElement.children.splice(index, 1);
+                }
               }
-
-              const index = parentElement.children.indexOf(id);
-              parentElement.children.splice(index, 1);
             }
 
             this._adjustParentTreeWeight(parentElement, -weight);


### PR DESCRIPTION
## Summary

Fixes #36937 (`Cannot remove node "1428" because no matching node was found in the Store`).

The Store currently throws an uncaught error whenever a `TREE_OPERATION_REMOVE` references a node (or its parent) that it no longer has a record of. Throwing here crashes the entire DevTools extension panel rather than just failing to process one stale operation.

This happens when the backend sends a duplicate or desynced removal for an id that the Store has already removed (or never received an ADD for). The reporter's repro is a production build with no local reproduction available, so this PR does not attempt to fix whatever backend condition produces the stale/duplicate REMOVE — it makes the frontend Store tolerant of it, which is the same approach already taken for the analogous cases:

- Reorder-children referencing a missing node
- Suspense resize/reorder referencing a node removed earlier in the same batch

## Change

In `store.js`'s `TREE_OPERATION_REMOVE` handling:
- If the node itself is missing from `_idToElement`, skip it instead of throwing (nothing left to clean up).
- If the node's parent is missing (already removed), skip the parent-children splice instead of throwing, since the child is still removed from `_idToElement` either way.

## How did you test this change?

Added a regression test to `store-test.js` that sends a `REMOVE` batch containing a duplicate id for an already-removed node and asserts it no longer throws.

- `yarn test store-test` — full suite passes, including the new test
- `yarn linc` — lint passes