### PR TITLE
[devtools] Document that Store consistency throws must not be worked around

### DIFF
--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -608,6 +608,11 @@ export default class Store extends EventEmitter<{
       root = this._idToElement.get(rootID);
 
       if (root === undefined) {
+        // If this throws, the operations sent by the backend were inconsistent
+        // with the Store's tree. The bug is in whatever produced these
+        // operations (usually the backend renderer), not here. Keep this throw
+        // and fix the root cause there instead of working around it in the
+        // Store.
         this._throwAndEmitError(
           Error(
             `Couldn't find root with id "${rootID}": no matching node was found in the Store.`,
@@ -644,6 +649,11 @@ export default class Store extends EventEmitter<{
         const child = this._idToElement.get(childID);
 
         if (child === undefined) {
+          // If this throws, the operations sent by the backend were
+          // inconsistent with the Store's tree. The bug is in whatever produced
+          // these operations (usually the backend renderer), not here. Keep
+          // this throw and fix the root cause there instead of working around
+          // it in the Store.
           this._throwAndEmitError(
             Error(
               `Couldn't child element with id "${childID}": no matching node was found in the Store.`,
@@ -1431,6 +1441,11 @@ export default class Store extends EventEmitter<{
           i += 3;
 
           if (this._idToElement.has(id)) {
+            // If this throws, the operations sent by the backend were
+            // inconsistent with the Store's tree. The bug is in whatever
+            // produced these operations (usually the backend renderer), not
+            // here. Keep this throw and fix the root cause there instead of
+            // working around it in the Store.
             this._throwAndEmitError(
               Error(
                 `Cannot add node "${id}" because a node with that id is already in the Store.`,
@@ -1541,6 +1556,11 @@ export default class Store extends EventEmitter<{
 
             const parentElement = this._idToElement.get(parentID);
             if (parentElement === undefined) {
+              // If this throws, the operations sent by the backend were
+              // inconsistent with the Store's tree. The bug is in whatever
+              // produced these operations (usually the backend renderer), not
+              // here. Keep this throw and fix the root cause there instead of
+              // working around it in the Store.
               this._throwAndEmitError(
                 Error(
                   `Cannot add child "${id}" to parent "${parentID}" because parent node was not found in the Store.`,
@@ -1617,6 +1637,11 @@ export default class Store extends EventEmitter<{
             const element = this._idToElement.get(id);
 
             if (element === undefined) {
+              // If this throws, the operations sent by the backend were
+              // inconsistent with the Store's tree. The bug is in whatever
+              // produced these operations (usually the backend renderer), not
+              // here. Keep this throw and fix the root cause there instead of
+              // working around it in the Store.
               this._throwAndEmitError(
                 Error(
                   `Cannot remove node "${id}" because no matching node was found in the Store.`,
@@ -1630,6 +1655,11 @@ export default class Store extends EventEmitter<{
 
             const {children, ownerID, parentID, weight} = element;
             if (children.length > 0) {
+              // If this throws, the operations sent by the backend were
+              // inconsistent with the Store's tree. The bug is in whatever
+              // produced these operations (usually the backend renderer), not
+              // here. Keep this throw and fix the root cause there instead of
+              // working around it in the Store.
               this._throwAndEmitError(
                 Error(`Node "${id}" was removed before its children.`),
               );
@@ -1657,6 +1687,11 @@ export default class Store extends EventEmitter<{
 
               parentElement = this._idToElement.get(parentID);
               if (parentElement === undefined) {
+                // If this throws, the operations sent by the backend were
+                // inconsistent with the Store's tree. The bug is in whatever
+                // produced these operations (usually the backend renderer), not
+                // here. Keep this throw and fix the root cause there instead of
+                // working around it in the Store.
                 this._throwAndEmitError(
                   Error(
                     `Cannot remove node "${id}" from parent "${parentID}" because no matching node was found in the Store.`,
@@ -1696,6 +1731,11 @@ export default class Store extends EventEmitter<{
 
           const element = this._idToElement.get(id);
           if (element === undefined) {
+            // If this throws, the operations sent by the backend were
+            // inconsistent with the Store's tree. The bug is in whatever
+            // produced these operations (usually the backend renderer), not
+            // here. Keep this throw and fix the root cause there instead of
+            // working around it in the Store.
             this._throwAndEmitError(
               Error(
                 `Cannot reorder children for node "${id}" because no matching node was found in the Store.`,
@@ -1707,6 +1747,11 @@ export default class Store extends EventEmitter<{
 
           const children = element.children;
           if (children.length !== numChildren) {
+            // If this throws, the operations sent by the backend were
+            // inconsistent with the Store's tree. The bug is in whatever
+            // produced these operations (usually the backend renderer), not
+            // here. Keep this throw and fix the root cause there instead of
+            // working around it in the Store.
             this._throwAndEmitError(
               Error(
                 `Children cannot be added or removed during a reorder operation.`,
@@ -1824,6 +1869,11 @@ export default class Store extends EventEmitter<{
           let name = stringTable[nameStringID];
 
           if (this._idToSuspense.has(id)) {
+            // If this throws, the operations sent by the backend were
+            // inconsistent with the Store's tree. The bug is in whatever
+            // produced these operations (usually the backend renderer), not
+            // here. Keep this throw and fix the root cause there instead of
+            // working around it in the Store.
             this._throwAndEmitError(
               Error(
                 `Cannot add suspense node "${id}" because a suspense node with that id is already in the Store.`,
@@ -1876,6 +1926,11 @@ export default class Store extends EventEmitter<{
           if (parentID !== 0) {
             const parentSuspense = this._idToSuspense.get(parentID);
             if (parentSuspense === undefined) {
+              // If this throws, the operations sent by the backend were
+              // inconsistent with the Store's tree. The bug is in whatever
+              // produced these operations (usually the backend renderer), not
+              // here. Keep this throw and fix the root cause there instead of
+              // working around it in the Store.
               this._throwAndEmitError(
                 Error(
                   `Cannot add suspense child "${id}" to parent suspense "${parentID}" because parent suspense node was not found in the Store.`,
@@ -1912,6 +1967,11 @@ export default class Store extends EventEmitter<{
             const suspense = this._idToSuspense.get(id);
 
             if (suspense === undefined) {
+              // If this throws, the operations sent by the backend were
+              // inconsistent with the Store's tree. The bug is in whatever
+              // produced these operations (usually the backend renderer), not
+              // here. Keep this throw and fix the root cause there instead of
+              // working around it in the Store.
               this._throwAndEmitError(
                 Error(
                   `Cannot remove suspense node "${id}" because no matching node was found in the Store.`,
@@ -1925,6 +1985,11 @@ export default class Store extends EventEmitter<{
 
             const {children, parentID, rects} = suspense;
             if (children.length > 0) {
+              // If this throws, the operations sent by the backend were
+              // inconsistent with the Store's tree. The bug is in whatever
+              // produced these operations (usually the backend renderer), not
+              // here. Keep this throw and fix the root cause there instead of
+              // working around it in the Store.
               this._throwAndEmitError(
                 Error(`Suspense node "${id}" was removed before its children.`),
               );
@@ -1954,6 +2019,11 @@ export default class Store extends EventEmitter<{
 
               parentSuspense = this._idToSuspense.get(parentID);
               if (parentSuspense === undefined) {
+                // If this throws, the operations sent by the backend were
+                // inconsistent with the Store's tree. The bug is in whatever
+                // produced these operations (usually the backend renderer), not
+                // here. Keep this throw and fix the root cause there instead of
+                // working around it in the Store.
                 this._throwAndEmitError(
                   Error(
                     `Cannot remove suspense node "${id}" from parent "${parentID}" because no matching node was found in the Store.`,
@@ -1965,6 +2035,11 @@ export default class Store extends EventEmitter<{
 
               const index = parentSuspense.children.indexOf(id);
               if (index === -1) {
+                // If this throws, the operations sent by the backend were
+                // inconsistent with the Store's tree. The bug is in whatever
+                // produced these operations (usually the backend renderer), not
+                // here. Keep this throw and fix the root cause there instead of
+                // working around it in the Store.
                 this._throwAndEmitError(
                   Error(
                     `Cannot remove suspense node "${id}" from parent "${parentID}" because it is not a child of the parent.`,
@@ -1985,6 +2060,11 @@ export default class Store extends EventEmitter<{
 
           const suspense = this._idToSuspense.get(id);
           if (suspense === undefined) {
+            // If this throws, the operations sent by the backend were
+            // inconsistent with the Store's tree. The bug is in whatever
+            // produced these operations (usually the backend renderer), not
+            // here. Keep this throw and fix the root cause there instead of
+            // working around it in the Store.
             this._throwAndEmitError(
               Error(
                 `Cannot reorder children for suspense node "${id}" because no matching node was found in the Store.`,
@@ -1996,6 +2076,11 @@ export default class Store extends EventEmitter<{
 
           const children = suspense.children;
           if (children.length !== numChildren) {
+            // If this throws, the operations sent by the backend were
+            // inconsistent with the Store's tree. The bug is in whatever
+            // produced these operations (usually the backend renderer), not
+            // here. Keep this throw and fix the root cause there instead of
+            // working around it in the Store.
             this._throwAndEmitError(
               Error(
                 `Suspense children cannot be added or removed during a reorder operation.`,
@@ -2036,6 +2121,11 @@ export default class Store extends EventEmitter<{
 
           const suspense = this._idToSuspense.get(id);
           if (suspense === undefined) {
+            // If this throws, the operations sent by the backend were
+            // inconsistent with the Store's tree. The bug is in whatever
+            // produced these operations (usually the backend renderer), not
+            // here. Keep this throw and fix the root cause there instead of
+            // working around it in the Store.
             this._throwAndEmitError(
               Error(
                 `Cannot set rects for suspense node "${id}" because no matching node was found in the Store.`,
@@ -2123,6 +2213,11 @@ export default class Store extends EventEmitter<{
             const suspense = this._idToSuspense.get(id);
 
             if (suspense === undefined) {
+              // If this throws, the operations sent by the backend were
+              // inconsistent with the Store's tree. The bug is in whatever
+              // produced these operations (usually the backend renderer), not
+              // here. Keep this throw and fix the root cause there instead of
+              // working around it in the Store.
               this._throwAndEmitError(
                 Error(
                   `Cannot update suspenders of suspense node "${id}" because no matching node was found in the Store.`,

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -608,11 +608,7 @@ export default class Store extends EventEmitter<{
       root = this._idToElement.get(rootID);
 
       if (root === undefined) {
-        // If this throws, the operations sent by the backend were inconsistent
-        // with the Store's tree. The bug is in whatever produced these
-        // operations (usually the backend renderer), not here. Keep this throw
-        // and fix the root cause there instead of working around it in the
-        // Store.
+        // We should never reach this. This is a bug in the backend renderer.
         this._throwAndEmitError(
           Error(
             `Couldn't find root with id "${rootID}": no matching node was found in the Store.`,
@@ -649,11 +645,7 @@ export default class Store extends EventEmitter<{
         const child = this._idToElement.get(childID);
 
         if (child === undefined) {
-          // If this throws, the operations sent by the backend were
-          // inconsistent with the Store's tree. The bug is in whatever produced
-          // these operations (usually the backend renderer), not here. Keep
-          // this throw and fix the root cause there instead of working around
-          // it in the Store.
+          // We should never reach this. This is a bug in the backend renderer.
           this._throwAndEmitError(
             Error(
               `Couldn't child element with id "${childID}": no matching node was found in the Store.`,
@@ -1441,11 +1433,7 @@ export default class Store extends EventEmitter<{
           i += 3;
 
           if (this._idToElement.has(id)) {
-            // If this throws, the operations sent by the backend were
-            // inconsistent with the Store's tree. The bug is in whatever
-            // produced these operations (usually the backend renderer), not
-            // here. Keep this throw and fix the root cause there instead of
-            // working around it in the Store.
+            // We should never reach this. This is a bug in the backend renderer.
             this._throwAndEmitError(
               Error(
                 `Cannot add node "${id}" because a node with that id is already in the Store.`,
@@ -1556,11 +1544,7 @@ export default class Store extends EventEmitter<{
 
             const parentElement = this._idToElement.get(parentID);
             if (parentElement === undefined) {
-              // If this throws, the operations sent by the backend were
-              // inconsistent with the Store's tree. The bug is in whatever
-              // produced these operations (usually the backend renderer), not
-              // here. Keep this throw and fix the root cause there instead of
-              // working around it in the Store.
+              // We should never reach this. This is a bug in the backend renderer.
               this._throwAndEmitError(
                 Error(
                   `Cannot add child "${id}" to parent "${parentID}" because parent node was not found in the Store.`,
@@ -1637,11 +1621,7 @@ export default class Store extends EventEmitter<{
             const element = this._idToElement.get(id);
 
             if (element === undefined) {
-              // If this throws, the operations sent by the backend were
-              // inconsistent with the Store's tree. The bug is in whatever
-              // produced these operations (usually the backend renderer), not
-              // here. Keep this throw and fix the root cause there instead of
-              // working around it in the Store.
+              // We should never reach this. This is a bug in the backend renderer.
               this._throwAndEmitError(
                 Error(
                   `Cannot remove node "${id}" because no matching node was found in the Store.`,
@@ -1655,11 +1635,7 @@ export default class Store extends EventEmitter<{
 
             const {children, ownerID, parentID, weight} = element;
             if (children.length > 0) {
-              // If this throws, the operations sent by the backend were
-              // inconsistent with the Store's tree. The bug is in whatever
-              // produced these operations (usually the backend renderer), not
-              // here. Keep this throw and fix the root cause there instead of
-              // working around it in the Store.
+              // We should never reach this. This is a bug in the backend renderer.
               this._throwAndEmitError(
                 Error(`Node "${id}" was removed before its children.`),
               );
@@ -1687,11 +1663,7 @@ export default class Store extends EventEmitter<{
 
               parentElement = this._idToElement.get(parentID);
               if (parentElement === undefined) {
-                // If this throws, the operations sent by the backend were
-                // inconsistent with the Store's tree. The bug is in whatever
-                // produced these operations (usually the backend renderer), not
-                // here. Keep this throw and fix the root cause there instead of
-                // working around it in the Store.
+                // We should never reach this. This is a bug in the backend renderer.
                 this._throwAndEmitError(
                   Error(
                     `Cannot remove node "${id}" from parent "${parentID}" because no matching node was found in the Store.`,
@@ -1731,11 +1703,7 @@ export default class Store extends EventEmitter<{
 
           const element = this._idToElement.get(id);
           if (element === undefined) {
-            // If this throws, the operations sent by the backend were
-            // inconsistent with the Store's tree. The bug is in whatever
-            // produced these operations (usually the backend renderer), not
-            // here. Keep this throw and fix the root cause there instead of
-            // working around it in the Store.
+            // We should never reach this. This is a bug in the backend renderer.
             this._throwAndEmitError(
               Error(
                 `Cannot reorder children for node "${id}" because no matching node was found in the Store.`,
@@ -1747,11 +1715,7 @@ export default class Store extends EventEmitter<{
 
           const children = element.children;
           if (children.length !== numChildren) {
-            // If this throws, the operations sent by the backend were
-            // inconsistent with the Store's tree. The bug is in whatever
-            // produced these operations (usually the backend renderer), not
-            // here. Keep this throw and fix the root cause there instead of
-            // working around it in the Store.
+            // We should never reach this. This is a bug in the backend renderer.
             this._throwAndEmitError(
               Error(
                 `Children cannot be added or removed during a reorder operation.`,
@@ -1869,11 +1833,7 @@ export default class Store extends EventEmitter<{
           let name = stringTable[nameStringID];
 
           if (this._idToSuspense.has(id)) {
-            // If this throws, the operations sent by the backend were
-            // inconsistent with the Store's tree. The bug is in whatever
-            // produced these operations (usually the backend renderer), not
-            // here. Keep this throw and fix the root cause there instead of
-            // working around it in the Store.
+            // We should never reach this. This is a bug in the backend renderer.
             this._throwAndEmitError(
               Error(
                 `Cannot add suspense node "${id}" because a suspense node with that id is already in the Store.`,
@@ -1926,11 +1886,7 @@ export default class Store extends EventEmitter<{
           if (parentID !== 0) {
             const parentSuspense = this._idToSuspense.get(parentID);
             if (parentSuspense === undefined) {
-              // If this throws, the operations sent by the backend were
-              // inconsistent with the Store's tree. The bug is in whatever
-              // produced these operations (usually the backend renderer), not
-              // here. Keep this throw and fix the root cause there instead of
-              // working around it in the Store.
+              // We should never reach this. This is a bug in the backend renderer.
               this._throwAndEmitError(
                 Error(
                   `Cannot add suspense child "${id}" to parent suspense "${parentID}" because parent suspense node was not found in the Store.`,
@@ -1967,11 +1923,7 @@ export default class Store extends EventEmitter<{
             const suspense = this._idToSuspense.get(id);
 
             if (suspense === undefined) {
-              // If this throws, the operations sent by the backend were
-              // inconsistent with the Store's tree. The bug is in whatever
-              // produced these operations (usually the backend renderer), not
-              // here. Keep this throw and fix the root cause there instead of
-              // working around it in the Store.
+              // We should never reach this. This is a bug in the backend renderer.
               this._throwAndEmitError(
                 Error(
                   `Cannot remove suspense node "${id}" because no matching node was found in the Store.`,
@@ -1985,11 +1937,7 @@ export default class Store extends EventEmitter<{
 
             const {children, parentID, rects} = suspense;
             if (children.length > 0) {
-              // If this throws, the operations sent by the backend were
-              // inconsistent with the Store's tree. The bug is in whatever
-              // produced these operations (usually the backend renderer), not
-              // here. Keep this throw and fix the root cause there instead of
-              // working around it in the Store.
+              // We should never reach this. This is a bug in the backend renderer.
               this._throwAndEmitError(
                 Error(`Suspense node "${id}" was removed before its children.`),
               );
@@ -2019,11 +1967,7 @@ export default class Store extends EventEmitter<{
 
               parentSuspense = this._idToSuspense.get(parentID);
               if (parentSuspense === undefined) {
-                // If this throws, the operations sent by the backend were
-                // inconsistent with the Store's tree. The bug is in whatever
-                // produced these operations (usually the backend renderer), not
-                // here. Keep this throw and fix the root cause there instead of
-                // working around it in the Store.
+                // We should never reach this. This is a bug in the backend renderer.
                 this._throwAndEmitError(
                   Error(
                     `Cannot remove suspense node "${id}" from parent "${parentID}" because no matching node was found in the Store.`,
@@ -2035,11 +1979,7 @@ export default class Store extends EventEmitter<{
 
               const index = parentSuspense.children.indexOf(id);
               if (index === -1) {
-                // If this throws, the operations sent by the backend were
-                // inconsistent with the Store's tree. The bug is in whatever
-                // produced these operations (usually the backend renderer), not
-                // here. Keep this throw and fix the root cause there instead of
-                // working around it in the Store.
+                // We should never reach this. This is a bug in the backend renderer.
                 this._throwAndEmitError(
                   Error(
                     `Cannot remove suspense node "${id}" from parent "${parentID}" because it is not a child of the parent.`,
@@ -2060,11 +2000,7 @@ export default class Store extends EventEmitter<{
 
           const suspense = this._idToSuspense.get(id);
           if (suspense === undefined) {
-            // If this throws, the operations sent by the backend were
-            // inconsistent with the Store's tree. The bug is in whatever
-            // produced these operations (usually the backend renderer), not
-            // here. Keep this throw and fix the root cause there instead of
-            // working around it in the Store.
+            // We should never reach this. This is a bug in the backend renderer.
             this._throwAndEmitError(
               Error(
                 `Cannot reorder children for suspense node "${id}" because no matching node was found in the Store.`,
@@ -2076,11 +2012,7 @@ export default class Store extends EventEmitter<{
 
           const children = suspense.children;
           if (children.length !== numChildren) {
-            // If this throws, the operations sent by the backend were
-            // inconsistent with the Store's tree. The bug is in whatever
-            // produced these operations (usually the backend renderer), not
-            // here. Keep this throw and fix the root cause there instead of
-            // working around it in the Store.
+            // We should never reach this. This is a bug in the backend renderer.
             this._throwAndEmitError(
               Error(
                 `Suspense children cannot be added or removed during a reorder operation.`,
@@ -2121,11 +2053,7 @@ export default class Store extends EventEmitter<{
 
           const suspense = this._idToSuspense.get(id);
           if (suspense === undefined) {
-            // If this throws, the operations sent by the backend were
-            // inconsistent with the Store's tree. The bug is in whatever
-            // produced these operations (usually the backend renderer), not
-            // here. Keep this throw and fix the root cause there instead of
-            // working around it in the Store.
+            // We should never reach this. This is a bug in the backend renderer.
             this._throwAndEmitError(
               Error(
                 `Cannot set rects for suspense node "${id}" because no matching node was found in the Store.`,
@@ -2213,11 +2141,7 @@ export default class Store extends EventEmitter<{
             const suspense = this._idToSuspense.get(id);
 
             if (suspense === undefined) {
-              // If this throws, the operations sent by the backend were
-              // inconsistent with the Store's tree. The bug is in whatever
-              // produced these operations (usually the backend renderer), not
-              // here. Keep this throw and fix the root cause there instead of
-              // working around it in the Store.
+              // We should never reach this. This is a bug in the backend renderer.
               this._throwAndEmitError(
                 Error(
                   `Cannot update suspenders of suspense node "${id}" because no matching node was found in the Store.`,


### PR DESCRIPTION
There's been an influx of PRs attempting to fix inconsistent operations by just removing the throw when reconciling the operations with the store.

Throwing in the store has always led to discovery of a backend bug so we should never stop throwing for general case.

I've added a comment for all the throwAndEmit when we handle operations in the store. Hopefully that triggers LLMs to re-attempt the fix.