### PR TITLE
[test] Add Flight regression test for async debug info surviving Promise GC

### DIFF
--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
@@ -3932,4 +3932,232 @@ describe('ReactFlightAsyncDebugInfo', () => {
       `);
     }
   });
+
+  it('does not lose I/O debug info when intermediate promises are garbage collected', async () => {
+    // Get a handle on the garbage collector without running the test with --expose-gc.
+    const v8 = require('v8');
+    const vm = require('vm');
+    v8.setFlagsFromString('--expose-gc');
+    const gc = vm.runInNewContext('gc');
+    v8.setFlagsFromString('--no-expose-gc');
+
+    // The global setImmediate is patched to setTimeout in this test which
+    // registers as new I/O in async_hooks. Use the real setImmediate for
+    // yielding to the event loop while waiting for GC so that it doesn't add
+    // I/O entries to the debug info of the component below.
+    const {setImmediate: realSetImmediate} = require('timers');
+    function tick() {
+      return new Promise(resolve => realSetImmediate(resolve));
+    }
+
+    let ioPromiseRef = null;
+    let collectedIntermediatePromises = false;
+
+    async function getData(text) {
+      const promise = delay(1);
+      ioPromiseRef = new WeakRef(promise);
+      await promise;
+      return text.toUpperCase();
+    }
+
+    async function waitForGarbageCollection(weakRef) {
+      // deref() keeps the target alive until the end of the current task, so
+      // check it on a later tick than the gc() call.
+      let collected = false;
+      for (let i = 0; !collected && i < 100; i++) {
+        gc();
+        await tick();
+        collected = weakRef.deref() === undefined;
+        await tick();
+      }
+      // The destroy() hooks of collected promises fire asynchronously. Yield
+      // a few more times to ensure they have all run.
+      for (let i = 0; i < 5; i++) {
+        gc();
+        await tick();
+      }
+      return collected;
+    }
+
+    async function Component() {
+      const result = await getData('hi');
+      // At this point the intermediate promises (the delay() promise and
+      // getData's own async function promise) are unreachable. The async
+      // debug info graph holds them only weakly through WeakRefs. Force them
+      // to be garbage collected, which fires their async_hooks destroy()
+      // hooks, before this component resolves, which is when React walks the
+      // async graph to emit the component's debug info.
+      collectedIntermediatePromises =
+        await waitForGarbageCollection(ioPromiseRef);
+      return result;
+    }
+
+    const stream = ReactServerDOMServer.renderToPipeableStream(<Component />);
+
+    const readable = new Stream.PassThrough(streamOptions);
+
+    const result = ReactServerDOMClient.createFromNodeStream(readable, {
+      moduleMap: {},
+      moduleLoading: {},
+    });
+    stream.pipe(readable);
+
+    expect(await result).toBe('HI');
+    // If this fails, the GC helper above no longer actually collects the
+    // promises and this test is not testing anything.
+    expect(collectedIntermediatePromises).toBe(true);
+
+    await finishLoadingStream(readable);
+    if (
+      __DEV__ &&
+      gate(
+        flags =>
+          flags.enableComponentPerformanceTrack && flags.enableAsyncDebugInfo,
+      )
+    ) {
+      const debugInfo = getDebugInfo(result);
+      // The I/O entry for delay() must survive the garbage collection of the
+      // intermediate promises. The graph nodes are intentionally held
+      // strongly (only the promises themselves are held weakly through
+      // WeakRefs) so that the originating I/O is still reachable when the
+      // debug info is emitted after the promises are gone.
+      expect(debugInfo).toContainEqual(
+        expect.objectContaining({
+          awaited: expect.objectContaining({name: 'delay'}),
+        }),
+      );
+      expect(debugInfo).toMatchInlineSnapshot(`
+        [
+          {
+            "time": 0,
+          },
+          {
+            "env": "Server",
+            "key": null,
+            "name": "Component",
+            "props": {},
+            "stack": [
+              [
+                "Object.<anonymous>",
+                "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js",
+                3995,
+                109,
+                3936,
+                87,
+              ],
+            ],
+          },
+          {
+            "time": 0,
+          },
+          {
+            "awaited": {
+              "end": 0,
+              "env": "Server",
+              "name": "delay",
+              "owner": {
+                "env": "Server",
+                "key": null,
+                "name": "Component",
+                "props": {},
+                "stack": [
+                  [
+                    "Object.<anonymous>",
+                    "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js",
+                    3995,
+                    109,
+                    3936,
+                    87,
+                  ],
+                ],
+              },
+              "stack": [
+                [
+                  "delay",
+                  "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js",
+                  87,
+                  12,
+                  86,
+                  3,
+                ],
+                [
+                  "getData",
+                  "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js",
+                  3957,
+                  21,
+                  3956,
+                  5,
+                ],
+                [
+                  "Component",
+                  "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js",
+                  3983,
+                  26,
+                  3982,
+                  5,
+                ],
+              ],
+              "start": 0,
+              "value": {
+                "value": undefined,
+              },
+            },
+            "env": "Server",
+            "owner": {
+              "env": "Server",
+              "key": null,
+              "name": "Component",
+              "props": {},
+              "stack": [
+                [
+                  "Object.<anonymous>",
+                  "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js",
+                  3995,
+                  109,
+                  3936,
+                  87,
+                ],
+              ],
+            },
+            "stack": [
+              [
+                "getData",
+                "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js",
+                3959,
+                7,
+                3956,
+                5,
+              ],
+              [
+                "Component",
+                "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js",
+                3983,
+                26,
+                3982,
+                5,
+              ],
+            ],
+          },
+          {
+            "time": 0,
+          },
+          {
+            "time": 0,
+          },
+          {
+            "awaited": {
+              "byteSize": 0,
+              "end": 0,
+              "name": "rsc stream",
+              "owner": null,
+              "start": 0,
+              "value": {
+                "value": "stream",
+              },
+            },
+          },
+        ]
+      `);
+    }
+  });
 });


### PR DESCRIPTION

For PROMISE async resources, the async_hooks `destroy` hook fires when the promise is garbage collected, which can happen at any time. The async debug info graph accounts for this: nodes hold promises only through WeakRefs, but hold other nodes strongly through their `previous` and `awaited` fields, so that the deferred debug info walk (which runs when a task resolves, is serialized, or is aborted) can still reach the originating I/O node after intermediate promises are gone. The `destroy` hook therefore only deletes the `pendingOperations` map entry and must leave the node's links intact.

This test forces a real garbage collection of the intermediate promises inside an async server component, after its data await resolved but before the component itself resolves, and asserts that the I/O debug info for the awaited `delay()` still gets emitted. A fix that severs `previous`/`awaited` in the destroy hook (as proposed in #36995) would orphan the I/O node and silently drop this information, which no existing test caught because none of them trigger a garbage collection.

## How did you test this change?

- [x] fails as expected on #36995
  ```
  FAIL packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js (9.7 s)
  ● ReactFlightAsyncDebugInfo › does not lose I/O debug info when intermediate promises are garbage collected

    expect(received).toContainEqual(expected) // deep equality

    Expected value: ObjectContaining {"awaited": ObjectContaining {"name": "delay"}}
    Received array: [{"time": 0}, {"env": "Server", "key": null, "name": "Component", "props": {}, "stack": [["Object.<anonymous>", "/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js", 3995, 109, 3936, 87]]}, {"time": 0}, {"awaited": {"byteSize": 0, "end": 0, "name": "rsc stream", "owner": null, "start": 0, "value": {"value": "stream"}}}]

      4022 |       // WeakRefs) so that the originating I/O is still reachable when the
      4023 |       // debug info is emitted after the promises are gone.
    > 4024 |       expect(debugInfo).toContainEqual(
           |                         ^
      4025 |         expect.objectContaining({
      4026 |           awaited: expect.objectContaining({name: 'delay'}),
      4027 |         }),

      at Object.<anonymous> (packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js:4024:25)
   ```
   -- https://github.com/react/react/actions/runs/29486909765/job/87583666395?pr=36995#step:9:69