### PR TITLE
[DevTools] Add hotkeys (Ctrl+Shift+X) to start inspecting node

### DIFF
--- a/packages/react-devtools-extensions/chrome/manifest.json
+++ b/packages/react-devtools-extensions/chrome/manifest.json
@@ -61,5 +61,15 @@
       ],
       "run_at": "document_start"
     }
-  ]
+  ],
+
+  "commands": {
+    "inspect_node": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+X",
+        "mac": "Command+Shift+X"
+      },
+      "description": "Toggle on element/node inspector on React Devtools Component"
+    }
+  }
 }

--- a/packages/react-devtools-extensions/firefox/manifest.json
+++ b/packages/react-devtools-extensions/firefox/manifest.json
@@ -66,5 +66,15 @@
       ],
       "run_at": "document_start"
     }
-  ]
+  ],
+
+  "commands": {
+    "inspect_node": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+X",
+        "mac": "Command+Shift+X"
+      },
+      "description": "Toggle on element/node inspector on React Devtools Component"
+    }
+  }
 }

--- a/packages/react-devtools-extensions/src/background/index.js
+++ b/packages/react-devtools-extensions/src/background/index.js
@@ -267,6 +267,20 @@ chrome.runtime.onMessage.addListener((message, sender) => {
   }
 });
 
+chrome.commands.onCommand.addListener(command => {
+  switch (command) {
+    case 'inspect_node':
+      chrome.tabs.query({active: true, currentWindow: true}, tabs => {
+        if (tabs[0]?.id != null) {
+          chrome.tabs.sendMessage(tabs[0].id, {command: 'inspect_node'});
+        }
+      });
+      return;
+    default:
+      return;
+  }
+});
+
 chrome.tabs.onActivated.addListener(({tabId: activeTabId}) => {
   for (const registeredTabId in ports) {
     if (

--- a/packages/react-devtools-extensions/src/contentScripts/backendManager.js
+++ b/packages/react-devtools-extensions/src/contentScripts/backendManager.js
@@ -177,6 +177,17 @@ function activateBackend(version: string, hook: DevToolsHook) {
   // This covers the case of syncing saved values after reloading/navigating while DevTools remain open.
   bridge.send('extensionBackendInitialized');
 
+  // Listen for hotkey commands (e.g. Ctrl+Shift+X to start inspecting)
+  window.addEventListener('message', event => {
+    if (
+      event.data?.source === 'react-devtools-content-script' &&
+      event.data?.payload?.type === 'command' &&
+      event.data?.payload?.command === 'inspect_node'
+    ) {
+      agent.startInspectingNative();
+    }
+  });
+
   // this backend is activated
   requiredBackends.delete(version);
 }

--- a/packages/react-devtools-extensions/src/contentScripts/proxy.js
+++ b/packages/react-devtools-extensions/src/contentScripts/proxy.js
@@ -224,6 +224,20 @@ let evalRequestId = 0;
 const evalRequestCallbacks = new Map<number, Function>();
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg?.command) {
+    window.postMessage(
+      {
+        source: 'react-devtools-content-script',
+        payload: {
+          type: 'command',
+          command: msg.command,
+        },
+      },
+      '*',
+    );
+    return;
+  }
+
   switch (msg?.source) {
     case 'devtools-page-eval': {
       const {scriptId, args} = msg.payload;

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -1023,6 +1023,10 @@ export default class Agent extends EventEmitter<{
     this._bridge.send('profilingStatus', this._isProfiling);
   };
 
+  startInspectingNative: () => void = () => {
+    this.emit('startInspectingNative');
+  };
+
   stopInspectingNative: (selected: boolean) => void = selected => {
     this._bridge.send('stopInspectingHost', selected);
   };

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
@@ -37,6 +37,10 @@ export default function setupHighlighter(
   bridge.addListener('scrollTo', scrollDocumentTo);
   bridge.addListener('requestScrollPosition', sendScroll);
 
+  agent.addListener('startInspectingNative', () => {
+    startInspectingHost(false);
+  });
+
   let applyingScroll = false;
 
   function scrollDocumentTo({

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectHostNodesToggle.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectHostNodesToggle.js
@@ -47,7 +47,7 @@ export default function InspectHostNodesToggle({
     <Toggle
       onChange={handleChange}
       isChecked={isInspecting}
-      title="Select an element in the page to inspect it">
+      title="Select an element in the page to inspect it (Cmd/Ctrl Shift X)">
       <ButtonIcon type="search" />
     </Toggle>
   );


### PR DESCRIPTION
Cherry-pick and adapt original PR #17473 by @gejimayu to current DevTools architecture.

### Changes
- Add commands entry to Chrome/Firefox manifest.json
- Update InspectHostNodesToggle tooltip  
- Add startInspectingNative method to Agent class
- Wire agent event to Highlighter's startInspectingHost
- Add window message listener in backendManager.js for hotkey commands

Background.js and contentScript.js already contained the hotkey forwarding logic from a prior partial merge.