### PR TITLE
Add support for SyntheticKeyboardEvent isComposing

### DIFF
--- a/packages/react-dom-bindings/src/events/SyntheticEvent.js
+++ b/packages/react-dom-bindings/src/events/SyntheticEvent.js
@@ -452,6 +452,7 @@ const KeyboardEventInterface: EventInterfaceType = {
   altKey: 0,
   metaKey: 0,
   repeat: 0,
+  isComposing: 0,
   locale: 0,
   getModifierState: getEventModifierState,
   // Legacy Interface


### PR DESCRIPTION
Fixes #13104

Just added \isComposing\ to SyntheticKeyboardEvent interface.