### PR TITLE
[DevTools] Use original window methods instead of allowing overrides

### DIFF
--- a/packages/react-devtools-extensions/src/backend.js
+++ b/packages/react-devtools-extensions/src/backend.js
@@ -16,6 +16,12 @@ import setupNativeStyleEditor from 'react-devtools-shared/src/backend/NativeStyl
 
 import {COMPACT_VERSION_NAME} from './utils';
 
+// Capture original window methods before app scripts can override them.
+const _window = {
+  addEventListener: window.addEventListener.bind(window),
+  removeEventListener: window.removeEventListener.bind(window),
+};
+
 setup(window.__REACT_DEVTOOLS_GLOBAL_HOOK__);
 
 function setup(hook: ?DevToolsHook) {
@@ -31,4 +37,6 @@ function setup(hook: ?DevToolsHook) {
   });
 
   hook.emit('devtools-backend-installed', COMPACT_VERSION_NAME);
+
+  hook.__devtoolsOriginalWindow = _window;
 }

--- a/packages/react-devtools-extensions/src/contentScripts/backendManager.js
+++ b/packages/react-devtools-extensions/src/contentScripts/backendManager.js
@@ -149,6 +149,7 @@ function activateBackend(version: string, hook: DevToolsHook) {
     bridge,
     getIfReloadedAndProfiling(),
     onReloadAndProfile,
+    hook.__devtoolsOriginalWindow,
   );
   // Agent read flags successfully, we can count it as successful launch
   // Clean up flags, so that next reload won't start profiling

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -22,6 +22,7 @@ import {currentBridgeProtocol} from 'react-devtools-shared/src/bridge';
 
 import type {BackendBridge} from 'react-devtools-shared/src/bridge';
 import type {
+  _Window,
   InstanceAndStyle,
   HostInstance,
   OwnersList,
@@ -293,6 +294,7 @@ export default class Agent extends EventEmitter<{
       recordChangeDescriptions: boolean,
       recordTimeline: boolean,
     ) => void,
+    _window?: _Window,
   ) {
     super();
 
@@ -361,7 +363,7 @@ export default class Agent extends EventEmitter<{
     bridge.addListener('overrideProps', this.overrideProps);
     bridge.addListener('overrideState', this.overrideState);
 
-    setupHighlighter(bridge, this);
+    setupHighlighter(bridge, this, _window);
     setupTraceUpdates(this);
 
     // By this time, Store should already be initialized and intercept events

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -44,6 +44,11 @@ export type WorkTag = number;
 export type WorkFlags = number;
 export type ExpirationTime = number;
 
+export type _Window = {
+  addEventListener: Function,
+  removeEventListener: Function,
+};
+
 export type WorkTagMap = {
   CacheComponent: WorkTag,
   ClassComponent: WorkTag,

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
@@ -11,7 +11,7 @@ import Agent from 'react-devtools-shared/src/backend/agent';
 import {hideOverlay, showOverlay} from './Highlighter';
 import {isReactNativeEnvironment} from 'react-devtools-shared/src/backend/utils';
 
-import type {HostInstance} from 'react-devtools-shared/src/backend/types';
+import type {_Window, HostInstance} from 'react-devtools-shared/src/backend/types';
 import type {BackendBridge} from 'react-devtools-shared/src/bridge';
 import type {RendererInterface} from '../../types';
 
@@ -26,6 +26,7 @@ let inspectOnlySuspenseNodes = false;
 export default function setupHighlighter(
   bridge: BackendBridge,
   agent: Agent,
+  _window?: _Window,
 ): void {
   bridge.addListener('clearHostInstanceHighlight', clearHostInstanceHighlight);
   bridge.addListener('highlightHostInstance', highlightHostInstance);
@@ -116,16 +117,20 @@ export default function setupHighlighter(
     registerListenersOnWindow(window);
   }
 
-  function registerListenersOnWindow(window: any) {
-    // This plug-in may run in non-DOM environments (e.g. React Native).
-    if (window && typeof window.addEventListener === 'function') {
-      window.addEventListener('click', onClick, true);
-      window.addEventListener('mousedown', onMouseEvent, true);
-      window.addEventListener('mouseover', onMouseEvent, true);
-      window.addEventListener('mouseup', onMouseEvent, true);
-      window.addEventListener('pointerdown', onPointerDown, true);
-      window.addEventListener('pointermove', onPointerMove, true);
-      window.addEventListener('pointerup', onPointerUp, true);
+  function registerListenersOnWindow(targetWindow: any) {
+    // Use original window methods if captured (to avoid overrides from app code).
+    const addEventListener =
+      _window != null && targetWindow === window
+        ? _window.addEventListener
+        : targetWindow?.addEventListener;
+    if (typeof addEventListener === 'function') {
+      addEventListener('click', onClick, true);
+      addEventListener('mousedown', onMouseEvent, true);
+      addEventListener('mouseover', onMouseEvent, true);
+      addEventListener('mouseup', onMouseEvent, true);
+      addEventListener('pointerdown', onPointerDown, true);
+      addEventListener('pointermove', onPointerMove, true);
+      addEventListener('pointerup', onPointerUp, true);
     } else {
       agent.emit('startInspectingNative');
     }
@@ -144,16 +149,20 @@ export default function setupHighlighter(
     iframesListeningTo = new Set();
   }
 
-  function removeListenersOnWindow(window: any) {
-    // This plug-in may run in non-DOM environments (e.g. React Native).
-    if (window && typeof window.removeEventListener === 'function') {
-      window.removeEventListener('click', onClick, true);
-      window.removeEventListener('mousedown', onMouseEvent, true);
-      window.removeEventListener('mouseover', onMouseEvent, true);
-      window.removeEventListener('mouseup', onMouseEvent, true);
-      window.removeEventListener('pointerdown', onPointerDown, true);
-      window.removeEventListener('pointermove', onPointerMove, true);
-      window.removeEventListener('pointerup', onPointerUp, true);
+  function removeListenersOnWindow(targetWindow: any) {
+    // Use original window methods if captured (to avoid overrides from app code).
+    const removeEventListener =
+      _window != null && targetWindow === window
+        ? _window.removeEventListener
+        : targetWindow?.removeEventListener;
+    if (typeof removeEventListener === 'function') {
+      removeEventListener('click', onClick, true);
+      removeEventListener('mousedown', onMouseEvent, true);
+      removeEventListener('mouseover', onMouseEvent, true);
+      removeEventListener('mouseup', onMouseEvent, true);
+      removeEventListener('pointerdown', onPointerDown, true);
+      removeEventListener('pointermove', onPointerMove, true);
+      removeEventListener('pointerup', onPointerUp, true);
     } else {
       agent.emit('stopInspectingNative');
     }


### PR DESCRIPTION
Certain apps intercept and override window methods for logging. When the overrides aren't implemented correctly, DevTools breaks because the backend shares the same window object.

Fix: capture original addEventListener/removeEventListener at module load time in backend.js (before app scripts run) and thread them through to the Highlighter.

Adapted from original PR #25087 by @lunaruan.