### PR TITLE
[DevTools] Harden Bridge and Wall lifecycle types

### DIFF
--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -163,7 +163,11 @@ export function connectToDevTools(options: ?ConnectOptions) {
           }
         };
       },
-      send(event: string, payload: any, transferable?: Array<any>) {
+      send(
+        event: string,
+        payload: mixed,
+        transferable?: $ReadOnlyArray<mixed>,
+      ) {
         if (ws.readyState === ws.OPEN) {
           // $FlowFixMe[constant-condition]
           if (__DEBUG__) {
@@ -327,9 +331,9 @@ export function connectToDevTools(options: ?ConnectOptions) {
 }
 
 type ConnectWithCustomMessagingOptions = {
-  onSubscribe: (cb: Function) => void,
-  onUnsubscribe: (cb: Function) => void,
-  onMessage: (event: string, payload: any) => void,
+  onSubscribe: (cb: (message: mixed) => void) => void,
+  onUnsubscribe: (cb: (message: mixed) => void) => void,
+  onMessage: (event: string, payload: mixed) => void,
   nativeStyleEditorValidAttributes?: $ReadOnlyArray<string>,
   resolveRNStyle?: ResolveNativeStyle,
   onSettingsUpdated?: (settings: $ReadOnly<DevToolsHookSettings>) => void,
@@ -358,14 +362,14 @@ export function connectWithCustomMessagingProtocol({
   }
 
   const wall: Wall = {
-    listen(fn: Function) {
+    listen(fn: (message: mixed) => void) {
       onSubscribe(fn);
 
       return () => {
         onUnsubscribe(fn);
       };
     },
-    send(event: string, payload: any) {
+    send(event: string, payload: mixed) {
       onMessage(event, payload);
     },
   };

--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -209,7 +209,7 @@ function onError({code, message}: $FlowFixMe) {
 
 function openProfiler() {
   // Mocked up bridge and store to allow the DevTools to be rendered
-  bridge = new Bridge({listen: () => {}, send: () => {}});
+  bridge = new Bridge({listen: () => () => {}, send: () => {}});
   store = new Store(bridge, {});
 
   // Ensure the Profiler tab is shown initially.
@@ -260,7 +260,7 @@ function initialize(socket: WebSocket) {
         }
       };
     },
-    send(event: string, payload: any, transferable?: Array<any>) {
+    send(event: string, payload: mixed, transferable?: $ReadOnlyArray<mixed>) {
       if (socket.readyState === socket.OPEN) {
         socket.send(JSON.stringify({event, payload}));
       }

--- a/packages/react-devtools-extensions/src/background/index.js
+++ b/packages/react-devtools-extensions/src/background/index.js
@@ -163,7 +163,7 @@ function connectExtensionAndProxyPorts(
     );
   }
 
-  function extensionPortMessageListener(message: any) {
+  function extensionPortMessageListener(message: mixed) {
     try {
       proxyPort.postMessage(message);
     } catch (e) {
@@ -175,7 +175,7 @@ function connectExtensionAndProxyPorts(
     }
   }
 
-  function proxyPortMessageListener(message: any) {
+  function proxyPortMessageListener(message: mixed) {
     try {
       extensionPort.postMessage(message);
     } catch (e) {

--- a/packages/react-devtools-extensions/src/contentScripts/backendManager.js
+++ b/packages/react-devtools-extensions/src/contentScripts/backendManager.js
@@ -133,7 +133,7 @@ function activateBackend(version: string, hook: DevToolsHook) {
         window.removeEventListener('message', listener);
       };
     },
-    send(event: string, payload: any, transferable?: Array<any>) {
+    send(event: string, payload: mixed, transferable?: $ReadOnlyArray<mixed>) {
       window.postMessage(
         {
           source: 'react-devtools-bridge',

--- a/packages/react-devtools-extensions/src/contentScripts/proxy.js
+++ b/packages/react-devtools-extensions/src/contentScripts/proxy.js
@@ -71,7 +71,7 @@ function sayHelloToBackendManager() {
   );
 }
 
-function handleMessageFromDevtools(message: any) {
+function handleMessageFromDevtools(message: mixed) {
   window.postMessage(
     {
       source: 'react-devtools-content-script',

--- a/packages/react-devtools-extensions/src/main/index.js
+++ b/packages/react-devtools-extensions/src/main/index.js
@@ -2,7 +2,7 @@
 /** @flow */
 
 import type {RootType} from 'react-dom/src/client/ReactDOMRoot';
-import type {FrontendBridge, Message} from 'react-devtools-shared/src/bridge';
+import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
 import type {
   TabID,
   ViewElementSource,
@@ -59,7 +59,7 @@ const hookNamesModuleLoaderFunction = () => resolvedParseHookNames;
 function createBridge() {
   bridge = new Bridge({
     listen(fn) {
-      const bridgeListener = (message: Message) => fn(message);
+      const bridgeListener = (message: mixed) => fn(message);
       // Store the reference so that we unsubscribe from the same object.
       const portOnMessage = port.onMessage;
       portOnMessage.addListener(bridgeListener);
@@ -72,7 +72,7 @@ function createBridge() {
       };
     },
 
-    send(event: string, payload: any, transferable?: Array<any>) {
+    send(event: string, payload: mixed, transferable?: $ReadOnlyArray<mixed>) {
       port?.postMessage({event, payload}, transferable);
     },
   });

--- a/packages/react-devtools-fusebox/src/frontend.d.ts
+++ b/packages/react-devtools-fusebox/src/frontend.d.ts
@@ -14,14 +14,14 @@ export type MessagePayload =
   | MessagePayload[];
 export type Message = {event: string; payload?: MessagePayload};
 
-export type WallListener = (message: Message) => void;
+export type WallListener = (message: unknown) => void;
 export type Wall = {
-  listen: (fn: WallListener) => Function;
+  listen: (fn: WallListener) => () => void;
   send: (event: string, payload?: MessagePayload) => void;
 };
 
 export type Bridge = {
-  addListener(event: string, listener: (params: unknown) => any): void;
+  addListener(event: string, listener: (params: unknown) => unknown): void;
   removeListener(event: string, listener: Function): void;
   shutdown: () => void;
 };

--- a/packages/react-devtools-fusebox/src/frontend.js
+++ b/packages/react-devtools-fusebox/src/frontend.js
@@ -32,7 +32,7 @@ export function createBridge(wall?: Wall): FrontendBridge {
     return new Bridge(wall);
   }
 
-  return new Bridge({listen: () => {}, send: () => {}});
+  return new Bridge({listen: () => () => {}, send: () => {}});
 }
 
 export function createStore(bridge: FrontendBridge, config?: Config): Store {

--- a/packages/react-devtools-inline/src/backend.js
+++ b/packages/react-devtools-inline/src/backend.js
@@ -103,7 +103,11 @@ export function createBridge(contentWindow: any, wall?: Wall): BackendBridge {
           contentWindow.removeEventListener('message', onMessage);
         };
       },
-      send(event: string, payload: any, transferable?: Array<any>) {
+      send(
+        event: string,
+        payload: mixed,
+        transferable?: $ReadOnlyArray<mixed>,
+      ) {
         parent.postMessage({event, payload}, '*', transferable);
       },
     };

--- a/packages/react-devtools-inline/src/frontend.js
+++ b/packages/react-devtools-inline/src/frontend.js
@@ -34,7 +34,11 @@ export function createBridge(contentWindow: any, wall?: Wall): FrontendBridge {
           window.removeEventListener('message', onMessage);
         };
       },
-      send(event: string, payload: any, transferable?: Array<any>) {
+      send(
+        event: string,
+        payload: mixed,
+        transferable?: $ReadOnlyArray<mixed>,
+      ) {
         contentWindow.postMessage({event, payload}, '*', transferable);
       },
     };

--- a/packages/react-devtools-shared/src/__tests__/bridge-test.js
+++ b/packages/react-devtools-shared/src/__tests__/bridge-test.js
@@ -40,14 +40,86 @@ describe('Bridge', () => {
     expect(wall.send).toHaveBeenCalledWith('shutdown', undefined);
     expect(shutdownCallback).toHaveBeenCalledTimes(1);
 
-    // Verify that the Bridge doesn't send messages after shutdown.
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // Using a Bridge after shutdown is a lifecycle error.
     wall.send.mockClear();
-    bridge.send('should not send');
+    expect(() => bridge.send('should not send')).toThrow(
+      'Cannot send a message through a Bridge that has been shut down.',
+    );
+    expect(() => bridge.addListener('event', () => {})).toThrow(
+      'Cannot add a listener through a Bridge that has been shut down.',
+    );
+    expect(() => bridge.emit('event')).toThrow(
+      'Cannot emit an event through a Bridge that has been shut down.',
+    );
+    expect(() => bridge.shutdown()).toThrow(
+      'Cannot shut down through a Bridge that has been shut down.',
+    );
     jest.runAllTimers();
     expect(wall.send).not.toHaveBeenCalled();
-    expect(console.warn).toHaveBeenCalledWith(
-      'Cannot send message "should not send" through a Bridge that has been shutdown.',
+  });
+
+  // @reactVersion >=16.0
+  it('validates messages received from the wall', () => {
+    let wallListener: ((message: mixed) => void) | null = null;
+    const wall = {
+      listen: jest.fn(listener => {
+        wallListener = listener;
+        return () => {};
+      }),
+      send: jest.fn(),
+    };
+    const bridge = new Bridge(wall);
+    const listener = jest.fn();
+    bridge.addListener('event', listener);
+
+    const dispatch = (message: mixed) => {
+      if (wallListener === null) {
+        throw new Error('Expected the Bridge to subscribe to the wall.');
+      }
+      wallListener(message);
+    };
+
+    // Walls may share their transport with unrelated or legacy messages.
+    dispatch(null);
+    dispatch({type: 'event'});
+    expect(listener).not.toHaveBeenCalled();
+
+    expect(() => dispatch({event: 123})).toThrow(
+      'Bridge event names must be non-empty strings.',
     );
+    expect(() => dispatch({event: ''})).toThrow(
+      'Bridge event names must be non-empty strings.',
+    );
+
+    dispatch({event: 'event', payload: 123});
+    expect(listener).toHaveBeenCalledWith(123);
+  });
+
+  // @reactVersion >=16.0
+  it('requires Wall.listen to return a cleanup function', () => {
+    expect(
+      () =>
+        new Bridge({
+          listen: () => undefined,
+          send: jest.fn(),
+        }),
+    ).toThrow('Wall.listen() must return an unlisten function.');
+  });
+
+  // @reactVersion >=16.0
+  it('flushes pending messages when wall cleanup throws', () => {
+    const expectedError = new Error('Failed to unsubscribe');
+    const wall = {
+      listen: jest.fn(() => () => {
+        throw expectedError;
+      }),
+      send: jest.fn(),
+    };
+    const bridge = new Bridge(wall);
+
+    bridge.send('update', 'value');
+    expect(() => bridge.shutdown()).toThrow(expectedError);
+    expect(wall.send).toHaveBeenCalledWith('update', 'value');
+    expect(wall.send).toHaveBeenCalledWith('shutdown', undefined);
   });
 });

--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -258,7 +258,7 @@ beforeEach(() => {
         }
       };
     },
-    send(event: string, payload: any, transferable?: Array<any>) {
+    send(event: string, payload: mixed, transferable?: $ReadOnlyArray<mixed>) {
       bridgeListeners.forEach(callback => callback({event, payload}));
     },
   });

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -9,7 +9,7 @@
 
 import EventEmitter from './events';
 
-import type {ComponentFilter, Wall} from './frontend/types';
+import type {ComponentFilter, Wall, WallMessage} from './frontend/types';
 import type {
   InspectedElementPayload,
   OwnersList,
@@ -74,9 +74,17 @@ export const currentBridgeProtocol: BridgeProtocol =
 
 type ElementAndRendererID = {id: number, rendererID: RendererID};
 
-export type Message = {
+export type Message = WallMessage;
+
+type QueuedMessage = {
   event: string,
-  payload: any,
+  payload: mixed,
+};
+
+type EventArguments<Payload> = Payload extends void ? [] : [Payload];
+
+type EventEmitterEvents<Events: Object> = {
+  [Event in keyof Events]: EventArguments<Events[Event]>,
 };
 
 type HighlightHostInstance = {
@@ -101,7 +109,7 @@ type OverrideValue = {
   ...ElementAndRendererID,
   path: Array<string | number>,
   wasForwarded?: boolean,
-  value: any,
+  value: mixed,
 };
 
 type OverrideHookState = {
@@ -131,7 +139,7 @@ type OverrideValueAtPath = {
   type: PathType,
   hookID?: ?number,
   path: Array<string | number>,
-  value: any,
+  value: mixed,
 };
 
 type OverrideError = {
@@ -197,95 +205,96 @@ export type SavedPreferencesParams = {
 };
 
 export type BackendEvents = {
-  backendInitialized: [],
-  backendVersion: [string],
-  bridgeProtocol: [BridgeProtocol],
-  extensionBackendInitialized: [],
-  fastRefreshScheduled: [],
-  getSavedPreferences: [],
-  inspectedElement: [InspectedElementPayload],
-  inspectedScreen: [InspectedElementPayload],
-  isReloadAndProfileSupportedByBackend: [boolean],
-  operations: [Array<number>],
-  ownersList: [OwnersList],
-  environmentNames: [Array<string>],
-  profilingData: [ProfilingDataBackend],
-  profilingStatus: [boolean],
-  reloadAppForProfiling: [],
-  saveToClipboard: [string],
-  selectElement: [number | null],
-  shutdown: [],
-  stopInspectingHost: [boolean],
-  scrollTo: [{left: number, top: number, right: number, bottom: number}],
-  syncSelectionToBuiltinElementsPanel: [],
-  unsupportedRendererVersion: [],
+  backendInitialized: void,
+  backendVersion: string,
+  bridgeProtocol: BridgeProtocol,
+  extensionBackendInitialized: void,
+  fastRefreshScheduled: void,
+  getSavedPreferences: void,
+  inspectedElement: InspectedElementPayload,
+  inspectedScreen: InspectedElementPayload,
+  isReloadAndProfileSupportedByBackend: boolean,
+  operations: Array<number>,
+  ownersList: OwnersList,
+  environmentNames: Array<string>,
+  profilingData: ProfilingDataBackend,
+  profilingStatus: boolean,
+  reloadAppForProfiling: void,
+  saveToClipboard: string,
+  selectElement: number | null,
+  shutdown: void,
+  stopInspectingHost: boolean,
+  scrollTo: {left: number, top: number, right: number, bottom: number},
+  syncSelectionToBuiltinElementsPanel: void,
+  unsupportedRendererVersion: void,
 
-  extensionComponentsPanelShown: [],
-  extensionComponentsPanelHidden: [],
+  extensionComponentsPanelShown: void,
+  extensionComponentsPanelHidden: void,
 
-  resumeElementPolling: [],
-  pauseElementPolling: [],
+  resumeElementPolling: void,
+  pauseElementPolling: void,
 
   // React Native style editor plug-in.
-  isNativeStyleEditorSupported: [
-    {isSupported: boolean, validAttributes: ?$ReadOnlyArray<string>},
-  ],
-  NativeStyleEditor_styleAndLayout: [StyleAndLayoutPayload],
+  isNativeStyleEditorSupported: {
+    isSupported: boolean,
+    validAttributes: ?$ReadOnlyArray<string>,
+  },
+  NativeStyleEditor_styleAndLayout: StyleAndLayoutPayload,
 
-  hookSettings: [$ReadOnly<DevToolsHookSettings>],
+  hookSettings: $ReadOnly<DevToolsHookSettings>,
 };
 
 type StartProfilingParams = ProfilingSettings;
 type ReloadAndProfilingParams = ProfilingSettings;
 
 export type FrontendEvents = {
-  clearErrorsAndWarnings: [{rendererID: RendererID}],
-  clearErrorsForElementID: [ElementAndRendererID],
-  clearHostInstanceHighlight: [],
-  clearWarningsForElementID: [ElementAndRendererID],
-  copyElementPath: [CopyElementPathParams],
-  deletePath: [DeletePath],
-  getBackendVersion: [],
-  getBridgeProtocol: [],
-  getIfHasUnsupportedRendererVersion: [],
-  getOwnersList: [ElementAndRendererID],
-  getProfilingData: [{rendererID: RendererID}],
-  getProfilingStatus: [],
-  highlightHostInstance: [HighlightHostInstance],
-  highlightHostInstances: [HighlightHostInstances],
-  inspectElement: [InspectElementParams],
-  inspectScreen: [InspectScreenParams],
-  logElementToConsole: [ElementAndRendererID],
-  overrideError: [OverrideError],
-  overrideSuspense: [OverrideSuspense],
-  overrideSuspenseMilestone: [OverrideSuspenseMilestone],
-  overrideValueAtPath: [OverrideValueAtPath],
-  profilingData: [ProfilingDataBackend],
-  reloadAndProfile: [ReloadAndProfilingParams],
-  renamePath: [RenamePath],
-  savedPreferences: [SavedPreferencesParams],
-  setTraceUpdatesEnabled: [boolean],
-  shutdown: [],
-  startInspectingHost: [boolean],
-  startProfiling: [StartProfilingParams],
-  stopInspectingHost: [],
-  scrollToHostInstance: [ScrollToHostInstance],
-  scrollTo: [{left: number, top: number, right: number, bottom: number}],
-  requestScrollPosition: [],
-  stopProfiling: [],
-  storeAsGlobal: [StoreAsGlobalParams],
-  updateComponentFilters: [Array<ComponentFilter>],
-  getEnvironmentNames: [],
-  updateHookSettings: [$ReadOnly<DevToolsHookSettings>],
-  viewAttributeSource: [ViewAttributeSourceParams],
-  viewElementSource: [ElementAndRendererID],
+  clearErrorsAndWarnings: {rendererID: RendererID},
+  clearErrorsForElementID: ElementAndRendererID,
+  clearHostInstanceHighlight: void,
+  clearWarningsForElementID: ElementAndRendererID,
+  copyElementPath: CopyElementPathParams,
+  deletePath: DeletePath,
+  getBackendVersion: void,
+  getBridgeProtocol: void,
+  getIfHasUnsupportedRendererVersion: void,
+  getOwnersList: ElementAndRendererID,
+  getProfilingData: {rendererID: RendererID},
+  getProfilingStatus: void,
+  highlightHostInstance: HighlightHostInstance,
+  highlightHostInstances: HighlightHostInstances,
+  inspectElement: InspectElementParams,
+  inspectScreen: InspectScreenParams,
+  logElementToConsole: ElementAndRendererID,
+  overrideError: OverrideError,
+  overrideSuspense: OverrideSuspense,
+  overrideSuspenseMilestone: OverrideSuspenseMilestone,
+  overrideValueAtPath: OverrideValueAtPath,
+  profilingData: ProfilingDataBackend,
+  reloadAndProfile: ReloadAndProfilingParams,
+  renamePath: RenamePath,
+  savedPreferences: SavedPreferencesParams,
+  setTraceUpdatesEnabled: boolean,
+  shutdown: void,
+  startInspectingHost: boolean,
+  startProfiling: StartProfilingParams,
+  stopInspectingHost: void,
+  scrollToHostInstance: ScrollToHostInstance,
+  scrollTo: {left: number, top: number, right: number, bottom: number},
+  requestScrollPosition: void,
+  stopProfiling: void,
+  storeAsGlobal: StoreAsGlobalParams,
+  updateComponentFilters: Array<ComponentFilter>,
+  getEnvironmentNames: void,
+  updateHookSettings: $ReadOnly<DevToolsHookSettings>,
+  viewAttributeSource: ViewAttributeSourceParams,
+  viewElementSource: ElementAndRendererID,
 
-  syncSelectionFromBuiltinElementsPanel: [],
+  syncSelectionFromBuiltinElementsPanel: void,
 
   // React Native style editor plug-in.
-  NativeStyleEditor_measure: [ElementAndRendererID],
-  NativeStyleEditor_renameAttribute: [NativeStyleEditor_RenameAttributeParams],
-  NativeStyleEditor_setValue: [NativeStyleEditor_SetValueParams],
+  NativeStyleEditor_measure: ElementAndRendererID,
+  NativeStyleEditor_renameAttribute: NativeStyleEditor_RenameAttributeParams,
+  NativeStyleEditor_setValue: NativeStyleEditor_SetValueParams,
 
   // Temporarily support newer standalone front-ends sending commands to older embedded backends.
   // We do this because React Native embeds the React DevTools backend,
@@ -297,35 +306,34 @@ export type FrontendEvents = {
   // Note that this approach does no support the combination of a newer backend with an older frontend.
   // It would be more work to support both approaches (and not run handlers twice)
   // so I chose to support the more likely/common scenario (and the one more difficult for an end user to "fix").
-  overrideContext: [OverrideValue],
-  overrideHookState: [OverrideHookState],
-  overrideProps: [OverrideValue],
-  overrideState: [OverrideValue],
+  overrideContext: OverrideValue,
+  overrideHookState: OverrideHookState,
+  overrideProps: OverrideValue,
+  overrideState: OverrideValue,
 
-  getHookSettings: [],
+  getHookSettings: void,
 };
 
 class Bridge<
   OutgoingEvents: Object,
   IncomingEvents: Object,
-> extends EventEmitter<IncomingEvents> {
+> extends EventEmitter<EventEmitterEvents<IncomingEvents>> {
   _isShutdown: boolean = false;
-  _messageQueue: Array<any> = [];
+  _messageQueue: Array<QueuedMessage> = [];
   _scheduledFlush: boolean = false;
   _wall: Wall;
-  _wallUnlisten: Function | null = null;
+  _wallUnlisten: (() => void) | null = null;
 
   constructor(wall: Wall) {
     super();
 
     this._wall = wall;
 
-    this._wallUnlisten =
-      wall.listen((message: Message) => {
-        if (message && message.event) {
-          (this as any).emit(message.event, message.payload);
-        }
-      }) || null;
+    const wallUnlisten = wall.listen(this._handleMessage);
+    if (typeof wallUnlisten !== 'function') {
+      throw new TypeError('Wall.listen() must return an unlisten function.');
+    }
+    this._wallUnlisten = wallUnlisten;
 
     // Temporarily support older standalone front-ends sending commands to newer embedded backends.
     // We do this because React Native embeds the React DevTools backend,
@@ -339,15 +347,30 @@ class Bridge<
     return this._wall;
   }
 
+  addListener<Event: $Keys<EventEmitterEvents<IncomingEvents>>>(
+    event: Event,
+    listener: (...EventEmitterEvents<IncomingEvents>[Event]) => mixed,
+  ): void {
+    this._assertNotShutdown('add a listener');
+    super.addListener(event, listener);
+  }
+
+  emit<Event: $Keys<EventEmitterEvents<IncomingEvents>>>(
+    event: Event,
+    ...args: EventEmitterEvents<IncomingEvents>[Event]
+  ): void {
+    this._assertNotShutdown('emit an event');
+    super.emit(event, ...args);
+  }
+
   send<EventName: $Keys<OutgoingEvents>>(
     event: EventName,
-    ...payload: OutgoingEvents[EventName]
-  ) {
-    if (this._isShutdown) {
-      console.warn(
-        `Cannot send message "${event}" through a Bridge that has been shutdown.`,
-      );
-      return;
+    payload?: OutgoingEvents[EventName],
+  ): void {
+    this._assertNotShutdown('send a message');
+
+    if (typeof event !== 'string' || event.length === 0) {
+      throw new TypeError('Bridge event names must be non-empty strings.');
     }
 
     // When we receive a message:
@@ -358,7 +381,10 @@ class Bridge<
     // - if there *has* been a message flushed in the last BATCH_DURATION ms
     //   (or we're waiting for our setTimeout-0 to fire), then _timeoutID will
     //   be set, and we'll simply add to the queue and wait for that
-    this._messageQueue.push(event, payload);
+    this._messageQueue.push({
+      event,
+      payload,
+    });
     if (!this._scheduledFlush) {
       this._scheduledFlush = true;
       // $FlowFixMe[cannot-resolve-name]
@@ -375,11 +401,8 @@ class Bridge<
     }
   }
 
-  shutdown() {
-    if (this._isShutdown) {
-      console.warn('Bridge was already shutdown.');
-      return;
-    }
+  shutdown(): void {
+    this._assertNotShutdown('shut down');
 
     // Queue the shutdown outgoing message for subscribers.
     this.emit('shutdown');
@@ -388,27 +411,23 @@ class Bridge<
     // Mark this bridge as destroyed, i.e. disable its public API.
     this._isShutdown = true;
 
-    // Disable the API inherited from EventEmitter that can add more listeners and send more messages.
-    // $FlowFixMe[cannot-write] This property is not writable.
-    this.addListener = function () {};
-    // $FlowFixMe[cannot-write] This property is not writable.
-    this.emit = function () {};
-    // NOTE: There's also EventEmitter API like `on` and `prependListener` that we didn't add to our Flow type of EventEmitter.
-
     // Unsubscribe this bridge incoming message listeners to be sure, and so they don't have to do that.
     this.removeAllListeners();
 
     // Stop accepting and emitting incoming messages from the wall.
     const wallUnlisten = this._wallUnlisten;
-    if (wallUnlisten) {
-      wallUnlisten();
+    this._wallUnlisten = null;
+    try {
+      if (wallUnlisten !== null) {
+        wallUnlisten();
+      }
+    } finally {
+      // Synchronously flush all queued outgoing messages.
+      // At this step the subscribers' code may run in this call stack.
+      do {
+        this._flush();
+      } while (this._messageQueue.length);
     }
-
-    // Synchronously flush all queued outgoing messages.
-    // At this step the subscribers' code may run in this call stack.
-    do {
-      this._flush();
-    } while (this._messageQueue.length);
   }
 
   _flush: () => void = () => {
@@ -417,9 +436,9 @@ class Bridge<
     // It is a private method that the bridge ensures is only called at the right times.
     try {
       if (this._messageQueue.length) {
-        for (let i = 0; i < this._messageQueue.length; i += 2) {
-          // This only supports one argument in practice but the types suggests it should support multiple.
-          this._wall.send(this._messageQueue[i], this._messageQueue[i + 1][0]);
+        for (let i = 0; i < this._messageQueue.length; i++) {
+          const {event, payload} = this._messageQueue[i];
+          this._wall.send(event, payload);
         }
         this._messageQueue.length = 0;
       }
@@ -428,6 +447,35 @@ class Bridge<
       // They're already handled so they shouldn't queue more flushes.
       this._scheduledFlush = false;
     }
+  };
+
+  _assertNotShutdown(action: string): void {
+    if (this._isShutdown) {
+      throw new Error(
+        `Cannot ${action} through a Bridge that has been shut down.`,
+      );
+    }
+  }
+
+  _handleMessage: (message: mixed) => void = message => {
+    // Some Walls share a transport with unrelated messages or legacy DevTools
+    // protocols. A message without an event field does not belong to this Bridge.
+    if (
+      message === null ||
+      typeof message !== 'object' ||
+      !('event' in message)
+    ) {
+      return;
+    }
+
+    const event = message.event;
+    if (typeof event !== 'string' || event.length === 0) {
+      throw new TypeError('Bridge event names must be non-empty strings.');
+    }
+
+    this._assertNotShutdown('receive a message');
+    // The wire event name cannot be statically refined to a key of IncomingEvents.
+    (this as any).emit(event, message.payload);
   };
 
   // Temporarily support older standalone backends by forwarding "overrideValueAtPath" commands

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.js
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.js
@@ -275,12 +275,8 @@ export default function DevTools({
 
   useLayoutEffect(() => {
     return () => {
-      try {
-        // Shut the Bridge down synchronously (during unmount).
-        bridge.shutdown();
-      } catch (error) {
-        // Attempting to use a disconnected port.
-      }
+      // Shut the Bridge down synchronously (during unmount).
+      bridge.shutdown();
     };
   }, [bridge]);
 

--- a/packages/react-devtools-shared/src/devtools/views/WarnIfLegacyBackendDetected.js
+++ b/packages/react-devtools-shared/src/devtools/views/WarnIfLegacyBackendDetected.js
@@ -22,8 +22,12 @@ export default function WarnIfLegacyBackendDetected(_: {}): null {
   // We do this by listening to a message that it broadcasts but the v4 backend doesn't.
   // In this case the frontend should show upgrade instructions.
   useEffect(() => {
-    // Wall.listen returns a cleanup function
-    let unlisten: $FlowFixMe = bridge.wall.listen(message => {
+    let unlisten: (() => void) | null = null;
+    unlisten = bridge.wall.listen(message => {
+      if (message === null || typeof message !== 'object') {
+        return;
+      }
+
       switch (message.type) {
         case 'call':
         case 'event':
@@ -38,7 +42,7 @@ export default function WarnIfLegacyBackendDetected(_: {}): null {
           });
 
           // Once we've identified the backend version, it's safe to unsubscribe.
-          if (typeof unlisten === 'function') {
+          if (unlisten !== null) {
             unlisten();
             unlisten = null;
           }
@@ -54,7 +58,7 @@ export default function WarnIfLegacyBackendDetected(_: {}): null {
         case 'overrideComponentFilters':
           // Any of these is sufficient to indicate a v4 backend.
           // Once we've identified the backend version, it's safe to unsubscribe.
-          if (typeof unlisten === 'function') {
+          if (unlisten !== null) {
             unlisten();
             unlisten = null;
           }
@@ -65,7 +69,7 @@ export default function WarnIfLegacyBackendDetected(_: {}): null {
     });
 
     return () => {
-      if (typeof unlisten === 'function') {
+      if (unlisten !== null) {
         unlisten();
         unlisten = null;
       }

--- a/packages/react-devtools-shared/src/frontend/types.js
+++ b/packages/react-devtools-shared/src/frontend/types.js
@@ -23,10 +23,20 @@ import type {UnknownSuspendersReason} from '../constants';
 
 export type BrowserTheme = 'dark' | 'light';
 
+export type WallMessage = {
+  event: string,
+  payload?: mixed,
+};
+
 export type Wall = {
-  // `listen` returns the "unlisten" function.
-  listen: (fn: Function) => Function,
-  send: (event: string, payload: any, transferable?: Array<any>) => void,
+  // A Wall may share its transport with unrelated or legacy messages, so the
+  // Bridge must refine incoming values at the boundary.
+  listen: (fn: (message: mixed) => void) => () => void,
+  send: (
+    event: string,
+    payload: mixed,
+    transferable?: $ReadOnlyArray<mixed>,
+  ) => void,
 };
 
 // WARNING

--- a/packages/react-devtools-shell/src/multi/devtools.js
+++ b/packages/react-devtools-shell/src/multi/devtools.js
@@ -43,6 +43,12 @@ function init(appIframe, devtoolsContainer, appSource) {
       }
 
       wall._listeners.push(listener);
+      return () => {
+        const index = wall._listeners.indexOf(listener);
+        if (index !== -1) {
+          wall._listeners.splice(index, 1);
+        }
+      };
     },
     send(event, payload) {
       if (__DEBUG__) {

--- a/scripts/flow/react-devtools.js
+++ b/scripts/flow/react-devtools.js
@@ -58,9 +58,11 @@ interface ExtensionRuntimeSender {
 interface ExtensionRuntimePort {
   disconnect(): void;
   name: string;
-  onMessage: ExtensionEvent<(message: any, port: ExtensionRuntimePort) => void>;
+  onMessage: ExtensionEvent<
+    (message: mixed, port: ExtensionRuntimePort) => void,
+  >;
   onDisconnect: ExtensionEvent<(port: ExtensionRuntimePort) => void>;
-  postMessage(message: mixed, transferable?: Array<mixed>): void;
+  postMessage(message: mixed, transferable?: $ReadOnlyArray<mixed>): void;
   sender?: ExtensionRuntimeSender;
 }
 


### PR DESCRIPTION
Builds on #37048 by replacing `any`-based Bridge and Wall boundaries with typed `mixed` values and explicit runtime validation. Invalid messages and post-shutdown operations now throw, while shutdown reliably flushes queued messages even if cleanup fails.

Strengthens the DevTools Bridge and Wall contracts:
  - Models event dictionaries as event-to-payload maps, using `void` for events without payloads.
  - Types `send(event, payload?)` directly, eliminating runtime payload-arity handling.
  - Replaces broad `any` transport types with `mixed` and boundary validation.
  - Throws on invalid lifecycle usage instead of warning or silently returning.
  - Ensures shutdown flushes queued messages even when Wall cleanup fails.
  - Updates Wall implementations and adds Bridge lifecycle coverage.